### PR TITLE
fix(llm): keep Nemotron reasoning parsing for force_nonempty_content requests

### DIFF
--- a/lib/llm/PREPROCESSOR_CASES.md
+++ b/lib/llm/PREPROCESSOR_CASES.md
@@ -48,7 +48,7 @@ the request. The exact arg name and value varies per family:
 
 - `kimi_k25` — `thinking: false`
 - `nemotron_nano` / `nemotron3` / `nemotron_v3` —
-  `enable_thinking: false` OR `force_nonempty_content: true`
+  `enable_thinking: false`; `force_nonempty_content: true` keeps parsing enabled and defers reasoning until content is known
 - `deepseek_r1` / `deepseek_v4` — `thinking: false` OR
   `thinking_mode: "chat"` (matches V4 formatter's `resolve_thinking_mode`
   convention; keeps parser and prompt synchronized)
@@ -118,9 +118,7 @@ included here as a baseline reminder that the preprocessor owns this.
 **Function:** `OpenAIPreprocessor::strip_leading_reasoning_start_from_stream`
 
 When PRE.2 disables a Nemotron force-reasoning parser, Dynamo must not
-run the reasoning parser. However, vLLM-compatible Nemotron templates can
-still produce a leading `<think>` in disabled-thinking modes such as
-`force_nonempty_content=true`. The preprocessor strips only that leading
+run the reasoning parser. However, vLLM-compatible Nemotron templates can still produce a leading `<think>` when thinking is explicitly disabled. The preprocessor strips only that leading
 marker, buffers split prefixes like `"<thi"` + `"nk>answer"`, tracks
 state per streamed choice, and emits the remaining bytes as normal
 `content`.
@@ -148,7 +146,7 @@ if you know the answer, fill it in.
 | `deepseek_v3_2` / `deepseek_v4` (DSML) | ? — DSML markers (`<｜DSML｜tool_calls>`); likely YES | `thinking=false` / `thinking_mode=chat` | — | **NEEDS ON** even when last_is_tool (V4 formatter seeds `<think>`); see #8901 | DSv3.2 / DSv4 grammar. |
 | `deepseek_r1` (reasoning) | NO (uses plain `<think>`) | `thinking=false` | — | — | DeepSeek-R1. |
 | `nemotron_deci` (tool) | ? | — | — | — | Nemotron tool parser. |
-| `nemotron_nano` / `nemotron3` / `nemotron_v3` (reasoning) | ? | `enable_thinking=false` / `force_nonempty_content=true` | YES when PRE.2 disables reasoning | — | Dynamically distinguish bare guided JSON from `reasoning</think>JSON`; `nemotron_v3` is the vLLM-compatible alias. |
+| `nemotron_nano` / `nemotron3` / `nemotron_v3` (reasoning) | ? | `enable_thinking=false`; `force_nonempty_content=true` keeps parsing enabled | YES when explicit thinking disablement fires PRE.2 | — | Dynamically distinguish bare guided JSON from `reasoning</think>JSON`; `nemotron_v3` is the vLLM-compatible alias. |
 | `llama3_json` (tool) | ? — `<\|python_tag\|>` is a special token, likely YES | — | — | — | Llama 3.x. |
 | `hermes` (tool) | NO | — | — | — | Plain XML `<tool_call>...</tool_call>`. |
 | `qwen3_coder` (tool) | NO | — | — | — | Plain XML `<tool_call><function=...>`. |

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -18,7 +18,10 @@ use axum::{
     extract::State,
     http::{HeaderMap, Request, StatusCode},
     middleware::{self, Next},
-    response::{IntoResponse, Response, sse::Sse},
+    response::{
+        IntoResponse, Response,
+        sse::{KeepAlive, Sse},
+    },
     routing::{get, post},
 };
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
@@ -28,7 +31,7 @@ use tracing::Instrument;
 use super::{
     RouteDoc,
     disconnect::{
-        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_keep_alive,
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_activity,
     },
     metrics::{
         CancellationLabels, Endpoint, ErrorType, InflightGuard,
@@ -677,16 +680,19 @@ async fn anthropic_messages(
         let keep_alive = state.sse_keep_alive_for_response(
             move_reasoning_to_content_when_empty && parsing_options.reasoning_parser.is_some(),
         );
-        let stream = monitor_for_disconnects_with_keep_alive(
+        let stream = monitor_for_disconnects_with_activity(
             full_stream,
             ctx,
             inflight_guard,
             stream_handle,
-            keep_alive,
             activity_rx,
         );
 
-        Ok(Sse::new(stream).into_response())
+        let mut sse_stream = Sse::new(stream);
+        if let Some(keep_alive) = keep_alive {
+            sse_stream = sse_stream.keep_alive(KeepAlive::default().interval(keep_alive));
+        }
+        Ok(sse_stream.into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
 

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -521,6 +521,14 @@ async fn anthropic_messages(
     let parsing_options = parsing_options
         .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
 
+    // Computed before `request` moves into `generate`. Only a stream that can
+    // withhold every data frame needs forced keep-alive frames.
+    let stream_can_defer_all_output =
+        crate::preprocessor::OpenAIPreprocessor::stream_can_defer_all_output(
+            parsing_options.reasoning_parser.as_deref(),
+            request.chat_template_args.as_ref(),
+        );
+
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     tracing::trace!("Issuing generate call for Anthropic messages");
@@ -677,9 +685,7 @@ async fn anthropic_messages(
             }
         };
 
-        let keep_alive = state.sse_keep_alive_for_response(
-            move_reasoning_to_content_when_empty && parsing_options.reasoning_parser.is_some(),
-        );
+        let keep_alive = state.sse_keep_alive_for_response(stream_can_defer_all_output);
         let stream = monitor_for_disconnects_with_activity(
             full_stream,
             ctx,

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -601,6 +601,7 @@ async fn anthropic_messages(
         // to `monitor_for_disconnects` below.
         let cancel_ctx = ctx.clone();
 
+        let (activity_tx, activity_rx) = tokio::sync::mpsc::unbounded_channel();
         let full_stream = async_stream::stream! {
             let mut events = Vec::with_capacity(4);
             converter.append_start_events(&mut events);
@@ -625,6 +626,7 @@ async fn anthropic_messages(
                         let Some(annotated_chunk) = maybe_chunk else {
                             break; // backend stream ended normally
                         };
+                        let _ = activity_tx.send(());
                         process_response_and_observe_metrics(
                             &annotated_chunk,
                             &mut response_collector,
@@ -679,6 +681,7 @@ async fn anthropic_messages(
             inflight_guard,
             stream_handle,
             keep_alive,
+            activity_rx,
         );
 
         Ok(Sse::new(stream).into_response())

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -674,7 +674,9 @@ async fn anthropic_messages(
             }
         };
 
-        let keep_alive = state.sse_keep_alive_for_response(move_reasoning_to_content_when_empty);
+        let keep_alive = state.sse_keep_alive_for_response(
+            move_reasoning_to_content_when_empty && parsing_options.reasoning_parser.is_some(),
+        );
         let stream = monitor_for_disconnects_with_keep_alive(
             full_stream,
             ctx,

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -360,6 +360,15 @@ async fn anthropic_messages(
         ),
     );
 
+    // Same backstop as the chat handler, so the two aggregation entry points
+    // cannot drift. See `wants_reasoning_as_content_when_empty`.
+    let move_reasoning_to_content_when_empty =
+        crate::preprocessor::OpenAIPreprocessor::wants_reasoning_as_content_when_empty(
+            request.chat_template_args.as_ref(),
+        );
+    let parsing_options = parsing_options
+        .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
+
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     // Create inflight_guard early to ensure all errors are counted

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -18,10 +18,7 @@ use axum::{
     extract::State,
     http::{HeaderMap, Request, StatusCode},
     middleware::{self, Next},
-    response::{
-        IntoResponse, Response,
-        sse::{KeepAlive, Sse},
-    },
+    response::{IntoResponse, Response, sse::Sse},
     routing::{get, post},
 };
 use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
@@ -30,7 +27,9 @@ use tracing::Instrument;
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects_with_keep_alive,
+    },
     metrics::{
         CancellationLabels, Endpoint, ErrorType, InflightGuard,
         process_chat_response_and_observe_metrics as process_response_and_observe_metrics,
@@ -510,6 +509,15 @@ async fn anthropic_messages(
         ),
     );
 
+    // Same backstop as the chat handler, so the two aggregation entry points
+    // cannot drift. See `wants_reasoning_as_content_when_empty`.
+    let move_reasoning_to_content_when_empty =
+        crate::preprocessor::OpenAIPreprocessor::wants_reasoning_as_content_when_empty(
+            request.chat_template_args.as_ref(),
+        );
+    let parsing_options = parsing_options
+        .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
+
     let mut response_collector = state.metrics_clone().create_response_collector(&model);
 
     tracing::trace!("Issuing generate call for Anthropic messages");
@@ -664,14 +672,16 @@ async fn anthropic_messages(
             }
         };
 
-        let stream = monitor_for_disconnects(full_stream, ctx, inflight_guard, stream_handle);
+        let keep_alive = state.sse_keep_alive_for_response(move_reasoning_to_content_when_empty);
+        let stream = monitor_for_disconnects_with_keep_alive(
+            full_stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+            keep_alive,
+        );
 
-        let mut sse_stream = Sse::new(stream);
-        if let Some(keep_alive) = state.sse_keep_alive() {
-            sse_stream = sse_stream.keep_alive(KeepAlive::default().interval(keep_alive));
-        }
-
-        Ok(sse_stream.into_response())
+        Ok(Sse::new(stream).into_response())
     } else {
         // Non-streaming path: aggregate stream into single response
 

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -33,6 +33,7 @@ use dynamo_runtime::engine::AsyncEngineContext;
 use futures::{Stream, StreamExt};
 use std::sync::Arc;
 use std::time::Duration;
+use tokio::sync::mpsc;
 
 use crate::http::service::error::SanitizedError;
 use crate::http::service::metrics::{CancellationLabels, ErrorType, InflightGuard, Metrics};
@@ -249,6 +250,7 @@ pub fn monitor_for_disconnects_with_keep_alive(
     inflight_guard: InflightGuard,
     stream_handle: ConnectionHandle,
     keep_alive: Option<Duration>,
+    activity_rx: mpsc::UnboundedReceiver<()>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     monitor_for_disconnects_with_timeout_error_and_keep_alive(
         stream,
@@ -257,7 +259,7 @@ pub fn monitor_for_disconnects_with_keep_alive(
         stream_handle,
         backend_stream_timeout(),
         openai_stream_error,
-        keep_alive,
+        keep_alive.map(|interval| (interval, activity_rx)),
     )
 }
 
@@ -287,7 +289,7 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
     error_formatter: StreamErrorFormatter,
-    keep_alive: Option<Duration>,
+    keep_alive: Option<(Duration, mpsc::UnboundedReceiver<()>)>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -298,10 +300,16 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
 
     async_stream::try_stream! {
         tokio::pin!(stream);
+        let (keep_alive, mut activity_rx) = match keep_alive {
+            Some((interval, rx)) => (Some(interval), Some(rx)),
+            None => (None, None),
+        };
         // Keep the context's watch-backed cancellation future alive across body frames.
         // Recreating it for every token repeatedly clones a receiver and churns Notify state.
         let stopped = context.stopped();
         tokio::pin!(stopped);
+        let mut inactivity_deadline =
+            inactivity_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
         loop {
             tokio::select! {
                 // Drain any ready SSE event before honoring a cancel or the
@@ -313,6 +321,8 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                 event = stream.next() => {
                     match event {
                         Some(Ok(event)) => {
+                            inactivity_deadline = inactivity_timeout
+                                .map(|timeout| tokio::time::Instant::now() + timeout);
                             yield event;
                         }
                         Some(Err(err)) => {
@@ -365,15 +375,27 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                 } => {
                     yield Event::default().comment("");
                 }
+                activity = async {
+                    match activity_rx.as_mut() {
+                        Some(rx) => rx.recv().await,
+                        None => std::future::pending::<Option<()>>().await,
+                    }
+                } => {
+                    if activity.is_some() {
+                        inactivity_deadline = inactivity_timeout
+                            .map(|timeout| tokio::time::Instant::now() + timeout);
+                    } else {
+                        activity_rx = None;
+                    }
+                }
                 // Circuit breaker for zombie backend workers: if the backend holds a live TCP
                 // connection but produces no output for `inactivity_timeout`, kill the engine
                 // context so that InflightGuard::drop() fires and dec() corrects the gauge.
-                // The sleep is re-created each iteration so it acts as an *inactivity* timeout
-                // (resets whenever a token is received), not a hard total-request deadline.
-                // When inactivity_timeout is None the pending() future never resolves.
+                // Only real stream activity resets this deadline. Client heartbeats must not
+                // keep a dead backend alive indefinitely.
                 _ = async {
-                    match inactivity_timeout {
-                        Some(d) => tokio::time::sleep(d).await,
+                    match inactivity_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
                         None => std::future::pending::<()>().await,
                     }
                 } => {
@@ -707,11 +729,12 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_keep_alive_resets_inactivity_timeout() {
+    async fn test_keep_alive_does_not_reset_inactivity_timeout() {
         let model = "keep-alive-model";
         let (metrics, guard, _context, handle) = setup_test(model, "req-keep-alive");
         let tracked_context = Arc::new(MockContext::with_kill_tracking());
         let engine_context: Arc<dyn AsyncEngineContext> = tracked_context.clone();
+        let (_activity_tx, activity_rx) = mpsc::unbounded_channel();
 
         let monitored = monitor_for_disconnects_with_timeout_error_and_keep_alive(
             hanging_stream(),
@@ -720,21 +743,16 @@ mod tests {
             handle,
             Some(Duration::from_secs(10)),
             openai_stream_error,
-            Some(Duration::from_secs(5)),
+            Some((Duration::from_secs(5), activity_rx)),
         );
         tokio::pin!(monitored);
 
-        for _ in 0..3 {
-            tokio::time::advance(Duration::from_secs(6)).await;
-            let _ = monitored
-                .next()
-                .await
-                .expect("heartbeat stream must stay open")
-                .expect("heartbeat must be valid");
-        }
-
-        assert!(!tracked_context.is_killed());
-        assert_eq!(metrics.get_inflight_count(model), 1);
+        tokio::time::advance(Duration::from_secs(6)).await;
+        assert!(monitored.next().await.unwrap().is_ok());
+        tokio::time::advance(Duration::from_secs(5)).await;
+        assert!(monitored.next().await.is_none());
+        assert!(tracked_context.is_killed());
+        assert_eq!(metrics.get_inflight_count(model), 0);
     }
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -186,11 +186,6 @@ async fn connection_monitor(
 
 type StreamErrorFormatter = fn(&(dyn std::error::Error + 'static)) -> (ErrorType, String);
 
-struct StreamActivity {
-    keep_alive: Option<Duration>,
-    receiver: mpsc::UnboundedReceiver<()>,
-}
-
 fn openai_stream_error(_error: &(dyn std::error::Error + 'static)) -> (ErrorType, String) {
     let error = SanitizedError::Internal;
     let body = serde_json::json!({
@@ -249,12 +244,11 @@ pub(crate) fn monitor_for_disconnects_with_error(
     )
 }
 
-pub fn monitor_for_disconnects_with_keep_alive(
+pub fn monitor_for_disconnects_with_activity(
     stream: impl Stream<Item = Result<Event, axum::Error>>,
     context: Arc<dyn AsyncEngineContext>,
     inflight_guard: InflightGuard,
     stream_handle: ConnectionHandle,
-    keep_alive: Option<Duration>,
     activity_rx: mpsc::UnboundedReceiver<()>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     monitor_for_disconnects_with_timeout_error_and_keep_alive(
@@ -264,10 +258,7 @@ pub fn monitor_for_disconnects_with_keep_alive(
         stream_handle,
         backend_stream_timeout(),
         openai_stream_error,
-        Some(StreamActivity {
-            keep_alive,
-            receiver: activity_rx,
-        }),
+        Some(activity_rx),
     )
 }
 
@@ -297,7 +288,7 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
     error_formatter: StreamErrorFormatter,
-    activity: Option<StreamActivity>,
+    mut activity_rx: Option<mpsc::UnboundedReceiver<()>>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -308,16 +299,10 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
 
     async_stream::try_stream! {
         tokio::pin!(stream);
-        let (keep_alive, mut activity_rx) = match activity {
-            Some(activity) => (activity.keep_alive, Some(activity.receiver)),
-            None => (None, None),
-        };
         // Keep the context's watch-backed cancellation future alive across body frames.
         // Recreating it for every token repeatedly clones a receiver and churns Notify state.
         let stopped = context.stopped();
         tokio::pin!(stopped);
-        let mut keep_alive_deadline =
-            keep_alive.map(|interval| tokio::time::Instant::now() + interval);
         let mut inactivity_deadline =
             inactivity_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
         loop {
@@ -331,8 +316,6 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                 event = stream.next() => {
                     match event {
                         Some(Ok(event)) => {
-                            keep_alive_deadline = keep_alive
-                                .map(|interval| tokio::time::Instant::now() + interval);
                             inactivity_deadline = inactivity_timeout
                                 .map(|timeout| tokio::time::Instant::now() + timeout);
                             yield event;
@@ -378,16 +361,6 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                         "request cancelled"
                     );
                     break;
-                }
-                _ = async {
-                    match keep_alive_deadline {
-                        Some(deadline) => tokio::time::sleep_until(deadline).await,
-                        None => std::future::pending::<()>().await,
-                    }
-                } => {
-                    keep_alive_deadline = keep_alive
-                        .map(|interval| tokio::time::Instant::now() + interval);
-                    yield Event::default().comment("");
                 }
                 activity = async {
                     match activity_rx.as_mut() {
@@ -757,10 +730,7 @@ mod tests {
             handle,
             Some(Duration::from_secs(10)),
             openai_stream_error,
-            Some(StreamActivity {
-                keep_alive: Some(Duration::from_secs(5)),
-                receiver: activity_rx,
-            }),
+            Some(activity_rx),
         );
         tokio::pin!(monitored);
 
@@ -771,17 +741,7 @@ mod tests {
             }
         });
 
-        let start = tokio::time::Instant::now();
-        let mut heartbeat_times = Vec::new();
-        while let Some(event) = monitored.next().await {
-            assert!(event.is_ok());
-            heartbeat_times.push(start.elapsed());
-            assert!(
-                heartbeat_times.len() < 10,
-                "heartbeat loop did not time out"
-            );
-        }
-        assert_eq!(heartbeat_times.first(), Some(&Duration::from_secs(5)));
+        assert!(monitored.next().await.is_none());
         assert!(tracked_context.is_killed());
         assert_eq!(metrics.get_inflight_count(model), 0);
     }

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -186,6 +186,11 @@ async fn connection_monitor(
 
 type StreamErrorFormatter = fn(&(dyn std::error::Error + 'static)) -> (ErrorType, String);
 
+struct StreamActivity {
+    keep_alive: Option<Duration>,
+    receiver: mpsc::UnboundedReceiver<()>,
+}
+
 fn openai_stream_error(_error: &(dyn std::error::Error + 'static)) -> (ErrorType, String) {
     let error = SanitizedError::Internal;
     let body = serde_json::json!({
@@ -259,7 +264,10 @@ pub fn monitor_for_disconnects_with_keep_alive(
         stream_handle,
         backend_stream_timeout(),
         openai_stream_error,
-        keep_alive.map(|interval| (interval, activity_rx)),
+        Some(StreamActivity {
+            keep_alive,
+            receiver: activity_rx,
+        }),
     )
 }
 
@@ -289,7 +297,7 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
     error_formatter: StreamErrorFormatter,
-    keep_alive: Option<(Duration, mpsc::UnboundedReceiver<()>)>,
+    activity: Option<StreamActivity>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -300,8 +308,8 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
 
     async_stream::try_stream! {
         tokio::pin!(stream);
-        let (keep_alive, mut activity_rx) = match keep_alive {
-            Some((interval, rx)) => (Some(interval), Some(rx)),
+        let (keep_alive, mut activity_rx) = match activity {
+            Some(activity) => (activity.keep_alive, Some(activity.receiver)),
             None => (None, None),
         };
         // Keep the context's watch-backed cancellation future alive across body frames.
@@ -749,7 +757,10 @@ mod tests {
             handle,
             Some(Duration::from_secs(10)),
             openai_stream_error,
-            Some((Duration::from_secs(5), activity_rx)),
+            Some(StreamActivity {
+                keep_alive: Some(Duration::from_secs(5)),
+                receiver: activity_rx,
+            }),
         );
         tokio::pin!(monitored);
 

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -214,13 +214,14 @@ pub fn monitor_for_disconnects(
     inflight_guard: InflightGuard,
     stream_handle: ConnectionHandle,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
-    monitor_for_disconnects_with_timeout_and_error(
+    monitor_for_disconnects_with_timeout_error_and_keep_alive(
         stream,
         context,
         inflight_guard,
         stream_handle,
         backend_stream_timeout(),
         openai_stream_error,
+        None,
     )
 }
 
@@ -231,13 +232,32 @@ pub(crate) fn monitor_for_disconnects_with_error(
     stream_handle: ConnectionHandle,
     error_formatter: StreamErrorFormatter,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
-    monitor_for_disconnects_with_timeout_and_error(
+    monitor_for_disconnects_with_timeout_error_and_keep_alive(
         stream,
         context,
         inflight_guard,
         stream_handle,
         backend_stream_timeout(),
         error_formatter,
+        None,
+    )
+}
+
+pub fn monitor_for_disconnects_with_keep_alive(
+    stream: impl Stream<Item = Result<Event, axum::Error>>,
+    context: Arc<dyn AsyncEngineContext>,
+    inflight_guard: InflightGuard,
+    stream_handle: ConnectionHandle,
+    keep_alive: Option<Duration>,
+) -> impl Stream<Item = Result<Event, axum::Error>> {
+    monitor_for_disconnects_with_timeout_error_and_keep_alive(
+        stream,
+        context,
+        inflight_guard,
+        stream_handle,
+        backend_stream_timeout(),
+        openai_stream_error,
+        keep_alive,
     )
 }
 
@@ -249,23 +269,25 @@ fn monitor_for_disconnects_with_timeout(
     stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
-    monitor_for_disconnects_with_timeout_and_error(
+    monitor_for_disconnects_with_timeout_error_and_keep_alive(
         stream,
         context,
         inflight_guard,
         stream_handle,
         inactivity_timeout,
         openai_stream_error,
+        None,
     )
 }
 
-fn monitor_for_disconnects_with_timeout_and_error(
+fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
     stream: impl Stream<Item = Result<Event, axum::Error>>,
     context: Arc<dyn AsyncEngineContext>,
     mut inflight_guard: InflightGuard,
     mut stream_handle: ConnectionHandle,
     inactivity_timeout: Option<Duration>,
     error_formatter: StreamErrorFormatter,
+    keep_alive: Option<Duration>,
 ) -> impl Stream<Item = Result<Event, axum::Error>> {
     stream_handle.arm();
 
@@ -334,6 +356,14 @@ fn monitor_for_disconnects_with_timeout_and_error(
                         "request cancelled"
                     );
                     break;
+                }
+                _ = async {
+                    match keep_alive {
+                        Some(d) => tokio::time::sleep(d).await,
+                        None => std::future::pending::<()>().await,
+                    }
+                } => {
+                    yield Event::default().comment("");
                 }
                 // Circuit breaker for zombie backend workers: if the backend holds a live TCP
                 // connection but produces no output for `inactivity_timeout`, kill the engine
@@ -674,6 +704,37 @@ mod tests {
             0,
             "inflight gauge leaked in phase 2"
         );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn test_keep_alive_resets_inactivity_timeout() {
+        let model = "keep-alive-model";
+        let (metrics, guard, _context, handle) = setup_test(model, "req-keep-alive");
+        let tracked_context = Arc::new(MockContext::with_kill_tracking());
+        let engine_context: Arc<dyn AsyncEngineContext> = tracked_context.clone();
+
+        let monitored = monitor_for_disconnects_with_timeout_error_and_keep_alive(
+            hanging_stream(),
+            engine_context,
+            guard,
+            handle,
+            Some(Duration::from_secs(10)),
+            openai_stream_error,
+            Some(Duration::from_secs(5)),
+        );
+        tokio::pin!(monitored);
+
+        for _ in 0..3 {
+            tokio::time::advance(Duration::from_secs(6)).await;
+            let _ = monitored
+                .next()
+                .await
+                .expect("heartbeat stream must stay open")
+                .expect("heartbeat must be valid");
+        }
+
+        assert!(!tracked_context.is_killed());
+        assert_eq!(metrics.get_inflight_count(model), 1);
     }
 
     // ─────────────────────────────────────────────────────────────────────────────

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -716,7 +716,7 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn test_keep_alive_does_not_reset_inactivity_timeout() {
+    async fn test_activity_signal_resets_inactivity_timeout() {
         let model = "keep-alive-model";
         let (metrics, guard, _context, handle) = setup_test(model, "req-keep-alive");
         let tracked_context = Arc::new(MockContext::with_kill_tracking());
@@ -734,14 +734,17 @@ mod tests {
         );
         tokio::pin!(monitored);
 
-        tokio::spawn(async move {
-            for _ in 0..3 {
-                tokio::time::sleep(Duration::from_secs(2)).await;
-                activity_tx.send(()).unwrap();
-            }
-        });
+        let next = monitored.next();
+        tokio::pin!(next);
 
-        assert!(monitored.next().await.is_none());
+        tokio::time::advance(Duration::from_secs(9)).await;
+        activity_tx.send(()).unwrap();
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(2)).await;
+        assert!(!tracked_context.is_killed());
+
+        tokio::time::advance(Duration::from_secs(8)).await;
+        assert!(next.await.is_none());
         assert!(tracked_context.is_killed());
         assert_eq!(metrics.get_inflight_count(model), 0);
     }

--- a/lib/llm/src/http/service/disconnect.rs
+++ b/lib/llm/src/http/service/disconnect.rs
@@ -308,6 +308,8 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
         // Recreating it for every token repeatedly clones a receiver and churns Notify state.
         let stopped = context.stopped();
         tokio::pin!(stopped);
+        let mut keep_alive_deadline =
+            keep_alive.map(|interval| tokio::time::Instant::now() + interval);
         let mut inactivity_deadline =
             inactivity_timeout.map(|timeout| tokio::time::Instant::now() + timeout);
         loop {
@@ -321,6 +323,8 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                 event = stream.next() => {
                     match event {
                         Some(Ok(event)) => {
+                            keep_alive_deadline = keep_alive
+                                .map(|interval| tokio::time::Instant::now() + interval);
                             inactivity_deadline = inactivity_timeout
                                 .map(|timeout| tokio::time::Instant::now() + timeout);
                             yield event;
@@ -368,11 +372,13 @@ fn monitor_for_disconnects_with_timeout_error_and_keep_alive(
                     break;
                 }
                 _ = async {
-                    match keep_alive {
-                        Some(d) => tokio::time::sleep(d).await,
+                    match keep_alive_deadline {
+                        Some(deadline) => tokio::time::sleep_until(deadline).await,
                         None => std::future::pending::<()>().await,
                     }
                 } => {
+                    keep_alive_deadline = keep_alive
+                        .map(|interval| tokio::time::Instant::now() + interval);
                     yield Event::default().comment("");
                 }
                 activity = async {
@@ -734,7 +740,7 @@ mod tests {
         let (metrics, guard, _context, handle) = setup_test(model, "req-keep-alive");
         let tracked_context = Arc::new(MockContext::with_kill_tracking());
         let engine_context: Arc<dyn AsyncEngineContext> = tracked_context.clone();
-        let (_activity_tx, activity_rx) = mpsc::unbounded_channel();
+        let (activity_tx, activity_rx) = mpsc::unbounded_channel();
 
         let monitored = monitor_for_disconnects_with_timeout_error_and_keep_alive(
             hanging_stream(),
@@ -747,10 +753,24 @@ mod tests {
         );
         tokio::pin!(monitored);
 
-        tokio::time::advance(Duration::from_secs(6)).await;
-        assert!(monitored.next().await.unwrap().is_ok());
-        tokio::time::advance(Duration::from_secs(5)).await;
-        assert!(monitored.next().await.is_none());
+        tokio::spawn(async move {
+            for _ in 0..3 {
+                tokio::time::sleep(Duration::from_secs(2)).await;
+                activity_tx.send(()).unwrap();
+            }
+        });
+
+        let start = tokio::time::Instant::now();
+        let mut heartbeat_times = Vec::new();
+        while let Some(event) = monitored.next().await {
+            assert!(event.is_ok());
+            heartbeat_times.push(start.elapsed());
+            assert!(
+                heartbeat_times.len() < 10,
+                "heartbeat loop did not time out"
+            );
+        }
+        assert_eq!(heartbeat_times.first(), Some(&Duration::from_secs(5)));
         assert!(tracked_context.is_killed());
         assert_eq!(metrics.get_inflight_count(model), 0);
     }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -2403,6 +2403,73 @@ mod tests {
         }
     }
 
+    /// A chunk whose delta renders as nothing is still an accounting event: the
+    /// engine generated those tokens. The chat SSE loop drops such chunks before
+    /// forwarding them (multi-byte token assembly, and the Nemotron
+    /// force_nonempty_content deferral, both produce them), so it observes their
+    /// metrics explicitly before discarding. This pins the helper it calls: an
+    /// empty delta carrying `llm_metrics` must still count.
+    #[test]
+    fn test_empty_delta_with_metrics_is_still_counted() {
+        use crate::protocols::common::metrics::LLMMetricAnnotation;
+        use dynamo_protocols::types::{
+            ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
+        };
+
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+        let model = "test-model";
+        let mut collector = metrics.clone().create_response_collector(model);
+        let mut guard = None;
+
+        #[allow(deprecated)]
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: None,
+                content: None,
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: None,
+        };
+        let data = NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![choice],
+                created: 0,
+                model: model.to_string(),
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            },
+            nvext: None,
+            llm_metrics: Some(LLMMetricAnnotation {
+                input_tokens: 10,
+                output_tokens: 4,
+                chunk_tokens: 4,
+                ..Default::default()
+            }),
+        };
+        let annotated = crate::types::Annotated::from_data(data);
+
+        process_chat_response_and_observe_metrics(&annotated, &mut collector, &mut guard);
+
+        assert_eq!(
+            metrics
+                .output_tokens_counter
+                .with_label_values(&[model])
+                .get(),
+            4,
+            "tokens on a non-renderable chunk must still be counted"
+        );
+    }
+
     #[test]
     fn test_output_tokens_counter_increments() {
         let metrics = Arc::new(Metrics::new());

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -2388,6 +2388,73 @@ mod tests {
         }
     }
 
+    /// A chunk whose delta renders as nothing is still an accounting event: the
+    /// engine generated those tokens. The chat SSE loop drops such chunks before
+    /// forwarding them (multi-byte token assembly, and the Nemotron
+    /// force_nonempty_content deferral, both produce them), so it observes their
+    /// metrics explicitly before discarding. This pins the helper it calls: an
+    /// empty delta carrying `llm_metrics` must still count.
+    #[test]
+    fn test_empty_delta_with_metrics_is_still_counted() {
+        use crate::protocols::common::metrics::LLMMetricAnnotation;
+        use dynamo_protocols::types::{
+            ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
+        };
+
+        let metrics = Arc::new(Metrics::new());
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+        let model = "test-model";
+        let mut collector = metrics.clone().create_response_collector(model);
+        let mut guard = None;
+
+        #[allow(deprecated)]
+        let choice = ChatChoiceStream {
+            index: 0,
+            delta: ChatCompletionStreamResponseDelta {
+                role: None,
+                content: None,
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: None,
+            logprobs: None,
+        };
+        let data = NvCreateChatCompletionStreamResponse {
+            inner: CreateChatCompletionStreamResponse {
+                id: "test".to_string(),
+                choices: vec![choice],
+                created: 0,
+                model: model.to_string(),
+                system_fingerprint: None,
+                object: "chat.completion.chunk".to_string(),
+                usage: None,
+                service_tier: None,
+            },
+            nvext: None,
+            llm_metrics: Some(LLMMetricAnnotation {
+                input_tokens: 10,
+                output_tokens: 4,
+                chunk_tokens: 4,
+                ..Default::default()
+            }),
+        };
+        let annotated = crate::types::Annotated::from_data(data);
+
+        process_chat_response_and_observe_metrics(&annotated, &mut collector, &mut guard);
+
+        assert_eq!(
+            metrics
+                .output_tokens_counter
+                .with_label_values(&[model])
+                .get(),
+            4,
+            "tokens on a non-renderable chunk must still be counted"
+        );
+    }
+
     #[test]
     fn test_output_tokens_counter_increments() {
         let metrics = Arc::new(Metrics::new());

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2636,6 +2636,14 @@ async fn chat_completions(
     let parsing_options = parsing_options
         .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
 
+    // Computed before `request` moves into `generate`. Only a stream that can
+    // withhold every data frame needs forced keep-alive frames.
+    let stream_can_defer_all_output =
+        crate::preprocessor::OpenAIPreprocessor::stream_can_defer_all_output(
+            parsing_options.reasoning_parser.as_deref(),
+            request.chat_template_args.as_ref(),
+        );
+
     let mut response_collector = state
         .metrics_clone()
         .create_response_collector(&metric_model);
@@ -2794,9 +2802,7 @@ async fn chat_completions(
                 }
             }
         };
-        let keep_alive = state.sse_keep_alive_for_response(
-            move_reasoning_to_content_when_empty && parsing_options.reasoning_parser.is_some(),
-        );
+        let keep_alive = state.sse_keep_alive_for_response(stream_can_defer_all_output);
         let stream = monitor_for_disconnects_with_activity(
             stream,
             ctx,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -35,7 +35,7 @@ use super::{
     RouteDoc,
     disconnect::{
         ConnectionHandle, create_connection_monitor, monitor_for_disconnects,
-        monitor_for_disconnects_with_keep_alive,
+        monitor_for_disconnects_with_activity,
     },
     error::{HttpError, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
@@ -2797,16 +2797,19 @@ async fn chat_completions(
         let keep_alive = state.sse_keep_alive_for_response(
             move_reasoning_to_content_when_empty && parsing_options.reasoning_parser.is_some(),
         );
-        let stream = monitor_for_disconnects_with_keep_alive(
+        let stream = monitor_for_disconnects_with_activity(
             stream,
             ctx,
             inflight_guard,
             stream_handle,
-            keep_alive,
             activity_rx,
         );
 
-        Ok(Sse::new(stream).into_response())
+        let mut sse_stream = Sse::new(stream);
+        if let Some(keep_alive) = keep_alive {
+            sse_stream = sse_stream.keep_alive(KeepAlive::default().interval(keep_alive));
+        }
+        Ok(sse_stream.into_response())
     } else {
         // Check first event for backend errors before aggregating (non-streaming only)
         let stream_with_check =

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2713,6 +2713,7 @@ async fn chat_completions(
         // Optionally prepend extra SSE events before each regular chunk:
         //   - `event: tool_call_dispatch`  — complete tool call detected early (tool dispatch)
         //   - `event: reasoning_dispatch`  — complete reasoning block (emitted once)
+        let (activity_tx, activity_rx) = tokio::sync::mpsc::unbounded_channel();
         let stream = async_stream::stream! {
             let mut stream = Box::pin(stream);
             let mut events: Vec<Result<Event, axum::Error>> = Vec::with_capacity(4);
@@ -2741,6 +2742,7 @@ async fn chat_completions(
 
                 // Drop empty chunks from multi-byte token assembly.
                 if response.data.as_ref().is_some_and(is_empty_stream_response) {
+                    let _ = activity_tx.send(());
                     // Not forwarded, but the engine still generated these tokens,
                     // so account for them before discarding. Otherwise the
                     // real-time output-token counter undercounts and TTFT is
@@ -2799,6 +2801,7 @@ async fn chat_completions(
             inflight_guard,
             stream_handle,
             keep_alive,
+            activity_rx,
         );
 
         Ok(Sse::new(stream).into_response())

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2794,7 +2794,9 @@ async fn chat_completions(
                 }
             }
         };
-        let keep_alive = state.sse_keep_alive_for_response(move_reasoning_to_content_when_empty);
+        let keep_alive = state.sse_keep_alive_for_response(
+            move_reasoning_to_content_when_empty && parsing_options.reasoning_parser.is_some(),
+        );
         let stream = monitor_for_disconnects_with_keep_alive(
             stream,
             ctx,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -33,7 +33,10 @@ use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::{
     RouteDoc,
-    disconnect::{ConnectionHandle, create_connection_monitor, monitor_for_disconnects},
+    disconnect::{
+        ConnectionHandle, create_connection_monitor, monitor_for_disconnects,
+        monitor_for_disconnects_with_keep_alive,
+    },
     error::{HttpError, invalid_argument},
     metadata::{attach_x_request_id, extract_metadata_from_http},
     metrics::{
@@ -2624,6 +2627,15 @@ async fn chat_completions(
         parsing_options.with_parallel_tool_calls(request.inner.parallel_tool_calls);
     let enforce_single_tool_call = request.inner.parallel_tool_calls == Some(false);
 
+    // Any force_nonempty_content=true request: surface reasoning as content when
+    // the turn produced none. See `wants_reasoning_as_content_when_empty`.
+    let move_reasoning_to_content_when_empty =
+        crate::preprocessor::OpenAIPreprocessor::wants_reasoning_as_content_when_empty(
+            request.chat_template_args.as_ref(),
+        );
+    let parsing_options = parsing_options
+        .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
+
     let mut response_collector = state
         .metrics_clone()
         .create_response_collector(&metric_model);
@@ -2729,6 +2741,18 @@ async fn chat_completions(
 
                 // Drop empty chunks from multi-byte token assembly.
                 if response.data.as_ref().is_some_and(is_empty_stream_response) {
+                    // Not forwarded, but the engine still generated these tokens,
+                    // so account for them before discarding. Otherwise the
+                    // real-time output-token counter undercounts and TTFT is
+                    // attributed to the first *renderable* chunk rather than the
+                    // first generated one. This already affected multi-byte token
+                    // assembly; the Nemotron force_nonempty_content deferral makes
+                    // empty chunks common enough to matter.
+                    process_chat_response_and_observe_metrics(
+                        &response,
+                        &mut response_collector,
+                        &mut http_queue_guard,
+                    );
                     continue;
                 }
                 if tool_dispatch_enabled {
@@ -2768,15 +2792,16 @@ async fn chat_completions(
                 }
             }
         };
-        let stream = monitor_for_disconnects(stream, ctx, inflight_guard, stream_handle);
+        let keep_alive = state.sse_keep_alive_for_response(move_reasoning_to_content_when_empty);
+        let stream = monitor_for_disconnects_with_keep_alive(
+            stream,
+            ctx,
+            inflight_guard,
+            stream_handle,
+            keep_alive,
+        );
 
-        let mut sse_stream = Sse::new(stream);
-
-        if let Some(keep_alive) = state.sse_keep_alive() {
-            sse_stream = sse_stream.keep_alive(KeepAlive::default().interval(keep_alive));
-        }
-
-        Ok(sse_stream.into_response())
+        Ok(Sse::new(stream).into_response())
     } else {
         // Check first event for backend errors before aggregating (non-streaming only)
         let stream_with_check =
@@ -3173,6 +3198,21 @@ async fn responses(
             request.inner.tool_choice.as_ref(),
         ),
     );
+
+    // NOTE: `move_reasoning_to_content_when_empty` is the aggregator flag and is
+    // not set here. A non-streaming Responses request DOES reach the aggregator
+    // (forcing stream=true on the converted request only drives internal
+    // streaming; the client-facing `streaming` flag still selects the aggregating
+    // branch below), so it reaches it with the flag false.
+    //
+    // That is currently unreachable rather than wrong: the Responses-to-chat
+    // conversion hard-codes `chat_template_args: None`, so
+    // `force_nonempty_content` can never be set on this path in the first place.
+    // If that conversion ever forwards chat_template_args, the streaming stage
+    // would still cover the reasoning-only case — `postprocessor_parsing_stream`
+    // gates on the request's own args via `wants_reasoning_as_content_when_empty`
+    // rather than on this flag — but the aggregator backstop should be wired here
+    // too at that point. Tracked as follow-up.
 
     let mut response_collector = state
         .metrics_clone()

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2099,6 +2099,15 @@ async fn chat_completions(
         parsing_options.with_parallel_tool_calls(request.inner.parallel_tool_calls);
     let enforce_single_tool_call = request.inner.parallel_tool_calls == Some(false);
 
+    // Any force_nonempty_content=true request: surface reasoning as content when
+    // the turn produced none. See `wants_reasoning_as_content_when_empty`.
+    let move_reasoning_to_content_when_empty =
+        crate::preprocessor::OpenAIPreprocessor::wants_reasoning_as_content_when_empty(
+            request.chat_template_args.as_ref(),
+        );
+    let parsing_options = parsing_options
+        .with_move_reasoning_to_content_when_empty(move_reasoning_to_content_when_empty);
+
     let mut response_collector = state
         .metrics_clone()
         .create_response_collector(&metric_model);
@@ -2204,6 +2213,18 @@ async fn chat_completions(
 
                 // Drop empty chunks from multi-byte token assembly.
                 if response.data.as_ref().is_some_and(is_empty_stream_response) {
+                    // Not forwarded, but the engine still generated these tokens,
+                    // so account for them before discarding. Otherwise the
+                    // real-time output-token counter undercounts and TTFT is
+                    // attributed to the first *renderable* chunk rather than the
+                    // first generated one. This already affected multi-byte token
+                    // assembly; the Nemotron force_nonempty_content deferral makes
+                    // empty chunks common enough to matter.
+                    process_chat_response_and_observe_metrics(
+                        &response,
+                        &mut response_collector,
+                        &mut http_queue_guard,
+                    );
                     continue;
                 }
                 if tool_dispatch_enabled {
@@ -2641,6 +2662,21 @@ async fn responses(
             request.inner.tool_choice.as_ref(),
         ),
     );
+
+    // NOTE: `move_reasoning_to_content_when_empty` is the aggregator flag and is
+    // not set here. A non-streaming Responses request DOES reach the aggregator
+    // (forcing stream=true on the converted request only drives internal
+    // streaming; the client-facing `streaming` flag still selects the aggregating
+    // branch below), so it reaches it with the flag false.
+    //
+    // That is currently unreachable rather than wrong: the Responses-to-chat
+    // conversion hard-codes `chat_template_args: None`, so
+    // `force_nonempty_content` can never be set on this path in the first place.
+    // If that conversion ever forwards chat_template_args, the streaming stage
+    // would still cover the reasoning-only case — `postprocessor_parsing_stream`
+    // gates on the request's own args via `wants_reasoning_as_content_when_empty`
+    // rather than on this flag — but the aggregator backstop should be wired here
+    // too at that point. Tracked as follow-up.
 
     let mut response_collector = state
         .metrics_clone()

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -168,6 +168,15 @@ fn sse_keep_alive_from_env() -> Option<Duration> {
     parse_sse_keep_alive(std::env::var(env_llm::DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS))
 }
 
+const DEFERRED_RESPONSE_KEEP_ALIVE: Duration = Duration::from_secs(15);
+
+fn effective_sse_keep_alive(
+    configured: Option<Duration>,
+    response_can_defer_all_output: bool,
+) -> Option<Duration> {
+    configured.or(response_can_defer_all_output.then_some(DEFERRED_RESPONSE_KEEP_ALIVE))
+}
+
 /// Lifecycle stage for the HTTP frontend.
 ///
 /// The stage gates readiness and request admission separately from the runtime
@@ -523,6 +532,17 @@ impl State {
     /// `DYN_HTTP_SSE_KEEP_ALIVE_INTERVAL_MS`.
     pub fn sse_keep_alive(&self) -> Option<Duration> {
         self.sse_keep_alive
+    }
+
+    /// Interval for a response that can intentionally suppress all generated
+    /// data frames while it waits to decide which output field owns the text.
+    /// Keep the configured interval when present; otherwise use Axum's standard
+    /// 15-second heartbeat so proxies and clients do not see an idle connection.
+    pub fn sse_keep_alive_for_response(
+        &self,
+        response_can_defer_all_output: bool,
+    ) -> Option<Duration> {
+        effective_sse_keep_alive(self.sse_keep_alive, response_can_defer_all_output)
     }
 
     /// Returns true if Anthropic billing preamble stripping is enabled.
@@ -1977,6 +1997,26 @@ mod tests {
             .checked_add(interval)
             .map(|_| interval);
         assert_eq!(parse_sse_keep_alive(Ok(u64::MAX.to_string())), expected);
+    }
+
+    #[test]
+    fn test_sse_keep_alive_for_deferred_response() {
+        let configured = Duration::from_millis(5000);
+        assert_eq!(
+            effective_sse_keep_alive(Some(configured), true),
+            Some(configured),
+            "an explicit interval must win"
+        );
+        assert_eq!(
+            effective_sse_keep_alive(None, true),
+            Some(Duration::from_secs(15)),
+            "a response that can suppress every data frame needs a heartbeat"
+        );
+        assert_eq!(
+            effective_sse_keep_alive(None, false),
+            None,
+            "ordinary responses keep the opt-in behavior"
+        );
     }
 
     #[test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4798,7 +4798,13 @@ impl OpenAIPreprocessor {
                 }
 
                 response.data = Some(data);
-                state.last_response = Some(response.clone());
+                if response
+                    .data
+                    .as_ref()
+                    .is_some_and(|data| !data.inner.choices.is_empty())
+                {
+                    state.last_response = Some(response.clone());
+                }
 
                 Some((response, state))
             } else if state.eof_flushed {
@@ -4816,21 +4822,23 @@ impl OpenAIPreprocessor {
                     // it here.
                     scrub_synthetic_chunk_metadata(&mut response)?;
                     let data = response.data.as_mut()?;
-                    data.inner.choices.retain_mut(|choice| {
-                        if let Some(buffer) = flushed.remove(&choice.index) {
-                            choice.delta.role = None;
+                    let mut template = data.inner.choices.first()?.clone();
+                    template.delta.role = None;
+                    template.delta.tool_calls = None;
+                    template.delta.function_call = None;
+                    template.delta.refusal = None;
+                    template.delta.reasoning_content = None;
+                    template.finish_reason = None;
+                    template.logprobs = None;
+                    data.inner.choices = flushed
+                        .drain()
+                        .map(|(index, buffer)| {
+                            let mut choice = template.clone();
+                            choice.index = index;
                             choice.delta.content = Some(ChatCompletionMessageContent::Text(buffer));
-                            choice.delta.tool_calls = None;
-                            choice.delta.function_call = None;
-                            choice.delta.refusal = None;
-                            choice.delta.reasoning_content = None;
-                            choice.finish_reason = None;
-                            choice.logprobs = None;
-                            true
-                        } else {
-                            false
-                        }
-                    });
+                            choice
+                        })
+                        .collect();
 
                     if data.inner.choices.is_empty() {
                         None

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4420,7 +4420,8 @@ impl OpenAIPreprocessor {
                                 }
                                 ChoiceReasoningState {
                                     parser,
-                                    guided_json_bypass_decision: None,
+                                    guided_json_bypass_decision: (!bypass_bare_guided_json)
+                                        .then_some(false),
                                     pending_reasoning: String::new(),
                                     pending_content: String::new(),
                                     left_reasoning: false,
@@ -4619,8 +4620,11 @@ impl OpenAIPreprocessor {
                 let flushed: Vec<(u32, Option<String>, Option<String>)> = indices
                     .into_iter()
                     .filter_map(|index| {
-                        let (content, reasoning) =
-                            drain_deferred_reasoning(state.choices.get_mut(&index)?);
+                        let choice_state = state.choices.get_mut(&index)?;
+                        if choice_state.guided_json_bypass_decision != Some(false) {
+                            return None;
+                        }
+                        let (content, reasoning) = drain_deferred_reasoning(choice_state);
                         (content.is_some() || reasoning.is_some())
                             .then_some((index, content, reasoning))
                     })

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4815,7 +4815,7 @@ impl OpenAIPreprocessor {
                 None
             } else {
                 state.eof_flushed = true;
-                let mut flushed = drain_undecided_buffers(&mut state.choices);
+                let flushed = drain_undecided_buffers(&mut state.choices);
                 if flushed.is_empty() {
                     None
                 } else {
@@ -4834,8 +4834,10 @@ impl OpenAIPreprocessor {
                     template.delta.reasoning_content = None;
                     template.finish_reason = None;
                     template.logprobs = None;
+                    let mut flushed: Vec<_> = flushed.into_iter().collect();
+                    flushed.sort_unstable_by_key(|(index, _)| *index);
                     data.inner.choices = flushed
-                        .drain()
+                        .into_iter()
                         .map(|(index, buffer)| {
                             let mut choice = template.clone();
                             choice.index = index;

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -62,7 +62,8 @@ use crate::protocols::common::timing::RequestTracker;
 use crate::tokenizers::Encoding;
 
 use dynamo_parsers::{
-    ReasoningParser, ReasoningParserType, tool_calling::parsers::get_tool_parser_map,
+    ReasoningParser, ReasoningParserType, reasoning::ParserResult,
+    tool_calling::parsers::get_tool_parser_map,
 };
 use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, ResponseStream};
 use dynamo_runtime::pipeline::{
@@ -299,6 +300,115 @@ where
 struct ChoiceReasoningState {
     parser: Box<dyn ReasoningParser>,
     guided_json_bypass_decision: Option<bool>,
+    // Reasoning text held back while it is still ambiguous. Only used on the
+    // `defer_reasoning_for_nonempty_content` path — see the buffering note on
+    // `ReasoningState`.
+    pending_reasoning: String,
+    // Whitespace-only normal text seen while still ambiguous. Held rather than
+    // emitted so the streaming path agrees with the aggregator, which counts
+    // whitespace-only content as empty.
+    pending_content: String,
+    // Set once this choice's parser has produced normal text, which for these
+    // force-reasoning parsers means it left the reasoning block. From then on
+    // the ambiguity is gone and deltas pass straight through.
+    left_reasoning: bool,
+    // Set once this choice has been drained, so the terminal-chunk drain and the
+    // end-of-stream fallback cannot both emit the same bytes. Reopened if the
+    // backend keeps sending content after `finish_reason`, so those bytes still
+    // get a destination.
+    drained: bool,
+    // Set the first time this choice's parser is finalized and NEVER reset, even
+    // when `drained` is reopened. `ReasoningParser::finish_reasoning_stream` is
+    // not documented to be idempotent, so calling it twice could re-emit text a
+    // parser had already handed over. Draining again is fine; finalizing again
+    // is not.
+    parser_finished: bool,
+}
+
+/// Strip every per-chunk field from a response that is being reused as the
+/// envelope for a synthetic end-of-stream chunk.
+///
+/// Both end-of-stream flushes build their chunk by cloning the last chunk they
+/// saw, because that is the only way to carry the buffered bytes out on a
+/// correctly-shaped response. The clone is not a new generation: it produced no
+/// tokens and re-channels bytes the parser was already holding. So everything
+/// describing the *original* chunk's generation has to go, or it is reported
+/// twice:
+///
+/// - `event` / `comment` — the annotation channel carries per-chunk payloads
+///   such as generated `token_ids`.
+/// - `error` — an error annotation must not be replayed on a later chunk.
+/// - `usage` / `llm_metrics` — `metrics.rs` sums `chunk_tokens` and samples an
+///   ITL point per chunk carrying `llm_metrics`.
+/// - `nvext` — per-chunk NVIDIA extensions. `merge_response_nvext` append-merges
+///   `completion_token_ids`, so a repeat turns `[42]` into `[42, 42]`, and
+///   fields it does not append (such as `prompt_logprobs`) are overwritten.
+///
+/// Kept as one function so the two call sites cannot drift apart: they already
+/// did, which is how `nvext` survived on both.
+fn scrub_synthetic_chunk_metadata(
+    response: &mut Annotated<NvCreateChatCompletionStreamResponse>,
+) -> Option<()> {
+    response.event = None;
+    response.comment = None;
+    response.error = None;
+    let data = response.data.as_mut()?;
+    data.inner.usage = None;
+    data.llm_metrics = None;
+    data.nvext = None;
+    Some(())
+}
+
+/// Drain what a choice still holds on the `defer_reasoning_for_nonempty_content`
+/// path, returning `(content, reasoning_content)` to add to its delta. Shared by
+/// the terminal-chunk drain and the end-of-stream fallback so the two cannot
+/// disagree about which channel the leftover bytes belong to.
+fn drain_deferred_reasoning(state: &mut ChoiceReasoningState) -> (Option<String>, Option<String>) {
+    if state.drained {
+        return (None, None);
+    }
+    state.drained = true;
+    let pending = std::mem::take(&mut state.pending_reasoning);
+    let pending_content = std::mem::take(&mut state.pending_content);
+    // Finalize at most once per choice; see `parser_finished`.
+    let result = if state.parser_finished {
+        ParserResult::default()
+    } else {
+        state.parser_finished = true;
+        state.parser.finish_reasoning_stream()
+    };
+
+    if state.left_reasoning {
+        // An answer already streamed as content, so the non-empty-content
+        // promise is met and the parser's own split stands: a later truncated
+        // reasoning block stays reasoning instead of being appended to the
+        // answer. `pending_content` is empty here — it was released with the
+        // answer when the choice left reasoning.
+        let mut content = pending_content;
+        content.push_str(&result.normal_text);
+        (
+            (!content.is_empty()).then_some(content),
+            (!result.reasoning_text.is_empty()).then_some(result.reasoning_text),
+        )
+    } else {
+        // No real answer ever arrived, so everything held is all the response
+        // has and must land in content — including a truncated `<think>` prefix,
+        // which the parser reports as reasoning or normal text depending on
+        // where it stopped. Held whitespace is dropped rather than prepended when
+        // there is reasoning to surface, matching the aggregator, which replaces
+        // whitespace-only content with the reasoning text instead of
+        // concatenating.
+        let mut text = pending;
+        text.push_str(&result.reasoning_text);
+        text.push_str(&result.normal_text);
+        if text.is_empty() {
+            // ...but if whitespace is genuinely all the turn produced, it is the
+            // whole response. Returning nothing here would hand back an empty
+            // `content` to a request that explicitly asked for non-empty content.
+            text = pending_content;
+        }
+        ((!text.is_empty()).then_some(text), None)
+    }
 }
 
 struct ReasoningState {
@@ -307,6 +417,55 @@ struct ReasoningState {
     prompt_injected_reasoning: bool,
     bypass_bare_guided_json: bool,
     choices: HashMap<u32, ChoiceReasoningState>,
+    // Last emitted content-bearing response, reused as the envelope to carry any
+    // text the parsers are still buffering when the upstream stream ends. Only
+    // retained when `defer_reasoning_for_nonempty_content` is set, to keep the
+    // per-token clone off the common reasoning hot path. Chunks with no choices
+    // (the trailing usage-only chunk) are never retained — that envelope has no
+    // delta slot to attach the flushed bytes to, so the flush would be dropped.
+    last_response: Option<Annotated<NvCreateChatCompletionStreamResponse>>,
+    // Nemotron force-reasoning parsers start inside the reasoning block, so
+    // leading model output with no `<think>` is reported as reasoning even when
+    // it is really the whole answer. Under `force_nonempty_content=true` the
+    // chat template promises non-empty `content`, so emitting that text as
+    // `reasoning_content` would leave `content` empty — the exact failure the
+    // flag exists to prevent.
+    //
+    // When this is set, reasoning deltas are held in each choice's
+    // `pending_reasoning` until the ambiguity resolves:
+    //   - the parser produces normal text (it left the reasoning block), so the
+    //     buffer really was reasoning: emit it as `reasoning_content` and stream
+    //     the answer as `content` from then on; or
+    //   - the stream ends first, so no answer is coming: emit the buffer (plus
+    //     anything `finish_reasoning_stream` still holds, e.g. a truncated
+    //     `<think>` prefix) as `content`.
+    //
+    // The cost is real and worth stating plainly: everything held is delivered
+    // in one delta rather than token by token. For a turn that does reason, that
+    // is the `reasoning_content` up to `</think>`, after which the answer streams
+    // normally. For a turn with no `</think>` at all the held text IS the answer,
+    // so the whole answer lands in a single delta on the terminal chunk — on
+    // `main` (parser off, leading `<think>` stripped) that case streamed
+    // incrementally.
+    //
+    // There is no cheaper split available: these parsers emit reasoning with no
+    // opening `<think>` (see the `nemotron_nano` mapping in dynamo-parsers), so
+    // until `</think>` arrives the same bytes are equally consistent with
+    // reasoning and with a plain answer. Emitting eagerly is what leaked reasoning
+    // into `content` in the first place. Scoped to the flag so no other parser
+    // pays it.
+    defer_reasoning_for_nonempty_content: bool,
+    // Set once the backend has sent an error annotation. The end-of-stream
+    // flush must not run after that: an error is terminal, and emitting
+    // recovered reasoning as ordinary `content` after it would put text on the
+    // wire that the generation never successfully produced.
+    //
+    // This matters because the flush is the only place bytes can arrive after
+    // the last upstream chunk. `/v1/chat/completions` ends its SSE on the error
+    // and never sees it, but `/v1/responses` and `/v1/messages` both record the
+    // error and keep consuming (`saw_error = true; continue;`), so without this
+    // latch they emit the synthetic content chunk and only then report failure.
+    saw_terminal_error: bool,
 }
 
 /// Per-image routing payload accumulated by `gather_multi_modal_data` and
@@ -2990,12 +3149,20 @@ impl OpenAIPreprocessor {
                 Box::pin(stream)
             };
 
+        // Only a force_nonempty_content request needs the deferral and the EOF
+        // flush of a truncated `<think>` prefix; gating on the request keeps the
+        // per-token clone and the finish_reasoning_stream() flush off every
+        // other request's path. Same predicate the aggregator uses, so the
+        // streaming and non-streaming paths cannot disagree.
+        let defer_reasoning_for_nonempty_content =
+            Self::wants_reasoning_as_content_when_empty(request.chat_template_args.as_ref());
         let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if should_parse_reasoning {
             Box::pin(Self::parse_reasoning_content_from_stream_inner(
                 stream,
                 self.runtime_config.reasoning_parser.clone().unwrap(), // Safety: We already checked that parser is some, so gtg
                 prompt_injected_reasoning,
                 bypass_reasoning_for_bare_guided_json,
+                defer_reasoning_for_nonempty_content,
             ))
         } else if should_strip_disabled_reasoning_start {
             Box::pin(Self::strip_leading_reasoning_start_from_stream(
@@ -3003,6 +3170,12 @@ impl OpenAIPreprocessor {
             ))
         } else {
             Box::pin(stream)
+        };
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if defer_reasoning_for_nonempty_content
+        {
+            Box::pin(Self::hold_usage_until_stream_end(stream))
+        } else {
+            stream
         };
 
         // Check if tools are present and if we should apply jail
@@ -3944,6 +4117,44 @@ impl OpenAIPreprocessor {
         )
     }
 
+    /// Whether a request should surface parsed `reasoning_content` as `content`
+    /// when no content was generated: any request carrying
+    /// `force_nonempty_content=true`.
+    ///
+    /// Deliberately NOT keyed on the model or its reasoning parser. The flag is a
+    /// request-level contract — "this response will have non-empty content" — so
+    /// it is honored generically after parsing and before the response is sent,
+    /// rather than being reimplemented inside each model-specific parser. Keying
+    /// it on a parser allow-list means every new alias silently loses the
+    /// behavior until someone edits the list.
+    ///
+    /// Note it rides in on `chat_template_args` but is NOT consumed by the chat
+    /// template: the Nemotron template never reads `force_nonempty_content`, and
+    /// rendering with it set produces a byte-identical prompt. It is a
+    /// serving-layer flag that upstream happens to transport through the template
+    /// kwargs, which is why the check belongs in postprocessing and not in a
+    /// parser. So a client can set it on any model, and doing so is an explicit
+    /// request for non-empty content — honoring it generically is the intent, not
+    /// an accident of where the flag is declared.
+    ///
+    /// Drives both paths. The chat and Anthropic HTTP handlers pass it to the
+    /// aggregator via `ParsingOptions::move_reasoning_to_content_when_empty` for
+    /// non-streaming, and `postprocessor_parsing_stream` passes it as
+    /// `defer_reasoning_for_nonempty_content` so the streaming path can hold
+    /// reasoning back and reach the same answer at the terminal chunk. Both must
+    /// use this one predicate or the two paths would disagree on the same input.
+    ///
+    /// `enable_thinking` is intentionally not consulted here: when thinking is
+    /// off, reasoning parsing is disabled, so `reasoning_content` is always empty
+    /// and the move is vacuous rather than suppressed.
+    pub(crate) fn wants_reasoning_as_content_when_empty(
+        chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> bool {
+        chat_template_args.is_some_and(|args| {
+            args.get("force_nonempty_content") == Some(&serde_json::Value::Bool(true))
+        })
+    }
+
     /// Parsers that begin streaming in reasoning mode (force_reasoning=true).
     /// These swallow any leading text without an open `<think>` tag as
     /// reasoning_content, so they cannot run on guided-decoding output where
@@ -4052,7 +4263,10 @@ impl OpenAIPreprocessor {
     /// Check if reasoning parsing should be disabled based on per-request parameters.
     /// For kimi_k25/K3: disabled when chat_template_args contains "thinking": false.
     /// For Nemotron force-reasoning aliases: disabled when chat_template_args
-    ///   contains "enable_thinking": false or "force_nonempty_content": true.
+    ///   contains "enable_thinking": false. "force_nonempty_content": true does
+    ///   NOT disable parsing (streaming or non-streaming): the parser stays on so
+    ///   reasoning is split from the answer, and reasoning is surfaced as content
+    ///   only when no content was generated (non-streaming, in the aggregator).
     /// For DeepSeek: follows the same effective mode used by the prompt renderer.
     /// For Mistral: disabled unless `reasoning_effort` is present and not `none`.
     /// For gemma4: disabled when chat_template_args contains "enable_thinking": false.
@@ -4072,16 +4286,22 @@ impl OpenAIPreprocessor {
                 dynamo_renderer::thinking_bool_from_args(chat_template_args) == Some(false)
             }
             parser if Self::is_nemotron_force_reasoning(parser) => {
-                if dynamo_renderer::thinking_bool_from_args(chat_template_args) == Some(false) {
-                    return true;
-                }
-                if let Some(args) = chat_template_args
-                    && let Some(force_nonempty) = args.get("force_nonempty_content")
-                    && force_nonempty == &serde_json::Value::Bool(true)
-                {
-                    return true;
-                }
-                false
+                // `enable_thinking=false` turns reasoning off entirely (streaming
+                // and non-streaming). `force_nonempty_content=true` does NOT
+                // disable parsing: keeping the parser on splits reasoning from the
+                // answer, so a reasoning+answer turn no longer leaks the reasoning
+                // text and `</think>` into `content`.
+                //
+                // The reasoning-*only* move (surface reasoning as content when the
+                // answer is empty) happens on both paths, by different means.
+                // Non-streaming uses the aggregator flag
+                // ParsingOptions::move_reasoning_to_content_when_empty. Streaming
+                // cannot retract a reasoning_content delta already sent, so it
+                // instead holds reasoning back until it knows whether an answer
+                // follows — see `defer_reasoning_for_nonempty_content` and
+                // `drain_deferred_reasoning`. Both end with the same contract: a
+                // reasoning-only turn surfaces its text as `content`.
+                dynamo_renderer::thinking_bool_from_args(chat_template_args) == Some(false)
             }
             Some("deepseek_v3" | "deepseek_v3_1") => {
                 !Self::deepseek_renderer_reasoning_enabled(chat_template_args, false)
@@ -4133,6 +4353,7 @@ impl OpenAIPreprocessor {
             parser_name,
             prompt_injected_reasoning,
             false,
+            false,
         )
     }
 
@@ -4141,6 +4362,7 @@ impl OpenAIPreprocessor {
         parser_name: String,
         prompt_injected_reasoning: bool,
         bypass_bare_guided_json: bool,
+        defer_reasoning_for_nonempty_content: bool,
     ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
@@ -4153,10 +4375,21 @@ impl OpenAIPreprocessor {
             prompt_injected_reasoning,
             bypass_bare_guided_json,
             choices: HashMap::new(),
+            last_response: None,
+            defer_reasoning_for_nonempty_content,
+            saw_terminal_error: false,
         };
 
         stream::unfold(state, |mut state| async move {
             if let Some(response) = state.stream.next().await {
+                // An error is terminal for the flush: latch it so the
+                // end-of-stream branch below stays quiet. The chunk still takes
+                // the normal path — `is_error()` keys on the annotation event,
+                // not on `data`, so short-circuiting here would change how a
+                // data-carrying error chunk is processed.
+                if response.is_error() {
+                    state.saw_terminal_error = true;
+                }
                 // Split disjoint field borrows so the per-choice map and the
                 // parser-factory inputs can be used together inside map_data.
                 // Scoped in a block so the borrows end before `state` moves.
@@ -4166,11 +4399,13 @@ impl OpenAIPreprocessor {
                         prompt_injected_reasoning,
                         bypass_bare_guided_json,
                         choices,
+                        defer_reasoning_for_nonempty_content,
                         ..
                     } = &mut state;
                     let parser_name = &*parser_name;
                     let prompt_injected_reasoning = *prompt_injected_reasoning;
                     let bypass_bare_guided_json = *bypass_bare_guided_json;
+                    let defer_reasoning = *defer_reasoning_for_nonempty_content;
 
                     response.map_data(|mut data| {
                         for choice in data.inner.choices.iter_mut() {
@@ -4186,6 +4421,11 @@ impl OpenAIPreprocessor {
                                 ChoiceReasoningState {
                                     parser,
                                     guided_json_bypass_decision: None,
+                                    pending_reasoning: String::new(),
+                                    pending_content: String::new(),
+                                    left_reasoning: false,
+                                    drained: false,
+                                    parser_finished: false,
                                 }
                             });
 
@@ -4231,22 +4471,227 @@ impl OpenAIPreprocessor {
                                 let parser_result = choice_state
                                     .parser
                                     .parse_reasoning_streaming_incremental(text, &[]);
-                                choice.delta.content = parser_result
-                                    .get_some_normal_text()
-                                    .map(ChatCompletionMessageContent::Text);
-                                choice.delta.reasoning_content = parser_result.get_some_reasoning();
+
+                                // A backend that keeps sending content after this
+                                // choice's `finish_reason` is out of protocol, but
+                                // it has still fed bytes to the parser. Reopen the
+                                // drain so they have somewhere to go at EOF instead
+                                // of being stranded in parser state.
+                                choice_state.drained = false;
+
+                                if defer_reasoning && !choice_state.left_reasoning {
+                                    // Still ambiguous: this text may be reasoning
+                                    // followed by an answer, or the answer itself
+                                    // reported as reasoning because the parser
+                                    // starts inside the reasoning block. Hold it.
+                                    choice_state
+                                        .pending_reasoning
+                                        .push_str(&parser_result.reasoning_text);
+                                    // Whitespace-only normal text does not settle
+                                    // anything: the aggregator treats such content
+                                    // as empty (matching vLLM's
+                                    // `not final_content.strip()`), so releasing
+                                    // here would make streaming and non-streaming
+                                    // disagree on the same turn. Hold it with the
+                                    // reasoning until real answer text arrives.
+                                    if parser_result.normal_text.trim().is_empty() {
+                                        choice_state
+                                            .pending_content
+                                            .push_str(&parser_result.normal_text);
+                                        choice.delta.content = None;
+                                        choice.delta.reasoning_content = None;
+                                    } else {
+                                        // Real answer text means the parser left
+                                        // the reasoning block, so everything held
+                                        // so far really was reasoning.
+                                        choice_state.left_reasoning = true;
+                                        choice.delta.reasoning_content = (!choice_state
+                                            .pending_reasoning
+                                            .is_empty())
+                                        .then(|| {
+                                            std::mem::take(&mut choice_state.pending_reasoning)
+                                        });
+                                        let mut text =
+                                            std::mem::take(&mut choice_state.pending_content);
+                                        text.push_str(&parser_result.normal_text);
+                                        choice.delta.content =
+                                            Some(ChatCompletionMessageContent::Text(text));
+                                    }
+                                } else {
+                                    choice.delta.content = parser_result
+                                        .get_some_normal_text()
+                                        .map(ChatCompletionMessageContent::Text);
+                                    choice.delta.reasoning_content =
+                                        parser_result.get_some_reasoning();
+                                }
+                            }
+
+                            // This choice is finishing, so drain what it holds
+                            // onto THIS delta. Emitting it as a later chunk
+                            // would put content after `finish_reason` (and
+                            // after the trailing usage chunk), where a client
+                            // that stops at the terminal chunk never sees it.
+                            // A parts delta has no text slot to append to, so
+                            // draining onto it would leave the recovered text
+                            // nowhere to go. Leave the choice undrained and let
+                            // the end-of-stream fallback emit it as its own
+                            // chunk instead of dropping it.
+                            let terminal_carries_parts = matches!(
+                                choice.delta.content,
+                                Some(ChatCompletionMessageContent::Parts(_))
+                            );
+                            // Also require that this choice was actually parsed.
+                            // A guided-JSON choice that bypassed the parser never
+                            // fed it anything, so finishing that parser could only
+                            // contribute text the choice never generated.
+                            if defer_reasoning
+                                && choice.finish_reason.is_some()
+                                && !terminal_carries_parts
+                                && bypass_decision == Some(false)
+                            {
+                                let (content, reasoning) = drain_deferred_reasoning(choice_state);
+                                if let Some(content) = content {
+                                    let merged = match choice.delta.content.take() {
+                                        Some(ChatCompletionMessageContent::Text(existing)) => {
+                                            existing + &content
+                                        }
+                                        Some(other) => {
+                                            // Unreachable: guarded above.
+                                            choice.delta.content = Some(other);
+                                            content
+                                        }
+                                        None => content,
+                                    };
+                                    if choice.delta.content.is_none() {
+                                        choice.delta.content =
+                                            Some(ChatCompletionMessageContent::Text(merged));
+                                    }
+                                }
+                                if let Some(reasoning) = reasoning {
+                                    choice.delta.reasoning_content = Some(
+                                        choice.delta.reasoning_content.take().unwrap_or_default()
+                                            + &reasoning,
+                                    );
+                                }
                             }
                         }
                         Ok(data)
                     })
                 };
 
+                // Retain a spare envelope only when an EOF flush may follow, so
+                // the common reasoning path avoids a full per-token clone. Skip
+                // chunks with no choices (the trailing usage-only chunk): they
+                // carry no delta slot, so using one as the flush envelope would
+                // drop the very bytes the flush exists to preserve.
+                if state.defer_reasoning_for_nonempty_content
+                    && processed_response
+                        .data
+                        .as_ref()
+                        .is_some_and(|data| !data.inner.choices.is_empty())
+                {
+                    state.last_response = Some(processed_response.clone());
+                }
                 Some((processed_response, state))
-            } else {
+            } else if !state.defer_reasoning_for_nonempty_content || state.saw_terminal_error {
+                // After a backend error the buffered bytes are dropped rather
+                // than surfaced: the request failed, so there is no answer to
+                // complete. See `saw_terminal_error`.
                 None
+            } else {
+                // Upstream ended with no answer for the choices still holding a
+                // pending buffer. Normally the terminal chunk already drained
+                // them, so this is the fallback for a stream that ends without
+                // any `finish_reason` — an aborted or truncated generation.
+                // The synthetic chunk it builds is the only case where recovered
+                // bytes arrive after the last upstream chunk, which is
+                // unavoidable when there was no terminal chunk to attach them
+                // to. Only the force_nonempty_content path reaches this branch;
+                // every other parser took the `None` branch above and keeps its
+                // original no-flush EOF behavior. Taking the envelope below
+                // rather than cloning it makes this branch one-shot: once it is
+                // gone the next poll ends the stream.
+                // Sorted so the emitted choice order is deterministic rather
+                // than following HashMap iteration order.
+                let mut indices: Vec<u32> = state.choices.keys().copied().collect();
+                indices.sort_unstable();
+                #[allow(clippy::type_complexity)]
+                let flushed: Vec<(u32, Option<String>, Option<String>)> = indices
+                    .into_iter()
+                    .filter_map(|index| {
+                        let (content, reasoning) =
+                            drain_deferred_reasoning(state.choices.get_mut(&index)?);
+                        (content.is_some() || reasoning.is_some())
+                            .then_some((index, content, reasoning))
+                    })
+                    .collect();
+                if flushed.is_empty() {
+                    return None;
+                }
+                let mut response = state.last_response.take()?;
+                // See `scrub_synthetic_chunk_metadata`: this chunk produced no
+                // tokens, so every per-chunk field from the envelope it was
+                // cloned from has to be dropped rather than reported twice.
+                scrub_synthetic_chunk_metadata(&mut response)?;
+                let data = response.data.as_mut()?;
+                // Rebuild the choice list from the flushed indices rather than
+                // reusing the envelope's own choices: with `n > 1` the last
+                // content-bearing chunk carries only the choices that happened
+                // to be interleaved into it, which need not be the set that has
+                // buffered bytes.
+                let template = data.inner.choices.first()?.clone();
+                data.inner.choices = flushed
+                    .into_iter()
+                    .map(|(index, content, reasoning)| {
+                        let mut choice = template.clone();
+                        choice.index = index;
+                        choice.delta.role = None;
+                        choice.delta.tool_calls = None;
+                        choice.delta.function_call = None;
+                        choice.delta.refusal = None;
+                        choice.finish_reason = None;
+                        choice.logprobs = None;
+                        choice.delta.content = content.map(ChatCompletionMessageContent::Text);
+                        choice.delta.reasoning_content = reasoning;
+                        choice
+                    })
+                    .collect();
+                Some((response, state))
             }
         })
         .fuse()
+    }
+
+    /// Hold the trailing usage-only chunk until every parser recovery chunk has
+    /// been emitted. A truncated upstream stream can end without
+    /// `finish_reason`, so reasoning recovery happens at EOF; forwarding usage
+    /// immediately would put that recovered content after the chunk clients
+    /// treat as the stream trailer.
+    fn hold_usage_until_stream_end<S>(
+        stream: S,
+    ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
+    where
+        S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
+    {
+        async_stream::stream! {
+            tokio::pin!(stream);
+            let mut pending_usage = None;
+            while let Some(response) = stream.next().await {
+                let is_usage_only = response.data.as_ref().is_some_and(|data| {
+                    data.inner.choices.is_empty() && data.inner.usage.is_some()
+                });
+                if is_usage_only {
+                    if let Some(previous) = pending_usage.replace(response) {
+                        yield previous;
+                    }
+                } else {
+                    yield response;
+                }
+            }
+            if let Some(usage) = pending_usage {
+                yield usage;
+            }
+        }
     }
 
     // Motivation: when Nemotron reasoning is disabled by request flags, the
@@ -4365,8 +4810,12 @@ impl OpenAIPreprocessor {
                     None
                 } else {
                     let mut response = state.last_response.clone()?;
+                    // Same envelope problem as the reasoning-stream flush: this
+                    // is a clone of an already-counted chunk, so it goes through
+                    // the shared scrub rather than repeating a partial copy of
+                    // it here.
+                    scrub_synthetic_chunk_metadata(&mut response)?;
                     let data = response.data.as_mut()?;
-                    data.inner.usage = None;
                     data.inner.choices.retain_mut(|choice| {
                         if let Some(buffer) = flushed.remove(&choice.index) {
                             choice.delta.role = None;
@@ -6383,7 +6832,7 @@ mod tests {
                     "SGLang gate mismatch for {description}"
                 );
                 assert_eq!(
-                    !OpenAIPreprocessor::is_reasoning_disabled_by_request(Some("kimi_k25"), args),
+                    !OpenAIPreprocessor::is_reasoning_disabled_by_request(Some("kimi_k25"), args,),
                     expected,
                     "postprocessor gate mismatch for {description}"
                 );
@@ -7197,8 +7646,8 @@ mod tests {
             (
                 Some("nemotron3"),
                 Some(&force_nonempty_content_true),
-                true,
-                "nemotron3 + force_nonempty_content=true → disabled",
+                false,
+                "nemotron3 + force_nonempty_content=true → NOT disabled (parser stays on)",
             ),
             (
                 Some("nemotron_v3"),
@@ -7209,8 +7658,8 @@ mod tests {
             (
                 Some("nemotron_v3"),
                 Some(&force_nonempty_content_true),
-                true,
-                "nemotron_v3 + force_nonempty_content=true → disabled",
+                false,
+                "nemotron_v3 + force_nonempty_content=true → NOT disabled (parser stays on)",
             ),
             // deepseek_v4 — same convention as deepseek_r1; verify all three aliases
             // (deepseek_v4 / deepseek-v4 / deepseekv4) plus both signal keys.
@@ -7331,6 +7780,8 @@ mod tests {
             ),
         ];
 
+        // The disable decision no longer depends on streaming — `enable_thinking`
+        // and the per-family signals decide it identically for both paths.
         for (parser, args, expected, desc) in cases {
             assert_eq!(
                 OpenAIPreprocessor::is_reasoning_disabled_by_request(parser, args),
@@ -7338,6 +7789,37 @@ mod tests {
                 "FAILED: {desc}",
             );
         }
+
+        // force_nonempty_content=true does NOT disable reasoning parsing for
+        // either path: the parser stays on so reasoning is split from the answer
+        // (no leak). Non-streaming additionally moves reasoning into content when
+        // no content was generated (the aggregator); streaming skips that move.
+        assert!(
+            !OpenAIPreprocessor::is_reasoning_disabled_by_request(
+                Some("nemotron3"),
+                Some(&force_nonempty_content_true),
+            ),
+            "nemotron3 + force_nonempty_content=true → NOT disabled",
+        );
+        assert!(
+            !OpenAIPreprocessor::is_reasoning_disabled_by_request(
+                Some("nemotron_v3"),
+                Some(&force_nonempty_content_true),
+            ),
+            "nemotron_v3 + force_nonempty_content=true → NOT disabled",
+        );
+        // enable_thinking=false disables entirely (user turned thinking off).
+        assert!(
+            OpenAIPreprocessor::is_reasoning_disabled_by_request(
+                Some("nemotron3"),
+                Some(&enable_thinking_false),
+            ),
+            "nemotron3 + enable_thinking=false → disabled",
+        );
+
+        // The force_nonempty_content=true → NOT disabled behavior is what lets a
+        // reasoning-only non-streaming turn surface reasoning as content; verify
+        // the aggregator half in test_move_reasoning_to_content_when_empty.
     }
 
     /// Different query strings must produce different hashes. `?v=1` and

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -3171,12 +3171,12 @@ impl OpenAIPreprocessor {
         } else {
             Box::pin(stream)
         };
-        let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if defer_reasoning_for_nonempty_content
-        {
-            Box::pin(Self::hold_usage_until_stream_end(stream))
-        } else {
-            stream
-        };
+        let stream: Pin<Box<dyn Stream<Item = _> + Send>> =
+            if defer_reasoning_for_nonempty_content || should_strip_disabled_reasoning_start {
+                Box::pin(Self::hold_usage_until_stream_end(stream))
+            } else {
+                stream
+            };
 
         // Check if tools are present and if we should apply jail
         let has_tools = request

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4155,6 +4155,33 @@ impl OpenAIPreprocessor {
         })
     }
 
+    /// Whether this request's stream can withhold every data frame while it
+    /// buffers, which is the only reason to force SSE keep-alive frames on.
+    ///
+    /// The HTTP handlers used to gate the heartbeat on
+    /// `wants_reasoning_as_content_when_empty && reasoning_parser.is_some()`,
+    /// but that is broader than the deferral it describes: the buffering only
+    /// runs when `postprocessor_parsing_stream` takes its `should_parse_reasoning`
+    /// branch. A `force_nonempty_content=true` request with reasoning disabled
+    /// (`enable_thinking=false`) defers nothing, yet still got heartbeats — and
+    /// the configured interval is opt-in precisely because some
+    /// OpenAI-compatible clients do not ignore SSE comment frames.
+    ///
+    /// Known gap: `skip_reasoning_for_guided_json` also suppresses the deferral,
+    /// but it is derived from guided-output inspection that is not available at
+    /// the HTTP layer, so a guided-JSON bypass still enables the heartbeat when
+    /// nothing is withheld. That direction is conservative — extra comment
+    /// frames on an opt-in path rather than a silent stream — and closing it
+    /// needs the guided-output derivation lifted out of the stream builder.
+    pub(crate) fn stream_can_defer_all_output(
+        reasoning_parser: Option<&str>,
+        chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> bool {
+        reasoning_parser.is_some()
+            && Self::wants_reasoning_as_content_when_empty(chat_template_args)
+            && !Self::is_reasoning_disabled_by_request(reasoning_parser, chat_template_args)
+    }
+
     /// Parsers that begin streaming in reasoning mode (force_reasoning=true).
     /// These swallow any leading text without an open `<think>` tag as
     /// reasoning_content, so they cannot run on guided-decoding output where

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -61,7 +61,8 @@ use crate::protocols::common::timing::RequestTracker;
 use crate::tokenizers::Encoding;
 
 use dynamo_parsers::{
-    ReasoningParser, ReasoningParserType, tool_calling::parsers::get_tool_parser_map,
+    ReasoningParser, ReasoningParserType, reasoning::ParserResult,
+    tool_calling::parsers::get_tool_parser_map,
 };
 use dynamo_runtime::engine::{AsyncEngine, AsyncEngineContextProvider, ResponseStream};
 use dynamo_runtime::pipeline::{
@@ -298,6 +299,81 @@ where
 struct ChoiceReasoningState {
     parser: Box<dyn ReasoningParser>,
     guided_json_bypass_decision: Option<bool>,
+    // Reasoning text held back while it is still ambiguous. Only used on the
+    // `defer_reasoning_for_nonempty_content` path — see the buffering note on
+    // `ReasoningState`.
+    pending_reasoning: String,
+    // Whitespace-only normal text seen while still ambiguous. Held rather than
+    // emitted so the streaming path agrees with the aggregator, which counts
+    // whitespace-only content as empty.
+    pending_content: String,
+    // Set once this choice's parser has produced normal text, which for these
+    // force-reasoning parsers means it left the reasoning block. From then on
+    // the ambiguity is gone and deltas pass straight through.
+    left_reasoning: bool,
+    // Set once this choice has been drained, so the terminal-chunk drain and the
+    // end-of-stream fallback cannot both emit the same bytes. Reopened if the
+    // backend keeps sending content after `finish_reason`, so those bytes still
+    // get a destination.
+    drained: bool,
+    // Set the first time this choice's parser is finalized and NEVER reset, even
+    // when `drained` is reopened. `ReasoningParser::finish_reasoning_stream` is
+    // not documented to be idempotent, so calling it twice could re-emit text a
+    // parser had already handed over. Draining again is fine; finalizing again
+    // is not.
+    parser_finished: bool,
+}
+
+/// Drain what a choice still holds on the `defer_reasoning_for_nonempty_content`
+/// path, returning `(content, reasoning_content)` to add to its delta. Shared by
+/// the terminal-chunk drain and the end-of-stream fallback so the two cannot
+/// disagree about which channel the leftover bytes belong to.
+fn drain_deferred_reasoning(state: &mut ChoiceReasoningState) -> (Option<String>, Option<String>) {
+    if state.drained {
+        return (None, None);
+    }
+    state.drained = true;
+    let pending = std::mem::take(&mut state.pending_reasoning);
+    let pending_content = std::mem::take(&mut state.pending_content);
+    // Finalize at most once per choice; see `parser_finished`.
+    let result = if state.parser_finished {
+        ParserResult::default()
+    } else {
+        state.parser_finished = true;
+        state.parser.finish_reasoning_stream()
+    };
+
+    if state.left_reasoning {
+        // An answer already streamed as content, so the non-empty-content
+        // promise is met and the parser's own split stands: a later truncated
+        // reasoning block stays reasoning instead of being appended to the
+        // answer. `pending_content` is empty here — it was released with the
+        // answer when the choice left reasoning.
+        let mut content = pending_content;
+        content.push_str(&result.normal_text);
+        (
+            (!content.is_empty()).then_some(content),
+            (!result.reasoning_text.is_empty()).then_some(result.reasoning_text),
+        )
+    } else {
+        // No real answer ever arrived, so everything held is all the response
+        // has and must land in content — including a truncated `<think>` prefix,
+        // which the parser reports as reasoning or normal text depending on
+        // where it stopped. Held whitespace is dropped rather than prepended when
+        // there is reasoning to surface, matching the aggregator, which replaces
+        // whitespace-only content with the reasoning text instead of
+        // concatenating.
+        let mut text = pending;
+        text.push_str(&result.reasoning_text);
+        text.push_str(&result.normal_text);
+        if text.is_empty() {
+            // ...but if whitespace is genuinely all the turn produced, it is the
+            // whole response. Returning nothing here would hand back an empty
+            // `content` to a request that explicitly asked for non-empty content.
+            text = pending_content;
+        }
+        ((!text.is_empty()).then_some(text), None)
+    }
 }
 
 struct ReasoningState {
@@ -306,6 +382,44 @@ struct ReasoningState {
     prompt_injected_reasoning: bool,
     bypass_bare_guided_json: bool,
     choices: HashMap<u32, ChoiceReasoningState>,
+    // Last emitted content-bearing response, reused as the envelope to carry any
+    // text the parsers are still buffering when the upstream stream ends. Only
+    // retained when `defer_reasoning_for_nonempty_content` is set, to keep the
+    // per-token clone off the common reasoning hot path. Chunks with no choices
+    // (the trailing usage-only chunk) are never retained — that envelope has no
+    // delta slot to attach the flushed bytes to, so the flush would be dropped.
+    last_response: Option<Annotated<NvCreateChatCompletionStreamResponse>>,
+    // Nemotron force-reasoning parsers start inside the reasoning block, so
+    // leading model output with no `<think>` is reported as reasoning even when
+    // it is really the whole answer. Under `force_nonempty_content=true` the
+    // chat template promises non-empty `content`, so emitting that text as
+    // `reasoning_content` would leave `content` empty — the exact failure the
+    // flag exists to prevent.
+    //
+    // When this is set, reasoning deltas are held in each choice's
+    // `pending_reasoning` until the ambiguity resolves:
+    //   - the parser produces normal text (it left the reasoning block), so the
+    //     buffer really was reasoning: emit it as `reasoning_content` and stream
+    //     the answer as `content` from then on; or
+    //   - the stream ends first, so no answer is coming: emit the buffer (plus
+    //     anything `finish_reasoning_stream` still holds, e.g. a truncated
+    //     `<think>` prefix) as `content`.
+    //
+    // The cost is real and worth stating plainly: everything held is delivered
+    // in one delta rather than token by token. For a turn that does reason, that
+    // is the `reasoning_content` up to `</think>`, after which the answer streams
+    // normally. For a turn with no `</think>` at all the held text IS the answer,
+    // so the whole answer lands in a single delta on the terminal chunk — on
+    // `main` (parser off, leading `<think>` stripped) that case streamed
+    // incrementally.
+    //
+    // There is no cheaper split available: these parsers emit reasoning with no
+    // opening `<think>` (see the `nemotron_nano` mapping in dynamo-parsers), so
+    // until `</think>` arrives the same bytes are equally consistent with
+    // reasoning and with a plain answer. Emitting eagerly is what leaked reasoning
+    // into `content` in the first place. Scoped to the flag so no other parser
+    // pays it.
+    defer_reasoning_for_nonempty_content: bool,
 }
 
 /// Per-image routing payload accumulated by `gather_multi_modal_data` and
@@ -2618,12 +2732,20 @@ impl OpenAIPreprocessor {
                 Box::pin(stream)
             };
 
+        // Only a force_nonempty_content request needs the deferral and the EOF
+        // flush of a truncated `<think>` prefix; gating on the request keeps the
+        // per-token clone and the finish_reasoning_stream() flush off every
+        // other request's path. Same predicate the aggregator uses, so the
+        // streaming and non-streaming paths cannot disagree.
+        let defer_reasoning_for_nonempty_content =
+            Self::wants_reasoning_as_content_when_empty(request.chat_template_args.as_ref());
         let stream: Pin<Box<dyn Stream<Item = _> + Send>> = if should_parse_reasoning {
             Box::pin(Self::parse_reasoning_content_from_stream_inner(
                 stream,
                 self.runtime_config.reasoning_parser.clone().unwrap(), // Safety: We already checked that parser is some, so gtg
                 prompt_injected_reasoning,
                 bypass_reasoning_for_bare_guided_json,
+                defer_reasoning_for_nonempty_content,
             ))
         } else if should_strip_disabled_reasoning_start {
             Box::pin(Self::strip_leading_reasoning_start_from_stream(
@@ -3376,6 +3498,44 @@ impl OpenAIPreprocessor {
         )
     }
 
+    /// Whether a request should surface parsed `reasoning_content` as `content`
+    /// when no content was generated: any request carrying
+    /// `force_nonempty_content=true`.
+    ///
+    /// Deliberately NOT keyed on the model or its reasoning parser. The flag is a
+    /// request-level contract — "this response will have non-empty content" — so
+    /// it is honored generically after parsing and before the response is sent,
+    /// rather than being reimplemented inside each model-specific parser. Keying
+    /// it on a parser allow-list means every new alias silently loses the
+    /// behavior until someone edits the list.
+    ///
+    /// Note it rides in on `chat_template_args` but is NOT consumed by the chat
+    /// template: the Nemotron template never reads `force_nonempty_content`, and
+    /// rendering with it set produces a byte-identical prompt. It is a
+    /// serving-layer flag that upstream happens to transport through the template
+    /// kwargs, which is why the check belongs in postprocessing and not in a
+    /// parser. So a client can set it on any model, and doing so is an explicit
+    /// request for non-empty content — honoring it generically is the intent, not
+    /// an accident of where the flag is declared.
+    ///
+    /// Drives both paths. The chat and Anthropic HTTP handlers pass it to the
+    /// aggregator via `ParsingOptions::move_reasoning_to_content_when_empty` for
+    /// non-streaming, and `postprocessor_parsing_stream` passes it as
+    /// `defer_reasoning_for_nonempty_content` so the streaming path can hold
+    /// reasoning back and reach the same answer at the terminal chunk. Both must
+    /// use this one predicate or the two paths would disagree on the same input.
+    ///
+    /// `enable_thinking` is intentionally not consulted here: when thinking is
+    /// off, reasoning parsing is disabled, so `reasoning_content` is always empty
+    /// and the move is vacuous rather than suppressed.
+    pub(crate) fn wants_reasoning_as_content_when_empty(
+        chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+    ) -> bool {
+        chat_template_args.is_some_and(|args| {
+            args.get("force_nonempty_content") == Some(&serde_json::Value::Bool(true))
+        })
+    }
+
     /// Parsers that begin streaming in reasoning mode (force_reasoning=true).
     /// These swallow any leading text without an open `<think>` tag as
     /// reasoning_content, so they cannot run on guided-decoding output where
@@ -3484,7 +3644,10 @@ impl OpenAIPreprocessor {
     /// Check if reasoning parsing should be disabled based on per-request parameters.
     /// For kimi_k25/K3: disabled when chat_template_args contains "thinking": false.
     /// For Nemotron force-reasoning aliases: disabled when chat_template_args
-    ///   contains "enable_thinking": false or "force_nonempty_content": true.
+    ///   contains "enable_thinking": false. "force_nonempty_content": true does
+    ///   NOT disable parsing (streaming or non-streaming): the parser stays on so
+    ///   reasoning is split from the answer, and reasoning is surfaced as content
+    ///   only when no content was generated (non-streaming, in the aggregator).
     /// For DeepSeek: follows the same effective mode used by the prompt renderer.
     /// For Mistral: disabled unless `reasoning_effort` is present and not `none`.
     /// For gemma4: disabled when chat_template_args contains "enable_thinking": false.
@@ -3504,16 +3667,22 @@ impl OpenAIPreprocessor {
                 dynamo_renderer::thinking_bool_from_args(chat_template_args) == Some(false)
             }
             parser if Self::is_nemotron_force_reasoning(parser) => {
-                if dynamo_renderer::thinking_bool_from_args(chat_template_args) == Some(false) {
-                    return true;
-                }
-                if let Some(args) = chat_template_args
-                    && let Some(force_nonempty) = args.get("force_nonempty_content")
-                    && force_nonempty == &serde_json::Value::Bool(true)
-                {
-                    return true;
-                }
-                false
+                // `enable_thinking=false` turns reasoning off entirely (streaming
+                // and non-streaming). `force_nonempty_content=true` does NOT
+                // disable parsing: keeping the parser on splits reasoning from the
+                // answer, so a reasoning+answer turn no longer leaks the reasoning
+                // text and `</think>` into `content`.
+                //
+                // The reasoning-*only* move (surface reasoning as content when the
+                // answer is empty) happens on both paths, by different means.
+                // Non-streaming uses the aggregator flag
+                // ParsingOptions::move_reasoning_to_content_when_empty. Streaming
+                // cannot retract a reasoning_content delta already sent, so it
+                // instead holds reasoning back until it knows whether an answer
+                // follows — see `defer_reasoning_for_nonempty_content` and
+                // `drain_deferred_reasoning`. Both end with the same contract: a
+                // reasoning-only turn surfaces its text as `content`.
+                dynamo_renderer::thinking_bool_from_args(chat_template_args) == Some(false)
             }
             Some("deepseek_v3" | "deepseek_v3_1") => {
                 !Self::deepseek_renderer_reasoning_enabled(chat_template_args, false)
@@ -3565,6 +3734,7 @@ impl OpenAIPreprocessor {
             parser_name,
             prompt_injected_reasoning,
             false,
+            false,
         )
     }
 
@@ -3573,6 +3743,7 @@ impl OpenAIPreprocessor {
         parser_name: String,
         prompt_injected_reasoning: bool,
         bypass_bare_guided_json: bool,
+        defer_reasoning_for_nonempty_content: bool,
     ) -> impl Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
@@ -3585,6 +3756,8 @@ impl OpenAIPreprocessor {
             prompt_injected_reasoning,
             bypass_bare_guided_json,
             choices: HashMap::new(),
+            last_response: None,
+            defer_reasoning_for_nonempty_content,
         };
 
         stream::unfold(state, |mut state| async move {
@@ -3598,11 +3771,13 @@ impl OpenAIPreprocessor {
                         prompt_injected_reasoning,
                         bypass_bare_guided_json,
                         choices,
+                        defer_reasoning_for_nonempty_content,
                         ..
                     } = &mut state;
                     let parser_name = &*parser_name;
                     let prompt_injected_reasoning = *prompt_injected_reasoning;
                     let bypass_bare_guided_json = *bypass_bare_guided_json;
+                    let defer_reasoning = *defer_reasoning_for_nonempty_content;
 
                     response.map_data(|mut data| {
                         for choice in data.inner.choices.iter_mut() {
@@ -3618,6 +3793,11 @@ impl OpenAIPreprocessor {
                                 ChoiceReasoningState {
                                     parser,
                                     guided_json_bypass_decision: None,
+                                    pending_reasoning: String::new(),
+                                    pending_content: String::new(),
+                                    left_reasoning: false,
+                                    drained: false,
+                                    parser_finished: false,
                                 }
                             });
 
@@ -3663,19 +3843,196 @@ impl OpenAIPreprocessor {
                                 let parser_result = choice_state
                                     .parser
                                     .parse_reasoning_streaming_incremental(text, &[]);
-                                choice.delta.content = parser_result
-                                    .get_some_normal_text()
-                                    .map(ChatCompletionMessageContent::Text);
-                                choice.delta.reasoning_content = parser_result.get_some_reasoning();
+
+                                // A backend that keeps sending content after this
+                                // choice's `finish_reason` is out of protocol, but
+                                // it has still fed bytes to the parser. Reopen the
+                                // drain so they have somewhere to go at EOF instead
+                                // of being stranded in parser state.
+                                choice_state.drained = false;
+
+                                if defer_reasoning && !choice_state.left_reasoning {
+                                    // Still ambiguous: this text may be reasoning
+                                    // followed by an answer, or the answer itself
+                                    // reported as reasoning because the parser
+                                    // starts inside the reasoning block. Hold it.
+                                    choice_state
+                                        .pending_reasoning
+                                        .push_str(&parser_result.reasoning_text);
+                                    // Whitespace-only normal text does not settle
+                                    // anything: the aggregator treats such content
+                                    // as empty (matching vLLM's
+                                    // `not final_content.strip()`), so releasing
+                                    // here would make streaming and non-streaming
+                                    // disagree on the same turn. Hold it with the
+                                    // reasoning until real answer text arrives.
+                                    if parser_result.normal_text.trim().is_empty() {
+                                        choice_state
+                                            .pending_content
+                                            .push_str(&parser_result.normal_text);
+                                        choice.delta.content = None;
+                                        choice.delta.reasoning_content = None;
+                                    } else {
+                                        // Real answer text means the parser left
+                                        // the reasoning block, so everything held
+                                        // so far really was reasoning.
+                                        choice_state.left_reasoning = true;
+                                        choice.delta.reasoning_content = (!choice_state
+                                            .pending_reasoning
+                                            .is_empty())
+                                        .then(|| {
+                                            std::mem::take(&mut choice_state.pending_reasoning)
+                                        });
+                                        let mut text =
+                                            std::mem::take(&mut choice_state.pending_content);
+                                        text.push_str(&parser_result.normal_text);
+                                        choice.delta.content =
+                                            Some(ChatCompletionMessageContent::Text(text));
+                                    }
+                                } else {
+                                    choice.delta.content = parser_result
+                                        .get_some_normal_text()
+                                        .map(ChatCompletionMessageContent::Text);
+                                    choice.delta.reasoning_content =
+                                        parser_result.get_some_reasoning();
+                                }
+                            }
+
+                            // This choice is finishing, so drain what it holds
+                            // onto THIS delta. Emitting it as a later chunk
+                            // would put content after `finish_reason` (and
+                            // after the trailing usage chunk), where a client
+                            // that stops at the terminal chunk never sees it.
+                            // A parts delta has no text slot to append to, so
+                            // draining onto it would leave the recovered text
+                            // nowhere to go. Leave the choice undrained and let
+                            // the end-of-stream fallback emit it as its own
+                            // chunk instead of dropping it.
+                            let terminal_carries_parts = matches!(
+                                choice.delta.content,
+                                Some(ChatCompletionMessageContent::Parts(_))
+                            );
+                            // Also require that this choice was actually parsed.
+                            // A guided-JSON choice that bypassed the parser never
+                            // fed it anything, so finishing that parser could only
+                            // contribute text the choice never generated.
+                            if defer_reasoning
+                                && choice.finish_reason.is_some()
+                                && !terminal_carries_parts
+                                && bypass_decision == Some(false)
+                            {
+                                let (content, reasoning) = drain_deferred_reasoning(choice_state);
+                                if let Some(content) = content {
+                                    let merged = match choice.delta.content.take() {
+                                        Some(ChatCompletionMessageContent::Text(existing)) => {
+                                            existing + &content
+                                        }
+                                        Some(other) => {
+                                            // Unreachable: guarded above.
+                                            choice.delta.content = Some(other);
+                                            content
+                                        }
+                                        None => content,
+                                    };
+                                    if choice.delta.content.is_none() {
+                                        choice.delta.content =
+                                            Some(ChatCompletionMessageContent::Text(merged));
+                                    }
+                                }
+                                if let Some(reasoning) = reasoning {
+                                    choice.delta.reasoning_content = Some(
+                                        choice.delta.reasoning_content.take().unwrap_or_default()
+                                            + &reasoning,
+                                    );
+                                }
                             }
                         }
                         Ok(data)
                     })
                 };
 
+                // Retain a spare envelope only when an EOF flush may follow, so
+                // the common reasoning path avoids a full per-token clone. Skip
+                // chunks with no choices (the trailing usage-only chunk): they
+                // carry no delta slot, so using one as the flush envelope would
+                // drop the very bytes the flush exists to preserve.
+                if state.defer_reasoning_for_nonempty_content
+                    && processed_response
+                        .data
+                        .as_ref()
+                        .is_some_and(|data| !data.inner.choices.is_empty())
+                {
+                    state.last_response = Some(processed_response.clone());
+                }
                 Some((processed_response, state))
-            } else {
+            } else if !state.defer_reasoning_for_nonempty_content {
                 None
+            } else {
+                // Upstream ended with no answer for the choices still holding a
+                // pending buffer. Normally the terminal chunk already drained
+                // them, so this is the fallback for a stream that ends without
+                // any `finish_reason` — an aborted or truncated generation.
+                // The synthetic chunk it builds is the only case where recovered
+                // bytes arrive after the last upstream chunk, which is
+                // unavoidable when there was no terminal chunk to attach them
+                // to. Only the force_nonempty_content path reaches this branch;
+                // every other parser took the `None` branch above and keeps its
+                // original no-flush EOF behavior. Taking the envelope below
+                // rather than cloning it makes this branch one-shot: once it is
+                // gone the next poll ends the stream.
+                // Sorted so the emitted choice order is deterministic rather
+                // than following HashMap iteration order.
+                let mut indices: Vec<u32> = state.choices.keys().copied().collect();
+                indices.sort_unstable();
+                #[allow(clippy::type_complexity)]
+                let flushed: Vec<(u32, Option<String>, Option<String>)> = indices
+                    .into_iter()
+                    .filter_map(|index| {
+                        let (content, reasoning) =
+                            drain_deferred_reasoning(state.choices.get_mut(&index)?);
+                        (content.is_some() || reasoning.is_some())
+                            .then_some((index, content, reasoning))
+                    })
+                    .collect();
+                if flushed.is_empty() {
+                    return None;
+                }
+                let mut response = state.last_response.take()?;
+                // Everything describing the cloned chunk's own generation is
+                // dropped: this chunk produced no tokens, it only re-channels
+                // bytes the parser was already holding. `metrics.rs` sums
+                // `chunk_tokens` and samples an ITL point per chunk carrying
+                // `llm_metrics`, and the annotation channel carries per-chunk
+                // payloads such as generated `token_ids` — keeping either would
+                // report the previous chunk's tokens a second time.
+                response.event = None;
+                response.comment = None;
+                let data = response.data.as_mut()?;
+                data.inner.usage = None;
+                data.llm_metrics = None;
+                // Rebuild the choice list from the flushed indices rather than
+                // reusing the envelope's own choices: with `n > 1` the last
+                // content-bearing chunk carries only the choices that happened
+                // to be interleaved into it, which need not be the set that has
+                // buffered bytes.
+                let template = data.inner.choices.first()?.clone();
+                data.inner.choices = flushed
+                    .into_iter()
+                    .map(|(index, content, reasoning)| {
+                        let mut choice = template.clone();
+                        choice.index = index;
+                        choice.delta.role = None;
+                        choice.delta.tool_calls = None;
+                        choice.delta.function_call = None;
+                        choice.delta.refusal = None;
+                        choice.finish_reason = None;
+                        choice.logprobs = None;
+                        choice.delta.content = content.map(ChatCompletionMessageContent::Text);
+                        choice.delta.reasoning_content = reasoning;
+                        choice
+                    })
+                    .collect();
+                Some((response, state))
             }
         })
         .fuse()
@@ -3797,8 +4154,15 @@ impl OpenAIPreprocessor {
                     None
                 } else {
                     let mut response = state.last_response.clone()?;
+                    // Same reason as the reasoning-stream flush above: this is a
+                    // clone of an already-counted chunk, so re-reporting its
+                    // `llm_metrics` or its annotation payload (generated
+                    // `token_ids`) would report the previous chunk's tokens twice.
+                    response.event = None;
+                    response.comment = None;
                     let data = response.data.as_mut()?;
                     data.inner.usage = None;
+                    data.llm_metrics = None;
                     data.inner.choices.retain_mut(|choice| {
                         if let Some(buffer) = flushed.remove(&choice.index) {
                             choice.delta.role = None;
@@ -5600,7 +5964,7 @@ mod tests {
                     "SGLang gate mismatch for {description}"
                 );
                 assert_eq!(
-                    !OpenAIPreprocessor::is_reasoning_disabled_by_request(Some("kimi_k25"), args),
+                    !OpenAIPreprocessor::is_reasoning_disabled_by_request(Some("kimi_k25"), args,),
                     expected,
                     "postprocessor gate mismatch for {description}"
                 );
@@ -5985,8 +6349,8 @@ mod tests {
             (
                 Some("nemotron3"),
                 Some(&force_nonempty_content_true),
-                true,
-                "nemotron3 + force_nonempty_content=true → disabled",
+                false,
+                "nemotron3 + force_nonempty_content=true → NOT disabled (parser stays on)",
             ),
             (
                 Some("nemotron_v3"),
@@ -5997,8 +6361,8 @@ mod tests {
             (
                 Some("nemotron_v3"),
                 Some(&force_nonempty_content_true),
-                true,
-                "nemotron_v3 + force_nonempty_content=true → disabled",
+                false,
+                "nemotron_v3 + force_nonempty_content=true → NOT disabled (parser stays on)",
             ),
             // deepseek_v4 — same convention as deepseek_r1; verify all three aliases
             // (deepseek_v4 / deepseek-v4 / deepseekv4) plus both signal keys.
@@ -6119,6 +6483,8 @@ mod tests {
             ),
         ];
 
+        // The disable decision no longer depends on streaming — `enable_thinking`
+        // and the per-family signals decide it identically for both paths.
         for (parser, args, expected, desc) in cases {
             assert_eq!(
                 OpenAIPreprocessor::is_reasoning_disabled_by_request(parser, args),
@@ -6126,6 +6492,37 @@ mod tests {
                 "FAILED: {desc}",
             );
         }
+
+        // force_nonempty_content=true does NOT disable reasoning parsing for
+        // either path: the parser stays on so reasoning is split from the answer
+        // (no leak). Non-streaming additionally moves reasoning into content when
+        // no content was generated (the aggregator); streaming skips that move.
+        assert!(
+            !OpenAIPreprocessor::is_reasoning_disabled_by_request(
+                Some("nemotron3"),
+                Some(&force_nonempty_content_true),
+            ),
+            "nemotron3 + force_nonempty_content=true → NOT disabled",
+        );
+        assert!(
+            !OpenAIPreprocessor::is_reasoning_disabled_by_request(
+                Some("nemotron_v3"),
+                Some(&force_nonempty_content_true),
+            ),
+            "nemotron_v3 + force_nonempty_content=true → NOT disabled",
+        );
+        // enable_thinking=false disables entirely (user turned thinking off).
+        assert!(
+            OpenAIPreprocessor::is_reasoning_disabled_by_request(
+                Some("nemotron3"),
+                Some(&enable_thinking_false),
+            ),
+            "nemotron3 + enable_thinking=false → disabled",
+        );
+
+        // The force_nonempty_content=true → NOT disabled behavior is what lets a
+        // reasoning-only non-streaming turn surface reasoning as content; verify
+        // the aggregator half in test_move_reasoning_to_content_when_empty.
     }
 
     /// Different query strings must produce different hashes. `?v=1` and

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -355,6 +355,16 @@ pub struct ParsingOptions {
     /// fire. `None` / `Some(true)` leave the tool calls untouched.
     #[serde(default)]
     pub parallel_tool_calls: Option<bool>,
+
+    /// Non-streaming only: when the aggregated message has no non-reasoning
+    /// `content`, move the parsed `reasoning_content` into `content` instead of
+    /// returning empty content. Set by the chat and Anthropic HTTP handlers for
+    /// any request carrying `force_nonempty_content=true` — the caller asked for
+    /// non-empty content, so a reasoning-only turn must surface the reasoning as
+    /// content. Not keyed on the model or its parser. When content was
+    /// generated, reasoning stays in `reasoning_content`.
+    #[serde(default)]
+    pub move_reasoning_to_content_when_empty: bool,
 }
 
 impl ParsingOptions {
@@ -364,6 +374,7 @@ impl ParsingOptions {
             reasoning_parser,
             experimental_v2_batch_eligible: false,
             parallel_tool_calls: None,
+            move_reasoning_to_content_when_empty: false,
         }
     }
 
@@ -380,6 +391,14 @@ impl ParsingOptions {
     /// untouched.
     pub fn with_parallel_tool_calls(mut self, parallel_tool_calls: Option<bool>) -> Self {
         self.parallel_tool_calls = parallel_tool_calls;
+        self
+    }
+
+    /// Set whether a reasoning-only aggregated message should surface its
+    /// `reasoning_content` as `content` (non-streaming force_nonempty_content;
+    /// see the field docs).
+    pub fn with_move_reasoning_to_content_when_empty(mut self, enabled: bool) -> Self {
+        self.move_reasoning_to_content_when_empty = enabled;
         self
     }
 }

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -344,6 +344,16 @@ pub struct ParsingOptions {
     /// fire. `None` / `Some(true)` leave the tool calls untouched.
     #[serde(default)]
     pub parallel_tool_calls: Option<bool>,
+
+    /// Non-streaming only: when the aggregated message has no non-reasoning
+    /// `content`, move the parsed `reasoning_content` into `content` instead of
+    /// returning empty content. Set by the chat and Anthropic HTTP handlers for
+    /// any request carrying `force_nonempty_content=true` — the caller asked for
+    /// non-empty content, so a reasoning-only turn must surface the reasoning as
+    /// content. Not keyed on the model or its parser. When content was
+    /// generated, reasoning stays in `reasoning_content`.
+    #[serde(default)]
+    pub move_reasoning_to_content_when_empty: bool,
 }
 
 impl ParsingOptions {
@@ -353,6 +363,7 @@ impl ParsingOptions {
             reasoning_parser,
             experimental_v2_batch_eligible: false,
             parallel_tool_calls: None,
+            move_reasoning_to_content_when_empty: false,
         }
     }
 
@@ -369,6 +380,14 @@ impl ParsingOptions {
     /// untouched.
     pub fn with_parallel_tool_calls(mut self, parallel_tool_calls: Option<bool>) -> Self {
         self.parallel_tool_calls = parallel_tool_calls;
+        self
+    }
+
+    /// Set whether a reasoning-only aggregated message should surface its
+    /// `reasoning_content` as `content` (non-streaming force_nonempty_content;
+    /// see the field docs).
+    pub fn with_move_reasoning_to_content_when_empty(mut self, enabled: bool) -> Self {
+        self.move_reasoning_to_content_when_empty = enabled;
         self
     }
 }

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -471,6 +471,38 @@ impl DeltaAggregator {
             }
         }
 
+        // for non-streaming `force_nonempty_content=true`
+        // requests, a reasoning-only turn leaves `content` empty because all
+        // output was split into `reasoning_content`. The chat template promised
+        // non-empty content, so surface the reasoning as content. Only when no
+        // content and no tool calls were produced; when content exists,
+        // reasoning stays in `reasoning_content`.
+        if parsing_options.move_reasoning_to_content_when_empty {
+            for choice in aggregator.choices.values_mut() {
+                let has_tool_calls = choice
+                    .tool_calls
+                    .as_ref()
+                    .is_some_and(|calls| !calls.is_empty());
+                // `content_parts` (multimodal) counts as content too — `From<DeltaChoice>`
+                // prefers parts over `text`, so moving reasoning into `text` here would be
+                // dropped. Only move when there is no content of either kind.
+                // Whitespace-only text counts as empty — matching vLLM's
+                // NemotronV3ReasoningParser (`not final_content.strip()`): a
+                // trailing newline after `</think>` must not block the move and
+                // leave semantically empty content.
+                if choice.text.trim().is_empty()
+                    && choice.content_parts.is_empty()
+                    && !has_tool_calls
+                    && choice
+                        .reasoning_content
+                        .as_deref()
+                        .is_some_and(|r| !r.trim().is_empty())
+                {
+                    choice.text = choice.reasoning_content.take().unwrap_or_default();
+                }
+            }
+        }
+
         // Extract aggregated choices and sort them by index.
         let mut choices: Vec<_> = aggregator
             .choices
@@ -681,6 +713,184 @@ mod tests {
             comment: None,
             error: None,
         }
+    }
+
+    /// Build a stream delta with `reasoning_content` set and optional (possibly
+    /// empty) text content — mirrors what the reasoning parser emits after
+    /// splitting think tags. Used by the force_nonempty_content test.
+    fn create_reasoning_delta(
+        index: u32,
+        content: &str,
+        reasoning_content: &str,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        // ALLOW: function_call is deprecated
+        #[allow(deprecated)]
+        let delta = dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+            content: Some(ChatCompletionMessageContent::Text(content.to_string())),
+            function_call: None,
+            tool_calls: None,
+            role: Some(dynamo_protocols::types::Role::Assistant),
+            refusal: None,
+            reasoning_content: Some(reasoning_content.to_string()),
+        };
+        let choice = dynamo_protocols::types::ChatChoiceStream {
+            index,
+            delta,
+            finish_reason: Some(dynamo_protocols::types::FinishReason::Stop),
+            logprobs: None,
+        };
+        let data = NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test_id".to_string(),
+                model: "nvidia/nvidia-nemotron-3-ultra".to_string(),
+                created: 1234567890,
+                service_tier: None,
+                usage: None,
+                system_fingerprint: None,
+                choices: vec![choice],
+                object: "chat.completion".to_string(),
+            },
+            nvext: None,
+            llm_metrics: None,
+        };
+        Annotated {
+            data: Some(data),
+            id: Some("test_id".to_string()),
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// with Nemotron `force_nonempty_content=true`, a non-streaming
+    /// reasoning-only turn must surface its reasoning as `content` (the chat
+    /// template promised non-empty content), but only when no content was
+    /// generated. Gated by `ParsingOptions::move_reasoning_to_content_when_empty`.
+    #[tokio::test]
+    async fn test_move_reasoning_to_content_when_empty() {
+        let reasoning_only = || {
+            Box::pin(stream::iter(vec![create_reasoning_delta(
+                0,
+                "",
+                "Let me think.",
+            )]))
+        };
+
+        // Repro: without the flag, a reasoning-only turn leaves content empty
+        // (None) even though force_nonempty_content promised non-empty content.
+        let resp = DeltaAggregator::apply(reasoning_only(), ParsingOptions::default())
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert!(
+            msg.content.is_none(),
+            "repro: content empty without the flag"
+        );
+        assert_eq!(msg.reasoning_content.as_deref(), Some("Let me think."));
+
+        // Fixed: with the flag, reasoning is moved into content and cleared.
+        let opts = ParsingOptions::default().with_move_reasoning_to_content_when_empty(true);
+        let resp = DeltaAggregator::apply(reasoning_only(), opts.clone())
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert_eq!(
+            msg.content.as_ref().unwrap(),
+            &ChatCompletionMessageContent::Text("Let me think.".to_string()),
+        );
+        assert_eq!(msg.reasoning_content, None);
+
+        // Whitespace-only content counts as empty (a trailing newline after
+        // `</think>` from the incremental parser) — matches vLLM's
+        // `not final_content.strip()` check; the move must still fire.
+        let whitespace_content = Box::pin(stream::iter(vec![create_reasoning_delta(
+            0,
+            "\n",
+            "Let me think.",
+        )]));
+        let resp = DeltaAggregator::apply(whitespace_content, opts.clone())
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert_eq!(
+            msg.content.as_ref().unwrap(),
+            &ChatCompletionMessageContent::Text("Let me think.".to_string()),
+        );
+        assert_eq!(msg.reasoning_content, None);
+
+        // When content WAS generated, reasoning stays in reasoning_content.
+        let with_content = Box::pin(stream::iter(vec![create_reasoning_delta(
+            0,
+            "The answer is 42.",
+            "Let me think.",
+        )]));
+        let resp = DeltaAggregator::apply(with_content, opts).await.unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert_eq!(
+            msg.content.as_ref().unwrap(),
+            &ChatCompletionMessageContent::Text("The answer is 42.".to_string()),
+        );
+        assert_eq!(msg.reasoning_content.as_deref(), Some("Let me think."));
+    }
+
+    /// Multimodal content lives in `content_parts`, and `From<DeltaChoice>` prefers
+    /// parts over `text` — so reasoning must NOT be moved when parts are present
+    /// (it would be silently dropped). Guards the `content_parts` half of the
+    /// no-content check.
+    #[tokio::test]
+    async fn test_move_reasoning_skips_when_content_parts_present() {
+        #[allow(deprecated)]
+        let delta = dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+            content: Some(ChatCompletionMessageContent::Parts(vec![
+                dynamo_protocols::types::ChatCompletionResponseContentPart::Text(
+                    dynamo_protocols::types::ChatCompletionResponseContentPartText {
+                        text: "an image".to_string(),
+                    },
+                ),
+            ])),
+            function_call: None,
+            tool_calls: None,
+            role: Some(dynamo_protocols::types::Role::Assistant),
+            refusal: None,
+            reasoning_content: Some("thinking".to_string()),
+        };
+        let choice = dynamo_protocols::types::ChatChoiceStream {
+            index: 0,
+            delta,
+            finish_reason: Some(dynamo_protocols::types::FinishReason::Stop),
+            logprobs: None,
+        };
+        let data = NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test_id".to_string(),
+                model: "m".to_string(),
+                created: 1,
+                service_tier: None,
+                usage: None,
+                system_fingerprint: None,
+                choices: vec![choice],
+                object: "chat.completion".to_string(),
+            },
+            nvext: None,
+            llm_metrics: None,
+        };
+        let annotated = Annotated {
+            data: Some(data),
+            id: Some("test_id".to_string()),
+            event: None,
+            comment: None,
+            error: None,
+        };
+        let opts = ParsingOptions::default().with_move_reasoning_to_content_when_empty(true);
+        let resp = DeltaAggregator::apply(Box::pin(stream::iter(vec![annotated])), opts)
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert!(matches!(
+            msg.content.as_ref().unwrap(),
+            ChatCompletionMessageContent::Parts(_)
+        ));
+        assert_eq!(msg.reasoning_content.as_deref(), Some("thinking"));
     }
 
     /// Build a stream delta carrying a raw list of tool-call chunks (no content).

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -435,6 +435,38 @@ impl DeltaAggregator {
             }
         }
 
+        // for non-streaming `force_nonempty_content=true`
+        // requests, a reasoning-only turn leaves `content` empty because all
+        // output was split into `reasoning_content`. The chat template promised
+        // non-empty content, so surface the reasoning as content. Only when no
+        // content and no tool calls were produced; when content exists,
+        // reasoning stays in `reasoning_content`.
+        if parsing_options.move_reasoning_to_content_when_empty {
+            for choice in aggregator.choices.values_mut() {
+                let has_tool_calls = choice
+                    .tool_calls
+                    .as_ref()
+                    .is_some_and(|calls| !calls.is_empty());
+                // `content_parts` (multimodal) counts as content too — `From<DeltaChoice>`
+                // prefers parts over `text`, so moving reasoning into `text` here would be
+                // dropped. Only move when there is no content of either kind.
+                // Whitespace-only text counts as empty — matching vLLM's
+                // NemotronV3ReasoningParser (`not final_content.strip()`): a
+                // trailing newline after `</think>` must not block the move and
+                // leave semantically empty content.
+                if choice.text.trim().is_empty()
+                    && choice.content_parts.is_empty()
+                    && !has_tool_calls
+                    && choice
+                        .reasoning_content
+                        .as_deref()
+                        .is_some_and(|r| !r.trim().is_empty())
+                {
+                    choice.text = choice.reasoning_content.take().unwrap_or_default();
+                }
+            }
+        }
+
         // Extract aggregated choices and sort them by index.
         let mut choices: Vec<_> = aggregator
             .choices
@@ -644,6 +676,184 @@ mod tests {
             comment: None,
             error: None,
         }
+    }
+
+    /// Build a stream delta with `reasoning_content` set and optional (possibly
+    /// empty) text content — mirrors what the reasoning parser emits after
+    /// splitting think tags. Used by the force_nonempty_content test.
+    fn create_reasoning_delta(
+        index: u32,
+        content: &str,
+        reasoning_content: &str,
+    ) -> Annotated<NvCreateChatCompletionStreamResponse> {
+        // ALLOW: function_call is deprecated
+        #[allow(deprecated)]
+        let delta = dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+            content: Some(ChatCompletionMessageContent::Text(content.to_string())),
+            function_call: None,
+            tool_calls: None,
+            role: Some(dynamo_protocols::types::Role::Assistant),
+            refusal: None,
+            reasoning_content: Some(reasoning_content.to_string()),
+        };
+        let choice = dynamo_protocols::types::ChatChoiceStream {
+            index,
+            delta,
+            finish_reason: Some(dynamo_protocols::types::FinishReason::Stop),
+            logprobs: None,
+        };
+        let data = NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test_id".to_string(),
+                model: "nvidia/nvidia-nemotron-3-ultra".to_string(),
+                created: 1234567890,
+                service_tier: None,
+                usage: None,
+                system_fingerprint: None,
+                choices: vec![choice],
+                object: "chat.completion".to_string(),
+            },
+            nvext: None,
+            llm_metrics: None,
+        };
+        Annotated {
+            data: Some(data),
+            id: Some("test_id".to_string()),
+            event: None,
+            comment: None,
+            error: None,
+        }
+    }
+
+    /// with Nemotron `force_nonempty_content=true`, a non-streaming
+    /// reasoning-only turn must surface its reasoning as `content` (the chat
+    /// template promised non-empty content), but only when no content was
+    /// generated. Gated by `ParsingOptions::move_reasoning_to_content_when_empty`.
+    #[tokio::test]
+    async fn test_move_reasoning_to_content_when_empty() {
+        let reasoning_only = || {
+            Box::pin(stream::iter(vec![create_reasoning_delta(
+                0,
+                "",
+                "Let me think.",
+            )]))
+        };
+
+        // Repro: without the flag, a reasoning-only turn leaves content empty
+        // (None) even though force_nonempty_content promised non-empty content.
+        let resp = DeltaAggregator::apply(reasoning_only(), ParsingOptions::default())
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert!(
+            msg.content.is_none(),
+            "repro: content empty without the flag"
+        );
+        assert_eq!(msg.reasoning_content.as_deref(), Some("Let me think."));
+
+        // Fixed: with the flag, reasoning is moved into content and cleared.
+        let opts = ParsingOptions::default().with_move_reasoning_to_content_when_empty(true);
+        let resp = DeltaAggregator::apply(reasoning_only(), opts.clone())
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert_eq!(
+            msg.content.as_ref().unwrap(),
+            &ChatCompletionMessageContent::Text("Let me think.".to_string()),
+        );
+        assert_eq!(msg.reasoning_content, None);
+
+        // Whitespace-only content counts as empty (a trailing newline after
+        // `</think>` from the incremental parser) — matches vLLM's
+        // `not final_content.strip()` check; the move must still fire.
+        let whitespace_content = Box::pin(stream::iter(vec![create_reasoning_delta(
+            0,
+            "\n",
+            "Let me think.",
+        )]));
+        let resp = DeltaAggregator::apply(whitespace_content, opts.clone())
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert_eq!(
+            msg.content.as_ref().unwrap(),
+            &ChatCompletionMessageContent::Text("Let me think.".to_string()),
+        );
+        assert_eq!(msg.reasoning_content, None);
+
+        // When content WAS generated, reasoning stays in reasoning_content.
+        let with_content = Box::pin(stream::iter(vec![create_reasoning_delta(
+            0,
+            "The answer is 42.",
+            "Let me think.",
+        )]));
+        let resp = DeltaAggregator::apply(with_content, opts).await.unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert_eq!(
+            msg.content.as_ref().unwrap(),
+            &ChatCompletionMessageContent::Text("The answer is 42.".to_string()),
+        );
+        assert_eq!(msg.reasoning_content.as_deref(), Some("Let me think."));
+    }
+
+    /// Multimodal content lives in `content_parts`, and `From<DeltaChoice>` prefers
+    /// parts over `text` — so reasoning must NOT be moved when parts are present
+    /// (it would be silently dropped). Guards the `content_parts` half of the
+    /// no-content check.
+    #[tokio::test]
+    async fn test_move_reasoning_skips_when_content_parts_present() {
+        #[allow(deprecated)]
+        let delta = dynamo_protocols::types::ChatCompletionStreamResponseDelta {
+            content: Some(ChatCompletionMessageContent::Parts(vec![
+                dynamo_protocols::types::ChatCompletionResponseContentPart::Text(
+                    dynamo_protocols::types::ChatCompletionResponseContentPartText {
+                        text: "an image".to_string(),
+                    },
+                ),
+            ])),
+            function_call: None,
+            tool_calls: None,
+            role: Some(dynamo_protocols::types::Role::Assistant),
+            refusal: None,
+            reasoning_content: Some("thinking".to_string()),
+        };
+        let choice = dynamo_protocols::types::ChatChoiceStream {
+            index: 0,
+            delta,
+            finish_reason: Some(dynamo_protocols::types::FinishReason::Stop),
+            logprobs: None,
+        };
+        let data = NvCreateChatCompletionStreamResponse {
+            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
+                id: "test_id".to_string(),
+                model: "m".to_string(),
+                created: 1,
+                service_tier: None,
+                usage: None,
+                system_fingerprint: None,
+                choices: vec![choice],
+                object: "chat.completion".to_string(),
+            },
+            nvext: None,
+            llm_metrics: None,
+        };
+        let annotated = Annotated {
+            data: Some(data),
+            id: Some("test_id".to_string()),
+            event: None,
+            comment: None,
+            error: None,
+        };
+        let opts = ParsingOptions::default().with_move_reasoning_to_content_when_empty(true);
+        let resp = DeltaAggregator::apply(Box::pin(stream::iter(vec![annotated])), opts)
+            .await
+            .unwrap();
+        let msg = &resp.inner.choices[0].message;
+        assert!(matches!(
+            msg.content.as_ref().unwrap(),
+            ChatCompletionMessageContent::Parts(_)
+        ));
+        assert_eq!(msg.reasoning_content.as_deref(), Some("thinking"));
     }
 
     /// Build a stream delta carrying a raw list of tool-call chunks (no content).

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -784,10 +784,7 @@ async fn test_sse_keep_alive_emits_comments_during_idle_stream() {
         body.extend_from_slice(&chunk);
 
         let body_text = String::from_utf8_lossy(&body);
-        if body_text
-            .split("\n\n")
-            .any(|frame| frame.trim_end().starts_with(':'))
-        {
+        if body_text.contains(":\n\n") {
             assert!(
                 !body_text.contains("data:"),
                 "model data arrived before the keep-alive comment: {body_text}"

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -784,7 +784,10 @@ async fn test_sse_keep_alive_emits_comments_during_idle_stream() {
         body.extend_from_slice(&chunk);
 
         let body_text = String::from_utf8_lossy(&body);
-        if body_text.contains(":\n\n") {
+        if body_text
+            .split("\n\n")
+            .any(|frame| frame.trim_end().starts_with(':'))
+        {
             assert!(
                 !body_text.contains("data:"),
                 "model data arrived before the keep-alive comment: {body_text}"

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1399,6 +1399,33 @@ async fn postprocessor_parsing_stream_strip_path_eof_flush_drops_nvext() {
     );
 }
 
+#[tokio::test]
+async fn postprocessor_parsing_stream_strip_path_flushes_partial_prefix_after_usage_chunk() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"enable_thinking": false})).unwrap());
+
+    let input_stream = stream::iter(
+        vec![mock_content_chunk("<thi"), mock_usage_only_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let output_chunks: Vec<_> = output_stream.collect().await;
+
+    let content = output_chunks
+        .iter()
+        .filter_map(|output| output.data.as_ref())
+        .flat_map(|data| data.inner.choices.iter())
+        .filter_map(|choice| choice.delta.content.as_ref())
+        .map(get_text)
+        .collect::<String>();
+    assert_eq!(content, "<thi");
+}
+
 /// Same envelope defect on the `force_nonempty_content` flush. This path is the
 /// one the flag added, so a repeated `nvext` here is a regression introduced by
 /// the feature rather than a pre-existing leak.

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -456,6 +456,34 @@ fn mock_final_chunk() -> NvCreateChatCompletionStreamResponse {
     }
 }
 
+/// Trailing usage-only chunk: `choices: []` plus a usage payload, matching what
+/// `transform_postprocessor_stream` appends when usage reporting is on (always
+/// for non-streaming). It carries no delta slot, so it must never be picked as
+/// the EOF-flush envelope.
+fn mock_usage_only_chunk() -> NvCreateChatCompletionStreamResponse {
+    use dynamo_protocols::types::{CompletionUsage, CreateChatCompletionStreamResponse};
+    NvCreateChatCompletionStreamResponse {
+        inner: CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices: vec![],
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: Some(CompletionUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
+            }),
+            service_tier: None,
+        },
+        nvext: None,
+        llm_metrics: None,
+    }
+}
+
 /// Terminal `finish_reason=Stop` chunk carrying one finish per listed choice
 /// index — the multi-choice analog of `mock_final_chunk`, so an `n > 1` stream
 /// flushes every choice's jail state.
@@ -712,12 +740,16 @@ async fn postprocessor_parsing_stream_nemotron_v3_enable_thinking_false_returns_
     assert_eq!(content, "This is plain content");
 }
 
-/// vLLM parity: `chat_template_kwargs={"force_nonempty_content": true}` turns
-/// a leading `<think>...` response into normal content instead of reasoning.
-/// Dynamo checks this in the postprocessor because request flags are applied
-/// before stream parsing, not inside the raw reasoning parser.
+/// Streaming Nemotron `force_nonempty_content=true`, reasoning-only turn: the
+/// parser stays ON (it is no longer disabled for streaming), so an unterminated
+/// `<think>...` with no answer parses entirely as reasoning. Under
+/// `force_nonempty_content` those deltas are held back rather than streamed as
+/// `reasoning_content`, because until the parser leaves the reasoning block it
+/// is not yet known whether an answer follows. Here none does, so at
+/// end-of-stream the held text is emitted as `content` — the template's
+/// non-empty-content promise is honored on the streaming path too.
 #[tokio::test]
-async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_strips_start_token() {
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_reasoning_only_becomes_content() {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
 
     let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
@@ -756,23 +788,135 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_strips_start_to
         }
     }
 
-    assert_eq!(reasoning, "");
-    assert_eq!(content, "This is plain content");
+    assert_eq!(
+        content, "This is plain content",
+        "with no answer to follow, the held reasoning is emitted as content"
+    );
+    assert_eq!(
+        reasoning, "",
+        "nothing is reported as reasoning_content when it had to become content"
+    );
 }
 
-/// Non-streaming parity for the Nemotron `force_nonempty_content` flag.
-///
-/// A `stream=false` request is not a separate code path: the engine always runs
-/// internally in streaming mode, and the HTTP layer folds the resulting deltas
-/// into a single response. The leading-`<think>` strip that
-/// `postprocessor_parsing_stream` applies must therefore survive that fold.
-///
-/// This test exercises the full non-streaming path: `postprocessor_parsing_stream`
-/// (where the `force_nonempty_content` strip lives), then
-/// `NvCreateChatCompletionResponse::from_annotated_stream` (the entrypoint the
-/// non-streaming handler uses). It asserts the aggregated message has non-empty,
-/// `<think>`-stripped `content` and empty `reasoning_content` — the guarantee
-/// clients that require non-empty content depend on.
+/// Streaming Nemotron `force_nonempty_content=true`, reasoning+answer turn: the
+/// headline fix (Case 1). With the parser on, `<think>reason</think>answer`
+/// streams `reason` as `reasoning_content` and `answer` as `content` — no
+/// reasoning text or raw `</think>` leaks into content. On `main` (and before
+/// this change) the parser was disabled for streaming and only the leading
+/// `<think>` was stripped, so `content` was `"reason</think>answer"`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_stream_reasoning_and_answer_split()
+{
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        reasoning, "Let me greet them.",
+        "reasoning must stream as reasoning_content, not leak into content"
+    );
+    assert_eq!(
+        content, "Hello!",
+        "answer must be the content, with no reasoning or </think> leaked in"
+    );
+}
+
+/// Streaming Nemotron `force_nonempty_content=true` with plain output and no
+/// `<think>` at all. Nemotron aliases are force-reasoning parsers, so keeping
+/// the parser on raises the question of whether leading text with no start
+/// token gets swallowed as `reasoning_content`. It does not: the answer streams
+/// through as `content` and `reasoning_content` stays empty. This pins the
+/// dynamo-parsers behavior the fix depends on, so a parser-side change that
+/// started treating bare leading text as reasoning fails here instead of
+/// silently emptying `content` for every plain Nemotron turn.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_stream_plain_content_stays_content()
+ {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("Hello"),
+        mock_content_chunk("!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "Hello!",
+        "plain output with no <think> must stay content"
+    );
+    assert_eq!(
+        reasoning, "",
+        "no <think> means nothing may be reported as reasoning_content"
+    );
+}
+
+/// Non-streaming parity for the Nemotron `force_nonempty_content` flag,
+/// reasoning-only case. Reasoning parsing stays ON for non-streaming, so a
+/// `<think>` with no answer parses entirely into `reasoning_content`, leaving
+/// `content` empty; the aggregator then surfaces reasoning as `content` when
+/// content is empty, gated by `ParsingOptions::move_reasoning_to_content_when_empty`.
+/// The chat handler sets that flag for `force_nonempty_content` via
+/// `OpenAIPreprocessor::wants_reasoning_as_content_when_empty`; this test mirrors
+/// it and asserts non-empty, `<think>`-stripped `content`.
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_strips_start_token() {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
@@ -800,9 +944,10 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_stri
         .expect("postprocessor_parsing_stream should build");
 
     // Step 2: the non-streaming fold, identical to the `stream=false` HTTP path.
+    // Options mirror what the chat handler sets for `force_nonempty_content`.
     let response = NvCreateChatCompletionResponse::from_annotated_stream(
         output_stream,
-        ParsingOptions::default(),
+        ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
     )
     .await
     .expect("aggregation should succeed");
@@ -811,7 +956,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_stri
     assert_eq!(
         choice.message.content.as_ref().map(get_text),
         Some("This is plain content"),
-        "aggregated content must be non-empty with the leading <think> stripped"
+        "reasoning-only turn must surface reasoning as non-empty content"
     );
     assert_eq!(
         choice.message.reasoning_content, None,
@@ -820,9 +965,10 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_stri
 }
 
 /// Non-streaming parity, EOF-flush case: when the stream ends after only a
-/// partial `<think>` prefix, those bytes are valid content that the strip
-/// flushes on the terminal chunk. This confirms the non-streaming fold keeps
-/// that flushed content instead of dropping it.
+/// partial `<think>` prefix (`<thi`), those bytes must not be dropped. Reasoning
+/// parsing stays on, so `parse_reasoning_content_from_stream` flushes the
+/// unterminated buffer at EOF and the aggregator move (mirroring the chat handler
+/// for `force_nonempty_content`) surfaces it as non-empty `content`.
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_flushes_partial_prefix()
 {
@@ -843,9 +989,10 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_flus
         .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
+    // Options mirror what the chat handler sets for `force_nonempty_content`.
     let response = NvCreateChatCompletionResponse::from_annotated_stream(
         output_stream,
-        ParsingOptions::default(),
+        ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
     )
     .await
     .expect("aggregation should succeed");
@@ -859,8 +1006,82 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_flus
     assert_eq!(choice.message.reasoning_content, None);
 }
 
+/// Regression for the leak this PR fixes: a non-streaming Nemotron turn that
+/// emits real reasoning AND a real answer must split them, not dump reasoning
+/// (and a raw `</think>`) into `content`. On `main` this returned
+/// `content = "Let me greet them.</think>Hello!"`, `reasoning_content = None`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_reasoning_and_answer_split() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+    let input_chunks = vec![
+        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let response = NvCreateChatCompletionResponse::from_annotated_stream(
+        output_stream,
+        ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
+    )
+    .await
+    .expect("aggregation should succeed");
+    let choice = &response.inner.choices[0];
+    assert_eq!(
+        choice.message.content.as_ref().map(get_text),
+        Some("Hello!"),
+        "answer must be the content, with no leaked reasoning or </think>"
+    );
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Let me greet them."),
+        "reasoning must be preserved in reasoning_content, not moved into content"
+    );
+}
+
+/// Same reasoning+answer input WITHOUT `force_nonempty_content`: non-streaming
+/// reasoning parsing is unchanged, so the split is identical. Confirms the flag
+/// is a no-op when content is already present.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_reasoning_and_answer_split_no_flag() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    let input_chunks = vec![
+        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let response = NvCreateChatCompletionResponse::from_annotated_stream(
+        output_stream,
+        ParsingOptions::default(),
+    )
+    .await
+    .expect("aggregation should succeed");
+    let choice = &response.inner.choices[0];
+    assert_eq!(
+        choice.message.content.as_ref().map(get_text),
+        Some("Hello!")
+    );
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Let me greet them.")
+    );
+}
+
 /// Regression: if the stream ends after a partial `<think>` prefix, those bytes
-/// are valid content and must be flushed before the terminal chunk is emitted.
+/// must be flushed (not dropped) before the terminal chunk is emitted. With the
+/// parser on for streaming, the parser reports the unterminated buffer as
+/// reasoning at `finish_reasoning_stream`, so `<thi` surfaces as
+/// `reasoning_content` and `content` stays empty (streaming does no move — the
+/// non-streaming aggregated path moves the same bytes into content).
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_on_finish()
 {
@@ -903,13 +1124,15 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial
         }
     }
 
+    assert_eq!(content, "<thi", "partial prefix must survive as content");
     assert_eq!(reasoning, "");
-    assert_eq!(content, "<thi");
     assert!(finish_reasons.contains(&FinishReason::Stop));
 }
 
 /// Regression: the EOF path has no terminal delta to carry the buffered bytes,
-/// so the postprocessor must emit one final content chunk itself.
+/// so the postprocessor must emit one final chunk itself. With the parser on,
+/// the unterminated `<thi` flushes as `reasoning_content` (streaming does no
+/// move); the point of the test is that the bytes are not silently dropped.
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_on_eof() {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
@@ -947,26 +1170,146 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial
         }
     }
 
+    assert_eq!(content, "<thi", "partial prefix must survive as content");
     assert_eq!(reasoning, "");
-    assert_eq!(content, "<thi");
 }
 
-/// Dynamo already represents streamed responses as `choices: Vec<_>`, so this
-/// test is not adding new `n > 1` behavior. It verifies that the Nemotron v3
-/// `force_nonempty_content=true` path does not use one shared strip buffer for
-/// all choices. Both choices receive a split `<think>` prefix (`"<thi"` then
-/// `"nk>..."`). If the helper keeps only one global buffer/decided flag, choice
-/// 0 can consume the prefix state and choice 1 can leak `<think>` or lose text.
-/// The expected behavior is that each `choice.index` strips its own leading
-/// prefix independently and returns only normal content.
+/// Regression: the EOF flush must survive the trailing usage-only chunk.
+///
+/// In production `transform_postprocessor_stream` appends a final usage chunk
+/// with `choices: []` (always on for non-streaming, opt-in for streaming). If
+/// the flush reuses that chunk as its envelope, the per-choice loop iterates an
+/// empty vec and the buffered bytes are dropped — exactly the truncated-`<think>`
+/// loss the flush exists to prevent. Only content-bearing chunks are retained as
+/// the envelope, so `<thi` still surfaces here.
 #[tokio::test]
-async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tracks_prefix_per_choice() {
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_after_usage_chunk()
+ {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
 
     let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
     request.chat_template_args = Some(
         serde_json::from_value(serde_json::json!({
             "force_nonempty_content": true
+        }))
+        .unwrap(),
+    );
+
+    let input_chunks = vec![mock_content_chunk("<thi"), mock_usage_only_chunk()];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut content = String::new();
+    let mut usage_chunks = 0;
+    let mut content_index = None;
+    let mut usage_index = None;
+    for (index, output) in output_chunks.iter().enumerate() {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        if data.inner.usage.is_some() {
+            usage_chunks += 1;
+            usage_index = Some(index);
+        }
+        for choice in &data.inner.choices {
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+                content_index = Some(index);
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "<thi",
+        "partial prefix must survive the trailing usage-only chunk"
+    );
+    assert_eq!(
+        usage_chunks, 1,
+        "the flush chunk must not duplicate the usage payload"
+    );
+    assert!(
+        content_index.expect("recovered content chunk") < usage_index.expect("usage chunk"),
+        "recovered content must precede the trailing usage-only chunk"
+    );
+}
+
+/// Each choice's parser flushes its own buffered bytes at EOF. With `n > 1` the
+/// last content-bearing chunk need not carry every choice, so the flush rebuilds
+/// the choice list from the indices that actually have buffered text rather than
+/// reusing whichever choices happened to be in that envelope.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_per_choice()
+{
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "force_nonempty_content": true
+        }))
+        .unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_multi_choice_content_chunk(&[(0, "<th"), (1, "<thi")]),
+        // Only choice 0 is present in the last content-bearing chunk; choice 1's
+        // buffered "<thi" must still be flushed.
+        mock_multi_choice_content_chunk(&[(0, "i")]),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut content_by_index: HashMap<u32, String> = HashMap::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(c) = &choice.delta.content {
+                content_by_index
+                    .entry(choice.index)
+                    .or_default()
+                    .push_str(get_text(c));
+            }
+            assert!(
+                choice.delta.reasoning_content.is_none(),
+                "no answer followed, so nothing may be reported as reasoning_content"
+            );
+        }
+    }
+
+    assert_eq!(content_by_index.get(&0).map(String::as_str), Some("<thi"));
+    assert_eq!(content_by_index.get(&1).map(String::as_str), Some("<thi"));
+}
+
+/// Dynamo already represents streamed responses as `choices: Vec<_>`, so this
+/// test is not adding new `n > 1` behavior. It verifies that the disabled-reasoning
+/// strip path (`enable_thinking=false`, which is where the leading-`<think>` strip
+/// still runs) does not use one shared strip buffer for all choices. Both choices
+/// receive a split `<think>` prefix (`"<thi"` then `"nk>..."`). If the helper keeps
+/// only one global buffer/decided flag, choice 0 can consume the prefix state and
+/// choice 1 can leak `<think>` or lose text. The expected behavior is that each
+/// `choice.index` strips its own leading prefix independently and returns only
+/// normal content. (`force_nonempty_content` no longer takes this path — it keeps
+/// the reasoning parser on — so this exercises the strip path via `enable_thinking`.)
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_disabled_reasoning_tracks_prefix_per_choice() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "enable_thinking": false
         }))
         .unwrap(),
     );
@@ -997,7 +1340,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tracks_prefix_p
             }
             assert!(
                 choice.delta.reasoning_content.is_none(),
-                "reasoning_content must stay empty when force_nonempty_content=true"
+                "reasoning_content must stay empty when reasoning is disabled"
             );
         }
     }
@@ -1006,6 +1349,139 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tracks_prefix_p
     assert_eq!(
         content_by_choice.get(&1).map(String::as_str),
         Some("Second")
+    );
+}
+
+/// The disabled-reasoning strip path ends its stream by cloning the last chunk
+/// as an envelope for whatever is still buffered. That clone drops `usage` and
+/// `llm_metrics` so the previous chunk's tokens are not counted twice, but it
+/// keeps `nvext` — so a per-chunk extension such as `completion_token_ids` is
+/// emitted a second time. Non-streaming aggregation append-merges that field,
+/// turning `[42]` into `[42, 42]`.
+///
+/// Unlike the reasoning-stream flush, this path is not gated on
+/// `force_nonempty_content`: it runs for any `enable_thinking=false` request
+/// against a force-reasoning parser.
+#[tokio::test]
+async fn postprocessor_parsing_stream_strip_path_eof_flush_drops_nvext() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "enable_thinking": false
+        }))
+        .unwrap(),
+    );
+
+    // `<thi` alone is an undecided `<think>` prefix, so the strip helper is
+    // still holding it when the stream ends — that is what triggers the
+    // end-of-stream flush and its cloned envelope.
+    let mut chunk = mock_multi_choice_content_chunk(&[(0, "<thi")]);
+    chunk.nvext = Some(serde_json::json!({ "completion_token_ids": [42] }));
+
+    let input_stream = stream::iter(vec![Annotated::from_data(chunk)]);
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let carrying_nvext = output_chunks
+        .iter()
+        .filter(|o| o.data.as_ref().is_some_and(|d| d.nvext.is_some()))
+        .count();
+
+    assert_eq!(
+        carrying_nvext, 1,
+        "nvext must be emitted once; the synthetic end-of-stream chunk must not repeat it"
+    );
+}
+
+/// Same envelope defect on the `force_nonempty_content` flush. This path is the
+/// one the flag added, so a repeated `nvext` here is a regression introduced by
+/// the feature rather than a pre-existing leak.
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_eof_flush_drops_nvext() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "force_nonempty_content": true
+        }))
+        .unwrap(),
+    );
+
+    let mut chunk = mock_content_chunk("reasoning with no answer");
+    chunk.nvext = Some(serde_json::json!({ "completion_token_ids": [42] }));
+
+    let input_stream = stream::iter(vec![Annotated::from_data(chunk)]);
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let carrying_nvext = output_chunks
+        .iter()
+        .filter(|o| o.data.as_ref().is_some_and(|d| d.nvext.is_some()))
+        .count();
+
+    assert_eq!(
+        carrying_nvext, 1,
+        "the recovered-bytes chunk must not repeat the envelope's nvext"
+    );
+}
+
+/// A backend error is terminal. The deferred-reasoning buffer must be dropped,
+/// not flushed as ordinary `content` after the error — otherwise a consumer that
+/// keeps reading past the error (`/v1/responses` and `/v1/messages` both do,
+/// via `saw_error = true; continue;`) shows the user text as if it were the
+/// answer, immediately before reporting that the request failed.
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_no_content_after_backend_error() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "force_nonempty_content": true
+        }))
+        .unwrap(),
+    );
+
+    // Deferred reasoning arrives, then the backend fails before any answer.
+    let input_stream = stream::iter(vec![
+        Annotated::from_data(mock_content_chunk("partial reasoning")),
+        Annotated::from_error("backend exploded"),
+    ]);
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let error_position = output_chunks
+        .iter()
+        .position(|o| o.is_error())
+        .expect("the backend error must still reach the client");
+
+    let content_after_error: String = output_chunks
+        .iter()
+        .skip(error_position + 1)
+        .filter_map(|o| o.data.as_ref())
+        .flat_map(|d| d.inner.choices.iter())
+        .filter_map(|c| c.delta.content.as_ref())
+        .map(get_text)
+        .collect();
+
+    assert!(
+        content_after_error.is_empty(),
+        "no content may be synthesized after a terminal error, got {content_after_error:?}"
     );
 }
 
@@ -3283,4 +3759,595 @@ async fn tool_choice_matrix_immediate_jail_reasoning_only_first_chunk() {
         "{case}: reasoning_content from the first chunk must reach the client, got: {reasoning:?}"
     );
     assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+}
+
+/// Recovered text must ship on the terminal chunk, not after it.
+///
+/// The held reasoning is only known to be the answer once the stream finishes,
+/// but emitting it as an extra chunk would place `content` after
+/// `finish_reason=stop` and after the trailing usage chunk. A streaming client
+/// that stops reading at the terminal chunk would then see empty content — the
+/// exact failure `force_nonempty_content` exists to prevent. So the drain
+/// happens on the chunk that carries `finish_reason`, and usage stays last.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_recovers_on_terminal_chunk() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>answer"),
+        mock_final_chunk(),
+        mock_usage_only_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut finish_index = None;
+    let mut content_indices = Vec::new();
+    let mut usage_indices = Vec::new();
+    let mut content = String::new();
+    for (i, output) in output_chunks.iter().enumerate() {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        if data.inner.usage.is_some() {
+            usage_indices.push(i);
+        }
+        for choice in &data.inner.choices {
+            if choice.finish_reason.is_some() {
+                finish_index = Some(i);
+            }
+            if let Some(c) = &choice.delta.content {
+                content_indices.push(i);
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(content, "answer", "the held text must still be recovered");
+    let finish_index = finish_index.expect("terminal chunk must survive");
+    assert!(
+        content_indices.iter().all(|i| *i <= finish_index),
+        "content must not be emitted after finish_reason: content at {content_indices:?}, finish at {finish_index}"
+    );
+    assert!(
+        usage_indices.iter().all(|i| *i > finish_index),
+        "the usage chunk must stay last"
+    );
+}
+
+/// Once an answer has streamed as content, the non-empty-content promise is met,
+/// so a later truncated reasoning block must stay in `reasoning_content` rather
+/// than being appended to the answer. Input `<think>r1</think>A<think>r2</th`
+/// ends mid-`</think>` of a second reasoning block: `content` is exactly the
+/// answer and the dangling `</th` is reported as reasoning.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_second_block_stays_reasoning() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![mock_content_chunk("<think>r1</think>A<think>r2</th")];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "A",
+        "a truncated later reasoning block must not leak into the answer"
+    );
+    assert_eq!(
+        reasoning, "r1r2</th",
+        "the dangling reasoning bytes stay in reasoning_content"
+    );
+}
+
+/// Pins the streaming granularity cost of the deferred path, which the
+/// concatenating assertions elsewhere cannot see.
+///
+/// With no `</think>` in the turn, the held text is the answer, so it can only
+/// be released once the stream is known to be over — it arrives as one delta on
+/// the terminal chunk instead of token by token. That is a real regression in
+/// granularity versus `main` for this case, accepted because these parsers emit
+/// reasoning with no opening `<think>`: until `</think>` arrives the bytes are
+/// equally consistent with reasoning and with a plain answer, and emitting
+/// eagerly is what leaked reasoning into `content`. If a future change restores
+/// incremental delivery here, this test should fail and force that tradeoff to
+/// be re-decided rather than drifting silently.
+///
+/// The contrast case is deliberate: once `</think>` has arrived the ambiguity is
+/// gone and the answer streams one delta per chunk again.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_delta_shape() {
+    async fn content_delta_count(chunks: Vec<NvCreateChatCompletionStreamResponse>) -> usize {
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_str(REQUEST_JSON).unwrap();
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+        );
+        let input_stream = stream::iter(chunks.into_iter().map(Annotated::from_data));
+        let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, false, false)
+            .expect("postprocessor_parsing_stream should build")
+            .collect()
+            .await;
+        output_chunks
+            .iter()
+            .filter_map(|o| o.data.as_ref())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter(|c| c.delta.content.is_some())
+            .count()
+    }
+
+    // No `</think>`: three source chunks of answer text collapse into one delta.
+    let no_close = vec![
+        mock_content_chunk("Hel"),
+        mock_content_chunk("lo"),
+        mock_content_chunk("!"),
+        mock_final_chunk(),
+    ];
+    assert_eq!(
+        content_delta_count(no_close).await,
+        1,
+        "without </think> the whole answer must arrive as a single delta"
+    );
+
+    // Same answer after a closing marker: streams one delta per source chunk.
+    let with_close = vec![
+        mock_content_chunk("r</think>Hel"),
+        mock_content_chunk("lo"),
+        mock_content_chunk("!"),
+        mock_final_chunk(),
+    ];
+    assert_eq!(
+        content_delta_count(with_close).await,
+        3,
+        "after </think> the answer must stream incrementally again"
+    );
+}
+
+/// The end-of-stream fallback clones the last content-bearing chunk as its
+/// envelope, and that chunk's tokens were already counted. `metrics.rs` sums
+/// `chunk_tokens` across chunks carrying `llm_metrics` and samples one ITL point
+/// per such chunk, so carrying the annotation over would double-count the tokens
+/// and add a latency sample for a chunk that generated nothing. The recovery
+/// chunk re-channels bytes the parser was already holding, so it must report no
+/// metrics of its own.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flush_drops_llm_metrics() {
+    use dynamo_llm::protocols::common::metrics::LLMMetricAnnotation;
+
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    // No terminal chunk, so the stream takes the EOF fallback that clones the
+    // envelope. The source chunk carries metrics, as it would in production.
+    let mut source = mock_content_chunk("<thi");
+    source.llm_metrics = Some(LLMMetricAnnotation {
+        input_tokens: 7,
+        output_tokens: 3,
+        chunk_tokens: 3,
+        ..Default::default()
+    });
+
+    let input_stream = stream::iter(vec![Annotated::from_data(source)]);
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let metric_bearing: Vec<usize> = output_chunks
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| {
+            o.data
+                .as_ref()
+                .is_some_and(|d| d.llm_metrics.as_ref().is_some_and(|m| m.chunk_tokens > 0))
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    assert_eq!(
+        metric_bearing.len(),
+        1,
+        "exactly one chunk may report chunk_tokens; the recovery chunk must not \
+         re-report the envelope's, got chunks {metric_bearing:?}"
+    );
+
+    let recovered: String = output_chunks
+        .iter()
+        .filter_map(|o| o.data.as_ref())
+        .flat_map(|d| d.inner.choices.iter())
+        .filter_map(|c| c.delta.content.as_ref().map(get_text))
+        .collect();
+    assert_eq!(recovered, "<thi", "the recovery itself must still happen");
+}
+
+/// A backend that keeps streaming after a choice's `finish_reason` is out of
+/// protocol, but those bytes still reach the parser, so they still need a
+/// destination. The terminal drain marks the choice drained; a later content
+/// chunk reopens it, so `r2` is emitted rather than stranded.
+///
+/// What is NOT recovered is whatever the parser is still buffering internally at
+/// that point — here the dangling `</th`. Recovering it would mean calling
+/// `finish_reasoning_stream` a second time on the same parser, and the trait does
+/// not promise that is idempotent, so a parser that re-emits on a second
+/// finalize would duplicate text. Losing it is the better trade twice over: the
+/// stream is already out of protocol, and the bytes in question are a truncated
+/// marker fragment, which should never reach `content` anyway.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_content_after_finish_survives() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>r1</think>A"),
+        mock_final_chunk(),
+        mock_content_chunk("<think>r2</th"),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(content, "A", "the answer is unchanged by the stray chunk");
+    assert_eq!(
+        reasoning, "r1r2",
+        "post-finish content is emitted, but the parser's dangling marker fragment is not \
+         re-finalized into the stream"
+    );
+}
+
+/// Streaming and non-streaming must agree on a turn whose only answer text is
+/// whitespace. The aggregator counts whitespace-only content as empty (matching
+/// vLLM's `not final_content.strip()`) and replaces it with the reasoning, so the
+/// streaming path holds whitespace back instead of treating it as the answer.
+/// Releasing it would settle the turn early and leave streaming with
+/// content="\n" and reasoning kept, disagreeing with non-streaming on the same
+/// input.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_whitespace_answer_parity() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>r1</think>\n"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "r1",
+        "a whitespace-only answer is empty, so the reasoning becomes the content"
+    );
+    assert_eq!(
+        reasoning, "",
+        "the moved text must not also be reported as reasoning"
+    );
+}
+
+/// The deferred drain attaches a choice's whole buffered payload to the chunk
+/// carrying `finish_reason`, which is a shape the downstream tool-call jail never
+/// saw before: every other test feeds content and the terminal chunk separately.
+/// If the jail finalized on `finish_reason` before consuming that chunk's own
+/// content, tool markup delivered this way would be dropped or leaked as raw text.
+///
+/// It does not. Both orderings extract the call cleanly with nothing leaking into
+/// `content`. The no-`</think>` case is strictly better than without the flag:
+/// there the force-reasoning parser swallows the markup as `reasoning_content` and
+/// no tool call is produced at all, whereas the drain routes it to the jail.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tool_call_survives_terminal_drain()
+{
+    let xml = "<tool_call>\n<function=get_weather>\n<parameter=location>\nSan Francisco\n</parameter>\n</function>\n</tool_call>";
+
+    for (case, payload) in [
+        // Reasoning closes first, so the jail sees the call mid-stream as usual.
+        ("reasoning then tool call", format!("thinking</think>{xml}")),
+        // No `</think>`: the call is held and drained onto the terminal chunk.
+        ("tool call with no </think>", xml.to_string()),
+    ] {
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
+        let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Auto);
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+        );
+
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(&payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_stream = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, true, false)
+            .expect("postprocessor_parsing_stream should build");
+        let DrainOutput {
+            content,
+            tool_calls,
+            ..
+        } = drain_stream(output_stream).await;
+
+        assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    }
+}
+
+/// The streaming and non-streaming paths must produce the same `content` and
+/// `reasoning_content` for the same model output. They reach it by different
+/// means — the aggregator moves reasoning into empty content, while the stream
+/// holds reasoning until it knows whether an answer follows — so nothing but a
+/// direct comparison proves they agree.
+///
+/// This is also why the streaming side buffers rather than emitting reasoning
+/// live and re-emitting it as content at the end: that alternative would leave a
+/// reasoning-only turn with the same text in BOTH fields on the streaming path
+/// and in only `content` on the non-streaming path, which is a different observable
+/// result for identical model output.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_stream_matches_aggregated() {
+    for (case, payload) in [
+        ("reasoning-only", "<think>Let me greet them."),
+        (
+            "reasoning+answer",
+            "<think>Let me greet them.</think>Hello!",
+        ),
+        ("plain, no <think>", "Hello!"),
+    ] {
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_str(REQUEST_JSON).unwrap();
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+        );
+
+        // Streaming: accumulate the deltas a client would receive.
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, false, false)
+            .expect("postprocessor_parsing_stream should build")
+            .collect()
+            .await;
+        let mut streamed_content = String::new();
+        let mut streamed_reasoning = String::new();
+        for output in &output_chunks {
+            let Some(data) = output.data.as_ref() else {
+                continue;
+            };
+            for choice in &data.inner.choices {
+                if let Some(c) = &choice.delta.content {
+                    streamed_content.push_str(get_text(c));
+                }
+                if let Some(r) = &choice.delta.reasoning_content {
+                    streamed_reasoning.push_str(r);
+                }
+            }
+        }
+
+        // Non-streaming: the same stream aggregated the way the chat handler does.
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let response = NvCreateChatCompletionResponse::from_annotated_stream(
+            preprocessor
+                .postprocessor_parsing_stream(input_stream, &request, false, false)
+                .expect("postprocessor_parsing_stream should build"),
+            ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
+        )
+        .await
+        .expect("aggregate");
+        let message = &response.inner.choices[0].message;
+        let aggregated_content = message
+            .content
+            .as_ref()
+            .map(get_text)
+            .unwrap_or_default()
+            .to_string();
+        let aggregated_reasoning = message.reasoning_content.clone().unwrap_or_default();
+
+        assert_eq!(
+            streamed_content, aggregated_content,
+            "{case}: content must match across paths"
+        );
+        assert_eq!(
+            streamed_reasoning, aggregated_reasoning,
+            "{case}: reasoning_content must match across paths"
+        );
+    }
+}
+
+/// `force_nonempty_content` is a request-level contract, not a model feature, so
+/// it is honored after parsing for ANY model rather than being keyed on a
+/// parser allow-list. `qwen3` is neither a Nemotron parser nor a force-reasoning
+/// one — before this was made generic the flag was ignored for it entirely, and
+/// a reasoning-only turn returned empty `content`.
+///
+/// The flag must also not over-reach: when an answer WAS generated, reasoning
+/// stays in `reasoning_content`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_applies_to_any_model() {
+    async fn run(force: bool, payload: &str) -> (String, String) {
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_str(REQUEST_JSON).unwrap();
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": force })).unwrap(),
+        );
+        let preprocessor = build_preprocessor(Some("qwen3"), None);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, false, false)
+            .expect("postprocessor_parsing_stream should build")
+            .collect()
+            .await;
+        let (mut content, mut reasoning) = (String::new(), String::new());
+        for output in &output_chunks {
+            let Some(data) = output.data.as_ref() else {
+                continue;
+            };
+            for choice in &data.inner.choices {
+                if let Some(c) = &choice.delta.content {
+                    content.push_str(get_text(c));
+                }
+                if let Some(r) = &choice.delta.reasoning_content {
+                    reasoning.push_str(r);
+                }
+            }
+        }
+        (content, reasoning)
+    }
+
+    // Reasoning-only turn: with the flag the reasoning becomes the answer.
+    assert_eq!(
+        run(true, "<think>Hm...</think>").await,
+        ("Hm...".to_string(), String::new()),
+        "a non-Nemotron model must honor force_nonempty_content"
+    );
+    // Without the flag the same turn is untouched.
+    assert_eq!(
+        run(false, "<think>Hm...</think>").await,
+        (String::new(), "Hm...".to_string()),
+        "requests without the flag must be unchanged"
+    );
+    // An answer was generated, so reasoning stays where it belongs.
+    assert_eq!(
+        run(true, "<think>Hm...</think>Hi!").await,
+        ("Hi!".to_string(), "Hm...".to_string()),
+        "the flag must not move reasoning when content exists"
+    );
+}
+
+/// A turn whose entire output is whitespace still has to come back with that
+/// whitespace under `force_nonempty_content=true`. Held whitespace is normally
+/// dropped in favour of the reasoning text (matching the aggregator), but when
+/// whitespace is genuinely all the model produced there is nothing to prefer it
+/// to — dropping it would hand back a completely empty `content` to the one
+/// request that asked for the opposite.
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_whitespace_only_turn_survives() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    // `</think>` leaves the reasoning block, so "\n  " is normal text — and it is
+    // whitespace-only, so it is held rather than settling the turn. Nothing else
+    // follows, so the held whitespace is the whole response.
+    let input_chunks = vec![mock_content_chunk("</think>\n  "), mock_final_chunk()];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "\n  ",
+        "whitespace-only output must not vanish for a force_nonempty_content request"
+    );
 }

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -4201,6 +4201,35 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tool_call_survi
     }
 }
 
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_guided_bypass_stays_quiet_at_eof() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("nemotron_nano"));
+    let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let json = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let input_stream = stream::iter(vec![Annotated::from_data(mock_content_chunk(json))]);
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning,
+        content,
+        tool_calls,
+        ..
+    } = drain_stream(output_stream).await;
+
+    assert!(reasoning.is_empty());
+    assert_clean_tool_call(
+        "bare guided JSON at EOF",
+        &content,
+        &tool_calls,
+        "San Francisco",
+    );
+}
+
 /// The streaming and non-streaming paths must produce the same `content` and
 /// `reasoning_content` for the same model output. They reach it by different
 /// means — the aggregator moves reasoning into empty content, while the stream

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -456,6 +456,34 @@ fn mock_final_chunk() -> NvCreateChatCompletionStreamResponse {
     }
 }
 
+/// Trailing usage-only chunk: `choices: []` plus a usage payload, matching what
+/// `transform_postprocessor_stream` appends when usage reporting is on (always
+/// for non-streaming). It carries no delta slot, so it must never be picked as
+/// the EOF-flush envelope.
+fn mock_usage_only_chunk() -> NvCreateChatCompletionStreamResponse {
+    use dynamo_protocols::types::{CompletionUsage, CreateChatCompletionStreamResponse};
+    NvCreateChatCompletionStreamResponse {
+        inner: CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices: vec![],
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: Some(CompletionUsage {
+                prompt_tokens: 1,
+                completion_tokens: 1,
+                total_tokens: 2,
+                prompt_tokens_details: None,
+                completion_tokens_details: None,
+            }),
+            service_tier: None,
+        },
+        nvext: None,
+        llm_metrics: None,
+    }
+}
+
 /// Terminal `finish_reason=Stop` chunk carrying one finish per listed choice
 /// index — the multi-choice analog of `mock_final_chunk`, so an `n > 1` stream
 /// flushes every choice's jail state.
@@ -712,12 +740,16 @@ async fn postprocessor_parsing_stream_nemotron_v3_enable_thinking_false_returns_
     assert_eq!(content, "This is plain content");
 }
 
-/// vLLM parity: `chat_template_kwargs={"force_nonempty_content": true}` turns
-/// a leading `<think>...` response into normal content instead of reasoning.
-/// Dynamo checks this in the postprocessor because request flags are applied
-/// before stream parsing, not inside the raw reasoning parser.
+/// Streaming Nemotron `force_nonempty_content=true`, reasoning-only turn: the
+/// parser stays ON (it is no longer disabled for streaming), so an unterminated
+/// `<think>...` with no answer parses entirely as reasoning. Under
+/// `force_nonempty_content` those deltas are held back rather than streamed as
+/// `reasoning_content`, because until the parser leaves the reasoning block it
+/// is not yet known whether an answer follows. Here none does, so at
+/// end-of-stream the held text is emitted as `content` — the template's
+/// non-empty-content promise is honored on the streaming path too.
 #[tokio::test]
-async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_strips_start_token() {
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_reasoning_only_becomes_content() {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
 
     let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
@@ -756,23 +788,135 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_strips_start_to
         }
     }
 
-    assert_eq!(reasoning, "");
-    assert_eq!(content, "This is plain content");
+    assert_eq!(
+        content, "This is plain content",
+        "with no answer to follow, the held reasoning is emitted as content"
+    );
+    assert_eq!(
+        reasoning, "",
+        "nothing is reported as reasoning_content when it had to become content"
+    );
 }
 
-/// Non-streaming parity for the Nemotron `force_nonempty_content` flag.
-///
-/// A `stream=false` request is not a separate code path: the engine always runs
-/// internally in streaming mode, and the HTTP layer folds the resulting deltas
-/// into a single response. The leading-`<think>` strip that
-/// `postprocessor_parsing_stream` applies must therefore survive that fold.
-///
-/// This test exercises the full non-streaming path: `postprocessor_parsing_stream`
-/// (where the `force_nonempty_content` strip lives), then
-/// `NvCreateChatCompletionResponse::from_annotated_stream` (the entrypoint the
-/// non-streaming handler uses). It asserts the aggregated message has non-empty,
-/// `<think>`-stripped `content` and empty `reasoning_content` — the guarantee
-/// clients that require non-empty content depend on.
+/// Streaming Nemotron `force_nonempty_content=true`, reasoning+answer turn: the
+/// headline fix (Case 1). With the parser on, `<think>reason</think>answer`
+/// streams `reason` as `reasoning_content` and `answer` as `content` — no
+/// reasoning text or raw `</think>` leaks into content. On `main` (and before
+/// this change) the parser was disabled for streaming and only the leading
+/// `<think>` was stripped, so `content` was `"reason</think>answer"`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_stream_reasoning_and_answer_split()
+{
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        reasoning, "Let me greet them.",
+        "reasoning must stream as reasoning_content, not leak into content"
+    );
+    assert_eq!(
+        content, "Hello!",
+        "answer must be the content, with no reasoning or </think> leaked in"
+    );
+}
+
+/// Streaming Nemotron `force_nonempty_content=true` with plain output and no
+/// `<think>` at all. Nemotron aliases are force-reasoning parsers, so keeping
+/// the parser on raises the question of whether leading text with no start
+/// token gets swallowed as `reasoning_content`. It does not: the answer streams
+/// through as `content` and `reasoning_content` stays empty. This pins the
+/// dynamo-parsers behavior the fix depends on, so a parser-side change that
+/// started treating bare leading text as reasoning fails here instead of
+/// silently emptying `content` for every plain Nemotron turn.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_stream_plain_content_stays_content()
+ {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("Hello"),
+        mock_content_chunk("!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "Hello!",
+        "plain output with no <think> must stay content"
+    );
+    assert_eq!(
+        reasoning, "",
+        "no <think> means nothing may be reported as reasoning_content"
+    );
+}
+
+/// Non-streaming parity for the Nemotron `force_nonempty_content` flag,
+/// reasoning-only case. Reasoning parsing stays ON for non-streaming, so a
+/// `<think>` with no answer parses entirely into `reasoning_content`, leaving
+/// `content` empty; the aggregator then surfaces reasoning as `content` when
+/// content is empty, gated by `ParsingOptions::move_reasoning_to_content_when_empty`.
+/// The chat handler sets that flag for `force_nonempty_content` via
+/// `OpenAIPreprocessor::wants_reasoning_as_content_when_empty`; this test mirrors
+/// it and asserts non-empty, `<think>`-stripped `content`.
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_strips_start_token() {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
@@ -800,9 +944,10 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_stri
         .expect("postprocessor_parsing_stream should build");
 
     // Step 2: the non-streaming fold, identical to the `stream=false` HTTP path.
+    // Options mirror what the chat handler sets for `force_nonempty_content`.
     let response = NvCreateChatCompletionResponse::from_annotated_stream(
         output_stream,
-        ParsingOptions::default(),
+        ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
     )
     .await
     .expect("aggregation should succeed");
@@ -811,7 +956,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_stri
     assert_eq!(
         choice.message.content.as_ref().map(get_text),
         Some("This is plain content"),
-        "aggregated content must be non-empty with the leading <think> stripped"
+        "reasoning-only turn must surface reasoning as non-empty content"
     );
     assert_eq!(
         choice.message.reasoning_content, None,
@@ -820,9 +965,10 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_stri
 }
 
 /// Non-streaming parity, EOF-flush case: when the stream ends after only a
-/// partial `<think>` prefix, those bytes are valid content that the strip
-/// flushes on the terminal chunk. This confirms the non-streaming fold keeps
-/// that flushed content instead of dropping it.
+/// partial `<think>` prefix (`<thi`), those bytes must not be dropped. Reasoning
+/// parsing stays on, so `parse_reasoning_content_from_stream` flushes the
+/// unterminated buffer at EOF and the aggregator move (mirroring the chat handler
+/// for `force_nonempty_content`) surfaces it as non-empty `content`.
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_flushes_partial_prefix()
 {
@@ -843,9 +989,10 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_flus
         .postprocessor_parsing_stream(input_stream, &request, false, false)
         .expect("postprocessor_parsing_stream should build");
 
+    // Options mirror what the chat handler sets for `force_nonempty_content`.
     let response = NvCreateChatCompletionResponse::from_annotated_stream(
         output_stream,
-        ParsingOptions::default(),
+        ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
     )
     .await
     .expect("aggregation should succeed");
@@ -859,8 +1006,82 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_aggregated_flus
     assert_eq!(choice.message.reasoning_content, None);
 }
 
+/// Regression for the leak this PR fixes: a non-streaming Nemotron turn that
+/// emits real reasoning AND a real answer must split them, not dump reasoning
+/// (and a raw `</think>`) into `content`. On `main` this returned
+/// `content = "Let me greet them.</think>Hello!"`, `reasoning_content = None`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_reasoning_and_answer_split() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+    let input_chunks = vec![
+        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let response = NvCreateChatCompletionResponse::from_annotated_stream(
+        output_stream,
+        ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
+    )
+    .await
+    .expect("aggregation should succeed");
+    let choice = &response.inner.choices[0];
+    assert_eq!(
+        choice.message.content.as_ref().map(get_text),
+        Some("Hello!"),
+        "answer must be the content, with no leaked reasoning or </think>"
+    );
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Let me greet them."),
+        "reasoning must be preserved in reasoning_content, not moved into content"
+    );
+}
+
+/// Same reasoning+answer input WITHOUT `force_nonempty_content`: non-streaming
+/// reasoning parsing is unchanged, so the split is identical. Confirms the flag
+/// is a no-op when content is already present.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_reasoning_and_answer_split_no_flag() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+    let request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    let input_chunks = vec![
+        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let response = NvCreateChatCompletionResponse::from_annotated_stream(
+        output_stream,
+        ParsingOptions::default(),
+    )
+    .await
+    .expect("aggregation should succeed");
+    let choice = &response.inner.choices[0];
+    assert_eq!(
+        choice.message.content.as_ref().map(get_text),
+        Some("Hello!")
+    );
+    assert_eq!(
+        choice.message.reasoning_content.as_deref(),
+        Some("Let me greet them.")
+    );
+}
+
 /// Regression: if the stream ends after a partial `<think>` prefix, those bytes
-/// are valid content and must be flushed before the terminal chunk is emitted.
+/// must be flushed (not dropped) before the terminal chunk is emitted. With the
+/// parser on for streaming, the parser reports the unterminated buffer as
+/// reasoning at `finish_reasoning_stream`, so `<thi` surfaces as
+/// `reasoning_content` and `content` stays empty (streaming does no move — the
+/// non-streaming aggregated path moves the same bytes into content).
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_on_finish()
 {
@@ -903,13 +1124,15 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial
         }
     }
 
+    assert_eq!(content, "<thi", "partial prefix must survive as content");
     assert_eq!(reasoning, "");
-    assert_eq!(content, "<thi");
     assert!(finish_reasons.contains(&FinishReason::Stop));
 }
 
 /// Regression: the EOF path has no terminal delta to carry the buffered bytes,
-/// so the postprocessor must emit one final content chunk itself.
+/// so the postprocessor must emit one final chunk itself. With the parser on,
+/// the unterminated `<thi` flushes as `reasoning_content` (streaming does no
+/// move); the point of the test is that the bytes are not silently dropped.
 #[tokio::test]
 async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_on_eof() {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
@@ -947,26 +1170,138 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial
         }
     }
 
+    assert_eq!(content, "<thi", "partial prefix must survive as content");
     assert_eq!(reasoning, "");
-    assert_eq!(content, "<thi");
 }
 
-/// Dynamo already represents streamed responses as `choices: Vec<_>`, so this
-/// test is not adding new `n > 1` behavior. It verifies that the Nemotron v3
-/// `force_nonempty_content=true` path does not use one shared strip buffer for
-/// all choices. Both choices receive a split `<think>` prefix (`"<thi"` then
-/// `"nk>..."`). If the helper keeps only one global buffer/decided flag, choice
-/// 0 can consume the prefix state and choice 1 can leak `<think>` or lose text.
-/// The expected behavior is that each `choice.index` strips its own leading
-/// prefix independently and returns only normal content.
+/// Regression: the EOF flush must survive the trailing usage-only chunk.
+///
+/// In production `transform_postprocessor_stream` appends a final usage chunk
+/// with `choices: []` (always on for non-streaming, opt-in for streaming). If
+/// the flush reuses that chunk as its envelope, the per-choice loop iterates an
+/// empty vec and the buffered bytes are dropped — exactly the truncated-`<think>`
+/// loss the flush exists to prevent. Only content-bearing chunks are retained as
+/// the envelope, so `<thi` still surfaces here.
 #[tokio::test]
-async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tracks_prefix_per_choice() {
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_after_usage_chunk()
+ {
     let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
 
     let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
     request.chat_template_args = Some(
         serde_json::from_value(serde_json::json!({
             "force_nonempty_content": true
+        }))
+        .unwrap(),
+    );
+
+    let input_chunks = vec![mock_content_chunk("<thi"), mock_usage_only_chunk()];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut content = String::new();
+    let mut usage_chunks = 0;
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        if data.inner.usage.is_some() {
+            usage_chunks += 1;
+        }
+        for choice in &data.inner.choices {
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "<thi",
+        "partial prefix must survive the trailing usage-only chunk"
+    );
+    assert_eq!(
+        usage_chunks, 1,
+        "the flush chunk must not duplicate the usage payload"
+    );
+}
+
+/// Each choice's parser flushes its own buffered bytes at EOF. With `n > 1` the
+/// last content-bearing chunk need not carry every choice, so the flush rebuilds
+/// the choice list from the indices that actually have buffered text rather than
+/// reusing whichever choices happened to be in that envelope.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flushes_partial_prefix_per_choice()
+{
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "force_nonempty_content": true
+        }))
+        .unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_multi_choice_content_chunk(&[(0, "<th"), (1, "<thi")]),
+        // Only choice 0 is present in the last content-bearing chunk; choice 1's
+        // buffered "<thi" must still be flushed.
+        mock_multi_choice_content_chunk(&[(0, "i")]),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let mut content_by_index: HashMap<u32, String> = HashMap::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(c) = &choice.delta.content {
+                content_by_index
+                    .entry(choice.index)
+                    .or_default()
+                    .push_str(get_text(c));
+            }
+            assert!(
+                choice.delta.reasoning_content.is_none(),
+                "no answer followed, so nothing may be reported as reasoning_content"
+            );
+        }
+    }
+
+    assert_eq!(content_by_index.get(&0).map(String::as_str), Some("<thi"));
+    assert_eq!(content_by_index.get(&1).map(String::as_str), Some("<thi"));
+}
+
+/// Dynamo already represents streamed responses as `choices: Vec<_>`, so this
+/// test is not adding new `n > 1` behavior. It verifies that the disabled-reasoning
+/// strip path (`enable_thinking=false`, which is where the leading-`<think>` strip
+/// still runs) does not use one shared strip buffer for all choices. Both choices
+/// receive a split `<think>` prefix (`"<thi"` then `"nk>..."`). If the helper keeps
+/// only one global buffer/decided flag, choice 0 can consume the prefix state and
+/// choice 1 can leak `<think>` or lose text. The expected behavior is that each
+/// `choice.index` strips its own leading prefix independently and returns only
+/// normal content. (`force_nonempty_content` no longer takes this path — it keeps
+/// the reasoning parser on — so this exercises the strip path via `enable_thinking`.)
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_disabled_reasoning_tracks_prefix_per_choice() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({
+            "enable_thinking": false
         }))
         .unwrap(),
     );
@@ -997,7 +1332,7 @@ async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tracks_prefix_p
             }
             assert!(
                 choice.delta.reasoning_content.is_none(),
-                "reasoning_content must stay empty when force_nonempty_content=true"
+                "reasoning_content must stay empty when reasoning is disabled"
             );
         }
     }
@@ -3283,4 +3618,595 @@ async fn tool_choice_matrix_immediate_jail_reasoning_only_first_chunk() {
         "{case}: reasoning_content from the first chunk must reach the client, got: {reasoning:?}"
     );
     assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+}
+
+/// Recovered text must ship on the terminal chunk, not after it.
+///
+/// The held reasoning is only known to be the answer once the stream finishes,
+/// but emitting it as an extra chunk would place `content` after
+/// `finish_reason=stop` and after the trailing usage chunk. A streaming client
+/// that stops reading at the terminal chunk would then see empty content — the
+/// exact failure `force_nonempty_content` exists to prevent. So the drain
+/// happens on the chunk that carries `finish_reason`, and usage stays last.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_recovers_on_terminal_chunk() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>answer"),
+        mock_final_chunk(),
+        mock_usage_only_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut finish_index = None;
+    let mut content_indices = Vec::new();
+    let mut usage_indices = Vec::new();
+    let mut content = String::new();
+    for (i, output) in output_chunks.iter().enumerate() {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        if data.inner.usage.is_some() {
+            usage_indices.push(i);
+        }
+        for choice in &data.inner.choices {
+            if choice.finish_reason.is_some() {
+                finish_index = Some(i);
+            }
+            if let Some(c) = &choice.delta.content {
+                content_indices.push(i);
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(content, "answer", "the held text must still be recovered");
+    let finish_index = finish_index.expect("terminal chunk must survive");
+    assert!(
+        content_indices.iter().all(|i| *i <= finish_index),
+        "content must not be emitted after finish_reason: content at {content_indices:?}, finish at {finish_index}"
+    );
+    assert!(
+        usage_indices.iter().all(|i| *i > finish_index),
+        "the usage chunk must stay last"
+    );
+}
+
+/// Once an answer has streamed as content, the non-empty-content promise is met,
+/// so a later truncated reasoning block must stay in `reasoning_content` rather
+/// than being appended to the answer. Input `<think>r1</think>A<think>r2</th`
+/// ends mid-`</think>` of a second reasoning block: `content` is exactly the
+/// answer and the dangling `</th` is reported as reasoning.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_second_block_stays_reasoning() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![mock_content_chunk("<think>r1</think>A<think>r2</th")];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "A",
+        "a truncated later reasoning block must not leak into the answer"
+    );
+    assert_eq!(
+        reasoning, "r1r2</th",
+        "the dangling reasoning bytes stay in reasoning_content"
+    );
+}
+
+/// Pins the streaming granularity cost of the deferred path, which the
+/// concatenating assertions elsewhere cannot see.
+///
+/// With no `</think>` in the turn, the held text is the answer, so it can only
+/// be released once the stream is known to be over — it arrives as one delta on
+/// the terminal chunk instead of token by token. That is a real regression in
+/// granularity versus `main` for this case, accepted because these parsers emit
+/// reasoning with no opening `<think>`: until `</think>` arrives the bytes are
+/// equally consistent with reasoning and with a plain answer, and emitting
+/// eagerly is what leaked reasoning into `content`. If a future change restores
+/// incremental delivery here, this test should fail and force that tradeoff to
+/// be re-decided rather than drifting silently.
+///
+/// The contrast case is deliberate: once `</think>` has arrived the ambiguity is
+/// gone and the answer streams one delta per chunk again.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_delta_shape() {
+    async fn content_delta_count(chunks: Vec<NvCreateChatCompletionStreamResponse>) -> usize {
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_str(REQUEST_JSON).unwrap();
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+        );
+        let input_stream = stream::iter(chunks.into_iter().map(Annotated::from_data));
+        let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, false, false)
+            .expect("postprocessor_parsing_stream should build")
+            .collect()
+            .await;
+        output_chunks
+            .iter()
+            .filter_map(|o| o.data.as_ref())
+            .flat_map(|d| d.inner.choices.iter())
+            .filter(|c| c.delta.content.is_some())
+            .count()
+    }
+
+    // No `</think>`: three source chunks of answer text collapse into one delta.
+    let no_close = vec![
+        mock_content_chunk("Hel"),
+        mock_content_chunk("lo"),
+        mock_content_chunk("!"),
+        mock_final_chunk(),
+    ];
+    assert_eq!(
+        content_delta_count(no_close).await,
+        1,
+        "without </think> the whole answer must arrive as a single delta"
+    );
+
+    // Same answer after a closing marker: streams one delta per source chunk.
+    let with_close = vec![
+        mock_content_chunk("r</think>Hel"),
+        mock_content_chunk("lo"),
+        mock_content_chunk("!"),
+        mock_final_chunk(),
+    ];
+    assert_eq!(
+        content_delta_count(with_close).await,
+        3,
+        "after </think> the answer must stream incrementally again"
+    );
+}
+
+/// The end-of-stream fallback clones the last content-bearing chunk as its
+/// envelope, and that chunk's tokens were already counted. `metrics.rs` sums
+/// `chunk_tokens` across chunks carrying `llm_metrics` and samples one ITL point
+/// per such chunk, so carrying the annotation over would double-count the tokens
+/// and add a latency sample for a chunk that generated nothing. The recovery
+/// chunk re-channels bytes the parser was already holding, so it must report no
+/// metrics of its own.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_flush_drops_llm_metrics() {
+    use dynamo_llm::protocols::common::metrics::LLMMetricAnnotation;
+
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    // No terminal chunk, so the stream takes the EOF fallback that clones the
+    // envelope. The source chunk carries metrics, as it would in production.
+    let mut source = mock_content_chunk("<thi");
+    source.llm_metrics = Some(LLMMetricAnnotation {
+        input_tokens: 7,
+        output_tokens: 3,
+        chunk_tokens: 3,
+        ..Default::default()
+    });
+
+    let input_stream = stream::iter(vec![Annotated::from_data(source)]);
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let metric_bearing: Vec<usize> = output_chunks
+        .iter()
+        .enumerate()
+        .filter(|(_, o)| {
+            o.data
+                .as_ref()
+                .is_some_and(|d| d.llm_metrics.as_ref().is_some_and(|m| m.chunk_tokens > 0))
+        })
+        .map(|(i, _)| i)
+        .collect();
+
+    assert_eq!(
+        metric_bearing.len(),
+        1,
+        "exactly one chunk may report chunk_tokens; the recovery chunk must not \
+         re-report the envelope's, got chunks {metric_bearing:?}"
+    );
+
+    let recovered: String = output_chunks
+        .iter()
+        .filter_map(|o| o.data.as_ref())
+        .flat_map(|d| d.inner.choices.iter())
+        .filter_map(|c| c.delta.content.as_ref().map(get_text))
+        .collect();
+    assert_eq!(recovered, "<thi", "the recovery itself must still happen");
+}
+
+/// A backend that keeps streaming after a choice's `finish_reason` is out of
+/// protocol, but those bytes still reach the parser, so they still need a
+/// destination. The terminal drain marks the choice drained; a later content
+/// chunk reopens it, so `r2` is emitted rather than stranded.
+///
+/// What is NOT recovered is whatever the parser is still buffering internally at
+/// that point — here the dangling `</th`. Recovering it would mean calling
+/// `finish_reasoning_stream` a second time on the same parser, and the trait does
+/// not promise that is idempotent, so a parser that re-emits on a second
+/// finalize would duplicate text. Losing it is the better trade twice over: the
+/// stream is already out of protocol, and the bytes in question are a truncated
+/// marker fragment, which should never reach `content` anyway.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_content_after_finish_survives() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>r1</think>A"),
+        mock_final_chunk(),
+        mock_content_chunk("<think>r2</th"),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(content, "A", "the answer is unchanged by the stray chunk");
+    assert_eq!(
+        reasoning, "r1r2",
+        "post-finish content is emitted, but the parser's dangling marker fragment is not \
+         re-finalized into the stream"
+    );
+}
+
+/// Streaming and non-streaming must agree on a turn whose only answer text is
+/// whitespace. The aggregator counts whitespace-only content as empty (matching
+/// vLLM's `not final_content.strip()`) and replaces it with the reasoning, so the
+/// streaming path holds whitespace back instead of treating it as the answer.
+/// Releasing it would settle the turn early and leave streaming with
+/// content="\n" and reasoning kept, disagreeing with non-streaming on the same
+/// input.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_whitespace_answer_parity() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    let input_chunks = vec![
+        mock_content_chunk("<think>r1</think>\n"),
+        mock_final_chunk(),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut reasoning = String::new();
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(r) = &choice.delta.reasoning_content {
+                reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "r1",
+        "a whitespace-only answer is empty, so the reasoning becomes the content"
+    );
+    assert_eq!(
+        reasoning, "",
+        "the moved text must not also be reported as reasoning"
+    );
+}
+
+/// The deferred drain attaches a choice's whole buffered payload to the chunk
+/// carrying `finish_reason`, which is a shape the downstream tool-call jail never
+/// saw before: every other test feeds content and the terminal chunk separately.
+/// If the jail finalized on `finish_reason` before consuming that chunk's own
+/// content, tool markup delivered this way would be dropped or leaked as raw text.
+///
+/// It does not. Both orderings extract the call cleanly with nothing leaking into
+/// `content`. The no-`</think>` case is strictly better than without the flag:
+/// there the force-reasoning parser swallows the markup as `reasoning_content` and
+/// no tool call is produced at all, whereas the drain routes it to the jail.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_tool_call_survives_terminal_drain()
+{
+    let xml = "<tool_call>\n<function=get_weather>\n<parameter=location>\nSan Francisco\n</parameter>\n</function>\n</tool_call>";
+
+    for (case, payload) in [
+        // Reasoning closes first, so the jail sees the call mid-stream as usual.
+        ("reasoning then tool call", format!("thinking</think>{xml}")),
+        // No `</think>`: the call is held and drained onto the terminal chunk.
+        ("tool call with no </think>", xml.to_string()),
+    ] {
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), Some("qwen3_coder"));
+        let mut request = streaming_tool_request(ChatCompletionToolChoiceOption::Auto);
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+        );
+
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(&payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_stream = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, true, false)
+            .expect("postprocessor_parsing_stream should build");
+        let DrainOutput {
+            content,
+            tool_calls,
+            ..
+        } = drain_stream(output_stream).await;
+
+        assert_clean_tool_call(case, &content, &tool_calls, "San Francisco");
+    }
+}
+
+/// The streaming and non-streaming paths must produce the same `content` and
+/// `reasoning_content` for the same model output. They reach it by different
+/// means — the aggregator moves reasoning into empty content, while the stream
+/// holds reasoning until it knows whether an answer follows — so nothing but a
+/// direct comparison proves they agree.
+///
+/// This is also why the streaming side buffers rather than emitting reasoning
+/// live and re-emitting it as content at the end: that alternative would leave a
+/// reasoning-only turn with the same text in BOTH fields on the streaming path
+/// and in only `content` on the non-streaming path, which is a different observable
+/// result for identical model output.
+#[tokio::test]
+async fn postprocessor_parsing_stream_nemotron_v3_force_nonempty_stream_matches_aggregated() {
+    for (case, payload) in [
+        ("reasoning-only", "<think>Let me greet them."),
+        (
+            "reasoning+answer",
+            "<think>Let me greet them.</think>Hello!",
+        ),
+        ("plain, no <think>", "Hello!"),
+    ] {
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_str(REQUEST_JSON).unwrap();
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+        );
+
+        // Streaming: accumulate the deltas a client would receive.
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, false, false)
+            .expect("postprocessor_parsing_stream should build")
+            .collect()
+            .await;
+        let mut streamed_content = String::new();
+        let mut streamed_reasoning = String::new();
+        for output in &output_chunks {
+            let Some(data) = output.data.as_ref() else {
+                continue;
+            };
+            for choice in &data.inner.choices {
+                if let Some(c) = &choice.delta.content {
+                    streamed_content.push_str(get_text(c));
+                }
+                if let Some(r) = &choice.delta.reasoning_content {
+                    streamed_reasoning.push_str(r);
+                }
+            }
+        }
+
+        // Non-streaming: the same stream aggregated the way the chat handler does.
+        let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let response = NvCreateChatCompletionResponse::from_annotated_stream(
+            preprocessor
+                .postprocessor_parsing_stream(input_stream, &request, false, false)
+                .expect("postprocessor_parsing_stream should build"),
+            ParsingOptions::default().with_move_reasoning_to_content_when_empty(true),
+        )
+        .await
+        .expect("aggregate");
+        let message = &response.inner.choices[0].message;
+        let aggregated_content = message
+            .content
+            .as_ref()
+            .map(get_text)
+            .unwrap_or_default()
+            .to_string();
+        let aggregated_reasoning = message.reasoning_content.clone().unwrap_or_default();
+
+        assert_eq!(
+            streamed_content, aggregated_content,
+            "{case}: content must match across paths"
+        );
+        assert_eq!(
+            streamed_reasoning, aggregated_reasoning,
+            "{case}: reasoning_content must match across paths"
+        );
+    }
+}
+
+/// `force_nonempty_content` is a request-level contract, not a model feature, so
+/// it is honored after parsing for ANY model rather than being keyed on a
+/// parser allow-list. `qwen3` is neither a Nemotron parser nor a force-reasoning
+/// one — before this was made generic the flag was ignored for it entirely, and
+/// a reasoning-only turn returned empty `content`.
+///
+/// The flag must also not over-reach: when an answer WAS generated, reasoning
+/// stays in `reasoning_content`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_applies_to_any_model() {
+    async fn run(force: bool, payload: &str) -> (String, String) {
+        let mut request: NvCreateChatCompletionRequest =
+            serde_json::from_str(REQUEST_JSON).unwrap();
+        request.chat_template_args = Some(
+            serde_json::from_value(serde_json::json!({ "force_nonempty_content": force })).unwrap(),
+        );
+        let preprocessor = build_preprocessor(Some("qwen3"), None);
+        let input_stream = stream::iter(
+            vec![mock_content_chunk(payload), mock_final_chunk()]
+                .into_iter()
+                .map(Annotated::from_data),
+        );
+        let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+            .postprocessor_parsing_stream(input_stream, &request, false, false)
+            .expect("postprocessor_parsing_stream should build")
+            .collect()
+            .await;
+        let (mut content, mut reasoning) = (String::new(), String::new());
+        for output in &output_chunks {
+            let Some(data) = output.data.as_ref() else {
+                continue;
+            };
+            for choice in &data.inner.choices {
+                if let Some(c) = &choice.delta.content {
+                    content.push_str(get_text(c));
+                }
+                if let Some(r) = &choice.delta.reasoning_content {
+                    reasoning.push_str(r);
+                }
+            }
+        }
+        (content, reasoning)
+    }
+
+    // Reasoning-only turn: with the flag the reasoning becomes the answer.
+    assert_eq!(
+        run(true, "<think>Hm...</think>").await,
+        ("Hm...".to_string(), String::new()),
+        "a non-Nemotron model must honor force_nonempty_content"
+    );
+    // Without the flag the same turn is untouched.
+    assert_eq!(
+        run(false, "<think>Hm...</think>").await,
+        (String::new(), "Hm...".to_string()),
+        "requests without the flag must be unchanged"
+    );
+    // An answer was generated, so reasoning stays where it belongs.
+    assert_eq!(
+        run(true, "<think>Hm...</think>Hi!").await,
+        ("Hi!".to_string(), "Hm...".to_string()),
+        "the flag must not move reasoning when content exists"
+    );
+}
+
+/// A turn whose entire output is whitespace still has to come back with that
+/// whitespace under `force_nonempty_content=true`. Held whitespace is normally
+/// dropped in favour of the reasoning text (matching the aggregator), but when
+/// whitespace is genuinely all the model produced there is nothing to prefer it
+/// to — dropping it would hand back a completely empty `content` to the one
+/// request that asked for the opposite.
+#[tokio::test]
+async fn postprocessor_parsing_stream_force_nonempty_whitespace_only_turn_survives() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args = Some(
+        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
+    );
+
+    // `</think>` leaves the reasoning block, so "\n  " is normal text — and it is
+    // whitespace-only, so it is held rather than settling the turn. Nothing else
+    // follows, so the held whitespace is the whole response.
+    let input_chunks = vec![mock_content_chunk("</think>\n  "), mock_final_chunk()];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build")
+        .collect()
+        .await;
+
+    let mut content = String::new();
+    for output in &output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            if let Some(c) = &choice.delta.content {
+                content.push_str(get_text(c));
+            }
+        }
+    }
+
+    assert_eq!(
+        content, "\n  ",
+        "whitespace-only output must not vanish for a force_nonempty_content request"
+    );
 }

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1352,6 +1352,43 @@ async fn postprocessor_parsing_stream_nemotron_v3_disabled_reasoning_tracks_pref
     );
 }
 
+#[tokio::test]
+async fn postprocessor_parsing_stream_disabled_reasoning_orders_eof_flush_by_choice() {
+    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
+    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
+    request.chat_template_args =
+        Some(serde_json::from_value(serde_json::json!({"enable_thinking": false})).unwrap());
+
+    let input_stream = stream::iter(vec![Annotated::from_data(mock_multi_choice_content_chunk(
+        &[(2, "<thi"), (0, "<thi"), (1, "<thi")],
+    ))]);
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let output_chunks: Vec<_> = output_stream.collect().await;
+
+    let recovered = output_chunks
+        .iter()
+        .filter_map(|output| output.data.as_ref())
+        .find(|data| {
+            data.inner.choices.iter().any(|choice| {
+                choice
+                    .delta
+                    .content
+                    .as_ref()
+                    .is_some_and(|content| get_text(content) == "<thi")
+            })
+        })
+        .expect("synthetic recovery chunk");
+    let indices: Vec<_> = recovered
+        .inner
+        .choices
+        .iter()
+        .map(|choice| choice.index)
+        .collect();
+    assert_eq!(indices, vec![0, 1, 2]);
+}
+
 /// The disabled-reasoning strip path ends its stream by cloning the last chunk
 /// as an envelope for whatever is still buffered. That clone drops `usage` and
 /// `llm_metrics` so the previous chunk's tokens are not counted twice, but it

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1416,14 +1416,34 @@ async fn postprocessor_parsing_stream_strip_path_flushes_partial_prefix_after_us
         .expect("postprocessor_parsing_stream should build");
     let output_chunks: Vec<_> = output_stream.collect().await;
 
+    let mut content_index = None;
+    let mut usage_index = None;
     let content = output_chunks
         .iter()
-        .filter_map(|output| output.data.as_ref())
-        .flat_map(|data| data.inner.choices.iter())
-        .filter_map(|choice| choice.delta.content.as_ref())
+        .enumerate()
+        .inspect(|(index, output)| {
+            if output
+                .data
+                .as_ref()
+                .is_some_and(|data| data.inner.usage.is_some())
+            {
+                usage_index = Some(*index);
+            }
+        })
+        .filter_map(|(index, output)| output.data.as_ref().map(|data| (index, data)))
+        .flat_map(|(index, data)| data.inner.choices.iter().map(move |choice| (index, choice)))
+        .filter_map(|(index, choice)| {
+            choice.delta.content.as_ref().inspect(|_| {
+                content_index = Some(index);
+            })
+        })
         .map(get_text)
         .collect::<String>();
     assert_eq!(content, "<thi");
+    assert!(
+        content_index.expect("recovered content chunk") < usage_index.expect("usage chunk"),
+        "recovered content must precede the trailing usage-only chunk"
+    );
 }
 
 /// Same envelope defect on the `force_nonempty_content` flush. This path is the


### PR DESCRIPTION
## Summary

This affects Nemotron requests sent **when `force_nonempty_content=true`**.

**Failing today:** when `force_nonempty_content=true`, Dynamo turns the reasoning parser off. It strips only the leading `<think>`, so the reasoning text and the `</think>` tag leak into `content`, and `reasoning_content` is empty — on **both** the streaming and non-streaming paths.

Model emits `<think>Let me greet them.</think>Hello!`:

```
content = "Let me greet them.</think>Hello!"   reasoning = null   ← reasoning + </think> leaked
```

**Fixed:** keep the parser on for both paths. Split reasoning from the answer normally so a reasoning+answer turn no longer leaks. For **non-streaming**, additionally move reasoning into `content` only when content would otherwise be empty (the aggregator flag `move_reasoning_to_content_when_empty`, set by the chat handler). An unterminated `<think>` prefix at end-of-stream (e.g. a truncated `<thi`) is flushed via `finish_reasoning_stream` so the bytes are surfaced instead of dropped.

```
content = "Hello!"   reasoning = "Let me greet them."
```

## Behavior chart — realistic model output, before and after

The Nemotron chat template decides what the model can emit ([`chat_template.jinja:199-203`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16/blob/main/chat_template.jinja#L202)):

```jinja
{%- if enable_thinking %}  {{- '<|im_start|>assistant\n<think>\n' }}
{%- else %}                {{- '<|im_start|>assistant\n<think></think>' }}
```

- `enable_thinking=true` — the prompt ends with an **open** `<think>`, so the model starts inside reasoning and emits `reasoning</think>answer`. It never emits a leading `<think>`; that lives in the prompt.
- `enable_thinking=false` — the prompt already contains **both** markers, so the model's first token is plain answer text and it can never emit `</think>`.

Every cell measured: **before PR 11251** = `main` at `36e8f4a4c0`, **after PR 11251** = this branch, with `prompt_injected_reasoning` set the way production sets it per mode. `force` is `force_nonempty_content`, `thinking` is `enable_thinking`. Streaming and non-streaming agree, so one table covers both.

### Part 1 — `force_nonempty_content=true` (`thinking` = `*`, don't care)

| Model emits | `force` | `thinking` | before PR 11251 | after PR 11251 | notes |
|---|:---:|:---:|---|---|---|
| `Hm...</think>Hi!`<br>*reasoning + answer* | true | `*` | content=`"Hm...</think>Hi!"`<br>reason=`""` | content=`"Hi!"`<br>reason=`"Hm..."` | ✅ **changed.** The reported bug — reasoning and a raw `</think>` leaked into `content` |
| `</think>Hi!`<br>*answer only, zero reasoning* | true | `*` | content=`"</think>Hi!"`<br>reason=`""` | content=`"Hi!"`<br>reason=`""` | ✅ **changed.** A bare `</think>` leaked into `content` |
| `Hm...`<br>*reasoning only, no answer* | true | `*` | content=`"Hm..."`<br>reason=`""` | content=`"Hm..."`<br>reason=`""` | unchanged — the flag already did this |
| `Hi!`<br>*plain answer* | true | `*` | content=`"Hi!"`<br>reason=`""` | content=`"Hi!"`<br>reason=`""` | unchanged |
| `Hm...</thi`<br>*truncated close marker* | true | `*` | content=`"Hm...</thi"`<br>reason=`""` | content=`"Hm...</thi"`<br>reason=`""` | ⚠️ unchanged — a marker **fragment** reaches `content`. Pre-existing on `main`, not introduced here |

**`content` is non-empty in every row — that is the flag's contract, and it holds independently of `thinking`.**

### Part 2 — `force_nonempty_content=false` (`thinking` matters)

| Model emits | `force` | `thinking` | before PR 11251 | after PR 11251 | notes |
|---|:---:|:---:|---|---|---|
| `Hm...</think>Hi!`<br>*reasoning + answer* | false | true | content=`"Hi!"`<br>reason=`"Hm..."` | content=`"Hi!"`<br>reason=`"Hm..."` | unchanged |
| `</think>Hi!`<br>*answer only* | false | true | content=`"Hi!"`<br>reason=`""` | content=`"Hi!"`<br>reason=`""` | unchanged |
| `Hm...`<br>*reasoning only* | false | true | content=`""`<br>reason=`"Hm..."` | content=`""`<br>reason=`"Hm..."` | unchanged |
| `Hm...</thi`<br>*truncated close marker* | false | true | content=`""`<br>reason=`"Hm..."` | content=`""`<br>reason=`"Hm..."` | unchanged |
| `Hi!`<br>*plain answer* | false | false | content=`"Hi!"`<br>reason=`""` | content=`"Hi!"`<br>reason=`""` | unchanged |

**Only Part 1 changes, and both changed rows are marker leaks into `content`.** Part 2 is byte-identical throughout — requests without the flag are untouched.

**This PR is what earns the `*`.** Before, `force=true` was not thinking-independent: the answer-only turn returned `content="</think>Hi!"` with thinking on but `"Hi!"` with it off. After, both return `"Hi!"`.

**`force_nonempty_content` is evaluated for any model, after parsing and before the response is sent.** The predicate that drives it reads only the request's `chat_template_args` — not the model, not its reasoning parser, and not `enable_thinking`. If `reasoning_content` is non-empty and `content` is empty, `content` becomes the reasoning and `reasoning_content` is cleared. With `thinking=false` that condition simply never fires, because parsing is off and `reasoning_content` is always empty — the flag is not being ignored, there is nothing to move.

### `normal_text` vs `content`

`normal_text` is the reasoning parser's own output field. The parser splits every chunk it is fed into exactly two buckets — `reasoning_text` and `normal_text`, where `normal_text` simply means "not reasoning". It is internal to Dynamo and never reaches the wire. `content` is the OpenAI field the client actually renders (`choice.delta.content` streaming, `message.content` non-streaming).

By default the two are the same thing, because the preprocessor assigns one straight to the other:

```rust
choice.delta.content = parser_result.get_some_normal_text().map(ChatCompletionMessageContent::Text);
```

They diverge only when something overrides where the text lands — which is exactly what this flag does. In the `thinking=true` / reasoning-only row above, `normal_text` is `""` because the parser, having started inside the reasoning block, classified the whole answer as reasoning; `content` is `"Hi!"` because the flag moved it there. The parser's judgement is unchanged; only the destination is.

Two details that matter when reading the table: `normal_text` is always a `String`, whereas `content` is an enum (`Text` or multimodal `Parts`) — which is why the drain has to check for `Parts` before merging text into it. And `normal_text` is a per-chunk delta, so any accumulated view of it lines up against the final `content` only after concatenation.

## Scope

The reasoning+answer leak is fixed on **both** paths: the parser stays on, so reasoning is split from the answer and neither the reasoning text nor `</think>` lands in `content`.

The reasoning-**only** move now happens on both paths too, by different means. Non-streaming uses the aggregator flag `move_reasoning_to_content_when_empty`. Streaming cannot retract a `reasoning_content` delta it has already sent, so it instead holds reasoning back per choice until the parser leaves the reasoning block (an answer is coming) or the turn finishes (no answer is coming, so the held text becomes `content`).

**The cost, stated plainly:** held text is delivered in one delta rather than token by token. For a turn that reasons, that is the reasoning up to `</think>`, after which the answer streams normally. For a turn with no `</think>` at all the held text *is* the answer, so the whole answer arrives in a single delta on the terminal chunk — on `main` that case streamed incrementally. There is no cheaper split available: these parsers emit reasoning with no opening `<think>` (see the `nemotron_nano` mapping in dynamo-parsers), so until `</think>` arrives the same bytes are equally consistent with reasoning and with a plain answer, and emitting eagerly is exactly what leaked reasoning into `content`. The buffering is gated on the flag, so no other parser pays it, and `..._delta_shape` pins the delta counts so this cannot drift silently.

Recovered text is drained onto the chunk carrying `finish_reason`, never after it, so a client that stops reading at the terminal chunk still sees it and the usage chunk stays last.

Requests without the flag are unchanged. `enable_thinking=false` still disables reasoning entirely on both paths. [DIS-2439](https://linear.app/nvidia/issue/DIS-2439) keeps the broader preprocessor-gate PRE.* flag-combination fixtures.

## Validation

Reproduced the leak on `main` by running Dynamo's own code (not asserted from reading it). Drop this temporary test into `lib/llm/tests/postprocessor_parsing_stream.rs` (helpers already exist there):

```rust
#[tokio::test]
async fn repro_force_nonempty_leak() {
    let preprocessor = build_preprocessor(Some("nemotron_v3"), None);
    let mut request: NvCreateChatCompletionRequest = serde_json::from_str(REQUEST_JSON).unwrap();
    request.chat_template_args = Some(
        serde_json::from_value(serde_json::json!({ "force_nonempty_content": true })).unwrap(),
    );
    let input_chunks = vec![
        mock_content_chunk("<think>Let me greet them.</think>Hello!"),
        mock_final_chunk(),
    ];
    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
    let output_stream = preprocessor
        .postprocessor_parsing_stream(input_stream, &request, false, false)
        .expect("build");
    // non-streaming: aggregate; streaming: collect the deltas directly
    let response = NvCreateChatCompletionResponse::from_annotated_stream(
        output_stream, ParsingOptions::default(),
    ).await.expect("aggregate");
    let choice = &response.inner.choices[0];
    eprintln!("content   = {:?}", choice.message.content.as_ref().map(get_text));
    eprintln!("reasoning = {:?}", choice.message.reasoning_content.as_deref());
}
```

Output on `main` — the leak (both paths): `content = Some("Let me greet them.</think>Hello!")`, `reasoning = None`.

On this branch (rebased on current `main`):

- `cargo test -p dynamo-llm --test postprocessor_parsing_stream` → **65 passed, 0 failed**.
- Full `cargo test -p dynamo-llm` suite (lib + all integration bins incl. `test_reasoning_parser`, `preprocessor`, `aggregators`) → **0 failures**.
- `cargo fmt --check` and `cargo clippy -p dynamo-llm --tests` clean.

New/updated tests (16 `force_nonempty` cases in `postprocessor_parsing_stream`):

- **Headline split** — `..._stream_reasoning_and_answer_split`, `..._reasoning_and_answer_split`, `..._no_flag`: reasoning and answer separate, flag is a no-op when content is present.
- **Plain output** — `..._stream_plain_content_stays_content`: `Hello!` with no `<think>` stays content. This was returning `""` before; it is the regression the review round caught.
- **Reasoning-only** — `..._reasoning_only_becomes_content`: held text becomes content when no answer follows.
- **Delivery shape** — `..._recovers_on_terminal_chunk` (nothing after `finish_reason`, usage last), `..._delta_shape` (1 delta without `</think>`, 3 after).
- **EOF recovery** — `..._flushes_partial_prefix_on_finish` / `_on_eof` / `_after_usage_chunk` / `_per_choice`, `..._flush_drops_llm_metrics` (no double-counted tokens), `..._content_after_finish_survives`.
- **Parity and channels** — `..._whitespace_answer_parity` (streaming matches the aggregator on whitespace-only answers), `..._second_block_stays_reasoning` (a truncated later reasoning block does not leak into the answer).
- **Downstream** — `..._tool_call_survives_terminal_drain`: the tool-call jail handles a payload drained onto the terminal chunk; strictly better than without the flag, where the markup is swallowed as reasoning and no call is extracted.
- The two `..._aggregated_*` tests from #11717 (DYN-3525) aggregate with the option the chat handler sets, exercising the production path.

Also verified end-to-end on a live deployment (Qwen3-0.6B on vLLM with `--dyn-reasoning-parser nemotron_v3`, frontend built from this branch) — both usage-enabled paths keep `content` non-empty, controls without the flag are unchanged, and reasoning+answer splits with no leak. Table in the review thread.

Note for reviewers: this replaces the streaming half of #11205's `force_nonempty_content` mechanism (disable-and-strip) with the shared reasoning parser plus per-choice deferral. Streaming edge cases that #11205 routed to `content` (unterminated `<think>`, partial `<thi`) still end up in `content`, now via the deferred drain rather than the strip.

## Related

[DIS-2322](https://linear.app/nvidia/issue/DIS-2322) · streaming reasoning-only move tracked in [DIS-2439](https://linear.app/nvidia/issue/DIS-2439)




















