### PR TITLE
fix(llm): reject unsupported RL fields for responses

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2484,6 +2484,21 @@ pub fn validate_response_unsupported_fields(
 ) -> Option<impl IntoResponse> {
     let inner = &request.inner;
 
+    if let Some(field) = request
+        .nvext
+        .as_ref()
+        .and_then(|nvext| nvext.extra_fields.as_ref())
+        .and_then(|fields| {
+            fields
+                .iter()
+                .find(|field| matches!(field.as_str(), "completion_token_ids" | "prompt_logprobs"))
+        })
+    {
+        return Some(ErrorMessage::not_implemented_error(format!(
+            "{VALIDATION_PREFIX}`nvext.extra_fields=[\"{field}\"]` is not supported by the Responses API."
+        )));
+    }
+
     if inner.background == Some(true) {
         return Some(ErrorMessage::not_implemented_error(
             VALIDATION_PREFIX.to_string() + "`background: true` is not supported.",
@@ -3876,6 +3891,67 @@ mod tests {
             result.is_none(),
             "store should be supported for audit opt-in"
         );
+    }
+
+    #[tokio::test]
+    async fn test_validate_unsupported_fields_rejects_rl_nvext_fields() {
+        for field in ["completion_token_ids", "prompt_logprobs"] {
+            for stream in [false, true] {
+                let mut request = make_base_request();
+                request.inner.stream = Some(stream);
+                request.nvext = Some(
+                    NvExt::builder()
+                        .extra_fields(vec![field.to_string()])
+                        .build()
+                        .unwrap(),
+                );
+
+                let response = validate_response_unsupported_fields(&request)
+                    .expect("RL nvext response field should be rejected")
+                    .into_response();
+                assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+
+                let body = axum::body::to_bytes(response.into_body(), get_body_limit())
+                    .await
+                    .unwrap();
+                let error: ErrorMessage = serde_json::from_slice(&body).unwrap();
+                assert_eq!(
+                    error.message,
+                    format!(
+                        "{VALIDATION_PREFIX}`nvext.extra_fields=[\"{field}\"]` is not supported by the Responses API."
+                    )
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_validate_unsupported_fields_rejects_mixed_nvext_fields() {
+        let mut request = make_base_request();
+        request.nvext = Some(
+            NvExt::builder()
+                .extra_fields(vec![
+                    "timing".to_string(),
+                    "completion_token_ids".to_string(),
+                ])
+                .build()
+                .unwrap(),
+        );
+
+        assert!(validate_response_unsupported_fields(&request).is_some());
+    }
+
+    #[test]
+    fn test_validate_unsupported_fields_accepts_supported_nvext_fields() {
+        let mut request = make_base_request();
+        request.nvext = Some(
+            NvExt::builder()
+                .extra_fields(vec!["timing".to_string(), "worker_id".to_string()])
+                .build()
+                .unwrap(),
+        );
+
+        assert!(validate_response_unsupported_fields(&request).is_none());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject `completion_token_ids` and `prompt_logprobs` when requested through `nvext.extra_fields` on `/v1/responses`
- return a field-specific 501 response before engine dispatch for both streaming and non-streaming requests
- leave Chat Completions, Completions, and supported Responses `nvext` fields unchanged

## Root cause

Responses requests are converted to the Chat Completions protocol internally. The non-streaming conversion copied the resulting chat response `nvext` verbatim, while the Responses streaming converter did not expose those fields. This unintentionally made the RL fields available only on the non-streaming Responses path.

Linear: https://linear.app/nvidia/issue/DYN-3392

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm test_validate_unsupported_fields --lib` (8 passed)
- `cargo test -p dynamo-llm protocols::openai --lib` (207 passed)
- `cargo clippy -p dynamo-llm --lib -- -D warnings`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Responses API requests now return a clear `501 Not Implemented` error when unsupported `nvext.extra_fields` values are included.
  * Requests using `completion_token_ids` or `prompt_logprobs` are now consistently rejected, while supported `nvext` fields continue to work as expected.
  * Validation behavior is now consistent across both streaming and non-streaming requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->