### PR TITLE
feat(vllm): add per-worker idle sleep TTL ladder

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -163,6 +163,15 @@ def cross_validate_config(
             "Shadow mode depends on GMS for VA-stable weight sharing."
         )
 
+    # Validate --idle-sleep-timeout requires vLLM sleep mode
+    if dynamo_config.idle_sleep_enabled and not getattr(
+        engine_config, "enable_sleep_mode", False
+    ):
+        raise ValueError(
+            "--idle-sleep-timeout requires vLLM sleep mode. "
+            "Add --enable-sleep-mode to the engine arguments."
+        )
+
 
 def update_dynamo_config_with_engine(
     dynamo_config: Config, engine_config: AsyncEngineArgs

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -215,6 +215,58 @@ class DynamoVllmArgGroup(ArgGroup):
             ),
         )
 
+        # Idle sleep TTL ladder
+        add_argument(
+            g,
+            flag_name="--idle-sleep-timeout",
+            env_var="DYN_VLLM_IDLE_SLEEP_TIMEOUT",
+            default=None,
+            arg_type=float,
+            help=(
+                "Seconds of idle time (zero in-flight requests) before the "
+                "worker auto-sleeps: it unregisters from discovery, drains, "
+                "and sleeps the engine at --idle-sleep-level. Requires vLLM "
+                "sleep mode (--enable-sleep-mode). Waking stays external via "
+                "the control/wake_up route. Disabled by default."
+            ),
+        )
+        add_argument(
+            g,
+            flag_name="--idle-sleep-level",
+            env_var="DYN_VLLM_IDLE_SLEEP_LEVEL",
+            default=1,
+            arg_type=int,
+            help=(
+                "Sleep level for idle auto-sleep: 1=weights only, "
+                "2=weights+buffers, 3=everything (default: 1)."
+            ),
+        )
+        add_argument(
+            g,
+            flag_name="--idle-sleep-escalate-timeout",
+            env_var="DYN_VLLM_IDLE_SLEEP_ESCALATE_TIMEOUT",
+            default=None,
+            arg_type=float,
+            help=(
+                "Additional seconds asleep before deepening the sleep to "
+                "--idle-sleep-escalate-level. Escalation briefly wakes the "
+                "engine to re-sleep at the deeper level, so expect a "
+                "transient GPU memory spike. Requires --idle-sleep-timeout. "
+                "Disabled by default."
+            ),
+        )
+        add_argument(
+            g,
+            flag_name="--idle-sleep-escalate-level",
+            env_var="DYN_VLLM_IDLE_SLEEP_ESCALATE_LEVEL",
+            default=2,
+            arg_type=int,
+            help=(
+                "Sleep level to escalate to after "
+                "--idle-sleep-escalate-timeout (default: 2)."
+            ),
+        )
+
         # Benchmark / self-profiling
         add_argument(
             g,
@@ -326,6 +378,12 @@ class DynamoVllmConfig(ConfigBase):
     # GMS shadow mode
     gms_shadow_mode: bool = False
 
+    # Idle sleep TTL ladder (None/0 = disabled)
+    idle_sleep_timeout: Optional[float] = None
+    idle_sleep_level: int = 1
+    idle_sleep_escalate_timeout: Optional[float] = None
+    idle_sleep_escalate_level: int = 2
+
     # Benchmark / self-profiling
     benchmark_mode: Optional[str] = None
     benchmark_prefill_granularity: int = 16
@@ -335,6 +393,11 @@ class DynamoVllmConfig(ConfigBase):
     benchmark_output_path: str = "/tmp/benchmark_results.json"
     benchmark_timeout: int = 300
 
+    @property
+    def idle_sleep_enabled(self) -> bool:
+        """True when idle auto-sleep is configured (timeout set and > 0)."""
+        return bool(self.idle_sleep_timeout)
+
     def validate(self) -> None:
         """Validate vLLM wrapper configuration."""
         self._resolve_disaggregation_mode()
@@ -343,6 +406,7 @@ class DynamoVllmConfig(ConfigBase):
         self._validate_multimodal_requires_flag()
         self._validate_embedding_worker_exclusivity()
         self._validate_custom_encoder()
+        self._validate_idle_sleep()
 
     def _resolve_embedding_transfer_mode(self) -> None:
         """Resolve embedding_transfer_mode from string to enum."""
@@ -561,6 +625,45 @@ class DynamoVllmConfig(ConfigBase):
                 f"--disaggregation-mode=agg (got {mode}). The custom encoder "
                 "runs in-process in a single aggregated worker."
             )
+
+    def _validate_idle_sleep(self) -> None:
+        """Validate the idle sleep TTL ladder configuration."""
+        if self.idle_sleep_timeout is not None and self.idle_sleep_timeout < 0:
+            raise ValueError(
+                "--idle-sleep-timeout must be >= 0 (0 disables idle sleep)"
+            )
+        if not self.idle_sleep_enabled:
+            if self.idle_sleep_escalate_timeout is not None:
+                raise ValueError(
+                    "--idle-sleep-escalate-timeout requires --idle-sleep-timeout"
+                )
+            return
+        if self.idle_sleep_level not in (1, 2, 3):
+            raise ValueError("--idle-sleep-level must be 1, 2 or 3")
+        if self.disaggregation_mode == DisaggregationMode.ENCODE:
+            raise ValueError(
+                "--idle-sleep-timeout is not supported for encode workers "
+                "(they do not expose the sleep/wake_up engine routes)"
+            )
+        if self.embedding_worker:
+            raise ValueError(
+                "--idle-sleep-timeout cannot be combined with --embedding-worker"
+            )
+        if self.gms_shadow_mode:
+            raise ValueError(
+                "--idle-sleep-timeout cannot be combined with --gms-shadow-mode: "
+                "shadow engines already manage their own pause lifecycle"
+            )
+        if self.idle_sleep_escalate_timeout is not None:
+            if self.idle_sleep_escalate_timeout <= 0:
+                raise ValueError("--idle-sleep-escalate-timeout must be > 0")
+            if self.idle_sleep_escalate_level not in (1, 2, 3):
+                raise ValueError("--idle-sleep-escalate-level must be 1, 2 or 3")
+            if self.idle_sleep_escalate_level <= self.idle_sleep_level:
+                raise ValueError(
+                    "--idle-sleep-escalate-level must be deeper than "
+                    "--idle-sleep-level"
+                )
 
     def _validate_embedding_worker_exclusivity(self) -> None:
         """Embedding worker is aggregated-only and exclusive of multimodal roles."""

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -16,7 +16,7 @@ import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, contextmanager
 from typing import (
     Any,
     AsyncIterator,
@@ -98,6 +98,7 @@ from dynamo.vllm.kv_connector_protocols import (
 from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
+from .idle_sleep import IdleSleepMonitor
 from .multimodal_utils.hash_utils import compute_mm_uuids_from_images
 from .multimodal_utils.model import (
     ModelFamily,
@@ -1088,6 +1089,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
     # hf_config.use_unified_vision_chunk on real instances.
     _use_unified_vision_chunk: bool = False
     _scale_ep_in_progress: bool = False
+    # Class-level default so test doubles that bypass __init__ via
+    # __new__ still behave as if idle sleep is disabled.
+    idle_monitor: Optional[IdleSleepMonitor] = None
 
     def __init__(
         self,
@@ -1141,6 +1145,20 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.dp_range = get_dp_range_for_worker(self.engine_client.vllm_config)
         self._pause_controller = VllmEnginePauseController(self.engine_client)
         self._pause_lock = asyncio.Lock()
+        # Opt-in idle sleep TTL ladder. The monitor drives the same
+        # unregister -> drain -> sleep path as the control/sleep route;
+        # wake stays external via control/wake_up.
+        if getattr(config, "idle_sleep_enabled", False):
+            self.idle_monitor = IdleSleepMonitor(
+                sleep_fn=self._idle_sleep,
+                timeout=config.idle_sleep_timeout,
+                level=config.idle_sleep_level,
+                escalate_fn=self._escalate_sleep,
+                escalate_timeout=config.idle_sleep_escalate_timeout,
+                escalate_level=config.idle_sleep_escalate_level,
+                shutdown_event=shutdown_event,
+            )
+            self.idle_monitor.start()
         # Maps request_id -> _DeferredAbort for in-flight decode-only requests so
         # admin abort_request can route through the deferred-abort path instead
         # of calling engine_client.abort() during the unsafe pre-first-token
@@ -1293,6 +1311,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "message": "Engine already sleeping",
                     }
 
+                if self.idle_monitor is not None:
+                    self.idle_monitor.notify_slept(level)
                 return {
                     "status": "ok",
                     "message": f"Engine slept (level={level})",
@@ -1318,6 +1338,59 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             f"Failed to re-register endpoint after sleep failure: {reg_err}"
                         )
                 return {"status": "error", "message": str(e)}
+
+    async def _idle_sleep(self, level: int) -> dict:
+        """Sleep transition invoked by the idle monitor.
+
+        Reuses the control/sleep route path so discovery stays consistent
+        (unregister -> drain -> sleep) and transitions stay single-flighted
+        under ``_pause_lock``.
+        """
+        return await self.sleep({"level": level})
+
+    async def _escalate_sleep(self, from_level: int, to_level: int) -> dict:
+        """Deepen an existing sleep without rejoining discovery.
+
+        vLLM cannot deepen a sleep in place, so the engine is briefly woken
+        and re-slept at the deeper level. Generation stays paused and the
+        endpoint stays unregistered throughout, so no requests can arrive.
+        """
+        async with self._pause_lock:
+            if not self._pause_controller.is_paused:
+                return {"status": "error", "message": "Engine is not sleeping"}
+            try:
+                await self.engine_client.wake_up()
+            except Exception as e:
+                logger.error(f"Failed to wake engine for sleep escalation: {e}")
+                return {"status": "error", "message": str(e)}
+            try:
+                await self.engine_client.sleep(to_level)
+            except Exception as e:
+                logger.error(f"Failed to escalate sleep to level {to_level}: {e}")
+                # Re-sleep at the previous depth so the controller's
+                # is_paused state stays truthful.
+                try:
+                    await self.engine_client.sleep(from_level)
+                except Exception:
+                    logger.exception(
+                        "Failed to restore sleep level %d after failed escalation",
+                        from_level,
+                    )
+                return {"status": "error", "message": str(e)}
+            return {
+                "status": "ok",
+                "message": f"Sleep escalated (level={from_level}->{to_level})",
+            }
+
+    @contextmanager
+    def _track_request_activity(self) -> Iterator[None]:
+        """Report request activity to the idle monitor (no-op when disabled)."""
+        monitor = self.idle_monitor
+        if monitor is None:
+            yield
+            return
+        with monitor.track_request():
+            yield
 
     async def scale_elastic_ep(self, body: dict) -> dict:
         """Scale the elastic expert-parallelism data-parallel size live.
@@ -1461,6 +1534,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     )
                 self._pause_controller.mark_resumed()
 
+                if self.idle_monitor is not None:
+                    self.idle_monitor.notify_woken()
                 return {
                     "status": "ok",
                     "message": "Engine woke",
@@ -2449,6 +2524,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def cleanup(self):
         """Clean up resources including temporary directories."""
+        if self.idle_monitor is not None:
+            self.idle_monitor.stop()
         for temp_dir in self.temp_dirs:
             try:
                 temp_dir.cleanup()
@@ -3259,7 +3336,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         request_id = context.id()
         logger.debug(f"Decode Request ID: {request_id}")
         first_token = True
-        with time_and_log_code_section(
+        with self._track_request_activity(), time_and_log_code_section(
             f"[DECODE] request: {request_id} generate"
         ) as decode_timer:
             if self.use_vllm_tokenizer:
@@ -3670,7 +3747,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         logger.debug(f"Prefill Request ID: {request_id}")
 
         # Token-in-token-out mode: internal protocol format
-        with time_and_log_code_section(f"[PREFILL] request: {request_id} generate"):
+        with self._track_request_activity(), time_and_log_code_section(
+            f"[PREFILL] request: {request_id} generate"
+        ):
             async for chunk in self._generate_token_mode(request, context, request_id):
                 yield chunk
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -1148,7 +1148,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # Opt-in idle sleep TTL ladder. The monitor drives the same
         # unregister -> drain -> sleep path as the control/sleep route;
         # wake stays external via control/wake_up.
-        if getattr(config, "idle_sleep_enabled", False):
+        if config.idle_sleep_enabled:
             self.idle_monitor = IdleSleepMonitor(
                 sleep_fn=self._idle_sleep,
                 timeout=config.idle_sleep_timeout,
@@ -1376,7 +1376,29 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "Failed to restore sleep level %d after failed escalation",
                         from_level,
                     )
+                    # The engine is awake but the controller still reports
+                    # paused and the endpoint is unregistered. Resume through
+                    # the wake path so state stays truthful; the idle monitor
+                    # re-sleeps after a fresh TTL.
+                    try:
+                        await self._pause_controller.resume()
+                        if self.generate_endpoint is not None:
+                            await self.generate_endpoint.register_endpoint_instance()
+                        self._pause_controller.mark_resumed()
+                        if self.idle_monitor is not None:
+                            self.idle_monitor.notify_woken()
+                        logger.info(
+                            "[Sleep] Recovered to awake state after failed "
+                            "escalation rollback"
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Failed to recover after failed escalation rollback; "
+                            "external wake_up required"
+                        )
                 return {"status": "error", "message": str(e)}
+            if self.idle_monitor is not None:
+                self.idle_monitor.notify_slept(to_level)
             return {
                 "status": "ok",
                 "message": f"Sleep escalated (level={from_level}->{to_level})",

--- a/components/src/dynamo/vllm/idle_sleep.py
+++ b/components/src/dynamo/vllm/idle_sleep.py
@@ -1,0 +1,251 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Idle sleep TTL ladder for vLLM workers.
+
+Tracks per-worker request activity and, once the worker has been idle
+(zero in-flight requests) for longer than a configurable TTL, invokes the
+same transition as the external ``control/sleep`` route (unregister from
+discovery -> drain -> engine sleep). An optional escalation TTL deepens
+the sleep level after a further period asleep. Waking stays external via
+the ``control/wake_up`` route; a successful wake resets the idle timer.
+
+This module intentionally has no vLLM/torch imports so it can be unit
+tested standalone.
+"""
+
+import asyncio
+import enum
+import logging
+import time
+from contextlib import contextmanager
+from typing import Any, Awaitable, Callable, Iterator, Optional
+
+logger = logging.getLogger(__name__)
+
+SleepFn = Callable[[int], Awaitable[dict]]
+EscalateFn = Callable[[int, int], Awaitable[dict]]
+
+
+class IdleSleepState(enum.Enum):
+    WARM = "warm"
+    ASLEEP = "asleep"
+
+
+class IdleSleepMonitor:
+    """Per-worker idle monitor implementing a WARM -> ASLEEP TTL ladder.
+
+    All transitions are single-flighted: the monitor runs one background
+    task, and the injected ``sleep_fn`` / ``escalate_fn`` are expected to
+    serialize against external sleep/wake via the handler's pause lock.
+    A sleep is only attempted when ``in_flight == 0`` and the idle time
+    exceeds the TTL; requests arriving mid-transition are drained by the
+    sleep path itself, same as an externally requested sleep.
+    """
+
+    def __init__(
+        self,
+        *,
+        sleep_fn: SleepFn,
+        timeout: float,
+        level: int = 1,
+        escalate_fn: Optional[EscalateFn] = None,
+        escalate_timeout: Optional[float] = None,
+        escalate_level: int = 2,
+        shutdown_event: Optional[asyncio.Event] = None,
+        poll_interval: Optional[float] = None,
+        time_source: Callable[[], float] = time.monotonic,
+    ):
+        if timeout <= 0:
+            raise ValueError("idle sleep timeout must be > 0")
+        if escalate_timeout is not None and escalate_timeout <= 0:
+            raise ValueError("idle sleep escalate timeout must be > 0")
+        if escalate_timeout is not None and escalate_fn is None:
+            raise ValueError("escalate_timeout requires escalate_fn")
+
+        self._sleep_fn = sleep_fn
+        self._escalate_fn = escalate_fn
+        self._timeout = timeout
+        self._level = level
+        self._escalate_timeout = escalate_timeout
+        self._escalate_level = escalate_level
+        self._shutdown_event = shutdown_event
+        self._poll_interval = (
+            poll_interval
+            if poll_interval is not None
+            else max(0.01, min(1.0, timeout / 4.0))
+        )
+        self._now = time_source
+
+        self._state = IdleSleepState.WARM
+        self._in_flight = 0
+        self._last_activity = self._now()
+        self._slept_at: Optional[float] = None
+        self._current_level: Optional[int] = None
+        self._task: Optional[asyncio.Task] = None
+
+    @property
+    def state(self) -> IdleSleepState:
+        return self._state
+
+    @property
+    def in_flight(self) -> int:
+        return self._in_flight
+
+    @property
+    def current_level(self) -> Optional[int]:
+        return self._current_level
+
+    def start(self) -> None:
+        """Start the background idle monitoring task."""
+        if self._task is not None:
+            return
+        self._task = asyncio.create_task(self._run())
+        logger.info(
+            "[IdleSleep] Monitor started (timeout=%.1fs, level=%d, "
+            "escalate_timeout=%s, escalate_level=%d)",
+            self._timeout,
+            self._level,
+            f"{self._escalate_timeout:.1f}s" if self._escalate_timeout else "off",
+            self._escalate_level,
+        )
+
+    def stop(self) -> None:
+        """Cancel the background idle monitoring task."""
+        if self._task is not None:
+            self._task.cancel()
+            self._task = None
+
+    def record_request_started(self) -> None:
+        self._in_flight += 1
+        self._last_activity = self._now()
+
+    def record_request_finished(self) -> None:
+        if self._in_flight > 0:
+            self._in_flight -= 1
+        self._last_activity = self._now()
+
+    @contextmanager
+    def track_request(self) -> Iterator[None]:
+        """Track one in-flight request for idle accounting."""
+        self.record_request_started()
+        try:
+            yield
+        finally:
+            self.record_request_finished()
+
+    def notify_slept(self, level: int) -> None:
+        """Record that the engine went to sleep (auto or external)."""
+        self._state = IdleSleepState.ASLEEP
+        self._slept_at = self._now()
+        self._current_level = level
+
+    def notify_woken(self) -> None:
+        """Record that the engine woke up; resets the idle timer."""
+        self._state = IdleSleepState.WARM
+        self._slept_at = None
+        self._current_level = None
+        self._last_activity = self._now()
+
+    async def _run(self) -> None:
+        while True:
+            try:
+                if self._shutdown_event and self._shutdown_event.is_set():
+                    logger.info(
+                        "[IdleSleep] Shutdown event detected, stopping idle monitor."
+                    )
+                    break
+
+                await self._tick()
+
+                if self._shutdown_event:
+                    try:
+                        await asyncio.wait_for(
+                            self._shutdown_event.wait(), timeout=self._poll_interval
+                        )
+                        logger.info(
+                            "[IdleSleep] Shutdown event detected, stopping idle monitor."
+                        )
+                        break
+                    except asyncio.TimeoutError:
+                        pass
+                else:
+                    await asyncio.sleep(self._poll_interval)
+            except asyncio.CancelledError:
+                logger.debug("[IdleSleep] Idle monitor task cancelled.")
+                break
+            except Exception:
+                logger.exception("[IdleSleep] Unexpected error in idle monitor loop")
+
+    async def _tick(self) -> None:
+        if self._state is IdleSleepState.WARM:
+            await self._maybe_sleep()
+        else:
+            await self._maybe_escalate()
+
+    async def _maybe_sleep(self) -> None:
+        if self._in_flight > 0:
+            return
+        idle_for = self._now() - self._last_activity
+        if idle_for < self._timeout:
+            return
+
+        result = await self._sleep_fn(self._level)
+        if _is_ok(result):
+            # notify_slept() may already have run via the sleep path; keep
+            # the transition idempotent by recording state here as well.
+            self.notify_slept(self._level)
+            logger.info(
+                "[IdleSleep] Worker auto-slept after %.1fs idle (level=%d)",
+                idle_for,
+                self._level,
+            )
+        else:
+            # Back off a full TTL before retrying so a persistent failure
+            # cannot hot-loop the sleep path.
+            self._last_activity = self._now()
+            logger.warning(
+                "[IdleSleep] Auto-sleep failed, retrying after %.1fs: %s",
+                self._timeout,
+                _message(result),
+            )
+
+    async def _maybe_escalate(self) -> None:
+        if (
+            self._escalate_timeout is None
+            or self._escalate_fn is None
+            or self._slept_at is None
+        ):
+            return
+        from_level = self._current_level if self._current_level is not None else 0
+        if from_level >= self._escalate_level:
+            return
+        if self._now() - self._slept_at < self._escalate_timeout:
+            return
+
+        result = await self._escalate_fn(from_level, self._escalate_level)
+        if _is_ok(result):
+            self._current_level = self._escalate_level
+            logger.info(
+                "[IdleSleep] Sleep escalated (level=%d->%d)",
+                from_level,
+                self._escalate_level,
+            )
+        else:
+            # Back off a full escalation TTL before retrying.
+            self._slept_at = self._now()
+            logger.warning(
+                "[IdleSleep] Sleep escalation failed, retrying after %.1fs: %s",
+                self._escalate_timeout,
+                _message(result),
+            )
+
+
+def _is_ok(result: Any) -> bool:
+    return isinstance(result, dict) and result.get("status") == "ok"
+
+
+def _message(result: Any) -> str:
+    if isinstance(result, dict):
+        return str(result.get("message", result))
+    return str(result)

--- a/components/src/dynamo/vllm/idle_sleep.py
+++ b/components/src/dynamo/vllm/idle_sleep.py
@@ -173,9 +173,10 @@ class IdleSleepMonitor:
                     await asyncio.sleep(self._poll_interval)
             except asyncio.CancelledError:
                 logger.debug("[IdleSleep] Idle monitor task cancelled.")
-                break
+                raise
             except Exception:
                 logger.exception("[IdleSleep] Unexpected error in idle monitor loop")
+                raise
 
     async def _tick(self) -> None:
         if self._state is IdleSleepState.WARM:

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -282,3 +282,77 @@ class TestValidateCustomEncoder:
         config.custom_encoder_class = None
         config.enable_multimodal = False
         config._validate_custom_encoder()
+
+
+class TestIdleSleepValidation:
+    """--idle-sleep-timeout TTL ladder validation."""
+
+    def test_disabled_by_default(self):
+        config = create_config()
+        assert config.idle_sleep_enabled is False
+        # Must not raise.
+        config._validate_idle_sleep()
+
+    def test_zero_timeout_is_disabled(self):
+        config = create_config()
+        config.idle_sleep_timeout = 0
+        assert config.idle_sleep_enabled is False
+        config._validate_idle_sleep()
+
+    def test_negative_timeout_rejected(self):
+        config = create_config()
+        config.idle_sleep_timeout = -1
+        with pytest.raises(ValueError, match="idle-sleep-timeout"):
+            config._validate_idle_sleep()
+
+    def test_ladder_accepted(self):
+        config = create_config()
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config.idle_sleep_timeout = 300
+        config.idle_sleep_escalate_timeout = 600
+        # Must not raise.
+        config._validate_idle_sleep()
+
+    def test_escalate_timeout_requires_timeout(self):
+        config = create_config()
+        config.idle_sleep_escalate_timeout = 600
+        with pytest.raises(ValueError, match="requires --idle-sleep-timeout"):
+            config._validate_idle_sleep()
+
+    @pytest.mark.parametrize("level", [0, 4])
+    def test_invalid_level_rejected(self, level):
+        config = create_config()
+        config.idle_sleep_timeout = 300
+        config.idle_sleep_level = level
+        with pytest.raises(ValueError, match="idle-sleep-level"):
+            config._validate_idle_sleep()
+
+    def test_escalate_level_must_be_deeper(self):
+        config = create_config()
+        config.idle_sleep_timeout = 300
+        config.idle_sleep_level = 2
+        config.idle_sleep_escalate_timeout = 600
+        config.idle_sleep_escalate_level = 2
+        with pytest.raises(ValueError, match="deeper"):
+            config._validate_idle_sleep()
+
+    def test_encode_worker_rejected(self):
+        config = create_config()
+        config.disaggregation_mode = DisaggregationMode.ENCODE
+        config.idle_sleep_timeout = 300
+        with pytest.raises(ValueError, match="encode workers"):
+            config._validate_idle_sleep()
+
+    def test_embedding_worker_rejected(self):
+        config = create_config()
+        config.embedding_worker = True
+        config.idle_sleep_timeout = 300
+        with pytest.raises(ValueError, match="embedding-worker"):
+            config._validate_idle_sleep()
+
+    def test_gms_shadow_mode_rejected(self):
+        config = create_config()
+        config.gms_shadow_mode = True
+        config.idle_sleep_timeout = 300
+        with pytest.raises(ValueError, match="gms-shadow-mode"):
+            config._validate_idle_sleep()

--- a/components/src/dynamo/vllm/tests/test_idle_sleep_monitor.py
+++ b/components/src/dynamo/vllm/tests/test_idle_sleep_monitor.py
@@ -248,6 +248,7 @@ def test_track_request_decrements_on_error():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_background_loop_sleeps_and_stops():
     sleep_fn = AsyncMock(return_value={"status": "ok"})
     slept = asyncio.Event()
@@ -274,6 +275,7 @@ async def test_background_loop_sleeps_and_stops():
 
 
 @pytest.mark.asyncio
+@pytest.mark.timeout(5)
 async def test_background_loop_exits_on_shutdown_event():
     shutdown_event = asyncio.Event()
     monitor = IdleSleepMonitor(

--- a/components/src/dynamo/vllm/tests/test_idle_sleep_monitor.py
+++ b/components/src/dynamo/vllm/tests/test_idle_sleep_monitor.py
@@ -1,0 +1,288 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the idle sleep TTL ladder monitor.
+
+`dynamo.vllm.idle_sleep` is stdlib-only, so these tests run without
+vLLM/torch installed (hence the file is not named ``test_vllm_*``).
+"""
+
+import asyncio
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.vllm.idle_sleep import IdleSleepMonitor, IdleSleepState
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+TIMEOUT = 10.0
+ESCALATE_TIMEOUT = 30.0
+
+
+class FakeClock:
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def make_monitor(clock: FakeClock, **overrides) -> IdleSleepMonitor:
+    kwargs = dict(
+        sleep_fn=AsyncMock(return_value={"status": "ok"}),
+        timeout=TIMEOUT,
+        level=1,
+        escalate_fn=AsyncMock(return_value={"status": "ok"}),
+        escalate_timeout=ESCALATE_TIMEOUT,
+        escalate_level=2,
+        time_source=clock,
+    )
+    kwargs.update(overrides)
+    return IdleSleepMonitor(**kwargs)
+
+
+def test_constructor_rejects_bad_config():
+    with pytest.raises(ValueError):
+        IdleSleepMonitor(sleep_fn=AsyncMock(), timeout=0)
+    with pytest.raises(ValueError):
+        IdleSleepMonitor(sleep_fn=AsyncMock(), timeout=10, escalate_timeout=0)
+    with pytest.raises(ValueError):
+        IdleSleepMonitor(sleep_fn=AsyncMock(), timeout=10, escalate_timeout=30)
+
+
+@pytest.mark.asyncio
+async def test_sleeps_after_idle_ttl():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    clock.advance(TIMEOUT - 0.1)
+    await monitor._tick()
+    monitor._sleep_fn.assert_not_awaited()
+    assert monitor.state is IdleSleepState.WARM
+
+    clock.advance(0.1)
+    await monitor._tick()
+    monitor._sleep_fn.assert_awaited_once_with(1)
+    assert monitor.state is IdleSleepState.ASLEEP
+    assert monitor.current_level == 1
+
+
+@pytest.mark.asyncio
+async def test_in_flight_request_blocks_sleep():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    monitor.record_request_started()
+    clock.advance(TIMEOUT * 5)
+    await monitor._tick()
+    monitor._sleep_fn.assert_not_awaited()
+
+    # The idle window restarts when the request finishes.
+    monitor.record_request_finished()
+    await monitor._tick()
+    monitor._sleep_fn.assert_not_awaited()
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    monitor._sleep_fn.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_request_activity_resets_idle_timer():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    clock.advance(TIMEOUT * 0.6)
+    with monitor.track_request():
+        pass
+
+    # Total elapsed exceeds the TTL, but only 0.6 * TIMEOUT has passed
+    # since the last request finished.
+    clock.advance(TIMEOUT * 0.6)
+    await monitor._tick()
+    monitor._sleep_fn.assert_not_awaited()
+
+    clock.advance(TIMEOUT * 0.4)
+    await monitor._tick()
+    monitor._sleep_fn.assert_awaited_once_with(1)
+
+
+@pytest.mark.asyncio
+async def test_escalates_to_deeper_level():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    assert monitor.state is IdleSleepState.ASLEEP
+
+    clock.advance(ESCALATE_TIMEOUT - 0.1)
+    await monitor._tick()
+    monitor._escalate_fn.assert_not_awaited()
+
+    clock.advance(0.1)
+    await monitor._tick()
+    monitor._escalate_fn.assert_awaited_once_with(1, 2)
+    assert monitor.current_level == 2
+
+    # Already at the deepest configured level: no further escalation.
+    clock.advance(ESCALATE_TIMEOUT * 5)
+    await monitor._tick()
+    monitor._escalate_fn.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_escalation_when_not_configured():
+    clock = FakeClock()
+    monitor = make_monitor(clock, escalate_fn=None, escalate_timeout=None)
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    assert monitor.state is IdleSleepState.ASLEEP
+
+    clock.advance(ESCALATE_TIMEOUT * 10)
+    await monitor._tick()
+    assert monitor.current_level == 1
+
+
+@pytest.mark.asyncio
+async def test_wake_resets_state_and_idle_timer():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    assert monitor.state is IdleSleepState.ASLEEP
+
+    monitor.notify_woken()
+    assert monitor.state is IdleSleepState.WARM
+    assert monitor.current_level is None
+
+    # A fresh full TTL must elapse before the next auto-sleep.
+    clock.advance(TIMEOUT - 0.1)
+    await monitor._tick()
+    monitor._sleep_fn.assert_awaited_once()
+
+    clock.advance(0.1)
+    await monitor._tick()
+    assert monitor._sleep_fn.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_external_sleep_is_tracked_and_escalated():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    # control/sleep route slept the engine directly.
+    monitor.notify_slept(1)
+    assert monitor.state is IdleSleepState.ASLEEP
+
+    clock.advance(ESCALATE_TIMEOUT)
+    await monitor._tick()
+    monitor._sleep_fn.assert_not_awaited()
+    monitor._escalate_fn.assert_awaited_once_with(1, 2)
+
+
+@pytest.mark.asyncio
+async def test_sleep_failure_backs_off_full_ttl():
+    clock = FakeClock()
+    monitor = make_monitor(
+        clock, sleep_fn=AsyncMock(return_value={"status": "error", "message": "boom"})
+    )
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    assert monitor._sleep_fn.await_count == 1
+    assert monitor.state is IdleSleepState.WARM
+
+    # No hot-loop: the retry waits out another full TTL.
+    await monitor._tick()
+    assert monitor._sleep_fn.await_count == 1
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    assert monitor._sleep_fn.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_escalation_failure_backs_off():
+    clock = FakeClock()
+    monitor = make_monitor(
+        clock,
+        escalate_fn=AsyncMock(return_value={"status": "error", "message": "boom"}),
+    )
+
+    clock.advance(TIMEOUT)
+    await monitor._tick()
+    clock.advance(ESCALATE_TIMEOUT)
+    await monitor._tick()
+    assert monitor._escalate_fn.await_count == 1
+    assert monitor.current_level == 1
+
+    await monitor._tick()
+    assert monitor._escalate_fn.await_count == 1
+
+    clock.advance(ESCALATE_TIMEOUT)
+    await monitor._tick()
+    assert monitor._escalate_fn.await_count == 2
+
+
+def test_track_request_decrements_on_error():
+    clock = FakeClock()
+    monitor = make_monitor(clock)
+
+    with pytest.raises(RuntimeError):
+        with monitor.track_request():
+            assert monitor.in_flight == 1
+            raise RuntimeError("request failed")
+    assert monitor.in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_background_loop_sleeps_and_stops():
+    sleep_fn = AsyncMock(return_value={"status": "ok"})
+    slept = asyncio.Event()
+
+    async def sleep_and_signal(level: int) -> dict:
+        result = await sleep_fn(level)
+        slept.set()
+        return result
+
+    monitor = IdleSleepMonitor(
+        sleep_fn=sleep_and_signal,
+        timeout=0.05,
+        level=2,
+        poll_interval=0.01,
+    )
+    monitor.start()
+    try:
+        await asyncio.wait_for(slept.wait(), timeout=2.0)
+    finally:
+        monitor.stop()
+
+    sleep_fn.assert_awaited_once_with(2)
+    assert monitor.state is IdleSleepState.ASLEEP
+
+
+@pytest.mark.asyncio
+async def test_background_loop_exits_on_shutdown_event():
+    shutdown_event = asyncio.Event()
+    monitor = IdleSleepMonitor(
+        sleep_fn=AsyncMock(return_value={"status": "ok"}),
+        timeout=60.0,
+        shutdown_event=shutdown_event,
+        poll_interval=0.01,
+    )
+    monitor.start()
+    task = monitor._task
+    shutdown_event.set()
+    await asyncio.wait_for(task, timeout=2.0)

--- a/components/src/dynamo/vllm/tests/test_vllm_idle_sleep_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_idle_sleep_handlers.py
@@ -99,6 +99,8 @@ async def test_escalate_sleep_wakes_and_resleeps_deeper():
     # Discovery is not rejoined: escalation happens while unregistered.
     handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
     assert handler._pause_controller.is_paused is True
+    assert handler.idle_monitor.state is IdleSleepState.ASLEEP
+    assert handler.idle_monitor.current_level == 2
 
 
 @pytest.mark.asyncio
@@ -125,6 +127,24 @@ async def test_escalate_sleep_restores_previous_level_on_failure():
     assert handler.engine_client.sleep.await_args_list[0].args == (2,)
     assert handler.engine_client.sleep.await_args_list[1].args == (1,)
     assert handler._pause_controller.is_paused is True
+
+
+@pytest.mark.asyncio
+async def test_escalate_sleep_recovers_when_rollback_also_fails():
+    handler = _make_handler()
+    await handler.sleep({"level": 1})
+    handler.engine_client.sleep = AsyncMock(side_effect=RuntimeError("sleep failed"))
+
+    result = await handler._escalate_sleep(1, 2)
+
+    assert result["status"] == "error"
+    # Escalation and rollback both failed: the handler resumes through the
+    # wake path so the controller, discovery, and monitor stay truthful.
+    handler.engine_client.resume_generation.assert_awaited_once()
+    handler.generate_endpoint.register_endpoint_instance.assert_awaited_once()
+    assert handler._pause_controller.is_paused is False
+    assert handler.idle_monitor.state is IdleSleepState.WARM
+    assert handler.idle_monitor.current_level is None
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_idle_sleep_handlers.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_idle_sleep_handlers.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("torch")
+pytest.importorskip("vllm.config")
+pytest.importorskip("vllm.v1.engine.exceptions")
+
+from dynamo.vllm.handlers import (  # noqa: E402
+    BaseWorkerHandler,
+    VllmEnginePauseController,
+)
+from dynamo.vllm.idle_sleep import IdleSleepMonitor, IdleSleepState  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _TestWorkerHandler(BaseWorkerHandler):
+    async def generate(self, request, context):
+        with self._track_request_activity():
+            yield {}
+
+
+def _make_handler(with_idle_monitor: bool = True) -> _TestWorkerHandler:
+    handler = _TestWorkerHandler.__new__(_TestWorkerHandler)
+    handler.engine_client = SimpleNamespace(
+        pause_generation=AsyncMock(),
+        sleep=AsyncMock(),
+        wake_up=AsyncMock(),
+        resume_generation=AsyncMock(),
+    )
+    handler.generate_endpoint = SimpleNamespace(
+        unregister_endpoint_instance=AsyncMock(),
+        register_endpoint_instance=AsyncMock(),
+    )
+    handler._pause_controller = VllmEnginePauseController(handler.engine_client)
+    handler._pause_lock = asyncio.Lock()
+    if with_idle_monitor:
+        handler.idle_monitor = IdleSleepMonitor(
+            sleep_fn=handler._idle_sleep,
+            timeout=60.0,
+            level=1,
+            escalate_fn=handler._escalate_sleep,
+            escalate_timeout=60.0,
+            escalate_level=2,
+        )
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_idle_sleep_reuses_sleep_route_path():
+    handler = _make_handler()
+
+    result = await handler._idle_sleep(1)
+
+    assert result["status"] == "ok"
+    handler.generate_endpoint.unregister_endpoint_instance.assert_awaited_once()
+    handler.engine_client.pause_generation.assert_awaited_once()
+    handler.engine_client.sleep.assert_awaited_once_with(1)
+    # The sleep path reports the transition back to the monitor.
+    assert handler.idle_monitor.state is IdleSleepState.ASLEEP
+    assert handler.idle_monitor.current_level == 1
+
+
+@pytest.mark.asyncio
+async def test_external_sleep_and_wake_update_idle_monitor():
+    handler = _make_handler()
+
+    await handler.sleep({"level": 2})
+    assert handler.idle_monitor.state is IdleSleepState.ASLEEP
+    assert handler.idle_monitor.current_level == 2
+
+    await handler.wake_up({})
+    assert handler.idle_monitor.state is IdleSleepState.WARM
+    assert handler.idle_monitor.current_level is None
+
+
+@pytest.mark.asyncio
+async def test_escalate_sleep_wakes_and_resleeps_deeper():
+    handler = _make_handler()
+    await handler.sleep({"level": 1})
+    handler.engine_client.sleep.reset_mock()
+
+    result = await handler._escalate_sleep(1, 2)
+
+    assert result["status"] == "ok"
+    handler.engine_client.wake_up.assert_awaited_once_with()
+    handler.engine_client.sleep.assert_awaited_once_with(2)
+    # Discovery is not rejoined: escalation happens while unregistered.
+    handler.generate_endpoint.register_endpoint_instance.assert_not_awaited()
+    assert handler._pause_controller.is_paused is True
+
+
+@pytest.mark.asyncio
+async def test_escalate_sleep_requires_sleeping_engine():
+    handler = _make_handler()
+
+    result = await handler._escalate_sleep(1, 2)
+
+    assert result["status"] == "error"
+    handler.engine_client.wake_up.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_escalate_sleep_restores_previous_level_on_failure():
+    handler = _make_handler()
+    await handler.sleep({"level": 1})
+    handler.engine_client.sleep = AsyncMock(
+        side_effect=[RuntimeError("escalate failed"), None]
+    )
+
+    result = await handler._escalate_sleep(1, 2)
+
+    assert result["status"] == "error"
+    assert handler.engine_client.sleep.await_args_list[0].args == (2,)
+    assert handler.engine_client.sleep.await_args_list[1].args == (1,)
+    assert handler._pause_controller.is_paused is True
+
+
+@pytest.mark.asyncio
+async def test_generate_tracks_in_flight_requests():
+    handler = _make_handler()
+    seen_in_flight = []
+
+    async def consume():
+        async for _ in handler.generate({}, SimpleNamespace(id=lambda: "r1")):
+            seen_in_flight.append(handler.idle_monitor.in_flight)
+
+    await consume()
+
+    assert seen_in_flight == [1]
+    assert handler.idle_monitor.in_flight == 0
+
+
+@pytest.mark.asyncio
+async def test_generate_without_idle_monitor_is_noop():
+    handler = _make_handler(with_idle_monitor=False)
+
+    chunks = [
+        chunk async for chunk in handler.generate({}, SimpleNamespace(id=lambda: "r1"))
+    ]
+
+    assert chunks == [{}]
+    assert handler.idle_monitor is None


### PR DESCRIPTION
## Overview:

Adds an opt-in idle sleep TTL to the vLLM backend: a worker that has been idle past a configured timeout puts itself to sleep through the same path as the existing `/engine/sleep` route, freeing its GPU memory until an external controller wakes it. An optional second timeout escalates a sleeping worker to a deeper level to also release pinned host RAM. Proposed in the contribution request below; no Rust changes.

## Details:

- Four new flags, all disabled by default: `--idle-sleep-timeout`, `--idle-sleep-level` (default 1), `--idle-sleep-escalate-timeout`, `--idle-sleep-escalate-level` (default 2). They require `--enable-sleep-mode` and are validated at startup in `cross_validate_config`.
- `idle_sleep.py` is a new stdlib-only idle monitor that tracks last-activity time and in-flight request count, with an injectable time source for deterministic tests. The Decode and Prefill `generate` handlers report activity through a context manager.
- Auto-sleep invokes the same code path as an externally requested sleep (unregister from discovery, drain, engine sleep), single-flighted under the existing pause lock, so routing state stays consistent. Wake remains external via the existing `/engine/wake_up` route, and a successful wake resets the idle timer, so this composes with planner or controller driven scale decisions without changing wake semantics.
- Escalation briefly wakes the engine and re-sleeps at the deeper level, since vLLM cannot deepen a sleep in place. The endpoint stays unregistered throughout, and a failed escalation rolls back to the shallower level. This caveat is documented in the flag help.

Motivation numbers, measured on one H100 with vLLM sleep mode and a small Qwen3 model: a sleeping engine frees ~98% of HBM (73.9 GiB to 1.4 GiB), level-1 wake is ~0.3 s in engine, level-2 wake including weight reload is under 1 s.

Testing: 32 new unit tests across `test_idle_sleep_monitor.py` (importable without vLLM or torch), `test_vllm_idle_sleep_handlers.py`, and additions to `test_backend_args.py`. Existing sleep/wake handler tests remain green and pre-commit is clean.

Implemented with AI assistance (Claude Code); every changed line has been reviewed by the submitter.

## Where should the reviewer start?

`components/src/dynamo/vllm/idle_sleep.py` (the monitor state machine), then `_idle_sleep` and `_escalate_sleep` in `handlers.py`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #11233

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11256" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable idle-sleep controls for vLLM workers, including timeout, sleep level, and optional escalation settings.
  * Enabled automatic idle sleep and wake tracking during request handling for smoother worker power-state management.

* **Bug Fixes**
  * Added validation to prevent unsupported idle-sleep combinations and misconfigurations.
  * Improved handling so idle-sleep behavior only activates when the required engine sleep mode is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->