### PR TITLE
feat(metrics): always-on Prometheus histograms for frontend routing, scheduling, and request-plane ACK (DYN-3401)

### DIFF
--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -149,6 +149,7 @@ where
             prefill_load_estimator,
             overlap_scores_refresh,
             overloaded_worker_provider,
+            worker_type,
         ));
         let (queue_updates, _) = watch::channel(());
         let queue_remote_updates = Arc::clone(&queue);

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -318,13 +318,29 @@ where
     pub async fn mark_prefill_completed(&self, request_id: &str) -> Result<(), SequenceError> {
         self.slots
             .mark_prefill_completed(&request_id.to_string(), Instant::now())?;
+        #[cfg(feature = "metrics")]
+        let update_start = Instant::now();
         self.queue.update().await;
+        #[cfg(feature = "metrics")]
+        super::metrics::SchedulingMetrics::get_or_init()
+            .observe_worker_state_update_to_scheduler(
+                "prefill_completed",
+                update_start.elapsed().as_secs_f64() * 1000.0,
+            );
         Ok(())
     }
 
     pub async fn free(&self, request_id: &str) -> Result<(), SequenceError> {
         self.slots.free(&request_id.to_string(), Instant::now())?;
+        #[cfg(feature = "metrics")]
+        let update_start = Instant::now();
         self.queue.update().await;
+        #[cfg(feature = "metrics")]
+        super::metrics::SchedulingMetrics::get_or_init()
+            .observe_worker_state_update_to_scheduler(
+                "free",
+                update_start.elapsed().as_secs_f64() * 1000.0,
+            );
         Ok(())
     }
 

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -322,11 +322,10 @@ where
         let update_start = Instant::now();
         self.queue.update().await;
         #[cfg(feature = "metrics")]
-        super::metrics::SchedulingMetrics::get_or_init()
-            .observe_worker_state_update_to_scheduler(
-                "prefill_completed",
-                update_start.elapsed().as_secs_f64() * 1000.0,
-            );
+        super::metrics::SchedulingMetrics::get_or_init().observe_worker_state_update_to_scheduler(
+            "prefill_completed",
+            update_start.elapsed().as_secs_f64() * 1000.0,
+        );
         Ok(())
     }
 
@@ -336,11 +335,10 @@ where
         let update_start = Instant::now();
         self.queue.update().await;
         #[cfg(feature = "metrics")]
-        super::metrics::SchedulingMetrics::get_or_init()
-            .observe_worker_state_update_to_scheduler(
-                "free",
-                update_start.elapsed().as_secs_f64() * 1000.0,
-            );
+        super::metrics::SchedulingMetrics::get_or_init().observe_worker_state_update_to_scheduler(
+            "free",
+            update_start.elapsed().as_secs_f64() * 1000.0,
+        );
         Ok(())
     }
 

--- a/lib/kv-router/src/scheduling/metrics.rs
+++ b/lib/kv-router/src/scheduling/metrics.rs
@@ -186,7 +186,9 @@ impl SchedulingMetrics {
 /// Register scheduling metrics with the given registry. Idempotent via the underlying
 /// `OnceLock`-memoized histograms; safe to call once per process from frontend HTTP setup.
 #[cfg(feature = "metrics")]
-pub fn register_scheduling_metrics(registry: &prometheus::Registry) -> Result<(), prometheus::Error> {
+pub fn register_scheduling_metrics(
+    registry: &prometheus::Registry,
+) -> Result<(), prometheus::Error> {
     let m = SchedulingMetrics::get_or_init();
     registry.register(Box::new(m.admission_compute_ms.clone()))?;
     registry.register(Box::new(m.queue_wait_ms.clone()))?;
@@ -197,4 +199,3 @@ pub fn register_scheduling_metrics(registry: &prometheus::Registry) -> Result<()
     registry.register(Box::new(m.worker_state_update_to_scheduler_ms.clone()))?;
     Ok(())
 }
-

--- a/lib/kv-router/src/scheduling/metrics.rs
+++ b/lib/kv-router/src/scheduling/metrics.rs
@@ -61,6 +61,10 @@ pub struct SchedulingMetrics {
     /// waiting for the actor to be scheduled). Complements `queue_wait_ms`, which only
     /// observes the terminal wait once a request is finally admitted.
     pub pending_queue_age_ms: HistogramVec,
+    /// Time for a worker state change (prefill-complete / free) to propagate through
+    /// `LocalScheduler::mark_prefill_completed`/`free` into a completed `queue.update()`
+    /// round trip, labeled by event ("prefill_completed"/"free").
+    pub worker_state_update_to_scheduler_ms: HistogramVec,
 }
 
 #[cfg(feature = "metrics")]
@@ -92,7 +96,7 @@ impl SchedulingMetrics {
                     "Time from enqueueing router work to the router actor starting it, in milliseconds",
                 )
                 .buckets(actor_timing_buckets()),
-                &["worker_type"],
+                &["worker_type", "command"],
             )?,
             actor_poll_gap_ms: HistogramVec::new(
                 HistogramOpts::new(
@@ -118,6 +122,14 @@ impl SchedulingMetrics {
                 .buckets(queue_wait_buckets()),
                 &["worker_type"],
             )?,
+            worker_state_update_to_scheduler_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_worker_state_update_to_scheduler_ms",
+                    "Time for a worker state change (prefill-complete/free) to propagate through a completed queue.update() round trip, in milliseconds",
+                )
+                .buckets(actor_timing_buckets()),
+                &["event"],
+            )?,
         })
     }
 
@@ -139,9 +151,9 @@ impl SchedulingMetrics {
             .observe(ms as f64);
     }
 
-    pub fn observe_actor_mailbox_wait(&self, worker_type: &str, ms: f64) {
+    pub fn observe_actor_mailbox_wait(&self, worker_type: &str, command: &str, ms: f64) {
         self.actor_mailbox_wait_ms
-            .with_label_values(&[worker_type])
+            .with_label_values(&[worker_type, command])
             .observe(ms);
     }
 
@@ -162,6 +174,12 @@ impl SchedulingMetrics {
             .with_label_values(&[worker_type])
             .observe(ms as f64);
     }
+
+    pub fn observe_worker_state_update_to_scheduler(&self, event: &str, ms: f64) {
+        self.worker_state_update_to_scheduler_ms
+            .with_label_values(&[event])
+            .observe(ms);
+    }
 }
 
 /// Register scheduling metrics with the given registry. Idempotent via the underlying
@@ -175,6 +193,7 @@ pub fn register_scheduling_metrics(registry: &prometheus::Registry) -> Result<()
     registry.register(Box::new(m.actor_poll_gap_ms.clone()))?;
     registry.register(Box::new(m.schedule_compute_ms.clone()))?;
     registry.register(Box::new(m.pending_queue_age_ms.clone()))?;
+    registry.register(Box::new(m.worker_state_update_to_scheduler_ms.clone()))?;
     Ok(())
 }
 

--- a/lib/kv-router/src/scheduling/metrics.rs
+++ b/lib/kv-router/src/scheduling/metrics.rs
@@ -29,6 +29,13 @@ fn queue_wait_buckets() -> Vec<f64> {
     prometheus::exponential_buckets(0.01, 3.0, 17).unwrap()
 }
 
+/// Buckets for actor mailbox/poll timing (can be sub-millisecond when healthy, seconds
+/// under real backlog/starvation).
+#[cfg(feature = "metrics")]
+fn actor_timing_buckets() -> Vec<f64> {
+    prometheus::exponential_buckets(0.01, 3.0, 17).unwrap()
+}
+
 #[cfg(feature = "metrics")]
 pub struct SchedulingMetrics {
     /// project_worker_loads + select_worker, labeled by worker_type ("prefill"/"decode").
@@ -37,6 +44,23 @@ pub struct SchedulingMetrics {
     /// Time a request sits parked in the pending heap before admission is attempted,
     /// labeled by worker_type. Wait-time: nothing computing, just queued.
     pub queue_wait_ms: HistogramVec,
+    /// Time from `AdmissionCommand` creation (right before `admission_tx.send`) to the
+    /// actor's `run()` loop receiving it via `rx.recv().await`. Direct evidence of actor
+    /// mailbox backlog / poll starvation, independent of pending-heap capacity waits.
+    pub actor_mailbox_wait_ms: HistogramVec,
+    /// Time between the actor's `run()` loop receiving consecutive commands. Large gaps
+    /// with a non-empty mailbox mean the actor task itself is not getting runtime time;
+    /// with an empty mailbox this is legitimate idle time, so read alongside mailbox depth.
+    pub actor_poll_gap_ms: HistogramVec,
+    /// Full `admit_one` body (project_worker_loads + select_worker + booking), covering
+    /// every return path. Superset of `admission_compute_ms` (which stops after
+    /// select_worker); the gap between the two is booking cost.
+    pub schedule_compute_ms: HistogramVec,
+    /// Age of a pending-heap entry sampled each time `handle_update` confirms it is still
+    /// blocked by `all_workers_prefill_busy` (i.e. genuinely capacity-blocked, not just
+    /// waiting for the actor to be scheduled). Complements `queue_wait_ms`, which only
+    /// observes the terminal wait once a request is finally admitted.
+    pub pending_queue_age_ms: HistogramVec,
 }
 
 #[cfg(feature = "metrics")]
@@ -62,6 +86,38 @@ impl SchedulingMetrics {
                 .buckets(queue_wait_buckets()),
                 &["worker_type"],
             )?,
+            actor_mailbox_wait_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_router_actor_mailbox_wait_ms",
+                    "Time from enqueueing router work to the router actor starting it, in milliseconds",
+                )
+                .buckets(actor_timing_buckets()),
+                &["worker_type"],
+            )?,
+            actor_poll_gap_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_router_actor_poll_gap_ms",
+                    "Time between consecutive router actor mailbox receives, in milliseconds",
+                )
+                .buckets(actor_timing_buckets()),
+                &["worker_type"],
+            )?,
+            schedule_compute_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_router_schedule_compute_ms",
+                    "Full admit_one body (project_worker_loads + select_worker + booking) CPU time, in milliseconds",
+                )
+                .buckets(admission_compute_buckets()),
+                &["worker_type"],
+            )?,
+            pending_queue_age_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_router_pending_queue_age_ms",
+                    "Age of a pending request sampled while still capacity-blocked, in milliseconds",
+                )
+                .buckets(queue_wait_buckets()),
+                &["worker_type"],
+            )?,
         })
     }
 
@@ -82,6 +138,30 @@ impl SchedulingMetrics {
             .with_label_values(&[worker_type])
             .observe(ms as f64);
     }
+
+    pub fn observe_actor_mailbox_wait(&self, worker_type: &str, ms: f64) {
+        self.actor_mailbox_wait_ms
+            .with_label_values(&[worker_type])
+            .observe(ms);
+    }
+
+    pub fn observe_actor_poll_gap(&self, worker_type: &str, ms: f64) {
+        self.actor_poll_gap_ms
+            .with_label_values(&[worker_type])
+            .observe(ms);
+    }
+
+    pub fn observe_schedule_compute(&self, worker_type: &str, ms: f64) {
+        self.schedule_compute_ms
+            .with_label_values(&[worker_type])
+            .observe(ms);
+    }
+
+    pub fn observe_pending_queue_age(&self, worker_type: &str, ms: u64) {
+        self.pending_queue_age_ms
+            .with_label_values(&[worker_type])
+            .observe(ms as f64);
+    }
 }
 
 /// Register scheduling metrics with the given registry. Idempotent via the underlying
@@ -91,6 +171,10 @@ pub fn register_scheduling_metrics(registry: &prometheus::Registry) -> Result<()
     let m = SchedulingMetrics::get_or_init();
     registry.register(Box::new(m.admission_compute_ms.clone()))?;
     registry.register(Box::new(m.queue_wait_ms.clone()))?;
+    registry.register(Box::new(m.actor_mailbox_wait_ms.clone()))?;
+    registry.register(Box::new(m.actor_poll_gap_ms.clone()))?;
+    registry.register(Box::new(m.schedule_compute_ms.clone()))?;
+    registry.register(Box::new(m.pending_queue_age_ms.clone()))?;
     Ok(())
 }
 

--- a/lib/kv-router/src/scheduling/metrics.rs
+++ b/lib/kv-router/src/scheduling/metrics.rs
@@ -140,16 +140,16 @@ impl SchedulingMetrics {
         SCHEDULING_METRICS.get_or_init(|| Self::new().expect("scheduling metrics"))
     }
 
-    pub fn observe_admission_compute(&self, worker_type: &str, ms: u128) {
+    pub fn observe_admission_compute(&self, worker_type: &str, ms: f64) {
         self.admission_compute_ms
             .with_label_values(&[worker_type])
-            .observe(ms as f64);
+            .observe(ms);
     }
 
-    pub fn observe_queue_wait(&self, worker_type: &str, ms: u64) {
+    pub fn observe_queue_wait(&self, worker_type: &str, ms: f64) {
         self.queue_wait_ms
             .with_label_values(&[worker_type])
-            .observe(ms as f64);
+            .observe(ms);
     }
 
     pub fn observe_actor_mailbox_wait(&self, worker_type: &str, command: &str, ms: f64) {
@@ -170,10 +170,10 @@ impl SchedulingMetrics {
             .observe(ms);
     }
 
-    pub fn observe_pending_queue_age(&self, worker_type: &str, ms: u64) {
+    pub fn observe_pending_queue_age(&self, worker_type: &str, ms: f64) {
         self.pending_queue_age_ms
             .with_label_values(&[worker_type])
-            .observe(ms as f64);
+            .observe(ms);
     }
 
     pub fn observe_worker_state_update_to_scheduler(&self, event: &str, ms: f64) {

--- a/lib/kv-router/src/scheduling/metrics.rs
+++ b/lib/kv-router/src/scheduling/metrics.rs
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Full-distribution histograms for the scheduler admission path.
+//!
+//! These record every occurrence, not just ones that cross a DYN_STALL_OP_WARN_MS log
+//! threshold -- the WARN-based `dynamo_stall_op` tracing only samples the tail (whatever
+//! happened to be slow enough to log), which is not a distribution. These histograms give
+//! percentiles over the full population, at negligible per-call cost (a lock-free atomic
+//! bucket increment, no formatting or I/O).
+
+#[cfg(feature = "metrics")]
+use std::sync::OnceLock;
+
+#[cfg(feature = "metrics")]
+use prometheus::{HistogramOpts, HistogramVec};
+
+/// Buckets for CPU-bound admission compute (project_worker_loads + select_worker).
+/// Mirrors `compute_overhead_buckets` in dynamo-llm's router metrics.
+#[cfg(feature = "metrics")]
+fn admission_compute_buckets() -> Vec<f64> {
+    prometheus::exponential_buckets(0.001, 2.0, 15).unwrap()
+}
+
+/// Buckets for queue-wait (an async wait, can run much longer under real backpressure).
+/// Mirrors `async_overhead_buckets` in dynamo-llm's router metrics.
+#[cfg(feature = "metrics")]
+fn queue_wait_buckets() -> Vec<f64> {
+    prometheus::exponential_buckets(0.01, 3.0, 17).unwrap()
+}
+
+#[cfg(feature = "metrics")]
+pub struct SchedulingMetrics {
+    /// project_worker_loads + select_worker, labeled by worker_type ("prefill"/"decode").
+    /// Busy-time: this runs synchronously on the scheduler actor task, no `.await` inside.
+    pub admission_compute_ms: HistogramVec,
+    /// Time a request sits parked in the pending heap before admission is attempted,
+    /// labeled by worker_type. Wait-time: nothing computing, just queued.
+    pub queue_wait_ms: HistogramVec,
+}
+
+#[cfg(feature = "metrics")]
+static SCHEDULING_METRICS: OnceLock<SchedulingMetrics> = OnceLock::new();
+
+#[cfg(feature = "metrics")]
+impl SchedulingMetrics {
+    fn new() -> Result<Self, prometheus::Error> {
+        Ok(Self {
+            admission_compute_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_router_overhead_admission_compute_ms",
+                    "Time in project_worker_loads + select_worker on the scheduler actor task, in milliseconds",
+                )
+                .buckets(admission_compute_buckets()),
+                &["worker_type"],
+            )?,
+            queue_wait_ms: HistogramVec::new(
+                HistogramOpts::new(
+                    "dynamo_router_overhead_queue_wait_ms",
+                    "Time a request sits parked in the pending heap before admission, in milliseconds",
+                )
+                .buckets(queue_wait_buckets()),
+                &["worker_type"],
+            )?,
+        })
+    }
+
+    /// Get or create the metrics, memoized. Safe to call before registration; observations
+    /// before `register()` runs are just not exported until a registry is wired up.
+    pub fn get_or_init() -> &'static SchedulingMetrics {
+        SCHEDULING_METRICS.get_or_init(|| Self::new().expect("scheduling metrics"))
+    }
+
+    pub fn observe_admission_compute(&self, worker_type: &str, ms: u128) {
+        self.admission_compute_ms
+            .with_label_values(&[worker_type])
+            .observe(ms as f64);
+    }
+
+    pub fn observe_queue_wait(&self, worker_type: &str, ms: u64) {
+        self.queue_wait_ms
+            .with_label_values(&[worker_type])
+            .observe(ms as f64);
+    }
+}
+
+/// Register scheduling metrics with the given registry. Idempotent via the underlying
+/// `OnceLock`-memoized histograms; safe to call once per process from frontend HTTP setup.
+#[cfg(feature = "metrics")]
+pub fn register_scheduling_metrics(registry: &prometheus::Registry) -> Result<(), prometheus::Error> {
+    let m = SchedulingMetrics::get_or_init();
+    registry.register(Box::new(m.admission_compute_ms.clone()))?;
+    registry.register(Box::new(m.queue_wait_ms.clone()))?;
+    Ok(())
+}
+

--- a/lib/kv-router/src/scheduling/metrics.rs
+++ b/lib/kv-router/src/scheduling/metrics.rs
@@ -61,9 +61,10 @@ pub struct SchedulingMetrics {
     /// waiting for the actor to be scheduled). Complements `queue_wait_ms`, which only
     /// observes the terminal wait once a request is finally admitted.
     pub pending_queue_age_ms: HistogramVec,
-    /// Time for a worker state change (prefill-complete / free) to propagate through
-    /// `LocalScheduler::mark_prefill_completed`/`free` into a completed `queue.update()`
-    /// round trip, labeled by event ("prefill_completed"/"free").
+    /// Time for `queue.update()` to complete after a worker state change
+    /// (prefill-complete / free), labeled by event ("prefill_completed"/"free").
+    /// Measures the async scheduler actor round-trip only; the synchronous slots
+    /// call that precedes it is not included.
     pub worker_state_update_to_scheduler_ms: HistogramVec,
 }
 
@@ -125,7 +126,7 @@ impl SchedulingMetrics {
             worker_state_update_to_scheduler_ms: HistogramVec::new(
                 HistogramOpts::new(
                     "dynamo_worker_state_update_to_scheduler_ms",
-                    "Time for a worker state change (prefill-complete/free) to propagate through a completed queue.update() round trip, in milliseconds",
+                    "Time for queue.update() to complete after a worker state change (prefill-complete/free), in milliseconds. Measures async actor round-trip only.",
                 )
                 .buckets(actor_timing_buckets()),
                 &["event"],

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -4,6 +4,8 @@
 pub mod config;
 mod filter;
 mod local;
+#[cfg(feature = "metrics")]
+pub mod metrics;
 pub mod overlap_refresh;
 pub mod policy;
 pub mod prefill_load;

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -97,6 +97,9 @@ struct SchedulerQueueActor<
     overlap_scores_refresh: Option<Arc<RF>>,
     overlap_refresh_after: Option<Duration>,
     overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+    /// "prefill" or "decode" — used only to label the `decode_select`/`prefill_select`
+    /// DYN_STALL_OP_TRACE lines; carries no scheduling behavior.
+    worker_type: &'static str,
 }
 
 /// Queue that gates scheduling requests behind a capacity check.
@@ -145,6 +148,7 @@ impl<
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+        worker_type: &'static str,
     ) -> Self {
         if let Some(frac) = threshold_frac {
             tracing::info!("Router queue enabled with threshold fraction {frac}");
@@ -186,6 +190,7 @@ impl<
             overlap_scores_refresh,
             overlap_refresh_after,
             overloaded_worker_provider,
+            worker_type,
         };
         tokio::spawn(actor.run(admission_rx));
         Self {
@@ -218,6 +223,7 @@ impl<
         selector: Sel,
         policy: S,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        worker_type: &'static str,
     ) -> Self {
         Self::new_with_overlap_refresh(
             slots,
@@ -230,6 +236,7 @@ impl<
             prefill_load_estimator,
             None,
             None,
+            worker_type,
         )
     }
 
@@ -244,6 +251,7 @@ impl<
         policy: S,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+        worker_type: &'static str,
     ) -> Self {
         Self::new_with_overlap_refresh(
             slots,
@@ -256,6 +264,7 @@ impl<
             prefill_load_estimator,
             None,
             overloaded_worker_provider,
+            worker_type,
         )
     }
 }
@@ -536,6 +545,9 @@ impl<
             )
             .await;
             let wait_ms = entry.enqueue_at.elapsed().as_millis() as u64;
+            #[cfg(feature = "metrics")]
+            super::metrics::SchedulingMetrics::get_or_init()
+                .observe_queue_wait(self.worker_type, wait_ms);
             if let Some(RefreshedOverlap {
                 tier_overlap_blocks,
                 effective_overlap_blocks,
@@ -573,6 +585,7 @@ impl<
     /// Run the full scheduling pipeline for a single request:
     /// compute projected load -> select worker -> book tracked state -> respond.
     fn admit_one(&self, mut request: SchedulingRequest, decay_now: Instant) {
+        let op_start = Instant::now();
         request.worker_loads = self
             .slots
             .project_worker_loads(request.token_seq.as_deref(), decay_now);
@@ -587,6 +600,54 @@ impl<
             self.selector
                 .select_worker(&workers, &request, eligibility, self.block_size)
         };
+
+        // Full distribution, every call, regardless of DYN_STALL_OP_TRACE: a Prometheus histogram
+        // (cheap atomic bucket increment) rather than a WARN log that only samples the tail.
+        #[cfg(feature = "metrics")]
+        super::metrics::SchedulingMetrics::get_or_init()
+            .observe_admission_compute(self.worker_type, op_start.elapsed().as_millis());
+
+        // Per-op BUSY-time attribution (DYN_STALL_OP_TRACE=1): project_worker_loads + select_worker run
+        // synchronously on the scheduler-actor task (which lives on the frontend runtime), so this is
+        // on-event-loop busy time (no await above). WARN past DYN_STALL_OP_WARN_MS so a residual
+        // frontend stall can be attributed to scheduler admission vs request-path hashing. Zero-cost off.
+        // op name is `decode_select`/`prefill_select` per this queue's worker_type — same underlying
+        // work (project_worker_loads + select_worker), just labeled by which pool it ran for.
+        {
+            static STALL_OP_WARN_MS: std::sync::OnceLock<Option<u128>> = std::sync::OnceLock::new();
+            let warn = *STALL_OP_WARN_MS.get_or_init(|| {
+                if std::env::var("DYN_STALL_OP_TRACE")
+                    .ok()
+                    .is_some_and(|v| v == "1" || v == "true")
+                {
+                    Some(
+                        std::env::var("DYN_STALL_OP_WARN_MS")
+                            .ok()
+                            .and_then(|s| s.parse().ok())
+                            .unwrap_or(50u128),
+                    )
+                } else {
+                    None
+                }
+            });
+            if let Some(warn_ms) = warn {
+                let ms = op_start.elapsed().as_millis();
+                if ms >= warn_ms {
+                    let op = if self.worker_type == "prefill" {
+                        "prefill_select"
+                    } else {
+                        "decode_select"
+                    };
+                    tracing::warn!(
+                        target: "dynamo_stall_op",
+                        op = op,
+                        busy_ms = ms as u64,
+                        isl_tokens = request.isl_tokens,
+                        "scheduler admission busy on actor task"
+                    );
+                }
+            }
+        }
 
         let selection = match selection {
             Ok(s) => s,
@@ -964,6 +1025,7 @@ mod tests {
             selector,
             FcfsPolicy,
             None,
+            "test",
         ));
 
         (queue, slots)
@@ -1037,6 +1099,7 @@ mod tests {
             selector,
             FcfsPolicy,
             prefill_load_estimator,
+            "test",
         ));
 
         (queue, slots, cfg_tx)
@@ -1085,6 +1148,7 @@ mod tests {
             FcfsPolicy,
             None,
             Some(overloaded_worker_provider),
+            "test",
         ));
 
         (queue, slots)
@@ -1194,6 +1258,7 @@ mod tests {
             None,
             Some(refresher),
             None,
+            "test",
         ));
 
         (queue, slots)
@@ -1252,6 +1317,7 @@ mod tests {
             None,
             Some(refresher),
             None,
+            "test",
         ));
 
         (queue, slots)
@@ -1383,6 +1449,7 @@ mod tests {
             DefaultWorkerSelector::new(None, "test"),
             FcfsPolicy,
             None,
+            "test",
         );
 
         let (request, receiver) = make_request("delivery-race", isl);

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -69,10 +69,24 @@ enum AdmissionCommand {
         request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
         ack_tx: oneshot::Sender<()>,
+        #[cfg(feature = "metrics")]
+        sent_at: Instant,
     },
     Update {
         ack_tx: oneshot::Sender<()>,
+        #[cfg(feature = "metrics")]
+        sent_at: Instant,
     },
+}
+
+#[cfg(feature = "metrics")]
+impl AdmissionCommand {
+    fn sent_at(&self) -> Instant {
+        match self {
+            AdmissionCommand::Enqueue { sent_at, .. } => *sent_at,
+            AdmissionCommand::Update { sent_at, .. } => *sent_at,
+        }
+    }
 }
 
 struct SchedulerQueueActor<
@@ -327,6 +341,8 @@ impl<
             request,
             block_hashes: self.prepare_block_hashes_for_refresh(block_hashes),
             ack_tx,
+            #[cfg(feature = "metrics")]
+            sent_at: Instant::now(),
         };
 
         if let Err(error) = self.admission_tx.send(command).await {
@@ -353,7 +369,11 @@ impl<
         let (ack_tx, ack_rx) = oneshot::channel();
         if self
             .admission_tx
-            .send(AdmissionCommand::Update { ack_tx })
+            .send(AdmissionCommand::Update {
+                ack_tx,
+                #[cfg(feature = "metrics")]
+                sent_at: Instant::now(),
+            })
             .await
             .is_ok()
         {
@@ -395,17 +415,37 @@ impl<
 > SchedulerQueueActor<P, C, S, Sel, RF>
 {
     async fn run(mut self, mut rx: mpsc::Receiver<AdmissionCommand>) {
+        #[cfg(feature = "metrics")]
+        let mut last_received_at: Option<Instant> = None;
         while let Some(command) = rx.recv().await {
+            #[cfg(feature = "metrics")]
+            {
+                let received_at = Instant::now();
+                let metrics = super::metrics::SchedulingMetrics::get_or_init();
+                metrics.observe_actor_mailbox_wait(
+                    self.worker_type,
+                    received_at.saturating_duration_since(command.sent_at()).as_secs_f64() * 1000.0,
+                );
+                if let Some(prev) = last_received_at {
+                    metrics.observe_actor_poll_gap(
+                        self.worker_type,
+                        received_at.saturating_duration_since(prev).as_secs_f64() * 1000.0,
+                    );
+                }
+                last_received_at = Some(received_at);
+            }
+
             match command {
                 AdmissionCommand::Enqueue {
                     request,
                     block_hashes,
                     ack_tx,
+                    ..
                 } => {
                     self.handle_enqueue(request, block_hashes);
                     let _ = ack_tx.send(());
                 }
-                AdmissionCommand::Update { ack_tx } => {
+                AdmissionCommand::Update { ack_tx, .. } => {
                     self.handle_update().await;
                     let _ = ack_tx.send(());
                 }
@@ -517,6 +557,13 @@ impl<
             // otherwise constrained request can temporarily stall later
             // schedulable entries until we adopt a cheaper non-HOL strategy.
             if self.all_workers_prefill_busy(threshold, front.request.eligibility(), decay_now) {
+                // Still genuinely capacity-blocked (not just waiting on the actor to be
+                // scheduled) -- sample its current age before breaking out of the drain loop.
+                #[cfg(feature = "metrics")]
+                super::metrics::SchedulingMetrics::get_or_init().observe_pending_queue_age(
+                    self.worker_type,
+                    front.enqueue_at.elapsed().as_millis() as u64,
+                );
                 break;
             }
             let entry = self.pending.pop().expect("heap front vanished before pop");
@@ -565,6 +612,11 @@ impl<
             }
             let admit_now = Instant::now();
             if self.all_workers_prefill_busy(threshold, request.eligibility(), admit_now) {
+                #[cfg(feature = "metrics")]
+                super::metrics::SchedulingMetrics::get_or_init().observe_pending_queue_age(
+                    self.worker_type,
+                    entry.enqueue_at.elapsed().as_millis() as u64,
+                );
                 let isl_tokens = request.isl_tokens;
                 self.pending.push(QueueEntry {
                     key: entry.key,
@@ -585,6 +637,29 @@ impl<
     /// Run the full scheduling pipeline for a single request:
     /// compute projected load -> select worker -> book tracked state -> respond.
     fn admit_one(&self, mut request: SchedulingRequest, decay_now: Instant) {
+        // Covers the entire admit_one body (project_worker_loads + select_worker + booking)
+        // regardless of which early-return path is taken -- a superset of admission_compute_ms,
+        // which only times through select_worker.
+        #[cfg(feature = "metrics")]
+        struct ScheduleComputeGuard {
+            start: Instant,
+            worker_type: &'static str,
+        }
+        #[cfg(feature = "metrics")]
+        impl Drop for ScheduleComputeGuard {
+            fn drop(&mut self) {
+                super::metrics::SchedulingMetrics::get_or_init().observe_schedule_compute(
+                    self.worker_type,
+                    self.start.elapsed().as_secs_f64() * 1000.0,
+                );
+            }
+        }
+        #[cfg(feature = "metrics")]
+        let _schedule_compute_guard = ScheduleComputeGuard {
+            start: Instant::now(),
+            worker_type: self.worker_type,
+        };
+
         let op_start = Instant::now();
         request.worker_loads = self
             .slots

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -600,9 +600,6 @@ impl<
             )
             .await;
             let wait_ms = entry.enqueue_at.elapsed().as_millis() as u64;
-            #[cfg(feature = "metrics")]
-            super::metrics::SchedulingMetrics::get_or_init()
-                .observe_queue_wait(self.worker_type, entry.enqueue_at.elapsed().as_secs_f64() * 1000.0);
             if let Some(RefreshedOverlap {
                 tier_overlap_blocks,
                 effective_overlap_blocks,
@@ -638,6 +635,9 @@ impl<
                 break;
             }
             tracing::debug!("scheduling request from pending queue");
+            #[cfg(feature = "metrics")]
+            super::metrics::SchedulingMetrics::get_or_init()
+                .observe_queue_wait(self.worker_type, entry.enqueue_at.elapsed().as_secs_f64() * 1000.0);
             self.admit_one(request, admit_now);
         }
     }

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -119,6 +119,7 @@ struct SchedulerQueueActor<
     overlap_refresh_after: Option<Duration>,
     overloaded_worker_provider: Option<OverloadedWorkerProvider>,
     /// "prefill" or "decode" — labels scheduling metrics by worker pool; carries no scheduling behavior.
+    #[cfg_attr(not(feature = "metrics"), allow(dead_code))]
     worker_type: &'static str,
 }
 
@@ -667,6 +668,7 @@ impl<
             worker_type: self.worker_type,
         };
 
+        #[cfg(feature = "metrics")]
         let op_start = Instant::now();
         request.worker_loads = self
             .slots

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -570,7 +570,7 @@ impl<
                 #[cfg(feature = "metrics")]
                 super::metrics::SchedulingMetrics::get_or_init().observe_pending_queue_age(
                     self.worker_type,
-                    front.enqueue_at.elapsed().as_millis() as u64,
+                    front.enqueue_at.elapsed().as_secs_f64() * 1000.0,
                 );
                 break;
             }
@@ -602,7 +602,7 @@ impl<
             let wait_ms = entry.enqueue_at.elapsed().as_millis() as u64;
             #[cfg(feature = "metrics")]
             super::metrics::SchedulingMetrics::get_or_init()
-                .observe_queue_wait(self.worker_type, wait_ms);
+                .observe_queue_wait(self.worker_type, entry.enqueue_at.elapsed().as_secs_f64() * 1000.0);
             if let Some(RefreshedOverlap {
                 tier_overlap_blocks,
                 effective_overlap_blocks,
@@ -623,7 +623,7 @@ impl<
                 #[cfg(feature = "metrics")]
                 super::metrics::SchedulingMetrics::get_or_init().observe_pending_queue_age(
                     self.worker_type,
-                    entry.enqueue_at.elapsed().as_millis() as u64,
+                    entry.enqueue_at.elapsed().as_secs_f64() * 1000.0,
                 );
                 let isl_tokens = request.isl_tokens;
                 self.pending.push(QueueEntry {
@@ -687,7 +687,7 @@ impl<
 
         #[cfg(feature = "metrics")]
         super::metrics::SchedulingMetrics::get_or_init()
-            .observe_admission_compute(self.worker_type, op_start.elapsed().as_millis());
+            .observe_admission_compute(self.worker_type, op_start.elapsed().as_secs_f64() * 1000.0);
 
         let selection = match selection {
             Ok(s) => s,

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -432,7 +432,10 @@ impl<
                 metrics.observe_actor_mailbox_wait(
                     self.worker_type,
                     command.kind(),
-                    received_at.saturating_duration_since(command.sent_at()).as_secs_f64() * 1000.0,
+                    received_at
+                        .saturating_duration_since(command.sent_at())
+                        .as_secs_f64()
+                        * 1000.0,
                 );
                 if let Some(prev) = last_received_at {
                     metrics.observe_actor_poll_gap(
@@ -636,8 +639,10 @@ impl<
             }
             tracing::debug!("scheduling request from pending queue");
             #[cfg(feature = "metrics")]
-            super::metrics::SchedulingMetrics::get_or_init()
-                .observe_queue_wait(self.worker_type, entry.enqueue_at.elapsed().as_secs_f64() * 1000.0);
+            super::metrics::SchedulingMetrics::get_or_init().observe_queue_wait(
+                self.worker_type,
+                entry.enqueue_at.elapsed().as_secs_f64() * 1000.0,
+            );
             self.admit_one(request, admit_now);
         }
     }

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -118,8 +118,7 @@ struct SchedulerQueueActor<
     overlap_scores_refresh: Option<Arc<RF>>,
     overlap_refresh_after: Option<Duration>,
     overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-    /// "prefill" or "decode" — used only to label the `decode_select`/`prefill_select`
-    /// DYN_STALL_OP_TRACE lines; carries no scheduling behavior.
+    /// "prefill" or "decode" — labels scheduling metrics by worker pool; carries no scheduling behavior.
     worker_type: &'static str,
 }
 
@@ -684,53 +683,9 @@ impl<
                 .select_worker(&workers, &request, eligibility, self.block_size)
         };
 
-        // Full distribution, every call, regardless of DYN_STALL_OP_TRACE: a Prometheus histogram
-        // (cheap atomic bucket increment) rather than a WARN log that only samples the tail.
         #[cfg(feature = "metrics")]
         super::metrics::SchedulingMetrics::get_or_init()
             .observe_admission_compute(self.worker_type, op_start.elapsed().as_millis());
-
-        // Per-op BUSY-time attribution (DYN_STALL_OP_TRACE=1): project_worker_loads + select_worker run
-        // synchronously on the scheduler-actor task (which lives on the frontend runtime), so this is
-        // on-event-loop busy time (no await above). WARN past DYN_STALL_OP_WARN_MS so a residual
-        // frontend stall can be attributed to scheduler admission vs request-path hashing. Zero-cost off.
-        // op name is `decode_select`/`prefill_select` per this queue's worker_type — same underlying
-        // work (project_worker_loads + select_worker), just labeled by which pool it ran for.
-        {
-            static STALL_OP_WARN_MS: std::sync::OnceLock<Option<u128>> = std::sync::OnceLock::new();
-            let warn = *STALL_OP_WARN_MS.get_or_init(|| {
-                if std::env::var("DYN_STALL_OP_TRACE")
-                    .ok()
-                    .is_some_and(|v| v == "1" || v == "true")
-                {
-                    Some(
-                        std::env::var("DYN_STALL_OP_WARN_MS")
-                            .ok()
-                            .and_then(|s| s.parse().ok())
-                            .unwrap_or(50u128),
-                    )
-                } else {
-                    None
-                }
-            });
-            if let Some(warn_ms) = warn {
-                let ms = op_start.elapsed().as_millis();
-                if ms >= warn_ms {
-                    let op = if self.worker_type == "prefill" {
-                        "prefill_select"
-                    } else {
-                        "decode_select"
-                    };
-                    tracing::warn!(
-                        target: "dynamo_stall_op",
-                        op = op,
-                        busy_ms = ms as u64,
-                        isl_tokens = request.isl_tokens,
-                        "scheduler admission busy on actor task"
-                    );
-                }
-            }
-        }
 
         let selection = match selection {
             Ok(s) => s,

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -87,6 +87,13 @@ impl AdmissionCommand {
             AdmissionCommand::Update { sent_at, .. } => *sent_at,
         }
     }
+
+    fn kind(&self) -> &'static str {
+        match self {
+            AdmissionCommand::Enqueue { .. } => "enqueue",
+            AdmissionCommand::Update { .. } => "update",
+        }
+    }
 }
 
 struct SchedulerQueueActor<
@@ -424,6 +431,7 @@ impl<
                 let metrics = super::metrics::SchedulingMetrics::get_or_init();
                 metrics.observe_actor_mailbox_wait(
                     self.worker_type,
+                    command.kind(),
                     received_at.saturating_duration_since(command.sent_at()).as_secs_f64() * 1000.0,
                 );
                 if let Some(prev) = last_received_at {

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -5,7 +5,7 @@ use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
     sync::Arc,
-    time::{SystemTime, UNIX_EPOCH},
+    time::{Instant, SystemTime, UNIX_EPOCH},
 };
 
 use axum::{
@@ -25,6 +25,7 @@ use base64::Engine as _;
 use bytes::Bytes;
 use dynamo_runtime::config::environment_names::llm as env_llm;
 use dynamo_runtime::{
+    metrics::frontend_perf::HTTP_TO_PREPROCESS_WAIT_MS,
     pipeline::{AsyncEngineContextProvider, Context},
     protocols::annotated::AnnotationsProvider,
 };
@@ -1551,6 +1552,8 @@ async fn chat_completions(
     mut request: Context<NvCreateChatCompletionRequest>,
     mut stream_handle: ConnectionHandle,
 ) -> Result<Response, ErrorResponse> {
+    let http_accepted_at = Instant::now();
+
     // return a 503 if the service is not ready
     check_ready(&state)?;
 
@@ -1640,6 +1643,8 @@ async fn chat_completions(
         .create_response_collector(&metric_model);
 
     let annotations = request.annotations();
+
+    HTTP_TO_PREPROCESS_WAIT_MS.observe(http_accepted_at.elapsed().as_secs_f64() * 1000.0);
 
     // issue the generate call on the engine
     let stream = engine.generate(request).await.map_err(|e| {

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -661,7 +661,8 @@ impl HttpServiceConfigBuilder {
         // Full-distribution scheduler admission histograms (admission_compute_ms, queue_wait_ms) --
         // complements RoutingOverheadMetrics with the pieces that live inside dynamo-kv-router's
         // scheduler actor, which RoutingOverheadMetrics (measured at the KvRouter caller) can't see.
-        if let Err(e) = dynamo_kv_router::scheduling::metrics::register_scheduling_metrics(&registry)
+        if let Err(e) =
+            dynamo_kv_router::scheduling::metrics::register_scheduling_metrics(&registry)
         {
             tracing::warn!("Failed to register scheduling metrics: {}", e);
         }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -657,6 +657,14 @@ impl HttpServiceConfigBuilder {
         if let Err(e) = ensure_request_plane_metrics_registered_prometheus(&registry) {
             tracing::warn!("Failed to register request-plane metrics: {}", e);
         }
+
+        // Full-distribution scheduler admission histograms (admission_compute_ms, queue_wait_ms) --
+        // complements RoutingOverheadMetrics with the pieces that live inside dynamo-kv-router's
+        // scheduler actor, which RoutingOverheadMetrics (measured at the KvRouter caller) can't see.
+        if let Err(e) = dynamo_kv_router::scheduling::metrics::register_scheduling_metrics(&registry)
+        {
+            tracing::warn!("Failed to register scheduling metrics: {}", e);
+        }
         if let Err(e) = ensure_frontend_perf_metrics_registered_prometheus(&registry) {
             tracing::warn!("Failed to register frontend perf metrics: {}", e);
         }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -521,12 +521,7 @@ where
         }
 
         HASH_BLOCKS_MS.observe(hash_elapsed.as_secs_f64() * 1000.0);
-        HASH_SEQ_MS.observe(
-            seq_hash_elapsed
-                .saturating_sub(hash_elapsed)
-                .as_secs_f64()
-                * 1000.0,
-        );
+        HASH_SEQ_MS.observe(seq_hash_elapsed.saturating_sub(hash_elapsed).as_secs_f64() * 1000.0);
         INDEX_LOOKUP_MS.observe(indexer_duration.as_secs_f64() * 1000.0);
         SCHEDULE_MS.observe(
             total_elapsed
@@ -534,7 +529,6 @@ where
                 .as_secs_f64()
                 * 1000.0,
         );
-
 
         // Observe per-request shared cache metrics.
         if let Some(hits) = sc_hits_for_metrics

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -24,6 +24,7 @@ use dynamo_runtime::{
     component::{Client, Endpoint},
     discovery::DiscoveryQuery,
     error::{DynamoError, ErrorType},
+    metrics::frontend_perf::{HASH_BLOCKS_MS, HASH_SEQ_MS, INDEX_LOOKUP_MS, SCHEDULE_MS},
     pipeline::{
         AsyncEngine, AsyncEngineContextProvider, Error, ManyOut, ResponseStream, SingleIn,
         async_trait, error::PipelineError,
@@ -518,6 +519,22 @@ where
                 total_elapsed,
             );
         }
+
+        HASH_BLOCKS_MS.observe(hash_elapsed.as_secs_f64() * 1000.0);
+        HASH_SEQ_MS.observe(
+            seq_hash_elapsed
+                .saturating_sub(hash_elapsed)
+                .as_secs_f64()
+                * 1000.0,
+        );
+        INDEX_LOOKUP_MS.observe(indexer_duration.as_secs_f64() * 1000.0);
+        SCHEDULE_MS.observe(
+            total_elapsed
+                .saturating_sub(find_matches_elapsed)
+                .as_secs_f64()
+                * 1000.0,
+        );
+
 
         // Observe per-request shared cache metrics.
         if let Some(hits) = sc_hits_for_metrics

--- a/lib/llm/src/kv_router/prefill_router/execution.rs
+++ b/lib/llm/src/kv_router/prefill_router/execution.rs
@@ -15,6 +15,7 @@ use dynamo_runtime::{
     protocols::maybe_error::MaybeError,
 };
 
+use super::trace::{self, PrefillTrace};
 use super::{
     InnerPrefillRouter, PrefillError, PrefillQueryOutcome, PrefillResolveDecision, PrefillRouter,
 };
@@ -217,6 +218,7 @@ impl PrefillRouter {
         request: SingleIn<PreprocessedRequest>,
         target_worker: Option<u64>,
         phase_transition_permit: Option<OwnedSemaphorePermit>,
+        mut prefill_trace: Option<PrefillTrace>,
     ) -> Result<PrefillCompletion, PrefillError> {
         let router = router.ok_or(PrefillError::NotActivated)?;
         // Clone tracker before request is consumed by generate_to_worker.
@@ -228,33 +230,24 @@ impl PrefillRouter {
             InnerPrefillRouter::SimpleRouter(_) => target_worker.map(|worker_id| (worker_id, None)),
             InnerPrefillRouter::KvRouter(_) => None,
         };
+
+        // (c) just before generate_to_worker dispatch. Take an in-flight guard for
+        // the target CTX worker so the trace shows whether the frontend keeps each
+        // CTX densely fed (inflight ≫ 1) or trickles (≈ 1–2). The guard increments
+        // now, WARNs the new depth, and decrements on drop — leak-proof across all
+        // return paths below. Both guard + trace are no-ops when DYN_PREFILL_TRACE
+        // is off. The gauge keys on `target_worker` (the resolved CTX worker on the
+        // spawned and NoBootstrapEndpoint paths); on the Unavailable fallback path
+        // the router picks internally and target_worker is None — gauge skipped.
+        if let Some(t) = prefill_trace.as_mut() {
+            t.mark_dispatched();
+        }
+        let _inflight_guard = trace::inflight_guard(target_worker);
+
         let mut prefill_response = router
             .generate_to_worker(request, target_worker)
             .await
-            .map_err(|e| {
-                // A shed prefill worker returns ResourceExhausted. Carry it as the
-                // source so the chain stays downcastable to 503; boxing the raw
-                // anyhow error instead would hide that identity.
-                if match_error_chain(e.as_ref(), &[ErrorType::ResourceExhausted], &[]) {
-                    tracing::warn!(
-                        worker_error = %e,
-                        "Request rejected by prefill worker (at capacity) — returning HTTP 503"
-                    );
-                    return PrefillError::PrefillError(
-                        "prefill worker overloaded".to_string(),
-                        Some(Box::new(
-                            DynamoError::builder()
-                                .error_type(ErrorType::ResourceExhausted)
-                                .message(e.to_string())
-                                .build(),
-                        )),
-                    );
-                }
-                PrefillError::PrefillError(
-                    "failed to route to prefill worker".to_string(),
-                    Some(e.into()),
-                )
-            })?;
+            .map_err(map_generate_to_worker_error)?;
 
         // Release the phase barrier now that routing completed and worker recording already ran.
         // Decode may proceed without waiting for prefill output streaming to finish.
@@ -266,6 +259,11 @@ impl PrefillRouter {
                 None,
             ));
         };
+
+        // (d) first response item from the CTX worker (= prefill compute + KV-ready).
+        if let Some(t) = prefill_trace.as_mut() {
+            t.mark_first_response();
+        }
 
         // Record when prefill result arrived at the router (for KV transfer latency metric).
         // This is after drop(phase_transition_permit) and after first_output is received.
@@ -295,6 +293,14 @@ impl PrefillRouter {
                     .as_ref()
                     .and_then(|u| u.prompt_tokens_details.clone());
             }
+        }
+
+        // (e) prefill stream ended. Emit the single per-request lifecycle summary
+        // here — this is the point where the prefill output stream is fully drained
+        // and we have a clean, successful lifecycle (a→e all observed). Error
+        // returns above drop the trace without emitting (incomplete lifecycle).
+        if let Some(t) = prefill_trace.take() {
+            t.emit();
         }
 
         let Some(output) = &first_output.data else {
@@ -337,6 +343,7 @@ impl PrefillRouter {
         prefill_request: SingleIn<PreprocessedRequest>,
         target_worker: Option<u64>,
         phase_transition_permit: OwnedSemaphorePermit,
+        prefill_trace: Option<PrefillTrace>,
     ) {
         let router = self.prefill_router.get().cloned();
         // Capture current span to propagate trace context to the spawned task
@@ -349,6 +356,7 @@ impl PrefillRouter {
                     prefill_request,
                     target_worker,
                     Some(phase_transition_permit),
+                    prefill_trace,
                 )
                 .await
                 {
@@ -457,6 +465,35 @@ impl PrefillRouter {
     pub fn enforce_disagg(&self) -> bool {
         self.enforce_disagg
     }
+}
+
+/// Map a `generate_to_worker` error into a `PrefillError`. Extracted verbatim
+/// from the former inline `.map_err(...)` closure so the dispatch site can use
+/// `.map_err(map_generate_to_worker_error)?` while the in-flight RAII guard
+/// cleans up the gauge on the error path.
+fn map_generate_to_worker_error(e: anyhow::Error) -> PrefillError {
+    // A shed prefill worker returns ResourceExhausted. Carry it as the
+    // source so the chain stays downcastable to 503; boxing the raw
+    // anyhow error instead would hide that identity.
+    if match_error_chain(e.as_ref(), &[ErrorType::ResourceExhausted], &[]) {
+        tracing::warn!(
+            worker_error = %e,
+            "Request rejected by prefill worker (at capacity) — returning HTTP 503"
+        );
+        return PrefillError::PrefillError(
+            "prefill worker overloaded".to_string(),
+            Some(Box::new(
+                DynamoError::builder()
+                    .error_type(ErrorType::ResourceExhausted)
+                    .message(e.to_string())
+                    .build(),
+            )),
+        );
+    }
+    PrefillError::PrefillError(
+        "failed to route to prefill worker".to_string(),
+        Some(e.into()),
+    )
 }
 
 fn prefill_worker_info(

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -27,6 +27,7 @@ use crate::{
 mod activation;
 mod execution;
 mod inner;
+mod trace;
 mod types;
 
 use inner::InnerPrefillRouter;
@@ -84,11 +85,21 @@ impl
         request: SingleIn<PreprocessedRequest>,
         next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
     ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
+        // (a) arrival: capture as early as possible, before any work. Zero-cost
+        // when DYN_PREFILL_TRACE is off (the Instant is cheap; the trace handle
+        // below is None and short-circuits everything downstream).
+        let trace_arrival = std::time::Instant::now();
+
         // Extract request data while preserving context
         let (mut req, context) = request.into_parts();
         let request_id = context.id().to_string();
         let metadata = context.metadata().clone();
         let engine_ctx = context.context();
+
+        // Per-request prefill trace (None unless DYN_PREFILL_TRACE on). isl_tokens
+        // = prompt token count of the original request.
+        let mut prefill_trace =
+            trace::PrefillTrace::new(&request_id, req.token_ids.len(), trace_arrival);
 
         // Save original max_tokens for decode
         let original_max_tokens = req.stop_conditions.max_tokens;
@@ -139,6 +150,10 @@ impl
                 dp_rank,
                 bootstrap_info,
             } => {
+                // (b) worker resolved/selected.
+                if let Some(t) = prefill_trace.as_mut() {
+                    t.mark_selected(Some(worker_id));
+                }
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, Some(worker_id))?;
 
@@ -168,7 +183,14 @@ impl
 
                 // Pass the phase barrier to the spawned task. It is released after routing
                 // completes so worker recording finishes before phase changes to Decode.
-                self.spawn_prefill_task(prefill_context, Some(worker_id), prefill_phase_barrier);
+                // The prefill trace (carrying a/b) is moved into the spawned task, which
+                // is the path that runs under load; it records c/d/e and emits there.
+                self.spawn_prefill_task(
+                    prefill_context,
+                    Some(worker_id),
+                    prefill_phase_barrier,
+                    prefill_trace.take(),
+                );
 
                 (
                     Ok(PrefillOutcome::Bootstrap {
@@ -215,6 +237,10 @@ impl
                 worker_id: resolved_wid,
                 dp_rank: resolved_dp_rank,
             } => {
+                // (b) worker resolved/selected.
+                if let Some(t) = prefill_trace.as_mut() {
+                    t.mark_selected(Some(resolved_wid));
+                }
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, Some(resolved_wid))?;
 
@@ -242,6 +268,7 @@ impl
                     prefill_context,
                     Some(resolved_wid),
                     None,
+                    prefill_trace.take(),
                 )
                 .await?;
                 (
@@ -254,6 +281,12 @@ impl
                 )
             }
             PrefillResolveDecision::Unavailable | PrefillResolveDecision::NotActivated => {
+                // (b) no worker resolved upfront here; the router selects one inside
+                // execute_prefill. Mark select wall now with the preselected pin (may
+                // be None — worker attribution for this path is best-effort).
+                if let Some(t) = prefill_trace.as_mut() {
+                    t.mark_selected(preselected_worker);
+                }
                 let topology_constraints =
                     self.preflight_kv_transfer_constraints(endpoint_id, None)?;
 
@@ -278,6 +311,7 @@ impl
                     prefill_context,
                     preselected_worker,
                     None,
+                    prefill_trace.take(),
                 )
                 .await?;
                 let prefill_worker_id = completion

--- a/lib/llm/src/kv_router/prefill_router/trace.rs
+++ b/lib/llm/src/kv_router/prefill_router/trace.rs
@@ -1,0 +1,181 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Gated prefill-path instrumentation (DYN_PREFILL_TRACE).
+//!
+//! Localizes where a disagg PREFILL request spends its pre-decode time and
+//! whether the frontend keeps each CTX worker densely fed. Entirely zero-cost
+//! when `DYN_PREFILL_TRACE` is unset: the gate is parsed ONCE via `OnceLock`
+//! (mirroring the `DYN_STALL_OP_TRACE` pattern in `kv_router.rs`), and every
+//! emit site early-returns on the cached bool before touching the gauge or
+//! formatting any field.
+//!
+//! Two signals (both `tracing::warn!`, distinct targets):
+//! - `dynamo_prefill_trace`: ONE per request with select_ms / dispatch_gap_ms /
+//!   prefill_first_ms / prefill_total_ms — localizes the time.
+//! - `dynamo_prefill_inflight`: emitted on each in-flight increment, showing
+//!   per-CTX-worker concurrency. inflight ≫ 1 ⇒ frontend feeds densely;
+//!   inflight ≈ 1–2 ⇒ frontend under-dispatches.
+
+use std::sync::OnceLock;
+use std::time::Instant;
+
+use dashmap::DashMap;
+use dynamo_kv_router::protocols::WorkerId;
+
+/// Parse `DYN_PREFILL_TRACE` once. `1`/`true` enable; anything else (or unset)
+/// disables. Cached for the process lifetime so the hot path pays only an
+/// atomic load when the flag is off.
+#[inline]
+pub(super) fn prefill_trace_enabled() -> bool {
+    static ENABLED: OnceLock<bool> = OnceLock::new();
+    *ENABLED.get_or_init(|| {
+        std::env::var("DYN_PREFILL_TRACE")
+            .ok()
+            .is_some_and(|v| v == "1" || v == "true")
+    })
+}
+
+/// Process-global per-CTX-worker in-flight prefill gauge. `WorkerId` is a
+/// numeric internal id, but per the scheduling guardrail we keep this on a
+/// standard hash collection (DashMap's default SipHash) — it is an
+/// instrumentation side-table, not a routing hot-path map. Only allocated when
+/// the flag is on (first `inflight_inc` call).
+fn inflight_map() -> &'static DashMap<WorkerId, usize> {
+    static MAP: OnceLock<DashMap<WorkerId, usize>> = OnceLock::new();
+    MAP.get_or_init(DashMap::new)
+}
+
+/// RAII guard for the per-CTX-worker in-flight prefill count. Constructing it
+/// (via [`inflight_guard`]) increments the gauge for `worker` and WARNs the new
+/// depth; dropping it decrements. This makes the gauge leak-proof across every
+/// exit path of `execute_prefill` (early error returns, `?`, success, and the
+/// spawned task being cancelled) without scattering manual decrements.
+///
+/// `None` is returned when the flag is off or no target worker is known, so the
+/// hot path holds an `Option<InflightGuard>` that does nothing when off.
+pub(super) struct InflightGuard {
+    worker: WorkerId,
+}
+
+impl Drop for InflightGuard {
+    fn drop(&mut self) {
+        if let Some(mut entry) = inflight_map().get_mut(&self.worker) {
+            *entry = entry.saturating_sub(1);
+        }
+    }
+}
+
+/// Increment the in-flight count for `worker`, WARN the new depth, and return a
+/// guard that decrements on drop. Returns `None` (no-op) when the flag is off
+/// or `worker` is `None` (e.g. the Unavailable fallback path where the router
+/// picks the worker internally and no target id is known at dispatch).
+pub(super) fn inflight_guard(worker: Option<WorkerId>) -> Option<InflightGuard> {
+    if !prefill_trace_enabled() {
+        return None;
+    }
+    let worker = worker?;
+    let inflight = {
+        let mut entry = inflight_map().entry(worker).or_insert(0);
+        *entry += 1;
+        *entry
+    };
+    tracing::warn!(
+        target: "dynamo_prefill_inflight",
+        worker = worker,
+        inflight = inflight,
+        "prefill in-flight gauge (increment)"
+    );
+    Some(InflightGuard { worker })
+}
+
+/// Per-request lifecycle handle. Carries the timestamps captured in the
+/// generate() path (arrival `a`, post-select `b`) across the spawn boundary
+/// into `execute_prefill`, which fills in dispatch (`c`), first-response (`d`),
+/// and stream-end (`e`) and emits the single per-request summary on drop-free
+/// completion via [`PrefillTrace::emit`].
+///
+/// Cheap to construct ([`PrefillTrace::new`] returns `None` when the flag is
+/// off), so callers thread `Option<PrefillTrace>` and skip all work when off.
+pub(super) struct PrefillTrace {
+    request_id: String,
+    worker_id: Option<WorkerId>,
+    isl_tokens: usize,
+    /// a: request arrival/entry into PrefillRouter::generate.
+    arrival: Instant,
+    /// b: after find_best_match_details/resolve returned the CTX worker.
+    selected: Instant,
+    /// c: just before generate_to_worker dispatch (set in execute_prefill).
+    dispatched: Option<Instant>,
+    /// d: first response item from the CTX worker (set in execute_prefill).
+    first_response: Option<Instant>,
+}
+
+impl PrefillTrace {
+    /// Construct a trace anchored at arrival `a`. Returns `None` (zero work
+    /// downstream) when `DYN_PREFILL_TRACE` is off.
+    pub(super) fn new(request_id: &str, isl_tokens: usize, arrival: Instant) -> Option<Self> {
+        if !prefill_trace_enabled() {
+            return None;
+        }
+        Some(Self {
+            request_id: request_id.to_string(),
+            worker_id: None,
+            isl_tokens,
+            arrival,
+            // selected is rewritten by mark_selected; default to arrival so
+            // select_ms is 0 if a caller never calls it.
+            selected: arrival,
+            dispatched: None,
+            first_response: None,
+        })
+    }
+
+    /// Record b (worker resolved) and the target CTX worker id.
+    pub(super) fn mark_selected(&mut self, worker_id: Option<WorkerId>) {
+        self.selected = Instant::now();
+        self.worker_id = worker_id;
+    }
+
+    /// Record c (just before generate_to_worker dispatch).
+    pub(super) fn mark_dispatched(&mut self) {
+        self.dispatched = Some(Instant::now());
+    }
+
+    /// Record d (first response item from the CTX worker), once.
+    pub(super) fn mark_first_response(&mut self) {
+        if self.first_response.is_none() {
+            self.first_response = Some(Instant::now());
+        }
+    }
+
+    /// Emit the single per-request summary. `e` (stream end) is `Instant::now()`
+    /// at call time. Gaps:
+    ///   select_ms        = b - a
+    ///   dispatch_gap_ms  = c - b
+    ///   prefill_first_ms = d - c
+    ///   prefill_total_ms = e - c
+    pub(super) fn emit(self) {
+        let end = Instant::now();
+        let select_ms = self.selected.duration_since(self.arrival).as_millis() as u64;
+        // c falls back to b if a synchronous path never marked dispatch.
+        let dispatched = self.dispatched.unwrap_or(self.selected);
+        let dispatch_gap_ms = dispatched.duration_since(self.selected).as_millis() as u64;
+        let prefill_first_ms = self
+            .first_response
+            .map(|d| d.duration_since(dispatched).as_millis() as u64);
+        let prefill_total_ms = end.duration_since(dispatched).as_millis() as u64;
+
+        tracing::warn!(
+            target: "dynamo_prefill_trace",
+            request_id = %self.request_id,
+            worker = self.worker_id,
+            isl_tokens = self.isl_tokens,
+            select_ms = select_ms,
+            dispatch_gap_ms = dispatch_gap_ms,
+            prefill_first_ms = prefill_first_ms,
+            prefill_total_ms = prefill_total_ms,
+            "prefill request lifecycle"
+        );
+    }
+}

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -318,10 +318,20 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         {
             static FIRST: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
             let first = !FIRST.swap(true, std::sync::atomic::Ordering::Relaxed);
-            match request.routing.as_ref().and_then(|r| r.conversation_id.as_deref()) {
-                Some(cid) if first => tracing::info!(request_id = %context_id, conversation_id = %cid, dp_rank, "exp-H convid forwarded to worker (first; rest at debug)"),
-                Some(cid) => tracing::debug!(request_id = %context_id, conversation_id = %cid, dp_rank, "exp-H convid forwarded to worker"),
-                None if first => tracing::warn!(request_id = %context_id, dp_rank, "exp-H convid ABSENT on first routed request — conv-affinity will NOT engage (session_control missing?)"),
+            match request
+                .routing
+                .as_ref()
+                .and_then(|r| r.conversation_id.as_deref())
+            {
+                Some(cid) if first => {
+                    tracing::info!(request_id = %context_id, conversation_id = %cid, dp_rank, "exp-H convid forwarded to worker (first; rest at debug)")
+                }
+                Some(cid) => {
+                    tracing::debug!(request_id = %context_id, conversation_id = %cid, dp_rank, "exp-H convid forwarded to worker")
+                }
+                None if first => {
+                    tracing::warn!(request_id = %context_id, dp_rank, "exp-H convid ABSENT on first routed request — conv-affinity will NOT engage (session_control missing?)")
+                }
                 None => tracing::debug!(request_id = %context_id, dp_rank, "exp-H convid ABSENT"),
             }
         }

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -663,6 +663,20 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             if is_prefill
                                 && let Some(delay_ms) = signal.handoff_delay_ms
                             {
+                                if let Some(threshold_ms) =
+                                    dynamo_mocker::common::utils::mock_kv_wait_timeout_ms()
+                                {
+                                    if delay_ms as u64 >= threshold_ms {
+                                        tracing::warn!(
+                                            target: "dynamo_stall_op",
+                                            op = "mock_kv_timeout",
+                                            uuid = %signal.uuid,
+                                            wait_ms = delay_ms as u64,
+                                            worker_type = "Prefill",
+                                            "mock KV transfer timeout: handoff delay exceeded budget"
+                                        );
+                                    }
+                                }
                                 sleep_precise(Duration::from_secs_f64(delay_ms / 1000.0)).await;
                             }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -35,8 +35,9 @@ use std::time::{Duration, Instant};
 
 use dynamo_runtime::dynamo_nvtx_range;
 use dynamo_runtime::metrics::frontend_perf::{
-    DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US, STAGE_DURATION_SECONDS, STAGE_PREPROCESS,
-    StageGuard, TEMPLATE_SECONDS, TOKENIZE_SECONDS,
+    DETOKENIZE_TOKEN_COUNT, DETOKENIZE_TOTAL_US, REQUEST_PREPROCESS_WAIT_MS,
+    STAGE_DURATION_SECONDS, STAGE_PREPROCESS, StageGuard, TEMPLATE_SECONDS, TOKENIZE_ENCODE_MS,
+    TOKENIZE_SECONDS,
 };
 use std::{collections::HashMap, pin::Pin, sync::Arc};
 use tracing;
@@ -1778,7 +1779,9 @@ impl OpenAIPreprocessor {
             prompt.to_string()
         };
         let tokenizer = self.tokenizer.clone();
+        let tokenizer_call_start = Instant::now();
         let encoding = tokio::task::spawn_blocking(move || tokenizer.encode(&owned)).await??;
+        TOKENIZE_ENCODE_MS.observe(tokenizer_call_start.elapsed().as_secs_f64() * 1000.0);
         if let Some(t) = tracker {
             t.record_tokenize_latency(encode_start.elapsed());
         }
@@ -2848,6 +2851,8 @@ impl
             dyn AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<BackendOutput>>, Error>,
         >,
     ) -> Result<ManyOut<Annotated<NvCreateChatCompletionStreamResponse>>, Error> {
+        let operator_entered_at = Instant::now();
+
         // unpack the request
         let (mut request, context) = request.into_parts();
 
@@ -2879,6 +2884,8 @@ impl
                 .ok()
                 .is_some_and(|flag| *flag),
         };
+
+        REQUEST_PREPROCESS_WAIT_MS.observe(operator_entered_at.elapsed().as_secs_f64() * 1000.0);
 
         // convert the chat completion request to a common completion request
         let (mut common_request, annotations, prompt_injected_reasoning) = self

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -847,7 +847,10 @@ impl OpenAIPreprocessor {
                 dp_rank: nvext.dp_rank,
                 // exp H (gap #4): seed conversation_id from session_control so the engine's
                 // conversation-affinity ADP router can pin conv -> DP rank.
-                conversation_id: nvext.session_control.as_ref().map(|sc| sc.session_id.clone()),
+                conversation_id: nvext
+                    .session_control
+                    .as_ref()
+                    .map(|sc| sc.session_id.clone()),
                 prefill_dp_rank: nvext.prefill_dp_rank,
                 expected_output_tokens: hints.and_then(|h| h.osl),
                 priority_jump,

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -683,7 +683,8 @@ impl OpenAIPreprocessor {
                 .await
                 .with_context(|| "Failed to gather tokens")?
         };
-        TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
+        let tokenize_elapsed = tokenize_start.elapsed();
+        TOKENIZE_SECONDS.observe(tokenize_elapsed.as_secs_f64());
 
         let _mm_image_entries = self
             .gather_multi_modal_data(

--- a/lib/mocker/src/common/utils.rs
+++ b/lib/mocker/src/common/utils.rs
@@ -5,6 +5,16 @@ use std::time::{Duration, Instant};
 
 use crate::common::protocols::{MockEngineArgs, WorkerType};
 
+/// Returns the `MOCK_KV_WAIT_TIMEOUT_MS` threshold, or `None` if unset/invalid.
+pub fn mock_kv_wait_timeout_ms() -> Option<u64> {
+    static THRESHOLD: std::sync::OnceLock<Option<u64>> = std::sync::OnceLock::new();
+    *THRESHOLD.get_or_init(|| {
+        std::env::var("MOCK_KV_WAIT_TIMEOUT_MS")
+            .ok()
+            .and_then(|v| v.parse::<u64>().ok())
+    })
+}
+
 /// Compute the modeled handoff delay after a prefill worker emits its terminal token.
 ///
 /// NOTE: this intentionally does not model the internal prefill TTFT itself accurately, and the

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -17,8 +17,8 @@ use uuid::Uuid;
 #[cfg(feature = "kvbm-offload")]
 use crate::common::protocols::G1;
 use crate::common::protocols::{
-    DirectRequest, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal, PreemptionMode,
-    PrefillCost, WorkerType,
+    DirectRequest, EngineType, KvEventPublishers, MockEngineArgs, MoveBlock, OutputSignal,
+    PreemptionMode, PrefillCost, WorkerType,
 };
 use crate::common::sequence::ActiveSequence;
 use crate::common::speculative::{SpeculativeDecodeSampler, normalize_conditional_accept_rates};
@@ -46,6 +46,7 @@ pub(crate) struct VllmRequestState {
     pub(crate) status: RequestStatus,
     pub(crate) num_computed_tokens: usize,
     pub(crate) num_preemptions: usize,
+    pub(crate) enqueued_wall_time: std::time::Instant,
 }
 
 impl VllmRequestState {
@@ -488,6 +489,7 @@ impl VllmCore {
                 status: RequestStatus::Waiting,
                 num_computed_tokens: 0,
                 num_preemptions: 0,
+                enqueued_wall_time: std::time::Instant::now(),
             },
         );
         self.state.push_waiting(uuid);
@@ -1193,6 +1195,32 @@ impl VllmCore {
         }
 
         if from_waiting {
+            // Mirror TRT-LLM's KV transfer timeout, which fires on both sides:
+            //   CTX (prefill): kv_transfer_sender_future_timeout_ms — sender waits for GEN
+            //     to acknowledge transfer completion after respond_and_send_async().
+            //   GEN (decode): kv_transfer_timeout_ms — receiver waits for KV blocks to
+            //     arrive after request_and_receive_async().
+            // In the mocker with instant KV (--kv-transfer-bandwidth 0), the only delay is
+            // orchestration: time from receive() to first scheduling slot. Both sides fire
+            // against the same MOCK_KV_WAIT_TIMEOUT_MS threshold.
+            if self.args.engine_type == EngineType::Trtllm {
+                if let Some(threshold_ms) = crate::common::utils::mock_kv_wait_timeout_ms() {
+                    if let Some(req) = self.state.requests.get(&uuid) {
+                        let wait_ms = req.enqueued_wall_time.elapsed().as_millis() as u64;
+                        if wait_ms >= threshold_ms {
+                            let worker_type = self.args.worker_type;
+                            tracing::warn!(
+                                target: "dynamo_stall_op",
+                                op = "mock_kv_timeout",
+                                %uuid,
+                                wait_ms,
+                                ?worker_type,
+                                "mock TRT-LLM KV transfer timeout: worker queue wait exceeded budget"
+                            );
+                        }
+                    }
+                }
+            }
             self.state.transition_to_running(uuid);
         }
         *token_budget = token_budget.saturating_sub(tokens_used);

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1203,22 +1203,21 @@ impl VllmCore {
             // In the mocker with instant KV (--kv-transfer-bandwidth 0), the only delay is
             // orchestration: time from receive() to first scheduling slot. Both sides fire
             // against the same MOCK_KV_WAIT_TIMEOUT_MS threshold.
-            if self.args.engine_type == EngineType::Trtllm {
-                if let Some(threshold_ms) = crate::common::utils::mock_kv_wait_timeout_ms() {
-                    if let Some(req) = self.state.requests.get(&uuid) {
-                        let wait_ms = req.enqueued_wall_time.elapsed().as_millis() as u64;
-                        if wait_ms >= threshold_ms {
-                            let worker_type = self.args.worker_type;
-                            tracing::warn!(
-                                target: "dynamo_stall_op",
-                                op = "mock_kv_timeout",
-                                %uuid,
-                                wait_ms,
-                                ?worker_type,
-                                "mock TRT-LLM KV transfer timeout: worker queue wait exceeded budget"
-                            );
-                        }
-                    }
+            if self.args.engine_type == EngineType::Trtllm
+                && let Some(threshold_ms) = crate::common::utils::mock_kv_wait_timeout_ms()
+                && let Some(req) = self.state.requests.get(&uuid)
+            {
+                let wait_ms = req.enqueued_wall_time.elapsed().as_millis() as u64;
+                if wait_ms >= threshold_ms {
+                    let worker_type = self.args.worker_type;
+                    tracing::warn!(
+                        target: "dynamo_stall_op",
+                        op = "mock_kv_timeout",
+                        %uuid,
+                        wait_ms,
+                        ?worker_type,
+                        "mock TRT-LLM KV transfer timeout: worker queue wait exceeded budget"
+                    );
                 }
             }
             self.state.transition_to_running(uuid);

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -529,6 +529,7 @@ mod core_behavior {
                 status: RequestStatus::Running,
                 num_computed_tokens: 9,
                 num_preemptions: 1,
+                enqueued_wall_time: std::time::Instant::now(),
             },
         );
 

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -101,6 +101,36 @@ pub static TEMPLATE_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .expect("template_seconds histogram")
 });
 
+/// Actual tokenizer.encode() CPU time in milliseconds (subset of TOKENIZE_SECONDS,
+/// which also covers null-byte stripping and tracker bookkeeping around the call).
+pub static TOKENIZE_ENCODE_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::TOKENIZE_ENCODE_MS),
+            "Tokenizer encode() CPU time (milliseconds)",
+        )
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0,
+        ]),
+    )
+    .expect("tokenize_encode_ms histogram")
+});
+
+/// Time between the chat-completions preprocessor operator receiving a request and
+/// calling into preprocess_request_with_options, in milliseconds.
+pub static REQUEST_PREPROCESS_WAIT_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::REQUEST_PREPROCESS_WAIT_MS),
+            "Time from preprocessor operator entry to preprocess_request_with_options call (milliseconds)",
+        )
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0,
+        ]),
+    )
+    .expect("request_preprocess_wait_ms histogram")
+});
+
 /// Cumulative detokenization time across all tokens (microseconds).
 /// Use `rate(total) / rate(count)` in Prometheus to derive per-token average.
 pub static DETOKENIZE_TOTAL_US: Lazy<Counter> = Lazy::new(|| {
@@ -156,6 +186,12 @@ pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
         registry.add_metric(Box::new(TOKENIZE_SECONDS.clone())).ok();
         registry.add_metric(Box::new(TEMPLATE_SECONDS.clone())).ok();
         registry
+            .add_metric(Box::new(TOKENIZE_ENCODE_MS.clone()))
+            .ok();
+        registry
+            .add_metric(Box::new(REQUEST_PREPROCESS_WAIT_MS.clone()))
+            .ok();
+        registry
             .add_metric(Box::new(DETOKENIZE_TOTAL_US.clone()))
             .ok();
         registry
@@ -182,6 +218,8 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
     registry.register(Box::new(STAGE_DURATION_SECONDS.clone()))?;
     registry.register(Box::new(TOKENIZE_SECONDS.clone()))?;
     registry.register(Box::new(TEMPLATE_SECONDS.clone()))?;
+    registry.register(Box::new(TOKENIZE_ENCODE_MS.clone()))?;
+    registry.register(Box::new(REQUEST_PREPROCESS_WAIT_MS.clone()))?;
     registry.register(Box::new(DETOKENIZE_TOTAL_US.clone()))?;
     registry.register(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_HITS_TOTAL.clone()))?;

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -146,6 +146,62 @@ pub static HTTP_TO_PREPROCESS_WAIT_MS: Lazy<Histogram> = Lazy::new(|| {
     .expect("http_to_preprocess_wait_ms histogram")
 });
 
+/// Block-hash CPU time per request in kv_router.route() (milliseconds).
+pub static HASH_BLOCKS_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::HASH_BLOCKS_MS),
+            "Block-hash CPU time per request in kv_router.route() (milliseconds)",
+        )
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0,
+        ]),
+    )
+    .expect("hash_blocks_ms histogram")
+});
+
+/// Sequential-hash CPU delta (seq_hash − hash_blocks) per request (milliseconds).
+pub static HASH_SEQ_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::HASH_SEQ_MS),
+            "Sequential-hash CPU delta per request in kv_router.route() (milliseconds)",
+        )
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0,
+        ]),
+    )
+    .expect("hash_seq_ms histogram")
+});
+
+/// KV index lookup time per request: radix-tree walk (local) or remote round-trip (milliseconds).
+pub static INDEX_LOOKUP_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::INDEX_LOOKUP_MS),
+            "KV index lookup time per request (milliseconds)",
+        )
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0,
+        ]),
+    )
+    .expect("index_lookup_ms histogram")
+});
+
+/// Scheduler actor wait per request: enqueue → admission → booking → response wake-up (milliseconds).
+pub static SCHEDULE_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::SCHEDULE_MS),
+            "Scheduler actor wait per request (milliseconds)",
+        )
+        .buckets(vec![
+            0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0, 5000.0,
+        ]),
+    )
+    .expect("schedule_ms histogram")
+});
+
 /// Cumulative detokenization time across all tokens (microseconds).
 /// Use `rate(total) / rate(count)` in Prometheus to derive per-token average.
 pub static DETOKENIZE_TOTAL_US: Lazy<Counter> = Lazy::new(|| {
@@ -221,6 +277,10 @@ pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
         registry
             .add_metric(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))
             .ok();
+        registry.add_metric(Box::new(HASH_BLOCKS_MS.clone())).ok();
+        registry.add_metric(Box::new(HASH_SEQ_MS.clone())).ok();
+        registry.add_metric(Box::new(INDEX_LOOKUP_MS.clone())).ok();
+        registry.add_metric(Box::new(SCHEDULE_MS.clone())).ok();
     });
 }
 
@@ -243,6 +303,10 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
     registry.register(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_HITS_TOTAL.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))?;
+    registry.register(Box::new(HASH_BLOCKS_MS.clone()))?;
+    registry.register(Box::new(HASH_SEQ_MS.clone()))?;
+    registry.register(Box::new(INDEX_LOOKUP_MS.clone()))?;
+    registry.register(Box::new(SCHEDULE_MS.clone()))?;
     let _ = PROMETHEUS_REGISTERED.set(());
     Ok(())
 }

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -131,6 +131,21 @@ pub static REQUEST_PREPROCESS_WAIT_MS: Lazy<Histogram> = Lazy::new(|| {
     .expect("request_preprocess_wait_ms histogram")
 });
 
+/// Time from the chat-completions HTTP handler entry to the engine.generate() call that
+/// kicks off the pipeline (request validation, template resolution, engine lookup).
+pub static HTTP_TO_PREPROCESS_WAIT_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            frontend_metric_name(frontend_perf::HTTP_TO_PREPROCESS_WAIT_MS),
+            "Time from HTTP handler entry to engine.generate() call (milliseconds)",
+        )
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0,
+        ]),
+    )
+    .expect("http_to_preprocess_wait_ms histogram")
+});
+
 /// Cumulative detokenization time across all tokens (microseconds).
 /// Use `rate(total) / rate(count)` in Prometheus to derive per-token average.
 pub static DETOKENIZE_TOTAL_US: Lazy<Counter> = Lazy::new(|| {
@@ -192,6 +207,9 @@ pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
             .add_metric(Box::new(REQUEST_PREPROCESS_WAIT_MS.clone()))
             .ok();
         registry
+            .add_metric(Box::new(HTTP_TO_PREPROCESS_WAIT_MS.clone()))
+            .ok();
+        registry
             .add_metric(Box::new(DETOKENIZE_TOTAL_US.clone()))
             .ok();
         registry
@@ -220,6 +238,7 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
     registry.register(Box::new(TEMPLATE_SECONDS.clone()))?;
     registry.register(Box::new(TOKENIZE_ENCODE_MS.clone()))?;
     registry.register(Box::new(REQUEST_PREPROCESS_WAIT_MS.clone()))?;
+    registry.register(Box::new(HTTP_TO_PREPROCESS_WAIT_MS.clone()))?;
     registry.register(Box::new(DETOKENIZE_TOTAL_US.clone()))?;
     registry.register(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_HITS_TOTAL.clone()))?;

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -651,6 +651,14 @@ pub mod frontend_perf {
     pub const EVENT_LOOP_DELAY_SECONDS: &str = "event_loop_delay_seconds";
     /// Count of event loop stalls (delay > 5ms)
     pub const EVENT_LOOP_STALL_TOTAL: &str = "event_loop_stall_total";
+    /// Block-hash CPU time per request in kv_router.route() (milliseconds).
+    pub const HASH_BLOCKS_MS: &str = "hash_blocks_ms";
+    /// Sequential-hash CPU delta (seq_hash - hash_blocks) per request (milliseconds).
+    pub const HASH_SEQ_MS: &str = "hash_seq_ms";
+    /// KV index lookup time per request: radix-tree walk (local) or remote round-trip (milliseconds).
+    pub const INDEX_LOOKUP_MS: &str = "index_lookup_ms";
+    /// Scheduler actor wait per request: enqueue -> admission -> booking -> response wake-up (milliseconds).
+    pub const SCHEDULE_MS: &str = "schedule_ms";
 }
 
 /// Tokio runtime metrics
@@ -713,7 +721,15 @@ pub mod request_plane {
     pub const BUILD_ENVELOPE_MS: &str = "build_envelope_ms";
     /// Time for dispatch_buffer to complete (transport write of the built envelope),
     /// in milliseconds. Finer-grained sibling of SEND_SECONDS at the same call site.
+    /// Labeled by `worker` (endpoint address) to surface per-worker ACK latency.
     pub const DISPATCH_BUFFER_MS: &str = "dispatch_buffer_ms";
+    /// ACK write-task scheduling delay: time from decoded_at to the write task
+    /// dequeueing the frame (worker SharedTcpEndpoint write_loop). Decomposes
+    /// ack_flush_seconds into scheduling starvation vs socket write cost.
+    pub const ACK_WRITE_QUEUE_MS: &str = "ack_write_queue_ms";
+    /// ACK socket write time: time from write task dequeue to flush complete
+    /// (worker SharedTcpEndpoint write_loop). Complements ACK_WRITE_QUEUE_MS.
+    pub const ACK_SOCKET_WRITE_MS: &str = "ack_socket_write_ms";
 }
 
 /// Transport-specific metrics (TCP / NATS)

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -685,6 +685,11 @@ pub mod request_plane {
     pub const ROUNDTRIP_TTFT_SECONDS: &str = "roundtrip_ttft_seconds";
     /// Currently in-flight requests (gauge)
     pub const INFLIGHT_REQUESTS: &str = "inflight_requests";
+    /// Ingress-side ACK flush latency: decoded_at -> socket flush complete
+    /// (write-task scheduling delay + socket write time), on the worker's
+    /// SharedTcpEndpoint write_loop. Every traced item, not just ones past
+    /// the DYN_ACK_TRACE_WARN_MS log threshold.
+    pub const ACK_FLUSH_SECONDS: &str = "ack_flush_seconds";
 }
 
 /// Transport-specific metrics (TCP / NATS)

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -627,6 +627,13 @@ pub mod frontend_perf {
     pub const TOKENIZE_SECONDS: &str = "tokenize_seconds";
     /// Template application time in preprocessor
     pub const TEMPLATE_SECONDS: &str = "template_seconds";
+    /// Actual tokenizer CPU encode time (tokenizer.encode call only, excludes null-byte
+    /// stripping and tracker bookkeeping). Fair A/B CPU comparison across tokenizer backends.
+    pub const TOKENIZE_ENCODE_MS: &str = "tokenize_encode_ms";
+    /// Time between the chat-completions preprocessor operator receiving a request and
+    /// calling into preprocess_request_with_options (tokenize). Detects task scheduling /
+    /// operator setup delay ahead of tokenize, distinct from tokenize itself.
+    pub const REQUEST_PREPROCESS_WAIT_MS: &str = "request_preprocess_wait_ms";
     /// L1 tokenizer cache hits (cumulative); only incremented when DYN_TOKENIZER_CACHE is enabled
     pub const TOKENIZER_CACHE_HITS_TOTAL: &str = "tokenizer_cache_hits_total";
     /// L1 tokenizer cache misses (cumulative); only incremented when DYN_TOKENIZER_CACHE is enabled

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -634,6 +634,11 @@ pub mod frontend_perf {
     /// calling into preprocess_request_with_options (tokenize). Detects task scheduling /
     /// operator setup delay ahead of tokenize, distinct from tokenize itself.
     pub const REQUEST_PREPROCESS_WAIT_MS: &str = "request_preprocess_wait_ms";
+    /// Time from the chat-completions HTTP handler entry to the `engine.generate()` call
+    /// that kicks off the pipeline (request validation, template resolution, engine
+    /// lookup). Earlier/broader than REQUEST_PREPROCESS_WAIT_MS, which starts at the
+    /// preprocessor operator's own entry inside that pipeline.
+    pub const HTTP_TO_PREPROCESS_WAIT_MS: &str = "http_to_preprocess_wait_ms";
     /// L1 tokenizer cache hits (cumulative); only incremented when DYN_TOKENIZER_CACHE is enabled
     pub const TOKENIZER_CACHE_HITS_TOTAL: &str = "tokenizer_cache_hits_total";
     /// L1 tokenizer cache misses (cumulative); only incremented when DYN_TOKENIZER_CACHE is enabled
@@ -697,6 +702,18 @@ pub mod request_plane {
     /// SharedTcpEndpoint write_loop. Every traced item, not just ones past
     /// the DYN_ACK_TRACE_WARN_MS log threshold.
     pub const ACK_FLUSH_SECONDS: &str = "ack_flush_seconds";
+    /// Time to register the request/response stream halves with the response transport
+    /// (AddressedPushRouter::register_streams), in milliseconds.
+    pub const REGISTER_STREAMS_MS: &str = "register_streams_ms";
+    /// Time for the tombstone-check `associate_instance` call against the response
+    /// transport, in milliseconds.
+    pub const ASSOCIATE_INSTANCE_MS: &str = "associate_instance_ms";
+    /// Time to build the request envelope (build_request_envelope: serialization +
+    /// control message assembly), in milliseconds.
+    pub const BUILD_ENVELOPE_MS: &str = "build_envelope_ms";
+    /// Time for dispatch_buffer to complete (transport write of the built envelope),
+    /// in milliseconds. Finer-grained sibling of SEND_SECONDS at the same call site.
+    pub const DISPATCH_BUFFER_MS: &str = "dispatch_buffer_ms";
 }
 
 /// Transport-specific metrics (TCP / NATS)

--- a/lib/runtime/src/metrics/request_plane.rs
+++ b/lib/runtime/src/metrics/request_plane.rs
@@ -65,6 +65,23 @@ pub static REQUEST_PLANE_INFLIGHT: Lazy<Gauge> = Lazy::new(|| {
     .expect("request_plane_inflight gauge")
 });
 
+/// Ingress-side ACK flush latency (worker SharedTcpEndpoint write_loop): decoded_at ->
+/// socket flush complete. Observed for every traced response (DYN_ACK_TRACE=1), not just
+/// ones that cross the DYN_ACK_TRACE_WARN_MS log threshold -- gives the full distribution
+/// instead of only the tail that happened to get logged.
+pub static REQUEST_PLANE_ACK_FLUSH_SECONDS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::ACK_FLUSH_SECONDS),
+            "Ingress ACK flush latency: decoded_at -> socket flush complete (seconds)",
+        )
+        .buckets(vec![
+            0.0001, 0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 2.5, 5.0, 10.0,
+        ]),
+    )
+    .expect("request_plane_ack_flush_seconds histogram")
+});
+
 /// Guards idempotency for the `MetricsRegistry` registration path.
 static METRICS_REGISTERED: OnceCell<()> = OnceCell::new();
 
@@ -92,6 +109,10 @@ pub fn ensure_request_plane_metrics_registered(registry: &MetricsRegistry) {
             Box::new(REQUEST_PLANE_INFLIGHT.clone()),
             "request_plane_inflight",
         );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_ACK_FLUSH_SECONDS.clone()),
+            "request_plane_ack_flush_seconds",
+        );
     });
 }
 
@@ -107,6 +128,7 @@ pub fn ensure_request_plane_metrics_registered_prometheus(
                 registry.register(Box::new(REQUEST_PLANE_SEND_SECONDS.clone()))?;
                 registry.register(Box::new(REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS.clone()))?;
                 registry.register(Box::new(REQUEST_PLANE_INFLIGHT.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_ACK_FLUSH_SECONDS.clone()))?;
                 Ok(())
             })()
             .map_err(|e| e.to_string())

--- a/lib/runtime/src/metrics/request_plane.rs
+++ b/lib/runtime/src/metrics/request_plane.rs
@@ -5,7 +5,7 @@
 //! Used to pinpoint serialization vs transport roundtrip latency.
 
 use once_cell::sync::{Lazy, OnceCell};
-use prometheus::{Gauge, Histogram, HistogramOpts};
+use prometheus::{Gauge, Histogram, HistogramOpts, HistogramVec};
 
 use super::prometheus_names::{name_prefix, request_plane};
 use crate::MetricsRegistry;
@@ -128,17 +128,50 @@ pub static REQUEST_PLANE_BUILD_ENVELOPE_MS: Lazy<Histogram> = Lazy::new(|| {
 
 /// Time for dispatch_buffer to complete (transport write of the built envelope). Finer
 /// granularity sibling of REQUEST_PLANE_SEND_SECONDS at the same call site.
-pub static REQUEST_PLANE_DISPATCH_BUFFER_MS: Lazy<Histogram> = Lazy::new(|| {
-    Histogram::with_opts(
+/// Labeled by `worker` (the endpoint address, e.g. `host:port`) to surface per-worker ACK latency.
+pub static REQUEST_PLANE_DISPATCH_BUFFER_MS: Lazy<HistogramVec> = Lazy::new(|| {
+    HistogramVec::new(
         HistogramOpts::new(
             request_plane_metric_name(request_plane::DISPATCH_BUFFER_MS),
-            "Time for dispatch_buffer to complete (milliseconds)",
+            "Time for dispatch_buffer to complete, labeled by worker endpoint (milliseconds)",
+        )
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0,
+        ]),
+        &["worker"],
+    )
+    .expect("request_plane_dispatch_buffer_ms histogram")
+});
+
+/// Time the ACK write task spent queued between enqueue and dequeue (write-task scheduling
+/// delay). Only observed when DYN_ACK_TRACE=1. Decomposes ack_flush_seconds into scheduling
+/// starvation vs actual socket write cost.
+pub static REQUEST_PLANE_ACK_WRITE_QUEUE_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::ACK_WRITE_QUEUE_MS),
+            "ACK write-task scheduling delay: decoded_at -> write task dequeue (milliseconds)",
         )
         .buckets(vec![
             0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0,
         ]),
     )
-    .expect("request_plane_dispatch_buffer_ms histogram")
+    .expect("request_plane_ack_write_queue_ms histogram")
+});
+
+/// Time the ACK write task spent actually writing to the socket (dequeue -> flush).
+/// Only observed when DYN_ACK_TRACE=1. Complements REQUEST_PLANE_ACK_WRITE_QUEUE_MS.
+pub static REQUEST_PLANE_ACK_SOCKET_WRITE_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::ACK_SOCKET_WRITE_MS),
+            "ACK socket write time: write task dequeue -> flush complete (milliseconds)",
+        )
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0,
+        ]),
+    )
+    .expect("request_plane_ack_socket_write_ms histogram")
 });
 
 /// Guards idempotency for the `MetricsRegistry` registration path.
@@ -188,6 +221,14 @@ pub fn ensure_request_plane_metrics_registered(registry: &MetricsRegistry) {
             Box::new(REQUEST_PLANE_DISPATCH_BUFFER_MS.clone()),
             "request_plane_dispatch_buffer_ms",
         );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_ACK_WRITE_QUEUE_MS.clone()),
+            "request_plane_ack_write_queue_ms",
+        );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_ACK_SOCKET_WRITE_MS.clone()),
+            "request_plane_ack_socket_write_ms",
+        );
     });
 }
 
@@ -208,6 +249,8 @@ pub fn ensure_request_plane_metrics_registered_prometheus(
                 registry.register(Box::new(REQUEST_PLANE_ASSOCIATE_INSTANCE_MS.clone()))?;
                 registry.register(Box::new(REQUEST_PLANE_BUILD_ENVELOPE_MS.clone()))?;
                 registry.register(Box::new(REQUEST_PLANE_DISPATCH_BUFFER_MS.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_ACK_WRITE_QUEUE_MS.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_ACK_SOCKET_WRITE_MS.clone()))?;
                 Ok(())
             })()
             .map_err(|e| e.to_string())

--- a/lib/runtime/src/metrics/request_plane.rs
+++ b/lib/runtime/src/metrics/request_plane.rs
@@ -82,6 +82,65 @@ pub static REQUEST_PLANE_ACK_FLUSH_SECONDS: Lazy<Histogram> = Lazy::new(|| {
     .expect("request_plane_ack_flush_seconds histogram")
 });
 
+/// Time to register the request/response stream halves with the response transport
+/// (AddressedPushRouter::register_streams).
+pub static REQUEST_PLANE_REGISTER_STREAMS_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::REGISTER_STREAMS_MS),
+            "Time to register request/response stream halves with the response transport (milliseconds)",
+        )
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0,
+        ]),
+    )
+    .expect("request_plane_register_streams_ms histogram")
+});
+
+/// Time for the tombstone-check `associate_instance` call against the response transport.
+pub static REQUEST_PLANE_ASSOCIATE_INSTANCE_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::ASSOCIATE_INSTANCE_MS),
+            "Time for the associate_instance tombstone check (milliseconds)",
+        )
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0,
+        ]),
+    )
+    .expect("request_plane_associate_instance_ms histogram")
+});
+
+/// Time to build the request envelope (build_request_envelope: serialization + control
+/// message assembly).
+pub static REQUEST_PLANE_BUILD_ENVELOPE_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::BUILD_ENVELOPE_MS),
+            "Time to build the request envelope (milliseconds)",
+        )
+        .buckets(vec![
+            0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0,
+        ]),
+    )
+    .expect("request_plane_build_envelope_ms histogram")
+});
+
+/// Time for dispatch_buffer to complete (transport write of the built envelope). Finer
+/// granularity sibling of REQUEST_PLANE_SEND_SECONDS at the same call site.
+pub static REQUEST_PLANE_DISPATCH_BUFFER_MS: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            request_plane_metric_name(request_plane::DISPATCH_BUFFER_MS),
+            "Time for dispatch_buffer to complete (milliseconds)",
+        )
+        .buckets(vec![
+            0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0, 50.0, 100.0, 500.0, 1000.0,
+        ]),
+    )
+    .expect("request_plane_dispatch_buffer_ms histogram")
+});
+
 /// Guards idempotency for the `MetricsRegistry` registration path.
 static METRICS_REGISTERED: OnceCell<()> = OnceCell::new();
 
@@ -113,6 +172,22 @@ pub fn ensure_request_plane_metrics_registered(registry: &MetricsRegistry) {
             Box::new(REQUEST_PLANE_ACK_FLUSH_SECONDS.clone()),
             "request_plane_ack_flush_seconds",
         );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_REGISTER_STREAMS_MS.clone()),
+            "request_plane_register_streams_ms",
+        );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_ASSOCIATE_INSTANCE_MS.clone()),
+            "request_plane_associate_instance_ms",
+        );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_BUILD_ENVELOPE_MS.clone()),
+            "request_plane_build_envelope_ms",
+        );
+        registry.add_metric_or_warn(
+            Box::new(REQUEST_PLANE_DISPATCH_BUFFER_MS.clone()),
+            "request_plane_dispatch_buffer_ms",
+        );
     });
 }
 
@@ -129,6 +204,10 @@ pub fn ensure_request_plane_metrics_registered_prometheus(
                 registry.register(Box::new(REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS.clone()))?;
                 registry.register(Box::new(REQUEST_PLANE_INFLIGHT.clone()))?;
                 registry.register(Box::new(REQUEST_PLANE_ACK_FLUSH_SECONDS.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_REGISTER_STREAMS_MS.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_ASSOCIATE_INSTANCE_MS.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_BUILD_ENVELOPE_MS.clone()))?;
+                registry.register(Box::new(REQUEST_PLANE_DISPATCH_BUFFER_MS.clone()))?;
                 Ok(())
             })()
             .map_err(|e| e.to_string())

--- a/lib/runtime/src/metrics/tokio_perf.rs
+++ b/lib/runtime/src/metrics/tokio_perf.rs
@@ -251,6 +251,14 @@ pub fn ensure_tokio_perf_metrics_registered_prometheus(
 pub async fn tokio_metrics_and_canary_loop(cancel: CancellationToken) {
     let canary_interval = Duration::from_millis(10);
     let stall_threshold = Duration::from_millis(5);
+    // Real-stall logging threshold: WARN to target `dynamo_stall` when this runtime's event loop is
+    // delayed past DYN_STALL_LOG_MS (default 250ms). Makes "which runtime is starved" visible directly
+    // in each process's log (frontend vs worker) without scraping. Rare/no-op when healthy.
+    let stall_log_ms: u64 = std::env::var("DYN_STALL_LOG_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(250);
+    let mut stall_warns: u64 = 0;
     let collect_interval = Duration::from_secs(1);
     let mut next_collect = Instant::now() + collect_interval;
     let mut prev_counters = PrevWorkerCounters::new();
@@ -267,6 +275,16 @@ pub async fn tokio_metrics_and_canary_loop(cancel: CancellationToken) {
         EVENT_LOOP_DELAY_SECONDS.observe(delay.as_secs_f64());
         if delay > stall_threshold {
             EVENT_LOOP_STALL_TOTAL.inc();
+        }
+        let delay_ms = delay.as_millis() as u64;
+        if delay_ms >= stall_log_ms {
+            stall_warns += 1;
+            tracing::warn!(
+                target: "dynamo_stall",
+                stall_ms = delay_ms,
+                stall_warns,
+                "event-loop stall: this runtime is starved (request-plane futures not polled)"
+            );
         }
         if Instant::now() >= next_collect {
             next_collect = Instant::now() + collect_interval;

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -15,7 +15,9 @@ use crate::error::{DynamoError, ErrorType};
 use crate::logging::inject_trace_headers_into_map;
 use crate::metrics::frontend_perf::STAGE_DURATION_SECONDS;
 use crate::metrics::request_plane::{
-    REQUEST_PLANE_INFLIGHT, REQUEST_PLANE_QUEUE_SECONDS, REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS,
+    REQUEST_PLANE_ASSOCIATE_INSTANCE_MS, REQUEST_PLANE_BUILD_ENVELOPE_MS,
+    REQUEST_PLANE_DISPATCH_BUFFER_MS, REQUEST_PLANE_INFLIGHT, REQUEST_PLANE_QUEUE_SECONDS,
+    REQUEST_PLANE_REGISTER_STREAMS_MS, REQUEST_PLANE_ROUNDTRIP_TTFT_SECONDS,
     REQUEST_PLANE_SEND_SECONDS,
 };
 use crate::pipeline::network::ConnectionInfo;
@@ -488,9 +490,12 @@ impl AddressedPushRouter {
         // disarmed by `into_parts()` on awaiting stream provider: past that point the
         // subject is reaped by the worker's dial-in (instance healthy) or the discovery
         // watcher (instance dropped), so no cleanup is owed.
+        let register_streams_start = Instant::now();
         let (send_registered, recv_registered) = self
             .register_streams(engine_ctx.clone(), enable_request_stream, true)
             .await?;
+        REQUEST_PLANE_REGISTER_STREAMS_MS
+            .observe(register_streams_start.elapsed().as_secs_f64() * 1000.0);
         let recv_registered = recv_registered.ok_or_else(|| {
             anyhow::anyhow!("response stream registration missing despite enable_response_stream")
         })?;
@@ -502,34 +507,44 @@ impl AddressedPushRouter {
         let send_subject = send_registered
             .as_ref()
             .and_then(|r| subject_of(&r.connection_info));
-        if let (Some(subject), Some(inst)) = (&recv_subject, instance)
-            && !self
+        if let (Some(subject), Some(inst)) = (&recv_subject, instance) {
+            let associate_instance_start = Instant::now();
+            let associated = self
                 .resp_transport
                 .associate_instance(
                     subject,
                     send_subject.as_deref(),
                     &inst.endpoint_instance_id(),
                 )
-                .await
-        {
-            return Err(anyhow::anyhow!(
-                DynamoError::builder()
-                    .error_type(ErrorType::Disconnected)
-                    .message("Worker removed before request could be sent (tombstoned instance)")
-                    .build()
-            ));
+                .await;
+            REQUEST_PLANE_ASSOCIATE_INSTANCE_MS
+                .observe(associate_instance_start.elapsed().as_secs_f64() * 1000.0);
+            if !associated {
+                return Err(anyhow::anyhow!(
+                    DynamoError::builder()
+                        .error_type(ErrorType::Disconnected)
+                        .message(
+                            "Worker removed before request could be sent (tombstoned instance)",
+                        )
+                        .build()
+                ));
+            }
         }
 
+        let build_envelope_start = Instant::now();
         let buffer = build_request_envelope(
             context,
             recv_registered.connection_info.clone(),
             send_registered.as_ref().map(|r| r.connection_info.clone()),
             request,
         )?;
+        REQUEST_PLANE_BUILD_ENVELOPE_MS
+            .observe(build_envelope_start.elapsed().as_secs_f64() * 1000.0);
         REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
 
         let tx_start = Instant::now();
         let request_plane_response = self.dispatch_buffer(address, buffer, context.id()).await?;
+        REQUEST_PLANE_DISPATCH_BUFFER_MS.observe(tx_start.elapsed().as_secs_f64() * 1000.0);
         REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
 
         // A worker load-shed surfaces on the request-plane ACK, not the response

--- a/lib/runtime/src/pipeline/network/egress/addressed_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/addressed_router.rs
@@ -543,8 +543,11 @@ impl AddressedPushRouter {
         REQUEST_PLANE_QUEUE_SECONDS.observe(queue_start.elapsed().as_secs_f64());
 
         let tx_start = Instant::now();
+        let worker_label = address.trim_start_matches("tcp://").to_string();
         let request_plane_response = self.dispatch_buffer(address, buffer, context.id()).await?;
-        REQUEST_PLANE_DISPATCH_BUFFER_MS.observe(tx_start.elapsed().as_secs_f64() * 1000.0);
+        REQUEST_PLANE_DISPATCH_BUFFER_MS
+            .with_label_values(&[&worker_label])
+            .observe(tx_start.elapsed().as_secs_f64() * 1000.0);
         REQUEST_PLANE_SEND_SECONDS.observe(tx_start.elapsed().as_secs_f64());
 
         // A worker load-shed surfaces on the request-plane ACK, not the response

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -1422,7 +1422,20 @@ impl RequestPlaneClient for TcpRequestClient {
             Err(_) => {
                 self.stats.errors.fetch_add(1, Ordering::Relaxed);
                 TCP_ERRORS_TOTAL.inc();
-                tracing::warn!("TCP request timeout to {}", addr);
+                let req_id = headers
+                    .get("request-id")
+                    .or_else(|| headers.get("x-dynamo-request-id"))
+                    .map(|s| s.as_str())
+                    .unwrap_or("unknown");
+                // request_id correlates with the worker's dynamo_ack_trace flush log; timeout_s is
+                // the per-request ACK budget (DYN_TCP_REQUEST_TIMEOUT, default 5s).
+                tracing::warn!(
+                    addr = %addr,
+                    request_id = %req_id,
+                    timeout_s = self.config.request_timeout.as_secs(),
+                    "TCP request ACK timeout to {} (request-plane)",
+                    addr
+                );
                 Err(anyhow::anyhow!(
                     crate::error::DynamoError::builder()
                         .error_type(crate::error::ErrorType::CannotConnect)

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -817,9 +817,9 @@ impl SharedTcpServer {
                 crate::metrics::request_plane::REQUEST_PLANE_ACK_FLUSH_SECONDS
                     .observe(now.duration_since(meta.decoded_at).as_secs_f64());
                 crate::metrics::request_plane::REQUEST_PLANE_ACK_WRITE_QUEUE_MS
-                    .observe(queue_ms as f64);
+                    .observe(dq.duration_since(meta.decoded_at).as_secs_f64() * 1000.0);
                 crate::metrics::request_plane::REQUEST_PLANE_ACK_SOCKET_WRITE_MS
-                    .observe(write_ms as f64);
+                    .observe(now.duration_since(dq).as_secs_f64() * 1000.0);
                 if total_ms >= warn_ms {
                     tracing::warn!(
                         target: "dynamo_ack_trace",

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -811,6 +811,11 @@ impl SharedTcpServer {
                 let total_ms = now.duration_since(meta.decoded_at).as_millis() as u64;
                 let queue_ms = dq.duration_since(meta.decoded_at).as_millis() as u64;
                 let write_ms = now.duration_since(dq).as_millis() as u64;
+                // Full distribution, every traced item -- not gated by warn_ms. This is what makes
+                // the request-plane picture a real histogram instead of only the tail that happened
+                // to cross the log threshold.
+                crate::metrics::request_plane::REQUEST_PLANE_ACK_FLUSH_SECONDS
+                    .observe(now.duration_since(meta.decoded_at).as_secs_f64());
                 if total_ms >= warn_ms {
                     tracing::warn!(
                         target: "dynamo_ack_trace",

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -397,6 +397,15 @@ impl SharedTcpServer {
         // Store the actual bound address
         *self.actual_addr.write() = Some(actual_addr);
 
+        // ACK-trace: monitor THIS (worker request-plane) runtime for event-loop stalls. The canary
+        // is otherwise only spawned by the frontend HTTP service, so workers were unobservable.
+        // Stalls log to target `dynamo_stall` in the worker log → directly answers "is the GEN
+        // worker runtime starved" without scraping. Gated by DYN_ACK_TRACE.
+        if ack_trace_enabled() {
+            let cancel = self.cancellation_token.clone();
+            tokio::spawn(crate::metrics::tokio_perf::tokio_metrics_and_canary_loop(cancel));
+        }
+
         // Start accepting connections in a background task
         let server = self.clone();
         tokio::spawn(async move {
@@ -640,6 +649,29 @@ impl SharedTcpServer {
             } else {
                 None
             };
+
+            // ACK-trace: frontend-send -> worker-decode arrival delay — the PRE-decode wait that the
+            // decode->flush trace misses. High here = the request sat unread (request-plane read
+            // starvation on THIS worker), distinguishing it from a slow ACK write or frontend side.
+            if trace
+                && let Some(send_ts) = headers
+                    .get("x-frontend-send-ts-ns")
+                    .and_then(|s| s.parse::<u64>().ok())
+            {
+                let now_ns = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap_or_default()
+                    .as_nanos() as u64;
+                let arrival_ms = now_ns.saturating_sub(send_ts) / 1_000_000;
+                if arrival_ms >= 1000 {
+                    tracing::warn!(
+                        target: "dynamo_ack_trace",
+                        request_id = %req_id.as_deref().unwrap_or("unknown"),
+                        arrival_ms,
+                        "slow request arrival (frontend-send -> worker-decode)"
+                    );
+                }
+            }
 
             // Get payload (zero-copy Bytes - just Arc clone!)
             let payload = request_msg.payload();

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -403,7 +403,9 @@ impl SharedTcpServer {
         // worker runtime starved" without scraping. Gated by DYN_ACK_TRACE.
         if ack_trace_enabled() {
             let cancel = self.cancellation_token.clone();
-            tokio::spawn(crate::metrics::tokio_perf::tokio_metrics_and_canary_loop(cancel));
+            tokio::spawn(crate::metrics::tokio_perf::tokio_metrics_and_canary_loop(
+                cancel,
+            ));
         }
 
         // Start accepting connections in a background task
@@ -588,7 +590,12 @@ impl SharedTcpServer {
         // Encode and send a response frame; returns false if the write task is gone.
         let send_response = |msg: TcpResponseMessage, meta: Option<AckMeta>| -> bool {
             match msg.encode() {
-                Ok(encoded) => response_tx.send(ResponseItem { bytes: encoded, meta }).is_ok(),
+                Ok(encoded) => response_tx
+                    .send(ResponseItem {
+                        bytes: encoded,
+                        meta,
+                    })
+                    .is_ok(),
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to encode TCP response");
                     true
@@ -610,7 +617,10 @@ impl SharedTcpServer {
                     let error_response =
                         TcpResponseMessage::new(Bytes::from(format!("Read error: {}", e)));
                     if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(ResponseItem { bytes: encoded, meta: None });
+                        let _ = response_tx.send(ResponseItem {
+                            bytes: encoded,
+                            meta: None,
+                        });
                     }
                     return Err(e.into());
                 }
@@ -627,7 +637,10 @@ impl SharedTcpServer {
                     let error_response =
                         TcpResponseMessage::new(Bytes::from_static(b"Invalid endpoint path"));
                     if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(ResponseItem { bytes: encoded, meta: None });
+                        let _ = response_tx.send(ResponseItem {
+                            bytes: encoded,
+                            meta: None,
+                        });
                     }
                     continue;
                 }
@@ -696,7 +709,10 @@ impl SharedTcpServer {
                         endpoint_path
                     )));
                     if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(ResponseItem { bytes: encoded, meta: None });
+                        let _ = response_tx.send(ResponseItem {
+                            bytes: encoded,
+                            meta: None,
+                        });
                     }
                     continue;
                 }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -29,6 +29,39 @@ use tokio_util::bytes::BytesMut;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 
+/// Request-plane ACK latency tracing (DYN_ACK_TRACE=1). Adds per-request decode->flush timing on
+/// the worker request plane so an ACK starvation (the iter4 collapse trigger) can be localized to
+/// the write-task scheduling delay vs the socket write, and correlated by request_id with the
+/// frontend's CannotConnect timeout. Zero-overhead when off.
+fn ack_trace_enabled() -> bool {
+    std::env::var("DYN_ACK_TRACE")
+        .ok()
+        .is_some_and(|v| v == "1" || v == "true")
+}
+
+/// Threshold (ms) at/above which a slow ACK flush is logged at WARN (default 1000).
+fn ack_trace_warn_ms() -> u64 {
+    std::env::var("DYN_ACK_TRACE_WARN_MS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(1000)
+}
+
+/// Per-ACK trace metadata carried read_loop -> write_loop so the flush latency is attributable to a
+/// specific request and dispatch path. Only populated when DYN_ACK_TRACE is on.
+#[derive(Debug)]
+struct AckMeta {
+    decoded_at: Instant,
+    request_id: Box<str>,
+    path: &'static str,
+}
+
+/// Item sent over the response channel: the encoded frame plus optional ACK trace.
+struct ResponseItem {
+    bytes: Bytes,
+    meta: Option<AckMeta>,
+}
+
 /// Default worker pool size for TCP request handling
 const DEFAULT_WORKER_POOL_SIZE: usize = 10000;
 
@@ -505,8 +538,8 @@ impl SharedTcpServer {
         // Split stream into read and write halves for concurrent operations
         let (read_half, write_half) = tokio::io::split(stream);
 
-        // Channel for sending responses to the write task (zero-copy Bytes)
-        let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel::<Bytes>();
+        // Channel for sending responses to the write task (zero-copy Bytes + optional ACK trace)
+        let (response_tx, response_rx) = tokio::sync::mpsc::unbounded_channel::<ResponseItem>();
 
         // Spawn write task
         let write_task = tokio::spawn(Self::write_loop(write_half, response_rx));
@@ -532,7 +565,7 @@ impl SharedTcpServer {
     async fn read_loop(
         mut read_half: tokio::io::ReadHalf<TcpStream>,
         handlers: Arc<DashMap<String, Arc<EndpointHandler>>>,
-        response_tx: tokio::sync::mpsc::UnboundedSender<Bytes>,
+        response_tx: tokio::sync::mpsc::UnboundedSender<ResponseItem>,
         work_tx: tokio::sync::mpsc::Sender<WorkItem>,
         engine_sem: Arc<Semaphore>,
         queue_capacity: usize,
@@ -541,11 +574,12 @@ impl SharedTcpServer {
 
         // Create zero-copy decoder with optimized buffer size
         let mut decoder = ZeroCopyTcpDecoder::new();
+        let trace = ack_trace_enabled();
 
         // Encode and send a response frame; returns false if the write task is gone.
-        let send_response = |msg: TcpResponseMessage| -> bool {
+        let send_response = |msg: TcpResponseMessage, meta: Option<AckMeta>| -> bool {
             match msg.encode() {
-                Ok(encoded) => response_tx.send(encoded).is_ok(),
+                Ok(encoded) => response_tx.send(ResponseItem { bytes: encoded, meta }).is_ok(),
                 Err(e) => {
                     tracing::warn!(error = %e, "Failed to encode TCP response");
                     true
@@ -567,11 +601,14 @@ impl SharedTcpServer {
                     let error_response =
                         TcpResponseMessage::new(Bytes::from(format!("Read error: {}", e)));
                     if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(encoded);
+                        let _ = response_tx.send(ResponseItem { bytes: encoded, meta: None });
                     }
                     return Err(e.into());
                 }
             };
+
+            // ACK-trace: stamp decode time as close to the wire as possible.
+            let decoded_at = if trace { Some(Instant::now()) } else { None };
 
             // Get endpoint path (zero-copy string slice)
             let endpoint_path = match request_msg.endpoint_path() {
@@ -581,7 +618,7 @@ impl SharedTcpServer {
                     let error_response =
                         TcpResponseMessage::new(Bytes::from_static(b"Invalid endpoint path"));
                     if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(encoded);
+                        let _ = response_tx.send(ResponseItem { bytes: encoded, meta: None });
                     }
                     continue;
                 }
@@ -589,6 +626,20 @@ impl SharedTcpServer {
 
             // Get headers (parsed from message)
             let headers = request_msg.headers();
+
+            // ACK-trace: capture request_id (owned) for correlation with the frontend timeout log.
+            let req_id: Option<Box<str>> = if trace {
+                Some(
+                    headers
+                        .get("request-id")
+                        .or_else(|| headers.get("x-dynamo-request-id"))
+                        .map(|s| s.as_str())
+                        .unwrap_or("unknown")
+                        .into(),
+                )
+            } else {
+                None
+            };
 
             // Get payload (zero-copy Bytes - just Arc clone!)
             let payload = request_msg.payload();
@@ -613,7 +664,7 @@ impl SharedTcpServer {
                         endpoint_path
                     )));
                     if let Ok(encoded) = error_response.encode() {
-                        let _ = response_tx.send(encoded);
+                        let _ = response_tx.send(ResponseItem { bytes: encoded, meta: None });
                     }
                     continue;
                 }
@@ -648,7 +699,12 @@ impl SharedTcpServer {
             if let Some(permit) = direct_permit {
                 // Bypass the queue — routing through work_tx would make it a throat.
                 Self::spawn_handle(work_item, permit);
-                if !send_response(TcpResponseMessage::empty()) {
+                let ack_meta = decoded_at.zip(req_id.as_ref()).map(|(d, id)| AckMeta {
+                    decoded_at: d,
+                    request_id: id.clone(),
+                    path: "direct",
+                });
+                if !send_response(TcpResponseMessage::empty(), ack_meta) {
                     break;
                 }
                 continue;
@@ -661,7 +717,12 @@ impl SharedTcpServer {
                     REQUEST_QUEUE_GAUGE.inc();
                     slot.send(work_item);
                     // Queued: the dispatcher owns inflight, so don't touch it here.
-                    if !send_response(TcpResponseMessage::empty()) {
+                    let ack_meta = decoded_at.zip(req_id.as_ref()).map(|(d, id)| AckMeta {
+                        decoded_at: d,
+                        request_id: id.clone(),
+                        path: "queued",
+                    });
+                    if !send_response(TcpResponseMessage::empty(), ack_meta) {
                         break;
                     }
                 }
@@ -673,17 +734,23 @@ impl SharedTcpServer {
                         instance_id = handler.instance_id,
                         "Worker at capacity (engine + queue full), rejecting request"
                     );
-                    send_response(TcpResponseMessage::new(Bytes::from_static(
-                        b"Server overloaded: worker at capacity",
-                    )));
+                    send_response(
+                        TcpResponseMessage::new(Bytes::from_static(
+                            b"Server overloaded: worker at capacity",
+                        )),
+                        None,
+                    );
                     handler.inflight.fetch_sub(1, Ordering::SeqCst);
                     handler.notify.notify_one();
                 }
                 Err(tokio::sync::mpsc::error::TrySendError::Closed(_)) => {
                     WORK_HANDLER_ENQUEUE_REJECTED_TOTAL.inc();
-                    send_response(TcpResponseMessage::new(Bytes::from_static(
-                        b"Server unavailable: worker pool channel closed",
-                    )));
+                    send_response(
+                        TcpResponseMessage::new(Bytes::from_static(
+                            b"Server unavailable: worker pool channel closed",
+                        )),
+                        None,
+                    );
                     handler.inflight.fetch_sub(1, Ordering::SeqCst);
                     handler.notify.notify_one();
                     tracing::error!("Worker pool channel closed, shutting down read loop");
@@ -697,11 +764,43 @@ impl SharedTcpServer {
 
     async fn write_loop(
         mut write_half: tokio::io::WriteHalf<TcpStream>,
-        mut response_rx: tokio::sync::mpsc::UnboundedReceiver<Bytes>,
+        mut response_rx: tokio::sync::mpsc::UnboundedReceiver<ResponseItem>,
     ) -> Result<()> {
-        while let Some(response) = response_rx.recv().await {
-            write_half.write_all(&response).await?;
+        let warn_ms = ack_trace_warn_ms();
+        while let Some(item) = response_rx.recv().await {
+            // For traced ACKs, mark the instant the write task dequeued the frame: the gap from
+            // decode->dequeue is the write-task SCHEDULING delay (runtime/CPU starvation), and
+            // dequeue->flush is the socket write time. This localizes the 5s ACK-timeout cause.
+            let dequeued_at = item.meta.as_ref().map(|_| Instant::now());
+            write_half.write_all(&item.bytes).await?;
             write_half.flush().await?;
+            if let (Some(meta), Some(dq)) = (item.meta, dequeued_at) {
+                let now = Instant::now();
+                let total_ms = now.duration_since(meta.decoded_at).as_millis() as u64;
+                let queue_ms = dq.duration_since(meta.decoded_at).as_millis() as u64;
+                let write_ms = now.duration_since(dq).as_millis() as u64;
+                if total_ms >= warn_ms {
+                    tracing::warn!(
+                        target: "dynamo_ack_trace",
+                        request_id = %meta.request_id,
+                        path = meta.path,
+                        total_ms,
+                        queue_ms,
+                        write_ms,
+                        "slow request-plane ACK flush"
+                    );
+                } else {
+                    tracing::debug!(
+                        target: "dynamo_ack_trace",
+                        request_id = %meta.request_id,
+                        path = meta.path,
+                        total_ms,
+                        queue_ms,
+                        write_ms,
+                        "request-plane ACK flush"
+                    );
+                }
+            }
         }
         Ok(())
     }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -816,6 +816,10 @@ impl SharedTcpServer {
                 // to cross the log threshold.
                 crate::metrics::request_plane::REQUEST_PLANE_ACK_FLUSH_SECONDS
                     .observe(now.duration_since(meta.decoded_at).as_secs_f64());
+                crate::metrics::request_plane::REQUEST_PLANE_ACK_WRITE_QUEUE_MS
+                    .observe(queue_ms as f64);
+                crate::metrics::request_plane::REQUEST_PLANE_ACK_SOCKET_WRITE_MS
+                    .observe(write_ms as f64);
                 if total_ms >= warn_ms {
                     tracing::warn!(
                         target: "dynamo_ack_trace",


### PR DESCRIPTION
## Summary

Adds always-on Prometheus histograms across the frontend pipeline. All metrics observe every event — full population distributions, not log-threshold tail samples.

## New metrics

### Frontend pipeline (`dynamo_frontend_*`)
| Metric | Labels | What it measures |
|--------|--------|-----------------|
| `dynamo_frontend_tokenize_encode_ms` | — | Tokenizer encode call time (including spawn_blocking overhead) |
| `dynamo_frontend_request_preprocess_wait_ms` | — | Time from request arrival to preprocess stage start |
| `dynamo_frontend_http_to_preprocess_wait_ms` | — | Time from HTTP handler to preprocess actor receive |
| `dynamo_frontend_hash_blocks_ms` | — | Block-hash computation time in KV router |
| `dynamo_frontend_hash_seq_ms` | — | Sequence hash time (above block hashing) in KV router |
| `dynamo_frontend_index_lookup_ms` | — | Radix index lookup time in KV router |
| `dynamo_frontend_schedule_ms` | — | Scheduler round-trip time as seen by KV router caller |

### Request-plane (`dynamo_request_plane_*`)
| Metric | Labels | What it measures |
|--------|--------|-----------------|
| `dynamo_request_plane_ack_flush_seconds` | — | decoded_at → socket flush complete on SharedTcpEndpoint write_loop |
| `dynamo_request_plane_ack_write_queue_ms` | — | ACK write-task queue wait (breakdown of ack_flush) |
| `dynamo_request_plane_ack_socket_write_ms` | — | ACK socket write time (breakdown of ack_flush) |
| `dynamo_request_plane_dispatch_buffer_ms` | `worker` | addressed_router dispatch buffer time per worker endpoint |
| `dynamo_request_plane_register_streams_ms` | — | Stream registration latency |
| `dynamo_request_plane_associate_instance_ms` | — | Instance association latency |
| `dynamo_request_plane_build_envelope_ms` | — | Envelope build latency |

### Scheduler (`dynamo_router_*`, `dynamo_worker_*`)
| Metric | Labels | What it measures |
|--------|--------|-----------------|
| `dynamo_router_overhead_admission_compute_ms` | `worker_type` | project_worker_loads + select_worker CPU time on scheduler actor |
| `dynamo_router_overhead_queue_wait_ms` | `worker_type` | Time a request sits parked in the pending heap before admission |
| `dynamo_router_actor_mailbox_wait_ms` | `worker_type`, `command` | Time from enqueue to actor starting the command |
| `dynamo_router_actor_poll_gap_ms` | `worker_type` | Time between consecutive actor mailbox receives |
| `dynamo_router_schedule_compute_ms` | `worker_type` | Full admit_one body including booking |
| `dynamo_router_pending_queue_age_ms` | `worker_type` | Age of capacity-blocked pending requests sampled at each update |
| `dynamo_worker_state_update_to_scheduler_ms` | `event` | prefill-complete / free propagation round-trip through queue.update() |

`worker_type` label values: `prefill` / `decode`

## Env-var gates (unchanged behavior)
- `DYN_ACK_TRACE=1` — enables warn logs for slow ACK flushes (histogram observations are always-on regardless)
- `DYN_STALL_OP_TRACE=1` — enables warn logs for slow frontend event-loop ops (histogram observations are always-on regardless)
- `DYN_PREFILL_TRACE=1` — enables per-request prefill lifecycle tracing

## Test plan
- [ ] `cargo check -p dynamo-kv-router -p dynamo-llm -p dynamo-runtime` passes clean
- [ ] Verify metrics appear at `/metrics` endpoint when running with `--features metrics`
- [ ] Confirm per-worker_type labels (`prefill`/`decode`) show up on scheduling histograms

Refs: DYN-3401