### PR TITLE
fix(vllm): backport Mistral fetch_images

### DIFF
--- a/container/deps/vllm/patches/v0.23.0/0001-pr45180-mistral-fetch-images.patch
+++ b/container/deps/vllm/patches/v0.23.0/0001-pr45180-mistral-fetch-images.patch
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+# SPDX-License-Identifier: Apache-2.0
+
+Backport the feature hunk from upstream vLLM PR #45180:
+[Bugfix] Add fetch_images to MistralCommonImageProcessor
+
+--- a/vllm/transformers_utils/processors/pixtral.py
++++ b/vllm/transformers_utils/processors/pixtral.py
+@@ -48,0 +49,4 @@
++    # Copied from Transformers (Apache-2.0):
++    # https://github.com/huggingface/transformers/blob/d20946079fd422335fbae3eeb98b7cd88334612f/src/transformers/image_processing_base.py#L473
++    def fetch_images(self, image_url_or_urls):
++        from transformers.image_utils import is_valid_image, load_image
+@@ -49,0 +54,12 @@
++        if isinstance(image_url_or_urls, (list, tuple)):
++            return [self.fetch_images(x) for x in image_url_or_urls]
++        if isinstance(image_url_or_urls, str):
++            return load_image(image_url_or_urls)
++        if is_valid_image(image_url_or_urls):
++            return image_url_or_urls
++        raise TypeError(
++            "only a single or a list of entries is supported but got "
++            f"type={type(image_url_or_urls)}"
++        )
++
++

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -186,6 +186,24 @@ RUN --mount=type=bind,source=./container/deps/vllm/protected_packages.txt,target
     export VLLM_OMNI_TARGET_DEVICE={{ device }}; \
     bash /tmp/install_vllm_omni.sh
 
+{% if device == "cuda" or device == "cpu" %}
+# Backport vLLM PR #45180 so Transformers >=5.10 can call
+# MistralCommonImageProcessor.fetch_images on the pinned vLLM 0.23.0 runtime.
+# Drop once the release branch takes a vLLM runtime that already includes it.
+RUN --mount=type=bind,source=./container/deps/vllm/patches/v0.23.0/0001-pr45180-mistral-fetch-images.patch,target=/tmp/0001-pr45180-mistral-fetch-images.patch,readonly \
+    set -eux; \
+    installed_vllm_version="$(python3 -c 'import importlib.metadata as md; print(md.version("vllm"))')"; \
+    test "${installed_vllm_version}" = "0.23.0"; \
+    apt-get update; \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends patch; \
+    site_parent="$(python3 -c 'import pathlib, vllm; print(pathlib.Path(vllm.__file__).resolve().parent.parent)')"; \
+    patch --batch --forward -p1 -d "${site_parent}" < /tmp/0001-pr45180-mistral-fetch-images.patch; \
+    apt-get purge -y patch; \
+    rm -rf /var/lib/apt/lists/*; \
+    python3 -c 'from vllm.transformers_utils.processors.pixtral import MistralCommonImageProcessor; assert hasattr(MistralCommonImageProcessor, "fetch_images"), "vLLM PR #45180 backport did not land"'
+
+{% endif %}
+
 {% if device == "xpu" %}
 # Remove conflicting standard triton package for XPU and reinstall triton-xpu
 # This must be done after vLLM-Omni installation to ensure no dependencies re-install triton


### PR DESCRIPTION
## Summary

Backport the vLLM `MistralCommonImageProcessor.fetch_images` fix onto the v1.3.0 RC2 runtime branch.
Essentially a cherry-pick of the vLLM upstream patch [#45180](https://github.com/vllm-project/vllm/pull/45180).

## Overview:

DYN-3373 reports that Mistral vision requests fail in the v1.3.0 RC runtime because the pinned vLLM `0.23.0` package is missing `MistralCommonImageProcessor.fetch_images`, which Transformers `>=5.10` calls during multimodal preprocessing.

NOTE to remove the patch when Dynamo is released on a commit after the vllm 0.24.0 bump (#11076)

## Details:

- Adds `container/deps/vllm/patches/v0.23.0/0001-pr45180-mistral-fetch-images.patch`.
- The patch contains only the feature hunk from upstream vLLM PR #45180.
- Updates `container/templates/vllm_runtime.Dockerfile` to apply the patch to installed vLLM `0.23.0` in CUDA/CPU runtime images.
- Adds a build-time assertion that `MistralCommonImageProcessor.fetch_images` exists after patching.

## Validation

- Confirmed this branch is based on the RC2 cut commit `fb7ae30d378f652c27e149c0caa17079378a8319`.
- Verified the patch applies cleanly to raw vLLM `v0.23.0` `pixtral.py` with `patch --dry-run --batch --forward -p1`.
- Applied the patch to a temp copy and inspected that `fetch_images` lands on `MistralCommonImageProcessor`.
- Ran `git diff --check`.
- Checked the patch file and Dockerfile change for trailing whitespace.

Not run: rendered Dockerfile/container build; local render was blocked because available Python environments did not have both `jinja2` and `yaml`.

## Where should the reviewer start?

- `container/deps/vllm/patches/v0.23.0/0001-pr45180-mistral-fetch-images.patch`
- `container/templates/vllm_runtime.Dockerfile`

## Related Issues

**🔗 This PR is linked to an issue:**

- Fixes DYN-3373
- NVBug 6410723
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11258" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->