### PR TITLE
fix(operator): preserve service volume mounts during conversion

### DIFF
--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -1293,7 +1293,7 @@ func convertExperimentalFromHub(src *v1beta1.DynamoComponentDeploymentSharedSpec
 // fields (Resources, Envs, Probes, EnvFromSecret, ExtraPodSpec,
 // ExtraPodMetadata, FrontendSidecar) following the same merge precedence the
 // v1alpha1 controller uses at reconcile time: ExtraPodSpec.MainContainer wins
-// over dedicated fields, except for env which is additive.
+// over dedicated fields, except for env and volumeMounts which are additive.
 func buildPodTemplateToHub(src *DynamoComponentDeploymentSharedSpec, dst *v1beta1.DynamoComponentDeploymentSharedSpec, ctx DynamoComponentDeploymentSharedSpecConversionContext) error {
 	podTpl, err := buildSharedPodTemplateFromAlpha(src, ctx.PodTemplateOrigin, false)
 	if err != nil {
@@ -1347,12 +1347,17 @@ func mergeExtraPodSpecMainContainer(src *DynamoComponentDeploymentSharedSpec, ma
 	}
 	main := src.ExtraPodSpec.MainContainer.DeepCopy()
 	baseEnvs := mainBase.Env
+	dedicatedVolumeMounts := slices.Clone(mainBase.VolumeMounts)
 	// Name must be "main" regardless of what MainContainer carried.
 	main.Name = mainContainerName
 	if err := mergo.Merge(mainBase, *main, mergo.WithOverride); err != nil {
 		return fmt.Errorf("merge main container: %w", err)
 	}
 	mainBase.Env = mergeEnvs(baseEnvs, main.Env)
+	// The v1alpha1 renderer merged extraPodSpec.mainContainer first, then
+	// appended the dedicated service-level mounts. Preserve that ordering rather
+	// than allowing mergo to replace the VolumeMounts slice.
+	mainBase.VolumeMounts = append(slices.Clone(main.VolumeMounts), dedicatedVolumeMounts...)
 	// StartupProbe has no dedicated v1alpha1 field; take it verbatim.
 	if main.StartupProbe != nil {
 		mainBase.StartupProbe = main.StartupProbe
@@ -1369,7 +1374,8 @@ func buildSharedPodTemplateFromAlpha(src *DynamoComponentDeploymentSharedSpec, p
 	// Main container: base from dedicated fields.
 	mainBase := buildMainContainerFromDedicated(src)
 
-	// Merge ExtraPodSpec.MainContainer on top, except for Env which is additive.
+	// Merge ExtraPodSpec.MainContainer on top, except for fields with legacy
+	// additive behavior handled by mergeExtraPodSpecMainContainer.
 	if err := mergeExtraPodSpecMainContainer(src, &mainBase); err != nil {
 		return nil, err
 	}
@@ -2196,7 +2202,8 @@ func restoreMainContainerFieldOrigins(dst, preserved *DynamoComponentDeploymentS
 		ensureExtraPodSpecMainContainer(dst).Resources = *preservedMain.Resources.DeepCopy()
 	}
 	currentVolumeMounts := withoutCompilationCacheMounts(currentMain.VolumeMounts, dst.VolumeMounts)
-	if volumeMountOriginsMatchNative(volumeMountsFromNative(preservedSemanticMain.VolumeMounts), currentVolumeMounts) &&
+	preservedVolumeMounts := withoutCompilationCacheMounts(preservedSemanticMain.VolumeMounts, preserved.VolumeMounts)
+	if volumeMountOriginsMatchNative(volumeMountsFromNative(preservedVolumeMounts), currentVolumeMounts) &&
 		(len(preserved.VolumeMounts) > 0 || len(preservedMain.VolumeMounts) > 0) {
 		dst.VolumeMounts = restorePreservedVolumeMountOrigins(preserved.VolumeMounts, dst.VolumeMounts, preservedMain.VolumeMounts)
 		ensureExtraPodSpecMainContainer(dst).VolumeMounts = cloneNativeVolumeMounts(preservedMain.VolumeMounts)

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -546,8 +546,10 @@ func ConvertToDynamoComponentDeploymentSharedSpec(src *v1beta1.DynamoComponentDe
 		return err
 	}
 
-	fillSharedAlphaOnlyFromPreserved(dst, restored, sharedHasMainContainer(src))
+	// Restore lossy cache flags before field-origin reconstruction so every
+	// compilation-cache mount is excluded from main-container origin matching.
 	restoreSharedPreservedFlatVolumeMounts(dst, restored, src)
+	fillSharedAlphaOnlyFromPreserved(dst, restored, sharedHasMainContainer(src))
 	pruneEmptyExtraPodSpec(dst, restored)
 	if save != nil {
 		if err := saveSharedHubOnlySpec(src, dst, save); err != nil {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion.go
@@ -927,7 +927,8 @@ func restoreSharedPreservedFlatVolumeMounts(dst, preserved *DynamoComponentDeplo
 	if !volumeMountsEqual(dst.VolumeMounts, visiblePreservedVolumeMountProjection(src, preserved.VolumeMounts)) {
 		return
 	}
-	dst.VolumeMounts = mergePreservedCompilationCacheVolumeMounts(preserved.VolumeMounts, dst.VolumeMounts)
+	restorablePreserved := restorablePreservedCompilationCacheMounts(src, preserved)
+	dst.VolumeMounts = mergePreservedCompilationCacheVolumeMounts(restorablePreserved, dst.VolumeMounts)
 }
 
 func firstPreservedCompilationCacheMatches(compilationCache *v1beta1.CompilationCacheConfig, mounts []VolumeMount) bool {
@@ -935,11 +936,42 @@ func firstPreservedCompilationCacheMatches(compilationCache *v1beta1.Compilation
 		if !mount.UseAsCompilationCache {
 			continue
 		}
-		return compilationCache != nil &&
-			compilationCache.PVCName == mount.Name &&
-			compilationCache.MountPath == mount.MountPoint
+		return compilationCacheMatchesVolumeMount(compilationCache, mount)
 	}
 	return compilationCache == nil
+}
+
+func compilationCacheMatchesVolumeMount(compilationCache *v1beta1.CompilationCacheConfig, mount VolumeMount) bool {
+	return compilationCache != nil &&
+		compilationCache.PVCName == mount.Name &&
+		compilationCache.MountPath == mount.MountPoint
+}
+
+func restorablePreservedCompilationCacheMounts(src *v1beta1.DynamoComponentDeploymentSharedSpec, preserved *DynamoComponentDeploymentSharedSpec) []VolumeMount {
+	main, mainPresent := sharedMainContainer(src)
+	secondaryMountsProjected := mainPresent || hasPodTemplateContent(preserved, false)
+	firstCompilationCacheSeen := false
+	live := make([]VolumeMount, 0, len(preserved.VolumeMounts))
+	for _, mount := range preserved.VolumeMounts {
+		if !mount.UseAsCompilationCache {
+			continue
+		}
+		if !firstCompilationCacheSeen {
+			firstCompilationCacheSeen = true
+			if compilationCacheMatchesVolumeMount(src.CompilationCache, mount) {
+				live = append(live, mount)
+			}
+			continue
+		}
+		// Secondary cache flags have no beta field. When alpha content creates a
+		// beta main container, its matching mount is their observable
+		// representation and absence means deletion. Cache-only alpha objects do
+		// not create a pod template, so those flags remain sparse-preserved state.
+		if !secondaryMountsProjected || nativeVolumeMountHasNamePath(main.VolumeMounts, mount.Name, mount.MountPoint) {
+			live = append(live, mount)
+		}
+	}
+	return live
 }
 
 func visiblePreservedVolumeMountProjection(src *v1beta1.DynamoComponentDeploymentSharedSpec, mounts []VolumeMount) []VolumeMount {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -18,6 +18,7 @@
 package v1alpha1
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -362,7 +363,94 @@ func TestBugDGD_ChangedCompilationCacheDoesNotRestoreStaleVolumeMounts(t *testin
 	}
 }
 
-func TestBugDGD_PodTemplateMountSurvivesMultipleCompilationCacheRestore(t *testing.T) {
+func TestBugDGD_DeletedSecondaryCompilationCacheDoesNotRestore(t *testing.T) {
+	in := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "secondary-cache-deleted", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					VolumeMounts: []VolumeMount{
+						{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true},
+						{Name: "compile-cache", MountPoint: "/compile", UseAsCompilationCache: true},
+					},
+					ExtraPodSpec: &ExtraPodSpec{
+						PodSpec: &corev1.PodSpec{
+							Volumes: []corev1.Volume{{
+								Name: "config",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{},
+								},
+							}},
+						},
+						MainContainer: &corev1.Container{
+							VolumeMounts: []corev1.VolumeMount{{Name: "config", MountPath: "/config"}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := in.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if len(hub.Spec.Components) != 1 || hub.Spec.Components[0].PodTemplate == nil {
+		t.Fatalf("expected one hub component with a podTemplate, got %#v", hub.Spec.Components)
+	}
+	mainFound := false
+	secondaryCacheDeleted := false
+	for i := range hub.Spec.Components[0].PodTemplate.Spec.Containers {
+		main := &hub.Spec.Components[0].PodTemplate.Spec.Containers[i]
+		if main.Name != mainContainerName {
+			continue
+		}
+		mainFound = true
+		main.VolumeMounts = slices.DeleteFunc(main.VolumeMounts, func(mount corev1.VolumeMount) bool {
+			deleted := mount.Name == "compile-cache" && mount.MountPath == "/compile"
+			secondaryCacheDeleted = secondaryCacheDeleted || deleted
+			return deleted
+		})
+	}
+	if !mainFound || !secondaryCacheDeleted {
+		t.Fatalf("expected to delete compile-cache from the hub main container, got %#v", hub.Spec.Components[0].PodTemplate.Spec.Containers)
+	}
+
+	assertDeletedCacheAbsent := func(stage string, got *DynamoGraphDeployment) {
+		t.Helper()
+		service := got.Spec.Services["worker"]
+		if service == nil || service.ExtraPodSpec == nil || service.ExtraPodSpec.MainContainer == nil {
+			t.Fatalf("%s: expected worker with extra main container, got %#v", stage, service)
+		}
+		wantServiceMounts := []VolumeMount{{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true}}
+		if diff := cmp.Diff(wantServiceMounts, service.VolumeMounts); diff != "" {
+			t.Fatalf("%s: deleted compilation cache was restored in service mounts (-want +got):\n%s", stage, diff)
+		}
+		wantExtraMounts := []corev1.VolumeMount{{Name: "config", MountPath: "/config"}}
+		if diff := cmp.Diff(wantExtraMounts, service.ExtraPodSpec.MainContainer.VolumeMounts); diff != "" {
+			t.Fatalf("%s: deleted compilation cache was restored in extra main-container mounts (-want +got):\n%s", stage, diff)
+		}
+	}
+
+	out := &DynamoGraphDeployment{}
+	if err := out.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	assertDeletedCacheAbsent("first round-trip", out)
+
+	hubAgain := &v1beta1.DynamoGraphDeployment{}
+	if err := out.ConvertTo(hubAgain); err != nil {
+		t.Fatalf("second ConvertTo() error = %v", err)
+	}
+	outAgain := &DynamoGraphDeployment{}
+	if err := outAgain.ConvertFrom(hubAgain); err != nil {
+		t.Fatalf("second ConvertFrom() error = %v", err)
+	}
+	assertDeletedCacheAbsent("second round-trip", outAgain)
+}
+
+func TestBugDGD_PodTemplateEditPreservesLiveMountsOnly(t *testing.T) {
 	in := &DynamoGraphDeployment{
 		ObjectMeta: metav1.ObjectMeta{Name: "multi-cache-edited-pod-template", Namespace: "ns"},
 		Spec: DynamoGraphDeploymentSpec{
@@ -397,7 +485,6 @@ func TestBugDGD_PodTemplateMountSurvivesMultipleCompilationCacheRestore(t *testi
 	}
 	want := []VolumeMount{
 		{Name: "model-cache", MountPoint: "/models", UseAsCompilationCache: true},
-		{Name: "compile-cache", MountPoint: "/compile", UseAsCompilationCache: true},
 		{Name: "runtime-cache", MountPoint: "/runtime"},
 	}
 	if diff := cmp.Diff(want, out.Spec.Services["worker"].VolumeMounts); diff != "" {

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -80,11 +80,18 @@ func TestBugDGD_SpokeServiceAndExtraVolumeMountsCompose(t *testing.T) {
 			Services: map[string]*DynamoComponentDeploymentSharedSpec{
 				"worker": {
 					ComponentType: "worker",
-					VolumeMounts: []VolumeMount{{
-						Name:                  "model-cache",
-						MountPoint:            "/models",
-						UseAsCompilationCache: true,
-					}},
+					VolumeMounts: []VolumeMount{
+						{
+							Name:                  "model-cache",
+							MountPoint:            "/models",
+							UseAsCompilationCache: true,
+						},
+						{
+							Name:                  "compile-cache",
+							MountPoint:            "/compile",
+							UseAsCompilationCache: true,
+						},
+					},
 					ExtraPodSpec: &ExtraPodSpec{
 						PodSpec: &corev1.PodSpec{
 							Volumes: []corev1.Volume{{
@@ -120,6 +127,7 @@ func TestBugDGD_SpokeServiceAndExtraVolumeMountsCompose(t *testing.T) {
 	wantHubMounts := []corev1.VolumeMount{
 		{Name: "config", MountPath: "/config"},
 		{Name: "model-cache", MountPath: "/models"},
+		{Name: "compile-cache", MountPath: "/compile"},
 	}
 	if diff := cmp.Diff(wantHubMounts, main.VolumeMounts); diff != "" {
 		t.Fatalf("converted main volume mounts mismatch (-want +got):\n%s", diff)
@@ -138,6 +146,12 @@ func TestBugDGD_SpokeServiceAndExtraVolumeMountsCompose(t *testing.T) {
 	}
 	if diff := cmp.Diff(in.Spec.Services["worker"].ExtraPodSpec.MainContainer.VolumeMounts, got.ExtraPodSpec.MainContainer.VolumeMounts); diff != "" {
 		t.Fatalf("extra main volume mounts changed after round-trip (-want +got):\n%s", diff)
+	}
+	if got.ExtraPodSpec.PodSpec == nil {
+		t.Fatalf("expected converted ExtraPodSpec.PodSpec, got nil")
+	}
+	if diff := cmp.Diff(in.Spec.Services["worker"].ExtraPodSpec.PodSpec.Volumes, got.ExtraPodSpec.PodSpec.Volumes); diff != "" {
+		t.Fatalf("extra pod volumes changed after round-trip (-want +got):\n%s", diff)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/shared_spec_conversion_bugs_test.go
@@ -73,6 +73,74 @@ func TestConvertFromSharedMemorySpec(t *testing.T) {
 	}
 }
 
+func TestBugDGD_SpokeServiceAndExtraVolumeMountsCompose(t *testing.T) {
+	in := &DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "volume-mounts", Namespace: "ns"},
+		Spec: DynamoGraphDeploymentSpec{
+			Services: map[string]*DynamoComponentDeploymentSharedSpec{
+				"worker": {
+					ComponentType: "worker",
+					VolumeMounts: []VolumeMount{{
+						Name:                  "model-cache",
+						MountPoint:            "/models",
+						UseAsCompilationCache: true,
+					}},
+					ExtraPodSpec: &ExtraPodSpec{
+						PodSpec: &corev1.PodSpec{
+							Volumes: []corev1.Volume{{
+								Name: "config",
+								VolumeSource: corev1.VolumeSource{
+									ConfigMap: &corev1.ConfigMapVolumeSource{},
+								},
+							}},
+						},
+						MainContainer: &corev1.Container{
+							VolumeMounts: []corev1.VolumeMount{{
+								Name:      "config",
+								MountPath: "/config",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeployment{}
+	if err := in.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if len(hub.Spec.Components) != 1 || hub.Spec.Components[0].PodTemplate == nil {
+		t.Fatalf("expected one converted component with a podTemplate, got %#v", hub.Spec.Components)
+	}
+	main, ok := findContainerByName(hub.Spec.Components[0].PodTemplate.Spec.Containers, mainContainerName)
+	if !ok {
+		t.Fatalf("expected converted main container, got %#v", hub.Spec.Components[0].PodTemplate.Spec.Containers)
+	}
+	wantHubMounts := []corev1.VolumeMount{
+		{Name: "config", MountPath: "/config"},
+		{Name: "model-cache", MountPath: "/models"},
+	}
+	if diff := cmp.Diff(wantHubMounts, main.VolumeMounts); diff != "" {
+		t.Fatalf("converted main volume mounts mismatch (-want +got):\n%s", diff)
+	}
+
+	out := &DynamoGraphDeployment{}
+	if err := out.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	got := out.Spec.Services["worker"]
+	if got == nil || got.ExtraPodSpec == nil || got.ExtraPodSpec.MainContainer == nil {
+		t.Fatalf("expected converted service and extra main container, got %#v", got)
+	}
+	if diff := cmp.Diff(in.Spec.Services["worker"].VolumeMounts, got.VolumeMounts); diff != "" {
+		t.Fatalf("service volume mounts changed after round-trip (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(in.Spec.Services["worker"].ExtraPodSpec.MainContainer.VolumeMounts, got.ExtraPodSpec.MainContainer.VolumeMounts); diff != "" {
+		t.Fatalf("extra main volume mounts changed after round-trip (-want +got):\n%s", diff)
+	}
+}
+
 func addGeneratedFrontendSidecarHubOnlySecurityContext(t *testing.T, podTemplate *corev1.PodTemplateSpec) {
 	t.Helper()
 	if podTemplate == nil {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6405,7 +6405,7 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 			},
 		},
 		{
-			name: "volumeMounts keep generated PVC when podTemplate has other volumes",
+			name: "volumeMounts compose with extra main container mounts",
 			component: &v1alpha1.DynamoComponentDeploymentSharedSpec{
 				ComponentType: commonconsts.ComponentTypeFrontend,
 				VolumeMounts: []v1alpha1.VolumeMount{
@@ -6416,6 +6416,14 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 				},
 				ExtraPodSpec: &v1alpha1.ExtraPodSpec{
 					PodSpec: &corev1.PodSpec{
+						InitContainers: []corev1.Container{
+							{
+								Name: "init",
+								VolumeMounts: []corev1.VolumeMount{
+									{Name: "test-pvc", MountPath: "/data"},
+								},
+							},
+						},
 						Volumes: []corev1.Volume{
 							{
 								Name: "config",
@@ -6427,11 +6435,17 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 							},
 						},
 					},
+					MainContainer: &corev1.Container{
+						VolumeMounts: []corev1.VolumeMount{
+							{Name: "config", MountPath: "/config"},
+						},
+					},
 				},
 			},
 			expectError:  false,
 			expectedPVCs: []string{"test-pvc"},
 			expectedMounts: []corev1.VolumeMount{
+				{Name: "config", MountPath: "/config"},
 				{Name: "test-pvc", MountPath: "/data"},
 				{Name: "shared-memory", MountPath: "/dev/shm"},
 			},

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -6385,6 +6385,7 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 		expectError    bool
 		expectedPVCs   []string
 		expectedMounts []corev1.VolumeMount
+		expectedInit   []corev1.VolumeMount
 	}{
 		{
 			name: "valid volumeMounts",
@@ -6448,6 +6449,9 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 				{Name: "config", MountPath: "/config"},
 				{Name: "test-pvc", MountPath: "/data"},
 				{Name: "shared-memory", MountPath: "/dev/shm"},
+			},
+			expectedInit: []corev1.VolumeMount{
+				{Name: "test-pvc", MountPath: "/data"},
 			},
 		},
 		{
@@ -6552,6 +6556,10 @@ func TestGenerateBasePodSpec_VolumeMounts(t *testing.T) {
 				if !found {
 					t.Errorf("GenerateBasePodSpec() expected volume mount %+v not found", expectedMount)
 				}
+			}
+			if tt.expectedInit != nil {
+				require.NotEmpty(t, podSpec.InitContainers)
+				assert.Equal(t, tt.expectedInit, podSpec.InitContainers[0].VolumeMounts)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fix bug where v1alpha1 services combining service-level PVC mounts with `extraPodSpec.mainContainer.volumeMounts` could lose the PVC mount during conversion to v1beta1.

The generic override merge replaced the complete `volumeMounts` slice. This caused generated workloads to omit the service PVC volume and could leave init containers referencing a nonexistent volume.

This change:

- Composes extra and service-level mounts using legacy v1alpha1 ordering.
- Leaves native v1beta1 PodTemplate behavior unchanged.
- Preserves mount provenance across DGD and DCD conversion round trips.
- Handles compilation-cache mounts without restoring stale configuration.
- Adds regression coverage for the invalid PodSpec reported in DYN-3391.

## Validation

- `go test ./api/... ./internal/dynamo -count=1`
- `go test ./internal/controller -count=1`
- Conversion round-trip fuzz tests with seeds `1`, `2`, `17`, and `99`, using 1,000 iterations per direction.
- `go test ./... -run '^$' -count=1`

Closes DYN-3391
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11263" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how additional pod settings are combined, so main-container volume mounts now keep the expected order and preserve existing mounts.
  * Fixed round-trip conversion so volume mounts and extra container mounts are retained more reliably, including compilation-cache mounts.
  * Updated related test coverage to verify volume mounts compose correctly in common deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->