### PR TITLE
fix(operator): avoid duplicate compilation cache mounts

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1729,6 +1729,7 @@ func applyCompilationCacheVolume(podSpec *corev1.PodSpec, compilationCache *v1be
 	if compilationCache == nil {
 		return nil
 	}
+	found := false
 	for i := range podSpec.Volumes {
 		volume := &podSpec.Volumes[i]
 		if volume.Name != compilationCache.PVCName {
@@ -1743,6 +1744,12 @@ func applyCompilationCacheVolume(podSpec *corev1.PodSpec, compilationCache *v1be
 		if volume.PersistentVolumeClaim.ReadOnly {
 			return fmt.Errorf("compilation cache PVC %q must be writable", compilationCache.PVCName)
 		}
+		if found {
+			return fmt.Errorf("compilation cache volume %q is defined more than once", compilationCache.PVCName)
+		}
+		found = true
+	}
+	if found {
 		return nil
 	}
 	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1686,19 +1686,38 @@ func applyCompilationCache(container *corev1.Container, component *v1beta1.Dynam
 	if component.CompilationCache == nil {
 		return nil
 	}
-	if component.CompilationCache.PVCName == "" {
+	compilationCache := component.CompilationCache
+	if compilationCache.PVCName == "" {
 		return fmt.Errorf("compilationCache.pvcName is required when compilationCache is set")
 	}
-	mountPath := component.CompilationCache.MountPath
+	mountPath := compilationCache.MountPath
 	if mountPath == "" {
 		mountPath = getDefaultCompilationCacheMountPoint(backendFramework)
 		if mountPath == "" {
 			return fmt.Errorf("compilationCache.mountPath is required for backend framework %s (no default available)", backendFramework)
 		}
-		component.CompilationCache.MountPath = mountPath
+		compilationCache.MountPath = mountPath
 	}
+
+	alreadyMounted := false
+	for _, mount := range container.VolumeMounts {
+		if mount.MountPath != mountPath {
+			continue
+		}
+		if mount.Name != compilationCache.PVCName {
+			return fmt.Errorf("compilationCache.mountPath %q is already used by volume %q", mountPath, mount.Name)
+		}
+		if mount.ReadOnly {
+			return fmt.Errorf("compilation cache volume %q at %q must be writable", compilationCache.PVCName, mountPath)
+		}
+		alreadyMounted = true
+	}
+	if alreadyMounted {
+		return nil
+	}
+
 	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      component.CompilationCache.PVCName,
+		Name:      compilationCache.PVCName,
 		MountPath: mountPath,
 	})
 	return nil

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -1508,11 +1508,11 @@ func GenerateBasePodSpec(
 			return nil, fmt.Errorf("failed to merge podTemplate main container: %w", err)
 		}
 	}
-	if err := validateContainerVolumeMounts(container.VolumeMounts); err != nil {
-		return nil, err
-	}
 
 	if err := applyCompilationCache(&container, component, backendFramework); err != nil {
+		return nil, err
+	}
+	if err := validateContainerVolumeMounts(container.VolumeMounts); err != nil {
 		return nil, err
 	}
 
@@ -1571,15 +1571,8 @@ func GenerateBasePodSpec(
 		}
 	}
 
-	if component.CompilationCache != nil {
-		podSpec.Volumes = appendUniqueVolume(podSpec.Volumes, corev1.Volume{
-			Name: component.CompilationCache.PVCName,
-			VolumeSource: corev1.VolumeSource{
-				PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
-					ClaimName: component.CompilationCache.PVCName,
-				},
-			},
-		})
+	if err := applyCompilationCacheVolume(&podSpec, component.CompilationCache); err != nil {
+		return nil, err
 	}
 
 	ApplySharedMemoryVolumeAndMount(&podSpec, &container, component.SharedMemorySize)
@@ -1699,9 +1692,15 @@ func applyCompilationCache(container *corev1.Container, component *v1beta1.Dynam
 		compilationCache.MountPath = mountPath
 	}
 
+	// Normalize cache mounts left by older conversions before validating the container.
+	normalizedMounts := make([]corev1.VolumeMount, 0, len(container.VolumeMounts)+1)
 	alreadyMounted := false
 	for _, mount := range container.VolumeMounts {
+		if mount.Name == compilationCache.PVCName && mount.MountPath == "" {
+			mount.MountPath = mountPath
+		}
 		if mount.MountPath != mountPath {
+			normalizedMounts = append(normalizedMounts, mount)
 			continue
 		}
 		if mount.Name != compilationCache.PVCName {
@@ -1710,26 +1709,51 @@ func applyCompilationCache(container *corev1.Container, component *v1beta1.Dynam
 		if mount.ReadOnly {
 			return fmt.Errorf("compilation cache volume %q at %q must be writable", compilationCache.PVCName, mountPath)
 		}
+		if alreadyMounted {
+			continue
+		}
+		normalizedMounts = append(normalizedMounts, mount)
 		alreadyMounted = true
 	}
-	if alreadyMounted {
-		return nil
+	if !alreadyMounted {
+		normalizedMounts = append(normalizedMounts, corev1.VolumeMount{
+			Name:      compilationCache.PVCName,
+			MountPath: mountPath,
+		})
 	}
-
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      compilationCache.PVCName,
-		MountPath: mountPath,
-	})
+	container.VolumeMounts = normalizedMounts
 	return nil
 }
 
-func appendUniqueVolume(volumes []corev1.Volume, volume corev1.Volume) []corev1.Volume {
-	for i := range volumes {
-		if volumes[i].Name == volume.Name {
-			return volumes
-		}
+func applyCompilationCacheVolume(podSpec *corev1.PodSpec, compilationCache *v1beta1.CompilationCacheConfig) error {
+	if compilationCache == nil {
+		return nil
 	}
-	return append(volumes, volume)
+	for i := range podSpec.Volumes {
+		volume := &podSpec.Volumes[i]
+		if volume.Name != compilationCache.PVCName {
+			continue
+		}
+		if volume.PersistentVolumeClaim == nil {
+			return fmt.Errorf("compilation cache volume %q must reference PVC %q", volume.Name, compilationCache.PVCName)
+		}
+		if volume.PersistentVolumeClaim.ClaimName != compilationCache.PVCName {
+			return fmt.Errorf("compilation cache volume %q references PVC %q instead of %q", volume.Name, volume.PersistentVolumeClaim.ClaimName, compilationCache.PVCName)
+		}
+		if volume.PersistentVolumeClaim.ReadOnly {
+			return fmt.Errorf("compilation cache PVC %q must be writable", compilationCache.PVCName)
+		}
+		return nil
+	}
+	podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+		Name: compilationCache.PVCName,
+		VolumeSource: corev1.VolumeSource{
+			PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{
+				ClaimName: compilationCache.PVCName,
+			},
+		},
+	})
+	return nil
 }
 
 func appendMissingPVCVolumesForMounts(volumes []corev1.Volume, mounts []corev1.VolumeMount) []corev1.Volume {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7199,6 +7199,42 @@ func TestApplyCompilationCacheVolume(t *testing.T) {
 			}},
 			expectedError: `compilation cache PVC "compilation-cache" must be writable`,
 		},
+		{
+			name: "duplicate matching PVC volumes are rejected",
+			volumes: []corev1.Volume{
+				{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName},
+					},
+				},
+				{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName},
+					},
+				},
+			},
+			expectedError: `compilation cache volume "compilation-cache" is defined more than once`,
+		},
+		{
+			name: "conflicting duplicate volume is rejected",
+			volumes: []corev1.Volume{
+				{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName},
+					},
+				},
+				{
+					Name: volumeName,
+					VolumeSource: corev1.VolumeSource{
+						EmptyDir: &corev1.EmptyDirVolumeSource{},
+					},
+				},
+			},
+			expectedError: `compilation cache volume "compilation-cache" must reference PVC "compilation-cache"`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7035,6 +7035,132 @@ func TestGenerateBasePodSpec_UseAsCompilationCache_BackendSupport(t *testing.T) 
 	}
 }
 
+func TestGenerateBasePodSpec_ConvertedCompilationCacheMountIsNotDuplicated(t *testing.T) {
+	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeFrontend,
+		VolumeMounts: []v1alpha1.VolumeMount{
+			{Name: "model-cache", MountPoint: "/models"},
+			{
+				Name:                  "compilation-cache",
+				MountPoint:            "/home/dynamo/.cache/vllm",
+				UseAsCompilationCache: true,
+			},
+		},
+	}
+
+	for _, deploymentType := range []commonconsts.MultinodeDeploymentType{
+		commonconsts.MultinodeDeploymentTypeGrove,
+		commonconsts.MultinodeDeploymentTypeLWS,
+	} {
+		t.Run(string(deploymentType), func(t *testing.T) {
+			podSpec, err := GenerateBasePodSpec(
+				betaComponent(t, component),
+				BackendFrameworkVLLM,
+				nil,
+				"test-deployment",
+				"default",
+				RoleMain,
+				1,
+				&configv1alpha1.OperatorConfiguration{},
+				deploymentType,
+				"test-service",
+				nil,
+				nil,
+			)
+			require.NoError(t, err)
+			require.NotEmpty(t, podSpec.Containers)
+
+			var compilationCacheMounts []corev1.VolumeMount
+			for _, mount := range podSpec.Containers[0].VolumeMounts {
+				if mount.MountPath == "/home/dynamo/.cache/vllm" {
+					compilationCacheMounts = append(compilationCacheMounts, mount)
+				}
+			}
+			require.Equal(t, []corev1.VolumeMount{{
+				Name:      "compilation-cache",
+				MountPath: "/home/dynamo/.cache/vllm",
+			}}, compilationCacheMounts)
+		})
+	}
+}
+
+func TestApplyCompilationCacheExistingMount(t *testing.T) {
+	const mountPath = "/home/dynamo/.cache/vllm"
+
+	tests := []struct {
+		name           string
+		mounts         []corev1.VolumeMount
+		expectedMounts []corev1.VolumeMount
+		expectedError  string
+	}{
+		{
+			name: "matching writable mount is preserved",
+			mounts: []corev1.VolumeMount{{
+				Name:      "compilation-cache",
+				MountPath: mountPath,
+				SubPath:   "model",
+			}},
+			expectedMounts: []corev1.VolumeMount{{
+				Name:      "compilation-cache",
+				MountPath: mountPath,
+				SubPath:   "model",
+			}},
+		},
+		{
+			name: "different volume at mount path is rejected",
+			mounts: []corev1.VolumeMount{{
+				Name:      "other-volume",
+				MountPath: mountPath,
+			}},
+			expectedError: `compilationCache.mountPath "/home/dynamo/.cache/vllm" is already used by volume "other-volume"`,
+		},
+		{
+			name: "read-only cache mount is rejected",
+			mounts: []corev1.VolumeMount{{
+				Name:      "compilation-cache",
+				MountPath: mountPath,
+				ReadOnly:  true,
+			}},
+			expectedError: `compilation cache volume "compilation-cache" at "/home/dynamo/.cache/vllm" must be writable`,
+		},
+		{
+			name: "same volume at another path does not satisfy cache mount",
+			mounts: []corev1.VolumeMount{{
+				Name:      "compilation-cache",
+				MountPath: "/other-path",
+			}},
+			expectedMounts: []corev1.VolumeMount{
+				{Name: "compilation-cache", MountPath: "/other-path"},
+				{Name: "compilation-cache", MountPath: mountPath},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			container := &corev1.Container{
+				VolumeMounts: append([]corev1.VolumeMount(nil), tt.mounts...),
+			}
+			component := &v1beta1.DynamoComponentDeploymentSharedSpec{
+				CompilationCache: &v1beta1.CompilationCacheConfig{
+					PVCName:   "compilation-cache",
+					MountPath: mountPath,
+				},
+			}
+
+			err := applyCompilationCache(container, component, BackendFrameworkVLLM)
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError)
+				assert.Equal(t, tt.mounts, container.VolumeMounts)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedMounts, container.VolumeMounts)
+		})
+	}
+}
+
 func TestGenerateBasePodSpec_SecurityContext(t *testing.T) {
 	secretsRetriever := &mockSecretsRetriever{}
 	controllerConfig := &configv1alpha1.OperatorConfiguration{}

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -7084,6 +7084,140 @@ func TestGenerateBasePodSpec_ConvertedCompilationCacheMountIsNotDuplicated(t *te
 	}
 }
 
+func TestGenerateBasePodSpec_ConvertedCompilationCacheUsesDefaultMount(t *testing.T) {
+	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: commonconsts.ComponentTypeFrontend,
+		VolumeMounts: []v1alpha1.VolumeMount{
+			{Name: "model-cache", MountPoint: "/models"},
+			{Name: "compilation-cache", UseAsCompilationCache: true},
+		},
+	}
+
+	podSpec, err := GenerateBasePodSpec(
+		betaComponent(t, component),
+		BackendFrameworkVLLM,
+		nil,
+		"test-deployment",
+		"default",
+		RoleMain,
+		1,
+		&configv1alpha1.OperatorConfiguration{},
+		commonconsts.MultinodeDeploymentTypeGrove,
+		"test-service",
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, podSpec.Containers)
+	assert.Contains(t, podSpec.Containers[0].VolumeMounts, corev1.VolumeMount{
+		Name:      "compilation-cache",
+		MountPath: commonconsts.DefaultVLLMCacheMountPoint,
+	})
+}
+
+func TestApplyCompilationCacheRepairsLegacyMounts(t *testing.T) {
+	container := &corev1.Container{
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: "model-cache", MountPath: "/models"},
+			{Name: "compilation-cache"},
+			{Name: "compilation-cache"},
+		},
+	}
+	component := &v1beta1.DynamoComponentDeploymentSharedSpec{
+		CompilationCache: &v1beta1.CompilationCacheConfig{PVCName: "compilation-cache"},
+	}
+
+	require.NoError(t, applyCompilationCache(container, component, BackendFrameworkVLLM))
+	assert.Equal(t, []corev1.VolumeMount{
+		{Name: "model-cache", MountPath: "/models"},
+		{Name: "compilation-cache", MountPath: commonconsts.DefaultVLLMCacheMountPoint},
+	}, container.VolumeMounts)
+	assert.Equal(t, commonconsts.DefaultVLLMCacheMountPoint, component.CompilationCache.MountPath)
+}
+
+func TestApplyCompilationCacheVolume(t *testing.T) {
+	const volumeName = "compilation-cache"
+	cache := &v1beta1.CompilationCacheConfig{PVCName: volumeName}
+
+	tests := []struct {
+		name            string
+		volumes         []corev1.Volume
+		expectedVolumes []corev1.Volume
+		expectedError   string
+	}{
+		{
+			name: "missing volume is added",
+			expectedVolumes: []corev1.Volume{{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName},
+				},
+			}},
+		},
+		{
+			name: "matching PVC volume is preserved",
+			volumes: []corev1.Volume{{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName},
+				},
+			}},
+			expectedVolumes: []corev1.Volume{{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName},
+				},
+			}},
+		},
+		{
+			name: "non-PVC volume is rejected",
+			volumes: []corev1.Volume{{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					EmptyDir: &corev1.EmptyDirVolumeSource{},
+				},
+			}},
+			expectedError: `compilation cache volume "compilation-cache" must reference PVC "compilation-cache"`,
+		},
+		{
+			name: "different PVC is rejected",
+			volumes: []corev1.Volume{{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: "other-pvc"},
+				},
+			}},
+			expectedError: `compilation cache volume "compilation-cache" references PVC "other-pvc" instead of "compilation-cache"`,
+		},
+		{
+			name: "read-only PVC is rejected",
+			volumes: []corev1.Volume{{
+				Name: volumeName,
+				VolumeSource: corev1.VolumeSource{
+					PersistentVolumeClaim: &corev1.PersistentVolumeClaimVolumeSource{ClaimName: volumeName, ReadOnly: true},
+				},
+			}},
+			expectedError: `compilation cache PVC "compilation-cache" must be writable`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			podSpec := &corev1.PodSpec{Volumes: append([]corev1.Volume(nil), tt.volumes...)}
+
+			err := applyCompilationCacheVolume(podSpec, cache)
+			if tt.expectedError != "" {
+				require.EqualError(t, err, tt.expectedError)
+				assert.Equal(t, tt.volumes, podSpec.Volumes)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedVolumes, podSpec.Volumes)
+		})
+	}
+}
+
 func TestApplyCompilationCacheExistingMount(t *testing.T) {
 	const mountPath = "/home/dynamo/.cache/vllm"
 


### PR DESCRIPTION
## Summary

Fix DYN-3377 by making compilation-cache mount injection idempotent.

Converted v1alpha1 components can represent a `useAsCompilationCache` volume in both the main container's `volumeMounts` and the v1beta1 `compilationCache` field. Pod generation previously appended the generated mount unconditionally, producing duplicate mount paths rejected by Grove PodCliqueSet validation.

This change:

- Reuses an existing writable mount with the configured PVC name and mount path.
- Rejects mount-path conflicts with a different volume.
- Rejects read-only compilation-cache mounts.
- Adds regression coverage for both Grove and LWS pod generation.

## Validation

- `go test ./internal/dynamo -run 'TestGenerateBasePodSpec_(UseAsCompilationCache_BackendSupport|ConvertedCompilationCacheMountIsNotDuplicated)|TestApplyCompilationCacheExistingMount' -count=1`
- `go test ./internal/dynamo ./internal/controller -count=1`
- `go test ./api/... ./internal/... -count=1`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11264" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compilation-cache mount handling to avoid duplicate mounts and preserve existing valid mounts.
  * Added checks to prevent conflicting mount paths and reject read-only cache mounts when write access is required.
  * Automatically uses a default mount path when one is not provided.

* **Tests**
  * Added coverage for compilation-cache mount deduplication and conflict handling across deployment types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->