### PR TITLE
feat(vllm): enable unified multimodal embedding cache

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -614,7 +614,7 @@ Request handling:
 | Feature | Description |
 |---------|-------------|
 | Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization. Unified hardcodes `ModelInput.Tokens`. |
-| Multimodal parity | The shared request and encoder-handoff contract are available. vLLM supports aggregated image and video inference; P/D execution, frontend decoding, embedding caching, SGLang/TRT-LLM execution, and separate encode workers remain separate work. |
+| Multimodal parity | The shared request and encoder-handoff contract are available. vLLM supports aggregated image and video inference with CPU embedding caching; P/D execution, frontend decoding, SGLang/TRT-LLM execution, and separate encode workers remain separate work. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path. |
 | LoRA adapters (SGLang / TRT-LLM) | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading. **vLLM is supported on the unified path** — see [What works today](#what-works-today); SGLang and TRT-LLM advertise no LoRA updates yet. |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload. |
@@ -631,7 +631,7 @@ Request handling:
 | `KvConnectorProtocol` abstraction | Legacy abstracts NIXL pull / Mooncake push; unified uses vLLM's internal connector only |
 | `--benchmark-mode` family | The `--benchmark-*` flag family (mode, prefill/decode granularities, warmup, output path, timeout) injects into `vllm_config.additional_config` |
 | "Omni" alternative entry point | `dynamo.vllm.omni.*` parallel mode for alternative tensor workflows |
-| Multimodal (vLLM) | P/D execution, frontend decoding, embedding caching, Qwen VL mRoPE handoff, `EncodeWorkerHandler`, and `--route-to-encoder` |
+| Multimodal (vLLM) | P/D execution, frontend decoding, Qwen VL mRoPE handoff, `EncodeWorkerHandler`, and `--route-to-encoder` |
 
 ### SGLang-specific gaps
 

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -79,6 +79,7 @@ from .logits_processing import (
     activate_logits_processors,
     register_dynamo_logits_processor,
 )
+from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.request_processor import VllmMultimodalRequestProcessor
 
 if TYPE_CHECKING:
@@ -175,6 +176,8 @@ class VllmLLMEngine(LLMEngine):
         dyn_reasoning_parser: Optional[str] = None,
         enable_rl: bool = False,
         enable_multimodal: bool = False,
+        multimodal_embedding_cache_capacity_gb: float = 0.0,
+        namespace: str = "dynamo",
     ):
         self.engine_args = engine_args
         self.disaggregation_mode = disaggregation_mode
@@ -184,6 +187,10 @@ class VllmLLMEngine(LLMEngine):
         self._dyn_reasoning_parser = dyn_reasoning_parser
         self.enable_rl = enable_rl
         self.enable_multimodal = enable_multimodal
+        self.multimodal_embedding_cache_capacity_gb = (
+            multimodal_embedding_cache_capacity_gb
+        )
+        self._namespace = namespace
         self.engine_client: AsyncLLM | None = None
         self._vllm_config: Any = None
         self._default_sampling_params: Any = None
@@ -293,6 +300,10 @@ class VllmLLMEngine(LLMEngine):
             dyn_reasoning_parser=config.dyn_reasoning_parser,
             enable_rl=config.enable_rl,
             enable_multimodal=config.enable_multimodal,
+            multimodal_embedding_cache_capacity_gb=(
+                config.multimodal_embedding_cache_capacity_gb
+            ),
+            namespace=config.namespace,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -321,6 +332,14 @@ class VllmLLMEngine(LLMEngine):
             register_dynamo_logits_processor(self.engine_args)
 
         self._prometheus_temp_dir = ensure_prometheus_multiproc_dir("vllm_prometheus_")
+
+        configure_multimodal_embedding_cache(
+            self.engine_args,
+            route_to_encoder=False,
+            capacity_gb=self.multimodal_embedding_cache_capacity_gb,
+            namespace=self._namespace,
+            component=self._component,
+        )
 
         vllm_config = self.engine_args.create_engine_config(
             usage_context=UsageContext.OPENAI_API_SERVER

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -62,6 +62,7 @@ from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
 from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
+from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
 from .snapshot import prepare_snapshot_engine
 
@@ -549,31 +550,14 @@ def setup_vllm_engine(
             configure_gms_lock_mode(engine_args)
             configure_mx_ports(engine_args)
 
-    # Configure ec_both mode with DynamoMultimodalEmbeddingCacheConnector.
-    # Must happen BEFORE engine setup so vLLM sees ec_transfer_config.
-    if (
-        not config.route_to_encoder
-        and config.multimodal_embedding_cache_capacity_gb > 0
-    ):
-        from vllm.config import ECTransferConfig
-
-        logger.info(
-            "Configuring ec_both mode with DynamoMultimodalEmbeddingCacheConnector "
-            "(capacity=%.2f GB)",
-            config.multimodal_embedding_cache_capacity_gb,
-        )
-        instance_id = 0
-        engine_id = f"{config.namespace}.{config.component}.backend.{instance_id}"
-        engine_args.ec_transfer_config = ECTransferConfig(
-            engine_id=engine_id,
-            ec_role="ec_both",
-            ec_connector="DynamoMultimodalEmbeddingCacheConnector",
-            ec_connector_module_path="dynamo.vllm.multimodal_utils.multimodal_embedding_cache_connector",
-            ec_connector_extra_config={
-                "multimodal_embedding_cache_capacity_gb": config.multimodal_embedding_cache_capacity_gb,
-            },
-        )
-        logger.info("Configured ec_both with engine_id=%s", engine_id)
+    # Must happen before create_engine_config() so vLLM sees ec_transfer_config.
+    configure_multimodal_embedding_cache(
+        engine_args,
+        route_to_encoder=config.route_to_encoder,
+        capacity_gb=config.multimodal_embedding_cache_capacity_gb,
+        namespace=config.namespace,
+        component=config.component,
+    )
 
     # Taken from build_async_engine_client_from_engine_args()
     usage_context = UsageContext.OPENAI_API_SERVER

--- a/components/src/dynamo/vllm/multimodal_utils/cache_config.py
+++ b/components/src/dynamo/vllm/multimodal_utils/cache_config.py
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Lightweight vLLM multimodal embedding-cache startup configuration."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def configure_multimodal_embedding_cache(
+    engine_args: object,
+    *,
+    route_to_encoder: bool,
+    capacity_gb: float,
+    namespace: str,
+    component: str,
+) -> None:
+    """Configure vLLM's CPU embedding cache before engine creation.
+
+    Separate encode-worker deployments use Dynamo's worker-layer cache. All
+    other vLLM deployments use the EC connector owned by vLLM. The vLLM config
+    import stays lazy so cache-disabled workers do not load EC-transfer code.
+    """
+    if route_to_encoder or capacity_gb <= 0:
+        return
+
+    from vllm.config import ECTransferConfig
+
+    engine_id = f"{namespace}.{component}.backend.0"
+    setattr(
+        engine_args,
+        "ec_transfer_config",
+        ECTransferConfig(
+            engine_id=engine_id,
+            ec_role="ec_both",
+            ec_connector="DynamoMultimodalEmbeddingCacheConnector",
+            ec_connector_module_path=(
+                "dynamo.vllm.multimodal_utils.multimodal_embedding_cache_connector"
+            ),
+            ec_connector_extra_config={
+                "multimodal_embedding_cache_capacity_gb": capacity_gb,
+            },
+        ),
+    )
+    logger.info(
+        "Configured multimodal embedding cache: engine_id=%s, capacity=%.2f GB",
+        engine_id,
+        capacity_gb,
+    )

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py
@@ -3,11 +3,13 @@
 
 """Unit tests for DynamoMultimodalEmbeddingCacheConnector."""
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
 import torch
 
+from dynamo.vllm.multimodal_utils import cache_config as cache_config_mod
 from dynamo.vllm.multimodal_utils import multimodal_embedding_cache_connector as mod
 
 pytestmark = [
@@ -26,6 +28,60 @@ def _make_vllm_config(capacity_gb: float = 1.0) -> MagicMock:
     config.model_config.get_hidden_size.return_value = 4096
     config.model_config.dtype = torch.float16
     return config
+
+
+class TestCacheConfiguration:
+    def test_disabled_capacity_leaves_engine_args_unchanged(self):
+        engine_args = SimpleNamespace()
+
+        cache_config_mod.configure_multimodal_embedding_cache(
+            engine_args,
+            route_to_encoder=False,
+            capacity_gb=0,
+            namespace="dynamo",
+            component="backend",
+        )
+
+        assert not hasattr(engine_args, "ec_transfer_config")
+
+    def test_encoder_routing_leaves_engine_args_unchanged(self):
+        engine_args = SimpleNamespace()
+
+        cache_config_mod.configure_multimodal_embedding_cache(
+            engine_args,
+            route_to_encoder=True,
+            capacity_gb=1,
+            namespace="dynamo",
+            component="backend",
+        )
+
+        assert not hasattr(engine_args, "ec_transfer_config")
+
+    def test_enabled_capacity_configures_dynamo_connector(self):
+        engine_args = SimpleNamespace()
+        transfer_config = object()
+
+        with patch("vllm.config.ECTransferConfig", return_value=transfer_config) as cls:
+            cache_config_mod.configure_multimodal_embedding_cache(
+                engine_args,
+                route_to_encoder=False,
+                capacity_gb=2.5,
+                namespace="deployment",
+                component="prefill",
+            )
+
+        assert engine_args.ec_transfer_config is transfer_config
+        cls.assert_called_once_with(
+            engine_id="deployment.prefill.backend.0",
+            ec_role="ec_both",
+            ec_connector="DynamoMultimodalEmbeddingCacheConnector",
+            ec_connector_module_path=(
+                "dynamo.vllm.multimodal_utils.multimodal_embedding_cache_connector"
+            ),
+            ec_connector_extra_config={
+                "multimodal_embedding_cache_capacity_gb": 2.5,
+            },
+        )
 
 
 class TestVersionCheck:

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py
@@ -171,6 +171,7 @@ async def test_from_args_retains_multimodal_runtime_configuration(monkeypatch):
         namespace="deployment",
         enable_rl=False,
         enable_multimodal=True,
+        multimodal_embedding_cache_capacity_gb=2.5,
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,
         engine_args=SimpleNamespace(
@@ -194,4 +195,6 @@ async def test_from_args_retains_multimodal_runtime_configuration(monkeypatch):
 
     assert actual_worker_config is worker_config
     assert engine.enable_multimodal is True
+    assert engine.multimodal_embedding_cache_capacity_gb == 2.5
+    assert engine._namespace == "deployment"
     assert from_runtime_config.call_args.kwargs["model_input"] is mod.ModelInput.Tokens

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -362,8 +362,10 @@ def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
         disaggregation_mode=CommonDisaggregationMode.AGGREGATED,
         headless=False,
         component="backend",
+        namespace="dynamo",
         route_to_encoder=False,
         enable_multimodal=False,
+        multimodal_embedding_cache_capacity_gb=0.0,
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,
     )
@@ -603,6 +605,7 @@ def test_setup_vllm_engine_reuses_engine_config_model_config(monkeypatch):
 
     config = SimpleNamespace(
         component="backend",
+        namespace="dynamo",
         engine_args=FakeEngineArgs(),
         gms_shadow_mode=False,
         multimodal_embedding_cache_capacity_gb=0,

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -168,7 +168,7 @@ Request handling:
 |---------|----------------|
 | Logprob response wire | Legacy handlers extract logprobs onto response chunks (vLLM `_extract_logprobs`, SGLang `_extract_logprobs` in `decode_handler`, TRT-LLM `_extract_logprobs` in `handler_base`); the unified `generate()` loops do not populate `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk`. vLLM's `build_sampling_params` still passes `output_options.logprobs` to the engine on the unified path, so the engine computes them, but the values are dropped before they reach the chunk. SGLang and TRT-LLM unified `generate()` do not read `output_options.logprobs` at all. |
 | Text-in-text-out mode | Unified hardcodes `ModelInput.Tokens`; no engine-side tokenization or chat templating path |
-| Multimodal parity | vLLM supports aggregated image and video inference. P/D multimodal execution, frontend decoding, embedding caching, separate encode workers, and SGLang/TRT-LLM execution remain unavailable through unified engines. |
+| Multimodal parity | vLLM supports aggregated image and video inference, including the CPU embedding cache. P/D multimodal execution, frontend decoding, separate encode workers, and SGLang/TRT-LLM execution remain unavailable through unified engines. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
 | LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading on prefill |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |

--- a/docs/features/multimodal/multimodal-vllm.md
+++ b/docs/features/multimodal/multimodal-vllm.md
@@ -246,11 +246,14 @@ flowchart LR
 
 ```bash
 bash examples/backends/vllm/launch/agg_multimodal.sh \
+    --unified \
     --model Qwen/Qwen3-VL-30B-A3B-Instruct-FP8 \
     --multimodal-embedding-cache-capacity-gb 10
 ```
 
-`dynamo.vllm` automatically configures `ec_both` mode with the `DynamoMultimodalEmbeddingCacheConnector` when the capacity is > 0.
+Both `dynamo.vllm` and the unified vLLM entry point automatically configure
+`ec_both` mode with the `DynamoMultimodalEmbeddingCacheConnector` when the
+capacity is greater than zero.
 
 **Launch with `vllm serve` (standalone, no Dynamo):**
 

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -113,6 +113,15 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                         payload=make_image_payload(["green"]),
                         extra_script_args=["--unified"],
                     ),
+                    MmCase(
+                        suffix="embedding_cache",
+                        payload=make_image_payload(["green"], repeat_count=2),
+                        extra_script_args=[
+                            "--unified",
+                            "--multimodal-embedding-cache-capacity-gb",
+                            "1",
+                        ],
+                    ),
                 ],
             ),
             "agg_unified_video": TopologyConfig(

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -115,7 +115,14 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                     ),
                     MmCase(
                         suffix="embedding_cache",
-                        payload=make_image_payload(["green"], repeat_count=2),
+                        payload=make_image_payload(
+                            ["green"],
+                            repeat_count=2,
+                            expected_log=[
+                                r"DynamoMultimodalEmbeddingCacheConnector "
+                                r"initialized: capacity_gb=1\.00"
+                            ],
+                        ),
                         extra_script_args=[
                             "--unified",
                             "--multimodal-embedding-cache-capacity-gb",

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -46,7 +46,7 @@ _COLOR_PROMPT_FILLER = (
 
 
 def make_image_payload(
-    expected_response: list[str], *, max_attempts: int = 1
+    expected_response: list[str], *, max_attempts: int = 1, repeat_count: int = 1
 ) -> ChatPayload:
     """Standard image color-identification payload using MULTIMODAL_IMG_URL.
 
@@ -54,6 +54,8 @@ def make_image_payload(
     ``run_serve_deployment`` — set >1 only for known-flaky multimodal
     smoke checks (see tests/README.md "Flaky Tests"). The server stays
     up across attempts; only the request/response is re-issued.
+    ``repeat_count`` sends the same image request repeatedly, which is useful
+    for cache smoke coverage.
     """
     return chat_payload(
         [
@@ -63,7 +65,7 @@ def make_image_payload(
                 "image_url": {"url": MULTIMODAL_IMG_URL},
             },
         ],
-        repeat_count=1,
+        repeat_count=repeat_count,
         expected_response=expected_response,
         temperature=0.0,
         max_tokens=100,

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -46,7 +46,11 @@ _COLOR_PROMPT_FILLER = (
 
 
 def make_image_payload(
-    expected_response: list[str], *, max_attempts: int = 1, repeat_count: int = 1
+    expected_response: list[str],
+    *,
+    max_attempts: int = 1,
+    repeat_count: int = 1,
+    expected_log: Optional[list[str]] = None,
 ) -> ChatPayload:
     """Standard image color-identification payload using MULTIMODAL_IMG_URL.
 
@@ -56,6 +60,8 @@ def make_image_payload(
     up across attempts; only the request/response is re-issued.
     ``repeat_count`` sends the same image request repeatedly, which is useful
     for cache smoke coverage.
+    ``expected_log`` contains regex patterns that must appear in the deployment
+    log, allowing callers to verify that optional multimodal paths were enabled.
     """
     return chat_payload(
         [
@@ -67,6 +73,7 @@ def make_image_payload(
         ],
         repeat_count=repeat_count,
         expected_response=expected_response,
+        expected_log=expected_log,
         temperature=0.0,
         max_tokens=100,
         max_attempts=max_attempts,


### PR DESCRIPTION
## Overview:

### Summary

Enables the existing vLLM multimodal CPU embedding cache from the unified backend while preserving legacy startup behavior. This is stack 3/5 for DIS-2033.

### Stack

This PR is part of the ordered replacement for #11147:

1. #11266 — shared request-processor refactor
2. #11267 — aggregated unified multimodal
3. #11268 — multimodal embedding cache
4. #11269 — frontend decoding and transfer
5. #11270 — multimodal P/D

Merge and retarget these PRs in order.

### Validation

- Cache enabled, disabled, and encoder-routing configuration paths have focused unit coverage.
- A repeated-image unified serve profile exercises cache reuse.
- `ruff check`, Python compilation, and `git diff --check` passed.
- Local pytest was not run because the workstation Python does not have pytest installed; CI is expected to provide the vLLM test environment.

## Details:

- Extracts the existing `ECTransferConfig` setup into a shared startup helper.
- Calls the helper before `create_engine_config` in both legacy and unified startup.
- Honors `--multimodal-embedding-cache-capacity-gb`; zero remains disabled.
- Continues using `DynamoMultimodalEmbeddingCacheConnector` and frontend-provided media hashes.

## Where should the reviewer start?

1. `components/src/dynamo/vllm/multimodal_utils/cache_config.py`
2. `components/src/dynamo/vllm/llm_engine.py`
3. `components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_multimodal_embedding_cache_connector.py`

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue:**

- [x] Confirmed — no related GitHub issue
- Tracking ticket: DIS-2033


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multimodal embedding cache configuration in unified and vLLM startup flows.
  * Expanded multimodal test coverage to validate cached image/video inference behavior.

* **Documentation**
  * Updated multimodal docs to reflect broader support for aggregated image/video inference with CPU embedding cache.
  * Clarified setup examples and launch guidance for unified multimodal runs.

* **Bug Fixes**
  * Improved engine initialization so cache settings are applied consistently before runtime startup.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->