### PR TITLE
feat(vllm): support unified multimodal prefill decode

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -7,9 +7,9 @@ routing, health-check canaries, OpenTelemetry tracing, and request-side
 guided decoding / structural tag.
 
 > **Work in progress.** Multimodal support is backend-specific: vLLM supports
-> aggregated image and video inference, while P/D multimodal execution,
-> separate encode workers, and SGLang / TRT-LLM multimodal execution remain
-> on their non-unified paths. Diffusion (image/video/DLLM),
+> aggregated and prefill/decode image and video inference, while separate
+> encode workers and SGLang / TRT-LLM multimodal execution remain on their
+> non-unified paths. Diffusion (image/video/DLLM),
 > LoRA (SGLang / TRT-LLM — vLLM is supported),
 > engine routes (pause/resume, profiling, weight updates),
 > text-in-text-out, and snapshot/CRIU are still on the non-unified
@@ -568,6 +568,11 @@ Lifecycle and runtime:
   here). vLLM/TRT-LLM share an extractor; SGLang has a cumulative-array
   variant. The sample engine and Rust mocker emit synthetic logprobs
   when `output_options.logprobs` is set.
+- **Multimodal (vLLM)** — image and video inference in aggregated and
+  prefill/decode deployments, frontend-rendered `mm_kwargs` transfer over
+  shared memory or NIXL, stable frontend hash forwarding, CPU embedding cache,
+  and Qwen-VL decode metadata reconstruction. Separate encode workers are not
+  supported by the unified vLLM entry point.
 
 Observability:
 - **Health-check canary** — `health_check_payload()` + operator
@@ -609,12 +614,12 @@ Request handling:
 - **Tool / reasoning parsers** — `WorkerConfig.tool_call_parser`,
   `reasoning_parser`, `exclude_tools_when_tool_choice_none`
 
-### Common gaps (all engines)
+### Remaining feature gaps
 
 | Feature | Description |
 |---------|-------------|
 | Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization. Unified hardcodes `ModelInput.Tokens`. |
-| Multimodal parity | The shared request and encoder-handoff contract are available. vLLM supports aggregated image and video inference with frontend decoding/transfer and CPU embedding caching; P/D execution, SGLang/TRT-LLM execution, and separate encode workers remain separate work. |
+| Multimodal parity | The shared request and encoder-handoff contract are available. vLLM supports aggregated and prefill/decode image and video inference; SGLang / TRT-LLM execution and separate encode workers remain separate work. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path. |
 | LoRA adapters (SGLang / TRT-LLM) | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading. **vLLM is supported on the unified path** — see [What works today](#what-works-today); SGLang and TRT-LLM advertise no LoRA updates yet. |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload. |
@@ -631,7 +636,7 @@ Request handling:
 | `KvConnectorProtocol` abstraction | Legacy abstracts NIXL pull / Mooncake push; unified uses vLLM's internal connector only |
 | `--benchmark-mode` family | The `--benchmark-*` flag family (mode, prefill/decode granularities, warmup, output path, timeout) injects into `vllm_config.additional_config` |
 | "Omni" alternative entry point | `dynamo.vllm.omni.*` parallel mode for alternative tensor workflows |
-| Multimodal (vLLM) | P/D execution, Qwen VL mRoPE handoff, `EncodeWorkerHandler`, and `--route-to-encoder` |
+| Separate multimodal encode worker | The unified entry point rejects `--disaggregation-mode encode` and `--route-to-encoder`. Encoder-managed embedding transfer remains on the legacy worker path. P/D video requests also reload raw media on decode because the handoff carries image metadata only. |
 
 ### SGLang-specific gaps
 

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -272,16 +272,6 @@ class VllmLLMEngine(LLMEngine):
                 "unified encode worker is available"
             )
 
-        if config.enable_multimodal and config.disaggregation_mode in (
-            DisaggregationMode.PREFILL,
-            DisaggregationMode.DECODE,
-        ):
-            raise NotImplementedError(
-                "multimodal P/D is not supported by the unified vLLM entry "
-                "point yet; use aggregated unified serving or `python -m "
-                "dynamo.vllm`"
-            )
-
         if not config.served_model_name:
             config.served_model_name = (
                 config.engine_args.served_model_name
@@ -372,6 +362,8 @@ class VllmLLMEngine(LLMEngine):
             enable_multimodal=self.enable_multimodal,
             enable_frontend_decoding=self.frontend_decoding,
         )
+        if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            self._multimodal_request_processor.initialize_prefill_handoff()
         # Resolve once the tokenizer is available (see logits_processor_spec()).
         self._logits_processor_spec = await self.logits_processor_spec()
         self._pause_controller = VllmEnginePauseController(self.engine_client)
@@ -598,10 +590,18 @@ class VllmLLMEngine(LLMEngine):
                     # prefill terminal so PrefillRouter can forward it.
                     if is_prefill:
                         kv_transfer_params = getattr(res, "kv_transfer_params", None)
+                        handoff_params: dict[str, Any] = {}
                         if kv_transfer_params is not None:
-                            out["disaggregated_params"] = {
-                                "kv_transfer_params": kv_transfer_params,
-                            }
+                            handoff_params["kv_transfer_params"] = kv_transfer_params
+                        embedding_params = multimodal_processor.build_prefill_handoff(
+                            multi_modal_data=prepared_prompt.multi_modal_data,
+                            prompt_token_ids=list(res.prompt_token_ids or []),
+                            mm_processor_kwargs=prepared_prompt.mm_processor_kwargs,
+                        )
+                        if embedding_params is not None:
+                            handoff_params["embedding_params"] = embedding_params
+                        if handoff_params:
+                            out["disaggregated_params"] = handoff_params
 
                 yield out
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py
@@ -107,6 +107,72 @@ async def test_generate_submits_prepared_multimodal_prompt(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_prefill_terminal_adds_embedding_handoff(monkeypatch):
+    from dynamo.vllm import llm_engine as mod
+
+    output = SimpleNamespace(
+        index=0,
+        token_ids=[42],
+        finish_reason="length",
+        stop_reason=None,
+        logprobs=None,
+    )
+    response = SimpleNamespace(
+        outputs=[output],
+        prompt_token_ids=[1, 99, 2],
+        prompt_logprobs=None,
+        kv_transfer_params={"remote_block_ids": [7]},
+    )
+    engine = _engine(DisaggregationMode.PREFILL, [response])
+    image = object()
+    handoff = {
+        "image_grid_thw": [[1, 2, 2]],
+        "embeddings_shape": [1, 16],
+    }
+    processor = SimpleNamespace(
+        prepare_prompt=AsyncMock(
+            return_value=PreparedMultimodalPrompt(
+                prompt={"prompt_token_ids": [1, 2]},
+                request={"token_ids": [1, 2]},
+                multi_modal_data={"image": image},
+                mm_processor_kwargs={"max_pixels": 1003520},
+            )
+        ),
+        build_prefill_handoff=MagicMock(return_value=handoff),
+    )
+    engine._multimodal_request_processor = processor
+    monkeypatch.setattr(
+        mod, "build_sampling_params", lambda *args, **kwargs: _sampling_params()
+    )
+
+    chunks = [
+        chunk
+        async for chunk in engine.generate(
+            {
+                "token_ids": [1, 2],
+                "sampling_options": {},
+                "stop_conditions": {},
+                "output_options": {},
+            },
+            _Context(),
+        )
+    ]
+
+    assert chunks[0]["disaggregated_params"] == {
+        "kv_transfer_params": {"remote_block_ids": [7]},
+        "embedding_params": {
+            "image_grid_thw": [[1, 2, 2]],
+            "embeddings_shape": [1, 16],
+        },
+    }
+    processor.build_prefill_handoff.assert_called_once_with(
+        multi_modal_data={"image": image},
+        prompt_token_ids=[1, 99, 2],
+        mm_processor_kwargs={"max_pixels": 1003520},
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("mode", "route_to_encoder", "message"),
     [
@@ -131,29 +197,6 @@ async def test_from_args_rejects_unsupported_multimodal_topologies(
     )
 
     with pytest.raises(NotImplementedError, match=message):
-        await mod.VllmLLMEngine.from_args([])
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "mode", [DisaggregationMode.PREFILL, DisaggregationMode.DECODE]
-)
-async def test_from_args_rejects_multimodal_pd_until_followup(monkeypatch, mode):
-    from dynamo.vllm import llm_engine as mod
-
-    config = SimpleNamespace(
-        disaggregation_mode=mode,
-        route_to_encoder=False,
-        headless=False,
-        enable_multimodal=True,
-    )
-    monkeypatch.setattr(
-        mod,
-        "parse_args",
-        lambda argv, fpm_trace_relay_supported=False: config,
-    )
-
-    with pytest.raises(NotImplementedError, match="multimodal P/D"):
         await mod.VllmLLMEngine.from_args([])
 
 
@@ -202,4 +245,3 @@ async def test_from_args_retains_multimodal_runtime_configuration(monkeypatch):
     worker_overrides = from_runtime_config.call_args.kwargs
     assert worker_overrides["media_decoder"] is not None
     assert worker_overrides["media_fetcher"] is not None
-    assert from_runtime_config.call_args.kwargs["model_input"] is mod.ModelInput.Tokens

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -58,7 +58,7 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 | [**KVBM**](../../components/kvbm/README.md) | ✅ | |
 | [**LMCache**](../../integrations/lmcache-integration.md) | ✅ | CUDA 12.9 and arm64/aarch64 containers may require building LMCache from source |
 | [**FlexKV**](../../integrations/flexkv-integration.md) | ✅ | |
-| [**Multimodal Support**](../../features/multimodal/multimodal-vllm.md) | ✅ | Aggregated image/video serving on legacy and unified Python backends |
+| [**Multimodal Support**](../../features/multimodal/multimodal-vllm.md) | ✅ | Aggregated and P/D image/video serving on legacy and unified Python backends; separate Encode workers use the legacy path |
 | [**Observability**](vllm-observability.md) | ✅ | Metrics and monitoring |
 | **WideEP** | ✅ | Support for DeepEP |
 | **DP Rank Routing** | ✅ | [Hybrid load balancing](https://docs.vllm.ai/en/stable/serving/data_parallel_deployment/?h=external+dp#hybrid-load-balancing) via external DP rank control |

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -41,10 +41,10 @@ Supported today:
 - structured backend errors
 - graceful shutdown and drain hooks
 
-Still use the lower-level Python worker path when you need features such as
-multimodal requests, LoRA adapter management, logprobs, guided decoding,
-engine-specific routes, custom request handling, or features that need direct
-control of the request payload.
+Still use the lower-level Python worker path when you need a backend-specific
+feature that has not reached its unified engine, a separate multimodal encode
+worker, engine-specific routes, custom request handling, or direct control of
+the request payload.
 
 After you implement the backend, package it into a runtime image with
 [Runtime Containers](custom-containers.md). For Kubernetes deployment, place the
@@ -146,8 +146,6 @@ Observability:
   `telemetry.engine_trace_kwargs(context)`
 
 Request handling:
-- vLLM image and video inference in aggregated deployments. See
-  [vLLM Multimodal](../features/multimodal/multimodal-vllm.md).
 - Guided decoding — wired per-engine on the request side with
   engine-specific coverage. vLLM (`StructuredOutputsParams`) and
   TRT-LLM (`GuidedDecodingParams`) cover JSON schema / regex / grammar
@@ -161,14 +159,17 @@ Request handling:
   backend advertises through model registration)
 - Tool / reasoning parser configuration (`tool_call_parser`,
   `reasoning_parser`, `exclude_tools_when_tool_choice_none`)
+- vLLM image and video inference in aggregated and prefill/decode deployments,
+  including frontend-rendered multimodal input transfer and the CPU embedding
+  cache. See [vLLM Multimodal](../features/multimodal/multimodal-vllm.md#unified-vllm-backend).
 
-**Not yet on the unified path (common to all engines)**
+**Remaining Python unified-backend gaps**
 
 | Feature | What's missing |
 |---------|----------------|
 | Logprob response wire | Legacy handlers extract logprobs onto response chunks (vLLM `_extract_logprobs`, SGLang `_extract_logprobs` in `decode_handler`, TRT-LLM `_extract_logprobs` in `handler_base`); the unified `generate()` loops do not populate `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk`. vLLM's `build_sampling_params` still passes `output_options.logprobs` to the engine on the unified path, so the engine computes them, but the values are dropped before they reach the chunk. SGLang and TRT-LLM unified `generate()` do not read `output_options.logprobs` at all. |
 | Text-in-text-out mode | Unified hardcodes `ModelInput.Tokens`; no engine-side tokenization or chat templating path |
-| Multimodal parity | vLLM supports aggregated image and video inference, including frontend decoding/transfer and the CPU embedding cache. P/D multimodal execution, separate encode workers, and SGLang/TRT-LLM execution remain unavailable through unified engines. |
+| Multimodal parity | vLLM supports aggregated and prefill/decode image and video inference. SGLang and TRT-LLM multimodal execution, separate encode workers, and the `ENCODE` role are not yet available through their unified engines. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
 | LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading on prefill |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |
@@ -960,7 +961,7 @@ Request handling:
 |---------|----------------|
 | `cum_log_probs` response wire | Completion-side `log_probs` / `top_logprobs` are populated on the unified path for vLLM, SGLang, and TRT-LLM (shared helpers in `components/src/dynamo/common/backend/logprobs.py`). Prompt-side logprobs ride on the final chunk's `LLMEngineOutput.engine_data["prompt_logprobs"]` (consumed by `prompt_logprobs_from_engine_data` in the response builders). `cum_log_probs` is still not emitted. |
 | Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
-| Multimodal | Images / video / embeddings, NIXL embedding transfer, separate encode workers; `ENCODE` disaggregation role |
+| Native Rust multimodal engines | The shared request fields are available, but native Rust engines do not yet implement image, video, embedding transfer, or the `ENCODE` role. The Python unified vLLM engine supports aggregated and prefill/decode image and video inference. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
 | LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |

--- a/docs/features/multimodal/multimodal-vllm.md
+++ b/docs/features/multimodal/multimodal-vllm.md
@@ -4,19 +4,25 @@
 title: vLLM Multimodal
 ---
 
-This document provides a comprehensive guide for multimodal inference using vLLM backend in Dynamo.
+This document provides a comprehensive guide for multimodal inference using the vLLM backend in Dynamo.
 
 <Warning>
-**Security Requirement**: All multimodal workers require the `--enable-multimodal` flag to be explicitly set at startup. This is a security feature to prevent unintended processing of multimodal data from untrusted sources. Workers will fail at startup if a multimodal worker mode is enabled without `--enable-multimodal`. This flag is analogous to `--enable-mm-embeds` in vllm serve but also extends it to all multimodal content (url, embeddings, b64).
+**Security Requirement**: All multimodal workers require the
+`--enable-multimodal` flag to be explicitly set at startup. This prevents
+unintended processing of multimodal data from untrusted sources. Media requests
+are rejected when the flag is absent, and workers configured with a multimodal
+role fail at startup. This flag is analogous to `--enable-mm-embeds` in vLLM
+serve but also extends it to all multimodal content (URL, embeddings, and
+base64 data).
 </Warning>
 
 ## Support Matrix
 
-| Modality                 | Aggregated | Disaggregated |
-| ------------------------ | ---------- | ------------- |
-| **Image**                | Yes        | Yes           |
-| **Video**                | Yes        | Yes           |
-| **Audio**                | Yes        | No            |
+| Modality | Aggregated | P/D | Separate encode worker |
+| --- | --- | --- | --- |
+| **Image** | Yes | Yes | Legacy entry point only |
+| **Video** | Yes | Yes | Processed by the language-model worker |
+| **Audio** | Yes | Yes, with decode reload | Not routed to the separate encoder |
 
 ### Supported URL Formats
 
@@ -29,12 +35,13 @@ This document provides a comprehensive guide for multimodal inference using vLLM
 
 The main multimodal vLLM launchers in this repo are:
 
-| Pattern                     | Device     | Launch Script                      | Best For                                                                                            |
-| --------------------------- | ---------- | ---------------------------------- | --------------------------------------------------------------------------------------------------- |
-| Aggregated                  | cuda       | `agg_multimodal.sh`                | Simplest image/video serving from a single multimodal worker on CUDA devices                        |
-| Aggregated                  | xpu        | `xpu/agg_multimodal_xpu.sh`        | Simplest image/video serving from a single multimodal worker on XPU devices                         |
-| E/PD (Encode + PD)          | cuda       | `disagg_multimodal_e_pd.sh`        | Simple example of separating encoder, good for testing embedding-cache workflows                    |
-| E/P/D (Full Disaggregation) | cuda       | `disagg_multimodal_epd.sh`         | Disaggregated image/video serving with separate encode, prefill, and decode workers on CUDA devices |
+| Pattern | Device | Launch script | Unified selection | Best for |
+| --- | --- | --- | --- | --- |
+| Aggregated | CUDA | `agg_multimodal.sh` | `--unified` | Simplest image/video serving from one worker |
+| Aggregated | XPU | `xpu/agg_multimodal_xpu.sh` | No | Image/video serving on XPU devices |
+| P/D | CUDA | `disagg_multimodal_p_d.sh` | `--unified` | Prefill/decode separation without a dedicated encoder |
+| E/PD (Encode + PD) | CUDA | `disagg_multimodal_e_pd.sh` | No | Separate encoder and embedding-cache workflows |
+| E/P/D (Full Disaggregation) | CUDA | `disagg_multimodal_epd.sh` | No | Separate encode, prefill, and decode workers |
 
 
 ## Image/Video Serving
@@ -57,11 +64,6 @@ bash launch/agg_multimodal.sh --unified --model Qwen/Qwen3-VL-2B-Instruct
 # XPU deployment
 bash launch/xpu/agg_multimodal_xpu.sh --model Qwen/Qwen3-VL-2B-Instruct
 ```
-
-The unified entry point supports HTTP, data-URL, and decoded image/video input
-in aggregated mode and forwards model processor options such as
-`mm_processor_kwargs`. Separate Encode workers and multimodal P/D remain on the
-legacy entry point until their follow-up changes land.
 
 **Image request:**
 
@@ -122,12 +124,43 @@ curl http://localhost:8000/v1/chat/completions \
     }' | jq
 ```
 
-### Unified Frontend Processing
+### P/D Serving
 
-The unified worker advertises frontend image-decoding support when
-`--frontend-decoding` is enabled. The Python vLLM frontend can also pre-render
-processor inputs and transfer them to an aggregated worker over shared memory
-or NIXL:
+Use the P/D launcher to separate prefill and decode without deploying a
+dedicated multimodal encoder:
+
+```bash
+cd $DYNAMO_HOME/examples/backends/vllm
+
+# Legacy vLLM worker path
+bash launch/disagg_multimodal_p_d.sh --model Qwen/Qwen3-VL-2B-Instruct
+
+# Unified vLLM worker path
+bash launch/disagg_multimodal_p_d.sh --unified \
+  --model Qwen/Qwen3-VL-2B-Instruct
+```
+
+For Qwen-VL images, prefill sends grid and embedding-shape metadata so decode
+can construct schema-valid placeholder embeddings and initialize mRoPE. Other
+model families use the expanded prompt token IDs produced during prefill.
+
+<Warning>
+The P/D handoff does not carry video embeddings. Video and audio inputs are
+loaded again on the decode worker. This preserves current behavior but adds
+media download and processing work. Mixed image-and-video P/D requests retain
+the same model-specific limitations as the legacy vLLM path.
+</Warning>
+
+### Unified vLLM Backend
+
+Pass `--unified` to the aggregated or P/D launchers to run
+`python -m dynamo.vllm.unified_main`. The unified path supports HTTP URLs,
+data URLs, frontend-decoded images, `mm_processor_kwargs`, frontend-provided
+multimodal hashes, and Kimi-style `vision_chunk` inputs.
+
+The Python vLLM frontend can pre-render multimodal processor inputs and send
+them to an aggregated unified worker. Shared memory is the same-node default;
+NIXL supports the transfer channel used by cross-node deployments:
 
 ```bash
 # Same-node shared-memory transfer
@@ -145,6 +178,15 @@ The frontend includes the original media references when transfer preparation
 is unavailable or partial. Fully transferred requests omit those references to
 avoid duplicating large inline data URIs in the backend payload. A receiver-side
 failure after a full transfer does not currently have a raw-media fallback.
+
+P/D prefill deliberately uses the original media because it still needs
+raw-media-derived metadata for the decode handoff.
+
+<Warning>
+The unified vLLM entry point does not provide a separate Encode worker and
+rejects both `--disaggregation-mode encode` and `--route-to-encoder`. Use the
+legacy E/PD or E/P/D launchers when a dedicated encoder is required.
+</Warning>
 
 ### E/PD Serving (Encode + PD)
 
@@ -275,9 +317,11 @@ bash examples/backends/vllm/launch/agg_multimodal.sh \
     --multimodal-embedding-cache-capacity-gb 10
 ```
 
-Both `dynamo.vllm` and the unified vLLM entry point automatically configure
-`ec_both` mode with the `DynamoMultimodalEmbeddingCacheConnector` when the
-capacity is greater than zero.
+Both `dynamo.vllm` and `dynamo.vllm.unified_main` automatically configure
+`ec_both` mode with `DynamoMultimodalEmbeddingCacheConnector` when capacity is
+greater than zero. A capacity of zero disables the CPU cache. Frontend-provided
+multimodal hashes are reused as cache identities so routing and embedding-cache
+lookups agree.
 
 **Launch with `vllm serve` (standalone, no Dynamo):**
 

--- a/examples/backends/vllm/launch/disagg_multimodal_p_d.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_p_d.sh
@@ -10,11 +10,13 @@
 # Trade-off: prefill does vision encoding internally (no dedicated encoder),
 # which uses more GPU memory on the prefill worker.
 set -e
-trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+pick_worker_module dynamo.vllm dynamo.vllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
 
 # Default values
 MODEL_NAME="Qwen/Qwen3-VL-2B-Instruct"
@@ -40,6 +42,7 @@ while [[ $# -gt 0 ]]; do
             echo "Options:"
             echo "  --model <model_name>   Specify the VLM model (default: $MODEL_NAME)"
             echo "  --single-gpu           Pack both workers on 1 GPU (for small models)"
+            echo "  --unified              Use the unified vLLM backend"
             echo "  -h, --help             Show this help message"
             exit 0
             ;;
@@ -49,6 +52,8 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
+
+trap dynamo_exit_trap EXIT
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 if [[ "$SINGLE_GPU" == "true" ]]; then
@@ -102,7 +107,7 @@ echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (${PREFILL_GPU_MEM_
 VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-${DYN_SYSTEM_PORT:-8081}} \
 CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU \
-python -m dynamo.vllm \
+python -m "$WORKER_MODULE" \
   --disaggregation-mode prefill \
   --enable-multimodal \
   --model $MODEL_NAME \
@@ -117,7 +122,7 @@ echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (${DECODE_GPU_MEM_ARG
 VLLM_NIXL_SIDE_CHANNEL_PORT=20099 \
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU \
-python -m dynamo.vllm \
+python -m "$WORKER_MODULE" \
   --disaggregation-mode decode \
   --enable-multimodal \
   --enable-mm-embeds \

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -55,6 +55,7 @@ VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     "epd": "disagg_multimodal_epd.sh",
     "epd_video": "disagg_multimodal_epd.sh",
     "p_d": "disagg_multimodal_p_d.sh",
+    "p_d_unified": "disagg_multimodal_p_d.sh",
 }
 
 VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
@@ -249,6 +250,19 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 profiled_vram_gib=15.7,
                 requested_vllm_kv_cache_bytes=1_714_881_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+            "p_d_unified": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=300,
+                single_gpu=True,
+                profiled_vram_gib=15.7,
+                requested_vllm_kv_cache_bytes=1_714_881_000,
+                tests=[
+                    MmCase(
+                        payload=make_image_payload(["green"]),
+                        extra_script_args=["--unified"],
+                    )
+                ],
             ),
         },
     ),


### PR DESCRIPTION
## Overview:

### Summary

Adds multimodal prefill/decode parity to the unified vLLM backend. This is stack 5/5 for DIS-2033 and completes the tracked implementation while leaving separate Encode workers out of scope.

### Stack

This PR is part of the ordered replacement for #11147:

1. #11266 — shared request-processor refactor
2. #11267 — aggregated unified multimodal
3. #11268 — multimodal embedding cache
4. #11269 — frontend decoding and transfer
5. #11270 — multimodal P/D

Merge and retarget these PRs in order.

### Validation

- The cumulative stack tip is byte-for-byte identical to the tracked tree in PR #11147.
- `ruff check`, Python compilation, `git diff --check`, launcher shell syntax, and `cargo fmt --all --check` passed.
- Focused unit coverage covers Qwen metadata, non-Qwen expanded tokens, prefill handoff, and video decode fallback; the serve profile adds unified Qwen P/D coverage.
- Local pytest was not run because the workstation Python does not have pytest installed; CI is expected to provide the vLLM test environment.

## Details:

- Adds model-specific embedding metadata to the prefill terminal handoff.
- Reconstructs Qwen-VL placeholder embeddings and grid metadata on decode.
- Uses expanded prefill token IDs for other model families.
- Preserves the legacy video/audio decode fallback that reloads raw media.
- Adds `--unified` selection to the multimodal P/D launcher and documents the remaining Encode/video limitations.

## Where should the reviewer start?

1. `components/src/dynamo/vllm/llm_engine.py`
2. `components/src/dynamo/vllm/multimodal_utils/request_processor.py`
3. `components/src/dynamo/vllm/multimodal_utils/models/qwen.py`
4. `examples/backends/vllm/launch/disagg_multimodal_p_d.sh`

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue:**

- [x] Confirmed — no related GitHub issue
- Tracking ticket: DIS-2033


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded multimodal serving support for the unified vLLM path, including prefill/decode image and video flows.
  * Added a new unified multimodal launch option and test coverage for this topology.

* **Bug Fixes**
  * Improved how multimodal context is passed between prefill and decode so image-related data is preserved more reliably.
  * Clarified and tightened support guidance for multimodal and backend-specific feature availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->