### PR TITLE
fix: populate Message on DGDR Validation success condition (#11261)

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -113,6 +113,7 @@ const (
 	ArgConfig  = "--config"
 
 	// Messages
+	MessageValidationPassed          = "DGDR spec validation passed"
 	MessageInitialized               = "DGDR initialized successfully"
 	MessageDiscoveringHardware       = "Discovering GPU hardware and preparing profiling job"
 	MessageProfilingJobCreated       = "Profiling job created"
@@ -527,6 +528,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.
 			Status:             metav1.ConditionTrue,
 			ObservedGeneration: dgdr.Generation,
 			Reason:             "ValidationPassed",
+			Message:            MessageValidationPassed,
 		})
 
 		// Initialize status — next reconcile will discover hardware and create the profiling job.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -138,6 +138,10 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			_ = k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)
 			Expect(updated.Status.ObservedGeneration).Should(Equal(updated.Generation))
+
+			validationCondition := meta.FindStatusCondition(updated.Status.Conditions, nvidiacomv1beta1.ConditionTypeValidation)
+			Expect(validationCondition).NotTo(BeNil())
+			Expect(validationCondition.Message).Should(Equal(MessageValidationPassed))
 		})
 
 		It("Should pass validation with minimal config", func() {


### PR DESCRIPTION
## Summary

- Cherry-pick merged PR #11261 to `release/1.3.0`.
- Add `MessageValidationPassed` and populate the `Message` field when DGDR validation succeeds.
- Add regression coverage for the persisted Validation condition message.

Relates to DYN-3386.

## Validation

- Regression proof: the focused controller test failed with an empty message when the assignment was removed, then passed with the implementation restored.
- `go test ./internal/controller -run '^TestControllers$' -ginkgo.focus='Should validate spec and transition to Pending' -ginkgo.v` — passed in 8.048s.
- Fresh release-branch CI at `76daa09bbb52ae672a95e202e0f39bc4eccf495e`: 12 passed, 7 expected skips, 0 failed or pending.
