### PR TITLE
fix(gms): bind snapshot saver threads to CUDA devices

### DIFF
--- a/lib/gpu_memory_service/cli/snapshot/saver.py
+++ b/lib/gpu_memory_service/cli/snapshot/saver.py
@@ -16,7 +16,7 @@ import os
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 
-from gpu_memory_service.common.cuda_utils import list_devices
+from gpu_memory_service.common import cuda_utils
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.snapshot.backends.sharded_ssd import (
     device_sharded_ssd_roots,
@@ -55,6 +55,9 @@ def _save_device(
         ",".join(shard_roots) or "-",
     )
     t0 = time.monotonic()
+    # This runs on a ThreadPoolExecutor thread; bind its CUDA device before
+    # any device work, mirroring the loader's _load_device.
+    cuda_utils.cuda_runtime_set_device(device)
     GMSStorageClient(
         output_dir,
         socket_path=get_socket_path(device),
@@ -119,7 +122,7 @@ def main(argv: list[str] | None = None) -> None:
     shard_size_bytes = args.shard_size_bytes
     sharded_ssd_roots = parse_sharded_ssd_roots(args.sharded_ssd_roots)
 
-    devices = list_devices()
+    devices = cuda_utils.list_devices()
     logger.info(
         "Starting GMS save for %d devices lock_timeout_ms=%d sharded_ssd_roots=%s",
         len(devices),

--- a/lib/gpu_memory_service/tests/test_snapshot_saver.py
+++ b/lib/gpu_memory_service/tests/test_snapshot_saver.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GMS snapshot saver CLI."""
+
+import pytest
+
+try:
+    from gpu_memory_service.cli.snapshot import saver
+except ModuleNotFoundError:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+def test_save_device_sets_cuda_context_before_storage_client(monkeypatch):
+    calls = []
+
+    class FakeStorageClient:
+        def __init__(self, output_dir, **kwargs):
+            calls.append(("init", output_dir, kwargs))
+
+        def save(self, *, max_workers):
+            calls.append(("save", {"max_workers": max_workers}))
+
+    monkeypatch.setattr(saver, "get_socket_path", lambda device: f"/tmp/gms-{device}")
+    monkeypatch.setattr(saver, "GMSStorageClient", FakeStorageClient)
+    monkeypatch.setattr(
+        saver.cuda_utils,
+        "cuda_runtime_set_device",
+        lambda device: calls.append(("set_device", device)),
+    )
+
+    saver._save_device(
+        "/checkpoints/run/versions/1",
+        3,
+        8,
+        60_000,
+        4 * 1024**3,
+        [],
+    )
+
+    assert calls[0] == ("set_device", 3)
+    assert calls[1][0] == "init"
+    assert calls[1][1] == "/checkpoints/run/versions/1/device-3"
+    assert calls[1][2]["socket_path"] == "/tmp/gms-3"
+    assert calls[1][2]["device"] == 3
+    assert calls[2] == ("save", {"max_workers": 8})


### PR DESCRIPTION
## Summary

The multi-GPU GMS checkpoint saver runs each device save on a `ThreadPoolExecutor` thread, but never made that thread's CUDA device current. The post-save synchronize/unmap path then failed on 8-GPU checkpoint jobs with:

```
fatal CUDA VMM error in cuCtxSynchronize: invalid device context
```

The loader already handles this (`_load_device` calls `cuda_utils.cuda_runtime_set_device(device)` before constructing its storage client); this PR mirrors that in `_save_device`, and adopts the loader's module-style `cuda_utils` import so tests can patch it the same way.

Independent, small correctness fix extracted from the validated snapshot/restore stack (patch-equivalent to experiment commit `d5352a7baf`, where the 8-GPU checkpoint job passed with it). Not duplicating any open PR.

## Validation

- New `lib/gpu_memory_service/tests/test_snapshot_saver.py`, mirroring the existing loader test (`test_load_device_sets_cuda_context_before_storage_client`): asserts `_save_device` binds the CUDA device **before** constructing `GMSStorageClient`. Fails without the fix, passes with it.
- `python -m pytest lib/gpu_memory_service/tests/test_snapshot_saver.py` → 1 passed.
- `pre-commit run` on changed files → all hooks pass.
- 8-GPU E2E on the snapshot stack: checkpoint Job completes; no `cuCtxSynchronize` fault.

AI assistance was used for test authoring; all changes reviewed by the author.
