### PR TITLE
fix(recipes): [cherry-pick 1.3.0] bump Hugging Face Hub helper-job pins to 1.16.4 (DYN-3335)

### DIFF
--- a/examples/backends/vllm/deploy/lora/multimodal/sync-lora-job.yaml
+++ b/examples/backends/vllm/deploy/lora/multimodal/sync-lora-job.yaml
@@ -15,7 +15,7 @@ spec:
         - -c
         - |
           set -eux
-          pip install --no-cache-dir huggingface-hub==1.11.0 awscli==1.44.80
+          pip install --no-cache-dir huggingface-hub==1.16.4 awscli==1.44.80
           hf download  $MODEL_NAME --local-dir /tmp/lora
           rm -rf /tmp/lora/.cache
           aws --endpoint-url=http://minio:9000 s3 mb s3://$LORA_ROOT_PATH || true

--- a/examples/backends/vllm/deploy/lora/sync-lora-job.yaml
+++ b/examples/backends/vllm/deploy/lora/sync-lora-job.yaml
@@ -15,7 +15,7 @@ spec:
         - -c
         - |
           set -eux
-          pip install --no-cache-dir huggingface-hub==1.11.0 awscli==1.44.80
+          pip install --no-cache-dir huggingface-hub==1.16.4 awscli==1.44.80
           hf download  $MODEL_NAME --local-dir /tmp/lora
           rm -rf /tmp/lora/.cache
           aws --endpoint-url=http://minio:9000 s3 mb s3://$LORA_ROOT_PATH || true

--- a/recipes/deepseek-r1/model-cache/model-download-sglang.yaml
+++ b/recipes/deepseek-r1/model-cache/model-download-sglang.yaml
@@ -27,7 +27,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download deepseek-ai/DeepSeek-R1
           volumeMounts:
             - name: model-cache

--- a/recipes/deepseek-r1/model-cache/model-download.yaml
+++ b/recipes/deepseek-r1/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download nvidia/DeepSeek-R1-FP4 --local-dir /model-cache/deepseek-r1-fp4
               hf download deepseek-ai/DeepSeek-R1 --local-dir /model-cache/deepseek-r1
           resources:

--- a/recipes/deepseek-v32-fp4/model-cache/model-download.yaml
+++ b/recipes/deepseek-v32-fp4/model-cache/model-download.yaml
@@ -38,7 +38,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME
           resources:
             requests:

--- a/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-flash/model-cache/model-download.yaml
@@ -32,7 +32,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME
           resources:
             requests:

--- a/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml
+++ b/recipes/deepseek-v4/deepseek-v4-pro/model-cache/model-download.yaml
@@ -32,7 +32,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME
           resources:
             requests:

--- a/recipes/glm-5-nvfp4/model-cache/model-download.yaml
+++ b/recipes/glm-5-nvfp4/model-cache/model-download.yaml
@@ -37,7 +37,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME
           resources:
             requests:

--- a/recipes/gpt-oss-120b/model-cache/model-download.yaml
+++ b/recipes/gpt-oss-120b/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION --exclude "original/*" --exclude "metal/*"
           resources:
             requests:

--- a/recipes/kimi-k2.5/model-cache/model-download.yaml
+++ b/recipes/kimi-k2.5/model-cache/model-download.yaml
@@ -43,7 +43,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME
               hf download $EAGLE_MODEL_NAME
           resources:

--- a/recipes/llama-3-70b/model-cache/model-download.yaml
+++ b/recipes/llama-3-70b/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION
           resources:
             requests:

--- a/recipes/nemotron-3-nano-omni/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-nano-omni/model-cache/model-download.yaml
@@ -38,7 +38,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download "$MODEL_NAME"
           resources:
             requests:

--- a/recipes/nemotron-3-super-fp8/model-cache/model-download.yaml
+++ b/recipes/nemotron-3-super-fp8/model-cache/model-download.yaml
@@ -32,7 +32,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME
           resources:
             requests:

--- a/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-235b-a22b-fp8/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION
           resources:
             requests:

--- a/recipes/qwen3-32b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-32b-fp8/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION
           resources:
             requests:

--- a/recipes/qwen3-32b/model-cache/model-download.yaml
+++ b/recipes/qwen3-32b/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION
           resources:
             requests:

--- a/recipes/qwen3-vl-30b/model-cache/model-download.yaml
+++ b/recipes/qwen3-vl-30b/model-cache/model-download.yaml
@@ -34,7 +34,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
           resources:
             requests:

--- a/recipes/qwen3-vl-32b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-vl-32b-fp8/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache
@@ -42,4 +42,3 @@ spec:
       - name: model-cache
         persistentVolumeClaim:
           claimName: model-cache
-

--- a/recipes/qwen3.6-35b/model-cache/model-download.yaml
+++ b/recipes/qwen3.6-35b/model-cache/model-download.yaml
@@ -49,7 +49,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download "$MODEL_NAME" --revision "$MODEL_REVISION"
           resources:
             requests:


### PR DESCRIPTION
## Summary

Cherry-pick of #10986 to `release/1.3.0` for DYN-3335 / NVBug 6401769.

- Updates the Hugging Face Hub CLI pin from `1.11.0` to `1.16.4` in 17 model-download recipes and two vLLM LoRA sync jobs, so the helper jobs install the `click` dependency required by `hf download`.
- Preserves the 18-file patch from #10986 without content changes.
- Adds the same pin replacement to `recipes/qwen3-vl-32b-fp8/model-cache/model-download.yaml`. DYN-3335 lists this as the seventeenth affected recipe, but #10986 omitted it; the file still has the broken pin on both `main` and `release/1.3.0`.

The remaining `main` copy of `qwen3-vl-32b-fp8` requires a separate follow-up PR.

**Original PR:** https://github.com/ai-dynamo/dynamo/pull/10986
**Linear:** https://linear.app/nvidia/issue/DYN-3335
**NVBug:** 6401769

## Validation

- The commit-time pre-commit suite passed, including YAML validation, conflict checks, codespell, whitespace checks, and the static pytest-marker report.
- The original 18-file subset has the same stable patch ID as #10986: `4d19db1e97acea77a3cc41d61f2938725665eee3`.
- Static inspection found no remaining `huggingface[_-]hub==1.11.0` pins in `recipes/` or the affected vLLM LoRA examples.
- All 19 changed helper-job files retain an `hf download` command.
- `git diff --check upstream/release/1.3.0...HEAD` passed.

A Kubernetes model-download job was not rerun for this release port. #10986 validated `huggingface_hub==1.16.4` in a clean Python environment; release CI remains required.

## Test plan

- [x] CI passes against `release/1.3.0`.
- [x] Review confirms the 18-file cherry-pick plus the one issue-required supplemental recipe change.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11273" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
