### PR TITLE
test(router): run ZMQ mocker E2E without NATS [DYN-2221]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1106,7 +1106,16 @@ def request_plane(request):
 
 
 @pytest.fixture
-def durable_kv_events(request, monkeypatch):
+def event_plane(request, monkeypatch):
+    """Explicit event plane for tests that must pin a transport."""
+    value = getattr(request, "param", None)
+    if value is not None:
+        monkeypatch.setenv("DYN_EVENT_PLANE", value)
+    return value
+
+
+@pytest.fixture
+def durable_kv_events(request, event_plane, monkeypatch):
     """
     Whether to use durable KV events via JetStream. Defaults to False (NATS Core mode).
 
@@ -1125,6 +1134,8 @@ def durable_kv_events(request, monkeypatch):
     """
     value = getattr(request, "param", False)
     if value:
+        if event_plane not in (None, "nats"):
+            raise ValueError("durable KV events require the NATS event plane")
         # Durable/JetStream KV events only exist on the NATS event plane. ZMQ is now
         # the default, so pin NATS here; otherwise the durable subscriber bails at
         # startup ("--durable-kv-events requires NATS event plane").
@@ -1161,7 +1172,12 @@ def runtime_services(request, discovery_backend, request_plane):
 
 @pytest.fixture()
 def runtime_services_dynamic_ports(
-    request, discovery_backend, request_plane, durable_kv_events, monkeypatch
+    request,
+    discovery_backend,
+    request_plane,
+    event_plane,
+    durable_kv_events,
+    monkeypatch,
 ):
     """Provide NATS and Etcd servers with truly dynamic ports per test.
 
@@ -1176,15 +1192,29 @@ def runtime_services_dynamic_ports(
 
     - If discovery_backend != "etcd", etcd is not started (returns None)
     - The event plane follows the runtime default (ZMQ). NATS is still started so
-      the NATS opt-in paths stay available; durable_kv_events=True pins
-      DYN_EVENT_PLANE=nats (see the durable_kv_events fixture).
+      the NATS opt-in paths stay available, unless a TCP test explicitly selects
+      the ZMQ event plane. durable_kv_events=True pins DYN_EVENT_PLANE=nats (see
+      the durable_kv_events fixture).
 
     Returns a tuple of (nats_process, etcd_process) where each has a .port attribute.
     """
     # Port cleanup is now handled in NatsServer and EtcdServer __exit__ methods
     # Start NATS when etcd is used so the NATS opt-in paths stay available.
     # When durable_kv_events=False (default), disable JetStream for faster startup
-    if discovery_backend == "etcd":
+    nats_required = (
+        request_plane == "nats" or event_plane == "nats" or durable_kv_events
+    )
+    nats_free = event_plane == "zmq" and not nats_required
+    if nats_free:
+        monkeypatch.delenv("NATS_SERVER", raising=False)
+
+    if discovery_backend == "etcd" and nats_free:
+        with EtcdServer(request, port=0) as etcd_process:
+            monkeypatch.setenv(
+                "ETCD_ENDPOINTS", f"http://localhost:{etcd_process.port}"
+            )
+            yield None, etcd_process
+    elif discovery_backend == "etcd":
         with NatsServer(
             request, port=0, disable_jetstream=not durable_kv_events
         ) as nats_process:
@@ -1200,7 +1230,7 @@ def runtime_services_dynamic_ports(
                 )
 
                 yield nats_process, etcd_process
-    elif request_plane == "nats":
+    elif nats_required:
         with NatsServer(
             request, port=0, disable_jetstream=not durable_kv_events
         ) as nats_process:

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -135,7 +135,7 @@ class MockerProcess:
         num_mockers: int = 1,
         store_backend: str = "etcd",
         request_plane: str = "nats",
-        zmq_kv_events: bool = False,
+        raw_kv_events: bool = False,
         standalone_indexer: bool = False,
         standalone_selector: bool = False,
         model_name: str = "mocker",
@@ -171,7 +171,7 @@ class MockerProcess:
         self.dp_size = mocker_args.get("dp_size")
         self.data_parallel_size = self.dp_size
 
-        if zmq_kv_events:
+        if raw_kv_events:
             dp_size = mocker_args.get("dp_size", 1)
             self._zmq_kv_events_ports = allocate_contiguous_ports(
                 num_mockers, dp_size, BASE_PORT_ZMQ
@@ -186,7 +186,7 @@ class MockerProcess:
                 num_mockers,
             )
 
-        if zmq_replay and zmq_kv_events:
+        if zmq_replay and raw_kv_events:
             dp_size = mocker_args.get("dp_size", 1)
             self._zmq_replay_ports = allocate_contiguous_ports(
                 num_mockers, dp_size, BASE_PORT_ZMQ + 1000
@@ -545,7 +545,7 @@ class DisaggMockerProcess:
         request_plane: str = "nats",
         enable_bootstrap: bool = False,
         event_plane: Optional[str] = None,
-        zmq_kv_events: bool = False,
+        raw_kv_events: bool = False,
         env_overrides: Optional[Dict[str, str]] = None,
     ):
         if worker_type not in ("prefill", "decode"):
@@ -578,7 +578,7 @@ class DisaggMockerProcess:
                 num_mockers,
             )
 
-        if zmq_kv_events:
+        if raw_kv_events:
             dp_size = mocker_args.get("dp_size", 1)
             self._zmq_kv_events_ports = allocate_contiguous_ports(
                 num_mockers, dp_size, BASE_PORT_ZMQ
@@ -686,7 +686,7 @@ def launch_disagg_workers(
     store_backend: str = "etcd",
     request_plane: str = "nats",
     event_plane: Optional[str] = None,
-    zmq_kv_events: bool = False,
+    raw_kv_events: bool = False,
 ) -> Iterator[tuple[DisaggMockerProcess, DisaggMockerProcess]]:
     if registration_order not in ("prefill_first", "decode_first"):
         raise ValueError(f"Unexpected registration order: {registration_order}")
@@ -703,7 +703,7 @@ def launch_disagg_workers(
             request_plane=request_plane,
             enable_bootstrap=enable_disagg_bootstrap,
             event_plane=event_plane,
-            zmq_kv_events=zmq_kv_events,
+            raw_kv_events=raw_kv_events,
         ) as prefill_workers:
             logger.info("Prefill workers using endpoint: %s", prefill_workers.endpoint)
             _wait_for_disagg_workers(
@@ -721,7 +721,7 @@ def launch_disagg_workers(
                 store_backend=store_backend,
                 request_plane=request_plane,
                 event_plane=event_plane,
-                zmq_kv_events=zmq_kv_events,
+                raw_kv_events=raw_kv_events,
             ) as decode_workers:
                 logger.info(
                     "Decode workers using endpoint: %s", decode_workers.endpoint
@@ -742,7 +742,7 @@ def launch_disagg_workers(
         store_backend=store_backend,
         request_plane=request_plane,
         event_plane=event_plane,
-        zmq_kv_events=zmq_kv_events,
+        raw_kv_events=raw_kv_events,
     ) as decode_workers:
         logger.info("Decode workers using endpoint: %s", decode_workers.endpoint)
         _wait_for_disagg_workers(
@@ -761,7 +761,7 @@ def launch_disagg_workers(
             request_plane=request_plane,
             enable_bootstrap=enable_disagg_bootstrap,
             event_plane=event_plane,
-            zmq_kv_events=zmq_kv_events,
+            raw_kv_events=raw_kv_events,
         ) as prefill_workers:
             logger.info("Prefill workers using endpoint: %s", prefill_workers.endpoint)
             _wait_for_disagg_workers(

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -739,28 +739,31 @@ def test_query_instance_id_returns_worker_and_tokens(
 @pytest.mark.timeout(300)  # bumped for xdist contention (was 29s; ~9.55s serial avg)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.parametrize(
-    "durable_kv_events,use_kv_events,zmq_kv_events,use_remote_indexer,router_predicted_ttl_secs",
+    "durable_kv_events,use_kv_events,zmq_kv_events,use_remote_indexer,router_predicted_ttl_secs,event_plane",
     [
-        (True, True, False, False, None),  # JetStream mode with KV events
+        (True, True, False, False, None, None),  # JetStream mode with KV events
         (
             False,
             True,
             False,
             False,
+            None,
             None,
         ),  # NATS Core mode with local indexer (default)
-        (False, True, False, False, 5.0),  # NATS Core mode with local side indexer
-        (False, True, False, True, None),  # NATS Core mode with a served remote indexer
-        (False, True, False, True, 5.0),  # Remote indexer plus local side indexer
-        (False, False, False, False, None),  # Approximate mode (--no-kv-events)
+        (False, True, False, False, 5.0, None),  # NATS Core with local side indexer
+        (False, True, False, True, None, None),  # NATS Core with remote indexer
+        (False, True, False, True, 5.0, None),  # Remote plus local side indexer
+        (False, False, False, False, None, None),  # Approximate (--no-kv-events)
         (
             False,
             False,
             False,
             True,
             None,
+            None,
         ),  # Approximate mode with a singleton served remote indexer
-        (False, True, True, False, None),  # ZMQ mode: mocker → ZMQ PUB → relay → NATS
+        # Raw engine ZMQ → relay → ZMQ event plane, with no NATS service.
+        (False, True, True, False, None, "zmq"),
     ],
     ids=[
         "jetstream",
@@ -770,9 +773,9 @@ def test_query_instance_id_returns_worker_and_tokens(
         "nats_core_remote_predict_on_route",
         "no_kv_events",
         "no_kv_events_remote",
-        "zmq",
+        "zmq_nats_free",
     ],
-    indirect=["durable_kv_events"],
+    indirect=["durable_kv_events", "event_plane"],
 )
 def test_router_decisions(
     request,
@@ -784,6 +787,7 @@ def test_router_decisions(
     zmq_kv_events,
     use_remote_indexer,
     router_predicted_ttl_secs,
+    event_plane,
 ):
     """Validate KV cache prefix reuse and dp_rank routing by sending progressive requests with overlapping prefixes.
 
@@ -794,14 +798,21 @@ def test_router_decisions(
     - Approximate mode (--no-kv-events): No KV events, router predicts cache state
       based on routing decisions with TTL-based expiration and pruning
     - Approximate mode with a singleton served remote indexer
+    - NATS-free ZMQ mode: raw engine and Dynamo event-plane hops both use ZMQ
     """
+    if event_plane == "zmq":
+        nats_process, _ = runtime_services_dynamic_ports
+        assert nats_process is None
+        assert "NATS_SERVER" not in os.environ
+
     # runtime_services_dynamic_ports handles NATS and etcd startup
     logger.info(
-        "Starting test router decisions: durable_kv_events=%s, use_kv_events=%s, use_remote_indexer=%s, router_predicted_ttl_secs=%s",
+        "Starting test router decisions: durable_kv_events=%s, use_kv_events=%s, use_remote_indexer=%s, router_predicted_ttl_secs=%s, event_plane=%s",
         durable_kv_events,
         use_kv_events,
         use_remote_indexer,
         router_predicted_ttl_secs,
+        event_plane,
     )
 
     # Create mocker args dictionary with dp_size=4

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -692,7 +692,7 @@ def test_indexers_sync(
         engine_process_kwargs={
             "num_mockers": NUM_MOCKERS,
             "store_backend": store_backend,
-            "zmq_kv_events": True,
+            "raw_kv_events": True,
             "zmq_replay": True,
             "standalone_indexer": True,
             "model_name": MODEL_NAME,
@@ -739,7 +739,7 @@ def test_query_instance_id_returns_worker_and_tokens(
 @pytest.mark.timeout(300)  # bumped for xdist contention (was 29s; ~9.55s serial avg)
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.parametrize(
-    "durable_kv_events,use_kv_events,zmq_kv_events,use_remote_indexer,router_predicted_ttl_secs,event_plane",
+    "durable_kv_events,use_kv_events,raw_kv_events,use_remote_indexer,router_predicted_ttl_secs,event_plane",
     [
         (True, True, False, False, None, None),  # JetStream mode with KV events
         (
@@ -784,7 +784,7 @@ def test_router_decisions(
     durable_kv_events,
     use_kv_events,
     request_plane,
-    zmq_kv_events,
+    raw_kv_events,
     use_remote_indexer,
     router_predicted_ttl_secs,
     event_plane,
@@ -826,9 +826,9 @@ def test_router_decisions(
 
     process_kwargs = {
         "num_mockers": NUM_MOCKERS,
-        "zmq_kv_events": zmq_kv_events,
-        "standalone_indexer": zmq_kv_events,
-        "standalone_selector": zmq_kv_events,
+        "raw_kv_events": raw_kv_events,
+        "standalone_indexer": raw_kv_events,
+        "standalone_selector": raw_kv_events,
         "model_name": MODEL_NAME,
     }
     if use_remote_indexer:


### PR DESCRIPTION
## Summary

- Make the existing DP4 mocker ZMQ router-decision case explicitly select the ZMQ event plane and run without starting or configuring NATS.
- Add event-plane fixture plumbing and reject durable KV-event configurations that contradict the NATS requirement.

## Validation

- `.venv/bin/ruff check tests/conftest.py tests/router/test_router_e2e_with_mockers.py`
- `.venv/bin/ruff format --check tests/conftest.py tests/router/test_router_e2e_with_mockers.py`
- `.venv/bin/python -m pytest tests/router/test_router_e2e_with_mockers.py::test_router_decisions --collect-only -q`
- The targeted E2E confirmed the NATS-free fixture setup, then stopped because this local build lacks the `kv-indexer` feature.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for router and indexer workflows across multiple event transport setups.
  * Added validation for event-transport compatibility in test environments.
  * Improved test startup handling to better reflect NATS-required and NATS-free scenarios.

* **Chores**
  * Updated test configuration to support the newer raw KV event path and event-plane selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->