### PR TITLE
perf(kv-router): batch CRTC removals by compressed node (cherry-pick #10858)

### DIFF
--- a/components/src/dynamo/common/backend/tests/test_dp_rank.py
+++ b/components/src/dynamo/common/backend/tests/test_dp_rank.py
@@ -35,7 +35,10 @@ def test_conversation_id_from_request():
     assert conversation_id_from_request({"routing": {"conversation_id": ""}}) is None
     assert (
         conversation_id_from_request(
-            {"token_ids": [], "routing": {"conversation_id": "conv-a:abc123", "dp_rank": 2}}
+            {
+                "token_ids": [],
+                "routing": {"conversation_id": "conv-a:abc123", "dp_rank": 2},
+            }
         )
         == "conv-a:abc123"
     )

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -10,7 +10,7 @@ use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
 use super::types::*;
-use crate::indexer::compressed_radix::{NodeState, RemoveOutcome};
+use crate::indexer::compressed_radix::NodeState;
 use crate::protocols::*;
 
 type NodeChildren = DashMap<LocalBlockHash, SharedNode, FxBuildHasher>;
@@ -656,19 +656,36 @@ impl Node {
         SplitLookupData { suffix }
     }
 
-    pub(super) fn remove_worker_for_hash(
+    pub(super) fn remove_worker_for_hashes(
         &self,
         worker: WorkerWithDpRank,
-        block_hash: ExternalSequenceBlockHash,
-    ) -> Option<RemoveOutcome> {
+        block_hashes: &[ExternalSequenceBlockHash],
+    ) -> Option<RemoveBatchOutcome> {
         let _gate = self.shape_gate.write();
         let mut state = self.state.write();
-        let pos = state.edge_index.get(&block_hash).copied()?;
+        let mut min_match = None;
+        let mut unmatched_hashes = Vec::new();
+
+        for &hash in block_hashes {
+            match state.edge_index.get(&hash).copied() {
+                Some(pos) => {
+                    if min_match.is_none_or(|(min_pos, _)| pos < min_pos) {
+                        min_match = Some((pos, hash));
+                    }
+                }
+                None => unmatched_hashes.push(hash),
+            }
+        }
+
+        let (pos, block_hash) = min_match?;
         let outcome = state.remove_worker_at_pos(worker, pos, block_hash);
         let should_clear_children = state.full_edge_workers.is_empty();
         drop(state);
         self.clear_children_if_unreachable(should_clear_children);
-        Some(outcome)
+        Some(RemoveBatchOutcome {
+            stale_hashes: outcome.stale_hashes,
+            unmatched_hashes,
+        })
     }
 
     #[cfg_attr(feature = "profile", inline(never))]

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -57,14 +57,31 @@ impl ConcurrentRadixTreeCompressed {
             return Err(KvCacheEventError::BlockNotFound);
         }
 
-        'outer: for block_hash in op.block_hashes {
-            let mut cur_node = match self.resolve_lookup(
+        let mut group_node: Option<SharedNode> = None;
+        let mut group_hashes: Vec<ExternalSequenceBlockHash> = Vec::new();
+
+        for block_hash in op.block_hashes {
+            if group_node
+                .as_ref()
+                .is_some_and(|node| node.contains_edge_hash(block_hash))
+            {
+                group_hashes.push(block_hash);
+                continue;
+            }
+
+            self.apply_removed_group(lookup, worker, group_node.take(), &group_hashes, id);
+            group_hashes.clear();
+
+            match self.resolve_lookup(
                 lookup,
                 worker,
                 block_hash,
                 LookupRepairDirection::TowardHead,
             ) {
-                Some(n) => n,
+                Some(node) => {
+                    group_node = Some(node);
+                    group_hashes.push(block_hash);
+                }
                 None => {
                     tracing::debug!(
                         worker_id = worker.worker_id.to_string(),
@@ -73,64 +90,127 @@ impl ConcurrentRadixTreeCompressed {
                         block_hash = ?block_hash,
                         "Block not found during remove; skipping"
                     );
-                    continue;
                 }
-            };
+            }
+        }
 
-            loop {
-                // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
-                // subtree when a mid-edge removal leaves the node alive for another
-                // worker. Otherwise stale descendants can be reused as store parents,
-                // reactivated by restoring only the removed block, or emitted by dumps
-                // without a valid worker-specific parent. Preserve CRTC's locking and
-                // snapshot guarantees when implementing the traversal.
-                match cur_node.remove_worker_for_hash(worker, block_hash) {
-                    Some(outcome) => {
-                        if let Some(wl) = lookup.get_mut(&worker) {
-                            for hash in outcome.stale_hashes {
-                                wl.remove(&hash);
-                            }
+        self.apply_removed_group(lookup, worker, group_node, &group_hashes, id);
+
+        Ok(())
+    }
+
+    pub(super) fn apply_removed_group(
+        &self,
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        node: Option<SharedNode>,
+        block_hashes: &[ExternalSequenceBlockHash],
+        id: u64,
+    ) {
+        let Some(cur_node) = node else {
+            return;
+        };
+        if block_hashes.is_empty() {
+            return;
+        }
+
+        match cur_node.remove_worker_for_hashes(worker, block_hashes) {
+            Some(outcome) => {
+                Self::remove_lookup_hashes(lookup, worker, outcome.stale_hashes);
+                for block_hash in outcome.unmatched_hashes {
+                    self.apply_removed_hash(lookup, worker, block_hash, id);
+                }
+            }
+            None => {
+                for &block_hash in block_hashes {
+                    self.apply_removed_hash(lookup, worker, block_hash, id);
+                }
+            }
+        }
+    }
+
+    fn apply_removed_hash(
+        &self,
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        block_hash: ExternalSequenceBlockHash,
+        id: u64,
+    ) {
+        let Some(mut cur_node) = self.resolve_lookup(
+            lookup,
+            worker,
+            block_hash,
+            LookupRepairDirection::TowardHead,
+        ) else {
+            tracing::debug!(
+                worker_id = worker.worker_id.to_string(),
+                dp_rank = worker.dp_rank,
+                id,
+                block_hash = ?block_hash,
+                "Block not found during batched remove fallback; skipping"
+            );
+            Self::remove_lookup_hashes(lookup, worker, [block_hash]);
+            return;
+        };
+
+        loop {
+            // TODO(CORRECTNESS): Invalidate this worker throughout the descendant
+            // subtree when a mid-edge removal leaves the node alive for another
+            // worker. Otherwise stale descendants can be reused as store parents,
+            // reactivated by restoring only the removed block, or emitted by dumps
+            // without a valid worker-specific parent. Preserve CRTC's locking and
+            // snapshot guarantees when implementing the traversal.
+            match cur_node.remove_worker_for_hashes(worker, std::slice::from_ref(&block_hash)) {
+                Some(outcome) => {
+                    debug_assert!(outcome.unmatched_hashes.is_empty());
+                    Self::remove_lookup_hashes(lookup, worker, outcome.stale_hashes);
+                    return;
+                }
+                None => {
+                    // Hash was moved to a descendant by a concurrent split.
+                    match Self::find_in_subtree(&cur_node, block_hash) {
+                        Some(resolved) => {
+                            self.repair_lookup_for_resolved_node(
+                                lookup,
+                                block_hash,
+                                &resolved,
+                                LookupRepairDirection::TowardHead,
+                            );
+                            #[cfg(feature = "bench")]
+                            self.bench_metrics
+                                .lookup_repair_scans
+                                .fetch_add(1, Ordering::Relaxed);
+                            cur_node = resolved;
+                            // Retry the loop with the resolved node.
                         }
-                        continue 'outer;
-                    }
-                    None => {
-                        // Hash was moved to a descendant by a concurrent split.
-                        match Self::find_in_subtree(&cur_node, block_hash) {
-                            Some(resolved) => {
-                                self.repair_lookup_for_resolved_node(
-                                    lookup,
-                                    block_hash,
-                                    &resolved,
-                                    LookupRepairDirection::TowardHead,
-                                );
-                                #[cfg(feature = "bench")]
-                                self.bench_metrics
-                                    .lookup_repair_scans
-                                    .fetch_add(1, Ordering::Relaxed);
-                                cur_node = resolved;
-                                // Retry the inner loop with the resolved node.
-                            }
-                            None => {
-                                // Hash not found anywhere -- evicted by a concurrent clear.
-                                tracing::debug!(
-                                    worker_id = worker.worker_id.to_string(),
-                                    dp_rank = worker.dp_rank,
-                                    id,
-                                    block_hash = ?block_hash,
-                                    "Block not found in subtree during remove; skipping"
-                                );
-                                if let Some(wl) = lookup.get_mut(&worker) {
-                                    wl.remove(&block_hash);
-                                }
-                                continue 'outer;
-                            }
+                        None => {
+                            // Hash not found anywhere -- evicted by a concurrent clear.
+                            tracing::debug!(
+                                worker_id = worker.worker_id.to_string(),
+                                dp_rank = worker.dp_rank,
+                                id,
+                                block_hash = ?block_hash,
+                                "Block not found in subtree during batched remove; skipping"
+                            );
+                            Self::remove_lookup_hashes(lookup, worker, [block_hash]);
+                            return;
                         }
                     }
                 }
             }
         }
+    }
 
-        Ok(())
+    fn remove_lookup_hashes(
+        lookup: &mut FxHashMap<WorkerWithDpRank, WorkerLookup>,
+        worker: WorkerWithDpRank,
+        hashes: impl IntoIterator<Item = ExternalSequenceBlockHash>,
+    ) {
+        if let Some(wl) = lookup.get_mut(&worker) {
+            for hash in hashes {
+                wl.remove(&hash);
+            }
+        }
     }
 
     pub(super) fn remove_or_clear_worker_blocks(

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -5,7 +5,7 @@ use super::*;
 use crate::indexer::{KvIndexerInterface, ThreadPoolIndexer};
 use crate::test_utils::{
     assert_score, flush_and_settle, make_remove_event_with_parent, make_store_event,
-    make_store_event_with_parent, snapshot_events, snapshot_tree,
+    make_store_event_with_parent, remove_event, snapshot_events, snapshot_tree,
 };
 use std::sync::{Arc, Barrier};
 use std::thread;
@@ -35,6 +35,19 @@ async fn index_block_count(index: &ThreadPoolIndexer<ConcurrentRadixTreeCompress
 
 fn local_hashes(query: &[u64]) -> Vec<LocalBlockHash> {
     query.iter().copied().map(LocalBlockHash).collect()
+}
+
+fn remove_hashes_with_parent(
+    prefix_hashes: &[u64],
+    local_hashes: &[u64],
+) -> Vec<ExternalSequenceBlockHash> {
+    match make_remove_event_with_parent(0, prefix_hashes, local_hashes)
+        .event
+        .data
+    {
+        KvCacheEventData::Removed(op) => op.block_hashes,
+        _ => unreachable!("make_remove_event_with_parent must create a remove event"),
+    }
 }
 
 fn apply_direct(
@@ -444,6 +457,206 @@ mod race_tests {
                 }
             }
         }
+    }
+}
+
+mod remove_tests {
+    use super::*;
+
+    #[test]
+    fn remove_multiple_hashes_from_same_compressed_edge() {
+        let index = Arc::new(ConcurrentRadixTreeCompressed::new());
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_remove_event_with_parent(0, &[1, 2], &[3, 4, 5]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2], &[3, 4, 5, 6]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+    }
+
+    #[test]
+    fn batched_remove_uses_minimum_edge_position_not_event_order() {
+        let index = ConcurrentRadixTreeCompressed::new();
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+
+        let remove_hashes = remove_hashes_with_parent(&[1, 2], &[3, 4, 5]);
+        let out_of_order_hashes = vec![remove_hashes[2], remove_hashes[0], remove_hashes[1]];
+        apply_direct(
+            &index,
+            &mut lookup0,
+            remove_event(0, 0, 0, out_of_order_hashes),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(2));
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2], &[3, 4, 5, 6]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 6);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(6));
+    }
+
+    #[test]
+    fn batched_remove_processes_hashes_moved_by_split_before_restore() {
+        let index = ConcurrentRadixTreeCompressed::new();
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+        let remove_hashes = remove_hashes_with_parent(&[1, 2], &[3, 4, 5]);
+        let group_node = lookup0
+            .get(&worker0)
+            .and_then(|worker_lookup| worker_lookup.get(&remove_hashes[0]))
+            .cloned()
+            .expect("remove hash should point to the pre-split group node");
+
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event_with_parent(1, &[1, 2, 3], &[7]),
+        );
+        assert_eq!(
+            index.edge_topology_for_test(),
+            vec![edge_topology(
+                &[1, 2, 3],
+                vec![
+                    edge_topology(&[4, 5, 6], vec![]),
+                    edge_topology(&[7], vec![])
+                ],
+            )],
+        );
+
+        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), &remove_hashes, 42);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 2);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2], &[3]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 3);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(3));
+    }
+
+    #[test]
+    fn batched_remove_falls_back_when_all_grouped_hashes_move_before_restore() {
+        let index = ConcurrentRadixTreeCompressed::new();
+        let worker0 = worker(0);
+        let worker1 = worker(1);
+        let mut lookup0 = direct_lookup();
+        let mut lookup1 = direct_lookup();
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event(0, &[1, 2, 3, 4, 5, 6]),
+        );
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event(1, &[1, 2, 3, 4, 5, 6]),
+        );
+        let remove_hashes = remove_hashes_with_parent(&[1, 2, 3], &[4, 5]);
+        let group_node = lookup0
+            .get(&worker0)
+            .and_then(|worker_lookup| worker_lookup.get(&remove_hashes[0]))
+            .cloned()
+            .expect("remove hash should point to the pre-split group node");
+
+        apply_direct(
+            &index,
+            &mut lookup1,
+            make_store_event_with_parent(1, &[1, 2, 3], &[7]),
+        );
+        assert_eq!(
+            index.edge_topology_for_test(),
+            vec![edge_topology(
+                &[1, 2, 3],
+                vec![
+                    edge_topology(&[4, 5, 6], vec![]),
+                    edge_topology(&[7], vec![])
+                ],
+            )],
+        );
+
+        index.apply_removed_group(&mut lookup0, worker0, Some(group_node), &remove_hashes, 42);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 3);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(3));
+
+        apply_direct(
+            &index,
+            &mut lookup0,
+            make_store_event_with_parent(0, &[1, 2, 3], &[4]),
+        );
+
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker0, 4);
+        assert_direct_score(&index, &[1, 2, 3, 4, 5, 6], worker1, 6);
+        assert_eq!(worker_lookup_len(&lookup0, worker0), Some(4));
     }
 }
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/types.rs
@@ -106,6 +106,11 @@ pub(super) struct SplitLookupData {
     pub(super) suffix: SharedNode,
 }
 
+pub(super) struct RemoveBatchOutcome {
+    pub(super) stale_hashes: Vec<ExternalSequenceBlockHash>,
+    pub(super) unmatched_hashes: Vec<ExternalSequenceBlockHash>,
+}
+
 #[derive(Clone, Copy)]
 pub(super) enum LookupRepairDirection {
     TowardTail,

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -665,17 +665,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LLMEngineOutput>, Error>
                             {
                                 if let Some(threshold_ms) =
                                     dynamo_mocker::common::utils::mock_kv_wait_timeout_ms()
+                                    && delay_ms as u64 >= threshold_ms
                                 {
-                                    if delay_ms as u64 >= threshold_ms {
-                                        tracing::warn!(
-                                            target: "dynamo_stall_op",
-                                            op = "mock_kv_timeout",
-                                            uuid = %signal.uuid,
-                                            wait_ms = delay_ms as u64,
-                                            worker_type = "Prefill",
-                                            "mock KV transfer timeout: handoff delay exceeded budget"
-                                        );
-                                    }
+                                    tracing::warn!(
+                                        target: "dynamo_stall_op",
+                                        op = "mock_kv_timeout",
+                                        uuid = %signal.uuid,
+                                        wait_ms = delay_ms as u64,
+                                        worker_type = "Prefill",
+                                        "mock KV transfer timeout: handoff delay exceeded budget"
+                                    );
                                 }
                                 sleep_precise(Duration::from_secs_f64(delay_ms / 1000.0)).await;
                             }


### PR DESCRIPTION
Cherry-picks #10858 (upstream commit 0bea3e0d7) onto feat/deepseek_v4_aa.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11277" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->