### PR TITLE
fix(gms): rebind non-parameter tensors after publish

### DIFF
--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -221,3 +221,75 @@ def materialize_module_from_gms(
             len(meta_tensors),
             meta_tensors[:10],
         )
+
+
+def rebind_nonparameter_tensors(
+    gms_client_memory_manager: "GMSClientMemoryManager",
+    model: torch.nn.Module,
+) -> int:
+    """Re-bind GMS-resident non-parameter tensors to private clones.
+
+    The publisher builds the whole model inside the GMS memory pool, so
+    buffers and tensor attributes (fp8 KV scales, quantization ranges, ...)
+    land in the same committed allocations as the weights, which are
+    remapped read-only after publish. Unlike parameters, these tensors can
+    be written after load (for example ``init_fp8_kv_scales`` on wake),
+    which faults on the read-only mapping. Cloning them into ordinary CUDA
+    memory gives the publisher the same binding semantics importers get
+    from ``materialize_module_from_gms``: parameters stay on the shared
+    read-only mapping, everything else is private and writable. The GMS
+    copies stay registered so importers can still materialize from them.
+
+    Must run before CUDA graph capture: the clones live at new addresses.
+
+    Returns the number of bytes rebound, i.e. how much memory is duplicated
+    between the read-only GMS copies and the private clones.
+    """
+    mappings = gms_client_memory_manager.mappings
+    rebound_bytes = 0
+    for name, tensor, tensor_type in list(_iter_module_tensors(model)):
+        if tensor_type == "parameter":
+            continue
+        ptr = int(tensor.data_ptr())
+        if not any(
+            va <= ptr < va + mapping.aligned_size for va, mapping in mappings.items()
+        ):
+            # Allocated outside the GMS pool; already private.
+            continue
+
+        mod, attr = _resolve_module_attr(model, name)
+        if (
+            tensor_type == "buffer"
+            and hasattr(mod, "_buffers")
+            and attr in mod._buffers
+        ):
+            mod._buffers[attr] = tensor.detach().clone()
+        elif attr.isdigit() and not isinstance(mod, torch.nn.Module):
+            # Element of a tensor list/tuple attribute.
+            if isinstance(mod, list):
+                mod[int(attr)] = tensor.detach().clone()
+            elif isinstance(mod, tuple):
+                # Tuples are immutable: rebuild the tuple on its owner.
+                container_name, _ = name.rsplit(".", 1)
+                owner, container_attr = _resolve_module_attr(model, container_name)
+                if isinstance(getattr(type(owner), container_attr, None), property):
+                    # Read-only derived attribute; the underlying tensors
+                    # are iterated (and rebound) separately.
+                    logger.debug("[GMS] Skipping property attribute %r", name)
+                    continue
+                elements = list(mod)
+                elements[int(attr)] = tensor.detach().clone()
+                setattr(owner, container_attr, tuple(elements))
+            else:
+                logger.debug("[GMS] Cannot rebind container element %r", name)
+                continue
+        else:
+            if isinstance(getattr(type(mod), attr, None), property):
+                # Read-only derived attribute; the underlying tensor is
+                # iterated (and rebound) separately.
+                logger.debug("[GMS] Skipping property attribute %r", name)
+                continue
+            setattr(mod, attr, tensor.detach().clone())
+        rebound_bytes += tensor.numel() * tensor.element_size()
+
+    return rebound_bytes

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -11,7 +11,10 @@ from typing import TYPE_CHECKING
 
 import torch
 from gpu_memory_service.client.torch.allocator import prune_allocations
-from gpu_memory_service.client.torch.module import register_module_tensors
+from gpu_memory_service.client.torch.module import (
+    rebind_nonparameter_tensors,
+    register_module_tensors,
+)
 from gpu_memory_service.common.locks import RequestedLockType
 
 if TYPE_CHECKING:
@@ -82,6 +85,13 @@ def finalize_gms_write(
     """Finalize GMS write mode: register tensors, commit, reconnect in read mode.
 
     Flow: register tensors -> sync -> unmap + commit -> connect(RO) -> remap
+    -> rebind non-parameter tensors to private clones
+
+    The rebind mirrors the importer binding semantics from
+    ``materialize_module_from_gms``: after publish, the read-only GMS
+    mapping backs parameters only, while buffers and tensor attributes that
+    may be written later (fp8 KV scale re-initialization on wake,
+    quantization range updates) live in ordinary CUDA memory.
 
     Args:
         allocator: The GMS client memory manager in write mode.
@@ -110,13 +120,17 @@ def finalize_gms_write(
     allocator.connect(RequestedLockType.RO)
     allocator.remap_all_vas()
 
+    rebound_bytes = rebind_nonparameter_tensors(allocator, model)
+
     logger.info(
         "[GMS] Committed %.2f GiB, switched to read mode with %d mappings "
-        "(pruned %d allocations / %.2f GiB before commit)",
+        "(pruned %d allocations / %.2f GiB before commit; rebound %.2f MiB "
+        "of non-parameter tensors to private memory)",
         total_bytes / (1 << 30),
         len(allocator.mappings),
         pruned_count,
         pruned_bytes / (1 << 30),
+        rebound_bytes / (1 << 20),
     )
 
     return GMSCommittedMemoryStats(

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -283,7 +283,11 @@ def test_finalize_gms_write_rebinds_nonparameter_tensors(running_gms):
     gms_model._buffers["scale"] = gms_scale
     _, gms_extra = _make_gms_tensor(writer, baseline_extra, tag="weights")
     gms_model.extra = gms_extra
-    del gms_weight, gms_scale, gms_extra
+    _, gms_list_item = _make_gms_tensor(writer, baseline_scale, tag="weights")
+    gms_model.tensor_list = [gms_list_item]
+    _, gms_tuple_item = _make_gms_tensor(writer, baseline_extra, tag="weights")
+    gms_model.tensor_tuple = (gms_tuple_item,)
+    del gms_weight, gms_scale, gms_extra, gms_list_item, gms_tuple_item
 
     weight_ptr = gms_model.linear.weight.data_ptr()
 
@@ -304,14 +308,20 @@ def test_finalize_gms_write_rebinds_nonparameter_tensors(running_gms):
         # The buffer and the tensor attr are rebound to private memory.
         assert not _in_gms(cast(torch.Tensor, gms_model.scale))
         assert not _in_gms(cast(torch.Tensor, gms_model.extra))
+        assert not _in_gms(gms_model.tensor_list[0])
+        assert not _in_gms(gms_model.tensor_tuple[0])
 
         # Values are preserved across the rebind.
         _assert_exact_tensor_equal(expected, gms_model(inputs))
+        _assert_exact_tensor_equal(baseline_scale, gms_model.tensor_list[0])
+        _assert_exact_tensor_equal(baseline_extra, gms_model.tensor_tuple[0])
 
         # The rebound copies are writable. Without the rebind these writes
         # would land on the PROT_READ weights mapping (Xid 31).
         cast(torch.Tensor, gms_model.scale).add_(1.0)
         cast(torch.Tensor, gms_model.extra).zero_()
+        gms_model.tensor_list[0].add_(1.0)
+        gms_model.tensor_tuple[0].zero_()
         torch.cuda.synchronize()
     finally:
         del gms_model

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -258,6 +258,66 @@ def test_finalize_gms_write_prunes_unreferenced_allocations(running_gms):
         reader.close()
 
 
+def test_finalize_gms_write_rebinds_nonparameter_tensors(running_gms):
+    from gpu_memory_service.integrations.common.utils import finalize_gms_write
+
+    socket_path = running_gms
+    torch.manual_seed(13)
+    baseline = _TinyModule().cuda()
+    gms_model = _TinyModule().cuda()
+    inputs = torch.randn(3, 8, device="cuda", dtype=torch.float32)
+    expected = baseline(inputs).detach().clone()
+
+    writer = GMSClientMemoryManager(socket_path, device=0)
+    writer.connect(RequestedLockType.RW)
+
+    baseline_weight = cast(torch.Tensor, baseline.linear.weight)
+    baseline_scale = cast(torch.Tensor, baseline.scale)
+    baseline_extra = cast(torch.Tensor, baseline.extra)
+
+    _, gms_weight = _make_gms_tensor(writer, baseline_weight, tag="weights")
+    gms_model.linear.weight = torch.nn.Parameter(
+        gms_weight, requires_grad=baseline_weight.requires_grad
+    )
+    _, gms_scale = _make_gms_tensor(writer, baseline_scale, tag="weights")
+    gms_model._buffers["scale"] = gms_scale
+    _, gms_extra = _make_gms_tensor(writer, baseline_extra, tag="weights")
+    gms_model.extra = gms_extra
+    del gms_weight, gms_scale, gms_extra
+
+    weight_ptr = gms_model.linear.weight.data_ptr()
+
+    finalize_gms_write(writer, gms_model)
+
+    def _in_gms(tensor: torch.Tensor) -> bool:
+        ptr = tensor.data_ptr()
+        return any(
+            va <= ptr < va + mapping.aligned_size
+            for va, mapping in writer.mappings.items()
+        )
+
+    try:
+        # Parameters keep their shared (now read-only) GMS binding.
+        assert gms_model.linear.weight.data_ptr() == weight_ptr
+        assert _in_gms(cast(torch.Tensor, gms_model.linear.weight))
+
+        # The buffer and the tensor attr are rebound to private memory.
+        assert not _in_gms(cast(torch.Tensor, gms_model.scale))
+        assert not _in_gms(cast(torch.Tensor, gms_model.extra))
+
+        # Values are preserved across the rebind.
+        _assert_exact_tensor_equal(expected, gms_model(inputs))
+
+        # The rebound copies are writable. Without the rebind these writes
+        # would land on the PROT_READ weights mapping (Xid 31).
+        cast(torch.Tensor, gms_model.scale).add_(1.0)
+        cast(torch.Tensor, gms_model.extra).zero_()
+        torch.cuda.synchronize()
+    finally:
+        del gms_model
+        writer.close()
+
+
 def test_live_gms_tensor_survives_unmap_and_remap(running_gms):
     socket_path = running_gms
     baseline = torch.arange(64, device="cuda", dtype=torch.float32).reshape(8, 8)


### PR DESCRIPTION
## Summary

Cherry-pick #11201 to `release/1.3.0` to prevent fatal GPU write faults when a GMS publisher writes mutable non-parameter tensors after the weights mapping becomes read-only.

- Rebinds GMS-resident buffers and tensor attributes to private CUDA allocations after publish, while parameters remain on the shared read-only mapping.
- Preserves importer materialization and GMS metadata behavior.
- Includes the end-to-end regression test from the merged main PR.
- Clean cherry-pick with no content changes or merge conflicts.

**Original PR:** #11201  
**Source merge commit:** `56a74283f705166a1f8bf48f1306f42d6846287c`  
**Release commit:** `f11595767389d52ec6c4fad977674569bde1479f`

## Dependencies

None. The source PR is merged to `main`, and this change has no stated PR dependency.

## Validation

- Fresh release-branch CI at `e0cefb302da6db1e4724871f2f8f0efbcb1bdd19`: 58 passed, 36 expected skips, 0 failed or pending.
- Exact GPU job `dynamo-runtime / test / gpu cuda13.0, amd64` ran `test_finalize_gms_write_rebinds_nonparameter_tensors`: passed; suite summary 28 passed, 3 skipped, 0 failed.
- Added focused list/tuple tensor coverage; pre-commit and DCO checks passed.

- Stable patch ID matches #11201: `6a2263e8bf746cda479e6ba5f2de8e7d10a0293b`.
- `pre-commit run --files lib/gpu_memory_service/client/torch/module.py lib/gpu_memory_service/integrations/common/utils.py lib/gpu_memory_service/tests/test_torch_integration.py` — passed.
- `git diff --check origin/release/1.3.0...HEAD` — passed.
- DCO signoff is present on the release commit.
- The original PR passed its live-GMS GPU regression suite (`5 passed`), full pre-commit suite, and stack-level snapshot restore E2E. The GPU/live-GMS test could not be rerun locally; release-branch CI executed it successfully at the tested head.
