### PR TITLE
feat(frontend): skip frontend tokenization via DYN_SKIP_FRONTEND_TOKENIZE

### DIFF
--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -163,6 +163,13 @@ class SglangLLMEngine(LLMEngine):
             server_args.enable_custom_logit_processor = True
             server_args.skip_tokenizer_init = False
 
+        # When the frontend skips tokenization, every worker role (prefill and
+        # decode/agg alike) receives raw prompt text and must tokenize it.
+        # SGLang's default skip_tokenizer_init=True leaves no tokenizer loaded,
+        # so force it off for all serving modes here.
+        if os.getenv("DYN_SKIP_FRONTEND_TOKENIZE") in ("1", "true"):
+            server_args.skip_tokenizer_init = False
+
         model_input = (
             ModelInput.Text if dynamo_args.use_sglang_tokenizer else ModelInput.Tokens
         )

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -1022,6 +1022,16 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             self.publisher.cleanup()
 
     def _get_input_param(self, request: Dict[str, Any]) -> Dict[str, Any]:
+        # When the frontend skipped tokenization (DYN_SKIP_FRONTEND_TOKENIZE=1),
+        # token_ids is empty and prompt_text carries the rendered prompt. Pass it
+        # as "prompt" so SGLang tokenizes internally. This differs from
+        # --use-sglang-tokenizer, which bypasses the Dynamo preprocessor entirely
+        # (sending a raw OpenAI ChatCompletionRequest); here the preprocessor still
+        # runs and applies the chat template before forwarding the rendered text.
+        prompt_text = request.get("prompt_text")
+        if not request.get("token_ids") and prompt_text:
+            return {"prompt": prompt_text}
+
         request_input = self.input_param_manager.get_input_param(
             request, use_tokenizer=self.use_sglang_tokenizer
         )

--- a/components/src/dynamo/sglang/tests/test_skip_frontend_tokenize.py
+++ b/components/src/dynamo/sglang/tests/test_skip_frontend_tokenize.py
@@ -1,0 +1,221 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for DYN_SKIP_FRONTEND_TOKENIZE behaviour in the SGLang engine.
+
+Tests cover:
+- _get_input_param returns {"prompt": text} when token_ids absent + prompt_text set.
+- _get_input_param falls through to input_param_manager on the normal token path.
+- from_args forces skip_tokenizer_init=False when DYN_SKIP_FRONTEND_TOKENIZE=1.
+
+No GPU or SGLang engine initialisation is required.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_handler():
+    """Return a BaseWorkerHandler instance with engine and tokenizer stubbed out."""
+    from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
+
+    handler = BaseWorkerHandler.__new__(BaseWorkerHandler)
+    handler.use_sglang_tokenizer = False
+    handler.input_param_manager = MagicMock()
+    handler.input_param_manager.get_input_param.return_value = [1, 2, 3]
+    return handler
+
+
+# ---------------------------------------------------------------------------
+# _get_input_param
+# ---------------------------------------------------------------------------
+
+
+def test_get_input_param_returns_prompt_text_dict_when_tokenization_skipped():
+    """{"prompt": text} is returned when token_ids absent and prompt_text set."""
+    handler = _make_handler()
+    request = {"prompt_text": "Hello from engine tokenizer", "sampling_options": {}}
+    result = handler._get_input_param(request)
+    assert result == {"prompt": "Hello from engine tokenizer"}
+    handler.input_param_manager.get_input_param.assert_not_called()
+
+
+def test_get_input_param_ignores_prompt_text_when_token_ids_present():
+    """Falls through to input_param_manager when token_ids is non-empty."""
+    handler = _make_handler()
+    handler.input_param_manager.get_input_param.return_value = [1, 2, 3]
+    request = {
+        "token_ids": [1, 2, 3],
+        "prompt_text": "should be ignored",
+    }
+    result = handler._get_input_param(request)
+    assert result != {"prompt": "should be ignored"}
+    handler.input_param_manager.get_input_param.assert_called_once()
+
+
+def test_get_input_param_fallthrough_when_no_prompt_text():
+    """Falls through to input_param_manager when prompt_text is absent."""
+    handler = _make_handler()
+    handler.input_param_manager.get_input_param.return_value = [10, 20]
+    request = {"token_ids": [10, 20]}
+    handler._get_input_param(request)
+    handler.input_param_manager.get_input_param.assert_called_once()
+
+
+def test_get_input_param_fallthrough_when_token_ids_and_prompt_text_both_empty():
+    """Both absent → falls through to input_param_manager (empty TokensPrompt path)."""
+    handler = _make_handler()
+    request = {}
+    handler._get_input_param(request)
+    handler.input_param_manager.get_input_param.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# from_args: skip_tokenizer_init enforcement
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_from_args_forces_skip_tokenizer_init_false_when_flag_set(monkeypatch):
+    """DYN_SKIP_FRONTEND_TOKENIZE=1 must force server_args.skip_tokenizer_init=False."""
+    monkeypatch.setenv("DYN_SKIP_FRONTEND_TOKENIZE", "1")
+
+    from dynamo.common.backend.engine import DisaggregationMode
+
+    server_args = SimpleNamespace(
+        skip_tokenizer_init=True,  # default SGLang behaviour
+        model_path="test-model",
+        served_model_name=None,
+        enable_custom_logit_processor=False,
+    )
+    dynamo_args = SimpleNamespace(
+        use_sglang_tokenizer=False,
+        namespace="test",
+        component="backend",
+        endpoint="generate",
+        # extra fields WorkerConfig.from_runtime_config reads
+        enable_prefix_caching=False,
+        session_control=False,
+        component_metrics_dp_ranks=[],
+    )
+    config = SimpleNamespace(
+        server_args=server_args,
+        dynamo_args=dynamo_args,
+        serving_mode=DisaggregationMode.AGGREGATED,
+    )
+
+    with patch(
+        "dynamo.sglang.llm_engine.parse_args", new=AsyncMock(return_value=config)
+    ):
+        with patch("dynamo.sglang.llm_engine.WorkerConfig") as mock_wc:
+            mock_wc.from_runtime_config.return_value = MagicMock()
+            from dynamo.sglang.llm_engine import SglangLLMEngine
+
+            await SglangLLMEngine.from_args([])
+
+    assert (
+        server_args.skip_tokenizer_init is False
+    ), "skip_tokenizer_init must be False when DYN_SKIP_FRONTEND_TOKENIZE=1"
+
+
+@pytest.mark.asyncio
+async def test_from_args_leaves_skip_tokenizer_init_unchanged_when_flag_absent(
+    monkeypatch,
+):
+    """Without the flag, skip_tokenizer_init is not modified."""
+    monkeypatch.delenv("DYN_SKIP_FRONTEND_TOKENIZE", raising=False)
+
+    from dynamo.common.backend.engine import DisaggregationMode
+
+    server_args = SimpleNamespace(
+        skip_tokenizer_init=True,
+        model_path="test-model",
+        served_model_name=None,
+        enable_custom_logit_processor=False,
+    )
+    dynamo_args = SimpleNamespace(
+        use_sglang_tokenizer=False,
+        namespace="test",
+        component="backend",
+        endpoint="generate",
+        enable_prefix_caching=False,
+        session_control=False,
+        component_metrics_dp_ranks=[],
+    )
+    config = SimpleNamespace(
+        server_args=server_args,
+        dynamo_args=dynamo_args,
+        serving_mode=DisaggregationMode.AGGREGATED,
+    )
+
+    with patch(
+        "dynamo.sglang.llm_engine.parse_args", new=AsyncMock(return_value=config)
+    ):
+        with patch("dynamo.sglang.llm_engine.WorkerConfig") as mock_wc:
+            mock_wc.from_runtime_config.return_value = MagicMock()
+            from dynamo.sglang.llm_engine import SglangLLMEngine
+
+            await SglangLLMEngine.from_args([])
+
+    assert (
+        server_args.skip_tokenizer_init is True
+    ), "skip_tokenizer_init must not be changed when DYN_SKIP_FRONTEND_TOKENIZE is absent"
+
+
+@pytest.mark.asyncio
+async def test_from_args_forces_skip_tokenizer_init_false_for_prefill_worker(
+    monkeypatch,
+):
+    """Prefill workers also receive raw prompt text and need the tokenizer."""
+    monkeypatch.setenv("DYN_SKIP_FRONTEND_TOKENIZE", "1")
+
+    from dynamo.common.backend.engine import DisaggregationMode
+
+    server_args = SimpleNamespace(
+        skip_tokenizer_init=True,
+        model_path="test-model",
+        served_model_name=None,
+        enable_custom_logit_processor=False,
+    )
+    dynamo_args = SimpleNamespace(
+        use_sglang_tokenizer=False,
+        namespace="test",
+        component="backend",
+        endpoint="generate",
+        enable_prefix_caching=False,
+        session_control=False,
+        component_metrics_dp_ranks=[],
+    )
+    config = SimpleNamespace(
+        server_args=server_args,
+        dynamo_args=dynamo_args,
+        serving_mode=DisaggregationMode.PREFILL,
+    )
+
+    with patch(
+        "dynamo.sglang.llm_engine.parse_args", new=AsyncMock(return_value=config)
+    ):
+        with patch("dynamo.sglang.llm_engine.WorkerConfig") as mock_wc:
+            mock_wc.from_runtime_config.return_value = MagicMock()
+            from dynamo.sglang.llm_engine import SglangLLMEngine
+
+            await SglangLLMEngine.from_args([])
+
+    assert server_args.skip_tokenizer_init is False, (
+        "Prefill workers receive raw prompt text and must tokenize it; "
+        "skip_tokenizer_init must be False"
+    )

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -383,6 +383,15 @@ class TrtllmLLMEngine(LLMEngine):
             "ON" if self._engine_conv_affinity else "OFF",
             self._attention_dp_size,
         )
+        if (
+            os.environ.get("DYN_SKIP_FRONTEND_TOKENIZE") in ("1", "true")
+            and not self._engine_conv_affinity
+        ):
+            logger.warning(
+                "DYN_SKIP_FRONTEND_TOKENIZE=1 has no effect for TRT-LLM without "
+                "DYN_ENGINE_CONV_AFFINITY=1. Frontend tokenization will proceed normally. "
+                "Set DYN_ENGINE_CONV_AFFINITY=1 to enable engine-side tokenization."
+            )
         self._convid_first_logged = False
         # Always start the metrics-poll thread: it pushes the latest
         # ComponentSnapshot into the framework's SnapshotPublisher and
@@ -858,8 +867,23 @@ class TrtllmLLMEngine(LLMEngine):
             max_tokens = stop_conditions.get("max_tokens")
             if max_tokens is not None:
                 sampling_params.max_tokens = max_tokens
-            elif self.max_seq_len is not None:
+            elif self.max_seq_len is not None and (
+                token_ids or not self._engine_conv_affinity
+            ):
                 sampling_params.max_tokens = max(1, self.max_seq_len - len(token_ids))
+            elif (
+                self.max_seq_len is not None
+                and not token_ids
+                and self._engine_conv_affinity
+            ):
+                # Frontend tokenization was skipped; engine tokenizes internally and
+                # enforces its own context-length cap (generate_async caps to
+                # max_input_len / max_seq_len when max_new_tokens is unset).
+                # Log once so operators can confirm TRT-LLM is enforcing the limit.
+                logger.debug(
+                    "max_tokens not set on skip-tokenize path; "
+                    "TRT-LLM will cap generation after tokenizing the prompt."
+                )
 
         # TODO: mirror visible/hidden stop-token handling from the disagg
         # path (handler_base.py) into a shared helper. See PR #9778.
@@ -893,8 +917,26 @@ class TrtllmLLMEngine(LLMEngine):
         # Prefill returns one non-streaming chunk carrying the handoff -
         # matches the legacy disagg wire format.
         streaming = not is_prefill
+        prompt_text = request.get("prompt_text")
+        if not token_ids and prompt_text and not self._engine_conv_affinity:
+            raise RuntimeError(
+                "Received a request with empty token_ids and prompt_text set, but "
+                "DYN_ENGINE_CONV_AFFINITY is not enabled. "
+                "DYN_SKIP_FRONTEND_TOKENIZE=1 requires DYN_ENGINE_CONV_AFFINITY=1 "
+                "for TRT-LLM."
+            )
+        # When frontend tokenization is skipped (DYN_SKIP_FRONTEND_TOKENIZE=1)
+        # AND conv-aware routing is active, token_ids is empty and prompt_text
+        # carries the rendered prompt. TRT-LLM generate_async accepts a plain
+        # string and tokenizes internally. Outside conv-aware mode the engine
+        # does not own routing decisions, so we require token_ids for KV routing.
+        engine_input = (
+            prompt_text
+            if (self._engine_conv_affinity and not token_ids and prompt_text)
+            else token_ids
+        )
         generation_result = self._engine.llm.generate_async(
-            inputs=token_ids,
+            inputs=engine_input,
             sampling_params=sampling_params,
             streaming=streaming,
             disaggregated_params=disaggregated_params,

--- a/components/src/dynamo/trtllm/tests/test_skip_frontend_tokenize.py
+++ b/components/src/dynamo/trtllm/tests/test_skip_frontend_tokenize.py
@@ -1,0 +1,166 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for DYN_SKIP_FRONTEND_TOKENIZE behaviour in the TRT-LLM engine.
+
+Tests cover:
+- engine_input selection (text vs token IDs) gated on DYN_ENGINE_CONV_AFFINITY.
+- max_tokens auto-cap bypass when token_ids is empty and conv-affinity is on.
+- startup warning when DYN_SKIP_FRONTEND_TOKENIZE=1 without DYN_ENGINE_CONV_AFFINITY=1.
+- runtime guard: empty token_ids + prompt_text without conv-affinity raises RuntimeError.
+
+No GPU or TRT-LLM engine initialisation is required.
+"""
+
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers that mirror the logic in TrtllmLLMEngine.generate()
+# ---------------------------------------------------------------------------
+
+
+def _engine_input(engine_conv_affinity: bool, token_ids: list, prompt_text):
+    """Mirror the engine_input selection ternary in generate()."""
+    return (
+        prompt_text
+        if (engine_conv_affinity and not token_ids and prompt_text)
+        else token_ids
+    )
+
+
+def _should_cap_max_tokens(engine_conv_affinity: bool, token_ids: list) -> bool:
+    """Mirror the max_tokens auto-cap condition in generate().
+
+    Returns True when the frontend-side cap should be applied.
+    """
+    return bool(token_ids or not engine_conv_affinity)
+
+
+# ---------------------------------------------------------------------------
+# engine_input selection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("engine_conv_affinity", "token_ids", "prompt_text", "expect_text"),
+    [
+        # skip path: conv-affinity ON, no token_ids, prompt_text present → text
+        (True, [], "Hello world", True),
+        (True, None, "Hello world", True),
+        # conv-affinity ON but token_ids present → IDs win
+        (True, [1, 2, 3], "Hello world", False),
+        # conv-affinity ON but no prompt_text → IDs (empty list)
+        (True, [], None, False),
+        # conv-affinity OFF → always use IDs regardless of prompt_text
+        (False, [], "Hello world", False),
+        (False, [1, 2, 3], "Hello world", False),
+        (False, [], None, False),
+    ],
+)
+def test_engine_input_selection(
+    engine_conv_affinity, token_ids, prompt_text, expect_text
+):
+    result = _engine_input(engine_conv_affinity, token_ids or [], prompt_text)
+    if expect_text:
+        assert result == prompt_text
+    else:
+        assert result == (token_ids or [])
+
+
+# ---------------------------------------------------------------------------
+# max_tokens auto-cap
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("engine_conv_affinity", "token_ids", "expect_cap"),
+    [
+        # conv-affinity ON, no token_ids → skip the cap (engine will determine length)
+        (True, [], False),
+        # conv-affinity ON, token_ids present → cap still applies
+        (True, [1, 2, 3], True),
+        # conv-affinity OFF → cap always applies
+        (False, [], True),
+        (False, [1, 2, 3], True),
+    ],
+)
+def test_max_tokens_cap_condition(engine_conv_affinity, token_ids, expect_cap):
+    assert _should_cap_max_tokens(engine_conv_affinity, token_ids) == expect_cap
+
+
+def test_max_tokens_cap_value_uses_remaining_context():
+    """Cap value is max(1, max_seq_len - len(token_ids))."""
+    max_seq_len = 4096
+    token_ids = list(range(100))
+    cap = max(1, max_seq_len - len(token_ids))
+    assert cap == 3996
+
+
+def test_max_tokens_cap_floor_is_one():
+    """Cap never goes below 1 even when prompt fills the context."""
+    max_seq_len = 4
+    token_ids = list(range(10))  # longer than context
+    cap = max(1, max_seq_len - len(token_ids))
+    assert cap == 1
+
+
+# ---------------------------------------------------------------------------
+# Warning when DYN_SKIP_FRONTEND_TOKENIZE=1 without DYN_ENGINE_CONV_AFFINITY
+# ---------------------------------------------------------------------------
+
+
+def _check_skip_tokenize_warning(skip_flag: str | None, conv_affinity: bool) -> bool:
+    """Mirror the startup warning condition from TrtllmLLMEngine.start()."""
+    return skip_flag in ("1", "true") and not conv_affinity
+
+
+@pytest.mark.parametrize(
+    ("skip_flag", "conv_affinity", "expect_warn"),
+    [
+        ("1", False, True),
+        ("true", False, True),
+        ("1", True, False),  # conv-affinity on: no warning
+        (None, False, False),  # flag absent: no warning
+        ("0", False, False),  # flag explicitly off: no warning
+    ],
+)
+def test_startup_warning_condition(skip_flag, conv_affinity, expect_warn):
+    assert _check_skip_tokenize_warning(skip_flag, conv_affinity) == expect_warn
+
+
+# ---------------------------------------------------------------------------
+# Runtime guard: empty token_ids + prompt_text without conv-affinity
+# ---------------------------------------------------------------------------
+
+
+def _runtime_guard(engine_conv_affinity: bool, token_ids: list, prompt_text):
+    """Mirror the runtime guard in TrtllmLLMEngine.generate()."""
+    if not token_ids and prompt_text and not engine_conv_affinity:
+        raise RuntimeError(
+            "DYN_SKIP_FRONTEND_TOKENIZE=1 requires DYN_ENGINE_CONV_AFFINITY=1 for TRT-LLM."
+        )
+
+
+def test_runtime_guard_raises_when_skip_without_conv_affinity():
+    """Empty token_ids + prompt_text without conv-affinity must raise RuntimeError."""
+    with pytest.raises(RuntimeError, match="DYN_ENGINE_CONV_AFFINITY"):
+        _runtime_guard(engine_conv_affinity=False, token_ids=[], prompt_text="Hello")
+
+
+def test_runtime_guard_passes_with_conv_affinity():
+    """No error when conv-affinity is on (text path)."""
+    _runtime_guard(engine_conv_affinity=True, token_ids=[], prompt_text="Hello")
+
+
+def test_runtime_guard_passes_with_token_ids():
+    """No error when token_ids is non-empty (normal path)."""
+    _runtime_guard(engine_conv_affinity=False, token_ids=[1, 2, 3], prompt_text=None)

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -295,7 +295,15 @@ class VllmLLMEngine(LLMEngine):
         request_id = context.id()
 
         token_ids = request.get("token_ids", [])
-        prompt = TokensPrompt(prompt_token_ids=token_ids)
+        prompt_text = request.get("prompt_text")
+        if not token_ids and prompt_text:
+            # Frontend tokenization was skipped (DYN_SKIP_FRONTEND_TOKENIZE=1);
+            # pass the rendered prompt text so vLLM tokenizes internally.
+            from vllm.inputs import TextPrompt
+
+            prompt = TextPrompt(prompt=prompt_text)
+        else:
+            prompt = TokensPrompt(prompt_token_ids=token_ids)
 
         # TODO: remove dict() once build_sampling_params accepts GenerateRequest
         sampling_params = build_sampling_params(

--- a/components/src/dynamo/vllm/tests/test_skip_frontend_tokenize.py
+++ b/components/src/dynamo/vllm/tests/test_skip_frontend_tokenize.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for DYN_SKIP_FRONTEND_TOKENIZE behaviour in the vLLM engine.
+
+These tests verify that generate() selects TextPrompt when token_ids is
+empty and prompt_text is present, and falls back to TokensPrompt otherwise.
+No GPU or vLLM engine initialisation is required.
+"""
+
+import pytest
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(token_ids=None, prompt_text=None):
+    req = {}
+    if token_ids is not None:
+        req["token_ids"] = token_ids
+    if prompt_text is not None:
+        req["prompt_text"] = prompt_text
+    return req
+
+
+def _prompt_type(token_ids, prompt_text):
+    """Mirror the selection logic from VllmLLMEngine.generate()."""
+    if not token_ids and prompt_text:
+        return "text"
+    return "tokens"
+
+
+# ---------------------------------------------------------------------------
+# Prompt selection logic
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("token_ids", "prompt_text", "expected"),
+    [
+        # skip path: no token_ids, prompt_text present → TextPrompt
+        ([], "Hello world", "text"),
+        (None, "Hello world", "text"),
+        # normal path: token_ids present → TokensPrompt regardless of prompt_text
+        ([1, 2, 3], None, "tokens"),
+        ([1, 2, 3], "Hello world", "tokens"),
+        # edge: both absent → empty TokensPrompt
+        ([], None, "tokens"),
+        (None, None, "tokens"),
+    ],
+)
+def test_prompt_type_selection(token_ids, prompt_text, expected):
+    assert _prompt_type(token_ids, prompt_text) == expected
+
+
+def test_text_prompt_is_a_dict_subtype():
+    """TextPrompt is a TypedDict; {"prompt": text} matches what SGLang/vLLM expect."""
+    from vllm.inputs import TextPrompt
+
+    tp = TextPrompt(prompt="Hello world")
+    assert tp["prompt"] == "Hello world"
+    assert isinstance(tp, dict)
+
+
+def test_tokens_prompt_carries_token_ids():
+    from vllm.inputs import TokensPrompt
+
+    tp = TokensPrompt(prompt_token_ids=[1, 2, 3])
+    assert tp["prompt_token_ids"] == [1, 2, 3]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -252,6 +252,17 @@ static DIM_FETCH_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
             .expect("dim-fetch http client construction failed")
     });
 
+/// Cached at first access — env var reads acquire the process-global env mutex,
+/// which would serialize every concurrent preprocessing thread on every request.
+static SKIP_FRONTEND_TOKENIZE: std::sync::LazyLock<bool> =
+    std::sync::LazyLock::new(|| {
+        std::env::var(
+            dynamo_runtime::config::environment_names::llm::DYN_SKIP_FRONTEND_TOKENIZE,
+        )
+        .ok()
+        .is_some_and(|v| v == "1" || v == "true")
+    });
+
 pub(crate) const PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY: &str =
     "dynamo.llm.preserve_omitted_max_tokens";
 
@@ -676,15 +687,28 @@ impl OpenAIPreprocessor {
             .as_ref()
             .is_some_and(|p| p.trim_end().ends_with("<think>"));
 
+        let skip_tokenize = *SKIP_FRONTEND_TOKENIZE;
+        if skip_tokenize && formatted_prompt.is_none() {
+            anyhow::bail!(
+                "DYN_SKIP_FRONTEND_TOKENIZE=1 requires a chat-template-rendered text \
+                 prompt. Raw token-ID completion requests and multimodal requests are \
+                 not supported with this flag."
+            );
+        }
+
         let tokenize_start = Instant::now();
-        let (token_ids, annotations) = {
+        let (token_ids, annotations) = if skip_tokenize {
+            (vec![], HashMap::new())
+        } else {
             let _nvtx = dynamo_nvtx_range!("preprocess.tokenize");
             self.gather_tokens(request, formatted_prompt.as_deref(), tracker)
                 .await
                 .with_context(|| "Failed to gather tokens")?
         };
-        let tokenize_elapsed = tokenize_start.elapsed();
-        TOKENIZE_SECONDS.observe(tokenize_elapsed.as_secs_f64());
+        if !skip_tokenize {
+            let tokenize_elapsed = tokenize_start.elapsed();
+            TOKENIZE_SECONDS.observe(tokenize_elapsed.as_secs_f64());
+        }
 
         let _mm_image_entries = self
             .gather_multi_modal_data(
@@ -706,6 +730,9 @@ impl OpenAIPreprocessor {
         // Install tokens on the builder. Done after MM routing built its
         // view so the routing-side borrow stays cheap and builder ownership
         // moves once.
+        if skip_tokenize {
+            builder.prompt_text(formatted_prompt.clone());
+        }
         builder.token_ids(token_ids);
 
         STAGE_DURATION_SECONDS
@@ -722,8 +749,10 @@ impl OpenAIPreprocessor {
 
         // If omitted, allow generation up to the remaining context length. Responses requests
         // preserve omission so backend adapters can compute the dynamic cap from their
-        // effective prompt length/tokenization.
-        if preprocessed.stop_conditions.max_tokens.is_none()
+        // effective prompt length/tokenization. When tokenization is skipped the engine
+        // applies its own cap once it knows the actual prompt length.
+        if !skip_tokenize
+            && preprocessed.stop_conditions.max_tokens.is_none()
             && let Some(max_tokens) = Self::omitted_max_tokens_default(
                 preprocessed.token_ids.len(),
                 self.context_length,

--- a/lib/llm/src/protocols/common/preprocessor.rs
+++ b/lib/llm/src/protocols/common/preprocessor.rs
@@ -256,6 +256,14 @@ pub struct PreprocessedRequest {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bootstrap_info: Option<BootstrapInfo>,
 
+    /// Rendered prompt text, set when frontend tokenization is skipped
+    /// (`DYN_SKIP_FRONTEND_TOKENIZE=1`). Engines use this as text input
+    /// so they can tokenize the prompt themselves; `token_ids` is empty
+    /// in that case and must not be used for routing or length estimation.
+    #[builder(default)]
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub prompt_text: Option<String>,
+
     /// Additional arguments for extensibility
     #[builder(default)]
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -307,6 +307,27 @@ pub mod llm {
     /// Enable streaming tool call dispatch (`event: tool_call_dispatch` SSE events)
     pub const DYN_ENABLE_STREAMING_TOOL_DISPATCH: &str = "DYN_ENABLE_STREAMING_TOOL_DISPATCH";
 
+    /// Skip prompt tokenization on the frontend and let the engine tokenize
+    /// instead. When set to `1` or `true` the preprocessor applies the chat
+    /// template (cheap) but skips `encode_with_timing` (expensive for long
+    /// prompts). The rendered prompt text is forwarded in `prompt_text` and
+    /// `token_ids` is left empty.
+    ///
+    /// Engine support:
+    /// - **vLLM**: uses `TextPrompt` when token_ids is empty and prompt_text is set.
+    /// - **SGLang**: passes `"prompt": prompt_text` directly to `async_generate`,
+    ///   bypassing `--use-sglang-tokenizer` (which replaces the Dynamo preprocessor
+    ///   entirely); SGLang tokenizes internally.
+    /// - **TRT-LLM**: only active when `DYN_ENGINE_CONV_AFFINITY=1` (conversation-
+    ///   aware routing). Outside that mode TRT-LLM still requires token IDs for KV
+    ///   routing decisions, so the flag is ignored.
+    ///
+    /// Side-effects (when active):
+    /// - KV prefix-cache routing is disabled (no token IDs → no block hashes).
+    /// - `max_tokens` is not auto-capped to the remaining context window; each
+    ///   engine applies its own cap after tokenizing.
+    pub const DYN_SKIP_FRONTEND_TOKENIZE: &str = "DYN_SKIP_FRONTEND_TOKENIZE";
+
     /// Enable streaming reasoning dispatch (`event: reasoning_dispatch` SSE events)
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";


### PR DESCRIPTION
## Summary

- Adds `DYN_SKIP_FRONTEND_TOKENIZE=1` env var that skips `encode_with_timing` in the Rust preprocessor. The rendered prompt text is forwarded to the engine via a new `PreprocessedRequest.prompt_text` field (`token_ids` is left empty).
- Each engine backend tokenizes the prompt itself:
  - **vLLM**: uses `TextPrompt` when `token_ids` is absent and `prompt_text` is present.
  - **SGLang**: forces `skip_tokenizer_init=False` for all worker roles (including prefill) at startup; `_get_input_param` returns `{"prompt": text}` on the skip path.
  - **TRT-LLM**: only active when `DYN_ENGINE_CONV_AFFINITY=1`. Without it, `start()` logs a `WARNING` and `generate()` raises `RuntimeError` if a skip-tokenized request arrives — prevents silent empty generation.
- `DYN_SKIP_FRONTEND_TOKENIZE` is cached in a `LazyLock` to avoid acquiring the env mutex per-request.
- Bails with a clear error when the flag is set but no rendered prompt text is available (raw token-ID completions, multimodal requests).

**Side-effects when active:** KV prefix-cache routing is disabled (no token IDs → no block hashes); `max_tokens` auto-cap is skipped and each engine applies its own cap after tokenizing.

## Test plan

- [ ] TRT-LLM pure-logic tests (`test_skip_frontend_tokenize.py`) pass locally: 21/21
- [ ] SGLang and vLLM tests require components installed — run in CI
- [ ] Manual: run agg SGLang / vLLM / TRT-LLM (with `DYN_ENGINE_CONV_AFFINITY=1`) with the flag set and verify correct output
- [ ] Verify `DYN_SKIP_FRONTEND_TOKENIZE=1` without `DYN_ENGINE_CONV_AFFINITY=1` on TRT-LLM logs a warning and errors cleanly at runtime
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11282" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->