### PR TITLE
ci(frontend): increase EPP build timeout

### DIFF
--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -335,7 +335,7 @@ jobs:
           IMAGE_REPOSITORY: ai-dynamo/dynamo
           AWS_DEFAULT_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           SCCACHE_S3_BUCKET: ${{ secrets.SCCACHE_S3_BUCKET }}
-        timeout-minutes: 20
+        timeout-minutes: 30
         run: |
           set -x
           EPP_REPOSITORY="${{ env.IMAGE_REPOSITORY }}/dynamo-epp"


### PR DESCRIPTION
## Summary

- Increase the frontend-only EPP image build step timeout from 20 to 30 minutes.
- Give the multi-architecture EPP build more headroom while retaining a tighter limit than the enclosing 45-minute frontend build job.
- Addresses the timeout observed in https://github.com/ai-dynamo/dynamo/actions/runs/28825131344/job/85486825118?pr=11194.

## Validation

- pre-commit run check-yaml --files .github/workflows/shared-build-image.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased the build timeout for the frontend-only image pipeline, giving the multi-architecture image build and push step more time to complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->