### PR TITLE
fix(operator): replace snapshot pods after GMS restart

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -642,6 +642,12 @@ func registerControllers(
 			return err
 		}
 	}
+
+	if runtimeConfig.Gate.Enabled(features.GMSSnapshot) {
+		if err := controller.SetupGMSPodReplacement(mgr, setupOptions); err != nil {
+			return err
+		}
+	}
 	if err := controller.SetupTopologyLabel(mgr, setupOptions); err != nil {
 		return err
 	}

--- a/deploy/operator/internal/controller/failover_cascade_controller.go
+++ b/deploy/operator/internal/controller/failover_cascade_controller.go
@@ -13,6 +13,8 @@ import (
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
@@ -109,6 +111,15 @@ func (r *failoverCascadeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		groveLabelPCSGReplicaIndex: pcsgReplica,
 		groveLabelPodIndex:         podIndex,
 	}
+	restoreTargetRequirement, err := labels.NewRequirement(
+		snapshotprotocol.RestoreTargetLabel,
+		selection.NotEquals,
+		[]string{commonconsts.KubeLabelValueTrue},
+	)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to build restore-target selector: %w", err)
+	}
+	groupSelector := labels.SelectorFromSet(labels.Set(groupLabels)).Add(*restoreTargetRequirement)
 
 	// Force delete (grace=0) intentionally: the distributed inference group is
 	// already broken when we get here, so giving the surviving engines a SIGTERM
@@ -116,7 +127,8 @@ func (r *failoverCascadeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	// half-torn-down NCCL/CUDA IPC state and stale UDS sockets on the shared
 	// hostPath. We deliberately skip preStop hooks and the graceful shutdown
 	// window; do NOT soften this to a positive grace period.
-	if err := r.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(pod.Namespace), groupLabels, client.GracePeriodSeconds(0)); err != nil {
+	if err := r.DeleteAllOf(ctx, &corev1.Pod{}, client.InNamespace(pod.Namespace),
+		client.MatchingLabelsSelector{Selector: groupSelector}, client.GracePeriodSeconds(0)); err != nil {
 		return ctrl.Result{}, fmt.Errorf("failed to cascade-delete engine group: %w", err)
 	}
 

--- a/deploy/operator/internal/controller/failover_cascade_controller.go
+++ b/deploy/operator/internal/controller/failover_cascade_controller.go
@@ -10,14 +10,14 @@ import (
 	"fmt"
 
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 )
@@ -32,36 +32,16 @@ const (
 	groveLabelPodIndex         = "grove.io/podclique-pod-index"
 )
 
-// FailoverCascadeReconciler watches GMS failover pods (restartPolicy: Never)
+// failoverCascadeReconciler watches GMS failover pods (restartPolicy: Never)
 // and cascade-deletes all pods in the same engine group when any member
 // reaches a terminal phase (Failed or Succeeded). This ensures broken
 // distributed inference groups are restarted cleanly by Grove.
 //
-// Background: GMS (GPU Memory Service) pods run with restartPolicy: Never so
-// that Kubernetes does not attempt to restart them in-place — a partial
-// restart would leave the distributed inference group in an inconsistent
-// state. Instead, this controller detects the terminal pod and deletes the
-// entire group.  Grove then sees the missing pods and recreates the whole
-// group from scratch.
-//
-// An engine group is identified by three Grove labels:
-//   - grove.io/podcliquescalinggroup              (PCSG name)
-//   - grove.io/podcliquescalinggroup-replica-index (PCSG replica — which copy of the group)
-//   - grove.io/podclique-pod-index                (pod index within the clique)
-//
-// Only pods carrying the dynamo failover engine-group-member label are
-// considered; see failoverCascadePredicate().
-type FailoverCascadeReconciler struct {
+// Only pods carrying the Dynamo failover engine-group-member label are
+// considered; see failoverCascadePredicate.
+type failoverCascadeReconciler struct {
 	client.Client
-	Recorder record.EventRecorder
-}
-
-// NewFailoverCascadeReconciler creates a new reconciler.
-func NewFailoverCascadeReconciler(c client.Client, recorder record.EventRecorder) *FailoverCascadeReconciler {
-	return &FailoverCascadeReconciler{
-		Client:   c,
-		Recorder: recorder,
-	}
+	recorder record.EventRecorder
 }
 
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete;deletecollection
@@ -72,15 +52,22 @@ func NewFailoverCascadeReconciler(c client.Client, recorder record.EventRecorder
 // DeleteAllOf is idempotent, so concurrent reconciles for multiple pods in the
 // same engine group are harmless — the first deletes the group and subsequent
 // calls are no-ops.
-func (r *FailoverCascadeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+func (r *failoverCascadeReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
 	var pod corev1.Pod
 	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
-		if errors.IsNotFound(err) {
+		if apierrors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Snapshot+GMS restore targets currently use IntraPod recovery. InterPod
+	// Snapshot+failover is follow-on work, so fail closed rather than cascade-
+	// deleting a cohort when the unsupported labels overlap.
+	if pod.Labels[snapshotprotocol.RestoreTargetLabel] == commonconsts.KubeLabelValueTrue {
+		return ctrl.Result{}, nil
 	}
 
 	if !isTerminalPhase(pod.Status.Phase) {
@@ -139,7 +126,7 @@ func (r *FailoverCascadeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 		"pcsgReplica", pcsgReplica,
 		"podIndex", podIndex,
 	)
-	r.Recorder.Eventf(&pod, corev1.EventTypeWarning, "FailoverCascade",
+	r.recorder.Eventf(&pod, corev1.EventTypeWarning, "FailoverCascade",
 		"Pod %s terminated (phase=%s); cascade-deleted engine group (pcsg=%s, replica=%s, index=%s)",
 		pod.Name, pod.Status.Phase, pcsg, pcsgReplica, podIndex,
 	)
@@ -147,16 +134,10 @@ func (r *FailoverCascadeReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{}, nil
 }
 
-// SetupWithManager registers a controller that watches all Pods (not just
-// owned ones) and uses failoverCascadePredicate to filter down to only the
-// failover-eligible phase transitions.  EnqueueRequestForObject means the
-// reconcile key is the pod itself (namespace/name), not a parent resource.
-func (r *FailoverCascadeReconciler) SetupWithManager(mgr ctrl.Manager) error {
+func (r *failoverCascadeReconciler) setupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("gms-failover-cascade").
-		Watches(&corev1.Pod{}, &handler.EnqueueRequestForObject{},
-			builder.WithPredicates(failoverCascadePredicate()),
-		).
+		For(&corev1.Pod{}, builder.WithPredicates(failoverCascadePredicate())).
 		Complete(r)
 }
 
@@ -165,32 +146,23 @@ func isTerminalPhase(phase corev1.PodPhase) bool {
 }
 
 // failoverCascadePredicate keeps the reconcile queue minimal by filtering
-// events at the informer level, before they ever reach Reconcile().
+// events at the informer level, before they ever reach Reconcile.
 //
-// It accepts only pods carrying the dynamo failover engine-group-member label
+// It accepts only pods carrying the Dynamo failover engine-group-member label
 // and only when they reach a terminal phase:
 //
-//   - CreateFunc: handles the edge case where the informer's initial list-watch
-//     delivers a pod that is already Failed/Succeeded (e.g. the informer cache
-//     started after the pod transitioned, so no Update event was observed).
-//     Without this, such pods would be silently ignored and their engine group
-//     would never be cascade-deleted.
-//
-//   - UpdateFunc: the primary path — fires when a Running/Pending pod
-//     transitions to Failed/Succeeded.  Pods that already have a
-//     deletionTimestamp are filtered out to avoid acting on pods that are
-//     being terminated by an ongoing cascade or DGD deletion.
-//
-//   - DeleteFunc / GenericFunc: always suppressed — pod deletions are the
-//     *result* of our cascade, not triggers for one.
+//   - CreateFunc handles an informer observing an already-terminal pod.
+//   - UpdateFunc handles a transition into a terminal phase.
+//   - DeleteFunc and GenericFunc suppress events that cannot initiate failover.
 func failoverCascadePredicate() predicate.Predicate {
-	hasLabel := func(labels map[string]string) bool {
-		return labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] == commonconsts.KubeLabelValueTrue
+	isEligible := func(labels map[string]string) bool {
+		return labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] == commonconsts.KubeLabelValueTrue &&
+			labels[snapshotprotocol.RestoreTargetLabel] != commonconsts.KubeLabelValueTrue
 	}
 
 	return predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			if !hasLabel(e.Object.GetLabels()) {
+			if !isEligible(e.Object.GetLabels()) {
 				return false
 			}
 			pod, ok := e.Object.(*corev1.Pod)
@@ -199,20 +171,14 @@ func failoverCascadePredicate() predicate.Predicate {
 			}
 			return isTerminalPhase(pod.Status.Phase)
 		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
+		DeleteFunc: func(event.DeleteEvent) bool {
 			return false
 		},
-		GenericFunc: func(e event.GenericEvent) bool {
+		GenericFunc: func(event.GenericEvent) bool {
 			return false
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			if !hasLabel(e.ObjectNew.GetLabels()) {
-				return false
-			}
-			// Ignore pods already being deleted — this avoids reacting to
-			// our own cascade-delete (which sets deletionTimestamp before
-			// the pod actually disappears from the cache).
-			if e.ObjectNew.GetDeletionTimestamp() != nil {
+			if !isEligible(e.ObjectNew.GetLabels()) || e.ObjectNew.GetDeletionTimestamp() != nil {
 				return false
 			}
 			newPod, ok := e.ObjectNew.(*corev1.Pod)
@@ -223,8 +189,6 @@ func failoverCascadePredicate() predicate.Predicate {
 			if !ok {
 				return false
 			}
-			// Only trigger on actual phase transitions to avoid processing
-			// the same pod twice (e.g. a metadata update on an already-Failed pod).
 			return !isTerminalPhase(oldPod.Status.Phase) && isTerminalPhase(newPod.Status.Phase)
 		},
 	}

--- a/deploy/operator/internal/controller/failover_cascade_controller_test.go
+++ b/deploy/operator/internal/controller/failover_cascade_controller_test.go
@@ -124,6 +124,8 @@ func TestFailoverCascade_DifferentGroupUnaffected(t *testing.T) {
 	differentPodIndex := newFailoverPod("different-pod-index", corev1.PodRunning, "0", "1")
 	differentMember := newFailoverPod("different-member", corev1.PodRunning, "0", "0")
 	differentMember.Labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] = "false"
+	restoreTarget := newFailoverPod("restore-target", corev1.PodRunning, "0", "0")
+	restoreTarget.Labels[snapshotprotocol.RestoreTargetLabel] = commonconsts.KubeLabelValueTrue
 	differentNamespace := newFailoverPod("different-namespace", corev1.PodRunning, "0", "0")
 	differentNamespace.Namespace = "other-ns"
 
@@ -141,6 +143,7 @@ func TestFailoverCascade_DifferentGroupUnaffected(t *testing.T) {
 			differentReplica,
 			differentPodIndex,
 			differentMember,
+			restoreTarget,
 			differentNamespace,
 		).
 		WithInterceptorFuncs(interceptor.Funcs{
@@ -158,16 +161,11 @@ func TestFailoverCascade_DifferentGroupUnaffected(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	t.Log("Verify the delete is namespace-scoped, selects all four labels, and uses zero grace")
+	t.Log("Verify the delete is namespace-scoped, excludes restore targets, and uses zero grace")
 	assert.Equal(t, cascadeTestNamespace, deleteOptions.Namespace)
-	selectedLabels, err := labels.ConvertSelectorToLabelsMap(deleteOptions.LabelSelector.String())
-	require.NoError(t, err)
-	assert.Equal(t, labels.Set{
-		commonconsts.KubeLabelDynamoFailoverEngineGroupMember: commonconsts.KubeLabelValueTrue,
-		groveLabelPCSG:             cascadeTestPCSG,
-		groveLabelPCSGReplicaIndex: "0",
-		groveLabelPodIndex:         "0",
-	}, selectedLabels)
+	assert.True(t, deleteOptions.LabelSelector.Matches(labels.Set(failedPod.Labels)))
+	assert.True(t, deleteOptions.LabelSelector.Matches(labels.Set(sibling.Labels)))
+	assert.False(t, deleteOptions.LabelSelector.Matches(labels.Set(restoreTarget.Labels)))
 	require.NotNil(t, deleteOptions.GracePeriodSeconds)
 	assert.Zero(t, *deleteOptions.GracePeriodSeconds)
 
@@ -183,6 +181,7 @@ func TestFailoverCascade_DifferentGroupUnaffected(t *testing.T) {
 	} {
 		require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}))
 	}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(restoreTarget), &corev1.Pod{}))
 }
 
 func TestFailoverCascade_MultipleFailedPodsAllDeleted(t *testing.T) {

--- a/deploy/operator/internal/controller/failover_cascade_controller_test.go
+++ b/deploy/operator/internal/controller/failover_cascade_controller_test.go
@@ -22,10 +22,13 @@ import (
 	"testing"
 
 	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -33,6 +36,8 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 )
 
 const (
@@ -56,7 +61,7 @@ func newFailoverPod(name string, phase corev1.PodPhase, replicaIdx, podIdx strin
 	}
 }
 
-func newCascadeReconciler(objs ...client.Object) (*FailoverCascadeReconciler, client.Client) {
+func newCascadeReconciler(objs ...client.Object) (*failoverCascadeReconciler, client.Client) {
 	scheme := runtime.NewScheme()
 	_ = corev1.AddToScheme(scheme)
 
@@ -66,7 +71,10 @@ func newCascadeReconciler(objs ...client.Object) (*FailoverCascadeReconciler, cl
 	}
 	c := cb.Build()
 
-	return NewFailoverCascadeReconciler(c, record.NewFakeRecorder(16)), c
+	return &failoverCascadeReconciler{
+		Client:   c,
+		recorder: record.NewFakeRecorder(16),
+	}, c
 }
 
 func TestFailoverCascade_FailedPodDeletesEntireGroup(t *testing.T) {
@@ -107,21 +115,74 @@ func TestFailoverCascade_SucceededPodDeletesEntireGroup(t *testing.T) {
 }
 
 func TestFailoverCascade_DifferentGroupUnaffected(t *testing.T) {
+	t.Log("Build a failed trigger, exact sibling, and Pods differing in each selector dimension")
+	failedPod := newFailoverPod("trigger", corev1.PodFailed, "0", "0")
+	sibling := newFailoverPod("sibling", corev1.PodRunning, "0", "0")
+	differentPCSG := newFailoverPod("different-pcsg", corev1.PodRunning, "0", "0")
+	differentPCSG.Labels[groveLabelPCSG] = "other-pcsg"
+	differentReplica := newFailoverPod("different-replica", corev1.PodRunning, "1", "0")
+	differentPodIndex := newFailoverPod("different-pod-index", corev1.PodRunning, "0", "1")
+	differentMember := newFailoverPod("different-member", corev1.PodRunning, "0", "0")
+	differentMember.Labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] = "false"
+	differentNamespace := newFailoverPod("different-namespace", corev1.PodRunning, "0", "0")
+	differentNamespace.Namespace = "other-ns"
 
-	failedPod := newFailoverPod("ldr-0", corev1.PodFailed, "0", "0")
-	differentGroup := newFailoverPod("ldr-1", corev1.PodRunning, "0", "1")
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
 
-	r, c := newCascadeReconciler(failedPod, differentGroup)
+	var deleteOptions client.DeleteAllOfOptions
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&corev1.Pod{}).
+		WithObjects(
+			failedPod,
+			sibling,
+			differentPCSG,
+			differentReplica,
+			differentPodIndex,
+			differentMember,
+			differentNamespace,
+		).
+		WithInterceptorFuncs(interceptor.Funcs{
+			DeleteAllOf: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteAllOfOption) error {
+				deleteOptions.ApplyOptions(opts)
+				return c.DeleteAllOf(ctx, obj, opts...)
+			},
+		}).
+		Build()
+	r := &failoverCascadeReconciler{Client: c, recorder: record.NewFakeRecorder(16)}
 
+	t.Log("Reconcile the failed trigger and capture the destructive delete options")
 	_, err := r.Reconcile(context.Background(), ctrl.Request{
-		NamespacedName: types.NamespacedName{Name: "ldr-0", Namespace: cascadeTestNamespace},
+		NamespacedName: client.ObjectKeyFromObject(failedPod),
 	})
 	require.NoError(t, err)
 
-	var remaining corev1.PodList
-	require.NoError(t, c.List(context.Background(), &remaining, client.InNamespace(cascadeTestNamespace)))
-	assert.Len(t, remaining.Items, 1, "only the different engine group pod should remain")
-	assert.Equal(t, "ldr-1", remaining.Items[0].Name)
+	t.Log("Verify the delete is namespace-scoped, selects all four labels, and uses zero grace")
+	assert.Equal(t, cascadeTestNamespace, deleteOptions.Namespace)
+	selectedLabels, err := labels.ConvertSelectorToLabelsMap(deleteOptions.LabelSelector.String())
+	require.NoError(t, err)
+	assert.Equal(t, labels.Set{
+		commonconsts.KubeLabelDynamoFailoverEngineGroupMember: commonconsts.KubeLabelValueTrue,
+		groveLabelPCSG:             cascadeTestPCSG,
+		groveLabelPCSGReplicaIndex: "0",
+		groveLabelPodIndex:         "0",
+	}, selectedLabels)
+	require.NotNil(t, deleteOptions.GracePeriodSeconds)
+	assert.Zero(t, *deleteOptions.GracePeriodSeconds)
+
+	t.Log("Verify only the exact engine group was deleted")
+	require.True(t, apierrors.IsNotFound(c.Get(context.Background(), client.ObjectKeyFromObject(failedPod), &corev1.Pod{})))
+	require.True(t, apierrors.IsNotFound(c.Get(context.Background(), client.ObjectKeyFromObject(sibling), &corev1.Pod{})))
+	for _, pod := range []*corev1.Pod{
+		differentPCSG,
+		differentReplica,
+		differentPodIndex,
+		differentMember,
+		differentNamespace,
+	} {
+		require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}))
+	}
 }
 
 func TestFailoverCascade_MultipleFailedPodsAllDeleted(t *testing.T) {
@@ -196,7 +257,7 @@ func TestFailoverCascade_MissingGroveLabelsIsNoop(t *testing.T) {
 			Namespace: cascadeTestNamespace,
 			Labels: map[string]string{
 				commonconsts.KubeLabelDynamoFailoverEngineGroupMember: commonconsts.KubeLabelValueTrue,
-				groveLabelPCSG: "my-pcsg",
+				groveLabelPCSG: cascadeTestPCSG,
 			},
 		},
 		Status: corev1.PodStatus{Phase: corev1.PodFailed},
@@ -273,4 +334,41 @@ func TestFailoverCascade_ConcurrentReconcileIsIdempotent(t *testing.T) {
 	var remaining corev1.PodList
 	require.NoError(t, c.List(context.Background(), &remaining, client.InNamespace(cascadeTestNamespace)))
 	assert.Empty(t, remaining.Items)
+}
+
+func TestFailoverCascade_SnapshotRestoreTargetCannotDeleteSibling(t *testing.T) {
+	t.Log("Build a terminal Snapshot restore target with every failover label and a matching sibling")
+	pod := gmsPodReplacementTestPod("snapshot-uid", 0)
+	pod.Status.Phase = corev1.PodFailed
+	pod.Labels[commonconsts.KubeLabelDynamoFailoverEngineGroupMember] = commonconsts.KubeLabelValueTrue
+	pod.Labels[groveLabelPCSG] = cascadeTestPCSG
+	pod.Labels[groveLabelPCSGReplicaIndex] = "0"
+	pod.Labels[groveLabelPodIndex] = "0"
+	sibling := newFailoverPod("sibling", corev1.PodRunning, "0", "0")
+	sibling.Namespace = pod.Namespace
+
+	t.Log("Verify the failover predicate rejects the unsupported Snapshot overlap")
+	pred := failoverCascadePredicate()
+	assert.False(t, pred.Create(event.CreateEvent{Object: pod}))
+	oldPod := pod.DeepCopy()
+	oldPod.Status.Phase = corev1.PodRunning
+	assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: pod}))
+
+	t.Log("Verify native GMS replacement does not admit the Pod before its sidecar restarts")
+	assert.False(t, gmsPodReplacementPredicate().Create(event.CreateEvent{Object: pod}))
+
+	t.Log("Reconcile defensively and verify neither the trigger nor sibling is cascade-deleted")
+	r, c := newCascadeReconciler(pod, sibling)
+	result, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: client.ObjectKeyFromObject(pod),
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, result)
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(pod), &corev1.Pod{}))
+	require.NoError(t, c.Get(context.Background(), client.ObjectKeyFromObject(sibling), &corev1.Pod{}))
+
+	t.Log("Verify native GMS replacement independently admits the same Pod after its sidecar restarts")
+	pod.Status.InitContainerStatuses[0].RestartCount = 1
+	assert.Equal(t, commonconsts.KubeLabelValueTrue, pod.Labels[snapshotprotocol.RestoreTargetLabel])
+	assert.True(t, gmsPodReplacementPredicate().Create(event.CreateEvent{Object: pod}))
 }

--- a/deploy/operator/internal/controller/gms_pod_replacement_controller.go
+++ b/deploy/operator/internal/controller/gms_pod_replacement_controller.go
@@ -1,0 +1,119 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	commonconsts "github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// gmsPodReplacementReconciler replaces Pods that cannot safely recover after
+// their native GMS sidecar restarts. The current eligibility policy is limited
+// to owned Snapshot restore-target Pods.
+type gmsPodReplacementReconciler struct {
+	client.Client
+	config        *configv1alpha1.OperatorConfiguration
+	runtimeConfig *commoncontroller.RuntimeConfig
+}
+
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch;delete
+
+func (r *gmsPodReplacementReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	var pod corev1.Pod
+	if err := r.Get(ctx, req.NamespacedName, &pod); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get GMS Pod replacement candidate %s: %w", req.NamespacedName, err)
+	}
+
+	if !pod.DeletionTimestamp.IsZero() || !isGMSPodReplacementEligible(&pod) {
+		return ctrl.Result{}, nil
+	}
+
+	// The UID precondition prevents a stale reconcile from deleting a same-named replacement.
+	uid := pod.UID
+	if err := r.Delete(ctx, &pod, client.Preconditions{UID: &uid}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("delete GMS Pod replacement candidate %s/%s: %w", pod.Namespace, pod.Name, err)
+	}
+	return ctrl.Result{}, nil
+}
+
+func (r *gmsPodReplacementReconciler) setupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("gms-pod-replacement").
+		For(&corev1.Pod{}, builder.WithPredicates(gmsPodReplacementPredicate())).
+		WithEventFilter(commoncontroller.EphemeralDeploymentEventFilter(r.config, r.runtimeConfig)).
+		Complete(r)
+}
+
+func isGMSPodReplacementEligible(pod *corev1.Pod) bool {
+	return pod != nil &&
+		pod.Labels[snapshotprotocol.RestoreTargetLabel] == commonconsts.KubeLabelValueTrue &&
+		metav1.GetControllerOf(pod) != nil &&
+		hasRestartedNativeGMSServer(pod)
+}
+
+func hasRestartedNativeGMSServer(pod *corev1.Pod) bool {
+	nativeSidecar := false
+	for i := range pod.Spec.InitContainers {
+		container := &pod.Spec.InitContainers[i]
+		if container.Name == gms.ServerContainerName &&
+			container.RestartPolicy != nil &&
+			*container.RestartPolicy == corev1.ContainerRestartPolicyAlways {
+			nativeSidecar = true
+			break
+		}
+	}
+	if !nativeSidecar {
+		return false
+	}
+
+	for i := range pod.Status.InitContainerStatuses {
+		status := &pod.Status.InitContainerStatuses[i]
+		if status.Name == gms.ServerContainerName && status.RestartCount > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func gmsPodReplacementPredicate() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			pod, ok := e.Object.(*corev1.Pod)
+			return ok && pod.DeletionTimestamp.IsZero() && isGMSPodReplacementEligible(pod)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			oldPod, oldOK := e.ObjectOld.(*corev1.Pod)
+			newPod, newOK := e.ObjectNew.(*corev1.Pod)
+			if !oldOK || !newOK || !newPod.DeletionTimestamp.IsZero() {
+				return false
+			}
+			return isGMSPodReplacementEligible(newPod) &&
+				(!isGMSPodReplacementEligible(oldPod) || oldPod.UID != newPod.UID)
+		},
+		DeleteFunc:  func(event.DeleteEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+	}
+}

--- a/deploy/operator/internal/controller/gms_pod_replacement_controller_test.go
+++ b/deploy/operator/internal/controller/gms_pod_replacement_controller_test.go
@@ -1,0 +1,260 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+)
+
+func TestGMSPodReplacementPredicate(t *testing.T) {
+	pred := gmsPodReplacementPredicate()
+
+	t.Run("admits restart transition", func(t *testing.T) {
+		oldPod := gmsPodReplacementTestPod("pod-uid", 0)
+		newPod := gmsPodReplacementTestPod("pod-uid", 1)
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("admits already-eligible create", func(t *testing.T) {
+		assert.True(t, pred.Create(event.CreateEvent{Object: gmsPodReplacementTestPod("pod-uid", 1)}))
+	})
+
+	t.Run("admits same-name replacement with a new UID", func(t *testing.T) {
+		oldPod := gmsPodReplacementTestPod("old-uid", 1)
+		newPod := gmsPodReplacementTestPod("new-uid", 1)
+		assert.True(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("rejects ineligible Pods", func(t *testing.T) {
+		tests := map[string]func(*corev1.Pod){
+			"not a restore target": func(pod *corev1.Pod) {
+				delete(pod.Labels, snapshotprotocol.RestoreTargetLabel)
+			},
+			"ownerless": func(pod *corev1.Pod) {
+				pod.OwnerReferences = nil
+			},
+			"ordinary init container": func(pod *corev1.Pod) {
+				pod.Spec.InitContainers[0].RestartPolicy = nil
+			},
+			"native sidecar has not restarted": func(pod *corev1.Pod) {
+				pod.Status.InitContainerStatuses[0].RestartCount = 0
+			},
+		}
+		for name, mutate := range tests {
+			t.Run(name, func(t *testing.T) {
+				pod := gmsPodReplacementTestPod("pod-uid", 1)
+				mutate(pod)
+				assert.False(t, pred.Create(event.CreateEvent{Object: pod}))
+			})
+		}
+	})
+
+	t.Run("rejects unchanged eligible and deleting Pods", func(t *testing.T) {
+		oldPod := gmsPodReplacementTestPod("pod-uid", 1)
+		newPod := gmsPodReplacementTestPod("pod-uid", 1)
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+
+		now := metav1.Now()
+		newPod.DeletionTimestamp = &now
+		assert.False(t, pred.Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod}))
+	})
+
+	t.Run("ignores deletion and generic events", func(t *testing.T) {
+		pod := gmsPodReplacementTestPod("pod-uid", 1)
+		assert.False(t, pred.Delete(event.DeleteEvent{Object: pod}))
+		assert.False(t, pred.Generic(event.GenericEvent{Object: pod}))
+	})
+}
+
+func TestGMSPodReplacementReconcile(t *testing.T) {
+	tests := []struct {
+		name        string
+		podExists   bool
+		mutate      func(*corev1.Pod)
+		wantDeleted bool
+	}{
+		{name: "eligible Pod is deleted", podExists: true, wantDeleted: true},
+		{
+			name:      "ineligible Pod is retained",
+			podExists: true,
+			mutate: func(pod *corev1.Pod) {
+				pod.Labels[snapshotprotocol.RestoreTargetLabel] = "false"
+			},
+		},
+		{
+			name:      "deleting Pod is retained",
+			podExists: true,
+			mutate: func(pod *corev1.Pod) {
+				now := metav1.Now()
+				pod.DeletionTimestamp = &now
+				pod.Finalizers = []string{"test.example/finalizer"}
+			},
+		},
+		{name: "missing Pod is harmless"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			pod := gmsPodReplacementTestPod("observed-uid", 1)
+			if test.mutate != nil {
+				test.mutate(pod)
+			}
+
+			var deleteUID *types.UID
+			builder := fake.NewClientBuilder().
+				WithScheme(gmsPodReplacementTestScheme(t)).
+				WithInterceptorFuncs(interceptor.Funcs{
+					Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+						deleteUID = (&client.DeleteOptions{}).ApplyOptions(opts).Preconditions.UID
+						return c.Delete(ctx, obj, opts...)
+					},
+				})
+			if test.podExists {
+				builder = builder.WithObjects(pod)
+			}
+			c := builder.Build()
+			reconciler := &gmsPodReplacementReconciler{Client: c}
+			key := client.ObjectKeyFromObject(pod)
+
+			result, err := reconciler.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+			require.NoError(t, err)
+			assert.Equal(t, ctrl.Result{}, result)
+
+			err = c.Get(context.Background(), key, &corev1.Pod{})
+			if test.wantDeleted || !test.podExists {
+				assert.True(t, apierrors.IsNotFound(err), "Get() error = %v", err)
+			} else {
+				require.NoError(t, err)
+			}
+
+			if test.wantDeleted {
+				require.NotNil(t, deleteUID)
+				assert.Equal(t, pod.UID, *deleteUID)
+			} else {
+				assert.Nil(t, deleteUID)
+			}
+		})
+	}
+}
+
+func TestGMSPodReplacementErrors(t *testing.T) {
+	retryErr := errors.New("client failed")
+
+	t.Run("get error is returned for retry", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(gmsPodReplacementTestScheme(t)).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Get: func(context.Context, client.WithWatch, client.ObjectKey, client.Object, ...client.GetOption) error {
+					return retryErr
+				},
+			}).
+			Build()
+		reconciler := &gmsPodReplacementReconciler{Client: c}
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: types.NamespacedName{Namespace: "inference", Name: "restore-worker"},
+		})
+		require.ErrorIs(t, err, retryErr)
+		assert.ErrorContains(t, err, "get GMS Pod replacement candidate")
+	})
+
+	t.Run("delete NotFound is harmless", func(t *testing.T) {
+		pod := gmsPodReplacementTestPod("observed-uid", 1)
+		c := gmsPodReplacementErrorClient(t, pod,
+			apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, pod.Name))
+		reconciler := &gmsPodReplacementReconciler{Client: c}
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(pod),
+		})
+		require.NoError(t, err)
+	})
+
+	t.Run("delete error is returned for retry", func(t *testing.T) {
+		pod := gmsPodReplacementTestPod("observed-uid", 1)
+		c := gmsPodReplacementErrorClient(t, pod, retryErr)
+		reconciler := &gmsPodReplacementReconciler{Client: c}
+
+		_, err := reconciler.Reconcile(context.Background(), ctrl.Request{
+			NamespacedName: client.ObjectKeyFromObject(pod),
+		})
+		require.ErrorIs(t, err, retryErr)
+		assert.ErrorContains(t, err, "delete GMS Pod replacement candidate inference/restore-worker")
+	})
+}
+
+func gmsPodReplacementErrorClient(t *testing.T, pod *corev1.Pod, deleteErr error) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().
+		WithScheme(gmsPodReplacementTestScheme(t)).
+		WithObjects(pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(context.Context, client.WithWatch, client.Object, ...client.DeleteOption) error {
+				return deleteErr
+			},
+		}).
+		Build()
+}
+
+func gmsPodReplacementTestPod(uid types.UID, restartCount int32) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "restore-worker",
+			Namespace: "inference",
+			UID:       uid,
+			Labels: map[string]string{
+				snapshotprotocol.RestoreTargetLabel: consts.KubeLabelValueTrue,
+			},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "restore-worker",
+				UID:        "owner-uid",
+				Controller: ptr.To(true),
+			}},
+		},
+		Spec: corev1.PodSpec{
+			InitContainers: []corev1.Container{{
+				Name:          gms.ServerContainerName,
+				RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+			}},
+		},
+		Status: corev1.PodStatus{
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name:         gms.ServerContainerName,
+				RestartCount: restartCount,
+			}},
+		},
+	}
+}
+
+func gmsPodReplacementTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	return scheme
+}

--- a/deploy/operator/internal/controller/pod_cache_contract_test.go
+++ b/deploy/operator/internal/controller/pod_cache_contract_test.go
@@ -17,14 +17,17 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/podcache"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 func TestProjectedPodSupportsControllerContract(t *testing.T) {
@@ -43,6 +46,7 @@ func TestProjectedPodSupportsControllerContract(t *testing.T) {
 				consts.KubeLabelDynamoFailoverEngineGroupMember: consts.KubeLabelValueTrue,
 				batchv1.JobNameLabel:                            "profiling-job",
 				"job-name":                                      "profiling-job",
+				snapshotprotocol.RestoreTargetLabel:             consts.KubeLabelValueTrue,
 			},
 			Annotations: map[string]string{
 				consts.KubeAnnotationTopologyLabelKey: "topology.kubernetes.io/zone",
@@ -57,6 +61,11 @@ func TestProjectedPodSupportsControllerContract(t *testing.T) {
 				Name:    consts.MainContainerName,
 				Command: []string{"python"},
 				Args:    []string{"-m", "dynamo.vllm"},
+			}},
+			InitContainers: []corev1.Container{{
+				Name:          gms.ServerContainerName,
+				Image:         "discarded-image",
+				RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 			}},
 			Volumes: []corev1.Volume{{
 				Name: "topology",
@@ -78,6 +87,9 @@ func TestProjectedPodSupportsControllerContract(t *testing.T) {
 					ExitCode: 23, Reason: "Error", Message: "profiling failed",
 				}},
 			}},
+			InitContainerStatuses: []corev1.ContainerStatus{{
+				Name: gms.ServerContainerName, RestartCount: 1,
+			}},
 		},
 	})
 
@@ -87,7 +99,12 @@ func TestProjectedPodSupportsControllerContract(t *testing.T) {
 	})
 
 	t.Run("failover", func(t *testing.T) {
-		assert.True(t, failoverCascadePredicate().Create(event.CreateEvent{Object: pod}))
+		assert.False(t, failoverCascadePredicate().Create(event.CreateEvent{Object: pod}),
+			"Snapshot restore targets must be excluded from failover cascade")
+	})
+
+	t.Run("GMS Pod replacement", func(t *testing.T) {
+		assert.True(t, gmsPodReplacementPredicate().Create(event.CreateEvent{Object: pod}))
 	})
 
 	t.Run("checkpoint and snapshot", func(t *testing.T) {

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -170,11 +170,22 @@ func SetupPodSnapshot(mgr ctrl.Manager, opts SetupOptions) error {
 }
 
 func SetupFailoverCascade(mgr ctrl.Manager) error {
-	if err := NewFailoverCascadeReconciler(
-		mgr.GetClient(),
-		mgr.GetEventRecorderFor("gms-failover-cascade"),
-	).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create GMS FailoverCascade controller: %w", err)
+	if err := (&failoverCascadeReconciler{
+		Client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("gms-failover-cascade"),
+	}).setupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create failover cascade controller: %w", err)
+	}
+	return nil
+}
+
+func SetupGMSPodReplacement(mgr ctrl.Manager, opts SetupOptions) error {
+	if err := (&gmsPodReplacementReconciler{
+		Client:        mgr.GetClient(),
+		config:        opts.Config,
+		runtimeConfig: opts.RuntimeConfig,
+	}).setupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create GMS Pod replacement controller: %w", err)
 	}
 	return nil
 }

--- a/deploy/operator/internal/dynamo/failover.go
+++ b/deploy/operator/internal/dynamo/failover.go
@@ -109,7 +109,8 @@ func applyGMSSharedResources(podSpec *corev1.PodSpec, c *corev1.Container, rank 
 // layout (a restarted engine re-imports IPC handles from the still-running
 // GMS server). In the inter-pod GMS failover layout, augmentEngineForGMS
 // overrides the engine's RestartPolicy to Never so the cohort can only be
-// recovered via FailoverCascadeReconciler; see the comment there.
+// recovered by the failover cascade controller; see
+// failover_cascade_controller.go.
 func gmsWeightServerPodSpec(basePodSpec *corev1.PodSpec, rank int32, gpuCount int) *corev1.PodSpec {
 	podSpec := basePodSpec.DeepCopy()
 	if len(podSpec.Containers) == 0 {
@@ -184,7 +185,7 @@ func gmsEngineEnvVars() []corev1.EnvVar {
 //     coordination via the failover lock file and DYN_VLLM_GMS_SHADOW_MODE.
 //     An in-place restart leaves the cohort in a half-torn-down state and
 //     blocks recovery. The correct recovery path is for the pod to exit,
-//     FailoverCascadeReconciler (see failover_cascade_controller.go) to
+//     the failover cascade controller (failover_cascade_controller.go) to
 //     force-delete the full engine group based on the
 //     KubeLabelDynamoFailoverEngineGroupMember label, and Grove to recreate
 //     the cohort from scratch. That label is applied in graph.go only when

--- a/deploy/operator/internal/dynamo/failover_test.go
+++ b/deploy/operator/internal/dynamo/failover_test.go
@@ -173,7 +173,7 @@ func TestAugmentEngineForGMS(t *testing.T) {
 
 	assert.Equal(t, corev1.RestartPolicyNever, podSpec.RestartPolicy,
 		"inter-pod failover engines must be RestartPolicyNever so the "+
-			"FailoverCascadeReconciler is the sole recovery path")
+			"failover cascade controller is the sole recovery path")
 }
 
 // TestAugmentEngineForGMS_StandaloneDoesNotForceRestartNever pins the

--- a/deploy/operator/internal/podcache/transform.go
+++ b/deploy/operator/internal/podcache/transform.go
@@ -13,6 +13,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 )
 
 // Configure installs Transform on the single typed Pod cache while preserving
@@ -83,6 +85,8 @@ func projectSpec(in corev1.PodSpec) corev1.PodSpec {
 		// Model endpoint classification requires the main container's command
 		// and arguments.
 		Containers: projectContainers(in.Containers),
+		// GMS Pod replacement requires native init-sidecar identity.
+		InitContainers: projectInitContainers(in.InitContainers),
 		// Topology label discovery inspects DownwardAPI label field paths.
 		Volumes: projectTopologyVolumes(in.Volumes),
 	}
@@ -101,6 +105,19 @@ func projectContainers(in []corev1.Container) []corev1.Container {
 		}
 	}
 	return out
+}
+
+func projectInitContainers(in []corev1.Container) []corev1.Container {
+	for i := range in {
+		if in[i].Name != gms.ServerContainerName {
+			continue
+		}
+		return []corev1.Container{{
+			Name:          in[i].Name,
+			RestartPolicy: in[i].RestartPolicy,
+		}}
+	}
+	return nil
 }
 
 func projectTopologyVolumes(in []corev1.Volume) []corev1.Volume {
@@ -149,9 +166,10 @@ func projectStatus(in corev1.PodStatus) corev1.PodStatus {
 		Phase: in.Phase,
 		// Model endpoint classification requires the Kubernetes Ready condition.
 		Conditions: projectReadyConditions(in.Conditions),
-		// DGDR diagnostics inspect waiting and terminated container failures.
-		ContainerStatuses:     projectContainerStatuses(in.ContainerStatuses),
-		InitContainerStatuses: projectContainerStatuses(in.InitContainerStatuses),
+		// DGDR diagnostics inspect container failures.
+		ContainerStatuses: projectContainerStatuses(in.ContainerStatuses),
+		// GMS Pod replacement also requires init-sidecar restart counts.
+		InitContainerStatuses: projectInitContainerStatuses(in.InitContainerStatuses),
 	}
 }
 
@@ -178,6 +196,16 @@ func projectContainerStatuses(in []corev1.ContainerStatus) []corev1.ContainerSta
 		out[i] = corev1.ContainerStatus{
 			Name:  in[i].Name,
 			State: projectContainerState(in[i].State),
+		}
+	}
+	return out
+}
+
+func projectInitContainerStatuses(in []corev1.ContainerStatus) []corev1.ContainerStatus {
+	out := projectContainerStatuses(in)
+	for i := range out {
+		if in[i].Name == gms.ServerContainerName {
+			out[i].RestartCount = in[i].RestartCount
 		}
 	}
 	return out

--- a/deploy/operator/internal/podcache/transform_test.go
+++ b/deploy/operator/internal/podcache/transform_test.go
@@ -17,6 +17,8 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gms"
 )
 
 func TestProjectConsumerContract(t *testing.T) {
@@ -50,7 +52,19 @@ func TestProjectConsumerContract(t *testing.T) {
 				},
 				ReadinessProbe: &corev1.Probe{InitialDelaySeconds: 10},
 			}},
-			InitContainers: []corev1.Container{{Name: "discarded-init", Image: "large-init"}},
+			InitContainers: []corev1.Container{
+				{
+					Name:          "unrelated-init",
+					Image:         "discard-me",
+					RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+				},
+				{
+					Name:          gms.ServerContainerName,
+					Image:         "large-init",
+					RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+					Env:           []corev1.EnvVar{{Name: "LARGE", Value: "discard-me"}},
+				},
+			},
 			Volumes: []corev1.Volume{
 				{
 					Name: "pod-labels",
@@ -99,12 +113,22 @@ func TestProjectConsumerContract(t *testing.T) {
 					}},
 				},
 			},
-			InitContainerStatuses: []corev1.ContainerStatus{{
-				Name: "init",
-				State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
-					Reason: "ErrImagePull", Message: "init pull failed",
-				}},
-			}},
+			InitContainerStatuses: []corev1.ContainerStatus{
+				{
+					Name:         "unrelated-init",
+					RestartCount: 3,
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{
+						Reason: "ErrImagePull", Message: "init pull failed",
+					}},
+				},
+				{
+					Name:         gms.ServerContainerName,
+					RestartCount: 5,
+					State: corev1.ContainerState{Terminated: &corev1.ContainerStateTerminated{
+						ExitCode: 1, Reason: "Error", Message: "GMS failed",
+					}},
+				},
+			},
 		},
 	}
 	wantMetadata := *pod.ObjectMeta.DeepCopy()
@@ -126,24 +150,34 @@ func TestProjectConsumerContract(t *testing.T) {
 		assert.Equal(t, corev1.Container{Name: "main", Command: []string{"python"}, Args: []string{"-m", "dynamo"}}, got.Spec.Containers[0])
 		assert.Equal(t, []corev1.PodCondition{{Type: corev1.PodReady, Status: corev1.ConditionTrue}}, got.Status.Conditions)
 	})
-	t.Run("failover DGDR and Recreate retain terminal and diagnostic state", func(t *testing.T) {
+	t.Run("failover DGDR GMS replacement and Recreate retain status state", func(t *testing.T) {
 		assert.Equal(t, corev1.PodRunning, got.Status.Phase)
 		require.Len(t, got.Status.ContainerStatuses, 2)
 		assert.Equal(t, "ImagePullBackOff", got.Status.ContainerStatuses[0].State.Waiting.Reason)
+		assert.Zero(t, got.Status.ContainerStatuses[0].RestartCount)
 		assert.Equal(t, int32(17), got.Status.ContainerStatuses[1].State.Terminated.ExitCode)
 		assert.Equal(t, "worker failed", got.Status.ContainerStatuses[1].State.Terminated.Message)
-		require.Len(t, got.Status.InitContainerStatuses, 1)
+		require.Len(t, got.Status.InitContainerStatuses, 2)
 		assert.Equal(t, "ErrImagePull", got.Status.InitContainerStatuses[0].State.Waiting.Reason)
+		assert.Zero(t, got.Status.InitContainerStatuses[0].RestartCount)
+		assert.Equal(t, "GMS failed", got.Status.InitContainerStatuses[1].State.Terminated.Message)
+		assert.Equal(t, int32(5), got.Status.InitContainerStatuses[1].RestartCount)
+	})
+	t.Run("GMS replacement retains only native init-sidecar identity", func(t *testing.T) {
+		assert.Equal(t, []corev1.Container{{
+			Name:          gms.ServerContainerName,
+			RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
+		}}, got.Spec.InitContainers)
 	})
 	t.Run("unused heavyweight fields are removed", func(t *testing.T) {
 		assert.Nil(t, got.ManagedFields)
-		assert.Empty(t, got.Spec.InitContainers)
+		assert.Empty(t, got.Spec.InitContainers[0].Image)
+		assert.Empty(t, got.Spec.InitContainers[0].Env)
 		assert.Empty(t, got.Spec.Containers[0].Image)
 		assert.Empty(t, got.Spec.Containers[0].Env)
 		assert.Empty(t, got.Spec.Containers[0].Resources)
 		assert.Empty(t, got.Status.PodIP)
 		assert.Empty(t, got.Status.ContainerStatuses[0].Image)
-		assert.Zero(t, got.Status.ContainerStatuses[0].RestartCount)
 		assert.Zero(t, got.Status.ContainerStatuses[1].State.Terminated.Signal)
 		assert.Empty(t, got.Status.ContainerStatuses[1].State.Terminated.ContainerID)
 	})


### PR DESCRIPTION
## Summary

- preserve Grove failover cascade as a focused private `failoverCascadeReconciler`, independently registered under the `Grove` gate
- add a private `gmsPodReplacementReconciler` that UID-safely replaces an owned Snapshot restore-target Pod after its native `gms-server` sidecar restarts
- make the policies fail-closed and scheduling-independent: Snapshot restore targets are excluded from InterPod failover cascade in both the predicate and reconcile path
- retain only the native `gms-server` identity, restart policy, and restart count required by replacement detection in the shared Pod cache

Both controllers use `For(Pod)` with separate queues and predicates. Existing feature gates remain unchanged. This is the first Pod-safety change in #12671; ordinary Snapshot + GMS enablement and Snapshot + failover restore coordination remain follow-up changes.

## Validation

- focused GMS Pod replacement, Grove failover cascade, overlap-safety, and Pod-cache contract tests under the race detector
- full `internal/podcache` and `internal/dynamo` tests; controller and `cmd` package compilation
- `go vet ./cmd ./internal/controller ./internal/dynamo ./internal/podcache`
- repository-pinned `make lint`
- pinned `make manifests` with no RBAC, CRD, webhook, or Helm drift
- `gofmt` and `git diff --check`

The Kubernetes envtest suite was not run locally because its `etcd` test binary is unavailable; the controller package compiles and all focused controller coverage passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic replacement of eligible pods after the native GMS sidecar restarts, when the snapshot feature is enabled.
  * Pod replacement uses safeguards to prevent deleting an unintended pod.

* **Bug Fixes**
  * Snapshot restore-target pods are no longer incorrectly removed during failover handling.
  * Improved pod status tracking for GMS sidecar restarts, including restart counts and termination state.

* **Tests**
  * Expanded coverage for pod replacement, failover exclusions, error handling, and safe deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->