### PR TITLE
docs(dgdr): add router override examples and unit tests for spec.overrides.dgd

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_dgd_override_merge.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_override_merge.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for apply_dgd_overrides — verifies router and planner overrides
+flow through spec.overrides.dgd correctly (GitHub #10269)."""
+
+import pytest
+
+from dynamo.profiler.utils.config_modifiers.protocol import apply_dgd_overrides
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.parallel,
+]
+
+
+def _base_dgd():
+    """Minimal generated DGD — simulates what the profiler produces."""
+    return {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "metadata": {"name": "generated"},
+        "spec": {
+            "services": {
+                "Frontend": {"envs": [{"name": "EXISTING_VAR", "value": "existing"}]},
+                "VllmWorker": {},
+                "VllmPrefillWorker": {"extraPodSpec": {"mainContainer": {"args": []}}},
+            }
+        },
+    }
+
+
+def test_router_mode_env_survives_merge():
+    base = _base_dgd()
+    override = {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "spec": {
+            "services": {
+                "Frontend": {"envs": [{"name": "DYN_ROUTER_MODE", "value": "kv"}]}
+            }
+        },
+    }
+
+    result = apply_dgd_overrides(base, override)
+
+    envs = result["spec"]["services"]["Frontend"]["envs"]
+    router_mode = next(e for e in envs if e["name"] == "DYN_ROUTER_MODE")
+    assert router_mode["value"] == "kv"
+
+
+def test_vllm_prefill_worker_kv_args_survive_merge():
+    base = _base_dgd()
+    override = {
+        "spec": {
+            "services": {
+                "VllmPrefillWorker": {
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "args": [
+                                "--enable-prefix-caching",
+                                "--kv-events-config",
+                                '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}',
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    result = apply_dgd_overrides(base, override)
+
+    args = result["spec"]["services"]["VllmPrefillWorker"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert "--enable-prefix-caching" in args
+    assert "--kv-events-config" in args
+    assert (
+        '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+        in args
+    )
+
+
+def test_approximate_kv_mode_envs_survive_merge():
+    base = _base_dgd()
+    override = {
+        "apiVersion": "nvidia.com/v1alpha1",
+        "kind": "DynamoGraphDeployment",
+        "spec": {
+            "services": {
+                "Frontend": {
+                    "envs": [
+                        {"name": "DYN_ROUTER_MODE", "value": "kv"},
+                        {"name": "DYN_ROUTER_USE_KV_EVENTS", "value": "false"},
+                    ]
+                }
+            }
+        },
+    }
+
+    result = apply_dgd_overrides(base, override)
+
+    envs = result["spec"]["services"]["Frontend"]["envs"]
+    router_mode = next(e for e in envs if e["name"] == "DYN_ROUTER_MODE")
+    assert router_mode["value"] == "kv"
+    kv_events = next(e for e in envs if e["name"] == "DYN_ROUTER_USE_KV_EVENTS")
+    assert kv_events["value"] == "false"
+
+
+def test_envelope_fields_are_stripped():
+    base = _base_dgd()
+    override = {"apiVersion": "nvidia.com/v1beta1", "kind": "SomethingElse"}
+
+    result = apply_dgd_overrides(base, override)
+
+    assert result["apiVersion"] == "nvidia.com/v1alpha1"
+    assert result["kind"] == "DynamoGraphDeployment"

--- a/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/protocol.py
@@ -15,6 +15,7 @@
 
 from __future__ import annotations
 
+import copy
 import logging
 from typing import Any, Protocol, Tuple
 from uuid import uuid4
@@ -34,6 +35,76 @@ from dynamo.profiler.utils.config import (
 from dynamo.profiler.utils.defaults import EngineType
 
 logger = logging.getLogger(__name__)
+
+
+def apply_dgd_overrides(base: dict, override: dict) -> dict:
+    """Merge *override* into *base* DGD config, preserving base envelope fields.
+
+    - Top-level envelope keys (``apiVersion``, ``kind``, ``metadata``) from
+      *override* are ignored so the base identity is never clobbered.
+    - ``spec.services`` is merged service-by-service.  For each service,
+      ``envs`` lists are merged by ``name`` (override wins on collision) and
+      ``extraPodSpec.mainContainer.args`` lists are extended with override
+      values that are not already present.  All other scalar/dict fields are
+      replaced by the override value.
+    """
+    _ENVELOPE_KEYS = {"apiVersion", "kind", "metadata"}
+
+    result = copy.deepcopy(base)
+
+    for key, value in override.items():
+        if key in _ENVELOPE_KEYS:
+            continue
+        if key == "spec" and isinstance(value, dict):
+            _merge_spec(result.setdefault("spec", {}), value)
+        else:
+            result[key] = copy.deepcopy(value)
+
+    return result
+
+
+def _merge_spec(base_spec: dict, override_spec: dict) -> None:
+    for key, value in override_spec.items():
+        if key == "services" and isinstance(value, dict):
+            base_services = base_spec.setdefault("services", {})
+            for svc_name, svc_override in value.items():
+                if svc_name not in base_services:
+                    base_services[svc_name] = copy.deepcopy(svc_override)
+                else:
+                    _merge_service(base_services[svc_name], svc_override)
+        else:
+            base_spec[key] = copy.deepcopy(value)
+
+
+def _merge_service(base_svc: dict, override_svc: dict) -> None:
+    for key, value in override_svc.items():
+        if key == "envs" and isinstance(value, list):
+            existing = {e["name"]: e for e in base_svc.get("envs", []) if "name" in e}
+            for env in value:
+                existing[env["name"]] = copy.deepcopy(env)
+            base_svc["envs"] = list(existing.values())
+        elif key == "extraPodSpec" and isinstance(value, dict):
+            _merge_extra_pod_spec(base_svc.setdefault("extraPodSpec", {}), value)
+        else:
+            base_svc[key] = copy.deepcopy(value)
+
+
+def _merge_extra_pod_spec(base_eps: dict, override_eps: dict) -> None:
+    for key, value in override_eps.items():
+        if key == "mainContainer" and isinstance(value, dict):
+            _merge_main_container(base_eps.setdefault("mainContainer", {}), value)
+        else:
+            base_eps[key] = copy.deepcopy(value)
+
+
+def _merge_main_container(base_mc: dict, override_mc: dict) -> None:
+    for key, value in override_mc.items():
+        if key == "args" and isinstance(value, list):
+            existing = base_mc.get("args", [])
+            extra = [a for a in value if a not in existing]
+            base_mc["args"] = existing + extra
+        else:
+            base_mc[key] = copy.deepcopy(value)
 
 
 class ConfigModifierProtocol(Protocol):

--- a/docs/kubernetes/dgdr-examples.md
+++ b/docs/kubernetes/dgdr-examples.md
@@ -85,6 +85,75 @@ spec:
 `spec.overrides.dgd` is not required to enable Planner; use it only when the
 generated DGD needs additional customization.
 
+### KV-Aware Router Override
+
+DGDR-generated deployments default to `round-robin` routing. Use
+`spec.overrides.dgd` to configure the generated `Frontend` service with a
+different router mode without editing the DGD directly.
+
+**Approximate KV routing** (no worker-side event publishing required):
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: qwen3-kv-router
+spec:
+  model: Qwen/Qwen3-0.6B
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1  # v1beta1 not yet supported for overrides
+      kind: DynamoGraphDeployment
+      spec:
+        services:
+          Frontend:
+            envs:
+              - name: DYN_ROUTER_MODE
+                value: kv
+              - name: DYN_ROUTER_USE_KV_EVENTS
+                value: "false"
+```
+
+**Event-driven KV routing for vLLM disaggregated serving** (enable worker
+KV-event publishing on the prefill worker):
+
+```yaml
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeploymentRequest
+metadata:
+  name: qwen3-disagg-kv-router
+spec:
+  model: Qwen/Qwen3-0.6B
+  backend: vllm
+  image: "nvcr.io/nvidia/ai-dynamo/dynamo-planner:1.2.1"
+  overrides:
+    dgd:
+      apiVersion: nvidia.com/v1alpha1  # v1beta1 not yet supported for overrides
+      kind: DynamoGraphDeployment
+      spec:
+        services:
+          Frontend:
+            envs:
+              - name: DYN_ROUTER_MODE
+                value: kv
+          VllmPrefillWorker:
+            extraPodSpec:
+              mainContainer:
+                args:
+                  - --enable-prefix-caching
+                  - --kv-events-config
+                  - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+```
+
+**Note**: Service names depend on the backend and topology selected by the
+profiler. Use `autoApply: false` and inspect the generated DGD before adding
+per-service overrides. For aggregated serving, override the single worker
+service (not a prefill worker). For cross-backend KV event flags, see
+[Router Operations](../components/router/router-operations.md#additional-notes)
+and the [Routing section in the DGDR Reference](dgdr.md#routing).
+
 ## Additional DGDR Patterns
 
 ### MoE Models (SGLang)


### PR DESCRIPTION
## Overview:

Adds practical KV-aware router override examples to `dgdr-examples.md` and unit tests verifying that router env vars and worker KV-event args survive the `spec.overrides.dgd` deep-merge.

## Details:

- `docs/kubernetes/dgdr-examples.md`: adds a `### KV-Aware Router Override` section with two copy-paste YAMLs - approximate KV routing (`DYN_ROUTER_USE_KV_EVENTS=false`) and event-driven KV routing for vLLM disaggregated serving (with `VllmPrefillWorker` KV-event args)
- `components/src/dynamo/profiler/tests/unit/test_dgd_override_merge.py`: new unit test file with four tests covering `apply_dgd_overrides`- router mode env, approximate KV mode envs, VllmPrefillWorker KV args, and envelope field stripping (`apiVersion`/`kind`)

Planner override coverage is already in `test_dgd_generation_planner_sla.py`.

## Where should the reviewer start?

- `docs/kubernetes/dgdr-examples.md` — the new `### KV-Aware Router Override` section (after the Planner-Enabled DGDR example)
- `components/src/dynamo/profiler/tests/unit/test_dgd_override_merge.py` - new test file

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #10269 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for configuring KV-aware routing in generated deployments.
  * Included examples for approximate KV routing and event-driven KV routing.
  * Clarified how to inspect generated resources before applying per-service overrides.
  * Added notes on service naming and router configuration options.

* **Tests**
  * Added unit coverage to verify deployment override merging keeps routing settings intact and preserves base deployment metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->