### PR TITLE
feat(trtllm): engine-owned conversation-aware ADP routing

### DIFF
--- a/components/src/dynamo/trtllm/conversation_affinity.py
+++ b/components/src/dynamo/trtllm/conversation_affinity.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for engine-owned conversation-aware ADP routing (opt-in).
+
+When TensorRT-LLM's ``attention_dp_config.kv_cache_routing_conversation_affinity`` is
+enabled, the engine's ``ConversationAwareADPRouter`` pins a conversation to an
+attention-DP rank (sticky, load-balanced first turn). Dynamo must then:
+
+  1. forward the stable conversation id via ``ConversationParams``, and
+  2. NOT force ``attention_dp_rank`` — an explicit rank is honored *before* affinity
+     in the engine and would bypass it.
+
+The conversation id is the frontend-forwarded ``agent_context.session_id`` — no new
+routing plumbing is added on the Rust side (see the serialized
+``PreprocessedRequest.agent_context`` field). When affinity is off, callers keep their
+existing Dynamo-owned DP-rank forcing unchanged.
+
+``ConversationParams`` and ``kv_cache_routing_conversation_affinity`` require a
+TensorRT-LLM build newer than 1.3.0rc20; on older wheels the import is absent and
+``CONVERSATION_PARAMS_AVAILABLE`` is False.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+try:  # Requires a TensorRT-LLM release newer than 1.3.0rc20.
+    from tensorrt_llm.llmapi import ConversationParams
+except ImportError:  # pragma: no cover - depends on installed wheel
+    ConversationParams = None  # type: ignore[assignment]
+
+CONVERSATION_PARAMS_AVAILABLE: bool = ConversationParams is not None
+
+
+def session_id_from_request(request: Mapping[str, Any]) -> Optional[str]:
+    """Return the stable conversation/session id the frontend forwards as
+    ``agent_context.session_id``, or ``None`` if absent, blank, or malformed.
+
+    Uses ``session_id`` (the active reasoning/tool chain), not ``parent_session_id``.
+    """
+    agent_context = request.get("agent_context")
+    if not isinstance(agent_context, dict):
+        return None
+    session_id = agent_context.get("session_id")
+    if isinstance(session_id, str) and session_id.strip():
+        return session_id.strip()
+    return None
+
+
+def engine_conversation_affinity_enabled(llm: Any) -> bool:
+    """Whether the resolved engine config enables conversation-affinity ADP routing.
+
+    Reads ``llm.args.attention_dp_config.kv_cache_routing_conversation_affinity``.
+    Only a genuine boolean ``True`` counts as enabled; tolerates a config model or a
+    plain dict, and defaults to False when the field is absent (e.g. older wheels).
+    """
+    adp_cfg = getattr(getattr(llm, "args", None), "attention_dp_config", None)
+    if adp_cfg is None:
+        return False
+    if isinstance(adp_cfg, dict):
+        return adp_cfg.get("kv_cache_routing_conversation_affinity") is True
+    return getattr(adp_cfg, "kv_cache_routing_conversation_affinity", None) is True
+
+
+def conversation_params_for(session_id: Optional[str]) -> Optional[Any]:
+    """Build ``ConversationParams`` for ``session_id``, or ``None`` when there is no id
+    (the engine router then applies its no-id balancing fallback). Requires the API."""
+    if session_id is None or ConversationParams is None:
+        return None
+    return ConversationParams(conversation_id=session_id)

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -61,6 +61,12 @@ from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import KvEventPublisher, ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.conversation_affinity import (
+    CONVERSATION_PARAMS_AVAILABLE,
+    conversation_params_for,
+    engine_conversation_affinity_enabled,
+    session_id_from_request,
+)
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
 from dynamo.trtllm.logits_processing.adapter import attach_logits_processors
 from dynamo.trtllm.request_handlers.handler_base import TRTLLMEnginePauseController
@@ -180,6 +186,10 @@ class TrtllmLLMEngine(LLMEngine):
         self._metrics_thread: Optional[threading.Thread] = None
         self._kv_events_thread: Optional[threading.Thread] = None
         self._attention_dp_size: int = 1
+        # Engine conversation-affinity gate; real value resolved in initialize().
+        # Default False so generate() is safe if reached before initialize()
+        # (e.g. unit tests that drive generate directly).
+        self._conversation_affinity: bool = False
         # Worker invokes on_ready callbacks serially during setup (see
         # `setup_kv_publishers` in lib/backend-common/src/publisher.rs); the
         # dict is fully populated before `_kv_events_thread` starts and
@@ -366,6 +376,19 @@ class TrtllmLLMEngine(LLMEngine):
         ) or getattr(self._trtllm_metrics_collector, "log_metrics_dict", None)
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
+        # Engine-owned conversation-affinity ADP routing (opt-in). When the engine's
+        # attention_dp_config.kv_cache_routing_conversation_affinity is enabled, its
+        # ConversationAwareADPRouter pins a conversation (agent_context.session_id) to a
+        # DP rank; this worker then forwards ConversationParams and does NOT force a rank.
+        self._conversation_affinity = engine_conversation_affinity_enabled(
+            self._engine.llm
+        )
+        if self._conversation_affinity and not CONVERSATION_PARAMS_AVAILABLE:
+            raise RuntimeError(
+                "attention_dp_config.kv_cache_routing_conversation_affinity is enabled but the "
+                "installed TensorRT-LLM build has no ConversationParams API (requires a release "
+                "newer than 1.3.0rc20)."
+            )
         # Always start the metrics-poll thread: it pushes the latest
         # ComponentSnapshot into the framework's SnapshotPublisher and
         # forwards each snap to `_log_iteration_stats` for `trtllm_kv_cache_*`.
@@ -824,16 +847,27 @@ class TrtllmLLMEngine(LLMEngine):
         if ignore_eos:
             sampling_params.ignore_eos = ignore_eos
 
-        # Honour the router's DP rank decision; without it TRT-LLM picks
-        # its own rank and KV events land on the wrong publisher.
-        rank = validate_global_dp_rank(
-            forced_dp_rank(request), 0, self._attention_dp_size, "TRT-LLM"
-        )
-        scheduling_params = (
-            SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
-            if rank is not None
-            else None
-        )
+        # In conversation-affinity mode let the engine's ConversationAwareADPRouter pick the
+        # attention-DP rank from the conversation id; do NOT force a rank (an explicit rank is
+        # honored before affinity and would bypass it). The rank is suppressed even without an
+        # id so the engine's no-id balancing fallback runs. Otherwise honour the router's DP
+        # rank decision; without it TRT-LLM picks its own rank and KV events land on the wrong
+        # publisher.
+        conversation_params = None
+        if self._conversation_affinity:
+            scheduling_params = None
+            conversation_params = conversation_params_for(
+                session_id_from_request(request)
+            )
+        else:
+            rank = validate_global_dp_rank(
+                forced_dp_rank(request), 0, self._attention_dp_size, "TRT-LLM"
+            )
+            scheduling_params = (
+                SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
+                if rank is not None
+                else None
+            )
 
         entries = logits_processors_for_request(
             self._logits_processor_spec,
@@ -844,12 +878,20 @@ class TrtllmLLMEngine(LLMEngine):
         # Prefill returns one non-streaming chunk carrying the handoff -
         # matches the legacy disagg wire format.
         streaming = not is_prefill
+        # Only pass conversation_params when affinity is active — older TRT-LLM builds'
+        # generate_async does not accept the keyword.
+        conv_kwargs = (
+            {"conversation_params": conversation_params}
+            if self._conversation_affinity
+            else {}
+        )
         generation_result = self._engine.llm.generate_async(
             inputs=token_ids,
             sampling_params=sampling_params,
             streaming=streaming,
             disaggregated_params=disaggregated_params,
             scheduling_params=scheduling_params,
+            **conv_kwargs,
             **telemetry.engine_trace_kwargs(context),
         )
 

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -43,6 +43,12 @@ from dynamo.nixl_connect import Connector
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.conversation_affinity import (
+    CONVERSATION_PARAMS_AVAILABLE,
+    conversation_params_for,
+    engine_conversation_affinity_enabled,
+    session_id_from_request,
+)
 from dynamo.trtllm.engine import TensorRTLLMEngine
 from dynamo.trtllm.logits_processing.adapter import create_trtllm_adapters
 from dynamo.trtllm.metrics import AdditionalMetricsCollector
@@ -255,6 +261,10 @@ class HandlerBase(BaseGenerativeHandler):
         self.publisher = config.publisher
         self.metrics_collector = config.metrics_collector
         self.disaggregation_mode = config.disaggregation_mode
+        # Engine-owned conversation-affinity ADP routing gate; resolved lazily on first
+        # request (engine may not be initialized at handler construction). See
+        # conversation_affinity.py. None = not yet resolved.
+        self._conversation_affinity: Optional[bool] = None
         self.encode_client = config.encode_client
         self.multimodal_processor = config.multimodal_processor
         self.first_generation = True
@@ -1095,11 +1105,33 @@ class HandlerBase(BaseGenerativeHandler):
         # Build trace headers for distributed tracing
         trace_headers = context.trace_headers()
 
+        # Resolve the engine-owned conversation-affinity gate once (lazily; the engine is
+        # initialized by first request). When on, the engine's ConversationAwareADPRouter
+        # picks the attention-DP rank from the conversation id, so we must NOT force a rank.
+        if self._conversation_affinity is None:
+            self._conversation_affinity = engine_conversation_affinity_enabled(
+                self.engine.llm
+            )
+            if self._conversation_affinity and not CONVERSATION_PARAMS_AVAILABLE:
+                raise RuntimeError(
+                    "attention_dp_config.kv_cache_routing_conversation_affinity is enabled but "
+                    "the installed TensorRT-LLM build has no ConversationParams API (requires a "
+                    "release newer than 1.3.0rc20)."
+                )
+        conv_affinity = self._conversation_affinity
+
         # Extract dp_rank from request's routing hints for attention DP routing
         routing = request.get("routing", {})
         dp_rank = routing.get("dp_rank") if routing else None
+        conversation_params = None
         scheduling_params = None
-        if dp_rank is not None:
+        if conv_affinity:
+            # Let the engine pick the rank from the conversation id (agent_context.session_id);
+            # do NOT force a rank (an explicit rank is honored before affinity and bypasses it).
+            conversation_params = conversation_params_for(
+                session_id_from_request(request)
+            )
+        elif dp_rank is not None:
             scheduling_params = SchedulingParams(
                 attention_dp_rank=dp_rank,
                 attention_dp_relax=False,  # Strict routing - use the rank dynamo router selected
@@ -1113,6 +1145,11 @@ class HandlerBase(BaseGenerativeHandler):
 
         try:
             # NEW: Updated engine call to include multimodal data
+            # Only pass conversation_params in affinity mode — older TRT-LLM builds'
+            # generate_async does not accept the keyword.
+            conv_kwargs = (
+                {"conversation_params": conversation_params} if conv_affinity else {}
+            )
             generation_result = self.engine.llm.generate_async(
                 inputs=processed_input,  # Use the correctly extracted inputs
                 sampling_params=sampling_params,
@@ -1120,6 +1157,7 @@ class HandlerBase(BaseGenerativeHandler):
                 streaming=streaming,
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
+                **conv_kwargs,
                 priority=priority,
             )
 

--- a/components/src/dynamo/trtllm/tests/test_conversation_affinity.py
+++ b/components/src/dynamo/trtllm/tests/test_conversation_affinity.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for engine-owned conversation-affinity ADP routing helpers.
+
+Wheel-independent: the ConversationParams import is guarded, so these run on any
+TensorRT-LLM build (including rc19, which lacks the API)."""
+
+import pytest
+
+from dynamo.trtllm.conversation_affinity import (
+    CONVERSATION_PARAMS_AVAILABLE,
+    conversation_params_for,
+    engine_conversation_affinity_enabled,
+    session_id_from_request,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_session_id_from_request_absent_or_malformed():
+    assert session_id_from_request({}) is None
+    assert session_id_from_request({"agent_context": None}) is None
+    assert session_id_from_request({"agent_context": "not-a-dict"}) is None
+    assert session_id_from_request({"agent_context": {}}) is None
+    assert session_id_from_request({"agent_context": {"session_id": ""}}) is None
+    assert session_id_from_request({"agent_context": {"session_id": "   "}}) is None
+    assert session_id_from_request({"agent_context": {"session_id": 123}}) is None
+
+
+def test_session_id_from_request_valid():
+    assert (
+        session_id_from_request({"agent_context": {"session_id": "run-123:agent-0"}})
+        == "run-123:agent-0"
+    )
+    # trims surrounding whitespace
+    assert session_id_from_request({"agent_context": {"session_id": " s1 "}}) == "s1"
+
+
+class _Cfg:
+    def __init__(self, value):
+        self.kv_cache_routing_conversation_affinity = value
+
+
+class _Args:
+    def __init__(self, adp_cfg):
+        self.attention_dp_config = adp_cfg
+
+
+class _Llm:
+    def __init__(self, args):
+        self.args = args
+
+
+def test_engine_conversation_affinity_enabled_dict():
+    assert (
+        engine_conversation_affinity_enabled(
+            _Llm(_Args({"kv_cache_routing_conversation_affinity": True}))
+        )
+        is True
+    )
+    assert (
+        engine_conversation_affinity_enabled(
+            _Llm(_Args({"kv_cache_routing_conversation_affinity": False}))
+        )
+        is False
+    )
+    assert engine_conversation_affinity_enabled(_Llm(_Args({}))) is False
+
+
+def test_engine_conversation_affinity_enabled_model():
+    assert engine_conversation_affinity_enabled(_Llm(_Args(_Cfg(True)))) is True
+    assert engine_conversation_affinity_enabled(_Llm(_Args(_Cfg(False)))) is False
+    # only a genuine boolean True enables it
+    assert engine_conversation_affinity_enabled(_Llm(_Args(_Cfg(1)))) is False
+
+
+def test_engine_conversation_affinity_enabled_missing():
+    assert engine_conversation_affinity_enabled(_Llm(_Args(None))) is False
+    assert engine_conversation_affinity_enabled(_Llm(None)) is False
+    assert engine_conversation_affinity_enabled(object()) is False
+
+
+def test_conversation_params_for_none_id_is_none():
+    assert conversation_params_for(None) is None
+
+
+@pytest.mark.skipif(
+    not CONVERSATION_PARAMS_AVAILABLE,
+    reason="ConversationParams requires TensorRT-LLM newer than 1.3.0rc20",
+)
+def test_conversation_params_for_builds_when_available():
+    params = conversation_params_for("run-123:agent-0")
+    assert params is not None
+    assert params.conversation_id == "run-123:agent-0"


### PR DESCRIPTION
> **DRAFT — blocked on a TensorRT-LLM dependency bump.** Opening now for **approach review** (per @PeaBrane's guidance in DM). Not for merge until the runtime carries the API (see "Dependency gate" below).

## What this PR does

Adds opt-in support for TensorRT-LLM's **engine-owned conversation-affinity ADP routing**. When the engine's `attention_dp_config.kv_cache_routing_conversation_affinity` is enabled, the TRT-LLM worker:
1. derives the conversation id from the frontend-forwarded **`agent_context.session_id`**,
2. passes it as **`ConversationParams`** to `generate_async`, and
3. **stops forcing `attention_dp_rank`**, so the engine's `ConversationAwareADPRouter` pins the conversation to a DP rank (sticky, load-balanced first turn).

When the engine policy is **off**, Dynamo-owned strict DP-rank forcing is **byte-for-byte unchanged**.

## Why this shape (design notes for review)

This is the main-appropriate re-implementation of the DSV4 feature branch's conversation-aware routing (`321567ee83`, #10517), following @PeaBrane's review guidance ("avoid duplicate routing plumbing; derive the id from session identity in the engine handlers"):

- **No Rust changes.** On `main` the session identity already reaches the worker via the serialized `PreprocessedRequest.agent_context` field (`lib/llm/src/protocols/common/preprocessor.rs:272`). The feature branch's approach added a *second* copy (`RoutingHints.conversation_id`) — dropped here entirely.
- **`agent_context.session_id`, not the old `session_control`** — `main` diverged; `session_control` doesn't exist here. Uses `session_id` (the active reasoning/tool chain), not `parent_session_id`.
- **Gated on the resolved engine config, not a `DYN_*` env var** — a Dynamo-side switch could disagree with the engine (e.g. suppress the rank when no engine router exists). The engine config is the single source of truth.
- **`ConversationParams`, not `disaggregated_params.conversation_id`** — the feature branch mutated disaggregation metadata (specific to a custom wheel). Upstream shipped a dedicated `ConversationParams` argument (`generate_async(..., conversation_params=...)`), which also covers ordinary aggregated requests (the old path only worked for P/D).
- **No `exp-H`/`gap #4` instrumentation** — all experimental one-shot logging stripped for production.

## Dependency gate ⛔ (why this is a draft)

`ConversationParams`, `kv_cache_routing_conversation_affinity`, and `ConversationAwareADPRouter` require a **TensorRT-LLM release newer than `1.3.0rc20`**. `main` currently pins **`1.3.0rc19`** (`pyproject.toml`, `container/context.yaml`), which has none of them — the API only exists on TRT-LLM `main` today (not in any release tag: rc20 is latest). So this cannot be enabled or e2e-tested here yet.

This PR is therefore safe-by-default and CI-clean: the `ConversationParams` import is guarded, the gate resolves `False` on rc19, and behavior is identical to today. Enabling it on an incompatible wheel **fails fast** at startup. The wheel/image bump (and the GPU integration + full handler test matrix) is a **prerequisite follow-up** to be landed first.

## Files
- `components/src/dynamo/trtllm/conversation_affinity.py` — new helper: session-id extraction, engine-config gate, `ConversationParams` builder (guarded import).
- `components/src/dynamo/trtllm/llm_engine.py` — unified path: resolve gate at init; suppress rank + pass `ConversationParams` when enabled.
- `components/src/dynamo/trtllm/request_handlers/handler_base.py` — legacy path: same, gate resolved lazily.
- `components/src/dynamo/trtllm/tests/test_conversation_affinity.py` — wheel-independent unit tests for the helpers.

## Testing
- `ruff check` / `ruff format --check` clean; helper unit tests pass (6 passed, 1 skipped where the API is absent).
- No Rust diff → no `cargo` exposure.
- **Deferred to the dependency-bump follow-up:** GPU integration (sticky rank across turns, no-id fallback, aggregated + P/D) and the mocked-`generate_async` handler matrix.

## Open questions for review
1. Which released TRT-LLM version/image will carry the post-rc20 API? (sole hard blocker)
2. Frontend per-rank accounting vs engine-owned placement (`push_router.rs` still stamps the frontend rank) — needs an e2e accounting pass; must not reintroduce Rust conversation plumbing.
3. Fail-startup on incompatible-wheel-with-affinity-enabled — currently yes; confirm desired.
