### PR TITLE
refactor: Default TCP request pool size

### DIFF
--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -131,6 +131,10 @@ class LlmRegistration:
     # them so the frontend's PrefillRouter can take its Bootstrap path.
     bootstrap_host: Optional[str] = None
     bootstrap_port: Optional[int] = None
+    # Backend-normalized sequence capacity owned by this local engine. This is
+    # consumed by worker-side admission and is not published in discovery.
+    # Keep new fields after the legacy positional constructor fields.
+    engine_max_num_seqs: Optional[int] = None
 
 
 @dataclass

--- a/components/src/dynamo/common/backend/tests/test_backend_bindings.py
+++ b/components/src/dynamo/common/backend/tests/test_backend_bindings.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dynamo.common.backend.engine import LlmRegistration as PyLlmRegistration
+
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 
@@ -76,6 +78,7 @@ def test_engine_config_full_kwargs_round_trip_through_getters():
             kv_cache_block_size=16,
             total_kv_blocks=1000,
             max_num_seqs=64,
+            engine_max_num_seqs=128,
             max_num_batched_tokens=2048,
         ),
     )
@@ -87,7 +90,34 @@ def test_engine_config_full_kwargs_round_trip_through_getters():
     assert llm.kv_cache_block_size == 16
     assert llm.total_kv_blocks == 1000
     assert llm.max_num_seqs == 64
+    assert llm.engine_max_num_seqs == 128
     assert llm.max_num_batched_tokens == 2048
+
+
+def test_llm_registration_preserves_legacy_positional_order():
+    legacy_args = (
+        2048,
+        16,
+        1000,
+        64,
+        2048,
+        2,
+        3,
+        "bootstrap.example",
+        9000,
+    )
+
+    for llm in (
+        PyLlmRegistration(*legacy_args),
+        backend.LlmRegistration(*legacy_args),
+    ):
+        assert llm.max_num_seqs == 64
+        assert llm.max_num_batched_tokens == 2048
+        assert llm.data_parallel_size == 2
+        assert llm.data_parallel_start_rank == 3
+        assert llm.bootstrap_host == "bootstrap.example"
+        assert llm.bootstrap_port == 9000
+        assert llm.engine_max_num_seqs is None
 
 
 def test_worker_config_minimum_args():

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -377,6 +377,11 @@ def build_runtime_config(
         engine_args.enable_local_indexer and not engine_args.is_decode()
     )
     rc.data_parallel_size = engine_args.dp_size
+    rc.engine_max_num_seqs = (
+        rc.max_num_seqs * max(engine_args.dp_size, 1)
+        if rc.max_num_seqs is not None
+        else None
+    )
     rc.set_engine_specific("output_replay_consumer", "true")
 
     bootstrap_port = engine_args.bootstrap_port

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -94,6 +94,26 @@ def test_build_runtime_config_uses_normalized_sglang_page_size_alias():
     assert runtime_config.runtime_data["output_replay_consumer"] == "true"
 
 
+@pytest.mark.parametrize(
+    "max_num_seqs, dp_size, expected_engine_max_num_seqs",
+    [
+        (7, 1, 7),
+        (7, 3, 21),
+    ],
+)
+def test_build_runtime_config_normalizes_engine_max_num_seqs(
+    max_num_seqs, dp_size, expected_engine_max_num_seqs
+):
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(max_num_seqs=max_num_seqs, dp_size=dp_size)
+    )
+
+    _, runtime_config = CONFIG.build_runtime_config(engine_args)
+
+    assert runtime_config.max_num_seqs == max_num_seqs
+    assert runtime_config.engine_max_num_seqs == expected_engine_max_num_seqs
+
+
 def test_build_mocker_engine_args_rejects_mismatched_sglang_sizes():
     with pytest.raises(Exception, match="block_size and sglang.page_size to match"):
         CONFIG.build_mocker_engine_args(

--- a/components/src/dynamo/sglang/capacity.py
+++ b/components/src/dynamo/sglang/capacity.py
@@ -3,10 +3,13 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from dynamo.common.native_offloading import native_offloading_capacity
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
@@ -47,6 +50,43 @@ def per_rank_max_running_requests(server_args: Any) -> int | None:
         return max_running_requests
 
     return max_running_requests // dp_size
+
+
+async def resolve_engine_max_num_seqs(
+    engine: Any, server_args: Any, local_dp_size: int
+) -> int | None:
+    """Return post-initialization concurrent-sequence capacity for this worker.
+
+    SGLang may clamp the configured maximum after KV profiling. Prefer the
+    scheduler-reported effective per-DP value and conservatively use the
+    smallest local rank. Fall back to the configured per-rank value when the
+    installed SGLang does not expose usable internal state.
+    """
+    effective: list[int] = []
+    try:
+        states = await engine.tokenizer_manager.get_internal_state()
+        if isinstance(states, dict):
+            states = [states]
+        if isinstance(states, (list, tuple)):
+            for state in states:
+                if not isinstance(state, dict):
+                    continue
+                value = state.get("effective_max_running_requests_per_dp")
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    effective.append(value)
+    except Exception as exc:
+        logger.warning(
+            "Unable to read SGLang effective scheduler capacity; falling back "
+            "to configured max_running_requests: %s",
+            exc,
+        )
+
+    per_rank = (
+        min(effective) if effective else per_rank_max_running_requests(server_args)
+    )
+    if per_rank is None or per_rank <= 0:
+        return None
+    return per_rank * max(local_dp_size, 1)
 
 
 def tokens_to_kv_blocks(tokens: int, page_size: int | None) -> int:

--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -92,22 +92,22 @@ async def init_llm_diffusion(
     )
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            output_type=parse_endpoint_types(dynamo_args.endpoint_types),
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Aggregated,
+            needs=[],
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                output_type=parse_endpoint_types(dynamo_args.endpoint_types),
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Aggregated,
-                needs=[],
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -72,23 +72,23 @@ async def init_embedding(
     ).to_dict()
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Text,
+            output_type=ModelType.Embedding,
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Aggregated,
+            needs=[],
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Text,
-                output_type=ModelType.Embedding,
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Aggregated,
-                needs=[],
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -144,6 +144,18 @@ async def init_decode(
         decode_needs = []
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            output_type=parse_endpoint_types(dynamo_args.endpoint_types),
+            readiness_gate=ready_event,
+            worker_type=decode_worker_type,
+            needs=decode_needs,
+            # Decode workers serve the LoRA load endpoints, so they may advertise capacity.
+            serves_lora_load=True,
+        )
         gather_tasks = [
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -166,18 +178,6 @@ async def init_decode(
             clear_endpoint.serve_endpoint(
                 handler.clear_kv_blocks,
                 metrics_labels=metrics_labels,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                output_type=parse_endpoint_types(dynamo_args.endpoint_types),
-                readiness_gate=ready_event,
-                worker_type=decode_worker_type,
-                needs=decode_needs,
-                # Decode workers serve the LoRA load endpoints, so they may advertise capacity.
-                serves_lora_load=True,
             ),
         ]
         await asyncio.gather(*gather_tasks)
@@ -283,6 +283,26 @@ async def init_prefill(
     ready_event = asyncio.Event()
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            # Prefill workers have no OpenAI surface — the role is carried
+            # by `worker_type=Prefill` below. We register the legacy
+            # `ModelType.Prefill` marker bit (not a surface) so an OLD
+            # frontend, which detects prefill via that bit, still routes
+            # disaggregated traffic during the cross-version rollout. A new
+            # frontend ignores it and dispatches off `worker_type`.
+            output_type=ModelType.Prefill,
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Prefill,
+            needs=[[WorkerType.Decode]],
+            # Prefill workers also serve the LoRA load endpoints (init_prefill), so they may
+            # advertise capacity.
+            serves_lora_load=True,
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -305,26 +325,6 @@ async def init_prefill(
             clear_endpoint.serve_endpoint(
                 handler.clear_kv_blocks,
                 metrics_labels=metrics_labels,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                # Prefill workers have no OpenAI surface — the role is carried
-                # by `worker_type=Prefill` below. We register the legacy
-                # `ModelType.Prefill` marker bit (not a surface) so an OLD
-                # frontend, which detects prefill via that bit, still routes
-                # disaggregated traffic during the cross-version rollout. A new
-                # frontend ignores it and dispatches off `worker_type`.
-                output_type=ModelType.Prefill,
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Prefill,
-                needs=[[WorkerType.Decode]],
-                # Prefill workers also serve the LoRA load endpoints (init_prefill), so they may
-                # advertise capacity.
-                serves_lora_load=True,
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/init_multimodal.py
+++ b/components/src/dynamo/sglang/init_multimodal.py
@@ -79,6 +79,27 @@ async def init_multimodal_encode_worker(
     ready_event = asyncio.Event()
 
     try:
+        await register_model_with_readiness_gate(
+            None,  # engine
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            # The encode worker is the OpenAI front door for sglang
+            # multimodal: it carries the Chat/Completions surface and
+            # delegates token generation to the internal PD worker via
+            # pd_worker_client. Its `worker_type=Encode` topology role gates
+            # serving on the downstream worker(s) — `needs` is a DNF: a P+D
+            # pair OR a single Aggregated peer — so the model is not
+            # advertised until the whole pipeline is live.
+            output_type=ModelType.Chat | ModelType.Completions,
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Encode,
+            needs=[
+                [WorkerType.Prefill, WorkerType.Decode],
+                [WorkerType.Aggregated],
+            ],
+        )
         _ = await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -86,27 +107,6 @@ async def init_multimodal_encode_worker(
                 metrics_labels=[
                     (prometheus_names.labels.MODEL, server_args.served_model_name),
                     (prometheus_names.labels.MODEL_NAME, server_args.served_model_name),
-                ],
-            ),
-            register_model_with_readiness_gate(
-                None,  # engine
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                # The encode worker is the OpenAI front door for sglang
-                # multimodal: it carries the Chat/Completions surface and
-                # delegates token generation to the internal PD worker via
-                # pd_worker_client. Its `worker_type=Encode` topology role gates
-                # serving on the downstream worker(s) — `needs` is a DNF: a P+D
-                # pair OR a single Aggregated peer — so the model is not
-                # advertised until the whole pipeline is live.
-                output_type=ModelType.Chat | ModelType.Completions,
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Encode,
-                needs=[
-                    [WorkerType.Prefill, WorkerType.Decode],
-                    [WorkerType.Aggregated],
                 ],
             ),
         )
@@ -173,22 +173,22 @@ async def init_multimodal_worker(
         readiness_needs = [[WorkerType.Encode]]
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            output_type=ModelType.Empty,
+            worker_type=readiness_worker_type,
+            needs=readiness_needs,
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 metrics_labels=[("model", server_args.served_model_name)],
                 graceful_shutdown=True,
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                output_type=ModelType.Empty,
-                worker_type=readiness_worker_type,
-                needs=readiness_needs,
             ),
         )
     except Exception as e:
@@ -227,22 +227,22 @@ async def init_multimodal_prefill_worker(
     # the decode worker / prefill router, never by the frontend. Registers a
     # topology card so the serving-readiness gate counts it.
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            output_type=ModelType.Empty,
+            worker_type=WorkerType.Prefill,
+            needs=[[WorkerType.Decode]],
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
                 metrics_labels=[("model", server_args.served_model_name)],
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                output_type=ModelType.Empty,
-                worker_type=WorkerType.Prefill,
-                needs=[[WorkerType.Decode]],
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -73,6 +73,7 @@ from dynamo.sglang.capacity import (
     get_hicache_native_offloading_capacity,
     kv_metrics_block_values,
     local_dp_rank_bounds,
+    resolve_engine_max_num_seqs,
     runtime_capacity,
 )
 from dynamo.sglang.logits_processing import activate_logits_processors
@@ -241,6 +242,9 @@ class SglangLLMEngine(LLMEngine):
 
         self._dp_start = capacity.data_parallel_start_rank
         self._dp_size = capacity.data_parallel_size
+        engine_max_num_seqs = await resolve_engine_max_num_seqs(
+            self.engine, self.server_args, self._dp_size
+        )
         return EngineConfig(
             model=self.server_args.model_path,
             served_model_name=self.server_args.served_model_name,
@@ -250,6 +254,7 @@ class SglangLLMEngine(LLMEngine):
                 kv_cache_block_size=page_size,
                 total_kv_blocks=capacity.total_kv_blocks,
                 max_num_seqs=capacity.max_num_seqs,
+                engine_max_num_seqs=engine_max_num_seqs,
                 max_num_batched_tokens=capacity.max_num_batched_tokens,
                 # Router needs the rank range to enumerate per-rank load.
                 data_parallel_size=self._dp_size,

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -31,6 +31,7 @@ from dynamo.sglang.capacity import (
     get_hicache_native_offloading_capacity,
     get_spec_decode_runtime_data,
     model_card_dp_rank_bounds,
+    resolve_engine_max_num_seqs,
     runtime_capacity,
 )
 
@@ -38,7 +39,9 @@ SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
-def _register_model_source_path(engine: sgl.Engine, server_args: ServerArgs) -> str:
+def _register_model_source_path(
+    engine: Optional[sgl.Engine], server_args: ServerArgs
+) -> str:
     """Pick the path passed to `register_model` for MDC construction.
 
     When `--model-path` is a remote URI (`s3://...`, `gs://...`), SGLang's
@@ -88,7 +91,7 @@ def _build_media_decoder_and_fetcher():
 
 
 async def _register_model_with_runtime_config(
-    engine: sgl.Engine,
+    engine: Optional[sgl.Engine],
     endpoint: Endpoint,
     server_args: ServerArgs,
     dynamo_args: DynamoConfig,
@@ -345,7 +348,7 @@ def _eagle_enabled_for(speculative_algorithm: Optional[str]) -> bool:
 
 
 async def _get_runtime_config(
-    engine: sgl.Engine, server_args: ServerArgs, dynamo_args: DynamoConfig
+    engine: Optional[sgl.Engine], server_args: ServerArgs, dynamo_args: DynamoConfig
 ) -> Optional[ModelRuntimeConfig]:
     """Extract runtime configuration from SGLang engine and args.
 
@@ -380,6 +383,10 @@ async def _get_runtime_config(
     registered_dp_size = end_dp_rank - start_dp_rank
     runtime_config.data_parallel_start_rank = start_dp_rank
     runtime_config.data_parallel_size = registered_dp_size
+    if engine is not None:
+        runtime_config.engine_max_num_seqs = await resolve_engine_max_num_seqs(
+            engine, server_args, registered_dp_size
+        )
     if registered_dp_size > 1:
         logging.info(
             "Registering with routable data_parallel rank range [%s, %s)",
@@ -510,7 +517,7 @@ async def _get_runtime_config(
 
 
 async def register_model_with_readiness_gate(
-    engine: sgl.Engine,
+    engine: Optional[sgl.Engine],
     generate_endpoint: Endpoint,
     server_args: ServerArgs,
     dynamo_args: DynamoConfig,

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -80,6 +80,58 @@ async def test_engine_sequence_capacity_returns_none_without_usable_limit():
 
 
 @pytest.mark.asyncio
+async def test_unified_start_reports_normalized_local_engine_capacity(monkeypatch):
+    from dynamo.sglang import llm_engine
+
+    backend = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=AsyncMock(
+                return_value=[
+                    {"effective_max_running_requests_per_dp": 7},
+                    {"effective_max_running_requests_per_dp": 5},
+                ]
+            )
+        ),
+        _scheduler_init_result=SimpleNamespace(scheduler_infos=[{}]),
+    )
+    server_args = SimpleNamespace(
+        model_path="Qwen/Qwen3-0.6B",
+        served_model_name="qwen",
+        context_length=4096,
+        max_running_requests=999,
+        page_size=16,
+        skip_tokenizer_init=True,
+        enable_trace=False,
+    )
+    engine = llm_engine.SglangLLMEngine(
+        server_args,
+        SimpleNamespace(use_sglang_tokenizer=False),
+        llm_engine.DisaggregationMode.AGGREGATED,
+    )
+    capacity = SimpleNamespace(
+        data_parallel_start_rank=2,
+        data_parallel_size=3,
+        max_num_seqs=5,
+        max_num_batched_tokens=1024,
+        total_kv_blocks=64,
+    )
+
+    monkeypatch.setattr(llm_engine.sgl, "Engine", lambda server_args: backend)
+    monkeypatch.setattr(
+        llm_engine, "SGLangEnginePauseController", lambda backend: object()
+    )
+    monkeypatch.setattr(llm_engine, "InputParamManager", lambda tokenizer: object())
+    monkeypatch.setattr(llm_engine, "runtime_capacity", lambda *_: capacity)
+    monkeypatch.setattr(llm_engine, "_get_runtime_data", lambda *_: None)
+    monkeypatch.setattr(engine, "_start_metrics_task", lambda: None)
+    monkeypatch.setattr(engine, "logits_processor_spec", AsyncMock(return_value=None))
+
+    config = await engine.start(worker_id=0)
+
+    assert config.llm.engine_max_num_seqs == 15
+
+
+@pytest.mark.asyncio
 async def test_proxy_registration_does_not_report_local_engine_capacity(monkeypatch):
     from dynamo.sglang import register
 

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
 from dynamo.sglang.capacity import (
     get_hicache_native_offloading_capacity,
     get_spec_decode_runtime_data,
+    resolve_engine_max_num_seqs,
 )
 
 pytestmark = [
@@ -17,6 +19,99 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@pytest.mark.asyncio
+async def test_engine_sequence_capacity_uses_smallest_effective_local_rank():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=AsyncMock(
+                return_value=[
+                    {"effective_max_running_requests_per_dp": 7},
+                    {"effective_max_running_requests_per_dp": True},
+                    {"effective_max_running_requests_per_dp": 5},
+                ]
+            )
+        )
+    )
+
+    capacity = await resolve_engine_max_num_seqs(
+        engine,
+        SimpleNamespace(max_running_requests=999, dp_size=1),
+        local_dp_size=3,
+    )
+
+    assert capacity == 15
+
+
+@pytest.mark.asyncio
+async def test_engine_sequence_capacity_falls_back_to_configured_per_rank(caplog):
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=AsyncMock(side_effect=RuntimeError("not supported"))
+        )
+    )
+
+    capacity = await resolve_engine_max_num_seqs(
+        engine,
+        SimpleNamespace(max_running_requests=24, dp_size=4),
+        local_dp_size=2,
+    )
+
+    assert capacity == 12
+    assert "falling back to configured max_running_requests" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_engine_sequence_capacity_returns_none_without_usable_limit():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=AsyncMock(return_value={"other": 1})
+        )
+    )
+
+    capacity = await resolve_engine_max_num_seqs(
+        engine,
+        SimpleNamespace(max_running_requests=None, dp_size=1),
+        local_dp_size=1,
+    )
+
+    assert capacity is None
+
+
+@pytest.mark.asyncio
+async def test_proxy_registration_does_not_report_local_engine_capacity(monkeypatch):
+    from dynamo.sglang import register
+
+    server_args = SimpleNamespace(
+        context_length=4096,
+        disaggregation_mode=None,
+        max_prefill_tokens=None,
+        page_size=16,
+        speculative_algorithm="NONE",
+    )
+    dynamo_args = register.DynamoConfig()
+    dynamo_args.enable_local_indexer = False
+    resolver = AsyncMock(return_value=99)
+    capacity = SimpleNamespace(
+        max_num_seqs=None,
+        max_num_batched_tokens=None,
+        total_kv_blocks=None,
+    )
+
+    monkeypatch.setattr(register, "resolve_engine_max_num_seqs", resolver)
+    monkeypatch.setattr(register, "model_card_dp_rank_bounds", lambda _: (0, 1))
+    monkeypatch.setattr(register, "get_sglang_worker_group_id", lambda _: None)
+    monkeypatch.setattr(
+        register, "_get_bootstrap_info_for_config", lambda _: (None, None)
+    )
+    monkeypatch.setattr(register, "_get_mooncake_runtime_data", lambda _: None)
+    monkeypatch.setattr(register, "runtime_capacity", lambda *_: capacity)
+
+    runtime_config = await register._get_runtime_config(None, server_args, dynamo_args)
+
+    resolver.assert_not_awaited()
+    assert runtime_config.engine_max_num_seqs is None
 
 
 def test_spec_decode_runtime_data_uses_speculative_num_steps():

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for SGLang backend components."""
 
+import asyncio
 import json
 import logging
 import os
@@ -66,6 +67,118 @@ pytestmark = [
 # Create SGLang-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
+
+
+@pytest.mark.asyncio
+async def test_decode_registers_capacity_before_serving_endpoints(monkeypatch):
+    from unittest.mock import AsyncMock, Mock
+
+    from dynamo.sglang import init_llm
+
+    registration_started = asyncio.Event()
+    registration_release = asyncio.Event()
+    all_endpoints_started = asyncio.Event()
+    started_endpoints: set[str] = set()
+
+    async def gated_registration(*_args, **_kwargs):
+        registration_started.set()
+        await registration_release.wait()
+
+    def endpoint(name: str):
+        async def serve(*_args, **_kwargs):
+            started_endpoints.add(name)
+            if len(started_endpoints) == 5:
+                all_endpoints_started.set()
+            await asyncio.Event().wait()
+
+        return SimpleNamespace(serve_endpoint=AsyncMock(side_effect=serve))
+
+    generate = endpoint("generate")
+    clear = endpoint("clear")
+    load_lora = endpoint("load_lora")
+    unload_lora = endpoint("unload_lora")
+    list_loras = endpoint("list_loras")
+    runtime = SimpleNamespace(
+        endpoint=Mock(side_effect=[generate, clear, load_lora, unload_lora, list_loras])
+    )
+
+    metrics_task = asyncio.create_task(asyncio.Event().wait())
+    publisher = SimpleNamespace(
+        component_gauges=SimpleNamespace(set_model_load_time=Mock())
+    )
+    handler = SimpleNamespace(
+        generate=Mock(),
+        load_lora=Mock(),
+        unload_lora=Mock(),
+        list_loras=Mock(),
+        clear_kv_blocks=Mock(),
+        register_engine_routes=Mock(),
+        cleanup=Mock(),
+    )
+    monkeypatch.setattr(
+        init_llm,
+        "setup_sgl_metrics",
+        AsyncMock(return_value=(publisher, metrics_task, [])),
+    )
+    monkeypatch.setattr(init_llm, "DecodeWorkerHandler", Mock(return_value=handler))
+    monkeypatch.setattr(
+        init_llm,
+        "SglangHealthCheckPayload",
+        Mock(return_value=SimpleNamespace(to_dict=lambda: {})),
+    )
+    monkeypatch.setattr(
+        init_llm, "register_model_with_readiness_gate", gated_registration
+    )
+
+    server_args = SimpleNamespace(
+        enable_forward_pass_metrics=False,
+        enable_trace=False,
+        node_rank=0,
+    )
+    dynamo_args = SimpleNamespace(
+        namespace="dyn",
+        component="backend",
+        endpoint="generate",
+        frontend_decoding=False,
+        endpoint_types="chat",
+        custom_jinja_template=None,
+        use_sglang_tokenizer=False,
+        sglang_trace_level=0,
+    )
+    config = SimpleNamespace(
+        server_args=server_args,
+        dynamo_args=dynamo_args,
+        serving_mode=DisaggregationMode.AGGREGATED,
+    )
+
+    task = asyncio.create_task(
+        init_llm.init_decode(
+            runtime,
+            config,
+            asyncio.Event(),
+            [],
+            snapshot_engine=SimpleNamespace(),
+        )
+    )
+    try:
+        await asyncio.wait_for(registration_started.wait(), timeout=1)
+        assert not started_endpoints
+
+        registration_release.set()
+        await asyncio.wait_for(all_endpoints_started.wait(), timeout=1)
+        assert started_endpoints == {
+            "generate",
+            "clear",
+            "load_lora",
+            "unload_lora",
+            "list_loras",
+        }
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    handler.cleanup.assert_called_once()
 
 
 def _make_sglang_config(**overrides):

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -78,7 +78,11 @@ from dynamo.trtllm.utils.request_utils import (
     request_cache_salt,
     stored_event_cache_salt,
 )
-from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
+from dynamo.trtllm.utils.trtllm_utils import (
+    deep_update,
+    engine_max_num_seqs,
+    warn_override_collisions,
+)
 
 if TYPE_CHECKING:
     from tensorrt_llm.metrics import MetricsCollector
@@ -419,6 +423,7 @@ class TrtllmLLMEngine(LLMEngine):
                 context_length=self.max_seq_len,
                 kv_cache_block_size=self.kv_block_size,
                 max_num_seqs=self.max_batch_size,
+                engine_max_num_seqs=engine_max_num_seqs(self._engine),
                 max_num_batched_tokens=self.max_num_tokens,
                 data_parallel_size=self._attention_dp_size,
             ),

--- a/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
@@ -20,9 +20,11 @@ pytestmark = [
 
 def test_engine_max_num_seqs_uses_post_init_engine_value():
     engine = SimpleNamespace(
-        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=37))
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=37)),
+        get_attention_dp_size=lambda: 4,
     )
 
+    # TRT-LLM reports one engine-wide budget; attention DP must not multiply it.
     assert engine_max_num_seqs(engine) == 37
 
 

--- a/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
@@ -5,7 +5,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.trtllm.utils.trtllm_utils import get_spec_decode_runtime_data
+from dynamo.trtllm.utils.trtllm_utils import (
+    engine_max_num_seqs,
+    get_spec_decode_runtime_data,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -13,6 +16,23 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+def test_engine_max_num_seqs_uses_post_init_engine_value():
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=37))
+    )
+
+    assert engine_max_num_seqs(engine) == 37
+
+
+@pytest.mark.parametrize("value", [None, 0, -1, True, "37"])
+def test_engine_max_num_seqs_ignores_invalid_values(value):
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=value))
+    )
+
+    assert engine_max_num_seqs(engine) is None
 
 
 def test_spec_decode_runtime_data_uses_max_draft_len():

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine.py
@@ -106,6 +106,7 @@ async def _check_start_populates_registration_metadata(started_engine):
     assert cfg.llm.context_length == 1024
     assert cfg.llm.kv_cache_block_size > 0
     assert cfg.llm.max_num_seqs == 4
+    assert cfg.llm.engine_max_num_seqs == 4
 
 
 async def _check_generate_streams_chunks_with_coherent_final_usage(started_engine):

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -77,3 +77,15 @@ def get_spec_decode_runtime_data(engine_args: Any) -> dict[str, Any] | None:
     if method:
         data["method"] = str(method)
     return data
+
+
+def engine_max_num_seqs(engine: Any) -> int | None:
+    """Return TRT-LLM's post-initialization, engine-wide request capacity."""
+    value = getattr(
+        getattr(getattr(engine, "llm", None), "args", None),
+        "max_batch_size",
+        None,
+    )
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    return value

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -65,7 +65,11 @@ from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
-from dynamo.trtllm.utils.trtllm_utils import deep_update, get_spec_decode_runtime_data
+from dynamo.trtllm.utils.trtllm_utils import (
+    deep_update,
+    engine_max_num_seqs,
+    get_spec_decode_runtime_data,
+)
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
@@ -548,6 +552,7 @@ async def init_llm_worker(
         # Need to get max_num_seqs and max_num_batched_tokens from engine_args
         # because they can be overridden by --extra-engine-args or --override-engine-args
         runtime_config.max_num_seqs = engine_args["max_batch_size"]
+        runtime_config.engine_max_num_seqs = engine_max_num_seqs(engine)
         runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
         runtime_config.reasoning_parser = config.dyn_reasoning_parser
         runtime_config.tool_call_parser = config.dyn_tool_call_parser

--- a/components/src/dynamo/vllm/capacity.py
+++ b/components/src/dynamo/vllm/capacity.py
@@ -10,6 +10,17 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def engine_max_num_seqs(max_num_seqs: int | None, local_dp_size: int) -> int | None:
+    """Normalize vLLM's per-rank scheduler limit to this worker's DP scope."""
+    if (
+        not isinstance(max_num_seqs, int)
+        or isinstance(max_num_seqs, bool)
+        or max_num_seqs <= 0
+    ):
+        return None
+    return max_num_seqs * max(local_dp_size, 1)
+
+
 def per_rank_kv_blocks(
     total_kv_blocks: int | None, data_parallel_size: int
 ) -> int | None:

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -68,7 +68,7 @@ from dynamo.vllm.cache_info import (
     configure_kv_event_block_size,
     get_configured_kv_event_block_size,
 )
-from dynamo.vllm.capacity import per_rank_kv_blocks
+from dynamo.vllm.capacity import engine_max_num_seqs, per_rank_kv_blocks
 from dynamo.vllm.kv_connector_protocols import (
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
 )
@@ -402,6 +402,9 @@ class VllmLLMEngine(LLMEngine):
                 kv_cache_block_size=block_size,
                 total_kv_blocks=per_rank_num_gpu_blocks,
                 max_num_seqs=vllm_config.scheduler_config.max_num_seqs,
+                engine_max_num_seqs=engine_max_num_seqs(
+                    vllm_config.scheduler_config.max_num_seqs, self._dp_range[1]
+                ),
                 max_num_batched_tokens=vllm_config.scheduler_config.max_num_batched_tokens,
                 # Router needs the rank range to enumerate per-rank load.
                 data_parallel_start_rank=self._dp_range[0],

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -52,6 +52,7 @@ from . import envs
 from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import (
+    engine_max_num_seqs,
     get_metrics_model_name,
     get_spec_decode_runtime_data,
     per_rank_kv_blocks,
@@ -694,6 +695,9 @@ async def register_vllm_model(
         num_gpu_blocks = 0
     runtime_config.total_kv_blocks = per_rank_kv_blocks(num_gpu_blocks, dp_range[1])
     runtime_config.max_num_seqs = runtime_values["max_num_seqs"]
+    runtime_config.engine_max_num_seqs = engine_max_num_seqs(
+        runtime_values["max_num_seqs"], dp_range[1]
+    )
     runtime_config.max_num_batched_tokens = runtime_values["max_num_batched_tokens"]
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     runtime_config.enable_local_indexer = (

--- a/components/src/dynamo/vllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/vllm/tests/test_runtime_metadata.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.vllm.capacity import get_metrics_model_name, get_spec_decode_runtime_data
+from dynamo.vllm.capacity import (
+    engine_max_num_seqs,
+    get_metrics_model_name,
+    get_spec_decode_runtime_data,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -13,6 +17,14 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@pytest.mark.parametrize(
+    "max_num_seqs, local_dp_size, expected",
+    [(8, 1, 8), (8, 3, 24), (8, 0, 8), (None, 2, None), (0, 2, None), (True, 2, None)],
+)
+def test_engine_max_num_seqs_normalizes_dp_scope(max_num_seqs, local_dp_size, expected):
+    assert engine_max_num_seqs(max_num_seqs, local_dp_size) == expected
 
 
 def test_spec_decode_runtime_data_uses_vllm_speculative_config():

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -502,6 +502,7 @@ async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
 
     assert engine_args.served_model_name == [served_model_name]
     assert config.served_model_name == served_model_name
+    assert config.llm.engine_max_num_seqs == 2
 
 
 def test_should_prefetch_model_for_default_load_format():

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -442,8 +442,8 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
-    """Return the Dynamo-normalized served model name from EngineConfig."""
+async def test_unified_start_returns_normalized_registration_metadata(monkeypatch):
+    """Return normalized model identity and local-DP capacity metadata."""
     from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
     from dynamo.vllm import llm_engine
 
@@ -471,7 +471,7 @@ async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
         "from_vllm_config",
         lambda **kwargs: engine_client,
     )
-    monkeypatch.setattr(llm_engine, "get_dp_range_for_worker", lambda config: (0, 1))
+    monkeypatch.setattr(llm_engine, "get_dp_range_for_worker", lambda config: (2, 3))
     monkeypatch.setattr(llm_engine, "per_rank_kv_blocks", lambda blocks, size: blocks)
     monkeypatch.setattr(
         llm_engine,
@@ -502,7 +502,7 @@ async def test_unified_start_returns_normalized_served_model_name(monkeypatch):
 
     assert engine_args.served_model_name == [served_model_name]
     assert config.served_model_name == served_model_name
-    assert config.llm.engine_max_num_seqs == 2
+    assert config.llm.engine_max_num_seqs == 6
 
 
 def test_should_prefetch_model_for_default_load_format():

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -6,6 +6,7 @@
 import asyncio
 import json
 import logging
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -45,6 +46,80 @@ def _make_config(**overrides) -> Mock:
     }
     defaults.update(overrides)
     return Mock(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_embedding_registers_capacity_before_serving_endpoint(monkeypatch):
+    registration_started = asyncio.Event()
+    registration_release = asyncio.Event()
+    serve_started = asyncio.Event()
+
+    async def gated_registration(*_args, **_kwargs):
+        registration_started.set()
+        await registration_release.wait()
+
+    async def serve(*_args, **_kwargs):
+        serve_started.set()
+        await asyncio.Event().wait()
+
+    endpoint = Mock()
+    endpoint.connection_id.return_value = 7
+    endpoint.serve_endpoint = AsyncMock(side_effect=serve)
+    runtime = Mock()
+    runtime.endpoint.return_value = endpoint
+
+    engine_client = Mock()
+    vllm_config = Mock()
+    engine_tuple: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        "/tmp/prom",
+        Mock(),
+    )
+    factory = WorkerFactory(
+        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_kv_event_publisher_fn=Mock(),
+        register_vllm_model_fn=gated_registration,
+        setup_fpm_relay_fn=Mock(),
+        setup_metrics_collection_fn=Mock(),
+    )
+    handler = Mock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.StatLoggerFactory", Mock(return_value=Mock())
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.EmbeddingWorkerHandler",
+        Mock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.VllmEmbeddingHealthCheckPayload",
+        Mock(return_value=SimpleNamespace(to_dict=lambda: {})),
+    )
+    config = _make_config(
+        namespace="dyn",
+        component="backend",
+        endpoint="generate",
+        model="model",
+        served_model_name="served-model",
+    )
+
+    task = asyncio.create_task(
+        factory._create_embedding_worker(runtime, config, asyncio.Event(), [])
+    )
+    try:
+        await asyncio.wait_for(registration_started.wait(), timeout=1)
+        endpoint.serve_endpoint.assert_not_called()
+
+        registration_release.set()
+        await asyncio.wait_for(serve_started.wait(), timeout=1)
+        endpoint.serve_endpoint.assert_awaited_once()
+    finally:
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    handler.cleanup.assert_called_once()
 
 
 def _single_rank_benchmark_payload(

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -729,24 +729,24 @@ class WorkerFactory:
 
         logger.info("Starting to serve the embedding worker endpoint...")
         try:
+            await self.register_vllm_model(
+                ModelInput.Text,
+                ModelType.Embedding,
+                generate_endpoint,
+                config,
+                engine_client,
+                vllm_config,
+                # Embedding workers have no prefill/decode split — they
+                # always serve a single pooling pass, so they advertise
+                # as Aggregated with no peer dependencies.
+                worker_type=WorkerType.Aggregated,
+                needs=[],
+            )
             await asyncio.gather(
                 generate_endpoint.serve_endpoint(
                     handler.generate,
                     metrics_labels=[("model", config.model)],
                     health_check_payload=embedding_health_check_payload,
-                ),
-                self.register_vllm_model(
-                    ModelInput.Text,
-                    ModelType.Embedding,
-                    generate_endpoint,
-                    config,
-                    engine_client,
-                    vllm_config,
-                    # Embedding workers have no prefill/decode split — they
-                    # always serve a single pooling pass, so they advertise
-                    # as Aggregated with no peer dependencies.
-                    worker_type=WorkerType.Aggregated,
-                    needs=[],
                 ),
             )
         except Exception as e:

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -713,6 +713,7 @@ mod tests {
         assert_eq!(llm.kv_cache_block_size, Some(64));
         assert_eq!(llm.total_kv_blocks, Some(16384));
         assert_eq!(llm.max_num_seqs, Some(256));
+        assert_eq!(llm.engine_max_num_seqs, Some(256));
         assert_eq!(llm.context_length, Some(8192));
         engine.cleanup().await.unwrap();
     }

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -359,6 +359,7 @@ impl LLMEngine for MockerBackend {
                 kv_cache_block_size: Some(self.engine_args.block_size as u32),
                 total_kv_blocks: Some(self.engine_args.num_gpu_blocks as u64),
                 max_num_seqs: self.engine_args.max_num_seqs.map(|v| v as u64),
+                engine_max_num_seqs: self.engine_args.max_num_seqs.map(|v| v as u64),
                 max_num_batched_tokens: self.engine_args.max_num_batched_tokens.map(|v| v as u64),
                 data_parallel_size: None,
                 data_parallel_start_rank: None,

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -123,6 +123,9 @@ pub struct LlmRegistration {
     pub total_kv_blocks: Option<u64>,
     /// Maximum number of concurrent in-flight sequences.
     pub max_num_seqs: Option<u64>,
+    /// Normalized concurrent-sequence capacity owned by this local engine.
+    /// Unlike `max_num_seqs`, its DP scope is backend-independent.
+    pub engine_max_num_seqs: Option<u64>,
     /// Maximum tokens the engine will process in a single batched step.
     pub max_num_batched_tokens: Option<u64>,
     /// DP ranks this worker hosts (default 1); the router enumerates per-rank

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1637,6 +1637,7 @@ async fn build_local_model(
         context_length: llm.context_length,
         total_kv_blocks: llm.total_kv_blocks,
         max_num_seqs: llm.max_num_seqs,
+        engine_max_num_seqs: llm.engine_max_num_seqs,
         max_num_batched_tokens: llm.max_num_batched_tokens,
         data_parallel_size: llm.data_parallel_size.unwrap_or(1),
         data_parallel_start_rank: llm.data_parallel_start_rank.unwrap_or(0),
@@ -1930,6 +1931,7 @@ mod tests {
                 context_length: Some(32_768),
                 total_kv_blocks: Some(100),
                 max_num_seqs: Some(16),
+                engine_max_num_seqs: Some(32),
                 max_num_batched_tokens: Some(8192),
                 ..Default::default()
             }),
@@ -1944,6 +1946,7 @@ mod tests {
         assert_eq!(runtime_config.context_length, Some(32_768));
         assert_eq!(runtime_config.total_kv_blocks, Some(100));
         assert_eq!(runtime_config.max_num_seqs, Some(16));
+        assert_eq!(runtime_config.engine_max_num_seqs, Some(32));
         assert_eq!(runtime_config.max_num_batched_tokens, Some(8192));
         assert_eq!(runtime_config.tool_call_parser.as_deref(), Some("kimi_k2"));
         assert_eq!(runtime_config.reasoning_parser.as_deref(), Some("kimi_k25"));

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -132,6 +132,7 @@ impl LlmRegistration {
         data_parallel_start_rank = None,
         bootstrap_host = None,
         bootstrap_port = None,
+        engine_max_num_seqs = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -144,6 +145,7 @@ impl LlmRegistration {
         data_parallel_start_rank: Option<u32>,
         bootstrap_host: Option<String>,
         bootstrap_port: Option<u16>,
+        engine_max_num_seqs: Option<u64>,
     ) -> Self {
         Self {
             inner: RsLlmRegistration {
@@ -151,6 +153,7 @@ impl LlmRegistration {
                 kv_cache_block_size,
                 total_kv_blocks,
                 max_num_seqs,
+                engine_max_num_seqs,
                 max_num_batched_tokens,
                 data_parallel_size,
                 data_parallel_start_rank,
@@ -175,6 +178,10 @@ impl LlmRegistration {
     #[getter]
     fn max_num_seqs(&self) -> Option<u64> {
         self.inner.max_num_seqs
+    }
+    #[getter]
+    fn engine_max_num_seqs(&self) -> Option<u64> {
+        self.inner.engine_max_num_seqs
     }
     #[getter]
     fn max_num_batched_tokens(&self) -> Option<u64> {
@@ -812,6 +819,10 @@ impl PyEngineCore {
                     kv_cache_block_size: opt_attr::<u32>(&v, "kv_cache_block_size")?,
                     total_kv_blocks: opt_attr::<u64>(&v, "total_kv_blocks")?,
                     max_num_seqs: opt_attr::<u64>(&v, "max_num_seqs")?,
+                    engine_max_num_seqs: opt_attr::<u64>(
+                        &v,
+                        "engine_max_num_seqs",
+                    )?,
                     max_num_batched_tokens: opt_attr::<u64>(&v, "max_num_batched_tokens")?,
                     data_parallel_size: opt_attr::<u32>(&v, "data_parallel_size")?,
                     data_parallel_start_rank: opt_attr::<u32>(&v, "data_parallel_start_rank")?,

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -819,10 +819,7 @@ impl PyEngineCore {
                     kv_cache_block_size: opt_attr::<u32>(&v, "kv_cache_block_size")?,
                     total_kv_blocks: opt_attr::<u64>(&v, "total_kv_blocks")?,
                     max_num_seqs: opt_attr::<u64>(&v, "max_num_seqs")?,
-                    engine_max_num_seqs: opt_attr::<u64>(
-                        &v,
-                        "engine_max_num_seqs",
-                    )?,
+                    engine_max_num_seqs: opt_attr::<u64>(&v, "engine_max_num_seqs")?,
                     max_num_batched_tokens: opt_attr::<u64>(&v, "max_num_batched_tokens")?,
                     data_parallel_size: opt_attr::<u32>(&v, "data_parallel_size")?,
                     data_parallel_start_rank: opt_attr::<u32>(&v, "data_parallel_start_rank")?,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -115,6 +115,11 @@ impl ModelRuntimeConfig {
     }
 
     #[setter]
+    fn set_engine_max_num_seqs(&mut self, capacity: Option<u64>) {
+        self.inner.engine_max_num_seqs = capacity;
+    }
+
+    #[setter]
     fn set_max_num_batched_tokens(&mut self, max_num_batched_tokens: u64) {
         self.inner.max_num_batched_tokens = Some(max_num_batched_tokens);
     }
@@ -205,6 +210,11 @@ impl ModelRuntimeConfig {
     #[getter]
     fn max_num_seqs(&self) -> Option<u64> {
         self.inner.max_num_seqs
+    }
+
+    #[getter]
+    fn engine_max_num_seqs(&self) -> Option<u64> {
+        self.inner.engine_max_num_seqs
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -860,6 +860,7 @@ class ModelRuntimeConfig:
     context_length: int | None
     total_kv_blocks: int | None
     max_num_seqs: int | None
+    engine_max_num_seqs: int | None
     max_num_batched_tokens: int | None
     tool_call_parser: str | None
     reasoning_parser: str | None
@@ -3296,6 +3297,7 @@ class backend:
             data_parallel_start_rank: Optional[int] = None,
             bootstrap_host: Optional[str] = None,
             bootstrap_port: Optional[int] = None,
+            engine_max_num_seqs: Optional[int] = None,
         ) -> None: ...
         @property
         def context_length(self) -> Optional[int]: ...
@@ -3305,6 +3307,8 @@ class backend:
         def total_kv_blocks(self) -> Optional[int]: ...
         @property
         def max_num_seqs(self) -> Optional[int]: ...
+        @property
+        def engine_max_num_seqs(self) -> Optional[int]: ...
         @property
         def max_num_batched_tokens(self) -> Optional[int]: ...
         @property

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -644,6 +644,16 @@ impl LocalModel {
             &self.card,
             model_suffix,
         )?;
+
+        if lora_info.is_none()
+            && let Some(engine_max_num_seqs) = self.runtime_config.worker_pool_engine_max_num_seqs()
+        {
+            endpoint
+                .drt()
+                .network_manager()
+                .server_with_engine_max_num_seqs(Some(engine_max_num_seqs))
+                .await?;
+        }
         let _instance = discovery.register(spec).await?;
 
         Ok(())

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -131,6 +131,12 @@ pub struct ModelRuntimeConfig {
 
     pub max_num_seqs: Option<u64>,
 
+    /// Normalized concurrent-sequence capacity owned by this local engine.
+    /// This is process-local admission metadata and must not be published in
+    /// the discovery model card.
+    #[serde(skip)]
+    pub engine_max_num_seqs: Option<u64>,
+
     pub max_num_batched_tokens: Option<u64>,
 
     pub tool_call_parser: Option<String>,
@@ -256,6 +262,7 @@ impl Default for ModelRuntimeConfig {
             context_length: None,
             total_kv_blocks: None,
             max_num_seqs: None,
+            engine_max_num_seqs: None,
             max_num_batched_tokens: None,
             tool_call_parser: None,
             reasoning_parser: None,
@@ -434,6 +441,13 @@ impl ModelRuntimeConfig {
         self.validate().map_err(|error| error.to_string())
     }
 
+    /// Return the normalized whole-engine maximum used for TCP pool sizing.
+    pub fn worker_pool_engine_max_num_seqs(&self) -> Option<usize> {
+        self.engine_max_num_seqs
+            .and_then(|capacity| usize::try_from(capacity).ok())
+            .filter(|capacity| *capacity > 0)
+    }
+
     pub fn set_engine_specific<T: Serialize>(&mut self, key: &str, value: T) -> anyhow::Result<()> {
         self.runtime_data
             .insert(key.to_string(), serde_json::to_value(value)?);
@@ -509,6 +523,48 @@ impl ModelRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn worker_pool_uses_normalized_engine_max_num_seqs() {
+        let config = ModelRuntimeConfig {
+            max_num_seqs: Some(3),
+            engine_max_num_seqs: Some(9),
+            data_parallel_size: 3,
+            ..Default::default()
+        };
+        assert_eq!(config.worker_pool_engine_max_num_seqs(), Some(9));
+    }
+
+    #[test]
+    fn worker_pool_does_not_infer_capacity_from_public_max_num_seqs() {
+        let without_normalized_hint = ModelRuntimeConfig {
+            max_num_seqs: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(
+            without_normalized_hint.worker_pool_engine_max_num_seqs(),
+            None
+        );
+
+        let zero = ModelRuntimeConfig {
+            engine_max_num_seqs: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(zero.worker_pool_engine_max_num_seqs(), None);
+    }
+
+    #[test]
+    fn engine_max_num_seqs_is_not_serialized() {
+        let config = ModelRuntimeConfig {
+            engine_max_num_seqs: Some(32),
+            ..Default::default()
+        };
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(!serialized.contains("engine_max_num_seqs"));
+
+        let deserialized: ModelRuntimeConfig = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.engine_max_num_seqs, None);
+    }
 
     // Env-touching tests use `temp_env` (snapshot + restore around the closure) and
     // `#[serial_test::serial]` (serialize against every other env-touching test in the

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -36,12 +36,10 @@ const DEFAULT_WORKER_POOL_SIZE: usize = 10000;
 /// this is a small overflow queue to handle burst traffic
 const DEFAULT_WORK_QUEUE_SIZE: usize = 16;
 
-/// Get work queue size from environment or use default
-fn get_work_queue_size() -> usize {
-    std::env::var("DYN_TCP_WORK_QUEUE_SIZE")
+fn parse_env_usize(name: &str) -> Option<usize> {
+    std::env::var(name)
         .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_WORK_QUEUE_SIZE)
+        .and_then(|value| value.parse::<usize>().ok())
 }
 
 /// Default small overflow queue when the engine-request limit is set but the
@@ -64,16 +62,14 @@ struct SizingConfig {
     queue_size: usize,
 }
 
-fn resolve_sizing(engine_max_num_seqs: Option<usize>) -> SizingConfig {
-    match std::env::var("DYN_ENGINE_REQUEST_LIMIT")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-    {
+fn resolve_sizing(
+    engine_max_num_seqs: Option<usize>,
+    env: impl Fn(&str) -> Option<usize>,
+) -> SizingConfig {
+    match env("DYN_ENGINE_REQUEST_LIMIT") {
         Some(engine_limit) => {
-            let queue_limit = std::env::var("DYN_DYNAMO_REQUEST_QUEUE_LIMIT")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
-                .unwrap_or(DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT);
+            let queue_limit =
+                env("DYN_DYNAMO_REQUEST_QUEUE_LIMIT").unwrap_or(DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT);
             // The single dispatcher holds one request between `recv()` and
             // acquiring an engine permit, so size the channel to limit-1:
             // channel + the dispatcher-held request cap "queued, not in engine"
@@ -84,9 +80,7 @@ fn resolve_sizing(engine_max_num_seqs: Option<usize>) -> SizingConfig {
             }
         }
         None => {
-            let pool_size = std::env::var("DYN_TCP_WORKER_POOL_SIZE")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
+            let pool_size = env("DYN_TCP_WORKER_POOL_SIZE")
                 .or_else(|| {
                     engine_max_num_seqs
                         .filter(|capacity| *capacity > 0)
@@ -99,7 +93,7 @@ fn resolve_sizing(engine_max_num_seqs: Option<usize>) -> SizingConfig {
                 .unwrap_or(DEFAULT_WORKER_POOL_SIZE);
             SizingConfig {
                 pool_size,
-                queue_size: get_work_queue_size(),
+                queue_size: env("DYN_TCP_WORK_QUEUE_SIZE").unwrap_or(DEFAULT_WORK_QUEUE_SIZE),
             }
         }
     }
@@ -177,10 +171,19 @@ impl SharedTcpServer {
         cancellation_token: CancellationToken,
         engine_max_num_seqs: Option<usize>,
     ) -> Arc<Self> {
+        let sizing = resolve_sizing(engine_max_num_seqs, parse_env_usize);
+        Self::new_with_sizing(bind_addr, cancellation_token, sizing)
+    }
+
+    fn new_with_sizing(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        sizing: SizingConfig,
+    ) -> Arc<Self> {
         let SizingConfig {
             pool_size: worker_pool_size,
             queue_size: work_queue_size,
-        } = resolve_sizing(engine_max_num_seqs);
+        } = sizing;
 
         tracing::info!(
             "Initializing TCP server with dispatcher (concurrency={}, queue={})",
@@ -782,50 +785,54 @@ mod tests {
     use std::time::Duration;
     use tokio::time::Instant;
 
+    fn sizing_env<const N: usize>(
+        values: [(&'static str, usize); N],
+    ) -> impl Fn(&str) -> Option<usize> {
+        move |name| {
+            values
+                .iter()
+                .find_map(|(key, value)| (*key == name).then_some(*value))
+        }
+    }
+
     #[test]
     fn worker_pool_size_precedence() {
-        temp_env::with_vars(
-            [
-                ("DYN_ENGINE_REQUEST_LIMIT", Some("7")),
-                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", Some("5")),
-                ("DYN_TCP_WORKER_POOL_SIZE", Some("99")),
-                ("DYN_TCP_WORK_QUEUE_SIZE", Some("123")),
-            ],
-            || {
-                let sizing = resolve_sizing(Some(20));
-                assert_eq!(sizing.pool_size, 7);
-                assert_eq!(sizing.queue_size, 4);
-            },
+        // Each case supplies an immutable environment view, so this test is
+        // independent from process-global state and other parallel tests.
+        let sizing = resolve_sizing(
+            Some(20),
+            sizing_env([
+                ("DYN_ENGINE_REQUEST_LIMIT", 7),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 5),
+                ("DYN_TCP_WORKER_POOL_SIZE", 99),
+                ("DYN_TCP_WORK_QUEUE_SIZE", 123),
+            ]),
         );
+        assert_eq!(sizing.pool_size, 7);
+        assert_eq!(sizing.queue_size, 4);
 
-        temp_env::with_vars(
-            [
-                ("DYN_ENGINE_REQUEST_LIMIT", None),
-                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", None),
-                ("DYN_TCP_WORKER_POOL_SIZE", Some("99")),
-                ("DYN_TCP_WORK_QUEUE_SIZE", Some("123")),
-            ],
-            || {
-                let sizing = resolve_sizing(Some(20));
-                assert_eq!(sizing.pool_size, 99);
-                assert_eq!(sizing.queue_size, 123);
-            },
+        let sizing = resolve_sizing(
+            Some(20),
+            sizing_env([
+                ("DYN_TCP_WORKER_POOL_SIZE", 99),
+                ("DYN_TCP_WORK_QUEUE_SIZE", 123),
+            ]),
         );
+        assert_eq!(sizing.pool_size, 99);
+        assert_eq!(sizing.queue_size, 123);
 
-        temp_env::with_vars_unset(
-            [
-                "DYN_ENGINE_REQUEST_LIMIT",
-                "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
-                "DYN_TCP_WORKER_POOL_SIZE",
-                "DYN_TCP_WORK_QUEUE_SIZE",
-            ],
-            || {
-                assert_eq!(resolve_sizing(Some(3)).pool_size, 5);
-                assert_eq!(resolve_sizing(Some(8)).pool_size, 12);
-                assert_eq!(resolve_sizing(None).pool_size, DEFAULT_WORKER_POOL_SIZE);
-                assert_eq!(resolve_sizing(None).queue_size, DEFAULT_WORK_QUEUE_SIZE);
-            },
-        );
+        let sizing = resolve_sizing(Some(20), sizing_env([("DYN_ENGINE_REQUEST_LIMIT", 7)]));
+        assert_eq!(sizing.pool_size, 7);
+        // The logical default is 16 queued requests: 15 in the
+        // channel plus one held by the dispatcher.
+        assert_eq!(sizing.queue_size, 15);
+        assert_eq!(sizing.queue_size + 1, 16);
+
+        assert_eq!(resolve_sizing(Some(3), |_| None).pool_size, 5);
+        assert_eq!(resolve_sizing(Some(8), |_| None).pool_size, 12);
+        let fallback = resolve_sizing(None, |_| None);
+        assert_eq!(fallback.pool_size, 10_000);
+        assert_eq!(fallback.queue_size, 16);
     }
 
     /// Mock handler that simulates slow request processing for testing
@@ -894,7 +901,14 @@ mod tests {
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         // Create SharedTcpServer
-        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone(), None);
+        let server = SharedTcpServer::new_with_sizing(
+            bind_addr,
+            cancellation_token.clone(),
+            SizingConfig {
+                pool_size: 10_000,
+                queue_size: 16,
+            },
+        );
 
         // Create a handler that takes 1s to process requests
         let handler = Arc::new(SlowMockHandler::new(Duration::from_secs(1)));
@@ -1241,20 +1255,15 @@ mod tests {
     async fn test_capacities_published_on_server_init() {
         crate::logging::init();
 
-        // SharedTcpServer::new publishes static capacities. Any test that instantiates
-        // a SharedTcpServer will have populated the gauges; we just assert they're > 0.
+        // SharedTcpServer::new publishes the resolved static capacities. Pin
+        // the numeric defaults rather than comparing against production constants.
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone(), None);
-
-        assert!(
-            WORK_HANDLER_POOL_CAPACITY.get() > 0,
-            "pool_capacity should be set to DEFAULT_WORKER_POOL_SIZE"
-        );
-        assert!(
-            WORK_HANDLER_QUEUE_CAPACITY.get() > 0,
-            "queue_capacity should be set to DEFAULT_WORK_QUEUE_SIZE"
-        );
+        let sizing = resolve_sizing(None, |_| None);
+        let _server =
+            SharedTcpServer::new_with_sizing(bind_addr, cancellation_token.clone(), sizing);
+        assert_eq!(WORK_HANDLER_POOL_CAPACITY.get(), 10_000);
+        assert_eq!(WORK_HANDLER_QUEUE_CAPACITY.get(), 16);
         cancellation_token.cancel();
     }
 }

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -33,16 +33,8 @@ use tracing::Instrument;
 const DEFAULT_WORKER_POOL_SIZE: usize = 10000;
 
 /// Default work queue size for TCP request handling
-/// this is 4X the worker pool size to handle burst traffic
-const DEFAULT_WORK_QUEUE_SIZE: usize = 40000;
-
-/// Get worker pool size from environment or use default
-fn get_worker_pool_size() -> usize {
-    std::env::var("DYN_TCP_WORKER_POOL_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_WORKER_POOL_SIZE)
-}
+/// this is a small overflow queue to handle burst traffic
+const DEFAULT_WORK_QUEUE_SIZE: usize = 16;
 
 /// Get work queue size from environment or use default
 fn get_work_queue_size() -> usize {
@@ -64,14 +56,15 @@ const DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT: usize = 16;
 ///
 /// * `DYN_ENGINE_REQUEST_LIMIT` set → pool = engine limit (N), queue = Q
 ///   (default 16). Hard cap N+Q.
-/// * unset → large defaults (10000 / 40000), so rejection only triggers under
-///   extreme saturation.
+/// * otherwise `DYN_TCP_WORKER_POOL_SIZE` set → explicit pool and TCP queue.
+/// * otherwise a reported `engine_max_num_seqs` sizes the pool at 1.5x.
+/// * otherwise the pool falls back to 10000. The TCP queue defaults to 16.
 struct SizingConfig {
     pool_size: usize,
     queue_size: usize,
 }
 
-fn resolve_sizing() -> SizingConfig {
+fn resolve_sizing(engine_max_num_seqs: Option<usize>) -> SizingConfig {
     match std::env::var("DYN_ENGINE_REQUEST_LIMIT")
         .ok()
         .and_then(|s| s.parse::<usize>().ok())
@@ -90,10 +83,25 @@ fn resolve_sizing() -> SizingConfig {
                 queue_size: queue_limit.saturating_sub(1).max(1),
             }
         }
-        None => SizingConfig {
-            pool_size: get_worker_pool_size(),
-            queue_size: get_work_queue_size(),
-        },
+        None => {
+            let pool_size = std::env::var("DYN_TCP_WORKER_POOL_SIZE")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .or_else(|| {
+                    engine_max_num_seqs
+                        .filter(|capacity| *capacity > 0)
+                        .map(|capacity| {
+                            capacity
+                                .saturating_add(capacity.div_ceil(2))
+                                .min(Semaphore::MAX_PERMITS)
+                        })
+                })
+                .unwrap_or(DEFAULT_WORKER_POOL_SIZE);
+            SizingConfig {
+                pool_size,
+                queue_size: get_work_queue_size(),
+            }
+        }
     }
 }
 
@@ -164,11 +172,15 @@ struct EndpointHandler {
 }
 
 impl SharedTcpServer {
-    pub fn new(bind_addr: SocketAddr, cancellation_token: CancellationToken) -> Arc<Self> {
+    pub fn new(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Arc<Self> {
         let SizingConfig {
             pool_size: worker_pool_size,
             queue_size: work_queue_size,
-        } = resolve_sizing();
+        } = resolve_sizing(engine_max_num_seqs);
 
         tracing::info!(
             "Initializing TCP server with dispatcher (concurrency={}, queue={})",
@@ -770,6 +782,52 @@ mod tests {
     use std::time::Duration;
     use tokio::time::Instant;
 
+    #[test]
+    fn worker_pool_size_precedence() {
+        temp_env::with_vars(
+            [
+                ("DYN_ENGINE_REQUEST_LIMIT", Some("7")),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", Some("5")),
+                ("DYN_TCP_WORKER_POOL_SIZE", Some("99")),
+                ("DYN_TCP_WORK_QUEUE_SIZE", Some("123")),
+            ],
+            || {
+                let sizing = resolve_sizing(Some(20));
+                assert_eq!(sizing.pool_size, 7);
+                assert_eq!(sizing.queue_size, 4);
+            },
+        );
+
+        temp_env::with_vars(
+            [
+                ("DYN_ENGINE_REQUEST_LIMIT", None),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", None),
+                ("DYN_TCP_WORKER_POOL_SIZE", Some("99")),
+                ("DYN_TCP_WORK_QUEUE_SIZE", Some("123")),
+            ],
+            || {
+                let sizing = resolve_sizing(Some(20));
+                assert_eq!(sizing.pool_size, 99);
+                assert_eq!(sizing.queue_size, 123);
+            },
+        );
+
+        temp_env::with_vars_unset(
+            [
+                "DYN_ENGINE_REQUEST_LIMIT",
+                "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+                "DYN_TCP_WORKER_POOL_SIZE",
+                "DYN_TCP_WORK_QUEUE_SIZE",
+            ],
+            || {
+                assert_eq!(resolve_sizing(Some(3)).pool_size, 5);
+                assert_eq!(resolve_sizing(Some(8)).pool_size, 12);
+                assert_eq!(resolve_sizing(None).pool_size, DEFAULT_WORKER_POOL_SIZE);
+                assert_eq!(resolve_sizing(None).queue_size, DEFAULT_WORK_QUEUE_SIZE);
+            },
+        );
+    }
+
     /// Mock handler that simulates slow request processing for testing
     struct SlowMockHandler {
         /// Tracks if a request is currently being processed
@@ -836,7 +894,7 @@ mod tests {
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         // Create SharedTcpServer
-        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone(), None);
 
         // Create a handler that takes 1s to process requests
         let handler = Arc::new(SlowMockHandler::new(Duration::from_secs(1)));
@@ -1187,7 +1245,7 @@ mod tests {
         // a SharedTcpServer will have populated the gauges; we just assert they're > 0.
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone(), None);
 
         assert!(
             WORK_HANDLER_POOL_CAPACITY.get() > 0,

--- a/lib/runtime/src/pipeline/network/manager.rs
+++ b/lib/runtime/src/pipeline/network/manager.rs
@@ -213,9 +213,19 @@ impl NetworkManager {
     /// - NATS mode is selected but NATS client is not available
     /// - Configuration is invalid (e.g., malformed bind address)
     pub async fn server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
+        self.server_with_engine_max_num_seqs(None).await
+    }
+
+    /// Get or create the request-plane server using the engine's normalized
+    /// maximum sequence count when this call performs the one-time creation.
+    /// Subsequent calls return the already-created fixed-size server.
+    pub async fn server_with_engine_max_num_seqs(
+        &self,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Result<Arc<dyn RequestPlaneServer>> {
         let server = self
             .server
-            .get_or_try_init(async { self.create_server().await })
+            .get_or_try_init(async { self.create_server(engine_max_num_seqs).await })
             .await?;
 
         Ok(server.clone())
@@ -253,14 +263,20 @@ impl NetworkManager {
     // PRIVATE: Server Creation
     // ============================================================================
 
-    async fn create_server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
+    async fn create_server(
+        &self,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Result<Arc<dyn RequestPlaneServer>> {
         match self.mode {
-            RequestPlaneMode::Tcp => self.create_tcp_server().await,
+            RequestPlaneMode::Tcp => self.create_tcp_server(engine_max_num_seqs).await,
             RequestPlaneMode::Nats => self.create_nats_server().await,
         }
     }
 
-    async fn create_tcp_server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
+    async fn create_tcp_server(
+        &self,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Result<Arc<dyn RequestPlaneServer>> {
         // Use the global TCP server to ensure all workers in the same process share
         // a single server. This is critical for correct endpoint routing.
         let server = GLOBAL_TCP_SERVER
@@ -277,7 +293,11 @@ impl NetworkManager {
                     "Creating TCP request plane server"
                 );
 
-                let server = SharedTcpServer::new(bind_addr, GLOBAL_TCP_SERVER_TOKEN.clone());
+                let server = SharedTcpServer::new(
+                    bind_addr,
+                    GLOBAL_TCP_SERVER_TOKEN.clone(),
+                    engine_max_num_seqs,
+                );
 
                 // Bind and start server, getting the actual bound address
                 let actual_addr = server.clone().bind_and_start().await?;

--- a/lib/sglang-sidecar/src/engine.rs
+++ b/lib/sglang-sidecar/src/engine.rs
@@ -567,6 +567,12 @@ fn build_engine_config(
     } else {
         (Some(0), Some(1))
     };
+    let engine_max_num_seqs =
+        max_num_seqs
+            .zip(data_parallel_size)
+            .map(|(per_rank_capacity, local_dp_size)| {
+                per_rank_capacity.saturating_mul(u64::from(local_dp_size))
+            });
 
     if mode.is_prefill() && (bootstrap_host.is_none() || bootstrap_port.is_none()) {
         return Err(client::protocol_error(
@@ -589,6 +595,7 @@ fn build_engine_config(
             kv_cache_block_size: page_size,
             total_kv_blocks,
             max_num_seqs,
+            engine_max_num_seqs,
             max_num_batched_tokens,
             data_parallel_size,
             data_parallel_start_rank,

--- a/lib/sglang-sidecar/src/engine.rs
+++ b/lib/sglang-sidecar/src/engine.rs
@@ -607,9 +607,10 @@ fn build_engine_config(
 
 #[cfg(test)]
 mod tests {
+    use dynamo_backend_common::DisaggregationMode;
     use serde_json::json;
 
-    use super::{Discovery, resolve_bootstrap_host_with_local};
+    use super::{Discovery, build_engine_config, resolve_bootstrap_host_with_local};
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
         Discovery {
@@ -668,5 +669,30 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("--bootstrap-host"));
+    }
+
+    #[test]
+    fn engine_config_normalizes_max_num_seqs_to_local_dp_scope() {
+        let config = build_engine_config(
+            &discovery(json!({
+                "max_running_requests": 48,
+                "dp_size": 4,
+                "enable_dp_attention": true,
+                "nnodes": 2,
+                "node_rank": 1
+            })),
+            DisaggregationMode::Aggregated,
+            None,
+            None,
+        )
+        .unwrap();
+        let llm = config
+            .llm
+            .expect("SGLang sidecar must register LLM capacity");
+
+        assert_eq!(llm.max_num_seqs, Some(12));
+        assert_eq!(llm.data_parallel_size, Some(2));
+        assert_eq!(llm.data_parallel_start_rank, Some(2));
+        assert_eq!(llm.engine_max_num_seqs, Some(24));
     }
 }

--- a/lib/vllm-rs-backend/src/backend.rs
+++ b/lib/vllm-rs-backend/src/backend.rs
@@ -81,6 +81,10 @@ fn default_engine_ready_timeout_secs() -> u64 {
     600
 }
 
+fn engine_max_num_seqs(max_num_seqs: Option<u64>, data_parallel_size: u32) -> Option<u64> {
+    max_num_seqs.map(|capacity| capacity.saturating_mul(u64::from(data_parallel_size.max(1))))
+}
+
 /// Dynamo backend implementation backed by a managed Python vLLM engine-core.
 ///
 /// The backend consumes tokenized [`PreprocessedRequest`] values produced by
@@ -316,6 +320,10 @@ impl LLMEngine for VllmBackend {
                 kv_cache_block_size: self.extra.block_size,
                 total_kv_blocks,
                 max_num_seqs: self.extra.max_num_seqs,
+                engine_max_num_seqs: engine_max_num_seqs(
+                    self.extra.max_num_seqs,
+                    data_parallel_size,
+                ),
                 max_num_batched_tokens: self.extra.max_num_batched_tokens,
                 data_parallel_size: Some(data_parallel_size),
                 // TODO: currently vLLM's Rust engine-core client only supports local data-parallel engines
@@ -599,7 +607,14 @@ impl ExtraEngineArgs {
 mod tests {
     use dynamo_backend_common::ModelInput;
 
-    use super::VllmBackend;
+    use super::{VllmBackend, engine_max_num_seqs};
+
+    #[test]
+    fn local_capacity_multiplies_explicit_per_rank_limit_by_dp_size() {
+        assert_eq!(engine_max_num_seqs(Some(128), 2), Some(256));
+        assert_eq!(engine_max_num_seqs(None, 2), None);
+        assert_eq!(engine_max_num_seqs(Some(u64::MAX), 2), Some(u64::MAX));
+    }
 
     #[test]
     fn from_args_auto_forwards_python_flags_without_separator() {

--- a/lib/vllm-rs-backend/src/backend.rs
+++ b/lib/vllm-rs-backend/src/backend.rs
@@ -182,6 +182,39 @@ impl VllmBackend {
         };
         Ok((engine, config))
     }
+
+    fn build_engine_config(
+        &self,
+        context_length: u32,
+        total_kv_blocks: Option<u64>,
+        data_parallel_size: u32,
+    ) -> EngineConfig {
+        EngineConfig {
+            model: self.model.clone(),
+            served_model_name: Some(
+                self.served_model_name
+                    .clone()
+                    .unwrap_or_else(|| self.model.clone()),
+            ),
+            runtime_data: Default::default(),
+            llm: Some(LlmRegistration {
+                context_length: Some(context_length),
+                kv_cache_block_size: self.extra.block_size,
+                total_kv_blocks,
+                max_num_seqs: self.extra.max_num_seqs,
+                engine_max_num_seqs: engine_max_num_seqs(
+                    self.extra.max_num_seqs,
+                    data_parallel_size,
+                ),
+                max_num_batched_tokens: self.extra.max_num_batched_tokens,
+                data_parallel_size: Some(data_parallel_size),
+                // TODO: currently vLLM's Rust engine-core client only supports local data-parallel engines
+                data_parallel_start_rank: Some(0),
+                bootstrap_host: None,
+                bootstrap_port: None,
+            }),
+        }
+    }
 }
 
 #[async_trait]
@@ -307,31 +340,7 @@ impl LLMEngine for VllmBackend {
             "vLLM backend started"
         );
 
-        Ok(EngineConfig {
-            model: self.model.clone(),
-            served_model_name: Some(
-                self.served_model_name
-                    .clone()
-                    .unwrap_or_else(|| self.model.clone()),
-            ),
-            runtime_data: Default::default(),
-            llm: Some(LlmRegistration {
-                context_length: Some(context_length),
-                kv_cache_block_size: self.extra.block_size,
-                total_kv_blocks,
-                max_num_seqs: self.extra.max_num_seqs,
-                engine_max_num_seqs: engine_max_num_seqs(
-                    self.extra.max_num_seqs,
-                    data_parallel_size,
-                ),
-                max_num_batched_tokens: self.extra.max_num_batched_tokens,
-                data_parallel_size: Some(data_parallel_size),
-                // TODO: currently vLLM's Rust engine-core client only supports local data-parallel engines
-                data_parallel_start_rank: Some(0),
-                bootstrap_host: None,
-                bootstrap_port: None,
-            }),
-        })
+        Ok(self.build_engine_config(context_length, total_kv_blocks, data_parallel_size))
     }
 
     async fn generate(
@@ -614,6 +623,27 @@ mod tests {
         assert_eq!(engine_max_num_seqs(Some(128), 2), Some(256));
         assert_eq!(engine_max_num_seqs(None, 2), None);
         assert_eq!(engine_max_num_seqs(Some(u64::MAX), 2), Some(u64::MAX));
+    }
+
+    #[test]
+    fn engine_config_reports_normalized_local_capacity() {
+        let (engine, _config) = VllmBackend::from_args(Some(vec![
+            "dynamo-vllm-rs-backend".to_string(),
+            "Qwen/Qwen3-0.6B".to_string(),
+            "--data-parallel-size".to_string(),
+            "2".to_string(),
+            "--max-num-seqs".to_string(),
+            "128".to_string(),
+        ]))
+        .unwrap();
+        let data_parallel_size = u32::try_from(engine.managed_engine.data_parallel_size).unwrap();
+
+        let config = engine.build_engine_config(4096, Some(1024), data_parallel_size);
+        let llm = config.llm.expect("vLLM backend must register LLM capacity");
+
+        assert_eq!(llm.max_num_seqs, Some(128));
+        assert_eq!(llm.data_parallel_size, Some(2));
+        assert_eq!(llm.engine_max_num_seqs, Some(256));
     }
 
     #[test]

--- a/tests/router/test_tcp_worker_pool_sizing_e2e.py
+++ b/tests/router/test_tcp_worker_pool_sizing_e2e.py
@@ -1,0 +1,113 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end TCP worker-pool startup sizing with a real mocker worker.
+
+Each parameter starts a fresh process so the process-global shared TCP server is
+initialized exactly once. The automatic case covers the complete path from
+mocker capacity normalization through model attachment and lazy TCP startup:
+serving too early would initialize the pool at the 10,000 fallback instead of
+the expected 1.5x engine capacity.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+import requests
+
+from tests.router.helper import generate_random_suffix
+from tests.router.mocker_process import _build_mocker_command
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import ServicePorts
+from tests.utils.prometheus import sum_metric_samples
+
+POOL_CAPACITY_METRIC = "dynamo_work_handler_pool_capacity"
+ENGINE_MAX_NUM_SEQS = 6
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+    pytest.mark.gpu_0,
+    pytest.mark.router,
+    pytest.mark.model("mocker"),
+]
+
+
+@pytest.mark.parametrize(
+    "engine_request_limit, tcp_worker_pool_size, expected_pool_size",
+    [
+        pytest.param(None, None, 9, id="automatic-1.5x"),
+        pytest.param(None, 13, 13, id="tcp-pool-override"),
+        pytest.param(17, None, 17, id="engine-limit-override"),
+        pytest.param(17, 13, 17, id="engine-limit-precedes-tcp-pool"),
+    ],
+)
+def test_tcp_worker_pool_startup_sizing(
+    request,
+    file_storage_backend,
+    dynamo_dynamic_ports: ServicePorts,
+    engine_request_limit: int | None,
+    tcp_worker_pool_size: int | None,
+    expected_pool_size: int,
+):
+    system_port = dynamo_dynamic_ports.system_ports[0]
+    namespace = f"test-worker-pool-{generate_random_suffix()}"
+    endpoint = f"dyn://{namespace}.mocker.generate"
+    command = _build_mocker_command(
+        endpoint=endpoint,
+        store_backend="file",
+        num_workers=1,
+        mocker_args={
+            "max_num_seqs": ENGINE_MAX_NUM_SEQS,
+            "dp_size": 1,
+        },
+    )
+
+    env = os.environ.copy()
+    for name in (
+        "DYN_ENGINE_REQUEST_LIMIT",
+        "DYN_TCP_WORKER_POOL_SIZE",
+        "DYN_TCP_RPC_PORT",
+        "NATS_SERVER",
+    ):
+        env.pop(name, None)
+    env.update(
+        {
+            "DYN_FILE_KV": str(file_storage_backend),
+            "DYN_REQUEST_PLANE": "tcp",
+            "DYN_EVENT_PLANE": "zmq",
+            "DYN_SYSTEM_PORT": str(system_port),
+        }
+    )
+    if engine_request_limit is not None:
+        env["DYN_ENGINE_REQUEST_LIMIT"] = str(engine_request_limit)
+    if tcp_worker_pool_size is not None:
+        env["DYN_TCP_WORKER_POOL_SIZE"] = str(tcp_worker_pool_size)
+
+    metrics_url = f"http://localhost:{system_port}/metrics"
+
+    def reports_expected_pool_capacity(response: requests.Response) -> bool:
+        return (
+            sum_metric_samples(response.text, POOL_CAPACITY_METRIC)
+            == expected_pool_size
+        )
+
+    process = ManagedProcess(
+        command=command,
+        env=env,
+        health_check_urls=[(metrics_url, reports_expected_pool_capacity)],
+        timeout=60,
+        display_output=True,
+        terminate_all_matching_process_names=False,
+        log_dir=f"{request.node.name}_worker_pool",
+        display_name="dynamo-mocker-worker-pool-sizing",
+    )
+    with process:
+        response = requests.get(metrics_url, timeout=5)
+        response.raise_for_status()
+        assert (
+            sum_metric_samples(response.text, POOL_CAPACITY_METRIC)
+            == expected_pool_size
+        )


### PR DESCRIPTION
## Overview:

Dynamically size the fixed TCP worker pool from the local engine’s effective sequence capacity.

When no explicit override is configured, the worker reports its normalized `engine_max_num_seqs` during registration and the TCP server starts with `ceil(1.5 × engine_max_num_seqs)` workers. This keeps TCP admission aligned with backend capacity while preserving the existing `10,000` fallback.

## Details:

TCP worker-pool sizing now follows this precedence:

1. `DYN_ENGINE_REQUEST_LIMIT`
2. `DYN_TCP_WORKER_POOL_SIZE`
3. `ceil(1.5 × engine_max_num_seqs)`
4. `10,000` fallback

The default `DYN_TCP_WORK_QUEUE_SIZE` is changed to `16`.

Additional changes:

- Add `engine_max_num_seqs` as process-local registration metadata, separate from the existing backend-dependent `max_num_seqs`.
- Normalize engine capacity in Python vLLM, Python SGLang, TensorRT-LLM, native vLLM, SGLang sidecar, and mocker integrations.
- Ensure capacity-bearing registration completes before the shared TCP server is initialized.
- Keep the TCP worker pool fixed after startup; this change does not introduce runtime resizing.
- Preserve existing Python and PyO3 positional-constructor compatibility.
- Add backend-focused tests proving each integration supplies the expected normalized capacity.
- Add a process-isolated mocker E2E covering automatic sizing and both environment-variable overrides.

Validation included:

- Automatic sizing and override-precedence mocker E2E
- Backend capacity unit tests
- Rust formatting and Clippy with warnings denied
- Applicable pre-commit hooks
- Real GPU-backed vLLM worker: `max_num_seqs=4` produced TCP pool capacity `6`
- Real GPU-backed TensorRT-LLM worker: `max_batch_size=4` produced TCP pool capacity `6`
- Both real workers initialized with TCP queue size `16` and successfully registered their endpoints

## Where should the reviewer start?

1. `lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs`
   - Pool-size precedence, automatic `1.5×` sizing, and queue defaults.

2. `lib/llm/src/local_model.rs`
   - Passes normalized engine capacity into the TCP server before endpoint serving begins.

3. `lib/llm/src/local_model/runtime_config.rs`
   - Defines and consumes `engine_max_num_seqs`.

4. Backend capacity adapters:
   - `components/src/dynamo/vllm/capacity.py`
   - `components/src/dynamo/sglang/capacity.py`
   - `components/src/dynamo/trtllm/utils/trtllm_utils.py`
   - `lib/vllm-rs-backend/src/backend.rs`
   - `lib/sglang-sidecar/src/engine.rs`

5. `tests/router/test_tcp_worker_pool_sizing_e2e.py`
   - Process-level automatic-sizing and override-precedence coverage.

## Related Issues

N/A