### PR TITLE
docs: snapshot zh-CN translations at version cut

### DIFF
--- a/.agents/skills/dynamo-docs/SKILL.md
+++ b/.agents/skills/dynamo-docs/SKILL.md
@@ -332,6 +332,9 @@ Design Docs, Documentation, Hidden Pages. To place a page, match the nearest exi
 - **Versioned navs.** Author only against `docs/` on `main` (the `pages-dev` set). When a release is
   cut, the publish step builds `pages-vX.Y.Z/` from the tagged `docs/` tree and rewrites nav paths —
   **never** edit a `pages-vX.Y.Z/` directory by hand. Write portable paths so the rewrite stays clean.
+  Translation mirrors snapshot the same way (`fern/translations/<lang>/pages-vX.Y.Z/` from the tag's
+  `pages-dev` mirror, links resolved under the tag's version slug); tags cut from branches without
+  `fern/translations` skip the snapshot.
 ### Redirects and the version model
 
 The site serves the same nav under three prefixes: **`dev`** (slug `dev`, tracks `main`, regenerated on

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -508,14 +508,16 @@ jobs:
 
           # Rewrites relative page links in the translation snapshot to site
           # URLs under this tag's version slug, from the tag's nav (see
-          # fern/resolve_translation_links.py). GITHUB_SHA is the tag commit,
-          # so GitHub-fallback links pin to the release.
+          # fern/resolve_translation_links.py). --github-ref pins the
+          # GitHub-fallback links to the tag itself, which stays faithful on
+          # workflow_dispatch rebuilds where GITHUB_SHA is not the tag commit.
           if compgen -G "docs-checkout/fern/translations/*/pages-$TAG" > /dev/null; then
             pip install --quiet pyyaml
             python3 source-checkout/fern/resolve_translation_links.py \
               --nav source-checkout/docs/index.yml \
               --translations-root docs-checkout/fern/translations \
-              --site-root /dynamo --version-slug "$TAG" --pages-dir "pages-$TAG"
+              --site-root /dynamo --version-slug "$TAG" \
+              --pages-dir "pages-$TAG" --github-ref "$TAG"
           fi
 
       - name: Create version config file

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -128,13 +128,30 @@ jobs:
             --exclude='index.yml' \
             source-checkout/docs/ docs-checkout/fern/pages-dev/
 
-          # Sync Fern's native-localization mirror as-is:
+          # Sync Fern's native-localization mirror:
           # fern/translations/<lang>/pages-dev/<path> pairs with the base page
-          # at fern/pages-dev/<path>, per locale
-          rm -rf docs-checkout/fern/translations
+          # at fern/pages-dev/<path>, per locale. Replace only the pages-dev
+          # mirrors -- versioned snapshots (pages-v*) are committed to this
+          # branch by the release job and must survive dev syncs (see #11195).
+          for d in docs-checkout/fern/translations/*/pages-dev; do
+            if [ -d "$d" ]; then
+              lang=$(basename "$(dirname "$d")")
+              if [ ! -d "source-checkout/fern/translations/$lang/pages-dev" ]; then
+                echo "Removing dev mirror for retired locale $lang..."
+                rm -rf "$d"
+              fi
+            fi
+          done
           if [ -d source-checkout/fern/translations ]; then
             echo "Syncing translations/ to docs-website branch..."
-            cp -r source-checkout/fern/translations docs-checkout/fern/translations
+            for lang_dir in source-checkout/fern/translations/*/; do
+              lang=$(basename "$lang_dir")
+              if [ -d "$lang_dir/pages-dev" ]; then
+                rm -rf "docs-checkout/fern/translations/$lang/pages-dev"
+                mkdir -p "docs-checkout/fern/translations/$lang"
+                cp -r "$lang_dir/pages-dev" "docs-checkout/fern/translations/$lang/pages-dev"
+              fi
+            done
           fi
 
           # Sync index.yml as versions/dev.yml and transform paths for docs-website layout
@@ -512,12 +529,20 @@ jobs:
           # GitHub-fallback links to the tag itself, which stays faithful on
           # workflow_dispatch rebuilds where GITHUB_SHA is not the tag commit.
           if compgen -G "docs-checkout/fern/translations/*/pages-$TAG" > /dev/null; then
-            pip install --quiet pyyaml
-            python3 source-checkout/fern/resolve_translation_links.py \
-              --nav source-checkout/docs/index.yml \
-              --translations-root docs-checkout/fern/translations \
-              --site-root /dynamo --version-slug "$TAG" \
-              --pages-dir "pages-$TAG" --github-ref "$TAG"
+            # The tag's own resolver runs; tags cut between the introduction
+            # of fern/translations and of --pages-dir carry an older script,
+            # so capability-gate to keep workflow_dispatch rebuilds of such
+            # tags working (skipping matches what their tag-push produced).
+            if grep -q -- '--pages-dir' source-checkout/fern/resolve_translation_links.py; then
+              pip install --quiet pyyaml
+              python3 source-checkout/fern/resolve_translation_links.py \
+                --nav source-checkout/docs/index.yml \
+                --translations-root docs-checkout/fern/translations \
+                --site-root /dynamo --version-slug "$TAG" \
+                --pages-dir "pages-$TAG" --github-ref "$TAG"
+            else
+              echo "::warning::$TAG's resolver predates --pages-dir; skipping translated-snapshot link resolution"
+            fi
           fi
 
       - name: Create version config file
@@ -634,6 +659,11 @@ jobs:
           git add "fern/pages-$TAG/"
           git add "fern/versions/$TAG.yml"
           git add fern/docs.yml
+          # Versioned translation snapshots (see #11195); the glob is empty
+          # for tags cut from branches without fern/translations.
+          for d in fern/translations/*/"pages-$TAG"; do
+            [ -d "$d" ] && git add "$d"
+          done
 
           if git diff --cached --quiet; then
             echo "No release artifact changes for $TAG; skipping commit and push."
@@ -645,6 +675,7 @@ jobs:
           - Created fern/pages-$TAG/ with documentation snapshot
           - Created fern/versions/$TAG.yml version navigation config
           - Updated fern/docs.yml to include $TAG in version list
+          - Snapshotted translation mirrors (fern/translations/*/pages-$TAG), when present
 
           Automated by fern-docs workflow
           Source tag: $TAG"

--- a/.github/workflows/fern-docs.yml
+++ b/.github/workflows/fern-docs.yml
@@ -445,14 +445,36 @@ jobs:
           echo "Created docs-checkout/fern/pages-$TAG/"
           ls -la "docs-checkout/fern/pages-$TAG/" | head -20
 
+          # Snapshot the translation mirrors alongside the base pages so the
+          # tagged version pairs its locales (see #11195). Same mirror-path
+          # convention as dev: fern/translations/<lang>/pages-$TAG/<path>
+          # pairs with fern/pages-$TAG/<path>.
+          if [ -d source-checkout/fern/translations ]; then
+            for lang_dir in source-checkout/fern/translations/*/; do
+              lang=$(basename "$lang_dir")
+              if [ -d "$lang_dir/pages-dev" ]; then
+                echo "Snapshotting translations for $lang -> pages-$TAG..."
+                rm -rf "docs-checkout/fern/translations/$lang/pages-$TAG"
+                mkdir -p "docs-checkout/fern/translations/$lang/pages-$TAG"
+                rsync -a "$lang_dir/pages-dev/" "docs-checkout/fern/translations/$lang/pages-$TAG/"
+              fi
+            done
+          fi
+
       - name: Update GitHub links to version tag
         run: |
           TAG="${{ steps.version.outputs.tag }}"
 
           echo "Pinning GitHub links from main to $TAG in docs-checkout/fern/pages-$TAG/..."
 
+          # Base pages plus any translation snapshots for this tag.
+          SNAP_DIRS="docs-checkout/fern/pages-$TAG"
+          for d in docs-checkout/fern/translations/*/"pages-$TAG"; do
+            [ -d "$d" ] && SNAP_DIRS="$SNAP_DIRS $d"
+          done
+
           # Pin tree/main and blob/main links before callout conversion.
-          find "docs-checkout/fern/pages-$TAG" -type f \( -name "*.md" -o -name "*.mdx" \) | while read -r file; do
+          find $SNAP_DIRS -type f \( -name "*.md" -o -name "*.mdx" \) | while read -r file; do
             if grep -q "github.com/ai-dynamo/dynamo/tree/main" "$file"; then
               echo "Updating tree links: $file"
               sed -i "s|github.com/ai-dynamo/dynamo/tree/main|github.com/ai-dynamo/dynamo/tree/$TAG|g" "$file"
@@ -460,7 +482,7 @@ jobs:
           done
 
           # Also update blob/main references (for direct file links)
-          find "docs-checkout/fern/pages-$TAG" -type f \( -name "*.md" -o -name "*.mdx" \) | while read -r file; do
+          find $SNAP_DIRS -type f \( -name "*.md" -o -name "*.mdx" \) | while read -r file; do
             if grep -q "github.com/ai-dynamo/dynamo/blob/main" "$file"; then
               echo "Updating blob links: $file"
               sed -i "s|github.com/ai-dynamo/dynamo/blob/main|github.com/ai-dynamo/dynamo/blob/$TAG|g" "$file"
@@ -475,7 +497,26 @@ jobs:
 
           echo "Converting callouts in pages-$TAG/ with the tag's convert_callouts.py..."
           python3 source-checkout/fern/convert_callouts.py --dir "docs-checkout/fern/pages-$TAG"
+          for d in docs-checkout/fern/translations/*/"pages-$TAG"; do
+            [ -d "$d" ] && python3 source-checkout/fern/convert_callouts.py --dir "$d"
+          done
           echo "Callout conversion complete."
+
+      - name: Resolve relative links in translated snapshot
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+
+          # Rewrites relative page links in the translation snapshot to site
+          # URLs under this tag's version slug, from the tag's nav (see
+          # fern/resolve_translation_links.py). GITHUB_SHA is the tag commit,
+          # so GitHub-fallback links pin to the release.
+          if compgen -G "docs-checkout/fern/translations/*/pages-$TAG" > /dev/null; then
+            pip install --quiet pyyaml
+            python3 source-checkout/fern/resolve_translation_links.py \
+              --nav source-checkout/docs/index.yml \
+              --translations-root docs-checkout/fern/translations \
+              --site-root /dynamo --version-slug "$TAG" --pages-dir "pages-$TAG"
+          fi
 
       - name: Create version config file
         run: |

--- a/fern/resolve_translation_links.py
+++ b/fern/resolve_translation_links.py
@@ -147,6 +147,12 @@ def main() -> int:
         required=True,
         help="version slug the translated pages belong to, e.g. dev",
     )
+    ap.add_argument(
+        "--pages-dir",
+        default="pages-dev",
+        help="translation subtree to process, mirroring the base pages dir "
+        "(pages-dev, or pages-vX.Y.Z for a release snapshot)",
+    )
     args = ap.parse_args()
 
     slugs = build_slug_map(args.nav)
@@ -154,7 +160,7 @@ def main() -> int:
 
     for lang_dir in sorted(p for p in args.translations_root.iterdir() if p.is_dir()):
         lang = lang_dir.name
-        pages_root = lang_dir / "pages-dev"
+        pages_root = lang_dir / args.pages_dir
         if not pages_root.is_dir():
             continue
         for page in sorted(pages_root.rglob("*")):
@@ -162,9 +168,10 @@ def main() -> int:
                 continue
             rel = page.relative_to(pages_root)  # mirrors docs/<rel>
             # links were authored from fern/translations/<lang>/pages-dev/<rel>
-            # in the source repo (same layout the sync publishes)
+            # in the source repo; version snapshots keep the same depth, so
+            # the deep-relative arithmetic is unchanged
             virtual_dir = (
-                PurePosixPath("fern/translations") / lang / "pages-dev" / rel.parent
+                PurePosixPath("fern/translations") / lang / args.pages_dir / rel.parent
             )
 
             def repl(m: re.Match) -> str:
@@ -180,7 +187,9 @@ def main() -> int:
                 if not target.endswith(PAGE_EXT):
                     return m.group(0)
                 q = PurePosixPath(os.path.normpath(str(virtual_dir / target)))
-                mirror_prefix = PurePosixPath("fern/translations") / lang / "pages-dev"
+                mirror_prefix = (
+                    PurePosixPath("fern/translations") / lang / args.pages_dir
+                )
                 if q.is_relative_to(mirror_prefix):
                     doc_rel = str(q.relative_to(mirror_prefix))
                 elif q.is_relative_to("docs"):

--- a/fern/resolve_translation_links.py
+++ b/fern/resolve_translation_links.py
@@ -61,12 +61,7 @@ import yaml
 
 LINK = re.compile(r"(!?)(\[[^\]]*\])\(([^)#\s]+)(#[^)]*)?\)")
 PAGE_EXT = (".md", ".mdx")
-# Fallback for links whose target isn't published in the nav (no site URL).
-# Pin to the build's commit: correct on PR-preview builds (the target may not
-# exist on main yet) and immune to later renames/moves on main.
-GITHUB_BLOB = "https://github.com/ai-dynamo/dynamo/blob/" + os.environ.get(
-    "GITHUB_SHA", "main"
-)
+GITHUB_REPO_BLOB = "https://github.com/ai-dynamo/dynamo/blob"
 
 
 def slugify(name: str) -> str:
@@ -153,7 +148,17 @@ def main() -> int:
         help="translation subtree to process, mirroring the base pages dir "
         "(pages-dev, or pages-vX.Y.Z for a release snapshot)",
     )
+    ap.add_argument(
+        "--github-ref",
+        default=os.environ.get("GITHUB_SHA", "main"),
+        help="ref for GitHub-fallback links (targets not published in the "
+        "nav). Defaults to the build's commit, which is correct for dev "
+        "syncs and PR previews; release snapshots pass the tag so fallback "
+        "links stay faithful to the release on workflow_dispatch rebuilds "
+        "too.",
+    )
     args = ap.parse_args()
+    github_blob = f"{GITHUB_REPO_BLOB}/{args.github_ref}"
 
     slugs = build_slug_map(args.nav)
     rewritten = warned = 0
@@ -221,7 +226,7 @@ def main() -> int:
                         f"linking to GitHub source"
                     )
                     warned += 1
-                    return f"{bang}{label}({GITHUB_BLOB}/docs/{doc_rel}{anchor})"
+                    return f"{bang}{label}({github_blob}/docs/{doc_rel}{anchor})"
                 # Locale sits between product and version in Fern URLs
                 # (/dynamo/zh-CN/dev/...); links starting with the product
                 # slug pass through Fern's renderer unmodified.

--- a/fern/resolve_translation_links.py
+++ b/fern/resolve_translation_links.py
@@ -44,8 +44,13 @@ rewritten to their GitHub source URL (with a warning) -- a relative path
 would naive-join into a dead link on the rendered page.
 
 Usage:
+    # dev sync (default --pages-dir pages-dev)
     resolve_translation_links.py --nav docs/index.yml \
         --translations-root fern/translations --site-root /dynamo --version-slug dev
+    # release snapshot
+    resolve_translation_links.py --nav docs/index.yml \
+        --translations-root fern/translations --site-root /dynamo \
+        --version-slug vX.Y.Z --pages-dir pages-vX.Y.Z --github-ref vX.Y.Z
 
 Delete this script (and re-shallow the deep-relative links) once Fern
 resolves relative links in translated content natively.


### PR DESCRIPTION
## Summary

Fixes ai-dynamo/dynamo#11195 — follow-up to ai-dynamo/dynamo#11161, closing the versioning gap flagged in its review.

Translations were structurally dev-only: the release-version job built `pages-<tag>` solely from the tagged `docs/` tree, while the `translations:` language picker is instance-wide. The first tag cut after native localization would ship a Latest whose 简体中文 toggle silently re-renders English, and the dev translations would keep drifting instead of freezing with the release.

* The release job snapshots `fern/translations/<lang>/pages-dev/` → `fern/translations/<lang>/pages-<tag>/` — the mirror-path convention Fern pairs per version — with force-rebuild parity via the same rm-and-copy shape as the base pages.
* The snapshot is included in the existing GitHub-link pinning and callout-conversion steps.
* `resolve_translation_links.py` gains `--pages-dir` (default `pages-dev`; the dev sync is untouched) and runs over the snapshot with the tag's version slug. GitHub-fallback links pin to the tag explicitly via `--github-ref` (correct on workflow_dispatch rebuilds too, where `GITHUB_SHA` is not the tag commit).

Per-version scoping of the picker itself (so untranslated versions don't offer a no-op toggle) remains a Fern-side ask and stays open on our side.

* **Persistence** (found by independent review): the release commit now stages the snapshot, and the dev sync replaces only each locale's `pages-dev` mirror instead of the whole `fern/translations` tree — without both, the snapshot published once from the working tree and vanished on the next dev sync. The release resolver invocation is also capability-gated so `workflow_dispatch` rebuilds of tags whose resolver predates `--pages-dir` warn and skip instead of failing.

## Test plan

Local replica of the publish pipeline (same harness used for ai-dynamo/dynamo#11161):

* Dev-flow regression: identical output (87 links to site URLs + 2 GitHub fallbacks), `fern check` 0 errors
* Git-backed persistence test: snapshot present in the release commit, survives a subsequent dev sync (which still refreshes the dev mirror, committing no deletions), locale retirement drops the dev mirror but keeps snapshots
* Release-branch cut simulation: all new blocks pass under `bash -e` with a source tree lacking `fern/translations`; resolver correctly skipped
* Simulated `v9.9.9` tag cut: snapshot links resolve to `/dynamo/v9.9.9/<slug>`, translated siblings to `/dynamo/zh-CN/v9.9.9/<slug>`, zero tag-slug leakage into the dev tree, and `fern check` passes on the assembled layout including `versions/v9.9.9.yml` and the docs.yml version entry

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)

## Summary by CodeRabbit

* **New Features**
  * Versioned documentation releases now include translated pages alongside the main documentation.
  * Relative links are now resolved correctly within translated release snapshots.
  * GitHub links in translated docs are updated to point to the release tag.
* **Bug Fixes**
  * Improved handling of translated documentation during release processing, including callouts and link rewriting across all supported languages.