### PR TITLE
fix(planner): handle zero-traffic metrics

### DIFF
--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -642,6 +642,13 @@ class NativePlannerBase:
         )
         m.accept_length = self._collect_accept_length(interval_str)
 
+        normalized_idle_metrics = m.normalize_idle_nans()
+        if normalized_idle_metrics:
+            logger.info(
+                "Zero traffic observed; treating undefined averages as 0: %s",
+                ", ".join(normalized_idle_metrics),
+            )
+
         hit_rate_str = f"{m.kv_hit_rate:.3f}" if m.kv_hit_rate is not None else "n/a"
         accept_length_str = (
             f"{m.accept_length:.3f}" if m.accept_length is not None else "n/a"

--- a/components/src/dynamo/planner/monitoring/traffic_metrics.py
+++ b/components/src/dynamo/planner/monitoring/traffic_metrics.py
@@ -61,6 +61,19 @@ class Metrics:
     kv_hit_rate: Optional[float] = None
     accept_length: Optional[float] = None
 
+    def normalize_idle_nans(self) -> list[str]:
+        """Replace undefined averages only for a confirmed idle window."""
+        if self.num_req != 0:
+            return []
+
+        normalized: list[str] = []
+        for field_name in ("ttft", "itl", "isl", "osl", "request_duration"):
+            value = getattr(self, field_name)
+            if value is not None and math.isnan(value):
+                setattr(self, field_name, 0.0)
+                normalized.append(field_name)
+        return normalized
+
     def is_valid(self) -> bool:
         """Check if all required metrics are valid (not None and not NaN)."""
         required = [

--- a/components/src/dynamo/planner/plugins/builtins/local_planner.py
+++ b/components/src/dynamo/planner/plugins/builtins/local_planner.py
@@ -113,6 +113,9 @@ class BuiltinLoadPredict:
         self._num_req_predictor = predictor_cls(config)
         self._isl_predictor = predictor_cls(config)
         self._osl_predictor = predictor_cls(config)
+        self._last_observed_isl: float | None = None
+        self._last_observed_osl: float | None = None
+        self._seen_live_traffic = False
         self._last_kv_hit_rate: float | None = None
         self._last_accept_length: float = 1.0
 
@@ -124,9 +127,7 @@ class BuiltinLoadPredict:
         if self._config.optimization_target != "sla":
             return
         for obs in observations:
-            self._num_req_predictor.add_data_point(obs.num_req)
-            self._isl_predictor.add_data_point(obs.isl)
-            self._osl_predictor.add_data_point(obs.osl)
+            self._observe_load(obs)
         log.info("Warmed builtin load predictors with %d intervals", len(observations))
         for predictor in (
             self._num_req_predictor,
@@ -135,11 +136,34 @@ class BuiltinLoadPredict:
         ):
             if hasattr(predictor, "reset_idle_skip"):
                 predictor.reset_idle_skip()
+        self._seen_live_traffic = False
+
+    def _observe_load(self, traffic: TrafficObservation) -> None:
+        self._num_req_predictor.add_data_point(traffic.num_req)
+
+        if traffic.num_req > 0:
+            self._seen_live_traffic = True
+            if math.isfinite(traffic.isl):
+                self._last_observed_isl = traffic.isl
+            if math.isfinite(traffic.osl):
+                self._last_observed_osl = traffic.osl
+
+        isl = traffic.isl
+        osl = traffic.osl
+        if traffic.num_req == 0 and self._seen_live_traffic:
+            # Average request lengths are undefined in an idle window. Carry the
+            # last observed request shape forward so time-based predictors still
+            # advance once per interval without learning artificial zero lengths.
+            isl = self._last_observed_isl if self._last_observed_isl is not None else 0
+            osl = self._last_observed_osl if self._last_observed_osl is not None else 0
+
+        if math.isfinite(isl):
+            self._isl_predictor.add_data_point(isl)
+        if math.isfinite(osl):
+            self._osl_predictor.add_data_point(osl)
 
     def _observe_traffic(self, traffic: TrafficObservation) -> None:
-        self._num_req_predictor.add_data_point(traffic.num_req)
-        self._isl_predictor.add_data_point(traffic.isl)
-        self._osl_predictor.add_data_point(traffic.osl)
+        self._observe_load(traffic)
         if traffic.kv_hit_rate is not None and not math.isnan(traffic.kv_hit_rate):
             self._last_kv_hit_rate = traffic.kv_hit_rate
         if traffic.accept_length is not None and math.isfinite(traffic.accept_length):

--- a/components/src/dynamo/planner/tests/unit/test_load_predictors.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_predictors.py
@@ -196,9 +196,9 @@ class TestProphetPredictorTimestamp:
         )
         buggy_next_ts = predictor.start_date + timedelta(seconds=predictor.curr_step)
 
-        assert expected_next_ts != buggy_next_ts, (
-            "Sanity check: the two timestamps must differ"
-        )
+        assert (
+            expected_next_ts != buggy_next_ts
+        ), "Sanity check: the two timestamps must differ"
 
         captured_future_df: list[pd.DataFrame] = []
 
@@ -436,9 +436,9 @@ class TestProphetPredictorMultipleStepSizes:
             predictor.predict_next()
 
         actual_ts = captured[0]["ds"].iloc[0]
-        assert actual_ts == expected_next_ts, (
-            f"step_size={step_size}: expected {expected_next_ts}, got {actual_ts}"
-        )
+        assert (
+            actual_ts == expected_next_ts
+        ), f"step_size={step_size}: expected {expected_next_ts}, got {actual_ts}"
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/planner/tests/unit/test_load_predictors.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_predictors.py
@@ -27,6 +27,8 @@ from dynamo.planner.core.load.predictors import (
     KalmanPredictor,
     ProphetPredictor,
 )
+from dynamo.planner.core.types import TrafficObservation, WorkerCapabilities
+from dynamo.planner.plugins.builtins.local_planner import BuiltinLoadPredict
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -59,6 +61,9 @@ def _make_config(
     cfg.kalman_q_trend = kalman_q_trend
     cfg.kalman_r = kalman_r
     cfg.kalman_min_points = kalman_min_points
+    cfg.load_predictor = "constant"
+    cfg.optimization_target = "sla"
+    cfg.speculative_nextn = 0
     return cfg
 
 
@@ -104,6 +109,36 @@ class TestConstantPredictor:
         predictor.add_data_point(10.0)
         predictor.add_data_point(float("nan"))
         assert predictor.predict_next() == 0
+
+
+class TestBuiltinLoadPredictIdleTraffic:
+    def test_carries_request_shape_forward_across_idle_windows(self):
+        plugin = BuiltinLoadPredict(_make_config(), WorkerCapabilities())
+
+        plugin._observe_traffic(
+            TrafficObservation(duration_s=60, num_req=10, isl=512, osl=128)
+        )
+        plugin._observe_traffic(
+            TrafficObservation(duration_s=60, num_req=0, isl=0, osl=0)
+        )
+        plugin._observe_traffic(
+            TrafficObservation(duration_s=60, num_req=0, isl=0, osl=0)
+        )
+
+        assert plugin._num_req_predictor.data_buffer == [10, 0, 0]
+        assert plugin._isl_predictor.data_buffer == [512, 512, 512]
+        assert plugin._osl_predictor.data_buffer == [128, 128, 128]
+
+    def test_leading_idle_windows_do_not_seed_request_shape(self):
+        plugin = BuiltinLoadPredict(_make_config(), WorkerCapabilities())
+
+        plugin._observe_traffic(
+            TrafficObservation(duration_s=60, num_req=0, isl=0, osl=0)
+        )
+
+        assert plugin._num_req_predictor.data_buffer == []
+        assert plugin._isl_predictor.data_buffer == []
+        assert plugin._osl_predictor.data_buffer == []
 
 
 # ---------------------------------------------------------------------------
@@ -161,9 +196,9 @@ class TestProphetPredictorTimestamp:
         )
         buggy_next_ts = predictor.start_date + timedelta(seconds=predictor.curr_step)
 
-        assert (
-            expected_next_ts != buggy_next_ts
-        ), "Sanity check: the two timestamps must differ"
+        assert expected_next_ts != buggy_next_ts, (
+            "Sanity check: the two timestamps must differ"
+        )
 
         captured_future_df: list[pd.DataFrame] = []
 
@@ -401,9 +436,9 @@ class TestProphetPredictorMultipleStepSizes:
             predictor.predict_next()
 
         actual_ts = captured[0]["ds"].iloc[0]
-        assert (
-            actual_ts == expected_next_ts
-        ), f"step_size={step_size}: expected {expected_next_ts}, got {actual_ts}"
+        assert actual_ts == expected_next_ts, (
+            f"step_size={step_size}: expected {expected_next_ts}, got {actual_ts}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/planner/tests/unit/test_prometheus.py
+++ b/components/src/dynamo/planner/tests/unit/test_prometheus.py
@@ -23,6 +23,7 @@ from dynamo import prometheus_names
 from dynamo.planner.monitoring.traffic_metrics import (
     FrontendMetric,
     FrontendMetricContainer,
+    Metrics,
     PrometheusAPIClient,
 )
 
@@ -109,6 +110,60 @@ def test_frontend_metric_container_with_nan_value():
     test_data["value"][1] = 42.5  # type: ignore[index]
     container = FrontendMetricContainer.model_validate(test_data)
     assert container.value[1] == 42.5
+
+
+def test_metrics_normalize_nan_averages_for_idle_window():
+    metrics = Metrics(
+        ttft=math.nan,
+        itl=math.nan,
+        num_req=0,
+        isl=math.nan,
+        osl=math.nan,
+        request_duration=math.nan,
+    )
+
+    normalized = metrics.normalize_idle_nans()
+
+    assert normalized == ["ttft", "itl", "isl", "osl", "request_duration"]
+    assert metrics.is_valid()
+    assert metrics.ttft == 0
+    assert metrics.itl == 0
+    assert metrics.isl == 0
+    assert metrics.osl == 0
+    assert metrics.request_duration == 0
+
+
+def test_metrics_keep_nan_averages_invalid_with_traffic():
+    metrics = Metrics(
+        ttft=math.nan,
+        itl=math.nan,
+        num_req=1,
+        isl=math.nan,
+        osl=math.nan,
+        request_duration=math.nan,
+    )
+
+    assert metrics.normalize_idle_nans() == []
+    assert not metrics.is_valid()
+
+
+def test_metrics_keep_missing_idle_averages_invalid():
+    metrics = Metrics(
+        ttft=None,
+        itl=math.nan,
+        num_req=0,
+        isl=math.nan,
+        osl=math.nan,
+        request_duration=math.nan,
+    )
+
+    assert metrics.normalize_idle_nans() == [
+        "itl",
+        "isl",
+        "osl",
+        "request_duration",
+    ]
+    assert not metrics.is_valid()
 
 
 def test_frontend_metric_with_partial_data():


### PR DESCRIPTION
## Summary

- Treat histogram-average NaN values as undefined only when the same observation has a trustworthy `num_req == 0`; positive-traffic NaNs and missing metrics remain invalid.
- Carry the last observed ISL/OSL through idle windows so ARIMA, Prophet, and Kalman predictors keep their fixed interval cadence without learning artificial zero-length requests.
- Preserve the existing leading-idle behavior before live traffic begins and add regression coverage for idle normalization and predictor history.

Root cause: frontend histogram averages evaluate `increase(sum) / increase(count)` as `0 / 0` during an idle window. The resulting NaN invalidated the whole traffic observation, including the valid zero request count, so throughput prediction returned `no_traffic_data` and never proposed scale-down.

Tracks [DYN-3388](https://linear.app/nvidia/issue/DYN-3388/dynamo130planner-throughput-only-sla-mode-never-scales-down-when).

## Validation

- `.venv/bin/python -m ruff format --check components/src/dynamo/planner/monitoring/traffic_metrics.py components/src/dynamo/planner/core/base.py components/src/dynamo/planner/plugins/builtins/local_planner.py components/src/dynamo/planner/tests/unit/test_prometheus.py components/src/dynamo/planner/tests/unit/test_load_predictors.py`
- `.venv/bin/python -m ruff check components/src/dynamo/planner/monitoring/traffic_metrics.py components/src/dynamo/planner/core/base.py components/src/dynamo/planner/plugins/builtins/local_planner.py components/src/dynamo/planner/tests/unit/test_prometheus.py components/src/dynamo/planner/tests/unit/test_load_predictors.py`
- `.venv/bin/python -m pytest components/src/dynamo/planner/tests/unit/test_prometheus.py components/src/dynamo/planner/tests/unit/test_load_predictors.py -q` (`62 passed`)
- `.venv/bin/python -m pytest components/src/dynamo/planner/tests/unit -q` (`415 passed`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of idle traffic windows so undefined latency and size averages are treated as zero when no requests are present.
  * Reduced skipped traffic observations by normalizing idle metrics before validation, making traffic summaries more consistent.
  * Refined load prediction behavior during idle periods to preserve recent traffic patterns and avoid learning misleading zero-length request shapes.
  * Updated test coverage to verify idle-traffic handling and metric validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->