### PR TITLE
fix(router): deprecate enforce-disagg (cherry-pick #11160)

### DIFF
--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -5,10 +5,11 @@
 
 Defines the router configuration parameters once so that both
 ``dynamo.frontend`` and other components can reuse them without duplication.
-Field names on ``RouterConfigBase`` match the ``RouterConfig`` Python
+Active field names on ``RouterConfigBase`` match the ``RouterConfig`` Python
 constructor kwargs 1:1 (for the non-positional args), so ``router_kwargs()``
 returns a dict that can be unpacked into
-``RouterConfig(mode, kv_config, **config.router_kwargs())``.
+``RouterConfig(mode, kv_config, **config.router_kwargs())``. Deprecated fields
+remain parseable but are not forwarded.
 """
 
 import logging
@@ -30,8 +31,12 @@ _ROUTER_FIELDS: tuple[str, ...] = (
     "active_decode_blocks_threshold",
     "active_prefill_tokens_threshold",
     "active_prefill_tokens_threshold_frac",
-    "enforce_disagg",
     "session_affinity_ttl_secs",
+)
+
+_ENFORCE_DISAGG_DEPRECATION = (
+    "--enforce-disagg and DYN_ENFORCE_DISAGG are deprecated and ignored; "
+    "routing topology and readiness are determined from registered worker types"
 )
 
 # Valid values for --admission-control.
@@ -87,6 +92,8 @@ class RouterConfigBase(ConfigBase):
     def router_kwargs(self) -> dict:
         """Return a dict suitable for ``RouterConfig(mode, kv_config, **kwargs)``."""
         self.apply_admission_control()
+        if self.enforce_disagg:
+            logger.warning(_ENFORCE_DISAGG_DEPRECATION)
         return {f: getattr(self, f) for f in _ROUTER_FIELDS}
 
     def apply_admission_control(self) -> None:
@@ -258,10 +265,8 @@ class RouterArgGroup(ArgGroup):
             default=False,
             dest="enforce_disagg",
             help=(
-                "Strictly enforce disaggregated mode. Requests will fail if the prefill router "
-                "has not activated yet (e.g., prefill workers still registering). This is stricter "
-                "than the default: without this flag, requests arriving before prefill workers are "
-                "discovered fall through to aggregated decode-only routing."
+                "DEPRECATED: accepted for compatibility but ignored. Routing topology and "
+                "readiness are determined from registered worker types."
             ),
         )
         add_argument(

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -399,7 +399,6 @@ def test_admission_control_token_capacity_preserves_busy_thresholds(
         "active_decode_blocks_threshold": 1.0,
         "active_prefill_tokens_threshold": 10_000_000,
         "active_prefill_tokens_threshold_frac": 64.0,
-        "enforce_disagg": False,
         "session_affinity_ttl_secs": None,
     }
 
@@ -438,10 +437,43 @@ def test_admission_control_token_capacity_with_custom_thresholds(
         "active_decode_blocks_threshold": 0.5,
         "active_prefill_tokens_threshold": 1000,
         "active_prefill_tokens_threshold_frac": 2.0,
-        "enforce_disagg": False,
         "session_affinity_ttl_secs": None,
     }
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
+
+
+def test_enforce_disagg_cli_is_deprecated_and_not_forwarded(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.delenv("DYN_ENFORCE_DISAGG", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    config = FrontendConfig.from_cli_args(parser.parse_args(["--enforce-disagg"]))
+    config.validate()
+    kwargs = config.router_kwargs()
+
+    assert config.enforce_disagg is True
+    assert "enforce_disagg" not in kwargs
+    assert "deprecated and ignored" in caplog.text
+
+
+def test_enforce_disagg_environment_is_deprecated_and_not_forwarded(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    monkeypatch.setenv("DYN_ENFORCE_DISAGG", "true")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    config.validate()
+    kwargs = config.router_kwargs()
+
+    assert config.enforce_disagg is True
+    assert "enforce_disagg" not in kwargs
+    assert "deprecated and ignored" in caplog.text
 
 
 def test_admission_control_explicit_none_with_threshold_raises(

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/decode_scorer.go
@@ -93,16 +93,15 @@ func DynDecodeScorerFactory(name string, rawParameters json.RawMessage, handle p
 		return nil, fmt.Errorf("Dynamo FFI init for decode scorer failed: %w", err)
 	}
 
-	enforceDisagg := getEnvBoolOrDefault("DYN_ENFORCE_DISAGG", false)
-	return NewDynDecodeScorer(handle.Context(), enforceDisagg).WithName(name), nil
+	warnDeprecatedEnforceDisagg(log.Log.WithName(DynDecodeScorerType))
+	return NewDynDecodeScorer(handle.Context()).WithName(name), nil
 }
 
 // NewDynDecodeScorer initializes a new DynDecodeScorer.
-func NewDynDecodeScorer(ctx context.Context, enforceDisagg bool) *DynDecodeScorer {
+func NewDynDecodeScorer(ctx context.Context) *DynDecodeScorer {
 	return &DynDecodeScorer{
-		typedName:     plugins.TypedName{Type: DynDecodeScorerType, Name: DynDecodeScorerType},
-		pluginState:   plugins.NewPluginState(ctx),
-		enforceDisagg: enforceDisagg,
+		typedName:   plugins.TypedName{Type: DynDecodeScorerType, Name: DynDecodeScorerType},
+		pluginState: plugins.NewPluginState(ctx),
 	}
 }
 
@@ -110,7 +109,6 @@ func NewDynDecodeScorer(ctx context.Context, enforceDisagg bool) *DynDecodeScore
 type DynDecodeScorer struct {
 	typedName      plugins.TypedName
 	pluginState    *plugins.PluginState
-	enforceDisagg  bool
 	firstTokenSeen sync.Map
 }
 
@@ -172,9 +170,6 @@ func (s *DynDecodeScorer) Score(ctx context.Context, cycleState *schedtypes.Cycl
 		if prefillID, ok := req.Headers[PrefillWorkerIDHeader]; ok {
 			logger.V(logutil.DEFAULT).Info("DynDecodeScorer: prefill worker header present",
 				"prefillWorkerID", prefillID)
-		} else if s.enforceDisagg {
-			logger.V(logutil.DEFAULT).Error(nil,
-				"DynDecodeScorer: prefill worker header missing and enforce_disagg=true")
 		} else {
 			logger.V(logutil.DEFAULT).Error(nil,
 				"DynDecodeScorer: x-dynamo-prefill-instance-id header missing — DynPrefillScorer did not set it")

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/profile_handler.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/profile_handler.go
@@ -46,22 +46,20 @@ func DisaggProfileHandlerFactory(name string, rawParameters json.RawMessage, _ p
 			return nil, fmt.Errorf("failed to parse %s plugin parameters: %w", DisaggProfileHandlerType, err)
 		}
 	}
-	enforceDisagg := getEnvBoolOrDefault("DYN_ENFORCE_DISAGG", false)
-	return NewDisaggProfileHandler(enforceDisagg).WithName(name), nil
+	warnDeprecatedEnforceDisagg(log.Log.WithName(DisaggProfileHandlerType))
+	return NewDisaggProfileHandler().WithName(name), nil
 }
 
 // NewDisaggProfileHandler initializes a new DisaggProfileHandler.
-func NewDisaggProfileHandler(enforceDisagg bool) *DisaggProfileHandler {
+func NewDisaggProfileHandler() *DisaggProfileHandler {
 	return &DisaggProfileHandler{
-		typedName:     plugins.TypedName{Type: DisaggProfileHandlerType, Name: DisaggProfileHandlerType},
-		enforceDisagg: enforceDisagg,
+		typedName: plugins.TypedName{Type: DisaggProfileHandlerType, Name: DisaggProfileHandlerType},
 	}
 }
 
 // DisaggProfileHandler is a ProfileHandler that orchestrates prefill/decode disaggregated serving.
 type DisaggProfileHandler struct {
-	typedName     plugins.TypedName
-	enforceDisagg bool
+	typedName plugins.TypedName
 }
 
 // TypedName returns the type and name tuple of this plugin instance.
@@ -103,10 +101,6 @@ func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.
 	if prefillResult, prefillDone := profileResults[PrefillProfileName]; prefillDone {
 		if _, decodeDone := profileResults[DecodeProfileName]; !decodeDone {
 			if prefillResult == nil {
-				if h.enforceDisagg {
-					logger.Info("DisaggProfileHandler: prefill profile failed and enforce_disagg=true, rejecting request")
-					return map[string]schedtypes.SchedulerProfile{}
-				}
 				logger.Info("DisaggProfileHandler: prefill profile failed (no workers?), falling back to aggregated decode")
 				cycleState.Write(PrefillEnabledStateKey, &PrefillEnabledState{Enabled: false})
 			}
@@ -123,16 +117,8 @@ func (h *DisaggProfileHandler) Pick(ctx context.Context, cycleState *schedtypes.
 }
 
 // ProcessResults aggregates the profile run results and designates the primary profile.
-func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.CycleState, req *schedtypes.InferenceRequest,
+func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.CycleState, _ *schedtypes.InferenceRequest,
 	profileResults map[string]*schedtypes.ProfileRunResult) (*schedtypes.SchedulingResult, error) {
-
-	if h.enforceDisagg && (req.Headers == nil || req.Headers[PrefillWorkerIDHeader] == "") {
-		if _, prefillRan := profileResults[PrefillProfileName]; prefillRan {
-			return nil, errors.New(
-				"disaggregated mode enforced (DYN_ENFORCE_DISAGG=true) but prefill workers " +
-					"are not available; request rejected")
-		}
-	}
 
 	if len(profileResults) == 0 {
 		return nil, errors.New("disagg profile handler received no profile results")
@@ -147,11 +133,6 @@ func (h *DisaggProfileHandler) ProcessResults(_ context.Context, _ *schedtypes.C
 	}
 
 	if profileResults[primaryProfile] == nil {
-		if h.enforceDisagg {
-			return nil, errors.New(
-				"disaggregated mode enforced (DYN_ENFORCE_DISAGG=true) but prefill workers " +
-					"are not available; request rejected")
-		}
 		return nil, fmt.Errorf("primary profile '%s' failed to produce a result", primaryProfile)
 	}
 

--- a/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/disagg/shared.go
@@ -31,6 +31,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"sync"
 
 	"github.com/go-logr/logr"
 	logutil "sigs.k8s.io/gateway-api-inference-extension/pkg/common/observability/logging"
@@ -158,4 +159,14 @@ func getEnvBoolOrDefault(key string, def bool) bool {
 		}
 	}
 	return def
+}
+
+var enforceDisaggDeprecationOnce sync.Once
+
+func warnDeprecatedEnforceDisagg(logger logr.Logger) {
+	if getEnvBoolOrDefault("DYN_ENFORCE_DISAGG", false) {
+		enforceDisaggDeprecationOnce.Do(func() {
+			logger.Info("DYN_ENFORCE_DISAGG is deprecated and ignored; routing topology and readiness come from registered worker types")
+		})
+	}
 }

--- a/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
+++ b/deploy/inference-gateway/epp/pkg/plugins/dynamo_kv_scorer/plugin.go
@@ -114,9 +114,8 @@ var (
 	ffiOnce sync.Once
 	ffiErr  error
 
-	ffiNamespace     string
-	ffiComponent     string
-	ffiEnforceDisagg bool
+	ffiNamespace string
+	ffiComponent string
 
 	routerInitialized bool
 
@@ -132,11 +131,12 @@ const UnsetDpRank = ^uint32(0)
 func loadDynamoConfig() {
 	ffiNamespace = getEnvOrDefault("DYN_NAMESPACE_PREFIX", getEnvOrDefault("DYN_NAMESPACE", "vllm-agg"))
 	ffiComponent = "backend" // This is not the same as DYN_COMPONENT=epp (in this case)
-	ffiEnforceDisagg = getEnvBoolOrDefault("DYN_ENFORCE_DISAGG", false)
+	if getEnvBoolOrDefault("DYN_ENFORCE_DISAGG", false) {
+		logger.Info("DYN_ENFORCE_DISAGG is deprecated and ignored; routing topology and readiness come from registered worker types")
+	}
 	logger.Info("Dynamo KV Scorer config loaded",
 		"namespace", ffiNamespace,
 		"component", ffiComponent,
-		"enforce_disagg", ffiEnforceDisagg,
 		"kvCacheBlockSize", getEnvOrDefault("DYN_KV_CACHE_BLOCK_SIZE", "(from discovery)"),
 		"modelName", getEnvOrDefault("DYN_MODEL_NAME", "(from discovery)"))
 }
@@ -176,7 +176,7 @@ func initFFI() error {
 		rc := C.create_routers(
 			ns,
 			cm,
-			C.bool(ffiEnforceDisagg),
+			C.bool(false),
 			&routerHandles,
 		)
 		if rc != C.QUERY_ROUTER_OK {

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -92,11 +92,7 @@ impl Router {
     ///
     /// This waits for at least one decode worker to appear, fetches the model
     /// card, initializes the preprocessor, and creates both routers.
-    pub async fn from_discovery(
-        namespace: &str,
-        component: &str,
-        enforce_disagg: bool,
-    ) -> Result<Self> {
+    pub async fn from_discovery(namespace: &str, component: &str) -> Result<Self> {
         validate_kube_discovery_mode()?;
 
         let runtime = Runtime::from_settings()?;
@@ -165,7 +161,6 @@ impl Router {
             block_size,
             Some(prefill_config),
             None,
-            enforce_disagg,
             None,
             model_name.clone(),
             actual_namespace.to_string(),
@@ -922,16 +917,8 @@ impl EndpointPicker for Router {
 
         // Try prefill routing first (disaggregated mode).
         //
-        // If the prefill router is not activated (no prefill workers
-        // discovered yet, or the inner router has been deactivated), this
-        // returns an error. Behavior on that error depends on
-        // `DYN_ENFORCE_DISAGG`:
-        //
-        // * `enforce_disagg = false` (default): fall back to aggregated
-        //   (decode-only) routing — matches `PrefillRouter::generate`.
-        // * `enforce_disagg = true`: surface the error to Envoy and let the
-        //   request fail. Silently downgrading to aggregated would defeat
-        //   the operator's explicit "strict disagg" policy.
+        // If the prefill router is not activated (no prefill workers discovered yet, or the inner
+        // router has been deactivated), fall back to aggregated routing.
         let prefill_result = self
             .route_prefill(
                 &tokens,
@@ -944,16 +931,6 @@ impl EndpointPicker for Router {
         let is_disaggregated = match &prefill_result {
             Ok(_) => true,
             Err(e) => {
-                if self.prefill_router.enforce_disagg() {
-                    tracing::warn!(
-                        error = %e,
-                        request_id = %req.request_id,
-                        "Prefill routing failed under DYN_ENFORCE_DISAGG=true; failing request"
-                    );
-                    return Err(PickError::RoutingFailed(format!(
-                        "prefill routing failed under enforce_disagg: {e}"
-                    )));
-                }
                 tracing::debug!(
                     error = %e,
                     "Prefill routing failed; falling back to aggregated mode"

--- a/deploy/inference-gateway/ext-proc/src/main.rs
+++ b/deploy/inference-gateway/ext-proc/src/main.rs
@@ -35,7 +35,6 @@ const TLS_HANDSHAKE_TIMEOUT: std::time::Duration = std::time::Duration::from_sec
 struct Config {
     namespace: String,
     component: String,
-    enforce_disagg: bool,
 }
 
 impl Config {
@@ -44,10 +43,15 @@ impl Config {
             .or_else(|| env_or("DYN_NAMESPACE", ""))
             .unwrap_or_else(|| "vllm-agg".to_string());
 
+        if parse_env("DYN_ENFORCE_DISAGG", false) {
+            tracing::warn!(
+                "DYN_ENFORCE_DISAGG is deprecated and ignored; routing topology and readiness are determined from registered worker types"
+            );
+        }
+
         Self {
             namespace,
             component: env_or("DYN_COMPONENT_NAME", "").unwrap_or_else(|| "backend".to_string()),
-            enforce_disagg: parse_env("DYN_ENFORCE_DISAGG", false),
         }
     }
 }
@@ -126,7 +130,6 @@ async fn main() -> Result<()> {
         health_port = HEALTH_PORT,
         namespace = %config.namespace,
         component = %config.component,
-        enforce_disagg = config.enforce_disagg,
         "Starting Dynamo Rust EPP"
     );
 
@@ -145,8 +148,7 @@ async fn main() -> Result<()> {
     );
 
     tracing::info!("Initializing KV-aware router from discovery...");
-    let router =
-        Router::from_discovery(&config.namespace, &config.component, config.enforce_disagg).await?;
+    let router = Router::from_discovery(&config.namespace, &config.component).await?;
 
     // Gate SERVING on pod-reflector readiness. `from_discovery` returns once
     // worker discovery and the model card are ready, but the K8s pod reflector's

--- a/docs/kubernetes/inference-gateway.md
+++ b/docs/kubernetes/inference-gateway.md
@@ -12,7 +12,7 @@ Integrate Dynamo with the Gateway API Inference Extension, also known as Inferen
 
 - EPP's default kv-routing approach is not token-aware because the prompt is not tokenized. But the Dynamo plugin uses a token-aware KV algorithm. It employs the dynamo router which implements kv routing by running your model's tokenizer inline. The EPP plugin configuration is embedded in the recipe-based GAIE deploy YAMLs under [`recipes/llama-3-70b/vllm/agg/gaie/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/llama-3-70b/vllm/agg/gaie) and [`recipes/llama-3-70b/vllm/disagg-single-node/gaie/`](https://github.com/ai-dynamo/dynamo/tree/main/recipes/llama-3-70b/vllm/disagg-single-node/gaie), following the GAIE/EPP configuration layout used by this repository.
 
-- Dynamo Integration with the Inference Gateway supports Aggregated and Disaggregated Serving. A request only exercises disaggregated routing when the EPP config defines a `prefill` profile and prefill workers are available. The recipe examples provide separate aggregated and disaggregated configs under `recipes/llama-3-70b/vllm/agg/gaie/` and `recipes/llama-3-70b/vllm/disagg-single-node/gaie/`. Unless `DYN_ENFORCE_DISAGG=true`, deployments without a `prefill` profile or prefill workers fall back to aggregated serving.
+- Dynamo Integration with the Inference Gateway supports Aggregated and Disaggregated Serving. A request only exercises disaggregated routing when the EPP config defines a `prefill` profile and prefill workers are available. The recipe examples provide separate aggregated and disaggregated configs under `recipes/llama-3-70b/vllm/agg/gaie/` and `recipes/llama-3-70b/vllm/disagg-single-node/gaie/`. Registered worker types determine routing topology and readiness; deployments without a `prefill` profile or prefill workers serve aggregated.
 
 - GAIE integration supports Data Parallelism.
 
@@ -183,7 +183,7 @@ resolution and router configuration:
 | `DYN_NAMESPACE_PREFIX` | *(unset)* | Dynamo discovery namespace (highest priority) |
 | `DYN_NAMESPACE` | `vllm-agg` | Dynamo discovery namespace (fallback) |
 | `DYN_COMPONENT_NAME` | `backend` | Dynamo component name |
-| `DYN_ENFORCE_DISAGG` | `false` | Enforce disaggregated prefill/decode routing |
+| `DYN_ENFORCE_DISAGG` | `false` | Deprecated and ignored. Registered worker types determine routing topology and readiness. |
 | `DYN_KUBE_DISCOVERY_MODE` | `pod` | Kubernetes discovery identity mode; Rust EPP currently rejects `container` |
 | `RUST_LOG` | `info` | Tracing log level filter |
 
@@ -291,11 +291,6 @@ kubectl apply -f recipes/llama-3-70b/model-cache/model-cache.yaml  -n ${NAMESPAC
 kubectl apply -f recipes/llama-3-70b/model-cache/model-download.yaml  -n ${NAMESPACE}
 ```
 We provide examples for llama-3-70b vLLM under the `recipes/llama-3-70b/vllm/agg/gaie/` for aggregated and `recipes/llama-3-70b/vllm/disagg-single-node/gaie/` for disaggregated serving.
-Note for the aggregated serving you need to disable DYN_ENFORCE_DISAGG in epp config.
-```bash
-  - name: DYN_ENFORCE_DISAGG
-    value: "false"
-```
 Use the proper folder in commands below.
 
 ```bash
@@ -384,9 +379,7 @@ To disable the EPP from listening for KV events (e.g., when prefix caching is of
 3. **Optionally** set `DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT=0` on the EPP to skip prefix-overlap scoring altogether, making the router select workers based on load only.
 
 - Set `DYN_BUSY_THRESHOLD` to configure the upper bound on how "full" a worker can be (often derived from kv_active_blocks or other load metrics) before the router skips it. If the selected worker exceeds this value, routing falls back to the next best candidate. By default the value is negative meaning this is not enabled.
-- Set `DYN_ENFORCE_DISAGG=true` (default: `false`) to control per-request behavior when prefill workers are unavailable:
-  - **`true` (recommended for disaggregated serving):** Requests fail with an error if prefill workers are not available. Use this when disaggregated serving is required and aggregated fallback is not acceptable.
-  - **`false` (default):** Requests gracefully fall back to aggregated mode (skip prefill, route directly to decode) when prefill workers are not available. When prefill workers appear later, subsequent requests automatically use disaggregated routing.
+- `DYN_ENFORCE_DISAGG` is deprecated and ignored. Registered worker types determine routing topology and readiness: decode workers that declare a prefill dependency stay unready until a prefill worker registers, while aggregated workers are ready without prefill.
 - Set `DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT` to control the device-local prefix-overlap credit multiplier, from 0.0 to 1.0. Higher values bias toward reusing workers with similar cached prefixes. (default: 1)
 - Set `DYN_ROUTER_PREFILL_LOAD_SCALE` to scale adjusted prompt-side prefill load before decode blocks are added. (default: 1)
 - Set `DYN_ROUTER_TEMPERATURE` (default: `0.0`) to soften or sharpen normalized worker sampling. Low temperature makes the router pick the top candidate deterministically; higher temperature lets lower-scoring workers through more often (exploration).

--- a/examples/backends/vllm/deploy/gaie/agg.yaml
+++ b/examples/backends/vllm/deploy/gaie/agg.yaml
@@ -43,8 +43,6 @@ spec:
             value: "128"
           - name: DYN_MODEL_NAME
             value: Qwen/Qwen3-0.6B
-          - name: DYN_ENFORCE_DISAGG
-            value: "false"
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/examples/backends/vllm/deploy/gaie/disagg.yaml
+++ b/examples/backends/vllm/deploy/gaie/disagg.yaml
@@ -42,8 +42,8 @@
 #     comfortable headroom; raise this only if you also raise
 #     ``gpu-memory-utilization``.
 #
-#   * ``DYN_ENFORCE_DISAGG=true`` on the EPP prevents fallback to aggregated
-#     serving when one role is unavailable (the test asserts disagg).
+#   * Registered prefill and decode worker types establish disaggregated
+#     serving. Both roles must be available before the model is ready.
 apiVersion: nvidia.com/v1beta1
 kind: DynamoGraphDeployment
 metadata:
@@ -104,8 +104,6 @@ spec:
             value: "16"
           - name: DYN_MODEL_NAME
             value: Qwen/Qwen3-0.6B
-          - name: DYN_ENFORCE_DISAGG
-            value: "true"
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -640,7 +640,7 @@ pub enum QueryRouterResult {
 /// # Arguments
 /// - `namespace`: Namespace for the model
 /// - `component`: Component name (defaults to "backend" if NULL or empty)
-/// - `enforce_disagg`: If true, requires prefill workers to be present at init time
+/// - `enforce_disagg`: Deprecated compatibility parameter. The value is ignored.
 /// - `out_handle`: Output handle
 ///
 /// # Safety
@@ -654,6 +654,12 @@ pub unsafe extern "C" fn create_routers(
     out_handle: *mut RouterHandlesPtr,
 ) -> QueryRouterResult {
     initialize_tracing();
+
+    if enforce_disagg {
+        tracing::warn!(
+            "enforce_disagg is deprecated and ignored; routing topology and readiness are determined from registered worker types"
+        );
+    }
 
     if namespace.is_null() || out_handle.is_null() {
         return QueryRouterResult::ErrInvalidParam;
@@ -812,7 +818,6 @@ pub unsafe extern "C" fn create_routers(
             block_size,
             Some(prefill_config),
             None,
-            enforce_disagg,
             None,
             model_name.clone(),
             actual_namespace.clone(),

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -428,7 +428,6 @@ pub struct RouterConfig {
     active_prefill_tokens_threshold: Option<u64>,
     /// Threshold for active prefill tokens as fraction of max_num_batched_tokens
     active_prefill_tokens_threshold_frac: Option<f64>,
-    enforce_disagg: bool,
     session_affinity_ttl_secs: Option<u64>,
 }
 
@@ -445,6 +444,14 @@ impl RouterConfig {
         enforce_disagg: bool,
         session_affinity_ttl_secs: Option<u64>,
     ) -> PyResult<Self> {
+        if enforce_disagg {
+            static WARN_ONCE: std::sync::Once = std::sync::Once::new();
+            WARN_ONCE.call_once(|| {
+                tracing::warn!(
+                    "enforce_disagg is deprecated and ignored; routing topology and readiness are determined from registered worker types"
+                );
+            });
+        }
         if session_affinity_ttl_secs.is_some_and(|ttl| !(1..=31_536_000).contains(&ttl)) {
             return Err(PyValueError::new_err(
                 "session_affinity_ttl_secs must be between 1 and 31536000",
@@ -456,7 +463,6 @@ impl RouterConfig {
             active_decode_blocks_threshold,
             active_prefill_tokens_threshold,
             active_prefill_tokens_threshold_frac,
-            enforce_disagg,
             session_affinity_ttl_secs,
         })
     }
@@ -472,7 +478,7 @@ impl From<RouterConfig> for RsRouterConfig {
                 active_prefill_tokens_threshold: rc.active_prefill_tokens_threshold,
                 active_prefill_tokens_threshold_frac: rc.active_prefill_tokens_threshold_frac,
             },
-            enforce_disagg: rc.enforce_disagg,
+            enforce_disagg: false,
             session_affinity_ttl_secs: rc.session_affinity_ttl_secs,
         }
     }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1565,7 +1565,7 @@ class RouterConfig:
             active_decode_blocks_threshold: Threshold percentage (0.0-1.0) for decode blocks busy detection
             active_prefill_tokens_threshold: Literal token count threshold for prefill busy detection
             active_prefill_tokens_threshold_frac: Fraction of max_num_batched_tokens for busy detection
-            enforce_disagg: Strictly enforce disaggregated mode, failing requests if no prefill workers are available
+            enforce_disagg: Deprecated and ignored. Routing topology and readiness come from registered worker types.
         """
         ...
 

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -485,7 +485,7 @@ impl Model {
     ///
     /// Differs from [`Self::is_displayable`] in that it does **not** fall back
     /// to prefill-only WorkerSets: requires a WorkerSet that has a serving
-    /// engine attached, workers connected, and `can_serve_requests()` true.
+    /// engine attached and workers connected.
     /// Used by KServe gRPC `model_ready` / `server_ready` to avoid the race
     /// where a `ModelDeploymentCard` is registered before its WorkerSet has
     /// been wired up.
@@ -509,7 +509,7 @@ impl Model {
 
         self.worker_sets.iter().any(|entry| {
             let ws = entry.value();
-            if ws.worker_count() == 0 || !ws.can_serve_requests() {
+            if ws.worker_count() == 0 {
                 return false;
             }
             ws.has_any_serving_engine() || (!any_set_has_engine && ws.is_prefill_set())
@@ -671,28 +671,21 @@ impl Model {
         // Fast path: single set (same zero-worker filtering as the multi-set path below)
         if snapshot.len() == 1 {
             let ws = &snapshot[0];
-            if ws.worker_count() == 0
-                || !ws.can_serve_requests()
-                || !ready_namespaces.contains(ws.namespace())
-            {
+            if ws.worker_count() == 0 || !ready_namespaces.contains(ws.namespace()) {
                 return None;
             }
             return extract(ws);
         }
 
-        // Collect eligible sets with their worker counts, skipping sets with no workers,
-        // sets whose prefill router has died under enforce_disagg, or sets in a namespace
-        // whose worker set is incomplete.
+        // Collect eligible sets with their worker counts, skipping sets with no workers or sets in
+        // a namespace whose worker set is incomplete.
         // In-process models (no discovery watcher) return count=1, so they always participate.
         // Discovery models with count=0 have no available workers and are skipped.
         let eligible: Vec<(T, usize)> = snapshot
             .iter()
             .filter_map(|ws| {
                 let count = ws.worker_count();
-                if count == 0
-                    || !ws.can_serve_requests()
-                    || !ready_namespaces.contains(ws.namespace())
-                {
+                if count == 0 || !ready_namespaces.contains(ws.namespace()) {
                     return None;
                 }
                 extract(ws).map(|val| (val, count))
@@ -1006,7 +999,7 @@ mod tests {
 
     /// Build a WorkerSet with a deactivated PrefillRouter simulating "was activated, now dead".
     /// worker_count defaults to 1 (no instance_count_rx -> in-process default).
-    fn make_worker_set_with_dead_prefill(namespace: &str, enforce_disagg: bool) -> Arc<WorkerSet> {
+    fn make_worker_set_with_dead_prefill(namespace: &str) -> Arc<WorkerSet> {
         let mut ws = WorkerSet::new(
             namespace.to_string(),
             "abc".to_string(),
@@ -1015,7 +1008,6 @@ mod tests {
         let pr = PrefillRouter::disabled(
             std::sync::Arc::new(crate::discovery::ModelManager::new()),
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
-            enforce_disagg,
             None,
         );
         pr.mark_active_for_test();
@@ -1025,7 +1017,7 @@ mod tests {
     }
 
     /// Baseline: a WorkerSet without a PrefillRouter is always displayable
-    /// (worker_count=1, is_prefill_set=true, no can_serve_requests block).
+    /// (worker_count=1, is_prefill_set=true).
     #[test]
     fn test_is_displayable_true_basic() {
         let model = Model::new("llama".to_string());
@@ -1036,77 +1028,16 @@ mod tests {
         );
     }
 
-    /// When the prefill engine dies and enforce_disagg is set, the model must be
-    /// hidden from /v1/models.
+    /// Prefill-router lifecycle is not a separate model-visibility policy. Registered worker
+    /// topology gates the serving-ready model list and request selection.
     #[test]
-    fn test_is_displayable_false_when_prefill_dies_enforce_disagg() {
+    fn test_is_displayable_ignores_prefill_router_lifecycle() {
         let model = Model::new("llama".to_string());
-        model.add_worker_set(
-            "ns1".to_string(),
-            make_worker_set_with_dead_prefill("ns1", true),
-        );
-
-        assert!(
-            !model.is_displayable(),
-            "model must be hidden when prefill died and enforce_disagg=true"
-        );
-    }
-
-    /// When enforce_disagg is false the deployment can fall back to aggregated mode,
-    /// so the model should remain visible in /v1/models.
-    #[test]
-    fn test_is_displayable_true_when_prefill_dies_no_enforce() {
-        let model = Model::new("llama".to_string());
-        model.add_worker_set(
-            "ns1".to_string(),
-            make_worker_set_with_dead_prefill("ns1", false),
-        );
+        model.add_worker_set("ns1".to_string(), make_worker_set_with_dead_prefill("ns1"));
 
         assert!(
             model.is_displayable(),
-            "model must remain visible when prefill died but enforce_disagg=false (fallback)"
-        );
-    }
-
-    /// A single WorkerSet with a deactivated prefill router (enforce_disagg=true) must be
-    /// skipped by select_worker_set_with(), causing engine accessors to return Err.
-    #[test]
-    fn test_dead_prefill_single_set_not_selectable() {
-        let model = Model::new("llama".to_string());
-        model.add_worker_set(
-            "ns1".to_string(),
-            make_worker_set_with_dead_prefill("ns1", true),
-        );
-
-        assert!(model.get_chat_engine().is_err());
-        assert!(model.get_completions_engine().is_err());
-    }
-
-    /// With two WorkerSets -- one healthy, one with dead prefill -- the healthy set
-    /// keeps the model displayable. Removing the healthy set hides the model.
-    #[test]
-    fn test_dead_prefill_multi_set_skips_dead_namespace() {
-        let model = Model::new("llama".to_string());
-
-        // Healthy set (no prefill constraint)
-        model.add_worker_set("healthy".to_string(), make_worker_set("healthy", "abc"));
-
-        // Dead set (deactivated prefill + enforce_disagg)
-        model.add_worker_set(
-            "dead".to_string(),
-            make_worker_set_with_dead_prefill("dead", true),
-        );
-
-        assert!(
-            model.is_displayable(),
-            "model must be displayable when at least one healthy set exists"
-        );
-
-        // Removing the healthy set leaves only the dead set -- model must be hidden.
-        model.remove_worker_set("healthy");
-        assert!(
-            !model.is_displayable(),
-            "model must be hidden when only the dead prefill set remains"
+            "prefill-router lifecycle must not override registered topology"
         );
     }
 

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1140,7 +1140,7 @@ impl ModelManager {
 
     /// Deactivate the prefill router on the decode WorkerSet for the given model/namespace.
     /// Called by the watcher when all prefill workers in a namespace are removed.
-    /// After deactivation, requests fall back to aggregated mode (or fail if enforce_disagg).
+    /// After deactivation, requests fall back to aggregated mode.
     pub fn deactivate_prefill_router_for_decode(&self, model_name: &str, namespace: &str) {
         if let Some(model) = self.get_model(model_name)
             && let Some(ws) = model.get_worker_set(namespace)
@@ -1911,16 +1911,11 @@ mod tests {
     use crate::kv_router::PrefillRouter;
 
     /// Helper: make a WorkerSet with an activated PrefillRouter attached.
-    fn make_worker_set_with_prefill_router(
-        namespace: &str,
-        mdcsum: &str,
-        enforce_disagg: bool,
-    ) -> WorkerSet {
+    fn make_worker_set_with_prefill_router(namespace: &str, mdcsum: &str) -> WorkerSet {
         let mut ws = make_worker_set(namespace, mdcsum);
         let pr = PrefillRouter::disabled(
             std::sync::Arc::new(ModelManager::new()),
             dynamo_runtime::pipeline::RouterMode::RoundRobin,
-            enforce_disagg,
             None,
         );
         pr.mark_active_for_test();
@@ -1943,16 +1938,15 @@ mod tests {
         mm.deactivate_prefill_router_for_decode("llama", "ns1");
     }
 
-    /// Full pipeline test: deactivate finds the WorkerSet, calls deactivate() on its
-    /// PrefillRouter, and the model is hidden from model_display_names() when
-    /// enforce_disagg=true.
+    /// Deactivation updates routing lifecycle but does not add a second visibility policy on top
+    /// of registered worker topology.
     #[test]
-    fn test_deactivate_prefill_router_for_decode_hides_model() {
+    fn test_deactivate_prefill_router_for_decode_keeps_model_visible() {
         let mm = ModelManager::new();
         mm.add_worker_set(
             "llama",
             "ns1",
-            make_worker_set_with_prefill_router("ns1", "abc", true),
+            make_worker_set_with_prefill_router("ns1", "abc"),
         );
 
         // Model is visible before deactivation.
@@ -1960,108 +1954,17 @@ mod tests {
 
         mm.deactivate_prefill_router_for_decode("llama", "ns1");
 
-        // Model must be hidden after deactivation with enforce_disagg=true.
-        assert!(
-            !mm.model_display_names().contains("llama"),
-            "model must be hidden after prefill deactivation with enforce_disagg=true"
-        );
+        assert!(mm.model_display_names().contains("llama"));
+        let router = mm
+            .get_model("llama")
+            .and_then(|model| model.get_worker_set("ns1"))
+            .and_then(|ws| ws.prefill_router.clone())
+            .expect("prefill router");
+        assert!(router.is_deactivated());
 
         // Idempotent: calling again must not panic.
         mm.deactivate_prefill_router_for_decode("llama", "ns1");
-        assert!(!mm.model_display_names().contains("llama"));
-    }
-
-    /// Full disagg lifecycle with enforce_disagg=true:
-    /// decode registers -> prefill registers -> prefill dies -> model hidden.
-    #[test]
-    fn test_disagg_lifecycle_prefill_death_hides_model() {
-        let mm = ModelManager::new();
-
-        // Step 1: Decode WorkerSet with a PrefillRouter (not yet deactivated).
-        mm.add_worker_set(
-            "llama",
-            "decode-ns",
-            make_worker_set_with_prefill_router("decode-ns", "abc", true),
-        );
-        assert!(
-            mm.model_display_names().contains("llama"),
-            "step 1: model must be visible with active prefill router"
-        );
-
-        // Step 2: Prefill WorkerSet registers (same model, different namespace key).
-        mm.add_worker_set("llama", "prefill-ns", make_worker_set("prefill-ns", "abc"));
-        assert!(
-            mm.model_display_names().contains("llama"),
-            "step 2: model must be visible with both decode and prefill"
-        );
-
-        // Step 3: Prefill WorkerSet removed (engine dies).
-        mm.remove_worker_set("llama", "prefill-ns");
-
-        // Step 4: Deactivate the prefill router on the decode side.
-        mm.deactivate_prefill_router_for_decode("llama", "decode-ns");
-        assert!(
-            !mm.model_display_names().contains("llama"),
-            "step 4: model must be hidden after prefill death with enforce_disagg=true"
-        );
-    }
-
-    /// Full disagg lifecycle with enforce_disagg=false (fallback allowed).
-    #[test]
-    fn test_disagg_lifecycle_prefill_death_keeps_model_no_enforce() {
-        let mm = ModelManager::new();
-
-        mm.add_worker_set(
-            "llama",
-            "decode-ns",
-            make_worker_set_with_prefill_router("decode-ns", "abc", false),
-        );
         assert!(mm.model_display_names().contains("llama"));
-
-        // Deactivate -- model stays visible (enforce_disagg=false, fallback allowed).
-        mm.deactivate_prefill_router_for_decode("llama", "decode-ns");
-        assert!(
-            mm.model_display_names().contains("llama"),
-            "model must remain visible (enforce_disagg=false, fallback allowed)"
-        );
-    }
-
-    /// Full disagg lifecycle including prefill rejoin after transient failure.
-    /// decode registers -> prefill dies -> model hidden -> prefill rejoins -> model visible.
-    #[test]
-    fn test_disagg_lifecycle_prefill_rejoin_restores_model() {
-        let mm = ModelManager::new();
-
-        // Decode WorkerSet with enforce_disagg=true.
-        mm.add_worker_set(
-            "llama",
-            "decode-ns",
-            make_worker_set_with_prefill_router("decode-ns", "abc", true),
-        );
-        assert!(mm.model_display_names().contains("llama"));
-
-        // Prefill dies -> deactivate.
-        mm.deactivate_prefill_router_for_decode("llama", "decode-ns");
-        assert!(
-            !mm.model_display_names().contains("llama"),
-            "model must be hidden after prefill death"
-        );
-
-        // Prefill rejoins -> mark the synthetic test router active again. A real
-        // PrefillRouter has an initialized inner router for reactivate() to reuse.
-        if let Some(model) = mm.get_model("llama")
-            && let Some(ws) = model.get_worker_set("decode-ns")
-            && let Some(ref pr) = ws.prefill_router
-        {
-            pr.mark_active_for_test();
-        } else {
-            panic!("decode WorkerSet or prefill_router not found");
-        }
-
-        assert!(
-            mm.model_display_names().contains("llama"),
-            "model must be visible again after prefill rejoin"
-        );
     }
 
     // -- is_model_ready_to_serve / has_any_ready_model tests --

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -605,7 +605,7 @@ impl ModelWatcher {
             //
             // PREFILL teardown (cached endpoint is stale): drop everything for
             // this key and deactivate the decode-side router so requests fall
-            // back to aggregated mode (or fail cleanly with `enforce_disagg`).
+            // back to aggregated mode.
             //
             // DECODE teardown: keep `PrefillReady` (the cached endpoint is still
             // valid for future decode rebuilds — that's PR 8965's primary
@@ -1069,7 +1069,6 @@ impl ModelWatcher {
                             card.kv_cache_block_size,
                             Some(prefill_config),
                             self.prefill_load_estimator.clone(),
-                            router_config.enforce_disagg,
                             router_config.session_affinity_ttl_secs,
                             model_name.clone(),
                             namespace.clone(),
@@ -1100,7 +1099,6 @@ impl ModelWatcher {
                         kv_chooser.clone(),
                         prefill_chooser.clone(),
                         uses_multimodal_cache_routing(card),
-                        router_config.enforce_disagg,
                         router_config.session_affinity_ttl_secs,
                     )
                     .await

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -197,16 +197,6 @@ impl WorkerSet {
     pub fn set_instance_watcher(&mut self, rx: watch::Receiver<Vec<u64>>) {
         self.instance_count_rx = Some(rx);
     }
-
-    /// Whether this WorkerSet can serve requests. Delegates to the prefill router
-    /// if one exists; otherwise always returns true.
-    /// When the prefill router is deactivated and enforce_disagg is set, this returns
-    /// false, causing the model to be hidden from /v1/models and requests to be rejected.
-    pub fn can_serve_requests(&self) -> bool {
-        self.prefill_router
-            .as_ref()
-            .is_none_or(|pr| pr.can_serve_requests())
-    }
 }
 
 #[cfg(test)]

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -47,6 +47,8 @@ pub struct RouterConfig {
     pub kv_router_config: KvRouterConfig,
     /// Load threshold configuration for overload detection
     pub load_threshold_config: LoadThresholdConfig,
+    /// Deprecated compatibility field. Routing and readiness ignore this value.
+    #[serde(default)]
     pub enforce_disagg: bool,
     #[serde(default)]
     pub session_affinity_ttl_secs: Option<u64>,
@@ -68,6 +70,9 @@ impl RouterConfig {
         self
     }
 
+    #[deprecated(
+        note = "enforce_disagg is ignored; topology and readiness come from registered worker types"
+    )]
     pub fn with_enforce_disagg(mut self, enforce_disagg: bool) -> Self {
         self.enforce_disagg = enforce_disagg;
         self

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -238,7 +238,6 @@ pub async fn build_preprocessed_routing(
     chooser: Option<Arc<KvRouter>>,
     prefill_chooser: Option<Arc<PrefillRouter>>,
     enable_multimodal_cache_indexer: bool,
-    enforce_disagg: bool,
     session_affinity_ttl_secs: Option<u64>,
 ) -> anyhow::Result<PreprocessedRouting> {
     // Fail fast on an unsupported LoRA + router-mode combination BEFORE waiting for the initial
@@ -289,7 +288,6 @@ pub async fn build_preprocessed_routing(
         PrefillRouter::disabled(
             model_manager.clone(),
             router_mode,
-            enforce_disagg,
             session_affinity_ttl_secs,
         )
     });

--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -29,7 +29,6 @@ impl PrefillRouter {
     pub fn disabled(
         model_manager: Arc<ModelManager>,
         router_mode: RouterMode,
-        enforce_disagg: bool,
         session_affinity_ttl_secs: Option<u64>,
     ) -> Arc<Self> {
         Arc::new(Self {
@@ -38,7 +37,6 @@ impl PrefillRouter {
             endpoint_id: std::sync::OnceLock::new(),
             cancel_token: tokio_util::sync::CancellationToken::new(),
             router_mode,
-            enforce_disagg,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
             prefill_load_estimator: None,
             model_name: String::new(), // Not used for disabled router
@@ -56,7 +54,6 @@ impl PrefillRouter {
         kv_cache_block_size: u32,
         kv_router_config: Option<KvRouterConfig>,
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
-        enforce_disagg: bool,
         session_affinity_ttl_secs: Option<u64>,
         model_name: String,
         namespace: String,
@@ -72,7 +69,6 @@ impl PrefillRouter {
             endpoint_id: std::sync::OnceLock::new(),
             cancel_token: cancel_token.clone(),
             router_mode,
-            enforce_disagg,
             session_affinity_ttl: session_affinity_ttl_secs.map(std::time::Duration::from_secs),
             prefill_load_estimator,
             model_name,
@@ -239,7 +235,7 @@ impl PrefillRouter {
     // -- Prefill death handling --
 
     /// Deactivate the prefill router. Called when all prefill workers are removed.
-    /// After deactivation, requests fall back to aggregated mode (or fail if enforce_disagg).
+    /// After deactivation, requests fall back to aggregated mode.
     /// The inner router is preserved so that when workers rejoin (same endpoint/discovery),
     /// the Client's discovery subscription picks them up automatically.
     pub fn deactivate(&self) {
@@ -259,7 +255,6 @@ impl PrefillRouter {
         tracing::info!(
             model_name = %self.model_name,
             namespace = %self.namespace,
-            enforce_disagg = self.enforce_disagg,
             "Prefill router deactivated (all prefill workers removed)"
         );
     }
@@ -267,9 +262,8 @@ impl PrefillRouter {
     /// Reactivate a deactivated router. Called when prefill workers rejoin.
     /// The inner router's Client re-discovers workers via its discovery subscription.
     ///
-    /// Note: there is a brief race between entering `Active` (making
-    /// `can_serve_requests()` return true) and the Client actually rediscovering
-    /// workers. Requests arriving in this window may fail at prefill resolution.
+    /// Note: there is a brief race between entering `Active` and the Client
+    /// actually rediscovering workers. Requests arriving in this window may fail at prefill resolution.
     /// This is bounded by discovery propagation time (typically sub-second).
     ///
     /// Also note: reactivation reuses the existing inner router built from the
@@ -331,13 +325,6 @@ impl PrefillRouter {
 
     pub(super) fn lifecycle_state(&self) -> PrefillLifecycleState {
         PrefillLifecycleState::from_atomic(self.lifecycle.load(Ordering::Acquire))
-    }
-
-    /// Whether this router can serve requests in its current state.
-    /// Strict disaggregated routing requires active prefill workers; otherwise
-    /// pending and unavailable routers can use aggregated fallback.
-    pub fn can_serve_requests(&self) -> bool {
-        !self.enforce_disagg || self.lifecycle_state() == PrefillLifecycleState::Active
     }
 
     /// Mark this router as active for testing purposes.

--- a/lib/llm/src/kv_router/prefill_router/mod.rs
+++ b/lib/llm/src/kv_router/prefill_router/mod.rs
@@ -127,7 +127,6 @@ pub struct PrefillRouter {
     endpoint_id: OnceLock<EndpointId>,
     cancel_token: CancellationToken,
     router_mode: RouterMode,
-    enforce_disagg: bool,
     session_affinity_ttl: Option<std::time::Duration>,
     prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
     /// Model name (used for logging / lifecycle messages).
@@ -169,13 +168,10 @@ impl
         // Save original max_tokens for decode
         let original_max_tokens = req.stop_conditions.max_tokens;
 
-        // If prefill router is not activated (no prefill workers discovered) or has been
-        // deactivated (all prefill workers died), this is aggregated mode -- route directly
-        // to decode. With --enforce-disagg, fail instead of falling back.
+        // If the prefill router is not activated (no prefill workers discovered) or has been
+        // deactivated (all prefill workers died), route directly to the backend. Model admission
+        // remains gated by the registered worker topology before the request reaches this stage.
         if self.lifecycle_state() != PrefillLifecycleState::Active {
-            if self.enforce_disagg {
-                return Err(anyhow::anyhow!(PrefillError::NotActivated));
-            }
             return next.generate(context.map(|_| req)).await;
         }
 
@@ -320,10 +316,6 @@ impl
 }
 
 impl PrefillRouter {
-    pub fn enforce_disagg(&self) -> bool {
-        self.enforce_disagg
-    }
-
     fn prepare_prefill_dispatch(
         &self,
         request: &mut PreprocessedRequest,
@@ -542,61 +534,44 @@ mod tests {
         }
     }
 
-    fn make_test_router(enforce_disagg: bool) -> Arc<PrefillRouter> {
+    fn make_test_router() -> Arc<PrefillRouter> {
         PrefillRouter::disabled(
             Arc::new(crate::discovery::ModelManager::new()),
             RouterMode::RoundRobin,
-            enforce_disagg,
             None,
         )
     }
 
     #[test]
-    fn pending_state_uses_aggregated_fallback_only_when_allowed() {
-        let strict = make_test_router(true);
-        let fallback = make_test_router(false);
-
-        for router in [&strict, &fallback] {
-            assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Pending);
-            assert!(!router.is_activated());
-            assert!(!router.is_deactivated());
-        }
-        assert!(!strict.can_serve_requests());
-        assert!(fallback.can_serve_requests());
+    fn pending_state_is_tracked() {
+        let router = make_test_router();
+        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Pending);
+        assert!(!router.is_activated());
+        assert!(!router.is_deactivated());
     }
 
     #[test]
-    fn active_state_serves_strict_and_fallback_routers() {
-        for enforce_disagg in [true, false] {
-            let router = make_test_router(enforce_disagg);
-            router.mark_active_for_test();
+    fn active_state_is_tracked() {
+        let router = make_test_router();
+        router.mark_active_for_test();
 
-            assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Active);
-            assert!(!router.is_deactivated());
-            assert!(router.can_serve_requests());
-        }
+        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Active);
+        assert!(!router.is_deactivated());
     }
 
     #[test]
-    fn unavailable_state_blocks_strict_and_allows_aggregated_fallback() {
-        let strict = make_test_router(true);
-        let fallback = make_test_router(false);
-        strict.mark_active_for_test();
-        fallback.mark_active_for_test();
-        strict.deactivate();
-        fallback.deactivate();
+    fn unavailable_state_is_tracked() {
+        let router = make_test_router();
+        router.mark_active_for_test();
+        router.deactivate();
 
-        for router in [&strict, &fallback] {
-            assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Unavailable);
-            assert!(router.is_deactivated());
-        }
-        assert!(!strict.can_serve_requests());
-        assert!(fallback.can_serve_requests());
+        assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Unavailable);
+        assert!(router.is_deactivated());
     }
 
     #[test]
     fn deactivation_is_idempotent() {
-        let router = make_test_router(true);
+        let router = make_test_router();
         router.mark_active_for_test();
         router.deactivate();
         router.deactivate();
@@ -605,7 +580,7 @@ mod tests {
 
     #[test]
     fn pending_router_latches_worker_availability_transitions() {
-        let router = make_test_router(true);
+        let router = make_test_router();
         router.deactivate();
         assert_eq!(router.lifecycle_state(), PrefillLifecycleState::Unavailable);
 
@@ -617,7 +592,7 @@ mod tests {
 
     #[test]
     fn activation_does_not_overwrite_latched_deactivation() {
-        let router = make_test_router(true);
+        let router = make_test_router();
         router.deactivate();
 
         assert_eq!(

--- a/recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/deploy.yaml
@@ -49,7 +49,6 @@ spec:
           args:
             - -m
             - dynamo.frontend
-            - --enforce-disagg
           env:
             - name: POD_UID
               valueFrom:

--- a/recipes/glm-5-nvfp4/sglang/disagg/efa/deploy.yaml
+++ b/recipes/glm-5-nvfp4/sglang/disagg/efa/deploy.yaml
@@ -58,7 +58,6 @@ spec:
           args:
             - -m
             - dynamo.frontend
-            - --enforce-disagg
           env:
             - name: POD_UID
               valueFrom:

--- a/recipes/llama-3-70b/vllm/disagg-single-node/gaie/deploy.yaml
+++ b/recipes/llama-3-70b/vllm/disagg-single-node/gaie/deploy.yaml
@@ -60,8 +60,6 @@ spec:
             value: "128"
           - name: DYN_MODEL_NAME
             value: RedHatAI/Llama-3.3-70B-Instruct-FP8-dynamic
-          - name: DYN_ENFORCE_DISAGG
-            value: "true"
           envFrom:
           - secretRef:
               name: hf-token-secret

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -153,7 +153,6 @@ def _test_router_basic(
     store_backend: str = "etcd",
     request_plane: str = "nats",
     router_mode: str = "kv",
-    enforce_disagg: bool = False,
     min_initial_workers: int | None = None,
 ):
     """Basic router test: start router, wait for workers and send concurrent requests via HTTP frontend.
@@ -177,7 +176,6 @@ def _test_router_basic(
         store_backend: Storage backend to use ("etcd" or "file"). Defaults to "etcd".
         request_plane: Request plane to use ("nats", "tcp"). Defaults to "nats".
         router_mode: Router mode ("kv", "round-robin", "random", "power-of-two", "direct"). Defaults to "kv".
-        enforce_disagg: Whether to pass --enforce-disagg to the frontend. Defaults to False.
         min_initial_workers: Optional frontend startup worker gate. Defaults to None.
 
     Raises:
@@ -190,7 +188,6 @@ def _test_router_basic(
         frontend_port,
         engine_workers.namespace,
         store_backend,
-        enforce_disagg=enforce_disagg,
         request_plane=request_plane,
         router_mode=router_mode,
         min_initial_workers=min_initial_workers,
@@ -1120,8 +1117,8 @@ def _probe_overload_529_and_assert(
     """Send staggered streaming requests until the router rejects with 529.
 
     Shared core for the aggregated and disaggregated overload tests. The caller
-    is responsible for starting the frontend (with the desired thresholds and,
-    for disagg, ``enforce_disagg=True``) and for waiting until it is ready.
+    is responsible for starting the frontend with the desired thresholds and
+    waiting until it is ready.
 
     Sends unique (shuffled) prompts 0.1s apart until the router rejects, then
     asserts:
@@ -1335,11 +1332,10 @@ def _test_disagg_router_overload_529(
     """Verify disaggregated load-shedding: clients get 529 when the gated pool is busy.
 
     Assumes the prefill and decode workers are already running (kept alive by the
-    caller); this function owns the frontend (router) lifecycle. The frontend is
-    started with ``--enforce-disagg`` so prefill and decode are routed by separate
-    pools — and so the model only becomes ready (listed in ``/v1/models``) once the
-    prefill router has activated, meaning the readiness wait below already gates on
-    prefill registration.
+    caller); this function owns the frontend (router) lifecycle. Registered
+    prefill and decode worker types establish separate pools. The model only
+    becomes ready (listed in ``/v1/models``) once both worker types are available,
+    so the readiness wait below gates on prefill registration.
 
     Two configurations exercise the two pools (driven by the thresholds the
     caller passes):
@@ -1362,7 +1358,6 @@ def _test_disagg_router_overload_529(
         frontend_port=frontend_port,
         namespace=decode_workers.namespace,
         store_backend=store_backend,
-        enforce_disagg=True,
         blocks_threshold=blocks_threshold,
         tokens_threshold=tokens_threshold,
         tokens_threshold_frac=tokens_threshold_frac,
@@ -2183,7 +2178,6 @@ def _test_router_decisions_disagg(
         frontend_port,
         decode_workers.namespace,
         store_backend,
-        enforce_disagg=True,
         request_plane=request_plane,
         durable_kv_events=durable_kv_events,
         min_initial_workers=decode_workers.num_workers,
@@ -2383,7 +2377,6 @@ def _test_disagg_topology_required_prefill_pin_match_and_mismatch(
         block_size,
         frontend_port,
         namespace=decode_workers.namespace,
-        enforce_disagg=True,
         request_plane=request_plane,
         min_initial_workers=decode_workers.num_workers,
     ):
@@ -2513,7 +2506,6 @@ def _test_router_decisions_disagg_round_robin_prefill_dp_rank(
         frontend_port,
         decode_workers.namespace,
         store_backend,
-        enforce_disagg=True,
         request_plane=request_plane,
         router_mode="round-robin",
         min_initial_workers=decode_workers.num_workers,
@@ -3354,7 +3346,6 @@ def _test_disagg_direct_mode(
         BLOCK_SIZE,
         frontend_port,
         decode_workers.namespace,
-        enforce_disagg=True,
         request_plane=request_plane,
         router_mode="direct",
     ):

--- a/tests/router/router_process.py
+++ b/tests/router/router_process.py
@@ -45,7 +45,6 @@ class FrontendRouterProcess(ManagedProcess):
         frontend_port: int,
         namespace: str,
         store_backend: str = "etcd",
-        enforce_disagg: bool = False,
         blocks_threshold: float | str | None = None,
         tokens_threshold: int | str | None = None,
         tokens_threshold_frac: float | str | None = None,
@@ -75,9 +74,6 @@ class FrontendRouterProcess(ManagedProcess):
 
         if router_mode == "kv":
             command.extend(["--kv-cache-block-size", str(block_size)])
-
-        if enforce_disagg:
-            command.append("--enforce-disagg")
 
         if blocks_threshold is not None:
             command.extend(["--active-decode-blocks-threshold", str(blocks_threshold)])

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -136,10 +136,10 @@ _FAST_SPEEDUP = 100.0
 ROUTER_DISAGG_OVERLOAD_529_CASES = (
     pytest.param(
         {
-            # A single prefill worker is sufficient to verify
-            # overloaded -> no free prefill worker -> 529, and --enforce-disagg
-            # means the model only lists once the prefill router has activated,
-            # so frontend readiness already gates on prefill registration.
+            # A single prefill worker is sufficient to verify overloaded -> no
+            # free prefill worker -> 529. Registered worker types make the model
+            # list only after the prefill router activates, so frontend readiness
+            # already gates on prefill registration.
             "num_prefill": 1,
             "num_decode": 1,
             "max_tokens": 1,


### PR DESCRIPTION
## Summary
- Cherry-pick of #11160 to release/1.3.0
- Deprecates `--enforce-disagg` and `DYN_ENFORCE_DISAGG` as accepted no-op compatibility settings. Registered worker types remain the sole source of truth for aggregated versus disaggregated topology and model readiness.

Fixes DYN-3345

## Original PR
- Main PR: #11160
- Merge commit: 38ed7b2ece5b123941a6fdf79060fc0c08a955aa

## Conflict resolution
Three doc files touched by the original PR do not exist on `release/1.3.0` (`deploy/inference-gateway/ext-proc/DEVEL.md`, `docs/kubernetes/gateway-api/README.mdx`, `docs/kubernetes/gateway-api/reference.mdx`). The equivalent deprecation wording was applied to this branch's `docs/kubernetes/inference-gateway.md` instead; all code changes applied cleanly.

## Validation on release/1.3.0
- `cargo test -p dynamo-llm --lib discovery::model::tests::` (48 passed)
- `cargo test -p dynamo-llm --lib prefill_router` (24 passed)
- `pytest components/src/dynamo/common/tests/configuration/test_kv_router_args.py` (36 passed)
- Go EPP plugin build left to CI (no local Go toolchain)

## Test plan
- [ ] CI passes
- [ ] Verified fix works on release branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11295" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->