### PR TITLE
fix: Bump Qwen3-VL-32B-FP8 Hugging Face Hub Pin to Restore hf download

### DIFF
--- a/recipes/qwen3-vl-32b-fp8/model-cache/model-download.yaml
+++ b/recipes/qwen3-vl-32b-fp8/model-cache/model-download.yaml
@@ -33,7 +33,7 @@ spec:
           args:
             - |
               set -eux
-              pip install --no-cache-dir huggingface_hub==1.11.0
+              pip install --no-cache-dir huggingface_hub==1.16.4
               hf download $MODEL_NAME --revision $MODEL_REVISION
           volumeMounts:
             - name: model-cache


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

The Qwen3-VL-32B-FP8 model-cache job still installed huggingface_hub==1.11.0 before running hf download, while the other sibling model-cache jobs had already been bumped to  huggingface_hub==1.16.4

The specific reason was clarified in PR #10986, which miss fixing for Qwen3-VL-32B-FP8

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Hugging Face client used during model download jobs to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->