### PR TITLE
refactor(router): unify selection service lifecycle [DYN-3585]

### DIFF
--- a/docs/components/router/standalone-selection.md
+++ b/docs/components/router/standalone-selection.md
@@ -1,5 +1,5 @@
 ---
-# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Standalone Selection Service
 subtitle: Select workers and account for reservations without forwarding inference requests
@@ -38,6 +38,24 @@ Launch the service from the repository root:
 
 The service binds to `0.0.0.0` and does not provide authentication. Run it on a
 trusted internal network or place it behind an appropriate network policy.
+
+## Embedded Rust API
+
+Use `SelectionServiceBuilder` to embed selection without the HTTP server. The
+resulting `SelectionService` owns worker registration, KV-event listeners,
+indexer recovery, replica synchronization, and shutdown. It exposes the same
+worker, selection, bookkeeping, inspection, peer-membership, and recovery
+operations as the standalone HTTP service.
+
+`SelectionCore::new_local` creates an intentionally unsynchronized core for
+tests and local-only use. Production integrations should use
+`SelectionServiceBuilder` so startup recovery, readiness, and background-task
+lifecycle remain consistent with the standalone service.
+
+The C and Go bindings do not currently expose `SelectionService`. An EPP
+integration requires separate FFI lifecycle, error-mapping, worker, and peer
+APIs. Those bindings should wrap `SelectionService` rather than construct
+`SelectionCore` directly.
 
 ### CLI
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -29,7 +29,8 @@ use dynamo_kv_router::services::indexer::{self, IndexerConfig};
 #[cfg(feature = "select-service")]
 use dynamo_kv_router::services::selection::{
     self, OverlapScoresRequest, PotentialLoadsRequest, ReservationRequest, SelectAndReserveRequest,
-    SelectRequest, SelectionCore, SelectionError, SelectionServiceConfig, WorkerRequest,
+    SelectRequest, SelectionError, SelectionService as RustSelectionService,
+    SelectionServiceBuilder, SelectionServiceConfig, WorkerPatchRequest, WorkerRequest,
 };
 #[cfg(feature = "slot-tracker")]
 use dynamo_kv_router::services::slot_tracker::{self, SlotTrackerConfig};
@@ -381,11 +382,11 @@ fn selection_to_pyerr(err: SelectionError) -> PyErr {
     })
 }
 
-/// In-process handle to a runtime-free Dynamo `SelectionCore`.
+/// In-process handle to a managed Dynamo `SelectionService`.
 #[cfg(feature = "select-service")]
 #[pyclass]
 pub(crate) struct SelectionService {
-    inner: Arc<SelectionCore>,
+    inner: Arc<RustSelectionService>,
 }
 
 #[cfg(feature = "select-service")]
@@ -393,14 +394,31 @@ pub(crate) struct SelectionService {
 impl SelectionService {
     /// Create a selection service. `indexer_threads` sizes the KV indexer pool.
     #[new]
-    #[pyo3(signature = (*, indexer_threads = 4))]
-    fn new(indexer_threads: usize) -> Self {
-        let inner = Arc::new(SelectionCore::new(
-            kv_router_config_from_dynamo_env(),
-            indexer_threads,
-            tokio_util::sync::CancellationToken::new(),
-        ));
-        Self { inner }
+    #[pyo3(signature = (*, indexer_threads = 4, indexer_peers = None, replica_sync_port = None, replica_sync_peers = None))]
+    fn new(
+        indexer_threads: usize,
+        indexer_peers: Option<Vec<String>>,
+        replica_sync_port: Option<u16>,
+        replica_sync_peers: Option<Vec<String>>,
+    ) -> PyResult<Self> {
+        let replica_sync_peers = replica_sync_peers.unwrap_or_default();
+        if replica_sync_port.is_none() && !replica_sync_peers.is_empty() {
+            return Err(PyValueError::new_err(
+                "replica_sync_peers requires replica_sync_port",
+            ));
+        }
+        let mut builder = SelectionServiceBuilder::new(kv_router_config_from_dynamo_env())
+            .indexer_threads(indexer_threads)
+            .indexer_peers(indexer_peers.unwrap_or_default());
+        if let Some(port) = replica_sync_port {
+            builder = builder.replica_sync(port, replica_sync_peers);
+        }
+        let inner = pyo3_async_runtimes::tokio::get_runtime()
+            .block_on(builder.build())
+            .map_err(to_pyerr)?;
+        Ok(Self {
+            inner: Arc::new(inner),
+        })
     }
 
     /// Stop the service: cancel KV-event listeners and scheduling so that
@@ -408,8 +426,12 @@ impl SelectionService {
     ///
     /// The KV indexer thread pool is released when the last Python handle is
     /// dropped. Idempotent, and also run automatically on drop.
-    fn shutdown(&self) {
-        self.inner.shutdown();
+    fn shutdown<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
+        let service = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            service.shutdown().await;
+            Ok(())
+        })
     }
 
     /// Upsert a worker and subscribe to its live KV events via each `kv_events_endpoints`.
@@ -419,6 +441,25 @@ impl SelectionService {
         let core = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             let record = core.upsert_worker(req).await.map_err(selection_to_pyerr)?;
+            Python::with_gil(|py| pythonize(py, &record).map(|o| o.unbind()).map_err(to_pyerr))
+        })
+    }
+
+    /// Patch supplied worker fields and reconcile KV-event listeners.
+    fn patch_worker<'p>(
+        &self,
+        py: Python<'p>,
+        worker_id: u64,
+        patch: PyObject,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let patch: WorkerPatchRequest =
+            depythonize(patch.bind(py)).map_err(|e| PyValueError::new_err(e.to_string()))?;
+        let service = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let record = service
+                .patch_worker(worker_id, patch)
+                .await
+                .map_err(selection_to_pyerr)?;
             Python::with_gil(|py| pythonize(py, &record).map(|o| o.unbind()).map_err(to_pyerr))
         })
     }
@@ -585,6 +626,69 @@ impl SelectionService {
             Python::with_gil(|py| pythonize(py, &resp).map(|o| o.unbind()).map_err(to_pyerr))
         })
     }
+
+    /// Add a live selector replica peer. Returns whether membership changed.
+    fn register_replica_peer<'p>(
+        &self,
+        py: Python<'p>,
+        endpoint: String,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let service = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            service
+                .register_replica_peer(endpoint)
+                .await
+                .map_err(to_pyerr)
+        })
+    }
+
+    /// Remove a selector replica peer. Returns whether membership changed.
+    fn deregister_replica_peer<'p>(
+        &self,
+        py: Python<'p>,
+        endpoint: String,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let service = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            service
+                .deregister_replica_peer(endpoint)
+                .await
+                .map_err(to_pyerr)
+        })
+    }
+
+    /// List configured selector replica peers.
+    fn list_replica_peers(&self) -> Vec<String> {
+        self.inner.list_replica_peers()
+    }
+
+    /// Export the current indexer state in the standalone `/dump` shape.
+    fn indexer_snapshot<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
+        let service = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            let snapshot = service.indexer_snapshot().await;
+            Python::with_gil(|py| {
+                pythonize(py, &snapshot)
+                    .map(|o| o.unbind())
+                    .map_err(to_pyerr)
+            })
+        })
+    }
+
+    /// Recover indexer state from the first reachable standalone peer.
+    fn recover_indexer_from_peers<'p>(
+        &self,
+        py: Python<'p>,
+        peers: Vec<String>,
+    ) -> PyResult<Bound<'p, PyAny>> {
+        let service = Arc::clone(&self.inner);
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            service
+                .recover_indexer_from_peers(&peers)
+                .await
+                .map_err(to_pyerr)
+        })
+    }
 }
 
 #[cfg(all(test, feature = "select-service"))]
@@ -593,19 +697,11 @@ mod selection_service_lifecycle_tests {
 
     #[test]
     fn idempotent_shutdown() {
-        let service = SelectionService::new(1);
-        service.shutdown();
-
-        // Idempotent: a second shutdown and the final drop must not panic.
-        service.shutdown();
+        let service = SelectionService::new(1, None, None, None).unwrap();
+        let runtime = pyo3_async_runtimes::tokio::get_runtime();
+        runtime.block_on(service.inner.shutdown());
+        runtime.block_on(service.inner.shutdown());
         drop(service);
-    }
-}
-
-#[cfg(feature = "select-service")]
-impl Drop for SelectionService {
-    fn drop(&mut self) {
-        self.inner.shutdown();
     }
 }
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -396,6 +396,7 @@ impl SelectionService {
     #[new]
     #[pyo3(signature = (*, indexer_threads = 4, indexer_peers = None, replica_sync_port = None, replica_sync_peers = None))]
     fn new(
+        py: Python<'_>,
         indexer_threads: usize,
         indexer_peers: Option<Vec<String>>,
         replica_sync_port: Option<u16>,
@@ -413,8 +414,8 @@ impl SelectionService {
         if let Some(port) = replica_sync_port {
             builder = builder.replica_sync(port, replica_sync_peers);
         }
-        let inner = pyo3_async_runtimes::tokio::get_runtime()
-            .block_on(builder.build())
+        let inner = py
+            .allow_threads(|| pyo3_async_runtimes::tokio::get_runtime().block_on(builder.build()))
             .map_err(to_pyerr)?;
         Ok(Self {
             inner: Arc::new(inner),
@@ -426,7 +427,13 @@ impl SelectionService {
     ///
     /// The KV indexer thread pool is released when the last Python handle is
     /// dropped. Idempotent, and also run automatically on drop.
-    fn shutdown<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
+    fn shutdown(&self, py: Python<'_>) {
+        let service = Arc::clone(&self.inner);
+        py.allow_threads(|| pyo3_async_runtimes::tokio::get_runtime().block_on(service.shutdown()));
+    }
+
+    /// Await service shutdown without blocking the Python event loop.
+    fn shutdown_async<'p>(&self, py: Python<'p>) -> PyResult<Bound<'p, PyAny>> {
         let service = Arc::clone(&self.inner);
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
             service.shutdown().await;
@@ -697,10 +704,12 @@ mod selection_service_lifecycle_tests {
 
     #[test]
     fn idempotent_shutdown() {
-        let service = SelectionService::new(1, None, None, None).unwrap();
-        let runtime = pyo3_async_runtimes::tokio::get_runtime();
-        runtime.block_on(service.inner.shutdown());
-        runtime.block_on(service.inner.shutdown());
+        let service =
+            Python::with_gil(|py| SelectionService::new(py, 1, None, None, None)).unwrap();
+        Python::with_gil(|py| {
+            service.shutdown(py);
+            service.shutdown(py);
+        });
         drop(service);
     }
 }

--- a/lib/bindings/python/tests/test_kv_bindings.py
+++ b/lib/bindings/python/tests/test_kv_bindings.py
@@ -239,7 +239,7 @@ async def test_selection_service_selects_registered_worker(monkeypatch):
         assert selected["dp_rank"] == 0
         assert selected["endpoint"] == "http://worker-1:8000"
     finally:
-        service.shutdown()
+        await service.shutdown_async()
 
 
 @pytest.mark.skipif(

--- a/lib/kv-router/src/services/common/mod.rs
+++ b/lib/kv-router/src/services/common/mod.rs
@@ -11,5 +11,5 @@ pub(crate) mod zmq;
 #[cfg(any(feature = "standalone-slot-tracker", feature = "standalone-selection"))]
 pub(crate) mod replica_sync;
 
-#[cfg(any(feature = "standalone-slot-tracker", feature = "standalone-selection"))]
+#[cfg(feature = "standalone-slot-tracker")]
 pub(crate) mod replica_sync_http;

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -9,7 +9,8 @@ use std::task::{Context, Poll};
 use anyhow::{Context as _, Result, anyhow};
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Mutex, mpsc, oneshot};
+use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
 use crate::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
@@ -34,6 +35,41 @@ pub(crate) type ReplicaEventSender = mpsc::Sender<ScopedReplicaEvent>;
 pub(crate) struct ReplicaSyncConfig {
     process_id: u64,
     outbound_tx: ReplicaEventSender,
+}
+
+#[derive(Debug)]
+pub(crate) struct ReplicaSyncRuntime {
+    config: ReplicaSyncConfig,
+    cancel_token: CancellationToken,
+    publisher_task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ReplicaSyncRuntime {
+    pub(crate) fn config(&self) -> ReplicaSyncConfig {
+        self.config.clone()
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.cancel_token.cancel();
+        if let Some(task) = self.publisher_task.lock().await.take() {
+            let _ = task.await;
+        }
+    }
+
+    fn abort(&self) {
+        self.cancel_token.cancel();
+        if let Ok(mut task) = self.publisher_task.try_lock()
+            && let Some(task) = task.take()
+        {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for ReplicaSyncRuntime {
+    fn drop(&mut self) {
+        self.abort();
+    }
 }
 
 impl ReplicaSyncConfig {
@@ -183,7 +219,7 @@ pub(crate) fn setup_replica_sync(
     port: Option<u16>,
     initial_peers: &[String],
     cancel_token: CancellationToken,
-) -> Result<Option<ReplicaSyncConfig>> {
+) -> Result<Option<ReplicaSyncRuntime>> {
     let Some(port) = port else {
         if !initial_peers.is_empty() {
             anyhow::bail!("--replica-sync-peers requires --replica-sync-port");
@@ -193,8 +229,13 @@ pub(crate) fn setup_replica_sync(
 
     let bind_endpoint = replica_sync_bind_endpoint(port)?;
     let process_id = generate_process_id();
-    let outbound_tx = start_replica_publisher(&bind_endpoint, cancel_token)?;
-    Ok(Some(ReplicaSyncConfig::new(process_id, outbound_tx)))
+    let (outbound_tx, publisher_task) =
+        start_replica_publisher(&bind_endpoint, cancel_token.clone())?;
+    Ok(Some(ReplicaSyncRuntime {
+        config: ReplicaSyncConfig::new(process_id, outbound_tx),
+        cancel_token,
+        publisher_task: Mutex::new(Some(publisher_task)),
+    }))
 }
 
 pub(crate) fn setup_scoped_replica_sync(
@@ -229,13 +270,13 @@ pub(crate) fn setup_scoped_replica_sync(
 pub(crate) fn start_replica_publisher(
     bind_endpoint: &str,
     cancel_token: CancellationToken,
-) -> Result<ReplicaEventSender> {
+) -> Result<(ReplicaEventSender, JoinHandle<()>)> {
     validate_endpoint(bind_endpoint)?;
     let mut socket = create_bound_pub_socket(bind_endpoint)
         .with_context(|| format!("failed to bind replica publisher to `{bind_endpoint}`"))?;
     let (tx, mut rx) = mpsc::channel::<ScopedReplicaEvent>(REPLICA_EVENT_CHANNEL_CAPACITY);
 
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         loop {
             let event = tokio::select! {
                 _ = cancel_token.cancelled() => break,
@@ -270,24 +311,29 @@ pub(crate) fn start_replica_publisher(
         }
     });
 
-    Ok(tx)
+    Ok((tx, task))
 }
 
 #[derive(Debug, thiserror::Error)]
 #[cfg_attr(not(feature = "standalone-slot-tracker"), allow(dead_code))]
-pub(crate) enum PeerError {
+pub enum ReplicaPeerError {
     #[error(transparent)]
     InvalidEndpoint(#[from] anyhow::Error),
+
+    #[allow(dead_code)]
+    #[error("replica sync is disabled")]
+    Disabled,
 
     #[error("replica peer manager is unavailable")]
     Unavailable,
 }
 
-#[derive(Clone)]
 #[cfg_attr(not(feature = "standalone-slot-tracker"), allow(dead_code))]
 pub(crate) struct PeerManager {
     command_tx: mpsc::Sender<PeerCommand>,
     peers: Arc<RwLock<HashSet<String>>>,
+    cancel_token: CancellationToken,
+    subscriber_task: Mutex<Option<JoinHandle<()>>>,
 }
 
 #[cfg_attr(not(feature = "standalone-slot-tracker"), allow(dead_code))]
@@ -326,10 +372,11 @@ impl PeerManager {
         let peers = Arc::new(RwLock::new(configured_peers));
         let (command_tx, mut command_rx) = mpsc::channel(PEER_COMMAND_CHANNEL_CAPACITY);
         let task_peers = Arc::clone(&peers);
-        tokio::spawn(async move {
+        let task_cancel = cancel_token.clone();
+        let subscriber_task = tokio::spawn(async move {
             loop {
                 tokio::select! {
-                    _ = cancel_token.cancelled() => break,
+                    _ = task_cancel.cancelled() => break,
                     command = command_rx.recv() => {
                         let Some(command) = command else {
                             break;
@@ -348,35 +395,40 @@ impl PeerManager {
             }
         });
 
-        Ok(Self { command_tx, peers })
+        Ok(Self {
+            command_tx,
+            peers,
+            cancel_token,
+            subscriber_task: Mutex::new(Some(subscriber_task)),
+        })
     }
 
     #[cfg_attr(not(feature = "standalone-slot-tracker"), allow(dead_code))]
-    pub(crate) async fn register_peer(&self, endpoint: String) -> Result<bool, PeerError> {
-        validate_endpoint(&endpoint).map_err(PeerError::InvalidEndpoint)?;
+    pub(crate) async fn register_peer(&self, endpoint: String) -> Result<bool, ReplicaPeerError> {
+        validate_endpoint(&endpoint).map_err(ReplicaPeerError::InvalidEndpoint)?;
         let (response, result) = oneshot::channel();
         self.command_tx
             .send(PeerCommand::Register { endpoint, response })
             .await
-            .map_err(|_| PeerError::Unavailable)?;
+            .map_err(|_| ReplicaPeerError::Unavailable)?;
         result
             .await
-            .map_err(|_| PeerError::Unavailable)?
-            .map_err(PeerError::InvalidEndpoint)
+            .map_err(|_| ReplicaPeerError::Unavailable)?
+            .map_err(ReplicaPeerError::InvalidEndpoint)
     }
 
     #[cfg_attr(not(feature = "standalone-slot-tracker"), allow(dead_code))]
-    pub(crate) async fn deregister_peer(&self, endpoint: String) -> Result<bool, PeerError> {
-        validate_endpoint(&endpoint).map_err(PeerError::InvalidEndpoint)?;
+    pub(crate) async fn deregister_peer(&self, endpoint: String) -> Result<bool, ReplicaPeerError> {
+        validate_endpoint(&endpoint).map_err(ReplicaPeerError::InvalidEndpoint)?;
         let (response, result) = oneshot::channel();
         self.command_tx
             .send(PeerCommand::Deregister { endpoint, response })
             .await
-            .map_err(|_| PeerError::Unavailable)?;
+            .map_err(|_| ReplicaPeerError::Unavailable)?;
         result
             .await
-            .map_err(|_| PeerError::Unavailable)?
-            .map_err(PeerError::InvalidEndpoint)
+            .map_err(|_| ReplicaPeerError::Unavailable)?
+            .map_err(ReplicaPeerError::InvalidEndpoint)
     }
 
     #[cfg_attr(not(feature = "standalone-slot-tracker"), allow(dead_code))]
@@ -384,6 +436,28 @@ impl PeerManager {
         let mut peers: Vec<_> = self.peers.read().iter().cloned().collect();
         peers.sort();
         peers
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        self.cancel_token.cancel();
+        if let Some(task) = self.subscriber_task.lock().await.take() {
+            let _ = task.await;
+        }
+    }
+
+    fn abort(&self) {
+        self.cancel_token.cancel();
+        if let Ok(mut task) = self.subscriber_task.try_lock()
+            && let Some(task) = task.take()
+        {
+            task.abort();
+        }
+    }
+}
+
+impl Drop for PeerManager {
+    fn drop(&mut self) {
+        self.abort();
     }
 }
 
@@ -513,7 +587,7 @@ mod tests {
     async fn dynamic_peer_registration_controls_delivery() {
         let endpoint = reserve_tcp_endpoint();
         let cancel_token = CancellationToken::new();
-        let outbound =
+        let (outbound, publisher_task) =
             start_replica_publisher(&endpoint, cancel_token.child_token()).expect("publisher");
         let (received_tx, mut received_rx) = mpsc::channel(16);
         let manager = PeerManager::start(Vec::new(), cancel_token.child_token(), move |event| {
@@ -551,6 +625,8 @@ mod tests {
         );
 
         cancel_token.cancel();
+        manager.shutdown().await;
+        publisher_task.await.unwrap();
     }
 
     #[cfg(feature = "standalone-slot-tracker")]
@@ -559,8 +635,10 @@ mod tests {
         let endpoint_a = reserve_tcp_endpoint();
         let endpoint_b = reserve_tcp_endpoint();
         let cancel_token = CancellationToken::new();
-        let outbound_a = start_replica_publisher(&endpoint_a, cancel_token.child_token()).unwrap();
-        let outbound_b = start_replica_publisher(&endpoint_b, cancel_token.child_token()).unwrap();
+        let (outbound_a, publisher_a) =
+            start_replica_publisher(&endpoint_a, cancel_token.child_token()).unwrap();
+        let (outbound_b, publisher_b) =
+            start_replica_publisher(&endpoint_b, cancel_token.child_token()).unwrap();
         let registry_a = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
             cancel_token.clone(),
             ReplicaSyncConfig::new(11, outbound_a),
@@ -570,7 +648,7 @@ mod tests {
             ReplicaSyncConfig::new(22, outbound_b),
         ));
         let dispatch_registry_b = Arc::clone(&registry_b);
-        let _peer_b =
+        let peer_b =
             PeerManager::start(vec![endpoint_a], cancel_token.child_token(), move |event| {
                 dispatch_registry_b.dispatch_replica_event(event)
             })
@@ -610,6 +688,9 @@ mod tests {
         registry_a.free(&key, "target").unwrap();
         wait_for_load(&registry_b, 0, 0).await;
         cancel_token.cancel();
+        peer_b.shutdown().await;
+        publisher_a.await.unwrap();
+        publisher_b.await.unwrap();
     }
 
     #[cfg(feature = "standalone-slot-tracker")]

--- a/lib/kv-router/src/services/common/replica_sync_http.rs
+++ b/lib/kv-router/src/services/common/replica_sync_http.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::fmt;
+use std::sync::Arc;
 
 use axum::extract::State;
 use axum::extract::rejection::JsonRejection;
@@ -11,7 +12,7 @@ use axum::routing::{get, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 
-use super::replica_sync::{PeerError, PeerManager};
+use super::replica_sync::{PeerManager, ReplicaPeerError};
 
 #[derive(Debug, Deserialize)]
 struct PeerRequest {
@@ -19,7 +20,7 @@ struct PeerRequest {
 }
 
 async fn register_peer(
-    State(peer_manager): State<Option<PeerManager>>,
+    State(peer_manager): State<Option<Arc<PeerManager>>>,
     payload: Result<Json<PeerRequest>, JsonRejection>,
 ) -> Response {
     let Json(req) = match payload {
@@ -37,7 +38,7 @@ async fn register_peer(
 }
 
 async fn deregister_peer(
-    State(peer_manager): State<Option<PeerManager>>,
+    State(peer_manager): State<Option<Arc<PeerManager>>>,
     payload: Result<Json<PeerRequest>, JsonRejection>,
 ) -> Response {
     let Json(req) = match payload {
@@ -54,11 +55,11 @@ async fn deregister_peer(
     }
 }
 
-async fn list_peers(State(peer_manager): State<Option<PeerManager>>) -> Response {
+async fn list_peers(State(peer_manager): State<Option<Arc<PeerManager>>>) -> Response {
     Json(
         peer_manager
             .as_ref()
-            .map(PeerManager::list_peers)
+            .map(|peer_manager| peer_manager.list_peers())
             .unwrap_or_default(),
     )
     .into_response()
@@ -76,15 +77,16 @@ fn json_error(status: StatusCode, error: impl fmt::Display) -> Response {
         .into_response()
 }
 
-fn peer_error(error: PeerError) -> Response {
+fn peer_error(error: ReplicaPeerError) -> Response {
     let status = match &error {
-        PeerError::InvalidEndpoint(_) => StatusCode::BAD_REQUEST,
-        PeerError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+        ReplicaPeerError::InvalidEndpoint(_) => StatusCode::BAD_REQUEST,
+        ReplicaPeerError::Disabled => StatusCode::CONFLICT,
+        ReplicaPeerError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
     };
     json_error(status, error)
 }
 
-pub(crate) fn router(peer_manager: Option<PeerManager>) -> Router {
+pub(crate) fn router(peer_manager: Option<Arc<PeerManager>>) -> Router {
     Router::new()
         .route("/replica_sync/register_peer", post(register_peer))
         .route("/replica_sync/deregister_peer", post(deregister_peer))
@@ -151,7 +153,7 @@ mod tests {
     async fn manages_replica_sync_peers() {
         let cancel_token = CancellationToken::new();
         let peer_manager = PeerManager::start(Vec::new(), cancel_token.clone(), |_| {}).unwrap();
-        let app = router(Some(peer_manager));
+        let app = router(Some(Arc::new(peer_manager)));
         let endpoint = "tcp://127.0.0.1:19092";
         let body = format!(r#"{{"endpoint":"{endpoint}"}}"#);
 

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -101,7 +101,9 @@ pub struct SelectionCore {
 }
 
 impl SelectionCore {
-    pub fn new(
+    /// Create an intentionally local selector without replica synchronization
+    /// or startup recovery.
+    pub fn new_local(
         kv_router_config: crate::config::KvRouterConfig,
         indexer_threads: usize,
         cancel_token: CancellationToken,
@@ -109,7 +111,7 @@ impl SelectionCore {
         Self::new_inner(kv_router_config, indexer_threads, cancel_token, None, true)
     }
 
-    pub(crate) fn new_for_server(
+    pub(super) fn new_managed(
         kv_router_config: crate::config::KvRouterConfig,
         indexer_threads: usize,
         cancel_token: CancellationToken,
@@ -1026,6 +1028,7 @@ mod tests {
             expected_output_tokens: None,
             priority_jump: None,
             strict_priority: None,
+            session_id: None,
             pinned_worker: None,
             allowed_worker_ids: None,
             routing_constraints: RoutingConstraints::default(),
@@ -1043,6 +1046,7 @@ mod tests {
             expected_output_tokens: None,
             priority_jump: None,
             strict_priority: None,
+            session_id: None,
             pinned_worker: None,
             allowed_worker_ids: None,
             routing_constraints: RoutingConstraints::default(),
@@ -1073,7 +1077,7 @@ mod tests {
     #[test]
     fn parent_cancel_cancels_core() {
         let parent = CancellationToken::new();
-        let core = SelectionCore::new(test_config(false), 1, parent.clone());
+        let core = SelectionCore::new_local(test_config(false), 1, parent.clone());
 
         assert!(!core.cancel_token.is_cancelled());
         parent.cancel();
@@ -1083,7 +1087,7 @@ mod tests {
     #[test]
     fn shutdown_keeps_parent_alive() {
         let parent = CancellationToken::new();
-        let core = SelectionCore::new(test_config(false), 1, parent.clone());
+        let core = SelectionCore::new_local(test_config(false), 1, parent.clone());
 
         core.shutdown();
 
@@ -1094,7 +1098,7 @@ mod tests {
     #[tokio::test]
     async fn shutdown_cancels_listeners() {
         let parent = CancellationToken::new();
-        let core = SelectionCore::new(test_config(true), 1, parent);
+        let core = SelectionCore::new_local(test_config(true), 1, parent);
 
         let record = core
             .upsert_worker(worker_with_kv_events(1))
@@ -1109,7 +1113,7 @@ mod tests {
 
     #[tokio::test]
     async fn shutdown_reports_not_ready_and_rejects_new_work() {
-        let core = SelectionCore::new(test_config(false), 1, CancellationToken::new());
+        let core = SelectionCore::new_local(test_config(false), 1, CancellationToken::new());
         core.upsert_worker(worker(1)).await.expect("worker upsert");
         assert!(core.ready().ready);
 
@@ -1170,7 +1174,11 @@ mod tests {
     async fn queued_selection_errors_on_shutdown() {
         let mut config = test_config(false);
         config.router_queue_threshold = Some(0.0);
-        let core = Arc::new(SelectionCore::new(config, 1, CancellationToken::new()));
+        let core = Arc::new(SelectionCore::new_local(
+            config,
+            1,
+            CancellationToken::new(),
+        ));
 
         let record = core.upsert_worker(worker(1)).await.expect("worker upsert");
         assert_eq!(record.lifecycle, WorkerLifecycle::Schedulable);
@@ -1199,7 +1207,11 @@ mod tests {
     async fn queued_selection_returns_refreshed_overlap_snapshot() {
         let mut config = test_config(false);
         config.router_queue_threshold = Some(0.0);
-        let core = Arc::new(SelectionCore::new(config, 1, CancellationToken::new()));
+        let core = Arc::new(SelectionCore::new_local(
+            config,
+            1,
+            CancellationToken::new(),
+        ));
 
         for worker_id in [1, 2] {
             let mut request = worker(worker_id);
@@ -1261,6 +1273,7 @@ mod tests {
                     expected_output_tokens: None,
                     priority_jump: None,
                     strict_priority: None,
+                    session_id: None,
                     pinned_worker: None,
                     allowed_worker_ids: None,
                     routing_constraints: RoutingConstraints::default(),

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -11,14 +11,17 @@ mod core;
 mod error;
 mod input;
 mod server;
+mod service;
 mod types;
 
 #[cfg(test)]
 mod tests;
 
+pub use crate::services::common::replica_sync::ReplicaPeerError;
 pub use core::{SelectionCore, SelectionServiceConfig};
 pub use error::SelectionError;
 pub use server::{AppState, run_server};
+pub use service::{SelectionService, SelectionServiceBuilder};
 pub use types::{
     ModelLoadResponse, OutputBlockRequest, OverlapScoresRequest, OverlapScoresResponse,
     PotentialLoadsRequest, ReadyResponse, ReservationRequest, ReservationResponse,

--- a/lib/kv-router/src/services/selection/server.rs
+++ b/lib/kv-router/src/services/selection/server.rs
@@ -12,13 +12,12 @@ use axum::routing::{delete, get, patch, post};
 use axum::{Json, Router};
 use serde::Deserialize;
 use tokio::net::TcpListener;
-use tokio_util::sync::CancellationToken;
 
 use crate::protocols::WorkerId;
-use crate::services::common::replica_sync::{PeerManager, setup_replica_sync};
-use crate::services::common::replica_sync_http;
+use crate::services::common::replica_sync::ReplicaPeerError;
 
-use super::core::{SelectionCore, SelectionServiceConfig};
+use super::core::SelectionServiceConfig;
+use super::service::SelectionService;
 use super::types::{
     OutputBlockRequest, OverlapScoresRequest, PotentialLoadsRequest, REQUEST_BODY_LIMIT_BYTES,
     ReservationRequest, SelectAndReserveRequest, SelectRequest, WorkerPatchRequest, WorkerRequest,
@@ -31,7 +30,12 @@ struct FilterQuery {
 }
 
 pub struct AppState {
-    pub core: Arc<SelectionCore>,
+    pub service: Arc<SelectionService>,
+}
+
+#[derive(Debug, Deserialize)]
+struct PeerRequest {
+    endpoint: String,
 }
 
 async fn create_worker(
@@ -42,7 +46,7 @@ async fn create_worker(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    match state.core.upsert_worker(req).await {
+    match state.service.upsert_worker(req).await {
         Ok(worker) => (StatusCode::CREATED, Json(worker)).into_response(),
         Err(error) => error.into_response(),
     }
@@ -57,7 +61,7 @@ async fn patch_worker(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    match state.core.patch_worker(worker_id, req).await {
+    match state.service.patch_worker(worker_id, req).await {
         Ok(worker) => Json(worker).into_response(),
         Err(error) => error.into_response(),
     }
@@ -67,7 +71,7 @@ async fn delete_worker(
     State(state): State<Arc<AppState>>,
     Path(worker_id): Path<WorkerId>,
 ) -> Response {
-    match state.core.delete_worker(worker_id).await {
+    match state.service.delete_worker(worker_id).await {
         Ok(worker) => Json(worker).into_response(),
         Err(error) => error.into_response(),
     }
@@ -79,7 +83,7 @@ async fn list_workers(
 ) -> Response {
     Json(
         state
-            .core
+            .service
             .list_workers(params.model_name.as_deref(), params.tenant_id.as_deref()),
     )
     .into_response()
@@ -95,7 +99,7 @@ async fn select(
         Err(error) => return json_rejection(error),
     };
     match state
-        .core
+        .service
         .select_with_policy_class(req, policy_class_from_headers(&headers))
         .await
     {
@@ -114,7 +118,7 @@ async fn select_and_reserve(
         Err(error) => return json_rejection(error),
     };
     match state
-        .core
+        .service
         .select_and_reserve_with_policy_class(req, policy_class_from_headers(&headers))
         .await
     {
@@ -131,7 +135,7 @@ async fn create_reservation(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    match state.core.create_reservation(req).await {
+    match state.service.create_reservation(req).await {
         Ok(response) => (StatusCode::CREATED, Json(response)).into_response(),
         Err(error) => error.into_response(),
     }
@@ -141,7 +145,7 @@ async fn prefill_complete(
     State(state): State<Arc<AppState>>,
     Path(reservation_id): Path<String>,
 ) -> Response {
-    match state.core.prefill_complete(&reservation_id).await {
+    match state.service.prefill_complete(&reservation_id).await {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => error.into_response(),
     }
@@ -151,7 +155,7 @@ async fn delete_reservation(
     State(state): State<Arc<AppState>>,
     Path(reservation_id): Path<String>,
 ) -> Response {
-    match state.core.free_reservation(&reservation_id).await {
+    match state.service.free_reservation(&reservation_id).await {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => error.into_response(),
     }
@@ -167,7 +171,7 @@ async fn add_output_block(
         Err(error) => return json_rejection(error),
     };
     match state
-        .core
+        .service
         .add_output_block(&reservation_id, req.decay_fraction)
     {
         Ok(()) => json_ok(StatusCode::OK),
@@ -180,7 +184,7 @@ async fn health() -> Response {
 }
 
 async fn ready(State(state): State<Arc<AppState>>) -> Response {
-    let response = state.core.ready();
+    let response = state.service.ready();
     if response.ready {
         Json(response).into_response()
     } else {
@@ -191,7 +195,7 @@ async fn ready(State(state): State<Arc<AppState>>) -> Response {
 async fn loads(State(state): State<Arc<AppState>>, Query(params): Query<FilterQuery>) -> Response {
     Json(
         state
-            .core
+            .service
             .loads(params.model_name.as_deref(), params.tenant_id.as_deref()),
     )
     .into_response()
@@ -205,7 +209,7 @@ async fn potential_loads(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    match state.core.potential_loads(req).await {
+    match state.service.potential_loads(req).await {
         Ok(response) => Json(response).into_response(),
         Err(error) => error.into_response(),
     }
@@ -219,14 +223,48 @@ async fn overlap_scores(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    match state.core.overlap_scores(req).await {
+    match state.service.overlap_scores(req).await {
         Ok(response) => Json(response).into_response(),
         Err(error) => error.into_response(),
     }
 }
 
 async fn dump_events(State(state): State<Arc<AppState>>) -> Response {
-    Json(state.core.dump_indexer_events().await).into_response()
+    Json(state.service.indexer_snapshot().await).into_response()
+}
+
+async fn register_peer(
+    State(state): State<Arc<AppState>>,
+    payload: Result<Json<PeerRequest>, JsonRejection>,
+) -> Response {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(error) => return json_rejection(error),
+    };
+    match state.service.register_replica_peer(req.endpoint).await {
+        Ok(true) => json_ok(StatusCode::CREATED),
+        Ok(false) => json_ok(StatusCode::OK),
+        Err(error) => replica_peer_error(error),
+    }
+}
+
+async fn deregister_peer(
+    State(state): State<Arc<AppState>>,
+    payload: Result<Json<PeerRequest>, JsonRejection>,
+) -> Response {
+    let Json(req) = match payload {
+        Ok(payload) => payload,
+        Err(error) => return json_rejection(error),
+    };
+    match state.service.deregister_replica_peer(req.endpoint).await {
+        Ok(true) => json_ok(StatusCode::OK),
+        Ok(false) => json_error(StatusCode::NOT_FOUND, "peer not found"),
+        Err(error) => replica_peer_error(error),
+    }
+}
+
+async fn list_peers(State(state): State<Arc<AppState>>) -> Response {
+    Json(state.service.list_replica_peers()).into_response()
 }
 
 async fn not_found() -> Response {
@@ -253,6 +291,15 @@ fn json_rejection(error: JsonRejection) -> Response {
     json_error(error.status(), error.body_text())
 }
 
+fn replica_peer_error(error: ReplicaPeerError) -> Response {
+    let status = match &error {
+        ReplicaPeerError::InvalidEndpoint(_) => StatusCode::BAD_REQUEST,
+        ReplicaPeerError::Disabled => StatusCode::CONFLICT,
+        ReplicaPeerError::Unavailable => StatusCode::SERVICE_UNAVAILABLE,
+    };
+    json_error(status, error)
+}
+
 fn policy_class_from_headers(headers: &HeaderMap) -> Option<String> {
     headers
         .get("x-dynamo-meta-policy-class")
@@ -262,7 +309,7 @@ fn policy_class_from_headers(headers: &HeaderMap) -> Option<String> {
         .map(str::to_string)
 }
 
-pub(crate) fn create_router(state: Arc<AppState>, peer_manager: Option<PeerManager>) -> Router {
+pub(crate) fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         .route("/select", post(select))
         .route("/select_and_reserve", post(select_and_reserve))
@@ -287,74 +334,40 @@ pub(crate) fn create_router(state: Arc<AppState>, peer_manager: Option<PeerManag
         .route("/potential_loads", post(potential_loads))
         .route("/overlap_scores", post(overlap_scores))
         .route("/dump", get(dump_events))
+        .route("/replica_sync/register_peer", post(register_peer))
+        .route("/replica_sync/deregister_peer", post(deregister_peer))
+        .route("/replica_sync/peers", get(list_peers))
         .fallback(not_found)
         .method_not_allowed_fallback(method_not_allowed)
         .layer(axum::extract::DefaultBodyLimit::max(
             REQUEST_BODY_LIMIT_BYTES,
         ))
         .with_state(state)
-        .merge(replica_sync_http::router(peer_manager))
 }
 
 pub async fn run_server(config: SelectionServiceConfig) -> anyhow::Result<()> {
-    let cancel_token = CancellationToken::new();
-    let shutdown_token = cancel_token.clone();
-    tokio::spawn(async move {
-        tokio::signal::ctrl_c().await.ok();
-        tracing::info!("received shutdown signal");
-        shutdown_token.cancel();
-    });
-
-    let replica_runtime = setup_replica_sync(
-        config.replica_sync_port,
-        &config.replica_sync_peers,
-        cancel_token.child_token(),
-    )?;
-
     tracing::info!(
         port = config.port,
         threads = config.threads,
         indexer_peers = config.indexer_peers.len(),
-        replica_sync = replica_runtime.is_some(),
+        replica_sync = config.replica_sync_port.is_some(),
         "Starting Dynamo selection service"
     );
 
-    let core = Arc::new(SelectionCore::new_for_server(
-        config.kv_router_config,
-        config.threads,
-        cancel_token.clone(),
-        replica_runtime,
-    ));
-    if !config.indexer_peers.is_empty() {
-        match core.recover_indexer_from_peers(&config.indexer_peers).await {
-            Ok(true) => tracing::info!("Selection indexer recovery completed"),
-            Ok(false) => {
-                tracing::warn!("No reachable selection indexer peers; starting with empty state")
-            }
-            Err(error) => {
-                tracing::warn!(%error, "Selection indexer recovery failed; starting with empty state")
-            }
-        }
-    }
-    core.signal_indexer_ready();
-
-    let peer_manager = if config.replica_sync_port.is_some() {
-        let dispatch_core = Arc::clone(&core);
-        Some(PeerManager::start(
-            config.replica_sync_peers,
-            cancel_token.child_token(),
-            move |event| dispatch_core.dispatch_replica_event(event),
-        )?)
-    } else {
-        None
-    };
-
-    let app = create_router(Arc::new(AppState { core }), peer_manager);
     let listener = TcpListener::bind(("0.0.0.0", config.port)).await?;
-    axum::serve(listener, app)
+    let service = Arc::new(config.service_builder().build().await?);
+    let app = create_router(Arc::new(AppState {
+        service: Arc::clone(&service),
+    }));
+    let shutdown_service = Arc::clone(&service);
+    let result = axum::serve(listener, app)
         .with_graceful_shutdown(async move {
-            cancel_token.cancelled().await;
+            tokio::signal::ctrl_c().await.ok();
+            tracing::info!("received shutdown signal");
+            shutdown_service.shutdown().await;
         })
-        .await?;
+        .await;
+    service.shutdown().await;
+    result?;
     Ok(())
 }

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -1,0 +1,461 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use tokio_util::sync::CancellationToken;
+
+use crate::config::KvRouterConfig;
+use crate::protocols::WorkerId;
+use crate::scheduling::PotentialLoad;
+use crate::services::common::replica_sync::{
+    PeerManager, ReplicaPeerError, ReplicaSyncRuntime, setup_replica_sync,
+};
+
+use super::core::{SelectionCore, SelectionServiceConfig};
+use super::error::SelectionError;
+use super::types::{
+    ModelLoadResponse, OverlapScoresRequest, OverlapScoresResponse, PotentialLoadsRequest,
+    ReadyResponse, ReservationRequest, ReservationResponse, SelectAndReserveRequest, SelectRequest,
+    SelectResponse, WorkerCatalogRecord, WorkerPatchRequest, WorkerRequest,
+};
+
+pub struct SelectionServiceBuilder {
+    kv_router_config: KvRouterConfig,
+    indexer_threads: usize,
+    indexer_peers: Vec<String>,
+    replica_sync_port: Option<u16>,
+    replica_sync_peers: Vec<String>,
+}
+
+impl SelectionServiceBuilder {
+    pub fn new(kv_router_config: KvRouterConfig) -> Self {
+        Self {
+            kv_router_config,
+            indexer_threads: 4,
+            indexer_peers: Vec::new(),
+            replica_sync_port: None,
+            replica_sync_peers: Vec::new(),
+        }
+    }
+
+    pub fn indexer_threads(mut self, indexer_threads: usize) -> Self {
+        self.indexer_threads = indexer_threads;
+        self
+    }
+
+    pub fn indexer_peers(mut self, indexer_peers: Vec<String>) -> Self {
+        self.indexer_peers = indexer_peers;
+        self
+    }
+
+    pub fn replica_sync(mut self, port: u16, peers: Vec<String>) -> Self {
+        self.replica_sync_port = Some(port);
+        self.replica_sync_peers = peers;
+        self
+    }
+
+    pub async fn build(self) -> anyhow::Result<SelectionService> {
+        let cancel_token = CancellationToken::new();
+        let mut startup_guard = StartupGuard::new(cancel_token.clone());
+        let replica_runtime = setup_replica_sync(
+            self.replica_sync_port,
+            &self.replica_sync_peers,
+            cancel_token.child_token(),
+        )?;
+        let replica_config = replica_runtime.as_ref().map(ReplicaSyncRuntime::config);
+        let core = Arc::new(SelectionCore::new_managed(
+            self.kv_router_config,
+            self.indexer_threads,
+            cancel_token.clone(),
+            replica_config,
+        ));
+
+        if !self.indexer_peers.is_empty() {
+            match core.recover_indexer_from_peers(&self.indexer_peers).await {
+                Ok(true) => tracing::info!("Selection indexer recovery completed"),
+                Ok(false) => {
+                    tracing::warn!(
+                        "No reachable selection indexer peers; starting with empty state"
+                    )
+                }
+                Err(error) => {
+                    tracing::warn!(%error, "Selection indexer recovery failed; starting with empty state")
+                }
+            }
+        }
+        core.signal_indexer_ready();
+
+        let peer_manager = if replica_runtime.is_some() {
+            let weak_core = Arc::downgrade(&core);
+            Some(PeerManager::start(
+                self.replica_sync_peers,
+                cancel_token.child_token(),
+                move |event| {
+                    if let Some(core) = weak_core.upgrade() {
+                        core.dispatch_replica_event(event);
+                    }
+                },
+            )?)
+        } else {
+            None
+        };
+
+        startup_guard.disarm();
+        Ok(SelectionService {
+            core,
+            peer_manager,
+            replica_runtime,
+            cancel_token,
+        })
+    }
+}
+
+impl SelectionServiceConfig {
+    pub fn service_builder(&self) -> SelectionServiceBuilder {
+        let mut builder = SelectionServiceBuilder::new(self.kv_router_config.clone())
+            .indexer_threads(self.threads)
+            .indexer_peers(self.indexer_peers.clone());
+        if let Some(port) = self.replica_sync_port {
+            builder = builder.replica_sync(port, self.replica_sync_peers.clone());
+        }
+        builder
+    }
+}
+
+struct StartupGuard {
+    cancel_token: CancellationToken,
+    armed: bool,
+}
+
+impl StartupGuard {
+    fn new(cancel_token: CancellationToken) -> Self {
+        Self {
+            cancel_token,
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for StartupGuard {
+    fn drop(&mut self) {
+        if self.armed {
+            self.cancel_token.cancel();
+        }
+    }
+}
+
+pub struct SelectionService {
+    core: Arc<SelectionCore>,
+    peer_manager: Option<PeerManager>,
+    replica_runtime: Option<ReplicaSyncRuntime>,
+    cancel_token: CancellationToken,
+}
+
+impl SelectionService {
+    #[cfg(test)]
+    pub(super) fn new_local_for_test(
+        kv_router_config: KvRouterConfig,
+        indexer_threads: usize,
+    ) -> Self {
+        let cancel_token = CancellationToken::new();
+        Self {
+            core: Arc::new(SelectionCore::new_local(
+                kv_router_config,
+                indexer_threads,
+                cancel_token.clone(),
+            )),
+            peer_manager: None,
+            replica_runtime: None,
+            cancel_token,
+        }
+    }
+
+    pub async fn upsert_worker(
+        &self,
+        req: WorkerRequest,
+    ) -> Result<WorkerCatalogRecord, SelectionError> {
+        self.core.upsert_worker(req).await
+    }
+
+    pub async fn patch_worker(
+        &self,
+        worker_id: WorkerId,
+        patch: WorkerPatchRequest,
+    ) -> Result<WorkerCatalogRecord, SelectionError> {
+        self.core.patch_worker(worker_id, patch).await
+    }
+
+    pub async fn delete_worker(
+        &self,
+        worker_id: WorkerId,
+    ) -> Result<WorkerCatalogRecord, SelectionError> {
+        self.core.delete_worker(worker_id).await
+    }
+
+    pub fn list_workers(
+        &self,
+        model_name: Option<&str>,
+        tenant_id: Option<&str>,
+    ) -> Vec<WorkerCatalogRecord> {
+        self.core.list_workers(model_name, tenant_id)
+    }
+
+    pub async fn select(&self, req: SelectRequest) -> Result<SelectResponse, SelectionError> {
+        self.core.select(req).await
+    }
+
+    pub async fn select_with_policy_class(
+        &self,
+        req: SelectRequest,
+        policy_class: Option<String>,
+    ) -> Result<SelectResponse, SelectionError> {
+        self.core.select_with_policy_class(req, policy_class).await
+    }
+
+    pub async fn select_and_reserve(
+        &self,
+        req: SelectAndReserveRequest,
+    ) -> Result<SelectResponse, SelectionError> {
+        self.core.select_and_reserve(req).await
+    }
+
+    pub async fn select_and_reserve_with_policy_class(
+        &self,
+        req: SelectAndReserveRequest,
+        policy_class: Option<String>,
+    ) -> Result<SelectResponse, SelectionError> {
+        self.core
+            .select_and_reserve_with_policy_class(req, policy_class)
+            .await
+    }
+
+    pub async fn create_reservation(
+        &self,
+        req: ReservationRequest,
+    ) -> Result<ReservationResponse, SelectionError> {
+        self.core.create_reservation(req).await
+    }
+
+    pub async fn prefill_complete(&self, reservation_id: &str) -> Result<(), SelectionError> {
+        self.core.prefill_complete(reservation_id).await
+    }
+
+    pub fn add_output_block(
+        &self,
+        reservation_id: &str,
+        decay_fraction: Option<f64>,
+    ) -> Result<(), SelectionError> {
+        self.core.add_output_block(reservation_id, decay_fraction)
+    }
+
+    pub async fn free_reservation(&self, reservation_id: &str) -> Result<(), SelectionError> {
+        self.core.free_reservation(reservation_id).await
+    }
+
+    pub fn ready(&self) -> ReadyResponse {
+        self.core.ready()
+    }
+
+    pub fn loads(
+        &self,
+        model_name: Option<&str>,
+        tenant_id: Option<&str>,
+    ) -> Vec<ModelLoadResponse> {
+        self.core.loads(model_name, tenant_id)
+    }
+
+    pub async fn potential_loads(
+        &self,
+        req: PotentialLoadsRequest,
+    ) -> Result<Vec<PotentialLoad>, SelectionError> {
+        self.core.potential_loads(req).await
+    }
+
+    pub async fn overlap_scores(
+        &self,
+        req: OverlapScoresRequest,
+    ) -> Result<OverlapScoresResponse, SelectionError> {
+        self.core.overlap_scores(req).await
+    }
+
+    pub async fn register_replica_peer(&self, endpoint: String) -> Result<bool, ReplicaPeerError> {
+        let peer_manager = self
+            .peer_manager
+            .as_ref()
+            .ok_or(ReplicaPeerError::Disabled)?;
+        peer_manager.register_peer(endpoint).await
+    }
+
+    pub async fn deregister_replica_peer(
+        &self,
+        endpoint: String,
+    ) -> Result<bool, ReplicaPeerError> {
+        let peer_manager = self
+            .peer_manager
+            .as_ref()
+            .ok_or(ReplicaPeerError::Disabled)?;
+        peer_manager.deregister_peer(endpoint).await
+    }
+
+    pub fn list_replica_peers(&self) -> Vec<String> {
+        self.peer_manager
+            .as_ref()
+            .map(PeerManager::list_peers)
+            .unwrap_or_default()
+    }
+
+    pub async fn indexer_snapshot(&self) -> serde_json::Value {
+        self.core.dump_indexer_events().await
+    }
+
+    pub async fn recover_indexer_from_peers(&self, peers: &[String]) -> anyhow::Result<bool> {
+        self.core.recover_indexer_from_peers(peers).await
+    }
+
+    pub async fn cancelled(&self) {
+        self.cancel_token.cancelled().await;
+    }
+
+    pub async fn shutdown(&self) {
+        self.cancel_token.cancel();
+        self.core.shutdown();
+        if let (Some(peer_manager), Some(replica_runtime)) =
+            (&self.peer_manager, &self.replica_runtime)
+        {
+            tokio::join!(peer_manager.shutdown(), replica_runtime.shutdown());
+        } else if let Some(peer_manager) = &self.peer_manager {
+            peer_manager.shutdown().await;
+        } else if let Some(replica_runtime) = &self.replica_runtime {
+            replica_runtime.shutdown().await;
+        }
+    }
+}
+
+impl Drop for SelectionService {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+        self.core.shutdown();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::TcpListener as StdTcpListener;
+    use std::time::Duration;
+
+    use axum::Json;
+    use axum::Router;
+    use axum::extract::State;
+    use axum::routing::get;
+    use tokio::sync::Notify;
+
+    use super::*;
+
+    fn test_config() -> KvRouterConfig {
+        KvRouterConfig {
+            use_kv_events: false,
+            router_queue_threshold: None,
+            ..Default::default()
+        }
+    }
+
+    fn reserve_tcp_port() -> u16 {
+        StdTcpListener::bind("127.0.0.1:0")
+            .unwrap()
+            .local_addr()
+            .unwrap()
+            .port()
+    }
+
+    async fn build_on_port(port: u16) -> SelectionService {
+        tokio::time::timeout(Duration::from_secs(5), async move {
+            loop {
+                match SelectionServiceBuilder::new(test_config())
+                    .indexer_threads(1)
+                    .replica_sync(port, Vec::new())
+                    .build()
+                    .await
+                {
+                    Ok(service) => return service,
+                    Err(_) => tokio::time::sleep(Duration::from_millis(20)).await,
+                }
+            }
+        })
+        .await
+        .expect("replica port was not released")
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn startup_and_shutdown_release_replica_resources() {
+        let port = reserve_tcp_port();
+        let failed = SelectionServiceBuilder::new(test_config())
+            .indexer_threads(1)
+            .replica_sync(port, vec!["invalid".to_string()])
+            .build()
+            .await;
+        assert!(failed.is_err());
+
+        let service = build_on_port(port).await;
+        let weak_core = Arc::downgrade(&service.core);
+        service.shutdown().await;
+        let replacement = build_on_port(port).await;
+        drop(service);
+        assert!(weak_core.upgrade().is_none());
+        replacement.shutdown().await;
+
+        let drop_port = reserve_tcp_port();
+        let dropped = build_on_port(drop_port).await;
+        let dropped_core = Arc::downgrade(&dropped.core);
+        drop(dropped);
+        assert!(dropped_core.upgrade().is_none());
+        let replacement = build_on_port(drop_port).await;
+        replacement.shutdown().await;
+    }
+
+    #[derive(Clone)]
+    struct RecoveryGate {
+        requested: Arc<Notify>,
+        release: Arc<Notify>,
+    }
+
+    async fn gated_dump(State(gate): State<RecoveryGate>) -> Json<serde_json::Value> {
+        gate.requested.notify_one();
+        gate.release.notified().await;
+        Json(serde_json::json!({}))
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn startup_waits_for_indexer_recovery() {
+        let gate = RecoveryGate {
+            requested: Arc::new(Notify::new()),
+            release: Arc::new(Notify::new()),
+        };
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let peer_url = format!("http://{}", listener.local_addr().unwrap());
+        let app = Router::new()
+            .route("/dump", get(gated_dump))
+            .with_state(gate.clone());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await });
+
+        let build = tokio::spawn(
+            SelectionServiceBuilder::new(test_config())
+                .indexer_threads(1)
+                .indexer_peers(vec![peer_url])
+                .build(),
+        );
+        tokio::time::timeout(Duration::from_secs(3), gate.requested.notified())
+            .await
+            .expect("recovery peer was not queried");
+        assert!(!build.is_finished());
+
+        gate.release.notify_one();
+        let service = build.await.unwrap().unwrap();
+        service.shutdown().await;
+        server.abort();
+    }
+}

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -5,12 +5,14 @@ use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode, header};
 use axum::response::Response;
+use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::mpsc;
-use tokio_util::sync::CancellationToken;
 use tower::ServiceExt;
 
+use super::input::{MmRoutingInfoRequest, PromptRequest};
+use super::server::create_router;
+use super::*;
 use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
 use crate::protocols::{
     BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, OverlapScores, StorageTier,
@@ -18,11 +20,6 @@ use crate::protocols::{
 };
 use crate::scheduling::config::RouterConfigOverride;
 use crate::scheduling::overlap::build_overlap_scores_response;
-use crate::services::common::replica_sync::ReplicaSyncConfig;
-
-use super::input::{MmRoutingInfoRequest, PromptRequest};
-use super::server::create_router;
-use super::*;
 
 fn test_config() -> crate::config::KvRouterConfig {
     crate::config::KvRouterConfig {
@@ -33,12 +30,8 @@ fn test_config() -> crate::config::KvRouterConfig {
 }
 
 fn app() -> Router {
-    let core = Arc::new(SelectionCore::new(
-        test_config(),
-        1,
-        CancellationToken::new(),
-    ));
-    create_router(Arc::new(AppState { core }), None)
+    let service = Arc::new(SelectionService::new_local_for_test(test_config(), 1));
+    create_router(Arc::new(AppState { service }))
 }
 
 async fn response_json(response: Response) -> serde_json::Value {
@@ -223,8 +216,8 @@ async fn ready_and_select_report_not_ready_without_schedulable_workers() {
 async fn incomplete_worker_is_accepted_but_not_schedulable() {
     let mut config = test_config();
     config.router_queue_threshold = Some(1.0);
-    let core = Arc::new(SelectionCore::new(config, 1, CancellationToken::new()));
-    let app = create_router(Arc::new(AppState { core }), None);
+    let service = Arc::new(SelectionService::new_local_for_test(config, 1));
+    let app = create_router(Arc::new(AppState { service }));
 
     let response = post(
         app.clone(),
@@ -419,8 +412,8 @@ policy_classes:
 
     let mut config = test_config();
     config.router_policy_config = Some(policy_file.path().to_string_lossy().into_owned());
-    let core = Arc::new(SelectionCore::new(config, 1, CancellationToken::new()));
-    let app = create_router(Arc::new(AppState { core }), None);
+    let service = Arc::new(SelectionService::new_local_for_test(config, 1));
+    let app = create_router(Arc::new(AppState { service }));
 
     assert_eq!(
         register_worker(app.clone(), Some(4)).await.status(),
@@ -625,60 +618,46 @@ async fn explicit_reservation_rejects_unschedulable_worker() {
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn selector_replica_sync_propagates_request_lifecycle() {
-    let cancel_token = CancellationToken::new();
-    let (outbound_a, mut inbound_a) =
-        mpsc::channel(crate::services::common::replica_sync::REPLICA_EVENT_CHANNEL_CAPACITY);
-    let (outbound_b, mut inbound_b) =
-        mpsc::channel(crate::services::common::replica_sync::REPLICA_EVENT_CHANNEL_CAPACITY);
-    let core_a = Arc::new(SelectionCore::new_for_server(
-        test_config(),
-        1,
-        cancel_token.child_token(),
-        Some(ReplicaSyncConfig::new(11, outbound_a)),
-    ));
-    let core_b = Arc::new(SelectionCore::new_for_server(
-        test_config(),
-        1,
-        cancel_token.child_token(),
-        Some(ReplicaSyncConfig::new(22, outbound_b)),
-    ));
-    core_a.signal_indexer_ready();
-    core_b.signal_indexer_ready();
-
-    let dispatch_b = Arc::clone(&core_b);
-    let forward_a = tokio::spawn(async move {
-        while let Some(event) = inbound_a.recv().await {
-            dispatch_b.dispatch_replica_event(event);
-        }
-    });
-    let dispatch_a = Arc::clone(&core_a);
-    let forward_b = tokio::spawn(async move {
-        while let Some(event) = inbound_b.recv().await {
-            dispatch_a.dispatch_replica_event(event);
-        }
-    });
-
-    let app_a = create_router(
-        Arc::new(AppState {
-            core: Arc::clone(&core_a),
-        }),
-        None,
+    let port_a = reserve_tcp_port();
+    let port_b = reserve_tcp_port();
+    let config_a = SelectionServiceConfig {
+        port: 8092,
+        threads: 1,
+        indexer_peers: Vec::new(),
+        replica_sync_port: Some(port_a),
+        replica_sync_peers: Vec::new(),
+        kv_router_config: test_config(),
+    };
+    let service_a = Arc::new(config_a.service_builder().build().await.unwrap());
+    let service_b = Arc::new(
+        SelectionServiceBuilder::new(test_config())
+            .indexer_threads(1)
+            .replica_sync(port_b, Vec::new())
+            .build()
+            .await
+            .unwrap(),
     );
-    let app_b = create_router(
-        Arc::new(AppState {
-            core: Arc::clone(&core_b),
-        }),
-        None,
-    );
+    service_b
+        .register_replica_peer(format!("tcp://127.0.0.1:{port_a}"))
+        .await
+        .unwrap();
+
+    let app_a = create_router(Arc::new(AppState {
+        service: Arc::clone(&service_a),
+    }));
     assert_eq!(
         register_worker(app_a.clone(), None).await.status(),
         StatusCode::CREATED
     );
-    assert_eq!(
-        register_worker(app_b, None).await.status(),
-        StatusCode::CREATED
-    );
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    let worker: WorkerRequest = serde_json::from_value(serde_json::json!({
+        "worker_id": 1,
+        "model_name": "model",
+        "endpoint": "http://worker-1:8000",
+        "block_size": 4
+    }))
+    .unwrap();
+    service_b.upsert_worker(worker).await.unwrap();
+    tokio::time::sleep(Duration::from_millis(200)).await;
 
     let response = post(
         app_a.clone(),
@@ -687,7 +666,7 @@ async fn selector_replica_sync_propagates_request_lifecycle() {
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);
-    wait_for_core_load(&core_b, 1, 1, 4).await;
+    wait_for_service_load(&service_b, 1, 1, 4).await;
 
     let response = post(
         app_a.clone(),
@@ -696,7 +675,7 @@ async fn selector_replica_sync_propagates_request_lifecycle() {
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);
-    wait_for_core_load(&core_b, 1, 1, 0).await;
+    wait_for_service_load(&service_b, 1, 1, 0).await;
 
     let response = app_a
         .oneshot(
@@ -709,22 +688,21 @@ async fn selector_replica_sync_propagates_request_lifecycle() {
         .await
         .unwrap();
     assert_eq!(response.status(), StatusCode::OK);
-    wait_for_core_load(&core_b, 0, 0, 0).await;
+    wait_for_service_load(&service_b, 0, 0, 0).await;
 
-    cancel_token.cancel();
-    forward_a.abort();
-    forward_b.abort();
+    service_a.shutdown().await;
+    service_b.shutdown().await;
 }
 
-async fn wait_for_core_load(
-    core: &SelectionCore,
+async fn wait_for_service_load(
+    service: &SelectionService,
     expected_requests: usize,
     expected_blocks: usize,
     expected_tokens: usize,
 ) {
     tokio::time::timeout(Duration::from_secs(5), async {
         loop {
-            let loads = core.loads(Some("model"), Some("default"));
+            let loads = service.loads(Some("model"), Some("default"));
             if let Some(load) = loads.first().and_then(|model| model.loads.first())
                 && load.active_requests == expected_requests
                 && load.potential_decode_blocks == expected_blocks
@@ -737,6 +715,14 @@ async fn wait_for_core_load(
     })
     .await
     .unwrap();
+}
+
+fn reserve_tcp_port() -> u16 {
+    StdTcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
 }
 
 #[tokio::test]
@@ -762,8 +748,8 @@ async fn dump_exposes_compatible_indexer_snapshot() {
 async fn reconcile_rolls_back_partial_listener_registration() {
     let mut config = test_config();
     config.use_kv_events = true;
-    let core = Arc::new(SelectionCore::new(config, 1, CancellationToken::new()));
-    let app = create_router(Arc::new(AppState { core }), None);
+    let service = Arc::new(SelectionService::new_local_for_test(config, 1));
+    let app = create_router(Arc::new(AppState { service }));
 
     let response = post(
         app.clone(),

--- a/lib/kv-router/src/services/slot_tracker/mod.rs
+++ b/lib/kv-router/src/services/slot_tracker/mod.rs
@@ -34,23 +34,28 @@ pub async fn run_server(config: SlotTrackerConfig) -> anyhow::Result<()> {
         shutdown_token.cancel();
     });
 
-    let replica_config = setup_replica_sync(
+    let replica_runtime = setup_replica_sync(
         config.replica_sync_port,
         &config.replica_sync_peers,
         cancel_token.child_token(),
     )?;
-    let (registry, peer_manager) = if let Some(replica_config) = replica_config {
+    let (registry, peer_manager) = if let Some(replica_runtime) = &replica_runtime {
+        let replica_config = replica_runtime.config();
         let process_id = replica_config.process_id();
         let registry = Arc::new(SlotTrackerRegistry::new_with_replica_sync(
             cancel_token.clone(),
             replica_config,
         ));
-        let dispatch_registry = Arc::clone(&registry);
-        let peer_manager = PeerManager::start(
+        let dispatch_registry = Arc::downgrade(&registry);
+        let peer_manager = Arc::new(PeerManager::start(
             config.replica_sync_peers,
             cancel_token.child_token(),
-            move |event| dispatch_registry.dispatch_replica_event(event),
-        )?;
+            move |event| {
+                if let Some(registry) = dispatch_registry.upgrade() {
+                    registry.dispatch_replica_event(event);
+                }
+            },
+        )?);
         tracing::info!(
             port = config.port,
             replica_sync_port = config.replica_sync_port,
@@ -69,15 +74,22 @@ pub async fn run_server(config: SlotTrackerConfig) -> anyhow::Result<()> {
         )
     };
 
-    let app = create_router(Arc::new(AppState { registry }), peer_manager);
+    let app = create_router(
+        Arc::new(AppState { registry }),
+        peer_manager.as_ref().map(Arc::clone),
+    );
     let listener = TcpListener::bind(("0.0.0.0", config.port)).await?;
     tracing::info!("HTTP server listening on 0.0.0.0:{}", config.port);
-    axum::serve(listener, app)
+    let result = axum::serve(listener, app)
         .with_graceful_shutdown(async move {
             cancel_token.cancelled().await;
             tracing::info!("Received shutdown signal, stopping HTTP server");
         })
-        .await?;
+        .await;
+    if let (Some(peer_manager), Some(replica_runtime)) = (&peer_manager, &replica_runtime) {
+        tokio::join!(peer_manager.shutdown(), replica_runtime.shutdown());
+    }
+    result?;
 
     Ok(())
 }

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -306,7 +306,10 @@ fn service_error(error: ServiceError) -> Response {
     }
 }
 
-pub(crate) fn create_router(state: Arc<AppState>, peer_manager: Option<PeerManager>) -> Router {
+pub(crate) fn create_router(
+    state: Arc<AppState>,
+    peer_manager: Option<Arc<PeerManager>>,
+) -> Router {
     Router::new()
         .route("/register", post(register))
         .route("/unregister", post(unregister))


### PR DESCRIPTION
## Summary

- Add a managed public `SelectionServiceBuilder`/`SelectionService` facade shared by standalone HTTP and embedded Rust/Python consumers.
- Own replica-sync tasks, cancellation, recovery/readiness sequencing, and awaitable shutdown without retaining `SelectionCore`.
- Keep C/Go EPP FFI work explicitly deferred while documenting that future bindings must use the service facade.

## Validation

- `cargo test -p dynamo-kv-router --features standalone-selection`
- `cargo test -p dynamo-kv-router --features standalone-slot-tracker`
- `cargo clippy --no-deps --all-targets -- -D warnings` and `cargo fmt` in `lib/kv-router`
- `cargo clippy --no-default-features -- -D warnings` and `cargo fmt` in `lib/bindings/python`
- `fern check` (0 errors)
- `cargo test --manifest-path lib/bindings/python/Cargo.toml --features select-service selection_service` reaches the link step but cannot link the repository's PyO3 `extension-module` test harness on this macOS environment because Python C API symbols are intentionally unresolved outside maturin.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11298" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a higher-level selection service with support for worker updates, peer registration, replica sync, indexer snapshots, and recovery.
  * Expanded Python bindings to support async shutdown and additional replica-sync configuration and management actions.
  * Documented how to embed the standalone selection service without running the HTTP server.

* **Bug Fixes**
  * Improved graceful shutdown so background replica and peer tasks stop cleanly.
  * Tightened replica-sync error handling and HTTP responses for disabled or unavailable peer actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->