### PR TITLE
fix(gms): defer vLLM publication until after memory profiling

### DIFF
--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -226,6 +226,8 @@ def materialize_module_from_gms(
 def rebind_nonparameter_tensors(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
+    *,
+    retain_gms_tensors: list[torch.Tensor] | None = None,
 ) -> int:
     """Re-bind GMS-resident non-parameter tensors to private clones.
 
@@ -244,6 +246,11 @@ def rebind_nonparameter_tensors(
 
     Returns the number of bytes rebound, i.e. how much memory is duplicated
     between the read-only GMS copies and the private clones.
+
+    If ``retain_gms_tensors`` is provided, the original GMS-backed tensors
+    are appended to it. A deferred writer that rebinds before commit must
+    keep those references alive so the underlying GMS pool allocations are
+    not freed before the layout is published.
     """
     mappings = gms_client_memory_manager.mappings
     rebound_bytes = 0
@@ -290,6 +297,8 @@ def rebind_nonparameter_tensors(
                 logger.debug("[GMS] Skipping property attribute %r", name)
                 continue
             setattr(mod, attr, tensor.detach().clone())
+        if retain_gms_tensors is not None:
+            retain_gms_tensors.append(tensor)
         rebound_bytes += tensor.numel() * tensor.element_size()
 
     return rebound_bytes

--- a/lib/gpu_memory_service/integrations/common/__init__.py
+++ b/lib/gpu_memory_service/integrations/common/__init__.py
@@ -8,6 +8,8 @@ from gpu_memory_service.integrations.common.utils import (
     GMS_TAGS,
     GMSCommittedMemoryStats,
     finalize_gms_write,
+    prepare_gms_write,
+    publish_gms_write,
     setup_meta_tensor_workaround,
 )
 
@@ -15,6 +17,8 @@ __all__ = [
     "GMS_TAGS",
     "GMSCommittedMemoryStats",
     "patch_empty_cache",
+    "prepare_gms_write",
+    "publish_gms_write",
     "setup_meta_tensor_workaround",
     "finalize_gms_write",
 ]

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -28,6 +28,7 @@ GMS_TAGS = ("weights", "kv_cache")
 class GMSCommittedMemoryStats:
     committed_bytes: int
     pruned_bytes: int
+    pruned_count: int = 0
 
 
 def get_gms_lock_mode(extra_config: dict):
@@ -78,6 +79,52 @@ def setup_meta_tensor_workaround() -> None:
         pass
 
 
+def prepare_gms_write(
+    allocator: "GMSClientMemoryManager",
+    model: torch.nn.Module,
+) -> GMSCommittedMemoryStats:
+    """Register model tensors and prune unreferenced allocations.
+
+    This is the first half of a GMS write: it does not commit. The allocator
+    keeps its RW lease until :func:`publish_gms_write`, which lets a caller
+    defer publication (e.g. until after vLLM memory profiling).
+
+    Args:
+        allocator: The GMS client memory manager in write mode.
+        model: The loaded model with weights to register.
+
+    Returns:
+        Committed/pruned byte stats for the write awaiting publication.
+    """
+    referenced_allocation_ids = register_module_tensors(allocator, model)
+    before_prune_bytes = allocator.total_bytes
+    before_prune_count = len(allocator.mappings)
+
+    # prune_allocations synchronizes allocator.device before destroying
+    # unreferenced mappings. allocator.commit() performs the publish-barrier
+    # sync before committing the remaining registered weights.
+    prune_allocations(
+        allocator,
+        referenced_allocation_ids=referenced_allocation_ids,
+    )
+    total_bytes = allocator.total_bytes
+    pruned_bytes = before_prune_bytes - total_bytes
+    pruned_count = before_prune_count - len(allocator.mappings)
+
+    return GMSCommittedMemoryStats(
+        committed_bytes=int(total_bytes),
+        pruned_bytes=int(pruned_bytes),
+        pruned_count=pruned_count,
+    )
+
+
+def publish_gms_write(allocator: "GMSClientMemoryManager") -> None:
+    """Publish a prepared write: commit, reconnect read-only, restore VAs."""
+    allocator.commit()
+    allocator.connect(RequestedLockType.RO)
+    allocator.remap_all_vas()
+
+
 def finalize_gms_write(
     allocator: "GMSClientMemoryManager",
     model: torch.nn.Module,
@@ -100,40 +147,19 @@ def finalize_gms_write(
     Returns:
         Committed/pruned byte stats.
     """
-    referenced_allocation_ids = register_module_tensors(allocator, model)
-    before_prune_bytes = allocator.total_bytes
-    before_prune_count = len(allocator.mappings)
-
-    # prune_allocations synchronizes allocator.device before destroying
-    # unreferenced mappings. allocator.commit() performs the publish-barrier
-    # sync before committing the remaining registered weights.
-    prune_allocations(
-        allocator,
-        referenced_allocation_ids=referenced_allocation_ids,
-    )
-    total_bytes = allocator.total_bytes
-    pruned_bytes = before_prune_bytes - total_bytes
-    pruned_count = before_prune_count - len(allocator.mappings)
-
-    allocator.commit()
-
-    allocator.connect(RequestedLockType.RO)
-    allocator.remap_all_vas()
-
+    stats = prepare_gms_write(allocator, model)
+    publish_gms_write(allocator)
     rebound_bytes = rebind_nonparameter_tensors(allocator, model)
 
     logger.info(
         "[GMS] Committed %.2f GiB, switched to read mode with %d mappings "
         "(pruned %d allocations / %.2f GiB before commit; rebound %.2f MiB "
         "of non-parameter tensors to private memory)",
-        total_bytes / (1 << 30),
+        stats.committed_bytes / (1 << 30),
         len(allocator.mappings),
-        pruned_count,
-        pruned_bytes / (1 << 30),
+        stats.pruned_count,
+        stats.pruned_bytes / (1 << 30),
         rebound_bytes / (1 << 20),
     )
 
-    return GMSCommittedMemoryStats(
-        committed_bytes=int(total_bytes),
-        pruned_bytes=int(pruned_bytes),
-    )
+    return stats

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -19,12 +19,17 @@ from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
-from gpu_memory_service.client.torch.module import materialize_module_from_gms
+from gpu_memory_service.client.torch.module import (
+    materialize_module_from_gms,
+    rebind_nonparameter_tensors,
+)
 from gpu_memory_service.common.locks import GrantedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import (
-    finalize_gms_write,
+    GMSCommittedMemoryStats,
     get_gms_lock_mode,
+    prepare_gms_write,
+    publish_gms_write,
     setup_meta_tensor_workaround,
     strip_gms_model_loader_config,
 )
@@ -52,6 +57,12 @@ logger = logging.getLogger(__name__)
 _last_imported_weights_bytes: int = 0
 _last_model_memory_usage_offset_bytes: int = 0
 
+# First writer's GMS client awaiting publication after vLLM memory profiling.
+# The retained tensors keep rebound-away GMS pool allocations alive until
+# commit; see rebind_nonparameter_tensors.
+_pending_gms_client: "GMSClientMemoryManager | None" = None
+_pending_retained_gms_tensors: list[torch.Tensor] = []
+
 
 def get_imported_weights_bytes() -> int:
     """Return bytes of weights imported in the last load_model call."""
@@ -61,6 +72,79 @@ def get_imported_weights_bytes() -> int:
 def get_model_memory_usage_offset_bytes() -> int:
     """Return the offset to add to imported bytes for vLLM model_memory_usage."""
     return _last_model_memory_usage_offset_bytes
+
+
+def has_pending_gms_write() -> bool:
+    """Return whether this process still owns an unpublished GMS write."""
+    return _pending_gms_client is not None
+
+
+def _store_pending_gms_write(
+    gms_client: "GMSClientMemoryManager",
+    stats: GMSCommittedMemoryStats,
+    rebound_bytes: int,
+    retained_gms_tensors: list[torch.Tensor],
+) -> None:
+    global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
+    global _pending_gms_client, _pending_retained_gms_tensors
+
+    if _pending_gms_client is not None:
+        raise RuntimeError("A GMS write is already awaiting publication")
+    _pending_gms_client = gms_client
+    _pending_retained_gms_tensors = retained_gms_tensors
+    _last_imported_weights_bytes = stats.committed_bytes
+    _last_model_memory_usage_offset_bytes = stats.pruned_bytes + rebound_bytes
+
+
+def _take_pending_gms_write() -> "GMSClientMemoryManager | None":
+    global _pending_gms_client, _pending_retained_gms_tensors
+
+    gms_client = _pending_gms_client
+    _pending_gms_client = None
+    _pending_retained_gms_tensors = []
+    return gms_client
+
+
+def publish_pending_gms_write() -> bool:
+    """Publish and clear the pending vLLM first-writer state, if any.
+
+    On publication failure the writer is released best-effort and the
+    original error propagates; the engine cannot serve without published
+    weights, and process teardown lets GMS clear the aborted layout.
+    """
+    gms_client = _take_pending_gms_write()
+    if gms_client is None:
+        return False
+
+    try:
+        publish_gms_write(gms_client)
+    except BaseException:
+        try:
+            gms_client.close(best_effort=True)
+        except BaseException:
+            logger.exception("[GMS] Failed to release a failed pending write")
+        raise
+
+    logger.info(
+        "[GMS] Published %.2f GiB after vLLM memory profiling and switched "
+        "to read mode",
+        _last_imported_weights_bytes / (1 << 30),
+    )
+    return True
+
+
+def abort_pending_gms_write() -> bool:
+    """Abort and clear the pending vLLM first-writer state, if any.
+
+    Releases the RPC lease best-effort without CUDA cleanup: an abort may
+    run with CUDA in an error state where a normal close synchronizes and
+    calls os._exit.
+    """
+    gms_client = _take_pending_gms_write()
+    if gms_client is None:
+        return False
+    gms_client.close(best_effort=True)
+    return True
 
 
 # =============================================================================
@@ -203,16 +287,20 @@ def _load_write_mode(
     default_loader,
     target_device: torch.device,
 ) -> torch.nn.Module:
-    """Load model from disk and publish weights to GMS (RW mode).
+    """Load model from disk and prepare weights for GMS publication (RW mode).
 
     Initializes model using GMS memory pool, loads weights from disk,
-    registers tensors with GMS, and commits for cross-process sharing.
+    registers tensors with GMS, and prepares a write that is published only
+    after vLLM memory profiling (see GMSWorker.determine_available_memory).
+    Deferring the commit keeps waiting RO consumers (snapshot saver, peer
+    engines) off the device while vLLM profiles memory.
 
     When MX is active, uses LoadStrategyChain for automatic weight source
     detection (RDMA P2P -> ModelStreamer -> GDS -> disk) with fallback.
     The chain also handles NIXL registration and metadata publishing.
     """
-    global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
+    if _pending_gms_client is not None:
+        raise RuntimeError("A GMS write is already awaiting publication")
 
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
@@ -239,12 +327,19 @@ def _load_write_mode(
 
             torch.cuda.empty_cache()
 
-    finalize_result = finalize_gms_write(gms_client, model)
-    _last_imported_weights_bytes = finalize_result.committed_bytes
-    _last_model_memory_usage_offset_bytes = finalize_result.pruned_bytes
+    stats = prepare_gms_write(gms_client, model)
+    # The private clones must exist before vLLM profiles memory so the
+    # profiled peak covers them. The retained GMS originals stay alive until
+    # commit, for readers to materialize from.
+    retained_gms_tensors: list[torch.Tensor] = []
+    rebound_bytes = rebind_nonparameter_tensors(
+        gms_client, model, retain_gms_tensors=retained_gms_tensors
+    )
+    _store_pending_gms_write(gms_client, stats, rebound_bytes, retained_gms_tensors)
 
     logger.info(
-        "[GMS] Write mode: published %.2f GiB " "(vLLM memory offset %.2f GiB)",
+        "[GMS] Write mode: prepared %.2f GiB for publication after profiling "
+        "(vLLM memory offset %.2f GiB)",
         _last_imported_weights_bytes / (1 << 30),
         _last_model_memory_usage_offset_bytes / (1 << 30),
     )

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -37,7 +37,11 @@ from gpu_memory_service.integrations.common.utils import (
     get_gms_ro_connect_timeout_ms,
 )
 from gpu_memory_service.integrations.vllm.model_loader import (
+    abort_pending_gms_write,
+    get_imported_weights_bytes,
     get_mx_load_context,
+    has_pending_gms_write,
+    publish_pending_gms_write,
     register_gms_loader,
 )
 from gpu_memory_service.integrations.vllm.patches import (
@@ -151,19 +155,44 @@ class GMSWorker(Worker):
         # Parent will set device again (harmless) and do memory checks
         super().init_device()
 
+    @torch.inference_mode()
     def determine_available_memory(self) -> int:
         """
         Determine actual available memory for the engine.
 
         During a failover scenario, this function may be called while there is an active engine colocated on the same device.
         We want our assessment to ignore the kv cache allocation of the active engine if there is one.
+
+        A first writer defers its GMS commit until profiling completes here:
+        waiting RO consumers (snapshot saver, peer engines) would otherwise
+        attach to the device mid-profile and perturb vLLM's memory accounting.
+        On failure the pending write is released and the error propagates;
+        the GMS server also clears an uncommitted layout if this process dies.
         """
+        try:
+            available = self._determine_available_memory_before_gms_publish()
+        except BaseException:
+            try:
+                abort_pending_gms_write()
+            except BaseException:
+                logger.exception("[GMS] Failed to release pending write")
+            raise
+        publish_pending_gms_write()
+        return available
+
+    def _determine_available_memory_before_gms_publish(self) -> int:
         if not is_scratch_kv_enabled():
             return super().determine_available_memory()
 
         import vllm.envs as envs
         from vllm.config import CUDAGraphMode
         from vllm.platforms import current_platform
+
+        # A pending first writer's GMS MemPool and private rebound
+        # allocations are both visible in PyTorch's absolute peak. An RO
+        # import's GMS mappings are not, so only those imported bytes need
+        # adding below.
+        has_pending_write = has_pending_gms_write()
 
         torch.cuda.reset_peak_memory_stats()
         self.model_runner.profile_run()
@@ -183,14 +212,10 @@ class GMSWorker(Worker):
         )
         self.cudagraph_memory_estimate = cudagraph_memory_estimate
 
-        # GMS weights mapped via cuMemMap are invisible to PyTorch's memory
-        # stats on RO engines. Add them explicitly. On RW engines, torch_peak
-        # already includes weights so skip to avoid double-counting.
-        weights_memory = int(getattr(self.model_runner, "model_memory_usage", 0))
-        if torch_peak < weights_memory:
-            non_kv_cache_memory = torch_peak + weights_memory
-        else:
-            non_kv_cache_memory = torch_peak
+        invisible_weights_memory = (
+            0 if has_pending_write else get_imported_weights_bytes()
+        )
+        non_kv_cache_memory = torch_peak + invisible_weights_memory
 
         projected_available = (
             self.requested_memory
@@ -202,14 +227,14 @@ class GMSWorker(Worker):
         msg = (
             "[GMS] projected available memory "
             "%.2f GiB (requested=%.2f GiB, non_kv=%.2f GiB, "
-            "torch_peak=%.2f GiB, weights=%.2f GiB, "
+            "torch_peak=%.2f GiB, invisible_weights=%.2f GiB, "
             "cudagraph_estimate=%.2f GiB, cudagraph_applied=%.2f GiB)"
             % (
                 projected_available / (1 << 30),
                 self.requested_memory / (1 << 30),
                 non_kv_cache_memory / (1 << 30),
                 torch_peak / (1 << 30),
-                weights_memory / (1 << 30),
+                invisible_weights_memory / (1 << 30),
                 cudagraph_memory_estimate / (1 << 30),
                 cudagraph_memory_estimate_applied / (1 << 30),
             )
@@ -228,6 +253,10 @@ class GMSWorker(Worker):
         enable_sleep_mode the manager connects RW at init and allocates real
         backing immediately.
         """
+        # EngineCore can skip determine_available_memory for models with no
+        # KV cache. Publish before connector setup, allocation, or warm-up.
+        publish_pending_gms_write()
+
         from vllm.distributed.kv_transfer import ensure_kv_transfer_initialized
 
         ensure_kv_transfer_initialized(self.vllm_config, kv_cache_config)
@@ -270,11 +299,11 @@ class GMSWorker(Worker):
 
             imported_weights_bytes = get_imported_weights_bytes()
             memory_usage_offset_bytes = get_model_memory_usage_offset_bytes()
-            # The offset is not committed/restored GMS weight state. It is the
-            # load-time allocation footprint pruned before commit. vLLM uses
-            # model_memory_usage for KV-cache sizing, not only as a literal
-            # live-weight counter; reporting committed GMS bytes only can
-            # overestimate safe KV capacity and allocate an oversized cache.
+            # The offset is not committed/restored GMS weight state. It is
+            # load-time memory excluded from committed GMS bytes (pruned
+            # load-time allocations plus private rebound clones). vLLM uses
+            # model_memory_usage for KV sizing, so omitting it can allocate
+            # an oversized cache.
             model_memory_usage_bytes = int(
                 imported_weights_bytes + memory_usage_offset_bytes
             )

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -1,0 +1,165 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for deferred GMS write publication in the vLLM integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from _deps import HAS_GMS, HAS_TORCH
+
+if not HAS_GMS:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
+
+if not HAS_TORCH:
+    pytest.skip("torch is required", allow_module_level=True)
+
+from gpu_memory_service.integrations.common import utils as common_utils
+from gpu_memory_service.integrations.vllm import model_loader
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+class _FakeAllocator:
+    def __init__(self, events: list[str], *, fail_commit: bool = False):
+        self.events = events
+        self.fail_commit = fail_commit
+        self.total_bytes = 100
+        self.mappings = {
+            1: SimpleNamespace(allocation_id="weight", aligned_size=60),
+            2: SimpleNamespace(allocation_id="scratch", aligned_size=40),
+        }
+
+    def commit(self):
+        self.events.append("commit")
+        if self.fail_commit:
+            raise RuntimeError("commit failed")
+
+    def connect(self, lock_type):
+        self.events.append("connect")
+
+    def remap_all_vas(self):
+        self.events.append("remap")
+
+    def close(self, *, best_effort=False):
+        self.events.append("close_best_effort" if best_effort else "close")
+
+
+@pytest.fixture
+def gms_write(monkeypatch):
+    """A prepared (registered + pruned, uncommitted) fake GMS write."""
+    events = []
+    allocator = _FakeAllocator(events)
+
+    def register(_allocator, _model):
+        events.append("register")
+        return {"weight"}
+
+    def prune(_allocator, *, referenced_allocation_ids):
+        assert referenced_allocation_ids == {"weight"}
+        events.append("prune")
+        _allocator.mappings.pop(2)
+        _allocator.total_bytes = 60
+
+    monkeypatch.setattr(common_utils, "register_module_tensors", register)
+    monkeypatch.setattr(common_utils, "prune_allocations", prune)
+    monkeypatch.setattr(
+        common_utils,
+        "rebind_nonparameter_tensors",
+        lambda _allocator, _model, **_kwargs: events.append("rebind") or 12,
+    )
+
+    stats = common_utils.prepare_gms_write(allocator, object())
+    return allocator, stats, events
+
+
+@pytest.fixture(autouse=True)
+def clear_pending_write(monkeypatch):
+    monkeypatch.setattr(model_loader, "_pending_gms_client", None)
+    monkeypatch.setattr(model_loader, "_pending_retained_gms_tensors", [])
+    monkeypatch.setattr(model_loader, "_last_imported_weights_bytes", 0)
+    monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
+
+
+def test_prepare_registers_prunes_and_defers_commit(gms_write):
+    """Prepare must not commit; accounting covers pruned and rebound bytes."""
+    allocator, stats, events = gms_write
+
+    assert events == ["register", "prune"]
+    assert stats.committed_bytes == 60
+    assert stats.pruned_bytes == 40
+    assert stats.pruned_count == 1
+
+    model_loader._store_pending_gms_write(allocator, stats, 12, [])
+
+    assert model_loader.get_imported_weights_bytes() == 60
+    assert model_loader.get_model_memory_usage_offset_bytes() == 52
+
+
+def test_pending_write_publish_clears_pending(gms_write):
+    allocator, stats, events = gms_write
+    model_loader._store_pending_gms_write(allocator, stats, 12, [])
+    assert model_loader.has_pending_gms_write()
+
+    assert model_loader.publish_pending_gms_write()
+
+    assert events == ["register", "prune", "commit", "connect", "remap"]
+    assert not model_loader.has_pending_gms_write()
+    assert not model_loader.publish_pending_gms_write()
+
+
+def test_pending_write_abort_releases_writer_without_cuda_cleanup(gms_write):
+    allocator, stats, events = gms_write
+    retained = [object()]
+    model_loader._store_pending_gms_write(allocator, stats, 12, retained)
+
+    assert model_loader.abort_pending_gms_write()
+
+    assert events == ["register", "prune", "close_best_effort"]
+    assert "close" not in events
+    assert model_loader._pending_retained_gms_tensors == []
+    assert not model_loader.has_pending_gms_write()
+    assert not model_loader.abort_pending_gms_write()
+
+
+def test_publication_failure_releases_writer_and_preserves_error(gms_write):
+    allocator, stats, events = gms_write
+    allocator.fail_commit = True
+    model_loader._store_pending_gms_write(allocator, stats, 12, [])
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        model_loader.publish_pending_gms_write()
+
+    assert events == ["register", "prune", "commit", "close_best_effort"]
+    assert not model_loader.has_pending_gms_write()
+
+
+def test_eager_finalize_preserves_publish_then_rebind_order(gms_write):
+    """SGLang/TRT-LLM keep the eager register->commit->reconnect->rebind flow."""
+    allocator, _, events = gms_write
+    events.clear()
+    allocator.total_bytes = 100
+    allocator.mappings[2] = SimpleNamespace(allocation_id="scratch", aligned_size=40)
+
+    stats = common_utils.finalize_gms_write(allocator, object())
+
+    assert stats.committed_bytes == 60
+    assert stats.pruned_bytes == 40
+    assert events == [
+        "register",
+        "prune",
+        "commit",
+        "connect",
+        "remap",
+        "rebind",
+    ]


### PR DESCRIPTION
## Summary

vLLM memory profiling requires that no GPU memory beyond the profiled peak appears afterwards. With eager GMS publication during `load_model`, a waiting RO consumer (snapshot saver, peer engine) attached to the device the moment the writer committed — in the middle of profiling — perturbing vLLM's memory accounting.

This PR defers the vLLM first-writer's GMS commit until after profiling:

- Split `finalize_gms_write` into `prepare_gms_write` (register + prune, RW lease retained) and `PreparedGMSWrite.publish()` (commit → reconnect RO → remap).
- The vLLM loader prepares the write and rebinds non-parameter tensors to private clones **before** profiling (so the profiled peak covers them), retaining the GMS originals on the pending write until commit.
- `GMSWorker.determine_available_memory` publishes the pending write after profiling completes, before KV allocation and graph capture; `initialize_from_config` publishes as a fallback for models that skip profiling. The override also regains the `@torch.inference_mode()` decorator it had dropped from upstream vLLM.
- Scratch-KV accounting now adds imported GMS bytes only for RO engines (whose cuMemMap'd weights are invisible to PyTorch peak stats); a pending writer's mempool and rebound clones are already visible, replacing the fragile `torch_peak < weights` heuristic.

Failure handling is crash-only by design: a local profiling failure aborts the pending write best-effort and the error propagates; if the process dies, the GMS server clears the uncommitted layout on RW disconnect (`cleanup_connection` → `RW_ABORT`), and vLLM tears down all ranks on any rank failure. No cross-rank coordination is needed.

SGLang and TensorRT-LLM keep the eager `finalize_gms_write` path unchanged (ordering covered by a dedicated test).

Note: this rewrite intentionally drops the earlier revision's cross-rank coordination collectives and the snapshot-saver single-lease/session-adoption work. The saver-lease consistency fix is a separate concern and will come as its own PR. The pre-existing commit→connect(RO) writer-preference race is unchanged; the clean fix is a server-side atomic commit-and-downgrade RPC (follow-up).

## Validation

- `pytest lib/gpu_memory_service/tests/test_gms_write_publication.py` — 15 passed (vLLM installed; worker tests exercise real `GMSWorker` methods)
- `pytest lib/gpu_memory_service/tests/` — 67 passed
- `pre-commit run` (isort, black, flake8, ruff, codespell) — clean on all changed files
- `git diff --check` — clean
