### PR TITLE
perf(snapshot): gate concurrent CUDA restore on checkpoint manifest

### DIFF
--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -6,9 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"os/exec"
+	"path"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -341,30 +344,116 @@ func LockAndCheckpointProcessTree(ctx context.Context, cudaPIDs []int, log logr.
 	return timings, nil
 }
 
+// HasJobFile reports whether the checkpointed CUDA processes are coordinated
+// through a cuda-checkpoint job file. The decision mirrors Dynamo's
+// checkpoint-time WrapLaunchJob choice, read back from the container
+// entrypoint: an entrypoint wrapped with `cuda-checkpoint --launch-job`
+// coordinates all CUDA processes through one job, and cuda-checkpoint
+// requires operations on processes in a job to run sequentially. An unknown
+// entrypoint fails closed and is treated as having a job file.
+//
+// Workloads that join a cuda-checkpoint job by other means (for example by
+// setting the job-file environment variable themselves) are outside the
+// Dynamo checkpoint contract and are not detected here.
+func HasJobFile(entrypointArgs []string) (bool, string) {
+	if len(entrypointArgs) == 0 {
+		return true, "container entrypoint is unknown"
+	}
+	if path.Base(entrypointArgs[0]) == "cuda-checkpoint" && slices.Contains(entrypointArgs, "--launch-job") {
+		return true, "container entrypoint is wrapped with cuda-checkpoint --launch-job"
+	}
+	return false, "container entrypoint is not wrapped with cuda-checkpoint --launch-job"
+}
+
 // RestoreAndUnlockProcessTree restores and unlocks CUDA state for the given PIDs.
-func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap string, log logr.Logger) (RestorePhaseTimings, error) {
-	var timings RestorePhaseTimings
+// When concurrent is true (the checkpoint manifest recorded no cuda-checkpoint
+// job file), per-PID operations within each phase run concurrently; otherwise
+// they run serially. All restores must succeed before any unlock starts.
+func RestoreAndUnlockProcessTree(ctx context.Context, cudaPIDs []int, deviceMap string, concurrent bool, log logr.Logger) (RestorePhaseTimings, error) {
+	return restoreAndUnlockProcessTree(
+		ctx,
+		cudaPIDs,
+		concurrent,
+		func(ctx context.Context, pid int) error {
+			return restoreProcess(ctx, pid, deviceMap, log)
+		},
+		func(ctx context.Context, pid int) error {
+			return unlock(ctx, pid, log)
+		},
+		getState,
+		log,
+	)
+}
+
+func restoreAndUnlockProcessTree(
+	ctx context.Context,
+	cudaPIDs []int,
+	concurrent bool,
+	restore func(context.Context, int) error,
+	unlock func(context.Context, int) error,
+	getProcessState func(context.Context, int) (string, error),
+	log logr.Logger,
+) (timings RestorePhaseTimings, err error) {
+	mode := "serial"
+	if concurrent {
+		mode = "concurrent"
+	}
+	log.Info("Selected CUDA restore execution mode", "mode", mode, "pid_count", len(cudaPIDs))
 
 	start := time.Now()
-	for _, pid := range cudaPIDs {
-		if err := restoreProcess(ctx, pid, deviceMap, log); err != nil {
-			timings.TotalDuration = time.Since(start)
-			return timings, err
-		}
+	defer func() {
+		timings.TotalDuration = time.Since(start)
+	}()
+
+	if err := runPIDOperations(ctx, cudaPIDs, "restore", concurrent, restore); err != nil {
+		return timings, err
 	}
 
-	for _, pid := range cudaPIDs {
-		if err := unlock(ctx, pid, log); err != nil {
-			timings.TotalDuration = time.Since(start)
-			state, stateErr := getState(ctx, pid)
-			if stateErr == nil && state == "running" {
-				log.Info("cuda-checkpoint-helper unlock returned error but process is already running", "pid", pid)
-				continue
-			}
-			return timings, err
+	tolerantUnlock := func(ctx context.Context, pid int) error {
+		err := unlock(ctx, pid)
+		if err == nil {
+			return nil
 		}
+		state, stateErr := getProcessState(ctx, pid)
+		if stateErr == nil && state == "running" {
+			log.Info("cuda-checkpoint-helper unlock returned error but process is already running", "pid", pid)
+			return nil
+		}
+		return err
 	}
-	timings.TotalDuration = time.Since(start)
+	if err := runPIDOperations(ctx, cudaPIDs, "unlock", concurrent, tolerantUnlock); err != nil {
+		return timings, err
+	}
 
 	return timings, nil
+}
+
+// runPIDOperations runs op for each PID, serially or one goroutine per PID,
+// and joins failures in input PID order.
+func runPIDOperations(ctx context.Context, pids []int, action string, concurrent bool, op func(context.Context, int) error) error {
+	errs := make([]error, len(pids))
+	wrap := func(pid int, err error) error {
+		if err == nil {
+			return nil
+		}
+		return fmt.Errorf("CUDA %s failed for pid %d: %w", action, pid, err)
+	}
+
+	if !concurrent {
+		for i, pid := range pids {
+			errs[i] = wrap(pid, op(ctx, pid))
+		}
+		return errors.Join(errs...)
+	}
+
+	var wg sync.WaitGroup
+	for i, pid := range pids {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			errs[i] = wrap(pid, op(ctx, pid))
+		}()
+	}
+	wg.Wait()
+	return errors.Join(errs...)
 }

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -3,9 +3,11 @@ package cuda
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -86,6 +88,239 @@ func TestBuildDeviceMap(t *testing.T) {
 			}
 			if got != tc.want {
 				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRestoreAndUnlockProcessTreeConcurrentPhaseBarrier(t *testing.T) {
+	pids := []int{101, 202, 303}
+	restoreStarted := make(chan int, len(pids))
+	releaseRestore := make(chan struct{})
+	unlockStarted := make(chan int, len(pids))
+	errCh := make(chan error, 1)
+
+	go func() {
+		_, err := restoreAndUnlockProcessTree(
+			context.Background(),
+			pids,
+			true,
+			func(ctx context.Context, pid int) error {
+				restoreStarted <- pid
+				select {
+				case <-releaseRestore:
+					return nil
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			},
+			func(_ context.Context, pid int) error {
+				unlockStarted <- pid
+				return nil
+			},
+			func(context.Context, int) (string, error) {
+				return "", errors.New("unexpected state check")
+			},
+			logr.Discard(),
+		)
+		errCh <- err
+	}()
+
+	for range pids {
+		select {
+		case <-restoreStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("restore operations did not all start concurrently")
+		}
+	}
+	select {
+	case pid := <-unlockStarted:
+		t.Fatalf("unlock for pid %d started before all restores completed", pid)
+	default:
+	}
+
+	close(releaseRestore)
+	for range pids {
+		select {
+		case <-unlockStarted:
+		case <-time.After(2 * time.Second):
+			t.Fatal("unlock operations did not all start")
+		}
+	}
+
+	select {
+	case err := <-errCh:
+		if err != nil {
+			t.Fatalf("restoreAndUnlockProcessTree: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("restoreAndUnlockProcessTree did not complete")
+	}
+}
+
+func TestRestoreAndUnlockProcessTreeSerialOrdering(t *testing.T) {
+	pids := []int{303, 101, 202}
+	var calls []string
+
+	_, err := restoreAndUnlockProcessTree(
+		context.Background(),
+		pids,
+		false,
+		func(_ context.Context, pid int) error {
+			calls = append(calls, fmt.Sprintf("restore:%d", pid))
+			return nil
+		},
+		func(_ context.Context, pid int) error {
+			calls = append(calls, fmt.Sprintf("unlock:%d", pid))
+			return nil
+		},
+		func(context.Context, int) (string, error) {
+			return "", errors.New("unexpected state check")
+		},
+		logr.Discard(),
+	)
+	if err != nil {
+		t.Fatalf("restoreAndUnlockProcessTree: %v", err)
+	}
+
+	want := []string{
+		"restore:303",
+		"restore:101",
+		"restore:202",
+		"unlock:303",
+		"unlock:101",
+		"unlock:202",
+	}
+	if strings.Join(calls, ",") != strings.Join(want, ",") {
+		t.Fatalf("calls %v, want %v", calls, want)
+	}
+}
+
+func TestRestoreAndUnlockProcessTreeWaitsAndOrdersErrors(t *testing.T) {
+	pids := []int{303, 101, 202}
+	var completed atomic.Int32
+	var unlockCalls atomic.Int32
+
+	_, err := restoreAndUnlockProcessTree(
+		context.Background(),
+		pids,
+		true,
+		func(_ context.Context, pid int) error {
+			defer completed.Add(1)
+			if pid == 202 {
+				time.Sleep(20 * time.Millisecond)
+				return nil
+			}
+			return fmt.Errorf("restore error %d", pid)
+		},
+		func(context.Context, int) error {
+			unlockCalls.Add(1)
+			return nil
+		},
+		func(context.Context, int) (string, error) {
+			return "", errors.New("unexpected state check")
+		},
+		logr.Discard(),
+	)
+	if err == nil {
+		t.Fatal("expected restore error")
+	}
+	if completed.Load() != int32(len(pids)) {
+		t.Fatalf("completed %d restores, want %d", completed.Load(), len(pids))
+	}
+	if unlockCalls.Load() != 0 {
+		t.Fatalf("unlock called %d times after restore failure", unlockCalls.Load())
+	}
+	errText := err.Error()
+	first := strings.Index(errText, "pid 303")
+	second := strings.Index(errText, "pid 101")
+	if first < 0 || second < 0 || first >= second {
+		t.Fatalf("errors are not in PID input order: %q", errText)
+	}
+}
+
+func TestRestoreAndUnlockProcessTreeAcceptsAlreadyRunning(t *testing.T) {
+	pids := []int{101, 202}
+
+	_, err := restoreAndUnlockProcessTree(
+		context.Background(),
+		pids,
+		false,
+		func(context.Context, int) error {
+			return nil
+		},
+		func(_ context.Context, pid int) error {
+			return fmt.Errorf("unlock error %d", pid)
+		},
+		func(_ context.Context, pid int) (string, error) {
+			if pid == 101 {
+				return "running", nil
+			}
+			return "checkpointed", nil
+		},
+		logr.Discard(),
+	)
+	if err == nil {
+		t.Fatal("expected unlock error for non-running process")
+	}
+	if strings.Contains(err.Error(), "pid 101") {
+		t.Fatalf("already-running process returned an error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "pid 202") {
+		t.Fatalf("missing PID attribution: %v", err)
+	}
+}
+
+func TestHasJobFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		entrypointArgs []string
+		want           bool
+		reason         string
+	}{
+		{
+			name:           "launch-job wrapped entrypoint",
+			entrypointArgs: []string{"cuda-checkpoint", "--launch-job", "python3"},
+			want:           true,
+			reason:         "is wrapped with cuda-checkpoint --launch-job",
+		},
+		{
+			name:           "launch-job wrapped entrypoint with absolute path",
+			entrypointArgs: []string{"/usr/local/bin/cuda-checkpoint", "--launch-job", "python3"},
+			want:           true,
+			reason:         "is wrapped with cuda-checkpoint --launch-job",
+		},
+		{
+			name:   "nil entrypoint args",
+			want:   true,
+			reason: "unknown",
+		},
+		{
+			name:           "empty entrypoint args",
+			entrypointArgs: []string{},
+			want:           true,
+			reason:         "unknown",
+		},
+		{
+			name:           "ordinary entrypoint",
+			entrypointArgs: []string{"python3", "-m", "dynamo.vllm"},
+			reason:         "is not wrapped with cuda-checkpoint --launch-job",
+		},
+		{
+			name:           "launch-job flag without cuda-checkpoint entrypoint",
+			entrypointArgs: []string{"python3", "--launch-job"},
+			reason:         "is not wrapped with cuda-checkpoint --launch-job",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, reason := HasJobFile(tc.entrypointArgs)
+			if got != tc.want {
+				t.Fatalf("HasJobFile() = %t, want %t (reason %q)", got, tc.want, reason)
+			}
+			if !strings.Contains(reason, tc.reason) {
+				t.Fatalf("reason %q does not contain %q", reason, tc.reason)
 			}
 		})
 	}

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -190,6 +190,7 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		log.V(1).Info("Resolved checkpoint CUDA PID mapping", "host_pids", cudaHostPIDs, "namespace_pids", cudaNamespacePIDs)
 	}
 	var gpuUUIDs []string
+	cudaHasJobFile := true // fail closed: only cleared by a positive determination below
 	if len(cudaHostPIDs) > 0 {
 		gpuUUIDs, err = cuda.DiscoverGPUUUIDs(
 			ctx,
@@ -204,6 +205,14 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		if err != nil {
 			return nil, fmt.Errorf("failed to discover source GPU UUIDs: %w", err)
 		}
+
+		var entrypointArgs []string
+		if ociSpec != nil && ociSpec.Process != nil {
+			entrypointArgs = ociSpec.Process.Args
+		}
+		var reason string
+		cudaHasJobFile, reason = cuda.HasJobFile(entrypointArgs)
+		log.Info("Determined CUDA checkpoint job-file usage", "has_job_file", cudaHasJobFile, "reason", reason)
 	}
 
 	return &types.CheckpointContainerSnapshot{
@@ -218,6 +227,7 @@ func inspectContainer(ctx context.Context, rt snapshotruntime.Runtime, log logr.
 		CUDAHostPIDs:   cudaHostPIDs,
 		CUDANSPIDs:     cudaNamespacePIDs,
 		GPUUUIDs:       gpuUUIDs,
+		CUDAHasJobFile: cudaHasJobFile,
 	}, nil
 }
 
@@ -240,7 +250,7 @@ func configureCheckpoint(
 		types.NewOverlayManifest(cfg.Overlay, state.UpperDir, state.OCISpec),
 	)
 	if len(state.CUDANSPIDs) > 0 {
-		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs)
+		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs, state.CUDAHasJobFile)
 	}
 
 	if err := types.WriteManifest(checkpointDir, m); err != nil {

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -162,7 +162,7 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 			"restored_cuda_pids", restorePIDs,
 			"criu_callback_pid", restoredPID,
 		)
-		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, log)
+		_, err = cuda.RestoreAndUnlockProcessTree(ctx, restorePIDs, opts.CUDADeviceMap, !m.CUDA.HasJobFile, log)
 		if err != nil {
 			return nil, 0, fmt.Errorf("CUDA restore failed: %w", err)
 		}

--- a/deploy/snapshot/internal/types/inspect.go
+++ b/deploy/snapshot/internal/types/inspect.go
@@ -28,6 +28,13 @@ type CheckpointContainerSnapshot struct {
 	CUDAHostPIDs   []int    // host-visible PIDs used for checkpoint-side CUDA actions
 	CUDANSPIDs     []int    // namespace-relative PIDs stored in the checkpoint manifest
 	GPUUUIDs       []string // source GPU UUIDs from kubelet PodResources API
+
+	// CUDAHasJobFile records whether the workload's CUDA processes are
+	// coordinated through a cuda-checkpoint job file, determined at
+	// checkpoint time from the launch-job entrypoint wrapping. When true
+	// (or when the entrypoint is unknown), restore-side cuda-checkpoint
+	// operations must run serially.
+	CUDAHasJobFile bool
 }
 
 // RestoreContainerSnapshot holds inspected state for the restore target.

--- a/deploy/snapshot/internal/types/manifest.go
+++ b/deploy/snapshot/internal/types/manifest.go
@@ -128,12 +128,21 @@ func NewOverlayManifest(exclusions OverlaySettings, upperDir string, ociSpec *sp
 type CUDAManifest struct {
 	PIDs           []int    `yaml:"pids"`
 	SourceGPUUUIDs []string `yaml:"sourceGpuUuids"`
+	// HasJobFile records whether the workload was launched under a
+	// cuda-checkpoint job file (its entrypoint was wrapped with
+	// `cuda-checkpoint --launch-job`, or the entrypoint was unknown, which
+	// is treated the same). When true, restore-side cuda-checkpoint
+	// operations must run serially; when false they may run concurrently.
+	// Manifests written before this field existed unmarshal to false and
+	// restore concurrently.
+	HasJobFile bool `yaml:"hasJobFile"`
 }
 
-func NewCUDAManifest(pids []int, sourceGPUUUIDs []string) CUDAManifest {
+func NewCUDAManifest(pids []int, sourceGPUUUIDs []string, hasJobFile bool) CUDAManifest {
 	return CUDAManifest{
 		PIDs:           append([]int(nil), pids...),
 		SourceGPUUUIDs: append([]string(nil), sourceGPUUUIDs...),
+		HasJobFile:     hasJobFile,
 	}
 }
 

--- a/deploy/snapshot/internal/types/manifest_test.go
+++ b/deploy/snapshot/internal/types/manifest_test.go
@@ -32,7 +32,7 @@ func TestManifestRoundTrip(t *testing.T) {
 			BindMountDests: []string{"/data"},
 		},
 	)
-	original.CUDA = NewCUDAManifest([]int{42, 43}, []string{"GPU-aaa", "GPU-bbb"})
+	original.CUDA = NewCUDAManifest([]int{42, 43}, []string{"GPU-aaa", "GPU-bbb"}, true /* hasJobFile */)
 
 	if err := WriteManifest(dir, original); err != nil {
 		t.Fatalf("WriteManifest: %v", err)
@@ -85,6 +85,32 @@ func TestManifestRoundTrip(t *testing.T) {
 	}
 	if len(loaded.CUDA.SourceGPUUUIDs) != 2 || loaded.CUDA.SourceGPUUUIDs[0] != "GPU-aaa" {
 		t.Errorf("CUDA.SourceGPUUUIDs = %v", loaded.CUDA.SourceGPUUUIDs)
+	}
+	if !loaded.CUDA.HasJobFile {
+		t.Error("CUDA.HasJobFile should be true")
+	}
+}
+
+func TestCUDAManifestHasJobFileDefaultsToFalse(t *testing.T) {
+	dir := t.TempDir()
+
+	// A manifest written before the hasJobFile field existed unmarshals to
+	// false, meaning restore treats it as having no job file.
+	content := []byte(`checkpointId: sha256:abc123
+cudaRestore:
+  pids: [42]
+  sourceGpuUuids: [GPU-aaa]
+`)
+	if err := os.WriteFile(filepath.Join(dir, manifestFilename), content, 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	loaded, err := ReadManifest(dir)
+	if err != nil {
+		t.Fatalf("ReadManifest: %v", err)
+	}
+	if loaded.CUDA.HasJobFile {
+		t.Error("CUDA.HasJobFile should default to false when absent")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Record at checkpoint time whether the workload was launched under a cuda-checkpoint job file, via `cuda.HasJobFile`: Dynamo's `WrapLaunchJob` decision read back from the container's OCI-spec entrypoint (`cuda-checkpoint --launch-job` wrapping). An unknown entrypoint is treated as having a job file. The result is persisted in a new `CUDAManifest.HasJobFile` field, always written explicitly.
- Gate restore-side CUDA execution on that manifest field. Per NVIDIA cuda-checkpoint docs, operations on processes in the same launch job must run sequentially, so `hasJobFile: true` restores serially; `hasJobFile: false` restores concurrently. Manifests written before this field existed unmarshal to false and restore concurrently — old checkpoints are not supported by this change.
- When concurrent restore is allowed, run per-PID restore and unlock operations in parallel within each phase, retaining a strict restore-before-unlock barrier and deterministic input-PID-ordered error reporting.
- No process-environment inspection anywhere: the gate is a pure round-trip of Dynamo's own wrapping decision. Workloads that join a cuda-checkpoint job by other means (e.g. setting the job-file environment variable themselves) are outside the Dynamo checkpoint contract and are documented as such in code.

## Validation

```console
cd deploy/snapshot && go build ./... && go vet ./...
cd deploy/snapshot && go test ./...
cd deploy/snapshot && go test -race -count=10 ./internal/cuda
cd deploy/snapshot && go test -race ./internal/executor ./internal/types
gofmt -l deploy/snapshot/internal deploy/snapshot/cmd deploy/snapshot/protocol   # clean
pre-commit run --files <the changed files>
```

All pass (including 10 race-detector iterations of the new concurrency tests). Unit tests validate the serial/concurrent gating, the restore-before-unlock barrier, error ordering, and manifest defaulting (absent field ⇒ no job file). No GPU end-to-end validation has been run yet; the tests do not establish CUDA restore performance.
