### PR TITLE
feat(gms): add namespaced layout metadata

### DIFF
--- a/lib/gpu_memory_service/README.md
+++ b/lib/gpu_memory_service/README.md
@@ -39,7 +39,7 @@ This leads to:
 │  │ └────────────────┘ │                                                              │
 │  │                    │                  ┌─────────────────────────────────────────┐ │
 │  │ ┌────────────────┐ │                  │    GMSClientMemoryManager (Reader)      │ │
-│  │ │ Metadata Store │ │                  │                                         │ │
+│  │ │ Metadata Stores│ │                  │                                         │ │
 │  │ └────────────────┘ │ ◄── Unix ───────►│  ┌─────────────────────────────────┐    │ │
 │  │                    │    Socket        │  │         GMS Session             │    │ │
 │  └────────────────────┘       +          │  └─────────────────────────────────┘    │ │
@@ -69,7 +69,7 @@ The server consists of three main components:
 
 2. **State Machine (FSM)** - Manages global lock state, waiter coordination, and disconnect cleanup.
 
-3. **Metadata Store / Layout State** - `GMS` owns the metadata table and committed layout hash. Allocations and metadata live in one flat store that is cleared on each new writer connect or writer abort.
+3. **Metadata Stores / Layout State** - `GMS` owns allocation-anchored tensor metadata, allocation-independent namespaced layout metadata, and the committed layout hash. Both metadata stores are cleared on each new writer connect or writer abort.
 
 Each GMS server is responsible for managing memory of only 1 GPU, and does not interact with GMS servers corresponding to other GPUs.
 
@@ -197,10 +197,11 @@ flowchart LR
 - `RW_ABORT` discards the current RW layout and returns the system to `EMPTY`.
 - `RW -> EMPTY` does not require allocating a new layout first; it happens immediately when the writer drops the session before commit.
 - There is no RPC that clears the active RW layout while keeping the same writer session alive. To abandon a partially built RW layout, the writer must disconnect or call `abort()`, and any later RW build starts from a fresh `RW_CONNECT`.
-- Allocations and metadata live in one flat store that is cleared on `RW_CONNECT` and `RW_ABORT`.
+- Allocations, allocation-anchored tensor metadata, and namespaced layout metadata form one published layout. All are cleared on `RW_CONNECT` and `RW_ABORT`.
 - RO requests are served only from the committed layout, while RW requests mutate only the active layout.
-- Read RPCs (`export`, allocation lookup/listing, metadata lookup/listing) operate on that single live store. This is safe because the FSM prevents RW and RO sessions from coexisting.
-- `metadata_put` validates allocation ownership and offset bounds, `free` cascades metadata cleanup, and `commit` rejects dangling metadata references.
+- Read RPCs (`export`, allocation lookup/listing, and both metadata APIs) operate on that single live layout. This is safe because the FSM prevents RW and RO sessions from coexisting.
+- `metadata_put` stores tensor metadata and validates allocation ownership and offset bounds. `free` cascades only that allocation-anchored metadata, and `commit` rejects dangling references.
+- `layout_metadata_put(namespace, key, value)` stores opaque application bytes without an allocation anchor. These entries survive allocation pruning, are isolated from tensor enumeration, and publish atomically with `commit`.
 
 ### Allocation Backpressure on OOM
 
@@ -278,6 +279,9 @@ sequenceDiagram
         W->>C: mgr.metadata_put(key, allocation_id, offset, shape)
     end
 
+    W->>C: mgr.layout_metadata_put(namespace, key, opaque_bytes)
+    C->>S: Store allocation-independent application metadata
+
     W->>C: mgr.commit()
     C->>GPU: synchronize()
     C->>GPU: cuMemUnmap(...) + cuMemRelease(...)
@@ -316,6 +320,39 @@ sequenceDiagram
 
     Note over R,C: Keep connection open during inference
 ```
+
+### Namespaced Layout Metadata
+
+Framework integrations can publish small, opaque compatibility envelopes with
+the same commit as the tensor layout:
+
+```python
+manager.layout_metadata_put(
+    "trtllm",
+    "committed_weight_envelope",
+    serialized_envelope,
+)
+manager.commit()
+```
+
+The namespace and key are separate protocol fields; GMS does not interpret the
+value or define a framework schema. Put/delete operations require RW, while
+get/list are available in RW and RO sessions. Layout metadata is not returned
+by `metadata_list()` and is not deleted when an allocation is freed. It is
+cleared with the rest of the layout on a new writer or writer abort, and its
+bytes contribute to the committed memory-layout hash.
+
+Because those bytes contribute to the hash, an application envelope cannot
+embed the final hash without creating a self-reference. Readers should fetch
+the envelope and `get_memory_layout_hash()` from the same RO session, or place a
+publisher-generated layout generation ID in the envelope.
+
+GMS snapshots persist this store in the optional, versioned
+`gms_layout_metadata.json` file. New loaders accept legacy snapshots without
+that file and ignore undeclared sidecars; new manifests declare the sidecar so
+deleting it is a load error. Servers and clients must use compatible GMS
+package versions because the wire protocol does not currently negotiate
+optional RPC capabilities.
 
 ### Unmap/Remap Flow (Memory Pressure)
 
@@ -438,7 +475,8 @@ During `remap_all_vas()`:
 
 On commit, the server computes a hash of:
 - All allocation layout slots, sizes, aligned sizes, and tags
-- All metadata keys, offsets, and values
+- All tensor metadata keys, offsets, and values
+- All layout metadata namespaces, keys, and opaque values
 
 On `remap_all_vas()`, this hash is checked:
 - If match: Safe to remap (layout unchanged)
@@ -512,11 +550,17 @@ class GMSClientMemoryManager:
     def unmap_va(va: int) -> None                                    # Keeps VA reservation
     def free_va(va: int) -> None                                     # Releases VA reservation
 
-    # --- Tier 1: Metadata ---
+    # --- Tier 1: Tensor metadata (allocation-anchored) ---
     def metadata_put(key: str, allocation_id: str, offset_bytes: int, value: bytes) -> bool
     def metadata_get(key: str) -> Optional[Tuple[str, int, bytes]]
     def metadata_list(prefix: str = "") -> List[str]
     def metadata_delete(key: str) -> bool
+
+    # --- Tier 1: Layout metadata (allocation-independent application bytes) ---
+    def layout_metadata_put(namespace: str, key: str, value: bytes) -> bool
+    def layout_metadata_get(namespace: str, key: str) -> Optional[bytes]
+    def layout_metadata_list(namespace: Optional[str] = None, prefix: str = "") -> List[LayoutMetadataKey]
+    def layout_metadata_delete(namespace: str, key: str) -> bool
 
     # --- Tier 2: Convenience ---
     def create_mapping(allocation_id=None, size=0, tag="default") -> int  # Allocate or import

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -11,7 +11,9 @@ Tier 1 (Atomic Operations):
     get_handle_info, free_handle, commit, list_handles,
     get_memory_layout_hash
   - VA ops (local address space): reserve_va, map_va, unmap_va, free_va
-  - Metadata: metadata_put, metadata_get, metadata_list, metadata_delete
+  - Tensor metadata: metadata_put, metadata_get, metadata_list, metadata_delete
+  - Layout metadata: layout_metadata_put, layout_metadata_get,
+    layout_metadata_list, layout_metadata_delete
 
 Tier 2 (Convenience — compose Tier 1 with error handling + sync):
   - create_mapping, destroy_mapping
@@ -51,7 +53,10 @@ from gpu_memory_service.common.cuda_utils import (
     cumem_unmap,
 )
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
-from gpu_memory_service.common.protocol.messages import GetAllocationResponse
+from gpu_memory_service.common.protocol.messages import (
+    GetAllocationResponse,
+    LayoutMetadataKey,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -64,7 +69,8 @@ class StaleMemoryLayoutError(Exception):
     reader was unmapped. The caller should re-import the model from scratch.
 
     IMPORTANT: This is a LAYOUT check, NOT a CONTENT check.
-    - Detected: Allocation sizes changed, tensors added/removed, metadata structure changed
+    - Detected: Allocation sizes changed, tensors added/removed, tensor or layout
+      metadata changed
     - NOT detected: Data values modified in-place
 
     This design is intentional: unmap/remap enables use cases like RL training
@@ -370,6 +376,33 @@ class GMSClientMemoryManager:
 
     def metadata_delete(self, key: str) -> bool:
         return self._client_rpc.metadata_delete(key)
+
+    # ==================== Tier 1: Layout Metadata ====================
+
+    def layout_metadata_put(self, namespace: str, key: str, value: bytes) -> bool:
+        """Store opaque application metadata with the active memory layout.
+
+        Layout metadata is independent of tensor allocations. It is published
+        atomically by :meth:`commit` and remains available to read-only
+        sessions until a new writer replaces or aborts the layout.
+        """
+        return self._client_rpc.layout_metadata_put(namespace, key, value)
+
+    def layout_metadata_get(self, namespace: str, key: str) -> Optional[bytes]:
+        """Return one layout metadata value, or ``None`` when absent."""
+        return self._client_rpc.layout_metadata_get(namespace, key)
+
+    def layout_metadata_list(
+        self,
+        namespace: Optional[str] = None,
+        prefix: str = "",
+    ) -> List[LayoutMetadataKey]:
+        """List layout metadata keys, optionally filtered by namespace/prefix."""
+        return self._client_rpc.layout_metadata_list(namespace, prefix)
+
+    def layout_metadata_delete(self, namespace: str, key: str) -> bool:
+        """Delete one layout metadata value from the active writer layout."""
+        return self._client_rpc.layout_metadata_delete(namespace, key)
 
     # ==================== Tier 1: VA Operations (local) ====================
 

--- a/lib/gpu_memory_service/client/session.py
+++ b/lib/gpu_memory_service/client/session.py
@@ -28,6 +28,15 @@ from gpu_memory_service.common.protocol.messages import (
     GetStateHashRequest,
     GetStateHashResponse,
     HandshakeResponse,
+    LayoutMetadataDeleteRequest,
+    LayoutMetadataDeleteResponse,
+    LayoutMetadataGetRequest,
+    LayoutMetadataGetResponse,
+    LayoutMetadataKey,
+    LayoutMetadataListRequest,
+    LayoutMetadataListResponse,
+    LayoutMetadataPutRequest,
+    LayoutMetadataPutResponse,
     ListAllocationsRequest,
     ListAllocationsResponse,
     MetadataDeleteRequest,
@@ -204,6 +213,41 @@ class _GMSClientSession:
     def metadata_list(self, prefix: str = "") -> List[str]:
         return self._transport.request(
             MetadataListRequest(prefix=prefix), MetadataListResponse
+        ).keys
+
+    def layout_metadata_put(self, namespace: str, key: str, value: bytes) -> bool:
+        return self._transport.request(
+            LayoutMetadataPutRequest(
+                namespace=namespace,
+                key=key,
+                value=value,
+            ),
+            LayoutMetadataPutResponse,
+        ).success
+
+    def layout_metadata_get(self, namespace: str, key: str) -> Optional[bytes]:
+        response = self._transport.request(
+            LayoutMetadataGetRequest(namespace=namespace, key=key),
+            LayoutMetadataGetResponse,
+        )
+        if not response.found:
+            return None
+        return response.value
+
+    def layout_metadata_delete(self, namespace: str, key: str) -> bool:
+        return self._transport.request(
+            LayoutMetadataDeleteRequest(namespace=namespace, key=key),
+            LayoutMetadataDeleteResponse,
+        ).deleted
+
+    def layout_metadata_list(
+        self,
+        namespace: Optional[str] = None,
+        prefix: str = "",
+    ) -> List[LayoutMetadataKey]:
+        return self._transport.request(
+            LayoutMetadataListRequest(namespace=namespace, prefix=prefix),
+            LayoutMetadataListResponse,
         ).keys
 
     def get_memory_layout_hash(self) -> str:

--- a/lib/gpu_memory_service/common/protocol/messages.py
+++ b/lib/gpu_memory_service/common/protocol/messages.py
@@ -144,12 +144,58 @@ class MetadataListResponse(msgspec.Struct, tag="metadata_list_response"):
     keys: List[str] = []
 
 
+class LayoutMetadataKey(msgspec.Struct):
+    namespace: str
+    key: str
+
+
+class LayoutMetadataPutRequest(msgspec.Struct, tag="layout_metadata_put_request"):
+    namespace: str
+    key: str
+    value: bytes
+
+
+class LayoutMetadataPutResponse(msgspec.Struct, tag="layout_metadata_put_response"):
+    success: bool
+
+
+class LayoutMetadataGetRequest(msgspec.Struct, tag="layout_metadata_get_request"):
+    namespace: str
+    key: str
+
+
+class LayoutMetadataGetResponse(msgspec.Struct, tag="layout_metadata_get_response"):
+    found: bool
+    value: Optional[bytes] = None
+
+
+class LayoutMetadataDeleteRequest(msgspec.Struct, tag="layout_metadata_delete_request"):
+    namespace: str
+    key: str
+
+
+class LayoutMetadataDeleteResponse(
+    msgspec.Struct, tag="layout_metadata_delete_response"
+):
+    deleted: bool
+
+
+class LayoutMetadataListRequest(msgspec.Struct, tag="layout_metadata_list_request"):
+    namespace: Optional[str] = None
+    prefix: str = ""
+
+
+class LayoutMetadataListResponse(msgspec.Struct, tag="layout_metadata_list_response"):
+    keys: List[LayoutMetadataKey] = []
+
+
 class GetStateHashRequest(msgspec.Struct, tag="get_memory_layout_hash_request"):
     pass
 
 
 class GetStateHashResponse(msgspec.Struct, tag="get_memory_layout_hash_response"):
-    memory_layout_hash: str  # Hash of allocations + metadata, empty if not committed
+    # Hash of allocations plus tensor/layout metadata; empty if not committed.
+    memory_layout_hash: str
 
 
 class GetRuntimeStateRequest(msgspec.Struct, tag="get_runtime_state_request"):
@@ -208,6 +254,14 @@ Message = Union[
     MetadataDeleteResponse,
     MetadataListRequest,
     MetadataListResponse,
+    LayoutMetadataPutRequest,
+    LayoutMetadataPutResponse,
+    LayoutMetadataGetRequest,
+    LayoutMetadataGetResponse,
+    LayoutMetadataDeleteRequest,
+    LayoutMetadataDeleteResponse,
+    LayoutMetadataListRequest,
+    LayoutMetadataListResponse,
     GetStateHashRequest,
     GetStateHashResponse,
     GetRuntimeStateRequest,

--- a/lib/gpu_memory_service/server/gms.py
+++ b/lib/gpu_memory_service/server/gms.py
@@ -32,6 +32,15 @@ from gpu_memory_service.common.protocol.messages import (
     GetStateHashRequest,
     GetStateHashResponse,
     GMSRuntimeEvent,
+    LayoutMetadataDeleteRequest,
+    LayoutMetadataDeleteResponse,
+    LayoutMetadataGetRequest,
+    LayoutMetadataGetResponse,
+    LayoutMetadataKey,
+    LayoutMetadataListRequest,
+    LayoutMetadataListResponse,
+    LayoutMetadataPutRequest,
+    LayoutMetadataPutResponse,
     ListAllocationsRequest,
     ListAllocationsResponse,
     MetadataDeleteRequest,
@@ -78,6 +87,7 @@ class GMS:
         self._sessions = GMSSessionManager()
         self._events: deque[GMSRuntimeEvent] = deque(maxlen=self._MAX_EVENTS)
         self._metadata: dict[str, MetadataEntry] = {}
+        self._layout_metadata: dict[tuple[str, str], bytes] = {}
         self._memory_layout_hash = ""
         logger.info("GMS initialized: device=%d", device)
 
@@ -186,12 +196,33 @@ class GMS:
             rank = allocation_ranks_by_id[entry.allocation_id]
             h.update(f"{key}:{rank}:{entry.offset_bytes}:".encode())
             h.update(entry.value)
+
+        if self._layout_metadata:
+            # Preserve the legacy hash byte-for-byte when this store is empty.
+            # When it is populated, fix the boundary after the legacy stream
+            # before hashing the separately framed application-owned fields.
+            legacy_layout_digest = h.digest()
+            h = hashlib.sha256()
+            h.update(b"\x00gms-layout-state-v2\x00")
+            h.update(legacy_layout_digest)
+            for (namespace, key), value in sorted(self._layout_metadata.items()):
+                for field in (namespace.encode("utf-8"), key.encode("utf-8"), value):
+                    h.update(len(field).to_bytes(8, byteorder="big"))
+                    h.update(field)
         return h.hexdigest()
 
     def _clear_layout_state(self) -> int:
         self._metadata.clear()
+        self._layout_metadata.clear()
         self._memory_layout_hash = ""
         return self._allocations.clear_all()
+
+    @staticmethod
+    def _validate_layout_metadata_key(namespace: str, key: str) -> None:
+        if not namespace:
+            raise ValueError("layout metadata namespace must not be empty")
+        if not key:
+            raise ValueError("layout metadata key must not be empty")
 
     def on_connect(self, conn: Connection) -> None:
         if conn.mode == GrantedLockType.RW:
@@ -405,5 +436,39 @@ class GMS:
                     key for key in self._metadata if key.startswith(msg.prefix)
                 )
             return MetadataListResponse(keys=keys), -1, False
+
+        if msg_type is LayoutMetadataPutRequest:
+            self._validate_layout_metadata_key(msg.namespace, msg.key)
+            self._layout_metadata[(msg.namespace, msg.key)] = msg.value
+            return LayoutMetadataPutResponse(success=True), -1, False
+
+        if msg_type is LayoutMetadataGetRequest:
+            self._validate_layout_metadata_key(msg.namespace, msg.key)
+            value = self._layout_metadata.get((msg.namespace, msg.key))
+            if value is None:
+                return LayoutMetadataGetResponse(found=False), -1, False
+            return LayoutMetadataGetResponse(found=True, value=value), -1, False
+
+        if msg_type is LayoutMetadataDeleteRequest:
+            self._validate_layout_metadata_key(msg.namespace, msg.key)
+            return (
+                LayoutMetadataDeleteResponse(
+                    deleted=self._layout_metadata.pop((msg.namespace, msg.key), None)
+                    is not None
+                ),
+                -1,
+                False,
+            )
+
+        if msg_type is LayoutMetadataListRequest:
+            if msg.namespace == "":
+                raise ValueError("layout metadata namespace must not be empty")
+            keys = [
+                LayoutMetadataKey(namespace=namespace, key=key)
+                for namespace, key in sorted(self._layout_metadata)
+                if (msg.namespace is None or namespace == msg.namespace)
+                and key.startswith(msg.prefix)
+            ]
+            return LayoutMetadataListResponse(keys=keys), -1, False
 
         raise ValueError(f"Unknown request: {msg_type.__name__}")

--- a/lib/gpu_memory_service/server/session.py
+++ b/lib/gpu_memory_service/server/session.py
@@ -19,6 +19,10 @@ from gpu_memory_service.common.protocol.messages import (
     GetAllocationStateRequest,
     GetLockStateRequest,
     GetStateHashRequest,
+    LayoutMetadataDeleteRequest,
+    LayoutMetadataGetRequest,
+    LayoutMetadataListRequest,
+    LayoutMetadataPutRequest,
     ListAllocationsRequest,
     MetadataDeleteRequest,
     MetadataGetRequest,
@@ -39,6 +43,8 @@ RW_REQUIRED: frozenset[type] = frozenset(
         FreeAllocationRequest,
         MetadataPutRequest,
         MetadataDeleteRequest,
+        LayoutMetadataPutRequest,
+        LayoutMetadataDeleteRequest,
         CommitRequest,
     }
 )
@@ -50,6 +56,8 @@ RO_ALLOWED: frozenset[type] = frozenset(
         ListAllocationsRequest,
         MetadataGetRequest,
         MetadataListRequest,
+        LayoutMetadataGetRequest,
+        LayoutMetadataListRequest,
         GetLockStateRequest,
         GetAllocationStateRequest,
         GetStateHashRequest,

--- a/lib/gpu_memory_service/snapshot/disk.py
+++ b/lib/gpu_memory_service/snapshot/disk.py
@@ -18,6 +18,8 @@ from gpu_memory_service.snapshot.backends.pinned_host import (
 from gpu_memory_service.snapshot.model import AllocationEntry, SaveManifest
 
 _SAVE_COPY_BUFFERS = 1
+LAYOUT_METADATA_FILENAME = "gms_layout_metadata.json"
+LAYOUT_METADATA_FORMAT_VERSION = 1
 
 
 class _NullLogger:
@@ -169,7 +171,13 @@ def load_manifest_and_metadata(
             AllocationEntry(**allocation)
             for allocation in manifest_payload.get("allocations", [])
         ],
+        layout_metadata_file=manifest_payload.get("layout_metadata_file"),
     )
+    if manifest.layout_metadata_file not in (None, LAYOUT_METADATA_FILENAME):
+        raise ValueError(
+            "Unsupported layout metadata snapshot file: "
+            f"{manifest.layout_metadata_file!r}"
+        )
 
     metadata_path = os.path.join(input_dir, "gms_metadata.json")
     raw_meta: Dict[str, Any] = {}
@@ -186,3 +194,73 @@ def load_manifest_and_metadata(
         for key, entry in raw_meta.items()
     }
     return manifest, metadata
+
+
+def load_layout_metadata(
+    input_dir: str,
+    *,
+    required: bool = False,
+) -> Dict[Tuple[str, str], bytes]:
+    """Load optional, allocation-independent metadata from a GMS snapshot."""
+    metadata_path = os.path.join(input_dir, LAYOUT_METADATA_FILENAME)
+    if not os.path.exists(metadata_path):
+        if required:
+            raise FileNotFoundError(
+                "Snapshot manifest requires missing layout metadata file: "
+                f"{metadata_path}"
+            )
+        return {}
+
+    with open(metadata_path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    if not isinstance(payload, dict):
+        raise ValueError(f"Invalid {LAYOUT_METADATA_FILENAME}: expected an object")
+    format_version = payload.get("format_version")
+    if format_version != LAYOUT_METADATA_FORMAT_VERSION:
+        raise ValueError(
+            f"Unsupported {LAYOUT_METADATA_FILENAME} format_version: {format_version!r}"
+        )
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"Invalid {LAYOUT_METADATA_FILENAME}: entries must be a list")
+
+    result: Dict[Tuple[str, str], bytes] = {}
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(
+                f"Invalid {LAYOUT_METADATA_FILENAME} entry {index}: expected an object"
+            )
+        namespace = entry.get("namespace")
+        key = entry.get("key")
+        encoded_value = entry.get("value")
+        if not isinstance(namespace, str) or not namespace:
+            raise ValueError(
+                f"Invalid {LAYOUT_METADATA_FILENAME} entry {index}: "
+                "namespace must be a non-empty string"
+            )
+        if not isinstance(key, str) or not key:
+            raise ValueError(
+                f"Invalid {LAYOUT_METADATA_FILENAME} entry {index}: "
+                "key must be a non-empty string"
+            )
+        if not isinstance(encoded_value, str):
+            raise ValueError(
+                f"Invalid {LAYOUT_METADATA_FILENAME} entry {index}: "
+                "value must be a base64 string"
+            )
+
+        identity = (namespace, key)
+        if identity in result:
+            raise ValueError(
+                f"Duplicate {LAYOUT_METADATA_FILENAME} entry: "
+                f"namespace={namespace!r}, key={key!r}"
+            )
+        try:
+            result[identity] = base64.b64decode(encoded_value, validate=True)
+        except ValueError as exc:
+            raise ValueError(
+                f"Invalid {LAYOUT_METADATA_FILENAME} entry {index}: "
+                "value is not valid base64"
+            ) from exc
+    return result

--- a/lib/gpu_memory_service/snapshot/model.py
+++ b/lib/gpu_memory_service/snapshot/model.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Optional
 
 
 @dataclass(frozen=True)
@@ -27,3 +27,4 @@ class SaveManifest:
     layout_hash: str
     device: int
     allocations: List[AllocationEntry] = field(default_factory=list)
+    layout_metadata_file: Optional[str] = None

--- a/lib/gpu_memory_service/snapshot/storage_client.py
+++ b/lib/gpu_memory_service/snapshot/storage_client.py
@@ -19,7 +19,10 @@ from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.protocol.messages import GetAllocationResponse
 from gpu_memory_service.snapshot.disk import (
+    LAYOUT_METADATA_FILENAME,
+    LAYOUT_METADATA_FORMAT_VERSION,
     DeviceToFileWriter,
+    load_layout_metadata,
     load_manifest_and_metadata,
     plan_shard_layout,
 )
@@ -108,6 +111,7 @@ class GMSStorageClient:
                 use_absolute_shard_paths=use_absolute_shard_paths,
             )
             metadata = self._save_metadata(mm)
+            layout_metadata = self._save_layout_metadata(mm)
         except Exception:
             mm.close()
             raise
@@ -118,11 +122,18 @@ class GMSStorageClient:
             encoding="utf-8",
         ) as handle:
             json.dump(metadata, handle, indent=2)
+        with open(
+            os.path.join(output_dir, LAYOUT_METADATA_FILENAME),
+            "w",
+            encoding="utf-8",
+        ) as handle:
+            json.dump(layout_metadata, handle, indent=2)
         manifest = SaveManifest(
             timestamp=time.time(),
             layout_hash=layout_hash,
             device=self.device,
             allocations=entries,
+            layout_metadata_file=LAYOUT_METADATA_FILENAME,
         )
         with open(
             os.path.join(output_dir, "manifest.json"),
@@ -257,6 +268,13 @@ class GMSStorageClient:
 
         try:
             manifest, saved_metadata = load_manifest_and_metadata(input_dir)
+            if manifest.layout_metadata_file is None:
+                saved_layout_metadata = {}
+            else:
+                saved_layout_metadata = load_layout_metadata(
+                    input_dir,
+                    required=True,
+                )
             sources = build_file_transfer_sources(input_dir, manifest.allocations)
             session = backend.start_restore(sources)
             with GMSClientMemoryManager(self._socket_path, device=self.device) as mm:
@@ -273,6 +291,7 @@ class GMSStorageClient:
                 )
 
                 self._restore_metadata(mm, saved_metadata, id_map)
+                self._restore_layout_metadata(mm, saved_layout_metadata)
                 if not mm.commit():
                     raise RuntimeError("GMS commit failed after restore")
         finally:
@@ -281,9 +300,11 @@ class GMSStorageClient:
             backend.close()
 
         logger.info(
-            "load_to_gms complete: %d allocations, %d metadata keys",
+            "load_to_gms complete: %d allocations, %d tensor metadata keys, "
+            "%d layout metadata keys",
             len(id_map),
             len(saved_metadata),
+            len(saved_layout_metadata),
         )
         return id_map
 
@@ -316,3 +337,42 @@ class GMSStorageClient:
                 "value": base64.b64encode(value).decode("ascii"),
             }
         return result
+
+    def _restore_layout_metadata(
+        self,
+        mm: Any,
+        saved_layout_metadata: Mapping[Tuple[str, str], bytes],
+    ) -> None:
+        for (namespace, key), value in saved_layout_metadata.items():
+            if not mm.layout_metadata_put(namespace, key, value):
+                raise RuntimeError(
+                    "Failed to write layout metadata "
+                    f"namespace={namespace!r}, key={key!r}"
+                )
+        logger.info(
+            "Restored %d layout metadata keys",
+            len(saved_layout_metadata),
+        )
+
+    def _save_layout_metadata(self, mm: Any) -> Dict[str, Any]:
+        entries = []
+        for item in mm.layout_metadata_list():
+            value = mm.layout_metadata_get(item.namespace, item.key)
+            if value is None:
+                logger.warning(
+                    "Layout metadata key disappeared during dump: namespace=%r, key=%r",
+                    item.namespace,
+                    item.key,
+                )
+                continue
+            entries.append(
+                {
+                    "namespace": item.namespace,
+                    "key": item.key,
+                    "value": base64.b64encode(value).decode("ascii"),
+                }
+            )
+        return {
+            "format_version": LAYOUT_METADATA_FORMAT_VERSION,
+            "entries": entries,
+        }

--- a/lib/gpu_memory_service/tests/test_layout_metadata.py
+++ b/lib/gpu_memory_service/tests/test_layout_metadata.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit coverage for GMS layout metadata protocol and snapshots."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+
+import pytest
+from _deps import HAS_GMS
+
+if not HAS_GMS:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
+
+from gpu_memory_service.common.protocol.messages import (  # noqa: E402
+    LayoutMetadataDeleteRequest,
+    LayoutMetadataDeleteResponse,
+    LayoutMetadataGetRequest,
+    LayoutMetadataGetResponse,
+    LayoutMetadataKey,
+    LayoutMetadataListRequest,
+    LayoutMetadataListResponse,
+    LayoutMetadataPutRequest,
+    LayoutMetadataPutResponse,
+    decode_message,
+    encode_message,
+)
+from gpu_memory_service.server.allocations import AllocationInfo  # noqa: E402
+from gpu_memory_service.server.gms import GMS, MetadataEntry  # noqa: E402
+from gpu_memory_service.snapshot.disk import (  # noqa: E402
+    LAYOUT_METADATA_FILENAME,
+    load_layout_metadata,
+)
+from gpu_memory_service.snapshot.storage_client import GMSStorageClient  # noqa: E402
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        LayoutMetadataPutRequest("trtllm", "identity", b"\x00\xff"),
+        LayoutMetadataPutResponse(success=True),
+        LayoutMetadataGetRequest("trtllm", "identity"),
+        LayoutMetadataGetResponse(found=True, value=b"payload"),
+        LayoutMetadataGetResponse(found=False),
+        LayoutMetadataDeleteRequest("trtllm", "identity"),
+        LayoutMetadataDeleteResponse(deleted=True),
+        LayoutMetadataListRequest(namespace="trtllm", prefix="source"),
+        LayoutMetadataListResponse(
+            keys=[LayoutMetadataKey(namespace="trtllm", key="source_identity")]
+        ),
+    ],
+)
+def test_layout_metadata_protocol_round_trip(message):
+    assert decode_message(encode_message(message)) == message
+
+
+def test_layout_hash_without_layout_metadata_preserves_legacy_algorithm():
+    service = object.__new__(GMS)
+    service._metadata = {
+        "tensor.0": MetadataEntry(
+            allocation_id="allocation",
+            offset_bytes=16,
+            value=b"tensor-spec",
+        )
+    }
+    service._layout_metadata = {}
+    allocation = AllocationInfo(
+        allocation_id="allocation",
+        size=4096,
+        aligned_size=4096,
+        handle=0,
+        export_fd=-1,
+        tag="weights",
+        layout_slot=0,
+        created_at=0.0,
+    )
+    expected = hashlib.sha256()
+    expected.update(b"0:4096:4096:weights")
+    expected.update(b"tensor.0:0:16:")
+    expected.update(b"tensor-spec")
+
+    assert service._compute_memory_layout_hash([allocation]) == expected.hexdigest()
+
+
+def test_load_layout_metadata_accepts_legacy_snapshot(tmp_path):
+    assert load_layout_metadata(str(tmp_path)) == {}
+
+
+def test_load_layout_metadata_requires_manifest_declared_sidecar(tmp_path):
+    with pytest.raises(FileNotFoundError, match="manifest requires missing"):
+        load_layout_metadata(str(tmp_path), required=True)
+
+
+def test_load_layout_metadata_decodes_namespaced_opaque_bytes(tmp_path):
+    payload = {
+        "format_version": 1,
+        "entries": [
+            {
+                "namespace": "trtllm",
+                "key": "committed_weight_envelope",
+                "value": "AP8=",
+            },
+            {
+                "namespace": "vllm",
+                "key": "identity",
+                "value": "dmFsdWU=",
+            },
+        ],
+    }
+    (tmp_path / LAYOUT_METADATA_FILENAME).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    assert load_layout_metadata(str(tmp_path)) == {
+        ("trtllm", "committed_weight_envelope"): b"\x00\xff",
+        ("vllm", "identity"): b"value",
+    }
+
+
+@pytest.mark.parametrize(
+    ("payload", "match"),
+    [
+        ({"format_version": 2, "entries": []}, "Unsupported.*format_version"),
+        (
+            {
+                "format_version": 1,
+                "entries": [
+                    {"namespace": "trtllm", "key": "identity", "value": "YQ=="},
+                    {"namespace": "trtllm", "key": "identity", "value": "Yg=="},
+                ],
+            },
+            "Duplicate.*namespace='trtllm'.*key='identity'",
+        ),
+        (
+            {
+                "format_version": 1,
+                "entries": [{"namespace": "trtllm", "key": "identity", "value": "!!!"}],
+            },
+            "not valid base64",
+        ),
+    ],
+)
+def test_load_layout_metadata_rejects_invalid_snapshot(tmp_path, payload, match):
+    (tmp_path / LAYOUT_METADATA_FILENAME).write_text(
+        json.dumps(payload), encoding="utf-8"
+    )
+
+    with pytest.raises(ValueError, match=match):
+        load_layout_metadata(str(tmp_path))
+
+
+class _FakeLayoutMetadataManager:
+    def __init__(self, values=None):
+        self.values = dict(values or {})
+
+    def layout_metadata_list(self):
+        return [
+            LayoutMetadataKey(namespace=namespace, key=key)
+            for namespace, key in sorted(self.values)
+        ]
+
+    def layout_metadata_get(self, namespace, key):
+        return self.values.get((namespace, key))
+
+    def layout_metadata_put(self, namespace, key, value):
+        self.values[(namespace, key)] = value
+        return True
+
+
+def test_storage_client_serializes_and_restores_layout_metadata():
+    client = object.__new__(GMSStorageClient)
+    source = _FakeLayoutMetadataManager(
+        {
+            ("trtllm", "identity"): b"\x00\xff",
+            ("vllm", "identity"): b"value",
+        }
+    )
+
+    saved = client._save_layout_metadata(source)
+    assert saved == {
+        "format_version": 1,
+        "entries": [
+            {"namespace": "trtllm", "key": "identity", "value": "AP8="},
+            {"namespace": "vllm", "key": "identity", "value": "dmFsdWU="},
+        ],
+    }
+
+    destination = _FakeLayoutMetadataManager()
+    decoded = {
+        (entry["namespace"], entry["key"]): base64.b64decode(entry["value"])
+        for entry in saved["entries"]
+    }
+    client._restore_layout_metadata(destination, decoded)
+    assert destination.values == source.values

--- a/lib/gpu_memory_service/tests/test_runtime_flows.py
+++ b/lib/gpu_memory_service/tests/test_runtime_flows.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import itertools
+import json
 import os
 import signal
 import socket
@@ -51,6 +52,10 @@ from gpu_memory_service.server import allocations as server_allocations
 from gpu_memory_service.server.allocations import GMSAllocationManager
 from gpu_memory_service.server.fsm import ServerState
 from gpu_memory_service.server.rpc import GMSRPCServer
+from gpu_memory_service.snapshot import storage_client as snapshot_storage_client
+from gpu_memory_service.snapshot.disk import LAYOUT_METADATA_FILENAME
+from gpu_memory_service.snapshot.model import AllocationEntry
+from gpu_memory_service.snapshot.storage_client import GMSStorageClient
 
 pytestmark = [
     pytest.mark.pre_merge,
@@ -345,12 +350,89 @@ def test_rw_commit_publishes_allocations_metadata_and_layout_hash(running_gms):
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_layout_metadata_coexists_with_tensor_metadata_and_survives_commit(
+    running_gms,
+):
+    _, socket_path = running_gms
+    opaque_identity = b"\x00\xfftrtllm-identity\x80"
+
+    writer = GMSClientMemoryManager(socket_path, device=0)
+    try:
+        writer.connect(RequestedLockType.RW)
+        allocation_id, _ = writer.allocate_handle(4096, "weights")
+        writer.metadata_put("tensor.0", allocation_id, 0, b"tensor-spec")
+        writer.layout_metadata_put("trtllm", "weight_layout", b"post_transform")
+        writer.layout_metadata_put("other", "source_identity", b"other-value")
+        writer.layout_metadata_put("trtllm", "source_identity", opaque_identity)
+        writer.layout_metadata_put("trtllm", "temporary", b"delete-me")
+        assert writer.layout_metadata_delete("trtllm", "temporary")
+        assert not writer.layout_metadata_delete("trtllm", "temporary")
+        assert writer.layout_metadata_get("trtllm", "temporary") is None
+        assert writer.commit()
+    finally:
+        writer.close()
+
+    reader = GMSClientMemoryManager(socket_path, device=0)
+    try:
+        reader.connect(RequestedLockType.RO)
+        assert reader.metadata_list() == ["tensor.0"]
+        assert reader.metadata_get("tensor.0") == (
+            allocation_id,
+            0,
+            b"tensor-spec",
+        )
+        assert (
+            reader.layout_metadata_get("trtllm", "source_identity") == opaque_identity
+        )
+        assert reader.layout_metadata_get("trtllm", "missing") is None
+        assert [
+            (item.namespace, item.key) for item in reader.layout_metadata_list()
+        ] == [
+            ("other", "source_identity"),
+            ("trtllm", "source_identity"),
+            ("trtllm", "weight_layout"),
+        ]
+        assert [
+            (item.namespace, item.key)
+            for item in reader.layout_metadata_list(namespace="trtllm", prefix="source")
+        ] == [("trtllm", "source_identity")]
+    finally:
+        reader.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_layout_metadata_is_independent_of_allocation_lifetime(running_gms):
+    _, socket_path = running_gms
+
+    writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
+    try:
+        allocation_id, _ = writer.allocate(4096, "weights")
+        writer.metadata_put("tensor.0", allocation_id, 0, b"tensor-spec")
+        writer.layout_metadata_put("trtllm", "source_identity", b"identity")
+
+        assert writer.free(allocation_id)
+        assert writer.metadata_list() == []
+        assert writer.layout_metadata_get("trtllm", "source_identity") == b"identity"
+        assert writer.commit()
+    finally:
+        writer.close()
+
+    reader = _GMSClientSession(socket_path, RequestedLockType.RO, None)
+    try:
+        assert reader.list_allocations() == []
+        assert reader.layout_metadata_get("trtllm", "source_identity") == b"identity"
+    finally:
+        reader.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
 def test_rw_disconnect_aborts_layout_and_next_writer_starts_clean(running_gms):
     server, socket_path = running_gms
 
     writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
     allocation_id, _ = writer.allocate(4096, "weights")
     writer.metadata_put("stale", allocation_id, 0, b"value")
+    writer.layout_metadata_put("trtllm", "stale", b"identity")
     _drop_connection(writer)
 
     _wait_for_server_state(server, ServerState.EMPTY)
@@ -359,8 +441,201 @@ def test_rw_disconnect_aborts_layout_and_next_writer_starts_clean(running_gms):
     try:
         assert next_writer.list_allocations() == []
         assert next_writer.metadata_list() == []
+        assert next_writer.layout_metadata_list() == []
     finally:
         next_writer.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_new_writer_clears_committed_layout_metadata(running_gms):
+    _, socket_path = running_gms
+
+    writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
+    writer.layout_metadata_put("trtllm", "source_identity", b"stale")
+    writer.commit()
+
+    reader = _GMSClientSession(socket_path, RequestedLockType.RO, None)
+    try:
+        assert reader.layout_metadata_get("trtllm", "source_identity") == b"stale"
+    finally:
+        reader.close()
+
+    next_writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
+    try:
+        assert next_writer.layout_metadata_list() == []
+    finally:
+        next_writer.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_layout_metadata_validates_keys_and_rejects_ro_mutation(running_gms):
+    _, socket_path = running_gms
+
+    writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
+    try:
+        with pytest.raises(RuntimeError, match="namespace must not be empty"):
+            writer.layout_metadata_put("", "source_identity", b"identity")
+        with pytest.raises(RuntimeError, match="key must not be empty"):
+            writer.layout_metadata_put("trtllm", "", b"identity")
+        with pytest.raises(RuntimeError, match="namespace must not be empty"):
+            writer.layout_metadata_list(namespace="")
+
+        writer.layout_metadata_put("trtllm", "source_identity", b"identity")
+        assert writer.commit()
+    finally:
+        writer.close()
+
+    reader = _GMSClientSession(socket_path, RequestedLockType.RO, None)
+    try:
+        with pytest.raises(RuntimeError, match="not allowed for RO session"):
+            reader.layout_metadata_put("trtllm", "source_identity", b"changed")
+        with pytest.raises(RuntimeError, match="not allowed for RO session"):
+            reader.layout_metadata_delete("trtllm", "source_identity")
+        assert reader.layout_metadata_get("trtllm", "source_identity") == b"identity"
+    finally:
+        reader.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_layout_metadata_hash_is_order_independent_and_value_sensitive(running_gms):
+    _, socket_path = running_gms
+
+    def publish_and_get_hash(entries):
+        writer = _GMSClientSession(socket_path, RequestedLockType.RW, None)
+        try:
+            for namespace, key, value in entries:
+                writer.layout_metadata_put(namespace, key, value)
+            assert writer.commit()
+        finally:
+            writer.close()
+
+        reader = _GMSClientSession(socket_path, RequestedLockType.RO, None)
+        try:
+            return reader.get_memory_layout_hash()
+        finally:
+            reader.close()
+
+    first_hash = publish_and_get_hash(
+        [("trtllm", "z", b"last"), ("other", "a", b"first")]
+    )
+    reordered_hash = publish_and_get_hash(
+        [("other", "a", b"first"), ("trtllm", "z", b"last")]
+    )
+    changed_hash = publish_and_get_hash(
+        [("other", "a", b"changed"), ("trtllm", "z", b"last")]
+    )
+
+    assert first_hash
+    assert reordered_hash == first_hash
+    assert changed_hash != first_hash
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+@pytest.mark.parametrize("include_layout_metadata", [True, False])
+def test_layout_metadata_snapshot_round_trip(
+    running_gms,
+    monkeypatch,
+    tmp_path,
+    include_layout_metadata,
+):
+    _, socket_path = running_gms
+    identity = b"\x00identity\xff"
+    writer = _GMSClientSession(socket_path, RequestedLockType.RW, 1_000)
+    try:
+        allocation_id, aligned_size = writer.allocate(4096, "weights")
+        writer.metadata_put("tensor.0", allocation_id, 0, b"tensor-spec")
+        if include_layout_metadata:
+            writer.layout_metadata_put("trtllm", "source_identity", identity)
+        writer.commit()
+    finally:
+        writer.close()
+
+    def skip_shard_writes(
+        self,
+        shard_dirs,
+        allocations_info,
+        va_list,
+        *,
+        max_workers,
+        use_absolute_shard_paths=False,
+    ):
+        del self, shard_dirs, va_list, max_workers, use_absolute_shard_paths
+        return [
+            AllocationEntry(
+                allocation_id=info.allocation_id,
+                size=info.size,
+                aligned_size=info.aligned_size,
+                tag=info.tag,
+                tensor_file=f"shards/{info.allocation_id}.bin",
+                tensor_offset=0,
+            )
+            for info in allocations_info
+        ]
+
+    class FakeTransferSession:
+        def restore(self, targets):
+            assert len(targets) == 1
+            target = targets[allocation_id]
+            assert target.byte_count == aligned_size
+
+        def close(self):
+            pass
+
+    class FakeTransferBackend:
+        def start_restore(self, sources):
+            assert len(sources) == 1
+            return FakeTransferSession()
+
+        def close(self):
+            pass
+
+    monkeypatch.setattr(GMSStorageClient, "_write_shards", skip_shard_writes)
+    monkeypatch.setattr(
+        snapshot_storage_client,
+        "create_transfer_backend",
+        lambda name, config: FakeTransferBackend(),
+    )
+
+    snapshot_dir = tmp_path / "snapshot"
+    storage = GMSStorageClient(
+        output_dir=str(snapshot_dir),
+        socket_path=socket_path,
+        device=0,
+        timeout_ms=1_000,
+    )
+    source_manifest = storage.save()
+    assert source_manifest.layout_metadata_file == LAYOUT_METADATA_FILENAME
+    if not include_layout_metadata:
+        manifest_path = snapshot_dir / "manifest.json"
+        manifest_payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+        manifest_payload.pop("layout_metadata_file")
+        manifest_path.write_text(json.dumps(manifest_payload), encoding="utf-8")
+        stray_sidecar = {
+            "format_version": 1,
+            "entries": [
+                {
+                    "namespace": "trtllm",
+                    "key": "source_identity",
+                    "value": "c3RyYXk=",
+                }
+            ],
+        }
+        (snapshot_dir / LAYOUT_METADATA_FILENAME).write_text(
+            json.dumps(stray_sidecar), encoding="utf-8"
+        )
+    id_map = storage.load_to_gms(str(snapshot_dir))
+    assert set(id_map) == {allocation_id}
+
+    reader = _GMSClientSession(socket_path, RequestedLockType.RO, 1_000)
+    try:
+        assert reader.get_memory_layout_hash() == source_manifest.layout_hash
+        assert reader.metadata_list() == ["tensor.0"]
+        expected_identity = identity if include_layout_metadata else None
+        assert (
+            reader.layout_metadata_get("trtllm", "source_identity") == expected_identity
+        )
+    finally:
+        reader.close()
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
@@ -814,6 +1089,43 @@ def test_remap_all_vas_rejects_stale_layout_after_new_layout_commit(
         next_writer.close()
         reader.close()
         writer.close()
+
+
+@pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)
+def test_remap_all_vas_rejects_layout_metadata_only_change(running_gms):
+    _, socket_path = running_gms
+
+    first_writer = GMSClientMemoryManager(socket_path, device=0)
+    reader = GMSClientMemoryManager(socket_path, device=0)
+    second_writer = GMSClientMemoryManager(socket_path, device=0)
+    try:
+        first_writer.connect(RequestedLockType.RW)
+        first_va = first_writer.create_mapping(size=4096, tag="weights")
+        first_allocation_id = first_writer.mappings[first_va].allocation_id
+        first_writer.metadata_put("tensor.0", first_allocation_id, 0, b"tensor-spec")
+        first_writer.layout_metadata_put("trtllm", "generation", b"first")
+        assert first_writer.commit()
+
+        reader.connect(RequestedLockType.RO)
+        reader.create_mapping(allocation_id=first_allocation_id)
+        reader.unmap_all_vas()
+        reader.abort()
+
+        second_writer.connect(RequestedLockType.RW)
+        second_va = second_writer.create_mapping(size=4096, tag="weights")
+        second_allocation_id = second_writer.mappings[second_va].allocation_id
+        second_writer.metadata_put("tensor.0", second_allocation_id, 0, b"tensor-spec")
+        second_writer.layout_metadata_put("trtllm", "generation", b"second")
+        assert second_writer.commit()
+
+        reader.connect(RequestedLockType.RO)
+        with pytest.raises(StaleMemoryLayoutError, match="Layout changed"):
+            reader.remap_all_vas()
+        reader.abort()
+    finally:
+        second_writer.close()
+        reader.close()
+        first_writer.close()
 
 
 @pytest.mark.timeout(_SOCKET_TEST_TIMEOUT_SECONDS)


### PR DESCRIPTION
## Summary

- add an allocation-independent, namespaced `layout_metadata_*` RPC and client API for opaque application metadata
- publish layout metadata atomically with the GMS layout, include it in stale-layout hashing, and preserve the legacy hash when the new store is empty
- keep application metadata separate from allocation-anchored tensor metadata so pruning cannot delete it and tensor materialization never parses it
- persist layout metadata in a versioned, manifest-declared snapshot sidecar while keeping legacy snapshots compatible and ignoring undeclared sidecars
- document the lifecycle and compatibility contract and add protocol, lifecycle, remap, and snapshot coverage

## Motivation

The existing GMS metadata table is allocation-anchored: freeing or pruning an allocation cascades its metadata, and Torch tensor materialization interprets every entry as a tensor specification. Framework-level compatibility envelopes therefore cannot safely use that table.

This change provides a generic GMS-owned transport for small application-defined byte payloads without adding TensorRT-LLM-specific schema or identity fields to GMS.

## Compatibility

- Existing `Metadata*` messages, unprefixed tensor keys, and tensor loading behavior are unchanged.
- Layouts without layout metadata retain the previous memory-layout hash byte-for-byte.
- Old snapshot manifests remain valid and do not consume undeclared sidecars.
- The new RPCs require a G1-capable GMS client and server; protocol capability negotiation remains out of scope.

## Validation

- `pytest -q lib/gpu_memory_service/tests/test_layout_metadata.py` — 17 passed
- `pytest -q lib/gpu_memory_service/tests/test_runtime_flows.py` — 30 passed, 1 skipped (`pynvml` unavailable)
- `pytest -q lib/gpu_memory_service/tests -m gpu_0 --ignore=lib/gpu_memory_service/tests/test_failover_lock.py` — 32 passed, 4 skipped (optional Torch-dependent cases)
- Black 23.1.0, isort 5.12.0, Ruff, and `git diff --check`
