### PR TITLE
fix: kvbm ci test failure

### DIFF
--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -453,11 +453,15 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [config, vllm-build]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        test_type: ['KVBM Test A', 'KVBM Test B']
     uses: ./.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: kvbm
-      test_type: KVBM Test
+      test_type: ${{ matrix.test_type }}
       # KVBM post-merge coverage currently targets the aws-dev-02 H100 cluster.
       amd_runner: aws-dev-02-tester-amd-gpu-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -453,15 +453,11 @@ jobs:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
     needs: [config, vllm-build]
     if: github.event_name != 'workflow_dispatch' || needs.config.outputs.run_vllm == 'true'
-    strategy:
-      fail-fast: false
-      matrix:
-        test_type: ['KVBM Test A', 'KVBM Test B']
     uses: ./.github/workflows/shared-test.yml
     with:
       dd_env: post-merge
       test_suite_name: kvbm
-      test_type: ${{ matrix.test_type }}
+      test_type: KVBM Test
       # KVBM post-merge coverage currently targets the aws-dev-02 H100 cluster.
       amd_runner: aws-dev-02-tester-amd-gpu-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -161,9 +161,6 @@ jobs:
           MINIO_ROOT_PASSWORD: minioadmin
           MINIO_VOLUMES: /tmp/minio-data
           MINIO_CONSOLE_ADDRESS: ':9001'
-        ports:
-          - 9000:9000
-          - 9001:9001
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -173,10 +173,6 @@ jobs:
           KVBM_MLA_BACKEND: ${{ inputs.kvbm_mla_backend }}
         run: |
           echo "KVBM_MLA_BACKEND=${KVBM_MLA_BACKEND}" >> "$GITHUB_ENV"
-      - name: Hold KVBM validation pods for placement check
-        if: ${{ github.ref_name == 'fix/kvbm-ci-test-failure' && (inputs.test_type == 'KVBM Test A' || inputs.test_type == 'KVBM Test B') }}
-        shell: bash
-        run: sleep 600
       # Experimental: trialing Datadog Test Visibility. Remove if not kept.
       - name: Configure Datadog Test Visibility
         continue-on-error: true

--- a/.github/workflows/shared-test.yml
+++ b/.github/workflows/shared-test.yml
@@ -173,6 +173,10 @@ jobs:
           KVBM_MLA_BACKEND: ${{ inputs.kvbm_mla_backend }}
         run: |
           echo "KVBM_MLA_BACKEND=${KVBM_MLA_BACKEND}" >> "$GITHUB_ENV"
+      - name: Hold KVBM validation pods for placement check
+        if: ${{ github.ref_name == 'fix/kvbm-ci-test-failure' && (inputs.test_type == 'KVBM Test A' || inputs.test_type == 'KVBM Test B') }}
+        shell: bash
+        run: sleep 600
       # Experimental: trialing Datadog Test Visibility. Remove if not kept.
       - name: Configure Datadog Test Visibility
         continue-on-error: true


### PR DESCRIPTION
## Overview:

  Fix H100 KVBM CI initialization failures caused by MinIO service containers reserving fixed host
  ports on shared Kubernetes runner nodes.

  ## Details:

  This removes the `services.minio.ports` mappings from `.github/workflows/shared-test.yml`. The
  MinIO service still runs in the workflow pod and remains reachable from the job container, but it
  no longer reserves host ports `9000` and `9001`, avoiding same-node port collisions when multiple
  KVBM jobs run concurrently on H100 nodes.

  Validation:
  - Duplicated KVBM validation jobs completed successfully:
  https://github.com/ai-dynamo/dynamo/actions/runs/28839944694
  - Verified two KVBM workflow pods could run on the same H100 node with MinIO `Host Port: <none>`.
  - Confirmed no `NodePorts` / fixed host-port scheduling error appeared during the same-node
  validation.

  ## Where should the reviewer start?

  `.github/workflows/shared-test.yml`

  ## Related Issues

  **🚫 This PR is NOT linked to an issue**:
  - [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a shared test workflow to stop explicitly exposing two service ports in the test environment.
  * No user-facing product behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->