### PR TITLE
fix(trtllm): route conv_id via ConversationParams for newer trtllm builds

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -825,15 +825,28 @@ class TrtllmLLMEngine(LLMEngine):
             )
             disaggregated_params = self._decode_prefill_handoff(prefill_result)
 
-        # exp H (gap #4): forward the conversation/session id (set by the frontend KV
-        # router into RoutingHints.conversation_id) onto disaggregated_params so the
-        # engine's conversation-affinity ADP router can pin conv -> DP rank.
+        # exp H (gap #4): forward the conversation/session id so the engine's
+        # ConversationAwareADPRouter can pin conv -> DP rank. Older trtllm builds
+        # carried this on disaggregated_params; newer builds expose a dedicated
+        # ConversationParams object on generate_async().
         conv_id = conversation_id_from_request(request)
-        if disaggregated_params is not None and conv_id is not None:
-            disaggregated_params.conversation_id = conv_id
+        conversation_params = None
+        if conv_id is not None:
+            if disaggregated_params is not None and hasattr(
+                type(disaggregated_params), "conversation_id"
+            ):
+                disaggregated_params.conversation_id = conv_id
+            else:
+                from tensorrt_llm.llmapi import ConversationParams
+
+                conversation_params = ConversationParams(conversation_id=conv_id)
         # exp-H (gap #4): confirm propagation at run time. PERF-SAFE: log the FIRST request at
         # INFO (one-shot) so it's confirmable WITHOUT enabling debug at benchmark time; rest debug.
-        _set_on_disagg = disaggregated_params is not None and conv_id is not None
+        _set_on_disagg = (
+            conv_id is not None
+            and disaggregated_params is not None
+            and hasattr(type(disaggregated_params), "conversation_id")
+        )
         if not self._convid_first_logged:
             self._convid_first_logged = True
             logger.info(
@@ -893,14 +906,19 @@ class TrtllmLLMEngine(LLMEngine):
         # Prefill returns one non-streaming chunk carrying the handoff -
         # matches the legacy disagg wire format.
         streaming = not is_prefill
-        generation_result = self._engine.llm.generate_async(
-            inputs=token_ids,
-            sampling_params=sampling_params,
-            streaming=streaming,
-            disaggregated_params=disaggregated_params,
-            scheduling_params=scheduling_params,
+        generate_kwargs = {
+            "inputs": token_ids,
+            "sampling_params": sampling_params,
+            "streaming": streaming,
+            "disaggregated_params": disaggregated_params,
+            "scheduling_params": scheduling_params,
             **telemetry.engine_trace_kwargs(context),
-        )
+        }
+        # Only pass conversation_params when we built one; older trtllm
+        # builds don't accept the kwarg at all.
+        if conversation_params is not None:
+            generate_kwargs["conversation_params"] = conversation_params
+        generation_result = self._engine.llm.generate_async(**generate_kwargs)
 
         request_id = context.id()
         if request_id is not None:

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -74,6 +74,12 @@ from dynamo.trtllm.utils.disagg_utils import (
 )
 from dynamo.trtllm.utils.trtllm_utils import deep_update, warn_override_collisions
 
+try:
+    from tensorrt_llm.llmapi import ConversationParams
+except ImportError:
+    # Older TRT-LLM builds carry conversation_id on DisaggregatedParams instead.
+    ConversationParams = None
+
 if TYPE_CHECKING:
     from tensorrt_llm.metrics import MetricsCollector
 
@@ -832,14 +838,18 @@ class TrtllmLLMEngine(LLMEngine):
         conv_id = conversation_id_from_request(request)
         conversation_params = None
         if conv_id is not None:
-            if disaggregated_params is not None and hasattr(
+            if ConversationParams is not None:
+                conversation_params = ConversationParams(conversation_id=conv_id)
+            elif disaggregated_params is not None and hasattr(
                 type(disaggregated_params), "conversation_id"
             ):
                 disaggregated_params.conversation_id = conv_id
-            else:
-                from tensorrt_llm.llmapi import ConversationParams
-
-                conversation_params = ConversationParams(conversation_id=conv_id)
+            elif self._engine_conv_affinity:
+                raise RuntimeError(
+                    "DYN_ENGINE_CONV_AFFINITY=1 requires a TRT-LLM build that "
+                    "supports ConversationParams or "
+                    "DisaggregatedParams.conversation_id"
+                )
         # exp-H (gap #4): confirm propagation at run time. PERF-SAFE: log the FIRST request at
         # INFO (one-shot) so it's confirmable WITHOUT enabling debug at benchmark time; rest debug.
         _set_on_disagg = (

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -78,6 +78,8 @@ try:
     from tensorrt_llm.llmapi import ConversationParams
 except ImportError:
     # Older TRT-LLM builds carry conversation_id on DisaggregatedParams instead.
+    # TODO: Drop this fallback once Dynamo's minimum TRT-LLM version guarantees
+    # ConversationParams.
     ConversationParams = None
 
 if TYPE_CHECKING:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -55,6 +55,12 @@ from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParamsCodec,
 )
 
+try:
+    from tensorrt_llm.llmapi import ConversationParams
+except ImportError:
+    # Older TRT-LLM builds carry conversation_id on DisaggregatedParams instead.
+    ConversationParams = None
+
 if TYPE_CHECKING:
     # tensorrt_llm may use a different version that doesn't have MetricsCollector,
     # so guard this import inside TYPE_CHECKING to avoid runtime import errors.
@@ -758,14 +764,18 @@ class HandlerBase(BaseGenerativeHandler):
         _conv_id = conversation_id_from_request(request)
         conversation_params = None
         if _conv_id is not None:
-            if disaggregated_params is not None and hasattr(
+            if ConversationParams is not None:
+                conversation_params = ConversationParams(conversation_id=_conv_id)
+            elif disaggregated_params is not None and hasattr(
                 type(disaggregated_params), "conversation_id"
             ):
                 disaggregated_params.conversation_id = _conv_id
-            else:
-                from tensorrt_llm.llmapi import ConversationParams
-
-                conversation_params = ConversationParams(conversation_id=_conv_id)
+            elif os.environ.get("DYN_ENGINE_CONV_AFFINITY") == "1":
+                raise RuntimeError(
+                    "DYN_ENGINE_CONV_AFFINITY=1 requires a TRT-LLM build that "
+                    "supports ConversationParams or "
+                    "DisaggregatedParams.conversation_id"
+                )
 
         return (
             disaggregated_params,

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -664,7 +664,7 @@ class HandlerBase(BaseGenerativeHandler):
         self,
         request: dict,
         ep_disaggregated_params: Optional[Any],
-    ) -> tuple[Any, Any, dict]:
+    ) -> tuple[Any, Any, dict, Any]:
         """
         Setup disaggregated_params based on disaggregation mode.
 
@@ -686,7 +686,11 @@ class HandlerBase(BaseGenerativeHandler):
             ep_disaggregated_params: Optional params from encode worker (EPD flow)
 
         Returns:
-            Tuple of (disaggregated_params, ep_disaggregated_params, epd_metadata)
+            Tuple of (disaggregated_params, ep_disaggregated_params, epd_metadata,
+            conversation_params). conversation_params is a tensorrt_llm ConversationParams
+            when the installed trtllm exposes the newer generate_async(conversation_params=)
+            API (DisaggregatedParams no longer carries conversation_id); otherwise None,
+            and the id is placed on disaggregated_params for the older API.
         """
         disaggregated_params = None
         epd_metadata: dict[str, Any] = {}
@@ -694,7 +698,12 @@ class HandlerBase(BaseGenerativeHandler):
         # Canary probe: use its pre-built disagg params (skip prefill_result decode
         # and skip the mode-specific request_type overrides).
         if request.get(HEALTH_CHECK_KEY) and request.get("disaggregated_params"):
-            return LlmDisaggregatedParams(**request["disaggregated_params"]), None, {}
+            return (
+                LlmDisaggregatedParams(**request["disaggregated_params"]),
+                None,
+                {},
+                None,
+            )
 
         # PREFILL mode: setup context_only params
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
@@ -742,13 +751,28 @@ class HandlerBase(BaseGenerativeHandler):
             ep_disaggregated_params = disaggregated_params
 
         # exp-H (gap #4): plumb conversation_id (frontend seeded routing.conversation_id from
-        # nvext.session_control) onto disaggregated_params so the engine's ConversationAwareADPRouter
-        # can pin conv -> DP rank. Covers PREFILL (context_only) / AGGREGATED / DECODE (generation_only).
+        # nvext.session_control) so the engine's ConversationAwareADPRouter can pin
+        # conv -> DP rank. Older trtllm builds carried this on disaggregated_params;
+        # newer builds (that predate the compat field) expose a dedicated
+        # ConversationParams object accepted by LLM.generate_async(conversation_params=).
         _conv_id = conversation_id_from_request(request)
-        if disaggregated_params is not None and _conv_id is not None:
-            disaggregated_params.conversation_id = _conv_id
+        conversation_params = None
+        if _conv_id is not None:
+            if disaggregated_params is not None and hasattr(
+                type(disaggregated_params), "conversation_id"
+            ):
+                disaggregated_params.conversation_id = _conv_id
+            else:
+                from tensorrt_llm.llmapi import ConversationParams
 
-        return disaggregated_params, ep_disaggregated_params, epd_metadata
+                conversation_params = ConversationParams(conversation_id=_conv_id)
+
+        return (
+            disaggregated_params,
+            ep_disaggregated_params,
+            epd_metadata,
+            conversation_params,
+        )
 
     async def _prepare_input_for_generation(
         self,
@@ -985,6 +1009,7 @@ class HandlerBase(BaseGenerativeHandler):
             disaggregated_params,
             ep_disaggregated_params,
             epd_metadata,
+            conversation_params,
         ) = self._setup_disaggregated_params_for_mode(request, ep_disaggregated_params)
 
         # Prepare input for generation (handles multimodal/text flows)
@@ -1130,9 +1155,13 @@ class HandlerBase(BaseGenerativeHandler):
         if not _EXPH_FIRST_LOGGED:
             _EXPH_FIRST_LOGGED = True
             _cid = (
-                disaggregated_params.conversation_id
-                if disaggregated_params is not None
-                else None
+                conversation_params.conversation_id
+                if conversation_params is not None
+                else (
+                    getattr(disaggregated_params, "conversation_id", None)
+                    if disaggregated_params is not None
+                    else None
+                )
             )
             logging.info(
                 "exp-H FIRST req: conversation_id=%s attention_dp_rank_forced=%s "
@@ -1148,15 +1177,20 @@ class HandlerBase(BaseGenerativeHandler):
 
         try:
             # NEW: Updated engine call to include multimodal data
-            generation_result = self.engine.llm.generate_async(
-                inputs=processed_input,  # Use the correctly extracted inputs
-                sampling_params=sampling_params,
-                disaggregated_params=disaggregated_params,
-                streaming=streaming,
-                trace_headers=trace_headers,
-                scheduling_params=scheduling_params,
-                priority=priority,
-            )
+            generate_kwargs = {
+                "inputs": processed_input,
+                "sampling_params": sampling_params,
+                "disaggregated_params": disaggregated_params,
+                "streaming": streaming,
+                "trace_headers": trace_headers,
+                "scheduling_params": scheduling_params,
+                "priority": priority,
+            }
+            # Only pass conversation_params when we built one — older trtllm
+            # builds don't accept the kwarg at all.
+            if conversation_params is not None:
+                generate_kwargs["conversation_params"] = conversation_params
+            generation_result = self.engine.llm.generate_async(**generate_kwargs)
 
             # In disagg decode mode, wrap abort() to defer until first token
             # (KV transfer complete).

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -59,6 +59,8 @@ try:
     from tensorrt_llm.llmapi import ConversationParams
 except ImportError:
     # Older TRT-LLM builds carry conversation_id on DisaggregatedParams instead.
+    # TODO: Drop this fallback once Dynamo's minimum TRT-LLM version guarantees
+    # ConversationParams.
     ConversationParams = None
 
 if TYPE_CHECKING:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -578,7 +578,7 @@ class TestDisaggRequestId:
     def test_disagg_request_id_populated_in_prefill_mode(self):
         """When mode is PREFILL and no ep_disaggregated_params, disagg_request_id is set."""
         handler = self._make_prefill_handler()
-        disagg_params, _, _ = handler._setup_disaggregated_params_for_mode(
+        disagg_params, _, _, _ = handler._setup_disaggregated_params_for_mode(
             request={}, ep_disaggregated_params=None
         )
         assert disagg_params is not None
@@ -590,7 +590,7 @@ class TestDisaggRequestId:
         handler = self._make_prefill_handler()
         ids = set()
         for _ in range(10):
-            params, _, _ = handler._setup_disaggregated_params_for_mode(
+            params, _, _, _ = handler._setup_disaggregated_params_for_mode(
                 request={}, ep_disaggregated_params=None
             )
             ids.add(params.disagg_request_id)
@@ -604,7 +604,7 @@ class TestDisaggRequestId:
         # Make bool(ep_params) truthy so the if-branch is taken
         ep_params.__bool__ = lambda self: True
 
-        params, _, _ = handler._setup_disaggregated_params_for_mode(
+        params, _, _, _ = handler._setup_disaggregated_params_for_mode(
             request={}, ep_disaggregated_params=ep_params
         )
         assert params.disagg_request_id is not None
@@ -618,7 +618,7 @@ class TestDisaggRequestId:
         ep_params.disagg_request_id = existing_id
         ep_params.__bool__ = lambda self: True
 
-        params, _, _ = handler._setup_disaggregated_params_for_mode(
+        params, _, _, _ = handler._setup_disaggregated_params_for_mode(
             request={}, ep_disaggregated_params=ep_params
         )
         assert params.disagg_request_id == existing_id
@@ -632,10 +632,10 @@ class TestDisaggRequestId:
         """Handlers with different machine_ids produce non-overlapping snowflake IDs."""
         handler_a = self._make_prefill_handler(machine_id=1)
         handler_b = self._make_prefill_handler(machine_id=2)
-        params_a, _, _ = handler_a._setup_disaggregated_params_for_mode(
+        params_a, _, _, _ = handler_a._setup_disaggregated_params_for_mode(
             request={}, ep_disaggregated_params=None
         )
-        params_b, _, _ = handler_b._setup_disaggregated_params_for_mode(
+        params_b, _, _, _ = handler_b._setup_disaggregated_params_for_mode(
             request={}, ep_disaggregated_params=None
         )
         assert params_a.disagg_request_id != params_b.disagg_request_id

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -23,6 +23,7 @@ from dynamo.llm.exceptions import EngineShutdown
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+from dynamo.trtllm.request_handlers import handler_base as handler_base_module
 from dynamo.trtllm.request_handlers.handler_base import HandlerBase
 
 pytestmark = [
@@ -639,6 +640,93 @@ class TestDisaggRequestId:
             request={}, ep_disaggregated_params=None
         )
         assert params_a.disagg_request_id != params_b.disagg_request_id
+
+
+class TestConversationParamsCompatibility:
+    def _make_handler(self, mode=DisaggregationMode.AGGREGATED) -> HandlerBase:
+        config = MagicMock()
+        config.shutdown_event = None
+        config.disagg_machine_id = 42
+        handler = _ConcreteHandler(config)
+        handler.disaggregation_mode = mode
+        return handler
+
+    def test_prefers_conversation_params_when_available(self):
+        class FakeConversationParams:
+            def __init__(self, conversation_id):
+                self.conversation_id = conversation_id
+
+        handler = self._make_handler()
+        request = {"routing": {"conversation_id": "conv-new"}}
+
+        with mock.patch.object(
+            handler_base_module, "ConversationParams", FakeConversationParams
+        ):
+            (
+                disagg_params,
+                _,
+                _,
+                conversation_params,
+            ) = handler._setup_disaggregated_params_for_mode(request, None)
+
+        assert disagg_params is None
+        assert conversation_params.conversation_id == "conv-new"
+
+    def test_uses_legacy_disaggregated_params_field(self):
+        class LegacyDisaggregatedParams:
+            conversation_id = None
+
+            def __init__(self, **kwargs):
+                self.request_type = kwargs.get("request_type")
+                self.disagg_request_id = kwargs.get("disagg_request_id")
+
+        handler = self._make_handler(DisaggregationMode.PREFILL)
+        request = {"routing": {"conversation_id": "conv-old"}}
+
+        with (
+            mock.patch.object(handler_base_module, "ConversationParams", None),
+            mock.patch.object(
+                handler_base_module,
+                "LlmDisaggregatedParams",
+                LegacyDisaggregatedParams,
+            ),
+        ):
+            (
+                disagg_params,
+                _,
+                _,
+                conversation_params,
+            ) = handler._setup_disaggregated_params_for_mode(request, None)
+
+        assert conversation_params is None
+        assert disagg_params.conversation_id == "conv-old"
+
+    def test_missing_api_is_ignored_when_affinity_disabled(self, monkeypatch):
+        monkeypatch.delenv("DYN_ENGINE_CONV_AFFINITY", raising=False)
+        handler = self._make_handler()
+        request = {"routing": {"conversation_id": "conv-unused"}}
+
+        with mock.patch.object(handler_base_module, "ConversationParams", None):
+            (
+                disagg_params,
+                _,
+                _,
+                conversation_params,
+            ) = handler._setup_disaggregated_params_for_mode(request, None)
+
+        assert disagg_params is None
+        assert conversation_params is None
+
+    def test_missing_api_fails_clearly_when_affinity_enabled(self, monkeypatch):
+        monkeypatch.setenv("DYN_ENGINE_CONV_AFFINITY", "1")
+        handler = self._make_handler()
+        request = {"routing": {"conversation_id": "conv-required"}}
+
+        with (
+            mock.patch.object(handler_base_module, "ConversationParams", None),
+            pytest.raises(RuntimeError, match="requires a TRT-LLM build"),
+        ):
+            handler._setup_disaggregated_params_for_mode(request, None)
 
 
 class TestHealthCheckPriority:


### PR DESCRIPTION
## Summary

Older trtllm carried `conversation_id` on `DisaggregatedParams`; newer builds
predate that compat field and expose a dedicated `ConversationParams` object
accepted by `LLM.generate_async()`. The old setattr path raises
`AttributeError` on the slotted dataclass, killing every request under
`DYN_ENGINE_CONV_AFFINITY=1`.

Guard the setter with `hasattr` and, when the field is absent, build a
`ConversationParams` and forward it via a conditional kwarg (avoids passing
`conversation_params=None` to older trtllm that doesn't accept the kwarg).
Applied at both dynamo→trtllm generation paths (`handler_base.py`,
`llm_engine.py`) and the associated tuple/log/tests.

## Test plan
- [x] Verified on trtllm `ace7187363c0` (rc15.post1) substrate — first-request `exp-H FIRST req` log confirms `conversation_id=...` extracted and forwarded through the `ConversationParams` path (validated in c2824 SLO20 smoke + 4x sweep runs on GB300)
- [x] No `AttributeError.conversation_id` in FE/CTX/GEN logs across ~700k successful requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11309" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->