### PR TITLE
fix(runtime): [cherry-pick 1.3.0] give event publishers unique discovery identities (DYN-3359) (#11014)

### DIFF
--- a/lib/runtime/src/discovery/kube.rs
+++ b/lib/runtime/src/discovery/kube.rs
@@ -115,11 +115,11 @@ impl Discovery for KubeDiscoveryClient {
     }
 
     async fn register_internal(&self, spec: DiscoverySpec) -> Result<DiscoveryInstance> {
-        let instance_id = self.instance_id();
-        let instance = spec.with_instance_id(instance_id);
+        let instance = spec.into_instance(self.instance_id());
+        let instance_id = instance.instance_id();
 
         tracing::debug!(
-            "Registering instance: {:?} with instance_id={:x}",
+            "Registering discovery instance: {:?}, instance_id={:x}",
             instance,
             instance_id
         );
@@ -200,7 +200,7 @@ impl Discovery for KubeDiscoveryClient {
     }
 
     async fn unregister(&self, instance: DiscoveryInstance) -> Result<()> {
-        let instance_id = self.instance_id();
+        let instance_id = instance.instance_id();
 
         // Write to local metadata and persist to CR
         // IMPORTANT: Hold the write lock across the CR write to prevent race conditions

--- a/lib/runtime/src/discovery/kv_store.rs
+++ b/lib/runtime/src/discovery/kv_store.rs
@@ -157,8 +157,8 @@ impl Discovery for KVStoreDiscovery {
     }
 
     async fn register_internal(&self, spec: DiscoverySpec) -> Result<DiscoveryInstance> {
-        let instance_id = self.instance_id();
-        let instance = spec.with_instance_id(instance_id);
+        let instance = spec.into_instance(self.instance_id());
+        let instance_id = instance.instance_id();
 
         let (bucket_name, key_path) = match &instance {
             DiscoveryInstance::Endpoint(inst) => {
@@ -269,7 +269,7 @@ impl Discovery for KVStoreDiscovery {
         // Use revision 0 for initial registration
         let outcome = bucket.insert(&key, instance_json.into(), 0).await?;
         tracing::debug!(
-            "KVStoreDiscovery::register: Successfully registered instance_id={}, key={}, outcome={:?}",
+            "KVStoreDiscovery::register: Registration insert completed instance_id={}, key={}, outcome={:?}",
             instance_id,
             key_path,
             outcome

--- a/lib/runtime/src/discovery/mock.rs
+++ b/lib/runtime/src/discovery/mock.rs
@@ -158,7 +158,7 @@ impl Discovery for MockDiscovery {
     }
 
     async fn register_internal(&self, spec: DiscoverySpec) -> Result<DiscoveryInstance> {
-        let instance = spec.with_instance_id(self.instance_id);
+        let instance = spec.into_instance(self.instance_id);
 
         self.registry
             .instances

--- a/lib/runtime/src/discovery/mod.rs
+++ b/lib/runtime/src/discovery/mod.rs
@@ -326,6 +326,11 @@ pub enum DiscoverySpec {
         component: String,
         /// Topic name for this channel (e.g., "kv-events", "kv-metrics")
         topic: String,
+        /// Unique identity of this publisher incarnation.
+        ///
+        /// A process can host multiple publishers for the same topic, so event
+        /// channels cannot use the process-level discovery instance ID.
+        publisher_id: u64,
         /// Event transport type (NATS subject prefix or ZMQ endpoint)
         transport: EventTransport,
     },
@@ -368,8 +373,12 @@ impl DiscoverySpec {
         })
     }
 
-    /// Attaches an instance ID to create a DiscoveryInstance
-    pub fn with_instance_id(self, instance_id: u64) -> DiscoveryInstance {
+    /// Converts this registration spec into a discovery instance.
+    ///
+    /// Endpoint and model specs use `default_instance_id`, normally the
+    /// discovery client's process-level ID. Event channel specs already carry
+    /// a publisher-level ID, so they use that instead.
+    pub fn into_instance(self, default_instance_id: u64) -> DiscoveryInstance {
         match self {
             Self::Endpoint {
                 namespace,
@@ -381,7 +390,7 @@ impl DiscoverySpec {
                 namespace,
                 component,
                 endpoint,
-                instance_id,
+                instance_id: default_instance_id,
                 transport,
                 device_type,
             }),
@@ -395,7 +404,7 @@ impl DiscoverySpec {
                 namespace,
                 component,
                 endpoint,
-                instance_id,
+                instance_id: default_instance_id,
                 card_json,
                 model_suffix,
             },
@@ -403,15 +412,21 @@ impl DiscoverySpec {
                 namespace,
                 component,
                 topic,
+                publisher_id,
                 transport,
             } => DiscoveryInstance::EventChannel {
                 namespace,
                 component,
                 topic,
-                instance_id,
+                instance_id: publisher_id,
                 transport,
             },
         }
+    }
+
+    /// Compatibility alias for [`DiscoverySpec::into_instance`].
+    pub fn with_instance_id(self, default_instance_id: u64) -> DiscoveryInstance {
+        self.into_instance(default_instance_id)
     }
 }
 
@@ -765,7 +780,9 @@ fn find_conflicting_model_name(
 #[async_trait]
 pub trait Discovery: Send + Sync {
     /// Returns a unique identifier for this worker (e.g lease id if using etcd or generated id for memory store)
-    /// Discovery objects created by this worker will be associated with this id.
+    /// Endpoint and model objects created by this worker use this ID. Event
+    /// channels use a publisher-level ID because a worker can own more than one
+    /// publisher for the same topic.
     fn instance_id(&self) -> u64;
 
     /// Registers an object in the discovery plane with the instance id

--- a/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
+++ b/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
@@ -58,8 +58,9 @@ impl DynamicSubscriber {
         let (event_tx, event_rx) = mpsc::channel::<Bytes>(channel_cap);
 
         // Track active endpoint connections with instance ID to endpoint mapping
-        let active_endpoints: Arc<RwLock<HashMap<String, (String, CancellationToken)>>> =
-            Arc::new(RwLock::new(HashMap::new()));
+        let active_endpoints: Arc<
+            RwLock<HashMap<DiscoveryInstanceId, (String, CancellationToken)>>,
+        > = Arc::new(RwLock::new(HashMap::new()));
 
         // Clone self for the spawned task
         let subscriber_clone = Arc::clone(&self);
@@ -103,19 +104,19 @@ impl DynamicSubscriber {
                 match event_result {
                     Ok(DiscoveryEvent::Added(instance)) => {
                         tracing::info!(instance = ?instance, "Discovery Added event received");
-                        let instance_id = instance.instance_id().to_string();
+                        let instance_id = instance.id();
 
                         // Extract ZMQ endpoint from the instance
-                        if let Some(endpoint) = Self::extract_zmq_endpoint(&instance) {
+                        if let Some(endpoint) = Self::extract_zmq_endpoint(&instance, &zmq_topic) {
                             let mut endpoints_guard = endpoints.write().await;
 
                             // Skip if instance already tracked
                             if endpoints_guard.contains_key(&instance_id) {
-                                tracing::debug!(endpoint = %endpoint, instance_id = %instance_id, "Already connected to ZMQ publisher");
+                                tracing::debug!(endpoint = %endpoint, ?instance_id, "Already connected to ZMQ publisher");
                                 continue;
                             }
 
-                            tracing::info!(endpoint = %endpoint, instance_id = %instance_id, "Connecting to new ZMQ publisher");
+                            tracing::info!(endpoint = %endpoint, ?instance_id, "Connecting to new ZMQ publisher");
 
                             // Create cancellation token for this endpoint's stream
                             let endpoint_cancel = CancellationToken::new();
@@ -151,25 +152,44 @@ impl DynamicSubscriber {
                                 endpoints_clone.write().await.remove(&instance_id_clone);
                             });
                         } else {
-                            tracing::warn!(
+                            tracing::debug!(
                                 instance = ?instance,
-                                "Discovery Added event did not contain a ZMQ endpoint"
+                                expected_topic = %zmq_topic,
+                                "Discovery event is not a matching ZMQ publisher"
                             );
                         }
                     }
                     Ok(DiscoveryEvent::Removed(instance_id)) => {
-                        let id_str = instance_id.instance_id().to_string();
+                        let is_expected_topic = matches!(
+                            &instance_id,
+                            DiscoveryInstanceId::EventChannel(channel_id)
+                                if channel_id.topic == zmq_topic
+                        );
+                        if !is_expected_topic {
+                            tracing::debug!(
+                                ?instance_id,
+                                expected_topic = %zmq_topic,
+                                "Ignoring removal for unrelated event channel"
+                            );
+                            continue;
+                        }
+
                         tracing::info!(
-                            instance_id = %id_str,
+                            ?instance_id,
                             "ZMQ publisher removed from discovery, cancelling endpoint stream"
                         );
 
                         // Cancel the endpoint's stream via its CancellationToken
-                        if let Some((_endpoint, cancel)) = endpoints.write().await.remove(&id_str) {
+                        if let Some((_endpoint, cancel)) =
+                            endpoints.write().await.remove(&instance_id)
+                        {
                             cancel.cancel();
-                            tracing::info!(instance_id = %id_str, "Cancelled endpoint stream");
+                            tracing::info!(?instance_id, "Cancelled endpoint stream");
                         } else {
-                            tracing::warn!(instance_id = %id_str, "No active endpoint found for removed stream instance");
+                            tracing::debug!(
+                                ?instance_id,
+                                "No active endpoint found for removed stream instance"
+                            );
                         }
                     }
                     Err(e) => {
@@ -201,8 +221,11 @@ impl DynamicSubscriber {
     }
 
     /// Extract ZMQ endpoint from a discovery instance.
-    fn extract_zmq_endpoint(instance: &DiscoveryInstance) -> Option<String> {
-        if let DiscoveryInstance::EventChannel { transport, .. } = instance
+    fn extract_zmq_endpoint(instance: &DiscoveryInstance, expected_topic: &str) -> Option<String> {
+        if let DiscoveryInstance::EventChannel {
+            topic, transport, ..
+        } = instance
+            && topic == expected_topic
             && let EventTransport::Zmq { endpoint } = transport
         {
             return Some(endpoint.clone());
@@ -276,5 +299,43 @@ impl DynamicSubscriber {
 impl Drop for DynamicSubscriber {
     fn drop(&mut self) {
         self.cancel_token.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn event_channel(topic: &str, transport: EventTransport) -> DiscoveryInstance {
+        DiscoveryInstance::EventChannel {
+            namespace: "test-ns".to_string(),
+            component: "test-component".to_string(),
+            topic: topic.to_string(),
+            instance_id: 1,
+            transport,
+        }
+    }
+
+    #[test]
+    fn extracts_only_matching_zmq_topic() {
+        let matching = event_channel("kv-events", EventTransport::zmq("tcp://127.0.0.1:1"));
+        let wrong_topic = event_channel("kv-metrics", EventTransport::zmq("tcp://127.0.0.1:2"));
+        let wrong_transport = event_channel(
+            "kv-events",
+            EventTransport::nats("namespace.test-ns.component.test-component"),
+        );
+
+        assert_eq!(
+            DynamicSubscriber::extract_zmq_endpoint(&matching, "kv-events").as_deref(),
+            Some("tcp://127.0.0.1:1")
+        );
+        assert_eq!(
+            DynamicSubscriber::extract_zmq_endpoint(&wrong_topic, "kv-events"),
+            None
+        );
+        assert_eq!(
+            DynamicSubscriber::extract_zmq_endpoint(&wrong_transport, "kv-events"),
+            None
+        );
     }
 }

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -30,6 +30,7 @@ use anyhow::Result;
 use bytes::Bytes;
 use futures::{Stream, StreamExt};
 use lru::LruCache;
+use rand::TryRngCore;
 use serde::Serialize;
 use serde::de::DeserializeOwned;
 use std::pin::Pin;
@@ -285,6 +286,8 @@ pub struct EventPublisher {
     tx: Arc<dyn EventTransportTx>,
     codec: Arc<Codec>,
     runtime_handle: tokio::runtime::Handle,
+    // Keeps unregister work in graceful-shutdown Phase 2 when dropped before shutdown.
+    graceful_shutdown_tracker: Arc<crate::utils::GracefulShutdownTracker>,
     /// Discovery client and registered instance for unregistration on drop
     discovery_client: Option<Arc<dyn Discovery>>,
     discovery_instance: Option<crate::discovery::DiscoveryInstance>,
@@ -346,10 +349,17 @@ impl EventPublisher {
         topic: String,
         transport_kind: EventTransportKind,
     ) -> Result<Self> {
-        let publisher_id = drt.discovery().instance_id();
+        // Publishers are discovery objects in their own right. A single process
+        // can host multiple publishers for the same scope/topic, each with its
+        // own ZMQ endpoint and sequence space, so the process ID is not unique
+        // enough here.
+        let publisher_id = rand::rngs::OsRng
+            .try_next_u64()
+            .map_err(|error| anyhow::anyhow!("failed to generate publisher ID: {error}"))?;
         let discovery = Some(drt.discovery());
         let runtime_handle = drt.runtime().secondary();
         let subject = format!("{}.{}", scope.subject_prefix(), topic);
+        let graceful_shutdown_tracker = drt.graceful_shutdown_tracker();
 
         // Use Msgpack codec for all transports
         enum TransportSetup {
@@ -434,17 +444,18 @@ impl EventPublisher {
                     namespace: scope.namespace().to_string(),
                     component: scope.component().unwrap_or("").to_string(),
                     topic: topic.clone(),
+                    publisher_id,
                     transport: transport_config,
                 };
 
-                let registered_instance = drt.discovery().register(spec).await?;
+                let discovery_instance = drt.discovery().register(spec).await?;
                 tracing::info!(
                     topic = %topic,
                     transport = ?transport_kind,
-                    instance_id = %registered_instance.instance_id(),
+                    publisher_id = %publisher_id,
                     "EventPublisher registered with discovery"
                 );
-                (tx, codec, Some(registered_instance))
+                (tx, codec, Some(discovery_instance))
             }
             TransportSetup::ZmqDirect(tx, codec, public_endpoint) => {
                 let transport_config = EventTransport::zmq(public_endpoint);
@@ -452,17 +463,18 @@ impl EventPublisher {
                     namespace: scope.namespace().to_string(),
                     component: scope.component().unwrap_or("").to_string(),
                     topic: topic.clone(),
+                    publisher_id,
                     transport: transport_config,
                 };
 
-                let registered_instance = drt.discovery().register(spec).await?;
+                let discovery_instance = drt.discovery().register(spec).await?;
                 tracing::info!(
                     topic = %topic,
                     transport = ?transport_kind,
-                    instance_id = %registered_instance.instance_id(),
+                    publisher_id = %publisher_id,
                     "EventPublisher registered with discovery (direct mode)"
                 );
-                (tx, codec, Some(registered_instance))
+                (tx, codec, Some(discovery_instance))
             }
             TransportSetup::ZmqBroker(tx, codec) => {
                 tracing::info!(
@@ -483,6 +495,7 @@ impl EventPublisher {
             tx,
             codec,
             runtime_handle,
+            graceful_shutdown_tracker,
             discovery_client: discovery,
             discovery_instance,
         })
@@ -535,25 +548,27 @@ impl Drop for EventPublisher {
             (self.discovery_client.take(), self.discovery_instance.take())
         {
             let topic = self.topic.clone();
-            let instance_id = instance.instance_id();
+            let publisher_id = instance.instance_id();
             let runtime_handle = self.runtime_handle.clone();
+            let shutdown_guard = self.graceful_shutdown_tracker.register_task();
 
             // Drop can run outside any Tokio context (notably via PyO3 finalizers), so use
             // the runtime that created the publisher rather than the ambient thread state.
             let spawn_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
                 runtime_handle.spawn(async move {
+                    let _shutdown_guard = shutdown_guard;
                     match discovery.unregister(instance).await {
                         Ok(()) => {
                             tracing::info!(
                                 topic = %topic,
-                                instance_id = %instance_id,
+                                publisher_id = %publisher_id,
                                 "EventPublisher unregistered from discovery"
                             );
                         }
                         Err(e) => {
                             tracing::warn!(
                                 topic = %topic,
-                                instance_id = %instance_id,
+                                publisher_id = %publisher_id,
                                 error = %e,
                                 "Failed to unregister EventPublisher from discovery"
                             );
@@ -565,7 +580,7 @@ impl Drop for EventPublisher {
             if spawn_result.is_err() {
                 tracing::warn!(
                     topic = %self.topic,
-                    instance_id = %instance_id,
+                    publisher_id = %publisher_id,
                     "Skipping EventPublisher unregister during drop because the runtime is unavailable"
                 );
             }
@@ -806,7 +821,285 @@ fn current_timestamp_ms() -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::config::environment_names::event_plane as env;
+    use crate::config::environment_names::zmq_broker as broker_env;
+
+    #[tokio::test]
+    async fn same_topic_publishers_are_independent_across_recreation() {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let runtime = crate::Runtime::from_current().expect("create runtime handle");
+                let drt = DistributedRuntime::new(
+                    runtime,
+                    crate::distributed::DistributedConfig::process_local(),
+                )
+                .await
+                .expect("create distributed runtime");
+                let component = drt
+                    .namespace("event-publisher-test")
+                    .expect("create namespace")
+                    .component("worker")
+                    .expect("create component");
+
+                let publisher_a = EventPublisher::for_component_with_transport(
+                    &component,
+                    "events",
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create first publisher");
+                let publisher_b = EventPublisher::for_component_with_transport(
+                    &component,
+                    "events",
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create second publisher");
+                let publisher_a_id = publisher_a.publisher_id();
+                let publisher_b_id = publisher_b.publisher_id();
+
+                assert_ne!(publisher_a_id, publisher_b_id);
+
+                let query = DiscoveryQuery::EventChannels(EventChannelQuery::topic(
+                    "event-publisher-test",
+                    "worker",
+                    "events",
+                ));
+                let instances = drt
+                    .discovery()
+                    .list(query.clone())
+                    .await
+                    .expect("list event publishers");
+                assert_eq!(instances.len(), 2);
+                assert!(
+                    instances
+                        .iter()
+                        .any(|instance| instance.instance_id() == publisher_a_id)
+                );
+                assert!(
+                    instances
+                        .iter()
+                        .any(|instance| instance.instance_id() == publisher_b_id)
+                );
+
+                let mut subscriber = EventSubscriber::for_component_with_transport(
+                    &component,
+                    "events",
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create subscriber");
+                let mut received_a = false;
+                let mut received_b = false;
+
+                tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                    while !received_a || !received_b {
+                        publisher_a
+                            .publish_bytes(vec![0xa1])
+                            .await
+                            .expect("publish from first publisher");
+                        publisher_b
+                            .publish_bytes(vec![0xb2])
+                            .await
+                            .expect("publish from second publisher");
+
+                        if let Ok(Some(envelope)) = tokio::time::timeout(
+                            std::time::Duration::from_millis(100),
+                            subscriber.next(),
+                        )
+                        .await
+                        {
+                            let envelope = envelope.expect("receive event envelope");
+                            if envelope.publisher_id == publisher_a_id {
+                                assert_eq!(envelope.payload.as_ref(), &[0xa1]);
+                                received_a = true;
+                            } else if envelope.publisher_id == publisher_b_id {
+                                assert_eq!(envelope.payload.as_ref(), &[0xb2]);
+                                received_b = true;
+                            } else {
+                                panic!("event from unexpected publisher");
+                            }
+                        }
+
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                })
+                .await
+                .expect("subscriber should receive events from both publishers");
+
+                drop(publisher_a);
+                let publisher_a_recreated = EventPublisher::for_component_with_transport(
+                    &component,
+                    "events",
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("recreate first publisher");
+                let publisher_a_recreated_id = publisher_a_recreated.publisher_id();
+
+                assert_ne!(publisher_a_recreated_id, publisher_a_id);
+                assert_ne!(publisher_a_recreated_id, publisher_b_id);
+                assert_eq!(
+                    publisher_a_recreated.sequence.load(Ordering::SeqCst),
+                    0,
+                    "a recreated publisher starts a new sequence space"
+                );
+
+                tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                    loop {
+                        let instances = drt
+                            .discovery()
+                            .list(query.clone())
+                            .await
+                            .expect("list event publishers after recreation");
+                        if instances.len() == 2
+                            && instances
+                                .iter()
+                                .any(|instance| instance.instance_id() == publisher_b_id)
+                            && instances
+                                .iter()
+                                .any(|instance| instance.instance_id() == publisher_a_recreated_id)
+                        {
+                            break;
+                        }
+                        tokio::task::yield_now().await;
+                    }
+                })
+                .await
+                .expect("old publisher should unregister without removing current publishers");
+
+                let mut received_b_after_recreation = false;
+                let mut received_recreated_a = false;
+
+                tokio::time::timeout(std::time::Duration::from_secs(5), async {
+                    while !received_b_after_recreation || !received_recreated_a {
+                        publisher_b
+                            .publish_bytes(vec![0xb3])
+                            .await
+                            .expect("publish from second publisher after recreation");
+                        publisher_a_recreated
+                            .publish_bytes(vec![0xa2])
+                            .await
+                            .expect("publish from recreated publisher");
+
+                        if let Ok(Some(envelope)) = tokio::time::timeout(
+                            std::time::Duration::from_millis(100),
+                            subscriber.next(),
+                        )
+                        .await
+                        {
+                            let envelope = envelope.expect("receive event envelope after drop");
+                            if envelope.publisher_id == publisher_b_id
+                                && envelope.payload.as_ref() == [0xb3]
+                            {
+                                received_b_after_recreation = true;
+                            } else if envelope.publisher_id == publisher_a_recreated_id
+                                && envelope.payload.as_ref() == [0xa2]
+                            {
+                                received_recreated_a = true;
+                            }
+                        }
+
+                        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                    }
+                })
+                .await
+                .expect("subscriber should receive from surviving and recreated publishers");
+            },
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    async fn dropped_publisher_unregister_completes_within_graceful_shutdown() {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let runtime = crate::Runtime::from_current().expect("create runtime handle");
+                let drt = DistributedRuntime::new(
+                    runtime,
+                    crate::distributed::DistributedConfig::process_local(),
+                )
+                .await
+                .expect("create distributed runtime");
+                let component = drt
+                    .namespace("event-publisher-shutdown-test")
+                    .expect("create namespace")
+                    .component("worker")
+                    .expect("create component");
+
+                let publisher = EventPublisher::for_component_with_transport(
+                    &component,
+                    "events",
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create publisher");
+                let publisher_id = publisher.publisher_id();
+
+                let query = DiscoveryQuery::EventChannels(EventChannelQuery::topic(
+                    "event-publisher-shutdown-test",
+                    "worker",
+                    "events",
+                ));
+                let instances = drt
+                    .discovery()
+                    .list(query.clone())
+                    .await
+                    .expect("list event publishers");
+                assert_eq!(instances.len(), 1);
+                assert_eq!(instances[0].instance_id(), publisher_id);
+
+                let tracker = drt.graceful_shutdown_tracker();
+                assert_eq!(tracker.get_count(), 0);
+
+                let main_token = drt.runtime().primary_token();
+                let endpoint_token = drt.runtime().child_token();
+
+                // Dropping the publisher schedules the async discovery unregister.
+                // The drop path must synchronously take a graceful-shutdown guard so
+                // that `Runtime::shutdown` Phase 2 waits for the unregister task.
+                drop(publisher);
+                assert_eq!(
+                    tracker.get_count(),
+                    1,
+                    "dropping a publisher must register its unregister work with the graceful-shutdown tracker"
+                );
+
+                drt.runtime().shutdown();
+
+                tokio::time::timeout(std::time::Duration::from_secs(5), main_token.cancelled())
+                    .await
+                    .expect("graceful shutdown should complete once the unregister task finishes");
+
+                assert!(endpoint_token.is_cancelled());
+                assert_eq!(
+                    tracker.get_count(),
+                    0,
+                    "the unregister task must release its graceful-shutdown guard"
+                );
+
+                // Phase 3 (main token cancellation) only runs after Phase 2 drained
+                // the tracker, so the dropped publisher must already be unregistered.
+                let instances = drt
+                    .discovery()
+                    .list(query)
+                    .await
+                    .expect("list event publishers after shutdown");
+                assert!(
+                    instances.is_empty(),
+                    "unregister must complete within the graceful-shutdown window"
+                );
+            },
+        )
+        .await;
+    }
 
     #[test]
     fn test_event_scope_subject_prefix() {

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -60,25 +60,6 @@ MODEL_NAME = ROUTER_MODEL_NAME
 COUNTER_WORKER_SCRIPT = os.path.join(os.path.dirname(__file__), "counter_worker.py")
 
 
-@pytest.fixture(autouse=True)
-def _pin_nats_event_plane_for_mocker(request, monkeypatch):
-    """Pin the NATS event plane for etcd-backed mocker tests.
-
-    The mock engine publishes KV cache events instantly -- before the in-process
-    router's ZMQ subscription has connected (ZMQ slow-joiner) -- so on the (now
-    default) ZMQ event plane the router observes zero events and the routing
-    assertions fail. Real engines start slowly enough to avoid this, so the
-    vLLM/SGLang router e2e tests cover the ZMQ default; only the fast mocker needs
-    NATS here. file-backed variants keep the ZMQ default, and an explicitly set
-    DYN_EVENT_PLANE (e.g. via durable_kv_events) is left untouched.
-    """
-    callspec = getattr(request.node, "callspec", None)
-    store_backend = callspec.params.get("store_backend", "etcd") if callspec else "etcd"
-    if store_backend != "file" and not os.environ.get("DYN_EVENT_PLANE"):
-        monkeypatch.setenv("DYN_EVENT_PLANE", "nats")
-    yield
-
-
 pytestmark = [
     pytest.mark.pre_merge,
     pytest.mark.gpu_0,


### PR DESCRIPTION
## Overview:

Cherry-pick of #11014 onto release/1.3.0 for RC3.

Fixes DYN-3359 (nvbug 6407328): KV events from dp_rank>0 never reach the
router index; prefix reuse invisible on rank>0. Real regression exposed by
the ZMQ default-event-plane flip (#10902), affecting both legacy and unified
multi-DP publishing paths — root cause was a per-publisher discovery identity
collision.

Clean cherry-pick, no conflicts. patch-id identical to merged main commit
c9f9629ab.

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for an updated operator admission path and validation feedback for deployment requests.
  * Improved HTTP request handling for chat/completions endpoints, including better JSON error handling and clearer unsupported-field responses.
  * Added safer GPU memory handling so writable tensor state is preserved after shared-memory updates.

* **Bug Fixes**
  * Tightened deployment validation and compatibility across deployment versions.
  * Refined runtime behavior around frontend feature toggles and SGLang session handling.

* **Documentation**
  * Updated many examples and guides to use pinned `1.3.0` images and refreshed configuration guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->