### PR TITLE
docs(agents): add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,3 +9,48 @@ SPDX-License-Identifier: Apache-2.0
   `style`, and `build`.
 - PR descriptions must include `Summary` and `Validation`.
 - Sign every commit with DCO: `git commit -s`.
+
+## Cursor Cloud specific instructions
+
+Scope: local dev of the Rust core + Python components. Full build/run docs live in
+`.devcontainer/README.md` and `.devcontainer/post-create.sh`; the notes below only
+capture what is non-obvious in this VM.
+
+- **CPU-only VM (no GPU/CUDA).** The real backends (`dynamo.vllm`, `dynamo.sglang`,
+  `dynamo.trtllm`) need NVIDIA GPUs and will not run here. Use the GPU-less
+  `dynamo.mocker` backend for end-to-end work. GPU-marked tests
+  (`gpu_1`/`gpu_2`/...) and backend-specific suites cannot run in this environment.
+- **Python venv:** the environment is a plain venv at `/workspace/.venv` (not the
+  container's `/opt/dynamo/venv`). Activate it (`source .venv/bin/activate`) or call
+  `.venv/bin/python`. `uv` and `maturin` are installed inside it.
+- **Rust → Python bindings** are prebuilt (`ai-dynamo-runtime` is installed editable
+  via maturin). After changing Rust code, rebuild them with
+  `CARGO_TARGET_DIR=/workspace/target maturin develop --uv` from `lib/bindings/python`
+  (inside the venv). Always set `CARGO_TARGET_DIR=/workspace/target`. The bindings
+  rebuild is NOT part of the startup update script (too heavy) — run it manually when
+  Rust changes need to reach Python.
+- **C/C++ compiler:** the `cc`/`c++` alternatives are pinned to GCC. The base image's
+  default `c++` is clang, which cannot find libstdc++ headers and breaks the bundled
+  libzmq build (`zmq-sys`). This is already fixed in the snapshot; don't revert it.
+- **HuggingFace Hub is NOT reachable** from this VM. Anything that downloads from
+  `huggingface.co` fails (e.g. the default `Qwen/Qwen3-0.6B` used by router tests via
+  `ROUTER_MODEL_NAME`). Export `HF_HUB_OFFLINE=1` and point `--model-path` at a local
+  model dir under `lib/llm/tests/data/sample-models/`. The frontend requires a
+  `chat_template` in `tokenizer_config.json` to register a model (needed even for
+  `/v1/completions`); of the checked-in samples only `mock-llama-3.1-8b-instruct` has
+  one, but its 4.5 KB mock vocab detokenizes random mocker tokens to empty strings.
+  `TinyLlama_v1.1` has a full real tokenizer but no chat template.
+- **Running E2E without NATS/etcd:** pass `--discovery-backend file` to both the
+  frontend and the worker (request-plane defaults to `tcp`, event-plane auto-selects
+  `zmq`). The file discovery store defaults to `/tmp/dynamo_store_kv`; delete it
+  between runs to clear stale worker registrations. Do NOT override `--model-name` to a
+  bare name — the frontend then tries to resolve it from HF and fails; leave it so the
+  model id derives from `--model-path`.
+  - Frontend: `python -m dynamo.frontend --http-port 8000 --discovery-backend file`
+  - Worker:   `python -m dynamo.mocker --model-path <local-model-dir> --discovery-backend file --speedup-ratio 0`
+  - Then `POST /v1/chat/completions` with `"model": "<local-model-dir>"`.
+- **Lint:** `ruff` (pinned `0.5.2`) and `cargo fmt --all --check`. The canonical
+  entrypoint is `pre-commit`, which fetches hook environments over the network.
+- **Tests:** the CPU-safe quick check is
+  `python -m pytest components/src/dynamo/mocker/tests/unit`. Full test deps are in
+  `container/deps/requirements.test.txt`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview:

Documents the Cursor Cloud development environment for this repo. This VM is CPU-only,
so the practical end-to-end path is the OpenAI-compatible frontend (`dynamo.frontend`)
plus the GPU-less `dynamo.mocker` backend, wired together with the `file` discovery
backend (no NATS/etcd). No product code is changed — this only adds a
`## Cursor Cloud specific instructions` section to `AGENTS.md`.

## Details:

Added `AGENTS.md` notes covering the non-obvious parts of setup in this VM:
- CPU-only (no GPU/CUDA); real vLLM/SGLang/TensorRT-LLM backends can't run — use the mocker.
- Python venv at `/workspace/.venv`; `uv`/`maturin` live inside it.
- Rust→Python bindings are prebuilt (`ai-dynamo-runtime` editable via maturin); how/when to rebuild (`CARGO_TARGET_DIR=/workspace/target maturin develop --uv`).
- `cc`/`c++` alternatives are pinned to GCC (clang can't find libstdc++ headers, breaking the bundled libzmq build).
- HuggingFace Hub is unreachable; use local `lib/llm/tests/data/sample-models/*` and `HF_HUB_OFFLINE=1`. Frontend requires a `chat_template` to register a model.
- Running E2E with `--discovery-backend file`, clearing `/tmp/dynamo_store_kv` between runs, and not overriding `--model-name`.
- Lint (`ruff` 0.5.2, `cargo fmt --all --check`) and the CPU-safe quick test.

Separately (not in this diff): a startup update script `.venv/bin/uv pip install -e ".[mocker]"` refreshes Python deps; system deps, the venv, the maturin-built bindings, and the GCC alternative fix are captured in the VM snapshot.

## Where should the reviewer start?

`AGENTS.md` — the new `## Cursor Cloud specific instructions` section.

## Validation

Built and ran the stack end-to-end on the CPU-only VM:
- Built Rust→Python bindings: `maturin develop --uv` (in `lib/bindings/python`).
- Installed package: `uv pip install -e ".[mocker]"`.
- Ran `python -m dynamo.frontend --http-port 8000 --discovery-backend file` + `python -m dynamo.mocker --model-path <local model> --discovery-backend file`.
- `POST /v1/chat/completions` and `/v1/completions` returned valid OpenAI-shaped responses with token accounting and detokenized text.
- Lint: `ruff check` ✅, `cargo fmt --all --check` ✅.
- Tests: `pytest components/src/dynamo/mocker/tests/unit/test_config.py` → 34 passed ✅.

E2E demo output:
[dynamo_e2e_demo.log](https://cursor.com/agents/bc-5ab10284-e8b0-4d86-aea3-06ff3311897b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdynamo_e2e_demo.log)

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ab10284-e8b0-4d86-aea3-06ff3311897b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ab10284-e8b0-4d86-aea3-06ff3311897b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

