### PR TITLE
fix(operator): preserve Grove component kinds before creation

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -281,18 +281,17 @@ func (r *DynamoGraphDeploymentReconciler) Reconcile(ctx context.Context, req ctr
 	}
 
 	reconcileResult, err := r.reconcileResources(ctx, dynamoDeployment)
+	if err != nil {
+		logger.Error(err, "failed to reconcile the resources")
+		reason = "failed_to_reconcile_the_resources"
+		return ctrl.Result{}, err
+	}
 
 	state = reconcileResult.State
 	reason = reconcileResult.Reason
 	message = reconcileResult.Message
 	dynamoDeployment.Status.Components = reconcileResult.ComponentStatus
 	dynamoDeployment.Status.Restart = reconcileResult.RestartStatus
-
-	if err != nil {
-		logger.Error(err, "failed to reconcile the resources")
-		reason = "failed_to_reconcile_the_resources"
-		return ctrl.Result{}, err
-	}
 
 	// Override state based on rolling update status if a rolling update is in progress
 	if dynamoDeployment.Status.RollingUpdate != nil {
@@ -507,10 +506,16 @@ func (r *DynamoGraphDeploymentReconciler) getUpdatedInProgressForGrove(ctx conte
 		// single-node GMS components stall in the in-progress list because the
 		// corresponding PodClique never exists.
 		usesPCSG := component.GetNumberOfNodes() > 1 || component.IsInterPodGMSEnabled()
+		var readinessErr error
 		if usesPCSG {
-			isReady, reason, _ = dynamo.CheckPCSGReady(ctx, r.Client, resourceName, dgd.Namespace, logger)
+			isReady, reason, _, readinessErr = dynamo.CheckPCSGReady(ctx, r.Client, resourceName, dgd.Namespace, logger)
 		} else {
-			isReady, reason, _ = dynamo.CheckPodCliqueReady(ctx, r.Client, resourceName, dgd.Namespace, logger)
+			isReady, reason, _, readinessErr = dynamo.CheckPodCliqueReady(ctx, r.Client, resourceName, dgd.Namespace, logger)
+		}
+		if readinessErr != nil {
+			logger.Error(readinessErr, "failed to check component readiness", "componentName", componentName, "resourceName", resourceName)
+			updatedInProgress = append(updatedInProgress, componentName)
+			continue
 		}
 		if !isReady {
 			logger.V(1).Info("component not ready", "componentName", componentName, "resourceName", resourceName, "reason", reason)
@@ -662,11 +667,14 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGrovePodCliqueSet(
 		logger.Error(err, "failed to sync the Grove GangSet")
 		return nil, fmt.Errorf("failed to sync the Grove GangSet: %w", err)
 	}
+	allComponentsReady, reason, componentStatuses, err := dynamo.GetComponentReadinessAndServiceReplicaStatuses(ctx, r.Client, dynamoDeployment)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Grove component readiness: %w", err)
+	}
 	syncedGrovePodCliqueSetAsResource, err := commoncontroller.NewResourceWithComponentStatuses(
 		syncedGrovePodCliqueSet,
 		func() (bool, string, map[string]nvidiacomv1beta1.ComponentReplicaStatus) {
 			// Grove readiness: all underlying PodCliques and PodCliqueScalingGroups have replicas == availableReplicas
-			allComponentsReady, reason, componentStatuses := dynamo.GetComponentReadinessAndServiceReplicaStatuses(ctx, r.Client, dynamoDeployment)
 			if !allComponentsReady {
 				return false, reason, componentStatuses
 			}

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -44,6 +44,7 @@ import (
 	networkingv1 "k8s.io/api/networking/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -53,8 +54,10 @@ import (
 	"k8s.io/client-go/scale"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 )
 
 func newDynamoGraphDeploymentControllerTestScheme(t testing.TB) *runtime.Scheme {
@@ -589,6 +592,92 @@ func TestDynamoGraphDeploymentReconciler_reconcileResources_ValidatesGMSResource
 	g.Expect(err).To(gomega.HaveOccurred())
 	g.Expect(err.Error()).To(gomega.ContainSubstring("requires DRA"))
 	g.Expect(err.Error()).To(gomega.ContainSubstring("explicitly disabled"))
+}
+
+func TestDynamoGraphDeploymentReconciler_ReconcilePreservesStatusOnGroveReadinessError(t *testing.T) {
+	ctx := context.Background()
+	s := newDynamoGraphDeploymentControllerTestScheme(t)
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+			UID:       types.UID("dgd-uid"),
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			BackendFramework: "vllm",
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "frontend",
+					ComponentType: v1beta1.ComponentTypeFrontend,
+					Replicas:      ptr.To(int32(1)),
+				},
+			},
+		},
+		Status: v1beta1.DynamoGraphDeploymentStatus{
+			Components: map[string]v1beta1.ComponentReplicaStatus{
+				"frontend": {
+					ComponentKind:     v1beta1.ComponentKindPodClique,
+					ComponentNames:    []string{"test-dgd-0-frontend"},
+					Replicas:          3,
+					UpdatedReplicas:   2,
+					ReadyReplicas:     ptr.To(int32(1)),
+					AvailableReplicas: ptr.To(int32(1)),
+				},
+			},
+			Restart: &v1beta1.RestartStatus{
+				ObservedID: "known-restart",
+				Phase:      v1beta1.RestartPhaseRestarting,
+				InProgress: []string{"frontend"},
+			},
+		},
+	}
+	controller_common.AddFinalizer(dgd)
+	wantComponents := dgd.Status.Components
+	wantRestart := dgd.Status.Restart
+
+	podCliqueGetCalled := false
+	fakeKubeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(dgd).
+		WithStatusSubresource(dgd).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*grovev1alpha1.PodClique); ok {
+					podCliqueGetCalled = true
+					return fmt.Errorf("transient PodClique API error")
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+	reconciler := &DynamoGraphDeploymentReconciler{
+		Client:   fakeKubeClient,
+		Recorder: record.NewFakeRecorder(100),
+		Config: &configv1alpha1.OperatorConfiguration{
+			Namespace: configv1alpha1.NamespaceConfiguration{Restricted: "default"},
+		},
+		RuntimeConfig: &controller_common.RuntimeConfig{GroveEnabled: true},
+		ScaleClient:   &mockScaleClient{},
+		DockerSecretRetriever: &mockDockerSecretRetriever{
+			GetSecretsFunc: func(namespace, imageName string) ([]string, error) {
+				return nil, nil
+			},
+		},
+	}
+
+	_, err := reconciler.Reconcile(ctx, ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: dgd.Name, Namespace: dgd.Namespace},
+	})
+	require.ErrorContains(t, err, "transient PodClique API error")
+	require.True(t, podCliqueGetCalled, "expected reconciliation to reach Grove PodClique readiness")
+
+	stored := &v1beta1.DynamoGraphDeployment{}
+	require.NoError(t, fakeKubeClient.Get(ctx, client.ObjectKeyFromObject(dgd), stored))
+	assert.Equal(t, wantComponents, stored.Status.Components)
+	assert.Equal(t, wantRestart, stored.Status.Restart)
+	ready := meta.FindStatusCondition(stored.Status.Conditions, "Ready")
+	require.NotNil(t, ready)
+	assert.Equal(t, "failed_to_reconcile_the_resources", ready.Reason)
 }
 
 func TestDynamoGraphDeploymentReconciler_reconcileGMSResourceClaimTemplates_ToleratesNonGMSComponents(t *testing.T) {
@@ -2271,7 +2360,29 @@ func Test_reconcileGroveResources(t *testing.T) {
 		draEnabled             bool
 		wantReconcileResult    ReconcileResult
 		wantErrSubstring       string
+		interceptorFuncs       interceptor.Funcs
 	}{
+		{
+			name: "PodClique API error is propagated",
+			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
+				BackendFramework: "vllm",
+				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+					"frontend": {
+						ComponentType: string(commonconsts.ComponentTypeFrontend),
+						Replicas:      ptr.To(int32(1)),
+					},
+				},
+			},
+			wantErrSubstring: "transient API error",
+			interceptorFuncs: interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*grovev1alpha1.PodClique); ok {
+						return fmt.Errorf("transient API error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+		},
 		{
 			name: "singular frontend service with 2 replicas - creates a PodClique with 2 replicas - ready",
 			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
@@ -2555,6 +2666,7 @@ func Test_reconcileGroveResources(t *testing.T) {
 				WithScheme(s).
 				WithObjects(objects...).
 				WithStatusSubresource(objects...).
+				WithInterceptorFuncs(tt.interceptorFuncs).
 				Build()
 
 			recorder := record.NewFakeRecorder(100)

--- a/deploy/operator/internal/dynamo/grove.go
+++ b/deploy/operator/internal/dynamo/grove.go
@@ -79,7 +79,7 @@ func (d *GroveMultinodeDeployer) GetHostNames(serviceName string, numberOfNodes 
 // and returns the replica statuses for each component.
 // - PodCliques: spec.replicas == status.readyReplicas
 // - PodCliqueScalingGroups: spec.replicas == status.availableReplicas
-func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client client.Client, dgd *v1beta1.DynamoGraphDeployment) (bool, string, map[string]v1beta1.ComponentReplicaStatus) {
+func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client client.Client, dgd *v1beta1.DynamoGraphDeployment) (bool, string, map[string]v1beta1.ComponentReplicaStatus, error) {
 	logger := log.FromContext(ctx)
 	var notReadyComponents []string
 
@@ -92,13 +92,19 @@ func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client 
 		resourceName := fmt.Sprintf("%s-0-%s", PCSNameForDGD(dgd.Name, dgd.Spec.Components), strings.ToLower(componentName))
 
 		if usesPCSG {
-			ok, reason, componentStatus := CheckPCSGReady(ctx, client, resourceName, dgd.Namespace, logger)
+			ok, reason, componentStatus, err := CheckPCSGReady(ctx, client, resourceName, dgd.Namespace, logger)
+			if err != nil {
+				return false, "", nil, fmt.Errorf("failed to check component %q (pcsg/%s): %w", componentName, resourceName, err)
+			}
 			componentStatuses[componentName] = componentStatus
 			if !ok {
 				notReadyComponents = append(notReadyComponents, fmt.Sprintf("pcsg/%s: %s", resourceName, reason))
 			}
 		} else {
-			ok, reason, componentStatus := CheckPodCliqueReady(ctx, client, resourceName, dgd.Namespace, logger)
+			ok, reason, componentStatus, err := CheckPodCliqueReady(ctx, client, resourceName, dgd.Namespace, logger)
+			if err != nil {
+				return false, "", nil, fmt.Errorf("failed to check component %q (podclique/%s): %w", componentName, resourceName, err)
+			}
 			componentStatuses[componentName] = componentStatus
 			if !ok {
 				notReadyComponents = append(notReadyComponents, fmt.Sprintf("podclique/%s: %s", resourceName, reason))
@@ -107,26 +113,30 @@ func GetComponentReadinessAndServiceReplicaStatuses(ctx context.Context, client 
 	}
 
 	if len(notReadyComponents) > 0 {
-		return false, strings.Join(notReadyComponents, "; "), componentStatuses
+		return false, strings.Join(notReadyComponents, "; "), componentStatuses, nil
 	}
 
-	return true, "", componentStatuses
+	return true, "", componentStatuses, nil
 }
 
 // CheckPodCliqueReady determines if a Grove PodClique is fully ready and available.
 // It checks various status fields to ensure all replicas are available and the PodClique
 // configuration has been fully applied. This is the PodClique equivalent of IsDeploymentReady
 // for standard Kubernetes Deployments.
-func CheckPodCliqueReady(ctx context.Context, client client.Client, resourceName, namespace string, logger logr.Logger) (bool, string, v1beta1.ComponentReplicaStatus) {
+func CheckPodCliqueReady(ctx context.Context, client client.Client, resourceName, namespace string, logger logr.Logger) (bool, string, v1beta1.ComponentReplicaStatus, error) {
+	serviceStatus := v1beta1.ComponentReplicaStatus{
+		ComponentKind:  v1beta1.ComponentKindPodClique,
+		ComponentNames: []string{resourceName},
+	}
+
 	podClique := &grovev1alpha1.PodClique{}
 	err := client.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: namespace}, podClique)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(2).Info("PodClique not found", "resourceName", resourceName)
-			return false, "resource not found", v1beta1.ComponentReplicaStatus{}
+			return false, "resource not found", serviceStatus, nil
 		}
-		logger.V(1).Info("Failed to get PodClique", "error", err, "resourceName", resourceName)
-		return false, fmt.Sprintf("get error: %v", err), v1beta1.ComponentReplicaStatus{}
+		return false, "", v1beta1.ComponentReplicaStatus{}, fmt.Errorf("failed to get PodClique %s/%s: %w", namespace, resourceName, err)
 	}
 
 	desiredReplicas := podClique.Spec.Replicas
@@ -146,60 +156,60 @@ func CheckPodCliqueReady(ctx context.Context, client client.Client, resourceName
 		"replicas", replicas,
 	)
 
-	serviceStatus := v1beta1.ComponentReplicaStatus{
-		ComponentKind:   v1beta1.ComponentKindPodClique,
-		ComponentNames:  []string{resourceName},
-		Replicas:        podClique.Status.Replicas,
-		UpdatedReplicas: podClique.Status.UpdatedReplicas,
-		ReadyReplicas:   &readyReplicas,
-	}
+	serviceStatus.Replicas = podClique.Status.Replicas
+	serviceStatus.UpdatedReplicas = podClique.Status.UpdatedReplicas
+	serviceStatus.ReadyReplicas = &readyReplicas
 
 	if observedGeneration == nil {
 		logger.V(1).Info("PodClique observedGeneration is nil", "resourceName", resourceName)
-		return false, "observedGeneration is nil", serviceStatus
+		return false, "observedGeneration is nil", serviceStatus, nil
 	}
 
 	if observedGeneration != nil && *observedGeneration < generation {
 		logger.V(1).Info("PodClique spec not yet processed", "resourceName", resourceName, "generation", generation, "observedGeneration", observedGeneration)
-		return false, fmt.Sprintf("spec not yet processed: generation=%d, observedGeneration=%d", generation, *observedGeneration), serviceStatus
+		return false, fmt.Sprintf("spec not yet processed: generation=%d, observedGeneration=%d", generation, *observedGeneration), serviceStatus, nil
 	}
 
 	if desiredReplicas == 0 {
-		return true, "", serviceStatus
+		return true, "", serviceStatus, nil
 	}
 
 	if desiredReplicas != readyReplicas {
 		logger.V(1).Info("PodClique not ready", "resourceName", resourceName, "desired", desiredReplicas, "ready", readyReplicas)
-		return false, fmt.Sprintf("desired=%d, ready=%d", desiredReplicas, readyReplicas), serviceStatus
+		return false, fmt.Sprintf("desired=%d, ready=%d", desiredReplicas, readyReplicas), serviceStatus, nil
 	}
 
 	if desiredReplicas != updatedReplicas {
 		logger.V(1).Info("PodClique not fully updated", "resourceName", resourceName, "desired", desiredReplicas, "updated", updatedReplicas)
-		return false, fmt.Sprintf("desired=%d, updated=%d", desiredReplicas, updatedReplicas), serviceStatus
+		return false, fmt.Sprintf("desired=%d, updated=%d", desiredReplicas, updatedReplicas), serviceStatus, nil
 	}
 
 	if replicas != desiredReplicas {
 		logger.V(1).Info("PodClique performing rolling update", "resourceName", resourceName, "desired", desiredReplicas, "replicas", replicas)
-		return false, fmt.Sprintf("performing rolling update: desired=%d, replicas=%d", desiredReplicas, replicas), serviceStatus
+		return false, fmt.Sprintf("performing rolling update: desired=%d, replicas=%d", desiredReplicas, replicas), serviceStatus, nil
 	}
 
-	return true, "", serviceStatus
+	return true, "", serviceStatus, nil
 }
 
 // CheckPCSGReady determines if a Grove PodCliqueScalingGroup is fully ready and available.
 // It checks various status fields to ensure all replicas are available and the PodClique
 // configuration has been fully applied. This is the PodCliqueScalingGroup equivalent of IsDeploymentReady
 // for standard Kubernetes Deployments.
-func CheckPCSGReady(ctx context.Context, client client.Client, resourceName, namespace string, logger logr.Logger) (bool, string, v1beta1.ComponentReplicaStatus) {
+func CheckPCSGReady(ctx context.Context, client client.Client, resourceName, namespace string, logger logr.Logger) (bool, string, v1beta1.ComponentReplicaStatus, error) {
+	serviceStatus := v1beta1.ComponentReplicaStatus{
+		ComponentKind:  v1beta1.ComponentKindPodCliqueScalingGroup,
+		ComponentNames: []string{resourceName},
+	}
+
 	pcsg := &grovev1alpha1.PodCliqueScalingGroup{}
 	err := client.Get(ctx, types.NamespacedName{Name: resourceName, Namespace: namespace}, pcsg)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.V(2).Info("PodCliqueScalingGroup not found", "resourceName", resourceName)
-			return false, "resource not found", v1beta1.ComponentReplicaStatus{}
+			return false, "resource not found", serviceStatus, nil
 		}
-		logger.V(1).Info("Failed to get PodCliqueScalingGroup", "error", err, "resourceName", resourceName)
-		return false, fmt.Sprintf("get error: %v", err), v1beta1.ComponentReplicaStatus{}
+		return false, "", v1beta1.ComponentReplicaStatus{}, fmt.Errorf("failed to get PodCliqueScalingGroup %s/%s: %w", namespace, resourceName, err)
 	}
 
 	desiredReplicas := pcsg.Spec.Replicas
@@ -219,45 +229,41 @@ func CheckPCSGReady(ctx context.Context, client client.Client, resourceName, nam
 		"replicas", replicas,
 	)
 
-	serviceStatus := v1beta1.ComponentReplicaStatus{
-		ComponentKind:     v1beta1.ComponentKindPodCliqueScalingGroup,
-		ComponentNames:    []string{resourceName},
-		Replicas:          pcsg.Status.Replicas,
-		UpdatedReplicas:   pcsg.Status.UpdatedReplicas,
-		AvailableReplicas: &availableReplicas,
-	}
+	serviceStatus.Replicas = pcsg.Status.Replicas
+	serviceStatus.UpdatedReplicas = pcsg.Status.UpdatedReplicas
+	serviceStatus.AvailableReplicas = &availableReplicas
 
 	if observedGeneration == nil {
 		logger.V(1).Info("PodCliqueScalingGroup observedGeneration is nil", "resourceName", resourceName)
-		return false, "observedGeneration is nil", serviceStatus
+		return false, "observedGeneration is nil", serviceStatus, nil
 	}
 
 	if observedGeneration != nil && *observedGeneration < generation {
 		logger.V(1).Info("PodCliqueScalingGroup spec not yet processed", "resourceName", resourceName, "generation", generation, "observedGeneration", observedGeneration)
-		return false, fmt.Sprintf("spec not yet processed: generation=%d, observedGeneration=%d", generation, *observedGeneration), serviceStatus
+		return false, fmt.Sprintf("spec not yet processed: generation=%d, observedGeneration=%d", generation, *observedGeneration), serviceStatus, nil
 	}
 
 	if desiredReplicas == 0 {
 		// No replicas desired, so it's ready
-		return true, "", serviceStatus
+		return true, "", serviceStatus, nil
 	}
 
 	if desiredReplicas != availableReplicas {
 		logger.V(1).Info("PodCliqueScalingGroup not ready", "resourceName", resourceName, "desired", desiredReplicas, "available", availableReplicas)
-		return false, fmt.Sprintf("desired=%d, available=%d", desiredReplicas, availableReplicas), serviceStatus
+		return false, fmt.Sprintf("desired=%d, available=%d", desiredReplicas, availableReplicas), serviceStatus, nil
 	}
 
 	if desiredReplicas != updatedReplicas {
 		logger.V(1).Info("PodCliqueScalingGroup not fully updated", "resourceName", resourceName, "desired", desiredReplicas, "updated", updatedReplicas)
-		return false, fmt.Sprintf("desired=%d, updated=%d", desiredReplicas, updatedReplicas), serviceStatus
+		return false, fmt.Sprintf("desired=%d, updated=%d", desiredReplicas, updatedReplicas), serviceStatus, nil
 	}
 
 	if replicas != desiredReplicas {
 		logger.V(1).Info("PodCliqueScalingGroup performing rolling update", "resourceName", resourceName, "desired", desiredReplicas, "replicas", replicas)
-		return false, fmt.Sprintf("performing rolling update: desired=%d, replicas=%d", desiredReplicas, replicas), serviceStatus
+		return false, fmt.Sprintf("performing rolling update: desired=%d, replicas=%d", desiredReplicas, replicas), serviceStatus, nil
 	}
 
-	return true, "", serviceStatus
+	return true, "", serviceStatus, nil
 }
 
 // specToGroveTopologyConstraint converts a deployment-level SpecTopologyConstraint

--- a/deploy/operator/internal/dynamo/grove_test.go
+++ b/deploy/operator/internal/dynamo/grove_test.go
@@ -2,6 +2,7 @@ package dynamo
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -21,6 +22,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
@@ -28,6 +30,83 @@ func init() {
 	if err := v1beta1.AddToScheme(scheme.Scheme); err != nil {
 		panic(err)
 	}
+}
+
+func TestGetComponentReadinessAndServiceReplicaStatusesGetErrorDiscardsPartialStatuses(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	getErr := errors.New("transient API error")
+	dgd := &v1beta1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dgd",
+			Namespace: "default",
+		},
+		Spec: v1beta1.DynamoGraphDeploymentSpec{
+			Components: []v1beta1.DynamoComponentDeploymentSharedSpec{
+				{
+					ComponentName: "ready",
+					Replicas:      ptr.To(int32(1)),
+				},
+				{
+					ComponentName: "broken",
+					Replicas:      ptr.To(int32(1)),
+					Multinode: &v1beta1.MultinodeSpec{
+						NodeCount: 2,
+					},
+				},
+			},
+		},
+	}
+	readyPodClique := &grovev1alpha1.PodClique{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-dgd-0-ready",
+			Namespace:  "default",
+			Generation: 1,
+		},
+		Spec: grovev1alpha1.PodCliqueSpec{
+			Replicas: 1,
+		},
+		Status: grovev1alpha1.PodCliqueStatus{
+			Replicas:           1,
+			ReadyReplicas:      1,
+			UpdatedReplicas:    1,
+			ObservedGeneration: ptr.To(int64(1)),
+		},
+	}
+
+	s := runtime.NewScheme()
+	g.Expect(v1beta1.AddToScheme(s)).To(gomega.Succeed())
+	g.Expect(grovev1alpha1.AddToScheme(s)).To(gomega.Succeed())
+	successfulPodCliqueGets := 0
+	fakeKubeClient := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(readyPodClique).
+		WithStatusSubresource(readyPodClique).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+				if _, ok := obj.(*grovev1alpha1.PodCliqueScalingGroup); ok {
+					return getErr
+				}
+				if _, ok := obj.(*grovev1alpha1.PodClique); ok {
+					successfulPodCliqueGets++
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	ready, reason, serviceStatuses, err := GetComponentReadinessAndServiceReplicaStatuses(
+		context.Background(),
+		fakeKubeClient,
+		dgd,
+	)
+
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(errors.Is(err, getErr)).To(gomega.BeTrue())
+	g.Expect(err.Error()).To(gomega.ContainSubstring(`component "broken" (pcsg/test-dgd-0-broken)`))
+	g.Expect(successfulPodCliqueGets).To(gomega.Equal(1))
+	g.Expect(ready).To(gomega.BeFalse())
+	g.Expect(reason).To(gomega.BeEmpty())
+	g.Expect(serviceStatuses).To(gomega.BeNil())
 }
 
 func TestResolveKaiSchedulerQueueName(t *testing.T) {
@@ -344,7 +423,10 @@ func TestCheckPodCliqueReady(t *testing.T) {
 			namespace:          "default",
 			wantReady:          false,
 			wantReasonContains: "resource not found",
-			wantServiceStatus:  v1beta1.ComponentReplicaStatus{},
+			wantServiceStatus: v1beta1.ComponentReplicaStatus{
+				ComponentKind:  v1beta1.ComponentKindPodClique,
+				ComponentNames: []string{"missing-podclique"},
+			},
 		},
 		{
 			name:         "PodClique fully ready",
@@ -578,8 +660,9 @@ func TestCheckPodCliqueReady(t *testing.T) {
 				Build()
 
 			logger := log.FromContext(ctx)
-			ready, reason, serviceStatus := CheckPodCliqueReady(ctx, fakeKubeClient, tt.resourceName, tt.namespace, logger)
+			ready, reason, serviceStatus, err := CheckPodCliqueReady(ctx, fakeKubeClient, tt.resourceName, tt.namespace, logger)
 
+			g.Expect(err).NotTo(gomega.HaveOccurred())
 			g.Expect(ready).To(gomega.Equal(tt.wantReady))
 			if tt.wantReasonContains != "" {
 				g.Expect(reason).To(gomega.ContainSubstring(tt.wantReasonContains))
@@ -589,6 +672,34 @@ func TestCheckPodCliqueReady(t *testing.T) {
 			g.Expect(serviceStatus).To(gomega.Equal(tt.wantServiceStatus))
 		})
 	}
+}
+
+func TestCheckPodCliqueReadyGetError(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	getErr := errors.New("transient API error")
+	fakeKubeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return getErr
+			},
+		}).
+		Build()
+
+	ready, reason, serviceStatus, err := CheckPodCliqueReady(
+		context.Background(),
+		fakeKubeClient,
+		"test-podclique",
+		"default",
+		log.FromContext(context.Background()),
+	)
+
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(errors.Is(err, getErr)).To(gomega.BeTrue())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("PodClique default/test-podclique"))
+	g.Expect(ready).To(gomega.BeFalse())
+	g.Expect(reason).To(gomega.BeEmpty())
+	g.Expect(serviceStatus).To(gomega.Equal(v1beta1.ComponentReplicaStatus{}))
 }
 
 func TestCheckPCSGReady(t *testing.T) {
@@ -609,7 +720,10 @@ func TestCheckPCSGReady(t *testing.T) {
 			namespace:          "default",
 			wantReady:          false,
 			wantReasonContains: "resource not found",
-			wantServiceStatus:  v1beta1.ComponentReplicaStatus{},
+			wantServiceStatus: v1beta1.ComponentReplicaStatus{
+				ComponentKind:  v1beta1.ComponentKindPodCliqueScalingGroup,
+				ComponentNames: []string{"missing-pcsg"},
+			},
 		},
 		{
 			name:         "PCSG fully ready",
@@ -843,8 +957,9 @@ func TestCheckPCSGReady(t *testing.T) {
 				Build()
 
 			logger := log.FromContext(ctx)
-			ready, reason, serviceStatus := CheckPCSGReady(ctx, fakeKubeClient, tt.resourceName, tt.namespace, logger)
+			ready, reason, serviceStatus, err := CheckPCSGReady(ctx, fakeKubeClient, tt.resourceName, tt.namespace, logger)
 
+			g.Expect(err).NotTo(gomega.HaveOccurred())
 			g.Expect(ready).To(gomega.Equal(tt.wantReady))
 			if tt.wantReasonContains != "" {
 				g.Expect(reason).To(gomega.ContainSubstring(tt.wantReasonContains))
@@ -854,6 +969,34 @@ func TestCheckPCSGReady(t *testing.T) {
 			g.Expect(serviceStatus).To(gomega.Equal(tt.wantServiceStatus))
 		})
 	}
+}
+
+func TestCheckPCSGReadyGetError(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	getErr := errors.New("transient API error")
+	fakeKubeClient := fake.NewClientBuilder().
+		WithScheme(scheme.Scheme).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(_ context.Context, _ client.WithWatch, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return getErr
+			},
+		}).
+		Build()
+
+	ready, reason, serviceStatus, err := CheckPCSGReady(
+		context.Background(),
+		fakeKubeClient,
+		"test-pcsg",
+		"default",
+		log.FromContext(context.Background()),
+	)
+
+	g.Expect(err).To(gomega.HaveOccurred())
+	g.Expect(errors.Is(err, getErr)).To(gomega.BeTrue())
+	g.Expect(err.Error()).To(gomega.ContainSubstring("PodCliqueScalingGroup default/test-pcsg"))
+	g.Expect(ready).To(gomega.BeFalse())
+	g.Expect(reason).To(gomega.BeEmpty())
+	g.Expect(serviceStatus).To(gomega.Equal(v1beta1.ComponentReplicaStatus{}))
 }
 
 func Test_GetComponentReadinessAndServiceReplicaStatuses(t *testing.T) {
@@ -1146,7 +1289,35 @@ func Test_GetComponentReadinessAndServiceReplicaStatuses(t *testing.T) {
 			wantReady:              false,
 			wantReason:             "podclique/test-dgd-0-frontend: resource not found",
 			wantServiceStatuses: map[string]v1beta1.ComponentReplicaStatus{
-				"frontend": {},
+				"frontend": {
+					ComponentKind:  v1beta1.ComponentKindPodClique,
+					ComponentNames: []string{"test-dgd-0-frontend"},
+				},
+			},
+		},
+		{
+			name: "service resource not found - PCSG missing",
+			dgdSpec: v1alpha1.DynamoGraphDeploymentSpec{
+				Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+					"worker": {
+						ServiceName:     "worker",
+						DynamoNamespace: ptr.To("default"),
+						ComponentType:   string(commonconsts.ComponentTypeWorker),
+						Replicas:        ptr.To(int32(1)),
+						Multinode: &v1alpha1.MultinodeSpec{
+							NodeCount: 2,
+						},
+					},
+				},
+			},
+			existingGroveResources: []client.Object{},
+			wantReady:              false,
+			wantReason:             "pcsg/test-dgd-0-worker: resource not found",
+			wantServiceStatuses: map[string]v1beta1.ComponentReplicaStatus{
+				"worker": {
+					ComponentKind:  v1beta1.ComponentKindPodCliqueScalingGroup,
+					ComponentNames: []string{"test-dgd-0-worker"},
+				},
 			},
 		},
 	}
@@ -1180,8 +1351,9 @@ func Test_GetComponentReadinessAndServiceReplicaStatuses(t *testing.T) {
 				WithStatusSubresource(objects...).
 				Build()
 
-			ready, reason, serviceStatuses := GetComponentReadinessAndServiceReplicaStatuses(ctx, fakeKubeClient, betaDGD)
+			ready, reason, serviceStatuses, err := GetComponentReadinessAndServiceReplicaStatuses(ctx, fakeKubeClient, betaDGD)
 
+			g.Expect(err).NotTo(gomega.HaveOccurred())
 			g.Expect(ready).To(gomega.Equal(tt.wantReady))
 			g.Expect(reason).To(gomega.Equal(tt.wantReason))
 			g.Expect(serviceStatuses).To(gomega.Equal(tt.wantServiceStatuses))


### PR DESCRIPTION
## Summary

- represent a not-yet-created Grove child with its statically known component kind and resource name
- propagate non-NotFound PodClique and PodCliqueScalingGroup read errors so controller-runtime retries without replacing last-known component status
- add direct, aggregate, and top-level reconciliation regression coverage

## Overview

Initial Grove-backed DGD reconciliation can observe PodClique or
PodCliqueScalingGroup children before Grove creates them. Those normal
`NotFound` responses previously produced a zero-value
`ComponentReplicaStatus`, causing the API server to reject
`componentKind: ""`.

## Details

- `NotFound` remains a normal pending state and reports a schema-valid kind/name status.
- Other child GET failures return wrapped errors instead of zero-count replacement status.
- Aggregate status collection discards partial results and returns a nil map on errors.
- The DGD reconciler propagates those errors and preserves existing component/restart status while recording the failed reconciliation condition.

## Where should the reviewer start?

1. `deploy/operator/internal/dynamo/grove.go` for `NotFound` versus API-error semantics.
2. `deploy/operator/internal/controller/dynamographdeployment_controller.go` for error propagation and last-known status preservation.
3. The corresponding `*_test.go` files for direct, aggregate, and top-level regression coverage.

## Related Issues

None; this PR addresses the reported 1.3.0 RC.2 Grove status-write failure directly.

## Validation

- Reproduced on the `release/1.3.0` source platform chart with bundled Grove/KAI and `kubernetes-operator:1.3.0-rc.2`: 14 rejected `componentKind: Unsupported value: ""` status updates in a 20-second window.
- Rebased commit `03381f4d3` onto `main` and passed:
  - focused missing-child and transient-API-error tests
  - `go test ./internal/dynamo ./internal/controller -count=1`
  - Kubernetes 1.30 non-e2e envtest suite with `KUBECONFIG=/dev/null`: all 31 selected packages passed or had no test files
  - `git diff --check` and gofmt validation
- Built and deployed the equivalent pre-rebase `NotFound` fix in an isolated nscale vCluster. Repeating the DGD create window produced 0 invalid `componentKind` errors and valid status entries.
- Validation pods were pinned to a known non-DRA node and remained unscheduled; no DRA/GPU node was used.
