### PR TITLE
fix(router): dispatch ready requests behind blocked queue heads

### DIFF
--- a/docs/design-docs/request-level-dispatch-policies.md
+++ b/docs/design-docs/request-level-dispatch-policies.md
@@ -1,0 +1,67 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Request-Level Dispatch Policies
+subtitle: Holding and selecting individual requests in the KV router policy queue
+---
+
+The NVIDIA Dynamo KV router makes dispatch decisions on queued requests. A session-aware policy can retain private state across turns, but each dispatch decision still resolves to one active request.
+
+## Request-Level Mechanism
+
+The policy queue keeps one priority heap per policy class. Deficit Round Robin (DRR) chooses a class, while the class heap chooses its highest-priority dispatchable request.
+
+```mermaid
+flowchart LR
+    A["Tokenized request"] --> C["Policy class"]
+    C --> Q["Existing request heap"]
+    Q --> D{"Dispatchable now?"}
+    D -- Yes --> W["Existing worker selector"]
+    D -- No --> H["Remain held in the same heap"]
+    H --> Q
+```
+
+The dispatch predicate evaluates current worker eligibility and load. When a class head is blocked, the queue may dispatch the next highest-priority request in that class. The blocked request remains in its original heap with its original priority and queue accounting.
+
+This fallback preserves the existing fast path:
+
+- When no class head is blocked, the existing head-only heap and DRR path runs without heap mutation or allocation.
+- A blocked head triggers a scan only until the first dispatchable request in that class is exposed.
+- A class with no dispatchable request retains its DRR deficit.
+- Queue depth and token counters continue to include held requests.
+
+The queue does not create a second admission layer or a session queue.
+
+## Session-Stateful Policies
+
+A sequential agent session has at most one active Dynamo request. The request represents that session while it is queued or running. A policy-specific session table is needed only to retain information across the gap between requests.
+
+```mermaid
+stateDiagram-v2
+    [*] --> IdleState: previous request completed
+    IdleState --> Request: next request carries session_id
+    Request --> Held: policy returns hold
+    Held --> Request: policy state changes
+    Request --> Running: policy returns dispatch
+    Running --> IdleState: request completes
+    Running --> [*]: final request completes
+```
+
+Parallel branches use distinct session IDs. A parent session ID can preserve the relationship without introducing concurrent requests under one scheduling identity.
+
+## Future AgentAware Policy
+
+AgentAware routing is not implemented by this mechanism. A future implementation can keep its algorithm in a private module and use the request-level queue through four lifecycle points:
+
+| Lifecycle point | Policy responsibility | Existing router effect |
+| --- | --- | --- |
+| Request arrival | Read session state and choose hold, priority, and an optional worker pin | Populate the queued request |
+| Dispatch check | Decide whether the active request can run now | Return through the queue's dispatch predicate |
+| Request completion | Reconcile generated tokens and retain between-turn state | Update the private session table |
+| Final completion | Release the session record | Remove private policy state |
+
+Admission failures must roll back provisional session changes. Successful placement must commit only after worker selection and scheduler booking succeed.
+
+The initial algorithm may follow the [ThunderAgent paper](https://arxiv.org/abs/2602.13692) and Dynamo's [ThunderAgent Program Scheduler](../agents/thunderagent-router.md). Pressure thresholds, working-set accounting, pause and resume selection, decay, timeout behavior, and backend capacity inputs belong to that implementation, not to the generic queue.
+
+No AgentAware configuration is exposed until an algorithm implements this contract.

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -511,6 +511,8 @@ navigation:
             contents:
               - page: Router Design
                 path: design-docs/router-design.md
+              - page: Request-Level Dispatch Policies
+                path: design-docs/request-level-dispatch-policies.md
               - page: KVBM Design
                 path: design-docs/kvbm-design.md
               - page: Planner Design

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -141,7 +141,8 @@ pub struct PolicyQueue<T> {
     next_class: usize,
     next_enqueue_seq: u64,
     pending_count: usize,
-    dispatchable: Vec<bool>,
+    dispatchable_costs: Vec<Option<usize>>,
+    dispatchable_entries: Vec<Option<u64>>,
 }
 
 impl<T> PolicyQueue<T> {
@@ -162,7 +163,8 @@ impl<T> PolicyQueue<T> {
             next_class: 0,
             next_enqueue_seq: 0,
             pending_count: 0,
-            dispatchable: vec![false; class_count],
+            dispatchable_costs: vec![None; class_count],
+            dispatchable_entries: vec![None; class_count],
         }
     }
 
@@ -253,8 +255,10 @@ impl<T> PolicyQueue<T> {
         Ok(())
     }
 
-    /// Runs one DRR ring pass over dispatchable class heads. If no head has
-    /// enough credit, bulk-adds the minimum complete rounds needed for progress.
+    /// Runs one DRR ring pass over the highest-priority dispatchable request in
+    /// each class. A ready heap head stays on the allocation-free fast path; a
+    /// blocked head triggers a class-local scan. If no candidate has enough
+    /// credit, bulk-adds the minimum complete rounds needed for progress.
     pub fn pop_next(
         &mut self,
         mut is_dispatchable: impl FnMut(usize, &PolicyClassConfig, &T) -> bool,
@@ -264,56 +268,75 @@ impl<T> PolicyQueue<T> {
         }
 
         let class_count = self.classes.len();
-        self.dispatchable.fill(false);
+        self.dispatchable_costs.fill(None);
+        self.dispatchable_entries.fill(None);
         for offset in 0..class_count {
             // Rotate the starting point across calls so class vector order
             // cannot become a permanent scheduling preference.
             let class_index = (self.next_class + offset) % class_count;
-            let class = &mut self.classes[class_index];
-            let Some(front) = class.pending.peek() else {
-                class.deficit = 0;
+            let candidate = {
+                let class = &mut self.classes[class_index];
+                let Some(front) = class.pending.peek() else {
+                    class.deficit = 0;
+                    continue;
+                };
+                if is_dispatchable(class_index, &class.config, front.payload()) {
+                    Some((front.snapshot.scheduling_cost_tokens, front.enqueue_seq))
+                } else {
+                    class
+                        .pending
+                        .iter()
+                        .filter(|entry| {
+                            is_dispatchable(class_index, &class.config, entry.payload())
+                        })
+                        .max()
+                        .map(|entry| (entry.snapshot.scheduling_cost_tokens, entry.enqueue_seq))
+                }
+            };
+            let Some((cost, enqueue_seq)) = candidate else {
+                // A blocked class retains earned credit but does not accrue
+                // more until one of its requests becomes dispatchable.
                 continue;
             };
-            if !is_dispatchable(class_index, &class.config, front.payload()) {
-                // A blocked class retains earned credit but does not accrue
-                // more until its head becomes dispatchable.
-                continue;
-            }
-
-            self.dispatchable[class_index] = true;
-            if front.snapshot.scheduling_cost_tokens <= class.deficit {
-                // Quantum is granted per ring round, not per request. Spend
-                // carried credit before granting this class another quantum.
-                return Some(self.pop_class(class_index));
-            }
-            class.deficit = class.deficit.saturating_add(class.config.quantum);
-            if front.snapshot.scheduling_cost_tokens <= class.deficit {
-                // The normal single-round visit made this head affordable.
-                return Some(self.pop_class(class_index));
+            self.dispatchable_entries[class_index] = Some(enqueue_seq);
+            if self.visit_class(class_index, cost) {
+                return Some(self.pop_class_candidate(class_index));
             }
         }
 
+        self.finish_round()
+            .map(|class_index| self.pop_class_candidate(class_index))
+    }
+
+    fn visit_class(&mut self, class_index: usize, cost: usize) -> bool {
+        self.dispatchable_costs[class_index] = Some(cost);
+        let class = &mut self.classes[class_index];
+        if cost <= class.deficit {
+            // Spend carried credit before granting this class another quantum.
+            return true;
+        }
+        class.deficit = class.deficit.saturating_add(class.config.quantum);
+        cost <= class.deficit
+    }
+
+    fn finish_round(&mut self) -> Option<usize> {
         // Fast-forward the minimum number of complete virtual rounds needed
-        // for any dispatchable head to progress, avoiding repeated ring scans
-        // for requests much larger than their class quantum. If every head was
-        // blocked, `min()` returns `None` without changing any deficit.
+        // for any dispatchable request to progress. If all are blocked,
+        // `min()` returns `None` without changing any deficit.
         let rounds = self
-            .dispatchable
+            .dispatchable_costs
             .iter()
             .enumerate()
-            .filter_map(|(class_index, dispatchable)| {
-                if !dispatchable {
-                    return None;
-                }
+            .filter_map(|(class_index, cost)| {
+                let cost = (*cost)?;
                 let class = &self.classes[class_index];
-                let cost = class.pending.peek()?.snapshot.scheduling_cost_tokens;
                 let missing = cost.saturating_sub(class.deficit);
                 Some(missing.div_ceil(class.config.quantum))
             })
             .min()?;
 
-        for (class_index, dispatchable) in self.dispatchable.iter().copied().enumerate() {
-            if !dispatchable {
+        for (class_index, cost) in self.dispatchable_costs.iter().enumerate() {
+            if cost.is_none() {
                 continue;
             }
             let class = &mut self.classes[class_index];
@@ -324,20 +347,41 @@ impl<T> PolicyQueue<T> {
                 .saturating_add(class.config.quantum.saturating_mul(rounds));
         }
 
-        for offset in 0..class_count {
-            let class_index = (self.next_class + offset) % class_count;
-            let class = &self.classes[class_index];
-            if self.dispatchable[class_index]
-                && class
-                    .pending
-                    .peek()
-                    .is_some_and(|entry| entry.snapshot.scheduling_cost_tokens <= class.deficit)
-            {
-                return Some(self.pop_class(class_index));
-            }
+        let class_count = self.classes.len();
+        (0..class_count)
+            .map(|offset| (self.next_class + offset) % class_count)
+            .find(|&class_index| {
+                self.dispatchable_costs[class_index]
+                    .is_some_and(|cost| cost <= self.classes[class_index].deficit)
+            })
+    }
+
+    fn pop_class_candidate(&mut self, class_index: usize) -> PolicyQueueEntry<T> {
+        let enqueue_seq = self.dispatchable_entries[class_index]
+            .expect("selected policy class must have a dispatchable entry");
+        if self.classes[class_index]
+            .pending
+            .peek()
+            .is_some_and(|entry| entry.enqueue_seq == enqueue_seq)
+        {
+            return self.pop_class(class_index);
         }
 
-        None
+        let class = &mut self.classes[class_index];
+        let mut blocked = Vec::new();
+        let entry = loop {
+            let entry = class
+                .pending
+                .pop()
+                .expect("dispatchable policy class entry vanished");
+            if entry.enqueue_seq == enqueue_seq {
+                break entry;
+            }
+            blocked.push(entry);
+        };
+        class.pending.extend(blocked);
+        self.finish_pop(class_index, entry.snapshot);
+        entry
     }
 
     pub fn drain(self) -> impl Iterator<Item = PolicyQueueEntry<T>> {
@@ -347,19 +391,28 @@ impl<T> PolicyQueue<T> {
     }
 
     fn pop_class(&mut self, class_index: usize) -> PolicyQueueEntry<T> {
+        let entry = self.classes[class_index]
+            .pending
+            .pop()
+            .expect("policy class front vanished");
+        self.finish_pop(class_index, entry.snapshot);
+        entry
+    }
+
+    fn finish_pop(&mut self, class_index: usize, snapshot: QueueSnapshot) {
+        let class_count = self.classes.len();
         let class = &mut self.classes[class_index];
-        let entry = class.pending.pop().expect("policy class front vanished");
         class.deficit = class
             .deficit
-            .saturating_sub(entry.snapshot.scheduling_cost_tokens);
-        subtract_stats(&mut class.stats, entry.snapshot);
+            .saturating_sub(snapshot.scheduling_cost_tokens);
+        subtract_stats(&mut class.stats, snapshot);
         self.pending_count -= 1;
         // Empty classes discard stale credit. A class that can already afford
         // its next head keeps the cursor and spends its weighted burst;
         // otherwise the next call starts at the following class.
         if class.pending.is_empty() {
             class.deficit = 0;
-            self.next_class = (class_index + 1) % self.classes.len();
+            self.next_class = (class_index + 1) % class_count;
         } else if class
             .pending
             .peek()
@@ -367,9 +420,8 @@ impl<T> PolicyQueue<T> {
         {
             self.next_class = class_index;
         } else {
-            self.next_class = (class_index + 1) % self.classes.len();
+            self.next_class = (class_index + 1) % class_count;
         }
-        entry
     }
 }
 
@@ -496,6 +548,80 @@ policy_classes:
         assert_eq!(
             queue.pop_next(|_, _, _| true).unwrap().into_payload(),
             "keep"
+        );
+    }
+
+    #[test]
+    fn skipping_blocked_preserves_ready_priority_and_queue_accounting() {
+        let mut queue = PolicyQueue::new(profile(
+            r#"
+default_policy_family: default
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: default
+    policy_family: default
+    cache_bucket: all
+    quantum: 1
+"#,
+        ));
+        for (arrival, payload) in [(0.0, "blocked"), (1.0, "ready-1"), (2.0, "ready-2")] {
+            queue
+                .enqueue(0, 1, QueueSnapshot::new(1, 0), arrival, 0.0, 0, payload)
+                .unwrap();
+        }
+
+        assert_eq!(
+            queue
+                .pop_next(|_, _, payload| *payload != "blocked")
+                .unwrap()
+                .into_payload(),
+            "ready-1"
+        );
+        assert_eq!(queue.pending_count(), 2);
+        assert_eq!(queue.class_stats(0).requests, 2);
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "blocked"
+        );
+    }
+
+    #[test]
+    fn skipping_blocked_exposes_candidates_before_drr_selects_a_class() {
+        let mut queue = PolicyQueue::new(profile(
+            r#"
+default_policy_family: first
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: first
+    policy_family: first
+    cache_bucket: all
+    quantum: 1
+  - name: second
+    policy_family: second
+    cache_bucket: all
+    quantum: 1
+"#,
+        ));
+        for (class, arrival, payload) in [
+            (0, 0.0, "blocked"),
+            (0, 1.0, "first-ready"),
+            (1, 0.0, "second-ready"),
+        ] {
+            queue
+                .enqueue(class, 1, QueueSnapshot::new(1, 0), arrival, 0.0, 0, payload)
+                .unwrap();
+        }
+
+        assert_eq!(
+            queue
+                .pop_next(|_, _, payload| *payload != "blocked")
+                .unwrap()
+                .into_payload(),
+            "first-ready"
         );
     }
 

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -580,9 +580,6 @@ impl<
             let popped = {
                 let configs = self.workers_with_configs.borrow();
                 self.pending.pop_next(|_, class, queued| {
-                    // TODO: This preserves head-of-line blocking within each policy
-                    // class. A blocked constrained head can stall later entries in
-                    // that class until a bounded non-HOL strategy is introduced.
                     !Self::all_workers_prefill_busy_with(
                         &active_tokens,
                         &configs,
@@ -2302,7 +2299,7 @@ policy_classes:
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn test_pinned_head_blocks_class_backlog_despite_other_worker_capacity() {
+    async fn test_pinned_head_does_not_block_dispatchable_class_backlog() {
         let (queue, slots) = make_queue(2, 16, 256, Some(0.0));
 
         let (mut first, first_rx) = make_request("pinned-1", 256);
@@ -2326,11 +2323,12 @@ policy_classes:
 
         queue.update().await;
 
-        assert_eq!(queue.pending_count(), 2);
-        assert!(
-            unpinned_rx.try_recv().is_err(),
-            "unpinned request should remain queued behind the pinned head"
-        );
+        assert_eq!(queue.pending_count(), 1);
+        let unpinned_resp = unpinned_rx
+            .try_recv()
+            .expect("unpinned request should bypass the blocked pinned head");
+        let unpinned_resp = unpinned_resp.expect("scheduling returned error");
+        assert_eq!(unpinned_resp.best_worker, WorkerWithDpRank::new(0, 0));
         assert!(
             second_rx.try_recv().is_err(),
             "pinned request should still be queued"
@@ -2347,12 +2345,6 @@ policy_classes:
             .expect("pinned request should have been scheduled");
         let second_resp = second_resp.expect("scheduling returned error");
         assert_eq!(second_resp.best_worker, WorkerWithDpRank::new(1, 0));
-
-        let unpinned_resp = unpinned_rx
-            .try_recv()
-            .expect("unpinned request should have been scheduled");
-        let unpinned_resp = unpinned_resp.expect("scheduling returned error");
-        assert_eq!(unpinned_resp.best_worker, WorkerWithDpRank::new(0, 0));
         assert_eq!(queue.pending_count(), 0);
     }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
### Summary

Reworks the router change around the existing request-level policy queue: a blocked class head no longer prevents a lower-priority dispatchable request in the same class from using available worker capacity. This removes the prior AgentAware and ThunderAgent algorithm, configuration, lifecycle state, and backend-capacity dependency while leaving a narrow mechanism that a future session-aware policy can use.

### How This Was Implemented

- Keeps the existing heap-head path allocation-free and scans within a class only when its head is blocked.
- Records the selected request's queue sequence and DRR cost in preallocated per-class scratch state, preserving priority, deficit, queue counters, and the original request heap.
- Adds queue-level and live scheduler regressions for ready work behind blocked requests.
- Documents how a future AgentAware policy can reduce session state to request-level hold and dispatch decisions without adding a session queue.

### Before and After

| Scenario | Before | After |
|---|---|---|
| A pinned class head targets a busy worker while another worker can accept an unpinned request behind it | The entire class remains blocked | The unpinned request dispatches; the pinned request remains queued |

<details>
<summary>Walkthrough</summary>

#### Mental model

Policy classes and Deficit Round Robin (DRR) remain the outer scheduler. Within each class, the queue now selects the highest-priority request that is dispatchable under current worker eligibility and load.

```mermaid
flowchart LR
    A["Policy class heap"] --> H{"Head dispatchable?"}
    H -- Yes --> D["Existing head pop"]
    H -- No --> S["Find highest-priority ready request"]
    S --> D
    D --> W["Existing worker selector"]
```

#### State and ordering

Each class retains one `BinaryHeap`; no held or session-specific queue is added. A dispatchable head follows the original path. When the head is blocked, the queue scans that class, records the highest-priority dispatchable entry's enqueue sequence and scheduling cost, and lets the existing DRR accounting choose among classes.

If DRR selects an entry behind the head, the queue temporarily removes higher-priority blocked entries, pops the recorded entry, and restores the blocked entries. Queue depth and token counters include blocked requests throughout, and a class with no dispatchable request does not accrue more deficit.

#### Request lifecycle

The scheduler already passes a request-level dispatch predicate into `PolicyQueue::pop_next`. Worker constraints and current load produce that decision. The integration regression occupies one pinned worker, queues a second request pinned to the same worker, then queues an unpinned request; an update dispatches the unpinned request to the idle worker without releasing the blocked pin.

#### Boundaries and limitations

This PR does not expose AgentAware configuration or implement session working-set accounting, placement, pause/resume selection, decay, timeouts, completion-token reconciliation, or backend capacity inputs. The design page defines the future lifecycle contract and credits ThunderAgent, but policy-specific state remains deferred until an algorithm is implemented.

</details>

### Validation

- `cargo test -p dynamo-kv-router --lib` — 595 passed
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `pre-commit run --files docs/index.yml docs/design-docs/request-level-dispatch-policies.md lib/kv-router/src/scheduling/policy_queue.rs lib/kv-router/src/scheduling/queue.rs`
- `fern check` — 0 errors, 2 existing warnings
- `fern docs broken-links`
<!-- codex-pr-description:end -->
