### PR TITLE
fix(operator): reconcile DGDR through informer observations

### DIFF
--- a/deploy/operator/internal/controller/AGENTS.md
+++ b/deploy/operator/internal/controller/AGENTS.md
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reconciliation
+
+- Uncached API-server ("quorum") reads are most likely the wrong solution to informer-cache races.
+- Build level-driven reconcilers that tolerate stale cached state and converge from every observable state.
+- Watch every dependency whose create, update, or delete can unblock reconciliation. Let those events requeue the owning resource after changes become visible in the cache.
+- Treat a dependency that has not appeared in the cache yet as pending when its watch can drive progress; do not turn expected informer lag into a terminal failure.
+- After a successful write, either continue with the object returned by the client or wait for its watch event. Do not immediately read the write back through an uncached client.
+- Use durable status, conditions, or transaction markers when the reconciler must distinguish work that is pending from work that was previously observed and later deleted.
+- Use an uncached read only when a concrete correctness requirement cannot be represented with durable state and watches, and document that exception.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -823,7 +823,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	if err := r.removeGeneratedSpecAnnotation(ctx, dgdr); err != nil {
+	if err := r.clearGeneratedSpecAnnotation(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -1035,18 +1035,33 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	return ctrl.Result{}, nil
 }
 
-// removeGeneratedSpecAnnotation marks the DGD as observed in the informer cache.
-func (r *DynamoGraphDeploymentRequestReconciler) removeGeneratedSpecAnnotation(
+// clearGeneratedSpecAnnotation marks the DGD as observed in the informer cache.
+func (r *DynamoGraphDeploymentRequestReconciler) clearGeneratedSpecAnnotation(
 	ctx context.Context,
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
 ) error {
 	if dgdr.Annotations[AnnotationGeneratedDGDSpec] == "" {
 		return nil
 	}
-	delete(dgdr.Annotations, AnnotationGeneratedDGDSpec)
-	if err := r.Update(ctx, dgdr); err != nil {
-		return fmt.Errorf("failed to remove generated DGD annotation: %w", err)
+	annotations := map[string]any{AnnotationGeneratedDGDSpec: ""}
+	if additionalResources := dgdr.Annotations[AnnotationAdditionalResources]; additionalResources != "" {
+		annotations[AnnotationAdditionalResources] = additionalResources
 	}
+	apply := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": nvidiacomv1beta1.GroupVersion.String(),
+		"kind":       "DynamoGraphDeploymentRequest",
+		"metadata": map[string]any{
+			"name":            dgdr.Name,
+			"namespace":       dgdr.Namespace,
+			"resourceVersion": dgdr.ResourceVersion,
+			"annotations":     annotations,
+		},
+	}}
+	if err := r.Apply(ctx, client.ApplyConfigurationFromUnstructured(apply), client.FieldOwner("dynamo-operator-dgdr"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("failed to clear generated DGD annotation: %w", err)
+	}
+	dgdr.Annotations[AnnotationGeneratedDGDSpec] = ""
+	dgdr.ResourceVersion = apply.GetResourceVersion()
 	return nil
 }
 
@@ -1381,26 +1396,25 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		return true, nil
 	}
 
-	// Delete any existing output ConfigMap to ensure fresh profiling results
-	// This prevents using stale data from previous profiling runs
-	outputConfigMapName := getOutputConfigMapName(dgdr)
-	existingCM := &corev1.ConfigMap{}
-	err = r.Get(ctx, types.NamespacedName{
-		Name:      outputConfigMapName,
-		Namespace: dgdr.Namespace,
-	}, existingCM)
-	if err == nil {
-		// ConfigMap exists, delete it
-		logger.Info("Deleting existing output ConfigMap to ensure fresh profiling results", "configMap", outputConfigMapName)
-		if err := r.Delete(ctx, existingCM); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete existing output ConfigMap", "configMap", outputConfigMapName)
-			return false, fmt.Errorf("failed to delete existing output ConfigMap: %w", err)
+	// Delete stale output only before creating the profiling Job. Once the Job
+	// exists, the ConfigMap may contain fresh output from a fast profiler.
+	existingJob := &batchv1.Job{}
+	err = r.Get(ctx, types.NamespacedName{Name: getProfilingJobName(dgdr), Namespace: dgdr.Namespace}, existingJob)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to check for existing profiling Job: %w", err)
+	}
+	if apierrors.IsNotFound(err) {
+		outputConfigMapName := getOutputConfigMapName(dgdr)
+		existingCM := &corev1.ConfigMap{}
+		err = r.Get(ctx, types.NamespacedName{Name: outputConfigMapName, Namespace: dgdr.Namespace}, existingCM)
+		if err == nil {
+			logger.Info("Deleting existing output ConfigMap to ensure fresh profiling results", "configMap", outputConfigMapName)
+			if err := r.Delete(ctx, existingCM); err != nil && !apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("failed to delete existing output ConfigMap: %w", err)
+			}
+		} else if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to check for existing output ConfigMap: %w", err)
 		}
-		logger.Info("Successfully deleted old output ConfigMap", "configMap", outputConfigMapName)
-	} else if !apierrors.IsNotFound(err) {
-		// Unexpected error checking for ConfigMap
-		logger.Error(err, "Failed to check for existing output ConfigMap", "configMap", outputConfigMapName)
-		return false, fmt.Errorf("failed to check for existing output ConfigMap: %w", err)
 	}
 
 	// Ensure profiling job RBAC exists (only for cluster-wide installation)
@@ -2089,9 +2103,24 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	}
 	dgdr.Annotations[AnnotationGeneratedDGDSpec] = string(dgdYAML)
 
-	if err := r.Update(ctx, dgdr); err != nil {
+	annotations := map[string]any{AnnotationGeneratedDGDSpec: string(dgdYAML)}
+	if additionalResources := dgdr.Annotations[AnnotationAdditionalResources]; additionalResources != "" {
+		annotations[AnnotationAdditionalResources] = additionalResources
+	}
+	apply := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": nvidiacomv1beta1.GroupVersion.String(),
+		"kind":       "DynamoGraphDeploymentRequest",
+		"metadata": map[string]any{
+			"name":            dgdr.Name,
+			"namespace":       dgdr.Namespace,
+			"resourceVersion": dgdr.ResourceVersion,
+			"annotations":     annotations,
+		},
+	}}
+	if err := r.Apply(ctx, client.ApplyConfigurationFromUnstructured(apply), client.FieldOwner("dynamo-operator-dgdr"), client.ForceOwnership); err != nil {
 		return nil, "", fmt.Errorf("failed to persist generated DGDR annotations: %w", err)
 	}
+	dgdr.ResourceVersion = apply.GetResourceVersion()
 	return profilingResults, dgd.Name, nil
 }
 

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -139,6 +139,8 @@ const (
 	MessageModelCachePVCNotFound     = "model cache PVC %s not found in namespace %s"
 )
 
+var errProfilingOutputNotReady = errors.New("profiling output is not ready")
+
 // shell script template for the output copier sidecar.
 //
 // The sidecar is a continuous poller that:
@@ -421,16 +423,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) gpuDiscoveryReader() (client.Re
 	return r.APIReader, true
 }
 
-// authoritativeReader bypasses the informer cache when a read must observe a
-// write that causally preceded it. APIReader is configured in production; the
-// client fallback keeps unit tests and direct reconciler construction working.
-func (r *DynamoGraphDeploymentRequestReconciler) authoritativeReader() client.Reader {
-	if r.APIReader != nil {
-		return r.APIReader
-	}
-	return r.Client
-}
-
 // FinalizeResource implements commonController.Finalizer interface
 func (r *DynamoGraphDeploymentRequestReconciler) FinalizeResource(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) error {
 	logger := log.FromContext(ctx)
@@ -552,13 +544,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.
 	logger.Info("Handling pending phase", "name", dgdr.Name)
 
 	// Create profiling job (online or AIC)
-	requeue, err := r.createProfilingJob(ctx, dgdr)
+	waitForObservation, err := r.createProfilingJob(ctx, dgdr)
 	if err != nil {
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonProfilingJobFailed, err.Error())
 		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, MessageJobCreationFailed, err.Error())
 	}
-	if requeue {
-		// The successful DGDR update is watched and drives the next reconcile.
+	if waitForObservation {
+		// The successful write is watched and drives the next reconcile.
 		return ctrl.Result{}, nil
 	}
 
@@ -640,7 +632,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) checkProfilerFailureInConfigMap
 ) (bool, string, error) {
 	outputCMName := getOutputConfigMapName(dgdr)
 	cm := &corev1.ConfigMap{}
-	if err := r.authoritativeReader().Get(ctx, types.NamespacedName{
+	if err := r.Get(ctx, types.NamespacedName{
 		Name: outputCMName, Namespace: dgdr.Namespace,
 	}, cm); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -743,6 +735,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingPhase(ctx contex
 
 	profilingResults, dgdName, err := r.generateDGDSpec(ctx, dgdr)
 	if err != nil {
+		if errors.Is(err, errProfilingOutputNotReady) {
+			logger.Info("Waiting for profiling output ConfigMap", "name", dgdr.Name)
+			return ctrl.Result{}, nil
+		}
 		if apierrors.IsConflict(err) {
 			logger.Info("DGDR changed while persisting generated spec; retrying", "name", dgdr.Name)
 			return ctrl.Result{}, err
@@ -812,13 +808,16 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 	}
 
 	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
-	err := r.getDGD(ctx, types.NamespacedName{
+	err := r.Get(ctx, types.NamespacedName{
 		Name:      dgdr.Status.DGDName,
 		Namespace: dgdr.Namespace,
 	}, dgd)
 
 	if apierrors.IsNotFound(err) {
-		return r.handleDGDNotFound(ctx, dgdr)
+		if dgdr.Annotations[AnnotationGeneratedDGDSpec] != "" {
+			return r.createDGD(ctx, dgdr)
+		}
+		return r.handleDGDDeleted(ctx, dgdr)
 	}
 
 	if err != nil {
@@ -877,13 +876,13 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployedPhase(ctx context
 
 	// Check if DGD still exists and monitor its status
 	dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
-	err := r.getDGD(ctx, types.NamespacedName{
+	err := r.Get(ctx, types.NamespacedName{
 		Name:      dgdr.Status.DGDName,
 		Namespace: dgdr.Namespace,
 	}, dgd)
 
 	if apierrors.IsNotFound(err) {
-		return r.handleDGDNotFound(ctx, dgdr)
+		return r.handleDGDDeleted(ctx, dgdr)
 	}
 
 	if err != nil {
@@ -949,54 +948,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDGDDeleted(ctx context.Co
 	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
 }
 
-// getDGD confirms a cached NotFound directly with the API server. A DGD create
-// and the DGDR status event that follows it are delivered through independent
-// informers, so cache absence alone is not proof that the DGD was deleted.
-func (r *DynamoGraphDeploymentRequestReconciler) getDGD(
-	ctx context.Context,
-	key types.NamespacedName,
-	dgd *nvidiacomv1beta1.DynamoGraphDeployment,
-) error {
-	err := r.Get(ctx, key, dgd)
-	if apierrors.IsNotFound(err) && r.APIReader != nil {
-		return r.APIReader.Get(ctx, key, dgd)
-	}
-	return err
-}
-
-// handleDGDNotFound refreshes the DGDR before deciding whether absence means
-// "creation still pending" or "a previously created DGD was deleted". The
-// generated-spec annotation is the existing durable transaction marker: it is
-// removed only after the intended DGD is created or observed.
-func (r *DynamoGraphDeploymentRequestReconciler) handleDGDNotFound(
-	ctx context.Context,
-	cachedDGDR *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
-) (ctrl.Result, error) {
-	dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}
-	if err := r.authoritativeReader().Get(ctx, types.NamespacedName{
-		Name: cachedDGDR.Name, Namespace: cachedDGDR.Namespace,
-	}, dgdr); err != nil {
-		if apierrors.IsNotFound(err) {
-			return ctrl.Result{}, nil
-		}
-		return ctrl.Result{}, fmt.Errorf("failed to refresh DGDR after DGD was not found: %w", err)
-	}
-
-	switch dgdr.Status.Phase {
-	case nvidiacomv1beta1.DGDRPhaseDeploying:
-		if dgdr.Annotations[AnnotationGeneratedDGDSpec] != "" {
-			return r.createDGD(ctx, dgdr)
-		}
-		return r.handleDGDDeleted(ctx, dgdr)
-	case nvidiacomv1beta1.DGDRPhaseDeployed:
-		return r.handleDGDDeleted(ctx, dgdr)
-	default:
-		// The cached phase was stale; its authoritative watch event will select
-		// the appropriate handler.
-		return ctrl.Result{}, nil
-	}
-}
-
 // createDGD creates a DynamoGraphDeployment with the generated spec
 func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
@@ -1015,6 +966,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	// Determine DGD name and namespace from generated deployment
 	dgdName := generatedDGD.Name
 	dgdNamespace := dgdr.Namespace
+	if dgdr.Status.DGDName == "" {
+		dgdr.Status.DGDName = dgdName
+		return ctrl.Result{}, r.Status().Update(ctx, dgdr)
+	}
 
 	// Build labels (start with generated DGD's labels)
 	labels := make(map[string]string)
@@ -1055,21 +1010,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 
 	if err := r.Create(ctx, dgd); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			logger.Info("DGD already exists, updating status")
-			existingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
-			if getErr := r.authoritativeReader().Get(ctx, types.NamespacedName{Name: dgdName, Namespace: dgdNamespace}, existingDGD); getErr != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to get existing DGD %s: %w", dgdName, getErr)
-			}
-			if updateErr := r.persistDGDName(ctx, dgdr, dgdName); updateErr != nil {
-				return ctrl.Result{}, updateErr
-			}
-			if updateErr := r.removeGeneratedSpecAnnotation(ctx, dgdr); updateErr != nil {
-				logger.Error(updateErr, "Failed to remove generated-dgd-spec annotation on IsAlreadyExists path")
-				return ctrl.Result{}, updateErr
-			}
-			if adoptErr := r.adoptAdditionalResources(ctx, dgdr, existingDGD); adoptErr != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to adopt additional resources for existing DGD %s: %w", dgdName, adoptErr)
-			}
+			// The DGD watch reconciles again after the object is in the informer cache.
+			logger.Info("DGD already exists, waiting for informer observation")
 			return ctrl.Result{}, nil
 		}
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, MessageDeploymentCreationFailed, err.Error())
@@ -1085,53 +1027,15 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 
-	if err := r.persistDGDName(ctx, dgdr, dgdName); err != nil {
-		return ctrl.Result{}, err
-	}
-	if err := r.removeGeneratedSpecAnnotation(ctx, dgdr); err != nil {
-		// Return the error to force a retry. The DGD was created successfully, so a
-		// retry will hit the IsAlreadyExists path above and attempt cleanup again.
-		return ctrl.Result{}, fmt.Errorf("failed to remove generated-dgd-spec annotation after DGD creation: %w", err)
-	}
-	if err := r.adoptAdditionalResources(ctx, dgdr, dgd); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to adopt additional resources for DGD %s: %w", dgdName, err)
-	}
-
 	r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonDeploymentCreated,
 		fmt.Sprintf(MessageDeploymentCreated, dgdName))
-
-	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-		Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
-		Status:  metav1.ConditionFalse,
-		Reason:  nvidiacomv1beta1.EventReasonDeploymentCreated,
-		Message: fmt.Sprintf("DGD %s created, waiting for Ready", dgdName),
-	})
-
 	logger.Info("DynamoGraphDeployment created successfully", "name", dgdName)
 
-	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
+	// Keep the generated-spec marker until a cached read observes the DGD.
+	return ctrl.Result{}, nil
 }
 
-// persistDGDName records the DGD identity before the generated-spec transaction
-// marker is removed, so retries can recover even if later cleanup or adoption fails.
-func (r *DynamoGraphDeploymentRequestReconciler) persistDGDName(
-	ctx context.Context,
-	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
-	dgdName string,
-) error {
-	if dgdr.Status.DGDName == dgdName {
-		return nil
-	}
-	dgdr.Status.DGDName = dgdName
-	if err := r.Status().Update(ctx, dgdr); err != nil {
-		return fmt.Errorf("failed to persist DGD name %s before committing creation: %w", dgdName, err)
-	}
-	return nil
-}
-
-// removeGeneratedSpecAnnotation commits the creation transaction after a DGD
-// has been observed. Retrying this cleanup whenever the DGD exists repairs a
-// crash between Create and marker removal; a subsequent deletion is terminal.
+// removeGeneratedSpecAnnotation marks the DGD as observed in the informer cache.
 func (r *DynamoGraphDeploymentRequestReconciler) removeGeneratedSpecAnnotation(
 	ctx context.Context,
 	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
@@ -1139,9 +1043,8 @@ func (r *DynamoGraphDeploymentRequestReconciler) removeGeneratedSpecAnnotation(
 	if dgdr.Annotations[AnnotationGeneratedDGDSpec] == "" {
 		return nil
 	}
-	base := dgdr.DeepCopy()
 	delete(dgdr.Annotations, AnnotationGeneratedDGDSpec)
-	if err := r.Patch(ctx, dgdr, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+	if err := r.Update(ctx, dgdr); err != nil {
 		return fmt.Errorf("failed to remove generated DGD annotation: %w", err)
 	}
 	return nil
@@ -1453,8 +1356,7 @@ func GetGPUDiscoveryFailureReason(err error) string {
 }
 
 // createProfilingJob creates a Kubernetes Job for profiling using SyncResource.
-// It returns requeue=true when it persists discovered hardware and intentionally
-// skips job creation until the next reconcile sees the updated generation.
+// It returns true when a DGDR or Job write must be observed before advancing.
 func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (bool, error) {
 	logger := log.FromContext(ctx)
 
@@ -1760,7 +1662,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 	// Store the job name in status for observability
 	dgdr.Status.ProfilingJobName = job.Name
 
-	return false, nil
+	return modified, nil
 }
 
 // marshalDGDRSpec produces the JSON string passed to the profiler via --config.
@@ -1976,14 +1878,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) checkProfilingJobStatus(ctx con
 	jobName := getProfilingJobName(dgdr)
 
 	job := &batchv1.Job{}
-	key := types.NamespacedName{Name: jobName, Namespace: dgdr.Namespace}
-	err := r.Get(ctx, key, job)
-	if apierrors.IsNotFound(err) && r.APIReader != nil {
-		// Job Create events are filtered. Confirm cache absence directly because
-		// the DGDR phase update can be observed before the Job informer catches up.
-		err = r.APIReader.Get(ctx, key, job)
-	}
-	if err != nil {
+	if err := r.Get(ctx, types.NamespacedName{Name: jobName, Namespace: dgdr.Namespace}, job); err != nil {
 		return false, err
 	}
 
@@ -2115,8 +2010,8 @@ func computeDGDName(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) string 
 
 // generateDGDSpec reads profiling output from the sidecar ConfigMap, extracts the
 // DGD and supporting resources, then persists both generated annotations in one
-// optimistic patch. Patch updates dgdr's resourceVersion in place, so the caller
-// can safely commit status without a read-after-write cache lookup.
+// update. Update refreshes dgdr's resourceVersion, so the caller can safely
+// commit status without reading its write back through the informer cache.
 func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (*nvidiacomv1beta1.ProfilingResultsStatus, string, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Generating DGD spec from profiling results", "name", dgdr.Name, "backend", dgdr.Spec.Backend)
@@ -2124,14 +2019,14 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	// Read the generated spec from ConfigMap (created by sidecar)
 	outputConfigMapName := getOutputConfigMapName(dgdr)
 	cm := &corev1.ConfigMap{}
-	err := r.authoritativeReader().Get(ctx, types.NamespacedName{
+	err := r.Get(ctx, types.NamespacedName{
 		Name:      outputConfigMapName,
 		Namespace: dgdr.Namespace,
 	}, cm)
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, "", fmt.Errorf("output ConfigMap %s not found - profiling may not have completed yet", outputConfigMapName)
+			return nil, "", fmt.Errorf("%w: ConfigMap %s not found", errProfilingOutputNotReady, outputConfigMapName)
 		}
 		return nil, "", fmt.Errorf("failed to get output ConfigMap: %w", err)
 	}
@@ -2143,7 +2038,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	// Get YAML content from ConfigMap
 	yamlContent, exists := cm.Data[outputFile]
 	if !exists {
-		return nil, "", fmt.Errorf("key %s not found in ConfigMap %s", outputFile, outputConfigMapName)
+		return nil, "", fmt.Errorf("%w: key %s not found in ConfigMap %s", errProfilingOutputNotReady, outputFile, outputConfigMapName)
 	}
 
 	logger.Info("Found profiling output in ConfigMap", "configMap", outputConfigMapName, "outputFile", outputFile, "size", len(yamlContent))
@@ -2162,7 +2057,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 
 	logger.Info("Parsed profiling output", "profilerDGDName", dgd.Name, "additionalResources", len(additionalResources))
 
-	patchBase := dgdr.DeepCopy()
 	if len(additionalResources) > 0 {
 		if err := storeAdditionalResources(dgdr, additionalResources); err != nil {
 			logger.Error(err, "Failed to store additional resources")
@@ -2195,7 +2089,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	}
 	dgdr.Annotations[AnnotationGeneratedDGDSpec] = string(dgdYAML)
 
-	if err := r.Patch(ctx, dgdr, client.MergeFromWithOptions(patchBase, client.MergeFromWithOptimisticLock{})); err != nil {
+	if err := r.Update(ctx, dgdr); err != nil {
 		return nil, "", fmt.Errorf("failed to persist generated DGDR annotations: %w", err)
 	}
 	return profilingResults, dgd.Name, nil
@@ -2534,13 +2428,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
 		Named(consts.ResourceTypeDynamoGraphDeploymentRequest).
-		Owns(&batchv1.Job{}, builder.WithPredicates(predicate.Funcs{
-			// ignore creation cause we don't want to be called again after we create the job
-			CreateFunc:  func(ce event.CreateEvent) bool { return false },
-			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
-			UpdateFunc:  func(de event.UpdateEvent) bool { return true },
-			GenericFunc: func(ge event.GenericEvent) bool { return true },
-		})). // Watch Jobs created by this controller (via ownerReference)
+		Owns(&batchv1.Job{}). // Watch Jobs created by this controller (via ownerReference)
 		// Watch DGDs created by this controller (via label)
 		Watches(
 			&nvidiacomv1beta1.DynamoGraphDeployment{},
@@ -2558,13 +2446,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 						Namespace: dgdrNamespace,
 					},
 				}}
-			}),
-			builder.WithPredicates(predicate.Funcs{
-				// ignore creation cause we don't want to be called again after we create the DGD
-				CreateFunc:  func(ce event.CreateEvent) bool { return false },
-				DeleteFunc:  func(de event.DeleteEvent) bool { return true },
-				UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
-				GenericFunc: func(ge event.GenericEvent) bool { return true },
 			}),
 		).
 		// Watch output ConfigMaps for profiling sub-phase updates (via label)

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -61,20 +61,20 @@ func (m *MockRBACManager) EnsureServiceAccountWithRBAC(ctx context.Context, targ
 	return nil
 }
 
-// writeFaultClient injects a one-shot DGDR update conflict.
+// writeFaultClient injects a one-shot DGDR apply conflict.
 type writeFaultClient struct {
 	client.Client
-	updateConflictOnce bool
+	applyConflictOnce bool
 }
 
-func (c *writeFaultClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
-	if _, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeploymentRequest); ok && c.updateConflictOnce {
-		c.updateConflictOnce = false
+func (c *writeFaultClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	if c.applyConflictOnce {
+		c.applyConflictOnce = false
 		return apierrors.NewConflict(schema.GroupResource{
 			Group: nvidiacomv1beta1.GroupVersion.Group, Resource: "dynamographdeploymentrequests",
-		}, obj.GetName(), errors.New("injected update conflict"))
+		}, "injected", errors.New("injected apply conflict"))
 	}
-	return c.Client.Update(ctx, obj, opts...)
+	return c.Client.Apply(ctx, obj, opts...)
 }
 
 var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
@@ -487,6 +487,46 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 				_ = k8sClient.Delete(ctx, job)
 			}
 		})
+
+		It("Should preserve output written before the Job create event is observed", func() {
+			ctx := context.Background()
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr-fast-output", Namespace: defaultNamespace},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model: "test-model", Backend: "vllm", Image: "test-profiler:latest",
+					Hardware: &nvidiacomv1beta1.HardwareSpec{
+						NumGPUsPerNode: ptr.To[int32](8),
+						GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
+						VRAMMB:         ptr.To(81920.0),
+						TotalGPUs:      ptr.To[int32](8),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+
+			waitForObservation, err := reconciler.createProfilingJob(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForObservation).Should(BeTrue())
+
+			job := &batchv1.Job{}
+			jobKey := types.NamespacedName{Name: getProfilingJobName(dgdr), Namespace: dgdr.Namespace}
+			Expect(k8sClient.Get(ctx, jobKey, job)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, job) }()
+
+			outputCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: getOutputConfigMapName(dgdr), Namespace: dgdr.Namespace},
+				Data:       map[string]string{ProfilingOutputFile: "fast output"},
+			}
+			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
+
+			waitForObservation, err = reconciler.createProfilingJob(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForObservation).Should(BeFalse())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: outputCM.Name, Namespace: outputCM.Namespace}, outputCM)).Should(Succeed())
+			Expect(outputCM.Data[ProfilingOutputFile]).Should(Equal("fast output"))
+		})
 	})
 
 	Context("When profiling completes", func() {
@@ -656,7 +696,7 @@ spec:
 			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
 
-			reconciler.Client = &writeFaultClient{Client: k8sClient, updateConflictOnce: true}
+			reconciler.Client = &writeFaultClient{Client: k8sClient, applyConflictOnce: true}
 			_, err := reconciler.handleProfilingPhase(ctx, dgdr)
 			Expect(apierrors.IsConflict(err)).Should(BeTrue())
 
@@ -2362,7 +2402,7 @@ spec:
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseDeployed))
-			Expect(updated.Annotations).NotTo(HaveKey(AnnotationGeneratedDGDSpec))
+			Expect(updated.Annotations[AnnotationGeneratedDGDSpec]).Should(BeEmpty())
 
 			// Once an existing DGD has been observed, a later deletion must not be
 			// recreated from a marker left behind by a prior crash.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -61,73 +61,20 @@ func (m *MockRBACManager) EnsureServiceAccountWithRBAC(ctx context.Context, targ
 	return nil
 }
 
-// laggingReadClient simulates selected informer misses while writes still use
-// the real envtest client.
-type laggingReadClient struct {
-	client.Client
-	staleDGDR       *nvidiacomv1beta1.DynamoGraphDeploymentRequest
-	hiddenDGD       map[types.NamespacedName]bool
-	hiddenJob       map[types.NamespacedName]bool
-	hiddenConfigMap map[types.NamespacedName]bool
-}
-
-func (c *laggingReadClient) Get(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
-	if _, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeployment); ok && c.hiddenDGD[key] {
-		return apierrors.NewNotFound(schema.GroupResource{
-			Group: nvidiacomv1beta1.GroupVersion.Group, Resource: "dynamographdeployments",
-		}, key.Name)
-	}
-	if _, ok := obj.(*batchv1.Job); ok && c.hiddenJob[key] {
-		return apierrors.NewNotFound(schema.GroupResource{
-			Group: batchv1.GroupName, Resource: "jobs",
-		}, key.Name)
-	}
-	if _, ok := obj.(*corev1.ConfigMap); ok && c.hiddenConfigMap[key] {
-		return apierrors.NewNotFound(schema.GroupResource{Resource: "configmaps"}, key.Name)
-	}
-	if dgdr, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeploymentRequest); ok &&
-		c.staleDGDR != nil &&
-		key.Name == c.staleDGDR.Name && key.Namespace == c.staleDGDR.Namespace {
-		c.staleDGDR.DeepCopyInto(dgdr)
-		return nil
-	}
-	return c.Client.Get(ctx, key, obj, opts...)
-}
-
-// writeFaultClient injects one-shot DGDR write failures while delegating all
-// other operations to the envtest client.
+// writeFaultClient injects a one-shot DGDR update conflict.
 type writeFaultClient struct {
 	client.Client
-	patchConflictOnce   bool
-	statusUpdateErrOnce error
+	updateConflictOnce bool
 }
 
-func (c *writeFaultClient) Patch(ctx context.Context, obj client.Object, patch client.Patch, opts ...client.PatchOption) error {
-	if _, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeploymentRequest); ok && c.patchConflictOnce {
-		c.patchConflictOnce = false
+func (c *writeFaultClient) Update(ctx context.Context, obj client.Object, opts ...client.UpdateOption) error {
+	if _, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeploymentRequest); ok && c.updateConflictOnce {
+		c.updateConflictOnce = false
 		return apierrors.NewConflict(schema.GroupResource{
 			Group: nvidiacomv1beta1.GroupVersion.Group, Resource: "dynamographdeploymentrequests",
-		}, obj.GetName(), errors.New("injected optimistic-lock conflict"))
+		}, obj.GetName(), errors.New("injected update conflict"))
 	}
-	return c.Client.Patch(ctx, obj, patch, opts...)
-}
-
-func (c *writeFaultClient) Status() client.SubResourceWriter {
-	return &writeFaultStatusWriter{SubResourceWriter: c.Client.Status(), client: c}
-}
-
-type writeFaultStatusWriter struct {
-	client.SubResourceWriter
-	client *writeFaultClient
-}
-
-func (w *writeFaultStatusWriter) Update(ctx context.Context, obj client.Object, opts ...client.SubResourceUpdateOption) error {
-	if _, ok := obj.(*nvidiacomv1beta1.DynamoGraphDeploymentRequest); ok && w.client.statusUpdateErrOnce != nil {
-		err := w.client.statusUpdateErrOnce
-		w.client.statusUpdateErrOnce = nil
-		return err
-	}
-	return w.SubResourceWriter.Update(ctx, obj, opts...)
+	return c.Client.Update(ctx, obj, opts...)
 }
 
 var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
@@ -521,6 +468,18 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 				return job.Labels[nvidiacomv1beta1.LabelApp]
 			}, timeout, interval).Should(Equal(nvidiacomv1beta1.LabelValueDynamoProfiler))
 
+			// The Job create event is the observation barrier for entering Profiling.
+			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
+			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhasePending))
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
+			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+
 			// Clean up
 			jobName := getProfilingJobName(dgdr)
 			job := &batchv1.Job{}
@@ -531,7 +490,7 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 	})
 
 	Context("When profiling completes", func() {
-		It("Should tolerate a cached DGDR that has not observed its metadata write", func() {
+		It("Should persist generated annotations and status without reading back its own write", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-profiling-complete"
 			namespace := defaultNamespace
@@ -564,7 +523,6 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 			// Update status to Profiling using Status subresource
 			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
 			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
-			staleDGDR := dgdr.DeepCopy()
 
 			// Create completed profiling job
 			jobName := getProfilingJobName(dgdr)
@@ -633,12 +591,6 @@ spec:
 			Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, cm) }()
 
-			// Every cached DGDR read returns the pre-write object. Reconciliation must
-			// not depend on the informer observing its own metadata write.
-			reconciler.Client = &laggingReadClient{
-				Client: k8sClient, staleDGDR: staleDGDR,
-			}
-			reconciler.APIReader = k8sClient
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -665,33 +617,6 @@ spec:
 			additionalCM := &corev1.ConfigMap{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
-		})
-
-		It("Should confirm a cached profiling Job miss with the API server", func() {
-			ctx := context.Background()
-			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr-hidden-job", Namespace: defaultNamespace},
-			}
-			key := types.NamespacedName{Name: getProfilingJobName(dgdr), Namespace: defaultNamespace}
-			job := &batchv1.Job{
-				ObjectMeta: metav1.ObjectMeta{Name: key.Name, Namespace: key.Namespace},
-				Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
-					Containers: []corev1.Container{{Name: "test", Image: "test"}}, RestartPolicy: corev1.RestartPolicyNever,
-				}}},
-			}
-			Expect(k8sClient.Create(ctx, job)).Should(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, job) }()
-			job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
-			Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
-
-			reconciler.Client = &laggingReadClient{
-				Client: k8sClient, hiddenJob: map[types.NamespacedName]bool{key: true},
-			}
-			reconciler.APIReader = k8sClient
-
-			completed, err := reconciler.checkProfilingJobStatus(ctx, dgdr)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(completed).Should(BeTrue())
 		})
 
 		It("Should retry generated-annotation conflicts without failing profiling", func() {
@@ -731,8 +656,7 @@ spec:
 			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
 
-			reconciler.Client = &writeFaultClient{Client: k8sClient, patchConflictOnce: true}
-			reconciler.APIReader = k8sClient
+			reconciler.Client = &writeFaultClient{Client: k8sClient, updateConflictOnce: true}
 			_, err := reconciler.handleProfilingPhase(ctx, dgdr)
 			Expect(apierrors.IsConflict(err)).Should(BeTrue())
 
@@ -746,6 +670,56 @@ spec:
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: defaultNamespace}, &persisted)).Should(Succeed())
 			Expect(persisted.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseReady))
 			Expect(persisted.Annotations).To(HaveKey(AnnotationGeneratedDGDSpec))
+		})
+
+		It("Should wait for the watched ConfigMap to contain final output", func() {
+			ctx := context.Background()
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr-output-not-ready", Namespace: defaultNamespace},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model: "test-model", Backend: "vllm", AutoApply: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
+			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
+
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: getProfilingJobName(dgdr), Namespace: defaultNamespace},
+				Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}}, RestartPolicy: corev1.RestartPolicyNever,
+				}}},
+			}
+			Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, job) }()
+			job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+			Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
+
+			outputCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: getOutputConfigMapName(dgdr), Namespace: defaultNamespace},
+				Data:       map[string]string{"profiler_status": "success"},
+			}
+			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
+
+			_, err := reconciler.handleProfilingPhase(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, dgdr)).Should(Succeed())
+			Expect(dgdr.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+
+			outputCM.Data[ProfilingOutputFile] = `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: generated-name
+spec:
+  services: {}`
+			Expect(k8sClient.Update(ctx, outputCM)).Should(Succeed())
+
+			_, err = reconciler.handleProfilingPhase(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, dgdr)).Should(Succeed())
+			Expect(dgdr.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseReady))
 		})
 	})
 
@@ -848,11 +822,6 @@ spec:
 			}
 			Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, cm) }()
-			cmKey := types.NamespacedName{Name: outputConfigMapName, Namespace: namespace}
-			reconciler.Client = &laggingReadClient{
-				Client: k8sClient, hiddenConfigMap: map[types.NamespacedName]bool{cmKey: true},
-			}
-			reconciler.APIReader = k8sClient
 
 			// Reconcile to generate spec (transitions to Deploying because autoApply=true)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
@@ -884,50 +853,6 @@ spec:
 			// Clean up DGD
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: expectedDGDName, Namespace: namespace}, dgd)).Should(Succeed())
 			_ = k8sClient.Delete(ctx, dgd)
-		})
-
-		It("Should retain the generated spec when persisting DGD identity fails", func() {
-			ctx := context.Background()
-			dgdrName := "test-dgdr-dgd-name-write-failure"
-			dgdName := dgdrName + "-dgd"
-			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: dgdrName, Namespace: defaultNamespace,
-					Annotations: map[string]string{AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1alpha1
-kind: DynamoGraphDeployment
-metadata:
-  name: test-dgdr-dgd-name-write-failure-dgd
-spec:
-  services: {}
-`},
-				},
-				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{Model: "test-model"},
-			}
-			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
-
-			injectedErr := errors.New("injected DGD name status failure")
-			reconciler.Client = &writeFaultClient{Client: k8sClient, statusUpdateErrOnce: injectedErr}
-			reconciler.APIReader = k8sClient
-			_, err := reconciler.createDGD(ctx, dgdr)
-			Expect(err).To(MatchError(ContainSubstring(injectedErr.Error())))
-
-			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: defaultNamespace}, dgd)).Should(Succeed())
-			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
-			var persisted nvidiacomv1beta1.DynamoGraphDeploymentRequest
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: defaultNamespace}, &persisted)).Should(Succeed())
-			Expect(persisted.Status.DGDName).Should(BeEmpty())
-			Expect(persisted.Annotations).To(HaveKey(AnnotationGeneratedDGDSpec))
-
-			// Retry through the AlreadyExists path. The retained marker supplies the
-			// manifest until DGD identity is durably recorded.
-			reconciler.Client = k8sClient
-			_, err = reconciler.createDGD(ctx, &persisted)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: defaultNamespace}, &persisted)).Should(Succeed())
-			Expect(persisted.Status.DGDName).Should(Equal(dgdName))
-			Expect(persisted.Annotations).NotTo(HaveKey(AnnotationGeneratedDGDSpec))
 		})
 
 		It("Should create additional ConfigMaps without DGDR ownership and adopt them after DGD creation", func() {
@@ -1052,7 +977,7 @@ spec:
 			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
 			Expect(additionalCM.OwnerReferences).Should(BeEmpty())
 
-			// Second reconcile creates the DGD, then adopts the additional ConfigMaps.
+			// Second reconcile creates the DGD and waits for its create event.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -1061,6 +986,12 @@ spec:
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: expectedDGDName, Namespace: namespace}, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
+
+			// Third reconcile observes the DGD and adopts the additional ConfigMaps.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
 			Expect(additionalCM.OwnerReferences).Should(HaveLen(1))
@@ -1102,6 +1033,9 @@ spec:
 			}
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+			dgdr.Status.DGDName = dgdName
+			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1128,7 +1062,7 @@ spec:
 			Expect(k8sClient.Create(ctx, additionalCM)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
 
-			_, err := reconciler.createDGD(ctx, dgdr)
+			_, err := reconciler.handleDeployingPhase(ctx, dgdr)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
@@ -1281,7 +1215,7 @@ spec:
 	})
 
 	Context("When handling DGD deletion", func() {
-		It("Should not recreate a missing DGD from a stale transaction marker", func() {
+		It("Should transition to Failed phase when DGD is deleted", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-dgd-deleted"
 			namespace := defaultNamespace
@@ -1308,32 +1242,15 @@ spec:
 					AutoApply: ptr.To(true),
 				},
 			}
-			commonController.AddFinalizer(dgdr)
-
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
 
-			// The authoritative object has completed the creation transaction: it is
-			// Deploying with no generated-spec marker.
-			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+			// Update status to Deployed with Deployment info using Status subresource
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeployed
 			dgdr.Status.DGDName = "test-dgd-to-delete"
 			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
-			// The cache has the same phase and status but still sees the pre-creation
-			// marker. Only an authoritative annotation read distinguishes deletion
-			// from a creation that has not been attempted yet.
-			staleDGDR := dgdr.DeepCopy()
-			staleDGDR.Annotations = map[string]string{
-				AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1alpha1
-kind: DynamoGraphDeployment
-metadata:
-  name: test-dgd-to-delete
-spec:
-  services: {}`,
-			}
-			reconciler.Client = &laggingReadClient{Client: k8sClient, staleDGDR: staleDGDR}
-			reconciler.APIReader = k8sClient
-
+			// Reconcile when DGD doesn't exist (simulating deletion)
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -1343,8 +1260,6 @@ spec:
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
-			missingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
-			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, types.NamespacedName{Name: "test-dgd-to-delete", Namespace: namespace}, missingDGD))).Should(BeTrue())
 		})
 	})
 })
@@ -2374,7 +2289,7 @@ spec:
 	})
 
 	Context("v1beta1-specific behavior", func() {
-		It("Should confirm a cached DGD miss before declaring deletion", func() {
+		It("Should clear the creation marker only after observing the DGD", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-deployed-phase"
 			namespace := defaultNamespace
@@ -2437,13 +2352,8 @@ spec:
 			Expect(k8sClient.Status().Update(ctx, dgd)).Should(Succeed())
 
 			key := types.NamespacedName{Name: dgd.Name, Namespace: namespace}
-			reconciler.Client = &laggingReadClient{
-				Client: k8sClient, hiddenDGD: map[types.NamespacedName]bool{key: true},
-			}
-			reconciler.APIReader = k8sClient
 
-			// The cached miss must be confirmed through APIReader, which sees the
-			// successful DGD and allows the normal transition to Deployed.
+			// Observing the DGD commits creation by clearing the generated-spec marker.
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2547,7 +2457,13 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Reconcile again to start profiling (creates job, transitions to Profiling)
+			// Reconcile again to create the profiling Job.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile after observing the Job to transition to Profiling.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2744,6 +2660,12 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			// Reconcile after observing the Job to persist its name in status.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
 			// Check profilingJobName is set in status
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
@@ -2796,7 +2718,13 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Reconcile: create profiling job → Profiling + ProfilingPhase=Initializing
+			// Reconcile: create profiling Job and wait for informer observation.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile: observed profiling Job → Profiling + ProfilingPhase=Initializing.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2844,6 +2772,10 @@ spec:
 
 			// Reconcile: profiling complete → should clear profilingPhase, set
 			// ProfilingCompleted condition, populate profilingResults.selectedConfig
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2915,6 +2847,10 @@ spec:
 
 			// Drive to Profiling phase
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -3391,7 +3327,13 @@ var _ = Describe("DGDR Profiling Failure Attribution", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Second reconcile: Pending → Profiling
+			// Second reconcile: create profiling Job.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Third reconcile: observed profiling Job → Profiling.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -412,6 +412,10 @@ func TestCreateProfilingJobPersistsDiscoveredHardware(t *testing.T) {
 
 	requeue, err = r.createProfilingJob(ctx, &stored)
 	require.NoError(t, err)
+	require.True(t, requeue)
+
+	requeue, err = r.createProfilingJob(ctx, &stored)
+	require.NoError(t, err)
 	require.False(t, requeue)
 
 	job := &batchv1.Job{}
@@ -457,6 +461,10 @@ func TestCreateProfilingJobWithManualHardwareDoesNotRequireAPIReader(t *testing.
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, &fetched))
 
 	requeue, err := r.createProfilingJob(ctx, &fetched)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	requeue, err = r.createProfilingJob(ctx, &fetched)
 	require.NoError(t, err)
 	require.False(t, requeue)
 


### PR DESCRIPTION
## Summary

This is a focused simplification of #11250. It keeps the original fix—DGDR reconciliation must tolerate informer lag—but removes the uncached/API-server read paths and models the hand-offs as normal controller state transitions.

The stacked diff removes 361 lines and adds 275 lines, including tests and controller guidance.

### What changed

- Use Job creation as an observation barrier before moving from `Pending` to `Profiling`. The normal `Owns(Job)` watch now includes create events, so reconciliation advances only after the Job is present in the informer cache.
- Treat a completed Job whose cached output ConfigMap does not yet contain `final_config.yaml` as "not ready". The existing ConfigMap create/update watch drives the next reconciliation instead of an uncached read.
- Keep the generated-DGD annotation until the created DGD has been observed through the informer cache. The normal DGD create watch then drives marker clearing and additional-resource adoption.
- Preserve deletion semantics: once the DGD was observed and the generated-spec marker was cleared, a later cached `NotFound` means the DGD was deleted and the DGDR transitions to `Failed`.
- Apply controller-owned annotations with inline, resource-version-locked SSA and a dedicated field manager. Conflicts remain transient reconciliation errors, while unrelated fields retain their ownership.
- Delete stale profiler output only before the profiling Job exists, so the Job-observation reconcile cannot delete fresh output from a fast profiler.
- Remove `authoritativeReader`, `getDGD`, `handleDGDNotFound`, `persistDGDName`, optimistic-lock patch bookkeeping, and the synthetic split-reader test client.
- Add controller-local `AGENTS.md` guidance to prefer level-driven, cache-tolerant reconciliation and dependency watches over uncached reads.

## Why

Informer staleness is expected in a Kubernetes controller. A direct API read can hide missing watch edges, adds a second consistency model to the reconciler, and makes tests exercise different behavior from production.

The simpler state machine uses durable state plus informer events:

1. A Job write leaves the DGDR in `Pending`; the Job event advances it to `Profiling`.
2. Job completion without final cached output leaves the DGDR in `Profiling`; the ConfigMap event retries generation.
3. A DGD write leaves the generated-spec marker in place; observing the DGD clears it.
4. A DGD missing after that marker was cleared is an actual deletion.

This also handles controller restarts naturally: caches synchronize before workers run, so an already-created Job or DGD is observed before the state machine advances.

## Validation

- `GOCACHE=/private/tmp/dynamo-pr11250-go-cache go test ./internal/controller -count=1`
- `GOCACHE=/private/tmp/dynamo-pr11250-go-cache go test ./api/... ./internal/... -count=1`
- `GOCACHE=/private/tmp/dynamo-pr11250-go-cache go vet ./internal/controller`
- `git diff --check`
- repository pre-commit hooks
