### PR TITLE
refactor(llm): decouple HTTP handler engine resolution

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -15,7 +15,7 @@ use serde::Serialize;
 use super::ModelManagerError;
 use super::worker_monitor::LoadThresholdConfig;
 use super::worker_set::WorkerSet;
-use crate::protocols::openai::ParsingOptions;
+use crate::protocols::common::ParsingOptions;
 
 use crate::types::{
     RealtimeBidirectionalEngine,

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -494,7 +494,7 @@ impl ModelManager {
     ) -> Result<
         (
             OpenAIChatCompletionsStreamingEngine,
-            crate::protocols::openai::ParsingOptions,
+            crate::protocols::common::ParsingOptions,
         ),
         ModelManagerError,
     > {
@@ -510,7 +510,7 @@ impl ModelManager {
     ) -> Result<
         (
             OpenAICompletionsStreamingEngine,
-            crate::protocols::openai::ParsingOptions,
+            crate::protocols::common::ParsingOptions,
         ),
         ModelManagerError,
     > {
@@ -526,7 +526,7 @@ impl ModelManager {
     ) -> Result<
         (
             GenerateStreamingEngine,
-            crate::protocols::openai::ParsingOptions,
+            crate::protocols::common::ParsingOptions,
         ),
         ModelManagerError,
     > {

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -188,8 +188,8 @@ impl WorkerSet {
     }
 
     /// Build ParsingOptions from this WorkerSet's card configuration.
-    pub fn parsing_options(&self) -> crate::protocols::openai::ParsingOptions {
-        crate::protocols::openai::ParsingOptions::new(
+    pub fn parsing_options(&self) -> crate::protocols::common::ParsingOptions {
+        crate::protocols::common::ParsingOptions::new(
             self.card.runtime_config.tool_call_parser.clone(),
             self.card.runtime_config.reasoning_parser.clone(),
         )

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -10,7 +10,7 @@ use futures::{Stream, StreamExt, stream};
 use std::sync::Arc;
 
 use crate::http::service::metadata::extract_metadata_from_grpc;
-use crate::protocols::openai::ParsingOptions;
+use crate::protocols::common::ParsingOptions;
 use crate::protocols::openai::completions::{
     NvCreateCompletionRequest, NvCreateCompletionResponse,
 };

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -46,11 +46,11 @@ use crate::protocols::anthropic::types::{
     AnthropicErrorBody, AnthropicErrorResponse, SystemContent,
     chat_completion_to_anthropic_response,
 };
+use crate::protocols::common::ParsingOptions;
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
     apply_header_routing_overrides, session_affinity_from_headers,
 };
-use crate::protocols::openai::ParsingOptions;
 use crate::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
     NvCreateChatCompletionStreamResponse, aggregator::ChatCompletionAggregator,

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -50,13 +50,14 @@ use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, SESSION_AFFINITY_CONTEXT_KEY, agent_context_from_headers,
     apply_header_routing_overrides, session_affinity_from_headers,
 };
+use crate::protocols::openai::ParsingOptions;
 use crate::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
     NvCreateChatCompletionStreamResponse, aggregator::ChatCompletionAggregator,
 };
 use crate::protocols::unified::UnifiedRequest;
 use crate::request_template::{RequestTemplate, resolve_request_model};
-use crate::types::Annotated;
+use crate::types::{Annotated, openai::chat_completions::OpenAIChatCompletionsStreamingEngine};
 
 // Re-use helpers from the openai module (sibling under service/)
 use super::error::SanitizedError;
@@ -163,8 +164,9 @@ async fn handler_anthropic_messages(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.stream;
     let resolved_model = resolve_request_model(&request.model, template.as_ref());
+    let metric_model = state.manager().metric_model_for(resolved_model).to_string();
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: metric_model.clone(),
         endpoint: Endpoint::AnthropicMessages.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -193,8 +195,39 @@ async fn handler_anthropic_messages(
     )
     .await;
 
+    #[allow(clippy::result_large_err)]
     let response = tokio::spawn(
-        anthropic_messages(state, template, request, headers, stream_handle).in_current_span(),
+        async move {
+            anthropic_messages(
+                &state,
+                metric_model,
+                template,
+                request,
+                headers,
+                stream_handle,
+                |model| {
+                    state
+                        .manager()
+                        .get_chat_completions_engine_with_parsing(model)
+                        .map_err(|error| match error {
+                            crate::discovery::ModelManagerError::ModelUnavailable(_) => {
+                                anthropic_error(
+                                    StatusCode::SERVICE_UNAVAILABLE,
+                                    "overloaded_error",
+                                    &super::openai::model_not_ready_message(model),
+                                )
+                            }
+                            _ => anthropic_error(
+                                StatusCode::NOT_FOUND,
+                                "not_found_error",
+                                &format!("Model '{model}' not found"),
+                            ),
+                        })
+                },
+            )
+            .await
+        }
+        .in_current_span(),
     )
     .await
     .map_err(|e| {
@@ -211,11 +244,17 @@ async fn handler_anthropic_messages(
 /// Core logic for the Anthropic Messages endpoint.
 #[tracing::instrument(level = "debug", skip_all, fields(request_id = %request.id()))]
 async fn anthropic_messages(
-    state: Arc<service_v2::State>,
+    state: &Arc<service_v2::State>,
+    metric_model: String,
     template: Option<RequestTemplate>,
     mut request: Context<AnthropicCreateMessageRequest>,
     headers: HeaderMap,
     mut stream_handle: ConnectionHandle,
+    resolve: impl FnOnce(
+        &str,
+    )
+        -> Result<(OpenAIChatCompletionsStreamingEngine, ParsingOptions), Response>
+    + Send,
 ) -> Result<Response, Response> {
     let streaming = request.stream;
     let request_id = request.id().to_string();
@@ -240,32 +279,12 @@ async fn anthropic_messages(
     }
 
     let model = request.model.clone();
-    let metric_model = state.manager().metric_model_for(&model).to_string();
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     tracing::trace!("Received Anthropic messages request: {:?}", &*request);
 
-    // Look up engine and parsing options early so we know whether a reasoning
-    // parser is configured before converting the request.
-    let (engine, parsing_options) = state
-        .manager()
-        .get_chat_completions_engine_with_parsing(&model)
-        .map_err(|e| match e {
-            // Registered but not ready to serve yet → retryable 503 (mapped to
-            // "overloaded_error" by `anthropic_error`). Reuses the OpenAI path's
-            // canonical, customer-facing message so both APIs report the same
-            // text. Anything else is a genuine missing model → 404.
-            crate::discovery::ModelManagerError::ModelUnavailable(_) => anthropic_error(
-                StatusCode::SERVICE_UNAVAILABLE,
-                "overloaded_error",
-                &super::openai::model_not_ready_message(&model),
-            ),
-            _ => anthropic_error(
-                StatusCode::NOT_FOUND,
-                "not_found_error",
-                &format!("Model '{}' not found", model),
-            ),
-        })?;
+    // Resolve one engine/options snapshot before options shape the converted request.
+    let (engine, parsing_options) = resolve(&model)?;
 
     let (orig_request, context) = request.into_parts();
     let model_for_resp = orig_request.model.clone();

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -53,13 +53,13 @@ use super::{
 };
 use crate::engines::ValidateRequest;
 use crate::preprocessor::PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY;
+use crate::protocols::common::ParsingOptions;
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, AgentContext, SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId,
     agent_context_from_headers, apply_header_routing_overrides, session_affinity_from_headers,
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::{
-    ParsingOptions,
     audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest},
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -59,6 +59,7 @@ use crate::protocols::common::extensions::{
 };
 use crate::protocols::openai::chat_completions::aggregator::ChatCompletionAggregator;
 use crate::protocols::openai::{
+    ParsingOptions,
     audios::{NvAudioSpeechResponse, NvCreateAudioSpeechRequest},
     chat_completions::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
@@ -72,7 +73,13 @@ use crate::protocols::openai::{
 };
 use crate::protocols::unified::UnifiedRequest;
 use crate::request_template::{RequestTemplate, resolve_request_model};
-use crate::types::Annotated;
+use crate::types::{
+    Annotated,
+    openai::{
+        chat_completions::OpenAIChatCompletionsStreamingEngine,
+        completions::OpenAICompletionsStreamingEngine,
+    },
+};
 use dynamo_protocols::types::ChatCompletionMessageContent;
 use dynamo_protocols::types::ChatCompletionMessageToolCallChunk;
 use dynamo_protocols::types::ChatCompletionStreamResponseDelta;
@@ -640,11 +647,12 @@ async fn handler_completions(
     // create the context for the request
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
+    let metric_model = state
+        .manager()
+        .metric_model_for(&request.inner.model)
+        .to_string();
     let cancellation_labels = CancellationLabels {
-        model: state
-            .manager()
-            .metric_model_for(&request.inner.model)
-            .to_string(),
+        model: metric_model.clone(),
         endpoint: Endpoint::Completions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -661,14 +669,25 @@ async fn handler_completions(
 
     // possibly long running task
     // if this returns a streaming response, the stream handle will be armed and captured by the response stream
-    let response = tokio::spawn(completions(state, request, stream_handle).in_current_span())
-        .await
-        .map_err(|e| {
-            ErrorMessage::internal_server_error_with_details(
-                "Failed to await chat completions task",
-                format!("{e:?}"),
-            )
-        })?;
+    let response = tokio::spawn(
+        async move {
+            completions(&state, metric_model, request, stream_handle, |model| {
+                state
+                    .manager()
+                    .get_completions_engine_with_parsing(model)
+                    .map_err(|error| ErrorMessage::from_model_error(&error))
+            })
+            .await
+        }
+        .in_current_span(),
+    )
+    .await
+    .map_err(|e| {
+        ErrorMessage::internal_server_error_with_details(
+            "Failed to await chat completions task",
+            format!("{e:?}"),
+        )
+    })?;
 
     // if we got here, then we will return a response and the potentially long running task has completed successfully
     // without need to be cancelled.
@@ -679,14 +698,20 @@ async fn handler_completions(
 
 #[tracing::instrument(skip_all)]
 async fn completions(
-    state: Arc<service_v2::State>,
+    state: &Arc<service_v2::State>,
+    metric_model: String,
     request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
+    resolve: impl FnOnce(
+        &str,
+    )
+        -> Result<(OpenAICompletionsStreamingEngine, ParsingOptions), ErrorResponse>
+    + Send,
 ) -> Result<Response, ErrorResponse> {
     use crate::protocols::openai::completions::get_prompt_batch_size;
 
     // return a 503 if the service is not ready
-    check_ready(&state)?;
+    check_ready(state)?;
 
     // Validate stream_options is only used when streaming (NVBug 5662680)
     validate_completion_stream_options(&request)?;
@@ -699,19 +724,33 @@ async fn completions(
 
     // If single prompt or single-element batch, use original flow
     if batch_size == 1 {
-        return completions_single(state, request, stream_handle).await;
+        return completions_single(state, metric_model, request, stream_handle, resolve).await;
     }
 
     // Batch processing: handle multiple prompts
-    completions_batch(state, request, stream_handle, batch_size, n).await
+    completions_batch(
+        state,
+        metric_model,
+        request,
+        stream_handle,
+        batch_size,
+        n,
+        resolve,
+    )
+    .await
 }
 
 /// Handle single prompt completions (original logic)
 #[tracing::instrument(skip_all)]
 async fn completions_single(
-    state: Arc<service_v2::State>,
+    state: &Arc<service_v2::State>,
+    metric_model: String,
     request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
+    resolve: impl FnOnce(
+        &str,
+    )
+        -> Result<(OpenAICompletionsStreamingEngine, ParsingOptions), ErrorResponse>,
 ) -> Result<Response, ErrorResponse> {
     let request_id = request.id().to_string();
 
@@ -721,7 +760,6 @@ async fn completions_single(
     // todo - make the protocols be optional for model name
     // todo - when optional, if none, apply a default
     let model = request.inner.model.clone();
-    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     // Create inflight_guard early to ensure all errors are counted
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
@@ -735,14 +773,9 @@ async fn completions_single(
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
     // todo - error handling should be more robust
-    let (engine, parsing_options) = state
-        .manager()
-        .get_completions_engine_with_parsing(&model)
-        .map_err(|e| {
-            let err_response = ErrorMessage::from_model_error(&e);
-            inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-            err_response
-        })?;
+    let (engine, parsing_options) = resolve(&model).inspect_err(|err_response| {
+        inflight_guard.mark_error(extract_error_type_from_response(err_response));
+    })?;
 
     let mut response_collector = state
         .metrics_clone()
@@ -860,11 +893,16 @@ async fn completions_single(
 /// Handle batch prompt completions (multiple prompts with n choices each)
 #[tracing::instrument(skip_all)]
 async fn completions_batch(
-    state: Arc<service_v2::State>,
+    state: &Arc<service_v2::State>,
+    metric_model: String,
     request: Context<NvCreateCompletionRequest>,
     stream_handle: ConnectionHandle,
     batch_size: usize,
     n: u8,
+    resolve: impl FnOnce(
+        &str,
+    )
+        -> Result<(OpenAICompletionsStreamingEngine, ParsingOptions), ErrorResponse>,
 ) -> Result<Response, ErrorResponse> {
     use crate::protocols::openai::completions::extract_single_prompt;
     use futures::stream::{self, StreamExt};
@@ -872,7 +910,6 @@ async fn completions_batch(
     let request_id = request.id().to_string();
     let streaming = request.inner.stream.unwrap_or(false);
     let model = request.inner.model.clone();
-    let metric_model = state.manager().metric_model_for(&model).to_string();
 
     // Create inflight_guard early to ensure all errors are counted
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
@@ -885,14 +922,9 @@ async fn completions_batch(
     // Create http_queue_guard early - tracks time waiting to be processed
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
 
-    let (engine, parsing_options) = state
-        .manager()
-        .get_completions_engine_with_parsing(&model)
-        .map_err(|e| {
-            let err_response = ErrorMessage::from_model_error(&e);
-            inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-            err_response
-        })?;
+    let (engine, parsing_options) = resolve(&model).inspect_err(|err_response| {
+        inflight_guard.mark_error(extract_error_type_from_response(err_response));
+    })?;
 
     let mut response_collector = state
         .metrics_clone()
@@ -1245,8 +1277,9 @@ async fn handler_chat_completions(
     let request_id = get_or_create_request_id(&headers);
     let streaming = request.inner.stream.unwrap_or(false);
     let resolved_model = resolve_request_model(&request.inner.model, template.as_ref());
+    let metric_model = state.manager().metric_model_for(resolved_model).to_string();
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: metric_model.clone(),
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -1267,15 +1300,32 @@ async fn handler_chat_completions(
     )
     .await;
 
-    let response =
-        tokio::spawn(chat_completions(state, template, request, stream_handle).in_current_span())
+    let response = tokio::spawn(
+        async move {
+            chat_completions(
+                &state,
+                metric_model,
+                template,
+                request,
+                stream_handle,
+                |model| {
+                    state
+                        .manager()
+                        .get_chat_completions_engine_with_parsing(model)
+                        .map_err(|error| ErrorMessage::from_model_error(&error))
+                },
+            )
             .await
-            .map_err(|e| {
-                ErrorMessage::internal_server_error_with_details(
-                    "Failed to await chat completions task",
-                    format!("{e:?}"),
-                )
-            })?;
+        }
+        .in_current_span(),
+    )
+    .await
+    .map_err(|e| {
+        ErrorMessage::internal_server_error_with_details(
+            "Failed to await chat completions task",
+            format!("{e:?}"),
+        )
+    })?;
 
     // if we got here, then we will return a response and the potentially long running task has completed successfully
     // without need to be cancelled.
@@ -1763,13 +1813,20 @@ fn accumulate_reasoning_dispatch(
 /// Note: For all requests, streaming or non-streaming, we always call the engine with streaming enabled. For
 /// non-streaming requests, we will fold the stream into a single response as part of this handler.
 async fn chat_completions(
-    state: Arc<service_v2::State>,
+    state: &Arc<service_v2::State>,
+    metric_model: String,
     template: Option<RequestTemplate>,
     mut request: Context<NvCreateChatCompletionRequest>,
     mut stream_handle: ConnectionHandle,
+    resolve: impl FnOnce(
+        &str,
+    ) -> Result<
+        (OpenAIChatCompletionsStreamingEngine, ParsingOptions),
+        ErrorResponse,
+    > + Send,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
-    check_ready(&state)?;
+    check_ready(state)?;
 
     let request_id = request.id().to_string();
 
@@ -1794,8 +1851,6 @@ async fn chat_completions(
     // todo - when optional, if none, apply a default
     // todo - determine the proper error code for when a request model is not present
     let model = request.inner.model.clone();
-    let metric_model = state.manager().metric_model_for(&model).to_string();
-
     tracing::trace!("Received chat completions request: {:?}", request.content());
 
     // Create inflight_guard early to ensure all errors (including validation) are counted
@@ -1848,14 +1903,9 @@ async fn chat_completions(
 
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
-    let (engine, parsing_options) = state
-        .manager()
-        .get_chat_completions_engine_with_parsing(&model)
-        .map_err(|e| {
-            let err_response = ErrorMessage::from_model_error(&e);
-            inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-            err_response
-        })?;
+    let (engine, parsing_options) = resolve(&model).inspect_err(|err_response| {
+        inflight_guard.mark_error(extract_error_type_from_response(err_response));
+    })?;
 
     // Gate the experimental v2 batch finalize on the request's tool_choice, mirroring the
     // streaming gate (required/named + structural-tag stay on the v1 finalize path).
@@ -2173,8 +2223,9 @@ async fn handler_responses(
     let streaming = request.inner.stream.unwrap_or(false);
     let raw_model = request.inner.model.as_deref().unwrap_or("");
     let resolved_model = resolve_request_model(raw_model, template.as_ref());
+    let metric_model = state.manager().metric_model_for(resolved_model).to_string();
     let cancellation_labels = CancellationLabels {
-        model: state.manager().metric_model_for(resolved_model).to_string(),
+        model: metric_model.clone(),
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
@@ -2195,15 +2246,32 @@ async fn handler_responses(
     )
     .await;
 
-    let response =
-        tokio::spawn(responses(state, template, request, stream_handle).in_current_span())
+    let response = tokio::spawn(
+        async move {
+            responses(
+                &state,
+                metric_model,
+                template,
+                request,
+                stream_handle,
+                |model| {
+                    state
+                        .manager()
+                        .get_chat_completions_engine_with_parsing(model)
+                        .map_err(|error| ErrorMessage::from_model_error(&error))
+                },
+            )
             .await
-            .map_err(|e| {
-                ErrorMessage::internal_server_error_with_details(
-                    "Failed to await responses task",
-                    format!("{e:?}"),
-                )
-            })?;
+        }
+        .in_current_span(),
+    )
+    .await
+    .map_err(|e| {
+        ErrorMessage::internal_server_error_with_details(
+            "Failed to await responses task",
+            format!("{e:?}"),
+        )
+    })?;
 
     // if we got here, then we will return a response and the potentially long running task has completed successfully
     // without need to be cancelled.
@@ -2214,13 +2282,20 @@ async fn handler_responses(
 
 #[tracing::instrument(level = "debug", skip_all, fields(request_id = %request.id()))]
 async fn responses(
-    state: Arc<service_v2::State>,
+    state: &Arc<service_v2::State>,
+    metric_model: String,
     template: Option<RequestTemplate>,
     mut request: Context<NvCreateResponse>,
     mut stream_handle: ConnectionHandle,
+    resolve: impl FnOnce(
+        &str,
+    ) -> Result<
+        (OpenAIChatCompletionsStreamingEngine, ParsingOptions),
+        ErrorResponse,
+    > + Send,
 ) -> Result<Response, ErrorResponse> {
     // return a 503 if the service is not ready
-    check_ready(&state)?;
+    check_ready(state)?;
 
     // Apply template values if present. When no template and no client-supplied
     // max_output_tokens, leave it as None for response echoing and let the
@@ -2241,8 +2316,6 @@ async fn responses(
 
     let model = request.inner.model.clone().unwrap_or_default();
     let streaming = request.inner.stream.unwrap_or(false);
-    let metric_model = state.manager().metric_model_for(&model).to_string();
-
     // Create http_queue_guard early - tracks time waiting to be processed
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
@@ -2333,14 +2406,9 @@ async fn responses(
 
     tracing::trace!("Getting chat completions engine for model: {}", model);
 
-    let (engine, parsing_options) = state
-        .manager()
-        .get_chat_completions_engine_with_parsing(&model)
-        .map_err(|e| {
-            let err_response = ErrorMessage::from_model_error(&e);
-            inflight_guard.mark_error(extract_error_type_from_response(&err_response));
-            err_response
-        })?;
+    let (engine, parsing_options) = resolve(&model).inspect_err(|err_response| {
+        inflight_guard.mark_error(extract_error_type_from_response(err_response));
+    })?;
 
     // Gate the experimental v2 batch finalize on the request's tool_choice, mirroring the
     // streaming gate (required/named + structural-tag stay on the v1 finalize path).

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -44,6 +44,40 @@ pub trait OutputOptionsProvider {
     fn extract_output_options(&self) -> Result<OutputOptions>;
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize, Default)]
+pub struct ParsingOptions {
+    pub tool_call_parser: Option<String>,
+
+    pub reasoning_parser: Option<String>,
+
+    /// Request-side gate for routing the batch tool-call finalize through
+    /// `dynamo-parsers-v2` (see
+    /// `super::openai::chat_completions::tool_parser_v2::batch_tool_choice_eligible`). Defaults
+    /// `false` so any path that does not explicitly opt in stays on the v1 finalize path; the
+    /// chat HTTP handlers set it from the request's tool_choice. The env flag and family support
+    /// are checked separately in the aggregator.
+    #[serde(default)]
+    pub experimental_v2_batch_eligible: bool,
+}
+
+impl ParsingOptions {
+    pub fn new(tool_call_parser: Option<String>, reasoning_parser: Option<String>) -> Self {
+        Self {
+            tool_call_parser,
+            reasoning_parser,
+            experimental_v2_batch_eligible: false,
+        }
+    }
+
+    /// Set whether this request is eligible for the experimental v2 batch parser
+    /// (request-side tool_choice gate). See
+    /// `super::openai::chat_completions::tool_parser_v2::batch_tool_choice_eligible`.
+    pub fn with_experimental_v2_batch_eligible(mut self, eligible: bool) -> Self {
+        self.experimental_v2_batch_eligible = eligible;
+        self
+    }
+}
+
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
 pub enum FinishReason {
     #[serde(rename = "eos")]

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -319,37 +319,3 @@ pub trait DeltaGeneratorExt<ResponseType: Send + 'static + std::fmt::Debug>:
         None
     }
 }
-
-#[derive(Clone, Debug, Serialize, Deserialize, Default)]
-pub struct ParsingOptions {
-    pub tool_call_parser: Option<String>,
-
-    pub reasoning_parser: Option<String>,
-
-    /// Request-side gate for routing the batch tool-call finalize through
-    /// `dynamo-parsers-v2` (see
-    /// `chat_completions::tool_parser_v2::batch_tool_choice_eligible`). Defaults `false`
-    /// so any path that does not explicitly opt in stays on the v1 finalize path; the
-    /// chat HTTP handlers set it from the request's tool_choice. The env flag and family
-    /// support are checked separately in the aggregator.
-    #[serde(default)]
-    pub experimental_v2_batch_eligible: bool,
-}
-
-impl ParsingOptions {
-    pub fn new(tool_call_parser: Option<String>, reasoning_parser: Option<String>) -> Self {
-        Self {
-            tool_call_parser,
-            reasoning_parser,
-            experimental_v2_batch_eligible: false,
-        }
-    }
-
-    /// Set whether this request is eligible for the experimental v2 batch parser
-    /// (request-side tool_choice gate). See
-    /// `chat_completions::tool_parser_v2::batch_tool_choice_eligible`.
-    pub fn with_experimental_v2_batch_eligible(mut self, eligible: bool) -> Self {
-        self.experimental_v2_batch_eligible = eligible;
-        self
-    }
-}

--- a/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/chat_completions/aggregator.rs
@@ -10,9 +10,8 @@ use super::{NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse
 use crate::protocols::{
     Annotated,
     codec::{Message, SseCodecError},
-    common::extensions::merge_response_nvext,
+    common::{ParsingOptions, extensions::merge_response_nvext},
     convert_sse_stream,
-    openai::ParsingOptions,
 };
 
 use dynamo_protocols::types::ChatCompletionMessageContent;

--- a/lib/llm/src/protocols/openai/completions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/completions/aggregator.rs
@@ -10,9 +10,8 @@ use super::NvCreateCompletionResponse;
 use crate::protocols::{
     Annotated, DataStream,
     codec::{Message, SseCodecError},
-    common::{FinishReason, extensions::merge_response_nvext},
+    common::{FinishReason, ParsingOptions, extensions::merge_response_nvext},
     convert_sse_stream,
-    openai::ParsingOptions,
 };
 
 /// Aggregates a stream of [`CompletionResponse`]s into a single [`CompletionResponse`].

--- a/lib/llm/src/request_trace/payload_stream.rs
+++ b/lib/llm/src/request_trace/payload_stream.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::sync::oneshot;
 
-use crate::protocols::openai::ParsingOptions;
+use crate::protocols::common::ParsingOptions;
 use crate::protocols::openai::chat_completions::{
     DeltaAggregator, NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse,
 };

--- a/lib/llm/tests/aggregators.rs
+++ b/lib/llm/tests/aggregators.rs
@@ -4,8 +4,8 @@
 use dynamo_llm::protocols::{
     Annotated, ContentProvider, DataStream,
     codec::{Message, SseCodecError, create_message_stream},
+    common::ParsingOptions,
     openai::{
-        ParsingOptions,
         chat_completions::{
             NvCreateChatCompletionResponse, NvCreateChatCompletionStreamResponse,
             aggregator::ChatCompletionAggregator,

--- a/lib/llm/tests/test_streaming_usage.rs
+++ b/lib/llm/tests/test_streaming_usage.rs
@@ -3,8 +3,8 @@
 
 use async_trait::async_trait;
 use dynamo_llm::preprocessor::OpenAIPreprocessor;
+use dynamo_llm::protocols::common::ParsingOptions;
 use dynamo_llm::protocols::common::llm_backend::{BackendOutput, FinishReason};
-use dynamo_llm::protocols::openai::ParsingOptions;
 use dynamo_llm::protocols::openai::chat_completions::{
     NvCreateChatCompletionRequest, aggregator::ChatCompletionAggregator,
 };


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This mechanically moves ModelManager-dependent model lookup and metric-label resolution out of the production generation handler cores and into their existing Axum wrappers. It creates the resolver seam required for plane-independent frontend composition while preserving the runtime path and protocol behavior.

CLOSES: LLM-147

### How This Was Implemented
- Pass monomorphized resolver closures into Completions, Chat Completions, Responses, and Anthropic Messages cores.
- Keep each engine and its `ParsingOptions` resolved atomically through the existing `ModelManager` methods.
- Resolve the bounded metrics label in the wrapper and pass it into the core, removing all direct `ModelManager` access from those cores.
- Borrow the task-owned state so the default path adds no trait object, allocation, task, or `Arc` clone.

<details>
<summary>Walkthrough</summary>

#### Mental model

The Axum wrappers remain the runtime-backed composition layer. They provide a small callable that knows how to use `ModelManager`; the protocol cores invoke it without knowing which registry supplied the engine.

```mermaid
flowchart LR
    A["Axum protocol wrapper"] --> B["ModelManager-backed resolver closure"]
    B --> C["Atomic engine + ParsingOptions"]
    A --> D["Generation handler core"]
    C --> D
    D --> E["Existing preprocessing, engine call, and response conversion"]
```

#### State and ordering

The wrapper derives the same template-resolved model used for cancellation and metrics labels, then moves that bounded label into the spawned request task. The core still applies request-template defaults and invokes engine resolution at the original point after validation, so lookup ordering and error accounting do not change.

Each resolver returns one `(engine, ParsingOptions)` snapshot from the existing combined manager accessor. Tool and reasoning parser configuration therefore remains paired with the selected worker set.

#### Request lifecycle

Readiness checks, request context creation, disconnect monitoring, and the single existing Tokio task stay in the wrapper. Inside that task, the core performs the same validation and preprocessing, invokes the supplied resolver once, calls the engine, and runs the unchanged streaming or unary response path.

OpenAI resolver errors retain the existing `ErrorMessage::from_model_error` mapping and inflight error classification. Anthropic retains its existing 404 versus retryable 503 mapping.

#### Boundaries and limitations

This PR only decouples the production generation cores for Completions, Chat Completions, Responses, and Anthropic Messages. It does not add manual engine registration, change service construction, move handlers to another crate, introduce a backend trait, or modify embeddings, media, realtime, and model-listing handlers.

The default runtime-backed frontend remains the only composition in this PR. LLM-148 can add the manual composition by supplying another resolver without changing these protocol cores.

</details>

### Validation
- `cargo check -p dynamo-llm --lib`
- `cargo test -p dynamo-llm --lib http::service::` (127 passed)
- `cargo test -p dynamo-llm --test http-service --test http_metrics --test anthropic_http_replay` (19 passed)
- `cargo clippy -p dynamo-llm --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check 5767ea22bf..HEAD`

### Runtime Performance Validation
- Release A/B against parent PR #11281 with the same baseline mocker, fresh processes, isolated frontend CPUs, and ABBAAB ordering (3 scored runs/arm; 2,048 requests/run).
- Median throughput: `404.26 -> 431.21 req/s` (`+6.67%`).
- Median frontend CPU/request: `4.7168 -> 4.4971 ms` (`-4.66%`).
- All `12,288` scored requests completed with zero errors/cancellations; both predeclared 2% no-regression guards pass.
- Matched 30-second `perf`/DWARF profiles showed no new handler-resolution hotspot. Symbol-level deltas are qualitative because `perf` lost 4 baseline and 8 candidate chunks under load.
- Run-to-run spread was material, so these results establish no regression rather than an optimization claim.

<!-- codex-pr-description:end -->
