### PR TITLE
fix(router): disclose selected worker in non-KV modes for 1.3.0

### DIFF
--- a/lib/llm/src/lora/filtered_router.rs
+++ b/lib/llm/src/lora/filtered_router.rs
@@ -28,6 +28,9 @@ use crate::lora::filter::LoraFilter;
 use crate::lora::load_estimator::LoadEstimator;
 use crate::preprocessor::PreprocessedRequest;
 use crate::protocols::common::llm_backend::LLMEngineOutput;
+use crate::protocols::common::timing::{
+    RequestPhase, RequestTracker, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL,
+};
 
 /// Decrements the [`LoadEstimator`] counter for a LoRA when dropped.
 struct LoadGuard {
@@ -143,6 +146,18 @@ impl LoraFilteredRouter {
             }
         }
     }
+
+    fn record_worker(tracker: Option<&RequestTracker>, worker_id: u64) {
+        let Some(tracker) = tracker else {
+            return;
+        };
+        let worker_type = if tracker.phase() == RequestPhase::Prefill {
+            WORKER_TYPE_PREFILL
+        } else {
+            WORKER_TYPE_DECODE
+        };
+        tracker.record_worker(worker_id, None, worker_type);
+    }
 }
 
 #[async_trait]
@@ -163,7 +178,14 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // the inner load-aware push router so base traffic on a LoRA-enabled deployment keeps the
         // unmodified hot path (no avail/free scans, no set allocation, no LoadGuard).
         let Some(lora_name) = lora_name else {
-            return self.inner.generate(request).await;
+            let ((tracker, worker_id), stream) = self
+                .inner
+                .select_and_dispatch(request, |request, worker_id| {
+                    Ok((request.tracker.take(), worker_id))
+                })
+                .await?;
+            Self::record_worker(tracker.as_deref(), worker_id);
+            return Ok(stream);
         };
 
         self.load_estimator.increment_load(&lora_name);
@@ -229,10 +251,16 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
         // race where `target` disappears mid-dispatch reselects another replica-set worker rather
         // than escaping to an arbitrary worker outside the placement table.
         let candidate_set: std::collections::HashSet<u64> = candidates.iter().copied().collect();
-        let response_stream = self
+        let ((tracker, worker_id), response_stream) = self
             .inner
-            .direct_within(request, target, Some(&candidate_set))
+            .direct_within_prepared(
+                request,
+                target,
+                Some(&candidate_set),
+                |request, worker_id| Ok((request.tracker.take(), worker_id)),
+            )
             .await?;
+        Self::record_worker(tracker.as_deref(), worker_id);
         let tracking = LoadTrackingStream {
             inner: response_stream,
             _guard: guard,

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::time::Duration;
+use std::{sync::Arc, time::Duration};
 
 use dynamo_runtime::pipeline::{
     AsyncEngine, AsyncEngineContext, AsyncEngineContextProvider, Error, ManyOut, PushRouter,
@@ -15,7 +15,9 @@ use super::{
 };
 use crate::{
     preprocessor::PreprocessedRequest,
-    protocols::common::timing::{RequestPhase, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL},
+    protocols::common::timing::{
+        RequestPhase, RequestTracker, WORKER_TYPE_DECODE, WORKER_TYPE_PREFILL,
+    },
 };
 
 pub struct SessionAffinityPushRouter {
@@ -45,8 +47,8 @@ impl SessionAffinityPushRouter {
             .unwrap_or(RequestPhase::Aggregated)
     }
 
-    fn record_target(request: &PreprocessedRequest, target: AffinityTarget) {
-        let Some(tracker) = request.tracker.as_ref() else {
+    fn record_target(tracker: Option<&RequestTracker>, target: AffinityTarget) {
+        let Some(tracker) = tracker else {
             return;
         };
         let worker_type = if tracker.phase() == RequestPhase::Prefill {
@@ -55,6 +57,21 @@ impl SessionAffinityPushRouter {
             WORKER_TYPE_DECODE
         };
         tracker.record_worker(target.worker_id, target.dp_rank, worker_type);
+    }
+
+    fn prepare_resolved_target(
+        request: &mut PreprocessedRequest,
+        requested: AffinityTarget,
+        worker_id: u64,
+    ) -> (Option<Arc<RequestTracker>>, AffinityTarget) {
+        let dp_rank = requested
+            .dp_rank
+            .filter(|_| worker_id == requested.worker_id);
+        request.routing_mut().dp_rank = dp_rank;
+        (
+            request.tracker.take(),
+            AffinityTarget { worker_id, dp_rank },
+        )
     }
 
     fn direct_target(
@@ -107,6 +124,28 @@ impl SessionAffinityPushRouter {
             .await
     }
 
+    async fn select_and_dispatch_prefill_exact<M, F>(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        pinned_worker: Option<u64>,
+        dp_rank: Option<u32>,
+        prepare: F,
+    ) -> Result<(M, ManyOut<LlmResponse>), Error>
+    where
+        F: FnOnce(&mut PreprocessedRequest, u64, Option<u32>) -> Result<M, Error>,
+    {
+        let ((metadata, tracker, target), stream) = self
+            .inner
+            .select_and_dispatch_exact(request, pinned_worker, move |request, worker_id| {
+                let target = AffinityTarget { worker_id, dp_rank };
+                let metadata = prepare(request, worker_id, dp_rank)?;
+                Ok((metadata, request.tracker.take(), target))
+            })
+            .await?;
+        Self::record_target(tracker.as_deref(), target);
+        Ok((metadata, stream))
+    }
+
     pub async fn select_and_dispatch_prefill<M, F>(
         &self,
         request: SingleIn<PreprocessedRequest>,
@@ -123,10 +162,7 @@ impl SessionAffinityPushRouter {
         if !self.direct && session_id.is_none() {
             let pinned_worker = phase_worker_id(&request, RequestPhase::Prefill);
             return self
-                .inner
-                .select_and_dispatch_exact(request, pinned_worker, move |request, worker_id| {
-                    prepare(request, worker_id, None)
-                })
+                .select_and_dispatch_prefill_exact(request, pinned_worker, None, prepare)
                 .await;
         }
         let explicit = self.direct_target(
@@ -140,11 +176,11 @@ impl SessionAffinityPushRouter {
                 ));
             };
             return self
-                .inner
-                .select_and_dispatch_exact(
+                .select_and_dispatch_prefill_exact(
                     request,
                     Some(pinned_worker.worker_id),
-                    move |request, worker_id| prepare(request, worker_id, None),
+                    None,
+                    prepare,
                 )
                 .await;
         };
@@ -158,18 +194,11 @@ impl SessionAffinityPushRouter {
                 .or(explicit);
             let rank = selected.and_then(|target| target.dp_rank);
             return self
-                .inner
-                .select_and_dispatch_exact(
+                .select_and_dispatch_prefill_exact(
                     request,
                     selected.map(|target| target.worker_id),
-                    move |request, worker_id| {
-                        let target = AffinityTarget {
-                            worker_id,
-                            dp_rank: rank,
-                        };
-                        Self::record_target(request, target);
-                        prepare(request, worker_id, rank)
-                    },
+                    rank,
+                    prepare,
                 )
                 .await;
         }
@@ -190,19 +219,21 @@ impl SessionAffinityPushRouter {
                         worker_id,
                         dp_rank: rank,
                     };
-                    Self::record_target(request, target);
-                    Ok((prepare(request, worker_id, rank)?, target))
+                    let metadata = prepare(request, worker_id, rank)?;
+                    Ok((metadata, request.tracker.take(), target))
                 },
             )
             .await;
-        let ((metadata, target), stream) = match dispatch {
+        let ((metadata, tracker, target), stream) = match dispatch {
             Ok(result) => result,
             Err(error) => {
                 operation.invalidate();
                 return Err(error);
             }
         };
-        Ok((metadata, operation.into_stream(target, stream)?))
+        let stream = operation.into_stream(target, stream)?;
+        Self::record_target(tracker.as_deref(), target);
+        Ok((metadata, stream))
     }
 }
 
@@ -221,7 +252,20 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
             None
         };
         if !self.direct && session_id.is_none() {
-            return self.inner.generate(request).await;
+            let ((tracker, target), stream) = self
+                .inner
+                .select_and_dispatch(request, |request, worker_id| {
+                    Ok((
+                        request.tracker.take(),
+                        AffinityTarget {
+                            worker_id,
+                            dp_rank: None,
+                        },
+                    ))
+                })
+                .await?;
+            Self::record_target(tracker.as_deref(), target);
+            return Ok(stream);
         }
         let explicit = self.direct_target(explicit_target(&request, phase)?, phase)?;
         let Some(session_id) = session_id else {
@@ -230,7 +274,19 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                     "Direct routing requires an explicit {phase} target"
                 )));
             };
-            return self.inner.direct(request, target.worker_id).await;
+            let ((tracker, target), stream) = self
+                .inner
+                .direct_within_prepared(
+                    request,
+                    target.worker_id,
+                    None,
+                    move |request, worker_id| {
+                        Ok(Self::prepare_resolved_target(request, target, worker_id))
+                    },
+                )
+                .await?;
+            Self::record_target(tracker.as_deref(), target);
+            return Ok(stream);
         };
 
         let is_query_only = request.get_annotation_value("query_instance_id").is_some();
@@ -242,7 +298,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                 .query_target(&session_id, explicit)?
                 .or(explicit);
             let rank = target.and_then(|target| target.dp_rank);
-            let (_, stream) = self
+            let ((tracker, target), stream) = self
                 .inner
                 .select_and_dispatch_exact(
                     request,
@@ -251,17 +307,17 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                         if rank.is_some() {
                             request.routing_mut().dp_rank = rank;
                         }
-                        Self::record_target(
-                            request,
+                        Ok((
+                            request.tracker.take(),
                             AffinityTarget {
                                 worker_id,
                                 dp_rank: rank,
                             },
-                        );
-                        Ok(())
+                        ))
                     },
                 )
                 .await?;
+            Self::record_target(tracker.as_deref(), target);
             return Ok(stream);
         }
 
@@ -284,19 +340,20 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                         worker_id,
                         dp_rank: rank,
                     };
-                    Self::record_target(request, target);
-                    Ok(target)
+                    Ok((request.tracker.take(), target))
                 },
             )
             .await;
-        let (target, stream) = match dispatch {
+        let ((tracker, target), stream) = match dispatch {
             Ok(result) => result,
             Err(error) => {
                 operation.invalidate();
                 return Err(error);
             }
         };
-        operation.into_stream(target, stream)
+        let stream = operation.into_stream(target, stream)?;
+        Self::record_target(tracker.as_deref(), target);
+        Ok(stream)
     }
 }
 
@@ -321,6 +378,7 @@ mod tests {
     use crate::protocols::common::{
         extensions::{SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId},
         preprocessor::RoutingHints,
+        timing::RequestTracker,
     };
     use crate::session_affinity::AffinityAcquire;
 
@@ -360,6 +418,30 @@ mod tests {
             .expect("test router must enable affinity")
     }
 
+    #[test]
+    fn direct_fallback_clears_stale_dp_rank() {
+        let tracker = Arc::new(RequestTracker::new());
+        let mut content = request(Some(7), false);
+        content.routing_mut().dp_rank = Some(3);
+        content.tracker = Some(tracker.clone());
+
+        let (prepared_tracker, target) = SessionAffinityPushRouter::prepare_resolved_target(
+            &mut content,
+            AffinityTarget {
+                worker_id: 7,
+                dp_rank: Some(3),
+            },
+            8,
+        );
+
+        assert_eq!(content.routing.unwrap().dp_rank, None);
+        assert_eq!(tracker.prefill_worker_id(), None);
+        assert_eq!(tracker.decode_worker_id(), None);
+        SessionAffinityPushRouter::record_target(prepared_tracker.as_deref(), target);
+        assert_eq!(tracker.prefill_worker_id(), Some(8));
+        assert_eq!(tracker.decode_worker_id(), Some(8));
+    }
+
     #[tokio::test]
     async fn session_affinity_disabled_simple_router_has_no_coordinator() {
         let runtime = Runtime::from_current().unwrap();
@@ -384,6 +466,62 @@ mod tests {
         assert!(router.affinity.is_none());
 
         drop(router);
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn failed_non_kv_dispatch_does_not_record_selected_worker() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let component = distributed
+            .namespace("session_affinity_worker_disclosure".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap();
+
+        for (index, mode) in [
+            RouterMode::Random,
+            RouterMode::RoundRobin,
+            RouterMode::PowerOfTwoChoices,
+            RouterMode::LeastLoaded,
+            RouterMode::DeviceAwareWeighted,
+            RouterMode::Direct,
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let endpoint = component.endpoint(format!("mode-{index}"));
+            let client = endpoint.client().await.unwrap();
+            endpoint.register_endpoint_instance().await.unwrap();
+            let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+            let inner = PushRouter::from_client(client, mode).await.unwrap();
+            let router =
+                SessionAffinityPushRouter::new(inner, None, mode.is_direct_routing()).unwrap();
+            let tracker = Arc::new(RequestTracker::new());
+            let mut content = request(mode.is_direct_routing().then_some(worker_id), false);
+            content.tracker = Some(tracker.clone());
+
+            let _ = tokio::time::timeout(
+                Duration::from_millis(100),
+                router.generate(Context::new(content)),
+            )
+            .await;
+
+            assert_eq!(
+                tracker.prefill_worker_id(),
+                None,
+                "{mode:?} must not disclose a worker before dispatch succeeds"
+            );
+            assert_eq!(
+                tracker.decode_worker_id(),
+                None,
+                "{mode:?} must not disclose a worker before dispatch succeeds"
+            );
+        }
+
         runtime.shutdown();
     }
 
@@ -512,6 +650,50 @@ mod tests {
             phase_worker_id(&decode_only, RequestPhase::Aggregated),
             Some(99)
         );
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn failed_prefill_preparation_does_not_record_selected_worker() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("session_affinity_prefill_target".to_string())
+            .unwrap()
+            .component("workers".to_string())
+            .unwrap()
+            .endpoint("prefill".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let worker_id = client.wait_for_instances().await.unwrap()[0].id();
+
+        for (mode, direct) in [(RouterMode::Direct, true), (RouterMode::RoundRobin, false)] {
+            let inner = PushRouter::from_client(client.clone(), mode).await.unwrap();
+            let router = SessionAffinityPushRouter::new(inner, None, direct).unwrap();
+            let mut content = request(None, false);
+            content.routing_mut().prefill_worker_id = Some(worker_id);
+            content.routing_mut().prefill_dp_rank = Some(0);
+            let tracker = Arc::new(RequestTracker::new());
+            content.tracker = Some(tracker.clone());
+            let mut observed = None;
+
+            let error = router
+                .select_and_dispatch_prefill(Context::new(content), |_, worker_id, dp_rank| {
+                    observed = Some((worker_id, dp_rank));
+                    Err::<(), _>(anyhow::anyhow!("stop before dispatch"))
+                })
+                .await
+                .unwrap_err();
+
+            assert!(error.to_string().contains("stop before dispatch"));
+            assert_eq!(observed, Some((worker_id, None)));
+            assert_eq!(tracker.prefill_worker_id(), None);
+            assert_eq!(tracker.decode_worker_id(), None);
+        }
 
         runtime.shutdown();
     }

--- a/lib/runtime/src/pipeline/network/egress/push_router.rs
+++ b/lib/runtime/src/pipeline/network/egress/push_router.rs
@@ -79,6 +79,15 @@ impl OccupancyPermit {
         }
     }
 
+    fn retarget(&mut self, instance_id: u64) {
+        if self.instance_id == instance_id {
+            return;
+        }
+        self.state.increment(instance_id);
+        self.state.decrement(self.instance_id);
+        self.instance_id = instance_id;
+    }
+
     fn into_tracked_stream<U: Data>(mut self, stream: ManyOut<U>) -> ManyOut<U> {
         self.armed = false;
         let engine_ctx = stream.context();
@@ -668,6 +677,19 @@ where
 
     /// Issue a request to the next available instance in a round-robin fashion
     pub async fn round_robin(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.round_robin_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn round_robin_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let counter = self.round_robin_counter.fetch_add(1, Ordering::Relaxed) as usize;
 
         let (instance_id, candidate_count) = {
@@ -685,12 +707,25 @@ where
             "Selected worker"
         );
 
-        self.generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, None, prepare)
             .await
     }
 
     /// Issue a request to a random endpoint
     pub async fn random(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.random_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn random_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let (instance_id, candidate_count) = {
             let routing_instances = self.client.routing_instances();
             let count = routing_instances.free_ids().len();
@@ -707,13 +742,26 @@ where
             "Selected worker"
         );
 
-        self.generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, None, prepare)
             .await
     }
 
     /// Issue a request using power-of-two-choices: pick 2 random healthy workers,
     /// route to the one with fewer in-flight requests.
     pub async fn power_of_two_choices(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.power_of_two_choices_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn power_of_two_choices_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let state = self.occupancy_state()?;
         let instance_id = {
             let routing_instances = self.client.routing_instances();
@@ -724,14 +772,8 @@ where
         };
         state.increment(instance_id);
         let permit = OccupancyPermit::new(state, instance_id);
-
-        match self
-            .generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, Some(permit), prepare)
             .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
     }
 
     /// Issue a request to a specific endpoint
@@ -753,6 +795,23 @@ where
         instance_id: u64,
         allowed_fallback: Option<&HashSet<u64>>,
     ) -> anyhow::Result<ManyOut<U>> {
+        self.direct_within_prepared(request, instance_id, allowed_fallback, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    /// Like [`Self::direct_within`], but prepares the request after transport resolution and
+    /// returns the preparation metadata alongside the response stream.
+    pub async fn direct_within_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        instance_id: u64,
+        allowed_fallback: Option<&HashSet<u64>>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         // When fault detection is disabled, check the raw discovery list
         // (not filtered by report_instance_down) so transient failures
         // don't poison the instance for subsequent retries.
@@ -785,7 +844,7 @@ where
         let fallback = allowed_fallback
             .map(TransportFallback::Within)
             .unwrap_or(TransportFallback::Allow);
-        self.generate_with_fault_detection(instance_id, request, fallback)
+        self.generate_with_fault_detection_prepared(instance_id, request, fallback, prepare)
             .await
     }
 
@@ -825,6 +884,63 @@ where
         Ok((metadata, stream))
     }
 
+    /// Select a worker using the configured routing mode, prepare the request with the worker
+    /// that survives transport resolution, then dispatch with normal fallback behavior.
+    pub async fn select_and_dispatch<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
+        match self.router_mode {
+            RouterMode::Random => self.random_prepared(request, prepare).await,
+            RouterMode::RoundRobin => self.round_robin_prepared(request, prepare).await,
+            RouterMode::PowerOfTwoChoices => {
+                self.power_of_two_choices_prepared(request, prepare).await
+            }
+            RouterMode::LeastLoaded => self.least_loaded_prepared(request, prepare).await,
+            RouterMode::DeviceAwareWeighted => {
+                self.device_aware_weighted_prepared(request, prepare).await
+            }
+            RouterMode::KV => anyhow::bail!("KV routing should not call select_and_dispatch"),
+            RouterMode::Direct => anyhow::bail!(
+                "Direct routing should use direct_within_prepared instead of select_and_dispatch"
+            ),
+        }
+    }
+
+    async fn dispatch_selected<M, F>(
+        &self,
+        instance_id: u64,
+        request: SingleIn<T>,
+        mut permit: Option<OccupancyPermit>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
+        let (metadata, stream) = self
+            .generate_with_fault_detection_prepared(
+                instance_id,
+                request,
+                TransportFallback::Allow,
+                |request, resolved_instance_id| {
+                    if let Some(permit) = permit.as_mut() {
+                        permit.retarget(resolved_instance_id);
+                    }
+                    prepare(request, resolved_instance_id)
+                },
+            )
+            .await?;
+        let stream = match permit {
+            Some(permit) => permit.into_tracked_stream(stream),
+            None => stream,
+        };
+        Ok((metadata, stream))
+    }
+
     /// Issue a request using device-aware weighted routing.
     ///
     /// Instances are partitioned by device type (CPU vs non-CPU), then the router
@@ -834,6 +950,19 @@ where
     /// If only one device class exists (all CPU or all non-CPU), this naturally
     /// degenerates to least-loaded routing over the available instances.
     pub async fn device_aware_weighted(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.device_aware_weighted_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn device_aware_weighted_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let state = self.occupancy_state()?;
         let routing_instances = self.client.routing_instances();
         let instance_ids = routing_instances.free_ids().to_vec();
@@ -879,16 +1008,8 @@ where
             "Selected worker"
         );
 
-        match self
-            .generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, permit, prepare)
             .await
-        {
-            Ok(stream) => Ok(match permit {
-                Some(permit) => permit.into_tracked_stream(stream),
-                None => stream,
-            }),
-            Err(err) => Err(err),
-        }
     }
 
     fn device_aware_candidates(
@@ -956,6 +1077,19 @@ where
 
     /// Issue a request to the instance with the fewest active connections.
     pub async fn least_loaded(&self, request: SingleIn<T>) -> anyhow::Result<ManyOut<U>> {
+        self.least_loaded_prepared(request, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn least_loaded_prepared<M, F>(
+        &self,
+        request: SingleIn<T>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let state = self.occupancy_state()?;
         let routing_instances = self.client.routing_instances();
         let instance_ids = routing_instances.free_ids().to_vec();
@@ -972,13 +1106,8 @@ where
             "Selected worker"
         );
 
-        match self
-            .generate_with_fault_detection(instance_id, request, TransportFallback::Allow)
+        self.dispatch_selected(instance_id, request, Some(permit), prepare)
             .await
-        {
-            Ok(stream) => Ok(permit.into_tracked_stream(stream)),
-            Err(err) => Err(err),
-        }
     }
 
     /// Select the next worker according to the routing mode.
@@ -1185,6 +1314,21 @@ where
         request: SingleIn<T>,
         fallback: TransportFallback<'_>,
     ) -> anyhow::Result<ManyOut<U>> {
+        self.generate_with_fault_detection_prepared(instance_id, request, fallback, |_, _| Ok(()))
+            .await
+            .map(|(_, stream)| stream)
+    }
+
+    async fn generate_with_fault_detection_prepared<M, F>(
+        &self,
+        instance_id: u64,
+        mut request: SingleIn<T>,
+        fallback: TransportFallback<'_>,
+        prepare: F,
+    ) -> anyhow::Result<(M, ManyOut<U>)>
+    where
+        F: FnOnce(&mut T, u64) -> anyhow::Result<M>,
+    {
         let route_start = Instant::now();
         let request_id = request.id().to_string();
         let route_span = if matches!(self.router_mode, RouterMode::KV) {
@@ -1202,6 +1346,7 @@ where
 
         let (instance_id, address, transport_kind, instance) =
             self.resolve_transport(instance_id, fallback)?;
+        let metadata = prepare(&mut request, instance_id)?;
         let request = request.map(|req| AddressedRequest::with_instance(req, address, instance));
 
         STAGE_DURATION_SECONDS
@@ -1214,7 +1359,8 @@ where
             .generate(request)
             .instrument(route_span)
             .await;
-        self.wrap_with_fault_detection(stream, instance_id)
+        let stream = self.wrap_with_fault_detection(stream, instance_id)?;
+        Ok((metadata, stream))
     }
 
     /// Reject early if the selected worker is overloaded and fault detection
@@ -2400,6 +2546,49 @@ mod tests {
             );
         }
 
+        rt.shutdown();
+    }
+
+    #[tokio::test]
+    async fn prepared_dispatch_observes_worker_after_transport_fallback() {
+        let rt = Runtime::from_current().unwrap();
+        let drt = DistributedRuntime::new(rt.clone(), DistributedConfig::process_local())
+            .await
+            .unwrap();
+        let endpoint = drt
+            .namespace("test_prepared_transport_fallback".to_string())
+            .unwrap()
+            .component("test_component".to_string())
+            .unwrap()
+            .endpoint("test_endpoint".to_string());
+        let client = endpoint.client().await.unwrap();
+        endpoint.register_endpoint_instance().await.unwrap();
+        let real_id = client.wait_for_instances().await.unwrap()[0].id();
+        let stale_id = real_id.wrapping_add(1);
+        client.override_instance_avail(vec![stale_id, real_id]);
+        let router = PushRouter::<u64, TestResponse>::from_client(client, RouterMode::LeastLoaded)
+            .await
+            .unwrap();
+        let state = router.occupancy_state.clone().unwrap();
+        state.increment(real_id);
+        let state_for_prepare = state.clone();
+        let observed = Arc::new(AtomicU64::new(0));
+        let observed_for_prepare = observed.clone();
+
+        let _ = tokio::time::timeout(
+            std::time::Duration::from_millis(100),
+            router.select_and_dispatch(SingleIn::new(42), move |_, worker_id| {
+                assert_eq!(state_for_prepare.load(stale_id), 0);
+                assert_eq!(state_for_prepare.load(worker_id), 2);
+                observed_for_prepare.store(worker_id, Ordering::Relaxed);
+                Ok(())
+            }),
+        )
+        .await;
+
+        assert_eq!(observed.load(Ordering::Relaxed), real_id);
+        assert_eq!(state.load(real_id), 1);
+        state.decrement(real_id);
         rt.shutdown();
     }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Backports #11245 to `release/1.3.0` using the release branch's existing session-affinity API. It discloses the resolved worker for non-KV routing only after dispatch succeeds, preventing failed attempts from poisoning retry metadata.

CLOSES: DYN-3353

### Summary
- Add prepared-dispatch paths that return the worker selected after transport resolution.
- Record worker attribution for standard, session-affinity, direct, and LoRA routing only after a response stream is created successfully.
- Preserve occupancy accounting when transport fallback selects a different worker.

### How This Was Implemented
- The source cherry-pick conflicted only in `session_affinity/push_router.rs`: `release/1.3.0` retains the older `prepare(request, worker_id, dp_rank)` callback, while `main` uses the `AffinityTarget` callback introduced by #11079 after the release branch split.
- The resolution keeps the release callback and rank behavior unchanged, while adapting #11245's post-success recording order to it.
- #11217 is not included because the release branch never received #11079 and already has the local-affinity behavior that #11217 restores.

<details>
<summary>Walkthrough</summary>

#### Mental model

```mermaid
sequenceDiagram
    participant Router
    participant PushRouter
    participant Backend
    participant Tracker
    Router->>PushRouter: Select and prepare request
    PushRouter->>Backend: Dispatch to resolved worker
    Backend-->>PushRouter: Response stream created
    PushRouter->>Tracker: Record resolved worker and rank
```

#### State and ordering

The tracker is removed from the prepared request and returned as dispatch metadata. Worker attribution is committed only after dispatch returns a stream; preparation or dispatch failures leave the tracker unchanged so retry and fallback paths can record the worker that actually succeeds.

#### Boundaries and limitations

This backport does not import the distributed-affinity work or its later revert. The public release callback remains `(worker_id, dp_rank)`, and existing release routing behavior remains unchanged.

</details>

### Validation
- `cargo test -p dynamo-runtime -p dynamo-llm push_router::tests --lib` (41 passed)
- `cargo clippy -p dynamo-runtime -p dynamo-llm --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
<!-- codex-pr-description:end -->
