### PR TITLE
fix(snapshot): preserve CUDA ordinal mapping for DRA GPUs

### DIFF
--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -105,11 +105,34 @@ func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) 
 	return uuids, nil
 }
 
-// discoverVisibleGPUs is swapped out in tests.
-var discoverVisibleGPUs = GetGPUUUIDsViaNvidiaSmi
+type visibleGPUDiscovery func(context.Context, string, int) ([]string, error)
 
 // DiscoverGPUUUIDs resolves GPU UUIDs in the container's runtime ordinal order.
 func DiscoverGPUUUIDs(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName, hostProcPath string, pid int, log logr.Logger) ([]string, error) {
+	return discoverGPUUUIDs(
+		ctx,
+		clientset,
+		podName,
+		podNamespace,
+		containerName,
+		hostProcPath,
+		pid,
+		GetGPUUUIDsViaNvidiaSmi,
+		log,
+	)
+}
+
+func discoverGPUUUIDs(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	podName,
+	podNamespace,
+	containerName,
+	hostProcPath string,
+	pid int,
+	discoverVisibleGPUs visibleGPUDiscovery,
+	log logr.Logger,
+) ([]string, error) {
 	gpuUUIDs, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, clientset, podName, podNamespace, containerName, log)
 	if err != nil {
 		if hasNVIDIADRAAllocation {

--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -3,6 +3,7 @@ package cuda
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -104,43 +105,126 @@ func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) 
 	return uuids, nil
 }
 
-// DiscoverGPUUUIDs resolves GPU UUIDs according to the pod's allocation mode:
-// DRA-backed pods use the DRA API, classic nvidia.com/gpu pods use PodResources,
-// and nvidia-smi remains the last fallback for either path.
+type visibleGPUDiscovery func(context.Context, string, int) ([]string, error)
+
+// DiscoverGPUUUIDs resolves GPU UUIDs in the container's runtime ordinal order.
 func DiscoverGPUUUIDs(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName, hostProcPath string, pid int, log logr.Logger) ([]string, error) {
+	return discoverGPUUUIDs(
+		ctx,
+		clientset,
+		podName,
+		podNamespace,
+		containerName,
+		hostProcPath,
+		pid,
+		GetGPUUUIDsViaNvidiaSmi,
+		log,
+	)
+}
+
+func discoverGPUUUIDs(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	podName,
+	podNamespace,
+	containerName,
+	hostProcPath string,
+	pid int,
+	discoverVisibleGPUs visibleGPUDiscovery,
+	log logr.Logger,
+) ([]string, error) {
 	gpuUUIDs, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, clientset, podName, podNamespace, log)
-	fallbackReason := "DRA API returned no GPU UUIDs"
 	if err != nil {
+		if hasNVIDIADRAAllocation {
+			return nil, fmt.Errorf("DRA GPU UUID lookup failed: %w", err)
+		}
 		log.Error(
 			err,
 			"DRA API GPU UUID lookup failed, trying other discovery paths",
 			"pod", podNamespace+"/"+podName,
-			"has_nvidia_dra_allocation", hasNVIDIADRAAllocation,
 		)
 		gpuUUIDs = nil
-		fallbackReason = "DRA API GPU UUID lookup failed"
+	}
+
+	if hasNVIDIADRAAllocation {
+		if len(gpuUUIDs) == 0 {
+			return nil, errors.New(
+				"DRA GPU allocation has no resolvable UUIDs",
+			)
+		}
+		visibleGPUUUIDs, err := discoverVisibleGPUs(ctx, hostProcPath, pid)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"discover DRA GPUs in container ordinal order: %w",
+				err,
+			)
+		}
+		orderedUUIDs, err := orderDRAUUIDsByRuntime(gpuUUIDs, visibleGPUUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		log.Info(
+			"resolved DRA GPU UUIDs in container ordinal order",
+			"uuids", orderedUUIDs,
+		)
+		return orderedUUIDs, nil
+	}
+
+	gpuUUIDs, err = GetPodGPUUUIDs(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return nil, fmt.Errorf("PodResources GPU UUID lookup failed: %w", err)
 	}
 	if len(gpuUUIDs) > 0 {
 		return gpuUUIDs, nil
 	}
-	if !hasNVIDIADRAAllocation {
-		gpuUUIDs, err = GetPodGPUUUIDs(ctx, podName, podNamespace, containerName)
-		if err != nil {
-			return nil, fmt.Errorf("PodResources GPU UUID lookup failed: %w", err)
-		}
-		if len(gpuUUIDs) > 0 {
-			return gpuUUIDs, nil
-		}
-		fallbackReason = "PodResources API returned no GPU UUIDs"
-	}
 
-	log.Info(fallbackReason+", falling back to nvidia-smi", "pid", pid)
-	gpuUUIDs, err = GetGPUUUIDsViaNvidiaSmi(ctx, hostProcPath, pid)
+	log.Info("PodResources API returned no GPU UUIDs, falling back to nvidia-smi", "pid", pid)
+	gpuUUIDs, err = discoverVisibleGPUs(ctx, hostProcPath, pid)
 	if err != nil {
 		return nil, fmt.Errorf("nvidia-smi GPU UUID fallback failed: %w", err)
 	}
 	log.Info("nvidia-smi fallback discovered GPU UUIDs", "uuids", gpuUUIDs)
 	return gpuUUIDs, nil
+}
+
+func orderDRAUUIDsByRuntime(allocatedUUIDs, visibleUUIDs []string) ([]string, error) {
+	if len(allocatedUUIDs) != len(visibleUUIDs) {
+		return nil, fmt.Errorf(
+			"DRA allocation and container-visible GPU count differ: allocated=%d visible=%d",
+			len(allocatedUUIDs),
+			len(visibleUUIDs),
+		)
+	}
+
+	allocated := make(map[string]struct{}, len(allocatedUUIDs))
+	for _, uuid := range allocatedUUIDs {
+		if !gpuUUIDPattern.MatchString(uuid) {
+			return nil, fmt.Errorf("DRA allocation contains invalid GPU UUID %q", uuid)
+		}
+		if _, duplicate := allocated[uuid]; duplicate {
+			return nil, fmt.Errorf("DRA allocation contains duplicate GPU UUID %q", uuid)
+		}
+		allocated[uuid] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(visibleUUIDs))
+	for _, uuid := range visibleUUIDs {
+		if !gpuUUIDPattern.MatchString(uuid) {
+			return nil, fmt.Errorf("container reports invalid GPU UUID %q", uuid)
+		}
+		if _, duplicate := seen[uuid]; duplicate {
+			return nil, fmt.Errorf("container reports duplicate GPU UUID %q", uuid)
+		}
+		if _, ok := allocated[uuid]; !ok {
+			return nil, fmt.Errorf(
+				"container-visible GPU %q is not in the DRA allocation",
+				uuid,
+			)
+		}
+		seen[uuid] = struct{}{}
+	}
+
+	return append([]string(nil), visibleUUIDs...), nil
 }
 
 // FilterProcesses returns the subset of candidate PIDs that hold actual CUDA contexts.

--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -105,35 +105,12 @@ func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) 
 	return uuids, nil
 }
 
-type visibleGPUDiscovery func(context.Context, string, int) ([]string, error)
+// discoverVisibleGPUs is swapped out in tests.
+var discoverVisibleGPUs = GetGPUUUIDsViaNvidiaSmi
 
 // DiscoverGPUUUIDs resolves GPU UUIDs in the container's runtime ordinal order.
 func DiscoverGPUUUIDs(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName, hostProcPath string, pid int, log logr.Logger) ([]string, error) {
-	return discoverGPUUUIDs(
-		ctx,
-		clientset,
-		podName,
-		podNamespace,
-		containerName,
-		hostProcPath,
-		pid,
-		GetGPUUUIDsViaNvidiaSmi,
-		log,
-	)
-}
-
-func discoverGPUUUIDs(
-	ctx context.Context,
-	clientset kubernetes.Interface,
-	podName,
-	podNamespace,
-	containerName,
-	hostProcPath string,
-	pid int,
-	discoverVisibleGPUs visibleGPUDiscovery,
-	log logr.Logger,
-) ([]string, error) {
-	gpuUUIDs, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, clientset, podName, podNamespace, log)
+	gpuUUIDs, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, clientset, podName, podNamespace, containerName, log)
 	if err != nil {
 		if hasNVIDIADRAAllocation {
 			return nil, fmt.Errorf("DRA GPU UUID lookup failed: %w", err)

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -305,7 +305,7 @@ func TestDiscoverGPUUUIDsFallsBackToPodResourcesAfterDRAAPILookupError(t *testin
 	}
 }
 
-func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
+func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 	previousSocketPath := podResourcesSocketPath
 	podResourcesSocketPath = filepath.Join(t.TempDir(), "missing-kubelet.sock")
 	t.Cleanup(func() {
@@ -317,7 +317,8 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 	namespace := "default"
 	podName := "test-pod"
 	claimName := "gpu-claim"
-	uuid := "GPU-ffffffff-1111-2222-3333-444444444444"
+	uuid0 := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+	uuid1 := "GPU-bbbbbbbb-5555-6666-7777-888888888888"
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
@@ -337,6 +338,7 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 			Allocation: &resourcev1.AllocationResult{
 				Devices: resourcev1.DeviceAllocationResult{
 					Results: []resourcev1.DeviceRequestAllocationResult{
+						{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-1", Request: "gpu"},
 						{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-0", Request: "gpu"},
 					},
 				},
@@ -353,7 +355,13 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 				{
 					Name: "gpu-0",
 					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-						resourcev1.QualifiedName("uuid"): {StringValue: &uuid},
+						resourcev1.QualifiedName("uuid"): {StringValue: &uuid0},
+					},
+				},
+				{
+					Name: "gpu-1",
+					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+						resourcev1.QualifiedName("uuid"): {StringValue: &uuid1},
 					},
 				},
 			},
@@ -365,7 +373,7 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	got, err := DiscoverGPUUUIDs(
+	got, err := discoverGPUUUIDs(
 		ctx,
 		client,
 		podName,
@@ -373,12 +381,72 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 		"main",
 		"/proc",
 		123,
+		func(context.Context, string, int) ([]string, error) {
+			return []string{uuid0, uuid1}, nil
+		},
 		logr.Discard(),
 	)
 	if err != nil {
 		t.Fatalf("DiscoverGPUUUIDs: %v", err)
 	}
-	if len(got) != 1 || got[0] != uuid {
-		t.Fatalf("got %v, want [%s]", got, uuid)
+	want := []string{uuid0, uuid1}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestOrderDRAUUIDsByRuntimeRejectsMismatches(t *testing.T) {
+	uuid0 := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+	uuid1 := "GPU-bbbbbbbb-5555-6666-7777-888888888888"
+	uuid2 := "GPU-cccccccc-9999-aaaa-bbbb-cccccccccccc"
+
+	tests := []struct {
+		name      string
+		allocated []string
+		visible   []string
+	}{
+		{
+			name:      "count mismatch",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0},
+		},
+		{
+			name:      "different set",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0, uuid2},
+		},
+		{
+			name:      "duplicate allocation",
+			allocated: []string{uuid0, uuid0},
+			visible:   []string{uuid0, uuid1},
+		},
+		{
+			name:      "invalid allocation UUID",
+			allocated: []string{uuid0, "not-a-gpu-uuid"},
+			visible:   []string{uuid0, uuid1},
+		},
+		{
+			name:      "duplicate visible",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0, uuid0},
+		},
+		{
+			name:      "invalid visible UUID",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0, "not-a-gpu-uuid"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := orderDRAUUIDsByRuntime(tc.allocated, tc.visible); err == nil {
+				t.Fatalf("expected error, got %v", got)
+			}
+		})
 	}
 }

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -324,6 +324,14 @@ func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
 		Spec: corev1.PodSpec{
 			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+					},
+				},
+			},
 			ResourceClaims: []corev1.PodResourceClaim{
 				{
 					Name:              "gpu",
@@ -370,10 +378,18 @@ func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 
 	client := fake.NewSimpleClientset(pod, claim, slice)
 
+	previousDiscoverVisibleGPUs := discoverVisibleGPUs
+	discoverVisibleGPUs = func(context.Context, string, int) ([]string, error) {
+		return []string{uuid0, uuid1}, nil
+	}
+	t.Cleanup(func() {
+		discoverVisibleGPUs = previousDiscoverVisibleGPUs
+	})
+
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	got, err := discoverGPUUUIDs(
+	got, err := DiscoverGPUUUIDs(
 		ctx,
 		client,
 		podName,
@@ -381,9 +397,6 @@ func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 		"main",
 		"/proc",
 		123,
-		func(context.Context, string, int) ([]string, error) {
-			return []string{uuid0, uuid1}, nil
-		},
 		logr.Discard(),
 	)
 	if err != nil {

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -378,18 +378,10 @@ func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 
 	client := fake.NewSimpleClientset(pod, claim, slice)
 
-	previousDiscoverVisibleGPUs := discoverVisibleGPUs
-	discoverVisibleGPUs = func(context.Context, string, int) ([]string, error) {
-		return []string{uuid0, uuid1}, nil
-	}
-	t.Cleanup(func() {
-		discoverVisibleGPUs = previousDiscoverVisibleGPUs
-	})
-
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	got, err := DiscoverGPUUUIDs(
+	got, err := discoverGPUUUIDs(
 		ctx,
 		client,
 		podName,
@@ -397,6 +389,9 @@ func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 		"main",
 		"/proc",
 		123,
+		func(context.Context, string, int) ([]string, error) {
+			return []string{uuid0, uuid1}, nil
+		},
 		logr.Discard(),
 	)
 	if err != nil {

--- a/deploy/snapshot/internal/cuda/dra.go
+++ b/deploy/snapshot/internal/cuda/dra.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -19,7 +20,30 @@ type allocatedDRADevice struct {
 	device string
 }
 
-func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace string, log logr.Logger) ([]allocatedDRADevice, string, bool, error) {
+// containerResourceClaimRefs returns the names of the pod-level resource-claim
+// references exposed to the named container via container.resources.claims.
+// An empty containerName returns a nil map, meaning the pod-wide claim view
+// applies.
+func containerResourceClaimRefs(pod *corev1.Pod, containerName string) (map[string]struct{}, error) {
+	if containerName == "" {
+		return nil, nil
+	}
+	for _, containers := range [][]corev1.Container{pod.Spec.Containers, pod.Spec.InitContainers} {
+		for i := range containers {
+			if containers[i].Name != containerName {
+				continue
+			}
+			refs := make(map[string]struct{}, len(containers[i].Resources.Claims))
+			for _, claimRef := range containers[i].Resources.Claims {
+				refs[claimRef.Name] = struct{}{}
+			}
+			return refs, nil
+		}
+	}
+	return nil, fmt.Errorf("container %q not found in pod %s/%s spec", containerName, pod.Namespace, pod.Name)
+}
+
+func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName string, log logr.Logger) ([]allocatedDRADevice, string, bool, error) {
 	if clientset == nil {
 		return nil, "", false, nil
 	}
@@ -37,6 +61,11 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 	if pod.Spec.NodeName == "" {
 		log.V(1).Info("pod has no node name, skipping DRA API lookup")
 		return nil, "", false, nil
+	}
+
+	containerClaimRefs, err := containerResourceClaimRefs(pod, containerName)
+	if err != nil {
+		return nil, pod.Spec.NodeName, false, err
 	}
 
 	claimNamesByPodRef := make(map[string]string, len(pod.Spec.ResourceClaims))
@@ -57,6 +86,11 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 	var allocated []allocatedDRADevice
 	hasNVIDIADRAAllocation := false
 	for _, ref := range pod.Spec.ResourceClaims {
+		if containerClaimRefs != nil {
+			if _, exposed := containerClaimRefs[ref.Name]; !exposed {
+				continue
+			}
+		}
 		claimName := claimNamesByPodRef[ref.Name]
 		if claimName == "" {
 			log.V(1).Info("pod resource claim has no resolved claim name", "pod_claim", ref.Name)
@@ -86,9 +120,11 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 
 // GetGPUUUIDsViaDRAAPI resolves GPU UUIDs for a pod by querying the Kubernetes API:
 // Pod (resource claim refs) -> ResourceClaim (allocation results) -> ResourceSlice (device attributes).
-// It also reports whether the pod is using NVIDIA DRA GPU allocations at all.
-func GetGPUUUIDsViaDRAAPI(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace string, log logr.Logger) ([]string, bool, error) {
-	allocated, nodeName, hasNVIDIADRAAllocation, err := getAllocatedNVIDIADRADevices(ctx, clientset, podName, podNamespace, log)
+// A non-empty containerName restricts resolution to the claims that container
+// references via resources.claims. It also reports whether the pod (scoped to
+// that container) is using NVIDIA DRA GPU allocations at all.
+func GetGPUUUIDsViaDRAAPI(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName string, log logr.Logger) ([]string, bool, error) {
+	allocated, nodeName, hasNVIDIADRAAllocation, err := getAllocatedNVIDIADRADevices(ctx, clientset, podName, podNamespace, containerName, log)
 	if err != nil {
 		return nil, hasNVIDIADRAAllocation, err
 	}

--- a/deploy/snapshot/internal/cuda/dra.go
+++ b/deploy/snapshot/internal/cuda/dra.go
@@ -3,6 +3,7 @@ package cuda
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
@@ -20,11 +21,12 @@ type allocatedDRADevice struct {
 	device string
 }
 
-// containerResourceClaimRefs returns the names of the pod-level resource-claim
-// references exposed to the named container via container.resources.claims.
-// An empty containerName returns a nil map, meaning the pod-wide claim view
-// applies.
-func containerResourceClaimRefs(pod *corev1.Pod, containerName string) (map[string]struct{}, error) {
+// containerResourceClaimRefs returns the pod-level resource-claim references
+// exposed to the named container via container.resources.claims, mapped to
+// the set of claim request names the container is restricted to. A nil inner
+// set exposes every request in the claim. An empty containerName returns a
+// nil map, meaning the pod-wide claim view applies.
+func containerResourceClaimRefs(pod *corev1.Pod, containerName string) (map[string]map[string]struct{}, error) {
 	if containerName == "" {
 		return nil, nil
 	}
@@ -33,14 +35,46 @@ func containerResourceClaimRefs(pod *corev1.Pod, containerName string) (map[stri
 			if containers[i].Name != containerName {
 				continue
 			}
-			refs := make(map[string]struct{}, len(containers[i].Resources.Claims))
+			refs := make(map[string]map[string]struct{}, len(containers[i].Resources.Claims))
 			for _, claimRef := range containers[i].Resources.Claims {
-				refs[claimRef.Name] = struct{}{}
+				requests, seen := refs[claimRef.Name]
+				if seen && requests == nil {
+					// Already exposed without a request restriction.
+					continue
+				}
+				if claimRef.Request == "" {
+					refs[claimRef.Name] = nil
+					continue
+				}
+				if requests == nil {
+					requests = make(map[string]struct{})
+					refs[claimRef.Name] = requests
+				}
+				requests[claimRef.Request] = struct{}{}
 			}
 			return refs, nil
 		}
 	}
 	return nil, fmt.Errorf("container %q not found in pod %s/%s spec", containerName, pod.Namespace, pod.Name)
+}
+
+// resultMatchesRequests reports whether an allocation result belongs to one of
+// the claim request names a container is restricted to. Allocation results
+// for subrequests use the "<main request>/<subrequest>" form, so a container
+// reference to the main request matches its subrequest results too.
+func resultMatchesRequests(resultRequest string, requests map[string]struct{}) bool {
+	if requests == nil {
+		return true
+	}
+	if _, ok := requests[resultRequest]; ok {
+		return true
+	}
+	mainRequest, _, found := strings.Cut(resultRequest, "/")
+	if !found {
+		return false
+	}
+	_, ok := requests[mainRequest]
+	return ok
 }
 
 func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName string, log logr.Logger) ([]allocatedDRADevice, string, bool, error) {
@@ -65,8 +99,18 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 
 	containerClaimRefs, err := containerResourceClaimRefs(pod, containerName)
 	if err != nil {
-		return nil, pod.Spec.NodeName, false, err
+		// The pod defines resource claims but the target container cannot be
+		// resolved; fail rather than fall back to unverified discovery.
+		return nil, pod.Spec.NodeName, true, err
 	}
+	if containerClaimRefs != nil && len(containerClaimRefs) == 0 {
+		// The target container references no resource claims.
+		return nil, pod.Spec.NodeName, false, nil
+	}
+	// Probe state: the target container (or the whole pod, when containerName
+	// is empty) references resource claims. Every error past this point
+	// returns true so the caller fails closed instead of falling back to
+	// unverified discovery.
 
 	claimNamesByPodRef := make(map[string]string, len(pod.Spec.ResourceClaims))
 	for _, ref := range pod.Spec.ResourceClaims {
@@ -86,10 +130,13 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 	var allocated []allocatedDRADevice
 	hasNVIDIADRAAllocation := false
 	for _, ref := range pod.Spec.ResourceClaims {
+		var containerRequests map[string]struct{}
 		if containerClaimRefs != nil {
-			if _, exposed := containerClaimRefs[ref.Name]; !exposed {
+			requests, exposed := containerClaimRefs[ref.Name]
+			if !exposed {
 				continue
 			}
+			containerRequests = requests
 		}
 		claimName := claimNamesByPodRef[ref.Name]
 		if claimName == "" {
@@ -98,13 +145,16 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 		}
 		claim, err := clientset.ResourceV1().ResourceClaims(podNamespace).Get(ctx, claimName, metav1.GetOptions{})
 		if err != nil {
-			return nil, pod.Spec.NodeName, hasNVIDIADRAAllocation, fmt.Errorf("get resource claim %s/%s: %w", podNamespace, claimName, err)
+			return nil, pod.Spec.NodeName, true, fmt.Errorf("get resource claim %s/%s: %w", podNamespace, claimName, err)
 		}
 		if claim.Status.Allocation == nil || len(claim.Status.Allocation.Devices.Results) == 0 {
 			continue
 		}
 		for _, result := range claim.Status.Allocation.Devices.Results {
 			if result.Driver != nvidiaGPUDRADriver {
+				continue
+			}
+			if !resultMatchesRequests(result.Request, containerRequests) {
 				continue
 			}
 			hasNVIDIADRAAllocation = true
@@ -120,9 +170,12 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 
 // GetGPUUUIDsViaDRAAPI resolves GPU UUIDs for a pod by querying the Kubernetes API:
 // Pod (resource claim refs) -> ResourceClaim (allocation results) -> ResourceSlice (device attributes).
-// A non-empty containerName restricts resolution to the claims that container
-// references via resources.claims. It also reports whether the pod (scoped to
-// that container) is using NVIDIA DRA GPU allocations at all.
+// A non-empty containerName restricts resolution to the claims (and claim
+// requests) that container references via resources.claims.
+// On success, the returned bool reports whether NVIDIA DRA GPU allocations
+// were found for that container. With a non-nil error, it reports whether the
+// container was established to reference resource claims, in which case the
+// caller must fail instead of falling back to other discovery paths.
 func GetGPUUUIDsViaDRAAPI(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName string, log logr.Logger) ([]string, bool, error) {
 	allocated, nodeName, hasNVIDIADRAAllocation, err := getAllocatedNVIDIADRADevices(ctx, clientset, podName, podNamespace, containerName, log)
 	if err != nil {

--- a/deploy/snapshot/internal/cuda/dra_test.go
+++ b/deploy/snapshot/internal/cuda/dra_test.go
@@ -387,4 +387,140 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 			t.Errorf("got %v, want nil", got)
 		}
 	})
+
+	t.Run("shared claim requests scope to the target container", func(t *testing.T) {
+		nodeName := "node-1"
+		poolName := "pool-node-1"
+		namespace := "default"
+		podName := "test-pod"
+		claimName := "shared-gpu-claim"
+		mainUUID := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+		sidecarUUID := "GPU-bbbbbbbb-5555-6666-7777-888888888888"
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+			Spec: corev1.PodSpec{
+				NodeName: nodeName,
+				Containers: []corev1.Container{
+					{
+						Name: "main",
+						Resources: corev1.ResourceRequirements{
+							Claims: []corev1.ResourceClaim{{Name: "gpu", Request: "main-gpu"}},
+						},
+					},
+					{
+						Name: "sidecar",
+						Resources: corev1.ResourceRequirements{
+							Claims: []corev1.ResourceClaim{{Name: "gpu", Request: "sidecar-gpu"}},
+						},
+					},
+				},
+				ResourceClaims: []corev1.PodResourceClaim{
+					{
+						Name:              "gpu",
+						ResourceClaimName: &claimName,
+					},
+				},
+			},
+		}
+		claim := &resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: namespace},
+			Status: resourcev1.ResourceClaimStatus{
+				Allocation: &resourcev1.AllocationResult{
+					Devices: resourcev1.DeviceAllocationResult{
+						Results: []resourcev1.DeviceRequestAllocationResult{
+							// Subrequest form exercises "<request>/<subrequest>" matching.
+							{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-0", Request: "main-gpu/fallback"},
+							{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-1", Request: "sidecar-gpu"},
+						},
+					},
+				},
+			},
+		}
+		slice := &resourcev1.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: poolName + "-gpu.nvidia.com-xxx"},
+			Spec: resourcev1.ResourceSliceSpec{
+				Driver:   nvidiaGPUDRADriver,
+				NodeName: &nodeName,
+				Pool:     resourcev1.ResourcePool{Name: poolName},
+				Devices: []resourcev1.Device{
+					{
+						Name: "gpu-0",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							resourcev1.QualifiedName("uuid"): {StringValue: &mainUUID},
+						},
+					},
+					{
+						Name: "gpu-1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							resourcev1.QualifiedName("uuid"): {StringValue: &sidecarUUID},
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewSimpleClientset(pod, claim, slice)
+
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "main", log)
+		if err != nil {
+			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
+		}
+		if !hasNVIDIADRAAllocation {
+			t.Fatal("expected hasNVIDIADRAAllocation to be true")
+		}
+		if len(got) != 1 || got[0] != mainUUID {
+			t.Fatalf("got %v, want [%s]", got, mainUUID)
+		}
+
+		got, _, err = GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "sidecar", log)
+		if err != nil {
+			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
+		}
+		if len(got) != 1 || got[0] != sidecarUUID {
+			t.Fatalf("got %v, want [%s]", got, sidecarUUID)
+		}
+	})
+
+	t.Run("lookup failures after claims are referenced forbid fallback", func(t *testing.T) {
+		claimName := "gpu-claim"
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				NodeName: "node-1",
+				Containers: []corev1.Container{
+					{
+						Name: "main",
+						Resources: corev1.ResourceRequirements{
+							Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+						},
+					},
+				},
+				ResourceClaims: []corev1.PodResourceClaim{
+					{
+						Name:              "gpu",
+						ResourceClaimName: &claimName,
+					},
+				},
+			},
+		}
+		// The referenced ResourceClaim object is missing, so the claim GET fails.
+		client := fake.NewSimpleClientset(pod)
+
+		_, mustNotFallBack, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "main", log)
+		if err == nil {
+			t.Fatal("expected error for failed claim lookup")
+		}
+		if !mustNotFallBack {
+			t.Fatal("expected claim lookup failure to forbid fallback")
+		}
+
+		_, mustNotFallBack, err = GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "no-such-container", log)
+		if err == nil {
+			t.Fatal("expected error for unknown container name")
+		}
+		if !mustNotFallBack {
+			t.Fatal("expected unknown container to forbid fallback")
+		}
+	})
 }

--- a/deploy/snapshot/internal/cuda/dra_test.go
+++ b/deploy/snapshot/internal/cuda/dra_test.go
@@ -60,7 +60,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 	log := logr.Discard()
 
 	t.Run("nil clientset returns nil without error", func(t *testing.T) {
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, nil, "pod", "ns", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, nil, "pod", "ns", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -74,7 +74,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 
 	t.Run("empty pod name returns nil", func(t *testing.T) {
 		client := fake.NewSimpleClientset()
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "", "ns", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "", "ns", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -88,7 +88,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 
 	t.Run("pod not found returns error", func(t *testing.T) {
 		client := fake.NewSimpleClientset()
-		_, _, err := GetGPUUUIDsViaDRAAPI(ctx, client, "missing", "default", log)
+		_, _, err := GetGPUUUIDsViaDRAAPI(ctx, client, "missing", "default", "", log)
 		if err == nil {
 			t.Fatal("expected error when pod not found")
 		}
@@ -152,7 +152,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod, claim, slice)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "", log)
 		if err != nil {
 			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
 		}
@@ -227,7 +227,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod, claim, slice)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "", log)
 		if err != nil {
 			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
 		}
@@ -259,7 +259,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -352,7 +352,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod, directClaim, generatedClaim, slice)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "", log)
 		if err != nil {
 			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
 		}
@@ -376,7 +376,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 			Spec:       corev1.PodSpec{NodeName: "node-1"},
 		}
 		client := fake.NewSimpleClientset(pod)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}


### PR DESCRIPTION
## Summary

- Treat NVIDIA DRA `ResourceClaim.status.allocation.devices.results[]` as an
  allocated UUID **set**, not as CUDA/CDI ordinal order.
- For DRA-backed pods, run `nvidia-smi --query-gpu=gpu_uuid` in the target
  container's mount namespace to derive the runtime-visible ordering, then
  require exact count and set equality with the DRA allocation before returning
  it.
- Fail closed on unresolved DRA UUIDs, DRA lookup failures after NVIDIA DRA is
  detected, count/set mismatches, malformed GPU UUIDs, and duplicate UUIDs.
  Classic `nvidia.com/gpu` PodResources discovery remains unchanged.

This PR is based directly on `main` at `c42932d6c8` and contains only the CUDA
snapshot discovery fix and focused tests. It does not contain or depend on the
GMS backend, a vLLM overlay, no-launch experiments, concurrent restore work, or
#11285.

## Root cause and data flow

At checkpoint time, `DiscoverGPUUUIDs` obtains source UUIDs and stores their
order in the manifest as `cuda.sourceGpuUuids`. At restore time it obtains
another ordered target UUID list and passes both lists to `BuildDeviceMap`.

`BuildDeviceMap` intentionally has two behaviors:

1. If a source UUID is present in the target set, map that UUID to itself. This
   identity behavior makes a same-GPU/same-node restore insensitive to list
   permutations and returns an empty map when every UUID is retained.
2. For disjoint source and destination UUID sets, pair the remaining source and
   target UUIDs positionally. Cross-node correctness therefore requires both
   lists to represent the same CUDA ordinal convention.

Before this fix, DRA discovery copied the order of
`ResourceClaim.status.allocation.devices.results[]` through ResourceSlice UUID
resolution directly into those manifest/target lists. DRA allocation results
identify the allocated devices but do not define CUDA or CDI ordinal order.

The concrete eight-GPU experiment observed these raw DRA result orders:

```text
source:      [gpu-4,gpu-5,gpu-6,gpu-7,gpu-0,gpu-1,gpu-2,gpu-3]
destination: [gpu-5,gpu-6,gpu-7,gpu-0,gpu-1,gpu-2,gpu-3,gpu-4]
```

With disjoint cross-node UUID sets, positional pairing therefore produced
`S0 -> D1` instead of `S0 -> D0` (and likewise for every rank), an all-rank
rotation. Same-node restore hid the bug because source UUIDs still existed in
the destination set, so `BuildDeviceMap` selected UUID identity mappings rather
than positional pairing.

The rotation broke the required tuple of:

- vLLM world/local/DP/EP rank;
- that EP rank's expert range;
- CUDA/CDI ordinal and `/dev/nvidiaN`;
- GMS `device-N` serialized weight payload.

The restore could complete and inference could return HTTP 200, but model state
was attached to the wrong rank/expert shard and the generated output was
malformed. An HTTP success status was therefore not evidence of correct
restore.

## Fix

For an NVIDIA DRA allocation, the Kubernetes API remains authoritative for the
allowed physical GPU UUID set. The agent then executes `nvidia-smi` through
`nsenter` using the selected container process's mount namespace to derive the
runtime-visible order. It returns that order only after verifying:

- allocated and visible counts match;
- every value has the expected full-GPU UUID format;
- neither side contains duplicates; and
- every runtime-visible UUID belongs to the DRA allocation.

Because equal counts plus uniqueness plus membership imply exact set equality,
there is no fallback to the ResourceClaim result order on mismatch. Discovery
fails and aborts checkpoint/restore instead of constructing a potentially
corrupt device map.

## Review follow-ups

Commit `3f3e87641` addresses the review comments:

- **Container-scoped DRA claim resolution** (CodeRabbit + review agent):
  `GetGPUUUIDsViaDRAAPI` now takes `containerName` and resolves only the claims
  the target container references, so multi-container DRA pods no longer mix
  another container's GPUs into the ordered set.
- **Request-scoped shared claims + fail-closed DRA lookups + injected test
  seam** (human review, `4600bb302`): claim `request` references are honored
  when scoping (including subrequest results); DRA lookup failures after
  claim references are established forbid fallback regardless of iteration
  order; and the `visibleGPUDiscovery` test seam is injected rather than a
  mutable package variable.
- **CUDA ordering environment** (review agent): answered in-thread without a
  code change. `BuildDeviceMap` needs only a convention shared by both sides;
  identical pod env on checkpoint and restore makes index permutations cancel
  out, and the target deployments do not set `CUDA_VISIBLE_DEVICES` /
  `CUDA_DEVICE_ORDER`. A CUDA-runtime ordinal enumerator stays out of scope.

## Where should the reviewer start?

- `deploy/snapshot/internal/cuda/cuda.go` — `discoverGPUUUIDs` (discovery flow
  and fail-closed ordering) and `orderDRAUUIDsByRuntime`.
- `deploy/snapshot/internal/cuda/dra.go` — container-scoped claim resolution
  (`containerResourceClaimRefs`).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## End-to-end evidence

The implementation was exercised in fresh Build-on-Demand run
[28853108635](https://github.com/ai-dynamo/dynamo/actions/runs/28853108635),
which completed successfully and built the operator, snapshot agent, vLLM
runtime/copy, and vLLM placeholder from source commit
`37aebb1d9b50da30961063c6a58d92a179064c53` on the experimental validation
branch. This PR carries only that two-file fix rebased onto current `main`; the
large experimental artifacts are **not** committed here.

Validation used a retained checkpoint and performed no pre-snapshot inference:

- same-node restore succeeded and produced correct inference;
- cross-node restore succeeded on eight different destination GPU UUIDs and
  produced correct inference;
- after normalization, the same-node and cross-node JSON responses were
  byte-identical (SHA256
  `aaf60933f6b0f18a51d6917e7ce97051b7de45a549b14c7cfca760ce24a58609`);
- all 32 generated token logprobs were byte-identical, including the same first
  token (`The`, logprob `-1.0265568`) and answer token (`Paris`, logprob
  `-0.38737983`).

Local evidence is retained outside the repository under
`.gms-cross-node-ordinal-fix-28853108635/`, including the rank/device matrix,
normalized responses, transport excerpts, GPU health, image provenance, and
build metadata. Those experiment artifacts are evidence only and are not part
of this PR.

## Limitations and safety

- **CUDA ordering controls:** `nvidia-smi` reports the runtime-visible order in
  the validated deployment, where `CUDA_VISIBLE_DEVICES` was absent and
  `NVIDIA_VISIBLE_DEVICES=void`. A workload that applies a different
  process-local `CUDA_VISIBLE_DEVICES` permutation or changes
  `CUDA_DEVICE_ORDER` may not match `nvidia-smi` ordering. The exact-set checks
  prevent extra/missing GPUs but cannot infer an environment-only permutation.
  Because both checkpoint and restore derive their lists with the same
  convention and the restored process keeps its checkpointed environment, an
  index-based permutation applies identically on both sides and cancels out
  under positional pairing; environment introspection remains out of scope.
- **MIG:** the validator intentionally accepts full `GPU-...` UUIDs only. MIG
  instance identifiers are rejected rather than being mapped incorrectly; MIG
  checkpoint/restore needs a separately designed identity and ordinal model.
- **Pod-wide versus container-specific claims (addressed in review):** DRA
  claim resolution is now scoped to the target container: only pod resource
  claims referenced by that container's `resources.claims` entries are
  resolved, and allocation results are further filtered by the container's
  claim `request` names (including `"<request>/<subrequest>"` results). An
  unknown container name is an error; an empty container name keeps the
  pod-wide view for existing callers.
- **Binary provenance and `PATH`:** the agent selects host `nsenter` and
  resolves `nvidia-smi` through the entered command's `PATH`/mount namespace.
  A missing, shadowed, or incompatible binary causes discovery to fail; this PR
  does not add hard-coded distribution-specific binary paths or digest
  verification.
- **PID/mount namespace races:** the selected placeholder/workload PID must
  still identify the intended mount namespace when `nsenter` runs. Process
  exit/reuse causes command failure or a set mismatch in normal cases, but the
  code does not pin a pidfd or namespace file descriptor.
- **DRA detection fallback (tightened in review):** classic PodResources
  fallback now applies only when the pod itself cannot be fetched (nothing is
  known yet) or when the pod/container is positively determined not to
  reference resource claims. Once the target container is known to reference
  a DRA claim, any lookup failure (missing container, claim GET, RBAC,
  transient API error) is fatal and does not silently fall back.

These limitations are bounded by fail-closed validation where this change has
reliable information. Expanding into environment introspection, MIG semantics,
executable attestation, or pidfd-based namespace pinning would be materially
larger changes and should be reviewed separately.

## Validation

- `cd deploy/snapshot && go test ./internal/cuda`
  - passed (`ok .../internal/cuda`)
- `cd deploy/snapshot && go test ./...`
  - passed for all packages
- `cd deploy/snapshot && go vet ./...`
  - passed
- `pre-commit run --files` on the four changed files under `deploy/snapshot/internal/cuda/`
  - passed (codespell, case-conflict, merge-conflict, executable, line-ending,
    whitespace, and pytest-marker hooks; language-specific non-Go hooks skipped)
- `gofmt -l deploy/snapshot/internal/cuda/`
  - clean
- `git diff --check origin/main..HEAD`
  - passed
- End-to-end same-node and disjoint-UUID cross-node restore/inference:
  Build-on-Demand run 28853108635, as detailed above.

## Duplicate-work check

No issue number was supplied. Before creating this PR I searched open issues and
PRs for DRA ResourceClaim order, CUDA ordinal mapping, cross-node
cuda-checkpoint, `BuildDeviceMap`, `CUDA_DEVICE_ORDER`, DRA snapshot GPU UUID,
and ResourceClaim cuda-checkpoint terms. No open issue or PR implements this
fix.

Nearby open work is not duplicate:

- #11304 parallelizes independent CUDA restores; it does not change GPU
  discovery/order.
- #11323 accepts HAMi vGPU-suffixed UUID text; it does not derive DRA runtime
  ordinal order.
- #10951 changes PodSnapshot capture orchestration; it does not change CUDA
  UUID discovery or `BuildDeviceMap` inputs.
- #8833 wires GMS checkpoint/restore flow but does not fix DRA result ordering.

## AI assistance

AI assistance was used to rebase/extract the validated fix, run tests, review
limitations, and prepare this PR description. The human submitter remains
responsible for reviewing every changed line and for understanding and
defending the change end-to-end.
