### PR TITLE
perf(event-plane): scale direct ZMQ fan-in

### DIFF
--- a/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
+++ b/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
@@ -57,10 +57,46 @@ impl DynamicSubscriber {
             .unwrap_or(100_000);
         let (event_tx, event_rx) = mpsc::channel::<Bytes>(channel_cap);
 
-        // Track active endpoint connections with instance ID to endpoint mapping
-        let active_endpoints: Arc<
-            RwLock<HashMap<DiscoveryInstanceId, (String, CancellationToken)>>,
-        > = Arc::new(RwLock::new(HashMap::new()));
+        // One SUB socket can connect to many PUB endpoints. Keep publisher
+        // identity in discovery/envelopes while avoiding one socket and one
+        // pump task per publisher/subscriber pair.
+        let sub_transport = Arc::new(ZmqSubTransport::dynamic(&self.topic, channel_cap).await?);
+        let mut zmq_stream = sub_transport.subscribe(&self.topic).await?;
+
+        // Keep the existing bounded handoff semantics. The transport's
+        // broadcast channel uses the same capacity, so both queues remain
+        // bounded under a slow consumer.
+        let forward_cancel = self.cancel_token.clone();
+        let event_tx_for_pump = event_tx.clone();
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    _ = forward_cancel.cancelled() => break,
+                    event = zmq_stream.next() => {
+                        match event {
+                            Some(Ok(bytes)) => match event_tx_for_pump.try_send(bytes) {
+                                Ok(()) => {}
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    tracing::trace!("Event subscriber channel full; dropping event");
+                                }
+                                Err(mpsc::error::TrySendError::Closed(_)) => break,
+                            },
+                            Some(Err(error)) => {
+                                tracing::error!(%error, "Error receiving from dynamic ZMQ socket");
+                                break;
+                            }
+                            None => break,
+                        }
+                    }
+                }
+            }
+        });
+
+        // Track active publisher identities separately from endpoint ownership.
+        // The endpoint refcount check preserves correctness even if discovery
+        // ever reports two identities for one transport endpoint.
+        let active_endpoints: Arc<RwLock<HashMap<DiscoveryInstanceId, String>>> =
+            Arc::new(RwLock::new(HashMap::new()));
 
         // Clone self for the spawned task
         let subscriber_clone = Arc::clone(&self);
@@ -72,6 +108,7 @@ impl DynamicSubscriber {
         let zmq_topic = self.topic.clone();
         let cancel_token = self.cancel_token.clone();
         let endpoints = Arc::clone(&active_endpoints);
+        let sub_transport_for_watch = Arc::clone(&sub_transport);
 
         tokio::spawn(async move {
             tracing::debug!(
@@ -94,12 +131,18 @@ impl DynamicSubscriber {
 
             tracing::info!(?query, "Started dynamic discovery watch for ZMQ publishers");
 
-            while let Some(event_result) = watch_stream.next().await {
+            loop {
+                let event_result = tokio::select! {
+                    _ = cancel_token.cancelled() => {
+                        tracing::info!("Dynamic subscriber cancelled, stopping watch");
+                        break;
+                    }
+                    event = watch_stream.next() => {
+                        let Some(event) = event else { break };
+                        event
+                    }
+                };
                 tracing::debug!("Received discovery event: {:?}", event_result);
-                if cancel_token.is_cancelled() {
-                    tracing::info!("Dynamic subscriber cancelled, stopping watch");
-                    break;
-                }
 
                 match event_result {
                     Ok(DiscoveryEvent::Added(instance)) => {
@@ -108,49 +151,27 @@ impl DynamicSubscriber {
 
                         // Extract ZMQ endpoint from the instance
                         if let Some(endpoint) = Self::extract_zmq_endpoint(&instance, &zmq_topic) {
-                            let mut endpoints_guard = endpoints.write().await;
-
-                            // Skip if instance already tracked
-                            if endpoints_guard.contains_key(&instance_id) {
-                                tracing::debug!(endpoint = %endpoint, ?instance_id, "Already connected to ZMQ publisher");
-                                continue;
-                            }
-
-                            tracing::info!(endpoint = %endpoint, ?instance_id, "Connecting to new ZMQ publisher");
-
-                            // Create cancellation token for this endpoint's stream
-                            let endpoint_cancel = CancellationToken::new();
-                            endpoints_guard.insert(
-                                instance_id.clone(),
-                                (endpoint.clone(), endpoint_cancel.clone()),
-                            );
-                            drop(endpoints_guard);
-
-                            // Spawn task to handle this endpoint's stream
-                            let event_tx_clone = event_tx.clone();
-                            let zmq_topic_clone = zmq_topic.clone();
-                            let endpoint_clone = endpoint.clone();
-                            let endpoints_clone = Arc::clone(&endpoints);
-                            let instance_id_clone = instance_id.clone();
-
-                            tokio::spawn(async move {
-                                if let Err(e) = Self::consume_endpoint_stream(
-                                    &endpoint_clone,
-                                    &zmq_topic_clone,
-                                    event_tx_clone,
-                                    endpoint_cancel,
-                                )
-                                .await
-                                {
-                                    tracing::warn!(
-                                        endpoint = %endpoint_clone,
-                                        error = %e,
-                                        "Error consuming ZMQ endpoint stream"
-                                    );
+                            let should_connect = {
+                                let mut endpoints_guard = endpoints.write().await;
+                                if endpoints_guard.contains_key(&instance_id) {
+                                    tracing::debug!(endpoint = %endpoint, ?instance_id, "Already connected to ZMQ publisher");
+                                    continue;
                                 }
-                                // Clean up on stream termination
-                                endpoints_clone.write().await.remove(&instance_id_clone);
-                            });
+                                let already_connected =
+                                    endpoints_guard.values().any(|value| value == &endpoint);
+                                endpoints_guard.insert(instance_id.clone(), endpoint.clone());
+                                !already_connected
+                            };
+
+                            if should_connect {
+                                tracing::info!(endpoint = %endpoint, ?instance_id, "Connecting shared ZMQ subscriber to publisher");
+                                if let Err(error) =
+                                    sub_transport_for_watch.connect_endpoint(&endpoint).await
+                                {
+                                    endpoints.write().await.remove(&instance_id);
+                                    tracing::warn!(%endpoint, %error, "Failed to connect shared ZMQ subscriber");
+                                }
+                            }
                         } else {
                             tracing::debug!(
                                 instance = ?instance,
@@ -174,17 +195,23 @@ impl DynamicSubscriber {
                             continue;
                         }
 
-                        tracing::info!(
-                            ?instance_id,
-                            "ZMQ publisher removed from discovery, cancelling endpoint stream"
-                        );
+                        let removed = {
+                            let mut endpoints_guard = endpoints.write().await;
+                            let endpoint = endpoints_guard.remove(&instance_id);
+                            endpoint.map(|endpoint| {
+                                let still_used =
+                                    endpoints_guard.values().any(|value| value == &endpoint);
+                                (endpoint, !still_used)
+                            })
+                        };
 
-                        // Cancel the endpoint's stream via its CancellationToken
-                        if let Some((_endpoint, cancel)) =
-                            endpoints.write().await.remove(&instance_id)
-                        {
-                            cancel.cancel();
-                            tracing::info!(?instance_id, "Cancelled endpoint stream");
+                        if let Some((endpoint, should_disconnect)) = removed {
+                            if should_disconnect
+                                && let Err(error) =
+                                    sub_transport_for_watch.disconnect_endpoint(&endpoint).await
+                            {
+                                tracing::warn!(%endpoint, %error, "Failed to disconnect removed ZMQ publisher");
+                            }
                         } else {
                             tracing::debug!(
                                 ?instance_id,
@@ -199,10 +226,17 @@ impl DynamicSubscriber {
                 }
             }
 
-            // Cancel all active endpoints on shutdown
-            let endpoints_guard = endpoints.write().await;
-            for (_id, (_endpoint, cancel)) in endpoints_guard.iter() {
-                cancel.cancel();
+            // Disconnect each endpoint once on shutdown.
+            let remaining: std::collections::HashSet<String> = endpoints
+                .write()
+                .await
+                .drain()
+                .map(|(_, endpoint)| endpoint)
+                .collect();
+            for endpoint in remaining {
+                if let Err(error) = sub_transport_for_watch.disconnect_endpoint(&endpoint).await {
+                    tracing::debug!(%endpoint, %error, "Failed to disconnect ZMQ endpoint during shutdown");
+                }
             }
             tracing::info!("Discovery watch stream ended");
         });
@@ -211,6 +245,7 @@ impl DynamicSubscriber {
         let stream = async_stream::stream! {
             // Keep subscriber_clone alive by capturing it in the stream
             let _subscriber = subscriber_clone;
+            let _sub_transport = sub_transport;
             let mut rx = event_rx;
             while let Some(bytes) = rx.recv().await {
                 yield Ok(bytes);
@@ -231,63 +266,6 @@ impl DynamicSubscriber {
             return Some(endpoint.clone());
         }
         None
-    }
-
-    /// Consume events from a single endpoint and forward to the merged channel.
-    async fn consume_endpoint_stream(
-        endpoint: &str,
-        zmq_topic: &str,
-        event_tx: mpsc::Sender<Bytes>,
-        cancel_token: CancellationToken,
-    ) -> Result<()> {
-        // Connect to the endpoint
-        let sub_transport = ZmqSubTransport::connect(endpoint, zmq_topic).await?;
-        let mut stream = sub_transport.subscribe(zmq_topic).await?;
-
-        tracing::info!(endpoint = %endpoint, topic = %zmq_topic, "Started consuming ZMQ endpoint stream");
-
-        loop {
-            tokio::select! {
-                _ = cancel_token.cancelled() => {
-                    tracing::info!(endpoint = %endpoint, "Endpoint stream cancelled");
-                    break;
-                }
-
-                event = stream.next() => {
-                    match event {
-                        Some(Ok(bytes)) => {
-                            match event_tx.try_send(bytes) {
-                                Ok(()) => {}
-                                Err(mpsc::error::TrySendError::Full(_)) => {
-                                    // Consumer is behind; drop to bound memory.
-                                    // Best-effort plane — a stale estimate
-                                    // self-corrects on subsequent events.
-                                    tracing::trace!(endpoint = %endpoint, "Event subscriber channel full; dropping event");
-                                }
-                                Err(mpsc::error::TrySendError::Closed(_)) => {
-                                    tracing::warn!(endpoint = %endpoint, "Event channel closed, stopping endpoint stream");
-                                    break;
-                                }
-                            }
-                        }
-                        Some(Err(e)) => {
-                            tracing::error!(
-                                endpoint = %endpoint,
-                                error = %e,
-                                "Error receiving from ZMQ endpoint"
-                            );
-                            break;
-                        }
-                        None => {
-                            tracing::info!(endpoint = %endpoint, "ZMQ endpoint stream ended");
-                            break;
-                        }
-                    }
-                }
-            }
-        }
-
-        Ok(())
     }
 
     /// Stop watching and disconnect from all endpoints.

--- a/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
+++ b/lib/runtime/src/transports/event_plane/dynamic_subscriber.rs
@@ -63,9 +63,8 @@ impl DynamicSubscriber {
         let sub_transport = Arc::new(ZmqSubTransport::dynamic(&self.topic, channel_cap).await?);
         let mut zmq_stream = sub_transport.subscribe(&self.topic).await?;
 
-        // Keep the existing bounded handoff semantics. The transport's
-        // broadcast channel uses the same capacity, so both queues remain
-        // bounded under a slow consumer.
+        // Keep the existing bounded merged-handoff semantics under a slow
+        // consumer. The transport itself has a small queue feeding this task.
         let forward_cancel = self.cancel_token.clone();
         let event_tx_for_pump = event_tx.clone();
         tokio::spawn(async move {

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -33,7 +33,22 @@ use tokio::sync::{Mutex, broadcast, mpsc, oneshot};
 /// share one. `zmq::Context` is reference-counted; clones drive the same context.
 fn shared_zmq_context() -> Context {
     static CONTEXT: OnceLock<Context> = OnceLock::new();
-    CONTEXT.get_or_init(Context::new).clone()
+    CONTEXT
+        .get_or_init(|| {
+            let context = Context::new();
+            // A single default I/O thread becomes a bottleneck for bursty
+            // fan-in once all sockets share this context. Keep the pool
+            // bounded, while allowing up to four connections to make progress
+            // concurrently on hosts with enough CPUs.
+            let io_threads = std::thread::available_parallelism()
+                .map(|count| count.get().min(4))
+                .unwrap_or(1) as i32;
+            context
+                .set_io_threads(io_threads)
+                .expect("set I/O threads before creating ZMQ sockets");
+            context
+        })
+        .clone()
 }
 
 /// High Water Mark (HWM) for ZMQ sockets.

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -294,7 +294,7 @@ impl ZmqSubTransport {
 
     /// Create a subscriber whose single socket can be connected to and
     /// disconnected from publisher endpoints as discovery changes.
-    pub async fn dynamic(topic: &str, channel_capacity: usize) -> Result<Self> {
+    pub(crate) async fn dynamic(topic: &str, channel_capacity: usize) -> Result<Self> {
         // tmq only exposes builders that bind or connect. A SUB connect is
         // asynchronous, so using then immediately disconnecting an unbound
         // inproc endpoint gives us a configured socket without network I/O.
@@ -305,7 +305,10 @@ impl ZmqSubTransport {
             .subscribe(topic.as_bytes())?;
         socket.get_socket().disconnect(placeholder)?;
 
-        let (broadcast_tx, _) = broadcast::channel(channel_capacity);
+        // This queue only hands off to DynamicSubscriber's dedicated forwarding
+        // task. Cap its eager allocation while retaining enough headroom for a
+        // burst spanning many publisher connections.
+        let (broadcast_tx, _) = broadcast::channel(channel_capacity.min(16_384));
         let (endpoint_tx, endpoint_rx) = mpsc::unbounded_channel();
         let pump_handle =
             Self::start_dynamic_socket_pump(socket, broadcast_tx.clone(), endpoint_rx);
@@ -317,14 +320,14 @@ impl ZmqSubTransport {
         })
     }
 
-    pub async fn connect_endpoint(&self, endpoint: &str) -> Result<()> {
+    pub(crate) async fn connect_endpoint(&self, endpoint: &str) -> Result<()> {
         self.send_endpoint_command(|response| {
             EndpointCommand::Connect(endpoint.to_string(), response)
         })
         .await
     }
 
-    pub async fn disconnect_endpoint(&self, endpoint: &str) -> Result<()> {
+    pub(crate) async fn disconnect_endpoint(&self, endpoint: &str) -> Result<()> {
         self.send_endpoint_command(|response| {
             EndpointCommand::Disconnect(endpoint.to_string(), response)
         })

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -38,10 +38,10 @@ fn shared_zmq_context() -> Context {
             let context = Context::new();
             // A single default I/O thread becomes a bottleneck for bursty
             // fan-in once all sockets share this context. Keep the pool
-            // bounded, while allowing up to four connections to make progress
+            // bounded, while allowing up to eight connections to make progress
             // concurrently on hosts with enough CPUs.
             let io_threads = std::thread::available_parallelism()
-                .map(|count| count.get().min(4))
+                .map(|count| count.get().min(8))
                 .unwrap_or(1) as i32;
             context
                 .set_io_threads(io_threads)

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -25,7 +25,7 @@ use tmq::{
     publish::{Publish, publish},
     subscribe::{Subscribe, subscribe},
 };
-use tokio::sync::{Mutex, broadcast};
+use tokio::sync::{Mutex, broadcast, mpsc, oneshot};
 
 /// Returns the process-wide shared ZMQ context.
 ///
@@ -199,7 +199,13 @@ impl EventTransportTx for ZmqPubTransport {
 /// Uses a background async reader to fan out frames to multiple local subscribers.
 pub struct ZmqSubTransport {
     broadcast_tx: broadcast::Sender<Bytes>,
-    _socket_pump_handle: tokio::task::JoinHandle<()>,
+    socket_pump_handle: tokio::task::JoinHandle<()>,
+    endpoint_tx: Option<mpsc::UnboundedSender<EndpointCommand>>,
+}
+
+enum EndpointCommand {
+    Connect(String, oneshot::Sender<Result<()>>),
+    Disconnect(String, oneshot::Sender<Result<()>>),
 }
 
 impl ZmqSubTransport {
@@ -222,7 +228,8 @@ impl ZmqSubTransport {
 
         Ok(Self {
             broadcast_tx,
-            _socket_pump_handle: pump_handle,
+            socket_pump_handle: pump_handle,
+            endpoint_tx: None,
         })
     }
 
@@ -265,8 +272,65 @@ impl ZmqSubTransport {
 
         Ok(Self {
             broadcast_tx,
-            _socket_pump_handle: pump_handle,
+            socket_pump_handle: pump_handle,
+            endpoint_tx: None,
         })
+    }
+
+    /// Create a subscriber whose single socket can be connected to and
+    /// disconnected from publisher endpoints as discovery changes.
+    pub async fn dynamic(topic: &str, channel_capacity: usize) -> Result<Self> {
+        // tmq only exposes builders that bind or connect. A SUB connect is
+        // asynchronous, so using then immediately disconnecting an unbound
+        // inproc endpoint gives us a configured socket without network I/O.
+        let placeholder = "inproc://dynamo-event-plane-dynamic-placeholder";
+        let ctx = shared_zmq_context();
+        let socket = configure_subscribe_builder(subscribe(&ctx))
+            .connect(placeholder)?
+            .subscribe(topic.as_bytes())?;
+        socket.get_socket().disconnect(placeholder)?;
+
+        let (broadcast_tx, _) = broadcast::channel(channel_capacity);
+        let (endpoint_tx, endpoint_rx) = mpsc::unbounded_channel();
+        let pump_handle =
+            Self::start_dynamic_socket_pump(socket, broadcast_tx.clone(), endpoint_rx);
+
+        Ok(Self {
+            broadcast_tx,
+            socket_pump_handle: pump_handle,
+            endpoint_tx: Some(endpoint_tx),
+        })
+    }
+
+    pub async fn connect_endpoint(&self, endpoint: &str) -> Result<()> {
+        self.send_endpoint_command(|response| {
+            EndpointCommand::Connect(endpoint.to_string(), response)
+        })
+        .await
+    }
+
+    pub async fn disconnect_endpoint(&self, endpoint: &str) -> Result<()> {
+        self.send_endpoint_command(|response| {
+            EndpointCommand::Disconnect(endpoint.to_string(), response)
+        })
+        .await
+    }
+
+    async fn send_endpoint_command(
+        &self,
+        command: impl FnOnce(oneshot::Sender<Result<()>>) -> EndpointCommand,
+    ) -> Result<()> {
+        let endpoint_tx = self
+            .endpoint_tx
+            .as_ref()
+            .ok_or_else(|| anyhow!("ZMQ subscriber does not support dynamic endpoints"))?;
+        let (response_tx, response_rx) = oneshot::channel();
+        endpoint_tx
+            .send(command(response_tx))
+            .map_err(|_| anyhow!("ZMQ socket pump stopped"))?;
+        response_rx
+            .await
+            .map_err(|_| anyhow!("ZMQ socket pump stopped before acknowledging endpoint"))?
     }
 
     fn start_socket_pump(
@@ -280,62 +344,112 @@ impl ZmqSubTransport {
                     break;
                 };
 
-                let frames = match result {
-                    Ok(frames) => multipart_message(frames),
+                let multipart = match result {
+                    Ok(frames) => frames,
                     Err(error) => {
                         tracing::error!(error = %error, "ZMQ receive error in socket pump");
                         break;
                     }
                 };
 
-                if frames.len() != 4 {
-                    tracing::warn!(
-                        frame_count = frames.len(),
-                        "Unexpected multipart frame count in socket pump"
-                    );
-                    continue;
-                }
-
-                let publisher_id_bytes = &frames[1];
-                if publisher_id_bytes.len() != 8 {
-                    tracing::warn!(
-                        actual = publisher_id_bytes.len(),
-                        "Invalid publisher_id frame in socket pump"
-                    );
-                    continue;
-                }
-                let publisher_id =
-                    u64::from_be_bytes(publisher_id_bytes.as_slice().try_into().unwrap());
-
-                let sequence_bytes = &frames[2];
-                if sequence_bytes.len() != 8 {
-                    tracing::warn!(
-                        actual = sequence_bytes.len(),
-                        "Invalid sequence frame in socket pump"
-                    );
-                    continue;
-                }
-                let sequence = u64::from_be_bytes(sequence_bytes.as_slice().try_into().unwrap());
-
-                tracing::trace!(
-                    publisher_id = publisher_id,
-                    sequence = sequence,
-                    "Socket pump received ZMQ message"
-                );
-
-                let frame_bytes = Bytes::from(frames[3].clone());
-                match Frame::decode(frame_bytes) {
-                    Ok(frame) => {
-                        let _ = broadcast_tx.send(frame.payload);
-                    }
-                    Err(error) => {
-                        tracing::warn!(error = %error, "Failed to decode ZMQ frame in socket pump");
-                    }
-                }
+                Self::forward_multipart(multipart, &broadcast_tx);
             }
 
             tracing::info!("ZMQ socket pump task terminated");
         })
+    }
+
+    fn start_dynamic_socket_pump(
+        mut socket: Subscribe,
+        broadcast_tx: broadcast::Sender<Bytes>,
+        mut endpoint_rx: mpsc::UnboundedReceiver<EndpointCommand>,
+    ) -> tokio::task::JoinHandle<()> {
+        tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    command = endpoint_rx.recv() => {
+                        let Some(command) = command else { break };
+                        match command {
+                            EndpointCommand::Connect(endpoint, response) => {
+                                let result = socket.get_socket().connect(&endpoint).map_err(Into::into);
+                                let _ = response.send(result);
+                            }
+                            EndpointCommand::Disconnect(endpoint, response) => {
+                                let result = socket.get_socket().disconnect(&endpoint).map_err(Into::into);
+                                let _ = response.send(result);
+                            }
+                        }
+                    }
+                    result = socket.next() => {
+                        let Some(result) = result else { break };
+                        match result {
+                            Ok(multipart) => Self::forward_multipart(multipart, &broadcast_tx),
+                            Err(error) => {
+                                tracing::error!(error = %error, "ZMQ receive error in dynamic socket pump");
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+            tracing::info!("Dynamic ZMQ socket pump task terminated");
+        })
+    }
+
+    fn forward_multipart(multipart: Multipart, broadcast_tx: &broadcast::Sender<Bytes>) {
+        let frames = multipart_message(multipart);
+
+        if frames.len() != 4 {
+            tracing::warn!(
+                frame_count = frames.len(),
+                "Unexpected multipart frame count in socket pump"
+            );
+            return;
+        }
+
+        let publisher_id_bytes = &frames[1];
+        if publisher_id_bytes.len() != 8 {
+            tracing::warn!(
+                actual = publisher_id_bytes.len(),
+                "Invalid publisher_id frame in socket pump"
+            );
+            return;
+        }
+        let publisher_id = u64::from_be_bytes(publisher_id_bytes.as_slice().try_into().unwrap());
+
+        let sequence_bytes = &frames[2];
+        if sequence_bytes.len() != 8 {
+            tracing::warn!(
+                actual = sequence_bytes.len(),
+                "Invalid sequence frame in socket pump"
+            );
+            return;
+        }
+        let sequence = u64::from_be_bytes(sequence_bytes.as_slice().try_into().unwrap());
+
+        tracing::trace!(
+            publisher_id = publisher_id,
+            sequence = sequence,
+            "Socket pump received ZMQ message"
+        );
+
+        let frame_bytes = Bytes::from(frames[3].clone());
+        match Frame::decode(frame_bytes) {
+            Ok(frame) => {
+                let _ = broadcast_tx.send(frame.payload);
+            }
+            Err(error) => {
+                tracing::warn!(error = %error, "Failed to decode ZMQ frame in socket pump");
+            }
+        }
+    }
+}
+
+impl Drop for ZmqSubTransport {
+    fn drop(&mut self) {
+        // Dropping a JoinHandle detaches the task. Explicitly abort it so the
+        // pump releases its ZMQ socket and all connection/file resources.
+        self.socket_pump_handle.abort();
     }
 }
 


### PR DESCRIPTION
## Summary

- share one bounded process-wide ZMQ context instead of creating context threads per socket
- multiplex dynamically discovered publisher endpoints onto one SUB socket per subscriber
- abort socket-pump tasks on transport drop so churn releases sockets and file descriptors
- cap eager per-subscriber buffering while preserving the existing configurable merged queue

## Validation

- `cargo test -p dynamo-runtime transports::event_plane:: --lib` (19 passed)
- `cargo clippy -p dynamo-runtime --lib -- -D warnings`
- five-repetition direct-ZMQ sweeps from 1 to 128 publishers, plus 8×4 and 32×4 subscriber cases, unrelated-topic controls, and five-cycle churn
- 32×1: threads 133→14, FDs 810→265, median throughput +21.4%, comparable p99
- 8×4: threads 85→14, FDs 498→151, median throughput +6.8%, p99 3.64→2.73 ms
- baseline 64×1 and 32×4 saturated the 1,024-FD limit; candidate completed those and 128×1 with zero observed loss

Caveat: 128×1 still used 937 FDs, so larger publisher×subscriber matrices require further transport or deployment-level fan-in.

<!-- perf-agent-investigation:5ae6611e-27d1-4fff-8a67-f6e94d097028 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved dynamic event subscription handling so updates from newly discovered sources are merged more reliably.
  * Background processing now keeps subscriptions active more efficiently while supporting live add/remove of endpoints.

* **Bug Fixes**
  * Reduced missed events by using a bounded buffer that safely drops overflow instead of stalling.
  * Improved shutdown behavior so active subscriptions are cleaned up more consistently.
  * Better resource handling for streaming connections and message delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->