### PR TITLE
fix(planner): align replay FPM sampling with live

### DIFF
--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -113,20 +113,16 @@ def _build_fpm_from_dict(d: dict[str, Any]) -> ForwardPassMetrics:
 def _update_fpm_cache(
     cache: dict[tuple[str, int], ForwardPassMetrics],
     snapshots: list[dict[str, Any]],
-    active_count: int,
+    active_worker_ids: list[int],
 ) -> None:
     """Update a last-seen FPM cache with new snapshots and prune removed workers."""
     for snap in snapshots:
         fpm = _build_fpm_from_dict(snap)
         cache[(fpm.worker_id, fpm.dp_rank)] = fpm
 
-    # Prune by logical worker, retaining every DP-rank entry for each active
-    # worker. Workers are removed highest-ID-first during scale-down.
-    active_worker_ids = set(
-        sorted({worker_id for worker_id, _ in cache}, key=int)[:active_count]
-    )
+    active_worker_ids_as_str = {str(worker_id) for worker_id in active_worker_ids}
     for key in list(cache):
-        if key[0] not in active_worker_ids:
+        if key[0] not in active_worker_ids_as_str:
             del cache[key]
 
 
@@ -563,19 +559,18 @@ class ReplayPlannerAdapter:
             )
 
         fpm_observations = None
-        # The replay bridge may report multiple passes per callback. Collapse
-        # them to the latest value per worker/rank immediately so replay matches
-        # the live subscriber's latest-snapshot semantics and does not retain an
-        # unbounded intra-tick history.
+        # Merge each callback's latest worker/rank snapshots into the last-seen
+        # cache, then expose the cache only on FPM ticks. This matches the live
+        # subscriber's latest-snapshot semantics.
         _update_fpm_cache(
             self._prefill_fpm_cache,
             result.get("prefill_fpm_snapshots", []),
-            result["active_prefill_count"],
+            result["active_prefill_ids"],
         )
         _update_fpm_cache(
             self._decode_fpm_cache,
             result.get("decode_fpm_snapshots", []),
-            result["active_decode_count"],
+            result["active_decode_ids"],
         )
         if tick.need_worker_fpm:
             prefill_dict = (

--- a/components/src/dynamo/planner/offline/replay_adapter.py
+++ b/components/src/dynamo/planner/offline/replay_adapter.py
@@ -232,8 +232,6 @@ class ReplayPlannerAdapter:
         # Last-seen FPM caches (separate for prefill/decode)
         self._prefill_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
         self._decode_fpm_cache: dict[tuple[str, int], ForwardPassMetrics] = {}
-        self._pending_prefill_fpm_snaps: list[dict[str, Any]] = []
-        self._pending_decode_fpm_snaps: list[dict[str, Any]] = []
         # Partial traffic window accumulated across ticks until a throughput tick
         # consumes it (``None`` = nothing pending).
         self._pending_traffic: Optional[dict[str, Any]] = None
@@ -520,94 +518,10 @@ class ReplayPlannerAdapter:
             )
         return (target_p, target_d)
 
-    def _feed_extra_fpm_to_regression(
-        self,
-        decode_snaps: list[dict[str, Any]],
-        prefill_snaps: list[dict[str, Any]],
-    ) -> None:
-        """Feed accumulated FPM snapshots to regression, excluding the last
-        per worker (which will be added by _observe_fpm via fpm_observations).
-        This avoids double-counting the cached snapshot.
-
-        Works via ``_get_regression(kind)`` for orchestrator replay. Returns
-        early on easy mode (no regressions) or when the requested regression
-        slot isn't installed.
-        """
-        if self._is_easy_mode():
-            return  # easy mode has no regression models
-
-        if self._config.mode == "agg":
-            agg_reg = self._get_regression("agg")
-            if agg_reg is None:
-                return
-            last_idx_per_worker: dict[tuple[Any, int], int] = {}
-            for i, snap in enumerate(decode_snaps):
-                last_idx_per_worker[
-                    (snap["worker_id"], int(snap.get("dp_rank", 0)))
-                ] = i
-            exclude = set(last_idx_per_worker.values())
-            for i, snap in enumerate(decode_snaps):
-                if i in exclude:
-                    continue
-                fpm = _build_fpm_from_dict(snap)
-                if fpm.wall_time > 0.0:
-                    agg_reg.add_observations({(fpm.worker_id, fpm.dp_rank): fpm})
-        else:
-            has_prefill = self._config.mode in ("prefill", "disagg")
-            has_decode = self._config.mode in ("decode", "disagg")
-            if has_prefill:
-                p_reg = self._get_regression("prefill")
-                if p_reg is not None:
-                    last_idx: dict[tuple[Any, int], int] = {}
-                    for i, snap in enumerate(prefill_snaps):
-                        last_idx[(snap["worker_id"], int(snap.get("dp_rank", 0)))] = i
-                    exclude = set(last_idx.values())
-                    for i, snap in enumerate(prefill_snaps):
-                        if i in exclude:
-                            continue
-                        fpm = _build_fpm_from_dict(snap)
-                        if fpm.wall_time > 0.0:
-                            p_reg.add_observations({(fpm.worker_id, fpm.dp_rank): fpm})
-            if has_decode:
-                d_reg = self._get_regression("decode")
-                if d_reg is not None:
-                    last_idx = {}
-                    for i, snap in enumerate(decode_snaps):
-                        last_idx[(snap["worker_id"], int(snap.get("dp_rank", 0)))] = i
-                    exclude = set(last_idx.values())
-                    for i, snap in enumerate(decode_snaps):
-                        if i in exclude:
-                            continue
-                        fpm = _build_fpm_from_dict(snap)
-                        if fpm.wall_time > 0.0:
-                            d_reg.add_observations({(fpm.worker_id, fpm.dp_rank): fpm})
-
     def _is_easy_mode(self) -> bool:
         """Easy-mode check routed via config — both paths honour this
         the same way (no regression in non-SLA modes)."""
         return self._config.optimization_target != "sla"
-
-    def _get_regression(self, kind: str):
-        """Return the regression model for ``kind`` (``"agg"`` /
-        ``"prefill"`` / ``"decode"``).
-
-        Normal path: read from the orchestrator adapter's shared scaling
-        state. That state owns both benchmark-installed regressions and the
-        empty live-regression slots that replay must feed when no AIC data was
-        installed.
-        """
-        attr = f"_{kind}_regression"
-        state = getattr(self._engine, "_scaling_state", None)
-        if state is not None:
-            regression = getattr(state, attr, None)
-            if regression is not None:
-                return regression
-        # Benchmark regressions are also published to the orchestrator so
-        # external plugins can read them during bootstrap hooks.
-        orch = getattr(self._engine, "_orchestrator", None)
-        if orch is None:
-            return None
-        return orch.get_regression(kind)
 
     def _build_tick_input(
         self, tick: ScheduledTick, result: dict[str, Any]
@@ -649,37 +563,27 @@ class ReplayPlannerAdapter:
             )
 
         fpm_observations = None
-        if not hasattr(self, "_pending_prefill_fpm_snaps"):
-            self._pending_prefill_fpm_snaps = []
-        if not hasattr(self, "_pending_decode_fpm_snaps"):
-            self._pending_decode_fpm_snaps = []
-        self._pending_prefill_fpm_snaps.extend(result.get("prefill_fpm_snapshots", []))
-        self._pending_decode_fpm_snaps.extend(result.get("decode_fpm_snapshots", []))
+        # The replay bridge may report multiple passes per callback. Collapse
+        # them to the latest value per worker/rank immediately so replay matches
+        # the live subscriber's latest-snapshot semantics and does not retain an
+        # unbounded intra-tick history.
+        _update_fpm_cache(
+            self._prefill_fpm_cache,
+            result.get("prefill_fpm_snapshots", []),
+            result["active_prefill_count"],
+        )
+        _update_fpm_cache(
+            self._decode_fpm_cache,
+            result.get("decode_fpm_snapshots", []),
+            result["active_decode_count"],
+        )
         if tick.need_worker_fpm:
-            prefill_snaps = self._pending_prefill_fpm_snaps
-            decode_snaps = self._pending_decode_fpm_snaps
-            self._pending_prefill_fpm_snaps = []
-            self._pending_decode_fpm_snaps = []
-
-            _update_fpm_cache(
-                self._prefill_fpm_cache, prefill_snaps, result["active_prefill_count"]
-            )
-            _update_fpm_cache(
-                self._decode_fpm_cache, decode_snaps, result["active_decode_count"]
-            )
-
-            # In offline replay, we accumulate many FPM snapshots per tick
-            # (one per engine pass). Feed ALL non-idle snapshots directly to
-            # the regression models for a representative fit. The last-per-worker
-            # cache is only used for the FpmObservations dict (worker count
-            # reconciliation), not as the sole regression input.
             prefill_dict = (
                 dict(self._prefill_fpm_cache) if self._prefill_fpm_cache else None
             )
             decode_dict = (
                 dict(self._decode_fpm_cache) if self._decode_fpm_cache else None
             )
-            self._feed_extra_fpm_to_regression(decode_snaps, prefill_snaps)
             fpm_observations = FpmObservations(
                 prefill=prefill_dict,
                 decode=decode_dict,

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -1,18 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Regression test for the replay-path FPM feed.
-
-``ReplayPlannerAdapter._feed_extra_fpm_to_regression`` feeds accumulated
-intra-tick FPM snapshots into the regression model. The regression slots
-hold ``PlannerEnginePerfModel``, which exposes only
-``add_observations(dict)``. The pre-fix singular ``add_observation(fpm)``
-raised ``AttributeError`` on replay ticks that carried more than one FPM
-snapshot per worker.
-
-This test drives the method against a real orchestrator-owned regression and
-asserts it does not raise.
-"""
+"""Regression tests for planner replay FPM handling."""
 
 from __future__ import annotations
 
@@ -125,67 +114,19 @@ def test_install_benchmark_fpms_installs_regression_on_orchestrator_path():
     assert adapter._engine._orchestrator.get_regression("agg") is not None
 
 
-def test_get_regression_uses_orchestrator_scaling_state_without_aic_install():
-    """Replay without AIC benchmark FPMs still needs the live regression slot.
-
-    The orchestrator's public regression store is populated during benchmark
-    bootstrap for external-plugin access. No-AIC replay instead starts from
-    the adapter's ``PlannerScalingState`` regression and feeds intra-tick FPMs
-    into it.
-    """
-    cfg = _orch_agg_config_sla()
-    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
-    adapter._config = cfg
-    adapter._engine = OrchestratorEngineAdapter(cfg, _agg_caps())
-
-    assert adapter._engine._orchestrator.get_regression("agg") is None
-    assert adapter._get_regression("agg") is not None
-
-    decode_snaps = [
-        _snap("1", wall_time=1.0),
-        _snap("1", wall_time=2.0),  # last-per-worker -> excluded
-    ]
-    adapter._feed_extra_fpm_to_regression(
-        decode_snaps=decode_snaps,
-        prefill_snaps=[],
-    )
-
-
-def test_extra_fpm_feed_excludes_last_snapshot_per_worker_rank():
-    class RecordingRegression:
-        def __init__(self):
-            self.keys = []
-
-        def add_observations(self, observations):
-            self.keys.extend(observations)
-
-    regression = RecordingRegression()
-    adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
-    adapter._config = _agg_config_sla()
-    adapter._get_regression = lambda _kind: regression
-
-    adapter._feed_extra_fpm_to_regression(
-        decode_snaps=[
-            _snap("0", wall_time=1.0, dp_rank=0),
-            _snap("0", wall_time=1.0, dp_rank=1),
-            _snap("0", wall_time=2.0, dp_rank=0),
-            _snap("0", wall_time=2.0, dp_rank=1),
-        ],
-        prefill_snaps=[],
-    )
-
-    assert regression.keys == [("0", 0), ("0", 1)]
-
-
 def test_build_tick_input_maps_replay_accept_length():
     # The Rust simulation drains the per-tick traffic window into
     # ``result["traffic"]``; a need_traffic_metrics tick maps it onto
     # ``TickInput.traffic`` (accept_length, isl/osl, kv-hit, latency).
     adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
+    adapter._prefill_fpm_cache = {}
+    adapter._decode_fpm_cache = {}
 
     tick = ScheduledTick(at_s=60.0, need_traffic_metrics=True)
     result = {
         "now_ms": 1_000.0,
+        "active_prefill_count": 0,
+        "active_decode_count": 0,
         "traffic": {
             "duration_s": 60.0,
             "num_req": 4,
@@ -205,15 +146,13 @@ def test_build_tick_input_maps_replay_accept_length():
     assert adapter._last_traffic.accept_length == 2.5
 
 
-def test_build_tick_input_buffers_fpm_until_fpm_tick():
+def test_build_tick_input_keeps_only_latest_fpm_until_fpm_tick():
     cfg = PlannerConfig(mode="agg", optimization_target="throughput")
     adapter = ReplayPlannerAdapter.__new__(ReplayPlannerAdapter)
     adapter._config = cfg
     adapter._is_disagg = False
     adapter._prefill_fpm_cache = {}
     adapter._decode_fpm_cache = {}
-    adapter._pending_prefill_fpm_snaps = []
-    adapter._pending_decode_fpm_snaps = []
     adapter._scaling_target_prefill = None
     adapter._scaling_target_decode = None
 
@@ -222,18 +161,25 @@ def test_build_tick_input_buffers_fpm_until_fpm_tick():
         need_worker_states=True,
         need_worker_fpm=False,
     )
-    snap = _snap("1", wall_time=1.0)
     first = adapter._build_tick_input(
         no_fpm_tick,
         {
             "now_ms": 1_000.0,
             "active_prefill_count": 0,
             "active_decode_count": 1,
-            "decode_fpm_snapshots": [snap],
+            "decode_fpm_snapshots": [
+                _snap("0", wall_time=1.0, dp_rank=0),
+                _snap("0", wall_time=1.0, dp_rank=1),
+                _snap("0", wall_time=2.0, dp_rank=0),
+                _snap("0", wall_time=2.0, dp_rank=1),
+            ],
             "prefill_fpm_snapshots": [],
         },
     )
     assert first.fpm_observations is None
+    assert set(adapter._decode_fpm_cache) == {("0", 0), ("0", 1)}
+    assert adapter._decode_fpm_cache[("0", 0)].wall_time == 2.0
+    assert adapter._decode_fpm_cache[("0", 1)].wall_time == 2.0
 
     fpm_tick = ScheduledTick(
         at_s=7.0,
@@ -252,7 +198,9 @@ def test_build_tick_input_buffers_fpm_until_fpm_tick():
     )
 
     assert second.fpm_observations is not None
-    assert ("1", 0) in second.fpm_observations.decode
+    assert set(second.fpm_observations.decode) == {("0", 0), ("0", 1)}
+    assert second.fpm_observations.decode[("0", 0)].wall_time == 2.0
+    assert second.fpm_observations.decode[("0", 1)].wall_time == 2.0
 
 
 def test_replay_engine_caps_exposes_aic_nextn():

--- a/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
+++ b/components/src/dynamo/planner/tests/offline/test_replay_adapter_fpm.py
@@ -80,13 +80,30 @@ def test_fpm_cache_keeps_all_ranks_for_each_active_worker():
         _snap("1", wall_time=1.0, dp_rank=1),
     ]
 
-    _update_fpm_cache(cache, snapshots, active_count=2)
+    _update_fpm_cache(cache, snapshots, active_worker_ids=[0, 1])
 
     assert set(cache) == {("0", 0), ("0", 1), ("1", 0), ("1", 1)}
 
-    _update_fpm_cache(cache, [], active_count=1)
+    _update_fpm_cache(cache, [], active_worker_ids=[0])
 
     assert set(cache) == {("0", 0), ("0", 1)}
+
+
+def test_fpm_cache_prunes_by_active_identity_after_worker_replacement():
+    cache = {}
+    _update_fpm_cache(
+        cache,
+        [_snap("0", wall_time=1.0), _snap("1", wall_time=1.0)],
+        active_worker_ids=[0, 1],
+    )
+
+    _update_fpm_cache(
+        cache,
+        [_snap("2", wall_time=2.0)],
+        active_worker_ids=[0, 2],
+    )
+
+    assert set(cache) == {("0", 0), ("2", 0)}
 
 
 def _orch_agg_config_sla() -> PlannerConfig:
@@ -127,6 +144,8 @@ def test_build_tick_input_maps_replay_accept_length():
         "now_ms": 1_000.0,
         "active_prefill_count": 0,
         "active_decode_count": 0,
+        "active_prefill_ids": [],
+        "active_decode_ids": [],
         "traffic": {
             "duration_s": 60.0,
             "num_req": 4,
@@ -167,6 +186,8 @@ def test_build_tick_input_keeps_only_latest_fpm_until_fpm_tick():
             "now_ms": 1_000.0,
             "active_prefill_count": 0,
             "active_decode_count": 1,
+            "active_prefill_ids": [],
+            "active_decode_ids": [0],
             "decode_fpm_snapshots": [
                 _snap("0", wall_time=1.0, dp_rank=0),
                 _snap("0", wall_time=1.0, dp_rank=1),
@@ -192,6 +213,8 @@ def test_build_tick_input_keeps_only_latest_fpm_until_fpm_tick():
             "now_ms": 7_000.0,
             "active_prefill_count": 0,
             "active_decode_count": 1,
+            "active_prefill_ids": [],
+            "active_decode_ids": [0],
             "decode_fpm_snapshots": [],
             "prefill_fpm_snapshots": [],
         },

--- a/lib/bindings/python/rust/llm/replay.rs
+++ b/lib/bindings/python/rust/llm/replay.rs
@@ -2466,8 +2466,8 @@ impl PlannerHook for PyPlannerHook {
             prefill_fpm,
             decode_fpm,
             traffic,
-            active_prefill,
-            active_decode,
+            active_prefill_ids,
+            active_decode_ids,
             total_prefill,
             total_decode,
         } = metrics;
@@ -2478,8 +2478,10 @@ impl PlannerHook for PyPlannerHook {
                 "now_ms": now_ms,
                 "prefill_fpm_snapshots": fpm_snapshots_to_json(prefill_fpm),
                 "decode_fpm_snapshots": fpm_snapshots_to_json(decode_fpm),
-                "active_prefill_count": active_prefill,
-                "active_decode_count": active_decode,
+                "active_prefill_count": active_prefill_ids.len(),
+                "active_decode_count": active_decode_ids.len(),
+                "active_prefill_ids": active_prefill_ids,
+                "active_decode_ids": active_decode_ids,
                 "total_prefill_count": total_prefill,
                 "total_decode_count": total_decode,
                 "traffic": {

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -247,6 +247,10 @@ impl AggRuntime {
     /// planner via recurring `PlannerTick` events (one `on_tick` callback per tick).
     pub(in crate::replay) fn with_planner_hook(mut self, hook: Box<dyn PlannerHook>) -> Self {
         self.collect_fpm = true;
+        for worker_id in self.engine.active_group_ids() {
+            self.fpm_buffer
+                .activate_worker(worker_id, self.dp_size, self.now_ms);
+        }
         self.planner_hook = Some(hook);
         self
     }
@@ -330,7 +334,7 @@ impl AggRuntime {
         })?;
         snapshot.worker_id = worker_id.to_string();
         snapshot.dp_rank = dp_rank;
-        self.fpm_buffer.insert(worker_id, snapshot);
+        self.fpm_buffer.insert(worker_id, snapshot, self.now_ms);
         Ok(())
     }
 
@@ -717,6 +721,10 @@ impl AggRuntime {
         while let Some((stage, worker_id)) = pop_ready_worker_ready(&mut self.events, self.now_ms) {
             debug_assert_eq!(stage, SimulationWorkerStage::Aggregated);
             if self.engine.mark_worker_ready(worker_id) {
+                if self.collect_fpm {
+                    self.fpm_buffer
+                        .activate_worker(worker_id, self.dp_size, self.now_ms);
+                }
                 if let Some(router) = self.router.as_mut() {
                     router.add_worker(worker_id)?;
                     // Drain any requests that were queued while all workers
@@ -798,6 +806,8 @@ impl AggRuntime {
                 continue;
             }
             let active_decode_ids = self.engine.active_group_ids();
+            self.fpm_buffer
+                .emit_idle_due(&active_decode_ids, self.dp_size, self.now_ms);
             let metrics = PlannerTickMetrics {
                 now_ms: self.now_ms,
                 prefill_fpm: Vec::new(),
@@ -905,6 +915,10 @@ impl AggRuntime {
                     );
                 }
                 None => {
+                    if self.collect_fpm {
+                        self.fpm_buffer
+                            .activate_worker(id, self.dp_size, self.now_ms);
+                    }
                     if let Some(router) = self.router.as_mut() {
                         router.add_worker(id)?;
                     }
@@ -1097,6 +1111,27 @@ mod tests {
     use crate::replay::{TraceRequestStatsSnapshot, normalize_trace_requests};
     use dynamo_kv_router::config::{KvRouterConfig, RouterQueuePolicy};
     use rstest::rstest;
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
+    struct CaptureOnceHook {
+        at_ms: f64,
+        captured: Rc<RefCell<Option<PlannerTickMetrics>>>,
+    }
+
+    impl PlannerHook for CaptureOnceHook {
+        fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+            Ok(self.at_ms)
+        }
+
+        fn on_tick(
+            &mut self,
+            metrics: PlannerTickMetrics,
+        ) -> anyhow::Result<super::super::planner_hook::PlannerTickDecision> {
+            *self.captured.borrow_mut() = Some(metrics);
+            Ok(super::super::planner_hook::PlannerTickDecision::default())
+        }
+    }
 
     fn replay_args(enable_prefix_caching: bool, enable_chunked_prefill: bool) -> MockEngineArgs {
         MockEngineArgs::builder()
@@ -1440,6 +1475,74 @@ mod tests {
 
         assert!(identities.contains(&(0, "0".to_string(), 0)));
         assert!(identities.contains(&(0, "0".to_string(), 1)));
+    }
+
+    #[test]
+    fn planner_tick_emits_idle_fpm_after_simulated_second() {
+        let mut args = sglang_replay_args();
+        args.dp_size = 2;
+        let pending = normalize_trace_requests(
+            vec![
+                DirectRequest {
+                    tokens: vec![1; 8],
+                    max_output_tokens: 1,
+                    uuid: Some(Uuid::from_u128(9_201)),
+                    arrival_timestamp_ms: Some(0.0),
+                    ..Default::default()
+                },
+                DirectRequest {
+                    tokens: vec![2; 8],
+                    max_output_tokens: 1,
+                    uuid: Some(Uuid::from_u128(9_202)),
+                    arrival_timestamp_ms: Some(3_000.0),
+                    ..Default::default()
+                },
+            ],
+            1.0,
+        )
+        .unwrap();
+        let captured = Rc::new(RefCell::new(None));
+        let hook = CaptureOnceHook {
+            at_ms: 2_000.0,
+            captured: Rc::clone(&captured),
+        };
+
+        AggRuntime::new(
+            &args,
+            None,
+            None,
+            pending,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap()
+        .with_planner_hook(Box::new(hook))
+        .run()
+        .unwrap();
+
+        let metrics = captured
+            .borrow_mut()
+            .take()
+            .expect("planner tick must fire");
+        assert_eq!(metrics.now_ms, 2_000.0);
+        assert_eq!(metrics.decode_fpm.len(), 2);
+        assert!(metrics.decode_fpm.iter().all(|(worker_id, snapshot)| {
+            *worker_id == 0
+                && snapshot.wall_time_secs == 0.0
+                && snapshot.num_prefill_requests == 0
+                && snapshot.num_decode_requests == 0
+                && snapshot.num_queued_prefill == 0
+                && snapshot.num_queued_decode == 0
+        }));
+        assert_eq!(
+            metrics
+                .decode_fpm
+                .iter()
+                .map(|(_, snapshot)| snapshot.dp_rank)
+                .collect::<Vec<_>>(),
+            vec![0, 1]
+        );
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -7,7 +7,7 @@ pub(super) use super::components::ReplayMode;
 #[cfg(test)]
 use super::components::TrafficStats;
 use super::events::{SimulationEvent, SimulationWorkerStage};
-use super::planner_hook::{PlannerHook, PlannerTickMetrics};
+use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
     next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_worker_completion,
@@ -81,8 +81,8 @@ pub(in crate::replay) struct AggRuntime {
     router: Option<OfflineReplayRouter>,
     progress: ReplayProgress,
     stats: AggRuntimeStats,
-    /// Forward pass metrics accumulated between planner ticks.
-    fpm_buffer: Vec<(usize, ForwardPassSnapshot)>,
+    /// Latest forward pass metric per worker/rank since the previous planner tick.
+    fpm_buffer: LatestFpmBuffer,
     /// Traffic statistics accumulated between planner ticks.
     traffic: TrafficAccumulator,
     /// Optional cap on simulated wall-clock time. When set, `run()` exits
@@ -93,9 +93,8 @@ pub(in crate::replay) struct AggRuntime {
     /// calls back into the planner at each tick (the unified replacement for the
     /// old Python-driven `advance_to` stepping loop).
     planner_hook: Option<Box<dyn PlannerHook>>,
-    /// Whether to retain per-pass FPM snapshots. Only the planner consumes them, so
-    /// the plain `run()` path leaves this `false` (otherwise the buffer grows
-    /// unbounded for the whole run with no reader — the leak this gating fixes).
+    /// Whether to retain the latest FPM snapshot per worker/rank. Only the planner
+    /// consumes them, so the plain `run()` path leaves this `false`.
     collect_fpm: bool,
     #[cfg(test)]
     worker_active_requests: Vec<Vec<Uuid>>,
@@ -196,7 +195,7 @@ impl AggRuntime {
             stats: AggRuntimeStats::default(),
             #[cfg(not(test))]
             stats: AggRuntimeStats,
-            fpm_buffer: Vec::new(),
+            fpm_buffer: LatestFpmBuffer::default(),
             traffic: TrafficAccumulator::new(),
             max_sim_time_ms: None,
             planner_hook: None,
@@ -331,7 +330,7 @@ impl AggRuntime {
         })?;
         snapshot.worker_id = worker_id.to_string();
         snapshot.dp_rank = dp_rank;
-        self.fpm_buffer.push((worker_id, snapshot));
+        self.fpm_buffer.insert(worker_id, snapshot);
         Ok(())
     }
 
@@ -689,11 +688,6 @@ impl AggRuntime {
     }
 
     fn handle_engine_effects(&mut self, effects: EngineEffects) -> anyhow::Result<()> {
-        if self.collect_fpm {
-            for (rank_id, fpm) in effects.fpm_snapshots {
-                self.record_fpm(rank_id, fpm)?;
-            }
-        }
         self.apply_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
             let payload = self.engine.on_scheduled_completion(payload)?;
@@ -803,13 +797,14 @@ impl AggRuntime {
             if self.is_workload_done() {
                 continue;
             }
+            let active_decode_ids = self.engine.active_group_ids();
             let metrics = PlannerTickMetrics {
                 now_ms: self.now_ms,
                 prefill_fpm: Vec::new(),
-                decode_fpm: std::mem::take(&mut self.fpm_buffer),
+                decode_fpm: self.fpm_buffer.take(),
                 traffic: self.traffic.drain(self.now_ms),
-                active_prefill: 0,
-                active_decode: self.active_worker_count(),
+                active_prefill_ids: Vec::new(),
+                active_decode_ids,
                 total_prefill: 0,
                 total_decode: self.total_worker_count(),
             };
@@ -867,6 +862,7 @@ impl AggRuntime {
     }
 
     /// Number of active (non-pending-removal) workers.
+    #[cfg(test)]
     pub(in crate::replay) fn active_worker_count(&self) -> usize {
         self.engine.active_group_ids().len()
     }
@@ -1051,7 +1047,7 @@ impl AggRuntime {
 
     #[cfg(test)]
     fn drain_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.fpm_buffer)
+        self.fpm_buffer.take()
     }
 
     #[cfg(test)]

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -473,11 +473,7 @@ impl EngineComponent {
                     || !payload.output_signals.is_empty()
                     || !payload.lifecycle_events.is_empty()
                     || !payload.kv_events.is_empty()
-                    || payload.fpm.as_ref().is_some_and(fpm_has_scheduled_work)
-                    || effects
-                        .fpm_snapshots
-                        .iter()
-                        .any(|(_, snapshot)| fpm_has_scheduled_work(snapshot));
+                    || payload.fpm.as_ref().is_some_and(fpm_has_scheduled_work);
                 if made_progress {
                     effects.immediate_completions.push(payload);
                 }
@@ -807,7 +803,6 @@ mod tests {
         vllm.dispatch(0, request(Uuid::from_u128(10))).unwrap();
         let vllm_start = vllm.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(!vllm_start.pass_start_kv_events.is_empty());
-        assert!(vllm_start.fpm_snapshots.is_empty());
         let vllm_end = take_only_completion(vllm_start);
         assert!(vllm_end.kv_events.is_empty());
         assert!(vllm_end.fpm.is_some());
@@ -816,7 +811,6 @@ mod tests {
         sglang.dispatch(0, request(Uuid::from_u128(11))).unwrap();
         let sglang_start = sglang.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(sglang_start.pass_start_kv_events.is_empty());
-        assert!(sglang_start.fpm_snapshots.is_empty());
         let sglang_end = take_only_completion(sglang_start);
         assert!(!sglang_end.kv_events.is_empty());
         assert!(sglang_end.fpm.is_some());
@@ -918,7 +912,6 @@ mod tests {
         let second = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
         assert!(second.admissions.is_empty());
         assert!(second.pass_start_kv_events.is_empty());
-        assert!(second.fpm_snapshots.is_empty());
         assert_eq!(second.immediate_completions.len(), 1);
         assert!(second.scheduled_completions.is_empty());
         let second = take_only_completion(second);

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -257,6 +257,10 @@ impl EngineComponent {
             .collect()
     }
 
+    pub(in crate::replay::offline) fn dp_size(&self) -> u32 {
+        self.args.dp_size.max(1)
+    }
+
     pub(in crate::replay::offline) fn rank_id(
         &self,
         worker_id: usize,

--- a/lib/mocker/src/replay/offline/components/types.rs
+++ b/lib/mocker/src/replay/offline/components/types.rs
@@ -5,7 +5,7 @@ use dynamo_kv_router::protocols::RouterEvent;
 use uuid::Uuid;
 
 use super::super::runtime_utils::WorkerCompletionPayload;
-use crate::common::protocols::{DirectRequest, ForwardPassSnapshot};
+use crate::common::protocols::DirectRequest;
 use crate::loadgen::ReplayRequestHashes;
 use crate::scheduler::AdmissionEvent;
 
@@ -46,9 +46,6 @@ pub(in crate::replay::offline) struct EngineEffects {
     pub(in crate::replay::offline) pass_start_kv_events: Vec<RouterEvent>,
     pub(in crate::replay::offline) immediate_completions: Vec<WorkerCompletionPayload>,
     pub(in crate::replay::offline) scheduled_completions: Vec<ScheduledWorkerCompletion>,
-    /// Forward pass metrics snapshots emitted by workers during this drive cycle,
-    /// keyed by worker index. Collected for planner integration.
-    pub(in crate::replay::offline) fpm_snapshots: Vec<(usize, ForwardPassSnapshot)>,
 }
 
 impl EngineEffects {

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -16,7 +16,7 @@ use super::components::{
     ReadyArrival, ScheduledWorkerCompletion, TrafficAccumulator, WorkerAdmission,
 };
 use super::events::{SimulationEvent, SimulationWorkerStage};
-use super::planner_hook::{PlannerHook, PlannerTickMetrics};
+use super::planner_hook::{LatestFpmBuffer, PlannerHook, PlannerTickMetrics};
 use super::progress::ReplayProgress;
 use super::runtime_utils::{
     next_timestamp as choose_next_timestamp, pop_ready_planner_tick, pop_ready_transfer_complete,
@@ -31,9 +31,9 @@ use crate::common::handoff::{
     IssuedHandoffAction, NormalizedHandoffConformance, NormalizedHandoffEvent,
     NormalizedStoredTiming,
 };
-use crate::common::protocols::{
-    DirectRequest, EngineType, ForwardPassSnapshot, MockEngineArgs, OutputSignal,
-};
+#[cfg(test)]
+use crate::common::protocols::ForwardPassSnapshot;
+use crate::common::protocols::{DirectRequest, EngineType, MockEngineArgs, OutputSignal};
 use crate::loadgen::{ReplayRequestHashes, WorkloadDriver};
 use crate::replay::{
     OfflineDisaggReplayConfig, ReplayPrefillLoadEstimator, ReplayRouterMode, ReplayTerminalStatus,
@@ -286,9 +286,9 @@ pub(in crate::replay) struct DisaggRuntime {
     progress: ReplayProgress,
     stats: DisaggRuntimeStats,
     conformance_capture: Option<HandoffConformanceCapture>,
-    /// Forward pass metrics accumulated between planner ticks, keyed by (stage, worker_idx).
-    prefill_fpm_buffer: Vec<(usize, ForwardPassSnapshot)>,
-    decode_fpm_buffer: Vec<(usize, ForwardPassSnapshot)>,
+    /// Latest forward pass metric per worker/rank since the previous planner tick.
+    prefill_fpm_buffer: LatestFpmBuffer,
+    decode_fpm_buffer: LatestFpmBuffer,
     /// Traffic statistics accumulated between planner ticks.
     traffic: TrafficAccumulator,
     /// Optional cap on simulated wall-clock time. When set, `run()` exits
@@ -299,10 +299,9 @@ pub(in crate::replay) struct DisaggRuntime {
     /// calls back into the planner at each tick (this is the unified replacement
     /// for the old Python-driven `advance_to` stepping loop).
     planner_hook: Option<Box<dyn PlannerHook>>,
-    /// Whether to retain per-pass FPM snapshots in the buffers above. Only the
-    /// planner consumes them, so the plain `run()` path leaves this `false` —
-    /// otherwise the buffers grow unbounded (one entry per worker pass) for the
-    /// whole run with no reader (the memory leak this gating fixes).
+    /// Whether to retain the latest FPM snapshot per worker/rank in the buffers
+    /// above. Only the planner consumes them, so the plain `run()` path leaves this
+    /// `false`.
     collect_fpm: bool,
 }
 
@@ -470,8 +469,8 @@ impl DisaggRuntime {
             #[cfg(not(test))]
             stats: DisaggRuntimeStats,
             conformance_capture: capture_conformance.then(HandoffConformanceCapture::default),
-            prefill_fpm_buffer: Vec::new(),
-            decode_fpm_buffer: Vec::new(),
+            prefill_fpm_buffer: LatestFpmBuffer::default(),
+            decode_fpm_buffer: LatestFpmBuffer::default(),
             traffic: TrafficAccumulator::new(),
             max_sim_time_ms: None,
             planner_hook: None,
@@ -1496,7 +1495,7 @@ impl DisaggRuntime {
                     if self.collect_fpm
                         && let Some(fpm) = payload.fpm
                     {
-                        self.prefill_fpm_buffer.push((payload.worker_idx, fpm));
+                        self.prefill_fpm_buffer.insert(payload.worker_idx, fpm);
                     }
                     self.process_prefill_pass(
                         payload.worker_idx,
@@ -1512,7 +1511,7 @@ impl DisaggRuntime {
                     if self.collect_fpm
                         && let Some(fpm) = payload.fpm
                     {
-                        self.decode_fpm_buffer.push((payload.worker_idx, fpm));
+                        self.decode_fpm_buffer.insert(payload.worker_idx, fpm);
                     }
                     self.process_decode_pass(
                         payload.output_signals,
@@ -1598,9 +1597,6 @@ impl DisaggRuntime {
     }
 
     fn handle_prefill_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
-        if self.collect_fpm {
-            self.prefill_fpm_buffer.extend(effects.fpm_snapshots);
-        }
         self.record_prefill_admissions(effects.admissions);
         self.apply_prefill_router_events(effects.pass_start_kv_events)?;
         for payload in effects.immediate_completions {
@@ -1608,7 +1604,7 @@ impl DisaggRuntime {
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.prefill_fpm_buffer.push((payload.worker_idx, fpm));
+                self.prefill_fpm_buffer.insert(payload.worker_idx, fpm);
             }
             self.process_prefill_pass(
                 payload.worker_idx,
@@ -1662,16 +1658,13 @@ impl DisaggRuntime {
     }
 
     fn handle_decode_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
-        if self.collect_fpm {
-            self.decode_fpm_buffer.extend(effects.fpm_snapshots);
-        }
         self.record_decode_admissions(effects.admissions)?;
         for payload in effects.immediate_completions {
             let payload = self.decode_engine.on_scheduled_completion(payload)?;
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.decode_fpm_buffer.push((payload.worker_idx, fpm));
+                self.decode_fpm_buffer.insert(payload.worker_idx, fpm);
             }
             self.process_decode_pass(
                 payload.output_signals,
@@ -1830,13 +1823,15 @@ impl DisaggRuntime {
             if self.is_workload_done() {
                 continue;
             }
+            let active_prefill_ids = self.prefill_engine.active_group_ids();
+            let active_decode_ids = self.decode_engine.active_group_ids();
             let metrics = PlannerTickMetrics {
                 now_ms: self.now_ms,
-                prefill_fpm: std::mem::take(&mut self.prefill_fpm_buffer),
-                decode_fpm: std::mem::take(&mut self.decode_fpm_buffer),
+                prefill_fpm: self.prefill_fpm_buffer.take(),
+                decode_fpm: self.decode_fpm_buffer.take(),
                 traffic: self.traffic.drain(self.now_ms),
-                active_prefill: self.active_prefill_count(),
-                active_decode: self.active_decode_count(),
+                active_prefill_ids,
+                active_decode_ids,
                 total_prefill: self.total_prefill_count(),
                 total_decode: self.total_decode_count(),
             };
@@ -1924,10 +1919,7 @@ impl DisaggRuntime {
         self.now_ms = new_now_ms;
     }
 
-    pub(in crate::replay) fn active_prefill_count(&self) -> usize {
-        self.prefill_engine.active_worker_ids().len()
-    }
-
+    #[cfg(test)]
     pub(in crate::replay) fn active_decode_count(&self) -> usize {
         self.decode_engine.active_worker_ids().len()
     }
@@ -2081,12 +2073,12 @@ impl DisaggRuntime {
 
     #[cfg(test)]
     fn drain_prefill_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.prefill_fpm_buffer)
+        self.prefill_fpm_buffer.take()
     }
 
     #[cfg(test)]
     fn drain_decode_fpm(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
-        std::mem::take(&mut self.decode_fpm_buffer)
+        self.decode_fpm_buffer.take()
     }
 
     fn run_to_completion(&mut self) -> Result<()> {

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -515,6 +515,16 @@ impl DisaggRuntime {
     /// planner via recurring `PlannerTick` events (one `on_tick` callback per tick).
     pub(in crate::replay) fn with_planner_hook(mut self, hook: Box<dyn PlannerHook>) -> Self {
         self.collect_fpm = true;
+        let prefill_dp_size = self.prefill_engine.dp_size();
+        for worker_id in self.prefill_engine.active_group_ids() {
+            self.prefill_fpm_buffer
+                .activate_worker(worker_id, prefill_dp_size, self.now_ms);
+        }
+        let decode_dp_size = self.decode_engine.dp_size();
+        for worker_id in self.decode_engine.active_group_ids() {
+            self.decode_fpm_buffer
+                .activate_worker(worker_id, decode_dp_size, self.now_ms);
+        }
         self.planner_hook = Some(hook);
         self
     }
@@ -1495,7 +1505,8 @@ impl DisaggRuntime {
                     if self.collect_fpm
                         && let Some(fpm) = payload.fpm
                     {
-                        self.prefill_fpm_buffer.insert(payload.worker_idx, fpm);
+                        self.prefill_fpm_buffer
+                            .insert(payload.worker_idx, fpm, self.now_ms);
                     }
                     self.process_prefill_pass(
                         payload.worker_idx,
@@ -1511,7 +1522,8 @@ impl DisaggRuntime {
                     if self.collect_fpm
                         && let Some(fpm) = payload.fpm
                     {
-                        self.decode_fpm_buffer.insert(payload.worker_idx, fpm);
+                        self.decode_fpm_buffer
+                            .insert(payload.worker_idx, fpm, self.now_ms);
                     }
                     self.process_decode_pass(
                         payload.output_signals,
@@ -1604,7 +1616,8 @@ impl DisaggRuntime {
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.prefill_fpm_buffer.insert(payload.worker_idx, fpm);
+                self.prefill_fpm_buffer
+                    .insert(payload.worker_idx, fpm, self.now_ms);
             }
             self.process_prefill_pass(
                 payload.worker_idx,
@@ -1664,7 +1677,8 @@ impl DisaggRuntime {
             if self.collect_fpm
                 && let Some(fpm) = payload.fpm
             {
-                self.decode_fpm_buffer.insert(payload.worker_idx, fpm);
+                self.decode_fpm_buffer
+                    .insert(payload.worker_idx, fpm, self.now_ms);
             }
             self.process_decode_pass(
                 payload.output_signals,
@@ -1687,6 +1701,13 @@ impl DisaggRuntime {
             match stage {
                 SimulationWorkerStage::Prefill => {
                     if self.prefill_engine.mark_worker_ready(worker_id) {
+                        if self.collect_fpm {
+                            self.prefill_fpm_buffer.activate_worker(
+                                worker_id,
+                                self.prefill_engine.dp_size(),
+                                self.now_ms,
+                            );
+                        }
                         if let Some(router) = self.prefill_router.as_mut() {
                             router.add_worker(worker_id)?;
                             let effects = router.try_drain_pending(self.now_ms)?;
@@ -1698,6 +1719,13 @@ impl DisaggRuntime {
                 }
                 SimulationWorkerStage::Decode => {
                     if self.decode_engine.mark_worker_ready(worker_id) {
+                        if self.collect_fpm {
+                            self.decode_fpm_buffer.activate_worker(
+                                worker_id,
+                                self.decode_engine.dp_size(),
+                                self.now_ms,
+                            );
+                        }
                         if let Some(router) = self.decode_router.as_mut() {
                             router.add_worker(worker_id)?;
                             let effects = router.try_drain_pending(self.now_ms)?;
@@ -1825,6 +1853,16 @@ impl DisaggRuntime {
             }
             let active_prefill_ids = self.prefill_engine.active_group_ids();
             let active_decode_ids = self.decode_engine.active_group_ids();
+            self.prefill_fpm_buffer.emit_idle_due(
+                &active_prefill_ids,
+                self.prefill_engine.dp_size(),
+                self.now_ms,
+            );
+            self.decode_fpm_buffer.emit_idle_due(
+                &active_decode_ids,
+                self.decode_engine.dp_size(),
+                self.now_ms,
+            );
             let metrics = PlannerTickMetrics {
                 now_ms: self.now_ms,
                 prefill_fpm: self.prefill_fpm_buffer.take(),
@@ -1961,6 +1999,13 @@ impl DisaggRuntime {
                     );
                 }
                 None => {
+                    if self.collect_fpm {
+                        self.prefill_fpm_buffer.activate_worker(
+                            id,
+                            self.prefill_engine.dp_size(),
+                            self.now_ms,
+                        );
+                    }
                     if let Some(router) = self.prefill_router.as_mut() {
                         router.add_worker(id)?;
                     }
@@ -1997,6 +2042,13 @@ impl DisaggRuntime {
                     );
                 }
                 None => {
+                    if self.collect_fpm {
+                        self.decode_fpm_buffer.activate_worker(
+                            id,
+                            self.decode_engine.dp_size(),
+                            self.now_ms,
+                        );
+                    }
                     if let Some(router) = self.decode_router.as_mut() {
                         router.add_worker(id)?;
                     }

--- a/lib/mocker/src/replay/offline/disagg_tests.rs
+++ b/lib/mocker/src/replay/offline/disagg_tests.rs
@@ -1,18 +1,37 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::RefCell;
 use std::collections::VecDeque;
+use std::rc::Rc;
 
 use super::super::entrypoints::{
     run_concurrency_collect, run_concurrency_workload_collect, run_trace_collect,
     run_trace_workload_collect,
 };
+use super::super::planner_hook::PlannerTickDecision;
 use super::*;
 use crate::common::protocols::{
     EngineType, KvTransferTimingMode, MockEngineArgs, SglangArgs, WorkerType,
 };
 use crate::loadgen::{SessionTrace, Trace, TurnTrace};
 use crate::replay::TraceSimulationReport;
+
+struct CaptureOnceHook {
+    at_ms: f64,
+    captured: Rc<RefCell<Option<PlannerTickMetrics>>>,
+}
+
+impl PlannerHook for CaptureOnceHook {
+    fn initial_tick_ms(&mut self) -> anyhow::Result<f64> {
+        Ok(self.at_ms)
+    }
+
+    fn on_tick(&mut self, metrics: PlannerTickMetrics) -> anyhow::Result<PlannerTickDecision> {
+        *self.captured.borrow_mut() = Some(metrics);
+        Ok(PlannerTickDecision::default())
+    }
+}
 
 fn staged_args(worker_type: WorkerType, speedup_ratio: f64) -> MockEngineArgs {
     MockEngineArgs::builder()
@@ -265,6 +284,52 @@ fn request(
         dp_rank: 0,
         arrival_timestamp_ms: Some(arrival_ms),
         ..Default::default()
+    }
+}
+
+#[test]
+fn planner_tick_emits_idle_fpm_for_both_disagg_pools() {
+    let mut config = disagg_config();
+    config.num_prefill_workers = 1;
+    config.num_decode_workers = 1;
+    let pending = crate::replay::normalize_trace_requests(
+        vec![request(9_301, 64, 1, 0.0), request(9_302, 64, 1, 3_000.0)],
+        1.0,
+    )
+    .unwrap();
+    let captured = Rc::new(RefCell::new(None));
+    let hook = CaptureOnceHook {
+        at_ms: 2_000.0,
+        captured: Rc::clone(&captured),
+    };
+
+    DisaggRuntime::new(
+        &config,
+        None,
+        None,
+        pending,
+        ReplayMode::Trace,
+        ReplayRouterMode::RoundRobin,
+    )
+    .unwrap()
+    .with_planner_hook(Box::new(hook))
+    .run()
+    .unwrap();
+
+    let metrics = captured
+        .borrow_mut()
+        .take()
+        .expect("planner tick must fire");
+    assert_eq!(metrics.now_ms, 2_000.0);
+    for snapshots in [&metrics.prefill_fpm, &metrics.decode_fpm] {
+        assert_eq!(snapshots.len(), 1);
+        assert_eq!(snapshots[0].0, 0);
+        assert_eq!(snapshots[0].1.dp_rank, 0);
+        assert_eq!(snapshots[0].1.wall_time_secs, 0.0);
+        assert_eq!(snapshots[0].1.num_prefill_requests, 0);
+        assert_eq!(snapshots[0].1.num_decode_requests, 0);
+        assert_eq!(snapshots[0].1.num_queued_prefill, 0);
+        assert_eq!(snapshots[0].1.num_queued_decode, 0);
     }
 }
 

--- a/lib/mocker/src/replay/offline/planner_hook.rs
+++ b/lib/mocker/src/replay/offline/planner_hook.rs
@@ -18,16 +18,57 @@ use std::collections::BTreeMap;
 use super::components::TrafficStats;
 use crate::common::protocols::ForwardPassSnapshot;
 
+const IDLE_FPM_INTERVAL_MS: f64 = 1_000.0;
+
 /// Latest FPM snapshot for each logical worker and DP rank.
 #[derive(Debug, Default)]
 pub(super) struct LatestFpmBuffer {
     snapshots: BTreeMap<(usize, u32), ForwardPassSnapshot>,
+    last_publish_ms: BTreeMap<(usize, u32), f64>,
 }
 
 impl LatestFpmBuffer {
-    pub(super) fn insert(&mut self, worker_id: usize, snapshot: ForwardPassSnapshot) {
-        self.snapshots
-            .insert((worker_id, snapshot.dp_rank), snapshot);
+    pub(super) fn activate_worker(&mut self, worker_id: usize, dp_size: u32, now_ms: f64) {
+        for dp_rank in 0..dp_size.max(1) {
+            self.last_publish_ms
+                .entry((worker_id, dp_rank))
+                .or_insert(now_ms);
+        }
+    }
+
+    pub(super) fn insert(&mut self, worker_id: usize, snapshot: ForwardPassSnapshot, now_ms: f64) {
+        let key = (worker_id, snapshot.dp_rank);
+        self.snapshots.insert(key, snapshot);
+        self.last_publish_ms.insert(key, now_ms);
+    }
+
+    pub(super) fn emit_idle_due(&mut self, active_worker_ids: &[usize], dp_size: u32, now_ms: f64) {
+        debug_assert!(active_worker_ids.is_sorted());
+        let dp_size = dp_size.max(1);
+        let is_active = |(worker_id, dp_rank): &(usize, u32)| {
+            *dp_rank < dp_size && active_worker_ids.binary_search(worker_id).is_ok()
+        };
+        self.snapshots.retain(|key, _| is_active(key));
+        self.last_publish_ms.retain(|key, _| is_active(key));
+
+        for &worker_id in active_worker_ids {
+            for dp_rank in 0..dp_size {
+                let key = (worker_id, dp_rank);
+                let last_publish_ms = self.last_publish_ms.entry(key).or_insert(now_ms);
+                let elapsed_ms = now_ms - *last_publish_ms;
+                if elapsed_ms >= IDLE_FPM_INTERVAL_MS {
+                    *last_publish_ms +=
+                        (elapsed_ms / IDLE_FPM_INTERVAL_MS).floor() * IDLE_FPM_INTERVAL_MS;
+                    self.snapshots.insert(
+                        key,
+                        ForwardPassSnapshot {
+                            dp_rank,
+                            ..Default::default()
+                        },
+                    );
+                }
+            }
+        }
     }
 
     pub(super) fn take(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
@@ -53,6 +94,7 @@ mod tests {
                 wall_time_secs: 1.0,
                 ..Default::default()
             },
+            100.0,
         );
         buffer.insert(
             4,
@@ -61,6 +103,7 @@ mod tests {
                 wall_time_secs: 2.0,
                 ..Default::default()
             },
+            200.0,
         );
         buffer.insert(
             4,
@@ -69,18 +112,86 @@ mod tests {
                 wall_time_secs: 3.0,
                 ..Default::default()
             },
+            300.0,
+        );
+        buffer.insert(
+            5,
+            ForwardPassSnapshot {
+                dp_rank: 0,
+                wall_time_secs: 4.0,
+                ..Default::default()
+            },
+            400.0,
         );
 
         let snapshots = buffer.take();
 
-        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots.len(), 3);
         assert_eq!(snapshots[0].0, 4);
         assert_eq!(snapshots[0].1.dp_rank, 0);
         assert_eq!(snapshots[0].1.wall_time_secs, 2.0);
         assert_eq!(snapshots[1].0, 4);
         assert_eq!(snapshots[1].1.dp_rank, 1);
         assert_eq!(snapshots[1].1.wall_time_secs, 3.0);
+        assert_eq!(snapshots[2].0, 5);
+        assert_eq!(snapshots[2].1.dp_rank, 0);
+        assert_eq!(snapshots[2].1.wall_time_secs, 4.0);
         assert!(buffer.take().is_empty());
+    }
+
+    #[test]
+    fn latest_fpm_buffer_emits_idle_on_simulated_cadence() {
+        let mut buffer = LatestFpmBuffer::default();
+        buffer.activate_worker(4, 2, 100.0);
+
+        buffer.emit_idle_due(&[4], 2, 1_099.0);
+        assert!(buffer.take().is_empty());
+
+        buffer.emit_idle_due(&[4], 2, 1_100.0);
+        let snapshots = buffer.take();
+        assert_eq!(snapshots.len(), 2);
+        assert!(
+            snapshots
+                .iter()
+                .all(|(worker_id, snapshot)| { *worker_id == 4 && snapshot.wall_time_secs == 0.0 })
+        );
+
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 1,
+                wall_time_secs: 0.25,
+                ..Default::default()
+            },
+            1_500.0,
+        );
+        buffer.emit_idle_due(&[4], 2, 2_100.0);
+        let snapshots = buffer.take();
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].1.dp_rank, 0);
+        assert_eq!(snapshots[0].1.wall_time_secs, 0.0);
+        assert_eq!(snapshots[1].1.dp_rank, 1);
+        assert_eq!(snapshots[1].1.wall_time_secs, 0.25);
+
+        let mut delayed_observation = LatestFpmBuffer::default();
+        delayed_observation.activate_worker(8, 1, 0.0);
+        delayed_observation.emit_idle_due(&[8], 1, 1_500.0);
+        assert_eq!(delayed_observation.take().len(), 1);
+        delayed_observation.emit_idle_due(&[8], 1, 2_400.0);
+        assert_eq!(delayed_observation.take().len(), 1);
+
+        delayed_observation.insert(
+            8,
+            ForwardPassSnapshot {
+                wall_time_secs: 0.1,
+                ..Default::default()
+            },
+            3_000.0,
+        );
+        delayed_observation.emit_idle_due(&[], 1, 3_500.0);
+        assert!(delayed_observation.take().is_empty());
+        delayed_observation.emit_idle_due(&[8], 1, 4_000.0);
+        assert!(delayed_observation.take().is_empty());
     }
 }
 

--- a/lib/mocker/src/replay/offline/planner_hook.rs
+++ b/lib/mocker/src/replay/offline/planner_hook.rs
@@ -5,7 +5,7 @@
 //!
 //! A [`PlannerHook`] is invoked once per [`PlannerTick`](super::events::SimulationEventKind::PlannerTick)
 //! event inside the unified `run()` loop: it receives the metrics drained at the tick
-//! (per-pass FPM snapshots accumulated since the last tick, the traffic window, and worker
+//! (the latest FPM snapshot per worker/rank, the traffic window, and worker
 //! counts) and returns a scaling decision plus the time of the next tick. This replaces the
 //! old Python-driven `advance_to`/`apply_scaling` stepping loop — the planner's decision logic
 //! still lives in Python (via a PyO3 wrapper that implements this trait), but the simulation
@@ -13,8 +13,76 @@
 //!
 //! [`NoopPlannerHook`] is the inert stand-in for tests and the no-planner path.
 
+use std::collections::BTreeMap;
+
 use super::components::TrafficStats;
 use crate::common::protocols::ForwardPassSnapshot;
+
+/// Latest FPM snapshot for each logical worker and DP rank.
+#[derive(Debug, Default)]
+pub(super) struct LatestFpmBuffer {
+    snapshots: BTreeMap<(usize, u32), ForwardPassSnapshot>,
+}
+
+impl LatestFpmBuffer {
+    pub(super) fn insert(&mut self, worker_id: usize, snapshot: ForwardPassSnapshot) {
+        self.snapshots
+            .insert((worker_id, snapshot.dp_rank), snapshot);
+    }
+
+    pub(super) fn take(&mut self) -> Vec<(usize, ForwardPassSnapshot)> {
+        std::mem::take(&mut self.snapshots)
+            .into_iter()
+            .map(|((worker_id, _), snapshot)| (worker_id, snapshot))
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::LatestFpmBuffer;
+    use crate::common::protocols::ForwardPassSnapshot;
+
+    #[test]
+    fn latest_fpm_buffer_coalesces_each_worker_rank() {
+        let mut buffer = LatestFpmBuffer::default();
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 0,
+                wall_time_secs: 1.0,
+                ..Default::default()
+            },
+        );
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 0,
+                wall_time_secs: 2.0,
+                ..Default::default()
+            },
+        );
+        buffer.insert(
+            4,
+            ForwardPassSnapshot {
+                dp_rank: 1,
+                wall_time_secs: 3.0,
+                ..Default::default()
+            },
+        );
+
+        let snapshots = buffer.take();
+
+        assert_eq!(snapshots.len(), 2);
+        assert_eq!(snapshots[0].0, 4);
+        assert_eq!(snapshots[0].1.dp_rank, 0);
+        assert_eq!(snapshots[0].1.wall_time_secs, 2.0);
+        assert_eq!(snapshots[1].0, 4);
+        assert_eq!(snapshots[1].1.dp_rank, 1);
+        assert_eq!(snapshots[1].1.wall_time_secs, 3.0);
+        assert!(buffer.take().is_empty());
+    }
+}
 
 /// Metrics handed to the planner at one tick. The runtime has already advanced the clock to
 /// `now_ms` and settled all same-timestamp work before this is built, so the planner observes a
@@ -23,18 +91,18 @@ use crate::common::protocols::ForwardPassSnapshot;
 pub struct PlannerTickMetrics {
     /// Simulated clock at this tick (equals the scheduled tick time).
     pub now_ms: f64,
-    /// Every prefill FPM snapshot accumulated since the previous tick (empty in agg mode,
-    /// which routes all passes through `decode_fpm`).
+    /// Latest prefill FPM snapshot per worker/rank observed since the previous tick (empty in
+    /// agg mode, which routes all passes through `decode_fpm`).
     pub prefill_fpm: Vec<(usize, ForwardPassSnapshot)>,
-    /// Every decode (agg: aggregated) FPM snapshot accumulated since the previous tick.
+    /// Latest decode (agg: aggregated) FPM snapshot per worker/rank observed since the previous
+    /// tick.
     pub decode_fpm: Vec<(usize, ForwardPassSnapshot)>,
     /// Traffic stats over `[previous tick, now]`. Drained every tick; the Python side merges
-    /// partial windows across ticks that don't consume traffic (mirrors how it already
-    /// accumulates FPM snapshots).
+    /// partial windows across ticks that don't consume traffic.
     pub traffic: TrafficStats,
-    /// Active (ready, non-draining) worker counts. Agg reports decode only (`active_prefill = 0`).
-    pub active_prefill: usize,
-    pub active_decode: usize,
+    /// Active (ready, non-draining) logical worker IDs. Agg reports decode only.
+    pub active_prefill_ids: Vec<usize>,
+    pub active_decode_ids: Vec<usize>,
     /// Total workers including pending startup + pending removal.
     pub total_prefill: usize,
     pub total_decode: usize,


### PR DESCRIPTION
## Summary

- remove replay-only extra intra-tick regression tuning and its pending snapshot lists
- coalesce FPMs in Rust to the latest snapshot per logical worker and DP rank before crossing the PyO3 bridge
- synthesize the online publisher's one-second idle heartbeat from simulated time for agg and disagg replay, without adding wall-clock sleeps
- reset heartbeat cadence on active snapshots and initialize it when initial, immediate-scale-up, or delayed-startup workers become active
- prune the Python last-seen cache by exact active worker IDs, preserving DP ranks while correctly handling worker replacement
- remove the unused `EngineEffects.fpm_snapshots` path left behind by the old collection model

## Root cause and impact

Offline replay diverged from live engines in two directions: it directly tuned regressions with every intra-tick pass snapshot, while it emitted no FPM during idle gaps. The latter left the replay adapter's latest-value cache holding a stale busy snapshot even though online mocker and engine publishers emit a zero FPM after one second without a snapshot.

Replay now exposes the same latest-value semantics as the live subscriber. At each planner observation it materializes any simulated heartbeat that became due, preserving the original one-second phase even when planner ticks are irregular. Heartbeat state remains bounded by active worker/rank identities.

The normal planner consumer path is unchanged: an FPM-due tick passes the latest cached observations to `PlannerScalingState.observe_fpm`.

## Validation

- `cargo test -p dynamo-mocker --lib replay::offline` (156 passed)
- `cargo clippy -p dynamo-mocker --lib --no-deps -- -D warnings`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml`
- focused replay planner pytest selection (6 passed, 3 deselected)
- focused orchestrator FPM-consumer pytest selection (2 passed, 32 deselected)
- `pre-commit run --files` for all changed Python and Rust files
- three independent Rust agentic review passes, followed by re-review after addressing cadence, pruning, allocation, and disagg-coverage findings; no remaining findings
