### PR TITLE
perf(python): intern request-plane envelope keys

### DIFF
--- a/lib/bindings/python/rust/python_payload.rs
+++ b/lib/bindings/python/rust/python_payload.rs
@@ -10,7 +10,7 @@ use dynamo_runtime::pipeline::network::{
 use dynamo_runtime::protocols::annotated::Annotated;
 use dynamo_runtime::protocols::maybe_error::MaybeError;
 use pyo3::prelude::*;
-use pyo3::types::PyDict;
+use pyo3::types::{PyDict, PyString};
 use pythonize::{Depythonizer, Pythonizer, depythonize};
 use serde::de::Error as _;
 use serde::ser::Error as _;
@@ -211,7 +211,7 @@ fn parse_python_response(
         return Ok(Annotated::from_data(PythonPayload(item)));
     };
     let is_envelope = dict
-        .get_item("_dynamo_annotated")
+        .get_item(pyo3::intern!(py, "_dynamo_annotated"))
         .map_err(|error| error.to_string())?
         .and_then(|value| value.is_truthy().ok())
         .unwrap_or(false);
@@ -222,11 +222,14 @@ fn parse_python_response(
     // Keep the payload itself as the original Python object. Fully
     // depythonizing `Annotated<PythonPayload>` would rebuild the nested data
     // subtree and defeat the direct request-plane path's ownership reuse.
-    let data = optional_item(dict, "data")?.map(|value| PythonPayload(value.unbind()));
-    let id = extract_optional(dict, "id")?;
-    let event = extract_optional(dict, "event")?;
-    let comment = extract_optional(dict, "comment")?;
-    let error = optional_item(dict, "error")?
+    // Intern the fixed envelope keys: converting an `&str` for every lookup
+    // otherwise creates and hashes a temporary Python string for every frame.
+    let data =
+        optional_item(dict, pyo3::intern!(py, "data"))?.map(|value| PythonPayload(value.unbind()));
+    let id = extract_optional(dict, pyo3::intern!(py, "id"))?;
+    let event = extract_optional(dict, pyo3::intern!(py, "event"))?;
+    let comment = extract_optional(dict, pyo3::intern!(py, "comment"))?;
+    let error = optional_item(dict, pyo3::intern!(py, "error"))?
         .map(|value| depythonize(&value).map_err(|error| error.to_string()))
         .transpose()?;
 
@@ -241,14 +244,17 @@ fn parse_python_response(
 
 fn optional_item<'py>(
     dict: &Bound<'py, PyDict>,
-    name: &str,
+    name: &Bound<'py, PyString>,
 ) -> Result<Option<Bound<'py, PyAny>>, String> {
     dict.get_item(name)
         .map_err(|error| error.to_string())
         .map(|value| value.filter(|value| !value.is_none()))
 }
 
-fn extract_optional<'py, T>(dict: &Bound<'py, PyDict>, name: &str) -> Result<Option<T>, String>
+fn extract_optional<'py, T>(
+    dict: &Bound<'py, PyDict>,
+    name: &Bound<'py, PyString>,
+) -> Result<Option<T>, String>
 where
     T: FromPyObject<'py>,
 {


### PR DESCRIPTION
## Summary

- Intern the six fixed annotated-response envelope keys used by the direct Python request-plane adapter.
- Avoid creating and hashing temporary Python strings for every response frame without changing wire or Python semantics.
- Remove six PyObject allocations per annotated frame and reduce measured server instructions by 0.78%.

## Validation

- `cargo fmt --manifest-path lib/bindings/python/Cargo.toml -- --check`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --locked`
- `pytest -q lib/bindings/python/tests/test_request_plane_python_payload.py -m gpu_0`
- `DYN_REQUEST_PLANE_CODEC=json pytest -q lib/bindings/python/tests/test_request_plane_python_payload.py -m gpu_0`
- `pytest -q lib/bindings/python/tests/cancellation/test_cancellation.py::test_client_context_cancel[tcp]`
- Five interleaved A/B repetitions: MessagePack annotated-stream throughput flat (+0.08%), worker CPU -1.76% median; JSON throughput within noise (-0.83%).
- Warmup-gated Callgrind: 59,088 to 53,088 PyObject allocations and 302,984,060 to 300,632,701 instructions.

<!-- perf-agent-investigation:f95017bc-74a2-4fa0-bc68-58367a0960cc -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Python response handling for annotated payloads, making field extraction more reliable.
  * Reduced lookup overhead when reading common response fields, which may improve response processing efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->