### PR TITLE
perf(planner): coalesce quiescent idle predictions

### DIFF
--- a/components/src/dynamo/planner/plugins/builtins/local_planner.py
+++ b/components/src/dynamo/planner/plugins/builtins/local_planner.py
@@ -116,6 +116,7 @@ class BuiltinLoadPredict:
         self._last_observed_isl: float | None = None
         self._last_observed_osl: float | None = None
         self._seen_live_traffic = False
+        self._quiescent_idle_prediction: tuple[float, float, float] | None = None
         self._last_kv_hit_rate: float | None = None
         self._last_accept_length: float = 1.0
 
@@ -137,6 +138,7 @@ class BuiltinLoadPredict:
             if hasattr(predictor, "reset_idle_skip"):
                 predictor.reset_idle_skip()
         self._seen_live_traffic = False
+        self._quiescent_idle_prediction = None
 
     def _observe_load(self, traffic: TrafficObservation) -> None:
         self._num_req_predictor.add_data_point(traffic.num_req)
@@ -164,6 +166,9 @@ class BuiltinLoadPredict:
 
     def _observe_traffic(self, traffic: TrafficObservation) -> None:
         self._observe_load(traffic)
+        self._observe_runtime_metadata(traffic)
+
+    def _observe_runtime_metadata(self, traffic: TrafficObservation) -> None:
         if traffic.kv_hit_rate is not None and not math.isnan(traffic.kv_hit_rate):
             self._last_kv_hit_rate = traffic.kv_hit_rate
         if traffic.accept_length is not None and math.isfinite(traffic.accept_length):
@@ -216,10 +221,39 @@ class BuiltinLoadPredict:
         if metrics is None:
             return PredictStageResponse(reason="no_traffic_data")
 
-        self._observe_traffic(_traffic_observation(metrics))
-        nr, isl, osl = self._predict_load()
+        traffic = _traffic_observation(metrics)
+        if traffic.num_req == 0 and self._quiescent_idle_prediction is not None:
+            # Once the request predictor has reached zero, identical idle
+            # windows cannot affect a throughput decision. Coalesce them until
+            # traffic resumes instead of repeatedly updating/refitting three
+            # statistical models. Runtime metadata remains live while idle.
+            if self._config.load_predictor == "prophet":
+                # Prophet fits from scratch, so retaining each cheap sample
+                # preserves its bounded history and timestamp cadence without
+                # paying for a fit whose zero-demand result is unused.
+                self._observe_traffic(traffic)
+            else:
+                self._observe_runtime_metadata(traffic)
+            nr, isl, osl = self._quiescent_idle_prediction
+        else:
+            self._observe_traffic(traffic)
+            nr, isl, osl = self._predict_load()
         if nr is None or isl is None or osl is None:
+            self._quiescent_idle_prediction = None
             return PredictStageResponse(reason="predict_failed")
+
+        if (
+            traffic.num_req == 0
+            and self._seen_live_traffic
+            and nr <= 0
+            # Constant is exact and Prophet refits from retained samples.
+            # ARIMA and Kalman carry incremental state, so they must keep
+            # observing every interval even after forecasting zero.
+            and self._config.load_predictor in ("constant", "prophet")
+        ):
+            self._quiescent_idle_prediction = (nr, isl, osl)
+        elif traffic.num_req > 0:
+            self._quiescent_idle_prediction = None
 
         return PredictStageResponse(
             predictions=PredictionData(

--- a/components/src/dynamo/planner/tests/unit/test_load_predictors.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_predictors.py
@@ -29,6 +29,12 @@ from dynamo.planner.core.load.predictors import (
 )
 from dynamo.planner.core.types import TrafficObservation, WorkerCapabilities
 from dynamo.planner.plugins.builtins.local_planner import BuiltinLoadPredict
+from dynamo.planner.plugins.types import (
+    ObservationData,
+    PipelineContext,
+    PredictStageRequest,
+    TrafficMetrics,
+)
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -65,6 +71,16 @@ def _make_config(
     cfg.optimization_target = "sla"
     cfg.speculative_nextn = 0
     return cfg
+
+
+def _predict_request(num_req, isl, osl):
+    return PredictStageRequest(
+        context=PipelineContext(
+            observations=ObservationData(
+                traffic=TrafficMetrics(duration_s=60, num_req=num_req, isl=isl, osl=osl)
+            )
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -128,6 +144,60 @@ class TestBuiltinLoadPredictIdleTraffic:
         assert plugin._num_req_predictor.data_buffer == [10, 0, 0]
         assert plugin._isl_predictor.data_buffer == [512, 512, 512]
         assert plugin._osl_predictor.data_buffer == [128, 128, 128]
+
+    @pytest.mark.asyncio
+    async def test_resumed_traffic_exits_quiescent_idle_fast_path(self):
+        plugin = BuiltinLoadPredict(_make_config(), WorkerCapabilities())
+
+        await plugin.Predict(_predict_request(10, 512, 128))
+        await plugin.Predict(_predict_request(0, 0, 0))
+        for _ in range(100):
+            response = await plugin.Predict(_predict_request(0, 0, 0))
+            assert response.predictions.predicted_num_req == 0
+            assert response.predictions.predicted_isl == 512
+            assert response.predictions.predicted_osl == 128
+
+        response = await plugin.Predict(_predict_request(20, 2048, 512))
+
+        assert response.predictions.predicted_num_req == 20
+        assert response.predictions.predicted_isl == 2048
+        assert response.predictions.predicted_osl == 512
+        assert plugin._num_req_predictor.data_buffer == [10, 0, 20]
+        assert plugin._isl_predictor.data_buffer == [512, 512, 2048]
+        assert plugin._osl_predictor.data_buffer == [128, 128, 512]
+
+    @pytest.mark.asyncio
+    async def test_stateful_kalman_predictor_keeps_idle_cadence(self):
+        config = _make_config()
+        config.load_predictor = "kalman"
+        plugin = BuiltinLoadPredict(config, WorkerCapabilities())
+
+        await plugin.Predict(_predict_request(10, 512, 128))
+        for _ in range(10):
+            await plugin.Predict(_predict_request(0, 0, 0))
+
+        assert len(plugin._num_req_predictor.data_buffer) == 11
+        assert len(plugin._isl_predictor.data_buffer) == 11
+        assert len(plugin._osl_predictor.data_buffer) == 11
+        assert plugin._quiescent_idle_prediction is None
+
+    @pytest.mark.asyncio
+    async def test_quiescent_prophet_keeps_timestamp_cadence(self):
+        config = _make_config()
+        config.load_predictor = "prophet"
+        plugin = BuiltinLoadPredict(config, WorkerCapabilities())
+
+        await plugin.Predict(_predict_request(10, 512, 128))
+        await plugin.Predict(_predict_request(0, 0, 0))
+        for _ in range(10):
+            await plugin.Predict(_predict_request(0, 0, 0))
+
+        assert plugin._num_req_predictor.curr_step == 12
+        assert plugin._isl_predictor.curr_step == 12
+        assert plugin._osl_predictor.curr_step == 12
+        assert len(plugin._num_req_predictor.data_buffer) == 12
+        assert len(plugin._isl_predictor.data_buffer) == 12
+        assert len(plugin._osl_predictor.data_buffer) == 12
 
     def test_leading_idle_windows_do_not_seed_request_shape(self):
         plugin = BuiltinLoadPredict(_make_config(), WorkerCapabilities())


### PR DESCRIPTION
## Summary

- cache quiescent Constant predictions after live traffic so repeated idle windows do not grow predictor history
- retain every cheap Prophet idle sample and timestamp while skipping redundant fits once predicted demand reaches zero
- preserve per-tick ARIMA and Kalman updates because both predictors carry incremental state

## Validation

- `PYTHONPATH=components/src python -m pytest components/src/dynamo/planner/tests/unit -q` (418 passed)
- `PYTHONPATH=components/src python -m pytest components/src/dynamo/planner/tests/plugins/orchestrator -q` (86 passed)
- isort, black, flake8, and ruff pre-commit hooks on both changed files
- deterministic full-engine A/B: Prophet 1,000-idle median 52,634.757 ms -> 533.624 ms (98.986% lower); 100 traced idle scale proposals and resumed forecast/proposal match baseline

Publication recheck on `main` at `65a96739c9d526a4d4b57135513c20b639461e32`:

- `git diff --check origin/main...HEAD`
- `python -m compileall -q` on both changed files
- isort, black, flake8, and ruff pre-commit hooks on both changed files

<!-- perf-agent-investigation:998fa3de-7aa8-40d4-b6a2-1f492be58c87 -->