### PR TITLE
docs: fix GitHub stars links that 404 for anonymous readers

### DIFF
--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -8,7 +8,7 @@ max-toc-depth: 3
 
 Dynamo is an open-source distributed inference platform, built by a growing community of contributors. The project is licensed under [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE) and welcomes contributions of all sizes -- from typo fixes to major features. Community contributions have shaped core areas of Dynamo including backend integrations, documentation, deployment tooling, and performance improvements.
 
-With 200+ external contributors, 220+ merged community PRs, and new contributors joining every month, Dynamo is one of the fastest-growing open-source inference projects. Check out our [commit activity](https://github.com/ai-dynamo/dynamo/graphs/commit-activity) and [GitHub stars](https://github.com/ai-dynamo/dynamo/stargazers). This guide will help you get started.
+With 200+ external contributors, 220+ merged community PRs, and new contributors joining every month, Dynamo is one of the fastest-growing open-source inference projects. Check out our [commit activity](https://github.com/ai-dynamo/dynamo/graphs/commit-activity) and [GitHub stars](https://github.com/ai-dynamo/dynamo). This guide will help you get started.
 
 Join the community:
 

--- a/fern/translations/zh-CN/pages-dev/contribution-guide.md
+++ b/fern/translations/zh-CN/pages-dev/contribution-guide.md
@@ -8,7 +8,7 @@ max-toc-depth: 3
 
 Dynamo 是一个开源分布式推理平台，由不断壮大的贡献者社区共同构建。该项目采用 [Apache 2.0](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE) 许可证，欢迎各种规模的贡献 -- 从修正错别字到开发重要功能都包括在内。社区贡献已经塑造了 Dynamo 的核心领域，包括后端集成、文档、部署工具和性能改进。
 
-Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并且每月都有新贡献者加入，是增长最快的开源推理项目之一。欢迎查看我们的[提交活动](https://github.com/ai-dynamo/dynamo/graphs/commit-activity)和 [GitHub stars](https://github.com/ai-dynamo/dynamo/stargazers)。本指南将帮助你开始贡献。
+Dynamo 拥有 200 多位外部贡献者、220 多个已合并的社区 PR，并且每月都有新贡献者加入，是增长最快的开源推理项目之一。欢迎查看我们的[提交活动](https://github.com/ai-dynamo/dynamo/graphs/commit-activity)和 [GitHub stars](https://github.com/ai-dynamo/dynamo)。本指南将帮助你开始贡献。
 
 加入社区：
 


### PR DESCRIPTION
## Summary

GitHub now returns 404 for the `/stargazers` route to anonymous (logged-out) requests — reproduced on 2026-07-07 against unrelated repos such as `torvalds/linux`, so this is GitHub-side behavior, not a repo config issue. That leaves the "GitHub stars" links in the contribution guide dead for logged-out readers and fails the lychee docs-link-check.

This PR repoints the "GitHub stars" link in `docs/contribution-guide.md` and its zh-CN translation to the repository page, which shows the star count and is anonymously accessible.

Related: #11230 carries a temporary `.lycheeignore` entry for this route so its own link check stays green. Once this PR is on main and merged into that branch, the stopgap entry will be dropped there.

## Validation

- `curl -sI https://github.com/ai-dynamo/dynamo` returns 200 anonymously; `.../stargazers` returns 404.
- `pre-commit run --files` on both files: all hooks pass.
- Link-only change; no content or structure changes, so no docs nav or Fern frontmatter impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the contribution guide’s GitHub Stars link to use the current destination.
  * Applied the same link update in the Chinese contribution guide to keep the content consistent across languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->