### PR TITLE
fix(operator): prevent DGDR stalls after profiling (#11250)

### DIFF
--- a/deploy/operator/internal/controller/AGENTS.md
+++ b/deploy/operator/internal/controller/AGENTS.md
@@ -1,0 +1,14 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Reconciliation
+
+- Uncached API-server ("quorum") reads are most likely the wrong solution to informer-cache races.
+- Build level-driven reconcilers that tolerate stale cached state and converge from every observable state.
+- Watch every dependency whose create, update, or delete can unblock reconciliation. Let those events requeue the owning resource after changes become visible in the cache.
+- Treat a dependency that has not appeared in the cache yet as pending when its watch can drive progress; do not turn expected informer lag into a terminal failure.
+- After a successful write, either continue with the object returned by the client or wait for its watch event. Do not immediately read the write back through an uncached client.
+- Use durable status, conditions, or transaction markers when the reconciler must distinguish work that is pending from work that was previously observed and later deleted.
+- Use an uncached read only when a concrete correctness requirement cannot be represented with durable state and watches, and document that exception.

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller.go
@@ -76,6 +76,7 @@ const (
 
 	// Annotation keys
 	AnnotationAdditionalResources = "dgdr.nvidia.com/additional-resources"
+	AnnotationGeneratedDGDSpec    = "nvidia.com/generated-dgd-spec"
 
 	// Annotation keys for v1alpha1 round-trip compatibility.
 	// The conversion layer stores v1alpha1 fields that have no v1beta1 spec equivalent
@@ -137,6 +138,8 @@ const (
 	MessageConfigMapKeyNotFound      = "key %s not found in ConfigMap %s"
 	MessageModelCachePVCNotFound     = "model cache PVC %s not found in namespace %s"
 )
+
+var errProfilingOutputNotReady = errors.New("profiling output is not ready")
 
 // shell script template for the output copier sidecar.
 //
@@ -494,7 +497,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) Reconcile(ctx context.Context, 
 		return r.handleFailedPhase(ctx, dgdr)
 	default:
 		logger.Info("Unknown phase", "phase", dgdr.Status.Phase)
-		return r.updatePhaseAndRequeue(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, MessageInvalidState)
+		return r.updatePhase(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, MessageInvalidState)
 	}
 }
 
@@ -535,13 +538,14 @@ func (r *DynamoGraphDeploymentRequestReconciler) handlePendingPhase(ctx context.
 	logger.Info("Handling pending phase", "name", dgdr.Name)
 
 	// Create profiling job (online or AIC)
-	requeue, err := r.createProfilingJob(ctx, dgdr)
+	waitForObservation, err := r.createProfilingJob(ctx, dgdr)
 	if err != nil {
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, nvidiacomv1beta1.EventReasonProfilingJobFailed, err.Error())
 		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeProfiling, metav1.ConditionFalse, MessageJobCreationFailed, err.Error())
 	}
-	if requeue {
-		return ctrl.Result{Requeue: true}, nil
+	if waitForObservation {
+		// The successful write is watched and drives the next reconcile.
+		return ctrl.Result{}, nil
 	}
 
 	// Record event with appropriate message
@@ -720,19 +724,23 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleProfilingPhase(ctx contex
 		if err := r.Status().Update(ctx, dgdr); err != nil {
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{Requeue: true}, nil
+		return ctrl.Result{}, nil
 	}
 
 	profilingResults, dgdName, err := r.generateDGDSpec(ctx, dgdr)
 	if err != nil {
+		if errors.Is(err, errProfilingOutputNotReady) {
+			logger.Info("Waiting for profiling output ConfigMap", "name", dgdr.Name)
+			return ctrl.Result{}, nil
+		}
+		if apierrors.IsConflict(err) {
+			logger.Info("DGDR changed while persisting generated spec; retrying", "name", dgdr.Name)
+			return ctrl.Result{}, err
+		}
 		dgdr.ClearProfilingPhase()
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, MessageGenerationFailed, err.Error())
 		return r.updatePhaseWithCondition(ctx, dgdr, nvidiacomv1beta1.DGDRPhaseFailed, nvidiacomv1beta1.ConditionTypeSpecGenerated, metav1.ConditionFalse, MessageGenerationFailed, err.Error())
 	}
-	if err := r.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, dgdr); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to refetch DGDR after generateDGDSpec: %w", err)
-	}
-
 	dgdr.ClearProfilingPhase()
 	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
 		Type:               nvidiacomv1beta1.ConditionTypeProfiling,
@@ -800,15 +808,16 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployingPhase(ctx contex
 	}, dgd)
 
 	if apierrors.IsNotFound(err) {
-		// Annotation present means DGD was never created (spec ready but create not yet called).
-		// Annotation absent means DGD was previously created and then manually deleted.
-		if _, hasSpec := dgdr.Annotations["nvidia.com/generated-dgd-spec"]; hasSpec {
+		if dgdr.Annotations[AnnotationGeneratedDGDSpec] != "" {
 			return r.createDGD(ctx, dgdr)
 		}
 		return r.handleDGDDeleted(ctx, dgdr)
 	}
 
 	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if err := r.clearGeneratedSpecAnnotation(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
 	}
 
@@ -867,7 +876,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) handleDeployedPhase(ctx context
 	}, dgd)
 
 	if apierrors.IsNotFound(err) {
-		// DGD was deleted by user
 		return r.handleDGDDeleted(ctx, dgdr)
 	}
 
@@ -939,9 +947,9 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	logger := log.FromContext(ctx)
 
 	// Extract DGD spec from annotation (stored by generateDGDSpec)
-	dgdSpecYAML, ok := dgdr.Annotations["nvidia.com/generated-dgd-spec"]
+	dgdSpecYAML, ok := dgdr.Annotations[AnnotationGeneratedDGDSpec]
 	if !ok || dgdSpecYAML == "" {
-		return ctrl.Result{}, fmt.Errorf("generated DGD spec not found in annotation nvidia.com/generated-dgd-spec")
+		return ctrl.Result{}, fmt.Errorf("generated DGD spec not found in annotation %s", AnnotationGeneratedDGDSpec)
 	}
 
 	generatedDGD, err := r.extractDGDFromYAML([]byte(dgdSpecYAML))
@@ -952,6 +960,10 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 	// Determine DGD name and namespace from generated deployment
 	dgdName := generatedDGD.Name
 	dgdNamespace := dgdr.Namespace
+	if dgdr.Status.DGDName == "" {
+		dgdr.Status.DGDName = dgdName
+		return ctrl.Result{}, r.Status().Update(ctx, dgdr)
+	}
 
 	// Build labels (start with generated DGD's labels)
 	labels := make(map[string]string)
@@ -992,21 +1004,9 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 
 	if err := r.Create(ctx, dgd); err != nil {
 		if apierrors.IsAlreadyExists(err) {
-			logger.Info("DGD already exists, updating status")
-			existingDGD := &nvidiacomv1beta1.DynamoGraphDeployment{}
-			if getErr := r.Get(ctx, types.NamespacedName{Name: dgdName, Namespace: dgdNamespace}, existingDGD); getErr != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to get existing DGD %s: %w", dgdName, getErr)
-			}
-			if adoptErr := r.adoptAdditionalResources(ctx, dgdr, existingDGD); adoptErr != nil {
-				return ctrl.Result{}, fmt.Errorf("failed to adopt additional resources for existing DGD %s: %w", dgdName, adoptErr)
-			}
-			delete(dgdr.Annotations, "nvidia.com/generated-dgd-spec")
-			if updateErr := r.Update(ctx, dgdr); updateErr != nil {
-				logger.Error(updateErr, "Failed to remove generated-dgd-spec annotation on IsAlreadyExists path")
-				return ctrl.Result{}, updateErr
-			}
-			dgdr.Status.DGDName = dgdName
-			return ctrl.Result{}, r.Status().Update(ctx, dgdr)
+			// The DGD watch reconciles again after the object is in the informer cache.
+			logger.Info("DGD already exists, waiting for informer observation")
+			return ctrl.Result{}, nil
 		}
 		r.Recorder.Event(dgdr, corev1.EventTypeWarning, MessageDeploymentCreationFailed, err.Error())
 		// Admission webhook denials and other permanent API rejections (400/403/422)
@@ -1021,33 +1021,42 @@ func (r *DynamoGraphDeploymentRequestReconciler) createDGD(ctx context.Context, 
 		return ctrl.Result{}, err
 	}
 
-	if err := r.adoptAdditionalResources(ctx, dgdr, dgd); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to adopt additional resources for DGD %s: %w", dgdName, err)
-	}
-
-	delete(dgdr.Annotations, "nvidia.com/generated-dgd-spec")
-	if err := r.Update(ctx, dgdr); err != nil {
-		// Return the error to force a retry. The DGD was created successfully, so a
-		// retry will hit the IsAlreadyExists path above and attempt cleanup again.
-		return ctrl.Result{}, fmt.Errorf("failed to remove generated-dgd-spec annotation after DGD creation: %w", err)
-	}
-
-	// Update status
-	dgdr.Status.DGDName = dgdName
-
 	r.Recorder.Event(dgdr, corev1.EventTypeNormal, nvidiacomv1beta1.EventReasonDeploymentCreated,
 		fmt.Sprintf(MessageDeploymentCreated, dgdName))
-
-	meta.SetStatusCondition(&dgdr.Status.Conditions, metav1.Condition{
-		Type:    nvidiacomv1beta1.ConditionTypeDeploymentReady,
-		Status:  metav1.ConditionFalse,
-		Reason:  nvidiacomv1beta1.EventReasonDeploymentCreated,
-		Message: fmt.Sprintf("DGD %s created, waiting for Ready", dgdName),
-	})
-
 	logger.Info("DynamoGraphDeployment created successfully", "name", dgdName)
 
-	return ctrl.Result{}, r.Status().Update(ctx, dgdr)
+	// Keep the generated-spec marker until a cached read observes the DGD.
+	return ctrl.Result{}, nil
+}
+
+// clearGeneratedSpecAnnotation marks the DGD as observed in the informer cache.
+func (r *DynamoGraphDeploymentRequestReconciler) clearGeneratedSpecAnnotation(
+	ctx context.Context,
+	dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest,
+) error {
+	if dgdr.Annotations[AnnotationGeneratedDGDSpec] == "" {
+		return nil
+	}
+	annotations := map[string]any{AnnotationGeneratedDGDSpec: ""}
+	if additionalResources := dgdr.Annotations[AnnotationAdditionalResources]; additionalResources != "" {
+		annotations[AnnotationAdditionalResources] = additionalResources
+	}
+	apply := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": nvidiacomv1beta1.GroupVersion.String(),
+		"kind":       "DynamoGraphDeploymentRequest",
+		"metadata": map[string]any{
+			"name":            dgdr.Name,
+			"namespace":       dgdr.Namespace,
+			"resourceVersion": dgdr.ResourceVersion,
+			"annotations":     annotations,
+		},
+	}}
+	if err := r.Apply(ctx, client.ApplyConfigurationFromUnstructured(apply), client.FieldOwner("dynamo-operator-dgdr"), client.ForceOwnership); err != nil {
+		return fmt.Errorf("failed to clear generated DGD annotation: %w", err)
+	}
+	dgdr.Annotations[AnnotationGeneratedDGDSpec] = ""
+	dgdr.ResourceVersion = apply.GetResourceVersion()
+	return nil
 }
 
 // adoptAdditionalResources makes profiling-generated ConfigMaps follow the DGD lifecycle.
@@ -1356,8 +1365,7 @@ func GetGPUDiscoveryFailureReason(err error) string {
 }
 
 // createProfilingJob creates a Kubernetes Job for profiling using SyncResource.
-// It returns requeue=true when it persists discovered hardware and intentionally
-// skips job creation until the next reconcile sees the updated generation.
+// It returns true when a DGDR or Job write must be observed before advancing.
 func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (bool, error) {
 	logger := log.FromContext(ctx)
 
@@ -1382,26 +1390,25 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 		return true, nil
 	}
 
-	// Delete any existing output ConfigMap to ensure fresh profiling results
-	// This prevents using stale data from previous profiling runs
-	outputConfigMapName := getOutputConfigMapName(dgdr)
-	existingCM := &corev1.ConfigMap{}
-	err = r.Get(ctx, types.NamespacedName{
-		Name:      outputConfigMapName,
-		Namespace: dgdr.Namespace,
-	}, existingCM)
-	if err == nil {
-		// ConfigMap exists, delete it
-		logger.Info("Deleting existing output ConfigMap to ensure fresh profiling results", "configMap", outputConfigMapName)
-		if err := r.Delete(ctx, existingCM); err != nil && !apierrors.IsNotFound(err) {
-			logger.Error(err, "Failed to delete existing output ConfigMap", "configMap", outputConfigMapName)
-			return false, fmt.Errorf("failed to delete existing output ConfigMap: %w", err)
+	// Delete stale output only before creating the profiling Job. Once the Job
+	// exists, the ConfigMap may contain fresh output from a fast profiler.
+	existingJob := &batchv1.Job{}
+	err = r.Get(ctx, types.NamespacedName{Name: getProfilingJobName(dgdr), Namespace: dgdr.Namespace}, existingJob)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return false, fmt.Errorf("failed to check for existing profiling Job: %w", err)
+	}
+	if apierrors.IsNotFound(err) {
+		outputConfigMapName := getOutputConfigMapName(dgdr)
+		existingCM := &corev1.ConfigMap{}
+		err = r.Get(ctx, types.NamespacedName{Name: outputConfigMapName, Namespace: dgdr.Namespace}, existingCM)
+		if err == nil {
+			logger.Info("Deleting existing output ConfigMap to ensure fresh profiling results", "configMap", outputConfigMapName)
+			if err := r.Delete(ctx, existingCM); err != nil && !apierrors.IsNotFound(err) {
+				return false, fmt.Errorf("failed to delete existing output ConfigMap: %w", err)
+			}
+		} else if !apierrors.IsNotFound(err) {
+			return false, fmt.Errorf("failed to check for existing output ConfigMap: %w", err)
 		}
-		logger.Info("Successfully deleted old output ConfigMap", "configMap", outputConfigMapName)
-	} else if !apierrors.IsNotFound(err) {
-		// Unexpected error checking for ConfigMap
-		logger.Error(err, "Failed to check for existing output ConfigMap", "configMap", outputConfigMapName)
-		return false, fmt.Errorf("failed to check for existing output ConfigMap: %w", err)
 	}
 
 	// Ensure profiling job RBAC exists (only for cluster-wide installation)
@@ -1663,7 +1670,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) createProfilingJob(ctx context.
 	// Store the job name in status for observability
 	dgdr.Status.ProfilingJobName = job.Name
 
-	return false, nil
+	return modified, nil
 }
 
 // marshalDGDRSpec produces the JSON string passed to the profiler via --config.
@@ -2010,8 +2017,9 @@ func computeDGDName(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) string 
 }
 
 // generateDGDSpec reads profiling output from the sidecar ConfigMap, extracts the
-// DynamoGraphDeployment spec and pareto configs, stores the spec in an annotation via
-// r.Update, and returns the ProfilingResultsStatus and DGD name.
+// DGD and supporting resources, then persists both generated annotations in one
+// update. Update refreshes dgdr's resourceVersion, so the caller can safely
+// commit status without reading its write back through the informer cache.
 func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest) (*nvidiacomv1beta1.ProfilingResultsStatus, string, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Generating DGD spec from profiling results", "name", dgdr.Name, "backend", dgdr.Spec.Backend)
@@ -2026,7 +2034,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return nil, "", fmt.Errorf("output ConfigMap %s not found - profiling may not have completed yet", outputConfigMapName)
+			return nil, "", fmt.Errorf("%w: ConfigMap %s not found", errProfilingOutputNotReady, outputConfigMapName)
 		}
 		return nil, "", fmt.Errorf("failed to get output ConfigMap: %w", err)
 	}
@@ -2038,7 +2046,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	// Get YAML content from ConfigMap
 	yamlContent, exists := cm.Data[outputFile]
 	if !exists {
-		return nil, "", fmt.Errorf("key %s not found in ConfigMap %s", outputFile, outputConfigMapName)
+		return nil, "", fmt.Errorf("%w: key %s not found in ConfigMap %s", errProfilingOutputNotReady, outputFile, outputConfigMapName)
 	}
 
 	logger.Info("Found profiling output in ConfigMap", "configMap", outputConfigMapName, "outputFile", outputFile, "size", len(yamlContent))
@@ -2058,14 +2066,9 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	logger.Info("Parsed profiling output", "profilerDGDName", dgd.Name, "additionalResources", len(additionalResources))
 
 	if len(additionalResources) > 0 {
-		if err := r.storeAdditionalResources(ctx, dgdr, additionalResources); err != nil {
+		if err := storeAdditionalResources(dgdr, additionalResources); err != nil {
 			logger.Error(err, "Failed to store additional resources")
 			return nil, "", err
-		}
-		// storeAdditionalResources calls r.Update internally, bumping resourceVersion.
-		// Refetch so the subsequent r.Update for the spec annotation doesn't 409.
-		if err := r.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, dgdr); err != nil {
-			return nil, "", fmt.Errorf("failed to refetch DGDR after storing additional resources: %w", err)
 		}
 	}
 
@@ -2083,11 +2086,26 @@ func (r *DynamoGraphDeploymentRequestReconciler) generateDGDSpec(ctx context.Con
 	if dgdr.Annotations == nil {
 		dgdr.Annotations = make(map[string]string)
 	}
-	dgdr.Annotations["nvidia.com/generated-dgd-spec"] = string(dgdYAML)
+	dgdr.Annotations[AnnotationGeneratedDGDSpec] = string(dgdYAML)
 
-	if err := r.Update(ctx, dgdr); err != nil {
-		return nil, "", fmt.Errorf("failed to update DGDR with generated DGD annotation: %w", err)
+	annotations := map[string]any{AnnotationGeneratedDGDSpec: string(dgdYAML)}
+	if additionalResources := dgdr.Annotations[AnnotationAdditionalResources]; additionalResources != "" {
+		annotations[AnnotationAdditionalResources] = additionalResources
 	}
+	apply := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": nvidiacomv1beta1.GroupVersion.String(),
+		"kind":       "DynamoGraphDeploymentRequest",
+		"metadata": map[string]any{
+			"name":            dgdr.Name,
+			"namespace":       dgdr.Namespace,
+			"resourceVersion": dgdr.ResourceVersion,
+			"annotations":     annotations,
+		},
+	}}
+	if err := r.Apply(ctx, client.ApplyConfigurationFromUnstructured(apply), client.FieldOwner("dynamo-operator-dgdr"), client.ForceOwnership); err != nil {
+		return nil, "", fmt.Errorf("failed to persist generated DGDR annotations: %w", err)
+	}
+	dgdr.ResourceVersion = apply.GetResourceVersion()
 	return profilingResults, dgd.Name, nil
 }
 
@@ -2125,7 +2143,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) encodeBetaDGDManifest(dgd *nvid
 
 // storeAdditionalResources marshals additional resources to YAML and stores them in DGDR annotations.
 // Validates annotation size and fails gracefully if too large.
-func (r *DynamoGraphDeploymentRequestReconciler) storeAdditionalResources(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, resources []*unstructured.Unstructured) error {
+func storeAdditionalResources(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, resources []*unstructured.Unstructured) error {
 	if len(resources) == 0 {
 		return nil
 	}
@@ -2155,7 +2173,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) storeAdditionalResources(ctx co
 	}
 	dgdr.Annotations[AnnotationAdditionalResources] = string(resourcesYAML)
 
-	return r.Update(ctx, dgdr)
+	return nil
 }
 
 // extractResourcesFromYAML parses multi-document YAML from profiling output,
@@ -2304,8 +2322,9 @@ func setSucceededCondition(dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, 
 	})
 }
 
-// updatePhaseAndRequeue updates the DGDR phase and requeues
-func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseAndRequeue(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase, message string) (ctrl.Result, error) {
+// updatePhase updates the DGDR phase. The successful status write is watched
+// and drives any required follow-up reconcile without rate-limited requeueing.
+func (r *DynamoGraphDeploymentRequestReconciler) updatePhase(ctx context.Context, dgdr *nvidiacomv1beta1.DynamoGraphDeploymentRequest, phase nvidiacomv1beta1.DGDRPhase, message string) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 	logger.Info("Updating DGDR phase", "name", dgdr.Name, "phase", phase, "message", message)
 	dgdr.Status.Phase = phase
@@ -2314,7 +2333,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseAndRequeue(ctx conte
 	if err := r.Status().Update(ctx, dgdr); err != nil {
 		return ctrl.Result{}, err
 	}
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{}, nil
 }
 
 // updatePhaseWithCondition updates phase and adds/updates a condition
@@ -2345,7 +2364,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) updatePhaseWithCondition(
 		return ctrl.Result{}, err
 	}
 
-	return ctrl.Result{Requeue: true}, nil
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager
@@ -2353,13 +2372,7 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
 		Named(consts.ResourceTypeDynamoGraphDeploymentRequest).
-		Owns(&batchv1.Job{}, builder.WithPredicates(predicate.Funcs{
-			// ignore creation cause we don't want to be called again after we create the job
-			CreateFunc:  func(ce event.CreateEvent) bool { return false },
-			DeleteFunc:  func(de event.DeleteEvent) bool { return true },
-			UpdateFunc:  func(de event.UpdateEvent) bool { return true },
-			GenericFunc: func(ge event.GenericEvent) bool { return true },
-		})). // Watch Jobs created by this controller (via ownerReference)
+		Owns(&batchv1.Job{}). // Watch Jobs created by this controller (via ownerReference)
 		// Watch DGDs created by this controller (via label)
 		Watches(
 			&nvidiacomv1beta1.DynamoGraphDeployment{},
@@ -2377,13 +2390,6 @@ func (r *DynamoGraphDeploymentRequestReconciler) SetupWithManager(mgr ctrl.Manag
 						Namespace: dgdrNamespace,
 					},
 				}}
-			}),
-			builder.WithPredicates(predicate.Funcs{
-				// ignore creation cause we don't want to be called again after we create the DGD
-				CreateFunc:  func(ce event.CreateEvent) bool { return false },
-				DeleteFunc:  func(de event.DeleteEvent) bool { return true },
-				UpdateFunc:  func(ue event.UpdateEvent) bool { return true },
-				GenericFunc: func(ge event.GenericEvent) bool { return true },
 			}),
 		).
 		// Watch output ConfigMaps for profiling sub-phase updates (via label)

--- a/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeploymentrequest_controller_test.go
@@ -19,6 +19,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -31,13 +32,16 @@ import (
 	. "github.com/onsi/gomega"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
@@ -55,6 +59,22 @@ func (m *MockRBACManager) EnsureServiceAccountWithRBAC(ctx context.Context, targ
 		return m.EnsureServiceAccountWithRBACFunc(ctx, targetNamespace, serviceAccountName, clusterRoleName)
 	}
 	return nil
+}
+
+// writeFaultClient injects a one-shot DGDR apply conflict.
+type writeFaultClient struct {
+	client.Client
+	applyConflictOnce bool
+}
+
+func (c *writeFaultClient) Apply(ctx context.Context, obj runtime.ApplyConfiguration, opts ...client.ApplyOption) error {
+	if c.applyConflictOnce {
+		c.applyConflictOnce = false
+		return apierrors.NewConflict(schema.GroupResource{
+			Group: nvidiacomv1beta1.GroupVersion.Group, Resource: "dynamographdeploymentrequests",
+		}, "injected", errors.New("injected apply conflict"))
+	}
+	return c.Client.Apply(ctx, obj, opts...)
 }
 
 var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
@@ -452,6 +472,18 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 				return job.Labels[nvidiacomv1beta1.LabelApp]
 			}, timeout, interval).Should(Equal(nvidiacomv1beta1.LabelValueDynamoProfiler))
 
+			// The Job create event is the observation barrier for entering Profiling.
+			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
+			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhasePending))
+
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
+			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+
 			// Clean up
 			jobName := getProfilingJobName(dgdr)
 			job := &batchv1.Job{}
@@ -459,10 +491,50 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 				_ = k8sClient.Delete(ctx, job)
 			}
 		})
+
+		It("Should preserve output written before the Job create event is observed", func() {
+			ctx := context.Background()
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr-fast-output", Namespace: defaultNamespace},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model: "test-model", Backend: "vllm", Image: "test-profiler:latest",
+					Hardware: &nvidiacomv1beta1.HardwareSpec{
+						NumGPUsPerNode: ptr.To[int32](8),
+						GPUSKU:         nvidiacomv1beta1.GPUSKUTypeH100SXM,
+						VRAMMB:         ptr.To(81920.0),
+						TotalGPUs:      ptr.To[int32](8),
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+
+			waitForObservation, err := reconciler.createProfilingJob(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForObservation).Should(BeTrue())
+
+			job := &batchv1.Job{}
+			jobKey := types.NamespacedName{Name: getProfilingJobName(dgdr), Namespace: dgdr.Namespace}
+			Expect(k8sClient.Get(ctx, jobKey, job)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, job) }()
+
+			outputCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: getOutputConfigMapName(dgdr), Namespace: dgdr.Namespace},
+				Data:       map[string]string{ProfilingOutputFile: "fast output"},
+			}
+			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
+
+			waitForObservation, err = reconciler.createProfilingJob(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(waitForObservation).Should(BeFalse())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: outputCM.Name, Namespace: outputCM.Namespace}, outputCM)).Should(Succeed())
+			Expect(outputCM.Data[ProfilingOutputFile]).Should(Equal("fast output"))
+		})
 	})
 
 	Context("When profiling completes", func() {
-		It("Should generate DGD spec from ConfigMap", func() {
+		It("Should persist generated annotations and status without reading back its own write", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-profiling-complete"
 			namespace := defaultNamespace
@@ -531,8 +603,17 @@ var _ = Describe("DynamoGraphDeploymentRequest Controller", func() {
 			}}
 			Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
 
-			// Create output ConfigMap with DGD spec
-			dgdYAML := `apiVersion: nvidia.com/v1alpha1
+			// Include a prerequisite ConfigMap so the reconcile must retain both
+			// generated annotations while its DGDR cache remains stale.
+			const additionalConfigMapName = "planner-config-stale-cache"
+			dgdYAML := `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: planner-config-stale-cache
+data:
+  planner_config.json: "{}"
+---
+apiVersion: nvidia.com/v1alpha1
 kind: DynamoGraphDeployment
 metadata:
   name: test-dgd
@@ -554,7 +635,6 @@ spec:
 			Expect(k8sClient.Create(ctx, cm)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, cm) }()
 
-			// Reconcile to process the profiling completion
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -565,10 +645,11 @@ spec:
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 
 			// Check that DGD spec was generated (stored in annotation)
-			generatedSpec := updated.Annotations["nvidia.com/generated-dgd-spec"]
+			generatedSpec := updated.Annotations[AnnotationGeneratedDGDSpec]
 			Expect(generatedSpec).NotTo(BeEmpty())
 			Expect(generatedSpec).Should(ContainSubstring("apiVersion: nvidia.com/v1beta1"))
 			Expect(generatedSpec).Should(ContainSubstring("kind: DynamoGraphDeployment"))
+			Expect(updated.Annotations[AnnotationAdditionalResources]).Should(ContainSubstring(additionalConfigMapName))
 			Expect(updated.Status.ProfilingResults).ShouldNot(BeNil())
 			Expect(updated.Status.ProfilingResults.SelectedConfig).ShouldNot(BeNil())
 			Expect(string(updated.Status.ProfilingResults.SelectedConfig.Raw)).Should(ContainSubstring("nvidia.com/v1beta1"))
@@ -576,6 +657,113 @@ spec:
 
 			// autoApply defaults to true in v1beta1, so after profiling the DGDR transitions to Deploying
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseDeploying))
+
+			additionalCM := &corev1.ConfigMap{}
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
+		})
+
+		It("Should retry generated-annotation conflicts without failing profiling", func() {
+			ctx := context.Background()
+			dgdrName := "test-dgdr-generated-annotation-conflict"
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: dgdrName, Namespace: defaultNamespace},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model: "test-model", Backend: "vllm", AutoApply: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
+			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
+
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: getProfilingJobName(dgdr), Namespace: defaultNamespace},
+				Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}}, RestartPolicy: corev1.RestartPolicyNever,
+				}}},
+			}
+			Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, job) }()
+			job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+			Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
+
+			outputCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: getOutputConfigMapName(dgdr), Namespace: defaultNamespace},
+				Data: map[string]string{ProfilingOutputFile: `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: generated-name
+spec:
+  services: {}`},
+			}
+			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
+
+			reconciler.Client = &writeFaultClient{Client: k8sClient, applyConflictOnce: true}
+			_, err := reconciler.handleProfilingPhase(ctx, dgdr)
+			Expect(apierrors.IsConflict(err)).Should(BeTrue())
+
+			var persisted nvidiacomv1beta1.DynamoGraphDeploymentRequest
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: defaultNamespace}, &persisted)).Should(Succeed())
+			Expect(persisted.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+			Expect(persisted.Annotations).NotTo(HaveKey(AnnotationGeneratedDGDSpec))
+
+			_, err = reconciler.handleProfilingPhase(ctx, &persisted)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: defaultNamespace}, &persisted)).Should(Succeed())
+			Expect(persisted.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseReady))
+			Expect(persisted.Annotations).To(HaveKey(AnnotationGeneratedDGDSpec))
+		})
+
+		It("Should wait for the watched ConfigMap to contain final output", func() {
+			ctx := context.Background()
+			dgdr := &nvidiacomv1beta1.DynamoGraphDeploymentRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-dgdr-output-not-ready", Namespace: defaultNamespace},
+				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
+					Model: "test-model", Backend: "vllm", AutoApply: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseProfiling
+			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
+
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: getProfilingJobName(dgdr), Namespace: defaultNamespace},
+				Spec: batchv1.JobSpec{Template: corev1.PodTemplateSpec{Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "test", Image: "test"}}, RestartPolicy: corev1.RestartPolicyNever,
+				}}},
+			}
+			Expect(k8sClient.Create(ctx, job)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, job) }()
+			job.Status.Conditions = []batchv1.JobCondition{{Type: batchv1.JobComplete, Status: corev1.ConditionTrue}}
+			Expect(k8sClient.Status().Update(ctx, job)).Should(Succeed())
+
+			outputCM := &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: getOutputConfigMapName(dgdr), Namespace: defaultNamespace},
+				Data:       map[string]string{"profiler_status": "success"},
+			}
+			Expect(k8sClient.Create(ctx, outputCM)).Should(Succeed())
+			defer func() { _ = k8sClient.Delete(ctx, outputCM) }()
+
+			_, err := reconciler.handleProfilingPhase(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, dgdr)).Should(Succeed())
+			Expect(dgdr.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseProfiling))
+
+			outputCM.Data[ProfilingOutputFile] = `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: generated-name
+spec:
+  services: {}`
+			Expect(k8sClient.Update(ctx, outputCM)).Should(Succeed())
+
+			_, err = reconciler.handleProfilingPhase(ctx, dgdr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, dgdr)).Should(Succeed())
+			Expect(dgdr.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseReady))
 		})
 	})
 
@@ -833,7 +1021,7 @@ spec:
 			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
 			Expect(additionalCM.OwnerReferences).Should(BeEmpty())
 
-			// Second reconcile creates the DGD, then adopts the additional ConfigMaps.
+			// Second reconcile creates the DGD and waits for its create event.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -842,6 +1030,12 @@ spec:
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{}
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: expectedDGDName, Namespace: namespace}, dgd)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgd) }()
+
+			// Third reconcile observes the DGD and adopts the additional ConfigMaps.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
 			Expect(additionalCM.OwnerReferences).Should(HaveLen(1))
@@ -883,6 +1077,9 @@ spec:
 			}
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
+			dgdr.Status.Phase = nvidiacomv1beta1.DGDRPhaseDeploying
+			dgdr.Status.DGDName = dgdName
+			Expect(k8sClient.Status().Update(ctx, dgdr)).Should(Succeed())
 
 			dgd := &nvidiacomv1beta1.DynamoGraphDeployment{
 				ObjectMeta: metav1.ObjectMeta{
@@ -909,7 +1106,7 @@ spec:
 			Expect(k8sClient.Create(ctx, additionalCM)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, additionalCM) }()
 
-			_, err := reconciler.createDGD(ctx, dgdr)
+			_, err := reconciler.handleDeployingPhase(ctx, dgdr)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: additionalConfigMapName, Namespace: namespace}, additionalCM)).Should(Succeed())
@@ -1089,7 +1286,6 @@ spec:
 					AutoApply: ptr.To(true),
 				},
 			}
-
 			Expect(k8sClient.Create(ctx, dgdr)).Should(Succeed())
 			defer func() { _ = k8sClient.Delete(ctx, dgdr) }()
 
@@ -2137,7 +2333,7 @@ spec:
 	})
 
 	Context("v1beta1-specific behavior", func() {
-		It("Should transition to Deployed when DGD reaches Ready", func() {
+		It("Should clear the creation marker only after observing the DGD", func() {
 			ctx := context.Background()
 			dgdrName := "test-dgdr-deployed-phase"
 			namespace := defaultNamespace
@@ -2146,6 +2342,14 @@ spec:
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      dgdrName,
 					Namespace: namespace,
+					Annotations: map[string]string{
+						AnnotationGeneratedDGDSpec: `apiVersion: nvidia.com/v1alpha1
+kind: DynamoGraphDeployment
+metadata:
+  name: test-dgd-deployed
+spec:
+  services: {}`,
+					},
 				},
 				Spec: nvidiacomv1beta1.DynamoGraphDeploymentRequestSpec{
 					Model:   "test-model",
@@ -2191,7 +2395,9 @@ spec:
 			dgd.Status.State = nvidiacomv1beta1.DGDStateSuccessful
 			Expect(k8sClient.Status().Update(ctx, dgd)).Should(Succeed())
 
-			// Reconcile — should transition DGDR to Deployed
+			key := types.NamespacedName{Name: dgd.Name, Namespace: namespace}
+
+			// Observing the DGD commits creation by clearing the generated-spec marker.
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2200,6 +2406,18 @@ spec:
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
 			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseDeployed))
+			Expect(updated.Annotations[AnnotationGeneratedDGDSpec]).Should(BeEmpty())
+
+			// Once an existing DGD has been observed, a later deletion must not be
+			// recreated from a marker left behind by a prior crash.
+			Expect(k8sClient.Delete(ctx, dgd)).Should(Succeed())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
+			Expect(updated.Status.Phase).Should(Equal(nvidiacomv1beta1.DGDRPhaseFailed))
+			Expect(apierrors.IsNotFound(k8sClient.Get(ctx, key, &nvidiacomv1beta1.DynamoGraphDeployment{}))).Should(BeTrue())
 		})
 
 		It("Should set Succeeded condition at each phase transition", func() {
@@ -2283,7 +2501,13 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Reconcile again to start profiling (creates job, transitions to Profiling)
+			// Reconcile again to create the profiling Job.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile after observing the Job to transition to Profiling.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2480,6 +2704,12 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
+			// Reconcile after observing the Job to persist its name in status.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
 			// Check profilingJobName is set in status
 			var updated nvidiacomv1beta1.DynamoGraphDeploymentRequest
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: dgdrName, Namespace: namespace}, &updated)).Should(Succeed())
@@ -2532,7 +2762,13 @@ spec:
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Reconcile: create profiling job → Profiling + ProfilingPhase=Initializing
+			// Reconcile: create profiling Job and wait for informer observation.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Reconcile: observed profiling Job → Profiling + ProfilingPhase=Initializing.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2580,6 +2816,10 @@ spec:
 
 			// Reconcile: profiling complete → should clear profilingPhase, set
 			// ProfilingCompleted condition, populate profilingResults.selectedConfig
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
@@ -2644,6 +2884,10 @@ spec:
 
 			// Reconcile — partial hardware without discovery should fail validation
 			_, err := reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})
 			Expect(err).NotTo(HaveOccurred())
@@ -3003,7 +3247,13 @@ var _ = Describe("DGDR Profiling Failure Attribution", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 
-			// Second reconcile: Pending → Profiling
+			// Second reconcile: create profiling Job.
+			_, err = reconciler.Reconcile(ctx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Third reconcile: observed profiling Job → Profiling.
 			_, err = reconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: types.NamespacedName{Name: dgdrName, Namespace: namespace},
 			})

--- a/deploy/operator/internal/controller/enrich_hardware_test.go
+++ b/deploy/operator/internal/controller/enrich_hardware_test.go
@@ -412,6 +412,10 @@ func TestCreateProfilingJobPersistsDiscoveredHardware(t *testing.T) {
 
 	requeue, err = r.createProfilingJob(ctx, &stored)
 	require.NoError(t, err)
+	require.True(t, requeue)
+
+	requeue, err = r.createProfilingJob(ctx, &stored)
+	require.NoError(t, err)
 	require.False(t, requeue)
 
 	job := &batchv1.Job{}
@@ -457,6 +461,10 @@ func TestCreateProfilingJobWithManualHardwareDoesNotRequireAPIReader(t *testing.
 	require.NoError(t, fakeClient.Get(ctx, types.NamespacedName{Name: dgdr.Name, Namespace: dgdr.Namespace}, &fetched))
 
 	requeue, err := r.createProfilingJob(ctx, &fetched)
+	require.NoError(t, err)
+	require.True(t, requeue)
+
+	requeue, err = r.createProfilingJob(ctx, &fetched)
 	require.NoError(t, err)
 	require.False(t, requeue)
 


### PR DESCRIPTION
## Summary

- Backport #11250 to `release/1.3.0`.
- Prevent DynamoGraphDeploymentRequest reconciliation from stalling after profiling by waiting for watched API writes and tolerating informer lag.
- Resolve the release-branch conflict by retaining the removal of the deprecated WebUI Pareto test while preserving the backport regression coverage.

## Validation

- `git diff --check github/release/1.3.0...HEAD`
- `go test ./internal/controller` (suite setup blocked before running specs because `deploy/operator/bin/k8s/1.30.0-darwin-arm64/etcd` is not installed locally)

CP of #11250

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11340" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->
