### PR TITLE
feat(frontend): expose tokenizer cache token metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2874,9 +2874,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
+checksum = "eda65fd29fa8fc5395fc9430155d68d67a7eef216415a152cbf85e9916aa0bbf"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 dynamo-runtime = { path = "lib/runtime", version = "1.3.0" }
 dynamo-llm = { path = "lib/llm", version = "1.3.0" }
 dynamo-rl = { path = "lib/rl", version = "1.3.0" }
-dynamo-tokenizers = { version = "=1.3.2" }
+dynamo-tokenizers = { version = "=1.4.0" }
 dynamo-renderer = { version = "=1.3.5" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.3.0" }

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -224,6 +224,10 @@ The Dynamo HTTP Frontend (`python -m dynamo.frontend`) exposes `dynamo_frontend_
 - `dynamo_frontend_disconnected_clients`: Number of disconnected clients (gauge)
 - `dynamo_frontend_input_sequence_tokens`: Input sequence length (histogram)
 - `dynamo_frontend_cached_tokens`: Number of cached tokens (prefix cache hits) per request (histogram)
+- `dynamo_frontend_tokenizer_cache_hits_total`: L1 tokenizer prefix-cache hits across all models (counter)
+- `dynamo_frontend_tokenizer_cache_misses_total`: L1 tokenizer prefix-cache misses across all models (counter)
+- `dynamo_frontend_tokenizer_cache_cached_tokens_total`: Tokens returned from the L1 tokenizer prefix cache (counter, label: `model`)
+- `dynamo_frontend_tokenizer_cache_uncached_tokens_total`: Tokens freshly encoded after an L1 tokenizer prefix-cache lookup (counter, label: `model`)
 - `dynamo_frontend_inter_token_latency_seconds`: Inter-token latency (histogram)
 - `dynamo_frontend_output_sequence_tokens`: Output sequence length (histogram)
 - `dynamo_frontend_output_tokens_total`: Total number of output tokens generated (counter)
@@ -236,6 +240,31 @@ The Dynamo HTTP Frontend (`python -m dynamo.frontend`) exposes `dynamo_frontend_
 ```bash
 curl http://localhost:8000/metrics
 ```
+
+#### Tokenizer Cache Metrics
+
+The hit and miss counters record request-level cache outcomes across the frontend process. The cached
+and uncached token counters report exact token totals for each served model. A partial hit increments
+both token counters because it returns a cached prefix and freshly encodes the remaining suffix. A
+full hit increments only the cached-token counter, and a full miss increments only the uncached-token
+counter.
+
+Use the following PromQL expression to calculate the token reuse ratio for each model over five
+minutes:
+
+```promql
+sum by (model) (rate(dynamo_frontend_tokenizer_cache_cached_tokens_total[5m]))
+/
+(
+  sum by (model) (rate(dynamo_frontend_tokenizer_cache_cached_tokens_total[5m]))
+  +
+  sum by (model) (rate(dynamo_frontend_tokenizer_cache_uncached_tokens_total[5m]))
+)
+```
+
+The token counters do not increment when `DYN_TOKENIZER_CACHE=0`, when encoding fails, or when the
+cache has no registered special-token boundaries. The tiktoken cache currently has no registered
+boundaries, so its token counters remain unchanged.
 
 #### Stage and phase labels
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -243,11 +243,11 @@ curl http://localhost:8000/metrics
 
 #### Tokenizer Cache Metrics
 
-The hit and miss counters record request-level cache outcomes across the frontend process. The cached
-and uncached token counters report exact token totals for each served model. A partial hit increments
-both token counters because it returns a cached prefix and freshly encodes the remaining suffix. A
-full hit increments only the cached-token counter, and a full miss increments only the uncached-token
-counter.
+The hit and miss counters record one cache outcome per encode operation across the frontend process.
+A batch encode records one outcome per item. The cached and uncached token counters report exact
+token totals for each served model. When L1 is active, a partial hit increments both token counters
+because it returns a cached prefix and freshly encodes the remaining suffix. A full hit increments
+only the cached-token counter, and a full miss increments only the uncached-token counter.
 
 Use the following PromQL expression to calculate the token reuse ratio for each model over five
 minutes:
@@ -262,9 +262,11 @@ sum by (model) (rate(dynamo_frontend_tokenizer_cache_cached_tokens_total[5m]))
 )
 ```
 
-The token counters do not increment when `DYN_TOKENIZER_CACHE=0`, when encoding fails, or when the
-cache has no registered special-token boundaries. The tiktoken cache currently has no registered
-boundaries, so its token counters remain unchanged.
+The ratio is meaningful only for a model with an active L1 cache and observed tokens. The token
+counters do not increment when `DYN_TOKENIZER_CACHE=0`, when encoding fails, or when the cache has no
+registered special-token boundaries. The tiktoken path currently has no registered boundaries, so it
+bypasses L1 and exposes zero-valued token counter series; its ratio remains undefined until the cache
+observes tokens.
 
 #### Stage and phase labels
 

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1860,9 +1860,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
+checksum = "eda65fd29fa8fc5395fc9430155d68d67a7eef216415a152cbf85e9916aa0bbf"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2512,9 +2512,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.3.2"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "801685a07cfbc87d5e3f3ed55b920707b67f31dd660c62d1b3532a651fc9d013"
+checksum = "eda65fd29fa8fc5395fc9430155d68d67a7eef216415a152cbf85e9916aa0bbf"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -42,6 +42,19 @@ fn tokenizer_cache_bytes(value: Option<&str>) -> usize {
         .unwrap_or(DEFAULT_TOKENIZER_CACHE_BYTES)
 }
 
+fn tokenizer_cache_token_observer(model: &str) -> crate::tokenizers::CacheTokenUsageFn {
+    let cached_tokens = dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_CACHED_TOKENS_TOTAL
+        .with_label_values(&[model]);
+    let uncached_tokens =
+        dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL
+            .with_label_values(&[model]);
+
+    Arc::new(move |usage| {
+        cached_tokens.inc_by(usage.cached_tokens as u64);
+        uncached_tokens.inc_by(usage.uncached_tokens as u64);
+    })
+}
+
 /// Identify model deployment cards in the key-value store
 pub const ROOT_PATH: &str = "v1/mdc";
 
@@ -1142,7 +1155,8 @@ impl ModelDeploymentCard {
                                     dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_MISSES_TOTAL
                                         .inc();
                                 }),
-                            ),
+                            )
+                            .with_token_observer(tokenizer_cache_token_observer(self.name())),
                     )
                 } else {
                     raw
@@ -1180,7 +1194,8 @@ impl ModelDeploymentCard {
                                     dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_MISSES_TOTAL
                                         .inc();
                                 }),
-                            ),
+                            )
+                            .with_token_observer(tokenizer_cache_token_observer(self.name())),
                     )
                 } else {
                     raw
@@ -2082,6 +2097,50 @@ mod tests {
     use super::{HFConfig, ModelDeploymentCard};
     use std::collections::HashSet;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn tokenizer_cache_token_observer_records_per_model_totals() {
+        let model_a = "token-observer-test-model-a";
+        let model_b = "token-observer-test-model-b";
+        let cached_a = dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_CACHED_TOKENS_TOTAL
+            .with_label_values(&[model_a]);
+        let uncached_a =
+            dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL
+                .with_label_values(&[model_a]);
+        let cached_b = dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_CACHED_TOKENS_TOTAL
+            .with_label_values(&[model_b]);
+        let uncached_b =
+            dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL
+                .with_label_values(&[model_b]);
+
+        let before_a = (cached_a.get(), uncached_a.get());
+        let before_b = (cached_b.get(), uncached_b.get());
+
+        super::tokenizer_cache_token_observer(model_a)(crate::tokenizers::CacheTokenUsage {
+            cached_tokens: 7,
+            uncached_tokens: 5,
+        });
+
+        assert_eq!(
+            (cached_a.get(), uncached_a.get()),
+            (before_a.0 + 7, before_a.1 + 5)
+        );
+        assert_eq!((cached_b.get(), uncached_b.get()), before_b);
+
+        super::tokenizer_cache_token_observer(model_b)(crate::tokenizers::CacheTokenUsage {
+            cached_tokens: 3,
+            uncached_tokens: 11,
+        });
+
+        assert_eq!(
+            (cached_a.get(), uncached_a.get()),
+            (before_a.0 + 7, before_a.1 + 5)
+        );
+        assert_eq!(
+            (cached_b.get(), uncached_b.get()),
+            (before_b.0 + 3, before_b.1 + 11)
+        );
+    }
 
     #[test]
     fn tokenizer_cache_is_enabled_by_default_and_disabled_only_by_zero() {

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -55,6 +55,28 @@ fn tokenizer_cache_token_observer(model: &str) -> crate::tokenizers::CacheTokenU
     })
 }
 
+fn instrumented_tokenizer_cache(
+    raw: Arc<dyn crate::tokenizers::traits::Tokenizer>,
+    special_tokens: Vec<String>,
+    cache_bytes: usize,
+    cache_extend: bool,
+    model: &str,
+) -> Arc<dyn crate::tokenizers::traits::Tokenizer> {
+    Arc::new(
+        crate::tokenizers::CachedTokenizer::new(raw, special_tokens, cache_bytes)
+            .with_extend(cache_extend)
+            .with_observer(
+                Arc::new(|| {
+                    dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_HITS_TOTAL.inc();
+                }),
+                Arc::new(|| {
+                    dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_MISSES_TOTAL.inc();
+                }),
+            )
+            .with_token_observer(tokenizer_cache_token_observer(model)),
+    )
+}
+
 /// Identify model deployment cards in the key-value store
 pub const ROOT_PATH: &str = "v1/mdc";
 
@@ -1143,20 +1165,12 @@ impl ModelDeploymentCard {
                         specials = specials.len(),
                         "wrapping tokenizer in L1 prefix cache",
                     );
-                    Arc::new(
-                        crate::tokenizers::CachedTokenizer::new(raw, specials, cache_bytes)
-                            .with_extend(cache_extend)
-                            .with_observer(
-                                Arc::new(|| {
-                                    dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_HITS_TOTAL
-                                        .inc();
-                                }),
-                                Arc::new(|| {
-                                    dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_MISSES_TOTAL
-                                        .inc();
-                                }),
-                            )
-                            .with_token_observer(tokenizer_cache_token_observer(self.name())),
+                    instrumented_tokenizer_cache(
+                        raw,
+                        specials,
+                        cache_bytes,
+                        cache_extend,
+                        self.name(),
                     )
                 } else {
                     raw
@@ -1176,26 +1190,19 @@ impl ModelDeploymentCard {
 
                 let raw: Arc<dyn crate::tokenizers::traits::Tokenizer> = Arc::new(tokenizer);
                 if cache_enabled {
-                    // Empty specials -> L1 always misses; wrapper is a thin passthrough.
-                    // Special-token extraction for tiktoken is out of scope for v1.
+                    // Empty specials disable L1, so the wrapper bypasses cache observers.
+                    // The instrumentation helper still binds zero-valued per-model token
+                    // series, ready for future tiktoken special-token extraction.
                     tracing::info!(
                         cache_bytes,
-                        "wrapping tiktoken tokenizer in L1 cache (no special tokens registered; L1 will not hit until tiktoken special-token extraction is added)",
+                        "wrapping tiktoken tokenizer in L1 cache (no special tokens registered; L1 is disabled until tiktoken special-token extraction is added)",
                     );
-                    Arc::new(
-                        crate::tokenizers::CachedTokenizer::new(raw, Vec::new(), cache_bytes)
-                            .with_extend(cache_extend)
-                            .with_observer(
-                                Arc::new(|| {
-                                    dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_HITS_TOTAL
-                                        .inc();
-                                }),
-                                Arc::new(|| {
-                                    dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_MISSES_TOTAL
-                                        .inc();
-                                }),
-                            )
-                            .with_token_observer(tokenizer_cache_token_observer(self.name())),
+                    instrumented_tokenizer_cache(
+                        raw,
+                        Vec::new(),
+                        cache_bytes,
+                        cache_extend,
+                        self.name(),
                     )
                 } else {
                     raw

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -172,44 +172,34 @@ static REGISTERED: OnceCell<()> = OnceCell::new();
 /// first does not silently prevent the metrics from being registered in the prometheus registry.
 static PROMETHEUS_REGISTERED: OnceCell<()> = OnceCell::new();
 
-/// Register frontend perf metrics with the given registry. Idempotent.
-pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
-    let _ = REGISTERED.get_or_init(|| {
-        registry.add_metric(Box::new(STAGE_REQUESTS.clone())).ok();
-        registry
-            .add_metric(Box::new(STAGE_DURATION_SECONDS.clone()))
-            .ok();
-        registry.add_metric(Box::new(TOKENIZE_SECONDS.clone())).ok();
-        registry.add_metric(Box::new(TEMPLATE_SECONDS.clone())).ok();
-        registry
-            .add_metric(Box::new(DETOKENIZE_TOTAL_US.clone()))
-            .ok();
-        registry
-            .add_metric(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))
-            .ok();
-        registry
-            .add_metric(Box::new(TOKENIZER_CACHE_HITS_TOTAL.clone()))
-            .ok();
-        registry
-            .add_metric(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))
-            .ok();
-        registry
-            .add_metric(Box::new(TOKENIZER_CACHE_CACHED_TOKENS_TOTAL.clone()))
-            .ok();
-        registry
-            .add_metric(Box::new(TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.clone()))
-            .ok();
-    });
+fn register_frontend_perf_metrics(registry: &MetricsRegistry) {
+    registry.add_metric(Box::new(STAGE_REQUESTS.clone())).ok();
+    registry
+        .add_metric(Box::new(STAGE_DURATION_SECONDS.clone()))
+        .ok();
+    registry.add_metric(Box::new(TOKENIZE_SECONDS.clone())).ok();
+    registry.add_metric(Box::new(TEMPLATE_SECONDS.clone())).ok();
+    registry
+        .add_metric(Box::new(DETOKENIZE_TOTAL_US.clone()))
+        .ok();
+    registry
+        .add_metric(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))
+        .ok();
+    registry
+        .add_metric(Box::new(TOKENIZER_CACHE_HITS_TOTAL.clone()))
+        .ok();
+    registry
+        .add_metric(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))
+        .ok();
+    registry
+        .add_metric(Box::new(TOKENIZER_CACHE_CACHED_TOKENS_TOTAL.clone()))
+        .ok();
+    registry
+        .add_metric(Box::new(TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.clone()))
+        .ok();
 }
 
-/// Register frontend perf metrics with a raw Prometheus registry (e.g. for LLM HTTP service /metrics).
-/// Idempotent. Call this when the service exposes /metrics from its own registry.
-pub fn ensure_frontend_perf_metrics_registered_prometheus(
-    registry: &Registry,
-) -> Result<(), prometheus::Error> {
-    if PROMETHEUS_REGISTERED.get().is_some() {
-        return Ok(());
-    }
+fn register_frontend_perf_metrics_prometheus(registry: &Registry) -> Result<(), prometheus::Error> {
     registry.register(Box::new(STAGE_REQUESTS.clone()))?;
     registry.register(Box::new(STAGE_DURATION_SECONDS.clone()))?;
     registry.register(Box::new(TOKENIZE_SECONDS.clone()))?;
@@ -220,6 +210,23 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
     registry.register(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_CACHED_TOKENS_TOTAL.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.clone()))?;
+    Ok(())
+}
+
+/// Register frontend perf metrics with the given registry. Idempotent.
+pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
+    let _ = REGISTERED.get_or_init(|| register_frontend_perf_metrics(registry));
+}
+
+/// Register frontend perf metrics with a raw Prometheus registry (e.g. for LLM HTTP service /metrics).
+/// Idempotent. Call this when the service exposes /metrics from its own registry.
+pub fn ensure_frontend_perf_metrics_registered_prometheus(
+    registry: &Registry,
+) -> Result<(), prometheus::Error> {
+    if PROMETHEUS_REGISTERED.get().is_some() {
+        return Ok(());
+    }
+    register_frontend_perf_metrics_prometheus(registry)?;
     let _ = PROMETHEUS_REGISTERED.set(());
     Ok(())
 }
@@ -256,14 +263,14 @@ mod tests {
         let _ = TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.with_label_values(&[model]);
 
         let metrics_registry = MetricsRegistry::new();
-        ensure_frontend_perf_metrics_registered(&metrics_registry);
+        register_frontend_perf_metrics(&metrics_registry);
         assert_tokenizer_cache_token_metrics_registered(
             &metrics_registry.get_prometheus_registry().gather(),
             model,
         );
 
         let prometheus_registry = Registry::new();
-        ensure_frontend_perf_metrics_registered_prometheus(&prometheus_registry).unwrap();
+        register_frontend_perf_metrics_prometheus(&prometheus_registry).unwrap();
         assert_tokenizer_cache_token_metrics_registered(&prometheus_registry.gather(), model);
     }
 

--- a/lib/runtime/src/metrics/frontend_perf.rs
+++ b/lib/runtime/src/metrics/frontend_perf.rs
@@ -5,9 +5,11 @@
 //! Used by both runtime (route, transport_roundtrip) and llm (preprocess, postprocess, tokenize, template, detokenize).
 
 use once_cell::sync::{Lazy, OnceCell};
-use prometheus::{Counter, Histogram, HistogramOpts, HistogramVec, IntGaugeVec, Opts, Registry};
+use prometheus::{
+    Counter, Histogram, HistogramOpts, HistogramVec, IntCounterVec, IntGaugeVec, Opts, Registry,
+};
 
-use super::prometheus_names::{frontend_perf, name_prefix};
+use super::prometheus_names::{frontend_perf, labels, name_prefix};
 use crate::MetricsRegistry;
 
 pub use super::prometheus_names::frontend_perf::{STAGE_DISPATCH, STAGE_PREPROCESS, STAGE_ROUTE};
@@ -138,6 +140,30 @@ pub static TOKENIZER_CACHE_MISSES_TOTAL: Lazy<Counter> = Lazy::new(|| {
     .expect("tokenizer_cache_misses_total counter")
 });
 
+/// Tokens returned from the L1 tokenizer prefix cache, labeled by served model name.
+pub static TOKENIZER_CACHE_CACHED_TOKENS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            frontend_metric_name(frontend_perf::TOKENIZER_CACHE_CACHED_TOKENS_TOTAL),
+            "Total tokens returned from the L1 tokenizer prefix cache",
+        ),
+        &[labels::MODEL],
+    )
+    .expect("tokenizer_cache_cached_tokens_total counter vec")
+});
+
+/// Tokens freshly encoded after an L1 tokenizer prefix-cache lookup, labeled by served model name.
+pub static TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL: Lazy<IntCounterVec> = Lazy::new(|| {
+    IntCounterVec::new(
+        Opts::new(
+            frontend_metric_name(frontend_perf::TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL),
+            "Total tokens freshly encoded after an L1 tokenizer prefix-cache lookup",
+        ),
+        &[labels::MODEL],
+    )
+    .expect("tokenizer_cache_uncached_tokens_total counter vec")
+});
+
 /// Guards idempotency for the `MetricsRegistry` registration path.
 static REGISTERED: OnceCell<()> = OnceCell::new();
 
@@ -167,6 +193,12 @@ pub fn ensure_frontend_perf_metrics_registered(registry: &MetricsRegistry) {
         registry
             .add_metric(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))
             .ok();
+        registry
+            .add_metric(Box::new(TOKENIZER_CACHE_CACHED_TOKENS_TOTAL.clone()))
+            .ok();
+        registry
+            .add_metric(Box::new(TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.clone()))
+            .ok();
     });
 }
 
@@ -186,6 +218,8 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
     registry.register(Box::new(DETOKENIZE_TOKEN_COUNT.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_HITS_TOTAL.clone()))?;
     registry.register(Box::new(TOKENIZER_CACHE_MISSES_TOTAL.clone()))?;
+    registry.register(Box::new(TOKENIZER_CACHE_CACHED_TOKENS_TOTAL.clone()))?;
+    registry.register(Box::new(TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.clone()))?;
     let _ = PROMETHEUS_REGISTERED.set(());
     Ok(())
 }
@@ -193,6 +227,45 @@ pub fn ensure_frontend_perf_metrics_registered_prometheus(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn assert_tokenizer_cache_token_metrics_registered(
+        families: &[prometheus::proto::MetricFamily],
+        model: &str,
+    ) {
+        for name in [
+            "dynamo_frontend_tokenizer_cache_cached_tokens_total",
+            "dynamo_frontend_tokenizer_cache_uncached_tokens_total",
+        ] {
+            let family = families
+                .iter()
+                .find(|family| family.name() == name)
+                .unwrap_or_else(|| panic!("missing metric family {name}"));
+            assert!(family.get_metric().iter().any(|metric| {
+                metric
+                    .get_label()
+                    .iter()
+                    .any(|label| label.name() == labels::MODEL && label.value() == model)
+            }));
+        }
+    }
+
+    #[test]
+    fn test_tokenizer_cache_token_metrics_registered_with_model_label() {
+        let model = "frontend-perf-registration-test-model";
+        let _ = TOKENIZER_CACHE_CACHED_TOKENS_TOTAL.with_label_values(&[model]);
+        let _ = TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL.with_label_values(&[model]);
+
+        let metrics_registry = MetricsRegistry::new();
+        ensure_frontend_perf_metrics_registered(&metrics_registry);
+        assert_tokenizer_cache_token_metrics_registered(
+            &metrics_registry.get_prometheus_registry().gather(),
+            model,
+        );
+
+        let prometheus_registry = Registry::new();
+        ensure_frontend_perf_metrics_registered_prometheus(&prometheus_registry).unwrap();
+        assert_tokenizer_cache_token_metrics_registered(&prometheus_registry.gather(), model);
+    }
 
     #[test]
     fn test_stage_guard_inc_dec() {

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -652,6 +652,10 @@ pub mod frontend_perf {
     pub const TOKENIZER_CACHE_HITS_TOTAL: &str = "tokenizer_cache_hits_total";
     /// L1 tokenizer cache misses (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
     pub const TOKENIZER_CACHE_MISSES_TOTAL: &str = "tokenizer_cache_misses_total";
+    /// Tokens returned from the L1 tokenizer prefix cache (cumulative, labeled by model)
+    pub const TOKENIZER_CACHE_CACHED_TOKENS_TOTAL: &str = "tokenizer_cache_cached_tokens_total";
+    /// Tokens freshly encoded after an L1 tokenizer prefix-cache lookup (cumulative, labeled by model)
+    pub const TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL: &str = "tokenizer_cache_uncached_tokens_total";
     /// Cumulative detokenization time (microseconds); pair with DETOKENIZE_TOKEN_COUNT
     pub const DETOKENIZE_TOTAL_US: &str = "detokenize_total_us";
     /// Total tokens detokenized; use rate(total_us)/rate(count) for per-token average


### PR DESCRIPTION
## Summary

- Bump `dynamo-tokenizers` from `1.3.2` to `1.4.0` and refresh the root, Python binding, and KVBM lockfiles.
- Expose exact per-model cached and uncached tokenizer-token counters while preserving the existing aggregate hit/miss counters.
- Register the counters on both metrics paths, cover label isolation and registration, and document token-reuse semantics and PromQL derivation.

## Overview

Expose the token-level effectiveness of the frontend L1 tokenizer cache. Operators can compare cached and freshly encoded token rates per served model instead of inferring reuse from aggregate encode hit and miss counts.

## Details

- Add `dynamo_frontend_tokenizer_cache_cached_tokens_total` and `dynamo_frontend_tokenizer_cache_uncached_tokens_total`, labeled by `model`.
- Bind counter children once per model and attach the token observer alongside the existing hit/miss observer for HuggingFace, fastokens, and tiktoken construction paths.
- Share the instrumentation chain between tokenizer backends and isolate registry tests from process-global idempotency guards.
- Document partial-hit accounting, disabled-cache and failed-encode behavior, the current tiktoken L1 bypass, and a per-model reuse-ratio query.
- Keep the existing unlabeled cache hit and miss metrics unchanged.

## Where should the reviewer start?

Start with `lib/llm/src/model_card.rs` for observer construction and tokenizer wiring. Then review `lib/runtime/src/metrics/frontend_perf.rs` for metric definitions, registration, and tests, followed by `docs/observability/metrics.md` for operator-facing semantics.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `cargo pkgid -p dynamo-tokenizers`
- `cargo metadata --locked --no-deps --format-version 1`
- `cargo metadata --locked --no-deps --format-version 1 --manifest-path lib/bindings/python/Cargo.toml`
- `cargo metadata --locked --no-deps --format-version 1 --manifest-path lib/bindings/kvbm/Cargo.toml`
- `cargo test -p dynamo-runtime frontend_perf --locked`
- `cargo test -p dynamo-llm tokenizer_cache_token --locked`
- `cargo clippy -p dynamo-runtime -p dynamo-llm --all-targets --locked -- -D warnings`
- `cargo check --workspace --all-targets --locked`
- `cargo fmt --all --check`
- `fern check`
- `fern docs broken-links`
- `git diff --check`

`cargo clippy -p dynamo-runtime -p dynamo-llm --all-targets --all-features --locked -- -D warnings` was also attempted, but the host lacks the optional FFmpeg `libavutil.pc` system package; `ffmpeg-sys-next` failed before checking project code.