### PR TITLE
fix(operator): fix linter

### DIFF
--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2326,6 +2326,21 @@ func topologyDomainsContain(domains []v1beta1.TopologyDomain, want v1beta1.Topol
 	return false
 }
 
+func resolveGroveSchedulerQueue(ctx context.Context, annotations map[string]string, runtimeConfig *controller_common.RuntimeConfig) (string, error) {
+	if runtimeConfig.GroveEnabled && runtimeConfig.KaiSchedulerEnabled && runtimeConfig.VolcanoSchedulerEnabled {
+		return "", fmt.Errorf("kai-scheduler and volcano scheduler integrations cannot both be enabled for Grove")
+	}
+	if !runtimeConfig.GroveEnabled || !runtimeConfig.KaiSchedulerEnabled {
+		return "", nil
+	}
+
+	queueName, err := DetermineKaiSchedulerQueue(ctx, annotations)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine kai-scheduler queue: %w", err)
+	}
+	return queueName, nil
+}
+
 func GenerateGrovePodCliqueSet(
 	ctx context.Context,
 	dynamoDeployment *v1beta1.DynamoGraphDeployment,
@@ -2372,18 +2387,9 @@ func GenerateGrovePodCliqueSet(
 	// specToGroveTopologyConstraint returns nil when input is nil, so this is a no-op without TAS.
 	gangSet.Spec.Template.TopologyConstraint = specToGroveTopologyConstraint(dynamoDeployment.Spec.TopologyConstraint)
 
-	if runtimeConfig.GroveEnabled && runtimeConfig.KaiSchedulerEnabled && runtimeConfig.VolcanoSchedulerEnabled {
-		return nil, fmt.Errorf("kai-scheduler and volcano scheduler integrations cannot both be enabled for Grove")
-	}
-
-	// Validate kai-scheduler queue once if kai-scheduler is enabled
-	var validatedQueueName string
-	if runtimeConfig.GroveEnabled && runtimeConfig.KaiSchedulerEnabled {
-		var err error
-		validatedQueueName, err = DetermineKaiSchedulerQueue(ctx, dynamoDeployment.Annotations)
-		if err != nil {
-			return nil, fmt.Errorf("failed to determine kai-scheduler queue: %w", err)
-		}
+	validatedQueueName, err := resolveGroveSchedulerQueue(ctx, dynamoDeployment.Annotations, runtimeConfig)
+	if err != nil {
+		return nil, err
 	}
 
 	discoveryBackend := controller_common.GetDiscoveryBackend(operatorConfig.Discovery.Backend, dynamoDeployment.Annotations)


### PR DESCRIPTION
## Overview:

Refactors Grove `PodCliqueSet` generation to resolve a `golangci-lint` cyclomatic-complexity failure. The change reduces the complexity of `GenerateGrovePodCliqueSet` while preserving its existing scheduler validation and queue-resolution behavior.

## Details:

- Extracted Grove scheduler validation and KAI Scheduler queue resolution into `resolveGroveSchedulerQueue`.
- Preserved the existing validation that prevents KAI Scheduler and Volcano from being enabled together for Grove.
- Preserved KAI Scheduler queue lookup and error wrapping.
- Reduced `GenerateGrovePodCliqueSet` below the configured `gocyclo` threshold.
- No functional behavior or API changes are intended.

## Where should the reviewer start?

Start with `deploy/operator/internal/dynamo/graph.go`:

- Review the new `resolveGroveSchedulerQueue` helper.
- Review its use in `GenerateGrovePodCliqueSet`.
- Confirm that the extracted conditions and errors match the previous inline implementation.

## Validation:

- `golangci-lint run --timeout=5m` passes.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for scheduler queue selection to prevent conflicting scheduler settings.
  * When KAI integration is disabled, queue selection now correctly returns no queue.
  * Queue resolution errors are now handled more consistently, helping avoid invalid pod clique setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->