### PR TITLE
perf(mocker): reduce offline replay coordinator overhead

### DIFF
--- a/lib/mocker/src/replay/offline/agg.rs
+++ b/lib/mocker/src/replay/offline/agg.rs
@@ -650,17 +650,18 @@ impl AggRuntime {
 
     /// Start passes on every idle worker that can make progress at the current timestamp.
     fn drive_ready_workers(&mut self) -> anyhow::Result<bool> {
-        let mut changed = false;
-        loop {
+        let mut requires_restart = false;
+        while self.engine.has_ready() {
             let effects = self
                 .engine
                 .drive_ready(self.now_ms, Some(&mut self.collector))?;
             if effects.is_empty() {
-                return Ok(changed);
+                return Ok(requires_restart);
             }
-            changed = true;
+            requires_restart |= !effects.immediate_completions.is_empty();
             self.handle_engine_effects(effects)?;
         }
+        Ok(requires_restart)
     }
 
     fn handle_engine_effects(&mut self, effects: EngineEffects) -> anyhow::Result<()> {
@@ -692,55 +693,76 @@ impl AggRuntime {
 
     /// Activate workers whose startup period has elapsed at the current timestamp.
     fn apply_worker_ready_events(&mut self) -> anyhow::Result<bool> {
-        let mut changed = false;
+        let mut consumed = false;
         while let Some((stage, worker_id)) = pop_ready_worker_ready(&mut self.events, self.now_ms) {
+            consumed = true;
             debug_assert_eq!(stage, SimulationWorkerStage::Aggregated);
-            if self.engine.mark_worker_ready(worker_id) {
-                if let Some(router) = self.router.as_mut() {
-                    router.add_worker(worker_id)?;
-                    // Drain any requests that were queued while all workers
-                    // were busy — the new worker may have capacity for them.
-                    let effects = router.try_drain_pending(self.now_ms)?;
-                    self.dispatch_router_admissions(effects.admissions)?;
-                }
-                changed = true;
+            if self.engine.mark_worker_ready(worker_id)
+                && let Some(router) = self.router.as_mut()
+            {
+                router.add_worker(worker_id)?;
+                // Drain any requests that were queued while all workers
+                // were busy — the new worker may have capacity for them.
+                let effects = router.try_drain_pending(self.now_ms)?;
+                self.dispatch_router_admissions(effects.admissions)?;
             }
             // If mark_worker_ready returned false the worker was cancelled
             // during startup (scale-down) — the stale event is silently ignored.
         }
-        Ok(changed)
+        Ok(consumed)
     }
 
     /// Repeatedly process all work that becomes possible without advancing logical time.
     fn drain_current_timestamp(&mut self) -> anyhow::Result<()> {
         loop {
-            #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
-            let mut changed = false;
             #[cfg(feature = "kvbm-offload")]
             {
-                changed |= self.tick_offload_engines()?;
+                self.tick_offload_engines()?;
+                // A scheduled completion can make a worker idle after the
+                // opening tick, so give KVBM one same-timestamp promotion
+                // chance. Any deeper transport chain must expose its next
+                // completion through earliest_offload_deadline(); the outer
+                // scheduler will then revisit that deadline rather than
+                // restarting every replay phase for each tick effect.
+                if self.apply_worker_completions()? {
+                    self.tick_offload_engines()?;
+                }
             }
-            changed |= self.apply_worker_completions()?;
-            changed |= self.apply_worker_ready_events()?;
-            changed |= self.release_ready_arrivals()?;
-            changed |= self.drive_ready_workers()?;
+            #[cfg(not(feature = "kvbm-offload"))]
+            self.apply_worker_completions()?;
+            let worker_ready_event = self.apply_worker_ready_events()?;
+            self.release_ready_arrivals()?;
+            let immediate_completion = self.drive_ready_workers()?;
             let removed = self.engine.try_remove_drained();
             if let Some(router) = self.router.as_mut() {
                 for worker_id in &removed {
                     router.finalize_worker_removal(*worker_id)?;
                 }
             }
-            changed |= !removed.is_empty();
             // Planner ticks fire LAST so the planner observes a fully settled
             // timestamp; any scaling it applies is picked up by the next iteration.
-            if self.planner_hook.is_some() {
-                changed |= self.apply_planner_ticks()?;
-            }
+            let planner_tick = self.planner_hook.is_some() && self.apply_planner_ticks()?;
+            // A later phase can uncover an earlier-phase event at the same
+            // timestamp because each pop helper only consumes the heap head
+            // when its event kind matches. Settle that event here instead of
+            // relying on the outer scheduler to advance by zero and re-enter.
+            let current_event_pending = worker_ready_event
+                && self
+                    .events
+                    .peek()
+                    .is_some_and(|event| event.at_ms == self.now_ms);
 
-            if !changed {
+            if !immediate_completion && !planner_tick && !current_event_pending {
                 break;
             }
         }
+
+        debug_assert!(
+            self.events
+                .peek()
+                .is_none_or(|event| event.at_ms != self.now_ms),
+            "aggregated replay left an event at the settled timestamp"
+        );
 
         Ok(())
     }
@@ -1099,6 +1121,67 @@ mod tests {
             }));
         }
         builder.build().unwrap()
+    }
+
+    #[test]
+    fn drain_current_timestamp_settles_interleaved_event_kinds() {
+        let pending = normalize_trace_requests(
+            vec![DirectRequest {
+                tokens: vec![1; 8],
+                max_output_tokens: 2,
+                uuid: Some(Uuid::from_u128(9_100)),
+                arrival_timestamp_ms: Some(0.0),
+                ..Default::default()
+            }],
+            1.0,
+        )
+        .unwrap();
+        let mut runtime = AggRuntime::new(
+            &parity_args(EngineType::Vllm),
+            None,
+            None,
+            pending,
+            1,
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        // Reserve sequence zero for a later-phase event that will sort ahead
+        // of the worker completion produced by the first pass.
+        runtime.next_event_seq = 1;
+        runtime.drain_current_timestamp().unwrap();
+        let completion_ms = runtime
+            .events
+            .peek()
+            .filter(|event| {
+                matches!(
+                    event.kind,
+                    super::super::events::SimulationEventKind::WorkerCompletion { .. }
+                )
+            })
+            .expect("initial pass must schedule a worker completion")
+            .at_ms;
+        assert!(completion_ms > runtime.now_ms);
+
+        runtime.events.push(SimulationEvent {
+            at_ms: completion_ms,
+            seq_no: 0,
+            kind: super::super::events::SimulationEventKind::WorkerReady {
+                stage: SimulationWorkerStage::Aggregated,
+                worker_id: usize::MAX,
+            },
+        });
+        runtime.advance_now_ms(completion_ms);
+        runtime.drain_current_timestamp().unwrap();
+
+        assert!(
+            runtime
+                .events
+                .peek()
+                .is_none_or(|event| event.at_ms != completion_ms),
+            "drain must consume the completion uncovered by WorkerReady"
+        );
     }
 
     fn parity_requests() -> Vec<DirectRequest> {

--- a/lib/mocker/src/replay/offline/components/engine.rs
+++ b/lib/mocker/src/replay/offline/components/engine.rs
@@ -25,6 +25,8 @@ pub(in crate::replay::offline) struct EngineComponent {
     pass_mode: EnginePassMode,
     /// Workers keyed by stable ID (monotonic, never reused).
     workers: BTreeMap<usize, OfflineWorkerState>,
+    /// Ready workers, ordered by the same stable ID used by `workers`.
+    ready_workers: BTreeSet<usize>,
     /// Counter for generating the next stable worker ID.
     next_id: usize,
     /// Workers marked for removal — skipped by round-robin, removed when drained.
@@ -45,10 +47,15 @@ impl EngineComponent {
     ) -> Self {
         let count = workers.len();
         let map: BTreeMap<usize, OfflineWorkerState> = workers.into_iter().enumerate().collect();
+        let ready_workers = map
+            .iter()
+            .filter_map(|(&worker_id, worker)| worker.is_ready().then_some(worker_id))
+            .collect();
         Self {
             stage,
             pass_mode,
             workers: map,
+            ready_workers,
             next_id: count,
             pending_removal: BTreeSet::new(),
             pending_startup: BTreeSet::new(),
@@ -67,12 +74,53 @@ impl EngineComponent {
         self.capture_kv_events = capture_kv_events;
     }
 
+    fn refresh_ready(&mut self, worker_id: usize) {
+        let is_ready = self
+            .workers
+            .get(&worker_id)
+            .is_some_and(OfflineWorkerState::is_ready);
+        if is_ready {
+            self.ready_workers.insert(worker_id);
+        } else {
+            self.ready_workers.remove(&worker_id);
+        }
+        #[cfg(debug_assertions)]
+        debug_assert_eq!(
+            self.ready_workers.contains(&worker_id),
+            is_ready,
+            "offline replay ready-worker index diverged for worker {worker_id}"
+        );
+        #[cfg(test)]
+        self.assert_ready_index();
+    }
+
+    #[cfg(test)]
+    fn assert_ready_index(&self) {
+        assert!(
+            self.workers.iter().all(
+                |(&worker_id, worker)| self.ready_workers.contains(&worker_id) == worker.is_ready()
+            ),
+            "offline replay ready-worker index diverged from worker state"
+        );
+        assert!(
+            self.ready_workers
+                .iter()
+                .all(|worker_id| self.workers.contains_key(worker_id)),
+            "offline replay ready-worker index contains an unknown worker"
+        );
+    }
+
+    pub(in crate::replay::offline) fn has_ready(&self) -> bool {
+        !self.ready_workers.is_empty()
+    }
+
     /// Add a new worker, returning its stable ID.
     pub(in crate::replay::offline) fn add_worker(&mut self) -> usize {
         let id = self.next_id;
         self.next_id += 1;
         let worker = OfflineWorkerState::new(id, self.args.clone(), self.capture_kv_events);
         self.workers.insert(id, worker);
+        self.refresh_ready(id);
         id
     }
 
@@ -101,7 +149,10 @@ impl EngineComponent {
         });
         for &id in &removed {
             self.workers.remove(&id);
+            self.ready_workers.remove(&id);
         }
+        #[cfg(test)]
+        self.assert_ready_index();
         removed
     }
 
@@ -147,6 +198,7 @@ impl EngineComponent {
             for &id in &to_cancel {
                 self.pending_startup.remove(&id);
                 self.workers.remove(&id);
+                self.ready_workers.remove(&id);
             }
 
             // Mark active workers for removal if more excess remains.
@@ -190,7 +242,10 @@ impl EngineComponent {
     /// was actually pending startup (and is now active), `false` if the worker
     /// was already cancelled or unknown (stale event).
     pub(in crate::replay::offline) fn mark_worker_ready(&mut self, worker_id: usize) -> bool {
-        self.pending_startup.remove(&worker_id) && self.workers.contains_key(&worker_id)
+        let marked_ready =
+            self.pending_startup.remove(&worker_id) && self.workers.contains_key(&worker_id);
+        self.refresh_ready(worker_id);
+        marked_ready
     }
 
     pub(in crate::replay::offline) fn dispatch(
@@ -203,6 +258,7 @@ impl EngineComponent {
             .get_mut(&worker_id)
             .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?;
         worker.receive_request(request);
+        self.refresh_ready(worker_id);
         Ok(())
     }
 
@@ -211,11 +267,13 @@ impl EngineComponent {
         worker_id: usize,
         command: SchedulerCommand,
     ) -> anyhow::Result<SchedulerCommandEffects> {
-        let worker = self
+        let result = self
             .workers
             .get_mut(&worker_id)
-            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?;
-        worker.apply_command(command)
+            .ok_or_else(|| anyhow::anyhow!("offline replay selected unknown worker {worker_id}"))?
+            .apply_command(command);
+        self.refresh_ready(worker_id);
+        result
     }
 
     pub(in crate::replay::offline) fn worker_is_busy(
@@ -234,16 +292,29 @@ impl EngineComponent {
         now_ms: f64,
         mut collector: Option<&mut TraceCollector>,
     ) -> anyhow::Result<EngineEffects> {
-        for (&worker_id, worker) in self.workers.iter_mut() {
-            if !worker.is_ready() {
+        if self.pass_mode == EnginePassMode::Visible && collector.is_none() && self.has_ready() {
+            bail!("offline replay visible engine pass requires a collector");
+        }
+
+        // Effect-free zero-duration passes must not prevent a later ready
+        // worker from running, but retrying one immediately would tight-spin.
+        // Withhold them for this attempt and restore them before returning.
+        let mut stalled_workers = Vec::new();
+        while let Some(worker_id) = self.ready_workers.pop_first() {
+            let Some(worker) = self.workers.get_mut(&worker_id) else {
+                debug_assert!(
+                    false,
+                    "ready-worker index referenced unknown worker {worker_id}"
+                );
                 continue;
-            }
+            };
+            debug_assert!(worker.is_ready());
 
             let executed = match self.pass_mode {
                 EnginePassMode::Visible => {
-                    let Some(collector) = collector.as_deref_mut() else {
-                        bail!("offline replay visible engine pass requires a collector");
-                    };
+                    let collector = collector
+                        .as_deref_mut()
+                        .expect("visible pass collector checked before ready-worker selection");
                     worker.execute_pass(collector, now_ms)
                 }
                 EnginePassMode::Hidden => worker.execute_hidden_pass(now_ms),
@@ -294,9 +365,16 @@ impl EngineComponent {
                         .iter()
                         .any(|(_, snapshot)| fpm_has_scheduled_work(snapshot));
                 if !made_progress {
+                    if worker.is_ready() {
+                        stalled_workers.push(worker_id);
+                    }
                     continue;
                 }
                 effects.immediate_completions.push(payload);
+                for stalled_id in stalled_workers {
+                    self.ready_workers.insert(stalled_id);
+                }
+                self.refresh_ready(worker_id);
                 return Ok(effects);
             }
 
@@ -307,9 +385,18 @@ impl EngineComponent {
                     at_ms: executed.end_ms,
                     payload,
                 });
+            for stalled_id in stalled_workers {
+                self.ready_workers.insert(stalled_id);
+            }
+            self.refresh_ready(worker_id);
             return Ok(effects);
         }
 
+        for worker_id in stalled_workers {
+            self.ready_workers.insert(worker_id);
+        }
+        #[cfg(test)]
+        self.assert_ready_index();
         Ok(EngineEffects::default())
     }
 
@@ -324,11 +411,9 @@ impl EngineComponent {
                 payload.stage
             );
         }
-        let worker = self.workers.get_mut(&payload.worker_idx).ok_or_else(|| {
-            anyhow::anyhow!(
-                "offline replay completion for unknown worker {}",
-                payload.worker_idx
-            )
+        let worker_id = payload.worker_idx;
+        let worker = self.workers.get_mut(&worker_id).ok_or_else(|| {
+            anyhow::anyhow!("offline replay completion for unknown worker {}", worker_id)
         })?;
         worker.mark_idle();
         worker.mark_completed(payload.completed_requests);
@@ -337,6 +422,7 @@ impl EngineComponent {
             .lifecycle_events
             .extend(worker.retry_pending_destinations());
         payload.kv_events.extend(worker.drain_kv_events());
+        self.refresh_ready(worker_id);
         Ok(payload)
     }
 
@@ -372,18 +458,44 @@ impl EngineComponent {
             kv_events: Vec::new(),
             lifecycle_events: Vec::new(),
         };
-        for worker in self.workers.values_mut() {
+        let (workers, ready_workers) = (&mut self.workers, &mut self.ready_workers);
+        for (&worker_id, worker) in workers.iter_mut() {
             let worker_effects = if worker.is_busy() {
                 worker.tick_offload_transport_only(now_ms)
             } else {
                 worker.tick_offload_only(now_ms)
             };
+            if worker.is_ready() {
+                ready_workers.insert(worker_id);
+            } else {
+                ready_workers.remove(&worker_id);
+            }
             effects.kv_events.extend(worker_effects.kv_events);
             effects
                 .lifecycle_events
                 .extend(worker_effects.lifecycle_events);
         }
+        #[cfg(test)]
+        self.assert_ready_index();
         effects
+    }
+
+    #[cfg(all(test, feature = "kvbm-offload"))]
+    fn mark_worker_idle_for_test(&mut self, worker_id: usize) {
+        self.workers
+            .get_mut(&worker_id)
+            .expect("test worker must exist")
+            .mark_idle();
+        self.refresh_ready(worker_id);
+    }
+
+    #[cfg(all(test, feature = "kvbm-offload"))]
+    fn mark_worker_busy_for_test(&mut self, worker_id: usize) {
+        self.workers
+            .get_mut(&worker_id)
+            .expect("test worker must exist")
+            .mark_busy();
+        self.refresh_ready(worker_id);
     }
 
     #[cfg(test)]
@@ -432,6 +544,88 @@ mod tests {
         }
         assert_eq!(effects.scheduled_completions.len(), 1);
         effects.scheduled_completions.pop().unwrap().payload
+    }
+
+    #[test]
+    fn ready_worker_set_takes_stable_lowest_id_across_holes() {
+        let mut ready = BTreeSet::new();
+        assert!(ready.is_empty());
+        assert!(ready.insert(130));
+        assert!(ready.insert(64));
+        assert!(ready.insert(3));
+        assert!(!ready.insert(64));
+        assert!(ready.contains(&130));
+        assert!(ready.remove(&64));
+        assert!(!ready.remove(&64));
+        assert_eq!(ready.pop_first(), Some(3));
+        assert_eq!(ready.pop_first(), Some(130));
+        assert_eq!(ready.pop_first(), None);
+        assert!(ready.is_empty());
+    }
+
+    #[test]
+    fn ready_index_preserves_worker_order() {
+        let mut engine = engine_with_startup(2, None);
+        for worker_id in 0..2 {
+            engine
+                .dispatch(
+                    worker_id,
+                    DirectRequest {
+                        tokens: vec![worker_id as u32 + 1; 4],
+                        max_output_tokens: 1,
+                        uuid: Some(Uuid::from_u128(worker_id as u128 + 1)),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+        let mut collector = TraceCollector::default();
+        let first = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        assert_eq!(take_only_completion(first).worker_idx, 0);
+        let second = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        assert_eq!(take_only_completion(second).worker_idx, 1);
+    }
+
+    #[test]
+    fn stalled_worker_does_not_hide_later_productive_worker() {
+        let stalled_args = MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(16)
+            .max_num_batched_tokens(Some(4))
+            .max_num_seqs(Some(1))
+            .enable_chunked_prefill(false)
+            .worker_type(WorkerType::Decode)
+            .build()
+            .unwrap();
+        let productive_args = MockEngineArgs {
+            enable_chunked_prefill: true,
+            ..stalled_args.clone()
+        };
+        let mut engine = EngineComponent::new(
+            SimulationWorkerStage::Decode,
+            EnginePassMode::Visible,
+            vec![
+                OfflineWorkerState::new(0, stalled_args, false),
+                OfflineWorkerState::new(1, productive_args, false),
+            ],
+        );
+        for worker_id in 0..2 {
+            engine
+                .dispatch(
+                    worker_id,
+                    DirectRequest {
+                        tokens: vec![1; 8],
+                        max_output_tokens: 1,
+                        uuid: Some(Uuid::from_u128(worker_id as u128 + 10)),
+                        ..Default::default()
+                    },
+                )
+                .unwrap();
+        }
+        let mut collector = TraceCollector::default();
+        let effects = engine.drive_ready(0.0, Some(&mut collector)).unwrap();
+        assert_eq!(take_only_completion(effects).worker_idx, 1);
+        assert!(engine.ready_workers.contains(&0));
     }
 
     fn decode_engine_with_chunking(enable_chunked_prefill: bool) -> EngineComponent {
@@ -814,7 +1008,7 @@ mod tests {
         });
         // Model a reservation attempt at the t=0 boundary, before the GPU
         // compute interval becomes externally busy.
-        engine.workers.get_mut(&0).unwrap().mark_idle();
+        engine.mark_worker_idle_for_test(0);
 
         let handoff_id = HandoffId::from(Uuid::from_u128(102));
         let reserve = engine
@@ -837,7 +1031,7 @@ mod tests {
             .expect("reservation eviction should start G1 to G2 DMA");
         assert!((deadline - 20.0).abs() < 0.01);
 
-        engine.workers.get_mut(&0).unwrap().mark_busy();
+        engine.mark_worker_busy_for_test(0);
         assert_eq!(engine.earliest_offload_deadline(), Some(deadline));
         let transport = engine.tick_offload_engines(deadline);
         assert!(transport.lifecycle_events.is_empty());

--- a/lib/mocker/src/replay/offline/disagg.rs
+++ b/lib/mocker/src/replay/offline/disagg.rs
@@ -1537,15 +1537,15 @@ impl DisaggRuntime {
 
     /// Drain transfer completions scheduled for the current logical timestamp.
     fn apply_transfer_completions(&mut self) -> Result<bool> {
-        let mut changed = false;
+        let mut consumed = false;
         while let Some(handoff_id) = pop_ready_transfer_complete(&mut self.events, self.now_ms) {
+            consumed = true;
             let Some(uuid) = self.requests_by_handoff.get(&handoff_id).copied() else {
                 continue;
             };
             self.apply_handoff_fact(uuid, HandoffFact::TransferCompleted { handoff_id })?;
-            changed = true;
         }
-        Ok(changed)
+        Ok(consumed)
     }
 
     /// Release every admission made ready by the shared admission queue.
@@ -1576,30 +1576,32 @@ impl DisaggRuntime {
 
     /// Start passes on every idle prefill worker that can make progress at the current timestamp.
     fn drive_prefill_workers(&mut self) -> Result<bool> {
-        let mut changed = false;
-        loop {
+        let mut requires_restart = false;
+        while self.prefill_engine.has_ready() {
             let effects = self.prefill_engine.drive_ready(self.now_ms, None)?;
             if effects.is_empty() {
-                return Ok(changed);
+                return Ok(requires_restart);
             }
-            changed = true;
+            requires_restart |= !effects.immediate_completions.is_empty();
             self.handle_prefill_engine_effects(effects)?;
         }
+        Ok(requires_restart)
     }
 
     /// Start passes on every idle decode worker that can make progress at the current timestamp.
     fn drive_decode_workers(&mut self) -> Result<bool> {
-        let mut changed = false;
-        loop {
+        let mut requires_restart = false;
+        while self.decode_engine.has_ready() {
             let effects = self
                 .decode_engine
                 .drive_ready(self.now_ms, Some(&mut self.collector))?;
             if effects.is_empty() {
-                return Ok(changed);
+                return Ok(requires_restart);
             }
-            changed = true;
+            requires_restart |= !effects.immediate_completions.is_empty();
             self.handle_decode_engine_effects(effects)?;
         }
+        Ok(requires_restart)
     }
 
     fn handle_prefill_engine_effects(&mut self, effects: EngineEffects) -> Result<()> {
@@ -1694,8 +1696,9 @@ impl DisaggRuntime {
 
     /// Activate workers whose startup period has elapsed at the current timestamp.
     fn apply_worker_ready_events(&mut self) -> Result<bool> {
-        let mut changed = false;
+        let mut consumed = false;
         while let Some((stage, worker_id)) = pop_ready_worker_ready(&mut self.events, self.now_ms) {
+            consumed = true;
             match stage {
                 SimulationWorkerStage::Prefill => {
                     if self.prefill_engine.mark_worker_ready(worker_id) {
@@ -1705,7 +1708,6 @@ impl DisaggRuntime {
                             self.dispatch_prefill_admissions(effects.admissions)?;
                         }
                         self.wake_worker_waiters(SimulationWorkerStage::Prefill);
-                        changed = true;
                     }
                 }
                 SimulationWorkerStage::Decode => {
@@ -1716,7 +1718,6 @@ impl DisaggRuntime {
                             self.dispatch_decode_admissions(effects.admissions)?;
                         }
                         self.wake_worker_waiters(SimulationWorkerStage::Decode);
-                        changed = true;
                     }
                 }
                 SimulationWorkerStage::Aggregated => {
@@ -1724,50 +1725,79 @@ impl DisaggRuntime {
                 }
             }
         }
-        Ok(changed)
+        Ok(consumed)
     }
 
     /// Repeatedly process all work that becomes possible without advancing logical time.
     fn drain_current_timestamp(&mut self) -> Result<()> {
         loop {
-            #[cfg_attr(not(feature = "kvbm-offload"), allow(unused_mut))]
-            let mut changed = self.prune_stale_transfer_events();
+            self.prune_stale_transfer_events();
             #[cfg(feature = "kvbm-offload")]
             {
-                changed |= self.tick_offload_engines()?;
+                self.tick_offload_engines()?;
+                // A scheduled completion can make a worker idle after the
+                // opening tick, so promote newly available KVBM work before
+                // the later action and drive phases run. Any deeper transport
+                // chain must expose its next completion through
+                // earliest_offload_deadline(); the outer scheduler will then
+                // revisit that deadline without restarting every replay phase.
+                if self.apply_worker_completions()? {
+                    self.tick_offload_engines()?;
+                }
             }
-            changed |= self.apply_worker_completions()?;
-            changed |= self.apply_worker_ready_events()?;
-            changed |= self.apply_transfer_completions()?;
-            changed |= self.release_ready_arrivals()?;
-            changed |= self.drive_pending_actions()?;
-            changed |= self.drive_prefill_workers()?;
-            changed |= self.drive_decode_workers()?;
+            #[cfg(not(feature = "kvbm-offload"))]
+            self.apply_worker_completions()?;
+            let worker_ready_event = self.apply_worker_ready_events()?;
+            let transfer_completion = self.apply_transfer_completions()?;
+            self.release_ready_arrivals()?;
+            let pending_action_applied = self.drive_pending_actions()?;
+            let prefill_immediate_completion = self.drive_prefill_workers()?;
+            let decode_immediate_completion = self.drive_decode_workers()?;
+            let immediate_completion = prefill_immediate_completion || decode_immediate_completion;
             let removed_prefill = self.prefill_engine.try_remove_drained();
             if let Some(router) = self.prefill_router.as_mut() {
                 for worker_id in &removed_prefill {
                     router.finalize_worker_removal(*worker_id)?;
                 }
             }
-            changed |= !removed_prefill.is_empty();
             let removed_decode = self.decode_engine.try_remove_drained();
             if let Some(router) = self.decode_router.as_mut() {
                 for worker_id in &removed_decode {
                     router.finalize_worker_removal(*worker_id)?;
                 }
             }
-            changed |= !removed_decode.is_empty();
             // Planner ticks fire LAST so the planner observes a fully settled
             // timestamp (matching the old advance-then-tick ordering). Any scaling
             // it applies is picked up by the next loop iteration.
-            if self.planner_hook.is_some() {
-                changed |= self.apply_planner_ticks()?;
-            }
+            let planner_tick = self.planner_hook.is_some() && self.apply_planner_ticks()?;
+            // Lifecycle processing above can retire a transfer after the opening
+            // prune. Remove the now-stale event directly instead of restarting
+            // every phase solely for cleanup.
+            let stale_transfer_pruned = self.prune_stale_transfer_events();
+            // A later phase can uncover an earlier-phase event at the same
+            // timestamp because each pop helper only consumes the heap head
+            // when its event kind matches. Settle that event here instead of
+            // relying on the outer scheduler to advance by zero and re-enter.
+            let later_phase_changed = worker_ready_event
+                || transfer_completion
+                || pending_action_applied
+                || stale_transfer_pruned;
+            let current_event_pending = later_phase_changed
+                && self
+                    .events
+                    .peek()
+                    .is_some_and(|event| event.at_ms == self.now_ms);
 
-            if !changed {
+            if !immediate_completion && !planner_tick && !current_event_pending {
                 break;
             }
         }
+        debug_assert!(
+            self.events
+                .peek()
+                .is_none_or(|event| event.at_ms != self.now_ms),
+            "disaggregated replay left an event at the settled timestamp"
+        );
         Ok(())
     }
 
@@ -2224,6 +2254,92 @@ fn derive_decode_router_config(
     config.router_track_prefill_tokens = false;
     config.router_prefill_load_model = dynamo_kv_router::config::RouterPrefillLoadModel::None;
     config
+}
+
+#[cfg(test)]
+mod phase_loop_tests {
+    use super::super::events::SimulationEventKind;
+    use super::*;
+    use crate::common::protocols::WorkerType;
+
+    fn args(worker_type: WorkerType) -> MockEngineArgs {
+        MockEngineArgs::builder()
+            .block_size(4)
+            .num_gpu_blocks(64)
+            .max_num_batched_tokens(Some(16))
+            .max_num_seqs(Some(2))
+            .enable_prefix_caching(false)
+            .enable_chunked_prefill(true)
+            .speedup_ratio(1.0)
+            .decode_speedup_ratio(1.0)
+            .worker_type(worker_type)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn drain_current_timestamp_settles_interleaved_event_kinds() {
+        let config = OfflineDisaggReplayConfig {
+            prefill_args: args(WorkerType::Prefill),
+            decode_args: args(WorkerType::Decode),
+            num_prefill_workers: 1,
+            num_decode_workers: 1,
+        };
+        let mut runtime = DisaggRuntime::new(
+            &config,
+            None,
+            None,
+            VecDeque::from([DirectRequest {
+                tokens: vec![1; 8],
+                max_output_tokens: 2,
+                uuid: Some(Uuid::from_u128(9_200)),
+                arrival_timestamp_ms: Some(0.0),
+                ..Default::default()
+            }]),
+            ReplayMode::Trace,
+            ReplayRouterMode::RoundRobin,
+        )
+        .unwrap();
+
+        // Reserve sequence zero for a later-phase event that will sort ahead
+        // of the prefill completion produced by the first pass.
+        runtime.next_event_seq = 1;
+        runtime.drain_current_timestamp().unwrap();
+        let completion_ms = runtime
+            .events
+            .peek()
+            .filter(|event| {
+                matches!(
+                    event.kind,
+                    SimulationEventKind::WorkerCompletion {
+                        stage: SimulationWorkerStage::Prefill,
+                        ..
+                    }
+                )
+            })
+            .expect("initial prefill pass must schedule a worker completion")
+            .at_ms;
+        assert!(completion_ms > runtime.now_ms);
+
+        runtime.events.push(SimulationEvent {
+            at_ms: completion_ms,
+            seq_no: 0,
+            kind: SimulationEventKind::WorkerReady {
+                stage: SimulationWorkerStage::Prefill,
+                worker_id: usize::MAX,
+            },
+        });
+        runtime.advance_now_ms(completion_ms);
+        runtime.drain_current_timestamp().unwrap();
+
+        assert!(
+            runtime
+                .events
+                .peek()
+                .is_none_or(|event| event.at_ms != completion_ms),
+            "drain must consume the completion uncovered by WorkerReady"
+        );
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- replace repeated offline-worker readiness scans with an ordered `BTreeSet`, preserving deterministic lowest-worker-ID execution and zero-duration behavior
- fully settle interleaved same-timestamp events without redundant phase-loop restarts
- keep exhaustive ready-index validation test-only and document the KVBM wakeup/deadline contract

## Performance

Using one warm-up and three measured runs pinned to CPU 0:

- saturated shard-0 KV-router exemplar, 128 aggregate vLLM workers, replay concurrency 8192: 34.033M to 37.871M processed tokens/s (**+11.28%**)
- two-worker timestamped KV-router control: 40.853M to 40.592M processed tokens/s (**-0.64%**)

Summary request and token totals matched the baseline.

## Validation

- `cargo test -p dynamo-mocker replay::offline` (146 passed)
- `cargo test -p dynamo-mocker --features kvbm-offload replay::offline` (148 passed)
- `cargo clippy -p dynamo-mocker --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `pre-commit run --all-files`
