### PR TITLE
fix(container): install zstandard in sglang runtime image (DYN-3398)

### DIFF
--- a/container/deps/requirements.sglang.txt
+++ b/container/deps/requirements.sglang.txt
@@ -11,3 +11,4 @@
 
 blake3>=1.0.0,<2.0.0  # Dynamo SGLang multimodal request handlers import blake3 at startup
 imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive at top of file
+zstandard==0.23.0


### PR DESCRIPTION
## Overview:

The sglang-runtime image is missing the `zstandard` package, so the RL metadata upload path (#10034) fails at import time with `ModuleNotFoundError: No module named 'zstandard'` (NVBug 6418636 / DYN-3398).

## Details:

`container/templates/sglang_runtime.Dockerfile` installs everything `--no-deps`: the `ai_dynamo` wheels (L105-107), a cherry-picked `nvtx` from requirements.common.txt (L149-152), and `requirements.sglang.txt` (L159-163). Nothing transitive is ever resolved, so any core dependency not listed explicitly in `requirements.sglang.txt` is absent from the image -- and `zstandard` (declared in `pyproject.toml` and pinned in `requirements.common.txt`) was not listed. `components/src/dynamo/common/metadata_upload.py` imports it and raises `RuntimeError("Metadata upload requires zstandard. ...")`, making metadata upload non-functional in the official image.

This adds the single missing line to `container/deps/requirements.sglang.txt`, keeping the exact `zstandard==0.23.0` pin from `requirements.common.txt:44` to avoid SBOM drift. No Dockerfile, common-requirements, or runtime-code changes.

Validated by replaying the Dockerfile's exact `--no-deps` install sequence in a clean python:3.12 container: before the change `import zstandard` fails exactly as reported; with it, `zstandard 0.23.0 OK`. Fix produced by the gated agentic-fix pipeline (repro proven and validation independently re-run on a disposable instance) and operator-reviewed before this PR.

## Where should the reviewer start?

`container/deps/requirements.sglang.txt` -- the one-line diff -- and `container/templates/sglang_runtime.Dockerfile:159-163` for the `--no-deps` semantics that make the explicit listing necessary.

## Related Issues

Relates to internal trackers DYN-3398 / NVBug 6418636 (no public GitHub issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new pinned dependency to improve environment consistency and ensure reliable installs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->