### PR TITLE
fix(multimodal): thread trust_remote_code from engine config instead of hardcoding True (#10738)

### DIFF
--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -95,7 +95,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
 
         # Load tokenizer to convert image token string to integer ID
         self.tokenizer = AutoTokenizer.from_pretrained(
-            self.model, trust_remote_code=True
+            self.model, trust_remote_code=config.server_args.trust_remote_code
         )
 
         # Get image/video token strings and resolve them to integer IDs

--- a/components/src/dynamo/trtllm/engine.py
+++ b/components/src/dynamo/trtllm/engine.py
@@ -10,7 +10,7 @@ from typing import Any, Optional
 
 from tensorrt_llm import LLM, MultimodalEncoder
 from tensorrt_llm.llmapi.llm import BaseLLM
-from transformers import AutoConfig
+from transformers import PretrainedConfig
 
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.engine_monitor import TrtllmEngineMonitor
@@ -78,7 +78,7 @@ class TensorRTLLMEngine:
 
                 # Skip MultimodalEncoder for architectures that handle vision
                 # encoding inside the main model (e.g. Llama4).
-                if self._is_unsupported_encoder_arch(model):  # type: ignore
+                if self._is_unsupported_encoder_arch(model):  # type: ignore[arg-type]
                     return
 
                 max_batch_size = self.engine_args.get("max_batch_size", 1)
@@ -208,8 +208,8 @@ class TensorRTLLMEngine:
         """Return True if *model_path*'s architecture is not supported by
         TRT-LLM's standalone MultimodalEncoder."""
         try:
-            config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
-            archs = getattr(config, "architectures", None) or []
+            config, _ = PretrainedConfig.get_config_dict(model_path)
+            archs = config.get("architectures") or []
             return any(a in _UNSUPPORTED_STANDALONE_ENCODER_ARCHS for a in archs)
         except Exception:
             return False

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -440,7 +440,10 @@ async def init_llm_worker(
 
     if config.modality == Modality.MULTIMODAL:
         engine_args["skip_tokenizer_init"] = False
-        model_config = AutoConfig.from_pretrained(config.model, trust_remote_code=True)
+        model_config = AutoConfig.from_pretrained(
+            config.model,
+            trust_remote_code=engine_args.get("trust_remote_code", False),
+        )
         multimodal_processor = MultimodalRequestProcessor(
             model_type=model_config.model_type,
             model_dir=config.model,

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3558,7 +3558,10 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         # Cache Qwen VL grid parameters for computing image_grid_thw from
         # PIL images in the P/D path (no separate encode worker).
         if resolve_model_family(config.model) is ModelFamily.QWEN_VL:
-            self._qwen_grid_params = load_qwen_grid_params(config.model)
+            self._qwen_grid_params = load_qwen_grid_params(
+                config.model,
+                trust_remote_code=config.engine_args.trust_remote_code,
+            )
             if self._qwen_grid_params is None and self.embedding_loader is None:
                 logger.error(
                     "Qwen VL grid params failed to load and no encode worker "

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -64,10 +64,12 @@ class EncodeWorkerHandler:
 
         self.image_loader = ImageLoader(cache_size=CACHE_SIZE_MAXIMUM)
         self.image_processor = AutoImageProcessor.from_pretrained(
-            self.model, trust_remote_code=True
+            self.model, trust_remote_code=self.engine_args.trust_remote_code
         )
         self.vision_model = load_vision_model(
-            self.model, enforce_eager=self.engine_args.enforce_eager
+            self.model,
+            enforce_eager=self.engine_args.enforce_eager,
+            trust_remote_code=self.engine_args.trust_remote_code,
         )
         hidden_size = getattr(self.vision_model, "out_hidden_size", None)
         if hidden_size is None:

--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -155,7 +155,9 @@ def resolve_model_family(model_name: str) -> Optional[ModelFamily]:
     return None
 
 
-def load_vision_model(model_id: str, enforce_eager: bool = False) -> torch.nn.Module:
+def load_vision_model(
+    model_id: str, enforce_eager: bool = False, trust_remote_code: bool = False
+) -> torch.nn.Module:
     """
     Load a vision model from a HuggingFace model ID.
     """
@@ -173,6 +175,7 @@ def load_vision_model(model_id: str, enforce_eager: bool = False) -> torch.nn.Mo
         vllm_model = LLM(
             model=model_id,
             enforce_eager=enforce_eager,
+            trust_remote_code=trust_remote_code,
             # vLLM's free-memory precheck runs before kv_cache_memory_bytes applies;
             # default 0.9 fails on <=24 GiB GPUs when another worker shares the device.
             gpu_memory_utilization=0.2,
@@ -187,7 +190,10 @@ def load_vision_model(model_id: str, enforce_eager: bool = False) -> torch.nn.Mo
             vllm_model.llm_engine.engine_core.engine_core.model_executor.driver_worker.worker.model_runner.model.visual
         )
     return AutoModel.from_pretrained(
-        model_id, device_map="auto", torch_dtype=torch.float16, trust_remote_code=True
+        model_id,
+        device_map="auto",
+        torch_dtype=torch.float16,
+        trust_remote_code=trust_remote_code,
     )
 
 

--- a/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
+++ b/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
@@ -25,7 +25,9 @@ class QwenGridParams:
     vision_hidden_dim: int
 
 
-def load_qwen_grid_params(model_name: str) -> QwenGridParams | None:
+def load_qwen_grid_params(
+    model_name: str, trust_remote_code: bool = False
+) -> QwenGridParams | None:
     """Load Qwen VL grid parameters from model config.
 
     Reads AutoImageProcessor and vision_config at init time so that
@@ -35,10 +37,10 @@ def load_qwen_grid_params(model_name: str) -> QwenGridParams | None:
     """
     try:
         processor = AutoImageProcessor.from_pretrained(
-            model_name, trust_remote_code=True
+            model_name, trust_remote_code=trust_remote_code
         )
         vision_config = AutoConfig.from_pretrained(
-            model_name, trust_remote_code=True
+            model_name, trust_remote_code=trust_remote_code
         ).vision_config
 
         patch_size: int = processor.patch_size

--- a/components/src/dynamo/vllm/omni/audio_handler.py
+++ b/components/src/dynamo/vllm/omni/audio_handler.py
@@ -389,7 +389,7 @@ class AudioGenerationHandler:
 
                 self._tts_tokenizer = AutoTokenizer.from_pretrained(
                     self.config.model,
-                    trust_remote_code=True,
+                    trust_remote_code=self.config.engine_args.trust_remote_code,
                     padding_side="left",
                 )
 

--- a/examples/backends/trtllm/mm_router_worker/mm_processor.py
+++ b/examples/backends/trtllm/mm_router_worker/mm_processor.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from tensorrt_llm.inputs.multimodal import apply_mm_hashes
 from tensorrt_llm.inputs.utils import load_image
-from transformers import AutoConfig
+from transformers import PretrainedConfig
 
 logger = logging.getLogger(__name__)
 
@@ -253,15 +253,15 @@ def _get_replacement_id(model_path: str) -> int:
     """
 
     try:
-        config = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+        config, _ = PretrainedConfig.get_config_dict(model_path)
         # Some models (e.g. Qwen3-VL) store vocab_size in text_config, not top-level.
-        vocab_size = getattr(config, "vocab_size", None)
-        if vocab_size is None and hasattr(config, "text_config"):
-            vocab_size = getattr(config.text_config, "vocab_size", None)
+        vocab_size = config.get("vocab_size")
+        if vocab_size is None:
+            vocab_size = config.get("text_config", {}).get("vocab_size")
         if vocab_size is None:
             raise AttributeError("vocab_size not found in config or config.text_config")
         replacement_id = vocab_size + 1
-        logger.info(f"Got vocab_size={vocab_size} from AutoConfig")
+        logger.info(f"Got vocab_size={vocab_size} from config.json")
         return replacement_id
     except Exception as e:
         raise RuntimeError(

--- a/examples/backends/trtllm/mm_router_worker/mm_router_worker.py
+++ b/examples/backends/trtllm/mm_router_worker/mm_router_worker.py
@@ -102,6 +102,11 @@ def parse_args() -> argparse.Namespace:
         default="generate",
         help="Downstream TRT-LLM workers' endpoint name",
     )
+    parser.add_argument(
+        "--trust-remote-code",
+        action="store_true",
+        help="Allow loading model repos that execute custom code (HF trust_remote_code). Off by default.",
+    )
 
     return parser.parse_args()
 
@@ -159,12 +164,14 @@ async def worker(runtime: DistributedRuntime) -> None:
 
     # Initialize tokenizer and processor for MM processing
     logger.info(f"Loading tokenizer from {args.model}...")
-    tokenizer = tokenizer_factory(args.model)
+    tokenizer = tokenizer_factory(args.model, trust_remote_code=args.trust_remote_code)
 
     processor = None
     try:
         logger.info(f"Loading HuggingFace processor from {args.model}...")
-        processor = AutoProcessor.from_pretrained(args.model, trust_remote_code=True)
+        processor = AutoProcessor.from_pretrained(
+            args.model, trust_remote_code=args.trust_remote_code
+        )
     except Exception as e:
         logger.warning(f"Failed to load HF processor: {e}")
         logger.warning("Visual token expansion will not be available")


### PR DESCRIPTION
Cherry-pick of #10738 to `release/1.3.0`.

## Summary

Multimodal/encode workers hardcoded `trust_remote_code=True` when loading HF processors / tokenizers / configs, forcing custom remote code to execute on model load regardless of the operator's engine setting (CWE-829). This threads the value from each engine's own `trust_remote_code` (vLLM `engine_args`, SGLang `server_args`, TRT-LLM `arg_map`), defaulting to `False` — matching each engine's native default.

## Backport note

`release/1.3.0` predates the main-only multimodal request-processor refactor (#11266), so `request_processor.py` does not exist on this branch. The fix is threaded into 1.3.0's inline `load_qwen_grid_params(config.model, trust_remote_code=...)` call in `handlers.py` instead. All other load sites are byte-identical to the main change. No behavior difference; the refactor scaffolding is intentionally not pulled in.

## Compatibility

No change for deployments that need remote code — those already enable the engine flag, which now flows through to the multimodal sites. The only change is that workers no longer force it on when the operator did not ask.

## Validation

- `python -m py_compile` on all changed files.
- No hardcoded `trust_remote_code=True` remaining in `components/` or `examples/`.
- Framework integration tests run in CI.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11366" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->