### PR TITLE
fix(snapshot): preserve CUDA ordinal mapping for DRA GPUs (#11325) [release/1.3.0]

### DIFF
--- a/deploy/snapshot/internal/cuda/cuda.go
+++ b/deploy/snapshot/internal/cuda/cuda.go
@@ -3,6 +3,7 @@ package cuda
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os/exec"
 	"regexp"
@@ -104,43 +105,126 @@ func GetGPUUUIDsViaNvidiaSmi(ctx context.Context, hostProcPath string, pid int) 
 	return uuids, nil
 }
 
-// DiscoverGPUUUIDs resolves GPU UUIDs according to the pod's allocation mode:
-// DRA-backed pods use the DRA API, classic nvidia.com/gpu pods use PodResources,
-// and nvidia-smi remains the last fallback for either path.
+type visibleGPUDiscovery func(context.Context, string, int) ([]string, error)
+
+// DiscoverGPUUUIDs resolves GPU UUIDs in the container's runtime ordinal order.
 func DiscoverGPUUUIDs(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName, hostProcPath string, pid int, log logr.Logger) ([]string, error) {
-	gpuUUIDs, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, clientset, podName, podNamespace, log)
-	fallbackReason := "DRA API returned no GPU UUIDs"
+	return discoverGPUUUIDs(
+		ctx,
+		clientset,
+		podName,
+		podNamespace,
+		containerName,
+		hostProcPath,
+		pid,
+		GetGPUUUIDsViaNvidiaSmi,
+		log,
+	)
+}
+
+func discoverGPUUUIDs(
+	ctx context.Context,
+	clientset kubernetes.Interface,
+	podName,
+	podNamespace,
+	containerName,
+	hostProcPath string,
+	pid int,
+	discoverVisibleGPUs visibleGPUDiscovery,
+	log logr.Logger,
+) ([]string, error) {
+	gpuUUIDs, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, clientset, podName, podNamespace, containerName, log)
 	if err != nil {
+		if hasNVIDIADRAAllocation {
+			return nil, fmt.Errorf("DRA GPU UUID lookup failed: %w", err)
+		}
 		log.Error(
 			err,
 			"DRA API GPU UUID lookup failed, trying other discovery paths",
 			"pod", podNamespace+"/"+podName,
-			"has_nvidia_dra_allocation", hasNVIDIADRAAllocation,
 		)
 		gpuUUIDs = nil
-		fallbackReason = "DRA API GPU UUID lookup failed"
+	}
+
+	if hasNVIDIADRAAllocation {
+		if len(gpuUUIDs) == 0 {
+			return nil, errors.New(
+				"DRA GPU allocation has no resolvable UUIDs",
+			)
+		}
+		visibleGPUUUIDs, err := discoverVisibleGPUs(ctx, hostProcPath, pid)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"discover DRA GPUs in container ordinal order: %w",
+				err,
+			)
+		}
+		orderedUUIDs, err := orderDRAUUIDsByRuntime(gpuUUIDs, visibleGPUUUIDs)
+		if err != nil {
+			return nil, err
+		}
+		log.Info(
+			"resolved DRA GPU UUIDs in container ordinal order",
+			"uuids", orderedUUIDs,
+		)
+		return orderedUUIDs, nil
+	}
+
+	gpuUUIDs, err = GetPodGPUUUIDs(ctx, podName, podNamespace, containerName)
+	if err != nil {
+		return nil, fmt.Errorf("PodResources GPU UUID lookup failed: %w", err)
 	}
 	if len(gpuUUIDs) > 0 {
 		return gpuUUIDs, nil
 	}
-	if !hasNVIDIADRAAllocation {
-		gpuUUIDs, err = GetPodGPUUUIDs(ctx, podName, podNamespace, containerName)
-		if err != nil {
-			return nil, fmt.Errorf("PodResources GPU UUID lookup failed: %w", err)
-		}
-		if len(gpuUUIDs) > 0 {
-			return gpuUUIDs, nil
-		}
-		fallbackReason = "PodResources API returned no GPU UUIDs"
-	}
 
-	log.Info(fallbackReason+", falling back to nvidia-smi", "pid", pid)
-	gpuUUIDs, err = GetGPUUUIDsViaNvidiaSmi(ctx, hostProcPath, pid)
+	log.Info("PodResources API returned no GPU UUIDs, falling back to nvidia-smi", "pid", pid)
+	gpuUUIDs, err = discoverVisibleGPUs(ctx, hostProcPath, pid)
 	if err != nil {
 		return nil, fmt.Errorf("nvidia-smi GPU UUID fallback failed: %w", err)
 	}
 	log.Info("nvidia-smi fallback discovered GPU UUIDs", "uuids", gpuUUIDs)
 	return gpuUUIDs, nil
+}
+
+func orderDRAUUIDsByRuntime(allocatedUUIDs, visibleUUIDs []string) ([]string, error) {
+	if len(allocatedUUIDs) != len(visibleUUIDs) {
+		return nil, fmt.Errorf(
+			"DRA allocation and container-visible GPU count differ: allocated=%d visible=%d",
+			len(allocatedUUIDs),
+			len(visibleUUIDs),
+		)
+	}
+
+	allocated := make(map[string]struct{}, len(allocatedUUIDs))
+	for _, uuid := range allocatedUUIDs {
+		if !gpuUUIDPattern.MatchString(uuid) {
+			return nil, fmt.Errorf("DRA allocation contains invalid GPU UUID %q", uuid)
+		}
+		if _, duplicate := allocated[uuid]; duplicate {
+			return nil, fmt.Errorf("DRA allocation contains duplicate GPU UUID %q", uuid)
+		}
+		allocated[uuid] = struct{}{}
+	}
+
+	seen := make(map[string]struct{}, len(visibleUUIDs))
+	for _, uuid := range visibleUUIDs {
+		if !gpuUUIDPattern.MatchString(uuid) {
+			return nil, fmt.Errorf("container reports invalid GPU UUID %q", uuid)
+		}
+		if _, duplicate := seen[uuid]; duplicate {
+			return nil, fmt.Errorf("container reports duplicate GPU UUID %q", uuid)
+		}
+		if _, ok := allocated[uuid]; !ok {
+			return nil, fmt.Errorf(
+				"container-visible GPU %q is not in the DRA allocation",
+				uuid,
+			)
+		}
+		seen[uuid] = struct{}{}
+	}
+
+	return append([]string(nil), visibleUUIDs...), nil
 }
 
 // FilterProcesses returns the subset of candidate PIDs that hold actual CUDA contexts.

--- a/deploy/snapshot/internal/cuda/cuda_test.go
+++ b/deploy/snapshot/internal/cuda/cuda_test.go
@@ -305,7 +305,7 @@ func TestDiscoverGPUUUIDsFallsBackToPodResourcesAfterDRAAPILookupError(t *testin
 	}
 }
 
-func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
+func TestDiscoverGPUUUIDsOrdersDRAPodByContainerOrdinal(t *testing.T) {
 	previousSocketPath := podResourcesSocketPath
 	podResourcesSocketPath = filepath.Join(t.TempDir(), "missing-kubelet.sock")
 	t.Cleanup(func() {
@@ -317,12 +317,21 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 	namespace := "default"
 	podName := "test-pod"
 	claimName := "gpu-claim"
-	uuid := "GPU-ffffffff-1111-2222-3333-444444444444"
+	uuid0 := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+	uuid1 := "GPU-bbbbbbbb-5555-6666-7777-888888888888"
 
 	pod := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
 		Spec: corev1.PodSpec{
 			NodeName: nodeName,
+			Containers: []corev1.Container{
+				{
+					Name: "main",
+					Resources: corev1.ResourceRequirements{
+						Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+					},
+				},
+			},
 			ResourceClaims: []corev1.PodResourceClaim{
 				{
 					Name:              "gpu",
@@ -337,6 +346,7 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 			Allocation: &resourcev1.AllocationResult{
 				Devices: resourcev1.DeviceAllocationResult{
 					Results: []resourcev1.DeviceRequestAllocationResult{
+						{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-1", Request: "gpu"},
 						{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-0", Request: "gpu"},
 					},
 				},
@@ -353,7 +363,13 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 				{
 					Name: "gpu-0",
 					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
-						resourcev1.QualifiedName("uuid"): {StringValue: &uuid},
+						resourcev1.QualifiedName("uuid"): {StringValue: &uuid0},
+					},
+				},
+				{
+					Name: "gpu-1",
+					Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+						resourcev1.QualifiedName("uuid"): {StringValue: &uuid1},
 					},
 				},
 			},
@@ -365,7 +381,7 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	got, err := DiscoverGPUUUIDs(
+	got, err := discoverGPUUUIDs(
 		ctx,
 		client,
 		podName,
@@ -373,12 +389,72 @@ func TestDiscoverGPUUUIDsPrefersDRAForDRAPod(t *testing.T) {
 		"main",
 		"/proc",
 		123,
+		func(context.Context, string, int) ([]string, error) {
+			return []string{uuid0, uuid1}, nil
+		},
 		logr.Discard(),
 	)
 	if err != nil {
 		t.Fatalf("DiscoverGPUUUIDs: %v", err)
 	}
-	if len(got) != 1 || got[0] != uuid {
-		t.Fatalf("got %v, want [%s]", got, uuid)
+	want := []string{uuid0, uuid1}
+	if len(got) != len(want) {
+		t.Fatalf("got %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	}
+}
+
+func TestOrderDRAUUIDsByRuntimeRejectsMismatches(t *testing.T) {
+	uuid0 := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+	uuid1 := "GPU-bbbbbbbb-5555-6666-7777-888888888888"
+	uuid2 := "GPU-cccccccc-9999-aaaa-bbbb-cccccccccccc"
+
+	tests := []struct {
+		name      string
+		allocated []string
+		visible   []string
+	}{
+		{
+			name:      "count mismatch",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0},
+		},
+		{
+			name:      "different set",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0, uuid2},
+		},
+		{
+			name:      "duplicate allocation",
+			allocated: []string{uuid0, uuid0},
+			visible:   []string{uuid0, uuid1},
+		},
+		{
+			name:      "invalid allocation UUID",
+			allocated: []string{uuid0, "not-a-gpu-uuid"},
+			visible:   []string{uuid0, uuid1},
+		},
+		{
+			name:      "duplicate visible",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0, uuid0},
+		},
+		{
+			name:      "invalid visible UUID",
+			allocated: []string{uuid0, uuid1},
+			visible:   []string{uuid0, "not-a-gpu-uuid"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got, err := orderDRAUUIDsByRuntime(tc.allocated, tc.visible); err == nil {
+				t.Fatalf("expected error, got %v", got)
+			}
+		})
 	}
 }

--- a/deploy/snapshot/internal/cuda/dra.go
+++ b/deploy/snapshot/internal/cuda/dra.go
@@ -3,8 +3,10 @@ package cuda
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
 	resourcev1 "k8s.io/api/resource/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -19,7 +21,63 @@ type allocatedDRADevice struct {
 	device string
 }
 
-func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace string, log logr.Logger) ([]allocatedDRADevice, string, bool, error) {
+// containerResourceClaimRefs returns the pod-level resource-claim references
+// exposed to the named container via container.resources.claims, mapped to
+// the set of claim request names the container is restricted to. A nil inner
+// set exposes every request in the claim. An empty containerName returns a
+// nil map, meaning the pod-wide claim view applies.
+func containerResourceClaimRefs(pod *corev1.Pod, containerName string) (map[string]map[string]struct{}, error) {
+	if containerName == "" {
+		return nil, nil
+	}
+	for _, containers := range [][]corev1.Container{pod.Spec.Containers, pod.Spec.InitContainers} {
+		for i := range containers {
+			if containers[i].Name != containerName {
+				continue
+			}
+			refs := make(map[string]map[string]struct{}, len(containers[i].Resources.Claims))
+			for _, claimRef := range containers[i].Resources.Claims {
+				requests, seen := refs[claimRef.Name]
+				if seen && requests == nil {
+					// Already exposed without a request restriction.
+					continue
+				}
+				if claimRef.Request == "" {
+					refs[claimRef.Name] = nil
+					continue
+				}
+				if requests == nil {
+					requests = make(map[string]struct{})
+					refs[claimRef.Name] = requests
+				}
+				requests[claimRef.Request] = struct{}{}
+			}
+			return refs, nil
+		}
+	}
+	return nil, fmt.Errorf("container %q not found in pod %s/%s spec", containerName, pod.Namespace, pod.Name)
+}
+
+// resultMatchesRequests reports whether an allocation result belongs to one of
+// the claim request names a container is restricted to. Allocation results
+// for subrequests use the "<main request>/<subrequest>" form, so a container
+// reference to the main request matches its subrequest results too.
+func resultMatchesRequests(resultRequest string, requests map[string]struct{}) bool {
+	if requests == nil {
+		return true
+	}
+	if _, ok := requests[resultRequest]; ok {
+		return true
+	}
+	mainRequest, _, found := strings.Cut(resultRequest, "/")
+	if !found {
+		return false
+	}
+	_, ok := requests[mainRequest]
+	return ok
+}
+
+func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName string, log logr.Logger) ([]allocatedDRADevice, string, bool, error) {
 	if clientset == nil {
 		return nil, "", false, nil
 	}
@@ -39,6 +97,21 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 		return nil, "", false, nil
 	}
 
+	containerClaimRefs, err := containerResourceClaimRefs(pod, containerName)
+	if err != nil {
+		// The pod defines resource claims but the target container cannot be
+		// resolved; fail rather than fall back to unverified discovery.
+		return nil, pod.Spec.NodeName, true, err
+	}
+	if containerClaimRefs != nil && len(containerClaimRefs) == 0 {
+		// The target container references no resource claims.
+		return nil, pod.Spec.NodeName, false, nil
+	}
+	// Probe state: the target container (or the whole pod, when containerName
+	// is empty) references resource claims. Every error past this point
+	// returns true so the caller fails closed instead of falling back to
+	// unverified discovery.
+
 	claimNamesByPodRef := make(map[string]string, len(pod.Spec.ResourceClaims))
 	for _, ref := range pod.Spec.ResourceClaims {
 		if ref.ResourceClaimName != nil && *ref.ResourceClaimName != "" {
@@ -57,6 +130,14 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 	var allocated []allocatedDRADevice
 	hasNVIDIADRAAllocation := false
 	for _, ref := range pod.Spec.ResourceClaims {
+		var containerRequests map[string]struct{}
+		if containerClaimRefs != nil {
+			requests, exposed := containerClaimRefs[ref.Name]
+			if !exposed {
+				continue
+			}
+			containerRequests = requests
+		}
 		claimName := claimNamesByPodRef[ref.Name]
 		if claimName == "" {
 			log.V(1).Info("pod resource claim has no resolved claim name", "pod_claim", ref.Name)
@@ -64,13 +145,16 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 		}
 		claim, err := clientset.ResourceV1().ResourceClaims(podNamespace).Get(ctx, claimName, metav1.GetOptions{})
 		if err != nil {
-			return nil, pod.Spec.NodeName, hasNVIDIADRAAllocation, fmt.Errorf("get resource claim %s/%s: %w", podNamespace, claimName, err)
+			return nil, pod.Spec.NodeName, true, fmt.Errorf("get resource claim %s/%s: %w", podNamespace, claimName, err)
 		}
 		if claim.Status.Allocation == nil || len(claim.Status.Allocation.Devices.Results) == 0 {
 			continue
 		}
 		for _, result := range claim.Status.Allocation.Devices.Results {
 			if result.Driver != nvidiaGPUDRADriver {
+				continue
+			}
+			if !resultMatchesRequests(result.Request, containerRequests) {
 				continue
 			}
 			hasNVIDIADRAAllocation = true
@@ -86,9 +170,14 @@ func getAllocatedNVIDIADRADevices(ctx context.Context, clientset kubernetes.Inte
 
 // GetGPUUUIDsViaDRAAPI resolves GPU UUIDs for a pod by querying the Kubernetes API:
 // Pod (resource claim refs) -> ResourceClaim (allocation results) -> ResourceSlice (device attributes).
-// It also reports whether the pod is using NVIDIA DRA GPU allocations at all.
-func GetGPUUUIDsViaDRAAPI(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace string, log logr.Logger) ([]string, bool, error) {
-	allocated, nodeName, hasNVIDIADRAAllocation, err := getAllocatedNVIDIADRADevices(ctx, clientset, podName, podNamespace, log)
+// A non-empty containerName restricts resolution to the claims (and claim
+// requests) that container references via resources.claims.
+// On success, the returned bool reports whether NVIDIA DRA GPU allocations
+// were found for that container. With a non-nil error, it reports whether the
+// container was established to reference resource claims, in which case the
+// caller must fail instead of falling back to other discovery paths.
+func GetGPUUUIDsViaDRAAPI(ctx context.Context, clientset kubernetes.Interface, podName, podNamespace, containerName string, log logr.Logger) ([]string, bool, error) {
+	allocated, nodeName, hasNVIDIADRAAllocation, err := getAllocatedNVIDIADRADevices(ctx, clientset, podName, podNamespace, containerName, log)
 	if err != nil {
 		return nil, hasNVIDIADRAAllocation, err
 	}

--- a/deploy/snapshot/internal/cuda/dra_test.go
+++ b/deploy/snapshot/internal/cuda/dra_test.go
@@ -60,7 +60,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 	log := logr.Discard()
 
 	t.Run("nil clientset returns nil without error", func(t *testing.T) {
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, nil, "pod", "ns", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, nil, "pod", "ns", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -74,7 +74,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 
 	t.Run("empty pod name returns nil", func(t *testing.T) {
 		client := fake.NewSimpleClientset()
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "", "ns", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "", "ns", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -88,7 +88,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 
 	t.Run("pod not found returns error", func(t *testing.T) {
 		client := fake.NewSimpleClientset()
-		_, _, err := GetGPUUUIDsViaDRAAPI(ctx, client, "missing", "default", log)
+		_, _, err := GetGPUUUIDsViaDRAAPI(ctx, client, "missing", "default", "", log)
 		if err == nil {
 			t.Fatal("expected error when pod not found")
 		}
@@ -152,7 +152,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod, claim, slice)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "", log)
 		if err != nil {
 			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
 		}
@@ -227,7 +227,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod, claim, slice)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "", log)
 		if err != nil {
 			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
 		}
@@ -259,7 +259,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -352,7 +352,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 
 		client := fake.NewSimpleClientset(pod, directClaim, generatedClaim, slice)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "", log)
 		if err != nil {
 			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
 		}
@@ -376,7 +376,7 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 			Spec:       corev1.PodSpec{NodeName: "node-1"},
 		}
 		client := fake.NewSimpleClientset(pod)
-		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", log)
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "", log)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -385,6 +385,142 @@ func TestGetGPUUUIDsViaDRAAPI(t *testing.T) {
 		}
 		if got != nil {
 			t.Errorf("got %v, want nil", got)
+		}
+	})
+
+	t.Run("shared claim requests scope to the target container", func(t *testing.T) {
+		nodeName := "node-1"
+		poolName := "pool-node-1"
+		namespace := "default"
+		podName := "test-pod"
+		claimName := "shared-gpu-claim"
+		mainUUID := "GPU-aaaaaaaa-1111-2222-3333-444444444444"
+		sidecarUUID := "GPU-bbbbbbbb-5555-6666-7777-888888888888"
+
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: podName, Namespace: namespace},
+			Spec: corev1.PodSpec{
+				NodeName: nodeName,
+				Containers: []corev1.Container{
+					{
+						Name: "main",
+						Resources: corev1.ResourceRequirements{
+							Claims: []corev1.ResourceClaim{{Name: "gpu", Request: "main-gpu"}},
+						},
+					},
+					{
+						Name: "sidecar",
+						Resources: corev1.ResourceRequirements{
+							Claims: []corev1.ResourceClaim{{Name: "gpu", Request: "sidecar-gpu"}},
+						},
+					},
+				},
+				ResourceClaims: []corev1.PodResourceClaim{
+					{
+						Name:              "gpu",
+						ResourceClaimName: &claimName,
+					},
+				},
+			},
+		}
+		claim := &resourcev1.ResourceClaim{
+			ObjectMeta: metav1.ObjectMeta{Name: claimName, Namespace: namespace},
+			Status: resourcev1.ResourceClaimStatus{
+				Allocation: &resourcev1.AllocationResult{
+					Devices: resourcev1.DeviceAllocationResult{
+						Results: []resourcev1.DeviceRequestAllocationResult{
+							// Subrequest form exercises "<request>/<subrequest>" matching.
+							{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-0", Request: "main-gpu/fallback"},
+							{Driver: nvidiaGPUDRADriver, Pool: poolName, Device: "gpu-1", Request: "sidecar-gpu"},
+						},
+					},
+				},
+			},
+		}
+		slice := &resourcev1.ResourceSlice{
+			ObjectMeta: metav1.ObjectMeta{Name: poolName + "-gpu.nvidia.com-xxx"},
+			Spec: resourcev1.ResourceSliceSpec{
+				Driver:   nvidiaGPUDRADriver,
+				NodeName: &nodeName,
+				Pool:     resourcev1.ResourcePool{Name: poolName},
+				Devices: []resourcev1.Device{
+					{
+						Name: "gpu-0",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							resourcev1.QualifiedName("uuid"): {StringValue: &mainUUID},
+						},
+					},
+					{
+						Name: "gpu-1",
+						Attributes: map[resourcev1.QualifiedName]resourcev1.DeviceAttribute{
+							resourcev1.QualifiedName("uuid"): {StringValue: &sidecarUUID},
+						},
+					},
+				},
+			},
+		}
+
+		client := fake.NewSimpleClientset(pod, claim, slice)
+
+		got, hasNVIDIADRAAllocation, err := GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "main", log)
+		if err != nil {
+			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
+		}
+		if !hasNVIDIADRAAllocation {
+			t.Fatal("expected hasNVIDIADRAAllocation to be true")
+		}
+		if len(got) != 1 || got[0] != mainUUID {
+			t.Fatalf("got %v, want [%s]", got, mainUUID)
+		}
+
+		got, _, err = GetGPUUUIDsViaDRAAPI(ctx, client, podName, namespace, "sidecar", log)
+		if err != nil {
+			t.Fatalf("GetGPUUUIDsViaDRAAPI: %v", err)
+		}
+		if len(got) != 1 || got[0] != sidecarUUID {
+			t.Fatalf("got %v, want [%s]", got, sidecarUUID)
+		}
+	})
+
+	t.Run("lookup failures after claims are referenced forbid fallback", func(t *testing.T) {
+		claimName := "gpu-claim"
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: "default"},
+			Spec: corev1.PodSpec{
+				NodeName: "node-1",
+				Containers: []corev1.Container{
+					{
+						Name: "main",
+						Resources: corev1.ResourceRequirements{
+							Claims: []corev1.ResourceClaim{{Name: "gpu"}},
+						},
+					},
+				},
+				ResourceClaims: []corev1.PodResourceClaim{
+					{
+						Name:              "gpu",
+						ResourceClaimName: &claimName,
+					},
+				},
+			},
+		}
+		// The referenced ResourceClaim object is missing, so the claim GET fails.
+		client := fake.NewSimpleClientset(pod)
+
+		_, mustNotFallBack, err := GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "main", log)
+		if err == nil {
+			t.Fatal("expected error for failed claim lookup")
+		}
+		if !mustNotFallBack {
+			t.Fatal("expected claim lookup failure to forbid fallback")
+		}
+
+		_, mustNotFallBack, err = GetGPUUUIDsViaDRAAPI(ctx, client, "pod", "default", "no-such-container", log)
+		if err == nil {
+			t.Fatal("expected error for unknown container name")
+		}
+		if !mustNotFallBack {
+			t.Fatal("expected unknown container to forbid fallback")
 		}
 	})
 }


### PR DESCRIPTION
## Overview:

Cherry-pick of #11325 (`44ba389a4`, merged to `main`) into `release/1.3.0`.

## Details:

Fixes an all-rank GPU rotation on cross-node restore for DRA-backed pods: DRA
`ResourceClaim` allocation results were treated as CUDA ordinal order, but they
only identify the allocated device set. Discovery now derives the
container-visible order via `nvidia-smi` in the target container's mount
namespace and validates exact count/set equality against the (container- and
request-scoped) DRA allocation, failing closed on any mismatch, duplicate,
malformed UUID, or ambiguous claim lookup. Classic `nvidia.com/gpu`
PodResources discovery is unchanged.

The cherry-pick applied cleanly with no conflicts (`git cherry-pick --signoff
44ba389a4`); `go build ./...`, `go vet ./...`, and `go test ./...` pass in
`deploy/snapshot` on this branch.

## Where should the reviewer start?

This is a verbatim cherry-pick — review happened on #11325. Key files:

- `deploy/snapshot/internal/cuda/cuda.go` — `discoverGPUUUIDs`, `orderDRAUUIDsByRuntime`
- `deploy/snapshot/internal/cuda/dra.go` — container/request-scoped claim resolution

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
