### PR TITLE
fix(benchmarks): run the in-cluster benchmark Job on the frontend image (DYN-3395)

### DIFF
--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -16,8 +16,12 @@ spec:
         fsGroup: 1000
       containers:
       - name: benchmark-runner
+        # aiperf only talks HTTP to the frontend service, so this CPU-only Job
+        # runs on the frontend image, which ships the benchmarks package (incl.
+        # aiperf, with the prebuilt arm64 crick wheel). Backend runtime images
+        # deliberately do not carry benchmark tooling.
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:my-tag
+        image: nvcr.io/nvidia/ai-dynamo/frontend:my-tag
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -7,32 +7,6 @@
 ########## Runtime Image #########
 ##################################
 
-# aiperf depends on crick==0.0.8, which has no manylinux aarch64 wheel.
-# Build it from source on arm64 in a disposable stage so the compiler and
-# headers do not reach the runtime image. On amd64, /wheels stays empty and
-# uv resolves crick from its published PyPI wheel.
-FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS crick_builder
-ARG PYTHON_VERSION
-ARG TARGETARCH
-RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-    mkdir -p /wheels \
-    && if [ "$TARGETARCH" = "arm64" ]; then \
-        apt-get update -y \
-        && apt-get install -y --no-install-recommends \
-            ca-certificates \
-            gcc \
-            libc6-dev \
-            python${PYTHON_VERSION}-dev \
-            python${PYTHON_VERSION}-venv \
-        && apt-get clean \
-        && rm -rf /var/lib/apt/lists/*; \
-    fi
-RUN if [ "$TARGETARCH" = "arm64" ]; then \
-        python${PYTHON_VERSION} -m venv /tmp/buildenv \
-        && /tmp/buildenv/bin/pip install --no-cache-dir --upgrade pip wheel \
-        && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels; \
-    fi
-
 {% if platform == "multi" %}
 FROM --platform=linux/amd64 ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS vllm_runtime_amd64
 FROM --platform=linux/arm64 ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS vllm_runtime_arm64
@@ -295,17 +269,6 @@ RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/
     export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install {{ pip_target }} --reinstall-package imageio-ffmpeg --no-deps \
         --requirement /tmp/requirements.vllm.txt
-
-{% if target not in ("dev", "local-dev") %}
-# Install the benchmark CLI used by the in-cluster benchmark Job. UV_FIND_LINKS
-# supplies the arm64 crick wheel built above while remaining empty on amd64.
-COPY --chown=dynamo:0 --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
-RUN --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
-    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
-    export UV_CACHE_DIR=/root/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
-    uv pip install {{ pip_target }} --requirement /tmp/requirements.benchmark.txt && \
-    aiperf --version
-{% endif %}
 
 # Remove the vLLM source tree shipped in the base image to avoid pytest
 # collection conflicts (duplicate conftest plugin registration) and stale

--- a/container/templates/vllm_runtime.Dockerfile
+++ b/container/templates/vllm_runtime.Dockerfile
@@ -7,6 +7,32 @@
 ########## Runtime Image #########
 ##################################
 
+# aiperf depends on crick==0.0.8, which has no manylinux aarch64 wheel.
+# Build it from source on arm64 in a disposable stage so the compiler and
+# headers do not reach the runtime image. On amd64, /wheels stays empty and
+# uv resolves crick from its published PyPI wheel.
+FROM ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS crick_builder
+ARG PYTHON_VERSION
+ARG TARGETARCH
+RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
+    mkdir -p /wheels \
+    && if [ "$TARGETARCH" = "arm64" ]; then \
+        apt-get update -y \
+        && apt-get install -y --no-install-recommends \
+            ca-certificates \
+            gcc \
+            libc6-dev \
+            python${PYTHON_VERSION}-dev \
+            python${PYTHON_VERSION}-venv \
+        && apt-get clean \
+        && rm -rf /var/lib/apt/lists/*; \
+    fi
+RUN if [ "$TARGETARCH" = "arm64" ]; then \
+        python${PYTHON_VERSION} -m venv /tmp/buildenv \
+        && /tmp/buildenv/bin/pip install --no-cache-dir --upgrade pip wheel \
+        && /tmp/buildenv/bin/pip wheel --no-cache-dir --no-deps crick==0.0.8 -w /wheels; \
+    fi
+
 {% if platform == "multi" %}
 FROM --platform=linux/amd64 ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS vllm_runtime_amd64
 FROM --platform=linux/arm64 ${RUNTIME_IMAGE}:${RUNTIME_IMAGE_TAG} AS vllm_runtime_arm64
@@ -269,6 +295,17 @@ RUN --mount=type=bind,source=./container/deps/requirements.vllm.txt,target=/tmp/
     export UV_CACHE_DIR=/root/.cache/uv && \
     uv pip install {{ pip_target }} --reinstall-package imageio-ffmpeg --no-deps \
         --requirement /tmp/requirements.vllm.txt
+
+{% if target not in ("dev", "local-dev") %}
+# Install the benchmark CLI used by the in-cluster benchmark Job. UV_FIND_LINKS
+# supplies the arm64 crick wheel built above while remaining empty on amd64.
+COPY --chown=dynamo:0 --from=crick_builder /wheels/ /opt/dynamo/wheelhouse/extra/
+RUN --mount=type=bind,source=./container/deps/requirements.benchmark.txt,target=/tmp/requirements.benchmark.txt \
+    --mount=type=cache,target=/root/.cache/uv,sharing=locked \
+    export UV_CACHE_DIR=/root/.cache/uv UV_FIND_LINKS=/opt/dynamo/wheelhouse/extra && \
+    uv pip install {{ pip_target }} --requirement /tmp/requirements.benchmark.txt && \
+    aiperf --version
+{% endif %}
 
 # Remove the vLLM source tree shipped in the base image to avoid pytest
 # collection conflicts (duplicate conftest plugin registration) and stale


### PR DESCRIPTION
## Overview:

The in-cluster benchmark Job fails with `aiperf: command not found` (NVBug 6418326 / DYN-3395). Root cause: the Job manifest points at the vLLM **serving runtime** image, which deliberately does not carry benchmark tooling -- and `aiperf` never needed to run there in the first place.

## Details:

`benchmarks/incluster/benchmark_job.yaml` is a CPU-only Job (no GPU request) whose container does exactly one thing: run `aiperf profile` over HTTP against the frontend service (`http://vllm-agg-frontend:8000`). It has no dependency on vLLM or any backend code. This changes the Job's image to the **frontend image**, which already ships the benchmarks package (`benchmarks/pyproject.toml` pins `aiperf==0.10.0`) and already handles the arm64 `crick` problem with a prebuilt-wheel builder stage -- so the Job works on both architectures with no image changes anywhere.

An earlier revision of this PR installed the benchmark stack into the vLLM runtime image instead. CI showed why that was the wrong direction: the install pulled 61 packages into the serving environment, silently downgraded 9 of them (including `pyzmq`, `aiohttp`, `prometheus-client`), and tripped the license gate on three transitive dependencies -- all cost, no benefit, since the Job never needed the serving image. That revision is reverted here; the serving image is untouched.

## Where should the reviewer start?

`benchmarks/incluster/benchmark_job.yaml` -- the one-line image change (plus comment). Confirm the frontend image tag pattern matches how this Job is deployed (the `my-tag` placeholder is unchanged).

## Related Issues

Relates to internal trackers DYN-3395 / NVBug 6418326 (no public GitHub issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)