### PR TITLE
chore(ci): ignore intermittent Bitnami Helm repository 503s

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -18,6 +18,9 @@
 # Slow from GitHub runners and not part of Dynamo-owned documentation.
 ^https://martinfowler\.com/articles/practical-test-pyramid\.html
 
+# Helm artifact repository; its root endpoint intermittently returns 503.
+^https://charts\.bitnami\.com/bitnami/?$
+
 # Served by Netlify and intermittently fails from GitHub runners.
 ^https://etcd\.io/?$
 ^https://etcd\.io/docs/v3\.5/install/?$


### PR DESCRIPTION
## Summary

- Exclude the Bitnami Helm repository root from Lychee link checking.
- Avoid intermittent CI failures when `https://charts.bitnami.com/bitnami` returns `503 Service Unavailable`.
- Keep the exclusion narrowly scoped instead of globally accepting `503` responses.
- Continue validating actual Helm repository availability through existing `helm dependency build` steps.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11370" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of link checks by ignoring a flaky Bitnami charts repository URL that was intermittently returning errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->