### PR TITLE
feat: PR 4 Wrapper for the Imbedded Selection Service for the EPP and Standalone Selector Router Integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2463,6 +2463,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-stream",
+ "tokio-util",
  "tonic 0.13.1",
  "tonic-build 0.13.1",
  "tonic-health",

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -16,7 +16,11 @@ name = "dynamo-ext-proc"
 path = "src/main.rs"
 
 [dependencies]
-dynamo-kv-router = { workspace = true, features = ["metrics", "runtime-protocols"] }
+dynamo-kv-router = { workspace = true, features = [
+    "metrics",
+    "runtime-protocols",
+    "standalone-selection",
+] }
 dynamo-runtime = { workspace = true }
 
 anyhow = { workspace = true }
@@ -34,6 +38,7 @@ serde_json = { workspace = true }
 thiserror = { workspace = true }
 tokio = { workspace = true }
 tokio-rustls = { workspace = true }
+tokio-util = { workspace = true }
 # `net` for TcpListenerStream (serve_with_incoming), `sync` for ReceiverStream.
 # Declared explicitly rather than relying on workspace feature unification.
 tokio-stream = { workspace = true, features = ["net", "sync"] }

--- a/deploy/inference-gateway/ext-proc/Dockerfile
+++ b/deploy/inference-gateway/ext-proc/Dockerfile
@@ -33,10 +33,14 @@ ARG SCCACHE_REGION=""
 # protobuf-compiler provides protoc; libprotobuf-dev provides the well-known
 # .proto files (google/protobuf/struct.proto etc.) that our vendored Envoy
 # protos import. libclang-dev is needed by bindgen (nixl-sys transitive dep).
+# libzmq3-dev + pkg-config are needed by the `zmq` crate the in-process
+# selection service uses for KV-event and replica-sync sockets.
 RUN apt-get update && apt-get install -y --no-install-recommends \
     protobuf-compiler \
     libprotobuf-dev \
     libclang-dev \
+    libzmq3-dev \
+    pkg-config \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /dynamo
@@ -85,9 +89,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,id=cargo-registry-${TARG
 # =============================================================================
 FROM ${BASE_IMAGE}
 
+# libzmq5 is the runtime library for the embedded selector's ZMQ KV-event
+# subscriber (harmless if the binary was built HTTP-only).
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     libstdc++6 \
+    libzmq5 \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -17,9 +17,11 @@ pub mod epp;
 pub mod epp_standalone_config;
 pub mod inference_pool;
 pub mod offline_preprocessor;
+pub mod peer_discovery;
 pub mod picker;
 pub mod pod_discovery;
 pub mod proto;
+pub mod selector;
 pub mod server;
 
 pub use epp::Router;
@@ -28,4 +30,5 @@ pub use inference_pool::PoolState;
 pub use offline_preprocessor::build_offline_preprocessor;
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use pod_discovery::{PodDiscovery, RawWorker};
+pub use selector::{OverlapSummary, SelectRequest, SelectResponse, Selector, WorkerRegistration};
 pub use server::ExtProcServer;

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -1,0 +1,308 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Embedded-mode peer discovery.
+//!
+//! In replicated embedded mode each EPP pod runs its own in-process
+//! [`SelectionService`] with replica-sync enabled. This module watches the EPP's
+//! OWN Kubernetes `Service` EndpointSlices and keeps that service's replica-sync
+//! peer set in step with the live sibling EPP replicas: it registers peers that
+//! appear and deregisters peers that leave, so active-load/admission events flow
+//! across the whole EPP fleet over ZMQ.
+//!
+//! This mirrors the HTTP fleet's EndpointSlice watch, but the target is the EPP's
+//! own Service (siblings), not a separate selector Service, and the peers are
+//! wired into the in-process service rather than remote replicas. Built only with
+//! the `selector-embedded` feature.
+
+use std::collections::BTreeSet;
+use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use k8s_openapi::api::discovery::v1::EndpointSlice;
+use tokio::sync::watch;
+use tokio_util::sync::CancellationToken;
+
+use dynamo_kv_router::services::selection::SelectionService;
+
+/// Label Kubernetes sets on every EndpointSlice pointing back to its Service.
+const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
+
+/// Best-effort bound on how long startup waits for the initial EndpointSlice
+/// LIST before returning; the background task keeps syncing regardless.
+const INITIAL_LIST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Backoff before re-establishing the EndpointSlice watch if its stream ends.
+const WATCH_RESTART_BACKOFF: Duration = Duration::from_secs(3);
+
+/// Shared handle to the current EndpointSlice reflector store. The watch task
+/// swaps in a fresh store when it re-establishes the watch, so the reconcile
+/// loop always reads the live snapshot.
+type SharedStore = Arc<StdMutex<kube::runtime::reflector::Store<EndpointSlice>>>;
+
+/// Start the peer-discovery watch for the EPP's own `service_name` in
+/// `namespace`. Registers/deregisters replica-sync peers on `service` as sibling
+/// EPP pods come and go, dialing them on `sync_port`. `self_ip` (the pod's own
+/// IP) is excluded so a replica never peers with itself. Returns after the
+/// initial LIST (bounded); the watch keeps running until `cancel` fires.
+pub async fn spawn(
+    service: Arc<SelectionService>,
+    namespace: &str,
+    service_name: &str,
+    sync_port: u16,
+    self_ip: Option<String>,
+    cancel: CancellationToken,
+) -> Result<()> {
+    use kube::{Api, Client, runtime::reflector, runtime::watcher};
+
+    let client = Client::try_default()
+        .await
+        .context("building Kubernetes client for EPP peer discovery")?;
+    let slices: Api<EndpointSlice> = Api::namespaced(client, namespace);
+    let cfg_watch =
+        watcher::Config::default().labels(&format!("{SERVICE_NAME_LABEL}={service_name}"));
+
+    let initial_writer = reflector::store::Writer::default();
+    let store: SharedStore = Arc::new(StdMutex::new(initial_writer.as_reader()));
+    let (changes_tx, changes_rx) = watch::channel(0u64);
+
+    tracing::info!(
+        %namespace,
+        service = %service_name,
+        sync_port,
+        self_ip = ?self_ip,
+        "Starting EPP peer EndpointSlice watch (embedded replication)"
+    );
+
+    tokio::spawn(watch_loop(
+        slices,
+        cfg_watch,
+        initial_writer,
+        store.clone(),
+        changes_tx,
+        cancel.clone(),
+    ));
+
+    let store_for_wait = store.lock().expect("store lock poisoned").clone();
+    match tokio::time::timeout(INITIAL_LIST_TIMEOUT, store_for_wait.wait_until_ready()).await {
+        Ok(Ok(())) => tracing::info!("EPP peer EndpointSlice initial LIST sync complete"),
+        Ok(Err(e)) => {
+            tracing::warn!(error = %e, "EPP peer EndpointSlice writer dropped before initial LIST")
+        }
+        Err(_) => tracing::warn!(
+            "EPP peer EndpointSlice initial LIST timed out after {}s; continuing",
+            INITIAL_LIST_TIMEOUT.as_secs()
+        ),
+    }
+
+    tokio::spawn(reconcile_loop(
+        service, store, sync_port, self_ip, changes_rx, cancel,
+    ));
+    Ok(())
+}
+
+/// React to EndpointSlice changes: diff the live sibling set against the peers
+/// currently registered and apply the delta. Exits when `cancel` fires or the
+/// change channel closes.
+async fn reconcile_loop(
+    service: Arc<SelectionService>,
+    store: SharedStore,
+    sync_port: u16,
+    self_ip: Option<String>,
+    mut changes_rx: watch::Receiver<u64>,
+    cancel: CancellationToken,
+) {
+    let mut known: BTreeSet<String> = BTreeSet::new();
+    loop {
+        reconcile_once(&service, &store, sync_port, self_ip.as_deref(), &mut known).await;
+        tokio::select! {
+            _ = cancel.cancelled() => break,
+            changed = changes_rx.changed() => {
+                if changed.is_err() {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn reconcile_once(
+    service: &SelectionService,
+    store: &SharedStore,
+    sync_port: u16,
+    self_ip: Option<&str>,
+    known: &mut BTreeSet<String>,
+) {
+    let live = live_peer_ips(store, self_ip);
+    let added: Vec<String> = live.difference(known).cloned().collect();
+    let removed: Vec<String> = known.difference(&live).cloned().collect();
+
+    for ip in &added {
+        let endpoint = format!("tcp://{}", authority(ip, sync_port));
+        if let Err(e) = service.register_replica_peer(endpoint.clone()).await {
+            tracing::debug!(%endpoint, error = %e, "register_replica_peer failed");
+        }
+    }
+    for ip in &removed {
+        let endpoint = format!("tcp://{}", authority(ip, sync_port));
+        if let Err(e) = service.deregister_replica_peer(endpoint.clone()).await {
+            tracing::debug!(%endpoint, error = %e, "deregister_replica_peer failed");
+        }
+    }
+    if !added.is_empty() || !removed.is_empty() {
+        tracing::info!(added = ?added, removed = ?removed, total = live.len(), "EPP peer set changed");
+    }
+    *known = live;
+}
+
+/// Live sibling EPP IPs from the current EndpointSlice snapshot, excluding this
+/// pod's own IP so a replica never registers itself as a peer.
+fn live_peer_ips(store: &SharedStore, self_ip: Option<&str>) -> BTreeSet<String> {
+    let snapshot = store.lock().expect("store lock poisoned").clone();
+    let mut ips = ready_ips(snapshot.state().iter().map(|s| s.as_ref()));
+    if let Some(me) = self_ip {
+        ips.remove(me);
+    }
+    ips
+}
+
+/// Long-lived EndpointSlice watch. If the reflector stream ends (writer dropped
+/// / fatal — transient errors are retried inside the watcher), swap in a fresh
+/// store and re-establish after a backoff so discovery never gets stuck on a
+/// stale snapshot. Stops when `cancel` fires.
+async fn watch_loop(
+    slices: kube::Api<EndpointSlice>,
+    cfg_watch: kube::runtime::watcher::Config,
+    initial_writer: kube::runtime::reflector::store::Writer<EndpointSlice>,
+    store: SharedStore,
+    changes_tx: watch::Sender<u64>,
+    cancel: CancellationToken,
+) {
+    use futures::StreamExt;
+    use kube::runtime::{reflector, watcher};
+
+    let mut writer = Some(initial_writer);
+    let mut generation = 0u64;
+    loop {
+        if cancel.is_cancelled() {
+            return;
+        }
+        // First pass reuses the initial writer (already published to `store`);
+        // later passes create and publish a fresh one.
+        let writer = match writer.take() {
+            Some(w) => w,
+            None => {
+                let w = reflector::store::Writer::default();
+                *store.lock().expect("store lock poisoned") = w.as_reader();
+                w
+            }
+        };
+
+        let reflect = reflector::reflector(writer, watcher(slices.clone(), cfg_watch.clone()));
+        tokio::pin!(reflect);
+        loop {
+            tokio::select! {
+                _ = cancel.cancelled() => return,
+                item = reflect.next() => {
+                    if item.is_none() {
+                        break;
+                    }
+                    generation = generation.wrapping_add(1);
+                    let _ = changes_tx.send(generation);
+                }
+            }
+        }
+
+        tracing::warn!(
+            "EPP peer EndpointSlice reflector stream ended; re-establishing the watch in {}s",
+            WATCH_RESTART_BACKOFF.as_secs()
+        );
+        tokio::select! {
+            _ = cancel.cancelled() => return,
+            _ = tokio::time::sleep(WATCH_RESTART_BACKOFF) => {}
+        }
+        generation = generation.wrapping_add(1);
+        let _ = changes_tx.send(generation);
+    }
+}
+
+/// Format `host:port`, bracketing IPv6 literals (`fd00::1` -> `[fd00::1]`) so the
+/// resulting `tcp://` endpoint stays valid on dual-stack clusters.
+fn authority(ip: &str, port: u16) -> String {
+    if ip.contains(':') {
+        format!("[{ip}]:{port}")
+    } else {
+        format!("{ip}:{port}")
+    }
+}
+
+/// Collect non-terminating endpoint IPs from a set of EndpointSlices. Not-ready
+/// endpoints are kept: registering a peer whose ZMQ socket is not up yet is
+/// harmless (the sync connect retries), and it avoids missing a sibling that is
+/// still starting. Pure function.
+fn ready_ips<'a>(slices: impl Iterator<Item = &'a EndpointSlice>) -> BTreeSet<String> {
+    let mut ips = BTreeSet::new();
+    for slice in slices {
+        for endpoint in &slice.endpoints {
+            if endpoint
+                .conditions
+                .as_ref()
+                .and_then(|c| c.terminating)
+                .unwrap_or(false)
+            {
+                continue;
+            }
+            for addr in &endpoint.addresses {
+                if !addr.is_empty() {
+                    ips.insert(addr.clone());
+                }
+            }
+        }
+    }
+    ips
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
+
+    fn slice_with(ips: &[&str], terminating: bool) -> EndpointSlice {
+        EndpointSlice {
+            address_type: "IPv4".to_string(),
+            endpoints: ips
+                .iter()
+                .map(|ip| Endpoint {
+                    addresses: vec![ip.to_string()],
+                    conditions: Some(EndpointConditions {
+                        terminating: Some(terminating),
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn ready_ips_keeps_non_terminating() {
+        let slices = [slice_with(&["10.0.0.1", "10.0.0.2"], false)];
+        let ips = ready_ips(slices.iter());
+        assert!(ips.contains("10.0.0.1"));
+        assert!(ips.contains("10.0.0.2"));
+    }
+
+    #[test]
+    fn ready_ips_drops_terminating() {
+        let slices = [slice_with(&["10.0.0.9"], true)];
+        assert!(ready_ips(slices.iter()).is_empty());
+    }
+
+    #[test]
+    fn authority_brackets_ipv6_only() {
+        assert_eq!(authority("10.0.0.1", 9092), "10.0.0.1:9092");
+        assert_eq!(authority("fd00::1", 9092), "[fd00::1]:9092");
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
+++ b/deploy/inference-gateway/ext-proc/src/peer_discovery.rs
@@ -12,11 +12,10 @@
 //!
 //! This mirrors the HTTP fleet's EndpointSlice watch, but the target is the EPP's
 //! own Service (siblings), not a separate selector Service, and the peers are
-//! wired into the in-process service rather than remote replicas. Built only with
-//! the `selector-embedded` feature.
+//! wired into the in-process service rather than remote replicas.
 
 use std::collections::BTreeSet;
-use std::sync::{Arc, Mutex as StdMutex};
+use std::sync::Arc;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
@@ -33,13 +32,7 @@ const SERVICE_NAME_LABEL: &str = "kubernetes.io/service-name";
 /// LIST before returning; the background task keeps syncing regardless.
 const INITIAL_LIST_TIMEOUT: Duration = Duration::from_secs(30);
 
-/// Backoff before re-establishing the EndpointSlice watch if its stream ends.
-const WATCH_RESTART_BACKOFF: Duration = Duration::from_secs(3);
-
-/// Shared handle to the current EndpointSlice reflector store. The watch task
-/// swaps in a fresh store when it re-establishes the watch, so the reconcile
-/// loop always reads the live snapshot.
-type SharedStore = Arc<StdMutex<kube::runtime::reflector::Store<EndpointSlice>>>;
+type Store = kube::runtime::reflector::Store<EndpointSlice>;
 
 /// Start the peer-discovery watch for the EPP's own `service_name` in
 /// `namespace`. Registers/deregisters replica-sync peers on `service` as sibling
@@ -51,9 +44,10 @@ pub async fn spawn(
     namespace: &str,
     service_name: &str,
     sync_port: u16,
-    self_ip: Option<String>,
+    self_ip: String,
     cancel: CancellationToken,
 ) -> Result<()> {
+    use futures::StreamExt;
     use kube::{Api, Client, runtime::reflector, runtime::watcher};
 
     let client = Client::try_default()
@@ -63,28 +57,43 @@ pub async fn spawn(
     let cfg_watch =
         watcher::Config::default().labels(&format!("{SERVICE_NAME_LABEL}={service_name}"));
 
-    let initial_writer = reflector::store::Writer::default();
-    let store: SharedStore = Arc::new(StdMutex::new(initial_writer.as_reader()));
+    let writer = reflector::store::Writer::default();
+    let store = writer.as_reader();
+    let reflect = reflector::reflector(writer, watcher(slices, cfg_watch));
     let (changes_tx, changes_rx) = watch::channel(0u64);
 
     tracing::info!(
         %namespace,
         service = %service_name,
         sync_port,
-        self_ip = ?self_ip,
+        %self_ip,
         "Starting EPP peer EndpointSlice watch (embedded replication)"
     );
 
-    tokio::spawn(watch_loop(
-        slices,
-        cfg_watch,
-        initial_writer,
-        store.clone(),
-        changes_tx,
-        cancel.clone(),
-    ));
+    // EndpointSlice reflector stream -> bump the change generation. The watcher
+    // retries transient errors internally; the stream ends only on writer drop.
+    let cancel_watch = cancel.clone();
+    tokio::spawn(async move {
+        tokio::pin!(reflect);
+        let mut generation = 0u64;
+        loop {
+            tokio::select! {
+                _ = cancel_watch.cancelled() => return,
+                item = reflect.next() => match item {
+                    Some(_) => {
+                        generation = generation.wrapping_add(1);
+                        let _ = changes_tx.send(generation);
+                    }
+                    None => {
+                        tracing::warn!("EPP peer EndpointSlice reflector stream ended");
+                        return;
+                    }
+                },
+            }
+        }
+    });
 
-    let store_for_wait = store.lock().expect("store lock poisoned").clone();
+    let store_for_wait = store.clone();
     match tokio::time::timeout(INITIAL_LIST_TIMEOUT, store_for_wait.wait_until_ready()).await {
         Ok(Ok(())) => tracing::info!("EPP peer EndpointSlice initial LIST sync complete"),
         Ok(Err(e)) => {
@@ -107,15 +116,15 @@ pub async fn spawn(
 /// change channel closes.
 async fn reconcile_loop(
     service: Arc<SelectionService>,
-    store: SharedStore,
+    store: Store,
     sync_port: u16,
-    self_ip: Option<String>,
+    self_ip: String,
     mut changes_rx: watch::Receiver<u64>,
     cancel: CancellationToken,
 ) {
     let mut known: BTreeSet<String> = BTreeSet::new();
     loop {
-        reconcile_once(&service, &store, sync_port, self_ip.as_deref(), &mut known).await;
+        reconcile_once(&service, &store, sync_port, &self_ip, &mut known).await;
         tokio::select! {
             _ = cancel.cancelled() => break,
             changed = changes_rx.changed() => {
@@ -129,9 +138,9 @@ async fn reconcile_loop(
 
 async fn reconcile_once(
     service: &SelectionService,
-    store: &SharedStore,
+    store: &Store,
     sync_port: u16,
-    self_ip: Option<&str>,
+    self_ip: &str,
     known: &mut BTreeSet<String>,
 ) {
     let live = live_peer_ips(store, self_ip);
@@ -156,75 +165,16 @@ async fn reconcile_once(
     *known = live;
 }
 
-/// Live sibling EPP IPs from the current EndpointSlice snapshot, excluding this
-/// pod's own IP so a replica never registers itself as a peer.
-fn live_peer_ips(store: &SharedStore, self_ip: Option<&str>) -> BTreeSet<String> {
-    let snapshot = store.lock().expect("store lock poisoned").clone();
-    let mut ips = ready_ips(snapshot.state().iter().map(|s| s.as_ref()));
-    if let Some(me) = self_ip {
-        ips.remove(me);
-    }
+/// Live sibling EPP IPs from the current EndpointSlice snapshot, restricted to
+/// `self_ip`'s address family and excluding this pod's own IP. Restricting to a
+/// single family means a dual-stack sibling — which appears in both an IPv4 and
+/// an IPv6 slice — is registered exactly once. Registering both would open two
+/// ZMQ connections to the same peer and double-count its load.
+fn live_peer_ips(store: &Store, self_ip: &str) -> BTreeSet<String> {
+    let want_ipv6 = is_ipv6(self_ip);
+    let mut ips = peer_ips(store.state().iter().map(|s| s.as_ref()), want_ipv6);
+    ips.remove(self_ip);
     ips
-}
-
-/// Long-lived EndpointSlice watch. If the reflector stream ends (writer dropped
-/// / fatal — transient errors are retried inside the watcher), swap in a fresh
-/// store and re-establish after a backoff so discovery never gets stuck on a
-/// stale snapshot. Stops when `cancel` fires.
-async fn watch_loop(
-    slices: kube::Api<EndpointSlice>,
-    cfg_watch: kube::runtime::watcher::Config,
-    initial_writer: kube::runtime::reflector::store::Writer<EndpointSlice>,
-    store: SharedStore,
-    changes_tx: watch::Sender<u64>,
-    cancel: CancellationToken,
-) {
-    use futures::StreamExt;
-    use kube::runtime::{reflector, watcher};
-
-    let mut writer = Some(initial_writer);
-    let mut generation = 0u64;
-    loop {
-        if cancel.is_cancelled() {
-            return;
-        }
-        // First pass reuses the initial writer (already published to `store`);
-        // later passes create and publish a fresh one.
-        let writer = match writer.take() {
-            Some(w) => w,
-            None => {
-                let w = reflector::store::Writer::default();
-                *store.lock().expect("store lock poisoned") = w.as_reader();
-                w
-            }
-        };
-
-        let reflect = reflector::reflector(writer, watcher(slices.clone(), cfg_watch.clone()));
-        tokio::pin!(reflect);
-        loop {
-            tokio::select! {
-                _ = cancel.cancelled() => return,
-                item = reflect.next() => {
-                    if item.is_none() {
-                        break;
-                    }
-                    generation = generation.wrapping_add(1);
-                    let _ = changes_tx.send(generation);
-                }
-            }
-        }
-
-        tracing::warn!(
-            "EPP peer EndpointSlice reflector stream ended; re-establishing the watch in {}s",
-            WATCH_RESTART_BACKOFF.as_secs()
-        );
-        tokio::select! {
-            _ = cancel.cancelled() => return,
-            _ = tokio::time::sleep(WATCH_RESTART_BACKOFF) => {}
-        }
-        generation = generation.wrapping_add(1);
-        let _ = changes_tx.send(generation);
-    }
 }
 
 /// Format `host:port`, bracketing IPv6 literals (`fd00::1` -> `[fd00::1]`) so the
@@ -237,13 +187,23 @@ fn authority(ip: &str, port: u16) -> String {
     }
 }
 
-/// Collect non-terminating endpoint IPs from a set of EndpointSlices. Not-ready
-/// endpoints are kept: registering a peer whose ZMQ socket is not up yet is
-/// harmless (the sync connect retries), and it avoids missing a sibling that is
-/// still starting. Pure function.
-fn ready_ips<'a>(slices: impl Iterator<Item = &'a EndpointSlice>) -> BTreeSet<String> {
+fn is_ipv6(ip: &str) -> bool {
+    ip.contains(':')
+}
+
+/// Collect non-terminating endpoint IPs of the requested address family from a
+/// set of EndpointSlices. Not-ready endpoints are kept: registering a peer whose
+/// ZMQ socket is not up yet is harmless (the sync connect retries), and it avoids
+/// missing a sibling that is still starting. Pure function.
+fn peer_ips<'a>(
+    slices: impl Iterator<Item = &'a EndpointSlice>,
+    want_ipv6: bool,
+) -> BTreeSet<String> {
     let mut ips = BTreeSet::new();
     for slice in slices {
+        if slice.address_type.eq_ignore_ascii_case("IPv6") != want_ipv6 {
+            continue;
+        }
         for endpoint in &slice.endpoints {
             if endpoint
                 .conditions
@@ -268,9 +228,9 @@ mod tests {
     use super::*;
     use k8s_openapi::api::discovery::v1::{Endpoint, EndpointConditions};
 
-    fn slice_with(ips: &[&str], terminating: bool) -> EndpointSlice {
+    fn slice_with(ips: &[&str], terminating: bool, address_type: &str) -> EndpointSlice {
         EndpointSlice {
-            address_type: "IPv4".to_string(),
+            address_type: address_type.to_string(),
             endpoints: ips
                 .iter()
                 .map(|ip| Endpoint {
@@ -287,17 +247,34 @@ mod tests {
     }
 
     #[test]
-    fn ready_ips_keeps_non_terminating() {
-        let slices = [slice_with(&["10.0.0.1", "10.0.0.2"], false)];
-        let ips = ready_ips(slices.iter());
+    fn peer_ips_keeps_non_terminating() {
+        let slices = [slice_with(&["10.0.0.1", "10.0.0.2"], false, "IPv4")];
+        let ips = peer_ips(slices.iter(), false);
         assert!(ips.contains("10.0.0.1"));
         assert!(ips.contains("10.0.0.2"));
     }
 
     #[test]
-    fn ready_ips_drops_terminating() {
-        let slices = [slice_with(&["10.0.0.9"], true)];
-        assert!(ready_ips(slices.iter()).is_empty());
+    fn peer_ips_drops_terminating() {
+        let slices = [slice_with(&["10.0.0.9"], true, "IPv4")];
+        assert!(peer_ips(slices.iter(), false).is_empty());
+    }
+
+    #[test]
+    fn peer_ips_filters_by_address_family() {
+        // A dual-stack sibling is present in both an IPv4 and an IPv6 slice; only
+        // the family matching our own IP is kept, so it is registered once.
+        let slices = [
+            slice_with(&["10.0.0.1"], false, "IPv4"),
+            slice_with(&["fd00::1"], false, "IPv6"),
+        ];
+        let v4 = peer_ips(slices.iter(), false);
+        assert_eq!(v4.len(), 1);
+        assert!(v4.contains("10.0.0.1"));
+
+        let v6 = peer_ips(slices.iter(), true);
+        assert_eq!(v6.len(), 1);
+        assert!(v6.contains("fd00::1"));
     }
 
     #[test]

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -22,7 +22,6 @@ use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
 use anyhow::{Result, anyhow};
-use serde::{Deserialize, Serialize};
 
 use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
 use dynamo_kv_router::protocols::RoutingConstraints;
@@ -41,7 +40,7 @@ const DEFAULT_TENANT: &str = "default";
 
 /// A worker the EPP registers into the selector. Only the fields standalone
 /// mode populates are included; the selector defaults the rest.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkerRegistration {
     pub worker_id: u64,
     pub model_name: String,
@@ -49,57 +48,42 @@ pub struct WorkerRegistration {
     pub block_size: u32,
     pub data_parallel_size: u32,
     pub kv_events_endpoints: HashMap<u32, String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub replay_endpoint: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub total_kv_blocks: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub max_num_batched_tokens: Option<u64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub stable_routing_id: Option<String>,
 }
 
-/// A worker-selection request. Prompt fields are sent flat; raw `token_ids` let
-/// the selector compute block/sequence hashes.
-#[derive(Debug, Clone, Serialize)]
+/// A worker-selection request. Raw `token_ids` let the selector compute
+/// block/sequence hashes.
+#[derive(Debug, Clone)]
 pub struct SelectRequest {
     pub model_name: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub selection_id: Option<String>,
     pub token_ids: Vec<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub allowed_worker_ids: Option<HashSet<u64>>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub priority_jump: Option<f64>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub strict_priority: Option<u32>,
 }
 
 /// Observability overlap summary (matched token counts).
-#[derive(Debug, Clone, Default, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct OverlapSummary {
-    #[serde(default)]
     pub longest_matched: u32,
-    #[serde(default)]
     pub gpu: u32,
-    #[serde(default)]
     pub cpu: u32,
-    #[serde(default)]
     pub disk: u32,
 }
 
 /// The selector's choice for a prompt.
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone)]
 pub struct SelectResponse {
-    #[serde(default)]
     pub selection_id: Option<String>,
     pub worker_id: u64,
     pub dp_rank: u32,
     pub endpoint: String,
     pub block_size: u32,
-    #[serde(default)]
     pub overlap: OverlapSummary,
-    #[serde(default)]
     pub effective_prefill_tokens: usize,
 }
 
@@ -127,15 +111,23 @@ impl Selector {
         let mut builder =
             SelectionServiceBuilder::new(kv_router_config).indexer_threads(cfg.selector_threads);
 
-        let replicated = cfg.peer_service.is_some();
-        if replicated {
-            // Config validation guarantees peer_sync_port is set whenever
-            // peer_service is. Bind this replica's ZMQ replica-sync port; peers
-            // are registered dynamically by the EndpointSlice watch below.
-            let peer_sync_port = cfg
-                .peer_sync_port
-                .expect("peer_sync_port is required when peer_service is set");
-            builder = builder.replica_sync(peer_sync_port, Vec::new());
+        // Config validation already guarantees peer_sync_port is Some whenever
+        // peer_service is set; resolve the (name, port) pair once and surface the
+        // invariant as an error rather than a panic.
+        let replication: Option<(String, u16)> = match &cfg.peer_service {
+            Some(name) => {
+                let port = cfg.peer_sync_port.ok_or_else(|| {
+                    anyhow!("peer_sync_port is required when peer_service is set")
+                })?;
+                Some((name.clone(), port))
+            }
+            None => None,
+        };
+
+        if let Some((_, peer_sync_port)) = &replication {
+            // Bind this replica's ZMQ replica-sync port; peers are registered
+            // dynamically by the EndpointSlice watch below.
+            builder = builder.replica_sync(*peer_sync_port, Vec::new());
         }
 
         let service = Arc::new(
@@ -145,27 +137,27 @@ impl Selector {
                 .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
         );
 
-        if let Some(service_name) = cfg.peer_service.clone() {
-            // The EPP's own Service lives in the EPP's namespace (same as the
-            // pool); reuse the single resolved namespace.
-            let namespace = cfg.namespace.clone();
-            let peer_sync_port = cfg
-                .peer_sync_port
-                .expect("peer_sync_port is required when peer_service is set");
+        if let Some((service_name, peer_sync_port)) = replication {
+            // POD_IP is required (not advisory) in replicated mode: without it we
+            // can't exclude our own IP from the peer set, so this replica would
+            // sync with itself and double-count its own load. Fail fast rather
+            // than run in a knowingly-wrong state.
             let self_ip = std::env::var("POD_IP")
                 .ok()
                 .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty());
-            if self_ip.is_none() {
-                tracing::warn!(
-                    "DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; this replica cannot \
-                     exclude itself from its peer set. Inject POD_IP via the downward API \
-                     (fieldRef status.podIP)."
-                );
-            }
+                .filter(|s| !s.is_empty())
+                .ok_or_else(|| {
+                    anyhow!(
+                        "DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; inject POD_IP \
+                         via the downward API (fieldRef status.podIP) so this replica can \
+                         exclude itself from its peer set"
+                    )
+                })?;
+            // The EPP's own Service lives in the EPP's namespace (same as the
+            // pool); reuse the single resolved namespace.
             crate::peer_discovery::spawn(
                 service.clone(),
-                &namespace,
+                &cfg.namespace,
                 &service_name,
                 peer_sync_port,
                 self_ip,
@@ -176,7 +168,7 @@ impl Selector {
 
         tracing::info!(
             indexer_threads = cfg.selector_threads,
-            replicated,
+            replicated = cfg.peer_service.is_some(),
             "Initialized in-process selection service"
         );
 
@@ -239,15 +231,17 @@ impl Selector {
         Ok(())
     }
 
-    /// Select a worker for a prompt and book its load in one operation.
-    pub async fn select_and_reserve(&self, req: &SelectRequest) -> Result<SelectResponse> {
+    /// Select a worker for a prompt and book its load in one operation. Takes the
+    /// request by value so per-request fields (`token_ids`, `model_name`, ...) are
+    /// moved into the core request rather than cloned on the hot path.
+    pub async fn select_and_reserve(&self, req: SelectRequest) -> Result<SelectResponse> {
         let core_req = CoreSelectAndReserveRequest {
-            model_name: req.model_name.clone(),
+            model_name: req.model_name,
             tenant_id: DEFAULT_TENANT.to_string(),
-            selection_id: req.selection_id.clone(),
+            selection_id: req.selection_id,
             reservation_id: None,
             prompt: PromptRequest {
-                token_ids: Some(req.token_ids.clone()),
+                token_ids: Some(req.token_ids),
                 ..Default::default()
             },
             router_config_override: None,
@@ -256,7 +250,7 @@ impl Selector {
             priority_jump: req.priority_jump,
             strict_priority: req.strict_priority,
             pinned_worker: None,
-            allowed_worker_ids: req.allowed_worker_ids.clone(),
+            allowed_worker_ids: req.allowed_worker_ids,
             routing_constraints: RoutingConstraints::default(),
         };
         let resp = self
@@ -291,66 +285,5 @@ impl Drop for Selector {
         // Stop the peer-discovery watch; the service's own Drop stops the core,
         // KV-event listeners, scheduling, and replica-sync tasks.
         self.cancel.cancel();
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn worker_registration_serializes_expected_fields() {
-        let mut kv = HashMap::new();
-        kv.insert(0u32, "tcp://10.0.0.1:5557".to_string());
-        let reg = WorkerRegistration {
-            worker_id: 42,
-            model_name: "Qwen/Qwen3-0.6B".to_string(),
-            endpoint: "http://10.0.0.1:8000".to_string(),
-            block_size: 16,
-            data_parallel_size: 1,
-            kv_events_endpoints: kv,
-            replay_endpoint: None,
-            total_kv_blocks: Some(1000),
-            max_num_batched_tokens: None,
-            stable_routing_id: Some("vllm-0".to_string()),
-        };
-        let v = serde_json::to_value(&reg).unwrap();
-        assert_eq!(v["worker_id"], 42);
-        assert_eq!(v["model_name"], "Qwen/Qwen3-0.6B");
-        assert_eq!(v["endpoint"], "http://10.0.0.1:8000");
-        assert_eq!(v["block_size"], 16);
-        // Absent optional fields are omitted.
-        assert!(v.get("replay_endpoint").is_none());
-        assert!(v.get("max_num_batched_tokens").is_none());
-    }
-
-    #[test]
-    fn select_request_sends_flat_prompt() {
-        let req = SelectRequest {
-            model_name: "Qwen/Qwen3-0.6B".to_string(),
-            selection_id: Some("sel-1".to_string()),
-            token_ids: vec![1, 2, 3],
-            allowed_worker_ids: None,
-            priority_jump: None,
-            strict_priority: None,
-        };
-        let v = serde_json::to_value(&req).unwrap();
-        assert_eq!(v["token_ids"], serde_json::json!([1, 2, 3]));
-        assert_eq!(v["selection_id"], "sel-1");
-        assert!(v.get("allowed_worker_ids").is_none());
-    }
-
-    #[test]
-    fn select_response_deserializes() {
-        let v = serde_json::json!({
-            "worker_id": 7,
-            "dp_rank": 0,
-            "endpoint": "http://10.0.0.2:8000",
-            "block_size": 16
-        });
-        let resp: SelectResponse = serde_json::from_value(v).unwrap();
-        assert_eq!(resp.worker_id, 7);
-        assert_eq!(resp.endpoint, "http://10.0.0.2:8000");
-        assert_eq!(resp.effective_prefill_tokens, 0);
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/selector.rs
+++ b/deploy/inference-gateway/ext-proc/src/selector.rs
@@ -1,0 +1,356 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! In-process, runtime-free worker selector.
+//!
+//! Standalone mode runs the runtime-free selection service **in-process**: the
+//! EPP and a [`SelectionService`] are compiled into one binary and the EPP calls
+//! the selector's Rust API directly — no HTTP client, no second Deployment.
+//!
+//! With `DYN_EPP_PEER_SERVICE` set, [`Selector`] enables the service's
+//! replica-sync and starts a [`crate::peer_discovery`] watch of the EPP's own
+//! Service, so replicated EPP pods discover their siblings and sync active load
+//! over ZMQ (admission / prefill-complete / free). Without it, a single replica
+//! runs fully local.
+//!
+//! This module also owns the small plain types the reflector → topology adapter →
+//! router pipeline speaks ([`WorkerRegistration`], [`SelectRequest`],
+//! [`SelectResponse`]); the selector maps them to the selection service's own
+//! public request/response types (no JSON in the hot path).
+
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+use anyhow::{Result, anyhow};
+use serde::{Deserialize, Serialize};
+
+use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
+use dynamo_kv_router::protocols::RoutingConstraints;
+use dynamo_kv_router::services::selection::{
+    PromptRequest, SelectAndReserveRequest as CoreSelectAndReserveRequest, SelectionError,
+    SelectionService, SelectionServiceBuilder, WorkerRequest as CoreWorkerRequest,
+};
+use tokio::sync::Mutex;
+use tokio_util::sync::CancellationToken;
+
+use crate::epp_standalone_config::EppStandaloneConfig;
+
+/// Tenant scope for standalone mode. Must match between worker registration and
+/// selection; the selection service's own default is `"default"`.
+const DEFAULT_TENANT: &str = "default";
+
+/// A worker the EPP registers into the selector. Only the fields standalone
+/// mode populates are included; the selector defaults the rest.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct WorkerRegistration {
+    pub worker_id: u64,
+    pub model_name: String,
+    pub endpoint: String,
+    pub block_size: u32,
+    pub data_parallel_size: u32,
+    pub kv_events_endpoints: HashMap<u32, String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replay_endpoint: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub total_kv_blocks: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_num_batched_tokens: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stable_routing_id: Option<String>,
+}
+
+/// A worker-selection request. Prompt fields are sent flat; raw `token_ids` let
+/// the selector compute block/sequence hashes.
+#[derive(Debug, Clone, Serialize)]
+pub struct SelectRequest {
+    pub model_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_id: Option<String>,
+    pub token_ids: Vec<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub allowed_worker_ids: Option<HashSet<u64>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub priority_jump: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub strict_priority: Option<u32>,
+}
+
+/// Observability overlap summary (matched token counts).
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct OverlapSummary {
+    #[serde(default)]
+    pub longest_matched: u32,
+    #[serde(default)]
+    pub gpu: u32,
+    #[serde(default)]
+    pub cpu: u32,
+    #[serde(default)]
+    pub disk: u32,
+}
+
+/// The selector's choice for a prompt.
+#[derive(Debug, Clone, Deserialize)]
+pub struct SelectResponse {
+    #[serde(default)]
+    pub selection_id: Option<String>,
+    pub worker_id: u64,
+    pub dp_rank: u32,
+    pub endpoint: String,
+    pub block_size: u32,
+    #[serde(default)]
+    pub overlap: OverlapSummary,
+    #[serde(default)]
+    pub effective_prefill_tokens: usize,
+}
+
+/// In-process runtime-free selector wrapping a [`SelectionService`].
+pub struct Selector {
+    service: Arc<SelectionService>,
+    /// Cancels the peer-discovery watch on drop. The `SelectionService`'s own
+    /// `Drop` tears down its core + replica-sync tasks.
+    cancel: CancellationToken,
+    /// Last catalog we pushed into the service, keyed by `worker_id`. Lets
+    /// [`Selector::reconcile`] skip no-op upserts that would re-register
+    /// KV-event listeners.
+    current: Mutex<HashMap<u64, WorkerRegistration>>,
+}
+
+impl Selector {
+    /// Build an in-process selector from the standalone config. `selector_threads`
+    /// sizes the KV indexer pool; router scheduling comes from the standard
+    /// `DYN_ROUTER_*` environment. When `peer_service` is set, replica-sync is
+    /// enabled and a peer-discovery watch keeps the peer set in sync.
+    pub async fn new(cfg: &EppStandaloneConfig) -> Result<Self> {
+        let kv_router_config = kv_router_config_from_dynamo_env();
+        let cancel = CancellationToken::new();
+
+        let mut builder =
+            SelectionServiceBuilder::new(kv_router_config).indexer_threads(cfg.selector_threads);
+
+        let replicated = cfg.peer_service.is_some();
+        if replicated {
+            // Config validation guarantees peer_sync_port is set whenever
+            // peer_service is. Bind this replica's ZMQ replica-sync port; peers
+            // are registered dynamically by the EndpointSlice watch below.
+            let peer_sync_port = cfg
+                .peer_sync_port
+                .expect("peer_sync_port is required when peer_service is set");
+            builder = builder.replica_sync(peer_sync_port, Vec::new());
+        }
+
+        let service = Arc::new(
+            builder
+                .build()
+                .await
+                .map_err(|e| anyhow!("building embedded selection service: {e}"))?,
+        );
+
+        if let Some(service_name) = cfg.peer_service.clone() {
+            // The EPP's own Service lives in the EPP's namespace (same as the
+            // pool); reuse the single resolved namespace.
+            let namespace = cfg.namespace.clone();
+            let peer_sync_port = cfg
+                .peer_sync_port
+                .expect("peer_sync_port is required when peer_service is set");
+            let self_ip = std::env::var("POD_IP")
+                .ok()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty());
+            if self_ip.is_none() {
+                tracing::warn!(
+                    "DYN_EPP_PEER_SERVICE is set but POD_IP is unavailable; this replica cannot \
+                     exclude itself from its peer set. Inject POD_IP via the downward API \
+                     (fieldRef status.podIP)."
+                );
+            }
+            crate::peer_discovery::spawn(
+                service.clone(),
+                &namespace,
+                &service_name,
+                peer_sync_port,
+                self_ip,
+                cancel.clone(),
+            )
+            .await?;
+        }
+
+        tracing::info!(
+            indexer_threads = cfg.selector_threads,
+            replicated,
+            "Initialized in-process selection service"
+        );
+
+        Ok(Self {
+            service,
+            cancel,
+            current: Mutex::new(HashMap::new()),
+        })
+    }
+
+    fn worker_request(reg: &WorkerRegistration) -> CoreWorkerRequest {
+        CoreWorkerRequest {
+            worker_id: reg.worker_id,
+            model_name: reg.model_name.clone(),
+            tenant_id: DEFAULT_TENANT.to_string(),
+            endpoint: Some(reg.endpoint.clone()),
+            block_size: Some(reg.block_size),
+            data_parallel_size: Some(reg.data_parallel_size),
+            kv_events_endpoints: reg.kv_events_endpoints.clone(),
+            replay_endpoint: reg.replay_endpoint.clone(),
+            total_kv_blocks: reg.total_kv_blocks,
+            max_num_batched_tokens: reg.max_num_batched_tokens,
+            stable_routing_id: reg.stable_routing_id.clone(),
+            ..Default::default()
+        }
+    }
+
+    /// Drive the selector catalog toward `desired` (keyed by `worker_id`).
+    /// Idempotent: safe to call repeatedly.
+    pub async fn reconcile(&self, desired: &HashMap<u64, WorkerRegistration>) -> Result<()> {
+        let mut current = self.current.lock().await;
+
+        // Upsert new or changed workers.
+        for (worker_id, reg) in desired {
+            if current.get(worker_id) == Some(reg) {
+                continue;
+            }
+            self.service
+                .upsert_worker(Self::worker_request(reg))
+                .await
+                .map_err(|e| anyhow!("upsert_worker failed: {e}"))?;
+            current.insert(*worker_id, reg.clone());
+        }
+
+        // Delete workers that are no longer desired.
+        let stale: Vec<u64> = current
+            .keys()
+            .copied()
+            .filter(|id| !desired.contains_key(id))
+            .collect();
+        for worker_id in stale {
+            match self.service.delete_worker(worker_id).await {
+                // A worker that was never registered is not an error (idempotent).
+                Ok(_) | Err(SelectionError::NotFound(_)) => {}
+                Err(e) => return Err(anyhow!("delete_worker failed: {e}")),
+            }
+            current.remove(&worker_id);
+        }
+
+        Ok(())
+    }
+
+    /// Select a worker for a prompt and book its load in one operation.
+    pub async fn select_and_reserve(&self, req: &SelectRequest) -> Result<SelectResponse> {
+        let core_req = CoreSelectAndReserveRequest {
+            model_name: req.model_name.clone(),
+            tenant_id: DEFAULT_TENANT.to_string(),
+            selection_id: req.selection_id.clone(),
+            reservation_id: None,
+            prompt: PromptRequest {
+                token_ids: Some(req.token_ids.clone()),
+                ..Default::default()
+            },
+            router_config_override: None,
+            expected_output_tokens: None,
+            session_id: None,
+            priority_jump: req.priority_jump,
+            strict_priority: req.strict_priority,
+            pinned_worker: None,
+            allowed_worker_ids: req.allowed_worker_ids.clone(),
+            routing_constraints: RoutingConstraints::default(),
+        };
+        let resp = self
+            .service
+            .select_and_reserve(core_req)
+            .await
+            .map_err(|e| anyhow!("select_and_reserve failed: {e}"))?;
+        Ok(SelectResponse {
+            selection_id: resp.selection_id,
+            worker_id: resp.worker_id,
+            dp_rank: resp.dp_rank,
+            endpoint: resp.endpoint,
+            block_size: resp.block_size,
+            overlap: OverlapSummary {
+                longest_matched: resp.overlap.longest_matched,
+                gpu: resp.overlap.gpu,
+                cpu: resp.overlap.cpu,
+                disk: resp.overlap.disk,
+            },
+            effective_prefill_tokens: resp.effective_prefill_tokens,
+        })
+    }
+
+    /// Returns `true` once the selector can schedule at least one worker.
+    pub async fn any_ready(&self) -> bool {
+        self.service.ready().ready
+    }
+}
+
+impl Drop for Selector {
+    fn drop(&mut self) {
+        // Stop the peer-discovery watch; the service's own Drop stops the core,
+        // KV-event listeners, scheduling, and replica-sync tasks.
+        self.cancel.cancel();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn worker_registration_serializes_expected_fields() {
+        let mut kv = HashMap::new();
+        kv.insert(0u32, "tcp://10.0.0.1:5557".to_string());
+        let reg = WorkerRegistration {
+            worker_id: 42,
+            model_name: "Qwen/Qwen3-0.6B".to_string(),
+            endpoint: "http://10.0.0.1:8000".to_string(),
+            block_size: 16,
+            data_parallel_size: 1,
+            kv_events_endpoints: kv,
+            replay_endpoint: None,
+            total_kv_blocks: Some(1000),
+            max_num_batched_tokens: None,
+            stable_routing_id: Some("vllm-0".to_string()),
+        };
+        let v = serde_json::to_value(&reg).unwrap();
+        assert_eq!(v["worker_id"], 42);
+        assert_eq!(v["model_name"], "Qwen/Qwen3-0.6B");
+        assert_eq!(v["endpoint"], "http://10.0.0.1:8000");
+        assert_eq!(v["block_size"], 16);
+        // Absent optional fields are omitted.
+        assert!(v.get("replay_endpoint").is_none());
+        assert!(v.get("max_num_batched_tokens").is_none());
+    }
+
+    #[test]
+    fn select_request_sends_flat_prompt() {
+        let req = SelectRequest {
+            model_name: "Qwen/Qwen3-0.6B".to_string(),
+            selection_id: Some("sel-1".to_string()),
+            token_ids: vec![1, 2, 3],
+            allowed_worker_ids: None,
+            priority_jump: None,
+            strict_priority: None,
+        };
+        let v = serde_json::to_value(&req).unwrap();
+        assert_eq!(v["token_ids"], serde_json::json!([1, 2, 3]));
+        assert_eq!(v["selection_id"], "sel-1");
+        assert!(v.get("allowed_worker_ids").is_none());
+    }
+
+    #[test]
+    fn select_response_deserializes() {
+        let v = serde_json::json!({
+            "worker_id": 7,
+            "dp_rank": 0,
+            "endpoint": "http://10.0.0.2:8000",
+            "block_size": 16
+        });
+        let resp: SelectResponse = serde_json::from_value(v).unwrap();
+        assert_eq!(resp.worker_id, 7);
+        assert_eq!(resp.endpoint, "http://10.0.0.2:8000");
+        assert_eq!(resp.effective_prefill_tokens, 0);
+    }
+}

--- a/lib/kv-router/src/services/selection/input.rs
+++ b/lib/kv-router/src/services/selection/input.rs
@@ -20,7 +20,7 @@ pub struct MmRoutingInfoRequest {
     pub block_mm_infos: Vec<Option<BlockExtraInfo>>,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 pub struct PromptRequest {
     #[serde(default)]
     pub token_ids: Option<Vec<u32>>,

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -20,6 +20,7 @@ mod tests;
 pub use crate::services::common::replica_sync::ReplicaPeerError;
 pub use core::{SelectionCore, SelectionServiceConfig};
 pub use error::SelectionError;
+pub use input::PromptRequest;
 pub use server::{AppState, run_server};
 pub use service::{SelectionService, SelectionServiceBuilder};
 pub use types::{

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -265,6 +265,36 @@ impl WorkerCatalogRecord {
     }
 }
 
+// Manual `Default` (not derived) so `model_name`/`tenant_id` match the serde
+// defaults (`"default"`) rather than empty strings; a `..Default::default()`
+// caller that forgets to set them would otherwise store the worker under an
+// unexpected `("", "")` scope.
+impl Default for WorkerRequest {
+    fn default() -> Self {
+        Self {
+            worker_id: 0,
+            model_name: default_model_name(),
+            tenant_id: default_tenant_id(),
+            endpoint: None,
+            kv_events_endpoint: None,
+            kv_events_endpoints: HashMap::new(),
+            replay_endpoint: None,
+            block_size: None,
+            data_parallel_start_rank: None,
+            data_parallel_size: None,
+            max_num_batched_tokens: None,
+            total_kv_blocks: None,
+            stable_routing_id: None,
+            is_eagle: None,
+            taints: HashSet::new(),
+            topology_domains: HashMap::new(),
+            kv_transfer_domain: None,
+            kv_transfer_enforcement: None,
+            kv_transfer_preferred_weight: None,
+        }
+    }
+}
+
 #[derive(Debug, Deserialize)]
 pub struct WorkerRequest {
     pub worker_id: WorkerId,


### PR DESCRIPTION
## Summary

This PR lets the EPP run the runtime-free selection service **in-process** — the
EPP and the standalone selector are compiled into one binary and the EPP calls
its Rust API directly. 

It also supports running **more than one EPP replica**: replicas discover each
other and keep their active-load view in sync, so they don't each under-count
load and herd onto the same worker.

## Details

- **`selector.rs`** — a `Selector` that wraps an in-process `SelectionService`
  (from `dynamo-kv-router`)
- **`peer_discovery.rs`** — when `DYN_EPP_PEER_SERVICE` is set, the EPP watches
  its *own* Kubernetes Service's EndpointSlices and registers/deregisters sibling
  replicas as replica-sync peers. Admission / prefill-complete / free are then
  broadcast over ZMQ so every replica converges on the same active-load view.
  Unset ⇒ a single, fully-local replica.


This is a foundational building block: the topology adapter (#11074) and the
router wiring (#11075) build on `Selector`; the reservation release lifecycle
lands in #11155.


Replaces #11107, which GitHub auto-closed as "merged" 