### PR TITLE
fix: fix the needs_nixl flag to true when multimodal disagg is enabled

### DIFF
--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -458,8 +458,9 @@ async def init_llm_worker(
         default_sampling_params.detokenize = False
 
     connector = None
-    needs_nixl = config.disaggregation_mode != DisaggregationMode.AGGREGATED or (
+    needs_nixl = (
         config.modality == Modality.MULTIMODAL
+        and config.disaggregation_mode != DisaggregationMode.AGGREGATED
         and (
             config.frontend_decoding
             or config.disaggregation_mode == DisaggregationMode.ENCODE


### PR DESCRIPTION
## fix(trtllm): scope NIXL Connect initialization to multimodal disaggregated workers only

### Problem

The `needs_nixl` predicate in `init_llm_worker` used `disaggregation_mode != AGGREGATED` as its
primary condition, joined by `or`. This caused every non-aggregated worker — including plain text
PREFILL and DECODE workers — to attempt `nixl_connect.Connector()` initialization, even though
`nixl_connect` is only needed for multimodal embedding transfer over NIXL (not for KV-cache
disaggregation, which goes through TRTLLM nixl c++ libs integration). On nodes where the `nixl`
Python bindings are not installed, this produced a confusing deferred `ImportError` traceback from
inside `_create_connection()` for workers that never needed NIXL in the first place.

### Fix

Rewrote the predicate as a conjunction:

```python
needs_nixl = (
    config.modality == Modality.MULTIMODAL
    and config.disaggregation_mode != DisaggregationMode.AGGREGATED
    and (
        config.frontend_decoding
        or config.disaggregation_mode == DisaggregationMode.ENCODE
        or (
            config.disaggregation_mode == DisaggregationMode.PREFILL
            and bool(config.encode_endpoint)
        )
    )
)
```

- `modality == MULTIMODAL` — non-multimodal workers never need the nixl_connect path
- `disaggregation_mode != AGGREGATED` — hard gate ensuring aggregated workers never initialize
  nixl_connect, even if `frontend_decoding` is set
- The inner sub-conditions are unchanged: ENCODE worker, PREFILL worker with an encode endpoint,
  or frontend-decoding worker

Workers that do not satisfy all three conditions fall through to the existing
`"Skipping NIXL Connect initialization"` log line.

## Related Issues
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted worker startup behavior so the connection setup now only runs for supported multimodal, non-aggregated configurations.
  * This reduces unnecessary initialization for other setups and makes startup behavior more consistent across configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->