### PR TITLE
docs(agents): add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -144,3 +144,45 @@ Any change under `docs/`, `examples/`, or `recipes/` must follow
 [documentation style guide](docs/documentation-style-guide.md): SPDX headers, Fern
 frontmatter (no body `# H1`), GitHub-style admonitions, and backend casing
 (vLLM / SGLang / TensorRT-LLM). The deterministic subset is enforced pre-merge.
+
+## Cursor Cloud specific instructions
+
+The Cursor Cloud VM has **no GPU** and **restricted network egress** (Hugging Face and
+some other hosts are unreachable). The standard Build / Test / Lint commands above work;
+the notes below cover only the non-obvious caveats for this environment. The startup
+update script already activates `.venv` and refreshes the editable installs
+(`maturin develop`, `-e .`, `-e lib/gpu_memory_service`, `requirements.test.txt`), so a
+fresh session just needs `source .venv/bin/activate` before running anything.
+
+- **Toolchain:** `cc`/`c++` default to `clang`, which cannot compile/link the vendored
+  ZeroMQ (`zmq-sys`) C++ dependency (missing `libstdc++`). The snapshot pins `cc`→`gcc`
+  and `c++`→`g++` via `update-alternatives`; keep it that way or `maturin develop` /
+  `cargo build` will fail at the `zmq-sys` link step.
+- **No GPU:** the real backends (`dynamo.vllm`, `dynamo.sglang`, `dynamo.trtllm`) and the
+  `kvbm` bindings (need CUDA/NIXL) can't run here. Use `python -m dynamo.mocker` as a
+  GPU-free worker. `pytest -m unit tests/` passes except the optional `kvbm` import checks
+  in `tests/dependencies/test_kvbm_imports.py` (kvbm wheel not built) — expected.
+- **Offline models:** never rely on downloading from Hugging Face. Use the local
+  fixture models under `lib/llm/tests/data/sample-models/` and set `HF_HUB_OFFLINE=1`
+  `TRANSFORMERS_OFFLINE=1`. For `/v1/chat/completions` the model dir must contain a
+  `chat_template` (e.g. `mock-llama-3.1-8b-instruct`; `TinyLlama_v1.1` has none and only
+  works for non-chat paths).
+- **Run without etcd/NATS:** the frontend defaults to etcd discovery, which is not running.
+  Pass `--discovery-backend file` to both the frontend and the worker and point them at the
+  same `DYN_FILE_KV` dir (defaults to `$TMPDIR/dynamo_store_kv`). The default `tcp` request
+  plane and `zmq` event plane need no external services.
+- **GPU-free smoke test** (frontend + KV router + mock worker), each in its own shell:
+  ```bash
+  export HF_HUB_OFFLINE=1 TRANSFORMERS_OFFLINE=1 DYN_FILE_KV=/tmp/dynamo_store_kv
+  python -m dynamo.frontend --http-port 8000 --router-mode round-robin --discovery-backend file
+  python -m dynamo.mocker --model-path lib/llm/tests/data/sample-models/mock-llama-3.1-8b-instruct \
+      --discovery-backend file --speedup-ratio 1000
+  curl -s localhost:8000/v1/chat/completions -H 'Content-Type: application/json' \
+      -d '{"model":"lib/llm/tests/data/sample-models/mock-llama-3.1-8b-instruct","messages":[{"role":"user","content":"hi"}],"max_tokens":20}'
+  ```
+  The mocker simulates scheduling/KV/timing and returns token counts (`content` is `null`
+  because it emits placeholder token IDs, not real text) — that is expected.
+- **`pre-commit run --all-files`:** the deterministic hooks (isort, black, flake8,
+  clang-format, codespell, ruff, file checks) pass. The `pytest-marker-report` hook needs
+  the full backend deps installed to collect every test, so it reports gaps on this
+  GPU-free VM; treat its result as informational here.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Overview:

Sets up the Dynamo development environment on a Cursor Cloud VM (no GPU, restricted egress) and documents the non-obvious caveats discovered so future agents can build, test, lint, and run the GPU-free path (frontend + KV router + mock worker) without re-deriving them.

This PR only adds a `## Cursor Cloud specific instructions` section to `AGENTS.md`; no code is changed. Toolchain/system changes (gcc default, `uv`, system libs) are captured in the VM snapshot + startup update script rather than in the repo.

## Details:

Verified end-to-end in the Cloud VM:
- **Build:** system libs (`libhwloc-dev`, `libclang-dev`, `protobuf-compiler`, `cmake`, …), `uv`, `maturin develop` for the PyO3 bindings, editable installs of `ai-dynamo` and `gpu_memory_service`. Root cause fixed: default `cc`/`c++` are clang and cannot build/link the vendored ZeroMQ (`zmq-sys`); switched `update-alternatives` to `gcc`/`g++`.
- **Run (GPU-free):** `dynamo.frontend` + `dynamo.mocker` with `--discovery-backend file` (no etcd/NATS) using a local sample tokenizer with a `chat_template`; `/v1/chat/completions` (streaming + non-streaming) returns HTTP 200 through the router.
- **Test:** `pytest -m unit tests/` → 76 passed / 21 skipped (optional GPU/backends) / 2 optional `kvbm` import failures; `cargo test` core crates green.
- **Lint:** `pre-commit` deterministic hooks (isort, black, flake8, clang-format, codespell, ruff, file checks) pass; `cargo fmt --all --check` passes.

The AGENTS.md notes document: the gcc toolchain requirement, no-GPU worker via `dynamo.mocker`, offline Hugging Face handling with local fixture models, file-based discovery to avoid etcd/NATS, the `chat_template` requirement for chat completions, and the GPU-free smoke test.

## Where should the reviewer start?

`AGENTS.md` → the new `## Cursor Cloud specific instructions` section.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-0413ae34-4ea6-43bc-80ae-938ad2a623f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0413ae34-4ea6-43bc-80ae-938ad2a623f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

