### PR TITLE
fix(container): install zstandard in sglang runtime image

### DIFF
--- a/container/deps/requirements.sglang.txt
+++ b/container/deps/requirements.sglang.txt
@@ -11,3 +11,4 @@
 
 blake3>=1.0.0,<2.0.0  # Dynamo SGLang multimodal request handlers import blake3 at startup
 imageio-ffmpeg>=0.6.0  # binary skipped per --no-binary directive at top of file
+zstandard==0.23.0


### PR DESCRIPTION
## Summary

- Backport #11362 to release/1.3.0.
- Install `zstandard==0.23.0` explicitly in the SGLang runtime image, whose `--no-deps` installation path does not resolve this transitive runtime dependency.
- Restore the RL metadata upload path that imports `zstandard`.

## Validation

- `git diff --check release/1.3.0...HEAD`
- Confirmed the backport and source commit have the same stable patch ID: `6734ab9f3c249ae80f2bc250a1a0855dbab85337`.
- Confirmed `requirements.sglang.txt` uses the same `zstandard==0.23.0` pin as `requirements.common.txt`.