### PR TITLE
fix(profiler): backport unverified SLA warning to 1.3.0

### DIFF
--- a/components/src/dynamo/profiler/rapid.py
+++ b/components/src/dynamo/profiler/rapid.py
@@ -150,6 +150,23 @@ def _run_naive_fallback(
         "AIC does not support this combo — falling back to naive config generation."
     )
 
+    sla = dgdr.sla
+    if sla is not None and sla.e2eLatency is not None:
+        requested_sla = f"e2eLatency={sla.e2eLatency:.1f}ms"
+    elif sla is not None and sla.ttft is not None and sla.itl is not None:
+        requested_sla = f"ttft={sla.ttft:.1f}ms, itl={sla.itl:.1f}ms"
+    else:
+        requested_sla = "requested SLA"
+    logger.warning(
+        "SLA is unverified (%s): no performance estimates are available for "
+        "model=%s, system=%s, backend=%s. Naive fallback will generate a default "
+        "configuration that may not meet the requested SLA.",
+        requested_sla,
+        model,
+        system,
+        backend,
+    )
+
     generator_params = build_naive_generator_params(
         model_name=model,
         total_gpus=total_gpus,

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py
@@ -9,6 +9,7 @@ the end-to-end test suite.
 """
 
 import copy
+import logging
 from unittest.mock import patch
 
 import pandas as pd
@@ -118,6 +119,72 @@ class TestRunNaiveFallback:
         ):
             result = _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
         assert result["dgd_config"] is None
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_warns_when_ttft_itl_sla_is_unverified(self, caplog):
+        """Naive fallback warns that requested TTFT/ITL targets were not evaluated."""
+        dgdr = _make_dgdr(sla=SLASpec(ttft=1.0, itl=1.0))
+        with (
+            patch(
+                "dynamo.profiler.rapid.build_naive_generator_params",
+                return_value=copy.deepcopy(_FAKE_GENERATOR_PARAMS),
+            ),
+            patch(
+                "dynamo.profiler.rapid.generate_backend_artifacts",
+                return_value={},
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+
+        assert "SLA is unverified (ttft=1.0ms, itl=1.0ms)" in caplog.text
+        assert "model=Qwen/Qwen3-32B, system=l40s, backend=vllm" in caplog.text
+        assert "may not meet the requested SLA" in caplog.text
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_warns_when_e2e_sla_is_unverified(self, caplog):
+        """Naive fallback reports an end-to-end target without fake TTFT/ITL values."""
+        dgdr = _make_dgdr(sla=SLASpec(ttft=None, itl=None, e2eLatency=35000.0))
+        with (
+            patch(
+                "dynamo.profiler.rapid.build_naive_generator_params",
+                return_value=copy.deepcopy(_FAKE_GENERATOR_PARAMS),
+            ),
+            patch(
+                "dynamo.profiler.rapid.generate_backend_artifacts",
+                return_value={},
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+
+        assert "SLA is unverified (e2eLatency=35000.0ms)" in caplog.text
+        assert "ttft=" not in caplog.text
+        assert "itl=" not in caplog.text
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
+    def test_warns_when_sla_targets_are_absent(self, caplog):
+        """Naive fallback uses a generic label when no latency target is set."""
+        dgdr = _make_dgdr(sla=SLASpec(ttft=None, itl=None, e2eLatency=None))
+        with (
+            patch(
+                "dynamo.profiler.rapid.build_naive_generator_params",
+                return_value=copy.deepcopy(_FAKE_GENERATOR_PARAMS),
+            ),
+            patch(
+                "dynamo.profiler.rapid.generate_backend_artifacts",
+                return_value={},
+            ),
+            caplog.at_level(logging.WARNING),
+        ):
+            _run_naive_fallback(dgdr, "Qwen/Qwen3-32B", 4, "l40s", "vllm")
+
+        assert "SLA is unverified (requested SLA)" in caplog.text
+        assert "ttft=" not in caplog.text
+        assert "itl=" not in caplog.text
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0


### PR DESCRIPTION
#### Overview:

Backports the SLA verification warning from #11338 to `release/1.3.0`.

## Summary

- warn when naive fallback generates a default configuration without performance estimates
- include the requested TTFT/ITL or end-to-end SLA plus model, system, and backend context
- handle absent SLA targets without raising a formatting error
- preserve non-blocking fallback behavior

This supersedes closed PR #11358. The new branch is based directly on `origin/release/1.3.0`.

#### Details:

This cleanly cherry-picks merge commit `a7c327a18936b87c172cd3eeebe9b842b7650d6d` onto `release/1.3.0`.

#### Where should the reviewer start?

- `components/src/dynamo/profiler/rapid.py`
- `components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py`

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- Relates to #11338
- Relates to #11358
- Tracks [DYN-2396](https://linear.app/nvidia/issue/DYN-2396/dynamorelease100-dgdr-tc-92-infeasible-sla-targets-silently-accepted)
- Tracks [NVBug 5962846](https://nvbugspro.nvidia.com/bug/5962846)

## Validation

- `.venv/bin/python -m pytest components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py -q` (15 passed)
- `.venv/bin/python -m ruff check components/src/dynamo/profiler/rapid.py components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py`
- `.venv/bin/python -m ruff format --check components/src/dynamo/profiler/rapid.py components/src/dynamo/profiler/tests/unit/test_helpers_rapid.py`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11380" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->