### PR TITLE
docs(observability): update OTLP export docs for endpoint fallback and HTTP protocol [release/1.3.0]

### DIFF
--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -13,8 +13,11 @@ Set these on every Dynamo process (frontend, router, workers) for metrics, trace
 |---|---|---|
 | `DYN_SYSTEM_PORT=8081` | Unified system port (metrics + health). | Yes for metrics. |
 | `OTEL_EXPORT_ENABLED=true` | Enable OpenTelemetry export. **Without this, traces and logs never leave the process** — Loki and Tempo will show nothing even if they are healthy. | Yes for traces/logs. |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | OTLP gRPC endpoint for traces (e.g. `http://tempo:4317`). Must be a gRPC listener — Dynamo's exporter does not speak OTLP/HTTP, even though the OTel Collector also listens on `:4318`. | Yes for traces. |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP gRPC endpoint for logs (e.g. `http://loki-otlp:4317`). Same gRPC-only constraint as the traces endpoint above. | Yes for logs. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Generic OTLP endpoint for both traces and logs (e.g. `http://otel-collector:4317`). With `http/protobuf`, Dynamo appends the signal path (`/v1/traces`, `/v1/logs`). | Yes, unless both signal-specific endpoints below are set. |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Endpoint for traces only (e.g. `http://tempo:4317`), used as-is — no path is appended. Falls back to `OTEL_EXPORTER_OTLP_ENDPOINT`, then the protocol default (`http://localhost:4317` for `grpc`, `http://localhost:4318/v1/traces` for `http/protobuf`). | Optional override. |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Endpoint for logs only (e.g. `http://loki-otlp:4317`), used as-is. Same fallback chain as the traces endpoint (the `http/protobuf` default is `http://localhost:4318/v1/logs`). **Does not fall back to the traces endpoint** (changed in v1.3.0) — if you set only the traces endpoint, logs go to the protocol default and are silently dropped. | Optional override. |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP transport: `grpc` (default) or `http/protobuf`. Override per signal with `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` / `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL`. | Optional. |
+| `OTEL_TRACES_SAMPLE_RATIO` | Trace head-sampling ratio in `[0.0, 1.0]` (e.g. `0.01` keeps ~1% of traces). Unset exports every trace. | Optional. |
 | `DYN_LOGGING_JSONL=true` | Structured JSON log output (recommended for Loki). | Optional. |
 
 Source of truth: [`lib/runtime/src/logging.rs`](https://github.com/ai-dynamo/dynamo/blob/main/lib/runtime/src/logging.rs) `setup_logging()`.
@@ -57,9 +60,9 @@ For detailed setup instructions and configuration, see [Prometheus + Grafana Set
 | [Metrics](metrics.md) | Available metrics reference | `DYN_SYSTEM_PORT`† |
 | [Operator Metrics (Kubernetes)](../kubernetes/observability/operator-metrics.md) | Operator controller and webhook metrics for Kubernetes | N/A (configured via Helm) |
 | [Health Checks](health-checks.md) | Component health monitoring and readiness probes | `DYN_SYSTEM_PORT`†, `DYN_SYSTEM_STARTING_HEALTH_STATUS`, `DYN_SYSTEM_HEALTH_PATH`, `DYN_SYSTEM_LIVE_PATH`, `DYN_SYSTEM_USE_ENDPOINT_HEALTH_STATUS` |
-| [Tracing](tracing.md) | Distributed tracing with OpenTelemetry and Tempo | `DYN_LOGGING_JSONL`†, `OTEL_EXPORT_ENABLED`†, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`†, `OTEL_SERVICE_NAME`† |
+| [Tracing](tracing.md) | Distributed tracing with OpenTelemetry and Tempo | `DYN_LOGGING_JSONL`†, `OTEL_EXPORT_ENABLED`†, `OTEL_EXPORTER_OTLP_ENDPOINT`†, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`†, `OTEL_EXPORTER_OTLP_PROTOCOL`†, `OTEL_TRACES_SAMPLE_RATIO`, `OTEL_SERVICE_NAME`† |
 | [Request Replay Tracing](request-tracing.md) | Per-request JSONL capture for direct DynoSim replay | `DYN_REQUEST_TRACE`, `DYN_REQUEST_TRACE_OUTPUT_PATH` |
-| [Logging](logging.md) | Structured logging and OTLP log export to Loki | `DYN_LOGGING_JSONL`†, `DYN_LOG`, `DYN_LOG_USE_LOCAL_TZ`, `DYN_LOGGING_CONFIG_PATH`, `OTEL_SERVICE_NAME`†, `OTEL_EXPORT_ENABLED`†, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`†, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`† |
+| [Logging](logging.md) | Structured logging and OTLP log export to Loki | `DYN_LOGGING_JSONL`†, `DYN_LOG`, `DYN_LOG_USE_LOCAL_TZ`, `DYN_LOGGING_CONFIG_PATH`, `OTEL_SERVICE_NAME`†, `OTEL_EXPORT_ENABLED`†, `OTEL_EXPORTER_OTLP_ENDPOINT`†, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`†, `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`†, `OTEL_EXPORTER_OTLP_PROTOCOL`† |
 
 **Variables marked with † are shared across multiple observability systems.**
 

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -29,20 +29,32 @@ enabled via the `DYN_LOGGING_SPAN_EVENTS` environment variable.
 | `DYN_SKIP_SGLANG_LOG_FORMATTING` | Disable Dynamo's SGLang log configuration | `false` | `true` |
 | `OTEL_SERVICE_NAME` | Service name for trace and span information | `dynamo` | `dynamo-frontend` |
 | `OTEL_EXPORT_ENABLED` | Enable OTLP export of both traces and logs | `false` | `true` |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | OTLP gRPC endpoint for traces | `http://localhost:4317` | `http://tempo:4317` |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP gRPC endpoint for logs (defaults to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` if not set) | same as traces endpoint | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Default OTLP endpoint for traces and logs when signal-specific endpoints are unset | `http://localhost:4317` (`grpc`) / `http://localhost:4318` (`http/protobuf`) | `http://otel-collector:4317` |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Override endpoint for traces, used as-is | unset | `http://tempo:4317` |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Override endpoint for logs, used as-is | unset | `http://loki-collector:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | Default OTLP protocol for traces and logs | `grpc` | `http/protobuf` |
+| `OTEL_EXPORTER_OTLP_TRACES_PROTOCOL` | Override protocol for traces | unset | `grpc` |
+| `OTEL_EXPORTER_OTLP_LOGS_PROTOCOL` | Override protocol for logs | unset | `grpc` |
+| `OTEL_TRACES_SAMPLE_RATIO` | Trace head-sampling ratio in `[0.0, 1.0]`; unset exports every trace | unset (export all) | `0.01` |
 
 ## OTLP Log Export
 
 When `OTEL_EXPORT_ENABLED=true`, Dynamo exports both **traces and logs** via OTLP. Logs are sent to an OpenTelemetry Collector which routes them to Grafana Loki for aggregation and querying.
 
-By default, logs are exported to the same endpoint as traces (`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`). To send logs to a different endpoint, set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`:
+Set `OTEL_EXPORTER_OTLP_ENDPOINT` to configure the default OTLP collector endpoint for both traces and logs. To send logs somewhere else, set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`; to send traces somewhere else, set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.
+
+Signal-specific endpoints are used as-is. When using the generic `OTEL_EXPORTER_OTLP_ENDPOINT` with `http/protobuf`, Dynamo appends the signal path (`/v1/logs` or `/v1/traces`). With `grpc`, the endpoint is used without a path.
+
+> [!WARNING]
+> Changed in v1.3.0: `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` no longer falls back to `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. It now falls back to the generic `OTEL_EXPORTER_OTLP_ENDPOINT`, then the protocol default. A deployment that sets only the traces endpoint sends logs to the protocol default (`http://localhost:4317` for `grpc`, `http://localhost:4318/v1/logs` for `http/protobuf`), where they are silently dropped if no collector is listening. Also set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`, or use the generic `OTEL_EXPORTER_OTLP_ENDPOINT` for both signals.
 
 ```bash
 export OTEL_EXPORT_ENABLED=true
-export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://localhost:4317
-# Optional: send logs to a different endpoint
-# export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://localhost:4317
+# Generic endpoint applies to both traces and logs:
+export OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+# Optional per-signal overrides:
+# export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://tempo:4317
+# export OTEL_EXPORTER_OTLP_LOGS_ENDPOINT=http://loki-collector:4317
 ```
 
 The local observability stack (see [Getting Started](README.md#getting-started-quickly)) includes an OpenTelemetry Collector that receives OTLP on `localhost:4317` and routes traces to Tempo and logs to Loki. In Grafana, the Loki datasource is pre-configured with a derived field that links `trace_id` labels to Tempo, so you can jump directly from a log line to its corresponding trace.

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -11,7 +11,7 @@ Dynamo supports OpenTelemetry-based distributed tracing for visualizing request 
 
 **Requirements:** Set `DYN_LOGGING_JSONL=true` and `OTEL_EXPORT_ENABLED=true` to export traces to Tempo.
 
-**Note:** When OTLP export is enabled, Dynamo exports both **traces and logs**. Traces are sent to Tempo and logs are sent to Loki (via the OpenTelemetry Collector). To send logs to a separate endpoint, set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`; otherwise it defaults to the traces endpoint. See [Logging](logging.md#otlp-log-export) for details.
+**Note:** When OTLP export is enabled, Dynamo exports both **traces and logs**. Traces are sent to Tempo and logs are sent to Loki (via the OpenTelemetry Collector). To send logs to a separate endpoint, set `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT`; otherwise it falls back to the generic `OTEL_EXPORTER_OTLP_ENDPOINT`, then the protocol default — it does **not** follow the traces endpoint. See [Logging](logging.md#otlp-log-export) for details.
 
 This guide covers single GPU demo setup using Docker Compose. For Kubernetes deployments, see [Kubernetes Deployment](#kubernetes-deployment).
 
@@ -23,8 +23,11 @@ This guide covers single GPU demo setup using Docker Compose. For Kubernetes dep
 |----------|-------------|---------|---------|
 | `DYN_LOGGING_JSONL` | Enable JSONL logging format (required for tracing) | `false` | `true` |
 | `OTEL_EXPORT_ENABLED` | Enable OTLP trace export | `false` | `true` |
-| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | OTLP gRPC endpoint for traces | `http://localhost:4317` | `http://tempo:4317` |
-| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | OTLP gRPC endpoint for logs (defaults to traces endpoint) | same as traces | `http://localhost:4317` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Default OTLP endpoint for traces and logs when signal-specific endpoints are unset | `http://localhost:4317` (`grpc`) / `http://localhost:4318` (`http/protobuf`) | `http://otel-collector:4317` |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` | Override endpoint for traces, used as-is | unset | `http://tempo:4317` |
+| `OTEL_EXPORTER_OTLP_LOGS_ENDPOINT` | Override endpoint for logs, used as-is (does not fall back to the traces endpoint) | unset | `http://loki-collector:4317` |
+| `OTEL_EXPORTER_OTLP_PROTOCOL` | OTLP transport protocol: `grpc` or `http/protobuf` | `grpc` | `http/protobuf` |
+| `OTEL_TRACES_SAMPLE_RATIO` | Trace head-sampling ratio in `[0.0, 1.0]`; unset exports every trace | unset (export all) | `0.01` |
 | `OTEL_SERVICE_NAME` | Service name for identifying components | `dynamo` | `dynamo-frontend` |
 
 ## Getting Started Quickly


### PR DESCRIPTION
## Summary

- Cherry-pick of #11337 to `release/1.3.0`.
- The observability docs still described the pre-#10576 OTLP behavior; following them causes silent log loss (setting only `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` sends logs to the unused protocol default). The #10576 behavior (endpoint fallback chain, `http/protobuf` transport, `OTEL_TRACES_SAMPLE_RATIO`) is present on this branch, so the docs apply as-is.

## Conflict resolutions

- `docs/observability/README.md` (guide crosswalk table): kept this branch's row set — did **not** import the Forward Pass Metrics Tracing and Request Payload Logging rows, since those docs/features don't exist on `release/1.3.0` — and updated the OTLP env-var lists in the Tracing and Logging rows.
- `docs/observability/logging.md`: took the new env-var table; also updated the adjacent "OTLP Log Export" intro paragraphs and example block to main's wording — this branch's stale "logs default to the traces endpoint" text would directly contradict the v1.3.0 warning added right below it.
- `docs/observability/tracing.md`: applied cleanly, identical to main.

Fixes DYN-3406

## Original PR

- Main PR: #11337
- Merge commit: e42991068a2610deafacfe4795f418c0bc61df5b

## Test plan

- [ ] CI passes
- Docs-only change; no runtime surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)