### PR TITLE
test(trtllm): fix multimodal encoder test stub

### DIFF
--- a/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_encoder.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_multimodal_encoder.py
@@ -34,8 +34,10 @@ def trtllm_engine_module(monkeypatch):
     class _FakeBaseLLM:
         pass
 
-    class _FakeAutoConfig:
-        pass
+    class _FakePretrainedConfig:
+        @classmethod
+        def get_config_dict(cls, model_path):
+            return {}, {}
 
     trtllm_module = ModuleType("tensorrt_llm")
     trtllm_module.__path__ = []  # type: ignore[attr-defined]
@@ -47,7 +49,7 @@ def trtllm_engine_module(monkeypatch):
     llm_module = ModuleType("tensorrt_llm.llmapi.llm")
     llm_module.BaseLLM = _FakeBaseLLM  # type: ignore[attr-defined]
     transformers_module = ModuleType("transformers")
-    transformers_module.AutoConfig = _FakeAutoConfig  # type: ignore[attr-defined]
+    transformers_module.PretrainedConfig = _FakePretrainedConfig  # type: ignore[attr-defined]
 
     monkeypatch.setitem(sys.modules, "tensorrt_llm", trtllm_module)
     monkeypatch.setitem(sys.modules, "tensorrt_llm.llmapi", llmapi_module)


### PR DESCRIPTION
## Summary

- replace the stale `AutoConfig` test double with `PretrainedConfig`
- implement the `get_config_dict()` contract used by `TensorRTLLMEngine`
- restore the pre-merge CPU regression test introduced in #11292

## Overview

This fixes the deterministic import failure reported by OPS-7550 without changing production runtime behavior. The test remains hermetic and GPU-free.

## Details

PR #11292 added a fake `transformers` module exposing `AutoConfig`. Before its squash merge, `dynamo.trtllm.engine` changed to import `PretrainedConfig`, so the merged fixture failed during module import before the test body ran. The replacement fake exposes the current symbol and implements the two-value `get_config_dict()` contract used by the engine.

## Where should reviewer start?

Review `components/src/dynamo/trtllm/tests/test_trtllm_multimodal_encoder.py`, specifically the `_FakePretrainedConfig` definition and mocked `transformers.PretrainedConfig` assignment.

## Related Issues

- [OPS-7550](https://linear.app/nvidia/issue/OPS-7550/ci-failure-post-merge-ci-pipeline-trtllm-runtime-efa-cpu-test-cuda131)
- Regression introduced by #11292
- No GitHub issue; OPS-7550 is the tracking ticket.

## Validation

- exact failing test reproduced on current `main`
- corrected test file: `1 passed`
- nightly/pre-merge selector `(pre_merge or post_merge) and trtllm and gpu_0`: `1 passed`
- `git diff --check`
- file-scoped pre-commit hooks and repository pytest marker report
- DCO sign-off verified
- [full pre-merge run](https://github.com/ai-dynamo/dynamo/actions/runs/28914497040): all checks passed
- TRT-LLM CPU tests passed on AMD64 and ARM64
- TRT-LLM EFA multi-architecture image build passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test coverage to better match current configuration-loading behavior.
  * Adjusted mocked dependencies used in multimodal TRT-LLM tests for more realistic config handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->