### PR TITLE
fix(vllm): reject over-budget max tokens

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -498,6 +498,71 @@ def _prompt_token_ids_for_engine_data(
     return list(prompt_token_ids or [])
 
 
+def _prompt_token_count_for_validation(
+    request: Dict[str, Any],
+    embedding_sequence_length: int | None = None,
+    prompt_token_count: int | None = None,
+) -> int | None:
+    """Return the prompt length used for max-model-length validation."""
+    if prompt_token_count is not None:
+        return prompt_token_count
+    if embedding_sequence_length is not None:
+        return embedding_sequence_length
+
+    extra_args = request.get("extra_args") or {}
+    if isinstance(extra_args, dict):
+        expanded_token_ids = extra_args.get("expanded_token_ids")
+        if expanded_token_ids:
+            return len(expanded_token_ids)
+    if "token_ids" in request:
+        return len(request.get("token_ids") or [])
+    return None
+
+
+def _explicit_max_tokens_budget_error(
+    request: Dict[str, Any],
+    model_max_len: int | None,
+    embedding_sequence_length: int | None = None,
+    prompt_token_count: int | None = None,
+) -> str | None:
+    if model_max_len is None or model_max_len <= 0:
+        return None
+
+    stop_conditions = request.get("stop_conditions") or {}
+    max_tokens = stop_conditions.get("max_tokens")
+    if max_tokens is None:
+        max_tokens = request.get("max_tokens")
+    if not isinstance(max_tokens, int) or isinstance(max_tokens, bool):
+        return None
+
+    prompt_tokens = _prompt_token_count_for_validation(
+        request,
+        embedding_sequence_length=embedding_sequence_length,
+        prompt_token_count=prompt_token_count,
+    )
+    if prompt_tokens is None:
+        return None
+
+    requested_tokens = prompt_tokens + max_tokens
+    if requested_tokens <= model_max_len:
+        return None
+
+    return (
+        f"This model's maximum context length is {model_max_len} tokens. "
+        f"However, you requested {requested_tokens} tokens "
+        f"({prompt_tokens} in the messages, {max_tokens} in the completion). "
+        "Please reduce the length of the messages or completion."
+    )
+
+
+def _prompt_token_count_for_text_mode(
+    input_param_manager: InputParamManager, input_data: Any
+) -> int:
+    if isinstance(input_data, list):
+        return len(input_data)
+    return len(input_param_manager.tokenizer.encode(input_data))
+
+
 def _flatten_logprobs(
     log_probs: Any,
 ) -> Optional[list[float]]:
@@ -763,8 +828,7 @@ def build_sampling_params(
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
-    token_ids = request.get("token_ids", [])
-    input_length = len(token_ids)
+    input_length = _prompt_token_count_for_validation(request) or 0
     if model_max_len is not None and provided_max_tokens is None:
         # Ensure at least 1 token generation by default when possible
         dynamic_default = max(1, model_max_len - input_length)
@@ -2835,6 +2899,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         _apply_nvext_cache_salt(request, prompt)
 
+        budget_error = _explicit_max_tokens_budget_error(
+            request,
+            self.model_max_len,
+            embedding_sequence_length=embedding_sequence_length,
+        )
+        if budget_error is not None:
+            logger.error("Request %s: %s", request_id, budget_error)
+            yield {
+                "finish_reason": f"error: {budget_error}",
+                "index": 0,
+                "token_ids": [],
+            }
+            return
+
         # Build sampling params from request
         sampling_params = build_sampling_params(
             request,
@@ -2956,6 +3034,35 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             prompt = TextPrompt(prompt=input_data)
 
         _apply_nvext_cache_salt(request, prompt)
+
+        request_max_tokens = request.get("max_tokens")
+        prompt_token_count = (
+            _prompt_token_count_for_text_mode(self.input_param_manager, input_data)
+            if isinstance(request_max_tokens, int)
+            and not isinstance(request_max_tokens, bool)
+            else None
+        )
+        budget_error = _explicit_max_tokens_budget_error(
+            request,
+            self.model_max_len,
+            prompt_token_count=prompt_token_count,
+        )
+        if budget_error is not None:
+            logger.error("Request %s: %s", request_id, budget_error)
+            yield {
+                "id": request.get("id") or request.get("request_id", request_id),
+                "created": int(time.time()),
+                "object": "chat.completion.chunk",
+                "model": request.get("model", "unknown"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "finish_reason": f"error: {budget_error}",
+                    }
+                ],
+            }
+            return
 
         # Build sampling params from OpenAI-style request
         sampling_params = build_sampling_params_openai(

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1200,6 +1200,40 @@ def test_build_sampling_params_caps_omitted_max_tokens_to_generation_default():
     assert sp.max_tokens == remaining
 
 
+def test_explicit_max_tokens_budget_error_uses_prompt_and_completion_budget():
+    from dynamo.vllm.handlers import _explicit_max_tokens_budget_error
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 98},
+        "output_options": {},
+    }
+
+    error = _explicit_max_tokens_budget_error(request, model_max_len=100)
+
+    assert error is not None
+    assert "maximum context length is 100 tokens" in error
+    assert "requested 101 tokens (3 in the messages, 98 in the completion)" in error
+
+
+def test_explicit_max_tokens_budget_error_uses_expanded_prompt_tokens():
+    from dynamo.vllm.handlers import _explicit_max_tokens_budget_error
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 6},
+        "output_options": {},
+        "extra_args": {"expanded_token_ids": list(range(95))},
+    }
+
+    error = _explicit_max_tokens_budget_error(request, model_max_len=100)
+
+    assert error is not None
+    assert "requested 101 tokens (95 in the messages, 6 in the completion)" in error
+
+
 def _make_dynamo_config(**overrides):
     """Build a minimal fake DynamoConfig for update_engine_config_with_dynamo tests."""
     defaults = {
@@ -1584,6 +1618,7 @@ async def test_generate_text_mode_applies_nvext_cache_salt():
     handler = SimpleNamespace(
         input_param_manager=InputParams(),
         default_sampling_params={},
+        model_max_len=100,
         config=SimpleNamespace(disaggregation_mode=DisaggregationMode.AGGREGATED),
         engine_client=EngineClient(),
         _deferred_aborts={},
@@ -1607,3 +1642,127 @@ async def test_generate_text_mode_applies_nvext_cache_salt():
 
     assert chunks
     assert captured["prompt"]["cache_salt"] == "dynamo-cache-salt:tenant-a"
+
+
+@pytest.mark.asyncio
+async def test_generate_text_mode_rejects_explicit_max_tokens_over_context():
+    from dynamo.vllm.handlers import DecodeWorkerHandler
+
+    class InputParams:
+        def get_input_param(self, request, use_tokenizer):
+            assert use_tokenizer is True
+            return [1, 2, 3]
+
+    class EngineClient:
+        def __init__(self):
+            self.generate_called = False
+
+        def generate(self, *args, **kwargs):
+            self.generate_called = True
+            raise AssertionError("engine should not be called")
+
+    @asynccontextmanager
+    async def abort_monitor(*args, **kwargs):
+        yield
+
+    engine_client = EngineClient()
+    handler = SimpleNamespace(
+        input_param_manager=InputParams(),
+        default_sampling_params={},
+        model_max_len=100,
+        config=SimpleNamespace(disaggregation_mode=DisaggregationMode.AGGREGATED),
+        engine_client=engine_client,
+        _deferred_aborts={},
+        _shutdown_on_engine_dead=lambda exc: None,
+        _abort_monitor=abort_monitor,
+        _to_local_dp_rank=lambda rank: None,
+    )
+    context = SimpleNamespace(trace_headers=lambda: {})
+    request = {
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "prompt": "ignored after tokenization",
+        "max_tokens": 98,
+    }
+
+    chunks = [
+        chunk
+        async for chunk in DecodeWorkerHandler._generate_text_mode(
+            handler, request, context, "req-1"
+        )
+    ]
+
+    assert len(chunks) == 1
+    assert chunks[0]["id"] == "chatcmpl-test"
+    assert chunks[0]["model"] == "test-model"
+    assert chunks[0]["choices"][0]["finish_reason"] == (
+        "error: This model's maximum context length is 100 tokens. "
+        "However, you requested 101 tokens "
+        "(3 in the messages, 98 in the completion). "
+        "Please reduce the length of the messages or completion."
+    )
+    assert engine_client.generate_called is False
+
+
+@pytest.mark.asyncio
+async def test_generate_text_mode_rejects_string_prompt_over_context():
+    from dynamo.vllm.handlers import DecodeWorkerHandler
+
+    class Tokenizer:
+        def encode(self, text):
+            assert text == "rendered chat prompt"
+            return [1, 2, 3]
+
+    class InputParams:
+        tokenizer = Tokenizer()
+
+        def get_input_param(self, request, use_tokenizer):
+            assert use_tokenizer is True
+            return "rendered chat prompt"
+
+    class EngineClient:
+        def __init__(self):
+            self.generate_called = False
+
+        def generate(self, *args, **kwargs):
+            self.generate_called = True
+            raise AssertionError("engine should not be called")
+
+    @asynccontextmanager
+    async def abort_monitor(*args, **kwargs):
+        yield
+
+    engine_client = EngineClient()
+    handler = SimpleNamespace(
+        input_param_manager=InputParams(),
+        default_sampling_params={},
+        model_max_len=100,
+        config=SimpleNamespace(disaggregation_mode=DisaggregationMode.AGGREGATED),
+        engine_client=engine_client,
+        _deferred_aborts={},
+        _shutdown_on_engine_dead=lambda exc: None,
+        _abort_monitor=abort_monitor,
+        _to_local_dp_rank=lambda rank: None,
+    )
+    context = SimpleNamespace(trace_headers=lambda: {})
+    request = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 98,
+    }
+
+    chunks = [
+        chunk
+        async for chunk in DecodeWorkerHandler._generate_text_mode(
+            handler, request, context, "req-1"
+        )
+    ]
+
+    assert len(chunks) == 1
+    assert chunks[0]["choices"][0]["finish_reason"] == (
+        "error: This model's maximum context length is 100 tokens. "
+        "However, you requested 101 tokens "
+        "(3 in the messages, 98 in the completion). "
+        "Please reduce the length of the messages or completion."
+    )
+    assert engine_client.generate_called is False

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -767,6 +767,36 @@ class TestDecodeWorkerMultimodalBranching:
         assert len(chunks) == 1
         assert chunks[0]["message"] == "test stop"
 
+    async def test_over_budget_explicit_max_tokens_returns_error_before_engine(self):
+        handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
+        handler.model_max_len = 100
+        handler.engine_client = MagicMock()
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {"max_tokens": 98},
+            "output_options": {},
+        }
+        context = MagicMock()
+        chunks = []
+        async for chunk in handler._generate_token_mode(request, context, "req-1"):
+            chunks.append(chunk)
+
+        assert chunks == [
+            {
+                "finish_reason": (
+                    "error: This model's maximum context length is 100 tokens. "
+                    "However, you requested 101 tokens "
+                    "(3 in the messages, 98 in the completion). "
+                    "Please reduce the length of the messages or completion."
+                ),
+                "index": 0,
+                "token_ids": [],
+            }
+        ]
+        handler.engine_client.generate.assert_not_called()
+
     async def test_aggregated_mode_calls_extract_multimodal_data(self):
         """Aggregated mode delegates media loading to the shared processor."""
         handler = _make_decode_handler(disaggregation_mode="AGGREGATED")


### PR DESCRIPTION
## Overview:

Reject vLLM requests when an explicit `max_tokens` value would make the request exceed the model context length.

This aligns Dynamo's vLLM backend behavior with vLLM's own request validation, which rejects requests whose prompt tokens plus requested output tokens exceed the model context limit. See vLLM's renderer validation for the same shape of check: https://github.com/vllm-project/vllm/blob/main/vllm/renderers/params.py#L428-L438

## Details:

- Validate `input_tokens + max_tokens <= max_model_len` when `max_tokens` is provided explicitly.
- Keep the existing dynamic cap behavior for requests that omit `max_tokens`.
- Use expanded multimodal prompt token IDs when available so validation matches the prompt length sent to vLLM.
- Add unit coverage for omitted defaults, explicit over-budget requests, and expanded prompt token validation.

## Where should the reviewer start?

- `components/src/dynamo/vllm/handlers.py`
- `components/src/dynamo/vllm/tests/test_vllm_unit.py`

## Related Issues

**This PR is NOT linked to an issue**:
- [x] Confirmed -- no related issue

## Testing:

- `PYTHONPYCACHEPREFIX=/tmp/dynamo-pycache python3 -m py_compile components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/tests/test_vllm_unit.py`
- `git diff --check upstream/main...HEAD`

Not run locally:

- `pre-commit run --files components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/tests/test_vllm_unit.py` (`pre-commit` is not installed)
- `python3 -m pytest components/src/dynamo/vllm/tests/test_vllm_unit.py -k 'build_sampling_params_rejects_explicit_max_tokens_over_context or build_sampling_params_validates_expanded_prompt_tokens_for_max_tokens or build_sampling_params_caps_omitted_max_tokens_to_generation_default'` (`pytest` is not installed)
