### PR TITLE
fix: Avoid potential invalid device context failures in gms-storage-client save or load

### DIFF
--- a/lib/gpu_memory_service/cli/storage_runner.py
+++ b/lib/gpu_memory_service/cli/storage_runner.py
@@ -24,6 +24,7 @@ import argparse
 import logging
 import sys
 
+from gpu_memory_service.common import cuda_utils
 from gpu_memory_service.snapshot.backends.sharded_ssd import parse_sharded_ssd_roots
 from gpu_memory_service.snapshot.transfer import TransferBackendKind
 
@@ -64,6 +65,7 @@ def _run_save(args) -> None:
 
     _configure_logging(args.verbose)
     socket_path = _resolve_socket(args.device, args.socket_path)
+    cuda_utils.cuda_runtime_set_device(args.device)
 
     logger.info(
         "Saving GMS state: device=%s, socket=%s, output_dir=%s, "
@@ -102,6 +104,7 @@ def _run_load(args) -> None:
 
     _configure_logging(args.verbose)
     socket_path = _resolve_socket(args.device, args.socket_path)
+    cuda_utils.cuda_runtime_set_device(args.device)
 
     logger.info(
         "Loading GMS state: device=%s, socket=%s, input_dir=%s, "

--- a/lib/gpu_memory_service/tests/test_storage_runner.py
+++ b/lib/gpu_memory_service/tests/test_storage_runner.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the GMS storage client CLI."""
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+try:
+    from gpu_memory_service.cli import storage_runner
+except ModuleNotFoundError:
+    pytest.skip(
+        "gpu_memory_service package is not available in this test image",
+        allow_module_level=True,
+    )
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.none,
+    pytest.mark.gpu_0,
+]
+
+
+def test_run_save_sets_cuda_context_before_storage_client(monkeypatch):
+    calls = []
+
+    class FakeStorageClient:
+        def __init__(self, output_dir, **kwargs):
+            calls.append(("init", output_dir, kwargs))
+
+        def save(self, *, max_workers):
+            calls.append(("save", {"max_workers": max_workers}))
+            return SimpleNamespace(
+                allocations=[SimpleNamespace(tensor_file="shard_0000.bin")],
+                layout_hash="abc123",
+            )
+
+    fake_storage_client = ModuleType("gpu_memory_service.snapshot.storage_client")
+    fake_storage_client.GMSStorageClient = FakeStorageClient
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_memory_service.snapshot.storage_client",
+        fake_storage_client,
+    )
+    monkeypatch.setattr(storage_runner, "_resolve_socket", lambda *_: "/tmp/gms-3")
+    monkeypatch.setattr(
+        storage_runner.cuda_utils,
+        "cuda_runtime_set_device",
+        lambda device: calls.append(("set_device", device)),
+    )
+
+    storage_runner._run_save(
+        SimpleNamespace(
+            verbose=False,
+            device=3,
+            socket_path=None,
+            output_dir="/checkpoints",
+            save_workers=8,
+            sharded_ssd_roots="",
+            timeout_ms=60_000,
+            shard_size_bytes=4 * 1024**3,
+        )
+    )
+
+    assert calls[0] == ("set_device", 3)
+    assert calls[1][0] == "init"
+    assert calls[1][1] == "/checkpoints"
+    assert calls[1][2]["socket_path"] == "/tmp/gms-3"
+    assert calls[1][2]["device"] == 3
+    assert calls[2] == ("save", {"max_workers": 8})
+
+
+def test_run_load_sets_cuda_context_before_storage_client(monkeypatch):
+    calls = []
+
+    class FakeStorageClient:
+        def __init__(self, **kwargs):
+            calls.append(("init", kwargs))
+
+        def load_to_gms(self, input_dir, *, max_workers, clear_existing):
+            calls.append(
+                (
+                    "load_to_gms",
+                    {
+                        "input_dir": input_dir,
+                        "max_workers": max_workers,
+                        "clear_existing": clear_existing,
+                    },
+                )
+            )
+            return {"old": "new"}
+
+    fake_storage_client = ModuleType("gpu_memory_service.snapshot.storage_client")
+    fake_storage_client.GMSStorageClient = FakeStorageClient
+    monkeypatch.setitem(
+        sys.modules,
+        "gpu_memory_service.snapshot.storage_client",
+        fake_storage_client,
+    )
+    monkeypatch.setattr(storage_runner, "_resolve_socket", lambda *_: "/tmp/gms-3")
+    monkeypatch.setattr(
+        storage_runner.cuda_utils,
+        "cuda_runtime_set_device",
+        lambda device: calls.append(("set_device", device)),
+    )
+
+    storage_runner._run_load(
+        SimpleNamespace(
+            verbose=False,
+            device=3,
+            socket_path=None,
+            input_dir="/checkpoints",
+            no_clear=False,
+            transfer_backend="nixl",
+            timeout_ms=60_000,
+            sharded_ssd_roots="",
+            sharded_ssd_queues_per_root=2,
+            workers=16,
+        )
+    )
+
+    assert calls[0] == ("set_device", 3)
+    assert calls[1][0] == "init"
+    assert calls[1][1]["socket_path"] == "/tmp/gms-3"
+    assert calls[1][1]["device"] == 3
+    assert calls[2] == (
+        "load_to_gms",
+        {
+            "input_dir": "/checkpoints",
+            "max_workers": 16,
+            "clear_existing": True,
+        },
+    )


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Avoid potential invalid device context failures in gms-storage-client save or load

## Details:

<!-- Describe the changes made in this PR. -->

gms-storage-client supports the --device option, but the save and load commands did not fully apply its semantics.

For CUDA Driver API based save/load operations, --device N should mean both:

1. Connect to the GMS server/socket for device N.
2. Run subsequent CUDA VMM operations under the current CUDA context for device N.

The original code only did the first part and missed the second one.

As a result, in non-default device scenarios such as --device 3, the CLI nominally operates on device 3, but the CUDA Driver API calls still run without a current context for device 3.

This may fail with invalid device context.

As reference, the way snapshot does is correct to call cuda_utils.cuda_runtime_set_device(device)

https://github.com/weizhoublue/dynamo/blob/main/lib/gpu_memory_service/cli/snapshot/saver.py#L60

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11389" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured the selected CUDA device is set before running storage save and load actions, helping prevent device mismatch issues.
* **Tests**
  * Added coverage for the storage CLI to verify CUDA device setup happens in the correct order for both save and load flows.
  * Confirmed key arguments are passed through correctly during storage operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->