### PR TITLE
feat(operator): Allow configuring DGDR output-copier image via profiling job overrides.

### DIFF
--- a/deploy/operator/api/roundtrip_fuzz_test.go
+++ b/deploy/operator/api/roundtrip_fuzz_test.go
@@ -49,6 +49,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apitestingfuzzer "k8s.io/apimachinery/pkg/api/apitesting/fuzzer"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -179,6 +181,7 @@ func dynamoFuzzerFuncs(_ runtimeserializer.CodecFactory) []any {
 		fuzzAlphaDGDRStatus,
 		fuzzBetaDGDRSpec,
 		fuzzBetaDGDRStatus,
+		fuzzBetaDGDROverrides,
 		// PlacementStatus (v1alpha1 + v1beta1): pick admissible values so the
 		// round-trip fuzzer exercises Placement without producing shapes the CRD
 		// schema rejects. State draws from the enum; Score draws either nil or a
@@ -300,6 +303,88 @@ func fuzzBetaDGDRSpec(s *v1beta1.DynamoGraphDeploymentRequestSpec, c randfill.Co
 		autoApply := true
 		s.AutoApply = &autoApply
 	}
+}
+
+func fuzzBetaDGDROverrides(overrides *v1beta1.OverridesSpec, c randfill.Continue) {
+	// Fill the complete override normally first. This also produces the
+	// ProfilingJob == nil case without special alpha/beta logic.
+	c.FillNoCustom(overrides)
+
+	if overrides.ProfilingJob != nil {
+		fuzzDGDRProfilingJob(overrides.ProfilingJob, c)
+	}
+}
+
+func fuzzDGDRProfilingJob(job *batchv1.JobSpec, c randfill.Continue) {
+	fuzzDGDRProfilingPodTemplate(&job.Template, c)
+}
+
+func fuzzDGDRProfilingPodTemplate(template *corev1.PodTemplateSpec, c randfill.Continue) {
+	fuzzDGDRProfilingPodSpec(&template.Spec, c)
+}
+
+func fuzzDGDRProfilingPodSpec(podSpec *corev1.PodSpec, c randfill.Continue) {
+	names := fuzzDGDRProfilingContainerNames(c)
+	if names == nil {
+		podSpec.Containers = nil
+		return
+	}
+
+	podSpec.Containers = make([]corev1.Container, len(names))
+	for i, name := range names {
+		c.Fill(&podSpec.Containers[i])
+		podSpec.Containers[i].Name = name
+	}
+}
+
+const (
+	fuzzDGDRProfilerContainerName     = "profiler"
+	fuzzDGDROutputCopierContainerName = "output-copier"
+)
+
+func fuzzDGDRProfilingContainerNames(c randfill.Continue) []string {
+	switch c.Intn(10) {
+	case 0:
+		return nil
+	case 1:
+		return []string{}
+	}
+
+	extraNames := func() []string {
+		names := make([]string, 1+c.Intn(3))
+		for i := range names {
+			names[i] = fmt.Sprintf("container-%d", i)
+		}
+		return names
+	}
+
+	var names []string
+	switch c.Intn(7) {
+	case 0:
+		names = []string{fuzzDGDRProfilerContainerName}
+	case 1:
+		names = []string{fuzzDGDROutputCopierContainerName}
+	case 2:
+		names = extraNames()
+	case 3:
+		names = []string{fuzzDGDRProfilerContainerName, fuzzDGDROutputCopierContainerName}
+	case 4:
+		names = append([]string{fuzzDGDROutputCopierContainerName}, extraNames()...)
+	case 5:
+		names = append([]string{fuzzDGDRProfilerContainerName}, extraNames()...)
+	default:
+		names = append(
+			[]string{fuzzDGDRProfilerContainerName, fuzzDGDROutputCopierContainerName},
+			extraNames()...,
+		)
+	}
+
+	for i := len(names) - 1; i > 0; i-- {
+		j := c.Intn(i + 1)
+		names[i], names[j] = names[j], names[i]
+	}
+
+	return names
 }
 
 func fuzzBetaDGDRStatus(s *v1beta1.DynamoGraphDeploymentRequestStatus, c randfill.Continue) {

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -58,8 +58,9 @@ import (
 )
 
 const (
-	annDGDRSpec   = "nvidia.com/dgdr-spec"
-	annDGDRStatus = "nvidia.com/dgdr-status"
+	annDGDRSpec               = "nvidia.com/dgdr-spec"
+	annDGDRStatus             = "nvidia.com/dgdr-status"
+	dgdrProfilerContainerName = "profiler"
 )
 
 // Retired per-field annotations are no longer decoded, but must still be
@@ -228,7 +229,12 @@ func marshalDGDRHubSpec(src *v1beta1.DynamoGraphDeploymentRequestSpec) ([]byte, 
 }
 
 func restoreDGDRHubSpec(raw string) (v1beta1.DynamoGraphDeploymentRequestSpec, bool) {
-	return restorePreservedSpec[v1beta1.DynamoGraphDeploymentRequestSpec](raw, nil)
+	spec, ok := restorePreservedSpec[v1beta1.DynamoGraphDeploymentRequestSpec](raw, nil)
+	if !ok {
+		return spec, false
+	}
+	migrateLegacyUnnamedProfilerInOverrides(spec.Overrides)
+	return spec, true
 }
 
 func marshalDGDRSpokeSpec(src *DynamoGraphDeploymentRequestSpec) ([]byte, error) {
@@ -486,10 +492,17 @@ func projectProfilingConfigToProfilingJob(src *ProfilingConfigSpec, dst *v1beta1
 	podSpec := &dst.Overrides.ProfilingJob.Template.Spec
 
 	if src.Resources != nil {
-		if len(podSpec.Containers) == 0 {
-			podSpec.Containers = []corev1.Container{{}}
+		idx := dgdrProfilerContainerIndex(podSpec.Containers)
+		if idx < 0 {
+			// Alpha profilingConfig.resources always projects onto the canonical
+			// named profiler entry. containers is a map list keyed by name, so
+			// provenance must not be encoded as name:"".
+			podSpec.Containers = append(podSpec.Containers, corev1.Container{
+				Name: dgdrProfilerContainerName,
+			})
+			idx = len(podSpec.Containers) - 1
 		}
-		podSpec.Containers[0].Resources = *src.Resources
+		podSpec.Containers[idx].Resources = *src.Resources
 	}
 	if len(src.Tolerations) > 0 {
 		podSpec.Tolerations = src.Tolerations
@@ -758,10 +771,20 @@ func dgdrHubOnlyProfilingJob(src *batchv1.JobSpec) *batchv1.JobSpec {
 		return nil
 	}
 	save := src.DeepCopy()
-	if len(save.Template.Spec.Containers) > 0 {
-		save.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
-		if len(save.Template.Spec.Containers) == 1 && apiequality.Semantic.DeepEqual(save.Template.Spec.Containers[0], corev1.Container{}) {
-			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, 0, 1)
+	migrateLegacyUnnamedProfilerContainers(save.Template.Spec.Containers)
+	if idx := dgdrProfilerContainerIndex(save.Template.Spec.Containers); idx >= 0 {
+		hadProjectedResources := !apiequality.Semantic.DeepEqual(
+			save.Template.Spec.Containers[idx].Resources,
+			corev1.ResourceRequirements{},
+		)
+		save.Template.Spec.Containers[idx].Resources = corev1.ResourceRequirements{}
+		// Omit only when alpha alone reconstructs the same ordered list: a sole
+		// profiler whose only projected field was resources. An explicit
+		// name-only profiler (no resources) must remain in the annotation.
+		if hadProjectedResources &&
+			dgdrIsNameOnlyProfiler(save.Template.Spec.Containers[idx]) &&
+			len(save.Template.Spec.Containers) == 1 {
+			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, idx, idx+1)
 		}
 	}
 	save.Template.Spec.Tolerations = nil
@@ -776,16 +799,21 @@ func mergeDGDRHubOnlyProfilingJob(dst *batchv1.JobSpec, restored *batchv1.JobSpe
 	if dst == nil || restored == nil {
 		return
 	}
-	resources, hasResources := dgdrFirstContainerResources(dst)
+	resources, hasResources := dgdrProfilerContainerResources(dst)
 	tolerations := slices.Clone(dst.Template.Spec.Tolerations)
 	nodeSelector := maps.Clone(dst.Template.Spec.NodeSelector)
 
 	*dst = *restored.DeepCopy()
+	migrateLegacyUnnamedProfilerContainers(dst.Template.Spec.Containers)
 	if hasResources {
-		if len(dst.Template.Spec.Containers) == 0 {
-			dst.Template.Spec.Containers = []corev1.Container{{}}
+		idx := dgdrProfilerContainerIndex(dst.Template.Spec.Containers)
+		if idx < 0 {
+			dst.Template.Spec.Containers = append(dst.Template.Spec.Containers, corev1.Container{
+				Name: dgdrProfilerContainerName,
+			})
+			idx = len(dst.Template.Spec.Containers) - 1
 		}
-		dst.Template.Spec.Containers[0].Resources = resources
+		dst.Template.Spec.Containers[idx].Resources = resources
 	}
 	if len(tolerations) > 0 {
 		dst.Template.Spec.Tolerations = tolerations
@@ -795,12 +823,59 @@ func mergeDGDRHubOnlyProfilingJob(dst *batchv1.JobSpec, restored *batchv1.JobSpe
 	}
 }
 
-func dgdrFirstContainerResources(job *batchv1.JobSpec) (corev1.ResourceRequirements, bool) {
-	if job == nil || len(job.Template.Spec.Containers) == 0 {
+func dgdrProfilerContainerResources(job *batchv1.JobSpec) (corev1.ResourceRequirements, bool) {
+	if job == nil {
 		return corev1.ResourceRequirements{}, false
 	}
-	res := job.Template.Spec.Containers[0].Resources
+	idx := dgdrProfilerContainerIndex(job.Template.Spec.Containers)
+	if idx < 0 {
+		return corev1.ResourceRequirements{}, false
+	}
+	res := job.Template.Spec.Containers[idx].Resources
 	return res, !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{})
+}
+
+// dgdrProfilerContainerIndex returns the index of the canonical profiler
+// container (name == "profiler"). Matching is strict by map-list key.
+func dgdrProfilerContainerIndex(containers []corev1.Container) int {
+	for i := range containers {
+		if containers[i].Name == dgdrProfilerContainerName {
+			return i
+		}
+	}
+	return -1
+}
+
+func dgdrIsNameOnlyProfiler(c corev1.Container) bool {
+	return apiequality.Semantic.DeepEqual(c, corev1.Container{Name: dgdrProfilerContainerName})
+}
+
+// migrateLegacyUnnamedProfilerInOverrides renames a legacy name:"" profiler
+// placeholder in restored hub annotations before map-list merging.
+func migrateLegacyUnnamedProfilerInOverrides(overrides *v1beta1.OverridesSpec) {
+	if overrides == nil || overrides.ProfilingJob == nil {
+		return
+	}
+	migrateLegacyUnnamedProfilerContainers(overrides.ProfilingJob.Template.Spec.Containers)
+}
+
+// migrateLegacyUnnamedProfilerContainers implements the narrow decode-time
+// migration for old nvidia.com/dgdr-spec payloads that used an unnamed
+// synthetic profiler entry:
+//  1. If no name:profiler exists and a name:"" entry exists, rename that entry
+//     to profiler in place (preserve position and fields).
+//  2. If name:profiler already exists, leave any additional name:"" entry as a
+//     distinct map-list element.
+func migrateLegacyUnnamedProfilerContainers(containers []corev1.Container) {
+	if dgdrProfilerContainerIndex(containers) >= 0 {
+		return
+	}
+	for i := range containers {
+		if containers[i].Name == "" {
+			containers[i].Name = dgdrProfilerContainerName
+			return
+		}
+	}
 }
 
 // projectSLAAndWorkloadToProfilingConfigBlob writes SLA and Workload structured fields back into the JSON blob.
@@ -906,8 +981,13 @@ func projectProfilingJobToProfilingConfig(src *v1beta1.DynamoGraphDeploymentRequ
 		return
 	}
 	podSpec := &src.Overrides.ProfilingJob.Template.Spec
-	if len(podSpec.Containers) > 0 {
-		res := podSpec.Containers[0].Resources
+
+	// Migrate leftover unnamed profiler entries on a copy so live hub storage
+	// is not mutated. Lookup after that is strict by name.
+	containers := slices.Clone(podSpec.Containers)
+	migrateLegacyUnnamedProfilerContainers(containers)
+	if idx := dgdrProfilerContainerIndex(containers); idx >= 0 {
+		res := containers[idx].Resources
 		if !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{}) {
 			dst.ProfilingConfig.Resources = &res
 		}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -58,8 +58,10 @@ import (
 )
 
 const (
-	annDGDRSpec   = "nvidia.com/dgdr-spec"
-	annDGDRStatus = "nvidia.com/dgdr-status"
+	annDGDRSpec                   = "nvidia.com/dgdr-spec"
+	annDGDRStatus                 = "nvidia.com/dgdr-status"
+	dgdrProfilerContainerName     = "profiler"
+	dgdrOutputCopierContainerName = "output-copier"
 )
 
 // Retired per-field annotations are no longer decoded, but must still be
@@ -486,10 +488,12 @@ func projectProfilingConfigToProfilingJob(src *ProfilingConfigSpec, dst *v1beta1
 	podSpec := &dst.Overrides.ProfilingJob.Template.Spec
 
 	if src.Resources != nil {
-		if len(podSpec.Containers) == 0 {
-			podSpec.Containers = []corev1.Container{{}}
+		idx := dgdrProfilerContainerIndex(podSpec.Containers)
+		if idx < 0 {
+			podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: dgdrProfilerContainerName})
+			idx = len(podSpec.Containers) - 1
 		}
-		podSpec.Containers[0].Resources = *src.Resources
+		podSpec.Containers[idx].Resources = *src.Resources
 	}
 	if len(src.Tolerations) > 0 {
 		podSpec.Tolerations = src.Tolerations
@@ -758,10 +762,15 @@ func dgdrHubOnlyProfilingJob(src *batchv1.JobSpec) *batchv1.JobSpec {
 		return nil
 	}
 	save := src.DeepCopy()
-	if len(save.Template.Spec.Containers) > 0 {
-		save.Template.Spec.Containers[0].Resources = corev1.ResourceRequirements{}
-		if len(save.Template.Spec.Containers) == 1 && apiequality.Semantic.DeepEqual(save.Template.Spec.Containers[0], corev1.Container{}) {
-			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, 0, 1)
+	if idx := dgdrProfilerContainerIndex(save.Template.Spec.Containers); idx >= 0 {
+		save.Template.Spec.Containers[idx].Resources = corev1.ResourceRequirements{}
+		// A container that only carries the synthetic profiler name (from
+		// projecting v1alpha1 profilingConfig.resources) is not hub-only
+		// state — treat it as empty so spoke→hub does not emit dgdr-spec.
+		c := save.Template.Spec.Containers[idx]
+		if apiequality.Semantic.DeepEqual(c, corev1.Container{}) ||
+			apiequality.Semantic.DeepEqual(c, corev1.Container{Name: dgdrProfilerContainerName}) {
+			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, idx, idx+1)
 		}
 	}
 	save.Template.Spec.Tolerations = nil
@@ -776,16 +785,18 @@ func mergeDGDRHubOnlyProfilingJob(dst *batchv1.JobSpec, restored *batchv1.JobSpe
 	if dst == nil || restored == nil {
 		return
 	}
-	resources, hasResources := dgdrFirstContainerResources(dst)
+	resources, hasResources := dgdrProfilerContainerResources(dst)
 	tolerations := slices.Clone(dst.Template.Spec.Tolerations)
 	nodeSelector := maps.Clone(dst.Template.Spec.NodeSelector)
 
 	*dst = *restored.DeepCopy()
 	if hasResources {
-		if len(dst.Template.Spec.Containers) == 0 {
-			dst.Template.Spec.Containers = []corev1.Container{{}}
+		idx := dgdrProfilerContainerIndex(dst.Template.Spec.Containers)
+		if idx < 0 {
+			dst.Template.Spec.Containers = append(dst.Template.Spec.Containers, corev1.Container{Name: dgdrProfilerContainerName})
+			idx = len(dst.Template.Spec.Containers) - 1
 		}
-		dst.Template.Spec.Containers[0].Resources = resources
+		dst.Template.Spec.Containers[idx].Resources = resources
 	}
 	if len(tolerations) > 0 {
 		dst.Template.Spec.Tolerations = tolerations
@@ -795,12 +806,32 @@ func mergeDGDRHubOnlyProfilingJob(dst *batchv1.JobSpec, restored *batchv1.JobSpe
 	}
 }
 
-func dgdrFirstContainerResources(job *batchv1.JobSpec) (corev1.ResourceRequirements, bool) {
-	if job == nil || len(job.Template.Spec.Containers) == 0 {
+func dgdrProfilerContainerResources(job *batchv1.JobSpec) (corev1.ResourceRequirements, bool) {
+	if job == nil {
 		return corev1.ResourceRequirements{}, false
 	}
-	res := job.Template.Spec.Containers[0].Resources
+	idx := dgdrProfilerContainerIndex(job.Template.Spec.Containers)
+	if idx < 0 {
+		return corev1.ResourceRequirements{}, false
+	}
+	res := job.Template.Spec.Containers[idx].Resources
 	return res, !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{})
+}
+
+// dgdrProfilerContainerIndex matches the controller's named selection while
+// retaining the legacy first-non-sidecar fallback.
+func dgdrProfilerContainerIndex(containers []corev1.Container) int {
+	for i := range containers {
+		if containers[i].Name == dgdrProfilerContainerName {
+			return i
+		}
+	}
+	for i := range containers {
+		if containers[i].Name != dgdrOutputCopierContainerName {
+			return i
+		}
+	}
+	return -1
 }
 
 // projectSLAAndWorkloadToProfilingConfigBlob writes SLA and Workload structured fields back into the JSON blob.
@@ -906,8 +937,8 @@ func projectProfilingJobToProfilingConfig(src *v1beta1.DynamoGraphDeploymentRequ
 		return
 	}
 	podSpec := &src.Overrides.ProfilingJob.Template.Spec
-	if len(podSpec.Containers) > 0 {
-		res := podSpec.Containers[0].Resources
+	if idx := dgdrProfilerContainerIndex(podSpec.Containers); idx >= 0 {
+		res := podSpec.Containers[idx].Resources
 		if !apiequality.Semantic.DeepEqual(res, corev1.ResourceRequirements{}) {
 			dst.ProfilingConfig.Resources = &res
 		}

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion.go
@@ -490,7 +490,11 @@ func projectProfilingConfigToProfilingJob(src *ProfilingConfigSpec, dst *v1beta1
 	if src.Resources != nil {
 		idx := dgdrProfilerContainerIndex(podSpec.Containers)
 		if idx < 0 {
-			podSpec.Containers = append(podSpec.Containers, corev1.Container{Name: dgdrProfilerContainerName})
+			// Leave Name empty: this container is a projection of alpha
+			// profilingConfig.resources, not an explicit beta override. An empty
+			// name becomes a truly empty Container after resource stripping in
+			// dgdrHubOnlyProfilingJob, so spoke→hub does not emit dgdr-spec.
+			podSpec.Containers = append(podSpec.Containers, corev1.Container{})
 			idx = len(podSpec.Containers) - 1
 		}
 		podSpec.Containers[idx].Resources = *src.Resources
@@ -764,12 +768,10 @@ func dgdrHubOnlyProfilingJob(src *batchv1.JobSpec) *batchv1.JobSpec {
 	save := src.DeepCopy()
 	if idx := dgdrProfilerContainerIndex(save.Template.Spec.Containers); idx >= 0 {
 		save.Template.Spec.Containers[idx].Resources = corev1.ResourceRequirements{}
-		// A container that only carries the synthetic profiler name (from
-		// projecting v1alpha1 profilingConfig.resources) is not hub-only
-		// state — treat it as empty so spoke→hub does not emit dgdr-spec.
-		c := save.Template.Spec.Containers[idx]
-		if apiequality.Semantic.DeepEqual(c, corev1.Container{}) ||
-			apiequality.Semantic.DeepEqual(c, corev1.Container{Name: dgdrProfilerContainerName}) {
+		// Only drop truly empty containers. An explicit beta `name: profiler`
+		// entry must remain as hub list matching/order context after its
+		// resources are projected into alpha.
+		if apiequality.Semantic.DeepEqual(save.Template.Spec.Containers[idx], corev1.Container{}) {
 			save.Template.Spec.Containers = slices.Delete(save.Template.Spec.Containers, idx, idx+1)
 		}
 	}
@@ -793,7 +795,8 @@ func mergeDGDRHubOnlyProfilingJob(dst *batchv1.JobSpec, restored *batchv1.JobSpe
 	if hasResources {
 		idx := dgdrProfilerContainerIndex(dst.Template.Spec.Containers)
 		if idx < 0 {
-			dst.Template.Spec.Containers = append(dst.Template.Spec.Containers, corev1.Container{Name: dgdrProfilerContainerName})
+			// Same unnamed synthetic projection as projectProfilingConfigToProfilingJob.
+			dst.Template.Spec.Containers = append(dst.Template.Spec.Containers, corev1.Container{})
 			idx = len(dst.Template.Spec.Containers) - 1
 		}
 		dst.Template.Spec.Containers[idx].Resources = resources

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -25,9 +25,14 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const dgdrOutputCopierContainerName = "output-copier"
 
 func TestBugDGDRStaleHubDeployedPhaseRequiresDGDNameMatch(t *testing.T) {
 	const newDGDName = "new-deployed-dgd"
@@ -234,6 +239,434 @@ func TestBugDGDRProfilingConfigPreservesUnprojectableTypedKeys(t *testing.T) {
 		t.Fatal("profilingConfig.config = nil, want preserved opaque JSON")
 	}
 	assertDGDRJSONEqual(t, config, restored.Spec.ProfilingConfig.Config.Raw)
+}
+
+func TestBugDGDRProfilingJobResourcesFollowContainerName(t *testing.T) {
+	sidecarResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	profilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+	updatedProfilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+	tests := []struct {
+		name               string
+		containers         []corev1.Container
+		wantSpokeResources *corev1.ResourceRequirements
+		wantRestored       []corev1.Container
+	}{
+		{
+			name: "sidecar only",
+			containers: []corev1.Container{{
+				Name:      dgdrOutputCopierContainerName,
+				Resources: sidecarResources,
+			}},
+			wantRestored: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+			},
+		},
+		{
+			name: "sidecar before profiler",
+			containers: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: profilerResources},
+			},
+			wantSpokeResources: &profilerResources,
+			wantRestored: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+			},
+		},
+		{
+			name: "profiler before sidecar",
+			containers: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: profilerResources},
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+			},
+			wantSpokeResources: &profilerResources,
+			wantRestored: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log("Convert named v1beta1 profiling overrides to v1alpha1")
+			hub := &v1beta1.DynamoGraphDeploymentRequest{
+				Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+					Overrides: &v1beta1.OverridesSpec{
+						ProfilingJob: &batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{Containers: test.containers},
+							},
+						},
+					},
+				},
+			}
+			spoke := &DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertFrom(hub); err != nil {
+				t.Fatalf("ConvertFrom() error = %v", err)
+			}
+
+			t.Log("Verify only profiler resources are projected into the legacy field")
+			if diff := cmp.Diff(test.wantSpokeResources, spoke.Spec.ProfilingConfig.Resources); diff != "" {
+				t.Fatalf("profilingConfig.resources mismatch (-want +got):\n%s", diff)
+			}
+
+			t.Log("Update legacy profiler resources and convert back to v1beta1")
+			spoke.Spec.ProfilingConfig.Resources = &updatedProfilerResources
+			restored := &v1beta1.DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertTo(restored); err != nil {
+				t.Fatalf("ConvertTo() error = %v", err)
+			}
+
+			t.Log("Verify resources remain attached to their named containers")
+			if restored.Spec.Overrides == nil || restored.Spec.Overrides.ProfilingJob == nil {
+				t.Fatal("profilingJob override = nil, want restored named containers")
+			}
+			got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+			if diff := cmp.Diff(test.wantRestored, got); diff != "" {
+				t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBugDGDRProfilerFirstHubRoundTripPreservesOrder(t *testing.T) {
+	profilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+	sidecarResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	wantContainers := []corev1.Container{
+		{Name: dgdrProfilerContainerName, Resources: profilerResources},
+		{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+	}
+
+	t.Log("Start from a profiler-first v1beta1 override list")
+	hub := &v1beta1.DynamoGraphDeploymentRequest{
+		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+			Overrides: &v1beta1.OverridesSpec{
+				ProfilingJob: &batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: wantContainers},
+					},
+				},
+			},
+		},
+	}
+
+	t.Log("Convert hub → spoke → hub without changing alpha fields")
+	spoke := &DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	restored := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	t.Log("Verify profiler-first ordering and resources survive the round trip")
+	if restored.Spec.Overrides == nil || restored.Spec.Overrides.ProfilingJob == nil {
+		t.Fatal("profilingJob override = nil, want profiler-first containers")
+	}
+	got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	if diff := cmp.Diff(wantContainers, got); diff != "" {
+		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBugDGDRAlphaResourcesRoundTripOmitsPrivateAnnotation(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+
+	t.Log("Start from alpha-only profilingConfig.resources")
+	spoke := &DynamoGraphDeploymentRequest{
+		Spec: DynamoGraphDeploymentRequestSpec{
+			ProfilingConfig: ProfilingConfigSpec{
+				Resources: &resources,
+			},
+		},
+	}
+
+	t.Log("Convert spoke → hub → spoke")
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if _, ok := hub.Annotations[annDGDRSpec]; ok {
+		t.Fatalf("hub annotations[%q] = %q, want absent for alpha-only resources", annDGDRSpec, hub.Annotations[annDGDRSpec])
+	}
+	if hub.Spec.Overrides == nil || hub.Spec.Overrides.ProfilingJob == nil {
+		t.Fatal("hub profilingJob = nil, want named profiler projection")
+	}
+	gotHubContainers := hub.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	wantHubContainers := []corev1.Container{{
+		Name:      dgdrProfilerContainerName,
+		Resources: resources,
+	}}
+	if diff := cmp.Diff(wantHubContainers, gotHubContainers); diff != "" {
+		t.Fatalf("hub profiling containers mismatch (-want +got):\n%s", diff)
+	}
+
+	restored := &DynamoGraphDeploymentRequest{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	t.Log("Verify resources round-trip without introducing nvidia.com/dgdr-spec")
+	if diff := cmp.Diff(&resources, restored.Spec.ProfilingConfig.Resources); diff != "" {
+		t.Fatalf("profilingConfig.resources mismatch (-want +got):\n%s", diff)
+	}
+	if _, ok := restored.Annotations[annDGDRSpec]; ok {
+		t.Fatalf("spoke annotations[%q] present after round trip, want absent", annDGDRSpec)
+	}
+}
+
+func TestBugDGDRSidecarFirstHubRoundTripPreservesOrder(t *testing.T) {
+	profilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+	sidecarResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	wantContainers := []corev1.Container{
+		{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+		{Name: dgdrProfilerContainerName, Resources: profilerResources},
+	}
+
+	hub := &v1beta1.DynamoGraphDeploymentRequest{
+		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+			Overrides: &v1beta1.OverridesSpec{
+				ProfilingJob: &batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: wantContainers},
+					},
+				},
+			},
+		},
+	}
+
+	spoke := &DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	restored := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	if diff := cmp.Diff(wantContainers, got); diff != "" {
+		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBugDGDRNameOnlyProfilerPreserved(t *testing.T) {
+	wantContainers := []corev1.Container{{Name: dgdrProfilerContainerName}}
+
+	hub := &v1beta1.DynamoGraphDeploymentRequest{
+		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+			Overrides: &v1beta1.OverridesSpec{
+				ProfilingJob: &batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: wantContainers},
+					},
+				},
+			},
+		},
+	}
+
+	spoke := &DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	if spoke.Spec.ProfilingConfig.Resources != nil {
+		t.Fatalf("profilingConfig.resources = %#v, want nil for name-only profiler", spoke.Spec.ProfilingConfig.Resources)
+	}
+	restored := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	if diff := cmp.Diff(wantContainers, got); diff != "" {
+		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBugDGDRLegacyUnnamedAnnotationMigratesInPlace(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+	sidecarImage := "custom-output-copier:1"
+
+	t.Log("Seed a spoke object with a legacy unnamed profiler annotation")
+	spoke := &DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annDGDRSpec: mustDGDRHubSpecAnnotation(t, v1beta1.DynamoGraphDeploymentRequestSpec{
+					Overrides: &v1beta1.OverridesSpec{
+						ProfilingJob: &batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: "", Image: "custom-profiler:1"},
+										{Name: dgdrOutputCopierContainerName, Image: sidecarImage},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+		Spec: DynamoGraphDeploymentRequestSpec{
+			ProfilingConfig: ProfilingConfigSpec{
+				Resources: &resources,
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	want := []corev1.Container{
+		{Name: dgdrProfilerContainerName, Image: "custom-profiler:1", Resources: resources},
+		{Name: dgdrOutputCopierContainerName, Image: sidecarImage},
+	}
+	got := hub.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("migrated profiling containers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBugDGDRLiveHubUnnamedProfilerMigratesOnRoundTrip(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+	sidecarImage := "custom-output-copier:1"
+	tests := []struct {
+		name         string
+		containers   []corev1.Container
+		wantRestored []corev1.Container
+	}{
+		{
+			name: "sole unnamed profiler",
+			containers: []corev1.Container{
+				{Name: "", Resources: resources},
+			},
+			wantRestored: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: resources},
+			},
+		},
+		{
+			name: "unnamed profiler before sidecar",
+			containers: []corev1.Container{
+				{Name: "", Resources: resources},
+				{Name: dgdrOutputCopierContainerName, Image: sidecarImage},
+			},
+			wantRestored: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: resources},
+				{Name: dgdrOutputCopierContainerName, Image: sidecarImage},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log("Start from a stored hub object with a leftover unnamed profiler")
+			hub := &v1beta1.DynamoGraphDeploymentRequest{
+				Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+					Overrides: &v1beta1.OverridesSpec{
+						ProfilingJob: &batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{Containers: test.containers},
+							},
+						},
+					},
+				},
+			}
+
+			t.Log("Convert hub → spoke without mutating the stored hub containers")
+			spoke := &DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertFrom(hub); err != nil {
+				t.Fatalf("ConvertFrom() error = %v", err)
+			}
+			if hub.Spec.Overrides.ProfilingJob.Template.Spec.Containers[0].Name != "" {
+				t.Fatalf("stored hub container name = %q, want leftover empty name", hub.Spec.Overrides.ProfilingJob.Template.Spec.Containers[0].Name)
+			}
+			if diff := cmp.Diff(&resources, spoke.Spec.ProfilingConfig.Resources); diff != "" {
+				t.Fatalf("profilingConfig.resources mismatch (-want +got):\n%s", diff)
+			}
+
+			t.Log("Convert spoke → hub and rewrite the leftover entry as name:profiler")
+			restored := &v1beta1.DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertTo(restored); err != nil {
+				t.Fatalf("ConvertTo() error = %v", err)
+			}
+			got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+			if diff := cmp.Diff(test.wantRestored, got); diff != "" {
+				t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestBugDGDRLegacyUnnamedKeptDistinctWhenProfilerExists(t *testing.T) {
+	spoke := &DynamoGraphDeploymentRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{
+				annDGDRSpec: mustDGDRHubSpecAnnotation(t, v1beta1.DynamoGraphDeploymentRequestSpec{
+					Overrides: &v1beta1.OverridesSpec{
+						ProfilingJob: &batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: dgdrProfilerContainerName, Image: "named-profiler:1"},
+										{Name: "", Image: "unnamed-extra:1"},
+										{Name: dgdrOutputCopierContainerName, Image: "sidecar:1"},
+									},
+								},
+							},
+						},
+					},
+				}),
+			},
+		},
+	}
+
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	want := []corev1.Container{
+		{Name: dgdrProfilerContainerName, Image: "named-profiler:1"},
+		{Name: "", Image: "unnamed-extra:1"},
+		{Name: dgdrOutputCopierContainerName, Image: "sidecar:1"},
+	}
+	got := hub.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func mustDGDRHubSpecAnnotation(t *testing.T, spec v1beta1.DynamoGraphDeploymentRequestSpec) string {
+	t.Helper()
+	data, err := marshalDGDRHubSpec(&spec)
+	if err != nil {
+		t.Fatalf("marshal DGDR hub spec annotation: %v", err)
+	}
+	return string(data)
 }
 
 func mustDGDRHubStatusAnnotation(t *testing.T, status v1beta1.DynamoGraphDeploymentRequestStatus) string {

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -263,7 +263,7 @@ func TestBugDGDRProfilingJobResourcesFollowContainerName(t *testing.T) {
 			}},
 			wantRestored: []corev1.Container{
 				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
-				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+				{Resources: updatedProfilerResources},
 			},
 		},
 		{
@@ -276,6 +276,18 @@ func TestBugDGDRProfilingJobResourcesFollowContainerName(t *testing.T) {
 			wantRestored: []corev1.Container{
 				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
 				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+			},
+		},
+		{
+			name: "profiler before sidecar",
+			containers: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: profilerResources},
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+			},
+			wantSpokeResources: &profilerResources,
+			wantRestored: []corev1.Container{
+				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
 			},
 		},
 	}
@@ -320,6 +332,88 @@ func TestBugDGDRProfilingJobResourcesFollowContainerName(t *testing.T) {
 				t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
 			}
 		})
+	}
+}
+
+func TestBugDGDRProfilerFirstHubRoundTripPreservesOrder(t *testing.T) {
+	profilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+	sidecarResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	wantContainers := []corev1.Container{
+		{Name: dgdrProfilerContainerName, Resources: profilerResources},
+		{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+	}
+
+	t.Log("Start from a profiler-first v1beta1 override list")
+	hub := &v1beta1.DynamoGraphDeploymentRequest{
+		Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+			Overrides: &v1beta1.OverridesSpec{
+				ProfilingJob: &batchv1.JobSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: wantContainers},
+					},
+				},
+			},
+		},
+	}
+
+	t.Log("Convert hub → spoke → hub without changing alpha fields")
+	spoke := &DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+	restored := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(restored); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+
+	t.Log("Verify profiler-first ordering and resources survive the round trip")
+	if restored.Spec.Overrides == nil || restored.Spec.Overrides.ProfilingJob == nil {
+		t.Fatal("profilingJob override = nil, want profiler-first containers")
+	}
+	got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+	if diff := cmp.Diff(wantContainers, got); diff != "" {
+		t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBugDGDRAlphaResourcesRoundTripOmitsPrivateAnnotation(t *testing.T) {
+	resources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+
+	t.Log("Start from alpha-only profilingConfig.resources")
+	spoke := &DynamoGraphDeploymentRequest{
+		Spec: DynamoGraphDeploymentRequestSpec{
+			ProfilingConfig: ProfilingConfigSpec{
+				Resources: &resources,
+			},
+		},
+	}
+
+	t.Log("Convert spoke → hub → spoke")
+	hub := &v1beta1.DynamoGraphDeploymentRequest{}
+	if err := spoke.ConvertTo(hub); err != nil {
+		t.Fatalf("ConvertTo() error = %v", err)
+	}
+	if _, ok := hub.Annotations[annDGDRSpec]; ok {
+		t.Fatalf("hub annotations[%q] = %q, want absent for alpha-only resources", annDGDRSpec, hub.Annotations[annDGDRSpec])
+	}
+
+	restored := &DynamoGraphDeploymentRequest{}
+	if err := restored.ConvertFrom(hub); err != nil {
+		t.Fatalf("ConvertFrom() error = %v", err)
+	}
+
+	t.Log("Verify resources round-trip without introducing nvidia.com/dgdr-spec")
+	if diff := cmp.Diff(&resources, restored.Spec.ProfilingConfig.Resources); diff != "" {
+		t.Fatalf("profilingConfig.resources mismatch (-want +got):\n%s", diff)
+	}
+	if _, ok := restored.Annotations[annDGDRSpec]; ok {
+		t.Fatalf("spoke annotations[%q] present after round trip, want absent", annDGDRSpec)
 	}
 }
 

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentrequest_conversion_bugs_test.go
@@ -25,7 +25,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	v1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -234,6 +237,90 @@ func TestBugDGDRProfilingConfigPreservesUnprojectableTypedKeys(t *testing.T) {
 		t.Fatal("profilingConfig.config = nil, want preserved opaque JSON")
 	}
 	assertDGDRJSONEqual(t, config, restored.Spec.ProfilingConfig.Config.Raw)
+}
+
+func TestBugDGDRProfilingJobResourcesFollowContainerName(t *testing.T) {
+	sidecarResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("250m")},
+	}
+	profilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("1")},
+	}
+	updatedProfilerResources := corev1.ResourceRequirements{
+		Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("2")},
+	}
+	tests := []struct {
+		name               string
+		containers         []corev1.Container
+		wantSpokeResources *corev1.ResourceRequirements
+		wantRestored       []corev1.Container
+	}{
+		{
+			name: "sidecar only",
+			containers: []corev1.Container{{
+				Name:      dgdrOutputCopierContainerName,
+				Resources: sidecarResources,
+			}},
+			wantRestored: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+			},
+		},
+		{
+			name: "sidecar before profiler",
+			containers: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: profilerResources},
+			},
+			wantSpokeResources: &profilerResources,
+			wantRestored: []corev1.Container{
+				{Name: dgdrOutputCopierContainerName, Resources: sidecarResources},
+				{Name: dgdrProfilerContainerName, Resources: updatedProfilerResources},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Log("Convert named v1beta1 profiling overrides to v1alpha1")
+			hub := &v1beta1.DynamoGraphDeploymentRequest{
+				Spec: v1beta1.DynamoGraphDeploymentRequestSpec{
+					Overrides: &v1beta1.OverridesSpec{
+						ProfilingJob: &batchv1.JobSpec{
+							Template: corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{Containers: test.containers},
+							},
+						},
+					},
+				},
+			}
+			spoke := &DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertFrom(hub); err != nil {
+				t.Fatalf("ConvertFrom() error = %v", err)
+			}
+
+			t.Log("Verify only profiler resources are projected into the legacy field")
+			if diff := cmp.Diff(test.wantSpokeResources, spoke.Spec.ProfilingConfig.Resources); diff != "" {
+				t.Fatalf("profilingConfig.resources mismatch (-want +got):\n%s", diff)
+			}
+
+			t.Log("Update legacy profiler resources and convert back to v1beta1")
+			spoke.Spec.ProfilingConfig.Resources = &updatedProfilerResources
+			restored := &v1beta1.DynamoGraphDeploymentRequest{}
+			if err := spoke.ConvertTo(restored); err != nil {
+				t.Fatalf("ConvertTo() error = %v", err)
+			}
+
+			t.Log("Verify resources remain attached to their named containers")
+			if restored.Spec.Overrides == nil || restored.Spec.Overrides.ProfilingJob == nil {
+				t.Fatal("profilingJob override = nil, want restored named containers")
+			}
+			got := restored.Spec.Overrides.ProfilingJob.Template.Spec.Containers
+			if diff := cmp.Diff(test.wantRestored, got); diff != "" {
+				t.Fatalf("profiling containers mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
 }
 
 func mustDGDRHubStatusAnnotation(t *testing.T, status v1beta1.DynamoGraphDeploymentRequestStatus) string {

--- a/deploy/operator/internal/controller/profiling_job_overrides.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides.go
@@ -370,12 +370,54 @@ func applyPodSpecOverrides(spec *corev1.PodSpec, overrides *corev1.PodSpec) {
 	spec.InitContainers = mergeNamedSlice(spec.InitContainers, overrides.InitContainers, func(c corev1.Container) string { return c.Name })
 
 	if len(overrides.Containers) > 0 && len(spec.Containers) > 0 {
-		applyContainerOverrides(&spec.Containers[0], &overrides.Containers[0])
+		if profilerOverride := profilerContainerOverride(overrides.Containers); profilerOverride != nil {
+			applyContainerOverrides(&spec.Containers[0], profilerOverride)
+		}
+	}
+	if outputCopierOverride := findContainerOverride(overrides.Containers, ContainerNameOutputCopier); outputCopierOverride != nil {
+		if idx := findContainerIndex(spec.Containers, ContainerNameOutputCopier); idx >= 0 {
+			applyContainerOverrides(&spec.Containers[idx], outputCopierOverride)
+		}
 	}
 }
 
-// applyContainerOverrides merges fields from the user's first container override
-// into the controller-generated profiler container.
+// findContainerOverride returns the first override container with the given name.
+func findContainerOverride(containers []corev1.Container, name string) *corev1.Container {
+	for i := range containers {
+		if containers[i].Name == name {
+			return &containers[i]
+		}
+	}
+	return nil
+}
+
+// findContainerIndex returns the index of the container with the given name, or -1.
+func findContainerIndex(containers []corev1.Container, name string) int {
+	for i := range containers {
+		if containers[i].Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// profilerContainerOverride selects the override entry for the profiler container.
+// Prefers an entry named "profiler"; otherwise the first entry that is not the
+// output-copier sidecar (preserving backward compatibility for unnamed overrides).
+func profilerContainerOverride(overrides []corev1.Container) *corev1.Container {
+	if override := findContainerOverride(overrides, ContainerNameProfiler); override != nil {
+		return override
+	}
+	for i := range overrides {
+		if overrides[i].Name == "" || overrides[i].Name != ContainerNameOutputCopier {
+			return &overrides[i]
+		}
+	}
+	return nil
+}
+
+// applyContainerOverrides merges fields from the user's container override
+// into a controller-generated container (profiler or output-copier sidecar).
 func applyContainerOverrides(container *corev1.Container, overrides *corev1.Container) {
 	if overrides.Image != "" {
 		container.Image = overrides.Image

--- a/deploy/operator/internal/controller/profiling_job_overrides.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides.go
@@ -369,9 +369,9 @@ func applyPodSpecOverrides(spec *corev1.PodSpec, overrides *corev1.PodSpec) {
 	spec.Volumes = mergeNamedSlice(spec.Volumes, overrides.Volumes, func(v corev1.Volume) string { return v.Name })
 	spec.InitContainers = mergeNamedSlice(spec.InitContainers, overrides.InitContainers, func(c corev1.Container) string { return c.Name })
 
-	if len(overrides.Containers) > 0 && len(spec.Containers) > 0 {
-		if profilerOverride := profilerContainerOverride(overrides.Containers); profilerOverride != nil {
-			applyContainerOverrides(&spec.Containers[0], profilerOverride)
+	if profilerOverride := profilerContainerOverride(overrides.Containers); profilerOverride != nil {
+		if idx := findContainerIndex(spec.Containers, ContainerNameProfiler); idx >= 0 {
+			applyContainerOverrides(&spec.Containers[idx], profilerOverride)
 		}
 	}
 	if outputCopierOverride := findContainerOverride(overrides.Containers, ContainerNameOutputCopier); outputCopierOverride != nil {

--- a/deploy/operator/internal/controller/profiling_job_overrides.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides.go
@@ -376,7 +376,7 @@ func applyPodSpecOverrides(spec *corev1.PodSpec, overrides *corev1.PodSpec) {
 	}
 	if outputCopierOverride := findContainerOverride(overrides.Containers, ContainerNameOutputCopier); outputCopierOverride != nil {
 		if idx := findContainerIndex(spec.Containers, ContainerNameOutputCopier); idx >= 0 {
-			applyContainerOverrides(&spec.Containers[idx], outputCopierOverride)
+			applyOutputCopierOverrides(&spec.Containers[idx], outputCopierOverride)
 		}
 	}
 }
@@ -417,7 +417,7 @@ func profilerContainerOverride(overrides []corev1.Container) *corev1.Container {
 }
 
 // applyContainerOverrides merges fields from the user's container override
-// into a controller-generated container (profiler or output-copier sidecar).
+// into the controller-generated profiler container.
 func applyContainerOverrides(container *corev1.Container, overrides *corev1.Container) {
 	if overrides.Image != "" {
 		container.Image = overrides.Image
@@ -434,6 +434,19 @@ func applyContainerOverrides(container *corev1.Container, overrides *corev1.Cont
 
 	if len(overrides.EnvFrom) > 0 {
 		container.EnvFrom = append(container.EnvFrom, overrides.EnvFrom...)
+	}
+}
+
+// applyOutputCopierOverrides merges a narrow allowlist into the output-copier
+// sidecar: only image and resources. Other fields (env, envFrom, volumeMounts,
+// securityContext, command/args) are ignored so controller-owned mounts and
+// script wiring stay intact.
+func applyOutputCopierOverrides(container *corev1.Container, overrides *corev1.Container) {
+	if overrides.Image != "" {
+		container.Image = overrides.Image
+	}
+	if len(overrides.Resources.Requests) > 0 || len(overrides.Resources.Limits) > 0 || len(overrides.Resources.Claims) > 0 {
+		container.Resources = overrides.Resources
 	}
 }
 

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -28,7 +28,12 @@ import (
 	"k8s.io/utils/ptr"
 )
 
-const profilerEntrypoint = "python"
+const (
+	profilerEntrypoint        = "python"
+	outputCopierShell         = "/bin/sh"
+	outputCopierScriptStub    = "echo sidecar-script"
+	outputCopierOverrideImage = "internal-registry/kubectl:1.29"
+)
 
 func baseJob() *batchv1.Job {
 	return &batchv1.Job{
@@ -957,28 +962,28 @@ func TestApplyProfilingJobOverrides_SidecarUntouched(t *testing.T) {
 
 func TestApplyProfilingJobOverrides_OutputCopierImage(t *testing.T) {
 	job := baseJob()
-	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}
-	job.Spec.Template.Spec.Containers[1].Args = []string{"echo sidecar-script"}
+	job.Spec.Template.Spec.Containers[1].Command = []string{outputCopierShell, "-c"}
+	job.Spec.Template.Spec.Containers[1].Args = []string{outputCopierScriptStub}
 	applyProfilingJobOverrides(job, &batchv1.JobSpec{
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Name:  ContainerNameOutputCopier,
-						Image: "internal-registry/kubectl:1.29",
+						Image: outputCopierOverrideImage,
 					},
 				},
 			},
 		},
 	})
 	sidecar := job.Spec.Template.Spec.Containers[1]
-	if sidecar.Image != "internal-registry/kubectl:1.29" {
+	if sidecar.Image != outputCopierOverrideImage {
 		t.Errorf("expected output-copier image override, got %s", sidecar.Image)
 	}
-	if len(sidecar.Command) == 0 || sidecar.Command[0] != "/bin/sh" {
+	if len(sidecar.Command) == 0 || sidecar.Command[0] != outputCopierShell {
 		t.Error("output-copier command was unexpectedly overwritten")
 	}
-	if len(sidecar.Args) == 0 || sidecar.Args[0] != "echo sidecar-script" {
+	if len(sidecar.Args) == 0 || sidecar.Args[0] != outputCopierScriptStub {
 		t.Error("output-copier args were unexpectedly overwritten")
 	}
 }
@@ -991,7 +996,7 @@ func TestApplyProfilingJobOverrides_OutputCopierDoesNotOverrideProfiler(t *testi
 				Containers: []corev1.Container{
 					{
 						Name:  ContainerNameOutputCopier,
-						Image: "internal-registry/kubectl:1.29",
+						Image: outputCopierOverrideImage,
 					},
 				},
 			},
@@ -1004,11 +1009,11 @@ func TestApplyProfilingJobOverrides_OutputCopierDoesNotOverrideProfiler(t *testi
 
 func TestApplyProfilingJobOverrides_OutputCopierOnlyImageAndResources(t *testing.T) {
 	job := baseJob()
-	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}
-	job.Spec.Template.Spec.Containers[1].Args = []string{"echo sidecar-script"}
+	job.Spec.Template.Spec.Containers[1].Command = []string{outputCopierShell, "-c"}
+	job.Spec.Template.Spec.Containers[1].Args = []string{outputCopierScriptStub}
 	job.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{{
 		Name:  "SIDECAR_MODE",
-		Value: "default",
+		Value: "baseline",
 	}}
 	job.Spec.Template.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
 		Name:      VolumeNameProfilingOutput,
@@ -1025,7 +1030,7 @@ func TestApplyProfilingJobOverrides_OutputCopierOnlyImageAndResources(t *testing
 				Containers: []corev1.Container{
 					{
 						Name:  ContainerNameOutputCopier,
-						Image: "internal-registry/kubectl:1.29",
+						Image: outputCopierOverrideImage,
 						Env: []corev1.EnvVar{{
 							Name:  "SIDECAR_MODE",
 							Value: "custom",
@@ -1063,14 +1068,14 @@ func TestApplyProfilingJobOverrides_OutputCopierOnlyImageAndResources(t *testing
 	if sidecar == nil {
 		t.Fatal("output-copier container not found")
 	}
-	if sidecar.Image != "internal-registry/kubectl:1.29" {
+	if sidecar.Image != outputCopierOverrideImage {
 		t.Errorf("expected output-copier image override, got %s", sidecar.Image)
 	}
 	if sidecar.Resources.Limits.Cpu().Cmp(resource.MustParse("500m")) != 0 {
 		t.Errorf("expected output-copier CPU limit override, got %v", sidecar.Resources.Limits)
 	}
 	mode := findEnv(sidecar.Env, "SIDECAR_MODE")
-	if mode == nil || mode.Value != "default" {
+	if mode == nil || mode.Value != "baseline" {
 		t.Errorf("output-copier env overrides should be ignored, got %+v", mode)
 	}
 	if len(sidecar.EnvFrom) != 0 {
@@ -1086,25 +1091,25 @@ func TestApplyProfilingJobOverrides_OutputCopierOnlyImageAndResources(t *testing
 	if sidecar.SecurityContext == nil || sidecar.SecurityContext.RunAsNonRoot == nil || !*sidecar.SecurityContext.RunAsNonRoot {
 		t.Errorf("output-copier securityContext overrides should be ignored, got %+v", sidecar.SecurityContext)
 	}
-	if len(sidecar.Command) != 2 || sidecar.Command[0] != "/bin/sh" {
+	if len(sidecar.Command) != 2 || sidecar.Command[0] != outputCopierShell {
 		t.Errorf("output-copier command was unexpectedly overwritten: %v", sidecar.Command)
 	}
-	if len(sidecar.Args) != 1 || sidecar.Args[0] != "echo sidecar-script" {
+	if len(sidecar.Args) != 1 || sidecar.Args[0] != outputCopierScriptStub {
 		t.Errorf("output-copier args were unexpectedly overwritten: %v", sidecar.Args)
 	}
 }
 
 func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *testing.T) {
 	job := baseJob()
-	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}
-	job.Spec.Template.Spec.Containers[1].Args = []string{"echo sidecar-script"}
+	job.Spec.Template.Spec.Containers[1].Command = []string{outputCopierShell, "-c"}
+	job.Spec.Template.Spec.Containers[1].Args = []string{outputCopierScriptStub}
 	applyProfilingJobOverrides(job, &batchv1.JobSpec{
 		Template: corev1.PodTemplateSpec{
 			Spec: corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
 						Name:  ContainerNameOutputCopier,
-						Image: "internal-registry/kubectl:1.29",
+						Image: outputCopierOverrideImage,
 					},
 					{
 						Name:  ContainerNameProfiler,
@@ -1130,13 +1135,13 @@ func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *tes
 	if sidecar == nil {
 		t.Fatal("output-copier container not found")
 	}
-	if sidecar.Image != "internal-registry/kubectl:1.29" {
-		t.Errorf("output-copier image: want internal-registry/kubectl:1.29, got %s", sidecar.Image)
+	if sidecar.Image != outputCopierOverrideImage {
+		t.Errorf("output-copier image: want %s, got %s", outputCopierOverrideImage, sidecar.Image)
 	}
-	if len(sidecar.Command) == 0 || sidecar.Command[0] != "/bin/sh" {
+	if len(sidecar.Command) == 0 || sidecar.Command[0] != outputCopierShell {
 		t.Error("output-copier command was unexpectedly overwritten")
 	}
-	if len(sidecar.Args) == 0 || sidecar.Args[0] != "echo sidecar-script" {
+	if len(sidecar.Args) == 0 || sidecar.Args[0] != outputCopierScriptStub {
 		t.Error("output-copier args were unexpectedly overwritten")
 	}
 }

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -1002,6 +1002,98 @@ func TestApplyProfilingJobOverrides_OutputCopierDoesNotOverrideProfiler(t *testi
 	}
 }
 
+func TestApplyProfilingJobOverrides_OutputCopierOnlyImageAndResources(t *testing.T) {
+	job := baseJob()
+	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}
+	job.Spec.Template.Spec.Containers[1].Args = []string{"echo sidecar-script"}
+	job.Spec.Template.Spec.Containers[1].Env = []corev1.EnvVar{{
+		Name:  "SIDECAR_MODE",
+		Value: "default",
+	}}
+	job.Spec.Template.Spec.Containers[1].VolumeMounts = []corev1.VolumeMount{{
+		Name:      VolumeNameProfilingOutput,
+		MountPath: ProfilingOutputPath,
+		ReadOnly:  true,
+	}}
+	job.Spec.Template.Spec.Containers[1].SecurityContext = &corev1.SecurityContext{
+		RunAsNonRoot: ptr.To(true),
+	}
+
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  ContainerNameOutputCopier,
+						Image: "internal-registry/kubectl:1.29",
+						Env: []corev1.EnvVar{{
+							Name:  "SIDECAR_MODE",
+							Value: "custom",
+						}},
+						EnvFrom: []corev1.EnvFromSource{{
+							ConfigMapRef: &corev1.ConfigMapEnvSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: "sidecar-env"},
+							},
+						}},
+						VolumeMounts: []corev1.VolumeMount{
+							{
+								Name:      VolumeNameProfilingOutput,
+								MountPath: "/elsewhere",
+							},
+							{
+								Name:      "extra-logs",
+								MountPath: "/var/log/sidecar",
+							},
+						},
+						Resources: corev1.ResourceRequirements{
+							Limits: corev1.ResourceList{corev1.ResourceCPU: resource.MustParse("500m")},
+						},
+						SecurityContext: &corev1.SecurityContext{
+							RunAsNonRoot: ptr.To(false),
+						},
+						Command: []string{"/bin/bash"},
+						Args:    []string{"-c", "echo overridden"},
+					},
+				},
+			},
+		},
+	})
+
+	sidecar := findContainer(job.Spec.Template.Spec.Containers, ContainerNameOutputCopier)
+	if sidecar == nil {
+		t.Fatal("output-copier container not found")
+	}
+	if sidecar.Image != "internal-registry/kubectl:1.29" {
+		t.Errorf("expected output-copier image override, got %s", sidecar.Image)
+	}
+	if sidecar.Resources.Limits.Cpu().Cmp(resource.MustParse("500m")) != 0 {
+		t.Errorf("expected output-copier CPU limit override, got %v", sidecar.Resources.Limits)
+	}
+	mode := findEnv(sidecar.Env, "SIDECAR_MODE")
+	if mode == nil || mode.Value != "default" {
+		t.Errorf("output-copier env overrides should be ignored, got %+v", mode)
+	}
+	if len(sidecar.EnvFrom) != 0 {
+		t.Errorf("output-copier EnvFrom overrides should be ignored, got %v", sidecar.EnvFrom)
+	}
+	if len(sidecar.VolumeMounts) != 1 {
+		t.Fatalf("expected controller-owned volume mounts only, got %v", sidecar.VolumeMounts)
+	}
+	mount := sidecar.VolumeMounts[0]
+	if mount.Name != VolumeNameProfilingOutput || mount.MountPath != ProfilingOutputPath || !mount.ReadOnly {
+		t.Errorf("controller-owned profiling-output mount was changed: %+v", mount)
+	}
+	if sidecar.SecurityContext == nil || sidecar.SecurityContext.RunAsNonRoot == nil || !*sidecar.SecurityContext.RunAsNonRoot {
+		t.Errorf("output-copier securityContext overrides should be ignored, got %+v", sidecar.SecurityContext)
+	}
+	if len(sidecar.Command) != 2 || sidecar.Command[0] != "/bin/sh" {
+		t.Errorf("output-copier command was unexpectedly overwritten: %v", sidecar.Command)
+	}
+	if len(sidecar.Args) != 1 || sidecar.Args[0] != "echo sidecar-script" {
+		t.Errorf("output-copier args were unexpectedly overwritten: %v", sidecar.Args)
+	}
+}
+
 func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *testing.T) {
 	job := baseJob()
 	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -1000,6 +1000,53 @@ func TestApplyProfilingJobOverrides_OutputCopierDoesNotOverrideProfiler(t *testi
 	}
 }
 
+func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *testing.T) {
+	job := baseJob()
+	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}
+	job.Spec.Template.Spec.Containers[1].Args = []string{"echo sidecar-script"}
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  ContainerNameOutputCopier,
+						Image: "internal-registry/kubectl:1.29",
+					},
+					{
+						Name:  ContainerNameProfiler,
+						Image: "custom-profiler:v3",
+					},
+				},
+			},
+		},
+	})
+
+	profiler := findContainer(job.Spec.Template.Spec.Containers, ContainerNameProfiler)
+	if profiler == nil {
+		t.Fatal("profiler container not found")
+	}
+	if profiler.Image != "custom-profiler:v3" {
+		t.Errorf("profiler image: want custom-profiler:v3, got %s", profiler.Image)
+	}
+	if len(profiler.Command) == 0 || profiler.Command[0] != "python" {
+		t.Error("profiler command was unexpectedly overwritten")
+	}
+
+	sidecar := findContainer(job.Spec.Template.Spec.Containers, ContainerNameOutputCopier)
+	if sidecar == nil {
+		t.Fatal("output-copier container not found")
+	}
+	if sidecar.Image != "internal-registry/kubectl:1.29" {
+		t.Errorf("output-copier image: want internal-registry/kubectl:1.29, got %s", sidecar.Image)
+	}
+	if len(sidecar.Command) == 0 || sidecar.Command[0] != "/bin/sh" {
+		t.Error("output-copier command was unexpectedly overwritten")
+	}
+	if len(sidecar.Args) == 0 || sidecar.Args[0] != "echo sidecar-script" {
+		t.Error("output-copier args were unexpectedly overwritten")
+	}
+}
+
 func TestApplyProfilingJobOverrides_Combined(t *testing.T) {
 	job := baseJob()
 	applyProfilingJobOverrides(job, &batchv1.JobSpec{

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -953,6 +953,53 @@ func TestApplyProfilingJobOverrides_SidecarUntouched(t *testing.T) {
 	}
 }
 
+func TestApplyProfilingJobOverrides_OutputCopierImage(t *testing.T) {
+	job := baseJob()
+	job.Spec.Template.Spec.Containers[1].Command = []string{"/bin/sh", "-c"}
+	job.Spec.Template.Spec.Containers[1].Args = []string{"echo sidecar-script"}
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  ContainerNameOutputCopier,
+						Image: "internal-registry/kubectl:1.29",
+					},
+				},
+			},
+		},
+	})
+	sidecar := job.Spec.Template.Spec.Containers[1]
+	if sidecar.Image != "internal-registry/kubectl:1.29" {
+		t.Errorf("expected output-copier image override, got %s", sidecar.Image)
+	}
+	if len(sidecar.Command) == 0 || sidecar.Command[0] != "/bin/sh" {
+		t.Error("output-copier command was unexpectedly overwritten")
+	}
+	if len(sidecar.Args) == 0 || sidecar.Args[0] != "echo sidecar-script" {
+		t.Error("output-copier args were unexpectedly overwritten")
+	}
+}
+
+func TestApplyProfilingJobOverrides_OutputCopierDoesNotOverrideProfiler(t *testing.T) {
+	job := baseJob()
+	applyProfilingJobOverrides(job, &batchv1.JobSpec{
+		Template: corev1.PodTemplateSpec{
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name:  ContainerNameOutputCopier,
+						Image: "internal-registry/kubectl:1.29",
+					},
+				},
+			},
+		},
+	})
+	if job.Spec.Template.Spec.Containers[0].Image != "profiler:latest" {
+		t.Errorf("profiler image should be unchanged, got %s", job.Spec.Template.Spec.Containers[0].Image)
+	}
+}
+
 func TestApplyProfilingJobOverrides_Combined(t *testing.T) {
 	job := baseJob()
 	applyProfilingJobOverrides(job, &batchv1.JobSpec{

--- a/deploy/operator/internal/controller/profiling_job_overrides_test.go
+++ b/deploy/operator/internal/controller/profiling_job_overrides_test.go
@@ -28,6 +28,8 @@ import (
 	"k8s.io/utils/ptr"
 )
 
+const profilerEntrypoint = "python"
+
 func baseJob() *batchv1.Job {
 	return &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
@@ -56,7 +58,7 @@ func baseJob() *batchv1.Job {
 						{
 							Name:    "profiler",
 							Image:   "profiler:latest",
-							Command: []string{"python", "-m", "dynamo.profiler"},
+							Command: []string{profilerEntrypoint, "-m", "dynamo.profiler"},
 							Env: []corev1.EnvVar{
 								{Name: "OUTPUT_DIR", Value: "/output"},
 							},
@@ -926,7 +928,7 @@ func TestApplyProfilingJobOverrides_CommandAndArgsPreserved(t *testing.T) {
 		},
 	})
 	c := job.Spec.Template.Spec.Containers[0]
-	if len(c.Command) == 0 || c.Command[0] != "python" {
+	if len(c.Command) == 0 || c.Command[0] != profilerEntrypoint {
 		t.Error("command was unexpectedly overwritten")
 	}
 }
@@ -1028,7 +1030,7 @@ func TestApplyProfilingJobOverrides_NamedProfilerAndOutputCopierOverrides(t *tes
 	if profiler.Image != "custom-profiler:v3" {
 		t.Errorf("profiler image: want custom-profiler:v3, got %s", profiler.Image)
 	}
-	if len(profiler.Command) == 0 || profiler.Command[0] != "python" {
+	if len(profiler.Command) == 0 || profiler.Command[0] != profilerEntrypoint {
 		t.Error("profiler command was unexpectedly overwritten")
 	}
 
@@ -1128,7 +1130,7 @@ func TestApplyProfilingJobOverrides_Combined(t *testing.T) {
 	if profiler.Image != "profiler:v2" {
 		t.Errorf("image: want profiler:v2, got %s", profiler.Image)
 	}
-	if profiler.Command[0] != "python" {
+	if profiler.Command[0] != profilerEntrypoint {
 		t.Error("command was overwritten")
 	}
 	if profiler.Resources.Limits.Cpu().String() != "8" {

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -668,7 +668,7 @@ spec:
 The profiling job also runs an `output-copier` sidecar that relays profiler status and
 writes results to the output ConfigMap. By default it uses `bitnami/kubectl:latest`.
 In air-gapped or private-registry clusters, override the sidecar image via
-`overrides.profilingJob` (the image must include `kubectl` and a POSIX shell):
+`overrides.profilingJob`:
 
 ```yaml
 overrides:
@@ -679,6 +679,13 @@ overrides:
         - name: output-copier
           image: internal-registry/kubectl:1.29
 ```
+
+The replacement image must include `kubectl` and a shell at `/bin/sh` that supports
+`set -o pipefail` (for example bash; a dash-only `/bin/sh` is not sufficient), plus the
+utilities used by the sidecar script: `grep`, `awk`, `tr`, `sed`, `date`, `cat`, and
+`sleep`. For `output-copier`, only `image` and `resources` are merged; other fields
+(`env`, `envFrom`, `volumeMounts`, `securityContext`, `command`/`args`) are ignored so
+controller-owned mounts such as `profiling-output` at `/data` stay intact.
 
 **ConfigMaps:**
 - `dgdr-output-<name>`: Generated DGD configuration

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -665,6 +665,21 @@ spec:
                 claimName: dynamo-pvc
 ```
 
+The profiling job also runs an `output-copier` sidecar that relays profiler status and
+writes results to the output ConfigMap. By default it uses `bitnami/kubectl:latest`.
+In air-gapped or private-registry clusters, override the sidecar image via
+`overrides.profilingJob` (the image must include `kubectl` and a POSIX shell):
+
+```yaml
+overrides:
+  profilingJob:
+    template:
+      spec:
+        containers:
+        - name: output-copier
+          image: internal-registry/kubectl:1.29
+```
+
 **ConfigMaps:**
 - `dgdr-output-<name>`: Generated DGD configuration
 - `planner-profile-data-XXXX`: Profiling data for Planner and mocker consumers (JSON), with a generated suffix. Only created for thorough sweeping when profile data is needed.

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -666,7 +666,7 @@ spec:
 The profiling job also runs an `output-copier` sidecar that relays profiler status and
 writes results to the output ConfigMap. By default it uses `bitnami/kubectl:latest`.
 In air-gapped or private-registry clusters, override the sidecar image via
-`overrides.profilingJob` (the image must include `kubectl` and a POSIX shell):
+`overrides.profilingJob`:
 
 ```yaml
 overrides:
@@ -677,6 +677,13 @@ overrides:
         - name: output-copier
           image: internal-registry/kubectl:1.29
 ```
+
+The replacement image must include `kubectl` and a shell at `/bin/sh` that supports
+`set -o pipefail` (for example bash; a dash-only `/bin/sh` is not sufficient), plus the
+utilities used by the sidecar script: `grep`, `awk`, `tr`, `sed`, `date`, `cat`, and
+`sleep`. For `output-copier`, only `image` and `resources` are merged; other fields
+(`env`, `envFrom`, `volumeMounts`, `securityContext`, `command`/`args`) are ignored so
+controller-owned mounts such as `profiling-output` at `/data` stay intact.
 
 **ConfigMaps:**
 - `dgdr-output-<name>`: Generated DGD configuration

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/profiler/profiler-guide.md
@@ -663,6 +663,21 @@ spec:
                 claimName: dynamo-pvc
 ```
 
+The profiling job also runs an `output-copier` sidecar that relays profiler status and
+writes results to the output ConfigMap. By default it uses `bitnami/kubectl:latest`.
+In air-gapped or private-registry clusters, override the sidecar image via
+`overrides.profilingJob` (the image must include `kubectl` and a POSIX shell):
+
+```yaml
+overrides:
+  profilingJob:
+    template:
+      spec:
+        containers:
+        - name: output-copier
+          image: internal-registry/kubectl:1.29
+```
+
 **ConfigMaps:**
 - `dgdr-output-<name>`: Generated DGD configuration
 - `planner-profile-data-XXXX`: Profiling data for Planner and mocker consumers (JSON), with a generated suffix. Only created for thorough sweeping when profile data is needed.


### PR DESCRIPTION
Users in private-registry clusters can now override the sidecar image by name without changing the controller default.

## Overview:

DGDR profiling jobs run an `output-copier` sidecar that relays profiler status and writes results to the output ConfigMap. Today its image is hardcoded to `bitnami/kubectl:latest` in the operator, and `spec.overrides.profilingJob` only merges the first container (`profiler`), so users in private-registry or air-gapped clusters cannot override the sidecar image.

This PR extends the existing profiling job overrides merge logic so users can configure the `output-copier` image by container name, without adding new CRD fields.

## Details:

* Extended `applyProfilingJobOverrides` to merge container overrides by name:
  * Profiler: prefers `name: profiler`, otherwise the first entry that is not `output-copier` (preserves backward compatibility for unnamed overrides)
  * Output-copier: merges overrides for `name: output-copier` into the sidecar container
* Only safe fields are merged (image, resources, env, securityContext, volumeMounts); controller-owned `command`/`args` are preserved
* Documented the override pattern in `docs/components/profiler/profiler-guide.md`

**Example usage:**

```yaml
spec:
  overrides:
    profilingJob:
      template:
        spec:
          containers:
          - name: output-copier
            image: internal-registry/kubectl:1.29
```

The override image must include `kubectl` and a POSIX shell.

## Where should the reviewer start?

## Related Issues

Fixes ai-dynamo/dynamo#11895

---

![Open in Devin Review](https://camo.githubusercontent.com/a4be08b8baaff58c5f163b8bbf073f8cdff8e3a6c7e2f554b621f61ab1557d7e/68747470733a2f2f7374617469632e646576696e2e61692f6173736574732f67682d6f70656e2d696e2d646576696e2d7265766965772d6c696768742e7376673f763d31)

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how profiling job container overrides are applied, so sidecar changes now target the correct container more reliably.
  * Preserved the built-in command and arguments for the output-copier sidecar when only its image is overridden.
  * Prevented overrides intended for the output-copier from affecting the main profiler container.
* **Documentation**
  * Added guidance for accessing profiling artifacts, including details on the output-copier sidecar and how to replace its image for private or air-gapped environments.