### PR TITLE
fix(operator): enforce explicit cluster API ownership

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -76,8 +76,7 @@ dynamo-operator:
   namespaceRestriction:
     enabled: true
     targetNamespace: "my-tenant-namespace"  # Optional, defaults to release namespace
-  apiOwnership:
-    enabled: true
+  apiOwner: true
   upgradeCRD: true
 ```
 
@@ -89,8 +88,7 @@ upgrades:
 dynamo-operator:
   namespaceRestriction:
     enabled: true
-  apiOwnership:
-    enabled: false
+  apiOwner: false
   upgradeCRD: false
 ```
 
@@ -109,9 +107,9 @@ during the transfer.
 
 ### Validation and Safety
 
-The chart includes validation and a fixed cluster-scoped owner marker:
+The chart uses a fixed cluster-scoped ClusterRole as an API-ownership mutex:
 
-- **Single API Owner**: Only one Helm release can own the fixed API-owner ClusterRole
+- **Single API Owner**: Helm ownership of the fixed mutex prevents two releases from enabling `apiOwner`
 - **Flag Consistency**: Rejects `upgradeCRD: true` when API ownership is disabled
 - **Prevents Multiple Cluster-Wide**: Installation will fail if another cluster-wide operator exists
 - **Prevents Mixed Deployments (Type 1)**: Installation will fail if trying to install namespace-restricted operator when cluster-wide exists
@@ -153,9 +151,8 @@ The chart includes validation and a fixed cluster-scoped owner marker:
 | global.grove.install | bool | `false` | Whether this chart should install the bundled Grove subchart. When true, deploys the Grove operator cluster-wide. Integration is automatically enabled. NOTE: For production environments, it is recommended to install Grove separately. |
 | global.grove.enabled | bool | `false` | Whether to enable Grove integration (multinode orchestration via PodCliqueSets). Set to true when Grove is available in the cluster (installed externally). Automatically true when install=true. The operator uses this to decide whether to create PodCliqueSets for multinode deployments. |
 | dynamo-operator.enabled | bool | `true` | Whether to enable the Dynamo Kubernetes operator deployment |
-| dynamo-operator.apiOwnership | object | `{"enabled":true}` | Cluster-wide Dynamo API ownership settings. |
-| dynamo-operator.apiOwnership.enabled | bool | `true` | Whether this installation owns cluster-wide Dynamo API machinery. Exactly one installation per cluster may enable this. Running all parallel operators at the same version is strongly recommended; if versions differ, exactly one installation at the newest version must be the owner. Admission-affecting settings must also be compatible across installations. |
-| dynamo-operator.upgradeCRD | bool | `true` | Whether the API owner applies bundled CRDs via the operator init container. Requires apiOwnership.enabled=true. Helm's special CRD installation must be disabled separately when this installation must not bootstrap missing CRDs. |
+| dynamo-operator.apiOwner | bool | `true` | Whether this installation owns cluster-wide Dynamo API machinery. Defaults to true for backward compatibility. Exactly one installation per cluster may enable this. Running all parallel operators at the same version is strongly recommended; if versions differ, exactly one installation at the newest version must be the owner. Admission-affecting settings must also be compatible across installations. |
+| dynamo-operator.upgradeCRD | bool | `true` | Whether the API owner applies bundled CRDs via the operator init container. Requires apiOwner=true. Helm's special CRD installation must be disabled separately when this installation must not bootstrap missing CRDs. |
 | dynamo-operator.natsAddr | string | `""` | NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port" |
 | dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port" |
 | dynamo-operator.modelExpressURL | string | `""` | URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true). |

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -62,34 +62,72 @@ No action is required for most upgrades — the operator's built-in cert-control
 
 If you need multiple operator instances (e.g., for multi-tenancy), use namespace-scoped deployment:
 
+> **Version and ownership requirement:** Running all operators at the same
+> version is strongly recommended. Exactly one installation in the cluster may
+> enable API ownership. If versions differ, the owner must be one and only one
+> installation running the newest version—even when multiple installations run
+> that newest version. Admission-affecting settings, such as Grove enablement,
+> must also be compatible across installations because the owner defaults and
+> validates resources for every namespace.
+
 ```yaml
-# values.yaml
+# API owner values.yaml
 dynamo-operator:
   namespaceRestriction:
     enabled: true
     targetNamespace: "my-tenant-namespace"  # Optional, defaults to release namespace
+  apiOwnership:
+    enabled: true
+  upgradeCRD: true
 ```
+
+Every other namespaced installation must disable both ownership and CRD
+upgrades:
+
+```yaml
+# API non-owner values.yaml
+dynamo-operator:
+  namespaceRestriction:
+    enabled: true
+  apiOwnership:
+    enabled: false
+  upgradeCRD: false
+```
+
+The owner serves cluster-wide conversion and admission and owns their service
+references and CA bundles. With `upgradeCRD: false`, it still owns conversion
+and admission while CRD schemas are managed externally. Because Helm processes
+the chart's `crds/` directory independently of values, install non-owners with
+`--skip-crds` or use an owner-controlled CRD installation path. An owner using
+`upgradeCRD: false` must also use `--skip-crds` on its initial installation if
+Helm must not bootstrap missing CRDs.
+
+Ownership transfer is manual: install the replacement as a non-owner, disable
+ownership on the current owner, and then enable it on the replacement. There is
+no automatic failover, and admission or conversion can be briefly unavailable
+during the transfer.
 
 ### Validation and Safety
 
-The chart includes built-in validation to prevent all operator conflicts:
+The chart includes validation and a fixed cluster-scoped owner marker:
 
-- **Automatic Detection**: Scans for existing operators (both cluster-wide and namespace-restricted) during installation
+- **Single API Owner**: Only one Helm release can own the fixed API-owner ClusterRole
+- **Flag Consistency**: Rejects `upgradeCRD: true` when API ownership is disabled
 - **Prevents Multiple Cluster-Wide**: Installation will fail if another cluster-wide operator exists
 - **Prevents Mixed Deployments (Type 1)**: Installation will fail if trying to install namespace-restricted operator when cluster-wide exists
 - **Prevents Mixed Deployments (Type 2)**: Installation will fail if trying to install cluster-wide operator when namespace-restricted operators exist
-- **Safe Defaults**: Leader election uses shared ID for proper coordination
+- **Human Version Choice**: Helm cannot determine which image is newest; selecting exactly one owner among the newest-version installations is an administrator responsibility
 
 #### 🚫 **Blocked Conflict Scenarios**
 
 | Existing Operator | New Operator | Status | Reason |
 |-------------------|--------------|---------|--------|
 | None | Cluster-wide | ✅ **Allowed** | No conflicts |
-| None | Namespace-restricted | ✅ **Allowed** | No conflicts |
+| None | Namespace-restricted | ✅ **Allowed** | This installation must be the API owner |
 | Cluster-wide | Cluster-wide | ❌ **Blocked** | Multiple cluster managers |
 | Cluster-wide | Namespace-restricted | ❌ **Blocked** | Cluster-wide already manages target namespace |
 | Namespace-restricted | Cluster-wide | ❌ **Blocked** | Would conflict with existing namespace operators |
-| Namespace-restricted A | Namespace-restricted B (diff ns) | ✅ **Allowed** | Different scopes |
+| Namespace-restricted A | Namespace-restricted B (diff ns) | ✅ **Allowed** | Different scopes; exactly one installation owns the cluster API |
 
 ## 🔧 Configuration
 
@@ -115,7 +153,9 @@ The chart includes built-in validation to prevent all operator conflicts:
 | global.grove.install | bool | `false` | Whether this chart should install the bundled Grove subchart. When true, deploys the Grove operator cluster-wide. Integration is automatically enabled. NOTE: For production environments, it is recommended to install Grove separately. |
 | global.grove.enabled | bool | `false` | Whether to enable Grove integration (multinode orchestration via PodCliqueSets). Set to true when Grove is available in the cluster (installed externally). Automatically true when install=true. The operator uses this to decide whether to create PodCliqueSets for multinode deployments. |
 | dynamo-operator.enabled | bool | `true` | Whether to enable the Dynamo Kubernetes operator deployment |
-| dynamo-operator.upgradeCRD | bool | `true` | Whether to manage CRDs via a pre-install/pre-upgrade hook Job. The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply. |
+| dynamo-operator.apiOwnership | object | `{"enabled":true}` | Cluster-wide Dynamo API ownership settings. |
+| dynamo-operator.apiOwnership.enabled | bool | `true` | Whether this installation owns cluster-wide Dynamo API machinery. Exactly one installation per cluster may enable this. Running all parallel operators at the same version is strongly recommended; if versions differ, exactly one installation at the newest version must be the owner. Admission-affecting settings must also be compatible across installations. |
+| dynamo-operator.upgradeCRD | bool | `true` | Whether the API owner applies bundled CRDs via the operator init container. Requires apiOwnership.enabled=true. Helm's special CRD installation must be disabled separately when this installation must not bootstrap missing CRDs. |
 | dynamo-operator.natsAddr | string | `""` | NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port" |
 | dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port" |
 | dynamo-operator.modelExpressURL | string | `""` | URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true). |
@@ -167,7 +207,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.webhook.failurePolicy | string | `"Fail"` | Webhook failure policy controls how Kubernetes handles requests when the webhook is unavailable. 'Fail' (recommended for production) rejects requests if the webhook cannot be reached, ensuring strict validation. 'Ignore' allows requests through if the webhook is unavailable, providing availability over validation guarantees. |
 | dynamo-operator.webhook.podCheckpointRestoreFailurePolicy | string | `"Ignore"` | Failure policy for the Pod CREATE checkpoint-restore mutating webhook. Defaults to Ignore so a webhook outage falls back to cold-start instead of blocking workload Pods. |
 | dynamo-operator.webhook.timeoutSeconds | int | `10` | Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy. |
-| dynamo-operator.webhook.namespaceSelector | object | `{}` | Custom namespace selector for webhook validation. Use this to include or exclude specific namespaces from webhook validation. For CLUSTER-WIDE operators, you can exclude namespaces managed by namespace-restricted operators by using: matchExpressions: [{ key: "dynamo-operator", operator: "NotIn", values: ["namespace-restricted"] }]. For NAMESPACE-RESTRICTED operators, leave empty as it will be auto-configured to match only the operator's namespace. |
+| dynamo-operator.webhook.namespaceSelector | object | `{}` | Must remain empty. The API owner's admission webhooks are cluster-wide so they stay aligned with the cluster-wide CRD schema and conversion implementation. |
 | dynamo-operator.webhook.certManager.enabled | bool | `false` | Whether to use cert-manager for automatic certificate management. Requires cert-manager to be installed in the cluster. When enabled, cert-manager will provision and rotate certificates instead of the operator's built-in cert-controller. |
 | dynamo-operator.webhook.certManager.certificate.duration | string | `"8760h"` | Certificate duration for webhook certificates managed by cert-manager (e.g., "8760h" for 1 year). cert-manager will automatically renew the certificate before it expires. |
 | dynamo-operator.webhook.certManager.certificate.renewBefore | string | `"360h"` | Time before certificate expiration to trigger renewal (e.g., "360h" for 15 days). cert-manager will attempt to renew the certificate when this threshold is reached. |

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -62,34 +62,72 @@ No action is required for most upgrades — the operator's built-in cert-control
 
 If you need multiple operator instances (e.g., for multi-tenancy), use namespace-scoped deployment:
 
+> **Version and ownership requirement:** Running all operators at the same
+> version is strongly recommended. Exactly one installation in the cluster may
+> enable API ownership. If versions differ, the owner must be one and only one
+> installation running the newest version—even when multiple installations run
+> that newest version. Admission-affecting settings, such as Grove enablement,
+> must also be compatible across installations because the owner defaults and
+> validates resources for every namespace.
+
 ```yaml
-# values.yaml
+# API owner values.yaml
 dynamo-operator:
   namespaceRestriction:
     enabled: true
     targetNamespace: "my-tenant-namespace"  # Optional, defaults to release namespace
+  apiOwnership:
+    enabled: true
+  upgradeCRD: true
 ```
+
+Every other namespaced installation must disable both ownership and CRD
+upgrades:
+
+```yaml
+# API non-owner values.yaml
+dynamo-operator:
+  namespaceRestriction:
+    enabled: true
+  apiOwnership:
+    enabled: false
+  upgradeCRD: false
+```
+
+The owner serves cluster-wide conversion and admission and owns their service
+references and CA bundles. With `upgradeCRD: false`, it still owns conversion
+and admission while CRD schemas are managed externally. Because Helm processes
+the chart's `crds/` directory independently of values, install non-owners with
+`--skip-crds` or use an owner-controlled CRD installation path. An owner using
+`upgradeCRD: false` must also use `--skip-crds` on its initial installation if
+Helm must not bootstrap missing CRDs.
+
+Ownership transfer is manual: install the replacement as a non-owner, disable
+ownership on the current owner, and then enable it on the replacement. There is
+no automatic failover, and admission or conversion can be briefly unavailable
+during the transfer.
 
 ### Validation and Safety
 
-The chart includes built-in validation to prevent all operator conflicts:
+The chart includes validation and a fixed cluster-scoped owner marker:
 
-- **Automatic Detection**: Scans for existing operators (both cluster-wide and namespace-restricted) during installation
+- **Single API Owner**: Only one Helm release can own the fixed API-owner ClusterRole
+- **Flag Consistency**: Rejects `upgradeCRD: true` when API ownership is disabled
 - **Prevents Multiple Cluster-Wide**: Installation will fail if another cluster-wide operator exists
 - **Prevents Mixed Deployments (Type 1)**: Installation will fail if trying to install namespace-restricted operator when cluster-wide exists
 - **Prevents Mixed Deployments (Type 2)**: Installation will fail if trying to install cluster-wide operator when namespace-restricted operators exist
-- **Safe Defaults**: Leader election uses shared ID for proper coordination
+- **Human Version Choice**: Helm cannot determine which image is newest; selecting exactly one owner among the newest-version installations is an administrator responsibility
 
 #### 🚫 **Blocked Conflict Scenarios**
 
 | Existing Operator | New Operator | Status | Reason |
 |-------------------|--------------|---------|--------|
 | None | Cluster-wide | ✅ **Allowed** | No conflicts |
-| None | Namespace-restricted | ✅ **Allowed** | No conflicts |
+| None | Namespace-restricted | ✅ **Allowed** | This installation must be the API owner |
 | Cluster-wide | Cluster-wide | ❌ **Blocked** | Multiple cluster managers |
 | Cluster-wide | Namespace-restricted | ❌ **Blocked** | Cluster-wide already manages target namespace |
 | Namespace-restricted | Cluster-wide | ❌ **Blocked** | Would conflict with existing namespace operators |
-| Namespace-restricted A | Namespace-restricted B (diff ns) | ✅ **Allowed** | Different scopes |
+| Namespace-restricted A | Namespace-restricted B (diff ns) | ✅ **Allowed** | Different scopes; exactly one installation owns the cluster API |
 
 ## 🔧 Configuration
 

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -76,8 +76,7 @@ dynamo-operator:
   namespaceRestriction:
     enabled: true
     targetNamespace: "my-tenant-namespace"  # Optional, defaults to release namespace
-  apiOwnership:
-    enabled: true
+  apiOwner: true
   upgradeCRD: true
 ```
 
@@ -89,8 +88,7 @@ upgrades:
 dynamo-operator:
   namespaceRestriction:
     enabled: true
-  apiOwnership:
-    enabled: false
+  apiOwner: false
   upgradeCRD: false
 ```
 
@@ -109,9 +107,9 @@ during the transfer.
 
 ### Validation and Safety
 
-The chart includes validation and a fixed cluster-scoped owner marker:
+The chart uses a fixed cluster-scoped ClusterRole as an API-ownership mutex:
 
-- **Single API Owner**: Only one Helm release can own the fixed API-owner ClusterRole
+- **Single API Owner**: Helm ownership of the fixed mutex prevents two releases from enabling `apiOwner`
 - **Flag Consistency**: Rejects `upgradeCRD: true` when API ownership is disabled
 - **Prevents Multiple Cluster-Wide**: Installation will fail if another cluster-wide operator exists
 - **Prevents Mixed Deployments (Type 1)**: Installation will fail if trying to install namespace-restricted operator when cluster-wide exists

--- a/deploy/helm/charts/platform/components/operator/templates/_helpers.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_helpers.tpl
@@ -142,12 +142,12 @@ Returns: Error if invalid or missing auth, empty string if valid
 {{- end -}}
 
 {{/*
-The fixed cluster-scoped API owner role doubles as the single-owner marker.
-Keeping the name independent of a Helm release makes concurrent ownership a
-Kubernetes resource conflict instead of a last-writer-wins race.
+The fixed, release-independent ClusterRole name is the API-ownership mutex.
+Helm ownership metadata on this singleton resource prevents two releases from
+claiming ownership concurrently instead of allowing a last-writer-wins race.
 */}}
-{{- define "dynamo-operator.apiOwnerRoleName" -}}
-dynamo-operator-api-owner
+{{- define "dynamo-operator.apiOwnershipMutexName" -}}
+dynamo-operator-api-ownership-mutex
 {{- end -}}
 
 {{/*

--- a/deploy/helm/charts/platform/components/operator/templates/_helpers.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_helpers.tpl
@@ -142,6 +142,15 @@ Returns: Error if invalid or missing auth, empty string if valid
 {{- end -}}
 
 {{/*
+The fixed cluster-scoped API owner role doubles as the single-owner marker.
+Keeping the name independent of a Helm release makes concurrent ownership a
+Kubernetes resource conflict instead of a last-writer-wins race.
+*/}}
+{{- define "dynamo-operator.apiOwnerRoleName" -}}
+dynamo-operator-api-owner
+{{- end -}}
+
+{{/*
 Retrieve components docker registry secret name
 */}}
 {{- define "dynamo-operator.componentsDockerRegistrySecretName" -}}

--- a/deploy/helm/charts/platform/components/operator/templates/_helpers.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_helpers.tpl
@@ -142,12 +142,17 @@ Returns: Error if invalid or missing auth, empty string if valid
 {{- end -}}
 
 {{/*
-The fixed, release-independent ClusterRole name is the API-ownership mutex.
-Helm ownership metadata on this singleton resource prevents two releases from
-claiming ownership concurrently instead of allowing a last-writer-wins race.
+The API owner's fixed, release-independent webhook RBAC name. Helm ownership
+metadata on the singleton ClusterRole makes it the API-ownership mutex.
 */}}
-{{- define "dynamo-operator.apiOwnershipMutexName" -}}
-dynamo-operator-api-ownership-mutex
+{{- define "dynamo-operator.webhooksName" -}}
+dynamo-operator-webhooks
+{{- end -}}
+
+{{/* Labels identifying resources managed by the cluster API owner. */}}
+{{- define "dynamo-operator.apiOwnerLabels" -}}
+nvidia.com/dynamo-api-owner: "true"
+nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
 {{- end -}}
 
 {{/*

--- a/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
@@ -13,15 +13,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{/*
-Validation to prevent operator conflicts
-With the namespace scope marker lease mechanism, cluster-wide and namespace-restricted
-operators can now coexist safely. The cluster-wide operator automatically excludes
-namespaces that have namespace-restricted operators.
+{{/* Validate the explicit, cluster-wide API ownership contract. */}}
+{{- define "dynamo-operator.validateAPIOwnership" -}}
+{{- if and .Values.upgradeCRD (not .Values.apiOwnership.enabled) -}}
+  {{- fail "VALIDATION ERROR: upgradeCRD=true requires apiOwnership.enabled=true. A non-owner must not install or update cluster-wide CRD schemas." -}}
+{{- end -}}
 
-This validation only prevents:
-1. Multiple cluster-wide operators (would compete for the same resources)
-*/}}
+{{- if and (not .Values.namespaceRestriction.enabled) (not .Values.apiOwnership.enabled) -}}
+  {{- fail "VALIDATION ERROR: A cluster-wide operator must set apiOwnership.enabled=true. API non-owners are supported only for namespace-restricted installations." -}}
+{{- end -}}
+
+{{- if not (empty .Values.webhook.namespaceSelector) -}}
+  {{- fail "VALIDATION ERROR: webhook.namespaceSelector must be empty. The single API owner must serve admission cluster-wide so it stays aligned with the cluster-wide CRD schema and conversion implementation." -}}
+{{- end -}}
+
+{{- if .Values.apiOwnership.enabled -}}
+  {{- $ownerRoleName := include "dynamo-operator.apiOwnerRoleName" . -}}
+  {{- $existingOwner := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" $ownerRoleName -}}
+  {{- if $existingOwner -}}
+    {{- $annotations := $existingOwner.metadata.annotations | default dict -}}
+    {{- $existingRelease := index $annotations "meta.helm.sh/release-name" | default "unknown" -}}
+    {{- $existingNamespace := index $annotations "meta.helm.sh/release-namespace" | default "unknown" -}}
+    {{- if or (ne $existingRelease .Release.Name) (ne $existingNamespace .Release.Namespace) -}}
+      {{- fail (printf "VALIDATION ERROR: API ownership is already held by Helm release '%s' in namespace '%s' (ClusterRole: %s). Exactly one operator installation in the cluster may set apiOwnership.enabled=true. Running parallel operators at the same version is strongly recommended. If versions differ, the owner must be one and only one installation running the newest version." $existingRelease $existingNamespace $ownerRoleName) -}}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/* Validation to prevent overlapping cluster-wide reconciliation. */}}
 {{- define "dynamo-operator.validateClusterWideInstallation" -}}
 {{- $currentReleaseName := .Release.Name -}}
 
@@ -66,18 +86,15 @@ This validation only prevents:
 {{- end -}}
 
 {{- if $foundExistingClusterWideOperator -}}
-  {{/* Only prevent multiple cluster-wide operators, not namespace-restricted */}}
-  {{- if not .Values.namespaceRestriction.enabled -}}
-    {{- $uninstallCmd := printf "helm uninstall %s" $existingOperatorRelease -}}
-    {{- if $existingOperatorNamespace -}}
-      {{- $uninstallCmd = printf "helm uninstall %s -n %s" $existingOperatorRelease $existingOperatorNamespace -}}
-    {{- end -}}
+  {{- $uninstallCmd := printf "helm uninstall %s" $existingOperatorRelease -}}
+  {{- if $existingOperatorNamespace -}}
+    {{- $uninstallCmd = printf "helm uninstall %s -n %s" $existingOperatorRelease $existingOperatorNamespace -}}
+  {{- end -}}
 
-    {{- if $existingOperatorNamespace -}}
-      {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' in namespace '%s' (ClusterRole: %s). Only one cluster-wide Dynamo operator should be deployed per cluster. Either:\n1. Use the existing cluster-wide operator (no need to install another), or\n2. Uninstall the existing cluster-wide operator first: %s\n\nNote: You can install namespace-restricted operators alongside the cluster-wide operator using: --set namespaceRestriction.enabled=true" $existingOperatorRelease $existingOperatorNamespace $existingOperatorRoleName $uninstallCmd) -}}
-    {{- else -}}
-      {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' (ClusterRole: %s). Only one cluster-wide Dynamo operator should be deployed per cluster. Either:\n1. Use the existing cluster-wide operator (no need to install another), or\n2. Uninstall the existing cluster-wide operator first: %s\n\nNote: You can install namespace-restricted operators alongside the cluster-wide operator using: --set namespaceRestriction.enabled=true" $existingOperatorRelease $existingOperatorRoleName $uninstallCmd) -}}
-    {{- end -}}
+  {{- if $existingOperatorNamespace -}}
+    {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' in namespace '%s' (ClusterRole: %s). Cluster-wide and namespace-restricted operators must not be mixed because the cluster-wide reconcilers do not exclude namespaces managed by other operators. Uninstall the existing cluster-wide operator first: %s" $existingOperatorRelease $existingOperatorNamespace $existingOperatorRoleName $uninstallCmd) -}}
+  {{- else -}}
+    {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' (ClusterRole: %s). Cluster-wide and namespace-restricted operators must not be mixed because the cluster-wide reconcilers do not exclude namespaces managed by other operators. Uninstall the existing cluster-wide operator first: %s" $existingOperatorRelease $existingOperatorRoleName $uninstallCmd) -}}
   {{- end -}}
 {{- end -}}
 

--- a/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
@@ -15,27 +15,27 @@
 
 {{/* Validate the explicit, cluster-wide API ownership contract. */}}
 {{- define "dynamo-operator.validateAPIOwnership" -}}
-{{- if and .Values.upgradeCRD (not .Values.apiOwnership.enabled) -}}
-  {{- fail "VALIDATION ERROR: upgradeCRD=true requires apiOwnership.enabled=true. A non-owner must not install or update cluster-wide CRD schemas." -}}
+{{- if and .Values.upgradeCRD (not .Values.apiOwner) -}}
+  {{- fail "VALIDATION ERROR: upgradeCRD=true requires apiOwner=true. A non-owner must not install or update cluster-wide CRD schemas." -}}
 {{- end -}}
 
-{{- if and (not .Values.namespaceRestriction.enabled) (not .Values.apiOwnership.enabled) -}}
-  {{- fail "VALIDATION ERROR: A cluster-wide operator must set apiOwnership.enabled=true. API non-owners are supported only for namespace-restricted installations." -}}
+{{- if and (not .Values.namespaceRestriction.enabled) (not .Values.apiOwner) -}}
+  {{- fail "VALIDATION ERROR: A cluster-wide operator must set apiOwner=true. API non-owners are supported only for namespace-restricted installations." -}}
 {{- end -}}
 
 {{- if not (empty .Values.webhook.namespaceSelector) -}}
   {{- fail "VALIDATION ERROR: webhook.namespaceSelector must be empty. The single API owner must serve admission cluster-wide so it stays aligned with the cluster-wide CRD schema and conversion implementation." -}}
 {{- end -}}
 
-{{- if .Values.apiOwnership.enabled -}}
-  {{- $ownerRoleName := include "dynamo-operator.apiOwnerRoleName" . -}}
-  {{- $existingOwner := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" $ownerRoleName -}}
-  {{- if $existingOwner -}}
-    {{- $annotations := $existingOwner.metadata.annotations | default dict -}}
+{{- if .Values.apiOwner -}}
+  {{- $mutexName := include "dynamo-operator.apiOwnershipMutexName" . -}}
+  {{- $existingMutex := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" $mutexName -}}
+  {{- if $existingMutex -}}
+    {{- $annotations := $existingMutex.metadata.annotations | default dict -}}
     {{- $existingRelease := index $annotations "meta.helm.sh/release-name" | default "unknown" -}}
     {{- $existingNamespace := index $annotations "meta.helm.sh/release-namespace" | default "unknown" -}}
     {{- if or (ne $existingRelease .Release.Name) (ne $existingNamespace .Release.Namespace) -}}
-      {{- fail (printf "VALIDATION ERROR: API ownership is already held by Helm release '%s' in namespace '%s' (ClusterRole: %s). Exactly one operator installation in the cluster may set apiOwnership.enabled=true. Running parallel operators at the same version is strongly recommended. If versions differ, the owner must be one and only one installation running the newest version." $existingRelease $existingNamespace $ownerRoleName) -}}
+      {{- fail (printf "VALIDATION ERROR: The API-ownership mutex is already held by Helm release '%s' in namespace '%s' (mutex ClusterRole: %s). Exactly one operator installation in the cluster may set apiOwner=true. Running parallel operators at the same version is strongly recommended. If versions differ, the owner must be one and only one installation running the newest version." $existingRelease $existingNamespace $mutexName) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
@@ -28,14 +28,14 @@
 {{- end -}}
 
 {{- if .Values.apiOwner -}}
-  {{- $mutexName := include "dynamo-operator.apiOwnershipMutexName" . -}}
-  {{- $existingMutex := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" $mutexName -}}
+  {{- $webhooksName := include "dynamo-operator.webhooksName" . -}}
+  {{- $existingMutex := lookup "rbac.authorization.k8s.io/v1" "ClusterRole" "" $webhooksName -}}
   {{- if $existingMutex -}}
     {{- $annotations := $existingMutex.metadata.annotations | default dict -}}
     {{- $existingRelease := index $annotations "meta.helm.sh/release-name" | default "unknown" -}}
     {{- $existingNamespace := index $annotations "meta.helm.sh/release-namespace" | default "unknown" -}}
     {{- if or (ne $existingRelease .Release.Name) (ne $existingNamespace .Release.Namespace) -}}
-      {{- fail (printf "VALIDATION ERROR: The API-ownership mutex is already held by Helm release '%s' in namespace '%s' (mutex ClusterRole: %s). Exactly one operator installation in the cluster may set apiOwner=true. Running parallel operators at the same version is strongly recommended. If versions differ, the owner must be one and only one installation running the newest version." $existingRelease $existingNamespace $mutexName) -}}
+      {{- fail (printf "VALIDATION ERROR: The API-ownership mutex is already held by Helm release '%s' in namespace '%s' (ClusterRole: %s). Exactly one operator installation in the cluster may set apiOwner=true. Running parallel operators at the same version is strongly recommended. If versions differ, the owner must be one and only one installation running the newest version." $existingRelease $existingNamespace $webhooksName) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -65,7 +65,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if and .Values.apiOwnership.enabled .Values.upgradeCRD }}
+      {{- if and .Values.apiOwner .Values.upgradeCRD }}
       initContainers:
       - name: crd-apply
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
@@ -82,7 +82,7 @@ spec:
       - args:
         - --config=/etc/dynamo-operator/config.yaml
         - --operator-version={{ .Chart.AppVersion }}
-        - --api-owner={{ .Values.apiOwnership.enabled }}
+        - --api-owner={{ .Values.apiOwner }}
         command:
         - /manager
         env:

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 {{/* Validate installation to prevent conflicts */}}
+{{- include "dynamo-operator.validateAPIOwnership" . -}}
 {{- include "dynamo-operator.validateClusterWideInstallation" . -}}
 {{- include "dynamo-operator.validateConfiguration" . -}}
 {{- include "dynamo-operator.validateDiscoveryBackend" . -}}
@@ -64,7 +65,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.upgradeCRD }}
+      {{- if and .Values.apiOwnership.enabled .Values.upgradeCRD }}
       initContainers:
       - name: crd-apply
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}
@@ -81,6 +82,7 @@ spec:
       - args:
         - --config=/etc/dynamo-operator/config.yaml
         - --operator-version={{ .Chart.AppVersion }}
+        - --api-owner={{ .Values.apiOwnership.enabled }}
         command:
         - /manager
         env:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -27,8 +27,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    nvidia.com/dynamo-api-owner: "true"
-    nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
+  {{- include "dynamo-operator.apiOwnerLabels" . | nindent 4 }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
   {{- if .Values.webhook.certManager.enabled }}
   annotations:
@@ -178,8 +177,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    nvidia.com/dynamo-api-owner: "true"
-    nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
+  {{- include "dynamo-operator.apiOwnerLabels" . | nindent 4 }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
   {{- if .Values.webhook.certManager.enabled }}
   annotations:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.apiOwnership.enabled }}
+{{- if .Values.apiOwner }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if .Values.apiOwnership.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -26,6 +27,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
+    nvidia.com/dynamo-api-owner: "true"
     nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
   {{- if .Values.webhook.certManager.enabled }}
@@ -47,14 +49,6 @@ webhooks:
       path: /validate-nvidia-com-v1alpha1-dynamocomponentdeployment
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamocomponentdeployment.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -81,14 +75,6 @@ webhooks:
       path: /validate/nvidia.com/v1beta1/dynamographdeployments
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamographdeployment.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -115,14 +101,6 @@ webhooks:
       path: /validate-nvidia-com-v1alpha1-dynamocheckpoint
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamocheckpoint.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -149,14 +127,6 @@ webhooks:
       path: /validate-nvidia-com-v1alpha1-dynamomodel
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamomodel.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -183,14 +153,6 @@ webhooks:
       path: /validate-nvidia-com-v1beta1-dynamographdeploymentrequest
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamographdeploymentrequest.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -216,6 +178,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
+    nvidia.com/dynamo-api-owner: "true"
     nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
   {{- if .Values.webhook.certManager.enabled }}
@@ -237,14 +200,6 @@ webhooks:
       path: /mutate/nvidia.com/v1beta1/dynamographdeployments
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: mdynamographdeployment.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -272,14 +227,6 @@ webhooks:
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   matchPolicy: Exact
   name: mdynamocomponentdeploymentv1beta1.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -306,14 +253,6 @@ webhooks:
       path: /mutate-nvidia-com-v1beta1-dynamographdeploymentrequest
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: mdynamographdeploymentrequestv1beta1.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - nvidia.com
@@ -340,14 +279,6 @@ webhooks:
       path: /mutate-core-v1-pod-checkpoint-restore
   failurePolicy: {{ .Values.webhook.podCheckpointRestoreFailurePolicy | default "Ignore" }}
   name: mpodcheckpointrestore.kb.io
-  {{- if .Values.webhook.namespaceSelector }}
-  namespaceSelector:
-    {{- toYaml .Values.webhook.namespaceSelector | nindent 4 }}
-  {{- else if .Values.namespaceRestriction.enabled }}
-  namespaceSelector:
-    matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
-  {{- end }}
   rules:
   - apiGroups:
     - ""
@@ -361,3 +292,4 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
@@ -63,18 +63,20 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
----
 # ClusterRole for patching webhook configurations and CRDs (cluster-scoped resources).
-# These are cluster-scoped resources that cannot be granted via a namespace-scoped Role,
-# so they are always provided as a dedicated ClusterRole regardless of namespace-restriction mode.
+# Its fixed name is also the cluster-wide single-owner marker.
+{{- if .Values.apiOwnership.enabled }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-webhook-injector
+  name: {{ include "dynamo-operator.apiOwnerRoleName" . }}
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
+    nvidia.com/dynamo-api-owner: "true"
+    nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
@@ -98,21 +100,38 @@ rules:
   - watch
   - update
   - patch
+# Global admission reads checkpoint state outside the owner's namespace-scoped cache.
+- apiGroups:
+  - nvidia.com
+  resources:
+  - dynamocheckpoints
+  verbs:
+  - get
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  verbs:
+  - get
+  - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-webhook-injector-binding
+  name: {{ include "dynamo-operator.apiOwnerRoleName" . }}
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
+    nvidia.com/dynamo-api-owner: "true"
+    nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "dynamo-operator.fullname" . }}-{{ .Release.Namespace }}-webhook-injector
+  name: {{ include "dynamo-operator.apiOwnerRoleName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
@@ -63,20 +63,19 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
-# This fixed-name ClusterRole is the API-ownership mutex and carries owner-only permissions.
-# Helm ownership of the singleton name prevents two releases from becoming API owners.
+# This fixed-name ClusterRole grants owner-only webhook/CRD mutation and admission reads.
+# Helm ownership of the singleton makes it the mutex preventing two API owners.
 {{- if .Values.apiOwner }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "dynamo-operator.apiOwnershipMutexName" . }}
+  name: {{ include "dynamo-operator.webhooksName" . }}
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    nvidia.com/dynamo-api-owner: "true"
-    nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
+  {{- include "dynamo-operator.apiOwnerLabels" . | nindent 4 }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
 rules:
 - apiGroups:
@@ -118,18 +117,17 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "dynamo-operator.apiOwnershipMutexName" . }}
+  name: {{ include "dynamo-operator.webhooksName" . }}
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
     app.kubernetes.io/part-of: dynamo-operator
-    nvidia.com/dynamo-api-owner: "true"
-    nvidia.com/dynamo-operator-namespace: {{ .Release.Namespace }}
+  {{- include "dynamo-operator.apiOwnerLabels" . | nindent 4 }}
   {{- include "dynamo-operator.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "dynamo-operator.apiOwnershipMutexName" . }}
+  name: {{ include "dynamo-operator.webhooksName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
@@ -63,14 +63,14 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
-# ClusterRole for patching webhook configurations and CRDs (cluster-scoped resources).
-# Its fixed name is also the cluster-wide single-owner marker.
-{{- if .Values.apiOwnership.enabled }}
+# This fixed-name ClusterRole is the API-ownership mutex and carries owner-only permissions.
+# Helm ownership of the singleton name prevents two releases from becoming API owners.
+{{- if .Values.apiOwner }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "dynamo-operator.apiOwnerRoleName" . }}
+  name: {{ include "dynamo-operator.apiOwnershipMutexName" . }}
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
@@ -118,7 +118,7 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "dynamo-operator.apiOwnerRoleName" . }}
+  name: {{ include "dynamo-operator.apiOwnershipMutexName" . }}
   labels:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/created-by: dynamo-operator
@@ -129,7 +129,7 @@ metadata:
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "dynamo-operator.apiOwnerRoleName" . }}
+  name: {{ include "dynamo-operator.apiOwnershipMutexName" . }}
 subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -16,9 +16,22 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Whether to apply CRDs via an init container on the operator Deployment.
-# Uses server-side apply with the bundled /crd-apply binary.
-# Set to false if CRDs are managed externally (e.g., via GitOps or a separate pipeline).
+# -- Cluster-wide Dynamo API ownership settings.
+apiOwnership:
+  # -- Whether this installation owns the cluster-wide Dynamo API machinery: CRD
+  # conversion, admission webhooks, service references, CA bundles, and the RBAC
+  # needed to manage them. Exactly one operator installation in a cluster may set
+  # this to true. When multiple operators run, using the same operator version for
+  # all installations is strongly recommended. If versions differ, exactly one
+  # installation running the newest version must be the API owner. Admission-
+  # affecting settings must also be compatible across installations.
+  enabled: true
+
+# -- Whether the API owner applies bundled CRDs via an init container on the
+# operator Deployment. Uses server-side apply with the bundled /crd-apply
+# binary. Set to false if schemas are managed externally. This cannot be true
+# when apiOwnership.enabled is false. Helm's special CRD installation must be
+# disabled separately when this installation must not bootstrap missing CRDs.
 upgradeCRD: true
 
 featureGates:
@@ -218,17 +231,8 @@ webhook:
   # Timeout for webhook calls (in seconds)
   timeoutSeconds: 10
 
-  # Namespace selector for webhooks
-  # Use this to exclude certain namespaces from validation
-  #
-  # For CLUSTER-WIDE operators: Exclude namespaces with namespace-restricted operators
-  # namespaceSelector:
-  #   matchExpressions:
-  #   - key: dynamo-operator
-  #     operator: NotIn
-  #     values: ["namespace-restricted"]
-  #
-  # For NAMESPACE-RESTRICTED operators: Leave empty (auto-configured)
+  # Must remain empty. The API owner's admission webhooks are cluster-wide so
+  # they remain aligned with the cluster-wide CRD schema and conversion.
   namespaceSelector: {}
 
   # cert-manager integration (optional, alternative to built-in cert-controller)

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -16,21 +16,19 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# -- Cluster-wide Dynamo API ownership settings.
-apiOwnership:
-  # -- Whether this installation owns the cluster-wide Dynamo API machinery: CRD
-  # conversion, admission webhooks, service references, CA bundles, and the RBAC
-  # needed to manage them. Exactly one operator installation in a cluster may set
-  # this to true. When multiple operators run, using the same operator version for
-  # all installations is strongly recommended. If versions differ, exactly one
-  # installation running the newest version must be the API owner. Admission-
-  # affecting settings must also be compatible across installations.
-  enabled: true
+# -- Whether this installation owns the cluster-wide Dynamo API machinery: CRD
+# conversion, admission webhooks, service references, CA bundles, and the RBAC
+# needed to manage them. This defaults to true for backward compatibility.
+# Exactly one installation in a cluster may set this to true. When multiple
+# operators run, using the same operator version is strongly recommended. If
+# versions differ, exactly one installation running the newest version must be
+# the API owner. Admission-affecting settings must also be compatible.
+apiOwner: true
 
 # -- Whether the API owner applies bundled CRDs via an init container on the
 # operator Deployment. Uses server-side apply with the bundled /crd-apply
 # binary. Set to false if schemas are managed externally. This cannot be true
-# when apiOwnership.enabled is false. Helm's special CRD installation must be
+# when apiOwner is false. Helm's special CRD installation must be
 # disabled separately when this installation must not bootstrap missing CRDs.
 upgradeCRD: true
 

--- a/deploy/helm/charts/platform/tests/api_ownership_deployment_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_deployment_test.yaml
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: API ownership deployment
+templates:
+  - charts/dynamo-operator/templates/deployment.yaml
+  - charts/dynamo-operator/templates/operator-config.yaml
+tests:
+  - it: enables API ownership and CRD upgrades by default
+    template: charts/dynamo-operator/templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --api-owner=true
+        documentSelector:
+          path: kind
+          value: Deployment
+      - exists:
+          path: spec.template.spec.initContainers
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: disables cluster API mutation for a namespaced non-owner
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --api-owner=false
+        documentSelector:
+          path: kind
+          value: Deployment
+      - notExists:
+          path: spec.template.spec.initContainers
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: keeps API ownership when CRD schemas are externally managed
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --api-owner=true
+        documentSelector:
+          path: kind
+          value: Deployment
+      - notExists:
+          path: spec.template.spec.initContainers
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: rejects CRD upgrades by a non-owner
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.upgradeCRD: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "upgradeCRD=true requires apiOwnership.enabled=true"
+
+  - it: rejects a cluster-wide API non-owner
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - failedTemplate:
+          errorPattern: "A cluster-wide operator must set apiOwnership.enabled=true"
+
+  - it: rejects namespace-scoped admission
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.webhook.namespaceSelector.matchLabels.tenant: selected
+    asserts:
+      - failedTemplate:
+          errorPattern: "webhook.namespaceSelector must be empty"

--- a/deploy/helm/charts/platform/tests/api_ownership_deployment_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_deployment_test.yaml
@@ -25,7 +25,7 @@ tests:
     template: charts/dynamo-operator/templates/deployment.yaml
     set:
       dynamo-operator.namespaceRestriction.enabled: true
-      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.apiOwner: false
       dynamo-operator.upgradeCRD: false
     asserts:
       - contains:
@@ -61,20 +61,20 @@ tests:
     template: charts/dynamo-operator/templates/deployment.yaml
     set:
       dynamo-operator.namespaceRestriction.enabled: true
-      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.apiOwner: false
       dynamo-operator.upgradeCRD: true
     asserts:
       - failedTemplate:
-          errorPattern: "upgradeCRD=true requires apiOwnership.enabled=true"
+          errorPattern: "upgradeCRD=true requires apiOwner=true"
 
   - it: rejects a cluster-wide API non-owner
     template: charts/dynamo-operator/templates/deployment.yaml
     set:
-      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.apiOwner: false
       dynamo-operator.upgradeCRD: false
     asserts:
       - failedTemplate:
-          errorPattern: "A cluster-wide operator must set apiOwnership.enabled=true"
+          errorPattern: "A cluster-wide operator must set apiOwner=true"
 
   - it: rejects namespace-scoped admission
     template: charts/dynamo-operator/templates/deployment.yaml

--- a/deploy/helm/charts/platform/tests/api_ownership_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_rbac_test.yaml
@@ -11,7 +11,7 @@ tests:
           count: 4
       - equal:
           path: metadata.name
-          value: dynamo-operator-api-owner
+          value: dynamo-operator-api-ownership-mutex
         documentIndex: 2
       - equal:
           path: metadata.labels["nvidia.com/dynamo-api-owner"]
@@ -42,7 +42,7 @@ tests:
   - it: withholds cluster-scoped API RBAC from a non-owner
     set:
       dynamo-operator.namespaceRestriction.enabled: true
-      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.apiOwner: false
       dynamo-operator.upgradeCRD: false
     asserts:
       - hasDocuments:

--- a/deploy/helm/charts/platform/tests/api_ownership_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_rbac_test.yaml
@@ -1,0 +1,49 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: API ownership RBAC
+templates:
+  - charts/dynamo-operator/templates/webhook-rbac.yaml
+tests:
+  - it: gives the owner the fixed cluster-scoped ownership role
+    asserts:
+      - hasDocuments:
+          count: 4
+      - equal:
+          path: metadata.name
+          value: dynamo-operator-api-owner
+        documentIndex: 2
+      - equal:
+          path: metadata.labels["nvidia.com/dynamo-api-owner"]
+          value: "true"
+        documentIndex: 2
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - nvidia.com
+            resources:
+              - dynamocheckpoints
+            verbs:
+              - get
+        documentIndex: 2
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apps
+            resources:
+              - daemonsets
+            verbs:
+              - get
+              - list
+        documentIndex: 2
+
+  - it: withholds cluster-scoped API RBAC from a non-owner
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - hasDocuments:
+          count: 2

--- a/deploy/helm/charts/platform/tests/api_ownership_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_rbac_test.yaml
@@ -11,7 +11,7 @@ tests:
           count: 4
       - equal:
           path: metadata.name
-          value: dynamo-operator-api-ownership-mutex
+          value: dynamo-operator-webhooks
         documentIndex: 2
       - equal:
           path: metadata.labels["nvidia.com/dynamo-api-owner"]

--- a/deploy/helm/charts/platform/tests/api_ownership_webhooks_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_webhooks_test.yaml
@@ -21,7 +21,7 @@ tests:
   - it: does not render admission configurations for a non-owner
     set:
       dynamo-operator.namespaceRestriction.enabled: true
-      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.apiOwner: false
       dynamo-operator.upgradeCRD: false
     asserts:
       - hasDocuments:

--- a/deploy/helm/charts/platform/tests/api_ownership_webhooks_test.yaml
+++ b/deploy/helm/charts/platform/tests/api_ownership_webhooks_test.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: API ownership webhooks
+templates:
+  - charts/dynamo-operator/templates/webhook-configuration.yaml
+tests:
+  - it: renders admission configurations only for the owner
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: metadata.labels["nvidia.com/dynamo-api-owner"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["nvidia.com/dynamo-api-owner"]
+          value: "true"
+        documentIndex: 1
+
+  - it: does not render admission configurations for a non-owner
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.apiOwnership.enabled: false
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: makes namespaced owner admission cluster-wide
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+    asserts:
+      - notExists:
+          path: webhooks[0].namespaceSelector
+        documentIndex: 0
+      - notExists:
+          path: webhooks[0].namespaceSelector
+        documentIndex: 1

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -64,8 +64,12 @@ dynamo-operator:
   # -- Whether to enable the Dynamo Kubernetes operator deployment
   enabled: true
 
-  # -- Whether to manage CRDs via a pre-install/pre-upgrade hook Job.
-  # The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply.
+  # -- Cluster-wide Dynamo API ownership settings.
+  apiOwnership:
+    # -- Whether this installation owns cluster-wide Dynamo API machinery. Exactly one installation per cluster may enable this. Running all parallel operators at the same version is strongly recommended; if versions differ, exactly one installation at the newest version must be the owner. Admission-affecting settings must also be compatible across installations.
+    enabled: true
+
+  # -- Whether the API owner applies bundled CRDs via the operator init container. Requires apiOwnership.enabled=true. Helm's special CRD installation must be disabled separately when this installation must not bootstrap missing CRDs.
   upgradeCRD: true
 
   # Environment variables to pass to operator Deployment.
@@ -236,8 +240,7 @@ dynamo-operator:
     # -- Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy.
     timeoutSeconds: 10
 
-    # Namespace selector for webhook scope control
-    # -- Custom namespace selector for webhook validation. Use this to include or exclude specific namespaces from webhook validation. For CLUSTER-WIDE operators, you can exclude namespaces managed by namespace-restricted operators by using: matchExpressions: [{ key: "dynamo-operator", operator: "NotIn", values: ["namespace-restricted"] }]. For NAMESPACE-RESTRICTED operators, leave empty as it will be auto-configured to match only the operator's namespace.
+    # -- Must remain empty. The API owner's admission webhooks are cluster-wide so they stay aligned with the cluster-wide CRD schema and conversion implementation.
     namespaceSelector: {}
 
     # cert-manager integration for automated certificate lifecycle management

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -64,12 +64,10 @@ dynamo-operator:
   # -- Whether to enable the Dynamo Kubernetes operator deployment
   enabled: true
 
-  # -- Cluster-wide Dynamo API ownership settings.
-  apiOwnership:
-    # -- Whether this installation owns cluster-wide Dynamo API machinery. Exactly one installation per cluster may enable this. Running all parallel operators at the same version is strongly recommended; if versions differ, exactly one installation at the newest version must be the owner. Admission-affecting settings must also be compatible across installations.
-    enabled: true
+  # -- Whether this installation owns cluster-wide Dynamo API machinery. Defaults to true for backward compatibility. Exactly one installation per cluster may enable this. Running all parallel operators at the same version is strongly recommended; if versions differ, exactly one installation at the newest version must be the owner. Admission-affecting settings must also be compatible across installations.
+  apiOwner: true
 
-  # -- Whether the API owner applies bundled CRDs via the operator init container. Requires apiOwnership.enabled=true. Helm's special CRD installation must be disabled separately when this installation must not bootstrap missing CRDs.
+  # -- Whether the API owner applies bundled CRDs via the operator init container. Requires apiOwner=true. Helm's special CRD installation must be disabled separately when this installation must not bootstrap missing CRDs.
   upgradeCRD: true
 
   # Environment variables to pass to operator Deployment.

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -179,9 +179,12 @@ func main() {
 
 	var configFile string
 	var operatorVersion string
+	var apiOwner bool
 	flag.StringVar(&configFile, "config", "", "Path to operator configuration file (required)")
 	flag.StringVar(&operatorVersion, "operator-version", "unknown",
 		"Version of the operator (used in lease holder identity)")
+	flag.BoolVar(&apiOwner, "api-owner", true,
+		"Own cluster-wide CRD conversion, admission, and CA configuration")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -631,7 +634,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := registerWebhookHandlers(mgr, operatorCfg, runtimeConfig, operatorVersion); err != nil {
+	if err := registerWebhookHandlers(mgr, directClient, operatorCfg, runtimeConfig, operatorVersion); err != nil {
 		setupLog.Error(err, "failed to register webhooks")
 		os.Exit(1)
 	}
@@ -639,25 +642,29 @@ func main() {
 	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS
 	// secrets before this point. Auto mode can therefore patch admission and
 	// conversion CAs immediately; manual mode waits for externally provided
-	// ca.crt and only patches conversion, leaving admission CA management
-	// out-of-band.
-	caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
-	if err != nil {
-		setupLog.Error(err, "unable to create CA bundle injector")
-		os.Exit(1)
-	}
-	if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
-		if err := caInjector.InjectAll(mainCtx); err != nil {
-			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
+	// ca.crt and configures the conversion service and CA, leaving admission CA
+	// management out-of-band.
+	if apiOwner {
+		caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
+		if err != nil {
+			setupLog.Error(err, "unable to create CA bundle injector")
 			os.Exit(1)
+		}
+		if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
+			if err := caInjector.InjectAll(mainCtx); err != nil {
+				setupLog.Error(err, "failed to configure cluster-wide API webhooks")
+				os.Exit(1)
+			}
+		} else {
+			// Manual mode gets webhook CA material out-of-band. Missing ca.crt
+			// blocks startup instead of running with unauthenticated conversion.
+			if err := caInjector.ConfigureCRDConversionWebhook(mainCtx); err != nil {
+				setupLog.Error(err, "failed to configure CRD conversion webhook")
+				os.Exit(1)
+			}
 		}
 	} else {
-		// Manual mode gets webhook CA material out-of-band. Missing ca.crt
-		// blocks startup instead of running with unauthenticated conversion.
-		if err := caInjector.InjectCRDConversionCA(mainCtx); err != nil {
-			setupLog.Error(err, "failed to inject CRD conversion CA bundle")
-			os.Exit(1)
-		}
+		setupLog.Info("API ownership disabled; skipping cluster-wide CRD and admission configuration")
 	}
 
 	// mgr.Start reads tls.crt and tls.key from the projected Secret volume
@@ -793,6 +800,7 @@ func registerControllers(
 
 func registerWebhookHandlers(
 	mgr ctrl.Manager,
+	webhookClient client.Client,
 	operatorCfg *configv1alpha1.OperatorConfiguration,
 	runtimeConfig *commonController.RuntimeConfig,
 	operatorVersion string,
@@ -891,7 +899,9 @@ func registerWebhookHandlers(
 
 	setupLog.Info("Registering mutation webhooks")
 
-	podCheckpointRestoreMutator := webhookmutation.NewPodCheckpointRestoreMutator(mgr.GetClient(), operatorCfg)
+	// The API owner's admission is cluster-wide even when its controller cache
+	// is namespace-restricted, so webhook reads must bypass that cache.
+	podCheckpointRestoreMutator := webhookmutation.NewPodCheckpointRestoreMutator(webhookClient, operatorCfg)
 	if err := podCheckpointRestoreMutator.RegisterWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to register Pod checkpoint restore mutating webhook: %w", err)
 	}

--- a/deploy/operator/internal/cert/cert.go
+++ b/deploy/operator/internal/cert/cert.go
@@ -48,6 +48,7 @@ const (
 	defaultLookaheadInterval         = 90 * 24 * time.Hour
 	partOfLabel                      = "app.kubernetes.io/part-of"
 	partOfValue                      = "dynamo-operator"
+	apiOwnerLabel                    = "nvidia.com/dynamo-api-owner"
 	operatorNamespaceLabel           = "nvidia.com/dynamo-operator-namespace"
 	defaultMountedCertPollInterval   = 500 * time.Millisecond
 )
@@ -342,9 +343,8 @@ func NewCABundleInjector(cl client.Client, cfg *configv1alpha1.OperatorConfigura
 	return injector, nil
 }
 
-// InjectAll reads the CA bundle from the cert secret and injects it into all
-// webhook configurations owned by this operator instance (scoped by namespace
-// label), and into the multi-version CRD conversion webhooks.
+// InjectAll reads the CA bundle from the cert secret and configures all
+// admission and conversion webhooks owned by this operator instance.
 func (i *CABundleInjector) InjectAll(ctx context.Context) error {
 	caBundle, err := i.readCABundle(ctx)
 	if err != nil {
@@ -357,7 +357,7 @@ func (i *CABundleInjector) InjectAll(ctx context.Context) error {
 	if err := i.injectIntoMutatingWebhooks(ctx, caBundle); err != nil {
 		return err
 	}
-	if err := i.ensureCRDConversionCA(ctx, caBundle); err != nil {
+	if err := i.ensureCRDConversionWebhook(ctx, caBundle); err != nil {
 		return err
 	}
 
@@ -365,17 +365,17 @@ func (i *CABundleInjector) InjectAll(ctx context.Context) error {
 	return nil
 }
 
-// InjectCRDConversionCA reads the CA bundle from the cert secret and patches it
-// into the CRD conversion webhook configurations.
-func (i *CABundleInjector) InjectCRDConversionCA(ctx context.Context) error {
+// ConfigureCRDConversionWebhook reads the CA bundle from the cert secret and
+// configures the CRD conversion webhooks.
+func (i *CABundleInjector) ConfigureCRDConversionWebhook(ctx context.Context) error {
 	caBundle, err := i.waitForCABundle(ctx)
 	if err != nil {
 		return err
 	}
-	if err := i.ensureCRDConversionCA(ctx, caBundle); err != nil {
+	if err := i.ensureCRDConversionWebhook(ctx, caBundle); err != nil {
 		return err
 	}
-	i.logger.Info("CRD conversion webhook CA bundle injected")
+	i.logger.Info("CRD conversion webhooks configured")
 	return nil
 }
 
@@ -486,6 +486,7 @@ func buildCAArtifactsFromSecret(secret *corev1.Secret) (*certrotator.KeyPairArti
 func (i *CABundleInjector) webhookLabels() client.MatchingLabels {
 	return client.MatchingLabels{
 		partOfLabel:            partOfValue,
+		apiOwnerLabel:          "true",
 		operatorNamespaceLabel: i.namespace,
 	}
 }
@@ -528,20 +529,19 @@ func (i *CABundleInjector) injectIntoMutatingWebhooks(ctx context.Context, caBun
 	return nil
 }
 
-// ensureCRDConversionCA patches the CA bundle on the conversion webhooks that
-// are already present in the CRD manifests. Missing CRDs are tolerated with an
-// info-level log so that a standalone operator image can be brought up before
-// the CRDs are installed (helm install idempotency).
-func (i *CABundleInjector) ensureCRDConversionCA(ctx context.Context, caBundle []byte) error {
+// ensureCRDConversionWebhook points conversion at the API owner's Service and
+// patches its CA bundle. Missing CRDs are tolerated so that a standalone
+// operator image can start before CRDs are installed.
+func (i *CABundleInjector) ensureCRDConversionWebhook(ctx context.Context, caBundle []byte) error {
 	for _, name := range convertibleCRDs {
-		if err := i.patchCRDConversionCA(ctx, name, caBundle); err != nil {
+		if err := i.patchCRDConversionWebhook(ctx, name, caBundle); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (i *CABundleInjector) patchCRDConversionCA(ctx context.Context, crdName string, caBundle []byte) error {
+func (i *CABundleInjector) patchCRDConversionWebhook(ctx context.Context, crdName string, caBundle []byte) error {
 	crd := &apiextensionsv1.CustomResourceDefinition{}
 	if err := i.client.Get(ctx, types.NamespacedName{Name: crdName}, crd); err != nil {
 		if apierrors.IsNotFound(err) {
@@ -559,12 +559,19 @@ func (i *CABundleInjector) patchCRDConversionCA(ctx context.Context, crdName str
 		crd.Spec.Conversion.Webhook.ClientConfig.Service == nil {
 		return fmt.Errorf("CRD %s is missing conversion webhook configuration; regenerate and apply CRD manifests", crdName)
 	}
+	if i.cfg.Server.Webhook.ServiceName == "" {
+		return fmt.Errorf("configuring CRD %s conversion webhook: service name is required", crdName)
+	}
+	service := crd.Spec.Conversion.Webhook.ClientConfig.Service
+	service.Name = i.cfg.Server.Webhook.ServiceName
+	service.Namespace = i.namespace
 	crd.Spec.Conversion.Webhook.ClientConfig.CABundle = caBundle
 
 	if err := i.client.Patch(ctx, crd, client.MergeFrom(original)); err != nil {
-		return fmt.Errorf("patching CRD %s conversion CA bundle: %w", crdName, err)
+		return fmt.Errorf("patching CRD %s conversion webhook: %w", crdName, err)
 	}
-	i.logger.Info("Injected CA bundle into CRD conversion webhook", "crd", crdName)
+	i.logger.Info("Configured CRD conversion webhook", "crd", crdName,
+		"service", fmt.Sprintf("%s/%s", i.namespace, i.cfg.Server.Webhook.ServiceName))
 	return nil
 }
 

--- a/deploy/operator/internal/cert/cert_test.go
+++ b/deploy/operator/internal/cert/cert_test.go
@@ -291,7 +291,7 @@ func TestInjectIntoValidatingWebhooks(t *testing.T) {
 	wc := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-validating",
-			Labels: map[string]string{partOfLabel: partOfValue, operatorNamespaceLabel: testNamespace},
+			Labels: map[string]string{partOfLabel: partOfValue, apiOwnerLabel: "true", operatorNamespaceLabel: testNamespace},
 		},
 		Webhooks: []admissionregistrationv1.ValidatingWebhook{
 			{
@@ -361,11 +361,43 @@ func TestInjectIntoValidatingWebhooks_SkipsNonMatchingLabels(t *testing.T) {
 	}
 }
 
+func TestInjectIntoValidatingWebhooks_SkipsNonOwner(t *testing.T) {
+	wc := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "non-owner-validating",
+			Labels: map[string]string{partOfLabel: partOfValue, operatorNamespaceLabel: testNamespace},
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{
+			{
+				Name:                    "test.webhook.io",
+				ClientConfig:            admissionregistrationv1.WebhookClientConfig{},
+				SideEffects:             ptr.To(admissionregistrationv1.SideEffectClassNone),
+				AdmissionReviewVersions: []string{"v1"},
+			},
+		},
+	}
+
+	injector := newTestInjector(fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(wc), &configv1alpha1.OperatorConfiguration{})
+	ctx := context.Background()
+
+	if err := injector.injectIntoValidatingWebhooks(ctx, []byte("test-ca")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	if err := injector.client.Get(ctx, types.NamespacedName{Name: wc.Name}, updated); err != nil {
+		t.Fatalf("failed to get webhook config: %v", err)
+	}
+	if updated.Webhooks[0].ClientConfig.CABundle != nil {
+		t.Error("non-owner webhook config should not be patched")
+	}
+}
+
 func TestInjectIntoValidatingWebhooks_SkipsDifferentNamespace(t *testing.T) {
 	wc := &admissionregistrationv1.ValidatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "other-ns-validating",
-			Labels: map[string]string{partOfLabel: partOfValue, operatorNamespaceLabel: "other-ns"},
+			Labels: map[string]string{partOfLabel: partOfValue, apiOwnerLabel: "true", operatorNamespaceLabel: "other-ns"},
 		},
 		Webhooks: []admissionregistrationv1.ValidatingWebhook{
 			{
@@ -404,7 +436,7 @@ func TestInjectIntoMutatingWebhooks(t *testing.T) {
 	wc := &admissionregistrationv1.MutatingWebhookConfiguration{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "test-mutating",
-			Labels: map[string]string{partOfLabel: partOfValue, operatorNamespaceLabel: testNamespace},
+			Labels: map[string]string{partOfLabel: partOfValue, apiOwnerLabel: "true", operatorNamespaceLabel: testNamespace},
 		},
 		Webhooks: []admissionregistrationv1.MutatingWebhook{
 			{
@@ -479,7 +511,7 @@ func newDGDConversionCRD() *apiextensionsv1.CustomResourceDefinition {
 	)
 }
 
-func TestInjectCRDConversionCA_ReadsCABundleAndPatchesOnlyCABundle(t *testing.T) {
+func TestConfigureCRDConversionWebhook_ConfiguresOwnerServiceAndPreservesPath(t *testing.T) {
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: testNamespace,
@@ -495,10 +527,11 @@ func TestInjectCRDConversionCA_ReadsCABundleAndPatchesOnlyCABundle(t *testing.T)
 
 	cfg := &configv1alpha1.OperatorConfiguration{}
 	cfg.Server.Webhook.SecretName = testSecretName
+	cfg.Server.Webhook.ServiceName = testServiceName
 	injector := newTestInjector(fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret, crd), cfg)
 	ctx := context.Background()
 
-	if err := injector.InjectCRDConversionCA(ctx); err != nil {
+	if err := injector.ConfigureCRDConversionWebhook(ctx); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -513,14 +546,14 @@ func TestInjectCRDConversionCA_ReadsCABundleAndPatchesOnlyCABundle(t *testing.T)
 	if updated.Spec.Conversion.Strategy != apiextensionsv1.WebhookConverter {
 		t.Errorf("expected Webhook strategy, got %s", updated.Spec.Conversion.Strategy)
 	}
-	if updated.Spec.Conversion.Webhook.ClientConfig.Service.Name != testManifestServiceName {
+	if updated.Spec.Conversion.Webhook.ClientConfig.Service.Name != testServiceName {
 		t.Errorf("expected service name %s, got %s",
-			testManifestServiceName,
+			testServiceName,
 			updated.Spec.Conversion.Webhook.ClientConfig.Service.Name)
 	}
-	if updated.Spec.Conversion.Webhook.ClientConfig.Service.Namespace != testManifestNamespace {
+	if updated.Spec.Conversion.Webhook.ClientConfig.Service.Namespace != testNamespace {
 		t.Errorf("expected service namespace %s, got %s",
-			testManifestNamespace,
+			testNamespace,
 			updated.Spec.Conversion.Webhook.ClientConfig.Service.Namespace)
 	}
 	if updated.Spec.Conversion.Webhook.ClientConfig.Service.Path == nil ||
@@ -533,26 +566,26 @@ func TestInjectCRDConversionCA_ReadsCABundleAndPatchesOnlyCABundle(t *testing.T)
 	}
 }
 
-func TestEnsureCRDConversionCA_ErrorsWhenConversionMissing(t *testing.T) {
+func TestEnsureCRDConversionWebhook_ErrorsWhenConversionMissing(t *testing.T) {
 	crd := newDGDConversionCRD()
 	crd.Spec.Conversion = nil
 
 	cfg := &configv1alpha1.OperatorConfiguration{}
 	injector := newTestInjector(fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(crd), cfg)
 
-	if err := injector.ensureCRDConversionCA(context.Background(), []byte("test-ca")); err == nil {
+	if err := injector.ensureCRDConversionWebhook(context.Background(), []byte("test-ca")); err == nil {
 		t.Fatal("expected error when conversion webhook is missing")
 	}
 }
 
-func TestInjectCRDConversionCA_WaitsWhenSecretNotFound(t *testing.T) {
+func TestConfigureCRDConversionWebhook_WaitsWhenSecretNotFound(t *testing.T) {
 	cfg := &configv1alpha1.OperatorConfiguration{}
 	cfg.Server.Webhook.SecretName = testSecretName
 	injector := newTestInjector(fake.NewClientBuilder().WithScheme(newScheme()), cfg)
 	ctx, cancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
 	defer cancel()
 
-	err := injector.InjectCRDConversionCA(ctx)
+	err := injector.ConfigureCRDConversionWebhook(ctx)
 	if err == nil {
 		t.Fatal("expected context timeout while waiting for missing secret")
 	}
@@ -561,12 +594,12 @@ func TestInjectCRDConversionCA_WaitsWhenSecretNotFound(t *testing.T) {
 	}
 }
 
-func TestEnsureCRDConversionCA_SkipsWhenCRDNotFound(t *testing.T) {
+func TestEnsureCRDConversionWebhook_SkipsWhenCRDNotFound(t *testing.T) {
 	cfg := &configv1alpha1.OperatorConfiguration{}
 	injector := newTestInjector(fake.NewClientBuilder().WithScheme(newScheme()), cfg)
 	ctx := context.Background()
 
-	if err := injector.ensureCRDConversionCA(ctx, []byte("test-ca")); err != nil {
+	if err := injector.ensureCRDConversionWebhook(ctx, []byte("test-ca")); err != nil {
 		t.Fatalf("expected no error when CRD not found, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- add explicit `apiOwnership.enabled` control and enforce a single cluster API owner
- restrict CRD application, admission configuration, conversion/CA updates, and cluster API RBAC to that owner
- support externally managed schemas with `upgradeCRD=false` while retaining conversion and admission ownership
- document mixed-operator version, feature compatibility, Helm CRD, and manual ownership-transfer requirements

## Validation

- `go test ./cmd ./internal/cert -count=1`
- `helm unittest .` (29 tests passed)
- `helm lint .`
- repository pre-commit hooks

Linear: [DYN-3412](https://linear.app/nvidia/issue/DYN-3412/dynamorelease130operatorwebhook-multi-operator-cluster-wide-defaulter)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for explicit API ownership settings for the operator, including clear owner/non-owner deployment modes.
  * Webhook and CRD behavior now follows a cluster-wide ownership model with fixed owner labeling and safer compatibility rules.

* **Bug Fixes**
  * Prevents conflicting operator installs by validating ownership, version consistency, and webhook settings before deployment.
  * Improves handling of CRD conversion and webhook configuration so non-owner installs don’t bootstrap or modify cluster-wide API resources unexpectedly.

* **Documentation**
  * Expanded chart docs with examples, conflict scenarios, and guidance for multi-installation setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->