### PR TITLE
fix(deps): [cherry-pick 1.3.0] cap mpmath<1.4 in trtllm extra (DYN-3348) (#11402)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,11 @@ Repository = "https://github.com/ai-dynamo/dynamo.git"
 trtllm =[
     "uvloop",
     "tensorrt-llm==1.3.0rc19",
+    # tensorrt-llm declares an uncapped `mpmath>=1.3.0`; under `--pre` the resolver
+    # picks mpmath 1.5.0a0 (mpmath.libmp.bitcount removed) and backtracks sympy to
+    # the uncapped 1.14.0rc1, which still imports bitcount -> torch._dynamo dies at
+    # import (DYN-3348). Matches sympy 1.14's own cap; drop once TRT-LLM bounds mpmath.
+    "mpmath<1.4",
 ]
 
 vllm = [


### PR DESCRIPTION
## Overview:

Cherry-pick of #11402 to `release/1.3.0` (resolved onto this branch's `tensorrt-llm==1.3.0rc19` pin). Fixes the P0 release blocker DYN-3348 / NVBug 6406026: `pip install ai-dynamo[trtllm]` (1.3.0-rc1 wheels) installs successfully but the TRT-LLM backend crashes at import with `ImportError: cannot import name 'bitcount' from 'mpmath.libmp'`, so serve never becomes ready.

## Details:

- `tensorrt-llm` declares a **direct, uncapped** `mpmath>=1.3.0` (rc19 and rc20 alike).
- The trtllm pip install requires `--pre` — not droppable, tensorrt-llm's tree pins `flash-attn-4==4.0.0b11` and other pre-releases.
- Under `--pre` the resolver maximizes mpmath to **1.5.0a0** (uploaded to PyPI 2026-06-24 — the trigger for this regression), which removed `mpmath.libmp.bitcount`, and backtracks sympy to **1.14.0rc1** — the only sympy ≥1.13.3 without the `mpmath<1.4` cap — which still imports bitcount at `sympy/core/evalf.py:19`. `torch._dynamo` imports sympy at init → backend dies.
- Capping `mpmath<1.4` (sympy 1.14's own bound) restores `mpmath 1.3.0` and stable `sympy 1.14.0`; a resolve diff shows exactly these two pins change. QA validated the same constraint end-to-end on the DYN-3348 repro (health + chat completions pass).

**Release note:** the 1.3.0 wheels must be rebuilt (rc2) after this merges — the extras metadata is baked into `ai_dynamo-1.3.0-py3-none-any.whl` at build time. The trtllm container image is unaffected (pre-resolved NGC stack, `--no-deps` overlays).

## Where should the reviewer start?

`pyproject.toml` — the only file changed (5 added lines: 4 comment lines + the pin).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related GitHub issue (tracked in Linear: DYN-3348, NVBug 6406026; main PR: #11402)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11404" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->