### PR TITLE
fix(operator): emit Grove alpha.11 topology constraints

### DIFF
--- a/deploy/operator/internal/controller/dynamographdeployment_controller.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller.go
@@ -658,6 +658,7 @@ func (r *DynamoGraphDeploymentReconciler) reconcileGrovePodCliqueSet(
 		logger.Error(err, "failed to generate the Grove GangSet")
 		return nil, fmt.Errorf("failed to generate the Grove GangSet: %w", err)
 	}
+	prepareGroveTopologyConstraintUpgrade(grovePodCliqueSet, existingPodCliqueSet)
 	preserveGrovePodCliqueSetOrder(grovePodCliqueSet, existingPodCliqueSet)
 	preserveGrovePodCliqueSetReplicas(grovePodCliqueSet, existingPodCliqueSet, checkpointInfos)
 	_, syncedGrovePodCliqueSet, err := commoncontroller.SyncResource(ctx, r, dynamoDeployment, func(ctx context.Context) (*grovev1alpha1.PodCliqueSet, bool, error) {
@@ -724,6 +725,64 @@ func preserveGrovePodCliqueSetOrder(desired *grovev1alpha1.PodCliqueSet, existin
 	desired.Spec.Template.Cliques = orderLikeExisting(existing.Spec.Template.Cliques, desired.Spec.Template.Cliques, podCliqueTemplateName)
 	desired.Spec.Template.PodCliqueScalingGroupConfigs = orderLikeExisting(existing.Spec.Template.PodCliqueScalingGroupConfigs, desired.Spec.Template.PodCliqueScalingGroupConfigs, podCliqueScalingGroupConfigName)
 	desired.Spec.Template.ResourceClaimTemplates = orderLikeExisting(existing.Spec.Template.ResourceClaimTemplates, desired.Spec.Template.ResourceClaimTemplates, resourceClaimTemplateConfigName)
+}
+
+// prepareGroveTopologyConstraintUpgrade performs the first half of Grove's
+// supported legacy topology migration. A pre-alpha.9 constraint has
+// packDomain but no topologyName; Grove requires that object to be repaired by
+// adding topologyName before packDomain can be migrated to pack.required.
+// Keeping the legacy packing shape for this reconciliation lets the next
+// reconciliation apply the generated modern shape without recreating the PCS.
+func prepareGroveTopologyConstraintUpgrade(desired *grovev1alpha1.PodCliqueSet, existing *grovev1alpha1.PodCliqueSet) {
+	if desired == nil || existing == nil {
+		return
+	}
+
+	prepareLegacyGroveTopologyConstraintRepair(
+		desired.Spec.Template.TopologyConstraint,
+		existing.Spec.Template.TopologyConstraint,
+	)
+
+	existingCliqueConstraints := make(map[string]*grovev1alpha1.TopologyConstraint, len(existing.Spec.Template.Cliques))
+	for _, clique := range existing.Spec.Template.Cliques {
+		if clique != nil {
+			existingCliqueConstraints[clique.Name] = clique.TopologyConstraint
+		}
+	}
+	for _, clique := range desired.Spec.Template.Cliques {
+		if clique != nil {
+			prepareLegacyGroveTopologyConstraintRepair(clique.TopologyConstraint, existingCliqueConstraints[clique.Name])
+		}
+	}
+
+	existingScalingGroupConstraints := make(map[string]*grovev1alpha1.TopologyConstraint, len(existing.Spec.Template.PodCliqueScalingGroupConfigs))
+	for i := range existing.Spec.Template.PodCliqueScalingGroupConfigs {
+		config := &existing.Spec.Template.PodCliqueScalingGroupConfigs[i]
+		existingScalingGroupConstraints[config.Name] = config.TopologyConstraint
+	}
+	for i := range desired.Spec.Template.PodCliqueScalingGroupConfigs {
+		config := &desired.Spec.Template.PodCliqueScalingGroupConfigs[i]
+		prepareLegacyGroveTopologyConstraintRepair(config.TopologyConstraint, existingScalingGroupConstraints[config.Name])
+	}
+}
+
+func prepareLegacyGroveTopologyConstraintRepair(desired *grovev1alpha1.TopologyConstraint, existing *grovev1alpha1.TopologyConstraint) {
+	if desired == nil || existing == nil {
+		return
+	}
+	// A constraint without an explicit desired name inherits from its repaired
+	// parent and can migrate packDomain directly in the same update.
+	if desired.TopologyName == "" || existing.TopologyName != "" || existing.PackDomain == "" {
+		return
+	}
+
+	desired.PackDomain = existing.PackDomain
+	if existing.Pack == nil {
+		desired.Pack = nil
+		return
+	}
+	pack := *existing.Pack
+	desired.Pack = &pack
 }
 
 // Grove horizontal replicas are driven through scale subresources after creation;

--- a/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
+++ b/deploy/operator/internal/controller/dynamographdeployment_controller_test.go
@@ -2884,6 +2884,73 @@ func TestDynamoGraphDeploymentReconciler_prepareGroveRenderDeployment_PreservesL
 	g.Expect(decodeService.Spec.Selector[commonconsts.KubeLabelDynamoComponentType]).To(gomega.Equal(commonconsts.ComponentTypeWorker))
 }
 
+func TestPrepareGroveTopologyConstraintUpgrade(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	modernConstraint := func(topologyName string, domain grovev1alpha1.TopologyDomain) *grovev1alpha1.TopologyConstraint {
+		return &grovev1alpha1.TopologyConstraint{
+			TopologyName: topologyName,
+			Pack: &grovev1alpha1.TopologyPackConstraint{
+				RequiredDomain: domain,
+			},
+		}
+	}
+	legacyConstraint := func(domain grovev1alpha1.TopologyDomain) *grovev1alpha1.TopologyConstraint {
+		return &grovev1alpha1.TopologyConstraint{PackDomain: domain}
+	}
+
+	modern := &grovev1alpha1.PodCliqueSet{
+		Spec: grovev1alpha1.PodCliqueSetSpec{
+			Template: grovev1alpha1.PodCliqueSetTemplateSpec{
+				TopologyConstraint: modernConstraint("grove-topology", "zone"),
+				Cliques: []*grovev1alpha1.PodCliqueTemplateSpec{
+					{Name: "explicit", TopologyConstraint: modernConstraint("grove-topology", "rack")},
+					{Name: "inherited", TopologyConstraint: modernConstraint("", "rack")},
+				},
+				PodCliqueScalingGroupConfigs: []grovev1alpha1.PodCliqueScalingGroupConfig{
+					{Name: "workers", TopologyConstraint: modernConstraint("grove-topology", "block")},
+				},
+			},
+		},
+	}
+	existing := &grovev1alpha1.PodCliqueSet{
+		Spec: grovev1alpha1.PodCliqueSetSpec{
+			Template: grovev1alpha1.PodCliqueSetTemplateSpec{
+				TopologyConstraint: legacyConstraint("zone"),
+				Cliques: []*grovev1alpha1.PodCliqueTemplateSpec{
+					{Name: "inherited", TopologyConstraint: legacyConstraint("rack")},
+					{Name: "explicit", TopologyConstraint: legacyConstraint("rack")},
+				},
+				PodCliqueScalingGroupConfigs: []grovev1alpha1.PodCliqueScalingGroupConfig{
+					{Name: "workers", TopologyConstraint: legacyConstraint("block")},
+				},
+			},
+		},
+	}
+
+	firstStep := modern.DeepCopy()
+	prepareGroveTopologyConstraintUpgrade(firstStep, existing)
+
+	g.Expect(firstStep.Spec.Template.TopologyConstraint).To(gomega.Equal(&grovev1alpha1.TopologyConstraint{
+		TopologyName: "grove-topology",
+		PackDomain:   "zone",
+	}))
+	g.Expect(firstStep.Spec.Template.Cliques[0].TopologyConstraint).To(gomega.Equal(&grovev1alpha1.TopologyConstraint{
+		TopologyName: "grove-topology",
+		PackDomain:   "rack",
+	}))
+	// This constraint can inherit the topology name repaired on its parent, so
+	// Grove can migrate its packing field in the same update.
+	g.Expect(firstStep.Spec.Template.Cliques[1].TopologyConstraint).To(gomega.Equal(modern.Spec.Template.Cliques[1].TopologyConstraint))
+	g.Expect(firstStep.Spec.Template.PodCliqueScalingGroupConfigs[0].TopologyConstraint).To(gomega.Equal(&grovev1alpha1.TopologyConstraint{
+		TopologyName: "grove-topology",
+		PackDomain:   "block",
+	}))
+
+	secondStep := modern.DeepCopy()
+	prepareGroveTopologyConstraintUpgrade(secondStep, firstStep)
+	g.Expect(secondStep).To(gomega.Equal(modern), "a repaired constraint should proceed to pack.required on the next reconciliation")
+}
+
 func TestPreserveGrovePodCliqueSetReplicas(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2211,7 +2211,10 @@ func buildCliqueForRole(p cliqueParams) (*grovev1alpha1.PodCliqueTemplateSpec, e
 	}
 
 	if !p.usesPCSG {
-		clique.TopologyConstraint = toGroveTopologyConstraint(p.component.TopologyConstraint)
+		clique.TopologyConstraint = toGroveTopologyConstraint(
+			p.component.TopologyConstraint,
+			p.dynamoDeployment.Spec.TopologyConstraint,
+		)
 	}
 
 	labels, err := generateLabels(p.component, p.dynamoDeployment, p.componentName, p.discoveryContext)
@@ -2498,7 +2501,7 @@ func GenerateGrovePodCliqueSet(
 				CliqueNames:        cliqueNames,
 				Replicas:           replicas,
 				MinAvailable:       minAvailable,
-				TopologyConstraint: toGroveTopologyConstraint(component.TopologyConstraint),
+				TopologyConstraint: toGroveTopologyConstraint(component.TopologyConstraint, dynamoDeployment.Spec.TopologyConstraint),
 			}
 			if isInterPodGMS {
 				pcsg.ResourceSharing = gmsResourceSharingEntries(componentName, roles)

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -10015,10 +10015,50 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 				},
 			},
 			wantPCSTemplateTC: &grovev1alpha1.TopologyConstraint{
-				PackDomain: grovev1alpha1.TopologyDomain("zone"),
+				TopologyName: "test-topology",
+				Pack: &grovev1alpha1.TopologyPackConstraint{
+					RequiredDomain: grovev1alpha1.TopologyDomain("zone"),
+				},
 			},
 			wantCliqueTC: map[string]*grovev1alpha1.TopologyConstraint{
-				"worker": {PackDomain: grovev1alpha1.TopologyDomain("rack")},
+				"worker": {
+					Pack: &grovev1alpha1.TopologyPackConstraint{
+						RequiredDomain: grovev1alpha1.TopologyDomain("rack"),
+					},
+				},
+			},
+			wantPCSGCount: 0,
+		},
+		{
+			name: "service-only topology constraint - topology name is explicit on clique",
+			deployment: &v1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deploy",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.DynamoGraphDeploymentSpec{
+					TopologyConstraint: &v1alpha1.SpecTopologyConstraint{
+						TopologyProfile: "test-topology",
+					},
+					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+						"Worker": {
+							ComponentType: commonconsts.ComponentTypeWorker,
+							Replicas:      ptr.To(int32(2)),
+							TopologyConstraint: &v1alpha1.TopologyConstraint{
+								PackDomain: v1alpha1.TopologyDomain("rack"),
+							},
+						},
+					},
+				},
+			},
+			wantPCSTemplateTC: nil,
+			wantCliqueTC: map[string]*grovev1alpha1.TopologyConstraint{
+				"worker": {
+					TopologyName: "test-topology",
+					Pack: &grovev1alpha1.TopologyPackConstraint{
+						RequiredDomain: grovev1alpha1.TopologyDomain("rack"),
+					},
+				},
 			},
 			wantPCSGCount: 0,
 		},
@@ -10049,14 +10089,61 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 				},
 			},
 			wantPCSTemplateTC: &grovev1alpha1.TopologyConstraint{
-				PackDomain: grovev1alpha1.TopologyDomain("zone"),
+				TopologyName: "test-topology",
+				Pack: &grovev1alpha1.TopologyPackConstraint{
+					RequiredDomain: grovev1alpha1.TopologyDomain("zone"),
+				},
 			},
 			wantCliqueTC: map[string]*grovev1alpha1.TopologyConstraint{
 				"worker-ldr": nil,
 				"worker-wkr": nil,
 			},
 			wantPCSGTC: map[string]*grovev1alpha1.TopologyConstraint{
-				"worker": {PackDomain: grovev1alpha1.TopologyDomain("block")},
+				"worker": {
+					Pack: &grovev1alpha1.TopologyPackConstraint{
+						RequiredDomain: grovev1alpha1.TopologyDomain("block"),
+					},
+				},
+			},
+			wantPCSGCount: 1,
+		},
+		{
+			name: "service-only multinode constraint - topology name is explicit on scaling group",
+			deployment: &v1alpha1.DynamoGraphDeployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-deploy",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.DynamoGraphDeploymentSpec{
+					TopologyConstraint: &v1alpha1.SpecTopologyConstraint{
+						TopologyProfile: "test-topology",
+					},
+					Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{
+						"Worker": {
+							ComponentType: commonconsts.ComponentTypeWorker,
+							Replicas:      ptr.To(int32(2)),
+							Multinode: &v1alpha1.MultinodeSpec{
+								NodeCount: 4,
+							},
+							TopologyConstraint: &v1alpha1.TopologyConstraint{
+								PackDomain: v1alpha1.TopologyDomain("block"),
+							},
+						},
+					},
+				},
+			},
+			wantPCSTemplateTC: nil,
+			wantCliqueTC: map[string]*grovev1alpha1.TopologyConstraint{
+				"worker-ldr": nil,
+				"worker-wkr": nil,
+			},
+			wantPCSGTC: map[string]*grovev1alpha1.TopologyConstraint{
+				"worker": {
+					TopologyName: "test-topology",
+					Pack: &grovev1alpha1.TopologyPackConstraint{
+						RequiredDomain: grovev1alpha1.TopologyDomain("block"),
+					},
+				},
 			},
 			wantPCSGCount: 1,
 		},
@@ -10082,8 +10169,7 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 			if tt.wantPCSTemplateTC == nil {
 				assert.Nil(t, pcs.Spec.Template.TopologyConstraint, "expected PCS template TopologyConstraint to be nil")
 			} else {
-				assert.NotNil(t, pcs.Spec.Template.TopologyConstraint, "expected PCS template TopologyConstraint to be set")
-				assert.Equal(t, tt.wantPCSTemplateTC.PackDomain, pcs.Spec.Template.TopologyConstraint.PackDomain)
+				assert.Equal(t, tt.wantPCSTemplateTC, pcs.Spec.Template.TopologyConstraint)
 			}
 
 			// Verify clique-level TopologyConstraints (exhaustive)
@@ -10099,8 +10185,7 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 				if expectedTC == nil {
 					assert.Nil(t, clique.TopologyConstraint, "clique %q: expected nil TopologyConstraint", clique.Name)
 				} else {
-					assert.NotNil(t, clique.TopologyConstraint, "clique %q: expected non-nil TopologyConstraint", clique.Name)
-					assert.Equal(t, expectedTC.PackDomain, clique.TopologyConstraint.PackDomain, "clique %q: packDomain mismatch", clique.Name)
+					assert.Equal(t, expectedTC, clique.TopologyConstraint, "clique %q: topologyConstraint mismatch", clique.Name)
 				}
 			}
 			for expectedName := range tt.wantCliqueTC {
@@ -10123,8 +10208,7 @@ func TestGenerateGrovePodCliqueSet_TopologyConstraints(t *testing.T) {
 					if expectedTC == nil {
 						assert.Nil(t, pcsg.TopologyConstraint, "PCSG %q: expected nil TopologyConstraint", pcsg.Name)
 					} else {
-						assert.NotNil(t, pcsg.TopologyConstraint, "PCSG %q: expected non-nil TopologyConstraint", pcsg.Name)
-						assert.Equal(t, expectedTC.PackDomain, pcsg.TopologyConstraint.PackDomain, "PCSG %q: packDomain mismatch", pcsg.Name)
+						assert.Equal(t, expectedTC, pcsg.TopologyConstraint, "PCSG %q: topologyConstraint mismatch", pcsg.Name)
 					}
 				}
 			}

--- a/deploy/operator/internal/dynamo/grove.go
+++ b/deploy/operator/internal/dynamo/grove.go
@@ -266,25 +266,40 @@ func CheckPCSGReady(ctx context.Context, client client.Client, resourceName, nam
 	return true, "", serviceStatus, nil
 }
 
-// specToGroveTopologyConstraint converts a deployment-level SpecTopologyConstraint
-// to a Grove TopologyConstraint, extracting only the PackDomain.
+// specToGroveTopologyConstraint converts a deployment-level topology constraint
+// to the current Grove API shape.
 func specToGroveTopologyConstraint(tc *v1beta1.SpecTopologyConstraint) *grovev1alpha1.TopologyConstraint {
-	if tc == nil || tc.PackDomain == "" {
+	if tc == nil {
 		return nil
 	}
-	return &grovev1alpha1.TopologyConstraint{
-		PackDomain: grovev1alpha1.TopologyDomain(tc.PackDomain),
-	}
+	return groveTopologyConstraint(tc.ClusterTopologyName, tc.PackDomain)
 }
 
-// toGroveTopologyConstraint converts a service-level TopologyConstraint
-// to a Grove TopologyConstraint.
-func toGroveTopologyConstraint(tc *v1beta1.TopologyConstraint) *grovev1alpha1.TopologyConstraint {
+// toGroveTopologyConstraint converts a component-level topology constraint to
+// the current Grove API shape. Components inherit topologyName from a
+// constrained PodCliqueSet. When the deployment has no packing constraint,
+// there is no parent Grove constraint to inherit from, so each constrained
+// component carries the deployment's topologyName explicitly.
+func toGroveTopologyConstraint(tc *v1beta1.TopologyConstraint, deploymentTC *v1beta1.SpecTopologyConstraint) *grovev1alpha1.TopologyConstraint {
 	if tc == nil || tc.PackDomain == "" {
 		return nil
 	}
+	topologyName := ""
+	if deploymentTC != nil && deploymentTC.PackDomain == "" {
+		topologyName = deploymentTC.ClusterTopologyName
+	}
+	return groveTopologyConstraint(topologyName, tc.PackDomain)
+}
+
+func groveTopologyConstraint(topologyName string, packDomain v1beta1.TopologyDomain) *grovev1alpha1.TopologyConstraint {
+	if packDomain == "" {
+		return nil
+	}
 	return &grovev1alpha1.TopologyConstraint{
-		PackDomain: grovev1alpha1.TopologyDomain(tc.PackDomain),
+		TopologyName: topologyName,
+		Pack: &grovev1alpha1.TopologyPackConstraint{
+			RequiredDomain: grovev1alpha1.TopologyDomain(packDomain),
+		},
 	}
 }
 

--- a/deploy/operator/internal/dynamo/grove_schema_test.go
+++ b/deploy/operator/internal/dynamo/grove_schema_test.go
@@ -148,17 +148,65 @@ func TestGeneratedGroveTopologyConstraintsValidateAgainstPinnedCRD(t *testing.T)
 
 func TestLegacyGroveTopologyConstraintUpgradeValidatesAgainstPinnedCRD(t *testing.T) {
 	validator := newGrovePodCliqueSetRequestValidator(t)
-	modern := generateTopologyTestPodCliqueSet(t, "", false)
-	require.Len(t, modern.Spec.Template.Cliques, 1)
-	require.NotNil(t, modern.Spec.Template.Cliques[0].TopologyConstraint)
-	legacy := modern.DeepCopy()
-	legacy.Spec.Template.Cliques[0].TopologyConstraint = &grovev1alpha1.TopologyConstraint{PackDomain: "rack"}
-	repaired := modern.DeepCopy()
-	repaired.Spec.Template.Cliques[0].TopologyConstraint = &grovev1alpha1.TopologyConstraint{
-		TopologyName: "grove-topology",
-		PackDomain:   "rack",
+
+	tests := []struct {
+		name       string
+		modern     func(*testing.T) *grovev1alpha1.PodCliqueSet
+		constraint func(*grovev1alpha1.PodCliqueSet) *grovev1alpha1.TopologyConstraint
+		packDomain grovev1alpha1.TopologyDomain
+	}{
+		{
+			name: "template",
+			modern: func(t *testing.T) *grovev1alpha1.PodCliqueSet {
+				return generateTopologyTestPodCliqueSet(t, "zone", false)
+			},
+			constraint: func(pcs *grovev1alpha1.PodCliqueSet) *grovev1alpha1.TopologyConstraint {
+				return pcs.Spec.Template.TopologyConstraint
+			},
+			packDomain: "zone",
+		},
+		{
+			name: "clique",
+			modern: func(t *testing.T) *grovev1alpha1.PodCliqueSet {
+				pcs := generateTopologyTestPodCliqueSet(t, "", false)
+				require.Len(t, pcs.Spec.Template.Cliques, 1)
+				return pcs
+			},
+			constraint: func(pcs *grovev1alpha1.PodCliqueSet) *grovev1alpha1.TopologyConstraint {
+				return pcs.Spec.Template.Cliques[0].TopologyConstraint
+			},
+			packDomain: "rack",
+		},
+		{
+			name: "scaling group",
+			modern: func(t *testing.T) *grovev1alpha1.PodCliqueSet {
+				pcs := generateTopologyTestPodCliqueSet(t, "", true)
+				require.Len(t, pcs.Spec.Template.PodCliqueScalingGroupConfigs, 1)
+				return pcs
+			},
+			constraint: func(pcs *grovev1alpha1.PodCliqueSet) *grovev1alpha1.TopologyConstraint {
+				return pcs.Spec.Template.PodCliqueScalingGroupConfigs[0].TopologyConstraint
+			},
+			packDomain: "rack",
+		},
 	}
 
-	validator.validate(t, repaired, legacy)
-	validator.validate(t, modern, repaired)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			modern := tt.modern(t)
+			modernConstraint := tt.constraint(modern)
+			require.NotNil(t, modernConstraint)
+
+			legacy := modern.DeepCopy()
+			*tt.constraint(legacy) = grovev1alpha1.TopologyConstraint{PackDomain: tt.packDomain}
+			repaired := modern.DeepCopy()
+			*tt.constraint(repaired) = grovev1alpha1.TopologyConstraint{
+				TopologyName: modernConstraint.TopologyName,
+				PackDomain:   tt.packDomain,
+			}
+
+			validator.validate(t, repaired, legacy)
+			validator.validate(t, modern, repaired)
+		})
+	}
 }

--- a/deploy/operator/internal/dynamo/grove_schema_test.go
+++ b/deploy/operator/internal/dynamo/grove_schema_test.go
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package dynamo
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	v1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	controller_common "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	grovecrds "github.com/ai-dynamo/grove/operator/api/core/v1alpha1/crds"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
+	apitest "k8s.io/apiextensions-apiserver/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/utils/ptr"
+)
+
+type grovePodCliqueSetRequestValidator struct {
+	schemaValidator apiextensionsvalidation.SchemaValidator
+	celValidator    apitest.CELValidateFunc
+}
+
+func newGrovePodCliqueSetRequestValidator(t *testing.T) *grovePodCliqueSetRequestValidator {
+	t.Helper()
+
+	crdPath := filepath.Join(t.TempDir(), "grove.io_podcliquesets.yaml")
+	require.NoError(t, os.WriteFile(crdPath, []byte(grovecrds.PodCliqueSetCRD()), 0o600))
+	crd := apitest.MustLoadManifest[apiextensionsv1.CustomResourceDefinition](t, crdPath)
+
+	versionName := grovev1alpha1.SchemeGroupVersion.Version
+	var schema *apiextensionsv1.JSONSchemaProps
+	for i := range crd.Spec.Versions {
+		if crd.Spec.Versions[i].Name == versionName {
+			schema = crd.Spec.Versions[i].Schema.OpenAPIV3Schema
+			break
+		}
+	}
+	require.NotNil(t, schema, "Grove CRD has no %s schema", versionName)
+
+	var internalSchema apiextensions.JSONSchemaProps
+	require.NoError(t, apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(schema, &internalSchema, nil))
+	schemaValidator, _, err := apiextensionsvalidation.NewSchemaValidator(&internalSchema)
+	require.NoError(t, err)
+
+	celValidator, ok := apitest.VersionValidatorsFromFile(t, crdPath)[versionName]
+	require.True(t, ok, "Grove CRD has no %s CEL validator", versionName)
+	return &grovePodCliqueSetRequestValidator{
+		schemaValidator: schemaValidator,
+		celValidator:    celValidator,
+	}
+}
+
+func (v *grovePodCliqueSetRequestValidator) validate(t *testing.T, current, old *grovev1alpha1.PodCliqueSet) {
+	t.Helper()
+
+	toUnstructured := func(pcs *grovev1alpha1.PodCliqueSet) map[string]any {
+		if pcs == nil {
+			return nil
+		}
+		pcs = pcs.DeepCopy()
+		pcs.APIVersion = grovev1alpha1.SchemeGroupVersion.String()
+		pcs.Kind = "PodCliqueSet"
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(pcs)
+		require.NoError(t, err)
+		delete(obj, "status")
+		return obj
+	}
+
+	currentObject := toUnstructured(current)
+	oldObject := toUnstructured(old)
+	var schemaErrs field.ErrorList
+	if oldObject == nil {
+		schemaErrs = apiextensionsvalidation.ValidateCustomResource(nil, currentObject, v.schemaValidator)
+	} else {
+		schemaErrs = apiextensionsvalidation.ValidateCustomResourceUpdate(nil, currentObject, oldObject, v.schemaValidator)
+	}
+	require.Empty(t, schemaErrs)
+	require.Empty(t, v.celValidator(currentObject, oldObject))
+}
+
+func generateTopologyTestPodCliqueSet(t *testing.T, deploymentPack v1alpha1.TopologyDomain, multinode bool) *grovev1alpha1.PodCliqueSet {
+	t.Helper()
+
+	component := &v1alpha1.DynamoComponentDeploymentSharedSpec{
+		ComponentType: "worker",
+		Replicas:      ptr.To(int32(2)),
+		TopologyConstraint: &v1alpha1.TopologyConstraint{
+			PackDomain: "rack",
+		},
+	}
+	if multinode {
+		component.Multinode = &v1alpha1.MultinodeSpec{NodeCount: 2}
+	}
+	deployment := &v1alpha1.DynamoGraphDeployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-deploy", Namespace: "default"},
+		Spec: v1alpha1.DynamoGraphDeploymentSpec{
+			TopologyConstraint: &v1alpha1.SpecTopologyConstraint{
+				TopologyProfile: "grove-topology",
+				PackDomain:      deploymentPack,
+			},
+			Services: map[string]*v1alpha1.DynamoComponentDeploymentSharedSpec{"Worker": component},
+		},
+	}
+
+	pcs, err := GenerateGrovePodCliqueSet(
+		t.Context(),
+		betaDGD(t, deployment),
+		&configv1alpha1.OperatorConfiguration{},
+		&controller_common.RuntimeConfig{},
+		nil,
+		&mockSecretsRetriever{},
+		&RestartState{},
+		nil,
+		nil,
+	)
+	require.NoError(t, err)
+	return pcs
+}
+
+func TestGeneratedGroveTopologyConstraintsValidateAgainstPinnedCRD(t *testing.T) {
+	validator := newGrovePodCliqueSetRequestValidator(t)
+
+	tests := []struct {
+		name           string
+		deploymentPack v1alpha1.TopologyDomain
+		multinode      bool
+	}{
+		{name: "deployment and component constraints", deploymentPack: "zone"},
+		{name: "service-only single-node constraint"},
+		{name: "service-only multinode constraint", multinode: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pcs := generateTopologyTestPodCliqueSet(t, tt.deploymentPack, tt.multinode)
+			validator.validate(t, pcs, nil)
+		})
+	}
+}
+
+func TestLegacyGroveTopologyConstraintUpgradeValidatesAgainstPinnedCRD(t *testing.T) {
+	validator := newGrovePodCliqueSetRequestValidator(t)
+	modern := generateTopologyTestPodCliqueSet(t, "", false)
+	require.Len(t, modern.Spec.Template.Cliques, 1)
+	require.NotNil(t, modern.Spec.Template.Cliques[0].TopologyConstraint)
+	legacy := modern.DeepCopy()
+	legacy.Spec.Template.Cliques[0].TopologyConstraint = &grovev1alpha1.TopologyConstraint{PackDomain: "rack"}
+	repaired := modern.DeepCopy()
+	repaired.Spec.Template.Cliques[0].TopologyConstraint = &grovev1alpha1.TopologyConstraint{
+		TopologyName: "grove-topology",
+		PackDomain:   "rack",
+	}
+
+	validator.validate(t, repaired, legacy)
+	validator.validate(t, modern, repaired)
+}


### PR DESCRIPTION
## Overview:

Update Dynamo's Grove `PodCliqueSet` generation to use the topology constraint fields required by Grove `v0.1.0-alpha.11`.

New resources now emit `topologyName` and `pack.required` instead of the deprecated `packDomain` field. Existing legacy resources are migrated in place without recreating the `PodCliqueSet` or disrupting its workloads.

## Details:

### Problem

Dynamo currently generates the pre-alpha.9 Grove topology constraint shape:

```yaml
topologyConstraint:
  packDomain: rack
```

Grove alpha.11 rejects `packDomain` on newly created workloads and requires every constraint to resolve an explicit or inherited `topologyName`.

This causes newly generated topology-aware `PodCliqueSet` resources to be rejected or remain unresolved.

### Solution

New resources now use the current Grove shape:

```yaml
topologyConstraint:
  topologyName: grove-topology
  pack:
    required: rack
```

The implementation:

- Maps DGD `clusterTopologyName` to Grove `topologyName`.
- Emits `pack.required` instead of deprecated `packDomain` for new resources.
- Allows component constraints to inherit the deployment-level topology name.
- Adds an explicit topology name to service-only constraints when no constrained parent exists.
- Handles both single-node PodClique constraints and multinode PodCliqueScalingGroup constraints.

### Backward compatibility

Grove treats topology constraints as immutable but provides narrow upgrade exceptions for legacy resources. A legacy constraint cannot change both its missing topology name and deprecated packing representation in one update.

The reconciler therefore migrates legacy resources in two steps:

1. Add the missing `topologyName` while retaining `packDomain`.
2. Replace `packDomain` with the equivalent `pack.required` on the next reconciliation.

The existing `PodCliqueSet` update watch drives the second reconciliation. This avoids uncached reads, resource recreation, and workload disruption.

### Validation

Added coverage for:

- Deployment-level topology constraints.
- Service-only single-node constraints.
- Service-only multinode constraints.
- Two-phase migration of legacy constraints.
- Create and update validation against Grove alpha.11's embedded CRD and CEL rules.

The exact ARM64 Docker targets pass:

```bash
docker buildx build \
  --platform linux/arm64 \
  --target linter \
  --progress=plain \
  --build-context snapshot=../snapshot \
  .

docker buildx build \
  --platform linux/arm64 \
  --target tester \
  --progress=plain \
  --build-context snapshot=../snapshot \
  .
```

## Where should the reviewer start?

- `deploy/operator/internal/dynamo/grove.go`: conversion from Dynamo topology constraints to the Grove alpha.11 API shape.
- `deploy/operator/internal/dynamo/graph.go`: propagation of the deployment topology name to single-node and multinode component constraints.
- `deploy/operator/internal/controller/dynamographdeployment_controller.go`: two-phase compatibility migration for existing legacy `PodCliqueSet` resources.
- `deploy/operator/internal/dynamo/grove_schema_test.go`: validation against Grove alpha.11's embedded CRD and CEL rules.
- `deploy/operator/internal/controller/dynamographdeployment_controller_test.go`: compatibility migration coverage.

## Related Issues

**🔗 This PR is linked to an issue:**

- Closes #11399
- Closes DEP-1070

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11405" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grove deployments now support richer topology constraints across both service and deployment levels, including topology name and pack-domain settings.
  * Existing workloads can be automatically brought forward to the newer topology format during reconciliation.

* **Bug Fixes**
  * Improved handling of legacy topology settings so generated resources keep constraints consistent across templates, cliques, and scaling groups.
  * Added validation coverage to reduce mismatches between generated resources and the expected CRD schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->