### PR TITLE
feat: opt-in jemalloc for the frontend via LD_PRELOAD re-exec

### DIFF
--- a/components/src/dynamo/frontend/__main__.py
+++ b/components/src/dynamo/frontend/__main__.py
@@ -1,7 +1,49 @@
 #  SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #  SPDX-License-Identifier: Apache-2.0
 
-from dynamo.frontend.main import main
+import os
+import sys
+
+
+def _maybe_preload_jemalloc() -> None:
+    """Opt-in: re-exec the frontend under jemalloc.
+
+    The frontend's hot path under load is high-churn per-request allocation
+    (Vec::from_iter in the tokenizer id->token and serde_json serialization
+    paths); glibc ptmalloc spends a large share of loaded CPU on arena
+    management there, which jemalloc's per-thread caches avoid.
+
+    LD_PRELOAD is honored only at process start, so we set it and re-exec this
+    module once. Scoped to the frontend process only. Enable with
+    DYN_FRONTEND_JEMALLOC=1; requires libjemalloc2 (the runtime container already
+    ships it). No-op if jemalloc is already preloaded or the library is absent.
+    """
+    if os.environ.get("DYN_FRONTEND_JEMALLOC") != "1":
+        return
+    if "jemalloc" in os.environ.get("LD_PRELOAD", ""):
+        return  # already active (or we already re-exec'd)
+
+    import ctypes.util
+
+    lib = ctypes.util.find_library("jemalloc")
+    if not lib:
+        # Requested but unavailable: warn and stay on glibc rather than fail to
+        # start. (Logging isn't configured this early, so write to stderr.)
+        print(
+            "WARNING: DYN_FRONTEND_JEMALLOC=1 but libjemalloc was not found "
+            "(install libjemalloc2); continuing with the default allocator.",
+            file=sys.stderr,
+        )
+        return
+
+    existing = os.environ.get("LD_PRELOAD", "")
+    os.environ["LD_PRELOAD"] = f"{lib}:{existing}" if existing else lib
+    os.execv(sys.executable, [sys.executable, "-m", "dynamo.frontend", *sys.argv[1:]])
+
+
+_maybe_preload_jemalloc()
+
+from dynamo.frontend.main import main  # noqa: E402  (must follow the re-exec guard)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
## What

Opt-in jemalloc for the frontend process, enabled with `DYN_FRONTEND_JEMALLOC=1`.

`LD_PRELOAD` is only honored at process start, so the frontend entrypoint
(`python -m dynamo.frontend`) sets it and re-execs itself once. Scoped to the
frontend process only; off by default (stock path unchanged); a no-op if
`libjemalloc` isn't found (warns to stderr and continues on glibc).

```bash
DYN_FRONTEND_JEMALLOC=1 python -m dynamo.frontend --router-mode kv ...
```

## Why

Under load, the frontend's hot path is high-churn per-request allocation
(`Vec::from_iter` in the tokenizer id→token and `serde_json` serialization
paths). A CPU profile of the frontend pinned to 2 cores at ~200% (concurrency
196) shows glibc ptmalloc spending **~22% of loaded CPU** in arena management
(`_int_malloc` / `malloc_consolidate` / `_int_free` / `cfree`). Preloading
jemalloc — whose per-thread caches avoid that arena contention — cuts the
allocator's self-time to **~11%** (`malloc_consolidate` disappears entirely),
freeing ~10 CPU points for real request work.

This is the runtime, per-process counterpart to the container's deliberately
opt-in jemalloc: `libjemalloc2` is already installed in the runtime image
(the maintainers intentionally do **not** force it via `ENV LD_PRELOAD`), and
this flag lets an operator turn it on for just the frontend without a rebuild.

## Testing

End-to-end against the real frontend runtime (etcd + HTTP service):

| | jemalloc mapped | `LD_PRELOAD` | frontend start |
|---|---|---|---|
| `DYN_FRONTEND_JEMALLOC=1` | yes (`libjemalloc.so.2`) | set | ✅ normal |
| unset (default) | no | empty | ✅ normal (glibc) |

Clean in-place re-exec (same PID), no restart loop. `py_compile` + pre-commit pass.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11407" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->