### PR TITLE
perf(vllm): load independent multimodal inputs concurrently

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -11,8 +11,10 @@ multimodal UUIDs, and the model-specific prefill/decode handoff.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import pickle
+from collections.abc import Awaitable
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -47,6 +49,28 @@ IMAGE_URL_KEY = "image_url"
 VIDEO_URL_KEY = "video_url"
 AUDIO_URL_KEY = "audio_url"
 URL_VARIANT_KEY = "Url"
+
+
+async def _gather_media_loads(
+    loads: dict[str, Awaitable[Any]],
+) -> dict[str, Any]:
+    """Run independent media loads together and cancel siblings on failure."""
+    if not loads:
+        return {}
+    if len(loads) == 1:
+        name, load = next(iter(loads.items()))
+        return {name: await load}
+
+    names = list(loads)
+    tasks = [asyncio.ensure_future(loads[name]) for name in names]
+    try:
+        results = await asyncio.gather(*tasks)
+    except BaseException:
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
+        raise
+    return dict(zip(names, results, strict=True))
 
 
 def pad_mm_hashes_to_64(mm_hashes: list[str]) -> list[str]:
@@ -343,73 +367,93 @@ class VllmMultimodalRequestProcessor:
                         )
                     )
 
+            media_loads: dict[str, Awaitable[Any]] = {}
             image_items = mm_map.get(IMAGE_URL_KEY, [])
             image_key = "vision_chunk" if self.use_unified_vision_chunk else "image"
             if image_key not in vllm_mm_data and image_items:
-                with _nvtx.annotate("mm_backend:image_download", color="green"):
-                    images = await self.image_loader.load_image_batch(image_items)
-                if images:
-                    if self.use_unified_vision_chunk:
-                        chunks = [
-                            {"type": "image", "image": image, "uuid": None}
-                            for image in images
-                        ]
-                        vllm_mm_data[image_key] = (
-                            chunks[0] if len(chunks) == 1 else chunks
-                        )
-                    else:
-                        vllm_mm_data[image_key] = (
-                            images[0] if len(images) == 1 else images
-                        )
+
+                async def load_images() -> Any:
+                    with _nvtx.annotate("mm_backend:image_download", color="green"):
+                        return await self.image_loader.load_image_batch(image_items)
+
+                media_loads["image"] = load_images()
 
             video_items = mm_map.get(VIDEO_URL_KEY, [])
             if video_items:
-                videos = await self.video_loader.load_video_batch(video_items)
-                if videos:
-                    vllm_mm_data["video"] = videos[0] if len(videos) == 1 else videos
+                media_loads["video"] = self.video_loader.load_video_batch(video_items)
 
             audio_items = mm_map.get(AUDIO_URL_KEY, [])
             if audio_items:
-                audios = await self.audio_loader.load_audio_batch(audio_items)
-                if audios:
-                    vllm_mm_data["audio"] = audios[0] if len(audios) == 1 else audios
+                media_loads["audio"] = self.audio_loader.load_audio_batch(audio_items)
 
             if (
                 video_items
                 and mm_processor_kwargs
                 and mm_processor_kwargs.get("use_audio_in_video", False)
             ):
-                video_audios = []
-                for item in video_items:
-                    url = item.get(URL_VARIANT_KEY) if isinstance(item, dict) else None
-                    if not url:
-                        raise ValueError(
-                            "use_audio_in_video requires all video items to be "
-                            "URL-based. Got a non-URL video item (e.g. frontend-"
-                            "decoded). Audio extraction from decoded video data "
-                            "is not yet supported."
+
+                async def load_video_audios() -> list[Any]:
+                    video_audios = []
+                    for item in video_items:
+                        url = (
+                            item.get(URL_VARIANT_KEY)
+                            if isinstance(item, dict)
+                            else None
                         )
-                    try:
-                        video_audios.append(await self.audio_loader.load_audio(url))
-                    except Exception:
-                        logger.error(
-                            "Request %s failed to extract audio from video. "
-                            "use_audio_in_video requires every video to "
-                            "contain an audio stream.",
-                            request_id,
-                        )
-                        raise
-                if video_audios:
-                    existing = vllm_mm_data.get("audio")
-                    existing_items = (
-                        existing
-                        if isinstance(existing, list)
-                        else ([existing] if existing is not None else [])
-                    )
-                    all_audios = existing_items + video_audios
-                    vllm_mm_data["audio"] = (
-                        all_audios[0] if len(all_audios) == 1 else all_audios
-                    )
+                        if not url:
+                            raise ValueError(
+                                "use_audio_in_video requires all video items to be "
+                                "URL-based. Got a non-URL video item (e.g. frontend-"
+                                "decoded). Audio extraction from decoded video data "
+                                "is not yet supported."
+                            )
+                        try:
+                            video_audios.append(await self.audio_loader.load_audio(url))
+                        except Exception:
+                            logger.error(
+                                "Request %s failed to extract audio from video. "
+                                "use_audio_in_video requires every video to "
+                                "contain an audio stream.",
+                                request_id,
+                            )
+                            raise
+                    return video_audios
+
+                media_loads["video_audio"] = load_video_audios()
+
+            loaded_media = await _gather_media_loads(media_loads)
+
+            images = loaded_media.get("image")
+            if images:
+                if self.use_unified_vision_chunk:
+                    chunks = [
+                        {"type": "image", "image": image, "uuid": None}
+                        for image in images
+                    ]
+                    vllm_mm_data[image_key] = chunks[0] if len(chunks) == 1 else chunks
+                else:
+                    vllm_mm_data[image_key] = images[0] if len(images) == 1 else images
+
+            videos = loaded_media.get("video")
+            if videos:
+                vllm_mm_data["video"] = videos[0] if len(videos) == 1 else videos
+
+            audios = loaded_media.get("audio")
+            if audios:
+                vllm_mm_data["audio"] = audios[0] if len(audios) == 1 else audios
+
+            video_audios = loaded_media.get("video_audio")
+            if video_audios:
+                existing = vllm_mm_data.get("audio")
+                existing_items = (
+                    existing
+                    if isinstance(existing, list)
+                    else ([existing] if existing is not None else [])
+                )
+                all_audios = existing_items + video_audios
+                vllm_mm_data["audio"] = (
+                    all_audios[0] if len(all_audios) == 1 else all_audios
+                )
 
             return vllm_mm_data or None
         finally:

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -76,6 +77,137 @@ async def test_extracts_mixed_url_data_url_and_decoded_media():
     processor.video_loader.load_video_batch.assert_awaited_once_with(video_items)
     processor.audio_loader.load_audio_batch.assert_awaited_once_with(audio_items)
     processor.audio_loader.load_audio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_extracts_independent_modalities_concurrently():
+    processor = _processor()
+    started: set[str] = set()
+    all_started = asyncio.Event()
+
+    async def load(modality, value):
+        started.add(modality)
+        if len(started) == 3:
+            all_started.set()
+        await asyncio.wait_for(all_started.wait(), timeout=1)
+        return [value]
+
+    async def load_image(_):
+        return await load("image", image)
+
+    async def load_video(_):
+        return await load("video", video)
+
+    async def load_audio(_):
+        return await load("audio", audio)
+
+    image, video, audio = object(), object(), object()
+    processor.image_loader.load_image_batch.side_effect = load_image
+    processor.video_loader.load_video_batch.side_effect = load_video
+    processor.audio_loader.load_audio_batch.side_effect = load_audio
+
+    result = await processor.extract_multimodal_data(
+        {
+            "multi_modal_data": {
+                "image_url": [{"Url": "https://example.com/image.png"}],
+                "video_url": [{"Url": "https://example.com/video.mp4"}],
+                "audio_url": [{"Url": "https://example.com/audio.wav"}],
+            }
+        },
+        "request-concurrent",
+        None,
+    )
+
+    assert result == {"image": image, "video": video, "audio": audio}
+
+
+@pytest.mark.asyncio
+async def test_media_load_failure_cancels_sibling_loads():
+    processor = _processor()
+    image_started = asyncio.Event()
+    image_cancelled = asyncio.Event()
+    failure = RuntimeError("video decode failed")
+
+    async def load_image(_):
+        image_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            image_cancelled.set()
+            raise
+
+    async def load_video(_):
+        await image_started.wait()
+        raise failure
+
+    processor.image_loader.load_image_batch.side_effect = load_image
+    processor.video_loader.load_video_batch.side_effect = load_video
+
+    with pytest.raises(RuntimeError) as exc_info:
+        await processor.extract_multimodal_data(
+            {
+                "multi_modal_data": {
+                    "image_url": [{"Url": "https://example.com/image.png"}],
+                    "video_url": [{"Url": "https://example.com/video.mp4"}],
+                }
+            },
+            "request-failure",
+            None,
+        )
+
+    assert exc_info.value is failure
+    assert image_cancelled.is_set()
+
+
+@pytest.mark.asyncio
+async def test_extract_cancellation_cancels_all_media_loads():
+    processor = _processor()
+    started: set[str] = set()
+    all_started = asyncio.Event()
+    cancelled: set[str] = set()
+
+    async def block(modality):
+        started.add(modality)
+        if len(started) == 3:
+            all_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.add(modality)
+            raise
+
+    async def block_image(_):
+        await block("image")
+
+    async def block_video(_):
+        await block("video")
+
+    async def block_audio(_):
+        await block("audio")
+
+    processor.image_loader.load_image_batch.side_effect = block_image
+    processor.video_loader.load_video_batch.side_effect = block_video
+    processor.audio_loader.load_audio_batch.side_effect = block_audio
+    task = asyncio.create_task(
+        processor.extract_multimodal_data(
+            {
+                "multi_modal_data": {
+                    "image_url": [{"Url": "https://example.com/image.png"}],
+                    "video_url": [{"Url": "https://example.com/video.mp4"}],
+                    "audio_url": [{"Url": "https://example.com/audio.wav"}],
+                }
+            },
+            "request-cancelled",
+            None,
+        )
+    )
+    await asyncio.wait_for(all_started.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert cancelled == {"image", "video", "audio"}
 
 
 @pytest.mark.asyncio
@@ -238,6 +370,43 @@ async def test_audio_in_video_preserves_order_and_merges_standalone_audio():
         "video": [video_a, video_b],
         "audio": [standalone_audio, audio_a, audio_b],
     }
+
+
+@pytest.mark.asyncio
+async def test_audio_in_video_item_loading_remains_serial():
+    processor = _processor()
+    processor.video_loader.load_video_batch.return_value = [object(), object()]
+    active = 0
+    max_active = 0
+
+    async def load_audio(url):
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0)
+        active -= 1
+        return url
+
+    processor.audio_loader.load_audio.side_effect = load_audio
+    result = await processor.extract_multimodal_data(
+        {
+            "multi_modal_data": {
+                "video_url": [
+                    {"Url": "https://example.com/a.mp4"},
+                    {"Url": "https://example.com/b.mp4"},
+                ]
+            }
+        },
+        "request-audio-bounded",
+        None,
+        {"use_audio_in_video": True},
+    )
+
+    assert result["audio"] == [
+        "https://example.com/a.mp4",
+        "https://example.com/b.mp4",
+    ]
+    assert max_active == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

- load independent image, video, standalone-audio, and audio-from-video modality groups concurrently
- retain the direct single-modality path and existing per-loader item concurrency limits
- preserve deterministic output ordering and cancel/drain sibling tasks on failure or request cancellation

## Validation

- `pytest` relevant request-processor, unified multimodal/main, and media-loader suites: 76 passed
- targeted isort, black, flake8, codespell, ruff, and hygiene hooks
- focused real-loader A/B: mixed preparation median 37.181 ms base, 20.548 ms candidate (30 samples/arm)
- full `agg_multimodal.sh --unified` GPU A/B: mixed one-token TTFT median 67.682 ms base, 51.795 ms candidate
- focused admission throughput at concurrency 8: median 92.192 requests/s base, 109.044 requests/s candidate (7 trials/arm)

The repository-wide pytest marker-report hook could not collect in its isolated environment because `uvloop` was missing; direct relevant tests passed.

<!-- perf-agent-investigation:57088c31-971a-4578-af5f-1965f14266e6 -->
