### PR TITLE
perf(vllm): compact multimodal tensor views before transfer

### DIFF
--- a/components/src/dynamo/common/multimodal/mm_kwargs_transfer.py
+++ b/components/src/dynamo/common/multimodal/mm_kwargs_transfer.py
@@ -40,6 +40,61 @@ from dynamo.common.utils.runtime import run_async
 logger = logging.getLogger(__name__)
 
 
+def _compact_nested_tensor_storage(value: Any) -> tuple[Any, bool]:
+    """Compact tensor views whose pickle would include unused backing storage."""
+    if isinstance(value, torch.Tensor):
+        logical_bytes = value.numel() * value.element_size()
+        if value.untyped_storage().nbytes() > logical_bytes:
+            if value.device.type == "cpu" and value.is_contiguous() and value.dim():
+                # vLLM can return one item as a view of a multi-item batch.
+                # NumPy makes a compact, single-threaded copy; otherwise pickle
+                # serializes the full backing storage once per item.
+                byte_array = value.detach().view(torch.uint8).numpy().copy()
+                return (
+                    torch.from_numpy(byte_array).view(value.dtype).reshape(value.shape),
+                    True,
+                )
+            return value.clone(), True
+        return value, False
+    if isinstance(value, list):
+        compacted = [_compact_nested_tensor_storage(item) for item in value]
+        if any(changed for _, changed in compacted):
+            return [item for item, _ in compacted], True
+        return value, False
+    if isinstance(value, tuple):
+        compacted = [_compact_nested_tensor_storage(item) for item in value]
+        if any(changed for _, changed in compacted):
+            return tuple(item for item, _ in compacted), True
+        return value, False
+    return value, False
+
+
+def _compact_mm_kwargs_item(item: Any) -> Any:
+    """Copy a vLLM kwargs item while compacting tensor views for pickling."""
+    if not hasattr(item, "items"):
+        return item
+
+    elements = list(item.items())
+    if not all(
+        hasattr(element, "data") and hasattr(element, "field")
+        for _, element in elements
+    ):
+        return item
+
+    compacted_elements = {}
+    changed = False
+    for name, element in elements:
+        compacted_data, data_changed = _compact_nested_tensor_storage(element.data)
+        compacted_elements[name] = (
+            type(element)(data=compacted_data, field=element.field)
+            if data_changed
+            else element
+        )
+        changed = changed or data_changed
+
+    return type(item)(compacted_elements) if changed else item
+
+
 # ---------------------------------------------------------------------------
 # Wire protocol
 # ---------------------------------------------------------------------------
@@ -148,6 +203,7 @@ class MmKwargsSender(ABC):
             encoded_items: list[Any] = []
             cleanup_items: list[Any] = []
             mm_hashes: list[str] = []
+            compact_tensor_views = len(mm_features) > 1
 
             for i, feat in enumerate(mm_features):
                 if feat.mm_hash:
@@ -156,7 +212,12 @@ class MmKwargsSender(ABC):
                     continue
 
                 with _nvtx.annotate(self._pickle_nvtx_label, color=self._nvtx_color):
-                    pickled = pickle.dumps(feat.data)
+                    item = (
+                        _compact_mm_kwargs_item(feat.data)
+                        if compact_tensor_views
+                        else feat.data
+                    )
+                    pickled = pickle.dumps(item)
 
                 encoded, cleanup = await self._encode_item(i, pickled)
                 encoded_items.append(encoded)

--- a/components/src/dynamo/common/tests/multimodal/test_mm_kwargs_transfer.py
+++ b/components/src/dynamo/common/tests/multimodal/test_mm_kwargs_transfer.py
@@ -4,9 +4,11 @@
 """Unit tests for MM kwargs transfer (NIXL sender/receiver + SHM sender/receiver)."""
 
 import pickle
+from dataclasses import dataclass
 from unittest.mock import MagicMock
 
 import pytest
+import torch
 
 from dynamo.common.multimodal.mm_kwargs_transfer import (
     MmKwargsNixlSender,
@@ -22,6 +24,16 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@dataclass
+class _TestElement:
+    data: torch.Tensor
+    field: object
+
+
+class _TestItem(dict):
+    pass
 
 
 def _make_feature(data=None, mm_hash="hash_default"):
@@ -190,6 +202,64 @@ class TestMmKwargsShmTransfer:
             restored = pickle.loads(items[i])
             assert restored["name"] == f"image_{i}"
             assert len(restored["values"]) == (i + 1) * 100
+
+        await sender.cleanup(handles)
+
+    @pytest.mark.asyncio
+    async def test_compacts_shared_tensor_storage_before_pickling(self):
+        """Each item should serialize only its tensor view, not the full batch."""
+        batch = torch.arange(2048, dtype=torch.float32).reshape(2, 1024)
+        items = [
+            _TestItem({"pixels": _TestElement(batch[index], "batched")})
+            for index in range(2)
+        ]
+        features = [
+            _make_feature(data=item, mm_hash=f"hash_{index}")
+            for index, item in enumerate(items)
+        ]
+
+        sender = MmKwargsShmSender()
+        extra_update, handles = await sender.prepare(features, modality="image")
+
+        assert extra_update is not None
+        metadata = MmKwargsShmTransferMetadata.model_validate(
+            extra_update["mm_kwargs_shm"]
+        )
+        serialized_bytes = sum(item.size for item in metadata.items)
+        uncompact_bytes = sum(len(pickle.dumps(item)) for item in items)
+        logical_bytes = sum(item["pixels"].data.nbytes for item in items)
+        assert serialized_bytes < uncompact_bytes
+        assert serialized_bytes < logical_bytes * 2
+
+        receiver = MmKwargsShmReceiver()
+        results = await receiver.receive(metadata)
+        restored = [
+            pickle.loads(payload) for payload in results["__pickled_kwargs_item__"]
+        ]
+        for restored_item, original_item in zip(restored, items):
+            assert torch.equal(
+                restored_item["pixels"].data,
+                original_item["pixels"].data,
+            )
+            assert restored_item["pixels"].field == "batched"
+
+        await sender.cleanup(handles)
+
+    @pytest.mark.asyncio
+    async def test_does_not_copy_already_compact_tensor_storage(self):
+        tensor = torch.arange(1024, dtype=torch.float32)
+        item = _TestItem({"pixels": _TestElement(tensor, "batched")})
+        sender = MmKwargsShmSender()
+
+        extra_update, handles = await sender.prepare(
+            [_make_feature(data=item)], modality="image"
+        )
+
+        assert extra_update is not None
+        metadata = MmKwargsShmTransferMetadata.model_validate(
+            extra_update["mm_kwargs_shm"]
+        )
+        assert metadata.items[0].size == len(pickle.dumps(item))
 
         await sender.cleanup(handles)
 


### PR DESCRIPTION
## Summary

- Compact per-feature CPU tensor views when their backing storage contains unused multi-image batch data.
- Preserve the original single-feature path and the existing SHM/NIXL wire format.
- Add regression coverage for compact and already-compact tensor storage.

## Validation

- `82 passed` across multimodal transfer, frontend processor, and backend request-processor suites.
- Ruff and all applicable targeted pre-commit hooks passed; the repository-wide marker-report hook could not collect because its isolated environment lacked `uvloop`.
- Real Qwen3-VL four-image 512 px SHM payload: 50,340,637 bytes at base versus 12,591,604 bytes with the candidate.
- Same focused transfer boundary: 45.145 ms versus 12.705 ms median wall time and 45.116 ms versus 12.703 ms process CPU.
- Real-feature SHM and local UCX/NIXL round-trips preserved values and vLLM field semantics.

The benchmark isolates frontend serialization and transfer through unpickle; it does not claim complete request TTFT or GPU-throughput results.

<!-- perf-agent-investigation:9d8c8536-bc9d-4e9f-ba62-71818118842d -->
