### PR TITLE
perf(vllm): avoid dense Qwen decode placeholders

### DIFF
--- a/components/src/dynamo/vllm/multimodal_utils/model.py
+++ b/components/src/dynamo/vllm/multimodal_utils/model.py
@@ -24,6 +24,14 @@ from typing import Any, Dict, List, Optional
 import torch
 from transformers import AutoModel
 from vllm import LLM
+from vllm.inputs import mm_input
+from vllm.multimodal.inputs import (
+    MultiModalBatchedField,
+    MultiModalFieldElem,
+    MultiModalKwargsItem,
+    MultiModalKwargsItems,
+    PlaceholderRange,
+)
 from vllm.utils.system_utils import update_environment_variables
 
 logger = logging.getLogger(__name__)
@@ -304,3 +312,69 @@ def construct_qwen_decode_mm_data(
             "image_grid_thw": torch.tensor(image_grid_thw),
         }
     }
+
+
+def construct_qwen_decode_prompt(
+    prompt_token_ids_without_images: list[int],
+    image_token_id: int,
+    image_grid_thw: Optional[List[Any]],
+    image_placeholders: list[list[int]],
+    request_id: str,
+) -> Dict[str, Any]:
+    """Build a metadata-only Qwen input after a remote-prefill KV hit.
+
+    The decode worker needs the image grid to initialize mRoPE, but it does not
+    run the vision encoder because NIXL supplies the complete prefill KV state.
+    Rebuilding vLLM's expanded token IDs from compact insertion metadata avoids
+    allocating, hashing, and sending dense placeholder embeddings.
+    """
+    if image_grid_thw is None or len(image_grid_thw) == 0:
+        raise ValueError("No image grid provided for Qwen model.")
+    if len(image_grid_thw) != len(image_placeholders):
+        raise ValueError(
+            "image grid and placeholder counts differ for Qwen decode prompt"
+        )
+
+    prompt_token_ids: list[int] = []
+    compact_cursor = 0
+    for placeholder in image_placeholders:
+        offset, length = map(int, placeholder)
+        compact_count = offset - len(prompt_token_ids)
+        if compact_count < 0:
+            raise ValueError("Qwen image placeholders overlap or are out of order")
+        compact_end = compact_cursor + compact_count
+        prompt_token_ids.extend(
+            prompt_token_ids_without_images[compact_cursor:compact_end]
+        )
+        if len(prompt_token_ids) != offset:
+            raise ValueError("Qwen image placeholder offset exceeds prompt length")
+        prompt_token_ids.extend([image_token_id] * length)
+        compact_cursor = compact_end
+    prompt_token_ids.extend(prompt_token_ids_without_images[compact_cursor:])
+
+    items = []
+    ranges = []
+    hashes = []
+    for index, (grid, placeholder) in enumerate(
+        zip(image_grid_thw, image_placeholders)
+    ):
+        offset, length = map(int, placeholder)
+        items.append(
+            MultiModalKwargsItem(
+                {
+                    "image_grid_thw": MultiModalFieldElem(
+                        data=torch.tensor(grid),
+                        field=MultiModalBatchedField(keep_on_cpu=True),
+                    )
+                }
+            )
+        )
+        ranges.append(PlaceholderRange(offset=offset, length=length))
+        hashes.append(f"dynamo-pd-{request_id}-{index}")
+
+    return mm_input(
+        prompt_token_ids=prompt_token_ids,
+        mm_kwargs=MultiModalKwargsItems({"image": items}),
+        mm_hashes={"image": hashes},
+        mm_placeholders={"image": ranges},
+    )

--- a/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
+++ b/components/src/dynamo/vllm/multimodal_utils/models/qwen.py
@@ -23,6 +23,7 @@ class QwenGridParams:
     min_pixels: int
     max_pixels: int
     vision_hidden_dim: int
+    image_token_id: int | None = None
 
 
 def load_qwen_grid_params(
@@ -39,9 +40,10 @@ def load_qwen_grid_params(
         processor = AutoImageProcessor.from_pretrained(
             model_name, trust_remote_code=trust_remote_code
         )
-        vision_config = AutoConfig.from_pretrained(
+        model_config = AutoConfig.from_pretrained(
             model_name, trust_remote_code=trust_remote_code
-        ).vision_config
+        )
+        vision_config = model_config.vision_config
 
         patch_size: int = processor.patch_size
         merge_size: int = processor.merge_size
@@ -65,6 +67,9 @@ def load_qwen_grid_params(
         vision_hidden_dim: int = getattr(
             vision_config, "out_hidden_size", vision_config.hidden_size
         )
+        image_token_id = getattr(
+            model_config, "image_token_id", getattr(processor, "image_token_id", None)
+        )
 
         return QwenGridParams(
             patch_size=patch_size,
@@ -73,6 +78,7 @@ def load_qwen_grid_params(
             min_pixels=min_pixels,
             max_pixels=max_pixels,
             vision_hidden_dim=vision_hidden_dim,
+            image_token_id=image_token_id,
         )
     except (OSError, ValueError) as exc:
         logger.warning(
@@ -141,6 +147,7 @@ def build_qwen_embedding_params(
     multi_modal_data: Dict[str, Any],
     grid_params: QwenGridParams | None,
     mm_processor_kwargs: Optional[Dict[str, Any]] = None,
+    prompt_token_ids: Optional[list[int]] = None,
 ) -> Dict[str, Any] | None:
     """Build embedding parameters for Qwen VL decode.
 
@@ -167,10 +174,14 @@ def build_qwen_embedding_params(
         mm_processor_kwargs: Per-request image processor overrides. The
             ``min_pixels`` and ``max_pixels`` values must match the prefill
             processor so decode reconstructs the same grid.
+        prompt_token_ids: Expanded prefill tokens used to locate image-token
+            runs. When they exactly match the computed grids, the handoff
+            carries the prompt without those runs plus insertion metadata.
 
     Returns:
-        Dict with ``image_grid_thw`` and ``embeddings_shape``, or None if
-        no image data or parameters are unavailable.
+        Dict with ``image_grid_thw`` and ``embeddings_shape`` and, when safe,
+        compact prompt reconstruction metadata; or None if no image data or
+        parameters are unavailable.
     """
     embedding_params: Dict[str, Any] = {}
     image_data = multi_modal_data.get("image")
@@ -206,5 +217,41 @@ def build_qwen_embedding_params(
         if grid_thw is not None:
             embedding_params["image_grid_thw"] = grid_thw
             embedding_params["embeddings_shape"] = embeddings_shape
+            if prompt_token_ids is not None and grid_params.image_token_id is not None:
+                expected_lengths = [
+                    (int(t) * int(h) * int(w)) // (grid_params.merge_size**2)
+                    for t, h, w in grid_thw
+                ]
+                placeholders: list[list[int]] = []
+                cursor = 0
+                for expected_length in expected_lengths:
+                    try:
+                        offset = prompt_token_ids.index(
+                            grid_params.image_token_id, cursor
+                        )
+                    except ValueError:
+                        placeholders = []
+                        break
+                    end = offset
+                    while (
+                        end < len(prompt_token_ids)
+                        and prompt_token_ids[end] == grid_params.image_token_id
+                    ):
+                        end += 1
+                    if end - offset != expected_length:
+                        placeholders = []
+                        break
+                    placeholders.append([offset, expected_length])
+                    cursor = end
+
+                if len(placeholders) == len(grid_thw):
+                    prompt_token_ids_without_images = list(prompt_token_ids)
+                    for offset, length in reversed(placeholders):
+                        del prompt_token_ids_without_images[offset : offset + length]
+                    embedding_params["prompt_token_ids_without_images"] = (
+                        prompt_token_ids_without_images
+                    )
+                    embedding_params["image_token_id"] = grid_params.image_token_id
+                    embedding_params["image_placeholders"] = placeholders
     # TODO(DIS-1679): handle np.ndarray from --frontend-decoding NIXL path
     return embedding_params if embedding_params else None

--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -34,7 +34,12 @@ from dynamo.common.multimodal.video_loader import VideoLoader
 from dynamo.common.utils import nvtx_utils as _nvtx
 
 from .hash_utils import compute_mm_uuids_from_images
-from .model import ModelFamily, construct_qwen_decode_mm_data, resolve_model_family
+from .model import (
+    ModelFamily,
+    construct_qwen_decode_mm_data,
+    construct_qwen_decode_prompt,
+    resolve_model_family,
+)
 from .models.qwen import (
     QwenGridParams,
     build_qwen_embedding_params,
@@ -303,6 +308,7 @@ class VllmMultimodalRequestProcessor:
                 multi_modal_data,
                 self._qwen_grid_params,
                 mm_processor_kwargs,
+                prompt_token_ids,
             )
         return {"expanded_prompt_token_ids": prompt_token_ids}
 
@@ -597,11 +603,32 @@ class VllmMultimodalRequestProcessor:
             embedding_params = disaggregated_params.get("embedding_params") or None
             if self._model_family is ModelFamily.QWEN_VL:
                 if embedding_params is not None:
-                    multi_modal_data = construct_qwen_decode_mm_data(
-                        embedding_params.get("image_grid_thw"),
-                        embedding_params.get("embeddings_shape"),
-                        request_id,
+                    prompt_token_ids_without_images = embedding_params.get(
+                        "prompt_token_ids_without_images"
                     )
+                    image_token_id = embedding_params.get("image_token_id")
+                    image_placeholders = embedding_params.get("image_placeholders")
+                    if (
+                        prompt_token_ids_without_images is not None
+                        and image_token_id is not None
+                        and image_placeholders
+                    ):
+                        pre_rendered = construct_qwen_decode_prompt(
+                            prompt_token_ids_without_images,
+                            image_token_id,
+                            embedding_params.get("image_grid_thw"),
+                            image_placeholders,
+                            request_id,
+                        )
+                        request_for_prompt["token_ids"] = pre_rendered[
+                            "prompt_token_ids"
+                        ]
+                    else:
+                        multi_modal_data = construct_qwen_decode_mm_data(
+                            embedding_params.get("image_grid_thw"),
+                            embedding_params.get("embeddings_shape"),
+                            request_id,
+                        )
                 elif has_mm_data and request["multi_modal_data"].get(IMAGE_URL_KEY):
                     prefill_result = request.get("prefill_result")
                     message = (

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
@@ -537,6 +537,58 @@ async def test_qwen_decode_reconstructs_placeholder_embeddings(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_qwen_decode_uses_metadata_only_prompt_when_handoff_is_complete():
+    processor = _processor()
+
+    prepared = await processor.prepare_prompt(
+        {
+            "token_ids": [1, 99, 2],
+            "multi_modal_data": {"image_url": [{"Url": "https://image"}]},
+            "prefill_result": {
+                "disaggregated_params": {
+                    "embedding_params": {
+                        "image_grid_thw": [[1, 4, 4]],
+                        "embeddings_shape": [4, 2048],
+                        "prompt_token_ids_without_images": [1, 2],
+                        "image_token_id": 99,
+                        "image_placeholders": [[1, 4]],
+                    }
+                }
+            },
+        },
+        "request-compact",
+        None,
+        DisaggregationMode.DECODE,
+    )
+
+    assert prepared.prompt["type"] == "multimodal"
+    assert prepared.prompt["prompt_token_ids"] == [1, 99, 99, 99, 99, 2]
+    item = prepared.prompt["mm_kwargs"]["image"][0]
+    assert set(item) == {"image_grid_thw"}
+    assert item["image_grid_thw"].data.tolist() == [1, 4, 4]
+    assert prepared.prompt["mm_hashes"] == {"image": ["dynamo-pd-request-compact-0"]}
+    placeholder = prepared.prompt["mm_placeholders"]["image"][0]
+    assert (placeholder.offset, placeholder.length) == (1, 4)
+    assert prepared.request["token_ids"] == [1, 99, 99, 99, 99, 2]
+    processor.image_loader.load_image_batch.assert_not_awaited()
+
+
+def test_qwen_metadata_only_prompt_reconstructs_multiple_image_runs():
+    prompt = mod.construct_qwen_decode_prompt(
+        [1, 2, 3],
+        99,
+        [[1, 2, 4], [1, 2, 6]],
+        [[1, 2], [4, 3]],
+        "request-multi",
+    )
+
+    assert prompt["prompt_token_ids"] == [1, 99, 99, 2, 99, 99, 99, 3]
+    assert [
+        (item.offset, item.length) for item in prompt["mm_placeholders"]["image"]
+    ] == [(1, 2), (4, 3)]
+
+
+@pytest.mark.asyncio
 async def test_non_qwen_decode_uses_expanded_prompt_tokens():
     processor = _processor(model="llava-hf/llava-1.5-7b-hf")
 
@@ -715,8 +767,9 @@ def test_build_prefill_handoff_dispatches_by_model_and_forwards_processor_kwargs
     llava_processor = _processor(model="llava-hf/llava-1.5-7b-hf")
     observed = {}
 
-    def fake_build_qwen(data, params, processor_kwargs):
+    def fake_build_qwen(data, params, processor_kwargs, prompt_token_ids):
         observed["processor_kwargs"] = processor_kwargs
+        observed["prompt_token_ids"] = prompt_token_ids
         return {"image_grid_thw": [[1, 2, 2]]}
 
     monkeypatch.setattr(
@@ -731,6 +784,7 @@ def test_build_prefill_handoff_dispatches_by_model_and_forwards_processor_kwargs
         mm_processor_kwargs={"max_pixels": 1003520},
     ) == {"image_grid_thw": [[1, 2, 2]]}
     assert observed["processor_kwargs"] == {"max_pixels": 1003520}
+    assert observed["prompt_token_ids"] == [1, 99, 2]
     assert llava_processor.build_prefill_handoff(
         multi_modal_data=mm_data,
         prompt_token_ids=[1, 99, 2],
@@ -798,6 +852,51 @@ def test_qwen_handoff_computes_grid_for_pil_images():
     assert result == {
         "image_grid_thw": [[1, 30, 40]],
         "embeddings_shape": [300, 2048],
+    }
+
+
+def test_qwen_handoff_includes_compact_decode_metadata():
+    result = qwen_mod.build_qwen_embedding_params(
+        {"image": Image.new("RGB", (64, 64))},
+        qwen_mod.QwenGridParams(
+            patch_size=16,
+            merge_size=2,
+            factor=32,
+            min_pixels=1024,
+            max_pixels=4096,
+            vision_hidden_dim=2048,
+            image_token_id=99,
+        ),
+        prompt_token_ids=[1, 99, 99, 99, 99, 2],
+    )
+
+    assert result == {
+        "image_grid_thw": [[1, 4, 4]],
+        "embeddings_shape": [4, 2048],
+        "prompt_token_ids_without_images": [1, 2],
+        "image_token_id": 99,
+        "image_placeholders": [[1, 4]],
+    }
+
+
+def test_qwen_handoff_omits_compact_metadata_when_tokens_do_not_match_grid():
+    result = qwen_mod.build_qwen_embedding_params(
+        {"image": Image.new("RGB", (64, 64))},
+        qwen_mod.QwenGridParams(
+            patch_size=16,
+            merge_size=2,
+            factor=32,
+            min_pixels=1024,
+            max_pixels=4096,
+            vision_hidden_dim=2048,
+            image_token_id=99,
+        ),
+        prompt_token_ids=[1, 99, 99, 2],
+    )
+
+    assert result == {
+        "image_grid_thw": [[1, 4, 4]],
+        "embeddings_shape": [4, 2048],
     }
 
 


### PR DESCRIPTION
## Summary

- carry compact Qwen image-token insertion metadata in the unified P/D handoff
- pass vLLM grid-only multimodal input after complete remote prefill instead of allocating dense placeholder embeddings
- retain the dense path unless prefill token runs exactly match computed image grids, preserving rolling-worker compatibility

## Validation

- `39 passed` in `test_vllm_request_processor.py`
- Ruff checks passed on all changed files
- supported two-GPU unified Qwen P/D launcher completed 224/640/1280 px warm/cold and concurrency sweeps with NIXL compatibility passing
- at 1,600 visual tokens, focused vLLM engine IPC payload measured 6,561,913 bytes on base and 8,244 bytes on the candidate

<!-- perf-agent-investigation:74367c69-ff2c-402d-a754-4940431f164f -->