### PR TITLE
perf(kvbm): reduce block event hashing allocations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4805,6 +4805,7 @@ name = "kvbm-consolidator"
 version = "1.2.0"
 dependencies = [
  "anyhow",
+ "bytemuck",
  "dynamo-kv-hashing",
  "dynamo-kv-router",
  "dynamo-tokens",

--- a/lib/kvbm-consolidator/Cargo.toml
+++ b/lib/kvbm-consolidator/Cargo.toml
@@ -24,6 +24,7 @@ tokio = { workspace = true }
 tokio-stream = { workspace = true, features = ["sync"] }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+bytemuck = "1.22"
 
 [features]
 testing = []

--- a/lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs
+++ b/lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs
@@ -23,6 +23,8 @@ use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use dynamo_kv_hashing::compute_salt_hash;
+
 use crate::source::EventSource;
 use crate::tracker::{StoreInput, Tracker};
 use crate::wire::vllm_in::{KvEventBatch, RawKvEvent};
@@ -137,13 +139,11 @@ fn process_event(tracker: &mut Tracker, event: RawKvEvent, engine_source: EventS
                 return;
             }
 
-            let token_chunks: Vec<Vec<u32>> =
-                token_ids.chunks(block_size).map(|c| c.to_vec()).collect();
-
-            if token_chunks.len() != block_hashes.len() {
+            let token_chunk_count = token_ids.chunks(block_size).len();
+            if token_chunk_count != block_hashes.len() {
                 tracing::warn!(
                     "Token chunks ({}) don't match block hashes ({}), skipping event",
-                    token_chunks.len(),
+                    token_chunk_count,
                     block_hashes.len()
                 );
                 return;
@@ -153,18 +153,26 @@ fn process_event(tracker: &mut Tracker, event: RawKvEvent, engine_source: EventS
             let cache_namespace = cache_namespace
                 .filter(|namespace| !namespace.is_empty())
                 .map(Arc::<str>::from);
+            let salt_hash = cache_namespace.as_deref().and_then(|cache_namespace| {
+                compute_salt_hash(Some(cache_namespace), lora_name.as_deref()).ok()
+            });
 
-            for (i, block_hash) in block_hashes.into_iter().enumerate() {
+            for (block_hash, token_chunk) in
+                block_hashes.into_iter().zip(token_ids.chunks(block_size))
+            {
                 let hash_str = block_hash.into_u64().to_string();
-                tracker.handle_store_input(StoreInput::new(
-                    engine_source,
-                    hash_str.clone(),
-                    current_parent.clone(),
-                    token_chunks[i].clone(),
-                    block_size,
-                    lora_name.clone(),
-                    cache_namespace.clone(),
-                ));
+                tracker.handle_store_input(
+                    StoreInput::new(
+                        engine_source,
+                        hash_str.clone(),
+                        current_parent.clone(),
+                        token_chunk.to_vec(),
+                        block_size,
+                        lora_name.clone(),
+                        cache_namespace.clone(),
+                    )
+                    .with_precomputed_salt_hash(salt_hash),
+                );
                 current_parent = Some(hash_str);
             }
         }

--- a/lib/kvbm-consolidator/src/tracker.rs
+++ b/lib/kvbm-consolidator/src/tracker.rs
@@ -15,17 +15,16 @@
 //! - Publish REMOVE only when the last source drops the block.
 //! - Repeated stores from the same source with the same external hash are idempotent.
 //!
-//! Hash synthesis for external (vLLM / TRT-LLM) sources delegates entirely to
-//! [`dynamo_kv_hashing`]: the consolidator builds a single-block [`Request`] for each
-//! event, gets the [`BlockHash`] via [`Request::block_hashes`], and chains via
+//! Hash synthesis for external (vLLM / TRT-LLM) sources uses the canonical
+//! [`dynamo_kv_hashing`] salt and block hash functions, then chains via
 //! [`PositionalLineageHash::extend`] from the parent's PLH. KVBM events arrive with a
 //! PLH already computed by the upstream registry.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
-use dynamo_kv_hashing::Request;
-use dynamo_tokens::PositionalLineageHash;
+use dynamo_kv_hashing::{compute_block_hash, compute_salt_hash};
+use dynamo_tokens::{PositionalLineageHash, SaltHash};
 use kvbm_logical::{BlockRegistry, SequenceHash, registry::BlockRegistrationHandle};
 
 use crate::source::EventSource;
@@ -58,6 +57,7 @@ pub(crate) struct StoreInput {
     block_size: usize,
     lora_name: Option<String>,
     cache_namespace: Option<Arc<str>>,
+    precomputed_salt_hash: Option<SaltHash>,
 }
 
 impl StoreInput {
@@ -78,7 +78,13 @@ impl StoreInput {
             block_size,
             lora_name,
             cache_namespace,
+            precomputed_salt_hash: None,
         }
+    }
+
+    pub(crate) fn with_precomputed_salt_hash(mut self, salt_hash: Option<SaltHash>) -> Self {
+        self.precomputed_salt_hash = salt_hash;
+        self
     }
 }
 
@@ -130,27 +136,28 @@ impl Tracker {
     }
 
     /// Compute the PLH for a single block given its parent PLH (or none for root).
-    /// Hashing goes through [`dynamo_kv_hashing::Request`] so vLLM / TRT-LLM ingress
-    /// matches what kvbm-logical's `BlockRegistry::register_block` produces for the
-    /// same `(tokens, lora_name)` input.
+    /// Hashing uses the canonical `dynamo-kv-hashing` primitives so vLLM / TRT-LLM
+    /// ingress matches what kvbm-logical's `BlockRegistry::register_block` produces.
     fn compute_plh(
         parent_plh: Option<PositionalLineageHash>,
         token_ids: &[u32],
         block_size: usize,
         lora_name: Option<&str>,
         cache_namespace: Option<&str>,
+        salt_hash: Option<SaltHash>,
     ) -> Option<PositionalLineageHash> {
-        let request = Request::builder()
-            .tokens(token_ids.to_vec())
-            .lora_name(lora_name.map(str::to_string))
-            .salt(cache_namespace.map(str::to_string))
-            .build()
-            .ok()?;
-        let blocks = request.into_blocks(block_size as u32).ok()?;
-        let first = blocks.first()?;
+        if block_size == 0 || token_ids.len() < block_size {
+            return None;
+        }
+        let salt_hash = match salt_hash {
+            Some(hash) => hash,
+            None => compute_salt_hash(cache_namespace, lora_name).ok()?,
+        };
+        let block_hash =
+            compute_block_hash(bytemuck::cast_slice(&token_ids[..block_size]), salt_hash);
         Some(match parent_plh {
-            None => first.plh,
-            Some(parent) => parent.extend(first.block_hash),
+            None => PositionalLineageHash::root(block_hash),
+            Some(parent) => parent.extend(block_hash),
         })
     }
 
@@ -188,6 +195,7 @@ impl Tracker {
             block_size,
             lora_name,
             cache_namespace,
+            precomputed_salt_hash,
         } = input;
         let parent_key = parent_external_hash
             .as_ref()
@@ -222,6 +230,7 @@ impl Tracker {
             block_size,
             lora_name.as_deref(),
             cache_namespace.as_deref(),
+            precomputed_salt_hash,
         ) {
             Some(h) => h,
             None => {
@@ -455,6 +464,7 @@ impl Tracker {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_kv_hashing::Request;
     use pretty_assertions::assert_eq;
 
     fn tracker() -> Tracker {
@@ -978,6 +988,7 @@ mod tests {
 #[cfg(test)]
 mod proptest_tracker {
     use super::*;
+    use dynamo_kv_hashing::Request;
     use proptest::prelude::*;
 
     /// Catalogue of canonical PLHs for a deterministic chain of 12 blocks, used by


### PR DESCRIPTION
## Summary

- avoid building an owned universal-hashing `Request` for every consolidated KV block
- precompute explicit cache-namespace hashes once per stored event
- move each token chunk into tracker ownership with one allocation/copy instead of two
- preserve canonical salt, LoRA, block-hash, and positional-lineage semantics

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --locked -p kvbm-consolidator --features testing --tests -- -D warnings`
- `cargo test --locked -p kvbm-consolidator --features testing` — 50 passed, 1 intentionally ignored
- `cargo test --locked -p dynamo-kv-hashing` — 20 passed
- `cargo test --locked -p dynamo-kv-router cache_namespace` — 21 passed
- clean System-allocator benchmark, 150 events × 1,024 blocks × 64 tokens, 32-byte salt: median 95,046,563 ns base; 79,234,413 ns candidate
- allocation benchmark for the same batch: 2,304,051 vs 1,075,101 calls and 402,500,159 vs 177,629,759 allocated bytes

The benchmark replaces only ZMQ/msgpack decoding with preconstructed `RawKvEvent` values; it measures the real chunking, hashing, tracker, and event-queue path and makes no whole-system throughput claim. Performance measurements were not rerun after publication rebase because target drift did not overlap the changed paths or hashing mechanism.

<!-- perf-agent-investigation:ce2c4f8d-44c3-45a9-8bf4-59d110e48de8 -->