### PR TITLE
perf(kv-router): strengthen trace replay benchmarks [DYN-3584]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2402,6 +2402,7 @@ dependencies = [
  "futures-util",
  "hf-hub 0.4.3",
  "indicatif 0.18.4",
+ "libc",
  "minstant",
  "rand 0.9.4",
  "reqwest 0.12.28",

--- a/lib/bench/Cargo.toml
+++ b/lib/bench/Cargo.toml
@@ -66,6 +66,9 @@ dynamo-data-gen = { workspace = true }
 dynamo-mocker = { workspace = true }
 dynamo-kv-router = { workspace = true, features = ["bench", "metrics", "shard-metrics"] }
 
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = { workspace = true }
+
 [dev-dependencies]
 dynamo-tokens = { workspace = true }
 minstant = "0.1.7"

--- a/lib/bench/kv_router/INDEXER_BENCH.md
+++ b/lib/bench/kv_router/INDEXER_BENCH.md
@@ -1,350 +1,314 @@
-# Benchmarking the Sharded KV Router
+# KV Router Indexer Benchmark
 
-## Trace Data
+## Mooncake replay
 
-Benchmarks use JSONL trace files. Each line is a JSON object with fields:
+`mooncake_bench` uses deadline-driven replay for the production thread-pool
+indexers. Queries and writes are issued without waiting for earlier operations to
+complete, and throughput ends only after every query and event worker has
+drained. There is no separate replay mode.
 
-| Field | Type | Description |
-|-------|------|-------------|
-| `timestamp` | float (ms) | Absolute arrival time, or omit and use `delay` |
-| `delay` | float (ms) | Time since previous request (alternative to `timestamp`) |
-| `hash_ids` | `u64[]` | Block-level KV cache hash IDs |
-| `output_length` | `u64` | Output token count |
-| `input_length` | `u64` (optional) | Input token count |
+Supported backends are:
 
-### Public traces (Mooncake FAST25)
+- `nested-map` (`PositionalIndexer`)
+- `concurrent-radix-tree`
+- `concurrent-radix-tree-compressed`
 
-Use the Mooncake FAST25 arxiv trace as the primary benchmark trace unless you are intentionally testing a secondary workload. This is the trace most likely to match external benchmark discussions:
+The benchmark rejects single-threaded radix, branch-sharded CRTC, approximate
+writes, shard sampling, extra read stress, and in-process repetitions. Run each
+repetition in a fresh process.
+
+### Preparation and timing
+
+Each worker timeline is normalized so its first entry starts at zero, rescaled
+to the requested replay window, and stable-sorted by deadline, operation class,
+worker ID, and source order. Queries precede writes at equal deadlines. That
+ordering applies to queue acceptance; query execution may still race event
+application.
+
+Preparation consumes and releases the parsed trace, generated replay artifacts,
+worker timelines, and intermediate payload owners. The timed process retains
+only the prepared schedule, one flattened query-hash slab, and backend state.
+On Linux, the benchmark returns free preparation pages with `malloc_trim` and
+waits a fixed five seconds before constructing backend workers. It then
+page-touches the schedule once and performs the fixed lookup warm-up before
+timing. This explicit quiescence prevents the parallel event-generation phase
+and released allocator arenas from affecting the timed backend drain; JSON
+records it as `pre_run_quiescence_ms=5000`.
+
+Outside timing:
+
+- Trace parsing, event generation, normalization, scaling, and stable merge.
+- Fixed query queues, completion buffers, observation writers, and barriers.
+- Backend construction, page touching, and fixed lookup warm-up.
+- Completion harvesting, ID joins, sorting, percentiles, JSON, and file I/O.
+
+Inside timing:
+
+- Absolute-deadline query publication.
+- Owned `RouterEvent` submission through the production `ThreadPoolIndexer`
+  worker lookup and Flume queues.
+- Lookup service, event application, contention, required clock reads, and
+  fixed-slot completion records.
+- Query drain and FIFO event-worker seal barriers.
+
+The logical denominator is Request + Stored + Removed + Cleared. The block
+denominator includes request hashes and hashes in both Stored and Removed
+events. Cleared contributes one logical operation and zero block hashes.
+
+Issue lag is diagnostic. A trial is generator-valid when all operations are
+issued within `1.01 × replay_window`, IDs and per-worker FIFO order are exact,
+fixed buffers do not overflow, all operations succeed, and the timed drain
+completes. `kept_up` additionally requires total replay plus drain to finish
+within `1.10 × replay_window`.
+
+### Trace and build
 
 ```bash
-mkdir -p lib/kv-router/traces
-curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl \
-  -o lib/kv-router/traces/mooncake_trace.jsonl
+ROOT=$(git rev-parse --show-toplevel)
+TRACE="$ROOT/lib/kv-router/traces/mooncake_trace.jsonl"
+
+mkdir -p "$(dirname "$TRACE")"
+curl -L \
+  https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl \
+  -o "$TRACE"
+echo 'b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711  '"$TRACE" \
+  | shasum -a 256 -c -
+
+cargo bench --package dynamo-bench --bench mooncake_bench --no-run
+BIN=$(find target/release/deps -maxdepth 1 -type f -perm -111 \
+  -name 'mooncake_bench-*' | head -n1)
 ```
 
-Secondary traces:
+Linux uses absolute `CLOCK_MONOTONIC` sleeps followed by the configured spin.
+macOS uses a portable sleep-plus-spin timer for correctness tests only.
+
+### Single CRTC trial
+
+Select one logical CPU per physical core from the process's actual affinity
+mask. Keep event issuers and the timed query issuer disjoint from the backend
+mask. The parent coordinator shares the query-issuer CPU but remains parked in
+scoped-thread joins while issuance runs.
+
+The following command reproduces the measured 128-core binding. Adapt the masks
+to the host rather than assuming these CPU numbers are portable.
 
 ```bash
-curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/conversation_trace.jsonl \
-  -o lib/kv-router/traces/conversation_trace.jsonl
-curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/synthetic_trace.jsonl \
-  -o lib/kv-router/traces/synthetic_trace.jsonl
-curl -L https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/toolagent_trace.jsonl \
-  -o lib/kv-router/traces/toolagent_trace.jsonl
-```
+RESULTS=/path/to/mooncake-results
+mkdir -p "$RESULTS"
 
-| File | Description |
-|------|-------------|
-| `mooncake_trace.jsonl` | Primary arxiv workload: 23,608 requests over 1 hour, with two dominant hot prefixes |
-| `conversation_trace.jsonl` | Smaller conversational workload: 12,031 requests, different hash sequences from the arxiv trace |
-| `synthetic_trace.jsonl` | Synthetic workload: 3,993 requests, much smaller and structurally different |
-| `toolagent_trace.jsonl` | Agentic/tool-use workload: same request count and similar distribution to the arxiv trace, but different hash sequences |
-
-Trace shape summary from the current local copies:
-
-| File | Requests | Span | Avg blocks/request | Unique depth-2 prefixes | Top depth-2 prefixes |
-|------|---------:|------|-------------------:|------------------------:|----------------------|
-| `mooncake_trace.jsonl` | 23,608 | 3,600,000 ms | 17.3 | 6,557 | `[46,47]` × 9,203; `[74,75]` × 3,449 |
-| `conversation_trace.jsonl` | 12,031 | 3,536,999 ms | 24.0 | 7,373 | top prefix appears 43 times |
-| `synthetic_trace.jsonl` | 3,993 | 1,022,025 ms | 30.5 | 1,138 | top prefixes appear 24 times |
-| `toolagent_trace.jsonl` | 23,608 | 3,536,999 ms | 17.4 | 6,554 | `[46,47]` × 9,203; `[74,75]` × 3,449 |
-
----
-
-## Two benchmark modes
-
-**Steady-state** (`--benchmark-duration-ms 30000`): replays the trace at its natural arrival rate. Measures real-world p99 latency. Throughput will match the trace rate — both indexers should keep up, so ops/s will be similar; p99 is the meaningful comparison.
-
-**Peak throughput sweep** (`--sweep`): progressively shrinks the benchmark window to drive offered rate above saturation. Use this to compare maximum throughput across indexers.
-
----
-
-## Running the Benchmarks
-
-All benchmarks run through `mooncake_bench` in `dynamo-bench`. **Run from the repository root.** The bench binary runs in `lib/bench/`, so trace paths must be absolute — the commands below use `$(git rev-parse --show-toplevel)` for portability.
-
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  <TRACE_PATH> [global options] <INDEXER_SUBCOMMAND> [indexer options]
-```
-
-### Self-test (no trace required)
-
-```bash
-cargo test --package dynamo-bench --test mooncake_trace
-```
-
-### Steady-state (p99 at real-world request rate)
-
-**CRTC baseline (8 workers):**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
+numactl --interleave=all "$BIN" "$TRACE" \
+  --query-lanes 128 \
+  --issuer-cpus 0-3,65-68 \
+  --query-issuer-cpu 64 \
+  --backend-cpus 4-63,69-127 \
+  --issuer-spin-us 100 \
+  --issue-lag-diagnostic-threshold-us 250 \
+  --num-unique-inference-workers 128 \
+  --trace-duplication-factor 20 \
+  --trace-length-factor 4 \
+  --benchmark-duration-ms 750 \
+  --result-json-output "$RESULTS/crtc-01.json" \
   concurrent-radix-tree-compressed --num-event-workers 8
 ```
 
-**Branch-sharded depth=2 (2 shards × 4 workers):**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
-  branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
-```
-
-**Optional branch-sharded depth=4 (2 shards × 4 workers):**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 -d 7 \
-  branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 4
-```
-
-### Peak throughput sweep
-
-**CRTC baseline — sweep:**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 -d 7 \
-  --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
-  concurrent-radix-tree-compressed --num-event-workers 8
-```
-
-**Branch-sharded depth=2 — sweep:**
-```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --trace-simulation-duration-ms 10000 -d 7 \
-  --sweep --sweep-min-ms 1000 --sweep-max-ms 30000 --sweep-steps 8 \
-  branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
-```
-
-### Worker scaling
+For 20 fresh-process repetitions:
 
 ```bash
-for factor in 1 2 4 8 16 32; do
-  cargo bench --package dynamo-bench --bench mooncake_bench -- \
-    $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-    --trace-simulation-duration-ms 10000 --benchmark-duration-ms 30000 \
-    --num-unique-inference-workers 1000 \
-    --trace-duplication-factor $factor \
-    -d 7 \
-    branch-sharded-crtc --num-shards 2 --num-event-workers-per-shard 4 --prefix-depth 2
+for run in $(seq -w 1 20); do
+  numactl --interleave=all "$BIN" "$TRACE" \
+    --query-lanes 128 \
+    --issuer-cpus 0-3,65-68 \
+    --query-issuer-cpu 64 \
+    --backend-cpus 4-63,69-127 \
+    --issuer-spin-us 100 \
+    --issue-lag-diagnostic-threshold-us 250 \
+    --num-unique-inference-workers 128 \
+    --trace-duplication-factor 20 \
+    --trace-length-factor 4 \
+    --benchmark-duration-ms 750 \
+    --result-json-output "$RESULTS/crtc-$run.json" \
+    concurrent-radix-tree-compressed --num-event-workers 8
 done
+
+test "$(find "$RESULTS" -maxdepth 1 -name 'crtc-*.json' | wc -l | tr -d ' ')" = 20
 ```
 
-### Repeated overload benchmark
+The project-root Python environment may be used for post-processing:
 
-This short-window benchmark intentionally drives offered load into the millions of request/event ops per second. The run is useful for stress-shape comparisons, but warnings are expected and the achieved values should not be interpreted as clean steady-state capacity.
+```bash
+.venv/bin/python - <<'PY' "$RESULTS"
+import json
+import pathlib
+import statistics
+import sys
 
-**CRTC baseline (8 workers):**
+paths = sorted(pathlib.Path(sys.argv[1]).glob("crtc-*.json"))
+runs = [json.loads(path.read_text()) for path in paths]
+assert len(runs) == 20
+assert all(run["generator_valid"] for run in runs)
+values = [run["achieved_block_ops_per_sec"] for run in runs]
+print(f"runs={len(values)} mean={statistics.fmean(values):.3f} median={statistics.median(values):.3f}")
+PY
+```
+
+### Sweep
+
+Sweep cells use the same completion-correct implementation. Each cell regenerates
+and consumes a fresh corpus and constructs fresh backend state.
+
 ```bash
 cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
-  --num-unique-inference-workers 128 \
-  --trace-duplication-factor 20 \
-  --trace-length-factor 4 \
-  --benchmark-duration-ms 750 \
-  --benchmark-runs 20 \
-  concurrent-radix-tree-compressed \
-  --num-event-workers 8
+  "$TRACE" \
+  --sweep --sweep-min-ms 750 --sweep-max-ms 24000 --sweep-steps 6 \
+  --result-json-output /path/to/sweep.json \
+  concurrent-radix-tree-compressed --num-event-workers 8
 ```
 
-**Branch-sharded depth=2 with the same total event-worker count (2 shards × 4 workers):**
+### Result fields
+
+The versioned Mooncake JSON reports:
+
+- Corrected logical and block totals, offered rate, actual issue rate, and
+  completion/drain-inclusive achieved rate.
+- Query issue lag, queue wait, lookup service, and scheduled-to-completion
+  distributions.
+- Update issue lag, accepted-to-finished, and scheduled-to-finished
+  distributions.
+- Queue depth at producer stop, outstanding work, maximum reconstructed depth,
+  drain time, timer kind, CPU masks, exact-ID validity, and compact failure
+  reasons.
+
+Do not interpret overloaded lookup latency as an iso-throughput latency result.
+At a comfortable common load, report scheduler lag, queue wait, and lookup
+service separately and require negligible queue depth and drain.
+
+## Active Sequences replay
+
+`active_sequences_bench` uses the same deadline-driven measurement principles
+for `ActiveSequencesMultiWorker`, but it does not route operations through
+`ThreadPoolIndexer` or `RouterEvent`. Each lifecycle method is synchronous, so
+method return is the completion boundary.
+
+Preparation creates a data-only corpus with normalized per-worker deadlines,
+stable operation IDs, lifecycle metadata, and one flattened sequence-hash slab.
+It validates every Add → PrefillComplete → Free lifecycle before building the
+execution schedule. The schedule assigns each logical worker to one persistent
+operation lane, preallocates exact queue and completion capacity, materializes
+the owned `SequenceRequest` values outside timing, and releases the source trace
+and intermediate corpus storage. The complete schedule and payload storage are
+page-touched once before the clock starts.
+
+At a shared deadline, operations retain per-worker source order. In particular,
+an Add is accepted and completed on its sticky lane before an associated
+PrefillComplete or Free. The timed path queues compact operation IDs, performs
+no per-operation task or timer creation, and drains every lane before throughput
+ends.
+
+The result schema reports:
+
+- Add, PrefillComplete, and Free logical counts.
+- Input blocks, projection visits, add/registration visits, free/release visits,
+  and their total logical block visits.
+- Scheduled-to-accepted issue lag, accepted-to-started queue wait,
+  scheduled-to-completed latency, queue depth, outstanding work, and drain.
+- Separate service distributions for projection, add, composite project+add,
+  prefill completion, and free.
+- Worker projections produced and inspected, exact IDs, per-worker FIFO,
+  final-empty state, keep-up state, and compact failure reasons.
+
+Logical block visits describe benchmark-level sequence traversals. They are not
+CPU instructions or exact internal membership mutations, and input blocks alone
+are not reported as total block operations. Issue lag remains diagnostic. A run
+is generator-valid only when issuance completes within `1.01 × replay_window`,
+IDs and FIFO order are exact, fixed storage does not overflow, all methods
+succeed, every lane drains, and the final sequence state is empty.
+
+Build and run one cell from the repository root:
+
 ```bash
-cargo bench --package dynamo-bench --bench mooncake_bench -- \
-  $(git rev-parse --show-toplevel)/lib/kv-router/traces/mooncake_trace.jsonl \
+cargo bench --package dynamo-bench --bench active_sequences_bench --no-run
+
+cargo bench --package dynamo-bench --bench active_sequences_bench -- \
+  "$TRACE" \
+  --operation-lanes 128 \
+  --issuer-spin-us 75 \
+  --issue-lag-diagnostic-threshold-us 250 \
   --num-unique-inference-workers 128 \
-  --trace-duplication-factor 20 \
-  --trace-length-factor 4 \
-  --benchmark-duration-ms 750 \
-  --benchmark-runs 20 \
-  branch-sharded-crtc \
-  --num-shards 2 \
-  --num-event-workers-per-shard 4 \
-  --prefix-depth 2
+  --benchmark-duration-ms 4000 \
+  --result-json-output /path/to/active-sequences.json
 ```
 
-For a larger branch-sharded worker pool, use `--num-event-workers-per-shard 8` (16 total event workers with 2 shards).
+Sweep cells rebuild the prepared corpus and Active Sequences state independently:
 
----
-
-## Understanding the output
-
-### Standard fields (all indexers)
-
-| Field | Meaning |
-|-------|---------|
-| Offered ops/s | Planned request rate = total ops / benchmark window |
-| Achieved ops/s | Actual completed rate — matches offered when not saturated |
-| p99 latency | 99th-percentile `find_matches` latency |
-
-### Branch-sharded extra fields
-
-| Field | Meaning |
-|-------|---------|
-| Dispatched | Queries routed to one shard for anchored suffix lookup |
-| Shallow | Queries answered by router-owned TRIE state without shard dispatch |
-| Avg routing | Routing-TRIE traversal time |
-| Avg shard | CRTC traversal time on the dispatched shard |
-
----
-
-## Key CLI Flags
-
-| Flag | Default | What it does |
-|------|---------|-------------|
-| `-d N` | 1 | Worker duplication factor: replay the trace with N copies of each unique worker (higher = more write pressure) |
-| `--find-matches-concurrency N` | 0 | N additional tokio tasks issuing `find_matches` in a tight loop alongside trace replay; stresses the read path |
-| `--trace-simulation-duration-ms` | — | Rescale trace to this wall-clock duration (ms); omit to preserve original Mooncake timestamps |
-| `--benchmark-duration-ms` | 60000 | Measurement window; shorter = higher offered rate |
-| `--num-unique-inference-workers` | 1000 | Workers partitioned from the trace |
-| `--trace-length-factor` | 1 | Stretch each request's hash sequence |
-| `--trace-duplication-factor` | 1 | Create structurally identical copies with disjoint hash spaces |
-| `--seed` | 42 | RNG seed for worker-to-trace assignment |
-| `--sweep` | off | Find saturation point by varying benchmark window |
-| `--sweep-min-ms` | 1000 | Shortest benchmark window in sweep |
-| `--sweep-max-ms` | 50000 | Longest benchmark window in sweep |
-| `--sweep-steps` | 10 | Number of steps in sweep |
-| `--shard-metrics-csv FILE` | — | Sample shard block/node counts over time → CSV |
-
-### `branch-sharded-crtc` flags
-
-| Flag | Default | What it does |
-|------|---------|-------------|
-| `--num-shards` | 2 | Number of independent CRTC shards |
-| `--num-event-workers-per-shard` | 4 | OS threads per shard for KV event processing |
-| `--prefix-depth` | 2 | Maximum routing-trie depth before dispatching to one shard |
-
-Note: `branch-sharded-crtc` uses trie/anchor routing and does not support approximate pruning. It provides a stronger routing-correctness model for out-of-order events, at the cost of higher routing latency and a hot-branch shard collapse risk on dominant-prefix workloads (see Known Issues).
-
----
-
-## Results
-
-Trace: `mooncake_trace.jsonl` (Mooncake FAST25 arxiv trace). Config: 2 shards × 4 workers for branch-sharded, 8 workers for CRTC baseline, `--trace-simulation-duration-ms 10000`, `--benchmark-duration-ms 30000`, `-d 7`.
-
-### Steady-state — p99 at trace request rate (~17,268 ops/s offered)
-
-| Indexer | Achieved ops/s | p99 | Routing outcome | Avg routing | Avg shard |
-|---------|---------------|-----|-----------------|-------------|-----------|
-| CRTC baseline (8w) | 17,201 | 1,093 µs | — | — | — |
-| Branch-sharded depth=2 (2×4w) | 17,064 | 1,510 µs | 91.3% dispatched / 8.7% shallow | 388 µs | 161 µs |
-| Branch-sharded depth=4 (2×4w) | 16,939 | 5,263 µs | 86.1% dispatched / 13.9% shallow | 678 µs | 244 µs |
-
-All listed configs keep up with the offered trace rate. On this hot-prefix arxiv trace, branch-sharded routing is slower than CRTC in steady-state p99 because the routing TRIE does materially more work before dispatch and the stored block load collapses almost entirely onto one shard.
-
-The true-miss rate remains effectively zero in these runs.
-
-The routing TRIE provides a structural routing model that keeps shallow router state and shard anchors consistent, but it does not yet solve hot-branch load collapse. These numbers are useful for correctness and hot-prefix performance, but they do not show ideal multi-shard scaling.
-
-> **Shard imbalance warning (this trace):** `mooncake_trace.jsonl` contains two dominant depth-2 prefixes: `[46,47]` appears 9,203 times and `[74,75]` appears 3,449 times. Branch-sharded routing can therefore collapse most stored blocks onto one shard until adaptive hot-branch splitting is implemented.
-
-Shard block distribution:
-```text
-branch depth=2:  shard 0: 574 blocks (0.0%), 14 workers  shard 1: 2,094,155 blocks (100.0%), 7,000 workers
-branch depth=4:  shard 0: 80,570 blocks (4.0%), 3,983 workers  shard 1: 1,922,501 blocks (96.0%), 7,000 workers
+```bash
+cargo bench --package dynamo-bench --bench active_sequences_bench -- \
+  "$TRACE" \
+  --operation-lanes 128 \
+  --sweep --sweep-min-ms 1000 --sweep-max-ms 16000 --sweep-steps 5 \
+  --result-json-output /path/to/active-sequences-sweep.json
 ```
 
-See Known Issues below for the current hot-branch collapse behavior.
+The macOS timer is a correctness and profiling fallback. Do not publish local
+workstation throughput as an authoritative cross-system result.
 
-### Peak throughput sweep — `mooncake_trace.jsonl`
+## Validation evidence
 
-Clean peak is defined as the highest achieved ops/s where the benchmark keeps up with the offered block throughput. Rows marked ⚠ were overloaded and should not be treated as clean throughput ceilings. The sweep runs shortest windows first for multithreaded indexers, so use the standalone steady-state run above for trace-rate p99.
+The measurements below used one fixed host and one build:
 
-| Indexer | Clean peak achieved ops/s | p99 at clean peak | Notes |
-|---------|--------------------------:|-------------------|-------|
-| CRTC baseline (8w) | **118,157** | 1,087 µs | Best clean throughput on this hot-prefix trace |
-| Branch-sharded depth=2 (2×4w) | 16,699 | 12,332 µs | Sweep degrades heavily after overload; use steady-state run for normal p99 |
+| Item | Value |
+|---|---|
+| CPU | AMD EPYC 7742, 2 sockets × 64 physical cores, SMT disabled |
+| Memory | 1 TiB, interleaved across NUMA nodes |
+| Kernel | Linux 6.17.0-23-generic |
+| Rust | 1.93.1 |
+| CPU policy | performance governor, boost enabled |
+| Query lanes / event workers | 128 / 8 |
+| Event issuers | 8, each owning a contiguous 16-worker group |
+| Pre-run quiescence | Linux heap trim followed by a fixed 5,000 ms wait |
+| Corpus | 472,160 requests + 2,163,500 events; 75,554,938 corrected block operations |
 
-On this arxiv trace, CRTC has the highest clean throughput in the sweep. The hot-prefix distribution limits branch-sharded shard parallelism and caps clean peak throughput. This is the main reason the arxiv trace is a useful primary benchmark: it exposes the routing model under a less favorable and more realistic hot-prefix workload.
+Temporary validation machinery was removed before the final source state. The
+fully instrumented no-op pipeline passed all five 1× issue-span and correctness
+runs with a 100 µs spin. At 2×, only 2/5 runs met the `1.01 ×` issue-span target;
+that headroom check is diagnostic, not a trial-validity gate. Allocation auditing
+found zero benchmark-owned allocations or reallocations in the issuer, query
+transport, sample storage, and completion-write regions. Production Flume queue
+growth and backend allocations remain attributed production work.
 
-Full sweep data:
+The temporary A/B/C reproduction used 20 fresh processes per variant at the
+same 750 ms offered workload. A and B existed only for decomposition and were
+removed afterward.
 
-**CRTC baseline:**
+| Variant | Completion semantics | Mean corrected block ops/s (95% CI) | Keep-up evidence |
+|---|---|---:|---|
+| A | Historical closed loop; final update drain omitted | 93.257M (92.723–93.790M) | 18/20 appeared to keep up only because drain was omitted |
+| B | Closed loop; completion-correct timed drain | 8.651M (8.619–8.682M) | 0/20; mean drain 7.922s |
+| C | Deadline-driven; completion-correct timed drain | 9.167M (9.104–9.230M) | 0/20; mean drain 7.461s |
+| Final C | Cleaned normal replay; completion-correct timed drain | 9.081M (9.044–9.118M) | 20/20 generator-valid; 0/20 keep-up; mean drain 7.534s |
 
-| Benchmark window | Offered ops/s | Achieved ops/s | p99 |
-|-----------------|--------------|----------------|-----|
-| 30,000 ms | 17,268 | 17,219 | 1,027 µs |
-| 18,455 ms | 28,071 | 27,955 | 741 µs |
-| 11,352 ms | 45,635 | 45,309 | 771 µs |
-| 6,983 ms | 74,187 | 73,298 | 683 µs |
-| 4,296 ms | 120,589 | 118,157 | 1,087 µs |
-| 2,643 ms ⚠ | 196,008 | 160,615 | 1,281 µs |
-| 1,626 ms ⚠ | 318,603 | 178,812 | 1,236 µs |
-| 1,000 ms ⚠ | 518,049 | 164,820 | 1,511 µs |
+The historical Stored-only A denominator was 68.133M block ops/s
+(67.743–68.523M). It omitted Removed hashes and must not be compared with the
+corrected denominator. Paired C/B completed-throughput ratio was 1.0596
+(95% CI 1.0518–1.0675).
 
-**Branch-sharded depth=2:**
+The 750 ms load is deliberately overloaded: it offers 100.740M corrected block
+ops/s while CRTC completes about 9.08M block ops/s after drain. It is a
+measurement-semantics decomposition, not a capacity ceiling. Temporary C's
+lookup service p50/p99 was approximately 4.04/7.09 µs, while query queue-wait
+p50/p99 was approximately 71.6/203.5 µs; these are overload diagnostics, not
+headline latency.
 
-| Benchmark window | Offered ops/s | Achieved ops/s | p99 |
-|-----------------|--------------|----------------|-----|
-| 30,000 ms | 17,268 | 16,699 | 12,332 µs |
-| 18,455 ms ⚠ | 28,071 | 19,965 | 16,423 µs |
-| 11,352 ms ⚠ | 45,635 | 23,088 | 14,922 µs |
-| 6,983 ms ⚠ | 74,187 | 25,232 | 13,322 µs |
-| 4,296 ms ⚠ | 120,589 | 26,185 | 11,384 µs |
-| 2,643 ms ⚠ | 196,008 | 29,912 | 9,832 µs |
-| 1,626 ms ⚠ | 318,603 | 35,720 | 6,970 µs |
-| 1,000 ms ⚠ | 518,049 | 37,076 | 6,743 µs |
+Final C's mean lookup service p50/p99 was 4.21/7.31 µs, query queue-wait
+p50/p99 was 76.0/189.6 µs, and scheduled-to-completion p50/p99 was
+99.6/246.9 µs. All are overload diagnostics. Final C was 0.94% below temporary
+C, satisfying the preregistered 2% mean-agreement gate; their 95% CIs overlap.
 
-⚠ = bench warned it could not keep up with the offered rate.
-
-### Worker scaling — branch-sharded depth=2
-
-Config: 2 shards × 4 workers per shard, `--num-unique-inference-workers 1000`, `-d 7`, `--benchmark-duration-ms 30000`. `--trace-duplication-factor` duplicates request/hash spaces while keeping the worker identity count fixed; it increases branch diversity and event volume, but it does not multiply the number of worker identities.
-
-| Trace duplication | Achieved / offered ops/s | p99 | Avg routing | Avg shard | Anchor installs / reuses | Block split |
-|------------------:|--------------------------:|----:|------------:|----------:|-------------------------:|-------------|
-| 1× | 17,015 / 17,268 | 3,034 µs | 455 µs | 203 µs | 88,228 / 0 | 0.0% / 100.0% |
-| 2× | 33,554 / 34,536 | 6,383 µs | 515 µs | 297 µs | 176,386 / 14 | 91.9% / 8.1% |
-| 4× ⚠ | 42,596 / 69,073 | 4,916 µs | 451 µs | 258 µs | 352,842 / 28 | 89.7% / 10.3% |
-| 8× ⚠ | 40,695 / 138,147 | 5,489 µs | 473 µs | 280 µs | 705,593 / 98 | 76.6% / 23.4% |
-| 16× ⚠ | 42,607 / 276,295 | 4,630 µs | 454 µs | 259 µs | 1,410,983 / 182 | 82.0% / 18.0% |
-| 32× ⚠ | 35,018 / 552,590 | 5,928 µs | 529 µs | 319 µs | 2,822,050 / 343 | 84.8% / 15.2% |
-
-1× and 2× keep up with the offered load. 4× and higher are overloaded with this 30s window and should be treated as stress-shape data rather than clean capacity.
-
-Duplication increases branch diversity, but it does not reliably balance stored blocks because the hot routing path and branch lifetime skew still dominate. Achieved throughput saturates around 35-43k ops/s in the overloaded rows, and anchor installs scale roughly with event volume.
-
-### Repeated overload benchmark
-
-Config: `--num-unique-inference-workers 128`, `--trace-duplication-factor 20`, `--trace-length-factor 4`, `--benchmark-duration-ms 750`, `--benchmark-runs 20`. These runs generated 2,163,500 events: 1,007,958 `Stored` and 1,155,542 `Removed`. Every run warned that the benchmarker could not keep up, and macOS emitted malloc range-group warnings during event generation. Treat this as saturated stress data, not clean capacity.
-
-| Indexer | Event workers | Offered ops/s | Achieved ops/s p50 | Achieved ops/s p90 | Achieved ops/s p99 | Achieved ops/s mean |
-|---------|--------------:|--------------:|------------------:|------------------:|------------------:|-------------------:|
-| CRTC baseline | 8 | 3,514,213 | 1,897,506 | 2,712,728 | 2,773,248 | 1,897,265 |
-| Branch-sharded depth=2 | 2×4 | 3,514,213 | 594,934 | 664,920 | 703,730 | 593,921 |
-
-| Indexer | Offered block ops/s | Achieved block ops/s p50 | Achieved block ops/s p90 | Achieved block ops/s p99 | Achieved block ops/s mean |
-|---------|--------------------:|------------------------:|------------------------:|------------------------:|-------------------------:|
-| CRTC baseline | 73,600,216 | 39,740,576 | 56,814,248 | 58,081,760 | 39,735,535 |
-| Branch-sharded depth=2 | 73,600,216 | 12,460,051 | 13,925,808 | 14,738,639 | 12,438,834 |
-
-| Indexer | p99 latency p50 | p99 latency p90 | p99 latency p99 | p99 latency mean |
-|---------|----------------:|----------------:|----------------:|-----------------:|
-| CRTC baseline | 138 µs | 312 µs | 380 µs | 158 µs |
-| Branch-sharded depth=2 | 352 µs | 484 µs | 560 µs | 370 µs |
-
-Branch-sharded lands below CRTC on achieved ops/s in this overload run and has higher p99 lookup latency. Routing averages roughly 18-27 µs, shard traversal roughly 12-19 µs, and stored blocks still collapse heavily onto one shard (usually about 93-100% on shard 1), so this is not a balanced-sharding result. This command is dominated by event processing, especially `Removed` events; branch-sharded adds routing-TRIE and anchor bookkeeping on that path while CRTC applies events directly.
-
----
-
-## Known Issues
-
-### Hot-branch shard collapse and lifetime block skew
-
-`BranchShardedIndexer` uses a routing TRIE with static divergent-child shard assignment: the first child under a routing node stays with the parent shard, and later divergent siblings may split to other shards. Two skew modes remain:
-
-1. **Shared-prefix collapse:** if many requests share the same first `prefix_depth` blocks, they share the same routing path and land on one shard. On `mooncake_trace.jsonl`, the two hottest depth-2 prefixes account for 12,652 of 23,608 requests, and the branch-sharded depth=2 steady-state run above stores effectively all blocks on one shard.
-2. **Lifetime skew:** even when branch counts are distributed, branches are placed permanently and some conversations accumulate far more blocks than others. Over time, a few heavy branches can dominate one shard.
-
-The hot shard's larger tree drives up p99.
-
-**Future work — hot-branch splitting/rebalancing:** detect prefixes whose request or pending-prefill-token load would overload a shard, then split or migrate that hot branch across a small candidate shard set. This directly addresses the current collapse mode while preserving single-shard routing for cold branches.
-
-### `prefix_depth` must be tuned per workload
-
-If most requests share a long prompt prefix, all conversations may follow the same routing-TRIE path until the first divergent block. Set `prefix_depth` to span the shared prefix plus at least 1-2 unique blocks when you want the configured depth to expose more branch diversity.
-
-The routing TRIE avoids prefix-key collisions, but `prefix_depth` tuning alone does not solve a genuinely dominant hot branch. The code has an open TODO for adaptive hot-branch splitting. Until that is resolved, compare branch-sharded results on traces with narrow prefix diversity before choosing it for production.
+The measured base Git SHA was
+`337c22c09f14dc08e92092706506453da3c353c4`. The exact unstaged source archive
+SHA-256 was `c3a8493181f69fc614f1b04e815e61b6558a727bee335a6b908e92f18b4d4b88`,
+the optimized binary SHA-256 was
+`7c0a758cd1cfb65f676cd4550ab7780444958cf794690a4e8664c98daa031e4c`, and the
+frozen final result archive SHA-256 was
+`9d5dc04e03033db31a0560d239b9af62011f6342cba32fecd7410b1e738fa948`.
+Raw JSON, logs, allocation-audit output, and profiles remain external artifacts
+rather than repository content.

--- a/lib/bench/kv_router/active_sequences_bench.rs
+++ b/lib/bench/kv_router/active_sequences_bench.rs
@@ -1,15 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[path = "active_sequences_open_loop.rs"]
+mod active_sequences_open_loop;
 #[path = "active_sequences_shared.rs"]
 mod active_sequences_shared;
 
-use active_sequences_shared::{generate_sequence_events, run_benchmark};
+use active_sequences_open_loop::{
+    ActiveSequencesResult, ActiveSequencesRunConfig, PreparedActiveSequencesCorpus,
+    prepare_active_sequences_corpus, run_active_sequences_benchmark,
+};
+use active_sequences_shared::generate_sequence_events;
 use clap::Parser;
 use dynamo_bench::kv_router_common::args::CommonArgs;
 use dynamo_bench::kv_router_common::replay::process_mooncake_trace;
-use dynamo_bench::kv_router_common::results::BenchmarkResults;
-use dynamo_bench::kv_router_common::sweep::{compute_sweep_durations, print_sweep_summary};
+use dynamo_bench::kv_router_common::sweep::compute_sweep_durations;
 use tracing_subscriber::EnvFilter;
 
 fn init_sequence_logging(enabled: bool) {
@@ -33,25 +38,54 @@ fn init_sequence_logging(enabled: bool) {
 struct Args {
     #[clap(flatten)]
     common: CommonArgs,
+
+    /// Number of persistent sticky operation lanes.
+    #[clap(long, default_value = "128")]
+    operation_lanes: usize,
+
+    /// Busy-spin interval after the deadline issuer sleeps.
+    #[clap(long, default_value = "75")]
+    issuer_spin_us: u64,
+
+    /// Diagnostic late-issue threshold; it is not a validity gate.
+    #[clap(long, default_value = "50")]
+    issue_lag_diagnostic_threshold_us: u64,
+
+    /// JSON output path for one benchmark result.
+    #[clap(long, default_value = "active_sequences_result.json")]
+    result_json_output: String,
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-    init_sequence_logging(args.common.sequence_logs);
-
+fn validate_args(args: &Args) -> anyhow::Result<()> {
     if args.common.test {
         anyhow::bail!(
             "active_sequences_bench no longer supports --test; run `cargo test --package dynamo-bench --test active_sequences_trace` instead"
         );
     }
+    if args.operation_lanes == 0 {
+        anyhow::bail!("--operation-lanes must be at least 1");
+    }
+    if args.operation_lanes > u16::MAX as usize {
+        anyhow::bail!("--operation-lanes exceeds the u16 lane-ID space");
+    }
+    Ok(())
+}
 
-    let path = match args.common.mooncake_trace_path.as_deref() {
-        Some(p) => p,
-        None => {
-            eprintln!("No mooncake_trace_path provided, skipping benchmark");
-            return Ok(());
-        }
+fn run_config(args: &Args) -> ActiveSequencesRunConfig {
+    ActiveSequencesRunConfig {
+        operation_lanes: args.operation_lanes,
+        spin_us: args.issuer_spin_us,
+        issue_lag_diagnostic_threshold_us: args.issue_lag_diagnostic_threshold_us,
+    }
+}
+
+async fn prepare_benchmark(
+    args: &Args,
+    benchmark_duration_ms: u64,
+) -> anyhow::Result<Option<PreparedActiveSequencesCorpus>> {
+    let Some(path) = args.common.mooncake_trace_path.as_deref() else {
+        eprintln!("No mooncake_trace_path provided, skipping benchmark");
+        return Ok(None);
     };
     let traces = process_mooncake_trace(
         path,
@@ -61,7 +95,6 @@ async fn main() -> anyhow::Result<()> {
         args.common.num_unique_inference_workers,
         args.common.seed,
     )?;
-
     let seq_traces = generate_sequence_events(
         &traces,
         args.common.num_gpu_blocks,
@@ -69,47 +102,103 @@ async fn main() -> anyhow::Result<()> {
         args.common.trace_simulation_duration_ms,
     )
     .await?;
+    drop(traces);
 
+    Ok(Some(prepare_active_sequences_corpus(
+        seq_traces,
+        args.common.block_size,
+        benchmark_duration_ms,
+        args.common.inference_worker_duplication_factor,
+    )?))
+}
+
+fn print_result(result: &ActiveSequencesResult) {
+    println!(
+        "Logical throughput: offered={:.0} ops/s achieved={:.0} ops/s",
+        result.offered_logical_ops_per_sec, result.achieved_logical_ops_per_sec
+    );
+    println!(
+        "Logical block visits: offered={:.0}/s achieved={:.0}/s input_blocks={}",
+        result.offered_logical_block_visits_per_sec,
+        result.achieved_logical_block_visits_per_sec,
+        result.total_input_blocks,
+    );
+    println!(
+        "Service p99 (us): project={:.1} add={:.1} project+add={:.1} prefill_complete={:.1} free={:.1}",
+        result.project_service.p99_ns as f64 / 1_000.0,
+        result.add_service.p99_ns as f64 / 1_000.0,
+        result.project_and_add_service.p99_ns as f64 / 1_000.0,
+        result.prefill_complete_service.p99_ns as f64 / 1_000.0,
+        result.free_service.p99_ns as f64 / 1_000.0,
+    );
+    println!(
+        "generator_valid={} kept_up={} issue_span={:.3}ms drain={:.3}ms",
+        result.generator_valid,
+        result.kept_up,
+        result.issue_span_ns as f64 / 1e6,
+        result.drain_ns as f64 / 1e6,
+    );
+}
+
+fn result_path(base: &str, duration_ms: Option<u64>) -> String {
+    let stem = base.trim_end_matches(".json");
+    match duration_ms {
+        Some(duration_ms) => format!("{stem}_{duration_ms}ms.json"),
+        None => base.to_string(),
+    }
+}
+
+fn write_result(path: &str, result: &ActiveSequencesResult) -> anyhow::Result<()> {
+    std::fs::write(path, serde_json::to_string_pretty(result)?)?;
+    println!("Active Sequences result written to {path}");
+    Ok(())
+}
+
+async fn run_cell(
+    args: &Args,
+    benchmark_duration_ms: u64,
+    output_duration: Option<u64>,
+) -> anyhow::Result<()> {
+    let Some(corpus) = prepare_benchmark(args, benchmark_duration_ms).await? else {
+        return Ok(());
+    };
+    let result = run_active_sequences_benchmark(corpus, run_config(args)).await?;
+    print_result(&result);
+    write_result(
+        &result_path(&args.result_json_output, output_duration),
+        &result,
+    )?;
+    if !result.kept_up {
+        eprintln!(
+            "WARNING: Active Sequences replay did not keep up; inspect issue, queue, and drain metrics"
+        );
+    }
+    Ok(())
+}
+
+async fn async_main(args: Args) -> anyhow::Result<()> {
     if args.common.sweep {
         let durations = compute_sweep_durations(
             args.common.sweep_min_ms,
             args.common.sweep_max_ms,
             args.common.sweep_steps,
         );
-
-        let mut results: Vec<(u64, BenchmarkResults)> = Vec::new();
-        for &dur_ms in &durations {
-            println!("\n=== Sweep: benchmark_duration_ms = {} ===", dur_ms);
-            let run = run_benchmark(
-                &seq_traces,
-                args.common.block_size,
-                dur_ms,
-                args.common.inference_worker_duplication_factor,
-            )
-            .await?;
-            if !run.kept_up {
-                eprintln!(
-                    "WARNING: Benchmarker could not keep up. Rerun with a larger --benchmark-duration-ms."
-                );
-            }
-            results.push((dur_ms, run.results));
+        for duration_ms in durations.into_iter().rev() {
+            println!("\n=== Active Sequences sweep: benchmark_duration_ms={duration_ms} ===");
+            run_cell(&args, duration_ms, Some(duration_ms)).await?;
         }
-
-        print_sweep_summary("active-sequences", &results);
-    } else {
-        let run = run_benchmark(
-            &seq_traces,
-            args.common.block_size,
-            args.common.benchmark_duration_ms,
-            args.common.inference_worker_duplication_factor,
-        )
-        .await?;
-        if !run.kept_up {
-            eprintln!(
-                "WARNING: Benchmarker could not keep up. Rerun with a larger --benchmark-duration-ms."
-            );
-        }
+        return Ok(());
     }
 
-    Ok(())
+    run_cell(&args, args.common.benchmark_duration_ms, None).await
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    validate_args(&args)?;
+    init_sequence_logging(args.common.sequence_logs);
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()?
+        .block_on(async_main(args))
 }

--- a/lib/bench/kv_router/active_sequences_open_loop.rs
+++ b/lib/bench/kv_router/active_sequences_open_loop.rs
@@ -1,0 +1,1873 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeMap, HashMap};
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, mpsc};
+#[cfg(not(target_os = "linux"))]
+use std::time::Duration;
+use std::time::Instant;
+
+use dynamo_bench::kv_router_common::replay::NoopSequencePublisher;
+use dynamo_bench::kv_router_common::trace_gen::WorkerTimelines;
+use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
+use dynamo_kv_router::{
+    ActiveSequencesMultiWorker, SequenceError, SequenceRequest, WorkerLoadProjection,
+};
+use dynamo_tokens::SequenceHash;
+use rustc_hash::FxHashMap;
+use serde::Serialize;
+use tokio::sync::{Notify, oneshot};
+
+use super::active_sequences_shared::{SequenceTrace, SequenceTraceEntry};
+
+const RESULT_SCHEMA_VERSION: u32 = 1;
+const EMPTY_OPERATION_ID: u32 = u32::MAX;
+const START_LEAD_NS: u64 = 20_000_000;
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ActiveSequencesRunConfig {
+    pub(crate) operation_lanes: usize,
+    pub(crate) spin_us: u64,
+    pub(crate) issue_lag_diagnostic_threshold_us: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ActiveOperationKind {
+    ProjectAndAdd,
+    PrefillComplete,
+    Free,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct ActiveSequencesTotals {
+    pub(crate) adds: usize,
+    pub(crate) prefill_completes: usize,
+    pub(crate) frees: usize,
+    pub(crate) input_blocks: usize,
+    pub(crate) projection_block_visits: usize,
+    pub(crate) add_registration_block_visits: usize,
+    pub(crate) free_release_block_visits: usize,
+}
+
+impl ActiveSequencesTotals {
+    fn logical_operations(self) -> usize {
+        self.adds + self.prefill_completes + self.frees
+    }
+
+    fn logical_block_visits(self) -> usize {
+        self.projection_block_visits
+            + self.add_registration_block_visits
+            + self.free_release_block_visits
+    }
+}
+
+#[derive(Debug)]
+struct PreparedRequest {
+    request_id: String,
+    hash_start: u32,
+    hash_len: u32,
+    isl: usize,
+    output_length: u32,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct ActiveLogicalOperation {
+    pub(crate) id: u32,
+    pub(crate) deadline_ns: u64,
+    pub(crate) worker_id: u64,
+    pub(crate) source_ordinal: usize,
+    pub(crate) kind: ActiveOperationKind,
+    request_index: u32,
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedActiveSequencesCorpus {
+    pub(crate) operations: Vec<ActiveLogicalOperation>,
+    hashes: Box<[SequenceHash]>,
+    requests: Box<[PreparedRequest]>,
+    expected_operations_by_worker: Vec<(u64, usize)>,
+    totals: ActiveSequencesTotals,
+    benchmark_duration_ns: u64,
+    block_size: u32,
+    total_workers: usize,
+}
+
+impl PreparedActiveSequencesCorpus {
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn operation_hashes(&self, operation_id: u32) -> anyhow::Result<&[SequenceHash]> {
+        let operation = self
+            .operations
+            .get(operation_id as usize)
+            .filter(|operation| operation.kind == ActiveOperationKind::ProjectAndAdd)
+            .ok_or_else(|| anyhow::anyhow!("operation {operation_id} is not a prepared add"))?;
+        let request = &self.requests[operation.request_index as usize];
+        let start = request.hash_start as usize;
+        let end = start
+            .checked_add(request.hash_len as usize)
+            .ok_or_else(|| anyhow::anyhow!("operation {operation_id} hash range overflow"))?;
+        self.hashes.get(start..end).ok_or_else(|| {
+            anyhow::anyhow!(
+                "operation {operation_id} hash range {start}..{end} exceeds the flattened slab"
+            )
+        })
+    }
+
+    #[cfg(test)]
+    #[allow(dead_code)]
+    pub(crate) fn totals(&self) -> ActiveSequencesTotals {
+        self.totals
+    }
+}
+
+#[derive(Clone, Copy)]
+struct LifecycleState {
+    request_index: u32,
+    prefill_completed: bool,
+    freed: bool,
+}
+
+pub(crate) fn prepare_active_sequences_corpus(
+    traces: Vec<Vec<SequenceTrace>>,
+    block_size: u32,
+    benchmark_duration_ms: u64,
+    inference_worker_duplication_factor: usize,
+) -> anyhow::Result<PreparedActiveSequencesCorpus> {
+    if block_size == 0 {
+        anyhow::bail!("Active Sequences block size must be positive");
+    }
+    if inference_worker_duplication_factor == 0 {
+        anyhow::bail!("Active Sequences worker duplication factor must be positive");
+    }
+    if benchmark_duration_ms == 0 {
+        anyhow::bail!("Active Sequences replay window must be positive");
+    }
+
+    for (worker_id, worker_trace) in traces.iter().enumerate() {
+        for (source_ordinal, pair) in worker_trace.windows(2).enumerate() {
+            if pair[1].timestamp_us < pair[0].timestamp_us {
+                anyhow::bail!(
+                    "worker {worker_id} Active Sequences timestamps are not ordered at source indices {} and {}: prev={}, curr={}",
+                    source_ordinal,
+                    source_ordinal + 1,
+                    pair[0].timestamp_us,
+                    pair[1].timestamp_us,
+                );
+            }
+        }
+    }
+
+    let scaled = WorkerTimelines::new(traces).into_rescaled_from_first(
+        benchmark_duration_ms,
+        |entry| entry.timestamp_us,
+        |entry, timestamp_us| SequenceTrace {
+            entry: entry.entry,
+            timestamp_us,
+        },
+    );
+    let num_trace_workers = scaled.len();
+    if num_trace_workers == 0 {
+        anyhow::bail!("Active Sequences corpus has no worker timelines");
+    }
+
+    let total_workers = num_trace_workers
+        .checked_mul(inference_worker_duplication_factor)
+        .ok_or_else(|| anyhow::anyhow!("Active Sequences worker count overflow"))?;
+    let estimated_operations = scaled
+        .iter()
+        .map(Vec::len)
+        .sum::<usize>()
+        .checked_mul(inference_worker_duplication_factor)
+        .ok_or_else(|| anyhow::anyhow!("Active Sequences operation count overflow"))?;
+    if estimated_operations >= EMPTY_OPERATION_ID as usize {
+        anyhow::bail!("Active Sequences corpus exceeds the u32 operation-ID space");
+    }
+    if estimated_operations == 0 {
+        anyhow::bail!("Active Sequences corpus has no lifecycle operations");
+    }
+
+    let mut operations = Vec::with_capacity(estimated_operations);
+    let mut requests = Vec::new();
+    let mut hashes = Vec::new();
+    let mut expected_operations_by_worker = Vec::with_capacity(total_workers);
+    let mut totals = ActiveSequencesTotals::default();
+
+    for replica in 0..inference_worker_duplication_factor {
+        for (trace_idx, worker_trace) in scaled.iter().enumerate() {
+            let worker_id = (replica * num_trace_workers + trace_idx) as u64;
+            let mut lifecycle = HashMap::<String, LifecycleState>::new();
+            expected_operations_by_worker.push((worker_id, worker_trace.len()));
+
+            for (source_ordinal, trace_entry) in worker_trace.iter().enumerate() {
+                let deadline_ns = trace_entry.timestamp_us.saturating_mul(1_000);
+                let (kind, request_index) = match &trace_entry.entry {
+                    SequenceTraceEntry::Add {
+                        request_id,
+                        block_hashes,
+                        isl,
+                        output_length,
+                    } => {
+                        if lifecycle.contains_key(request_id) {
+                            anyhow::bail!(
+                                "worker {worker_id} request {request_id} has more than one Add"
+                            );
+                        }
+                        let hash_start = u32::try_from(hashes.len())?;
+                        let hash_len = u32::try_from(block_hashes.len())?;
+                        hashes.extend_from_slice(block_hashes);
+                        let request_index = u32::try_from(requests.len())?;
+                        requests.push(PreparedRequest {
+                            request_id: format!("{worker_id}:{request_id}"),
+                            hash_start,
+                            hash_len,
+                            isl: *isl,
+                            output_length: u32::try_from(*output_length).map_err(|_| {
+                                anyhow::anyhow!(
+                                    "worker {worker_id} request {request_id} output length exceeds u32"
+                                )
+                            })?,
+                        });
+                        lifecycle.insert(
+                            request_id.clone(),
+                            LifecycleState {
+                                request_index,
+                                prefill_completed: false,
+                                freed: false,
+                            },
+                        );
+                        totals.adds += 1;
+                        totals.input_blocks += block_hashes.len();
+                        totals.projection_block_visits += block_hashes.len();
+                        totals.add_registration_block_visits += block_hashes.len();
+                        (ActiveOperationKind::ProjectAndAdd, request_index)
+                    }
+                    SequenceTraceEntry::PrefillComplete { request_id } => {
+                        let state = lifecycle.get_mut(request_id).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "worker {worker_id} request {request_id} completes prefill before Add"
+                            )
+                        })?;
+                        if state.freed {
+                            anyhow::bail!(
+                                "worker {worker_id} request {request_id} completes prefill after Free"
+                            );
+                        }
+                        if state.prefill_completed {
+                            anyhow::bail!(
+                                "worker {worker_id} request {request_id} completes prefill more than once"
+                            );
+                        }
+                        state.prefill_completed = true;
+                        totals.prefill_completes += 1;
+                        (ActiveOperationKind::PrefillComplete, state.request_index)
+                    }
+                    SequenceTraceEntry::Free { request_id } => {
+                        let state = lifecycle.get_mut(request_id).ok_or_else(|| {
+                            anyhow::anyhow!(
+                                "worker {worker_id} request {request_id} is freed before Add"
+                            )
+                        })?;
+                        if state.freed {
+                            anyhow::bail!(
+                                "worker {worker_id} request {request_id} is freed more than once"
+                            );
+                        }
+                        state.freed = true;
+                        let request = &requests[state.request_index as usize];
+                        totals.frees += 1;
+                        totals.free_release_block_visits += request.hash_len as usize;
+                        (ActiveOperationKind::Free, state.request_index)
+                    }
+                };
+                operations.push(ActiveLogicalOperation {
+                    id: 0,
+                    deadline_ns,
+                    worker_id,
+                    source_ordinal,
+                    kind,
+                    request_index,
+                });
+            }
+
+            let unfinished = lifecycle
+                .iter()
+                .filter_map(|(request_id, state)| (!state.freed).then_some(request_id.as_str()))
+                .collect::<Vec<_>>();
+            if !unfinished.is_empty() {
+                anyhow::bail!(
+                    "worker {worker_id} has {} requests without a final Free: {}",
+                    unfinished.len(),
+                    unfinished.join(", ")
+                );
+            }
+        }
+    }
+
+    operations.sort_by_key(|operation| {
+        (
+            operation.deadline_ns,
+            operation.worker_id,
+            operation.source_ordinal,
+        )
+    });
+    for (id, operation) in operations.iter_mut().enumerate() {
+        operation.id = id as u32;
+    }
+
+    if operations.len() != totals.logical_operations() {
+        anyhow::bail!("Active Sequences logical-operation accounting mismatch");
+    }
+
+    Ok(PreparedActiveSequencesCorpus {
+        operations,
+        hashes: hashes.into_boxed_slice(),
+        requests: requests.into_boxed_slice(),
+        expected_operations_by_worker,
+        totals,
+        benchmark_duration_ns: benchmark_duration_ms.saturating_mul(1_000_000),
+        block_size,
+        total_workers,
+    })
+}
+
+struct ScheduledOperation {
+    id: u32,
+    deadline_ns: u64,
+    lane: usize,
+}
+
+struct LanePayloadSlot {
+    id: u32,
+    payload: Option<LanePayload>,
+}
+
+enum LanePayload {
+    ProjectAndAdd(SequenceRequest),
+    PrefillComplete(u32),
+    Free(u32),
+}
+
+pub(crate) struct PreparedActiveSequencesTrial {
+    dispatch: Vec<ScheduledOperation>,
+    lane_payloads: Vec<Box<[LanePayloadSlot]>>,
+    lane_request_ids: Vec<Box<[String]>>,
+    lane_capacities: Vec<usize>,
+    operation_workers: Box<[u64]>,
+    operation_kinds: Box<[ActiveOperationKind]>,
+    expected_operations_by_worker: Vec<(u64, usize)>,
+    totals: ActiveSequencesTotals,
+    benchmark_duration_ns: u64,
+    block_size: u32,
+    total_workers: usize,
+}
+
+impl PreparedActiveSequencesTrial {
+    fn page_touch_untimed(&self) {
+        let mut checksum = self.benchmark_duration_ns ^ u64::from(self.block_size);
+        for operation in &self.dispatch {
+            checksum ^= operation.deadline_ns ^ u64::from(operation.id) ^ operation.lane as u64;
+        }
+        for lane in &self.lane_payloads {
+            for slot in lane.iter() {
+                checksum ^= u64::from(slot.id);
+                match slot.payload.as_ref() {
+                    Some(LanePayload::ProjectAndAdd(request)) => {
+                        for byte in request.request_id.as_bytes() {
+                            checksum ^= u64::from(*byte);
+                        }
+                        if let Some(hashes) = request.token_sequence.as_deref() {
+                            for hash in hashes {
+                                checksum ^= *hash;
+                            }
+                        }
+                    }
+                    Some(LanePayload::PrefillComplete(request_index))
+                    | Some(LanePayload::Free(request_index)) => {
+                        checksum ^= u64::from(*request_index)
+                    }
+                    None => checksum ^= u64::MAX,
+                }
+            }
+        }
+        for request_ids in &self.lane_request_ids {
+            for request_id in request_ids.iter() {
+                for byte in request_id.as_bytes() {
+                    checksum ^= u64::from(*byte);
+                }
+            }
+        }
+        for (&worker_id, &kind) in self.operation_workers.iter().zip(&self.operation_kinds) {
+            checksum ^= worker_id ^ kind as u64;
+        }
+        for &(worker_id, count) in &self.expected_operations_by_worker {
+            checksum ^= worker_id ^ count as u64;
+        }
+        checksum ^= self.totals.logical_operations() as u64
+            ^ self.totals.logical_block_visits() as u64
+            ^ self.total_workers as u64;
+        black_box(checksum);
+    }
+}
+
+pub(crate) fn prepare_active_sequences_trial(
+    corpus: PreparedActiveSequencesCorpus,
+    operation_lanes: usize,
+) -> anyhow::Result<PreparedActiveSequencesTrial> {
+    if operation_lanes == 0 {
+        anyhow::bail!("Active Sequences operation-lane count must be positive");
+    }
+    if operation_lanes > u16::MAX as usize {
+        anyhow::bail!("Active Sequences operation-lane count exceeds u16");
+    }
+
+    let PreparedActiveSequencesCorpus {
+        operations,
+        hashes,
+        requests,
+        expected_operations_by_worker,
+        totals,
+        benchmark_duration_ns,
+        block_size,
+        total_workers,
+    } = corpus;
+    let mut lane_capacities = vec![0usize; operation_lanes];
+    for operation in &operations {
+        lane_capacities[operation.worker_id as usize % operation_lanes] += 1;
+    }
+    let mut lane_payloads = lane_capacities
+        .iter()
+        .map(|&capacity| Vec::with_capacity(capacity))
+        .collect::<Vec<_>>();
+    let mut lane_request_ids = (0..operation_lanes)
+        .map(|_| Vec::<String>::new())
+        .collect::<Vec<_>>();
+    let mut request_lane_indices = vec![None; requests.len()];
+    for operation in operations
+        .iter()
+        .filter(|operation| operation.kind == ActiveOperationKind::ProjectAndAdd)
+    {
+        let lane = operation.worker_id as usize % operation_lanes;
+        let request = &requests[operation.request_index as usize];
+        let lane_request_index = u32::try_from(lane_request_ids[lane].len())?;
+        lane_request_ids[lane].push(request.request_id.clone());
+        request_lane_indices[operation.request_index as usize] = Some((lane, lane_request_index));
+    }
+    let mut dispatch = Vec::with_capacity(operations.len());
+    let mut operation_workers = Vec::with_capacity(operations.len());
+    let mut operation_kinds = Vec::with_capacity(operations.len());
+
+    for operation in operations {
+        let request = requests
+            .get(operation.request_index as usize)
+            .ok_or_else(|| anyhow::anyhow!("operation {} has an invalid request", operation.id))?;
+        let lane = operation.worker_id as usize % operation_lanes;
+        let (request_lane, lane_request_index) = request_lane_indices
+            .get(operation.request_index as usize)
+            .and_then(|entry| *entry)
+            .ok_or_else(|| {
+                anyhow::anyhow!("operation {} has no prepared request ID", operation.id)
+            })?;
+        if request_lane != lane {
+            anyhow::bail!(
+                "operation {} request is assigned to another lane",
+                operation.id
+            );
+        }
+        let payload = match operation.kind {
+            ActiveOperationKind::ProjectAndAdd => {
+                let start = request.hash_start as usize;
+                let end = start
+                    .checked_add(request.hash_len as usize)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("operation {} hash range overflow", operation.id)
+                    })?;
+                let token_sequence = hashes
+                    .get(start..end)
+                    .ok_or_else(|| {
+                        anyhow::anyhow!("operation {} hash range exceeds the slab", operation.id)
+                    })?
+                    .to_vec();
+                LanePayload::ProjectAndAdd(SequenceRequest {
+                    request_id: request.request_id.clone(),
+                    token_sequence: Some(token_sequence),
+                    track_prefill_tokens: true,
+                    expected_output_tokens: Some(request.output_length),
+                    prefill_load_hint: Some(PrefillLoadHint {
+                        initial_effective_prefill_tokens: request.isl,
+                        expected_prefill_duration: None,
+                    }),
+                    worker: WorkerWithDpRank::from_worker_id(operation.worker_id),
+                    lora_name: None,
+                })
+            }
+            ActiveOperationKind::PrefillComplete => {
+                LanePayload::PrefillComplete(lane_request_index)
+            }
+            ActiveOperationKind::Free => LanePayload::Free(lane_request_index),
+        };
+        dispatch.push(ScheduledOperation {
+            id: operation.id,
+            deadline_ns: operation.deadline_ns,
+            lane,
+        });
+        lane_payloads[lane].push(LanePayloadSlot {
+            id: operation.id,
+            payload: Some(payload),
+        });
+        operation_workers.push(operation.worker_id);
+        operation_kinds.push(operation.kind);
+    }
+
+    if lane_payloads
+        .iter()
+        .zip(&lane_capacities)
+        .any(|(payloads, &capacity)| payloads.len() != capacity)
+    {
+        anyhow::bail!("Active Sequences lane-capacity accounting mismatch");
+    }
+
+    Ok(PreparedActiveSequencesTrial {
+        dispatch,
+        lane_payloads: lane_payloads
+            .into_iter()
+            .map(Vec::into_boxed_slice)
+            .collect(),
+        lane_request_ids: lane_request_ids
+            .into_iter()
+            .map(Vec::into_boxed_slice)
+            .collect(),
+        lane_capacities,
+        operation_workers: operation_workers.into_boxed_slice(),
+        operation_kinds: operation_kinds.into_boxed_slice(),
+        expected_operations_by_worker,
+        totals,
+        benchmark_duration_ns,
+        block_size,
+        total_workers,
+    })
+}
+
+struct OperationLane {
+    slots: Box<[AtomicU32]>,
+    published: AtomicUsize,
+    consumed: AtomicUsize,
+    closed: AtomicBool,
+    notify: Notify,
+}
+
+impl OperationLane {
+    fn new(capacity: usize) -> Self {
+        Self {
+            slots: (0..capacity)
+                .map(|_| AtomicU32::new(EMPTY_OPERATION_ID))
+                .collect::<Vec<_>>()
+                .into_boxed_slice(),
+            published: AtomicUsize::new(0),
+            consumed: AtomicUsize::new(0),
+            closed: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+
+    fn write(&self, cursor: usize, id: u32) -> Result<(), IssuerFailure> {
+        let Some(slot) = self.slots.get(cursor) else {
+            return Err(IssuerFailure::LaneOverflow);
+        };
+        slot.store(id, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn publish(&self, count: usize) {
+        self.published.store(count, Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    fn depth(&self) -> usize {
+        self.published
+            .load(Ordering::Acquire)
+            .saturating_sub(self.consumed.load(Ordering::Acquire))
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum CompletionFailure {
+    #[default]
+    None,
+    MissingPayload,
+    WorkerNotFound,
+    DuplicateRequest,
+    RequestNotFound,
+    ReplicaSyncPublishFailed,
+    InvalidRequestIndex,
+}
+
+impl CompletionFailure {
+    fn from_sequence_error(error: SequenceError) -> Self {
+        match error {
+            SequenceError::WorkerNotFound { .. } => Self::WorkerNotFound,
+            SequenceError::DuplicateRequest { .. } => Self::DuplicateRequest,
+            SequenceError::RequestNotFound { .. } => Self::RequestNotFound,
+            SequenceError::ReplicaSyncPublishFailed(_) => Self::ReplicaSyncPublishFailed,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct CompletionRecord {
+    id: u32,
+    started_ns: u64,
+    project_finished_ns: u64,
+    finished_ns: u64,
+    projection_count: u64,
+    projection_inspected: u64,
+    projection_digest: u64,
+    failure: CompletionFailure,
+}
+
+pub(crate) fn summarize_worker_projections(
+    projections: &FxHashMap<WorkerWithDpRank, WorkerLoadProjection>,
+) -> (u64, u64) {
+    let mut inspected = 0u64;
+    let mut digest = 0u64;
+    for (worker, projection) in projections {
+        let entry = mix64(worker.worker_id)
+            ^ mix64(u64::from(worker.dp_rank)).rotate_left(7)
+            ^ mix64(projection.active_prefill_tokens as u64).rotate_left(13)
+            ^ mix64(projection.active_decode_blocks as u64).rotate_left(29)
+            ^ mix64(projection.additional_active_blocks as u64).rotate_left(43);
+        digest ^= mix64(entry);
+        inspected += 1;
+    }
+    (inspected, digest)
+}
+
+pub(crate) fn accumulate_projection_digest(
+    aggregate: u64,
+    operation_id: u32,
+    projection_digest: u64,
+) -> u64 {
+    aggregate ^ mix64(projection_digest ^ u64::from(operation_id))
+}
+
+fn mix64(mut value: u64) -> u64 {
+    value ^= value >> 30;
+    value = value.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    value ^= value >> 27;
+    value = value.wrapping_mul(0x94d0_49bb_1331_11eb);
+    value ^ (value >> 31)
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum LaneFailure {
+    #[default]
+    None,
+    MissingPublishedId,
+    PayloadOrder,
+    CompletionOverflow,
+}
+
+struct LaneResult {
+    completions: Box<[CompletionRecord]>,
+    written: usize,
+    drain_ns: u64,
+    failure: LaneFailure,
+}
+
+fn execute_payload(
+    sequences: &ActiveSequencesMultiWorker<NoopSequencePublisher>,
+    clock: &BenchmarkClock,
+    id: u32,
+    request_ids: &[String],
+    payload: Option<LanePayload>,
+) -> CompletionRecord {
+    let started_ns = clock.now_ns();
+    let Some(payload) = payload else {
+        return CompletionRecord {
+            id,
+            started_ns,
+            finished_ns: clock.now_ns(),
+            failure: CompletionFailure::MissingPayload,
+            ..CompletionRecord::default()
+        };
+    };
+    let decay_now = tokio::time::Instant::now();
+
+    match payload {
+        LanePayload::ProjectAndAdd(request) => {
+            let projections =
+                sequences.project_worker_loads(request.token_sequence.as_deref(), decay_now);
+            let projection_count = projections.len() as u64;
+            let (projection_inspected, projection_digest) =
+                summarize_worker_projections(&projections);
+            drop(black_box(projections));
+            let project_finished_ns = clock.now_ns();
+            let failure = sequences
+                .add_request(request, decay_now)
+                .err()
+                .map(CompletionFailure::from_sequence_error)
+                .unwrap_or_default();
+            CompletionRecord {
+                id,
+                started_ns,
+                project_finished_ns,
+                finished_ns: clock.now_ns(),
+                projection_count,
+                projection_inspected,
+                projection_digest,
+                failure,
+            }
+        }
+        LanePayload::PrefillComplete(request_index) => {
+            let Some(request_id) = request_ids.get(request_index as usize) else {
+                return CompletionRecord {
+                    id,
+                    started_ns,
+                    finished_ns: clock.now_ns(),
+                    failure: CompletionFailure::InvalidRequestIndex,
+                    ..CompletionRecord::default()
+                };
+            };
+            let failure = sequences
+                .mark_prefill_completed(request_id, decay_now)
+                .err()
+                .map(CompletionFailure::from_sequence_error)
+                .unwrap_or_default();
+            CompletionRecord {
+                id,
+                started_ns,
+                finished_ns: clock.now_ns(),
+                failure,
+                ..CompletionRecord::default()
+            }
+        }
+        LanePayload::Free(request_index) => {
+            let Some(request_id) = request_ids.get(request_index as usize) else {
+                return CompletionRecord {
+                    id,
+                    started_ns,
+                    finished_ns: clock.now_ns(),
+                    failure: CompletionFailure::InvalidRequestIndex,
+                    ..CompletionRecord::default()
+                };
+            };
+            let failure = sequences
+                .free(request_id, decay_now)
+                .err()
+                .map(CompletionFailure::from_sequence_error)
+                .unwrap_or_default();
+            CompletionRecord {
+                id,
+                started_ns,
+                finished_ns: clock.now_ns(),
+                failure,
+                ..CompletionRecord::default()
+            }
+        }
+    }
+}
+
+async fn operation_lane_worker(
+    sequences: Arc<ActiveSequencesMultiWorker<NoopSequencePublisher>>,
+    lane: Arc<OperationLane>,
+    mut payloads: Box<[LanePayloadSlot]>,
+    request_ids: Box<[String]>,
+    clock: Arc<BenchmarkClock>,
+    ready: oneshot::Sender<()>,
+) -> LaneResult {
+    let mut completions = vec![CompletionRecord::default(); payloads.len()].into_boxed_slice();
+    let mut consumed = 0usize;
+    let mut failure = LaneFailure::None;
+    let _ = ready.send(());
+
+    loop {
+        let published = lane.published.load(Ordering::Acquire);
+        while consumed < published {
+            let id = lane.slots[consumed].load(Ordering::Relaxed);
+            if id == EMPTY_OPERATION_ID {
+                failure = LaneFailure::MissingPublishedId;
+                break;
+            }
+            let Some(payload_slot) = payloads.get_mut(consumed) else {
+                failure = LaneFailure::PayloadOrder;
+                break;
+            };
+            if payload_slot.id != id {
+                failure = LaneFailure::PayloadOrder;
+                break;
+            }
+            let Some(completion_slot) = completions.get_mut(consumed) else {
+                failure = LaneFailure::CompletionOverflow;
+                break;
+            };
+            *completion_slot = execute_payload(
+                sequences.as_ref(),
+                clock.as_ref(),
+                id,
+                &request_ids,
+                payload_slot.payload.take(),
+            );
+            consumed += 1;
+            lane.consumed.store(consumed, Ordering::Release);
+        }
+
+        if failure != LaneFailure::None {
+            break;
+        }
+        if lane.closed.load(Ordering::Acquire) && consumed == lane.published.load(Ordering::Acquire)
+        {
+            break;
+        }
+
+        let notified = lane.notify.notified();
+        if consumed == lane.published.load(Ordering::Acquire)
+            && !lane.closed.load(Ordering::Acquire)
+        {
+            notified.await;
+        }
+    }
+
+    LaneResult {
+        completions,
+        written: consumed,
+        drain_ns: clock.now_ns(),
+        failure,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct IssueRecord {
+    scheduled_ns: u64,
+    accepted_ns: u64,
+    lane: u16,
+    accepted: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IssuerFailure {
+    LaneOverflow,
+    DuplicateOperation,
+    InvalidLane,
+    DispatchMismatch,
+}
+
+struct IssuerOutput {
+    records: Box<[IssueRecord]>,
+    producer_stop_ns: u64,
+    failure: Option<IssuerFailure>,
+}
+
+fn issue_operations(
+    dispatch: Vec<ScheduledOperation>,
+    lanes: Vec<Arc<OperationLane>>,
+    operation_count: usize,
+    clock: Arc<BenchmarkClock>,
+    start_signal: Arc<AtomicU64>,
+    ready: mpsc::SyncSender<()>,
+) -> IssuerOutput {
+    let mut records = vec![IssueRecord::default(); operation_count].into_boxed_slice();
+    let mut lane_cursors = vec![0usize; lanes.len()].into_boxed_slice();
+    let mut touched_flags = vec![false; lanes.len()].into_boxed_slice();
+    let mut touched_lanes = Vec::with_capacity(lanes.len());
+    let mut failure = None;
+    if ready.send(()).is_err() {
+        return IssuerOutput {
+            records,
+            producer_stop_ns: clock.now_ns(),
+            failure: Some(IssuerFailure::DispatchMismatch),
+        };
+    }
+    while start_signal.load(Ordering::Acquire) == 0 {
+        std::hint::spin_loop();
+    }
+    let start_ns = start_signal.load(Ordering::Acquire);
+    let mut operations = dispatch.into_iter().peekable();
+
+    while failure.is_none() {
+        let Some(first) = operations.peek() else {
+            break;
+        };
+        let deadline_ns = first.deadline_ns;
+        clock.wait_until(start_ns.saturating_add(deadline_ns));
+        touched_lanes.clear();
+
+        while operations
+            .peek()
+            .is_some_and(|operation| operation.deadline_ns == deadline_ns)
+        {
+            let Some(operation) = operations.next() else {
+                failure = Some(IssuerFailure::DispatchMismatch);
+                break;
+            };
+            let Some(lane) = lanes.get(operation.lane) else {
+                failure = Some(IssuerFailure::InvalidLane);
+                break;
+            };
+            if let Err(error) = lane.write(lane_cursors[operation.lane], operation.id) {
+                failure = Some(error);
+                break;
+            }
+            lane_cursors[operation.lane] += 1;
+            if !touched_flags[operation.lane] {
+                touched_flags[operation.lane] = true;
+                touched_lanes.push(operation.lane);
+            }
+            let Some(record) = records.get_mut(operation.id as usize) else {
+                failure = Some(IssuerFailure::DuplicateOperation);
+                break;
+            };
+            if record.accepted {
+                failure = Some(IssuerFailure::DuplicateOperation);
+                break;
+            }
+            *record = IssueRecord {
+                scheduled_ns: start_ns.saturating_add(deadline_ns),
+                accepted_ns: clock.now_ns(),
+                lane: operation.lane as u16,
+                accepted: true,
+            };
+        }
+
+        for &lane_id in &touched_lanes {
+            lanes[lane_id].publish(lane_cursors[lane_id]);
+            touched_flags[lane_id] = false;
+        }
+    }
+
+    IssuerOutput {
+        records,
+        producer_stop_ns: clock.now_ns(),
+        failure,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub(crate) struct Distribution {
+    pub(crate) p50_ns: u64,
+    pub(crate) p99_ns: u64,
+    pub(crate) p999_ns: u64,
+    pub(crate) max_ns: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub(crate) struct ActiveSequencesResult {
+    pub(crate) schema_version: u32,
+    pub(crate) timer: &'static str,
+    pub(crate) benchmark_duration_ms: u64,
+    pub(crate) block_size: u32,
+    pub(crate) operation_lanes: usize,
+    pub(crate) total_workers: usize,
+    pub(crate) total_adds: usize,
+    pub(crate) total_prefill_completes: usize,
+    pub(crate) total_frees: usize,
+    pub(crate) total_logical_operations: usize,
+    pub(crate) total_input_blocks: usize,
+    pub(crate) projection_block_visits: usize,
+    pub(crate) add_registration_block_visits: usize,
+    pub(crate) free_release_block_visits: usize,
+    pub(crate) total_logical_block_visits: usize,
+    pub(crate) worker_projections_produced: u64,
+    pub(crate) worker_projections_inspected: u64,
+    pub(crate) worker_projection_digest: u64,
+    pub(crate) offered_logical_ops_per_sec: f64,
+    pub(crate) actual_issue_logical_ops_per_sec: f64,
+    pub(crate) achieved_logical_ops_per_sec: f64,
+    pub(crate) offered_logical_block_visits_per_sec: f64,
+    pub(crate) actual_issue_logical_block_visits_per_sec: f64,
+    pub(crate) achieved_logical_block_visits_per_sec: f64,
+    pub(crate) issue_lag: Distribution,
+    pub(crate) queue_wait: Distribution,
+    pub(crate) scheduled_to_completed: Distribution,
+    pub(crate) project_service: Distribution,
+    pub(crate) add_service: Distribution,
+    pub(crate) project_and_add_service: Distribution,
+    pub(crate) prefill_complete_service: Distribution,
+    pub(crate) free_service: Distribution,
+    pub(crate) delayed_operations: usize,
+    pub(crate) queue_depth_at_stop: Vec<usize>,
+    pub(crate) outstanding_at_stop: usize,
+    pub(crate) maximum_queue_depth: usize,
+    pub(crate) issue_span_ns: u64,
+    pub(crate) drain_ns: u64,
+    pub(crate) issued_operations: usize,
+    pub(crate) completed_operations: usize,
+    pub(crate) successful_operations: usize,
+    pub(crate) exact_ids: bool,
+    pub(crate) per_worker_fifo: bool,
+    pub(crate) zero_fixed_buffer_overflow: bool,
+    pub(crate) issue_span_valid: bool,
+    pub(crate) final_state_empty: bool,
+    pub(crate) generator_valid: bool,
+    pub(crate) kept_up: bool,
+    pub(crate) failure_reasons: Vec<String>,
+}
+
+pub(crate) async fn run_active_sequences_benchmark(
+    corpus: PreparedActiveSequencesCorpus,
+    config: ActiveSequencesRunConfig,
+) -> anyhow::Result<ActiveSequencesResult> {
+    let trial = prepare_active_sequences_trial(corpus, config.operation_lanes)?;
+    run_active_sequences_trial(trial, config).await
+}
+
+async fn run_active_sequences_trial(
+    trial: PreparedActiveSequencesTrial,
+    config: ActiveSequencesRunConfig,
+) -> anyhow::Result<ActiveSequencesResult> {
+    if config.operation_lanes != trial.lane_payloads.len() {
+        anyhow::bail!("Active Sequences run configuration does not match the prepared schedule");
+    }
+    trial.page_touch_untimed();
+
+    let dp_range: HashMap<u64, (u32, u32)> = (0..trial.total_workers as u64)
+        .map(|worker_id| (worker_id, (0, 1)))
+        .collect();
+    let sequences = Arc::new(ActiveSequencesMultiWorker::new_without_expiry(
+        NoopSequencePublisher,
+        trial.block_size as usize,
+        dp_range,
+        false,
+        0,
+        "bench",
+    ));
+    let clock = Arc::new(BenchmarkClock::new(config.spin_us.saturating_mul(1_000))?);
+    let lanes = trial
+        .lane_capacities
+        .iter()
+        .map(|&capacity| Arc::new(OperationLane::new(capacity)))
+        .collect::<Vec<_>>();
+
+    let mut ready_receivers = Vec::with_capacity(lanes.len());
+    let mut lane_tasks = Vec::with_capacity(lanes.len());
+    for ((lane, payloads), request_ids) in lanes
+        .iter()
+        .zip(trial.lane_payloads)
+        .zip(trial.lane_request_ids)
+    {
+        let (ready_tx, ready_rx) = oneshot::channel();
+        ready_receivers.push(ready_rx);
+        lane_tasks.push(tokio::spawn(operation_lane_worker(
+            Arc::clone(&sequences),
+            Arc::clone(lane),
+            payloads,
+            request_ids,
+            Arc::clone(&clock),
+            ready_tx,
+        )));
+    }
+    for receiver in ready_receivers {
+        receiver.await?;
+    }
+
+    let operation_count = trial.operation_workers.len();
+    let start_signal = Arc::new(AtomicU64::new(0));
+    let (issuer_ready_tx, issuer_ready_rx) = mpsc::sync_channel(0);
+    let issuer_handle = std::thread::spawn({
+        let issuer_lanes = lanes.iter().map(Arc::clone).collect::<Vec<_>>();
+        let clock = Arc::clone(&clock);
+        let start_signal = Arc::clone(&start_signal);
+        move || {
+            issue_operations(
+                trial.dispatch,
+                issuer_lanes,
+                operation_count,
+                clock,
+                start_signal,
+                issuer_ready_tx,
+            )
+        }
+    });
+
+    if issuer_ready_rx.recv().is_err() {
+        for lane in &lanes {
+            lane.close();
+        }
+        for task in lane_tasks {
+            let _ = task.await;
+        }
+        let _ = issuer_handle.join();
+        anyhow::bail!("Active Sequences issuer exited before becoming ready");
+    }
+    let start_ns = clock.now_ns().saturating_add(START_LEAD_NS);
+    start_signal.store(start_ns, Ordering::Release);
+    let issuer = match issuer_handle.join() {
+        Ok(issuer) => issuer,
+        Err(_) => {
+            for lane in &lanes {
+                lane.close();
+            }
+            for task in lane_tasks {
+                let _ = task.await;
+            }
+            anyhow::bail!("Active Sequences issuer panicked");
+        }
+    };
+    let queue_depth_at_stop = lanes.iter().map(|lane| lane.depth()).collect::<Vec<_>>();
+    for lane in &lanes {
+        lane.close();
+    }
+
+    let mut lane_results = Vec::with_capacity(lane_tasks.len());
+    for task in lane_tasks {
+        lane_results.push(task.await?);
+    }
+    let end_ns = lane_results
+        .iter()
+        .map(|result| result.drain_ns)
+        .max()
+        .unwrap_or(start_ns);
+
+    let obvious_empty = sequences.active_blocks().values().all(|&count| count == 0)
+        && sequences
+            .active_tokens(tokio::time::Instant::now())
+            .values()
+            .all(|&count| count == 0)
+        && sequences
+            .active_request_counts()
+            .values()
+            .all(|&count| count == 0)
+        && sequences.get_active_lora_counts().is_empty();
+    let all_lane_methods_succeeded = lane_results.iter().all(|result| {
+        result.failure == LaneFailure::None
+            && result.completions[..result.written]
+                .iter()
+                .all(|completion| completion.failure == CompletionFailure::None)
+    });
+    if all_lane_methods_succeeded && obvious_empty {
+        sequences.assert_completely_drained(tokio::time::Instant::now());
+    }
+
+    Ok(analyze_result(
+        &clock,
+        start_ns,
+        end_ns,
+        &trial.operation_workers,
+        &trial.operation_kinds,
+        trial.expected_operations_by_worker,
+        trial.lane_capacities,
+        trial.totals,
+        trial.benchmark_duration_ns,
+        trial.block_size,
+        trial.total_workers,
+        config,
+        issuer,
+        lane_results,
+        queue_depth_at_stop,
+        obvious_empty,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_result(
+    clock: &BenchmarkClock,
+    start_ns: u64,
+    end_ns: u64,
+    operation_workers: &[u64],
+    operation_kinds: &[ActiveOperationKind],
+    expected_operations_by_worker: Vec<(u64, usize)>,
+    lane_capacities: Vec<usize>,
+    totals: ActiveSequencesTotals,
+    benchmark_duration_ns: u64,
+    block_size: u32,
+    total_workers: usize,
+    config: ActiveSequencesRunConfig,
+    issuer: IssuerOutput,
+    lane_results: Vec<LaneResult>,
+    queue_depth_at_stop: Vec<usize>,
+    final_state_empty: bool,
+) -> ActiveSequencesResult {
+    let mut failure_reasons = Vec::new();
+    let mut exact_ids = true;
+    let mut per_worker_fifo = true;
+    let mut zero_fixed_buffer_overflow = true;
+    if let Some(failure) = issuer.failure {
+        exact_ids = false;
+        push_failure(&mut failure_reasons, format!("issuer_{failure:?}"));
+        if failure == IssuerFailure::LaneOverflow {
+            zero_fixed_buffer_overflow = false;
+        }
+    }
+    if !final_state_empty {
+        push_failure(&mut failure_reasons, "final_state_not_empty".to_string());
+    }
+
+    let mut expected_by_lane = vec![Vec::new(); config.operation_lanes];
+    let mut expected_by_worker = BTreeMap::<u64, Vec<u32>>::new();
+    for (id, record) in issuer.records.iter().enumerate() {
+        if !record.accepted {
+            continue;
+        }
+        if let Some(expected) = expected_by_lane.get_mut(record.lane as usize) {
+            expected.push(id as u32);
+        } else {
+            exact_ids = false;
+            push_failure(&mut failure_reasons, "issue_lane_out_of_range".to_string());
+        }
+        if let Some(&worker_id) = operation_workers.get(id) {
+            expected_by_worker
+                .entry(worker_id)
+                .or_default()
+                .push(id as u32);
+        }
+    }
+
+    let mut completions = vec![None; issuer.records.len()];
+    let mut actual_by_worker = BTreeMap::<u64, Vec<u32>>::new();
+    for (lane_id, result) in lane_results.into_iter().enumerate() {
+        if result.failure != LaneFailure::None {
+            if result.failure == LaneFailure::CompletionOverflow {
+                zero_fixed_buffer_overflow = false;
+            }
+            push_failure(
+                &mut failure_reasons,
+                format!("lane_{lane_id}_{:?}", result.failure),
+            );
+        }
+        if result.written != lane_capacities[lane_id] {
+            exact_ids = false;
+            push_failure(&mut failure_reasons, format!("lane_{lane_id}_incomplete"));
+        }
+        let actual_ids = result.completions[..result.written]
+            .iter()
+            .map(|completion| completion.id)
+            .collect::<Vec<_>>();
+        if expected_by_lane.get(lane_id) != Some(&actual_ids) {
+            exact_ids = false;
+            push_failure(&mut failure_reasons, format!("lane_{lane_id}_order"));
+        }
+        for completion in result.completions[..result.written].iter().copied() {
+            let id = completion.id as usize;
+            let Some(slot) = completions.get_mut(id) else {
+                exact_ids = false;
+                push_failure(
+                    &mut failure_reasons,
+                    "completion_id_out_of_range".to_string(),
+                );
+                continue;
+            };
+            if slot.replace(completion).is_some() {
+                exact_ids = false;
+                push_failure(&mut failure_reasons, "duplicate_completion".to_string());
+            }
+            if let Some(&worker_id) = operation_workers.get(id) {
+                actual_by_worker
+                    .entry(worker_id)
+                    .or_default()
+                    .push(completion.id);
+            }
+        }
+    }
+
+    for (worker_id, expected_count) in expected_operations_by_worker {
+        let expected = expected_by_worker.get(&worker_id).map_or(0, Vec::len);
+        if expected != expected_count {
+            exact_ids = false;
+            push_failure(
+                &mut failure_reasons,
+                format!("worker_{worker_id}_issue_count"),
+            );
+        }
+        if actual_by_worker.get(&worker_id) != expected_by_worker.get(&worker_id) {
+            per_worker_fifo = false;
+            push_failure(&mut failure_reasons, format!("worker_{worker_id}_fifo"));
+        }
+    }
+
+    let mut issue_lag = Vec::with_capacity(totals.logical_operations());
+    let mut queue_wait = Vec::with_capacity(totals.logical_operations());
+    let mut scheduled_to_completed = Vec::with_capacity(totals.logical_operations());
+    let mut project_service = Vec::with_capacity(totals.adds);
+    let mut add_service = Vec::with_capacity(totals.adds);
+    let mut project_and_add_service = Vec::with_capacity(totals.adds);
+    let mut prefill_complete_service = Vec::with_capacity(totals.prefill_completes);
+    let mut free_service = Vec::with_capacity(totals.frees);
+    let mut delayed_operations = 0usize;
+    let mut worker_projections_produced = 0u64;
+    let mut worker_projections_inspected = 0u64;
+    let mut worker_projection_digest = 0u64;
+    let mut successful_operations = 0usize;
+    let mut outstanding_at_stop = 0usize;
+    let mut queue_edges = lane_capacities
+        .iter()
+        .map(|&capacity| Vec::with_capacity(capacity.saturating_mul(2)))
+        .collect::<Vec<_>>();
+    let diagnostic_threshold_ns = config
+        .issue_lag_diagnostic_threshold_us
+        .saturating_mul(1_000);
+
+    for id in 0..issuer.records.len() {
+        let issue = issuer.records[id];
+        if !issue.accepted {
+            exact_ids = false;
+            push_failure(&mut failure_reasons, "missing_issue".to_string());
+            continue;
+        }
+        let Some(completion) = completions[id] else {
+            exact_ids = false;
+            push_failure(&mut failure_reasons, "missing_completion".to_string());
+            continue;
+        };
+        if completion.failure != CompletionFailure::None {
+            push_failure(
+                &mut failure_reasons,
+                format!("method_{:?}", completion.failure),
+            );
+        } else {
+            successful_operations += 1;
+        }
+
+        let lag = issue.accepted_ns.saturating_sub(issue.scheduled_ns);
+        issue_lag.push(lag);
+        delayed_operations += usize::from(lag > diagnostic_threshold_ns);
+        queue_wait.push(completion.started_ns.saturating_sub(issue.accepted_ns));
+        scheduled_to_completed.push(completion.finished_ns.saturating_sub(issue.scheduled_ns));
+        let lane = issue.lane as usize;
+        if let Some(edges) = queue_edges.get_mut(lane) {
+            edges.push((issue.accepted_ns, 1));
+            edges.push((completion.started_ns, -1));
+        }
+        if issue.accepted_ns <= issuer.producer_stop_ns
+            && completion.finished_ns > issuer.producer_stop_ns
+        {
+            outstanding_at_stop += 1;
+        }
+
+        match operation_kinds[id] {
+            ActiveOperationKind::ProjectAndAdd => {
+                if completion.projection_count != completion.projection_inspected {
+                    push_failure(
+                        &mut failure_reasons,
+                        "projection_inspection_incomplete".to_string(),
+                    );
+                }
+                project_service.push(
+                    completion
+                        .project_finished_ns
+                        .saturating_sub(completion.started_ns),
+                );
+                add_service.push(
+                    completion
+                        .finished_ns
+                        .saturating_sub(completion.project_finished_ns),
+                );
+                project_and_add_service
+                    .push(completion.finished_ns.saturating_sub(completion.started_ns));
+                worker_projections_produced =
+                    worker_projections_produced.saturating_add(completion.projection_count);
+                worker_projections_inspected =
+                    worker_projections_inspected.saturating_add(completion.projection_inspected);
+                worker_projection_digest = accumulate_projection_digest(
+                    worker_projection_digest,
+                    id as u32,
+                    completion.projection_digest,
+                );
+            }
+            ActiveOperationKind::PrefillComplete => prefill_complete_service
+                .push(completion.finished_ns.saturating_sub(completion.started_ns)),
+            ActiveOperationKind::Free => {
+                free_service.push(completion.finished_ns.saturating_sub(completion.started_ns));
+            }
+        }
+    }
+
+    let maximum_queue_depth = queue_edges
+        .iter_mut()
+        .map(|edges| maximum_depth(edges))
+        .max()
+        .unwrap_or(0);
+    let issue_span_ns = issuer.producer_stop_ns.saturating_sub(start_ns);
+    let drain_ns = end_ns.saturating_sub(issuer.producer_stop_ns);
+    let total_duration_ns = end_ns.saturating_sub(start_ns);
+    let issue_limit_ns = benchmark_duration_ns.saturating_mul(101) / 100;
+    let issue_span_valid = issue_span_ns <= issue_limit_ns;
+    if !issue_span_valid {
+        push_failure(&mut failure_reasons, "issue_span_exceeded".to_string());
+    }
+    let issued_operations = issuer
+        .records
+        .iter()
+        .filter(|record| record.accepted)
+        .count();
+    let completed_operations = completions
+        .iter()
+        .filter(|completion| completion.is_some())
+        .count();
+    exact_ids &= issued_operations == totals.logical_operations()
+        && completed_operations == totals.logical_operations();
+    if !exact_ids {
+        push_failure(&mut failure_reasons, "exact_id_validation".to_string());
+    }
+    if !zero_fixed_buffer_overflow {
+        push_failure(&mut failure_reasons, "fixed_buffer_overflow".to_string());
+    }
+    if successful_operations != totals.logical_operations() {
+        push_failure(
+            &mut failure_reasons,
+            "operation_completion_failure".to_string(),
+        );
+    }
+    let generator_valid = failure_reasons.is_empty();
+    let kept_up =
+        generator_valid && total_duration_ns <= benchmark_duration_ns.saturating_mul(110) / 100;
+    let offered_seconds = (benchmark_duration_ns as f64 / 1e9).max(f64::EPSILON);
+    let issue_seconds = (issue_span_ns as f64 / 1e9).max(f64::EPSILON);
+    let achieved_seconds = (total_duration_ns as f64 / 1e9).max(f64::EPSILON);
+
+    ActiveSequencesResult {
+        schema_version: RESULT_SCHEMA_VERSION,
+        timer: clock.timer_name(),
+        benchmark_duration_ms: benchmark_duration_ns / 1_000_000,
+        block_size,
+        operation_lanes: config.operation_lanes,
+        total_workers,
+        total_adds: totals.adds,
+        total_prefill_completes: totals.prefill_completes,
+        total_frees: totals.frees,
+        total_logical_operations: totals.logical_operations(),
+        total_input_blocks: totals.input_blocks,
+        projection_block_visits: totals.projection_block_visits,
+        add_registration_block_visits: totals.add_registration_block_visits,
+        free_release_block_visits: totals.free_release_block_visits,
+        total_logical_block_visits: totals.logical_block_visits(),
+        worker_projections_produced,
+        worker_projections_inspected,
+        worker_projection_digest,
+        offered_logical_ops_per_sec: totals.logical_operations() as f64 / offered_seconds,
+        actual_issue_logical_ops_per_sec: totals.logical_operations() as f64 / issue_seconds,
+        achieved_logical_ops_per_sec: totals.logical_operations() as f64 / achieved_seconds,
+        offered_logical_block_visits_per_sec: totals.logical_block_visits() as f64
+            / offered_seconds,
+        actual_issue_logical_block_visits_per_sec: totals.logical_block_visits() as f64
+            / issue_seconds,
+        achieved_logical_block_visits_per_sec: totals.logical_block_visits() as f64
+            / achieved_seconds,
+        issue_lag: distribution(issue_lag),
+        queue_wait: distribution(queue_wait),
+        scheduled_to_completed: distribution(scheduled_to_completed),
+        project_service: distribution(project_service),
+        add_service: distribution(add_service),
+        project_and_add_service: distribution(project_and_add_service),
+        prefill_complete_service: distribution(prefill_complete_service),
+        free_service: distribution(free_service),
+        delayed_operations,
+        queue_depth_at_stop,
+        outstanding_at_stop,
+        maximum_queue_depth,
+        issue_span_ns,
+        drain_ns,
+        issued_operations,
+        completed_operations,
+        successful_operations,
+        exact_ids,
+        per_worker_fifo,
+        zero_fixed_buffer_overflow,
+        issue_span_valid,
+        final_state_empty,
+        generator_valid,
+        kept_up,
+        failure_reasons,
+    }
+}
+
+fn push_failure(failures: &mut Vec<String>, failure: String) {
+    if !failures.contains(&failure) {
+        failures.push(failure);
+    }
+}
+
+fn maximum_depth(edges: &mut [(u64, i8)]) -> usize {
+    edges.sort_unstable_by(|left, right| left.0.cmp(&right.0).then_with(|| right.1.cmp(&left.1)));
+    let mut depth = 0isize;
+    let mut maximum = 0isize;
+    for &(_, delta) in edges.iter() {
+        depth += delta as isize;
+        maximum = maximum.max(depth);
+    }
+    maximum.max(0) as usize
+}
+
+fn distribution(mut values: Vec<u64>) -> Distribution {
+    if values.is_empty() {
+        return Distribution::default();
+    }
+    values.sort_unstable();
+    Distribution {
+        p50_ns: nearest_rank(&values, 50, 100),
+        p99_ns: nearest_rank(&values, 99, 100),
+        p999_ns: nearest_rank(&values, 999, 1_000),
+        max_ns: values.last().copied().unwrap_or_default(),
+    }
+}
+
+fn nearest_rank(values: &[u64], numerator: usize, denominator: usize) -> u64 {
+    let rank = values
+        .len()
+        .saturating_mul(numerator)
+        .div_ceil(denominator)
+        .max(1);
+    values[rank.saturating_sub(1).min(values.len() - 1)]
+}
+
+struct BenchmarkClock {
+    epoch: Instant,
+    spin_ns: u64,
+    #[cfg(target_os = "linux")]
+    monotonic_epoch_ns: u64,
+}
+
+impl BenchmarkClock {
+    fn new(spin_ns: u64) -> anyhow::Result<Self> {
+        #[cfg(target_os = "linux")]
+        let monotonic_epoch_ns = monotonic_now_ns()?;
+        Ok(Self {
+            epoch: Instant::now(),
+            spin_ns,
+            #[cfg(target_os = "linux")]
+            monotonic_epoch_ns,
+        })
+    }
+
+    fn now_ns(&self) -> u64 {
+        self.epoch.elapsed().as_nanos().min(u64::MAX as u128) as u64
+    }
+
+    fn wait_until(&self, target_ns: u64) {
+        let sleep_target = target_ns.saturating_sub(self.spin_ns);
+        let now = self.now_ns();
+        #[cfg(target_os = "linux")]
+        if sleep_target > now {
+            sleep_until_monotonic(self.monotonic_epoch_ns.saturating_add(sleep_target));
+        }
+        #[cfg(not(target_os = "linux"))]
+        if sleep_target > now {
+            std::thread::sleep(Duration::from_nanos(sleep_target - now));
+        }
+        while self.now_ns() < target_ns {
+            std::hint::spin_loop();
+        }
+    }
+
+    fn timer_name(&self) -> &'static str {
+        if cfg!(target_os = "linux") {
+            "clock_nanosleep_monotonic_absolute"
+        } else {
+            "portable_sleep_spin_non_authoritative"
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn monotonic_now_ns() -> anyhow::Result<u64> {
+    let mut timestamp = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut timestamp) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok((timestamp.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(timestamp.tv_nsec as u64))
+}
+
+#[cfg(target_os = "linux")]
+fn sleep_until_monotonic(target_ns: u64) {
+    let request = libc::timespec {
+        tv_sec: (target_ns / 1_000_000_000) as libc::time_t,
+        tv_nsec: (target_ns % 1_000_000_000) as libc::c_long,
+    };
+    loop {
+        let rc = unsafe {
+            libc::clock_nanosleep(
+                libc::CLOCK_MONOTONIC,
+                libc::TIMER_ABSTIME,
+                &request,
+                std::ptr::null_mut(),
+            )
+        };
+        if rc == 0 {
+            return;
+        }
+        if rc != libc::EINTR {
+            return;
+        }
+    }
+}
+
+#[cfg(test)]
+#[allow(dead_code, unused_imports)]
+mod tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+
+    use super::{
+        ActiveOperationKind, ActiveSequencesRunConfig, BenchmarkClock, CompletionFailure,
+        IssuerFailure, LanePayload, LanePayloadSlot, OperationLane,
+        prepare_active_sequences_corpus, run_active_sequences_benchmark,
+    };
+    use crate::active_sequences_shared::{SequenceTrace, SequenceTraceEntry};
+    use dynamo_bench::kv_router_common::replay::NoopSequencePublisher;
+    use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
+    use dynamo_kv_router::{ActiveSequencesMultiWorker, SequenceRequest};
+
+    fn add(request_id: &str, hashes: &[u64], timestamp_us: u64) -> SequenceTrace {
+        SequenceTrace {
+            entry: SequenceTraceEntry::Add {
+                request_id: request_id.to_string(),
+                block_hashes: hashes.to_vec(),
+                isl: hashes.len() * 128,
+                output_length: 8,
+            },
+            timestamp_us,
+        }
+    }
+
+    fn prefill(request_id: &str, timestamp_us: u64) -> SequenceTrace {
+        SequenceTrace {
+            entry: SequenceTraceEntry::PrefillComplete {
+                request_id: request_id.to_string(),
+            },
+            timestamp_us,
+        }
+    }
+
+    fn free(request_id: &str, timestamp_us: u64) -> SequenceTrace {
+        SequenceTrace {
+            entry: SequenceTraceEntry::Free {
+                request_id: request_id.to_string(),
+            },
+            timestamp_us,
+        }
+    }
+
+    fn request(request_id: &str, hashes: &[u64]) -> SequenceRequest {
+        SequenceRequest {
+            request_id: request_id.to_string(),
+            token_sequence: Some(hashes.to_vec()),
+            track_prefill_tokens: true,
+            expected_output_tokens: Some(8),
+            prefill_load_hint: Some(PrefillLoadHint {
+                initial_effective_prefill_tokens: hashes.len() * 128,
+                expected_prefill_duration: None,
+            }),
+            worker: WorkerWithDpRank::from_worker_id(0),
+            lora_name: None,
+        }
+    }
+
+    #[test]
+    fn preparation_normalizes_each_worker_and_preserves_equal_deadline_source_order() {
+        let traces = vec![
+            vec![add("a", &[1, 2], 10), prefill("a", 10), free("a", 20)],
+            vec![add("b", &[3], 1_000), prefill("b", 1_000), free("b", 1_010)],
+        ];
+        let corpus = prepare_active_sequences_corpus(traces, 128, 1_000, 1).unwrap();
+
+        for worker_id in 0..2 {
+            let worker_ops = corpus
+                .operations
+                .iter()
+                .filter(|operation| operation.worker_id == worker_id)
+                .collect::<Vec<_>>();
+            assert_eq!(worker_ops.first().unwrap().deadline_ns, 0);
+            assert_eq!(worker_ops.last().unwrap().deadline_ns, 1_000_000_000);
+            assert_eq!(
+                worker_ops
+                    .iter()
+                    .take(2)
+                    .map(|operation| operation.kind)
+                    .collect::<Vec<_>>(),
+                [
+                    ActiveOperationKind::ProjectAndAdd,
+                    ActiveOperationKind::PrefillComplete,
+                ]
+            );
+            assert_eq!(worker_ops[0].source_ordinal, 0);
+            assert_eq!(worker_ops[1].source_ordinal, 1);
+        }
+    }
+
+    #[test]
+    fn preparation_flattens_hashes_and_counts_logical_block_visits() {
+        let traces = vec![vec![
+            add("a", &[1, 2], 0),
+            prefill("a", 0),
+            add("b", &[3], 0),
+            prefill("b", 0),
+            free("a", 1),
+            free("b", 1),
+        ]];
+        let corpus = prepare_active_sequences_corpus(traces, 128, 100, 1).unwrap();
+        let add_operations = corpus
+            .operations
+            .iter()
+            .filter(|operation| operation.kind == ActiveOperationKind::ProjectAndAdd)
+            .map(|operation| {
+                (
+                    operation.source_ordinal,
+                    corpus.operation_hashes(operation.id).unwrap().to_vec(),
+                )
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(add_operations, [(0, vec![1, 2]), (2, vec![3]),]);
+        let totals = corpus.totals();
+        assert_eq!(totals.adds, 2);
+        assert_eq!(totals.prefill_completes, 2);
+        assert_eq!(totals.frees, 2);
+        assert_eq!(totals.input_blocks, 3);
+        assert_eq!(totals.projection_block_visits, 3);
+        assert_eq!(totals.add_registration_block_visits, 3);
+        assert_eq!(totals.free_release_block_visits, 3);
+        assert_eq!(totals.logical_block_visits(), 9);
+    }
+
+    #[test]
+    fn preparation_rejects_invalid_lifecycle() {
+        let error = prepare_active_sequences_corpus(vec![vec![free("missing", 0)]], 128, 100, 1)
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("freed before Add"));
+
+        let error =
+            prepare_active_sequences_corpus(vec![vec![add("unfinished", &[1], 0)]], 128, 100, 1)
+                .unwrap_err()
+                .to_string();
+        assert!(error.contains("without a final Free"));
+
+        let error = prepare_active_sequences_corpus(
+            vec![vec![add("unordered", &[1], 20), free("unordered", 10)]],
+            128,
+            100,
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("timestamps are not ordered"));
+
+        let error = prepare_active_sequences_corpus(
+            vec![vec![add("zero", &[1], 0), free("zero", 1)]],
+            128,
+            0,
+            1,
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("replay window must be positive"));
+    }
+
+    #[test]
+    fn fixed_lane_reports_overflow() {
+        let lane = OperationLane::new(1);
+        assert!(lane.write(0, 1).is_ok());
+        assert_eq!(lane.write(1, 2), Err(IssuerFailure::LaneOverflow));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn fixed_lane_does_not_lose_publish_before_wait() {
+        let lane = Arc::new(OperationLane::new(1));
+        lane.write(0, 7).unwrap();
+        lane.publish(1);
+        lane.close();
+        let sequences = Arc::new(ActiveSequencesMultiWorker::new_without_expiry(
+            NoopSequencePublisher,
+            128,
+            HashMap::from([(0, (0, 1))]),
+            false,
+            0,
+            "bench",
+        ));
+        let clock = Arc::new(BenchmarkClock::new(0).unwrap());
+        let (ready_tx, _ready_rx) = tokio::sync::oneshot::channel();
+        let result = super::operation_lane_worker(
+            sequences,
+            lane,
+            vec![LanePayloadSlot {
+                id: 7,
+                payload: Some(LanePayload::Free(0)),
+            }]
+            .into_boxed_slice(),
+            vec!["missing".to_string()].into_boxed_slice(),
+            clock,
+            ready_tx,
+        )
+        .await;
+        assert_eq!(result.written, 1);
+        assert_eq!(result.failure, super::LaneFailure::None);
+    }
+
+    #[test]
+    fn direct_executor_records_sequence_errors() {
+        let sequences = ActiveSequencesMultiWorker::new_without_expiry(
+            NoopSequencePublisher,
+            128,
+            HashMap::from([(0, (0, 1))]),
+            false,
+            0,
+            "bench",
+        );
+        let now = tokio::time::Instant::now();
+        sequences
+            .add_request(request("duplicate", &[1]), now)
+            .unwrap();
+        let clock = BenchmarkClock::new(0).unwrap();
+        let completion = super::execute_payload(
+            &sequences,
+            &clock,
+            0,
+            &[],
+            Some(LanePayload::ProjectAndAdd(request("duplicate", &[1]))),
+        );
+        assert_eq!(completion.failure, CompletionFailure::DuplicateRequest);
+        sequences.free(&"duplicate".to_string(), now).unwrap();
+        sequences.assert_completely_drained(now);
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn small_replay_has_exact_ids_timed_drain_and_stable_json_shape() {
+        let corpus = prepare_active_sequences_corpus(
+            vec![vec![add("a", &[1, 2], 10), prefill("a", 10), free("a", 10)]],
+            128,
+            100,
+            1,
+        )
+        .unwrap();
+        let result = run_active_sequences_benchmark(
+            corpus,
+            ActiveSequencesRunConfig {
+                operation_lanes: 1,
+                spin_us: 50,
+                issue_lag_diagnostic_threshold_us: 250,
+            },
+        )
+        .await
+        .unwrap();
+        assert!(result.generator_valid, "{:?}", result.failure_reasons);
+        assert!(result.final_state_empty);
+        assert!(result.exact_ids);
+        assert!(result.per_worker_fifo);
+        assert!(result.zero_fixed_buffer_overflow);
+        assert!(result.issue_span_valid);
+        assert_eq!(result.total_logical_operations, 3);
+        assert_eq!(result.issued_operations, 3);
+        assert_eq!(result.completed_operations, 3);
+        assert_eq!(result.successful_operations, 3);
+        assert_eq!(result.total_logical_block_visits, 6);
+        assert_eq!(result.worker_projections_produced, 1);
+        assert_eq!(result.worker_projections_inspected, 1);
+        assert_eq!(result.queue_depth_at_stop.len(), 1);
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["schema_version"], 1);
+        assert_eq!(json["total_adds"], 1);
+        assert_eq!(json["total_prefill_completes"], 1);
+        assert_eq!(json["total_frees"], 1);
+        assert_eq!(json["failure_reasons"], serde_json::json!([]));
+    }
+}

--- a/lib/bench/kv_router/active_sequences_shared.rs
+++ b/lib/bench/kv_router/active_sequences_shared.rs
@@ -2,21 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::hint::black_box;
-use std::sync::Arc;
 
-use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
-use dynamo_kv_router::{ActiveSequencesMultiWorker, SequenceRequest};
 use dynamo_mocker::loadgen::Trace;
 use dynamo_tokens::SequenceHash;
-use tokio::time::{Duration, Instant};
 
-use dynamo_bench::kv_router_common::replay::{NoopSequencePublisher, generate_replay_artifacts};
-use dynamo_bench::kv_router_common::results::{BenchmarkRun, compute_benchmark_run};
-use dynamo_bench::kv_router_common::trace_gen::{ReplayStartGate, WorkerTimelines};
+use dynamo_bench::kv_router_common::replay::generate_replay_artifacts;
 
 /// A single timestamped entry in a worker's sequence trace.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum SequenceTraceEntry {
     Add {
         request_id: String,
@@ -33,7 +26,7 @@ pub enum SequenceTraceEntry {
 }
 
 /// A timestamped sequence trace entry for benchmark replay.
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SequenceTrace {
     pub entry: SequenceTraceEntry,
     pub timestamp_us: u64,
@@ -66,20 +59,20 @@ pub async fn generate_sequence_events(
     let mut all_traces = Vec::with_capacity(artifacts.len());
 
     for artifact in artifacts {
-        let metadata = artifact
+        let mut metadata = artifact
             .requests
-            .iter()
+            .into_iter()
             .map(|request| {
-                (
+                Ok((
                     request.uuid,
                     RequestMetadata {
-                        block_hashes: request.replay_hashes.sequence_hashes.clone(),
+                        block_hashes: request.replay_hashes.sequence_hashes,
                         isl: request.input_length,
-                        output_length: request.output_length as u64,
+                        output_length: u64::try_from(request.output_length)?,
                     },
-                )
+                ))
             })
-            .collect::<HashMap<_, _>>();
+            .collect::<anyhow::Result<HashMap<_, _>>>()?;
 
         let mut entries = Vec::new();
         let mut seen = HashMap::new();
@@ -90,23 +83,24 @@ pub async fn generate_sequence_events(
 
             if let std::collections::hash_map::Entry::Vacant(entry) = seen.entry(signal.uuid) {
                 entry.insert(());
-                if let Some(meta) = metadata.get(&signal.uuid) {
-                    entries.push(SequenceTrace {
-                        entry: SequenceTraceEntry::Add {
-                            request_id: request_id.clone(),
-                            block_hashes: meta.block_hashes.clone(),
-                            isl: meta.isl,
-                            output_length: meta.output_length,
-                        },
-                        timestamp_us: timed_signal.timestamp_us,
-                    });
-                    entries.push(SequenceTrace {
-                        entry: SequenceTraceEntry::PrefillComplete {
-                            request_id: request_id.clone(),
-                        },
-                        timestamp_us: timed_signal.timestamp_us,
-                    });
-                }
+                let meta = metadata.remove(&signal.uuid).ok_or_else(|| {
+                    anyhow::anyhow!("output signal references unknown request {}", signal.uuid)
+                })?;
+                entries.push(SequenceTrace {
+                    entry: SequenceTraceEntry::Add {
+                        request_id: request_id.clone(),
+                        block_hashes: meta.block_hashes,
+                        isl: meta.isl,
+                        output_length: meta.output_length,
+                    },
+                    timestamp_us: timed_signal.timestamp_us,
+                });
+                entries.push(SequenceTrace {
+                    entry: SequenceTraceEntry::PrefillComplete {
+                        request_id: request_id.clone(),
+                    },
+                    timestamp_us: timed_signal.timestamp_us,
+                });
             }
 
             if signal.completed {
@@ -134,196 +128,4 @@ pub async fn generate_sequence_events(
     println!("Add events: {}, Free events: {}", total_adds, total_frees);
 
     Ok(all_traces)
-}
-
-/// Run the benchmark: replay sequence trace entries against a shared
-/// ActiveSequencesMultiWorker, measuring project_worker_loads /
-/// add_request / mark_prefill_completed / free latency.
-pub async fn run_benchmark(
-    traces: &[Vec<SequenceTrace>],
-    block_size: u32,
-    benchmark_duration_ms: u64,
-    inference_worker_duplication_factor: usize,
-) -> anyhow::Result<BenchmarkRun> {
-    let scaled = WorkerTimelines::from_rescaled(
-        traces,
-        benchmark_duration_ms,
-        |entry| entry.timestamp_us,
-        |entry, timestamp_us| SequenceTrace {
-            entry: entry.entry.clone(),
-            timestamp_us,
-        },
-    );
-    let num_trace_workers = scaled.len();
-
-    let total_workers = num_trace_workers * inference_worker_duplication_factor;
-    let dp_range: HashMap<u64, (u32, u32)> =
-        (0..total_workers as u64).map(|id| (id, (0, 1))).collect();
-    let multi = Arc::new(ActiveSequencesMultiWorker::new(
-        NoopSequencePublisher,
-        block_size as usize,
-        dp_range,
-        false,
-        0,
-        "bench",
-    ));
-
-    let total_blocks: usize = scaled
-        .iter()
-        .flat_map(|t| t.iter())
-        .map(|entry| match &entry.entry {
-            SequenceTraceEntry::Add { block_hashes, .. } => block_hashes.len(),
-            _ => 0,
-        })
-        .sum::<usize>()
-        * inference_worker_duplication_factor;
-
-    let mut tasks = Vec::new();
-    let start_gate = ReplayStartGate::new(total_workers);
-    for replica in 0..inference_worker_duplication_factor {
-        for (trace_idx, worker_trace) in scaled.iter().enumerate() {
-            let worker_id = (replica * num_trace_workers + trace_idx) as u64;
-            let worker = WorkerWithDpRank::from_worker_id(worker_id);
-            let trace = make_unique_trace(worker_trace, worker_id);
-            let multi = Arc::clone(&multi);
-            let start_gate = start_gate.clone();
-
-            tasks.push(tokio::spawn(async move {
-                let capacity = trace.len();
-                let mut latencies: Vec<u64> = Vec::with_capacity(capacity);
-
-                start_gate.wait_for_start().await;
-
-                let mut target = Instant::now();
-                let mut iter = trace.into_iter().peekable();
-
-                while let Some(entry) = iter.next() {
-                    let entry_ts = entry.timestamp_us;
-
-                    let start = minstant::Instant::now();
-                    apply_entry(&multi, worker, entry.entry).await;
-                    latencies.push(start.elapsed().as_nanos() as u64);
-
-                    while iter.peek().is_some_and(|e| e.timestamp_us == entry_ts) {
-                        let e = iter.next().unwrap();
-                        let start = minstant::Instant::now();
-                        apply_entry(&multi, worker, e.entry).await;
-                        latencies.push(start.elapsed().as_nanos() as u64);
-                    }
-
-                    if let Some(next) = iter.peek() {
-                        target += Duration::from_micros(next.timestamp_us - entry_ts);
-                    }
-
-                    if target > Instant::now() {
-                        tokio::time::sleep_until(target).await;
-                    }
-                }
-
-                Ok::<_, anyhow::Error>(latencies)
-            }));
-        }
-    }
-
-    let started_at = start_gate.start().await;
-
-    let mut all_latencies = Vec::new();
-    for task in tasks {
-        all_latencies.extend(task.await??);
-    }
-
-    let total_duration = started_at.elapsed();
-    multi.assert_completely_drained(Instant::now());
-
-    let run = compute_benchmark_run(
-        all_latencies.len(),
-        total_blocks,
-        benchmark_duration_ms,
-        total_duration,
-        all_latencies,
-    );
-
-    println!(
-        "Ops Throughput: offered={} ops/s achieved={} ops/s (project_worker_loads + add + prefill_complete + free)",
-        run.results.offered_ops_throughput, run.results.ops_throughput
-    );
-    println!(
-        "Block Throughput: offered={} block ops/s achieved={} block ops/s",
-        run.results.offered_block_throughput, run.results.block_throughput
-    );
-    println!("Latency p99: {}us", run.results.latency_p99_us);
-
-    Ok(run)
-}
-
-fn make_unique_trace(trace: &[SequenceTrace], worker_id: u64) -> Vec<SequenceTrace> {
-    trace
-        .iter()
-        .map(|entry| {
-            let new_entry = match &entry.entry {
-                SequenceTraceEntry::Add {
-                    request_id,
-                    block_hashes,
-                    isl,
-                    output_length,
-                } => SequenceTraceEntry::Add {
-                    request_id: format!("{worker_id}:{request_id}"),
-                    block_hashes: block_hashes.clone(),
-                    isl: *isl,
-                    output_length: *output_length,
-                },
-                SequenceTraceEntry::PrefillComplete { request_id } => {
-                    SequenceTraceEntry::PrefillComplete {
-                        request_id: format!("{worker_id}:{request_id}"),
-                    }
-                }
-                SequenceTraceEntry::Free { request_id } => SequenceTraceEntry::Free {
-                    request_id: format!("{worker_id}:{request_id}"),
-                },
-            };
-            SequenceTrace {
-                entry: new_entry,
-                timestamp_us: entry.timestamp_us,
-            }
-        })
-        .collect()
-}
-
-async fn apply_entry(
-    multi: &ActiveSequencesMultiWorker<NoopSequencePublisher>,
-    worker: WorkerWithDpRank,
-    entry: SequenceTraceEntry,
-) {
-    let decay_now = tokio::time::Instant::now();
-    match entry {
-        SequenceTraceEntry::Add {
-            request_id,
-            block_hashes,
-            isl,
-            output_length,
-        } => {
-            black_box(multi.project_worker_loads(Some(&block_hashes), decay_now));
-            let _ = multi.add_request(
-                SequenceRequest {
-                    request_id,
-                    token_sequence: Some(block_hashes),
-                    track_prefill_tokens: true,
-                    expected_output_tokens: Some(output_length as u32),
-                    prefill_load_hint: Some(PrefillLoadHint {
-                        initial_effective_prefill_tokens: isl,
-                        expected_prefill_duration: None,
-                    }),
-                    worker,
-                    lora_name: None,
-                },
-                decay_now,
-            );
-        }
-        SequenceTraceEntry::PrefillComplete { request_id } => {
-            let _ = multi.mark_prefill_completed(&request_id, decay_now);
-        }
-        SequenceTraceEntry::Free { request_id } => {
-            let _ = multi.free(&request_id, decay_now);
-        }
-    }
 }

--- a/lib/bench/kv_router/common/trace_gen.rs
+++ b/lib/bench/kv_router/common/trace_gen.rs
@@ -1,11 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
-
-use tokio::sync::Barrier;
-use tokio::time::Instant;
-
 #[derive(Clone, Debug, Default)]
 pub struct WorkerTimelines<T> {
     entries: Vec<Vec<T>>,
@@ -13,41 +8,6 @@ pub struct WorkerTimelines<T> {
 
 impl<T> WorkerTimelines<T> {
     pub fn new(entries: Vec<Vec<T>>) -> Self {
-        Self { entries }
-    }
-
-    pub fn from_rescaled<S, GetTimestamp, WithTimestamp>(
-        entries: &[Vec<S>],
-        benchmark_duration_ms: u64,
-        timestamp_of: GetTimestamp,
-        with_timestamp: WithTimestamp,
-    ) -> Self
-    where
-        GetTimestamp: Fn(&S) -> u64 + Copy,
-        WithTimestamp: Fn(&S, u64) -> T + Copy,
-    {
-        let target_us = u128::from(benchmark_duration_ms) * 1000;
-
-        let entries = entries
-            .iter()
-            .map(|worker_trace| {
-                if worker_trace.is_empty() {
-                    return Vec::new();
-                }
-
-                let max_timestamp_us = worker_trace.last().map(timestamp_of).unwrap_or(1).max(1);
-
-                worker_trace
-                    .iter()
-                    .map(|entry| {
-                        let scaled_timestamp = u128::from(timestamp_of(entry)) * target_us
-                            / u128::from(max_timestamp_us);
-                        with_timestamp(entry, scaled_timestamp.min(u128::from(u64::MAX)) as u64)
-                    })
-                    .collect()
-            })
-            .collect();
-
         Self { entries }
     }
 
@@ -67,149 +27,50 @@ impl<T> WorkerTimelines<T> {
         self.entries
     }
 
-    pub fn rescale<GetTimestamp, WithTimestamp>(
-        &self,
+    pub fn into_rescaled_from_first<GetTimestamp, WithTimestamp>(
+        self,
         benchmark_duration_ms: u64,
         timestamp_of: GetTimestamp,
         with_timestamp: WithTimestamp,
     ) -> Self
     where
         GetTimestamp: Fn(&T) -> u64 + Copy,
-        WithTimestamp: Fn(&T, u64) -> T + Copy,
+        WithTimestamp: Fn(T, u64) -> T + Copy,
     {
-        Self::from_rescaled(
-            &self.entries,
-            benchmark_duration_ms,
-            timestamp_of,
-            with_timestamp,
-        )
-    }
-}
+        let target_us = u128::from(benchmark_duration_ms) * 1000;
+        let entries = self
+            .entries
+            .into_iter()
+            .map(|worker_trace| {
+                let Some(first_timestamp_us) = worker_trace.first().map(timestamp_of) else {
+                    return Vec::new();
+                };
+                let span_us = worker_trace
+                    .last()
+                    .map(timestamp_of)
+                    .unwrap_or(first_timestamp_us)
+                    .saturating_sub(first_timestamp_us)
+                    .max(1);
 
-pub struct TimelineSource<'a, T> {
-    worker_idx: usize,
-    source: &'static str,
-    entries: &'a [T],
-}
+                worker_trace
+                    .into_iter()
+                    .map(|entry| {
+                        let relative_us = timestamp_of(&entry).saturating_sub(first_timestamp_us);
+                        let scaled_timestamp =
+                            u128::from(relative_us) * target_us / u128::from(span_us);
+                        with_timestamp(entry, scaled_timestamp.min(u128::from(u64::MAX)) as u64)
+                    })
+                    .collect()
+            })
+            .collect();
 
-impl<'a, T> TimelineSource<'a, T> {
-    pub fn new(worker_idx: usize, source: &'static str, entries: &'a [T]) -> Self {
-        Self {
-            worker_idx,
-            source,
-            entries,
-        }
-    }
-
-    pub fn validate_order(&self, timestamp_of: impl Fn(&T) -> u64) -> anyhow::Result<()> {
-        for i in 1..self.entries.len() {
-            let prev = timestamp_of(&self.entries[i - 1]);
-            let curr = timestamp_of(&self.entries[i]);
-            if curr < prev {
-                anyhow::bail!(
-                    "worker {} {} timestamps are not ordered at index {}: prev={}, curr={}",
-                    self.worker_idx,
-                    self.source,
-                    i,
-                    prev,
-                    curr
-                );
-            }
-        }
-
-        Ok(())
-    }
-}
-
-pub struct OrderedMerge<'a, L, R> {
-    left: TimelineSource<'a, L>,
-    right: TimelineSource<'a, R>,
-}
-
-impl<'a, L, R> OrderedMerge<'a, L, R> {
-    pub fn left_first(
-        worker_idx: usize,
-        left_source: &'static str,
-        left: &'a [L],
-        right_source: &'static str,
-        right: &'a [R],
-    ) -> Self {
-        Self {
-            left: TimelineSource::new(worker_idx, left_source, left),
-            right: TimelineSource::new(worker_idx, right_source, right),
-        }
-    }
-
-    pub fn merge<T, LeftTimestamp, RightTimestamp, MapLeft, MapRight>(
-        &self,
-        left_timestamp: LeftTimestamp,
-        right_timestamp: RightTimestamp,
-        map_left: MapLeft,
-        map_right: MapRight,
-    ) -> anyhow::Result<Vec<T>>
-    where
-        LeftTimestamp: Fn(&L) -> u64 + Copy,
-        RightTimestamp: Fn(&R) -> u64 + Copy,
-        MapLeft: Fn(&L) -> T,
-        MapRight: Fn(&R) -> T,
-    {
-        self.left.validate_order(left_timestamp)?;
-        self.right.validate_order(right_timestamp)?;
-
-        let mut left_idx = 0;
-        let mut right_idx = 0;
-        let mut merged = Vec::with_capacity(self.left.entries.len() + self.right.entries.len());
-
-        while left_idx < self.left.entries.len() || right_idx < self.right.entries.len() {
-            let take_left = right_idx >= self.right.entries.len()
-                || left_idx < self.left.entries.len()
-                    && left_timestamp(&self.left.entries[left_idx])
-                        <= right_timestamp(&self.right.entries[right_idx]);
-
-            if take_left {
-                merged.push(map_left(&self.left.entries[left_idx]));
-                left_idx += 1;
-                continue;
-            }
-
-            merged.push(map_right(&self.right.entries[right_idx]));
-            right_idx += 1;
-        }
-
-        Ok(merged)
-    }
-}
-
-#[derive(Clone)]
-pub struct ReplayStartGate {
-    ready_barrier: Arc<Barrier>,
-    start_barrier: Arc<Barrier>,
-}
-
-impl ReplayStartGate {
-    pub fn new(num_workers: usize) -> Self {
-        Self {
-            ready_barrier: Arc::new(Barrier::new(num_workers + 1)),
-            start_barrier: Arc::new(Barrier::new(num_workers + 1)),
-        }
-    }
-
-    pub async fn wait_for_start(&self) {
-        self.ready_barrier.wait().await;
-        self.start_barrier.wait().await;
-    }
-
-    pub async fn start(&self) -> Instant {
-        self.ready_barrier.wait().await;
-        let started_at = Instant::now();
-        self.start_barrier.wait().await;
-        started_at
+        Self { entries }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{OrderedMerge, WorkerTimelines};
+    use super::WorkerTimelines;
 
     #[derive(Clone, Debug, PartialEq, Eq)]
     struct Entry {
@@ -222,65 +83,8 @@ mod tests {
     }
 
     #[test]
-    fn ordered_merge_is_left_first_on_equal_timestamps() {
-        let reads = [
-            Entry {
-                timestamp_us: 10,
-                label: "r10",
-            },
-            Entry {
-                timestamp_us: 20,
-                label: "r20",
-            },
-        ];
-        let writes = [
-            Entry {
-                timestamp_us: 10,
-                label: "w10",
-            },
-            Entry {
-                timestamp_us: 30,
-                label: "w30",
-            },
-        ];
-
-        let merged = OrderedMerge::left_first(0, "reads", &reads, "writes", &writes)
-            .merge(ts, ts, |entry| entry.label, |entry| entry.label)
-            .unwrap();
-
-        assert_eq!(merged, ["r10", "w10", "r20", "w30"]);
-    }
-
-    #[test]
-    fn ordered_merge_rejects_unordered_sources_with_context() {
-        let reads = [
-            Entry {
-                timestamp_us: 20,
-                label: "late",
-            },
-            Entry {
-                timestamp_us: 10,
-                label: "early",
-            },
-        ];
-        let writes = [Entry {
-            timestamp_us: 30,
-            label: "write",
-        }];
-
-        let err = OrderedMerge::left_first(7, "reads", &reads, "writes", &writes)
-            .merge(ts, ts, |entry| entry.label, |entry| entry.label)
-            .unwrap_err()
-            .to_string();
-
-        assert!(err.contains("worker 7 reads timestamps are not ordered at index 1"));
-        assert!(err.contains("prev=20, curr=10"));
-    }
-
-    #[test]
-    fn worker_timelines_rescale_empty_and_nonzero_start_traces() {
+    fn worker_timelines_rescale_from_each_workers_first_entry() {
         let timelines = WorkerTimelines::new(vec![
-            Vec::new(),
             vec![
                 Entry {
                     timestamp_us: 10,
@@ -291,16 +95,27 @@ mod tests {
                     label: "b",
                 },
             ],
+            vec![
+                Entry {
+                    timestamp_us: 1_000,
+                    label: "c",
+                },
+                Entry {
+                    timestamp_us: 1_010,
+                    label: "d",
+                },
+            ],
         ]);
 
-        let scaled = timelines.rescale(1_000, ts, |entry, timestamp_us| Entry {
+        let scaled = timelines.into_rescaled_from_first(1_000, ts, |entry, timestamp_us| Entry {
             timestamp_us,
             label: entry.label,
         });
         let scaled = scaled.into_inner();
 
-        assert!(scaled[0].is_empty());
-        assert_eq!(scaled[1][0].timestamp_us, 500_000);
+        assert_eq!(scaled[0][0].timestamp_us, 0);
+        assert_eq!(scaled[0][1].timestamp_us, 1_000_000);
+        assert_eq!(scaled[1][0].timestamp_us, 0);
         assert_eq!(scaled[1][1].timestamp_us, 1_000_000);
     }
 }

--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -1,26 +1,33 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[path = "mooncake_open_loop.rs"]
+mod mooncake_open_loop;
 #[path = "mooncake_shared.rs"]
 mod mooncake_shared;
 
 use clap::{Parser, Subcommand};
 use dynamo_bench::kv_router_common::args::CommonArgs;
 use dynamo_bench::kv_router_common::replay::{generate_replay_artifacts, process_mooncake_trace};
-use dynamo_bench::kv_router_common::results::{
-    BenchmarkResults, print_benchmark_results_percentiles,
+use dynamo_bench::kv_router_common::sweep::compute_sweep_durations;
+use dynamo_kv_router::indexer::KvIndexerMetrics;
+use dynamo_kv_router::{
+    ConcurrentRadixTree, ConcurrentRadixTreeCompressed, PositionalIndexer, ThreadPoolIndexer,
 };
-use dynamo_bench::kv_router_common::sweep::{compute_sweep_durations, print_sweep_summary};
-use dynamo_kv_router::indexer::{KvIndexerInterface, KvIndexerMetrics, ShardSizeSnapshot};
+use mooncake_open_loop::{
+    OpenLoopConfig, OpenLoopResult, parse_cpu_list, pin_current_thread_to_cpus,
+    prepare_mooncake_corpus, prepare_open_loop_trial, run_open_loop, validate_cpu_partition,
+};
 use mooncake_shared::{
-    MooncakeBenchmarkConfig, MooncakeBenchmarkInput, MooncakeIndexerConfig,
-    PreparedMooncakeBenchmark, merge_worker_traces, prepare_scaled_benchmark,
-    run_prepared_benchmark,
+    MooncakeBenchmarkConfig, MooncakeIndexerConfig, MooncakeIndexerKind, PreparedMooncakeBenchmark,
+    merge_worker_traces, prepare_scaled_benchmark,
 };
-use serde::Serialize;
 use std::sync::Arc;
-use tokio::time::{Duration, Instant};
-use tokio_util::sync::CancellationToken;
+
+#[cfg(target_os = "linux")]
+const PRE_RUN_QUIESCENCE_MS: u64 = 5_000;
+#[cfg(not(target_os = "linux"))]
+const PRE_RUN_QUIESCENCE_MS: u64 = 0;
 
 /// Indexer backend selection and its backend-specific parameters.
 #[derive(Subcommand, Debug, Clone)]
@@ -106,9 +113,38 @@ struct Args {
     #[clap(flatten)]
     common: CommonArgs,
 
-    /// Output path for sweep results JSON.
-    #[clap(long, default_value = "sweep_results.json")]
-    sweep_json_output: String,
+    /// Number of persistent logical query lanes.
+    #[clap(long, default_value = "128")]
+    query_lanes: usize,
+
+    /// Number of native event-issuer threads.
+    #[clap(long, default_value = "8")]
+    issuer_threads: usize,
+
+    /// Busy-spin interval after the absolute issuer sleep.
+    #[clap(long, default_value = "75")]
+    issuer_spin_us: u64,
+
+    /// Diagnostic threshold for reporting late issue operations. It is not a validity gate.
+    #[clap(long, default_value = "50")]
+    issue_lag_diagnostic_threshold_us: u64,
+
+    /// Comma-separated logical CPUs or ranges for parallel deadline issuers.
+    #[clap(long)]
+    issuer_cpus: Option<String>,
+
+    /// Logical CPU for the timed query issuer. The parent coordinator is parked
+    /// on this CPU while scoped issuer threads run.
+    #[clap(long)]
+    query_issuer_cpu: Option<usize>,
+
+    /// Comma-separated logical CPUs or ranges used by query and event workers.
+    #[clap(long)]
+    backend_cpus: Option<String>,
+
+    /// JSON output path for a benchmark result.
+    #[clap(long, default_value = "mooncake_result.json")]
+    result_json_output: String,
 
     /// Comma-separated list of indexer names to benchmark and compare on the
     /// same plot. Overrides the subcommand indexer when present. Valid names:
@@ -140,10 +176,6 @@ struct Args {
     #[clap(long, default_value = "")]
     shard_metrics_csv: String,
 
-    /// How often (ms) to sample shard sizes when `--shard-metrics-csv` is set.
-    #[clap(long, default_value = "200")]
-    shard_metrics_interval_ms: u64,
-
     /// Number of independent benchmark trials to run over the same generated
     /// benchmark input. Each trial builds a fresh indexer.
     #[clap(long, default_value = "1")]
@@ -161,101 +193,6 @@ impl Args {
     }
 }
 
-#[derive(Serialize)]
-struct SweepStepResult {
-    duration_ms: u64,
-    #[serde(flatten)]
-    results: BenchmarkResults,
-}
-
-fn shard_metrics_output_path(
-    base_path: &str,
-    indexer_name: &str,
-    compare_count: usize,
-    run_idx: usize,
-    run_count: usize,
-) -> String {
-    if compare_count <= 1 && run_count <= 1 {
-        return base_path.to_string();
-    }
-
-    let stem = base_path.trim_end_matches(".csv");
-    let mut path = stem.to_string();
-    if compare_count > 1 {
-        path.push('_');
-        path.push_str(indexer_name);
-    }
-    if run_count > 1 {
-        path.push_str("_run");
-        path.push_str(&(run_idx + 1).to_string());
-    }
-    path.push_str(".csv");
-    path
-}
-
-// ---------------------------------------------------------------------------
-// Shard-size sampling (always compiled; only called when a CSV path is given)
-// ---------------------------------------------------------------------------
-
-/// A single row in the shard-size time-series CSV.
-#[derive(Clone)]
-struct ShardSampleRow {
-    elapsed_ms: u64,
-    snapshot: ShardSizeSnapshot,
-}
-
-/// Spawn a background tokio task that samples `indexer.shard_sizes()` every
-/// `interval_ms` milliseconds until `cancel` is triggered.
-///
-/// Returns a `JoinHandle` that resolves to all collected samples.
-fn start_shard_sampler(
-    indexer: Arc<dyn KvIndexerInterface + Send + Sync>,
-    interval_ms: u64,
-    cancel: tokio_util::sync::CancellationToken,
-) -> tokio::task::JoinHandle<Vec<ShardSampleRow>> {
-    tokio::spawn(async move {
-        let mut rows = Vec::new();
-        let start = Instant::now();
-        let mut interval = tokio::time::interval(Duration::from_millis(interval_ms));
-        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        loop {
-            tokio::select! {
-                _ = interval.tick() => {
-                    let elapsed_ms = start.elapsed().as_millis() as u64;
-                    for snap in indexer.shard_sizes().await {
-                        rows.push(ShardSampleRow { elapsed_ms, snapshot: snap });
-                    }
-                }
-                _ = cancel.cancelled() => break,
-            }
-        }
-        rows
-    })
-}
-
-/// Write the collected shard-size samples to a CSV file.
-fn write_shard_metrics_csv(rows: &[ShardSampleRow], path: &str) -> anyhow::Result<()> {
-    use std::io::Write;
-    let mut f = std::fs::File::create(path)?;
-    writeln!(
-        f,
-        "elapsed_ms,shard_idx,worker_count,block_count,node_count"
-    )?;
-    for r in rows {
-        writeln!(
-            f,
-            "{},{},{},{},{}",
-            r.elapsed_ms,
-            r.snapshot.shard_idx,
-            r.snapshot.worker_count,
-            r.snapshot.block_count,
-            r.snapshot.node_count,
-        )?;
-    }
-    println!("Shard metrics CSV written to {path}");
-    Ok(())
-}
-
 fn validate_args(args: &Args) -> anyhow::Result<()> {
     if args.common.test {
         anyhow::bail!(
@@ -267,6 +204,45 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
     }
     if args.common.sweep && args.benchmark_runs != 1 {
         anyhow::bail!("--benchmark-runs is only supported outside --sweep mode");
+    }
+    if args.query_lanes == 0 {
+        anyhow::bail!("--query-lanes must be at least 1");
+    }
+    if args.issuer_threads == 0 {
+        anyhow::bail!("--issuer-threads must be at least 1");
+    }
+    if args.num_event_workers > u16::MAX as usize {
+        anyhow::bail!("--num-event-workers exceeds the u16 queue-ID space");
+    }
+    if args.approx {
+        anyhow::bail!("corrected Mooncake replay does not support --approx");
+    }
+    if args.find_matches_concurrency != 0 {
+        anyhow::bail!("corrected Mooncake replay does not support --find-matches-concurrency");
+    }
+    if !args.shard_metrics_csv.is_empty() {
+        anyhow::bail!("corrected Mooncake replay does not support shard sampling");
+    }
+    if !args.common.sweep && args.benchmark_runs != 1 {
+        anyhow::bail!("repetitions must use fresh processes; invoke one trial per process");
+    }
+
+    for name in indexer_names(args) {
+        let config = if args.compare.is_empty() {
+            args.get_indexer().to_config()
+        } else {
+            MooncakeIndexerConfig::from_short_name(&name, args.num_event_workers)?
+        };
+        if !matches!(
+            config.kind,
+            MooncakeIndexerKind::NestedMap
+                | MooncakeIndexerKind::ConcurrentRadixTree
+                | MooncakeIndexerKind::ConcurrentRadixTreeCompressed
+        ) {
+            anyhow::bail!(
+                "corrected Mooncake replay supports only nested-map, concurrent-radix-tree, and concurrent-radix-tree-compressed; got {name}"
+            );
+        }
     }
     Ok(())
 }
@@ -287,38 +263,174 @@ fn indexer_config(args: &Args, name: &str) -> anyhow::Result<MooncakeIndexerConf
     }
 }
 
-fn build_indexer(
+fn open_loop_config(args: &Args) -> anyhow::Result<OpenLoopConfig> {
+    let config = parse_open_loop_config(args)?;
+    validate_cpu_partition(
+        &config.issuer_cpus,
+        config.query_issuer_cpu,
+        &config.backend_cpus,
+    )?;
+    Ok(config)
+}
+
+fn parse_open_loop_config(args: &Args) -> anyhow::Result<OpenLoopConfig> {
+    let backend_cpus = args
+        .backend_cpus
+        .as_deref()
+        .map(parse_cpu_list)
+        .transpose()?
+        .unwrap_or_default();
+    let issuer_cpus = args
+        .issuer_cpus
+        .as_deref()
+        .map(parse_cpu_list)
+        .transpose()?
+        .unwrap_or_default();
+    let issuer_threads = if issuer_cpus.is_empty() {
+        args.issuer_threads
+    } else {
+        issuer_cpus.len()
+    };
+    Ok(OpenLoopConfig {
+        query_lanes: args.query_lanes,
+        issuer_threads,
+        spin_us: args.issuer_spin_us,
+        issue_lag_diagnostic_threshold_us: args.issue_lag_diagnostic_threshold_us,
+        pre_run_quiescence_ms: PRE_RUN_QUIESCENCE_MS,
+        issuer_cpus,
+        query_issuer_cpu: args.query_issuer_cpu,
+        backend_cpus,
+    })
+}
+
+async fn run_open_loop_for_config(
     args: &Args,
     config: &MooncakeIndexerConfig,
-) -> anyhow::Result<Arc<dyn KvIndexerInterface + Send + Sync>> {
-    if args.approx {
-        config.build_approximate(
-            args.common.block_size,
-            Arc::new(KvIndexerMetrics::new_unregistered()),
-        )
-    } else {
-        Ok(config.build(
-            args.common.block_size,
-            Arc::new(KvIndexerMetrics::new_unregistered()),
-        ))
+    prepared: PreparedMooncakeBenchmark,
+    bench_config: MooncakeBenchmarkConfig,
+) -> anyhow::Result<OpenLoopResult> {
+    if config.num_event_workers > u16::MAX as usize {
+        anyhow::bail!("Mooncake event-worker count exceeds the u16 queue-ID space");
+    }
+    let corpus =
+        prepare_mooncake_corpus(prepared, bench_config.inference_worker_duplication_factor)?;
+    let trial = prepare_open_loop_trial(corpus, args.query_lanes)?;
+    quiesce_prepared_heap();
+    let metrics = || Some(Arc::new(KvIndexerMetrics::new_unregistered()));
+    let open_config = parse_open_loop_config(args)?;
+    pin_current_thread_to_cpus(&open_config.backend_cpus)?;
+
+    match config.kind {
+        MooncakeIndexerKind::NestedMap => {
+            let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
+                PositionalIndexer::new(config.jump_size),
+                config.num_event_workers,
+                args.common.block_size,
+                metrics(),
+            ));
+            run_backend(config.short_name(), indexer, trial, open_config).await
+        }
+        MooncakeIndexerKind::ConcurrentRadixTree => {
+            let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
+                ConcurrentRadixTree::new(),
+                config.num_event_workers,
+                args.common.block_size,
+                metrics(),
+            ));
+            run_backend(config.short_name(), indexer, trial, open_config).await
+        }
+        MooncakeIndexerKind::ConcurrentRadixTreeCompressed => {
+            let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
+                ConcurrentRadixTreeCompressed::new(),
+                config.num_event_workers,
+                args.common.block_size,
+                metrics(),
+            ));
+            run_backend(config.short_name(), indexer, trial, open_config).await
+        }
+        MooncakeIndexerKind::RadixTree | MooncakeIndexerKind::BranchShardedCrtc => {
+            anyhow::bail!(
+                "{} is not supported by corrected Mooncake replay",
+                config.short_name()
+            )
+        }
     }
 }
 
-fn benchmark_config(
-    args: &Args,
-    indexer_config: &MooncakeIndexerConfig,
-    benchmark_duration_ms: u64,
-) -> MooncakeBenchmarkConfig {
+#[cfg(target_os = "linux")]
+fn quiesce_prepared_heap() {
+    // Corpus construction releases large, multi-threaded preparation arenas.
+    // Return their free pages and let reclamation settle before backend workers start.
+    unsafe {
+        libc::malloc_trim(0);
+    }
+    std::thread::sleep(std::time::Duration::from_millis(PRE_RUN_QUIESCENCE_MS));
+}
+
+#[cfg(not(target_os = "linux"))]
+fn quiesce_prepared_heap() {}
+
+async fn run_backend<T: dynamo_kv_router::indexer::SyncIndexer>(
+    backend_name: &str,
+    indexer: Arc<ThreadPoolIndexer<T>>,
+    trial: mooncake_open_loop::PreparedOpenLoopTrial,
+    open_config: OpenLoopConfig,
+) -> anyhow::Result<OpenLoopResult> {
+    if let Some(cpu) = open_config.query_issuer_cpu {
+        pin_current_thread_to_cpus(&[cpu])?;
+    }
+    run_open_loop(backend_name, indexer, trial, open_config).await
+}
+
+fn print_open_loop_result(result: &OpenLoopResult) {
+    println!(
+        "Offered logical throughput: {:.0} ops/s | achieved: {:.0} ops/s",
+        result.offered_logical_ops_per_sec, result.achieved_logical_ops_per_sec
+    );
+    println!(
+        "Offered block throughput: {:.0} block ops/s | achieved: {:.0} block ops/s",
+        result.offered_block_ops_per_sec, result.achieved_block_ops_per_sec
+    );
+    println!(
+        "Query service p50/p99: {:.1}/{:.1} us | queue p99: {:.1} us",
+        result.query_service.p50_ns as f64 / 1_000.0,
+        result.query_service.p99_ns as f64 / 1_000.0,
+        result.query_queue_wait.p99_ns as f64 / 1_000.0,
+    );
+    println!(
+        "generator_valid={} kept_up={} issue_span={:.3} ms drain={:.3} ms",
+        result.generator_valid,
+        result.kept_up,
+        result.issue_span_ns as f64 / 1e6,
+        result.drain_ns as f64 / 1e6,
+    );
+}
+
+fn open_loop_output_path(base: &str, backend: &str, duration_ms: Option<u64>) -> String {
+    let stem = base.trim_end_matches(".json");
+    match duration_ms {
+        Some(duration_ms) => format!("{stem}_{backend}_{duration_ms}ms.json"),
+        None => format!("{stem}_{backend}.json"),
+    }
+}
+
+fn write_open_loop_result(path: &str, result: &OpenLoopResult) -> anyhow::Result<()> {
+    std::fs::write(path, serde_json::to_string_pretty(result)?)?;
+    println!("Mooncake result written to {path}");
+    Ok(())
+}
+
+fn benchmark_config(args: &Args, benchmark_duration_ms: u64) -> MooncakeBenchmarkConfig {
     MooncakeBenchmarkConfig {
         benchmark_duration_ms,
         inference_worker_duplication_factor: args.common.inference_worker_duplication_factor,
-        count_events: indexer_config.supports_remove(),
-        find_matches_concurrency: args.find_matches_concurrency,
-        block_size: args.common.block_size,
     }
 }
 
-async fn prepare_benchmark_input(args: &Args) -> anyhow::Result<Option<MooncakeBenchmarkInput>> {
+async fn prepare_benchmark(
+    args: &Args,
+    benchmark_duration_ms: u64,
+) -> anyhow::Result<Option<PreparedMooncakeBenchmark>> {
     let Some(path) = args.common.mooncake_trace_path.as_deref() else {
         eprintln!("No mooncake_trace_path provided, skipping benchmark");
         return Ok(None);
@@ -332,281 +444,99 @@ async fn prepare_benchmark_input(args: &Args) -> anyhow::Result<Option<MooncakeB
         args.common.num_unique_inference_workers,
         args.common.seed,
     )?;
-    let benchmark_input = if args.approx {
-        MooncakeBenchmarkInput::Approx(traces.clone())
-    } else {
-        MooncakeBenchmarkInput::KvEvents(
-            generate_replay_artifacts(
-                &traces,
-                args.common.num_gpu_blocks,
-                args.common.block_size,
-                args.common.trace_simulation_duration_ms,
-            )
-            .await?,
-        )
-    };
-
-    Ok(Some(benchmark_input))
+    let artifacts = generate_replay_artifacts(
+        &traces,
+        args.common.num_gpu_blocks,
+        args.common.block_size,
+        args.common.trace_simulation_duration_ms,
+    )
+    .await?;
+    drop(traces);
+    let merged = merge_worker_traces(artifacts, args.common.block_size)?;
+    Ok(Some(prepare_scaled_benchmark(
+        merged,
+        benchmark_duration_ms,
+    )))
 }
 
-async fn run_sweep_mode(
-    args: &Args,
-    indexer_names: &[String],
-    benchmark_input: &MooncakeBenchmarkInput,
-) -> anyhow::Result<()> {
-    let merged = merge_worker_traces(benchmark_input, args.common.block_size)?;
-    let durations_low_to_high = compute_sweep_durations(
+async fn run_open_loop_repeated_mode(args: &Args, indexer_names: &[String]) -> anyhow::Result<()> {
+    for name in indexer_names {
+        let config = indexer_config(args, name)?;
+        let bench_config = benchmark_config(args, args.common.benchmark_duration_ms);
+        let Some(prepared) = prepare_benchmark(args, bench_config.benchmark_duration_ms).await?
+        else {
+            return Ok(());
+        };
+        let result = run_open_loop_for_config(args, &config, prepared, bench_config).await?;
+        print_open_loop_result(&result);
+        let path = if indexer_names.len() == 1 {
+            args.result_json_output.clone()
+        } else {
+            open_loop_output_path(&args.result_json_output, config.short_name(), None)
+        };
+        write_open_loop_result(&path, &result)?;
+    }
+    Ok(())
+}
+
+async fn run_open_loop_sweep_mode(args: &Args, indexer_names: &[String]) -> anyhow::Result<()> {
+    let durations = compute_sweep_durations(
         args.common.sweep_min_ms,
         args.common.sweep_max_ms,
         args.common.sweep_steps,
     );
-    let durations_high_to_low: Vec<u64> = durations_low_to_high.iter().copied().rev().collect();
-
-    let mut all_results: Vec<(&str, Vec<(u64, BenchmarkResults)>)> = Vec::new();
-
-    for name in indexer_names {
-        println!("\n{}", "=".repeat(60));
-        println!("Benchmarking indexer: {}", name);
-        println!("{}", "=".repeat(60));
-
-        let config = indexer_config(args, name)?;
-        let multi_threaded = config.is_multi_threaded();
-        let durations = if multi_threaded {
-            &durations_high_to_low
-        } else {
-            &durations_low_to_high
-        };
-
-        let mut results: Vec<(u64, BenchmarkResults)> = Vec::new();
-        let mut consecutive_keeping_up = 0u32;
-
-        for &dur_ms in durations {
-            println!("\n=== Sweep: benchmark_duration_ms = {} ===", dur_ms);
-            let indexer = build_indexer(args, &config)?;
-            let bench_config = benchmark_config(args, &config, dur_ms);
-            let prepared = prepare_scaled_benchmark(&merged, bench_config);
-            let run = run_prepared_benchmark(indexer, &prepared, bench_config).await?;
-            warn_if_bench_did_not_keep_up(run.kept_up);
-            let result = run.results;
-
-            if multi_threaded {
-                if result.block_throughput >= result.offered_block_throughput * 0.95 {
-                    consecutive_keeping_up += 1;
-                } else {
-                    consecutive_keeping_up = 0;
-                }
-                results.push((dur_ms, result));
-                if consecutive_keeping_up >= 5 {
-                    println!("Early stop: achieved >= 95% offered for 5 consecutive steps");
-                    break;
-                }
-            } else {
-                let saturated = result.offered_block_throughput > result.block_throughput * 5.0;
-                results.push((dur_ms, result));
-                if saturated {
-                    println!("Early stop: offered throughput >5x achieved throughput");
-                    break;
-                }
-            }
-        }
-
-        results.sort_by_key(|(dur, _)| std::cmp::Reverse(*dur));
-        print_sweep_summary(name, &results);
-
-        all_results.push((name, results));
-    }
-
-    write_sweep_json(args, &all_results)?;
-    Ok(())
-}
-
-fn write_sweep_json(
-    args: &Args,
-    all_results: &[(&str, Vec<(u64, BenchmarkResults)>)],
-) -> anyhow::Result<()> {
-    let json_map: std::collections::BTreeMap<&str, Vec<SweepStepResult>> = all_results
-        .iter()
-        .map(|(name, results)| {
-            let steps = results
-                .iter()
-                .map(|(dur, r)| SweepStepResult {
-                    duration_ms: *dur,
-                    results: BenchmarkResults {
-                        offered_ops_throughput: r.offered_ops_throughput,
-                        ops_throughput: r.ops_throughput,
-                        offered_block_throughput: r.offered_block_throughput,
-                        block_throughput: r.block_throughput,
-                        latency_p99_us: r.latency_p99_us,
-                    },
-                })
-                .collect();
-            (*name, steps)
-        })
-        .collect();
-    std::fs::write(
-        &args.sweep_json_output,
-        serde_json::to_string_pretty(&json_map)?,
-    )?;
-    println!("Sweep results saved to {}", args.sweep_json_output);
-    Ok(())
-}
-
-async fn run_repeated_mode(
-    args: &Args,
-    indexer_names: &[String],
-    benchmark_input: &MooncakeBenchmarkInput,
-) -> anyhow::Result<()> {
-    let merged = merge_worker_traces(benchmark_input, args.common.block_size)?;
 
     for name in indexer_names {
         let config = indexer_config(args, name)?;
-        let mut repeated_results = Vec::with_capacity(args.benchmark_runs);
-        let bench_config = benchmark_config(args, &config, args.common.benchmark_duration_ms);
-        let prepared = prepare_scaled_benchmark(&merged, bench_config);
-
-        for run_idx in 0..args.benchmark_runs {
-            print_trial_header(name, run_idx, args.benchmark_runs);
-            repeated_results.push(
-                run_single_trial(args, name, &config, &prepared, bench_config, run_idx).await?,
+        for &duration_ms in durations.iter().rev() {
+            println!(
+                "\n=== Mooncake sweep: backend={} benchmark_duration_ms={} ===",
+                config.short_name(),
+                duration_ms
             );
+            let bench_config = benchmark_config(args, duration_ms);
+            let Some(prepared) =
+                prepare_benchmark(args, bench_config.benchmark_duration_ms).await?
+            else {
+                return Ok(());
+            };
+            let result = run_open_loop_for_config(args, &config, prepared, bench_config).await?;
+            print_open_loop_result(&result);
+            let path = open_loop_output_path(
+                &args.result_json_output,
+                config.short_name(),
+                Some(duration_ms),
+            );
+            write_open_loop_result(&path, &result)?;
         }
-
-        let title = format!("Repeated Benchmark Summary: {name}");
-        print_benchmark_results_percentiles(&title, &repeated_results);
     }
-
     Ok(())
 }
 
-fn print_trial_header(name: &str, run_idx: usize, run_count: usize) {
-    if run_count == 1 {
-        println!("\nBenchmarking indexer: {}", name);
-    } else {
-        println!(
-            "\nBenchmarking indexer: {} (run {}/{})",
-            name,
-            run_idx + 1,
-            run_count,
-        );
-    }
-}
-
-async fn run_single_trial(
-    args: &Args,
-    name: &str,
-    config: &MooncakeIndexerConfig,
-    prepared: &PreparedMooncakeBenchmark,
-    bench_config: MooncakeBenchmarkConfig,
-    run_idx: usize,
-) -> anyhow::Result<BenchmarkResults> {
-    let indexer = build_indexer(args, config)?;
-
-    let shard_cancel = CancellationToken::new();
-    let shard_sampler = if !args.shard_metrics_csv.is_empty() {
-        Some(start_shard_sampler(
-            indexer.clone(),
-            args.shard_metrics_interval_ms,
-            shard_cancel.clone(),
-        ))
-    } else {
-        None
-    };
-
-    let run = run_prepared_benchmark(indexer.clone(), prepared, bench_config).await;
-
-    shard_cancel.cancel();
-    if let Some(handle) = shard_sampler {
-        let rows = handle.await?;
-        let csv_path = shard_metrics_output_path(
-            &args.shard_metrics_csv,
-            name,
-            args.compare.len(),
-            run_idx,
-            args.benchmark_runs,
-        );
-        write_shard_metrics_csv(&rows, &csv_path)?;
-    }
-
-    let run = run?;
-    warn_if_bench_did_not_keep_up(run.kept_up);
-    print_indexer_report(&indexer).await;
-    Ok(run.results)
-}
-
-fn warn_if_bench_did_not_keep_up(kept_up: bool) {
-    if !kept_up {
-        eprintln!(
-            "WARNING: The benchmarker is unable to keep up with the request/event generation rate. Rerun with a larger --benchmark-duration-ms."
-        );
-    }
-}
-
-async fn print_indexer_report(indexer: &Arc<dyn KvIndexerInterface + Send + Sync>) {
-    let report = indexer.timing_report();
-    if !report.is_empty() {
-        println!("{}", report);
-    }
-    print_shard_distribution(indexer).await;
-    print_node_edge_lengths(indexer);
-}
-
-async fn print_shard_distribution(indexer: &Arc<dyn KvIndexerInterface + Send + Sync>) {
-    let sizes = indexer.shard_sizes().await;
-    if sizes.len() <= 1 {
-        return;
-    }
-
-    let total_blocks: usize = sizes.iter().map(|s| s.block_count).sum();
-    let total_nodes: usize = sizes.iter().map(|s| s.node_count).sum();
-    println!("Shard block distribution:");
-    for s in &sizes {
-        let pct = if total_blocks > 0 {
-            100.0 * s.block_count as f64 / total_blocks as f64
-        } else {
-            0.0
-        };
-        println!(
-            "  shard {}: {} blocks ({:.1}%), {} workers, {} nodes",
-            s.shard_idx, s.block_count, pct, s.worker_count, s.node_count
-        );
-    }
-    if total_nodes > 0 {
-        println!("  total nodes across shards: {}", total_nodes);
-    }
-}
-
-fn print_node_edge_lengths(indexer: &Arc<dyn KvIndexerInterface + Send + Sync>) {
-    let mut edge_lengths = indexer.node_edge_lengths();
-    if edge_lengths.is_empty() {
-        return;
-    }
-
-    let avg = edge_lengths.iter().sum::<usize>() as f64 / edge_lengths.len() as f64;
-    edge_lengths.sort_unstable();
-    let p99 = edge_lengths[edge_lengths.len() * 99 / 100];
-    println!(
-        "Node edge lengths ({} nodes): avg={:.1} hashes/node, p99={} hashes/node",
-        edge_lengths.len(),
-        avg,
-        p99,
-    );
-}
-
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    let args = Args::parse();
-    validate_args(&args)?;
-
-    let Some(benchmark_input) = prepare_benchmark_input(&args).await? else {
-        return Ok(());
-    };
+async fn async_main(args: Args) -> anyhow::Result<()> {
     let indexer_names = indexer_names(&args);
 
     if args.common.sweep {
-        run_sweep_mode(&args, &indexer_names, &benchmark_input).await?;
+        run_open_loop_sweep_mode(&args, &indexer_names).await?;
     } else {
-        run_repeated_mode(&args, &indexer_names, &benchmark_input).await?;
+        run_open_loop_repeated_mode(&args, &indexer_names).await?;
     }
 
     Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
+    let args = Args::parse();
+    validate_args(&args)?;
+    let config = open_loop_config(&args)?;
+
+    let mut runtime = tokio::runtime::Builder::new_multi_thread();
+    runtime.enable_all();
+    if !config.backend_cpus.is_empty() {
+        pin_current_thread_to_cpus(&config.backend_cpus)?;
+        runtime.worker_threads(config.backend_cpus.len());
+    }
+
+    let runtime = runtime.build()?;
+    runtime.block_on(async_main(args))
 }

--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -226,6 +226,9 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
     if !args.common.sweep && args.benchmark_runs != 1 {
         anyhow::bail!("repetitions must use fresh processes; invoke one trial per process");
     }
+    if args.common.mooncake_trace_path.is_none() {
+        return Ok(());
+    }
 
     for name in indexer_names(args) {
         let config = if args.compare.is_empty() {

--- a/lib/bench/kv_router/mooncake_open_loop.rs
+++ b/lib/bench/kv_router/mooncake_open_loop.rs
@@ -1654,12 +1654,12 @@ pub fn validate_cpu_partition(
             if !allowed.contains(&cpu) {
                 anyhow::bail!("CPU {cpu} is outside the process affinity mask");
             }
-            if let Some(core) = physical_core(cpu)? {
-                if let Some(existing) = selected_cores.insert(core, cpu) {
-                    anyhow::bail!(
-                        "CPUs {existing} and {cpu} are SMT siblings; select one logical CPU per physical core"
-                    );
-                }
+            if let Some(core) = physical_core(cpu)?
+                && let Some(existing) = selected_cores.insert(core, cpu)
+            {
+                anyhow::bail!(
+                    "CPUs {existing} and {cpu} are SMT siblings; select one logical CPU per physical core"
+                );
             }
         }
     }

--- a/lib/bench/kv_router/mooncake_open_loop.rs
+++ b/lib/bench/kv_router/mooncake_open_loop.rs
@@ -1,0 +1,1780 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeMap;
+use std::hint::black_box;
+use std::sync::atomic::{AtomicBool, AtomicU32, AtomicU64, AtomicUsize, Ordering};
+use std::sync::{Arc, Barrier};
+#[cfg(not(target_os = "linux"))]
+use std::time::Duration;
+use std::time::Instant;
+
+use dynamo_kv_router::LocalBlockHash;
+use dynamo_kv_router::indexer::{
+    ObservationError, SyncIndexer, ThreadPoolIndexer, ThreadPoolObservationPlan,
+};
+use dynamo_kv_router::protocols::{KvCacheEventData, RouterEvent};
+use serde::Serialize;
+use tokio::sync::{Notify, oneshot};
+
+use super::mooncake_shared::{MooncakeTraceTotals, PreparedMooncakeBenchmark, WorkerTraceEntry};
+
+const RESULT_SCHEMA_VERSION: u32 = 1;
+const EMPTY_OPERATION_ID: u32 = u32::MAX;
+
+#[derive(Clone, Debug)]
+pub struct OpenLoopConfig {
+    pub query_lanes: usize,
+    pub issuer_threads: usize,
+    pub spin_us: u64,
+    pub issue_lag_diagnostic_threshold_us: u64,
+    pub pre_run_quiescence_ms: u64,
+    pub issuer_cpus: Vec<usize>,
+    pub query_issuer_cpu: Option<usize>,
+    pub backend_cpus: Vec<usize>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+enum OperationKind {
+    #[default]
+    Query,
+    Event,
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct QuerySpec {
+    start: u32,
+    len: u32,
+    valid: bool,
+}
+
+#[derive(Debug)]
+struct QueryCorpus {
+    hashes: Box<[LocalBlockHash]>,
+    specs: Box<[QuerySpec]>,
+}
+
+#[derive(Debug)]
+pub(crate) enum MooncakeOperationPayload {
+    Query,
+    Event(RouterEvent),
+}
+
+#[derive(Debug)]
+pub(crate) struct MooncakeLogicalOperation {
+    pub(crate) id: u32,
+    pub(crate) deadline_ns: u64,
+    pub(crate) worker_id: u64,
+    pub(crate) source_ordinal: usize,
+    pub(crate) payload: MooncakeOperationPayload,
+}
+
+impl MooncakeLogicalOperation {
+    fn priority(&self) -> u8 {
+        match self.payload {
+            MooncakeOperationPayload::Query => 0,
+            MooncakeOperationPayload::Event(_) => 1,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct PreparedMooncakeCorpus {
+    pub(crate) operations: Vec<MooncakeLogicalOperation>,
+    query_corpus: QueryCorpus,
+    expected_events_by_worker: Vec<(u64, usize)>,
+    totals: MooncakeTraceTotals,
+    benchmark_duration_ns: u64,
+    block_size: u32,
+}
+
+#[cfg(test)]
+#[allow(dead_code)]
+impl PreparedMooncakeCorpus {
+    pub(crate) fn query_hashes(&self, operation_id: u32) -> anyhow::Result<&[LocalBlockHash]> {
+        let spec = self
+            .query_corpus
+            .specs
+            .get(operation_id as usize)
+            .filter(|spec| spec.valid)
+            .ok_or_else(|| anyhow::anyhow!("operation {operation_id} is not a prepared query"))?;
+        let start = spec.start as usize;
+        let end = start
+            .checked_add(spec.len as usize)
+            .ok_or_else(|| anyhow::anyhow!("query {operation_id} hash range overflow"))?;
+        self.query_corpus.hashes.get(start..end).ok_or_else(|| {
+            anyhow::anyhow!(
+                "query {operation_id} hash range {start}..{end} exceeds the flattened slab"
+            )
+        })
+    }
+
+    pub(crate) fn test_block_totals(&self) -> (usize, usize) {
+        (self.totals.request_blocks, self.totals.event_blocks())
+    }
+}
+
+#[derive(Debug)]
+enum DispatchPayload {
+    Query { lane: usize },
+    Event(RouterEvent),
+}
+
+#[derive(Debug)]
+struct DispatchEntry {
+    id: u32,
+    deadline_ns: u64,
+    deadline_group: u32,
+    worker_id: u64,
+    payload: DispatchPayload,
+}
+
+#[derive(Debug)]
+pub struct PreparedOpenLoopTrial {
+    dispatch: Vec<DispatchEntry>,
+    query_corpus: Arc<QueryCorpus>,
+    operation_workers: Box<[u64]>,
+    lane_capacities: Vec<usize>,
+    expected_events_by_worker: Vec<(u64, usize)>,
+    deadline_query_counts: Vec<u32>,
+    totals: MooncakeTraceTotals,
+    benchmark_duration_ns: u64,
+    block_size: u32,
+}
+
+impl PreparedOpenLoopTrial {
+    fn page_touch_untimed(&self) {
+        let mut checksum = self.benchmark_duration_ns;
+        checksum ^= u64::from(self.block_size);
+        for hash in &self.query_corpus.hashes {
+            checksum ^= hash.0;
+        }
+        for spec in &self.query_corpus.specs {
+            checksum ^=
+                u64::from(spec.start) ^ u64::from(spec.len) ^ u64::from(u8::from(spec.valid));
+        }
+        for entry in &self.dispatch {
+            checksum ^= entry.deadline_ns
+                ^ entry.worker_id
+                ^ u64::from(entry.id)
+                ^ u64::from(entry.deadline_group);
+            match &entry.payload {
+                DispatchPayload::Query { lane } => checksum ^= *lane as u64,
+                DispatchPayload::Event(event) => {
+                    checksum ^= event.worker_id ^ event.event.event_id;
+                    match &event.event.data {
+                        KvCacheEventData::Stored(store) => {
+                            for block in &store.blocks {
+                                checksum ^= block.block_hash.0 ^ block.tokens_hash.0;
+                            }
+                        }
+                        KvCacheEventData::Removed(remove) => {
+                            for hash in &remove.block_hashes {
+                                checksum ^= hash.0;
+                            }
+                        }
+                        KvCacheEventData::Cleared => {}
+                    }
+                }
+            }
+        }
+        for &worker_id in &self.operation_workers {
+            checksum ^= worker_id;
+        }
+        for &capacity in &self.lane_capacities {
+            checksum ^= capacity as u64;
+        }
+        for &(worker_id, event_count) in &self.expected_events_by_worker {
+            checksum ^= worker_id ^ event_count as u64;
+        }
+        for &query_count in &self.deadline_query_counts {
+            checksum ^= u64::from(query_count);
+        }
+        checksum ^= self.totals.requests as u64
+            ^ self.totals.stored_events as u64
+            ^ self.totals.removed_events as u64
+            ^ self.totals.cleared_events as u64
+            ^ self.totals.request_blocks as u64
+            ^ self.totals.stored_blocks as u64
+            ^ self.totals.removed_blocks as u64;
+        black_box(checksum);
+    }
+}
+
+pub(crate) fn prepare_mooncake_corpus(
+    prepared: PreparedMooncakeBenchmark,
+    inference_worker_duplication_factor: usize,
+) -> anyhow::Result<PreparedMooncakeCorpus> {
+    let num_trace_workers = prepared.worker_traces.len();
+    let estimated_ops = prepared
+        .worker_traces
+        .iter()
+        .map(Vec::len)
+        .sum::<usize>()
+        .checked_mul(inference_worker_duplication_factor)
+        .ok_or_else(|| anyhow::anyhow!("open-loop operation count overflow"))?;
+    if estimated_ops >= EMPTY_OPERATION_ID as usize {
+        anyhow::bail!("open-loop corpus exceeds the u32 operation-ID space");
+    }
+
+    let mut operations = Vec::with_capacity(estimated_ops);
+    let mut hash_slab = Vec::with_capacity(
+        prepared
+            .totals
+            .request_blocks
+            .saturating_mul(inference_worker_duplication_factor),
+    );
+    let mut events_by_worker = BTreeMap::<u64, usize>::new();
+
+    for replica in 0..inference_worker_duplication_factor {
+        for (base_worker, trace) in prepared.worker_traces.iter().enumerate() {
+            let worker_id = (base_worker + replica * num_trace_workers) as u64;
+            events_by_worker.entry(worker_id).or_default();
+            for (source_ordinal, entry) in trace.iter().enumerate() {
+                let deadline_ns = entry.timestamp_us.saturating_mul(1_000);
+                let (payload, query_spec) = match &entry.entry {
+                    WorkerTraceEntry::Request(hashes) => {
+                        let start = u32::try_from(hash_slab.len())?;
+                        let len = u32::try_from(hashes.len())?;
+                        hash_slab.extend_from_slice(hashes);
+                        (
+                            MooncakeOperationPayload::Query,
+                            QuerySpec {
+                                start,
+                                len,
+                                valid: true,
+                            },
+                        )
+                    }
+                    WorkerTraceEntry::Event {
+                        event,
+                        storage_tier,
+                    } => {
+                        if !storage_tier.is_gpu() {
+                            anyhow::bail!(
+                                "open-loop replay encountered non-GPU event for worker {worker_id}"
+                            );
+                        }
+                        *events_by_worker.entry(worker_id).or_default() += 1;
+                        (
+                            MooncakeOperationPayload::Event(RouterEvent::with_storage_tier(
+                                worker_id,
+                                event.clone(),
+                                *storage_tier,
+                            )),
+                            QuerySpec::default(),
+                        )
+                    }
+                };
+                operations.push((
+                    MooncakeLogicalOperation {
+                        id: 0,
+                        deadline_ns,
+                        worker_id,
+                        source_ordinal,
+                        payload,
+                    },
+                    query_spec,
+                ));
+            }
+        }
+    }
+
+    operations.sort_by_key(|(entry, _)| {
+        (
+            entry.deadline_ns,
+            entry.priority(),
+            entry.worker_id,
+            entry.source_ordinal,
+        )
+    });
+
+    let mut specs = vec![QuerySpec::default(); operations.len()].into_boxed_slice();
+    for (id, (entry, query_spec)) in operations.iter_mut().enumerate() {
+        entry.id = id as u32;
+        if query_spec.valid {
+            specs[id] = *query_spec;
+        }
+    }
+    let operations = operations
+        .into_iter()
+        .map(|(entry, _)| entry)
+        .collect::<Vec<_>>();
+
+    Ok(PreparedMooncakeCorpus {
+        operations,
+        query_corpus: QueryCorpus {
+            hashes: hash_slab.into_boxed_slice(),
+            specs,
+        },
+        expected_events_by_worker: events_by_worker.into_iter().collect(),
+        totals: prepared
+            .totals
+            .expanded(inference_worker_duplication_factor),
+        benchmark_duration_ns: prepared.benchmark_duration_ms.saturating_mul(1_000_000),
+        block_size: prepared.block_size,
+    })
+}
+
+pub(crate) fn prepare_open_loop_trial(
+    corpus: PreparedMooncakeCorpus,
+    query_lanes: usize,
+) -> anyhow::Result<PreparedOpenLoopTrial> {
+    if query_lanes == 0 {
+        anyhow::bail!("open-loop query lane count must be positive");
+    }
+    if query_lanes > u16::MAX as usize {
+        anyhow::bail!("open-loop query lane count exceeds the u16 queue-ID space");
+    }
+
+    let PreparedMooncakeCorpus {
+        operations,
+        query_corpus,
+        expected_events_by_worker,
+        totals,
+        benchmark_duration_ns,
+        block_size,
+    } = corpus;
+    let mut dispatch = Vec::with_capacity(operations.len());
+    let mut operation_workers = Vec::with_capacity(operations.len());
+    let mut lane_capacities = vec![0usize; query_lanes];
+    let mut deadline_query_counts = Vec::<u32>::new();
+    let mut previous_deadline = None;
+
+    for operation in operations {
+        operation_workers.push(operation.worker_id);
+        if previous_deadline != Some(operation.deadline_ns) {
+            previous_deadline = Some(operation.deadline_ns);
+            deadline_query_counts.push(0);
+        }
+        let deadline_group = deadline_query_counts.len() - 1;
+        let payload = match operation.payload {
+            MooncakeOperationPayload::Query => {
+                let lane = operation.worker_id as usize % query_lanes;
+                lane_capacities[lane] += 1;
+                deadline_query_counts[deadline_group] =
+                    deadline_query_counts[deadline_group].saturating_add(1);
+                DispatchPayload::Query { lane }
+            }
+            MooncakeOperationPayload::Event(event) => DispatchPayload::Event(event),
+        };
+        dispatch.push(DispatchEntry {
+            id: operation.id,
+            deadline_ns: operation.deadline_ns,
+            deadline_group: deadline_group as u32,
+            worker_id: operation.worker_id,
+            payload,
+        });
+    }
+
+    Ok(PreparedOpenLoopTrial {
+        dispatch,
+        query_corpus: Arc::new(query_corpus),
+        operation_workers: operation_workers.into_boxed_slice(),
+        lane_capacities,
+        expected_events_by_worker,
+        deadline_query_counts,
+        totals,
+        benchmark_duration_ns,
+        block_size,
+    })
+}
+
+struct QueryLane {
+    slots: Box<[AtomicU32]>,
+    published: AtomicUsize,
+    closed: AtomicBool,
+    notify: Notify,
+}
+
+impl QueryLane {
+    fn new(capacity: usize) -> Self {
+        let slots = (0..capacity)
+            .map(|_| AtomicU32::new(EMPTY_OPERATION_ID))
+            .collect::<Vec<_>>()
+            .into_boxed_slice();
+        Self {
+            slots,
+            published: AtomicUsize::new(0),
+            closed: AtomicBool::new(false),
+            notify: Notify::new(),
+        }
+    }
+
+    fn write(&self, cursor: usize, id: u32) -> Result<(), IssuerFailure> {
+        let Some(slot) = self.slots.get(cursor) else {
+            return Err(IssuerFailure::QueryLaneOverflow);
+        };
+        slot.store(id, Ordering::Relaxed);
+        Ok(())
+    }
+
+    fn publish(&self, count: usize) {
+        self.published.store(count, Ordering::Release);
+        self.notify.notify_one();
+    }
+
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+        self.notify.notify_one();
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct QueryCompletion {
+    id: u32,
+    started_ns: u64,
+    finished_ns: u64,
+    success: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum QueryLaneFailure {
+    #[default]
+    None,
+    InvalidOperationId,
+    InvalidHashRange,
+    MissingPublishedId,
+    CompletionOverflow,
+}
+
+struct QueryLaneResult {
+    completions: Box<[QueryCompletion]>,
+    written: usize,
+    drain_ns: u64,
+    failure: QueryLaneFailure,
+}
+
+async fn query_lane_worker<T: SyncIndexer>(
+    indexer: Arc<ThreadPoolIndexer<T>>,
+    lane: Arc<QueryLane>,
+    corpus: Arc<QueryCorpus>,
+    epoch: Instant,
+    ready: oneshot::Sender<()>,
+) -> QueryLaneResult {
+    let mut completions = vec![QueryCompletion::default(); lane.slots.len()].into_boxed_slice();
+    let mut consumed = 0usize;
+    let mut failure = QueryLaneFailure::None;
+    let _ = ready.send(());
+    loop {
+        let published = lane.published.load(Ordering::Acquire);
+        while consumed < published {
+            let id = lane.slots[consumed].load(Ordering::Relaxed);
+            if id == EMPTY_OPERATION_ID {
+                failure = QueryLaneFailure::MissingPublishedId;
+                break;
+            }
+            let Some(spec) = corpus.specs.get(id as usize).copied() else {
+                failure = QueryLaneFailure::InvalidOperationId;
+                break;
+            };
+            let start = spec.start as usize;
+            let end = start.saturating_add(spec.len as usize);
+            let Some(hashes) = corpus.hashes.get(start..end).filter(|_| spec.valid) else {
+                failure = QueryLaneFailure::InvalidHashRange;
+                break;
+            };
+            let Some(slot) = completions.get_mut(consumed) else {
+                failure = QueryLaneFailure::CompletionOverflow;
+                break;
+            };
+            let started_ns = elapsed_ns(epoch);
+            let output = indexer.backend().find_matches(hashes, false);
+            black_box(output);
+            let finished_ns = elapsed_ns(epoch);
+            *slot = QueryCompletion {
+                id,
+                started_ns,
+                finished_ns,
+                success: true,
+            };
+            consumed += 1;
+        }
+
+        if failure != QueryLaneFailure::None {
+            break;
+        }
+        if lane.closed.load(Ordering::Acquire) && consumed == lane.published.load(Ordering::Acquire)
+        {
+            break;
+        }
+
+        let notified = lane.notify.notified();
+        if consumed == lane.published.load(Ordering::Acquire)
+            && !lane.closed.load(Ordering::Acquire)
+        {
+            notified.await;
+        }
+    }
+
+    QueryLaneResult {
+        completions,
+        written: consumed,
+        drain_ns: elapsed_ns(epoch),
+        failure,
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+struct IssueRecord {
+    scheduled_ns: u64,
+    accepted_ns: u64,
+    queue_id: u16,
+    kind: OperationKind,
+    accepted: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum IssuerFailure {
+    QueryLaneOverflow,
+    Observation,
+    Affinity,
+    DispatchMismatch,
+    PeerFailed,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct LocalIssueRecord {
+    id: u32,
+    record: IssueRecord,
+}
+
+impl Default for LocalIssueRecord {
+    fn default() -> Self {
+        Self {
+            id: EMPTY_OPERATION_ID,
+            record: IssueRecord::default(),
+        }
+    }
+}
+
+struct IssuerOutput {
+    records: Box<[LocalIssueRecord]>,
+    written: usize,
+    issuer_cpu_ns: u64,
+    failure: Option<IssuerFailure>,
+}
+
+struct IssuerStorage {
+    records: Box<[LocalIssueRecord]>,
+    written: usize,
+    lane_cursors: Box<[usize]>,
+    touched_flags: Box<[bool]>,
+    touched_lanes: Vec<usize>,
+}
+
+impl IssuerStorage {
+    fn new(operation_count: usize, lane_count: usize) -> Self {
+        Self {
+            records: vec![LocalIssueRecord::default(); operation_count].into_boxed_slice(),
+            written: 0,
+            lane_cursors: vec![0; lane_count].into_boxed_slice(),
+            touched_flags: vec![false; lane_count].into_boxed_slice(),
+            touched_lanes: Vec::with_capacity(lane_count),
+        }
+    }
+
+    fn record(&mut self, id: u32, record: IssueRecord) -> Result<(), IssuerFailure> {
+        let Some(slot) = self.records.get_mut(self.written) else {
+            return Err(IssuerFailure::DispatchMismatch);
+        };
+        *slot = LocalIssueRecord { id, record };
+        self.written += 1;
+        Ok(())
+    }
+}
+
+struct IssuerAnalysisInput {
+    records: Box<[IssueRecord]>,
+    producer_stop_ns: u64,
+    issuer_cpu_ns: u64,
+    failure: Option<IssuerFailure>,
+}
+
+struct QueryIssuerContext<'a> {
+    lanes: &'a [Arc<QueryLane>],
+    deadline_ready: &'a [AtomicBool],
+    peer_failed: &'a AtomicBool,
+    clock: &'a BenchmarkClock,
+    start_ns: u64,
+}
+
+struct EventIssuerContext<'a, T: SyncIndexer> {
+    indexer: &'a ThreadPoolIndexer<T>,
+    deadline_ready: &'a [AtomicBool],
+    peer_failed: &'a AtomicBool,
+    clock: &'a BenchmarkClock,
+    start_ns: u64,
+}
+
+fn issue_queries(
+    context: QueryIssuerContext<'_>,
+    dispatch: Vec<DispatchEntry>,
+    mut storage: IssuerStorage,
+    initial_failure: Option<IssuerFailure>,
+) -> IssuerOutput {
+    let cpu_started = thread_cpu_time_ns();
+    let mut failure = initial_failure;
+    let mut entries = dispatch.into_iter().peekable();
+
+    while failure.is_none() {
+        let Some(first) = entries.peek() else {
+            break;
+        };
+        let deadline_ns = first.deadline_ns;
+        let deadline_group = first.deadline_group as usize;
+        context
+            .clock
+            .wait_until(context.start_ns.saturating_add(deadline_ns));
+        storage.touched_lanes.clear();
+
+        while entries
+            .peek()
+            .is_some_and(|entry| entry.deadline_ns == deadline_ns)
+        {
+            let Some(entry) = entries.next() else {
+                failure = Some(IssuerFailure::DispatchMismatch);
+                break;
+            };
+            let scheduled_ns = context.start_ns.saturating_add(deadline_ns);
+            match entry.payload {
+                DispatchPayload::Query { lane, .. } => {
+                    if let Err(error) =
+                        context.lanes[lane].write(storage.lane_cursors[lane], entry.id)
+                    {
+                        failure = Some(error);
+                        break;
+                    }
+                    storage.lane_cursors[lane] += 1;
+                    if !storage.touched_flags[lane] {
+                        storage.touched_flags[lane] = true;
+                        storage.touched_lanes.push(lane);
+                    }
+                    let record = IssueRecord {
+                        scheduled_ns,
+                        accepted_ns: context.clock.now_ns(),
+                        queue_id: lane as u16,
+                        kind: OperationKind::Query,
+                        accepted: true,
+                    };
+                    if let Err(error) = storage.record(entry.id, record) {
+                        failure = Some(error);
+                        break;
+                    }
+                }
+                DispatchPayload::Event(_) => failure = Some(IssuerFailure::DispatchMismatch),
+            }
+        }
+        publish_touched(
+            context.lanes,
+            &storage.lane_cursors,
+            &mut storage.touched_flags,
+            &storage.touched_lanes,
+        );
+        if failure.is_some() {
+            context.peer_failed.store(true, Ordering::Release);
+            break;
+        }
+        let Some(ready) = context.deadline_ready.get(deadline_group) else {
+            failure = Some(IssuerFailure::DispatchMismatch);
+            break;
+        };
+        ready.store(true, Ordering::Release);
+    }
+
+    if failure.is_some() {
+        context.peer_failed.store(true, Ordering::Release);
+    }
+    IssuerOutput {
+        records: storage.records,
+        written: storage.written,
+        issuer_cpu_ns: thread_cpu_time_ns().saturating_sub(cpu_started),
+        failure,
+    }
+}
+
+fn issue_events<T: SyncIndexer>(
+    context: EventIssuerContext<'_, T>,
+    dispatch: Vec<DispatchEntry>,
+    mut storage: IssuerStorage,
+    initial_failure: Option<IssuerFailure>,
+) -> IssuerOutput {
+    let cpu_started = thread_cpu_time_ns();
+    let mut failure = initial_failure;
+    let mut entries = dispatch.into_iter().peekable();
+
+    while failure.is_none() {
+        let Some(first) = entries.peek() else {
+            break;
+        };
+        let deadline_ns = first.deadline_ns;
+        let deadline_group = first.deadline_group as usize;
+        context
+            .clock
+            .wait_until(context.start_ns.saturating_add(deadline_ns));
+        if !wait_for_deadline_queries(
+            context.deadline_ready.get(deadline_group),
+            context.peer_failed,
+        ) {
+            failure = Some(IssuerFailure::PeerFailed);
+            break;
+        }
+
+        while entries
+            .peek()
+            .is_some_and(|entry| entry.deadline_ns == deadline_ns)
+        {
+            let Some(entry) = entries.next() else {
+                failure = Some(IssuerFailure::DispatchMismatch);
+                break;
+            };
+            let scheduled_ns = context.start_ns.saturating_add(deadline_ns);
+            match entry.payload {
+                DispatchPayload::Query { .. } => {
+                    failure = Some(IssuerFailure::DispatchMismatch);
+                    break;
+                }
+                DispatchPayload::Event(event) => {
+                    let enqueue_result = enqueue_event(&context, event, entry.id);
+                    match enqueue_result {
+                        Ok((event_worker, accepted_ns)) => {
+                            let record = IssueRecord {
+                                scheduled_ns,
+                                accepted_ns,
+                                queue_id: event_worker as u16,
+                                kind: OperationKind::Event,
+                                accepted: true,
+                            };
+                            if let Err(error) = storage.record(entry.id, record) {
+                                failure = Some(error);
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            failure = Some(IssuerFailure::Observation);
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if failure.is_some() {
+        context.peer_failed.store(true, Ordering::Release);
+    }
+    IssuerOutput {
+        records: storage.records,
+        written: storage.written,
+        issuer_cpu_ns: thread_cpu_time_ns().saturating_sub(cpu_started),
+        failure,
+    }
+}
+
+fn enqueue_event<T: SyncIndexer>(
+    context: &EventIssuerContext<'_, T>,
+    event: RouterEvent,
+    id: u32,
+) -> Result<(usize, u64), ()> {
+    context
+        .indexer
+        .enqueue_active_observation_owned(event, id, context.clock.epoch())
+        .map(|receipt| (receipt.event_worker, receipt.accepted_ns))
+        .map_err(|_| ())
+}
+
+fn wait_for_deadline_queries(
+    deadline_ready: Option<&AtomicBool>,
+    peer_failed: &AtomicBool,
+) -> bool {
+    let Some(ready) = deadline_ready else {
+        return false;
+    };
+    while !ready.load(Ordering::Acquire) {
+        if peer_failed.load(Ordering::Acquire) {
+            return false;
+        }
+        std::hint::spin_loop();
+    }
+    true
+}
+
+fn publish_touched(
+    lanes: &[Arc<QueryLane>],
+    lane_cursors: &[usize],
+    touched_flags: &mut [bool],
+    touched_lanes: &[usize],
+) {
+    for &lane in touched_lanes {
+        lanes[lane].publish(lane_cursors[lane]);
+        touched_flags[lane] = false;
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Serialize)]
+pub struct Distribution {
+    pub p50_ns: u64,
+    pub p99_ns: u64,
+    pub p999_ns: u64,
+    pub max_ns: u64,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OpenLoopResult {
+    pub schema_version: u32,
+    pub backend: String,
+    pub timer: &'static str,
+    pub benchmark_duration_ms: u64,
+    pub block_size: u32,
+    pub pre_run_quiescence_ms: u64,
+    pub query_lanes: usize,
+    pub issuer_threads: usize,
+    pub event_workers: usize,
+    pub issuer_cpus: Vec<usize>,
+    pub query_issuer_cpu: Option<usize>,
+    pub backend_cpus: Vec<usize>,
+    pub total_requests: usize,
+    pub total_events: usize,
+    pub total_stored_events: usize,
+    pub total_removed_events: usize,
+    pub total_cleared_events: usize,
+    pub total_request_blocks: usize,
+    pub total_stored_blocks: usize,
+    pub total_removed_blocks: usize,
+    pub total_logical_ops: usize,
+    pub total_block_ops: usize,
+    pub offered_logical_ops_per_sec: f64,
+    pub actual_issue_logical_ops_per_sec: f64,
+    pub achieved_logical_ops_per_sec: f64,
+    pub offered_block_ops_per_sec: f64,
+    pub actual_issue_block_ops_per_sec: f64,
+    pub achieved_block_ops_per_sec: f64,
+    pub read_issue_lag: Distribution,
+    pub update_issue_lag: Distribution,
+    pub generator_gate: &'static str,
+    pub query_queue_wait: Distribution,
+    pub query_service: Distribution,
+    pub query_scheduled_to_finished: Distribution,
+    pub update_accepted_to_finished: Distribution,
+    pub update_scheduled_to_finished: Distribution,
+    pub delayed_reads: usize,
+    pub delayed_updates: usize,
+    pub queue_depth_at_stop: Vec<usize>,
+    pub queued_queries_at_stop: usize,
+    pub maximum_query_queue_depth: usize,
+    pub outstanding_updates_at_stop: usize,
+    pub maximum_outstanding_updates: usize,
+    pub post_acceptance_completion_races: usize,
+    pub issuer_cpu_ns: u64,
+    pub issue_span_ns: u64,
+    pub drain_ns: u64,
+    pub generator_valid: bool,
+    pub kept_up: bool,
+    pub failure_reasons: Vec<String>,
+}
+
+fn partition_dispatch(
+    dispatch: Vec<DispatchEntry>,
+    event_issuer_count: usize,
+) -> anyhow::Result<(Vec<DispatchEntry>, Vec<Vec<DispatchEntry>>)> {
+    if event_issuer_count == 0 {
+        anyhow::bail!("event-issuer count must be positive");
+    }
+    let logical_workers = dispatch
+        .iter()
+        .map(|entry| entry.worker_id as usize)
+        .max()
+        .map_or(0, |worker| worker + 1);
+    let workers_per_issuer = logical_workers.div_ceil(event_issuer_count).max(1);
+    let event_shard_for =
+        |worker_id: u64| (worker_id as usize / workers_per_issuer).min(event_issuer_count - 1);
+    let mut query_count = 0usize;
+    let mut event_counts = vec![0usize; event_issuer_count];
+    for entry in &dispatch {
+        match entry.payload {
+            DispatchPayload::Query { .. } => query_count += 1,
+            DispatchPayload::Event(_) => event_counts[event_shard_for(entry.worker_id)] += 1,
+        }
+    }
+    let mut queries = Vec::with_capacity(query_count);
+    let mut event_shards = event_counts
+        .into_iter()
+        .map(Vec::with_capacity)
+        .collect::<Vec<_>>();
+    for entry in dispatch {
+        match entry.payload {
+            DispatchPayload::Query { .. } => queries.push(entry),
+            DispatchPayload::Event(_) => {
+                event_shards[event_shard_for(entry.worker_id)].push(entry);
+            }
+        }
+    }
+    Ok((queries, event_shards))
+}
+
+fn aggregate_issuer_outputs(
+    outputs: Vec<IssuerOutput>,
+    operation_count: usize,
+    producer_stop_ns: u64,
+) -> IssuerAnalysisInput {
+    let mut records = vec![IssueRecord::default(); operation_count].into_boxed_slice();
+    let mut issuer_cpu_ns = 0u64;
+    let mut failure = None;
+    for output in outputs {
+        issuer_cpu_ns = issuer_cpu_ns.saturating_add(output.issuer_cpu_ns);
+        failure = failure.or(output.failure);
+        for local in output.records[..output.written].iter().copied() {
+            let Some(slot) = records.get_mut(local.id as usize) else {
+                failure = failure.or(Some(IssuerFailure::DispatchMismatch));
+                continue;
+            };
+            if slot.accepted {
+                failure = failure.or(Some(IssuerFailure::DispatchMismatch));
+                continue;
+            }
+            *slot = local.record;
+        }
+    }
+    IssuerAnalysisInput {
+        records,
+        producer_stop_ns,
+        issuer_cpu_ns,
+        failure,
+    }
+}
+
+fn deadline_readiness(query_counts: Vec<u32>) -> Box<[AtomicBool]> {
+    query_counts
+        .into_iter()
+        .map(|count| AtomicBool::new(count == 0))
+        .collect::<Vec<_>>()
+        .into_boxed_slice()
+}
+
+pub async fn run_open_loop<T: SyncIndexer>(
+    backend_name: &str,
+    indexer: Arc<ThreadPoolIndexer<T>>,
+    trial: PreparedOpenLoopTrial,
+    config: OpenLoopConfig,
+) -> anyhow::Result<OpenLoopResult> {
+    trial.page_touch_untimed();
+    let clock = BenchmarkClock::new(config.spin_us.saturating_mul(1_000))?;
+    let epoch = clock.epoch();
+
+    for spec in trial
+        .query_corpus
+        .specs
+        .iter()
+        .filter(|spec| spec.valid)
+        .take(128)
+    {
+        let start = spec.start as usize;
+        let end = start + spec.len as usize;
+        black_box(
+            indexer
+                .backend()
+                .find_matches(&trial.query_corpus.hashes[start..end], false),
+        );
+    }
+
+    let lanes = trial
+        .lane_capacities
+        .iter()
+        .map(|&capacity| Arc::new(QueryLane::new(capacity)))
+        .collect::<Vec<_>>();
+    let mut ready_receivers = Vec::with_capacity(lanes.len());
+    let mut query_tasks = Vec::with_capacity(lanes.len());
+    for lane in &lanes {
+        let (ready_tx, ready_rx) = oneshot::channel();
+        ready_receivers.push(ready_rx);
+        query_tasks.push(tokio::spawn(query_lane_worker(
+            Arc::clone(&indexer),
+            Arc::clone(lane),
+            Arc::clone(&trial.query_corpus),
+            epoch,
+            ready_tx,
+        )));
+    }
+    for receiver in ready_receivers {
+        receiver.await?;
+    }
+
+    let issuer_count = config.issuer_threads;
+    let operation_count = trial.dispatch.len();
+    let (query_dispatch, event_dispatch_shards) = partition_dispatch(trial.dispatch, issuer_count)?;
+    let query_storage = IssuerStorage::new(query_dispatch.len(), lanes.len());
+    let issuer_storages = event_dispatch_shards
+        .iter()
+        .map(|shard| IssuerStorage::new(shard.len(), lanes.len()))
+        .collect::<Vec<_>>();
+    let deadline_ready = deadline_readiness(trial.deadline_query_counts);
+    let observation = indexer
+        .begin_observation(ThreadPoolObservationPlan {
+            epoch,
+            expected_events_by_worker: trial.expected_events_by_worker,
+        })
+        .await?;
+    let peer_failed = AtomicBool::new(false);
+    let start_signal = AtomicU64::new(0);
+    let ready_barrier = Barrier::new(issuer_count + 2);
+    let start_barrier = Barrier::new(issuer_count + 2);
+    let (start_ns, issuer_outputs) = std::thread::scope(|scope| {
+        let mut handles = Vec::with_capacity(issuer_count + 1);
+        let query_clock = &clock;
+        let query_lanes = &lanes;
+        let query_deadline_ready = deadline_ready.as_ref();
+        let query_peer_failed = &peer_failed;
+        let query_ready_barrier = &ready_barrier;
+        let query_start_barrier = &start_barrier;
+        let query_start_signal = &start_signal;
+        let query_cpu = config.query_issuer_cpu;
+        handles.push(scope.spawn(move || {
+            let mut initial_failure = pin_current_thread(query_cpu)
+                .err()
+                .map(|_| IssuerFailure::Affinity);
+            if initial_failure.is_some() {
+                query_peer_failed.store(true, Ordering::Release);
+            }
+            query_ready_barrier.wait();
+            query_start_barrier.wait();
+            if initial_failure.is_none() && query_peer_failed.load(Ordering::Acquire) {
+                initial_failure = Some(IssuerFailure::PeerFailed);
+            }
+            issue_queries(
+                QueryIssuerContext {
+                    lanes: query_lanes,
+                    deadline_ready: query_deadline_ready,
+                    peer_failed: query_peer_failed,
+                    clock: query_clock,
+                    start_ns: query_start_signal.load(Ordering::Acquire),
+                },
+                query_dispatch,
+                query_storage,
+                initial_failure,
+            )
+        }));
+        for (issuer_idx, (dispatch, storage)) in event_dispatch_shards
+            .into_iter()
+            .zip(issuer_storages)
+            .enumerate()
+        {
+            let issuer_cpu = config.issuer_cpus.get(issuer_idx).copied();
+            let issuer_clock = &clock;
+            let issuer_indexer = indexer.as_ref();
+            let issuer_deadline_ready = deadline_ready.as_ref();
+            let issuer_peer_failed = &peer_failed;
+            let issuer_ready_barrier = &ready_barrier;
+            let issuer_start_barrier = &start_barrier;
+            let issuer_start_signal = &start_signal;
+            handles.push(scope.spawn(move || {
+                let mut initial_failure = pin_current_thread(issuer_cpu)
+                    .err()
+                    .map(|_| IssuerFailure::Affinity);
+                if initial_failure.is_some() {
+                    issuer_peer_failed.store(true, Ordering::Release);
+                }
+                issuer_ready_barrier.wait();
+                issuer_start_barrier.wait();
+                if initial_failure.is_none() && issuer_peer_failed.load(Ordering::Acquire) {
+                    initial_failure = Some(IssuerFailure::PeerFailed);
+                }
+                issue_events(
+                    EventIssuerContext {
+                        indexer: issuer_indexer,
+                        deadline_ready: issuer_deadline_ready,
+                        peer_failed: issuer_peer_failed,
+                        clock: issuer_clock,
+                        start_ns: issuer_start_signal.load(Ordering::Acquire),
+                    },
+                    dispatch,
+                    storage,
+                    initial_failure,
+                )
+            }));
+        }
+
+        ready_barrier.wait();
+        let start_ns = clock.now_ns().saturating_add(20_000_000);
+        start_signal.store(start_ns, Ordering::Release);
+        start_barrier.wait();
+        let mut outputs = Vec::with_capacity(issuer_count + 1);
+        for handle in handles {
+            outputs.push(
+                handle
+                    .join()
+                    .map_err(|_| anyhow::anyhow!("open-loop issuer panicked"))?,
+            );
+        }
+        Ok::<_, anyhow::Error>((start_ns, outputs))
+    })?;
+
+    let producer_stop_ns = clock.now_ns();
+    let drain = observation.close_observed_producers();
+    let issuer_analysis =
+        aggregate_issuer_outputs(issuer_outputs, operation_count, producer_stop_ns);
+
+    for lane in &lanes {
+        lane.close();
+    }
+    let seal_future = drain.seal();
+    let query_future = async {
+        let mut results = Vec::with_capacity(query_tasks.len());
+        for task in query_tasks {
+            results.push(task.await?);
+        }
+        Ok::<_, tokio::task::JoinError>(results)
+    };
+    let (sealed, query_results) = tokio::join!(seal_future, query_future);
+    let sealed = sealed?;
+    let query_results = query_results?;
+    let query_drain_ns = query_results
+        .iter()
+        .map(|result| result.drain_ns)
+        .max()
+        .unwrap_or(start_ns);
+    let end_ns = query_drain_ns.max(sealed.latest_seal_ns());
+    let snapshot = sealed.harvest().await?;
+
+    Ok(analyze_result(
+        backend_name,
+        &clock,
+        start_ns,
+        end_ns,
+        trial.totals,
+        trial.benchmark_duration_ns,
+        trial.block_size,
+        &trial.operation_workers,
+        config,
+        issuer_analysis,
+        query_results,
+        snapshot,
+    ))
+}
+
+#[allow(clippy::too_many_arguments)]
+fn analyze_result(
+    backend_name: &str,
+    clock: &BenchmarkClock,
+    start_ns: u64,
+    end_ns: u64,
+    totals: MooncakeTraceTotals,
+    benchmark_duration_ns: u64,
+    block_size: u32,
+    operation_workers: &[u64],
+    config: OpenLoopConfig,
+    issuer: IssuerAnalysisInput,
+    query_results: Vec<QueryLaneResult>,
+    snapshot: dynamo_kv_router::indexer::ThreadPoolObservationSnapshot,
+) -> OpenLoopResult {
+    let IssuerAnalysisInput {
+        records,
+        producer_stop_ns,
+        issuer_cpu_ns,
+        failure: issuer_failure,
+    } = issuer;
+    let mut failure_reasons = Vec::new();
+    if let Some(failure) = issuer_failure {
+        failure_reasons.push(format!("issuer_{failure:?}"));
+    }
+
+    let mut expected_queries_by_lane = vec![Vec::new(); config.query_lanes];
+    let mut expected_events_by_worker = BTreeMap::<u64, Vec<u32>>::new();
+    for (id, record) in records
+        .iter()
+        .enumerate()
+        .filter(|(_, record)| record.accepted)
+    {
+        match record.kind {
+            OperationKind::Query => {
+                if let Some(expected) = expected_queries_by_lane.get_mut(record.queue_id as usize) {
+                    expected.push(id as u32);
+                }
+            }
+            OperationKind::Event => {
+                let worker_id = operation_workers[id];
+                expected_events_by_worker
+                    .entry(worker_id)
+                    .or_default()
+                    .push(id as u32);
+            }
+        }
+    }
+
+    let mut query_completions = vec![None; records.len()];
+    for (lane_idx, result) in query_results.into_iter().enumerate() {
+        if result.failure != QueryLaneFailure::None {
+            failure_reasons.push(format!("query_lane_{:?}", result.failure));
+        }
+        let actual_ids = result.completions[..result.written]
+            .iter()
+            .map(|completion| completion.id)
+            .collect::<Vec<_>>();
+        if expected_queries_by_lane.get(lane_idx) != Some(&actual_ids) {
+            failure_reasons.push(format!("query_lane_order_{lane_idx}"));
+        }
+        for completion in result.completions[..result.written].iter().copied() {
+            let slot = &mut query_completions[completion.id as usize];
+            if slot.replace(completion).is_some() {
+                failure_reasons.push("duplicate_query_completion".to_string());
+            }
+        }
+    }
+
+    let mut event_completions = vec![None; records.len()];
+    let mut actual_events_by_worker = BTreeMap::<u64, Vec<u32>>::new();
+    for (worker_idx, buffer) in snapshot.buffers.iter().enumerate() {
+        if buffer.overflowed() {
+            failure_reasons.push("event_completion_overflow".to_string());
+        }
+        if snapshot.seals[worker_idx].written != buffer.records().len() {
+            failure_reasons.push(format!("event_worker_seal_count_{worker_idx}"));
+        }
+        for completion in buffer.records().iter().copied() {
+            let id = completion.correlation_id as usize;
+            let Some(record) = records.get(id) else {
+                failure_reasons.push("event_completion_id_out_of_range".to_string());
+                continue;
+            };
+            if record.kind != OperationKind::Event {
+                failure_reasons.push(format!("non_event_completion_{id}"));
+                continue;
+            }
+            if record.queue_id as usize != worker_idx {
+                failure_reasons.push(format!("event_completion_queue_{id}"));
+            }
+            actual_events_by_worker
+                .entry(operation_workers[id])
+                .or_default()
+                .push(completion.correlation_id);
+            let slot = &mut event_completions[id];
+            if slot.replace(completion).is_some() {
+                failure_reasons.push("duplicate_event_completion".to_string());
+            }
+        }
+    }
+    for (worker_id, expected) in &expected_events_by_worker {
+        if actual_events_by_worker.get(worker_id) != Some(expected) {
+            failure_reasons.push(format!("event_worker_fifo_{worker_id}"));
+        }
+    }
+
+    let mut read_issue_lag = Vec::with_capacity(totals.requests);
+    let mut update_issue_lag = Vec::with_capacity(totals.events());
+    let mut query_queue_wait = Vec::with_capacity(totals.requests);
+    let mut query_service = Vec::with_capacity(totals.requests);
+    let mut query_end_to_end = Vec::with_capacity(totals.requests);
+    let mut update_accepted_to_finished = Vec::with_capacity(totals.events());
+    let mut update_end_to_end = Vec::with_capacity(totals.events());
+    let mut delayed_reads = 0usize;
+    let mut delayed_updates = 0usize;
+    let mut post_acceptance_completion_races = 0usize;
+    let tolerance_ns = config
+        .issue_lag_diagnostic_threshold_us
+        .saturating_mul(1_000);
+    let mut accepted_query_edges = Vec::with_capacity(totals.requests * 2);
+    let mut accepted_update_edges = Vec::with_capacity(totals.events() * 2);
+
+    for (id, record) in records.iter().enumerate() {
+        if !record.accepted {
+            failure_reasons.push(format!("unissued_operation_{id}"));
+            continue;
+        }
+        let issue_lag = record.accepted_ns.saturating_sub(record.scheduled_ns);
+        match record.kind {
+            OperationKind::Query => {
+                read_issue_lag.push(issue_lag);
+                delayed_reads += usize::from(issue_lag > tolerance_ns);
+                let Some(completion) = query_completions[id] else {
+                    failure_reasons.push(format!("missing_query_completion_{id}"));
+                    continue;
+                };
+                if !completion.success {
+                    failure_reasons.push(format!("failed_query_{id}"));
+                }
+                query_queue_wait.push(completion.started_ns.saturating_sub(record.accepted_ns));
+                query_service.push(completion.finished_ns.saturating_sub(completion.started_ns));
+                query_end_to_end.push(completion.finished_ns.saturating_sub(record.scheduled_ns));
+                accepted_query_edges.push((record.accepted_ns, 1i8));
+                accepted_query_edges.push((completion.started_ns.max(record.accepted_ns), -1i8));
+            }
+            OperationKind::Event => {
+                if record.queue_id == u16::MAX {
+                    failure_reasons.push(format!("missing_event_worker_{id}"));
+                }
+                update_issue_lag.push(issue_lag);
+                delayed_updates += usize::from(issue_lag > tolerance_ns);
+                let Some(completion) = event_completions[id] else {
+                    failure_reasons.push(format!("missing_event_completion_{id}"));
+                    continue;
+                };
+                if !completion.success {
+                    failure_reasons.push(format!("failed_event_{id}"));
+                }
+                if completion.finished_ns < record.accepted_ns {
+                    post_acceptance_completion_races += 1;
+                }
+                update_accepted_to_finished
+                    .push(completion.finished_ns.saturating_sub(record.accepted_ns));
+                update_end_to_end.push(completion.finished_ns.saturating_sub(record.scheduled_ns));
+                accepted_update_edges.push((record.accepted_ns, 1i8));
+                accepted_update_edges.push((completion.finished_ns.max(record.accepted_ns), -1i8));
+            }
+        }
+    }
+
+    let maximum_query_queue_depth = maximum_depth(&mut accepted_query_edges);
+    let maximum_outstanding = maximum_depth(&mut accepted_update_edges);
+    let queued_queries_at_stop = records
+        .iter()
+        .enumerate()
+        .filter(|(_, record)| record.kind == OperationKind::Query && record.accepted)
+        .filter(|(id, record)| {
+            query_completions[*id].is_some_and(|completion| {
+                record.accepted_ns <= producer_stop_ns && completion.started_ns > producer_stop_ns
+            })
+        })
+        .count();
+    let outstanding_at_stop = event_completions
+        .iter()
+        .flatten()
+        .filter(|completion| completion.finished_ns > producer_stop_ns)
+        .count();
+
+    let issue_span_ns = records
+        .iter()
+        .filter(|record| record.accepted)
+        .map(|record| record.accepted_ns)
+        .max()
+        .unwrap_or(start_ns)
+        .saturating_sub(start_ns);
+    let drain_ns = end_ns.saturating_sub(producer_stop_ns);
+    let elapsed_ns = end_ns.saturating_sub(start_ns).max(1);
+    let total_logical_ops = totals.requests + totals.events();
+    let total_block_ops = totals.total_block_ops();
+    let offered_seconds = benchmark_duration_ns.max(1) as f64 / 1e9;
+    let achieved_seconds = elapsed_ns as f64 / 1e9;
+    let issue_seconds = issue_span_ns.max(1) as f64 / 1e9;
+
+    let issue_span_valid = issue_span_ns <= benchmark_duration_ns.saturating_mul(101) / 100;
+    let generator_valid = failure_reasons.is_empty() && issue_span_valid;
+    let kept_up = generator_valid && elapsed_ns <= benchmark_duration_ns.saturating_mul(110) / 100;
+
+    OpenLoopResult {
+        schema_version: RESULT_SCHEMA_VERSION,
+        backend: backend_name.to_string(),
+        timer: clock.timer_name(),
+        benchmark_duration_ms: benchmark_duration_ns / 1_000_000,
+        block_size,
+        pre_run_quiescence_ms: config.pre_run_quiescence_ms,
+        query_lanes: config.query_lanes,
+        issuer_threads: config.issuer_threads,
+        event_workers: snapshot.buffers.len(),
+        issuer_cpus: config.issuer_cpus,
+        query_issuer_cpu: config.query_issuer_cpu,
+        backend_cpus: config.backend_cpus,
+        total_requests: totals.requests,
+        total_events: totals.events(),
+        total_stored_events: totals.stored_events,
+        total_removed_events: totals.removed_events,
+        total_cleared_events: totals.cleared_events,
+        total_request_blocks: totals.request_blocks,
+        total_stored_blocks: totals.stored_blocks,
+        total_removed_blocks: totals.removed_blocks,
+        total_logical_ops,
+        total_block_ops,
+        offered_logical_ops_per_sec: total_logical_ops as f64 / offered_seconds,
+        actual_issue_logical_ops_per_sec: total_logical_ops as f64 / issue_seconds,
+        achieved_logical_ops_per_sec: total_logical_ops as f64 / achieved_seconds,
+        offered_block_ops_per_sec: total_block_ops as f64 / offered_seconds,
+        actual_issue_block_ops_per_sec: total_block_ops as f64 / issue_seconds,
+        achieved_block_ops_per_sec: total_block_ops as f64 / achieved_seconds,
+        read_issue_lag: distribution(read_issue_lag),
+        update_issue_lag: distribution(update_issue_lag),
+        generator_gate: "issue_span_exact_completion",
+        query_queue_wait: distribution(query_queue_wait),
+        query_service: distribution(query_service),
+        query_scheduled_to_finished: distribution(query_end_to_end),
+        update_accepted_to_finished: distribution(update_accepted_to_finished),
+        update_scheduled_to_finished: distribution(update_end_to_end),
+        delayed_reads,
+        delayed_updates,
+        queue_depth_at_stop: snapshot.queue_depth_at_stop,
+        queued_queries_at_stop,
+        maximum_query_queue_depth,
+        outstanding_updates_at_stop: outstanding_at_stop,
+        maximum_outstanding_updates: maximum_outstanding,
+        post_acceptance_completion_races,
+        issuer_cpu_ns,
+        issue_span_ns,
+        drain_ns,
+        generator_valid,
+        kept_up,
+        failure_reasons,
+    }
+}
+
+fn maximum_depth(edges: &mut [(u64, i8)]) -> usize {
+    edges.sort_unstable_by(|left, right| left.0.cmp(&right.0).then_with(|| right.1.cmp(&left.1)));
+    let mut depth = 0isize;
+    let mut maximum = 0isize;
+    for &(_, delta) in edges.iter() {
+        depth += delta as isize;
+        maximum = maximum.max(depth);
+    }
+    maximum.max(0) as usize
+}
+
+fn distribution(mut values: Vec<u64>) -> Distribution {
+    if values.is_empty() {
+        return Distribution::default();
+    }
+    values.sort_unstable();
+    Distribution {
+        p50_ns: nearest_rank(&values, 50, 100),
+        p99_ns: nearest_rank(&values, 99, 100),
+        p999_ns: nearest_rank(&values, 999, 1_000),
+        max_ns: values.last().copied().unwrap_or_default(),
+    }
+}
+
+fn nearest_rank(values: &[u64], numerator: usize, denominator: usize) -> u64 {
+    let rank = values
+        .len()
+        .saturating_mul(numerator)
+        .div_ceil(denominator)
+        .max(1);
+    values[rank.saturating_sub(1).min(values.len() - 1)]
+}
+
+fn elapsed_ns(epoch: Instant) -> u64 {
+    epoch.elapsed().as_nanos().min(u64::MAX as u128) as u64
+}
+
+struct BenchmarkClock {
+    epoch: Instant,
+    spin_ns: u64,
+    #[cfg(target_os = "linux")]
+    monotonic_epoch_ns: u64,
+}
+
+impl BenchmarkClock {
+    fn new(spin_ns: u64) -> anyhow::Result<Self> {
+        #[cfg(target_os = "linux")]
+        let monotonic_epoch_ns = monotonic_now_ns()?;
+        Ok(Self {
+            epoch: Instant::now(),
+            spin_ns,
+            #[cfg(target_os = "linux")]
+            monotonic_epoch_ns,
+        })
+    }
+
+    fn epoch(&self) -> Instant {
+        self.epoch
+    }
+
+    fn now_ns(&self) -> u64 {
+        elapsed_ns(self.epoch)
+    }
+
+    fn wait_until(&self, target_ns: u64) {
+        let sleep_target = target_ns.saturating_sub(self.spin_ns);
+        let now = self.now_ns();
+        #[cfg(target_os = "linux")]
+        if sleep_target > now {
+            sleep_until_monotonic(self.monotonic_epoch_ns.saturating_add(sleep_target));
+        }
+        #[cfg(not(target_os = "linux"))]
+        {
+            if sleep_target > now {
+                std::thread::sleep(Duration::from_nanos(sleep_target - now));
+            }
+        }
+        while self.now_ns() < target_ns {
+            std::hint::spin_loop();
+        }
+    }
+
+    fn timer_name(&self) -> &'static str {
+        if cfg!(target_os = "linux") {
+            "clock_nanosleep_monotonic_absolute"
+        } else {
+            "portable_sleep_spin_non_authoritative"
+        }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn monotonic_now_ns() -> anyhow::Result<u64> {
+    let mut timestamp = libc::timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    let rc = unsafe { libc::clock_gettime(libc::CLOCK_MONOTONIC, &mut timestamp) };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok((timestamp.tv_sec as u64)
+        .saturating_mul(1_000_000_000)
+        .saturating_add(timestamp.tv_nsec as u64))
+}
+
+#[cfg(target_os = "linux")]
+fn sleep_until_monotonic(target_ns: u64) {
+    let request = libc::timespec {
+        tv_sec: (target_ns / 1_000_000_000) as libc::time_t,
+        tv_nsec: (target_ns % 1_000_000_000) as libc::c_long,
+    };
+    loop {
+        let rc = unsafe {
+            libc::clock_nanosleep(
+                libc::CLOCK_MONOTONIC,
+                libc::TIMER_ABSTIME,
+                &request,
+                std::ptr::null_mut(),
+            )
+        };
+        if rc == 0 {
+            return;
+        }
+        if rc != libc::EINTR {
+            return;
+        }
+    }
+}
+
+fn thread_cpu_time_ns() -> u64 {
+    #[cfg(target_os = "linux")]
+    {
+        let mut timestamp = libc::timespec {
+            tv_sec: 0,
+            tv_nsec: 0,
+        };
+        let rc = unsafe { libc::clock_gettime(libc::CLOCK_THREAD_CPUTIME_ID, &mut timestamp) };
+        if rc == 0 {
+            return (timestamp.tv_sec as u64)
+                .saturating_mul(1_000_000_000)
+                .saturating_add(timestamp.tv_nsec as u64);
+        }
+    }
+    0
+}
+
+fn pin_current_thread(cpu: Option<usize>) -> Result<(), ()> {
+    let Some(cpu) = cpu else {
+        return Ok(());
+    };
+    #[cfg(target_os = "linux")]
+    {
+        let mut set = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+        unsafe {
+            libc::CPU_ZERO(&mut set);
+            libc::CPU_SET(cpu, &mut set);
+        }
+        let rc = unsafe {
+            libc::sched_setaffinity(
+                0,
+                std::mem::size_of::<libc::cpu_set_t>(),
+                &set as *const libc::cpu_set_t,
+            )
+        };
+        if rc != 0 {
+            return Err(());
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    let _ = cpu;
+    Ok(())
+}
+
+pub fn parse_cpu_list(value: &str) -> anyhow::Result<Vec<usize>> {
+    let mut cpus = Vec::new();
+    for part in value
+        .split(',')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+    {
+        let Some((start, end)) = part.split_once('-') else {
+            cpus.push(part.parse()?);
+            continue;
+        };
+        let start: usize = start.parse()?;
+        let end: usize = end.parse()?;
+        if start > end {
+            anyhow::bail!("invalid descending CPU range {part}");
+        }
+        cpus.extend(start..=end);
+    }
+    cpus.sort_unstable();
+    cpus.dedup();
+    if cpus.is_empty() {
+        anyhow::bail!("CPU list must not be empty");
+    }
+    Ok(cpus)
+}
+
+pub fn validate_cpu_partition(
+    issuer_cpus: &[usize],
+    query_issuer_cpu: Option<usize>,
+    backend_cpus: &[usize],
+) -> anyhow::Result<()> {
+    if backend_cpus.is_empty() {
+        if !issuer_cpus.is_empty() || query_issuer_cpu.is_some() {
+            anyhow::bail!("--backend-cpus is required when generator CPUs are specified");
+        }
+        return Ok(());
+    }
+    if issuer_cpus.iter().any(|cpu| backend_cpus.contains(cpu)) {
+        anyhow::bail!("an issuer CPU overlaps the backend CPU set");
+    }
+    if query_issuer_cpu.is_some_and(|cpu| backend_cpus.contains(&cpu)) {
+        anyhow::bail!("query-issuer CPU overlaps the backend CPU set");
+    }
+    if query_issuer_cpu.is_some_and(|cpu| issuer_cpus.contains(&cpu)) {
+        anyhow::bail!("query and event issuer CPUs must be distinct");
+    }
+    let mut unique_issuers = issuer_cpus.to_vec();
+    unique_issuers.sort_unstable();
+    unique_issuers.dedup();
+    if unique_issuers.len() != issuer_cpus.len() {
+        anyhow::bail!("issuer CPUs must be unique");
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let allowed = allowed_cpu_set()?;
+        let mut selected_cores = BTreeMap::new();
+        for cpu in issuer_cpus
+            .iter()
+            .copied()
+            .chain(query_issuer_cpu)
+            .chain(backend_cpus.iter().copied())
+        {
+            if !allowed.contains(&cpu) {
+                anyhow::bail!("CPU {cpu} is outside the process affinity mask");
+            }
+            if let Some(core) = physical_core(cpu)? {
+                if let Some(existing) = selected_cores.insert(core, cpu) {
+                    anyhow::bail!(
+                        "CPUs {existing} and {cpu} are SMT siblings; select one logical CPU per physical core"
+                    );
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn pin_current_thread_to_cpus(cpus: &[usize]) -> anyhow::Result<()> {
+    if cpus.is_empty() {
+        return Ok(());
+    }
+    #[cfg(target_os = "linux")]
+    {
+        let mut set = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+        unsafe {
+            libc::CPU_ZERO(&mut set);
+            for &cpu in cpus {
+                libc::CPU_SET(cpu, &mut set);
+            }
+        }
+        let rc = unsafe {
+            libc::sched_setaffinity(
+                0,
+                std::mem::size_of::<libc::cpu_set_t>(),
+                &set as *const libc::cpu_set_t,
+            )
+        };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error().into());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn allowed_cpu_set() -> anyhow::Result<Vec<usize>> {
+    let mut set = unsafe { std::mem::zeroed::<libc::cpu_set_t>() };
+    let rc = unsafe {
+        libc::sched_getaffinity(
+            0,
+            std::mem::size_of::<libc::cpu_set_t>(),
+            &mut set as *mut libc::cpu_set_t,
+        )
+    };
+    if rc != 0 {
+        return Err(std::io::Error::last_os_error().into());
+    }
+    Ok((0..libc::CPU_SETSIZE as usize)
+        .filter(|&cpu| unsafe { libc::CPU_ISSET(cpu, &set) })
+        .collect())
+}
+
+#[cfg(target_os = "linux")]
+fn physical_core(cpu: usize) -> anyhow::Result<Option<(u32, u32)>> {
+    let topology = format!("/sys/devices/system/cpu/cpu{cpu}/topology");
+    let package_path = format!("{topology}/physical_package_id");
+    let core_path = format!("{topology}/core_id");
+    if !std::path::Path::new(&package_path).exists() || !std::path::Path::new(&core_path).exists() {
+        return Ok(None);
+    }
+    let package = std::fs::read_to_string(package_path)?.trim().parse()?;
+    let core = std::fs::read_to_string(core_path)?.trim().parse()?;
+    Ok(Some((package, core)))
+}
+
+impl From<ObservationError> for IssuerFailure {
+    fn from(_: ObservationError) -> Self {
+        Self::Observation
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[allow(unused_imports)]
+    use super::*;
+
+    #[test]
+    fn partition_assigns_contiguous_worker_groups_to_write_issuers() -> anyhow::Result<()> {
+        let mut dispatch = (0..128u32)
+            .map(|id| DispatchEntry {
+                id,
+                deadline_ns: u64::from(id),
+                deadline_group: id,
+                worker_id: u64::from(id),
+                payload: DispatchPayload::Query { lane: id as usize },
+            })
+            .collect::<Vec<_>>();
+        dispatch.extend((0..128u32).map(|id| DispatchEntry {
+            id: id + 128,
+            deadline_ns: u64::from(id),
+            deadline_group: id,
+            worker_id: u64::from(id),
+            payload: DispatchPayload::Event(RouterEvent::new(
+                u64::from(id),
+                dynamo_kv_router::protocols::KvCacheEvent {
+                    event_id: u64::from(id),
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 0,
+                },
+            )),
+        }));
+
+        let (queries, event_shards) = partition_dispatch(dispatch, 8)?;
+
+        assert_eq!(queries.len(), 128);
+        assert_eq!(event_shards.len(), 8);
+        assert!(event_shards.iter().all(|shard| !shard.is_empty()));
+        assert_eq!(event_shards.iter().map(Vec::len).sum::<usize>(), 128);
+        for (issuer, shard) in event_shards.iter().enumerate() {
+            let expected = issuer * 16..(issuer + 1) * 16;
+            assert!(
+                shard
+                    .iter()
+                    .all(|entry| expected.contains(&(entry.worker_id as usize)))
+            );
+        }
+        Ok(())
+    }
+}

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -1,28 +1,20 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::Arc;
 
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
-use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, RouterEvent, StorageTier, TokensWithHashes, WorkerWithDpRank,
-};
+use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, StorageTier};
 use dynamo_kv_router::{
     BranchShardedIndexer, ConcurrentRadixTree, ConcurrentRadixTreeCompressed, PositionalIndexer,
     ThreadPoolIndexer,
 };
-use dynamo_mocker::loadgen::Trace;
-use tokio::time::{Duration, Instant};
 use tokio_util::sync::CancellationToken;
 
 use dynamo_bench::kv_router_common::replay::WorkerReplayArtifacts;
-use dynamo_bench::kv_router_common::results::{BenchmarkRun, compute_benchmark_run};
-use dynamo_bench::kv_router_common::trace_gen::{OrderedMerge, ReplayStartGate, WorkerTimelines};
+use dynamo_bench::kv_router_common::trace_gen::WorkerTimelines;
 
 #[allow(dead_code)]
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -108,24 +100,6 @@ impl MooncakeIndexerConfig {
         }
     }
 
-    pub fn is_multi_threaded(&self) -> bool {
-        matches!(
-            self.kind,
-            MooncakeIndexerKind::NestedMap
-                | MooncakeIndexerKind::ConcurrentRadixTree
-                | MooncakeIndexerKind::ConcurrentRadixTreeCompressed
-                | MooncakeIndexerKind::BranchShardedCrtc
-        )
-    }
-
-    pub fn supports_remove(&self) -> bool {
-        true
-    }
-
-    pub fn supports_approximate(&self) -> bool {
-        !matches!(self.kind, MooncakeIndexerKind::BranchShardedCrtc)
-    }
-
     pub fn from_short_name(name: &str, num_event_workers: usize) -> anyhow::Result<Self> {
         let config = match name {
             "radix-tree" => Self::radix_tree(),
@@ -196,14 +170,6 @@ impl MooncakeIndexerConfig {
         }
     }
 
-    pub fn build_approximate(
-        &self,
-        block_size: u32,
-        metrics: Arc<KvIndexerMetrics>,
-    ) -> anyhow::Result<Arc<dyn KvIndexerInterface + Send + Sync>> {
-        self.build_approximate_with_prune_config(block_size, metrics, PruneConfig::default())
-    }
-
     pub fn build_approximate_with_prune_config(
         &self,
         block_size: u32,
@@ -256,95 +222,131 @@ impl MooncakeIndexerConfig {
 pub struct MooncakeBenchmarkConfig {
     pub benchmark_duration_ms: u64,
     pub inference_worker_duplication_factor: usize,
-    pub count_events: bool,
-    pub find_matches_concurrency: usize,
-    pub block_size: u32,
 }
 
 /// A single entry in a worker's merged benchmark timeline.
 #[derive(Clone)]
-enum WorkerTraceEntry {
+pub(crate) enum WorkerTraceEntry {
     Request(Vec<LocalBlockHash>),
     Event {
         event: KvCacheEvent,
         storage_tier: StorageTier,
-    },
-    ApproxWrite {
-        tokens: Vec<u32>,
-        num_blocks: usize,
     },
 }
 
 /// A timestamped entry in a worker's benchmark trace, used to replay requests
 /// and events at the correct relative timing.
 #[derive(Clone)]
-struct WorkerTrace {
-    entry: WorkerTraceEntry,
-    timestamp_us: u64,
+pub(crate) struct WorkerTrace {
+    pub(crate) entry: WorkerTraceEntry,
+    pub(crate) timestamp_us: u64,
 }
 
-#[derive(Clone)]
 pub(crate) struct MergedMooncakeBenchmark {
     worker_traces: WorkerTimelines<WorkerTrace>,
     block_size: u32,
 }
 
-#[derive(Clone, Copy)]
-struct PreparedTraceTotals {
-    requests: usize,
-    events: usize,
-    approx_writes: usize,
-    request_blocks: usize,
-    event_blocks: usize,
+#[derive(Clone, Copy, Debug, Default)]
+pub(crate) struct MooncakeTraceTotals {
+    pub(crate) requests: usize,
+    pub(crate) stored_events: usize,
+    pub(crate) removed_events: usize,
+    pub(crate) cleared_events: usize,
+    pub(crate) request_blocks: usize,
+    pub(crate) stored_blocks: usize,
+    pub(crate) removed_blocks: usize,
 }
 
-pub(crate) struct PreparedMooncakeBenchmark {
-    worker_traces: WorkerTimelines<WorkerTrace>,
-    seq_pool: Arc<Vec<Vec<LocalBlockHash>>>,
-    totals: PreparedTraceTotals,
-    benchmark_duration_ms: u64,
-    block_size: u32,
+impl MooncakeTraceTotals {
+    pub(crate) fn events(self) -> usize {
+        self.stored_events + self.removed_events + self.cleared_events
+    }
+
+    pub(crate) fn event_blocks(self) -> usize {
+        self.stored_blocks + self.removed_blocks
+    }
+
+    pub(crate) fn write_blocks(self) -> usize {
+        self.event_blocks()
+    }
+
+    pub(crate) fn total_block_ops(self) -> usize {
+        self.request_blocks + self.write_blocks()
+    }
+
+    pub(crate) fn expanded(self, factor: usize) -> Self {
+        Self {
+            requests: self.requests * factor,
+            stored_events: self.stored_events * factor,
+            removed_events: self.removed_events * factor,
+            cleared_events: self.cleared_events * factor,
+            request_blocks: self.request_blocks * factor,
+            stored_blocks: self.stored_blocks * factor,
+            removed_blocks: self.removed_blocks * factor,
+        }
+    }
 }
 
 #[derive(Clone)]
-pub enum MooncakeBenchmarkInput {
-    KvEvents(Vec<WorkerReplayArtifacts>),
-    Approx(Vec<Trace>),
+pub(crate) struct PreparedMooncakeBenchmark {
+    pub(crate) worker_traces: WorkerTimelines<WorkerTrace>,
+    pub(crate) totals: MooncakeTraceTotals,
+    pub(crate) benchmark_duration_ms: u64,
+    pub(crate) block_size: u32,
 }
 
 fn merge_event_worker_trace(
     worker_idx: usize,
-    artifact: &WorkerReplayArtifacts,
+    artifact: WorkerReplayArtifacts,
 ) -> anyhow::Result<Vec<WorkerTrace>> {
-    OrderedMerge::left_first(
-        worker_idx,
-        "requests",
-        &artifact.requests,
-        "kv_events",
-        &artifact.kv_events,
-    )
-    .merge(
-        |request| request.timestamp_us,
-        |event| event.timestamp_us,
-        |request| WorkerTrace {
-            timestamp_us: request.timestamp_us,
-            entry: WorkerTraceEntry::Request(request.replay_hashes.local_block_hashes.clone()),
-        },
-        |event| WorkerTrace {
-            timestamp_us: event.timestamp_us,
-            entry: WorkerTraceEntry::Event {
-                event: event.event.clone(),
-                storage_tier: event.storage_tier,
-            },
-        },
-    )
+    let WorkerReplayArtifacts {
+        requests,
+        output_signals: _,
+        kv_events,
+    } = artifact;
+    validate_timestamps(worker_idx, "requests", &requests, |request| {
+        request.timestamp_us
+    })?;
+    validate_timestamps(worker_idx, "kv_events", &kv_events, |event| {
+        event.timestamp_us
+    })?;
+
+    let mut requests = requests.into_iter().peekable();
+    let mut events = kv_events.into_iter().peekable();
+    let mut merged = Vec::with_capacity(requests.len() + events.len());
+    while requests.peek().is_some() || events.peek().is_some() {
+        let take_request = match (requests.peek(), events.peek()) {
+            (Some(request), Some(event)) => request.timestamp_us <= event.timestamp_us,
+            (Some(_), None) => true,
+            (None, Some(_)) => false,
+            (None, None) => break,
+        };
+        if take_request {
+            let request = requests.next().expect("peeked request must exist");
+            merged.push(WorkerTrace {
+                timestamp_us: request.timestamp_us,
+                entry: WorkerTraceEntry::Request(request.replay_hashes.local_block_hashes),
+            });
+        } else {
+            let event = events.next().expect("peeked event must exist");
+            merged.push(WorkerTrace {
+                timestamp_us: event.timestamp_us,
+                entry: WorkerTraceEntry::Event {
+                    event: event.event,
+                    storage_tier: event.storage_tier,
+                },
+            });
+        }
+    }
+    Ok(merged)
 }
 
 fn merge_event_worker_traces(
-    artifacts: &[WorkerReplayArtifacts],
+    artifacts: Vec<WorkerReplayArtifacts>,
 ) -> anyhow::Result<WorkerTimelines<WorkerTrace>> {
     let worker_traces = artifacts
-        .iter()
+        .into_iter()
         .enumerate()
         .map(|(worker_idx, artifact)| merge_event_worker_trace(worker_idx, artifact))
         .collect::<anyhow::Result<Vec<_>>>()?;
@@ -352,309 +354,73 @@ fn merge_event_worker_traces(
     Ok(WorkerTimelines::new(worker_traces))
 }
 
-fn merge_approx_worker_traces(
-    traces: &[Trace],
-    block_size: u32,
-) -> anyhow::Result<WorkerTimelines<WorkerTrace>> {
-    let mut worker_traces = Vec::with_capacity(traces.len());
-    for trace in traces {
-        let trace_block_size = trace.block_size;
-        let mut entries = Vec::new();
-        for session in &trace.sessions {
-            let mut timestamp_ms = session.first_arrival_timestamp_ms.unwrap_or(0.0);
-            for (turn_idx, turn) in session.turns.iter().enumerate() {
-                if turn_idx > 0 {
-                    timestamp_ms += turn.delay_after_previous_ms;
-                }
-                let replay_hashes = turn.to_replay_hashes(trace_block_size, block_size as usize)?;
-                let tokens = turn.synthesize_tokens(trace_block_size)?;
-                let timestamp_us = (timestamp_ms.max(0.0) * 1000.0) as u64;
-                entries.push(WorkerTrace {
-                    timestamp_us,
-                    entry: WorkerTraceEntry::Request(replay_hashes.local_block_hashes),
-                });
-                entries.push(WorkerTrace {
-                    timestamp_us,
-                    entry: WorkerTraceEntry::ApproxWrite {
-                        tokens,
-                        num_blocks: replay_hashes.sequence_hashes.len(),
-                    },
-                });
-            }
+fn validate_timestamps<T>(
+    worker_idx: usize,
+    source: &'static str,
+    entries: &[T],
+    timestamp_of: impl Fn(&T) -> u64,
+) -> anyhow::Result<()> {
+    for idx in 1..entries.len() {
+        let previous = timestamp_of(&entries[idx - 1]);
+        let current = timestamp_of(&entries[idx]);
+        if current < previous {
+            anyhow::bail!(
+                "worker {worker_idx} {source} timestamps are not ordered at index {idx}: prev={previous}, curr={current}"
+            );
         }
-        entries.sort_by_key(|entry| entry.timestamp_us);
-        worker_traces.push(entries);
     }
-
-    Ok(WorkerTimelines::new(worker_traces))
+    Ok(())
 }
 
 pub(crate) fn merge_worker_traces(
-    input: &MooncakeBenchmarkInput,
+    artifacts: Vec<WorkerReplayArtifacts>,
     block_size: u32,
 ) -> anyhow::Result<MergedMooncakeBenchmark> {
-    let worker_traces = match input {
-        MooncakeBenchmarkInput::KvEvents(artifacts) => merge_event_worker_traces(artifacts)?,
-        MooncakeBenchmarkInput::Approx(traces) => merge_approx_worker_traces(traces, block_size)?,
-    };
-
     Ok(MergedMooncakeBenchmark {
-        worker_traces,
+        worker_traces: merge_event_worker_traces(artifacts)?,
         block_size,
     })
 }
 
 pub(crate) fn prepare_scaled_benchmark(
-    merged: &MergedMooncakeBenchmark,
-    config: MooncakeBenchmarkConfig,
+    merged: MergedMooncakeBenchmark,
+    benchmark_duration_ms: u64,
 ) -> PreparedMooncakeBenchmark {
-    let worker_traces = merged.worker_traces.rescale(
-        config.benchmark_duration_ms,
+    let worker_traces = merged.worker_traces.into_rescaled_from_first(
+        benchmark_duration_ms,
         |entry| entry.timestamp_us,
         |entry, timestamp_us| WorkerTrace {
-            entry: entry.entry.clone(),
+            entry: entry.entry,
             timestamp_us,
         },
     );
 
-    let mut seq_pool = Vec::new();
-    let mut totals = PreparedTraceTotals {
-        requests: 0,
-        events: 0,
-        approx_writes: 0,
-        request_blocks: 0,
-        event_blocks: 0,
-    };
+    let mut totals = MooncakeTraceTotals::default();
 
     for entry in worker_traces.iter().flatten() {
         match &entry.entry {
             WorkerTraceEntry::Request(hashes) => {
                 totals.requests += 1;
                 totals.request_blocks += hashes.len();
-                seq_pool.push(hashes.clone());
             }
-            WorkerTraceEntry::Event { event, .. } => {
-                totals.events += 1;
-                totals.event_blocks += match &event.data {
-                    KvCacheEventData::Stored(store) => store.blocks.len(),
-                    _ => 0,
-                };
-            }
-            WorkerTraceEntry::ApproxWrite { num_blocks, .. } => {
-                totals.approx_writes += 1;
-                totals.event_blocks += *num_blocks;
-            }
+            WorkerTraceEntry::Event { event, .. } => match &event.data {
+                KvCacheEventData::Stored(store) => {
+                    totals.stored_events += 1;
+                    totals.stored_blocks += store.blocks.len();
+                }
+                KvCacheEventData::Removed(remove) => {
+                    totals.removed_events += 1;
+                    totals.removed_blocks += remove.block_hashes.len();
+                }
+                KvCacheEventData::Cleared => totals.cleared_events += 1,
+            },
         }
     }
 
     PreparedMooncakeBenchmark {
         worker_traces,
-        seq_pool: Arc::new(seq_pool),
         totals,
-        benchmark_duration_ms: config.benchmark_duration_ms,
+        benchmark_duration_ms,
         block_size: merged.block_size,
     }
-}
-
-#[allow(dead_code)]
-pub async fn run_benchmark(
-    indexer: Arc<dyn KvIndexerInterface + Send + Sync>,
-    input: &MooncakeBenchmarkInput,
-    config: MooncakeBenchmarkConfig,
-) -> anyhow::Result<BenchmarkRun> {
-    let merged = merge_worker_traces(input, config.block_size)?;
-    let prepared = prepare_scaled_benchmark(&merged, config);
-    run_prepared_benchmark(indexer, &prepared, config).await
-}
-
-pub(crate) async fn run_prepared_benchmark(
-    indexer: Arc<dyn KvIndexerInterface + Send + Sync>,
-    prepared: &PreparedMooncakeBenchmark,
-    config: MooncakeBenchmarkConfig,
-) -> anyhow::Result<BenchmarkRun> {
-    if prepared.benchmark_duration_ms != config.benchmark_duration_ms {
-        anyhow::bail!(
-            "prepared benchmark duration mismatch: prepared={}ms, requested={}ms",
-            prepared.benchmark_duration_ms,
-            config.benchmark_duration_ms
-        );
-    }
-    if prepared.block_size != config.block_size {
-        anyhow::bail!(
-            "prepared benchmark block size mismatch: prepared={}, requested={}",
-            prepared.block_size,
-            config.block_size
-        );
-    }
-
-    let num_trace_workers = prepared.worker_traces.len();
-    let mut task_inputs =
-        Vec::with_capacity(num_trace_workers * config.inference_worker_duplication_factor);
-    for replica in 0..config.inference_worker_duplication_factor {
-        for (worker_id, worker_trace) in prepared.worker_traces.iter().enumerate() {
-            let worker_id = worker_id + replica * num_trace_workers;
-            task_inputs.push((worker_id, worker_trace.clone()));
-        }
-    }
-
-    let num_find_match_tasks =
-        if config.find_matches_concurrency > 0 && !prepared.seq_pool.is_empty() {
-            config.find_matches_concurrency
-        } else {
-            0
-        };
-    let num_timed_tasks = task_inputs.len() + num_find_match_tasks;
-    let start_gate = ReplayStartGate::new(num_timed_tasks);
-
-    let mut tasks = Vec::new();
-    for (worker_id, trace) in task_inputs {
-        let indexer = Arc::clone(&indexer);
-        let start_gate = start_gate.clone();
-        tasks.push(tokio::spawn(async move {
-            let mut request_latencies = Vec::with_capacity(trace.len());
-
-            start_gate.wait_for_start().await;
-
-            let submit = |entry: WorkerTrace| async {
-                match entry.entry {
-                    WorkerTraceEntry::Request(request) => {
-                        let start = minstant::Instant::now();
-                        indexer.find_matches(request).await?;
-                        Ok::<Option<u64>, anyhow::Error>(Some(start.elapsed().as_nanos() as u64))
-                    }
-                    WorkerTraceEntry::Event {
-                        event,
-                        storage_tier,
-                    } => {
-                        if storage_tier.is_gpu() {
-                            indexer
-                                .apply_event(RouterEvent::with_storage_tier(
-                                    worker_id as u64,
-                                    event,
-                                    storage_tier,
-                                ))
-                                .await;
-                        }
-                        Ok(None)
-                    }
-                    WorkerTraceEntry::ApproxWrite { tokens, .. } => {
-                        let mut tokens_with_hashes =
-                            TokensWithHashes::new(tokens, config.block_size);
-                        indexer
-                            .process_routing_decision_for_request(
-                                &mut tokens_with_hashes,
-                                WorkerWithDpRank::from_worker_id(worker_id as u64),
-                            )
-                            .await?;
-                        Ok(None)
-                    }
-                }
-            };
-
-            let mut target = Instant::now();
-            let mut trace = trace.into_iter().peekable();
-
-            while let Some(entry) = trace.next() {
-                let entry_timestamp_us = entry.timestamp_us;
-
-                if let Some(latency) = submit(entry).await? {
-                    request_latencies.push(latency);
-                }
-
-                while let Some(next) = trace.peek() {
-                    if next.timestamp_us == entry_timestamp_us {
-                        if let Some(latency) = submit(trace.next().unwrap()).await? {
-                            request_latencies.push(latency);
-                        }
-                    } else {
-                        break;
-                    }
-                }
-
-                if let Some(next) = trace.peek() {
-                    target += Duration::from_micros(next.timestamp_us - entry_timestamp_us);
-                }
-
-                if target > Instant::now() {
-                    tokio::time::sleep_until(target).await;
-                }
-            }
-
-            Ok::<_, anyhow::Error>(request_latencies)
-        }));
-    }
-
-    let fm_stop = Arc::new(AtomicBool::new(false));
-    let mut fm_tasks = Vec::new();
-    if num_find_match_tasks > 0 {
-        for task_id in 0..num_find_match_tasks {
-            let indexer = Arc::clone(&indexer);
-            let pool = Arc::clone(&prepared.seq_pool);
-            let stop = Arc::clone(&fm_stop);
-            let start_gate = start_gate.clone();
-            fm_tasks.push(tokio::spawn(async move {
-                let mut latencies = Vec::new();
-                let mut idx = task_id % pool.len();
-
-                start_gate.wait_for_start().await;
-
-                while !stop.load(Ordering::Relaxed) {
-                    let seq = pool[idx].clone();
-                    let start = minstant::Instant::now();
-                    let _ = indexer.find_matches(seq).await;
-                    latencies.push(start.elapsed().as_nanos() as u64);
-                    idx = (idx + 1) % pool.len();
-                }
-                latencies
-            }));
-        }
-    }
-
-    let started_at = start_gate.start().await;
-
-    let mut latencies = Vec::new();
-    for task in tasks {
-        latencies.extend(task.await??);
-    }
-    let total_duration = started_at.elapsed();
-
-    fm_stop.store(true, Ordering::Relaxed);
-    for task in fm_tasks {
-        if let Ok(fm_latencies) = task.await {
-            latencies.extend(fm_latencies);
-        }
-    }
-
-    let replay_factor = config.inference_worker_duplication_factor;
-    let total_requests = prepared.totals.requests * replay_factor;
-    let total_writes = (prepared.totals.events + prepared.totals.approx_writes) * replay_factor;
-    let total_request_blocks = prepared.totals.request_blocks * replay_factor;
-    let total_event_blocks = prepared.totals.event_blocks * replay_factor;
-
-    let counted_events = if config.count_events { total_writes } else { 0 };
-    let counted_event_blocks = if config.count_events {
-        total_event_blocks
-    } else {
-        0
-    };
-
-    let run = compute_benchmark_run(
-        total_requests + counted_events,
-        total_request_blocks + counted_event_blocks,
-        config.benchmark_duration_ms,
-        total_duration,
-        latencies,
-    );
-
-    println!(
-        "Offered Ops Throughput: {} ops/s | Achieved: {} ops/s (requests + events)",
-        run.results.offered_ops_throughput as u64, run.results.ops_throughput as u64,
-    );
-    println!(
-        "Offered Block Throughput: {} block ops/s | Achieved: {} block ops/s",
-        run.results.offered_block_throughput as u64, run.results.block_throughput as u64,
-    );
-    println!("Latency p99: {}us", run.results.latency_p99_us);
-
-    Ok(run)
 }

--- a/lib/bench/tests/active_sequences_trace.rs
+++ b/lib/bench/tests/active_sequences_trace.rs
@@ -3,11 +3,21 @@
 
 mod support;
 
+#[path = "../kv_router/active_sequences_open_loop.rs"]
+mod active_sequences_open_loop;
 #[path = "../kv_router/active_sequences_shared.rs"]
 mod active_sequences_shared;
 
-use active_sequences_shared::{generate_sequence_events, run_benchmark};
-use dynamo_bench::kv_router_common::replay::process_mooncake_trace;
+use std::collections::HashMap;
+
+use active_sequences_open_loop::{
+    ActiveOperationKind, ActiveSequencesRunConfig, accumulate_projection_digest,
+    prepare_active_sequences_corpus, run_active_sequences_benchmark, summarize_worker_projections,
+};
+use active_sequences_shared::{SequenceTrace, SequenceTraceEntry, generate_sequence_events};
+use dynamo_bench::kv_router_common::replay::{NoopSequencePublisher, process_mooncake_trace};
+use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
+use dynamo_kv_router::{ActiveSequencesMultiWorker, SequenceRequest};
 
 const BLOCK_SIZE: u32 = 128;
 const NUM_GPU_BLOCKS: usize = 16384;
@@ -30,21 +40,135 @@ async fn active_sequences_trace_replays_without_warnings_or_leaks() -> anyhow::R
         TRACE_SIMULATION_DURATION_MS,
     )
     .await?;
-    let run = run_benchmark(&sequence_traces, BLOCK_SIZE, BENCHMARK_DURATION_MS, 1).await?;
+    let original_traces = sequence_traces.clone();
+    let corpus =
+        prepare_active_sequences_corpus(sequence_traces, BLOCK_SIZE, BENCHMARK_DURATION_MS, 1)?;
+    for operation in corpus
+        .operations
+        .iter()
+        .filter(|operation| operation.kind == ActiveOperationKind::ProjectAndAdd)
+    {
+        let SequenceTraceEntry::Add { block_hashes, .. } =
+            &original_traces[operation.worker_id as usize][operation.source_ordinal].entry
+        else {
+            panic!("prepared add points to a non-Add source entry");
+        };
+        assert_eq!(
+            corpus.operation_hashes(operation.id)?,
+            block_hashes,
+            "flattened hash slab diverged for operation {}",
+            operation.id
+        );
+    }
+    drop(original_traces);
+    let result = run_active_sequences_benchmark(
+        corpus,
+        ActiveSequencesRunConfig {
+            operation_lanes: NUM_UNIQUE_INFERENCE_WORKERS,
+            spin_us: 50,
+            issue_lag_diagnostic_threshold_us: 250,
+        },
+    )
+    .await?;
 
     assert!(
-        run.kept_up,
+        result.kept_up,
         "benchmark replay fell behind in test profile; increase BENCHMARK_DURATION_MS if this becomes too tight"
     );
     assert!(
-        run.results.ops_throughput > 0.0,
+        result.achieved_logical_ops_per_sec > 0.0,
         "benchmark replay should record positive throughput"
     );
+    assert!(result.generator_valid, "{:?}", result.failure_reasons);
+    assert!(result.final_state_empty);
+    assert_eq!(result.total_adds, result.total_frees);
     assert_eq!(
         warning_count.load(std::sync::atomic::Ordering::Relaxed),
         0,
         "sequence replay emitted warn/error logs from dynamo_kv_router::sequences or dynamo_mocker"
     );
 
+    Ok(())
+}
+
+fn small_sequence_trace() -> Vec<Vec<SequenceTrace>> {
+    vec![vec![
+        SequenceTrace {
+            entry: SequenceTraceEntry::Add {
+                request_id: "request-a".to_string(),
+                block_hashes: vec![1, 2],
+                isl: 256,
+                output_length: 8,
+            },
+            timestamp_us: 10,
+        },
+        SequenceTrace {
+            entry: SequenceTraceEntry::PrefillComplete {
+                request_id: "request-a".to_string(),
+            },
+            timestamp_us: 10,
+        },
+        SequenceTrace {
+            entry: SequenceTraceEntry::Free {
+                request_id: "request-a".to_string(),
+            },
+            timestamp_us: 10,
+        },
+    ]]
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn active_sequences_replay_matches_sequential_direct_oracle() -> anyhow::Result<()> {
+    let result = run_active_sequences_benchmark(
+        prepare_active_sequences_corpus(small_sequence_trace(), BLOCK_SIZE, 100, 1)?,
+        ActiveSequencesRunConfig {
+            operation_lanes: 1,
+            spin_us: 50,
+            issue_lag_diagnostic_threshold_us: 250,
+        },
+    )
+    .await?;
+
+    let oracle = ActiveSequencesMultiWorker::new_without_expiry(
+        NoopSequencePublisher,
+        BLOCK_SIZE as usize,
+        HashMap::from([(0, (0, 1))]),
+        false,
+        0,
+        "bench",
+    );
+    let now = tokio::time::Instant::now();
+    let hashes = vec![1, 2];
+    let projections = oracle.project_worker_loads(Some(&hashes), now);
+    let projection_count = projections.len() as u64;
+    let (projection_inspected, projection_digest) = summarize_worker_projections(&projections);
+    let projection_digest = accumulate_projection_digest(0, 0, projection_digest);
+    oracle.add_request(
+        SequenceRequest {
+            request_id: "0:request-a".to_string(),
+            token_sequence: Some(hashes),
+            track_prefill_tokens: true,
+            expected_output_tokens: Some(8),
+            prefill_load_hint: Some(PrefillLoadHint {
+                initial_effective_prefill_tokens: 256,
+                expected_prefill_duration: None,
+            }),
+            worker: WorkerWithDpRank::from_worker_id(0),
+            lora_name: None,
+        },
+        now,
+    )?;
+    oracle.mark_prefill_completed(&"0:request-a".to_string(), now)?;
+    oracle.free(&"0:request-a".to_string(), now)?;
+    oracle.assert_completely_drained(now);
+
+    assert!(result.generator_valid, "{:?}", result.failure_reasons);
+    assert!(result.final_state_empty);
+    assert_eq!(result.worker_projections_produced, projection_count);
+    assert_eq!(result.worker_projections_inspected, projection_inspected);
+    assert_eq!(result.worker_projection_digest, projection_digest);
+    assert_eq!(result.total_adds, 1);
+    assert_eq!(result.total_prefill_completes, 1);
+    assert_eq!(result.total_frees, 1);
     Ok(())
 }

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -7,6 +7,9 @@ mod support;
 #[path = "support/mooncake_g2_lower_tier.rs"]
 mod g2_lower_tier;
 
+#[allow(dead_code)]
+#[path = "../kv_router/mooncake_open_loop.rs"]
+mod mooncake_open_loop;
 #[path = "../kv_router/mooncake_shared.rs"]
 mod mooncake_shared;
 
@@ -26,15 +29,25 @@ use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexerInterface, KvIndexerMetrics};
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, RouterEvent, StorageTier, TokensWithHashes, WorkerWithDpRank,
+    ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
+    KvCacheStoredBlockData, OverlapScores, StorageTier, TokensWithHashes, WorkerWithDpRank,
 };
+use dynamo_kv_router::{ConcurrentRadixTreeCompressed, ThreadPoolIndexer};
 use dynamo_mocker::common::protocols::{EngineType, MockEngineArgs, SglangArgs};
-use dynamo_mocker::loadgen::{SessionTrace, Trace, TurnTrace};
-use dynamo_mocker::replay::ReplayKvEventVisibility;
+use dynamo_mocker::loadgen::{ReplayRequestHashes, SessionTrace, Trace, TurnTrace};
+use dynamo_mocker::replay::{
+    ReplayKvEventVisibility, ReplayTimedKvEvent, ReplayTimedRequest, ReplayWorkerArtifacts,
+};
+use mooncake_open_loop::{
+    MooncakeOperationPayload, OpenLoopConfig, PreparedMooncakeCorpus, prepare_mooncake_corpus,
+    prepare_open_loop_trial, run_open_loop,
+};
 use mooncake_shared::{
-    MooncakeBenchmarkConfig, MooncakeBenchmarkInput, MooncakeIndexerConfig, run_benchmark,
+    MooncakeBenchmarkConfig, MooncakeIndexerConfig, PreparedMooncakeBenchmark, WorkerTraceEntry,
+    merge_worker_traces, prepare_scaled_benchmark,
 };
 use tempfile::NamedTempFile;
+use uuid::Uuid;
 
 const BLOCK_SIZE: u32 = 128;
 const NUM_GPU_BLOCKS: usize = 16384;
@@ -49,6 +62,21 @@ const G2_TEST_NUM_GPU_BLOCKS: usize = 512;
 const G2_TEST_NUM_G2_BLOCKS: usize = 16_384;
 
 type NormalizedOverlapScores = BTreeMap<WorkerWithDpRank, u32>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ComparableOverlapScores {
+    scores: NormalizedOverlapScores,
+    frequencies: Vec<usize>,
+}
+
+impl From<OverlapScores> for ComparableOverlapScores {
+    fn from(overlap: OverlapScores) -> Self {
+        Self {
+            scores: overlap.scores.into_iter().collect(),
+            frequencies: overlap.frequencies,
+        }
+    }
+}
 
 #[derive(Clone)]
 struct MockEngineReplayArtifacts {
@@ -110,38 +138,42 @@ impl MockEngineParityKind {
     }
 }
 
+#[cfg(feature = "mocker-kvbm-offload")]
 #[derive(Clone)]
-enum ReplayEntryKind {
+enum DeviceReplayEntryKind {
     Request(Vec<LocalBlockHash>),
     Event {
         event: KvCacheEvent,
         storage_tier: StorageTier,
     },
-    ApproxWrite(Vec<u32>),
 }
 
+#[cfg(feature = "mocker-kvbm-offload")]
 #[derive(Clone)]
-struct ReplayEntry {
+struct DeviceReplayEntry {
     timestamp_us: u64,
     worker_id: u64,
     kind_rank: u8,
-    kind: ReplayEntryKind,
+    kind: DeviceReplayEntryKind,
 }
 
-fn collect_replay_entries(artifacts: &[WorkerReplayArtifacts]) -> Vec<ReplayEntry> {
+#[cfg(feature = "mocker-kvbm-offload")]
+fn collect_device_only_replay_entries(
+    artifacts: &[WorkerReplayArtifacts],
+) -> Vec<DeviceReplayEntry> {
     let mut entries = Vec::new();
     for (worker_id, artifact) in artifacts.iter().enumerate() {
-        entries.extend(artifact.requests.iter().map(|request| ReplayEntry {
+        entries.extend(artifact.requests.iter().map(|request| DeviceReplayEntry {
             timestamp_us: request.timestamp_us,
             worker_id: worker_id as u64,
             kind_rank: 0,
-            kind: ReplayEntryKind::Request(request.replay_hashes.local_block_hashes.clone()),
+            kind: DeviceReplayEntryKind::Request(request.replay_hashes.local_block_hashes.clone()),
         }));
-        entries.extend(artifact.kv_events.iter().map(|event| ReplayEntry {
+        entries.extend(artifact.kv_events.iter().map(|event| DeviceReplayEntry {
             timestamp_us: event.timestamp_us,
             worker_id: worker_id as u64,
             kind_rank: 1,
-            kind: ReplayEntryKind::Event {
+            kind: DeviceReplayEntryKind::Event {
                 event: event.event.clone(),
                 storage_tier: event.storage_tier,
             },
@@ -149,37 +181,6 @@ fn collect_replay_entries(artifacts: &[WorkerReplayArtifacts]) -> Vec<ReplayEntr
     }
     entries.sort_by_key(|entry| (entry.timestamp_us, entry.kind_rank, entry.worker_id));
     entries
-}
-
-fn collect_approx_replay_entries(traces: &[Trace]) -> anyhow::Result<Vec<ReplayEntry>> {
-    let mut entries = Vec::new();
-    for (worker_id, trace) in traces.iter().enumerate() {
-        let trace_block_size = trace.block_size;
-        for session in &trace.sessions {
-            let mut timestamp_ms = session.first_arrival_timestamp_ms.unwrap_or(0.0);
-            for (turn_idx, turn) in session.turns.iter().enumerate() {
-                if turn_idx > 0 {
-                    timestamp_ms += turn.delay_after_previous_ms;
-                }
-                let replay_hashes = turn.to_replay_hashes(trace_block_size, BLOCK_SIZE as usize)?;
-                let timestamp_us = (timestamp_ms.max(0.0) * 1000.0) as u64;
-                entries.push(ReplayEntry {
-                    timestamp_us,
-                    worker_id: worker_id as u64,
-                    kind_rank: 0,
-                    kind: ReplayEntryKind::Request(replay_hashes.local_block_hashes),
-                });
-                entries.push(ReplayEntry {
-                    timestamp_us,
-                    worker_id: worker_id as u64,
-                    kind_rank: 1,
-                    kind: ReplayEntryKind::ApproxWrite(turn.synthesize_tokens(trace_block_size)?),
-                });
-            }
-        }
-    }
-    entries.sort_by_key(|entry| (entry.timestamp_us, entry.kind_rank, entry.worker_id));
-    Ok(entries)
 }
 
 fn count_removed_kv_events(artifacts: &[WorkerReplayArtifacts]) -> usize {
@@ -225,39 +226,121 @@ async fn generate_mock_engine_parity_artifacts(
     Ok(artifact_sets)
 }
 
-#[derive(Clone, Copy, Debug)]
-enum MooncakeReplayMode {
-    KvEvents,
-    Approx,
-}
-
-impl MooncakeReplayMode {
-    fn name(self) -> &'static str {
-        match self {
-            MooncakeReplayMode::KvEvents => "kv-events",
-            MooncakeReplayMode::Approx => "approx",
-        }
+fn original_prepared_query(
+    prepared: &PreparedMooncakeBenchmark,
+    benchmark: MooncakeBenchmarkConfig,
+    worker_id: u64,
+    source_ordinal: usize,
+) -> anyhow::Result<&[LocalBlockHash]> {
+    let worker_id = usize::try_from(worker_id)?;
+    let num_workers = prepared.worker_traces.len();
+    let total_workers = num_workers
+        .checked_mul(benchmark.inference_worker_duplication_factor)
+        .ok_or_else(|| anyhow::anyhow!("prepared worker count overflow"))?;
+    if worker_id >= total_workers || num_workers == 0 {
+        anyhow::bail!("prepared dispatch references unknown worker {worker_id}");
     }
+    let base_worker = worker_id % num_workers;
+    let entry = prepared
+        .worker_traces
+        .iter()
+        .nth(base_worker)
+        .and_then(|trace| trace.get(source_ordinal))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "prepared dispatch references missing source entry {source_ordinal} for worker {worker_id}"
+            )
+        })?;
+    let WorkerTraceEntry::Request(hashes) = &entry.entry else {
+        anyhow::bail!(
+            "prepared dispatch query points to non-query source entry {source_ordinal} for worker {worker_id}"
+        );
+    };
+    Ok(hashes)
 }
 
-async fn collect_overlap_scores_for_replay(
+async fn collect_prepared_corpus_scores(
+    indexer: Arc<dyn KvIndexerInterface + Send + Sync>,
+    prepared: &PreparedMooncakeBenchmark,
+    benchmark: MooncakeBenchmarkConfig,
+    corpus: &PreparedMooncakeCorpus,
+) -> anyhow::Result<Vec<ComparableOverlapScores>> {
+    let mut scores = Vec::new();
+    let mut idx = 0usize;
+
+    while idx < corpus.operations.len() {
+        let deadline_ns = corpus.operations[idx].deadline_ns;
+        while idx < corpus.operations.len() && corpus.operations[idx].deadline_ns == deadline_ns {
+            let entry = &corpus.operations[idx];
+            match &entry.payload {
+                MooncakeOperationPayload::Query => {
+                    let request = corpus.query_hashes(entry.id)?;
+                    let original = original_prepared_query(
+                        prepared,
+                        benchmark,
+                        entry.worker_id,
+                        entry.source_ordinal,
+                    )?;
+                    assert_eq!(
+                        request, original,
+                        "flattened query slab diverged from source hashes for operation {}",
+                        entry.id
+                    );
+                    let overlap = indexer.find_matches(request.to_vec()).await?;
+                    scores.push(overlap.into());
+                }
+                MooncakeOperationPayload::Event(event) => indexer.apply_event(event.clone()).await,
+            }
+            idx += 1;
+        }
+        indexer.flush().await;
+    }
+
+    indexer.shutdown();
+    Ok(scores)
+}
+
+async fn collect_prepared_corpus_overlap_scores(
     config: &MooncakeIndexerConfig,
-    traces: &[Trace],
     artifacts: &[WorkerReplayArtifacts],
-    mode: MooncakeReplayMode,
+) -> anyhow::Result<Vec<ComparableOverlapScores>> {
+    Ok(
+        collect_prepared_corpus_overlap_scores_with_metrics(config, artifacts)
+            .await?
+            .0,
+    )
+}
+
+async fn collect_prepared_corpus_overlap_scores_with_metrics(
+    config: &MooncakeIndexerConfig,
+    artifacts: &[WorkerReplayArtifacts],
+) -> anyhow::Result<(Vec<ComparableOverlapScores>, Arc<KvIndexerMetrics>)> {
+    let benchmark = MooncakeBenchmarkConfig {
+        benchmark_duration_ms: BENCHMARK_DURATION_MS,
+        inference_worker_duplication_factor: 1,
+    };
+    let merged = merge_worker_traces(artifacts.to_vec(), BLOCK_SIZE)?;
+    let prepared = prepare_scaled_benchmark(merged, benchmark.benchmark_duration_ms);
+    let corpus = prepare_mooncake_corpus(
+        prepared.clone(),
+        benchmark.inference_worker_duplication_factor,
+    )?;
+    let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+    let indexer = config.build(BLOCK_SIZE, Arc::clone(&metrics));
+
+    Ok((
+        collect_prepared_corpus_scores(indexer, &prepared, benchmark, &corpus).await?,
+        metrics,
+    ))
+}
+
+#[cfg(feature = "mocker-kvbm-offload")]
+async fn collect_device_only_overlap_scores(
+    config: &MooncakeIndexerConfig,
+    artifacts: &[WorkerReplayArtifacts],
 ) -> anyhow::Result<Vec<NormalizedOverlapScores>> {
-    let indexer = match mode {
-        MooncakeReplayMode::KvEvents => {
-            config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()))
-        }
-        MooncakeReplayMode::Approx => {
-            config.build_approximate(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()))?
-        }
-    };
-    let entries = match mode {
-        MooncakeReplayMode::KvEvents => collect_replay_entries(artifacts),
-        MooncakeReplayMode::Approx => collect_approx_replay_entries(traces)?,
-    };
+    let indexer = config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()));
+    let entries = collect_device_only_replay_entries(artifacts);
     let mut scores = Vec::new();
     let mut idx = 0;
 
@@ -265,32 +348,25 @@ async fn collect_overlap_scores_for_replay(
         let timestamp_us = entries[idx].timestamp_us;
         while idx < entries.len() && entries[idx].timestamp_us == timestamp_us {
             match &entries[idx].kind {
-                ReplayEntryKind::Request(request) => {
+                DeviceReplayEntryKind::Request(request) => {
                     let overlap = indexer.find_matches(request.clone()).await?;
                     scores.push(overlap.scores.into_iter().collect());
                 }
-                ReplayEntryKind::Event {
+                DeviceReplayEntryKind::Event {
                     event,
                     storage_tier,
                 } => {
                     if storage_tier.is_gpu() {
                         indexer
-                            .apply_event(RouterEvent::with_storage_tier(
-                                entries[idx].worker_id,
-                                event.clone(),
-                                *storage_tier,
-                            ))
+                            .apply_event(
+                                dynamo_kv_router::protocols::RouterEvent::with_storage_tier(
+                                    entries[idx].worker_id,
+                                    event.clone(),
+                                    *storage_tier,
+                                ),
+                            )
                             .await;
                     }
-                }
-                ReplayEntryKind::ApproxWrite(tokens) => {
-                    let mut tokens_with_hashes = TokensWithHashes::new(tokens.clone(), BLOCK_SIZE);
-                    indexer
-                        .process_routing_decision_for_request(
-                            &mut tokens_with_hashes,
-                            WorkerWithDpRank::from_worker_id(entries[idx].worker_id),
-                        )
-                        .await?;
                 }
             }
             idx += 1;
@@ -302,80 +378,56 @@ async fn collect_overlap_scores_for_replay(
     Ok(scores)
 }
 
-async fn collect_overlap_scores_for_supported_modes(
-    config: &MooncakeIndexerConfig,
-    traces: &[Trace],
-    artifact_sets: &[MockEngineReplayArtifacts],
-) -> anyhow::Result<Vec<(String, Vec<NormalizedOverlapScores>)>> {
-    let mut results = Vec::new();
-    for artifact_set in artifact_sets {
-        results.push((
-            format!(
-                "{} {} ({})",
-                config.short_name(),
-                artifact_set.engine_name,
-                MooncakeReplayMode::KvEvents.name()
-            ),
-            collect_overlap_scores_for_replay(
-                config,
-                traces,
-                &artifact_set.artifacts,
-                MooncakeReplayMode::KvEvents,
-            )
-            .await?,
-        ));
-    }
-    if config.supports_approximate() {
-        results.push((
-            format!(
-                "{} ({})",
-                config.short_name(),
-                MooncakeReplayMode::Approx.name()
-            ),
-            collect_overlap_scores_for_replay(config, traces, &[], MooncakeReplayMode::Approx)
-                .await?,
-        ));
-    }
-    Ok(results)
-}
-
 async fn assert_overlap_score_parity(
     variants: &[MooncakeIndexerConfig],
-    traces: &[Trace],
     artifact_sets: &[MockEngineReplayArtifacts],
+    warning_count: Option<&Arc<std::sync::atomic::AtomicUsize>>,
 ) -> anyhow::Result<()> {
-    let mut expected_name = None;
-    let mut expected_scores = Vec::new();
+    let mut expected_by_replay = BTreeMap::<String, (String, Vec<ComparableOverlapScores>)>::new();
 
     for config in variants {
-        for (actual_name, actual_scores) in
-            collect_overlap_scores_for_supported_modes(config, traces, artifact_sets).await?
-        {
-            if expected_name.is_none() {
-                expected_name = Some(actual_name);
-                expected_scores = actual_scores;
+        if let Some(warning_count) = warning_count {
+            support::reset_warning_count(warning_count);
+        }
+
+        for artifact_set in artifact_sets {
+            let replay_name = format!("{} (kv-events)", artifact_set.engine_name);
+            let actual_name = format!("{} {replay_name}", config.short_name());
+            let actual_scores =
+                collect_prepared_corpus_overlap_scores(config, &artifact_set.artifacts).await?;
+            let Some((expected_name, expected_scores)) = expected_by_replay.get(&replay_name)
+            else {
+                expected_by_replay.insert(replay_name, (actual_name, actual_scores));
                 continue;
-            }
+            };
 
             assert_eq!(
                 actual_scores.len(),
                 expected_scores.len(),
                 "{} produced a different number of request overlap results than {}",
                 actual_name,
-                expected_name.as_deref().unwrap()
+                expected_name
             );
 
             for (request_idx, (actual, expected)) in
                 actual_scores.iter().zip(expected_scores.iter()).enumerate()
             {
                 assert_eq!(
-                    actual,
-                    expected,
+                    actual, expected,
                     "{} overlap scores diverged from {} at replay request {request_idx}",
-                    actual_name,
-                    expected_name.as_deref().unwrap()
+                    actual_name, expected_name
                 );
             }
+        }
+
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        if let Some(warning_count) = warning_count {
+            assert_eq!(
+                warning_count.load(Ordering::Relaxed),
+                0,
+                "{} parity replay emitted warn/error logs from dynamo_kv_router::indexer or dynamo_mocker",
+                config.short_name()
+            );
         }
     }
 
@@ -510,6 +562,134 @@ fn removed_legacy_branch_sharded_name_is_rejected() {
     assert!(!valid_names.contains(&removed_name));
 }
 
+#[test]
+fn open_loop_preparation_preserves_query_first_ties_and_removed_blocks() -> anyhow::Result<()> {
+    let artifacts = vec![ReplayWorkerArtifacts {
+        requests: vec![ReplayTimedRequest {
+            uuid: Uuid::nil(),
+            timestamp_us: 100,
+            scheduled_ready_at_ms: 0.0,
+            input_length: 2,
+            output_length: 1,
+            replay_hashes: ReplayRequestHashes {
+                local_block_hashes: vec![LocalBlockHash(1), LocalBlockHash(2)],
+                sequence_hashes: Vec::new(),
+            },
+        }],
+        output_signals: Vec::new(),
+        kv_events: vec![
+            ReplayTimedKvEvent {
+                event: KvCacheEvent {
+                    event_id: 7,
+                    data: KvCacheEventData::Removed(KvCacheRemoveData {
+                        block_hashes: vec![
+                            ExternalSequenceBlockHash(11),
+                            ExternalSequenceBlockHash(12),
+                            ExternalSequenceBlockHash(13),
+                        ],
+                    }),
+                    dp_rank: 0,
+                },
+                storage_tier: StorageTier::Device,
+                timestamp_us: 100,
+            },
+            ReplayTimedKvEvent {
+                event: KvCacheEvent {
+                    event_id: 8,
+                    data: KvCacheEventData::Stored(KvCacheStoreData {
+                        parent_hash: None,
+                        start_position: Some(0),
+                        blocks: vec![
+                            KvCacheStoredBlockData {
+                                block_hash: ExternalSequenceBlockHash(21),
+                                tokens_hash: LocalBlockHash(101),
+                                mm_extra_info: None,
+                            },
+                            KvCacheStoredBlockData {
+                                block_hash: ExternalSequenceBlockHash(22),
+                                tokens_hash: LocalBlockHash(102),
+                                mm_extra_info: None,
+                            },
+                        ],
+                    }),
+                    dp_rank: 0,
+                },
+                storage_tier: StorageTier::Device,
+                timestamp_us: 100,
+            },
+        ],
+    }];
+    let benchmark = MooncakeBenchmarkConfig {
+        benchmark_duration_ms: 1_000,
+        inference_worker_duplication_factor: 1,
+    };
+    let merged = merge_worker_traces(artifacts, BLOCK_SIZE)?;
+    let prepared = prepare_scaled_benchmark(merged, benchmark.benchmark_duration_ms);
+    let corpus = prepare_mooncake_corpus(prepared, benchmark.inference_worker_duplication_factor)?;
+
+    assert_eq!(corpus.operations.len(), 3);
+    assert!(
+        matches!(
+            corpus.operations[0].payload,
+            MooncakeOperationPayload::Query
+        ),
+        "query must be accepted before an equal-time event"
+    );
+    assert!(matches!(
+        corpus.operations[1].payload,
+        MooncakeOperationPayload::Event(_)
+    ));
+    assert!(matches!(
+        corpus.operations[2].payload,
+        MooncakeOperationPayload::Event(_)
+    ));
+    assert_eq!(corpus.test_block_totals(), (2, 5));
+    Ok(())
+}
+
+#[test]
+fn mooncake_preparation_normalizes_each_workers_first_entry_before_rescaling() -> anyhow::Result<()>
+{
+    let worker = |first_timestamp_us| ReplayWorkerArtifacts {
+        requests: [first_timestamp_us, first_timestamp_us + 100]
+            .into_iter()
+            .map(|timestamp_us| ReplayTimedRequest {
+                uuid: Uuid::nil(),
+                timestamp_us,
+                scheduled_ready_at_ms: 0.0,
+                input_length: 1,
+                output_length: 1,
+                replay_hashes: ReplayRequestHashes {
+                    local_block_hashes: vec![LocalBlockHash(timestamp_us)],
+                    sequence_hashes: Vec::new(),
+                },
+            })
+            .collect(),
+        output_signals: Vec::new(),
+        kv_events: Vec::new(),
+    };
+    let merged = merge_worker_traces(vec![worker(10), worker(1_000)], BLOCK_SIZE)?;
+    let prepared = prepare_scaled_benchmark(merged, 1_000);
+
+    for trace in prepared.worker_traces.iter() {
+        assert_eq!(trace.first().map(|entry| entry.timestamp_us), Some(0));
+        assert_eq!(
+            trace.last().map(|entry| entry.timestamp_us),
+            Some(1_000_000)
+        );
+    }
+    Ok(())
+}
+
+#[test]
+fn open_loop_cpu_list_parser_accepts_ranges() {
+    assert_eq!(
+        mooncake_open_loop::parse_cpu_list("0-2,5,7-8").unwrap(),
+        [0, 1, 2, 5, 7, 8]
+    );
+    assert!(mooncake_open_loop::parse_cpu_list("4-2").is_err());
+}
+
 #[tokio::test(flavor = "current_thread")]
 async fn generate_replay_artifacts_waits_for_completion_delay() -> anyhow::Result<()> {
     let trace = Trace {
@@ -554,6 +734,54 @@ async fn generate_replay_artifacts_waits_for_completion_delay() -> anyhow::Resul
         "expected second request to wait for completion plus delay"
     );
 
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mooncake_open_loop_smoke_completes_exact_ids_and_drains() -> anyhow::Result<()> {
+    let fixture = support::fixture_path("mooncake_trace_1000.jsonl")?;
+    let traces = process_mooncake_trace(&fixture, BLOCK_SIZE, 1, 1, 2, 42)?;
+    let artifacts = generate_replay_artifacts(&traces, NUM_GPU_BLOCKS, BLOCK_SIZE, None).await?;
+    let benchmark = MooncakeBenchmarkConfig {
+        benchmark_duration_ms: 5_000,
+        inference_worker_duplication_factor: 1,
+    };
+    let merged = merge_worker_traces(artifacts, BLOCK_SIZE)?;
+    let prepared = prepare_scaled_benchmark(merged, benchmark.benchmark_duration_ms);
+    let corpus = prepare_mooncake_corpus(prepared, benchmark.inference_worker_duplication_factor)?;
+    let trial = prepare_open_loop_trial(corpus, 2)?;
+    let indexer = Arc::new(ThreadPoolIndexer::new(
+        ConcurrentRadixTreeCompressed::new(),
+        2,
+        BLOCK_SIZE,
+    ));
+
+    let result = run_open_loop(
+        "concurrent-radix-tree-compressed",
+        indexer,
+        trial,
+        OpenLoopConfig {
+            query_lanes: 2,
+            issuer_threads: 3,
+            spin_us: 50,
+            issue_lag_diagnostic_threshold_us: 250,
+            pre_run_quiescence_ms: 0,
+            issuer_cpus: Vec::new(),
+            query_issuer_cpu: None,
+            backend_cpus: Vec::new(),
+        },
+    )
+    .await?;
+
+    assert!(result.total_requests > 0);
+    assert!(result.total_events > 0);
+    assert!(
+        result.failure_reasons.is_empty(),
+        "{:?}",
+        result.failure_reasons
+    );
+    assert_eq!(result.queue_depth_at_stop.len(), 2);
+    assert!(result.update_scheduled_to_finished.max_ns > 0);
     Ok(())
 }
 
@@ -624,82 +852,37 @@ async fn mooncake_trace_replays_without_warnings_across_indexer_variants() -> an
     ];
 
     for config in &variants {
-        let mut inputs = artifact_sets
-            .iter()
-            .map(|artifact_set| {
-                (
-                    format!(
-                        "{} {} ({})",
-                        config.short_name(),
-                        artifact_set.engine_name,
-                        MooncakeReplayMode::KvEvents.name()
-                    ),
-                    MooncakeBenchmarkInput::KvEvents(artifact_set.artifacts.clone()),
-                    MooncakeReplayMode::KvEvents,
-                )
-            })
-            .collect::<Vec<_>>();
-        if config.supports_approximate() {
-            inputs.push((
-                format!(
-                    "{} ({})",
-                    config.short_name(),
-                    MooncakeReplayMode::Approx.name()
-                ),
-                MooncakeBenchmarkInput::Approx(traces.clone()),
-                MooncakeReplayMode::Approx,
-            ));
-        }
-
-        for (label, input, mode) in inputs {
+        for artifact_set in &artifact_sets {
+            let label = format!(
+                "{} {} ({})",
+                config.short_name(),
+                artifact_set.engine_name,
+                "kv-events"
+            );
             support::reset_warning_count(&warning_count);
-
-            let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-            let indexer = match mode {
-                MooncakeReplayMode::KvEvents => config.build(BLOCK_SIZE, Arc::clone(&metrics)),
-                MooncakeReplayMode::Approx => {
-                    config.build_approximate(BLOCK_SIZE, Arc::clone(&metrics))?
-                }
-            };
-            let run = run_benchmark(
-                indexer,
-                &input,
-                MooncakeBenchmarkConfig {
-                    benchmark_duration_ms: BENCHMARK_DURATION_MS,
-                    inference_worker_duplication_factor: 1,
-                    count_events: config.supports_remove(),
-                    find_matches_concurrency: 0,
-                    block_size: BLOCK_SIZE,
-                },
+            let (scores, metrics) = collect_prepared_corpus_overlap_scores_with_metrics(
+                config,
+                &artifact_set.artifacts,
             )
             .await?;
 
             tokio::time::sleep(Duration::from_millis(50)).await;
 
-            assert!(
-                run.kept_up,
-                "{label} replay fell behind in test profile; increase BENCHMARK_DURATION_MS if this becomes too tight"
-            );
-            assert!(
-                run.results.ops_throughput > 0.0,
-                "{label} replay should record positive throughput"
-            );
+            assert!(!scores.is_empty(), "{label} should resolve queries");
             assert_eq!(
                 warning_count.load(Ordering::Relaxed),
                 0,
                 "{label} emitted warn/error logs from dynamo_kv_router::indexer or dynamo_mocker"
             );
-            if matches!(mode, MooncakeReplayMode::KvEvents) {
-                assert_eq!(
-                    support::duplicate_store_warning_count(metrics.as_ref()),
-                    0,
-                    "{label} recorded duplicate-store warning metrics"
-                );
-            }
+            assert_eq!(
+                support::duplicate_store_warning_count(metrics.as_ref()),
+                0,
+                "{label} recorded duplicate-store warning metrics"
+            );
         }
     }
 
-    assert_overlap_score_parity(&variants, &traces, &artifact_sets).await?;
+    assert_overlap_score_parity(&variants, &artifact_sets, Some(&warning_count)).await?;
 
     Ok(())
 }
@@ -715,7 +898,7 @@ async fn mooncake_trace_branch_sharded_depth4_matches_baseline() -> anyhow::Resu
         MooncakeIndexerConfig::branch_sharded_crtc(2, NUM_EVENT_WORKERS, 4),
     ];
 
-    assert_overlap_score_parity(&variants, &traces, &artifact_sets).await
+    assert_overlap_score_parity(&variants, &artifact_sets, None).await
 }
 
 #[cfg(feature = "mocker-kvbm-offload")]
@@ -742,11 +925,9 @@ async fn mooncake_trace_g2_events_replay_through_host_pinned_lower_tier() -> any
     );
     let (reference_scores, crtc_scores, host_pinned_dumped_events) =
         g2_lower_tier::collect_tiered_replay_scores(&artifacts).await?;
-    let device_only_scores = collect_overlap_scores_for_replay(
+    let device_only_scores = collect_device_only_overlap_scores(
         &MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS),
-        &traces,
         &artifacts,
-        MooncakeReplayMode::KvEvents,
     )
     .await?;
 

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -140,7 +140,7 @@ impl MockEngineParityKind {
 
 #[cfg(feature = "mocker-kvbm-offload")]
 #[derive(Clone)]
-enum DeviceReplayEntryKind {
+enum KvEventReplayEntryKind {
     Request(Vec<LocalBlockHash>),
     Event {
         event: KvCacheEvent,
@@ -150,30 +150,28 @@ enum DeviceReplayEntryKind {
 
 #[cfg(feature = "mocker-kvbm-offload")]
 #[derive(Clone)]
-struct DeviceReplayEntry {
+struct KvEventReplayEntry {
     timestamp_us: u64,
     worker_id: u64,
     kind_rank: u8,
-    kind: DeviceReplayEntryKind,
+    kind: KvEventReplayEntryKind,
 }
 
 #[cfg(feature = "mocker-kvbm-offload")]
-fn collect_device_only_replay_entries(
-    artifacts: &[WorkerReplayArtifacts],
-) -> Vec<DeviceReplayEntry> {
+fn collect_kv_event_replay_entries(artifacts: &[WorkerReplayArtifacts]) -> Vec<KvEventReplayEntry> {
     let mut entries = Vec::new();
     for (worker_id, artifact) in artifacts.iter().enumerate() {
-        entries.extend(artifact.requests.iter().map(|request| DeviceReplayEntry {
+        entries.extend(artifact.requests.iter().map(|request| KvEventReplayEntry {
             timestamp_us: request.timestamp_us,
             worker_id: worker_id as u64,
             kind_rank: 0,
-            kind: DeviceReplayEntryKind::Request(request.replay_hashes.local_block_hashes.clone()),
+            kind: KvEventReplayEntryKind::Request(request.replay_hashes.local_block_hashes.clone()),
         }));
-        entries.extend(artifact.kv_events.iter().map(|event| DeviceReplayEntry {
+        entries.extend(artifact.kv_events.iter().map(|event| KvEventReplayEntry {
             timestamp_us: event.timestamp_us,
             worker_id: worker_id as u64,
             kind_rank: 1,
-            kind: DeviceReplayEntryKind::Event {
+            kind: KvEventReplayEntryKind::Event {
                 event: event.event.clone(),
                 storage_tier: event.storage_tier,
             },
@@ -340,7 +338,7 @@ async fn collect_device_only_overlap_scores(
     artifacts: &[WorkerReplayArtifacts],
 ) -> anyhow::Result<Vec<NormalizedOverlapScores>> {
     let indexer = config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()));
-    let entries = collect_device_only_replay_entries(artifacts);
+    let entries = collect_kv_event_replay_entries(artifacts);
     let mut scores = Vec::new();
     let mut idx = 0;
 
@@ -348,11 +346,11 @@ async fn collect_device_only_overlap_scores(
         let timestamp_us = entries[idx].timestamp_us;
         while idx < entries.len() && entries[idx].timestamp_us == timestamp_us {
             match &entries[idx].kind {
-                DeviceReplayEntryKind::Request(request) => {
+                KvEventReplayEntryKind::Request(request) => {
                     let overlap = indexer.find_matches(request.clone()).await?;
                     scores.push(overlap.scores.into_iter().collect());
                 }
-                DeviceReplayEntryKind::Event {
+                KvEventReplayEntryKind::Event {
                     event,
                     storage_tier,
                 } => {

--- a/lib/bench/tests/support/mooncake_g2_lower_tier.rs
+++ b/lib/bench/tests/support/mooncake_g2_lower_tier.rs
@@ -14,8 +14,8 @@ use rustc_hash::FxHashMap;
 use tokio_util::sync::CancellationToken;
 
 use super::{
-    BLOCK_SIZE, NUM_EVENT_WORKERS, NormalizedOverlapScores, ReplayEntryKind, WorkerReplayArtifacts,
-    collect_replay_entries,
+    BLOCK_SIZE, KvEventReplayEntryKind, NUM_EVENT_WORKERS, NormalizedOverlapScores,
+    WorkerReplayArtifacts, collect_kv_event_replay_entries,
 };
 
 fn additive_device_and_host_pinned_scores(
@@ -236,7 +236,7 @@ pub(crate) async fn collect_tiered_replay_scores(
 )> {
     let reference = ReferenceTieredReplay::new();
     let crtc_lower_tier = CrtcLowerTierReplay::new();
-    let entries = collect_replay_entries(artifacts);
+    let entries = collect_kv_event_replay_entries(artifacts);
     let mut reference_scores = Vec::new();
     let mut crtc_scores = Vec::new();
     let mut idx = 0;
@@ -245,11 +245,11 @@ pub(crate) async fn collect_tiered_replay_scores(
         let timestamp_us = entries[idx].timestamp_us;
         while idx < entries.len() && entries[idx].timestamp_us == timestamp_us {
             match &entries[idx].kind {
-                ReplayEntryKind::Request(request) => {
+                KvEventReplayEntryKind::Request(request) => {
                     reference_scores.push(reference.find_matches(request).await?);
                     crtc_scores.push(crtc_lower_tier.find_matches(request));
                 }
-                ReplayEntryKind::Event {
+                KvEventReplayEntryKind::Event {
                     event,
                     storage_tier,
                 } => {
@@ -259,9 +259,6 @@ pub(crate) async fn collect_tiered_replay_scores(
                     crtc_lower_tier
                         .apply_event(entries[idx].worker_id, event.clone(), *storage_tier)
                         .await;
-                }
-                ReplayEntryKind::ApproxWrite(_) => {
-                    anyhow::bail!("approximate writes are not part of KV-event replay artifacts")
                 }
             }
             idx += 1;

--- a/lib/kv-router/src/indexer/concurrent_radix_tree.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree.rs
@@ -27,6 +27,8 @@ use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::VecDeque;
 
+#[cfg(feature = "bench")]
+use super::WorkerObservationState;
 use super::{
     EventKind, EventWarningKind, KvIndexerMetrics, PreBoundEventCounters, SyncIndexer,
     WorkerLookupStats, WorkerTask,
@@ -574,6 +576,8 @@ impl SyncIndexer for ConcurrentRadixTree {
     ) -> anyhow::Result<()> {
         let mut lookup = FxHashMap::default();
         let counters = metrics.as_ref().map(|m| m.prebind());
+        #[cfg(feature = "bench")]
+        let mut observation = WorkerObservationState::default();
 
         while let Ok(task) = event_receiver.recv() {
             match task {
@@ -599,6 +603,29 @@ impl SyncIndexer for ConcurrentRadixTree {
                     }
                     let _ = resp.send(applied);
                 }
+                #[cfg(feature = "bench")]
+                WorkerTask::InstallObservation { writer, resp } => {
+                    observation.install(writer, resp);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::ObservedEvent {
+                    event,
+                    correlation_id,
+                } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut lookup, event, counters.as_ref());
+                    observation.record(correlation_id, result.is_ok());
+                    if result.is_err() {
+                        tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::SealObservation(resp) => observation.seal(resp),
+                #[cfg(feature = "bench")]
+                WorkerTask::HarvestObservation(resp) => observation.harvest(resp),
                 WorkerTask::Anchor { worker, anchor } => {
                     if let Err(error) = self.apply_anchor(worker, anchor) {
                         tracing::warn!(?error, "Failed to apply anchor");

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/sync_impl.rs
@@ -3,6 +3,8 @@
 
 use super::*;
 use crate::indexer::AnchorCapableSyncIndexer;
+#[cfg(feature = "bench")]
+use crate::indexer::WorkerObservationState;
 
 // ============================================================================
 // SyncIndexer implementation for ConcurrentRadixTreeCompressed
@@ -17,6 +19,8 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
     ) -> anyhow::Result<()> {
         let mut lookup = FxHashMap::default();
         let counters = metrics.as_ref().map(|m| m.prebind());
+        #[cfg(feature = "bench")]
+        let mut observation = WorkerObservationState::default();
 
         while let Ok(task) = event_receiver.recv() {
             match task {
@@ -42,6 +46,29 @@ impl SyncIndexer for ConcurrentRadixTreeCompressed {
                     }
                     let _ = resp.send(applied);
                 }
+                #[cfg(feature = "bench")]
+                WorkerTask::InstallObservation { writer, resp } => {
+                    observation.install(writer, resp);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::ObservedEvent {
+                    event,
+                    correlation_id,
+                } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut lookup, event, counters.as_ref());
+                    observation.record(correlation_id, result.is_ok());
+                    if result.is_err() {
+                        tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::SealObservation(resp) => observation.seal(resp),
+                #[cfg(feature = "bench")]
+                WorkerTask::HarvestObservation(resp) => observation.harvest(resp),
                 WorkerTask::Anchor { worker, anchor } => {
                     if let Err(error) = self.apply_anchor(worker, anchor) {
                         tracing::warn!(?error, "Failed to apply anchor");

--- a/lib/kv-router/src/indexer/lower_tier.rs
+++ b/lib/kv-router/src/indexer/lower_tier.rs
@@ -20,6 +20,8 @@ use std::sync::Arc;
 use dashmap::DashMap;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
+#[cfg(feature = "bench")]
+use super::WorkerObservationState;
 use super::{EventKind, KvIndexerMetrics, SyncIndexer, WorkerLookupStats, WorkerTask};
 use crate::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheEventError, KvCacheStoreData,
@@ -503,6 +505,8 @@ impl SyncIndexer for LowerTierIndexer {
     ) -> anyhow::Result<()> {
         let mut worker_blocks = WorkerBlockIndex::default();
         let counters = metrics.as_ref().map(|m| m.prebind());
+        #[cfg(feature = "bench")]
+        let mut observation = WorkerObservationState::default();
 
         while let Ok(task) = event_receiver.recv() {
             match task {
@@ -528,6 +532,29 @@ impl SyncIndexer for LowerTierIndexer {
                     }
                     let _ = resp.send(applied);
                 }
+                #[cfg(feature = "bench")]
+                WorkerTask::InstallObservation { writer, resp } => {
+                    observation.install(writer, resp);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::ObservedEvent {
+                    event,
+                    correlation_id,
+                } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut worker_blocks, event);
+                    observation.record(correlation_id, result.is_ok());
+                    if let Err(ref error) = result {
+                        tracing::warn!(%error, "Failed to apply lower-tier event");
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::SealObservation(resp) => observation.seal(resp),
+                #[cfg(feature = "bench")]
+                WorkerTask::HarvestObservation(resp) => observation.harvest(resp),
                 WorkerTask::Anchor { worker, anchor } => {
                     if let Err(error) = self.apply_anchor(worker, anchor) {
                         tracing::warn!(?error, "Failed to apply anchor");

--- a/lib/kv-router/src/indexer/mod.rs
+++ b/lib/kv-router/src/indexer/mod.rs
@@ -63,6 +63,8 @@ mod local;
 mod lower_tier;
 mod lower_tier_indexers;
 mod metrics;
+#[cfg(feature = "bench")]
+mod observation;
 mod thread_pool;
 mod traits;
 mod types;
@@ -83,6 +85,8 @@ pub use local::*;
 pub use lower_tier::*;
 pub use lower_tier_indexers::*;
 pub use metrics::*;
+#[cfg(feature = "bench")]
+pub use observation::*;
 pub use thread_pool::*;
 pub use traits::*;
 pub use types::*;

--- a/lib/kv-router/src/indexer/observation.rs
+++ b/lib/kv-router/src/indexer/observation.rs
@@ -1,0 +1,247 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Instant;
+
+use tokio::sync::oneshot;
+
+use crate::protocols::WorkerId;
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct EventCompletion {
+    pub correlation_id: u32,
+    pub finished_ns: u64,
+    pub success: bool,
+}
+
+#[derive(Debug)]
+pub struct EventCompletionWriter {
+    epoch: Instant,
+    records: Box<[EventCompletion]>,
+    written: usize,
+    overflow: bool,
+}
+
+impl EventCompletionWriter {
+    pub fn new(epoch: Instant, capacity: usize) -> Self {
+        Self {
+            epoch,
+            records: vec![EventCompletion::default(); capacity].into_boxed_slice(),
+            written: 0,
+            overflow: false,
+        }
+    }
+
+    fn timestamp_ns(&self) -> u64 {
+        self.epoch.elapsed().as_nanos().min(u64::MAX as u128) as u64
+    }
+
+    fn record(&mut self, correlation_id: u32, success: bool) {
+        let finished_ns = self.timestamp_ns();
+        let Some(slot) = self.records.get_mut(self.written) else {
+            self.overflow = true;
+            return;
+        };
+        *slot = EventCompletion {
+            correlation_id,
+            finished_ns,
+            success,
+        };
+        self.written += 1;
+    }
+
+    fn seal(&self) -> ObservationSeal {
+        ObservationSeal {
+            sealed_ns: self.timestamp_ns(),
+            written: self.written,
+            overflow: self.overflow,
+        }
+    }
+
+    fn into_buffer(self) -> EventCompletionBuffer {
+        EventCompletionBuffer {
+            records: self.records,
+            written: self.written,
+            overflow: self.overflow,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ObservationSeal {
+    pub sealed_ns: u64,
+    pub written: usize,
+    pub overflow: bool,
+}
+
+#[derive(Debug)]
+pub struct EventCompletionBuffer {
+    records: Box<[EventCompletion]>,
+    written: usize,
+    overflow: bool,
+}
+
+impl EventCompletionBuffer {
+    pub fn records(&self) -> &[EventCompletion] {
+        &self.records[..self.written]
+    }
+
+    pub fn capacity(&self) -> usize {
+        self.records.len()
+    }
+
+    pub fn overflowed(&self) -> bool {
+        self.overflow
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum ObservationError {
+    #[error("an observation session is already active")]
+    AlreadyActive,
+    #[error("observation plan contains no workers")]
+    EmptyPlan,
+    #[error("observation plan contains duplicate worker {0}")]
+    DuplicateWorker(u64),
+    #[error("observation capacity overflow for event worker {0}")]
+    CapacityOverflow(usize),
+    #[error("worker {0} was not pre-registered")]
+    UnknownWorker(u64),
+    #[error("observed producer is closed")]
+    ProducerClosed,
+    #[error("event worker {0} is offline")]
+    WorkerOffline(usize),
+    #[error("event worker {0} rejected observation setup")]
+    InstallRejected(usize),
+    #[error("event worker {0} did not acknowledge observation setup")]
+    InstallCanceled(usize),
+    #[error("event worker {0} did not acknowledge the seal barrier")]
+    SealCanceled(usize),
+    #[error("event worker {0} rejected the seal barrier")]
+    SealRejected(usize),
+    #[error("event worker {0} seal task was already consumed")]
+    SealTaskConsumed(usize),
+    #[error("event worker {0} did not return its completion buffer")]
+    HarvestCanceled(usize),
+    #[error("event worker {0} harvest task was already consumed")]
+    HarvestTaskConsumed(usize),
+}
+
+#[derive(Debug)]
+pub struct ThreadPoolObservationPlan {
+    pub epoch: Instant,
+    pub expected_events_by_worker: Vec<(WorkerId, usize)>,
+}
+
+#[derive(Debug)]
+pub struct ObservedEnqueueReceipt {
+    pub accepted_ns: u64,
+    pub event_worker: usize,
+}
+
+#[derive(Debug)]
+pub struct ThreadPoolObservationSnapshot {
+    pub seals: Vec<ObservationSeal>,
+    pub buffers: Vec<EventCompletionBuffer>,
+    pub queue_depth_at_stop: Vec<usize>,
+}
+
+pub struct WorkerObservationState {
+    phase: ObservationPhase,
+    writer: Option<EventCompletionWriter>,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum ObservationPhase {
+    #[default]
+    Idle,
+    Recording,
+    Sealed,
+}
+
+impl Default for WorkerObservationState {
+    fn default() -> Self {
+        Self {
+            phase: ObservationPhase::Idle,
+            writer: None,
+        }
+    }
+}
+
+impl WorkerObservationState {
+    pub fn install(&mut self, writer: EventCompletionWriter, resp: oneshot::Sender<bool>) {
+        let accepted = self.phase == ObservationPhase::Idle;
+        if accepted {
+            self.writer = Some(writer);
+            self.phase = ObservationPhase::Recording;
+        }
+        let _ = resp.send(accepted);
+    }
+
+    pub fn record(&mut self, correlation_id: u32, success: bool) {
+        if self.phase != ObservationPhase::Recording {
+            return;
+        }
+        if let Some(writer) = self.writer.as_mut() {
+            writer.record(correlation_id, success);
+        }
+    }
+
+    pub fn seal(&mut self, resp: oneshot::Sender<Option<ObservationSeal>>) {
+        let seal = if self.phase == ObservationPhase::Recording {
+            self.phase = ObservationPhase::Sealed;
+            self.writer.as_ref().map(EventCompletionWriter::seal)
+        } else {
+            None
+        };
+        let _ = resp.send(seal);
+    }
+
+    pub fn harvest(&mut self, resp: oneshot::Sender<EventCompletionBuffer>) {
+        if self.phase != ObservationPhase::Sealed {
+            return;
+        }
+        let Some(writer) = self.writer.take() else {
+            return;
+        };
+        self.phase = ObservationPhase::Idle;
+        let _ = resp.send(writer.into_buffer());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fixed_writer_latches_overflow_without_growing() {
+        let mut writer = EventCompletionWriter::new(Instant::now(), 1);
+        writer.record(7, true);
+        writer.record(8, false);
+
+        let buffer = writer.into_buffer();
+        assert_eq!(buffer.capacity(), 1);
+        assert!(buffer.overflowed());
+        assert_eq!(buffer.records().len(), 1);
+        assert_eq!(buffer.records()[0].correlation_id, 7);
+    }
+
+    #[tokio::test]
+    async fn observation_state_requires_seal_before_harvest() {
+        let mut state = WorkerObservationState::default();
+        let (install_tx, install_rx) = oneshot::channel();
+        state.install(EventCompletionWriter::new(Instant::now(), 1), install_tx);
+        assert!(install_rx.await.unwrap());
+
+        state.record(9, true);
+        let (seal_tx, seal_rx) = oneshot::channel();
+        state.seal(seal_tx);
+        let seal = seal_rx.await.unwrap().unwrap();
+        assert_eq!(seal.written, 1);
+
+        let (harvest_tx, harvest_rx) = oneshot::channel();
+        state.harvest(harvest_tx);
+        let buffer = harvest_rx.await.unwrap();
+        assert_eq!(buffer.records()[0].correlation_id, 9);
+    }
+}

--- a/lib/kv-router/src/indexer/positional.rs
+++ b/lib/kv-router/src/indexer/positional.rs
@@ -25,6 +25,8 @@ use dashmap::mapref::entry::Entry;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 use std::sync::Arc;
 
+#[cfg(feature = "bench")]
+use super::WorkerObservationState;
 use super::{
     EventKind, EventWarningKind, KvIndexerMetrics, PreBoundEventCounters, SyncIndexer,
     WorkerLookupStats, WorkerTask,
@@ -212,6 +214,8 @@ impl SyncIndexer for PositionalIndexer {
     ) -> anyhow::Result<()> {
         let mut worker_blocks = FxHashMap::default();
         let counters = metrics.as_ref().map(|m| m.prebind());
+        #[cfg(feature = "bench")]
+        let mut observation = WorkerObservationState::default();
 
         while let Ok(task) = event_receiver.recv() {
             match task {
@@ -237,6 +241,29 @@ impl SyncIndexer for PositionalIndexer {
                     }
                     let _ = resp.send(applied);
                 }
+                #[cfg(feature = "bench")]
+                WorkerTask::InstallObservation { writer, resp } => {
+                    observation.install(writer, resp);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::ObservedEvent {
+                    event,
+                    correlation_id,
+                } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut worker_blocks, event, counters.as_ref());
+                    observation.record(correlation_id, result.is_ok());
+                    if result.is_err() {
+                        tracing::warn!("Failed to apply event: {:?}", result.as_ref().err());
+                    }
+                    if let Some(ref c) = counters {
+                        c.inc(kind, result);
+                    }
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::SealObservation(resp) => observation.seal(resp),
+                #[cfg(feature = "bench")]
+                WorkerTask::HarvestObservation(resp) => observation.harvest(resp),
                 WorkerTask::Anchor { worker, anchor } => {
                     if let Err(error) = self.apply_anchor(worker, anchor) {
                         tracing::warn!(?error, "Failed to apply anchor");

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -15,6 +15,11 @@ use dashmap::DashMap;
 use rustc_hash::FxBuildHasher;
 use tokio::sync::oneshot;
 
+#[cfg(feature = "bench")]
+use super::{
+    EventCompletionBuffer, EventCompletionWriter, ObservationError, ObservationSeal,
+    ObservedEnqueueReceipt, ThreadPoolObservationPlan, ThreadPoolObservationSnapshot,
+};
 use super::{
     KvIndexerInterface, KvIndexerMetrics, KvRouterError, ShardSizeSnapshot, SyncIndexer,
     WorkerLookupStats, WorkerTask, panic_payload_message,
@@ -22,6 +27,8 @@ use super::{
 use crate::indexer::pruning::{BlockEntry, PruneConfig, WorkerPruneManager};
 use crate::protocols::*;
 use dynamo_tokens::SequenceHash;
+#[cfg(feature = "bench")]
+use std::sync::atomic::{AtomicBool, Ordering as AtomicOrdering};
 
 /// Generic wrapper that provides [`KvIndexerInterface`] for any [`SyncIndexer`] backend.
 ///
@@ -80,6 +87,54 @@ pub struct ThreadPoolIndexer<T: SyncIndexer> {
 
     /// Synthetic event IDs for approximate store/remove events.
     synthetic_event_id: Arc<AtomicU64>,
+
+    #[cfg(feature = "bench")]
+    observation_active: AtomicBool,
+}
+
+#[cfg(feature = "bench")]
+struct ObservationLease<'a> {
+    active: &'a AtomicBool,
+}
+
+#[cfg(feature = "bench")]
+impl Drop for ObservationLease<'_> {
+    fn drop(&mut self) {
+        self.active.store(false, AtomicOrdering::Release);
+    }
+}
+
+#[cfg(feature = "bench")]
+pub struct ThreadPoolObservationSession<'a, T: SyncIndexer> {
+    indexer: &'a ThreadPoolIndexer<T>,
+    epoch: std::time::Instant,
+    seal_tasks: Vec<Option<WorkerTask>>,
+    seal_receivers: Vec<oneshot::Receiver<Option<ObservationSeal>>>,
+    harvest_tasks: Vec<Option<WorkerTask>>,
+    harvest_receivers: Vec<oneshot::Receiver<EventCompletionBuffer>>,
+    queue_depth_at_stop: Vec<usize>,
+    lease: ObservationLease<'a>,
+}
+
+#[cfg(feature = "bench")]
+pub struct ThreadPoolObservationDrain<'a, T: SyncIndexer> {
+    indexer: &'a ThreadPoolIndexer<T>,
+    seal_tasks: Vec<Option<WorkerTask>>,
+    seal_receivers: Vec<oneshot::Receiver<Option<ObservationSeal>>>,
+    harvest_tasks: Vec<Option<WorkerTask>>,
+    harvest_receivers: Vec<oneshot::Receiver<EventCompletionBuffer>>,
+    queue_depth_at_stop: Vec<usize>,
+    lease: ObservationLease<'a>,
+}
+
+#[cfg(feature = "bench")]
+pub struct ThreadPoolSealedObservation<'a, T: SyncIndexer> {
+    indexer: &'a ThreadPoolIndexer<T>,
+    seals: Vec<ObservationSeal>,
+    harvest_tasks: Vec<Option<WorkerTask>>,
+    harvest_receivers: Vec<oneshot::Receiver<EventCompletionBuffer>>,
+    queue_depth_at_stop: Vec<usize>,
+    lease: ObservationLease<'a>,
 }
 
 impl<T: SyncIndexer> ThreadPoolIndexer<T> {
@@ -217,6 +272,8 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
             prune_manager,
             prune_pump_cancel,
             synthetic_event_id,
+            #[cfg(feature = "bench")]
+            observation_active: AtomicBool::new(false),
         }
     }
 
@@ -232,6 +289,128 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
     /// itself.
     pub fn backend_arc(&self) -> Arc<T> {
         Arc::clone(&self.backend)
+    }
+
+    #[cfg(feature = "bench")]
+    pub async fn begin_observation(
+        &self,
+        plan: ThreadPoolObservationPlan,
+    ) -> Result<ThreadPoolObservationSession<'_, T>, ObservationError> {
+        if plan.expected_events_by_worker.is_empty() {
+            return Err(ObservationError::EmptyPlan);
+        }
+        if self
+            .observation_active
+            .compare_exchange(false, true, AtomicOrdering::AcqRel, AtomicOrdering::Acquire)
+            .is_err()
+        {
+            return Err(ObservationError::AlreadyActive);
+        }
+        let lease = ObservationLease {
+            active: &self.observation_active,
+        };
+
+        let mut seen = BTreeSet::new();
+        let mut expected_events_per_queue = vec![0usize; self.num_workers];
+        for &(worker_id, expected_events) in &plan.expected_events_by_worker {
+            if !seen.insert(worker_id) {
+                return Err(ObservationError::DuplicateWorker(worker_id));
+            }
+            let worker_idx = Self::get_or_assign_thread_idx(
+                &self.worker_assignments,
+                &self.worker_assignment_count,
+                worker_id,
+                self.num_workers,
+            );
+            expected_events_per_queue[worker_idx] = expected_events_per_queue[worker_idx]
+                .checked_add(expected_events)
+                .ok_or(ObservationError::CapacityOverflow(worker_idx))?;
+        }
+
+        let mut install_receivers = Vec::with_capacity(self.num_workers);
+        let mut seal_tasks = Vec::with_capacity(self.num_workers);
+        let mut seal_receivers = Vec::with_capacity(self.num_workers);
+        let mut harvest_tasks = Vec::with_capacity(self.num_workers);
+        let mut harvest_receivers = Vec::with_capacity(self.num_workers);
+
+        for (worker_idx, &capacity) in expected_events_per_queue.iter().enumerate() {
+            let (install_tx, install_rx) = oneshot::channel();
+            self.worker_event_channels[worker_idx]
+                .send(WorkerTask::InstallObservation {
+                    writer: EventCompletionWriter::new(plan.epoch, capacity),
+                    resp: install_tx,
+                })
+                .map_err(|_| ObservationError::WorkerOffline(worker_idx))?;
+            install_receivers.push(install_rx);
+
+            let (seal_tx, seal_rx) = oneshot::channel();
+            seal_tasks.push(Some(WorkerTask::SealObservation(seal_tx)));
+            seal_receivers.push(seal_rx);
+
+            let (harvest_tx, harvest_rx) = oneshot::channel();
+            harvest_tasks.push(Some(WorkerTask::HarvestObservation(harvest_tx)));
+            harvest_receivers.push(harvest_rx);
+        }
+
+        for (worker_idx, receiver) in install_receivers.into_iter().enumerate() {
+            let accepted = receiver
+                .await
+                .map_err(|_| ObservationError::InstallCanceled(worker_idx))?;
+            if !accepted {
+                return Err(ObservationError::InstallRejected(worker_idx));
+            }
+        }
+
+        Ok(ThreadPoolObservationSession {
+            indexer: self,
+            epoch: plan.epoch,
+            seal_tasks,
+            seal_receivers,
+            harvest_tasks,
+            harvest_receivers,
+            queue_depth_at_stop: vec![0; self.num_workers],
+            lease,
+        })
+    }
+
+    #[cfg(feature = "bench")]
+    #[doc(hidden)]
+    pub fn enqueue_active_observation_owned(
+        &self,
+        event: RouterEvent,
+        correlation_id: u32,
+        epoch: std::time::Instant,
+    ) -> Result<ObservedEnqueueReceipt, ObservationError> {
+        if !self.observation_active.load(AtomicOrdering::Acquire) {
+            return Err(ObservationError::ProducerClosed);
+        }
+        let worker_id = event.worker_id;
+        let worker_idx = self
+            .worker_assignments
+            .get(&worker_id)
+            .map(|entry| *entry)
+            .ok_or(ObservationError::UnknownWorker(worker_id))?;
+
+        self.worker_event_channels[worker_idx]
+            .send(WorkerTask::ObservedEvent {
+                event,
+                correlation_id,
+            })
+            .map_err(|_| ObservationError::WorkerOffline(worker_idx))?;
+        let accepted_ns = epoch.elapsed().as_nanos().min(u64::MAX as u128) as u64;
+        self.maybe_enqueue_cleanup(worker_idx);
+
+        Ok(ObservedEnqueueReceipt {
+            accepted_ns,
+            event_worker: worker_idx,
+        })
+    }
+
+    #[cfg(feature = "bench")]
+    fn capture_queue_depths(&self, depths: &mut [usize]) {
+        for (depth, channel) in depths.iter_mut().zip(&self.worker_event_channels) {
+            *depth = channel.len();
+        }
     }
 
     pub(crate) async fn worker_lookup_stats(&self) -> WorkerLookupStats {
@@ -556,6 +735,104 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
     }
 }
 
+#[cfg(feature = "bench")]
+impl<'a, T: SyncIndexer> ThreadPoolObservationSession<'a, T> {
+    pub fn enqueue_observed_owned(
+        &mut self,
+        event: RouterEvent,
+        correlation_id: u32,
+    ) -> Result<ObservedEnqueueReceipt, ObservationError> {
+        self.indexer
+            .enqueue_active_observation_owned(event, correlation_id, self.epoch)
+    }
+
+    pub fn close_observed_producers(mut self) -> ThreadPoolObservationDrain<'a, T> {
+        self.indexer
+            .capture_queue_depths(&mut self.queue_depth_at_stop);
+
+        ThreadPoolObservationDrain {
+            indexer: self.indexer,
+            seal_tasks: self.seal_tasks,
+            seal_receivers: self.seal_receivers,
+            harvest_tasks: self.harvest_tasks,
+            harvest_receivers: self.harvest_receivers,
+            queue_depth_at_stop: self.queue_depth_at_stop,
+            lease: self.lease,
+        }
+    }
+}
+
+#[cfg(feature = "bench")]
+impl<'a, T: SyncIndexer> ThreadPoolObservationDrain<'a, T> {
+    pub async fn seal(mut self) -> Result<ThreadPoolSealedObservation<'a, T>, ObservationError> {
+        for worker_idx in 0..self.indexer.num_workers {
+            let Some(task) = self.seal_tasks[worker_idx].take() else {
+                return Err(ObservationError::SealTaskConsumed(worker_idx));
+            };
+            self.indexer.worker_event_channels[worker_idx]
+                .send(task)
+                .map_err(|_| ObservationError::WorkerOffline(worker_idx))?;
+        }
+
+        let mut seals = Vec::with_capacity(self.indexer.num_workers);
+        for (worker_idx, receiver) in self.seal_receivers.into_iter().enumerate() {
+            let seal = receiver
+                .await
+                .map_err(|_| ObservationError::SealCanceled(worker_idx))?
+                .ok_or(ObservationError::SealRejected(worker_idx))?;
+            seals.push(seal);
+        }
+
+        Ok(ThreadPoolSealedObservation {
+            indexer: self.indexer,
+            seals,
+            harvest_tasks: self.harvest_tasks,
+            harvest_receivers: self.harvest_receivers,
+            queue_depth_at_stop: self.queue_depth_at_stop,
+            lease: self.lease,
+        })
+    }
+}
+
+#[cfg(feature = "bench")]
+impl<T: SyncIndexer> ThreadPoolSealedObservation<'_, T> {
+    pub fn latest_seal_ns(&self) -> u64 {
+        self.seals
+            .iter()
+            .map(|seal| seal.sealed_ns)
+            .max()
+            .unwrap_or_default()
+    }
+
+    pub async fn harvest(mut self) -> Result<ThreadPoolObservationSnapshot, ObservationError> {
+        for worker_idx in 0..self.indexer.num_workers {
+            let Some(task) = self.harvest_tasks[worker_idx].take() else {
+                return Err(ObservationError::HarvestTaskConsumed(worker_idx));
+            };
+            self.indexer.worker_event_channels[worker_idx]
+                .send(task)
+                .map_err(|_| ObservationError::WorkerOffline(worker_idx))?;
+        }
+
+        let mut buffers = Vec::with_capacity(self.indexer.num_workers);
+        for (worker_idx, receiver) in self.harvest_receivers.into_iter().enumerate() {
+            buffers.push(
+                receiver
+                    .await
+                    .map_err(|_| ObservationError::HarvestCanceled(worker_idx))?,
+            );
+        }
+
+        let snapshot = ThreadPoolObservationSnapshot {
+            seals: self.seals,
+            buffers,
+            queue_depth_at_stop: self.queue_depth_at_stop,
+        };
+        drop(self.lease);
+        Ok(snapshot)
+    }
+}
+
 impl<T: SyncIndexer> Drop for ThreadPoolIndexer<T> {
     fn drop(&mut self) {
         if let Some(cancel) = &self.prune_pump_cancel {
@@ -855,5 +1132,41 @@ mod tests {
     #[tokio::test]
     async fn cold_rank_remove_reserves_sticky_queue() {
         assert_cold_remove_reserves_sticky_queue(ColdRemoval::DpRank).await;
+    }
+
+    #[cfg(feature = "bench")]
+    #[tokio::test]
+    async fn observed_events_use_fixed_worker_buffers_and_fifo_seals() {
+        let indexer = ThreadPoolIndexer::new(ConcurrentRadixTreeCompressed::new(), 2, 16);
+        let epoch = std::time::Instant::now();
+        let mut observation = indexer
+            .begin_observation(ThreadPoolObservationPlan {
+                epoch,
+                expected_events_by_worker: vec![(1, 1), (2, 1)],
+            })
+            .await
+            .unwrap();
+
+        let first = observation
+            .enqueue_observed_owned(make_store_event(1, &[11]), 10)
+            .unwrap();
+        let second = observation
+            .enqueue_observed_owned(make_store_event(2, &[22]), 20)
+            .unwrap();
+        assert_ne!(first.event_worker, second.event_worker);
+
+        let sealed = observation.close_observed_producers().seal().await.unwrap();
+        assert!(sealed.latest_seal_ns() >= first.accepted_ns);
+        let snapshot = sealed.harvest().await.unwrap();
+        assert_eq!(snapshot.buffers.len(), 2);
+        assert!(snapshot.buffers.iter().all(|buffer| !buffer.overflowed()));
+        let mut ids = snapshot
+            .buffers
+            .iter()
+            .flat_map(|buffer| buffer.records().iter())
+            .map(|record| record.correlation_id)
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+        assert_eq!(ids, [10, 20]);
     }
 }

--- a/lib/kv-router/src/indexer/types.rs
+++ b/lib/kv-router/src/indexer/types.rs
@@ -11,6 +11,9 @@ use crate::protocols::*;
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
 
+#[cfg(feature = "bench")]
+use super::{EventCompletionBuffer, EventCompletionWriter, ObservationSeal};
+
 /// Trait for types that may represent an error response.
 /// Used for RPC-style responses that can indicate success or failure.
 pub trait MaybeError {
@@ -465,6 +468,20 @@ pub enum WorkerTask {
         event: RouterEvent,
         resp: oneshot::Sender<bool>,
     },
+    #[cfg(feature = "bench")]
+    InstallObservation {
+        writer: EventCompletionWriter,
+        resp: oneshot::Sender<bool>,
+    },
+    #[cfg(feature = "bench")]
+    ObservedEvent {
+        event: RouterEvent,
+        correlation_id: u32,
+    },
+    #[cfg(feature = "bench")]
+    SealObservation(oneshot::Sender<Option<ObservationSeal>>),
+    #[cfg(feature = "bench")]
+    HarvestObservation(oneshot::Sender<EventCompletionBuffer>),
     Anchor {
         worker: WorkerWithDpRank,
         anchor: AnchorTask,


### PR DESCRIPTION
## Summary

- Replace Mooncake's legacy replay with a deadline-driven, completion-correct dispatcher for the supported Positional, CRT, and CRTC thread-pool backends.
- Add `bench`-feature-only fixed completion observation for `ThreadPoolIndexer` while leaving ordinary production tasks unchanged.
- Correct Active Sequences replay with a data-only prepared corpus, fixed execution lanes, completion-inclusive drains, and operation-specific accounting and latency distributions.
- Expand focused parity, lifecycle, queueing, accounting, and documentation coverage.

## Validation

- `(cd lib/kv-router && cargo clippy --no-default-features --no-deps --all-targets -- -D warnings)`
- `(cd lib/kv-router && cargo clippy --no-default-features --features bench --no-deps --all-targets -- -D warnings)`
- `(cd lib/bench && cargo clippy --no-default-features --no-deps --all-targets -- -D warnings)`
- `cargo test -p dynamo-kv-router --no-default-features indexer::thread_pool::tests::cold_rank_remove_reserves_sticky_queue -- --exact` — 1 passed
- `cargo test -p dynamo-kv-router --no-default-features --features bench indexer::thread_pool::tests::observed_events_use_fixed_worker_buffers_and_fifo_seals -- --exact` — 1 passed
- `cargo test -p dynamo-kv-router --no-default-features --features bench indexer::observation::tests::fixed_writer_latches_overflow_without_growing -- --exact` — 1 passed
- `cargo test -p dynamo-bench --test active_sequences_trace --no-default-features -- --nocapture` — 9 passed
- `cargo test -p dynamo-bench --test mooncake_trace --no-default-features -- --nocapture` — 11 passed
- `cargo test -p dynamo-bench --bench active_sequences_bench --no-default-features --no-run`
- `cargo test -p dynamo-bench --bench mooncake_bench --no-default-features --no-run`
- `cargo fmt -p dynamo-kv-router -p dynamo-bench -- --check`
- `cargo metadata --locked --no-deps --format-version 1`
- `git diff --check`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11415" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new KV-router benchmark flows for Mooncake and active-sequence replay, including open-loop execution, improved trace preparation, and richer result reporting.
  * Added benchmark-only observation support so replay runs can capture per-worker event completions and snapshot data.
  * Added CPU affinity and partitioning options for more controlled benchmark runs.

* **Bug Fixes**
  * Tightened replay validation to catch unsupported modes, ordering issues, and invalid benchmark configurations earlier.
  * Improved trace normalization and timing behavior for more consistent benchmark results across runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->