### PR TITLE
fix(vllm): bound RL weight-update initialization

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -103,7 +103,8 @@ logger = logging.getLogger(__name__)
 
 _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
-_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S = 30.0
+_RL_INIT_WEIGHTS_TIMEOUT_ENV = "DYN_RL_INIT_WEIGHTS_TIMEOUT_S"
+_RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S = 30.0
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -121,6 +122,15 @@ def build_prompt_tokens_details(
     if num_cached_tokens is None:
         return None
     return {"cached_tokens": num_cached_tokens}
+
+
+def _rl_init_weights_timeout_s() -> float:
+    return float(
+        os.environ.get(
+            _RL_INIT_WEIGHTS_TIMEOUT_ENV,
+            str(_RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S),
+        )
+    )
 
 
 class _DeferredAbort:
@@ -1104,11 +1114,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             config.model,
         )
 
-    def _shutdown_on_engine_dead(self, e: EngineDeadError) -> NoReturn:
-        logger.error(f"vLLM EngineDeadError: {e}")
+    def _shutdown_worker(self) -> NoReturn:
         logger.warning("Initiating Dynamo Runtime shutdown.")
         self.runtime.shutdown()
         os._exit(1)
+
+    def _shutdown_on_engine_dead(self, e: EngineDeadError) -> NoReturn:
+        logger.error(f"vLLM EngineDeadError: {e}")
+        self._shutdown_worker()
 
     def init_embedding_loader(
         self, config: Config, encode_worker_client: Optional[Client] = None
@@ -1721,25 +1734,31 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         kwargs = {k: v for k, v in body.items() if k != "engine_rpc"}
         async with self._pause_lock:
             try:
-                await asyncio.wait_for(
-                    self.engine_client.collective_rpc(rpc, kwargs=kwargs),
-                    timeout=_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S,
+                timeout_s = _rl_init_weights_timeout_s()
+                rpc_task = asyncio.create_task(
+                    self.engine_client.collective_rpc(rpc, kwargs=kwargs)
                 )
+                try:
+                    done, _ = await asyncio.wait({rpc_task}, timeout=timeout_s)
+                except asyncio.CancelledError:
+                    rpc_task.cancel()
+                    await asyncio.gather(rpc_task, return_exceptions=True)
+                    raise
+                if rpc_task not in done:
+                    rpc_task.cancel()
+                    await asyncio.gather(rpc_task, return_exceptions=True)
+                    logger.error(
+                        f"[RL] init_weights_update_group timed out after "
+                        f"{timeout_s:.1f} seconds (rpc={rpc}); terminating the "
+                        "worker because EngineCore may still be blocked"
+                    )
+                    self._shutdown_worker()
+
+                await rpc_task
                 logger.info(f"[RL] Weight update group initialized (rpc={rpc})")
                 return {"status": "ok", "message": "Weight update group initialized"}
             except EngineDeadError as e:
                 self._shutdown_on_engine_dead(e)
-            except asyncio.TimeoutError:
-                logger.error(
-                    "[RL] init_weights_update_group timed out after %.1f seconds "
-                    "(rpc=%s); terminating the worker because EngineCore may "
-                    "still be blocked",
-                    _RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S,
-                    rpc,
-                )
-                logger.warning("Initiating Dynamo Runtime shutdown.")
-                self.runtime.shutdown()
-                os._exit(1)
             except Exception as e:
                 logger.error(f"[RL] init_weights_update_group failed: {e}")
                 return {"status": "error", "message": str(e)}

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -103,6 +103,7 @@ logger = logging.getLogger(__name__)
 
 _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
+_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S = 30.0
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -1720,11 +1721,25 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         kwargs = {k: v for k, v in body.items() if k != "engine_rpc"}
         async with self._pause_lock:
             try:
-                await self.engine_client.collective_rpc(rpc, kwargs=kwargs)
+                await asyncio.wait_for(
+                    self.engine_client.collective_rpc(rpc, kwargs=kwargs),
+                    timeout=_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S,
+                )
                 logger.info(f"[RL] Weight update group initialized (rpc={rpc})")
                 return {"status": "ok", "message": "Weight update group initialized"}
             except EngineDeadError as e:
                 self._shutdown_on_engine_dead(e)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[RL] init_weights_update_group timed out after %.1f seconds "
+                    "(rpc=%s); terminating the worker because EngineCore may "
+                    "still be blocked",
+                    _RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S,
+                    rpc,
+                )
+                logger.warning("Initiating Dynamo Runtime shutdown.")
+                self.runtime.shutdown()
+                os._exit(1)
             except Exception as e:
                 logger.error(f"[RL] init_weights_update_group failed: {e}")
                 return {"status": "error", "message": str(e)}

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1662,6 +1662,84 @@ class TestRLAdminRouteHardening:
         handler.engine_client.reset_prefix_cache.assert_awaited_once_with()
 
     @pytest.mark.asyncio
+    async def test_init_weights_update_group_succeeds_within_timeout(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock()
+
+        resp = await handler.init_weights_update_group(
+            {
+                "engine_rpc": "init_weight_transfer_engine",
+                "init_info": {"master_address": "trainer", "master_port": 29500},
+            }
+        )
+
+        assert resp == {
+            "status": "ok",
+            "message": "Weight update group initialized",
+        }
+        handler.engine_client.collective_rpc.assert_awaited_once_with(
+            "init_weight_transfer_engine",
+            kwargs={
+                "init_info": {
+                    "master_address": "trainer",
+                    "master_port": 29500,
+                }
+            },
+        )
+        assert not handler._pause_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_init_weights_update_group_timeout_exits_worker(self, monkeypatch):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+
+        rpc_cancelled = asyncio.Event()
+
+        async def blocked_rpc(*_args, **_kwargs):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                rpc_cancelled.set()
+                raise
+
+        handler.engine_client.collective_rpc = AsyncMock(side_effect=blocked_rpc)
+        monkeypatch.setattr(mod, "_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S", 0.01)
+        exit_mock = MagicMock(side_effect=SystemExit(1))
+        monkeypatch.setattr(mod.os, "_exit", exit_mock)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await handler.init_weights_update_group(
+                {"engine_rpc": "init_weight_transfer_engine"}
+            )
+
+        assert exc_info.value.code == 1
+        assert rpc_cancelled.is_set()
+        handler.runtime.shutdown.assert_called_once_with()
+        exit_mock.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_init_weights_update_group_returns_ordinary_errors(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock(
+            side_effect=RuntimeError("init failed")
+        )
+
+        resp = await handler.init_weights_update_group(
+            {"engine_rpc": "init_weight_transfer_engine"}
+        )
+
+        assert resp == {"status": "error", "message": "init failed"}
+        handler.runtime.shutdown.assert_not_called()
+        assert not handler._pause_lock.locked()
+
+    @pytest.mark.asyncio
     async def test_abort_request_surfaces_deferred_abort_failure(self):
         handler = _make_handler()
         handler.engine_client = MagicMock()

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1690,7 +1690,15 @@ class TestRLAdminRouteHardening:
         )
         assert not handler._pause_lock.locked()
 
+    def test_init_weights_update_group_timeout_defaults_to_30_seconds(
+        self, monkeypatch
+    ):
+        monkeypatch.delenv("DYN_RL_INIT_WEIGHTS_TIMEOUT_S", raising=False)
+
+        assert mod._rl_init_weights_timeout_s() == 30.0
+
     @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
     async def test_init_weights_update_group_timeout_exits_worker(self, monkeypatch):
         handler = _make_handler()
         handler._pause_lock = asyncio.Lock()
@@ -1707,7 +1715,7 @@ class TestRLAdminRouteHardening:
                 raise
 
         handler.engine_client.collective_rpc = AsyncMock(side_effect=blocked_rpc)
-        monkeypatch.setattr(mod, "_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S", 0.01)
+        monkeypatch.setenv("DYN_RL_INIT_WEIGHTS_TIMEOUT_S", "0.01")
         exit_mock = MagicMock(side_effect=SystemExit(1))
         monkeypatch.setattr(mod.os, "_exit", exit_mock)
 
@@ -1718,6 +1726,54 @@ class TestRLAdminRouteHardening:
 
         assert exc_info.value.code == 1
         assert rpc_cancelled.is_set()
+        handler.runtime.shutdown.assert_called_once_with()
+        exit_mock.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_init_weights_update_group_returns_inner_timeout_error(
+        self, monkeypatch
+    ):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock(
+            side_effect=TimeoutError("transport timed out")
+        )
+        exit_mock = MagicMock(side_effect=SystemExit(1))
+        monkeypatch.setattr(mod.os, "_exit", exit_mock)
+
+        resp = await handler.init_weights_update_group(
+            {"engine_rpc": "init_weight_transfer_engine"}
+        )
+
+        assert resp == {"status": "error", "message": "transport timed out"}
+        handler.runtime.shutdown.assert_not_called()
+        exit_mock.assert_not_called()
+        assert not handler._pause_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_init_weights_update_group_engine_dead_exits_worker(
+        self, monkeypatch
+    ):
+        from vllm.v1.engine.exceptions import EngineDeadError
+
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock(
+            side_effect=EngineDeadError("engine dead")
+        )
+        exit_mock = MagicMock(side_effect=SystemExit(1))
+        monkeypatch.setattr(mod.os, "_exit", exit_mock)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await handler.init_weights_update_group(
+                {"engine_rpc": "init_weight_transfer_engine"}
+            )
+
+        assert exc_info.value.code == 1
         handler.runtime.shutdown.assert_called_once_with()
         exit_mock.assert_called_once_with(1)
 


### PR DESCRIPTION
## Summary

- make the `init_weights_update_group` watchdog operator-configurable through `DYN_RL_INIT_WEIGHTS_TIMEOUT_S`, with a 30-second default
- distinguish Dynamo watchdog expiry from a `TimeoutError` raised by the underlying RPC, preserving the existing ordinary-error response for the latter
- share the fatal worker-shutdown sequence used by watchdog expiry and `EngineDeadError`
- cancel and await a still-pending initialization RPC before shutting down and exiting the worker

This is the Dynamo-side mitigation for [DYN-3418](https://linear.app/nvidia/issue/DYN-3418). The upstream vLLM TCPStore timeout remains unchanged.

`update_weights_from_distributed` and `destroy_weights_update_group` intentionally remain unbounded. Transfer duration scales with model size, and this PR is scoped to bounding the initialization rendezvous that can leave EngineCore wedged.

## Where should the reviewer start?

- `components/src/dynamo/vllm/handlers.py`: timeout resolution, RPC task lifecycle, and shared worker shutdown
- `components/src/dynamo/vllm/tests/test_vllm_worker_handler.py`: success, watchdog, inner-timeout, and engine-death coverage

## Related Issues

- Relates to [DYN-3418](https://linear.app/nvidia/issue/DYN-3418)
- [x] Confirmed — no related GitHub issue

## Validation

- lightweight standard-library harness over the exact edited methods — 5 passed (default/override, success, watchdog cancellation and exit, inner `TimeoutError`, and `EngineDeadError`)
- `python3 -m compileall -q components/src/dynamo/vllm/handlers.py components/src/dynamo/vllm/tests/test_vllm_worker_handler.py`
- `git diff --check`
- original handler suite before this review follow-up: 63 passed, 5 skipped; the updated full suite is covered by PR CI
