### PR TITLE
fix(vllm): [cherry-pick 1.3.0] bound RL weight-update initialization

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -121,6 +121,7 @@ logger = logging.getLogger(__name__)
 
 _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
+_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S = 30.0
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -1724,11 +1725,25 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         kwargs = {k: v for k, v in body.items() if k != "engine_rpc"}
         async with self._pause_lock:
             try:
-                await self.engine_client.collective_rpc(rpc, kwargs=kwargs)
+                await asyncio.wait_for(
+                    self.engine_client.collective_rpc(rpc, kwargs=kwargs),
+                    timeout=_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S,
+                )
                 logger.info(f"[RL] Weight update group initialized (rpc={rpc})")
                 return {"status": "ok", "message": "Weight update group initialized"}
             except EngineDeadError as e:
                 self._shutdown_on_engine_dead(e)
+            except asyncio.TimeoutError:
+                logger.error(
+                    "[RL] init_weights_update_group timed out after %.1f seconds "
+                    "(rpc=%s); terminating the worker because EngineCore may "
+                    "still be blocked",
+                    _RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S,
+                    rpc,
+                )
+                logger.warning("Initiating Dynamo Runtime shutdown.")
+                self.runtime.shutdown()
+                os._exit(1)
             except Exception as e:
                 logger.error(f"[RL] init_weights_update_group failed: {e}")
                 return {"status": "error", "message": str(e)}

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1526,6 +1526,84 @@ class TestRLAdminRouteHardening:
         handler.engine_client.reset_prefix_cache.assert_awaited_once_with()
 
     @pytest.mark.asyncio
+    async def test_init_weights_update_group_succeeds_within_timeout(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock()
+
+        resp = await handler.init_weights_update_group(
+            {
+                "engine_rpc": "init_weight_transfer_engine",
+                "init_info": {"master_address": "trainer", "master_port": 29500},
+            }
+        )
+
+        assert resp == {
+            "status": "ok",
+            "message": "Weight update group initialized",
+        }
+        handler.engine_client.collective_rpc.assert_awaited_once_with(
+            "init_weight_transfer_engine",
+            kwargs={
+                "init_info": {
+                    "master_address": "trainer",
+                    "master_port": 29500,
+                }
+            },
+        )
+        assert not handler._pause_lock.locked()
+
+    @pytest.mark.asyncio
+    async def test_init_weights_update_group_timeout_exits_worker(self, monkeypatch):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+
+        rpc_cancelled = asyncio.Event()
+
+        async def blocked_rpc(*_args, **_kwargs):
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                rpc_cancelled.set()
+                raise
+
+        handler.engine_client.collective_rpc = AsyncMock(side_effect=blocked_rpc)
+        monkeypatch.setattr(mod, "_RL_INIT_WEIGHTS_UPDATE_GROUP_TIMEOUT_S", 0.01)
+        exit_mock = MagicMock(side_effect=SystemExit(1))
+        monkeypatch.setattr(mod.os, "_exit", exit_mock)
+
+        with pytest.raises(SystemExit) as exc_info:
+            await handler.init_weights_update_group(
+                {"engine_rpc": "init_weight_transfer_engine"}
+            )
+
+        assert exc_info.value.code == 1
+        assert rpc_cancelled.is_set()
+        handler.runtime.shutdown.assert_called_once_with()
+        exit_mock.assert_called_once_with(1)
+
+    @pytest.mark.asyncio
+    async def test_init_weights_update_group_returns_ordinary_errors(self):
+        handler = _make_handler()
+        handler._pause_lock = asyncio.Lock()
+        handler.runtime = MagicMock()
+        handler.engine_client = MagicMock()
+        handler.engine_client.collective_rpc = AsyncMock(
+            side_effect=RuntimeError("init failed")
+        )
+
+        resp = await handler.init_weights_update_group(
+            {"engine_rpc": "init_weight_transfer_engine"}
+        )
+
+        assert resp == {"status": "error", "message": "init failed"}
+        handler.runtime.shutdown.assert_not_called()
+        assert not handler._pause_lock.locked()
+
+    @pytest.mark.asyncio
     async def test_abort_request_surfaces_deferred_abort_failure(self):
         handler = _make_handler()
         handler.engine_client = MagicMock()


### PR DESCRIPTION
## Summary

Backport of #11418 to `release/1.3.0`.

- bound `init_weights_update_group` with a fixed 30-second Dynamo watchdog
- shut down and exit the worker when vLLM does not complete initialization, allowing orchestration to replace a blocked EngineCore
- preserve the existing success, `EngineDeadError`, ordinary error, and `_pause_lock` behavior

This mitigates [DYN-3418](https://linear.app/nvidia/issue/DYN-3418) without changing the upstream vLLM TCPStore timeout.

## Validation

- `PYTHONPATH=<release-worktree>/components/src <isolated-env>/bin/python -m pytest components/src/dynamo/vllm/tests/test_vllm_worker_handler.py -q` — 58 passed, 9 skipped
- `git diff --check`