### PR TITLE
feat(frontend): make overload rejection status code configurable (#11249)

### DIFF
--- a/docs/fault-tolerance/request-rejection.md
+++ b/docs/fault-tolerance/request-rejection.md
@@ -210,6 +210,15 @@ Content-Type: application/json
 }
 ```
 
+#### Configuring the rejection status code
+
+The status code returned for overload rejections is configurable via the
+`DYN_HTTP_OVERLOAD_STATUS_CODE` environment variable on the frontend. It
+defaults to `529` ("Site is overloaded"). Operators whose proxies or clients
+only understand `503` Service Unavailable retry semantics can set
+`DYN_HTTP_OVERLOAD_STATUS_CODE=503`. Any valid HTTP status code is accepted; an
+unparseable or out-of-range value falls back to `529`.
+
 ### Client Retry Strategy
 
 Clients should implement exponential backoff when receiving 529 responses:

--- a/lib/llm/src/http/service/error.rs
+++ b/lib/llm/src/http/service/error.rs
@@ -1,11 +1,25 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::LazyLock;
+
 use axum::http::StatusCode;
+use dynamo_runtime::config::environment_names::llm as env_llm;
 use thiserror::Error;
 
+/// Overload / admission-control rejection status. Reads
+/// `DYN_HTTP_OVERLOAD_STATUS_CODE` (default 529); cached since env is fixed at
+/// runtime and this is on the rejection path.
 pub(crate) fn overload_status_code() -> StatusCode {
-    StatusCode::from_u16(529).expect("529 is a valid HTTP status code")
+    static CODE: LazyLock<StatusCode> = LazyLock::new(|| {
+        let default = StatusCode::from_u16(529).expect("529 is a valid HTTP status code");
+        std::env::var(env_llm::DYN_HTTP_OVERLOAD_STATUS_CODE)
+            .ok()
+            .and_then(|s| s.trim().parse::<u16>().ok())
+            .and_then(|n| StatusCode::from_u16(n).ok())
+            .unwrap_or(default)
+    });
+    *CODE
 }
 
 /// Implementation of the Completion Engines served by the HTTP service should

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -297,6 +297,13 @@ pub mod llm {
     pub const DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS: &str =
         "DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS";
 
+    /// HTTP status code returned when the frontend rejects a request because
+    /// all workers are overloaded. Defaults to 529 ("Site is overloaded"); set
+    /// to 503 for Service Unavailable retry semantics. Any valid HTTP status
+    /// code (100–999) is accepted; an unparseable or out-of-range value falls
+    /// back to 529.
+    pub const DYN_HTTP_OVERLOAD_STATUS_CODE: &str = "DYN_HTTP_OVERLOAD_STATUS_CODE";
+
     /// Enable LoRA adapter support (set to "true" to enable)
     pub const DYN_LORA_ENABLED: &str = "DYN_LORA_ENABLED";
 
@@ -715,6 +722,7 @@ mod tests {
             // LLM
             llm::DYN_HTTP_BODY_LIMIT_MB,
             llm::DYN_HTTP_GRACEFUL_SHUTDOWN_TIMEOUT_SECS,
+            llm::DYN_HTTP_OVERLOAD_STATUS_CODE,
             llm::DYN_HTTP_BACKEND_STREAM_TIMEOUT_SECS,
             llm::DYN_LORA_ENABLED,
             llm::DYN_LORA_PATH,


### PR DESCRIPTION
Backport of #11249 to `release/1.3.0`.

Adds `DYN_HTTP_OVERLOAD_STATUS_CODE` so operators can configure the frontend's overload rejection status code. 1.3.0 ships `529` (from #10941); this lets operators opt back into `503` (or any valid code) without a code change. **Default stays `529` — purely additive, no behavior change unless set.**

Clean cherry-pick — `release/1.3.0` has the identical `overload_status_code()` structure, so the backport is byte-identical to the main change (3 files, +32/-1). Build + env-var duplicate-name test verified on the release branch.

Cherry-pick candidate to avoid forcing the 529 behavior change on 1.3.0 operators.
