### PR TITLE
fix(sglang): complete unified guided decoding parity

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -598,14 +598,13 @@ Observability:
 
 Request handling:
 - **Guided decoding / structured outputs** — wired per-engine on the
-  request side, with engine-specific coverage:
+  request side with JSON schema, regex, grammar, and choice coverage:
   - vLLM (`build_sampling_params` → `StructuredOutputsParams`):
     JSON schema, regex, grammar, choice.
   - TRT-LLM (`GuidedDecodingParams`): JSON schema, regex, grammar,
     choice, `json_object`.
-  - SGLang (`_get_guided_decoding_params`): JSON schema only;
-    regex / grammar / choice are silently dropped (see SGLang gaps
-    below).
+  - SGLang (`_get_guided_decoding_params`): JSON schema, regex,
+    grammar through `ebnf`, and choice through an escaped regex.
 - **Structural tag generation** — `WorkerConfig.structural_tag_{mode,
   scope, schema}` + `serialize_structural_tag` helper
 - **Custom Jinja chat templates** — `WorkerConfig.custom_jinja_template`
@@ -656,7 +655,6 @@ Request handling:
 | `protocol.py` Pydantic models | `EmbeddingRequest`, `DisaggPreprocessedRequest`, multimodal content types |
 | `--disagg-config` YAML override | `--disagg-config` / `--disagg-config-key` for YAML-based disagg config |
 | `--enable-rl` | RL support via `call_tokenizer_manager` route |
-| Guided-decoding constraint coverage | `_get_guided_decoding_params` forwards only `json` (and `structural_tag`); `regex` / `grammar` / `choice` are silently dropped on the unified path even though SGLang's engine accepts them |
 
 ### TRT-LLM-specific gaps
 

--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -14,6 +14,7 @@ import json
 import logging
 import os
 import random
+import re
 import sys
 from collections.abc import AsyncGenerator
 from typing import TYPE_CHECKING, Any, Optional
@@ -1001,7 +1002,21 @@ class SglangLLMEngine(LLMEngine):
         if isinstance(guided_decoding, dict):
             json_schema = guided_decoding.get("json")
             if json_schema is not None:
-                return {"json_schema": json.dumps(json_schema)}
+                if not isinstance(json_schema, str):
+                    json_schema = json.dumps(json_schema)
+                return {"json_schema": json_schema}
+            regex = guided_decoding.get("regex")
+            if regex is not None:
+                return {"regex": regex}
+            grammar = guided_decoding.get("grammar")
+            if grammar is not None:
+                return {"ebnf": grammar}
+            choice = guided_decoding.get("choice")
+            if choice:
+                valid_choices = [item for item in choice if item is not None]
+                if valid_choices:
+                    alternatives = "|".join(re.escape(item) for item in valid_choices)
+                    return {"regex": f"({alternatives})"}
             structural_tag = guided_decoding.get("structural_tag")
             if structural_tag is not None:
                 return {"structural_tag": serialize_structural_tag(structural_tag)}

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -3,6 +3,7 @@
 
 """Unit tests for SGLang backend components."""
 
+import json
 import logging
 import os
 import re
@@ -86,6 +87,58 @@ def _make_sglang_config(**overrides):
     for key, value in overrides.items():
         setattr(config, key, value)
     return config
+
+
+@pytest.mark.parametrize(
+    ("guided_decoding", "expected"),
+    [
+        (
+            {"json": {"type": "object", "required": ["city"]}},
+            {"json_schema": json.dumps({"type": "object", "required": ["city"]})},
+        ),
+        (
+            {"json": '{"type":"object","required":["city"]}'},
+            {"json_schema": '{"type":"object","required":["city"]}'},
+        ),
+        ({"regex": r"[A-Z]{3}-\d{4}"}, {"regex": r"[A-Z]{3}-\d{4}"}),
+        (
+            {"grammar": 'root ::= "yes" | "no"'},
+            {"ebnf": 'root ::= "yes" | "no"'},
+        ),
+        ({"choice": ["yes", "no"]}, {"regex": "(yes|no)"}),
+    ],
+    ids=["json-object", "json-string", "regex", "grammar", "choice"],
+)
+def test_unified_guided_decoding_maps_sglang_constraints(guided_decoding, expected):
+    assert (
+        sglang_llm_engine.SglangLLMEngine._get_guided_decoding_params(guided_decoding)
+        == expected
+    )
+
+
+def test_unified_guided_decoding_escapes_choice_regex_metacharacters():
+    params = sglang_llm_engine.SglangLLMEngine._get_guided_decoding_params(
+        {"choice": ["a+b", "answer (A)", "[done]?"]}
+    )
+
+    assert params == {"regex": r"(a\+b|answer\ \(A\)|\[done\]\?)"}
+    for choice in ("a+b", "answer (A)", "[done]?"):
+        assert re.fullmatch(params["regex"], choice)
+
+
+def test_unified_guided_decoding_ignores_empty_choice():
+    assert (
+        sglang_llm_engine.SglangLLMEngine._get_guided_decoding_params({"choice": []})
+        == {}
+    )
+
+
+def test_unified_guided_decoding_preserves_structural_tag():
+    structural_tag = {"begin": "<tool>", "schema": {"type": "object"}}
+
+    assert sglang_llm_engine.SglangLLMEngine._get_guided_decoding_params(
+        {"structural_tag": structural_tag}
+    ) == {"structural_tag": json.dumps(structural_tag)}
 
 
 def test_compat_restores_sglang_top_level_exports():

--- a/docs/development/custom-backend.md
+++ b/docs/development/custom-backend.md
@@ -20,6 +20,8 @@ start the engine, stream generated chunks, handle cancellation, drain, and clean
 up. The Dynamo framework owns runtime registration, signal handling, model
 registration, and graceful shutdown.
 
-Use the lower-level Python worker path when your backend needs features that are still outside the unified contract, such as multimodal, LoRA adapter management, logprobs, guided decoding, engine-specific routes, or custom request handling.
+Use the lower-level Python worker path when your backend needs features that are
+still outside the unified contract, such as multimodal, LoRA adapter management,
+logprobs, engine-specific routes, or custom request handling.
 
 If your custom engine wants KV-cache-aware routing, also implement [KV Events for Custom Engines](../integrations/kv-events-custom-engines.md) so the Dynamo router can track which workers hold each prefix.

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -147,11 +147,10 @@ Observability:
 
 Request handling:
 - Guided decoding — wired per-engine on the request side with
-  engine-specific coverage. vLLM (`StructuredOutputsParams`) and
-  TRT-LLM (`GuidedDecodingParams`) cover JSON schema / regex / grammar
-  / choice; SGLang (`_get_guided_decoding_params`) covers JSON schema
-  only — regex / grammar / choice are silently dropped today (see the
-  SGLang-specific gaps in the package README)
+  JSON schema, regex, grammar, and choice coverage. vLLM uses
+  `StructuredOutputsParams`, TRT-LLM uses `GuidedDecodingParams`, and
+  SGLang maps the constraints to `json_schema`, `regex`, and `ebnf`;
+  SGLang translates choices to an escaped regex alternation
 - Structural tag generation via `WorkerConfig.structural_tag_{mode,
   scope, schema}` and `serialize_structural_tag`
 - Custom Jinja chat templates via
@@ -941,11 +940,10 @@ Observability:
 Request handling:
 - Guided decoding — request shape carries
   `SamplingOptions::guided_decoding` (`GuidedDecodingOptions`);
-  engine-side coverage on the existing Python-bridged engines is:
-  vLLM and TRT-LLM forward JSON schema / regex / grammar / choice;
-  SGLang forwards JSON schema only (regex / grammar / choice are
-  silently dropped today). A new Rust engine should forward whichever
-  variants its backend supports
+  vLLM, SGLang, and TRT-LLM forward JSON schema, regex, grammar, and
+  choice. SGLang translates grammar to `ebnf` and choices to an escaped
+  regex alternation. A new Rust engine should forward whichever variants
+  its backend supports
 - Structural tag generation — `WorkerConfig::structural_tag_{mode,
   scope, schema}` (typed enums)
 - Custom Jinja chat templates — `WorkerConfig::custom_jinja_template`


### PR DESCRIPTION
## Overview:

Complete guided-decoding parity for the unified SGLang backend across JSON schema, regex, grammar, and choice constraints.

## Details:

- Forward JSON schema, regex, grammar, and choice constraints through SGLang's native `json_schema`, `regex`, and `ebnf` parameters.
- Preserve serialized JSON schema strings while encoding object schemas exactly once.
- Translate non-empty choices to an escaped regex alternation, leave empty choices unconstrained, and preserve structural-tag handling.
- Add direct unit coverage for all supported constraint forms and retain the existing unified JSON-schema serve scenario.
- Update the unified-backend guide, SGLang package README, and custom-backend guidance to describe the completed parity.

## Where should the reviewer start?

- `components/src/dynamo/sglang/llm_engine.py` for the unified constraint translation.
- `components/src/dynamo/sglang/tests/test_sglang_unit.py` for mapping and edge-case coverage.
- `components/src/dynamo/sglang/README.md` and the guided-decoding documentation changes for the parity updates.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to [DIS-1988: Add guided decoding to unified backends](https://linear.app/nvidia/issue/DIS-1988/add-guided-decoding-to-unified-backends)
- Relates to [DIS-2009: Test guided decoding parity](https://linear.app/nvidia/issue/DIS-2009/test-guided-decoding-parity)
- Relates to [DIS-2010: Document guided decoding parity](https://linear.app/nvidia/issue/DIS-2010/document-guided-decoding-parity)

## Validation

- Passed pre-commit hooks for all changed files, including the amended runtime and unit coverage.
- Passed: `python3 -m compileall -q components/src/dynamo/sglang/llm_engine.py components/src/dynamo/sglang/tests/test_sglang_unit.py`.
- Passed: `git diff --check`.
- Passed: `npx --yes fern-api@5.67.1 check` (0 errors).
- Passed: `npx --yes fern-api@5.67.1 docs broken-links`.
- Not run locally: the focused SGLang unit selection and one-GPU `aggregated_unified` scenario. The cached SGLang image requires `libcuda.so.1` during test collection, and the host has no working NVIDIA driver. CI must run both the focused mapping tests and the existing schema-conformance serve payload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded guided-decoding support to handle JSON schema, regex, grammar, and choice constraints more consistently.
  * Improved handling of structured inputs so they’re preserved and translated correctly across supported paths.

* **Documentation**
  * Updated backend docs to reflect the broader guided-decoding coverage and corrected outdated feature-gap notes.

* **Tests**
  * Added unit coverage for constraint translation, escaping behavior, empty choice handling, and structured JSON encoding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->