### PR TITLE
fix(trtllm): complete unified guided decoding parity

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -253,6 +253,15 @@ class TrtllmLLMEngine(LLMEngine):
             "enable_iter_perf_stats": True,
         }
 
+        # Match the legacy worker path: select TRT-LLM's guided-decoding
+        # implementation at engine startup, before generic engine-arg overrides.
+        if config.guided_decoding_backend is not None:
+            engine_args["guided_decoding_backend"] = config.guided_decoding_backend
+            logger.info(
+                "Guided decoding enabled with backend: %s",
+                config.guided_decoding_backend,
+            )
+
         # Apply --extra-engine-args / --override-engine-args. Match the
         # legacy `dynamo.trtllm` path so profiler/parallel-scheduler
         # overrides behave the same way.

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -4,7 +4,7 @@
 import asyncio
 import re as re_mod
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -30,8 +30,10 @@ pytestmark = [
     pytest.mark.trtllm,
     pytest.mark.pre_merge,
     pytest.mark.gpu_1,
-    pytest.mark.profiled_vram_gib(0),
 ]
+
+# Intentionally omit profiled_vram_gib so this import-heavy module runs in the
+# sequential GPU stage instead of starting one TRT-LLM subprocess per test node.
 
 
 @dataclass
@@ -191,6 +193,16 @@ class TestOverrideSamplingParams:
 class TestLLMEngineOverrideSamplingParams:
     """Tests for the unified LLMEngine _override_sampling_params path."""
 
+    JSON_SCHEMA: ClassVar[dict[str, Any]] = {
+        "type": "object",
+        "properties": {"answer": {"type": "string"}},
+        "required": ["answer"],
+    }
+    JSON_SCHEMA_STRING: ClassVar[str] = (
+        '{"type":"object","properties":{"answer":{"type":"string"}},'
+        '"required":["answer"]}'
+    )
+
     def test_n_is_passed_through(self):
         sampling_params = MockSamplingParams()
         request = {"sampling_options": {"n": 2}}
@@ -208,6 +220,65 @@ class TestLLMEngineOverrideSamplingParams:
 
         assert result.n == 2
         assert result.best_of == 4
+
+    @pytest.mark.parametrize(
+        ("guided_decoding", "expected_attribute", "expected_value"),
+        [
+            ({"json": JSON_SCHEMA}, "json", JSON_SCHEMA),
+            ({"json": JSON_SCHEMA_STRING}, "json", JSON_SCHEMA_STRING),
+            ({"regex": "[0-9]+"}, "regex", "[0-9]+"),
+            (
+                {"grammar": 'root ::= "yes" | "no"'},
+                "grammar",
+                'root ::= "yes" | "no"',
+            ),
+            ({"choice": ["yes", "no", "maybe"]}, "regex", "(yes|no|maybe)"),
+        ],
+        ids=["json-object", "json-string", "regex", "grammar", "choice"],
+    )
+    def test_guided_decoding_constraints_are_converted(
+        self, guided_decoding, expected_attribute, expected_value
+    ):
+        sampling_params = MockSamplingParams()
+        request = {"sampling_options": {"guided_decoding": guided_decoding}}
+
+        result = TrtllmLLMEngine._override_sampling_params(sampling_params, request)
+
+        assert not isinstance(result.guided_decoding, dict)
+        assert getattr(result.guided_decoding, expected_attribute) == expected_value
+
+    def test_guided_decoding_choice_escapes_regex_metacharacters(self):
+        sampling_params = MockSamplingParams()
+        choices = ["yes (confirmed)", "no [rejected]", "maybe?"]
+        request = {"sampling_options": {"guided_decoding": {"choice": choices}}}
+
+        result = TrtllmLLMEngine._override_sampling_params(sampling_params, request)
+
+        expected = "(" + "|".join(re_mod.escape(choice) for choice in choices) + ")"
+        assert result.guided_decoding.regex == expected
+
+
+@pytest.mark.parametrize(
+    ("override", "expected"),
+    [
+        (None, "xgrammar"),
+        ('{"guided_decoding_backend": "llguidance"}', "llguidance"),
+    ],
+    ids=["configured", "engine-override"],
+)
+def test_unified_guided_decoding_backend_matches_legacy(override, expected):
+    argv = [
+        "--model-path",
+        "Qwen/Qwen3-0.6B",
+        "--guided-decoding-backend",
+        "xgrammar",
+    ]
+    if override is not None:
+        argv.extend(["--override-engine-args", override])
+
+    engine, _ = asyncio.run(TrtllmLLMEngine.from_args(argv))
+
+    assert engine.engine_args["guided_decoding_backend"] == expected
 
 
 class TestGuidedDecodingFromToolChoice:

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -24,6 +24,7 @@ from tests.utils.payload_builder import (
     chat_payload_default,
     completion_payload,
     completion_payload_default,
+    guided_decoding_chat_payload_default,
     metric_payload_default,
     multimodal_payload_default,
     router_selection_chat_payload_default,
@@ -99,7 +100,7 @@ trtllm_configs = {
         name="aggregated_unified",
         directory=trtllm_dir,
         script_name="agg.sh",
-        script_args=["--unified"],
+        script_args=["--unified", "--guided-decoding-backend", "xgrammar"],
         marks=[
             pytest.mark.core,
             pytest.mark.gpu_1,
@@ -116,6 +117,7 @@ trtllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            guided_decoding_chat_payload_default(),
         ],
     ),
     "disaggregated": TRTLLMConfig(


### PR DESCRIPTION
## Overview:

Complete guided-decoding parity for the unified TensorRT-LLM backend and cover its supported constraint translations independently of the legacy handler.

## Details:

- Forward `--guided-decoding-backend` into unified TensorRT-LLM engine arguments, matching the legacy worker path and preserving engine-argument override precedence.
- Add direct unified-engine coverage for JSON schema objects, serialized JSON schema strings, regex, grammar, and choice-to-regex conversion.
- Cover regex metacharacter escaping in choices and guided-decoding backend configuration and override behavior.
- Preserve the existing legacy `HandlerBase` tests and reuse the schema-validating payload in the one-GPU `aggregated_unified` serve scenario.

## Where should the reviewer start?

- `components/src/dynamo/trtllm/llm_engine.py` for engine configuration and unified sampling-parameter conversion.
- `components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py` for direct unified-path coverage.
- `tests/serve/test_trtllm.py` for the unified serve-scenario payload.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to [DIS-1988: Add guided decoding to unified backends](https://linear.app/nvidia/issue/DIS-1988/add-guided-decoding-to-unified-backends)
- Relates to [DIS-2009: Test guided decoding parity](https://linear.app/nvidia/issue/DIS-2009/test-guided-decoding-parity)

## Validation

- Passed pre-commit hooks for the amended runtime and mapping coverage:
  `SKIP=pytest-marker-report pre-commit run --files components/src/dynamo/trtllm/llm_engine.py`
  and
  `SKIP=pytest-marker-report pre-commit run --files components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py`.
- Passed: `python3 -m compileall -q components/src/dynamo/trtllm/llm_engine.py components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py`.
- Passed: `git diff --check`.
- Not run locally: the focused TensorRT-LLM unit selection and one-GPU `aggregated_unified` scenario. The cached TensorRT-LLM image requires `libcuda.so.1` on import, and the host has no working NVIDIA driver or precompiled engine. CI must run the direct conversion/configuration tests and configured schema-conformance payload.