### PR TITLE
test(vllm): cover unified guided decoding

### DIFF
--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1069,6 +1069,60 @@ def test_build_sampling_params_maps_max_thinking_tokens():
     assert sp.thinking_token_budget == 1024
 
 
+@pytest.mark.parametrize(
+    ("constraint_name", "constraint_value"),
+    [
+        pytest.param(
+            "json",
+            {
+                "type": "object",
+                "properties": {"answer": {"type": "string"}},
+                "required": ["answer"],
+            },
+            id="json-object",
+        ),
+        pytest.param(
+            "json",
+            json.dumps(
+                {
+                    "type": "object",
+                    "properties": {"answer": {"type": "string"}},
+                    "required": ["answer"],
+                }
+            ),
+            id="json-string",
+        ),
+        pytest.param("regex", r"(red|blue|green)", id="regex"),
+        pytest.param(
+            "grammar",
+            'root ::= "red" | "blue" | "green"',
+            id="grammar",
+        ),
+        pytest.param("choice", ["red", "blue", "green"], id="choice"),
+    ],
+)
+def test_build_sampling_params_maps_guided_decoding(constraint_name, constraint_value):
+    from vllm.sampling_params import StructuredOutputsParams
+
+    from dynamo.vllm.handlers import build_sampling_params
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {
+            "guided_decoding": {constraint_name: constraint_value},
+        },
+        "stop_conditions": {},
+        "output_options": {},
+    }
+
+    sp = build_sampling_params(request, default_sampling_params={})
+
+    assert isinstance(sp.structured_outputs, StructuredOutputsParams)
+    for field in ("json", "regex", "grammar", "choice"):
+        expected = constraint_value if field == constraint_name else None
+        assert getattr(sp.structured_outputs, field) == expected
+
+
 def test_build_sampling_params_caps_omitted_max_tokens_to_generation_default():
     from dynamo.vllm.handlers import build_sampling_params
 

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -35,6 +35,7 @@ from tests.utils.payload_builder import (
     elastic_ep_scale_payload,
     embedding_payload,
     embedding_payload_default,
+    guided_decoding_chat_payload_default,
     kv_events_metrics_payload,
     metric_payload_default,
     router_cached_tokens_chat_payload,
@@ -176,6 +177,7 @@ vllm_configs = {
         request_payloads=[
             chat_payload_default(),
             completion_payload_default(),
+            guided_decoding_chat_payload_default(),
         ],
     ),
     "elastic_ep_unified": VLLMConfig(


### PR DESCRIPTION
## Overview:

Add unified vLLM guided-decoding parity coverage for JSON schema, regex, grammar, and choice constraints.

## Details:

- Add parametrized unit coverage proving unified requests map JSON schema objects, serialized JSON schema strings, regex, grammar, and choice into vLLM `StructuredOutputsParams`.
- Reuse the existing schema-validating guided-decoding payload in the one-GPU `aggregated_unified` serve scenario.
- Keep runtime and legacy guided-decoding behavior unchanged because both paths already share the same mapping implementation.

## Where should the reviewer start?

- `components/src/dynamo/vllm/tests/test_vllm_unit.py` for the guided-decoding mapping cases.
- `tests/serve/test_vllm.py` for the unified serve-scenario payload.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to [DIS-1988: Add guided decoding to unified backends](https://linear.app/nvidia/issue/DIS-1988/add-guided-decoding-to-unified-backends)
- Relates to [DIS-2009: Test guided decoding parity](https://linear.app/nvidia/issue/DIS-2009/test-guided-decoding-parity)

## Validation

- Passed pre-commit hooks for the amended mapping coverage:
  `SKIP=pytest-marker-report pre-commit run --files components/src/dynamo/vllm/tests/test_vllm_unit.py`.
- Passed: `python3 -m compileall -q components/src/dynamo/vllm/tests/test_vllm_unit.py`.
- Passed: `git diff --check`.
- The original JSON-object, regex, grammar, and choice cases passed in the cached vLLM development image (4 passed, 93 deselected) before the serialized-string parity case was added.
- Not run locally: the one-GPU `aggregated_unified` serve scenario, because the host has no working NVIDIA driver. CI must run the configured schema-conformance payload.