### PR TITLE
feat(vllm-omni): Add dynamic LoRA lifecycle support for aggregated Omni workers

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -9,7 +9,6 @@ import math
 import os
 import struct
 import tempfile
-import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
@@ -86,6 +85,7 @@ from dynamo.vllm.kv_connector_protocols import (
 from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
+from .lora_state import LoRAState
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from .multimodal_utils.request_processor import (
     MissingMultimodalHandoffError,
@@ -1045,12 +1045,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.temp_dirs: list[tempfile.TemporaryDirectory] = []
         self.model_max_len = model_max_len
         self.model_config = model_config
-        # LoRA tracking: name -> LoRAInfo(id, path)
-        self.loaded_loras: dict[str, LoRAInfo] = {}
-        # Per-LoRA locks to prevent concurrent load operations for the same LoRA
-        self._lora_load_locks: dict[str, asyncio.Lock] = {}
-        # Guard lock-map access in case handlers are invoked from multiple threads.
-        self._lora_load_locks_guard = threading.Lock()
+        self._lora_state = LoRAState()
+        # Keep historical attribute names for compatibility with existing code.
+        self.loaded_loras = self._lora_state.loaded_loras
+        self._lora_load_locks = self._lora_state.lora_load_locks
+        self._lora_load_locks_guard = self._lora_state.lora_load_locks_guard
         self._paused: bool = False
         self._weight_version: str = "initial"
 
@@ -1894,22 +1893,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def _resolve_lora_request(self, model_name: str | None) -> LoRARequest | None:
         """Return a LoRARequest if model_name is a loaded adapter, else None."""
-        if model_name and (lora := self.loaded_loras.get(model_name)):
-            return LoRARequest(
-                lora_name=model_name,
-                lora_int_id=lora.id,
-                lora_path=lora.path,
-            )
-        return None
+        return self._lora_state.resolve_request(model_name)
 
     def _get_lora_lock(self, lora_name: str) -> asyncio.Lock:
         """Get/create the per-LoRA lock without eagerly allocating a new lock each call."""
-        with self._lora_load_locks_guard:
-            lock = self._lora_load_locks.get(lora_name)
-            if lock is None:
-                lock = asyncio.Lock()
-                self._lora_load_locks[lora_name] = lock
-            return lock
+        return self._lora_state.get_lock(lora_name)
 
     async def load_lora(self, request=None):
         """
@@ -2222,12 +2210,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 finally:
                     # Avoid lock-map growth on failed loads: if this attempt did not leave the LoRA
                     # loaded, remove the lock entry (best-effort).
-                    with self._lora_load_locks_guard:
-                        if (
-                            lora_name not in self.loaded_loras
-                            and self._lora_load_locks.get(lora_name) is lock
-                        ):
-                            self._lora_load_locks.pop(lora_name, None)
+                    self._lora_state.cleanup_lock_if_not_loaded(lora_name, lock)
         except Exception as e:
             logger.exception(f"Failed to load LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
@@ -2334,12 +2317,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     }
                 finally:
                     # Remove lock entry once the LoRA is not loaded (or never was).
-                    with self._lora_load_locks_guard:
-                        if (
-                            lora_name not in self.loaded_loras
-                            and self._lora_load_locks.get(lora_name) is lock
-                        ):
-                            self._lora_load_locks.pop(lora_name, None)
+                    self._lora_state.cleanup_lock_if_not_loaded(lora_name, lock)
         except Exception as e:
             logger.exception(f"Failed to unload LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
@@ -2350,7 +2328,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         Returns a dictionary of lora_name -> lora_id mappings.
         """
         try:
-            loras = {name: lora.id for name, lora in self.loaded_loras.items()}
+            loras = self._lora_state.list_lora_ids()
             yield {
                 "status": "success",
                 "loras": loras,

--- a/components/src/dynamo/vllm/lora_state.py
+++ b/components/src/dynamo/vllm/lora_state.py
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import threading
+
+from vllm.lora.request import LoRARequest
+
+from dynamo.common.lora.manager import LoRAInfo
+
+
+class LoRAState:
+    """Shared LoRA tracking and lock management for vLLM handlers."""
+
+    def __init__(self):
+        # name -> LoRAInfo(id, path)
+        self.loaded_loras: dict[str, LoRAInfo] = {}
+        # Per-LoRA lock to serialize concurrent load/unload operations.
+        self.lora_load_locks: dict[str, asyncio.Lock] = {}
+        self.lora_load_locks_guard = threading.Lock()
+
+    def resolve_request(self, model_name: str | None) -> LoRARequest | None:
+        """Return a LoRARequest when model_name targets a loaded adapter."""
+        if model_name and (lora := self.loaded_loras.get(model_name)):
+            return LoRARequest(
+                lora_name=model_name,
+                lora_int_id=lora.id,
+                lora_path=lora.path,
+            )
+        return None
+
+    def get_lock(self, lora_name: str) -> asyncio.Lock:
+        """Get/create per-LoRA lock without eagerly allocating locks."""
+        with self.lora_load_locks_guard:
+            lock = self.lora_load_locks.get(lora_name)
+            if lock is None:
+                lock = asyncio.Lock()
+                self.lora_load_locks[lora_name] = lock
+            return lock
+
+    def cleanup_lock_if_not_loaded(self, lora_name: str, lock: asyncio.Lock) -> None:
+        """Drop lock map entry when adapter is not loaded anymore."""
+        with self.lora_load_locks_guard:
+            if (
+                lora_name not in self.loaded_loras
+                and self.lora_load_locks.get(lora_name) is lock
+            ):
+                self.lora_load_locks.pop(lora_name, None)
+
+    def list_lora_ids(self) -> dict[str, int]:
+        """Return map of loaded LoRA names to integer IDs."""
+        return {name: lora.id for name, lora in self.loaded_loras.items()}

--- a/components/src/dynamo/vllm/omni/args.py
+++ b/components/src/dynamo/vllm/omni/args.py
@@ -24,6 +24,7 @@ from dynamo.common.configuration.groups.runtime_args import (
     DynamoRuntimeConfig,
 )
 from dynamo.common.configuration.utils import add_argument, add_negatable_bool_argument
+from dynamo.common.constants import DisaggregationMode
 
 logger = logging.getLogger(__name__)
 
@@ -372,6 +373,10 @@ class OmniConfig(DynamoRuntimeConfig):
 
     # Realtime (bidirectional) serving mode
     realtime: bool = False
+
+    # Compatibility fields used by shared LoRA registration logic.
+    disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED
+    route_to_encoder: bool = False
 
     @classmethod
     def from_cli_args(cls, args: argparse.Namespace) -> "OmniConfig":

--- a/components/src/dynamo/vllm/omni/base_handler.py
+++ b/components/src/dynamo/vllm/omni/base_handler.py
@@ -21,6 +21,7 @@ from dynamo._core import Context
 from dynamo.common.protocols.audio_protocol import NvAudioSpeechResponse
 from dynamo.common.utils.output_modalities import RequestType
 from dynamo.vllm.handlers import BaseWorkerHandler, build_sampling_params
+from dynamo.vllm.lora_state import LoRAState
 
 logger = logging.getLogger(__name__)
 
@@ -62,6 +63,12 @@ class BaseOmniHandler(BaseWorkerHandler[Dict[str, Any], Dict[str, Any]]):
         self.config = config
         self.model_max_len = config.engine_args.max_model_len
         self.shutdown_event = shutdown_event
+
+        self._lora_state = LoRAState()
+        # Keep historical attribute names for compatibility with existing code.
+        self.loaded_loras = self._lora_state.loaded_loras
+        self._lora_load_locks = self._lora_state.lora_load_locks
+        self._lora_load_locks_guard = self._lora_state.lora_load_locks_guard
 
         logger.info(f"{self.__class__.__name__} initialized successfully")
 

--- a/components/src/dynamo/vllm/omni/main.py
+++ b/components/src/dynamo/vllm/omni/main.py
@@ -11,6 +11,7 @@ import uvloop
 
 from dynamo import prometheus_names
 from dynamo.common.config_dump import dump_config
+from dynamo.common.rl import env_bool, first_endpoint_response
 from dynamo.common.storage import get_fs
 from dynamo.common.utils.graceful_shutdown import install_signal_handlers
 from dynamo.common.utils.output_modalities import get_output_modalities
@@ -31,6 +32,26 @@ logger = logging.getLogger(__name__)
 shutdown_endpoints: list = []
 
 
+def _register_lora_engine_routes(runtime, handler) -> None:
+    route_handlers = {
+        "load_lora": handler.load_lora,
+        "unload_lora": handler.unload_lora,
+        "list_loras": handler.list_loras,
+    }
+
+    for route_name, endpoint_handler in route_handlers.items():
+
+        async def _engine_route(
+            body: dict,
+            endpoint_handler=endpoint_handler,
+        ) -> dict:
+            return await first_endpoint_response(endpoint_handler, body)
+
+        runtime.register_engine_route(route_name, _engine_route)
+
+    logger.info("Registered LoRA engine routes: %s", ", ".join(route_handlers))
+
+
 async def init_omni(
     runtime: DistributedRuntime, config: OmniConfig, shutdown_event: asyncio.Event
 ):
@@ -43,6 +64,26 @@ async def init_omni(
 
     shutdown_endpoints[:] = [generate_endpoint]
 
+    env_lora_enabled = env_bool("DYN_LORA_ENABLED")
+    engine_lora_enabled = bool(getattr(config.engine_args, "enable_lora", False))
+    lora_enabled = env_lora_enabled or engine_lora_enabled
+    load_lora_endpoint = None
+    unload_lora_endpoint = None
+    list_loras_endpoint = None
+    if lora_enabled:
+        load_lora_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.load_lora"
+        )
+        unload_lora_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.unload_lora"
+        )
+        list_loras_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.list_loras"
+        )
+        shutdown_endpoints.extend(
+            [load_lora_endpoint, unload_lora_endpoint, list_loras_endpoint]
+        )
+
     media_fs = (
         get_fs(config.media_output_fs_url) if config.media_output_fs_url else None
     )
@@ -54,9 +95,13 @@ async def init_omni(
         shutdown_event=shutdown_event,
         media_output_fs=media_fs,
         media_output_http_url=config.media_output_http_url,
+        generate_endpoint=generate_endpoint,
     )
 
     logger.info("Omni worker initialized for model: %s", config.model)
+
+    if lora_enabled:
+        _register_lora_engine_routes(runtime, handler)
 
     setup_metrics_collection(config, generate_endpoint, logger)
 
@@ -93,21 +138,44 @@ async def init_omni(
             await VllmOmniHealthCheckPayload.create(handler.engine_client)
         ).to_dict()
 
-        await generate_endpoint.serve_endpoint(
-            handler.generate,
-            graceful_shutdown=True,
-            metrics_labels=[
-                (
-                    prometheus_names.labels.MODEL,
-                    config.served_model_name or config.model,
-                ),
-                (
-                    prometheus_names.labels.MODEL_NAME,
-                    config.served_model_name or config.model,
-                ),
-            ],
-            health_check_payload=health_check_payload,
-        )
+        model_metrics_labels = [
+            (
+                prometheus_names.labels.MODEL,
+                config.served_model_name or config.model,
+            ),
+            (
+                prometheus_names.labels.MODEL_NAME,
+                config.served_model_name or config.model,
+            ),
+        ]
+
+        serve_tasks = [
+            generate_endpoint.serve_endpoint(
+                handler.generate,
+                graceful_shutdown=True,
+                metrics_labels=model_metrics_labels,
+                health_check_payload=health_check_payload,
+            )
+        ]
+        if lora_enabled:
+            serve_tasks.extend(
+                [
+                    load_lora_endpoint.serve_endpoint(
+                        handler.load_lora,
+                        metrics_labels=model_metrics_labels,
+                    ),
+                    unload_lora_endpoint.serve_endpoint(
+                        handler.unload_lora,
+                        metrics_labels=model_metrics_labels,
+                    ),
+                    list_loras_endpoint.serve_endpoint(
+                        handler.list_loras,
+                        metrics_labels=model_metrics_labels,
+                    ),
+                ]
+            )
+
+        await asyncio.gather(*serve_tasks)
     except Exception as e:
         logger.error("Omni worker failed: %s", e)
         raise
@@ -120,6 +188,10 @@ async def worker():
     config = parse_omni_args()
 
     dump_config(config.dump_config_to, config)
+
+    if getattr(config.engine_args, "enable_lora", False):
+        if "DYN_LORA_ENABLED" not in os.environ:
+            os.environ["DYN_LORA_ENABLED"] = "true"
 
     if not config.served_model_name:
         config.served_model_name = config.engine_args.served_model_name = config.model

--- a/components/src/dynamo/vllm/omni/omni_handler.py
+++ b/components/src/dynamo/vllm/omni/omni_handler.py
@@ -2,12 +2,14 @@
 # SPDX-License-Identifier: Apache-2.0
 import asyncio
 import logging
+import os
 import random
 from dataclasses import dataclass
 from typing import Any, AsyncGenerator, Dict, Optional, Union, cast
 
 import PIL.Image
 from fsspec.implementations.dirfs import DirFileSystem
+from vllm.lora.request import LoRARequest
 from vllm.sampling_params import SamplingParams
 from vllm_omni.inputs.data import OmniDiffusionSamplingParams, OmniTextPrompt
 
@@ -16,9 +18,24 @@ from dynamo.common.multimodal import ImageLoader
 from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
 from dynamo.common.protocols.image_protocol import ImageNvExt, NvCreateImageRequest
 from dynamo.common.protocols.video_protocol import NvCreateVideoRequest, VideoNvExt
-from dynamo.common.utils.output_modalities import RequestType, parse_request_type
+from dynamo.common.rl import RLAdminValidationError, require_lora_load_request
+from dynamo.common.utils.output_modalities import (
+    RequestType,
+    get_output_modalities,
+    parse_request_type,
+)
 from dynamo.common.utils.video_utils import compute_num_frames, parse_size
+from dynamo.llm import (
+    ModelInput,
+    ModelRuntimeConfig,
+    ModelType,
+    WorkerType,
+    lora_name_to_id,
+    register_model,
+    unregister_model,
+)
 from dynamo.llm.exceptions import EngineShutdown
+from dynamo.vllm.handlers import LoRAInfo, get_lora_manager
 from dynamo.vllm.omni.audio_handler import AudioGenerationHandler
 from dynamo.vllm.omni.base_handler import BaseOmniHandler
 from dynamo.vllm.omni.output_formatter import OutputFormatter
@@ -57,6 +74,7 @@ class EngineInputs:
     speed: float = 1.0
     response_format: str | None = None
     output_format: str | None = None
+    lora_request: LoRARequest | None = None
 
 
 class OmniHandler(BaseOmniHandler):
@@ -66,6 +84,62 @@ class OmniHandler(BaseOmniHandler):
     Audio/TTS logic is delegated to AudioGenerationHandler via composition.
     """
 
+    @staticmethod
+    def _apply_lora_to_sampling_params(
+        sampling_params_list: list | None,
+        lora_request: LoRARequest | None,
+    ) -> None:
+        """Attach LoRA to diffusion sampling params in-place.
+
+        AsyncOmni diffusion stages consume LoRA from OmniDiffusionSamplingParams.
+        The top-level generate(lora_request=...) argument is not sufficient for
+        diffusion-only paths.
+        """
+        if lora_request is None or sampling_params_list is None:
+            return
+
+        for sp in sampling_params_list:
+            if isinstance(sp, OmniDiffusionSamplingParams):
+                sp.lora_request = lora_request
+
+    def _resolve_and_apply_lora(
+        self,
+        model_name: str | None,
+        sampling_params_list: list | None,
+    ) -> LoRARequest | None:
+        lora_request = super()._resolve_lora_request(model_name)
+        self._apply_lora_to_sampling_params(sampling_params_list, lora_request)
+        return lora_request
+
+    @staticmethod
+    def _extract_lora_name_from_request(request: Any) -> str | None:
+        """Best-effort LoRA name extraction for admin unload compatibility.
+
+        Accepts multiple request shapes used by compatibility aliases and
+        engine-update forwarding layers.
+        """
+        if not isinstance(request, dict):
+            return None
+
+        # Canonical body shape.
+        lora_name = request.get("lora_name")
+        if isinstance(lora_name, str) and lora_name:
+            return lora_name
+
+        # Compatibility shapes that may appear in alias forwarding.
+        for key in ("name", "adapter_name", "model"):
+            value = request.get(key)
+            if isinstance(value, str) and value:
+                return value
+
+        return None
+
+    @staticmethod
+    def _local_path_from_uri(uri: str) -> str:
+        if uri.startswith("file://"):
+            return uri[len("file://") :]
+        return uri
+
     def __init__(
         self,
         runtime,
@@ -74,6 +148,7 @@ class OmniHandler(BaseOmniHandler):
         shutdown_event: asyncio.Event | None = None,
         media_output_fs: Optional[DirFileSystem] = None,
         media_output_http_url: Optional[str] = None,
+        generate_endpoint=None,
     ):
         """Initialize the unified Omni handler.
 
@@ -95,6 +170,7 @@ class OmniHandler(BaseOmniHandler):
         self.media_output_fs = media_output_fs
         self.media_output_http_url = media_output_http_url
         self._image_loader = ImageLoader()
+        self.generate_endpoint = generate_endpoint
 
         self.output_formatter = OutputFormatter(
             model_name=config.served_model_name or config.model,
@@ -110,6 +186,244 @@ class OmniHandler(BaseOmniHandler):
             media_output_fs=media_output_fs,
             media_output_http_url=media_output_http_url,
         )
+
+    async def load_lora(self, request=None):
+        try:
+            lora_name, lora_uri = require_lora_load_request(request)
+        except RLAdminValidationError as e:
+            yield {"status": "error", "message": str(e)}
+            return
+        if lora_name in (self.config.served_model_name, self.config.model):
+            yield {
+                "status": "error",
+                "message": (
+                    "LoRA name must not match base model names "
+                    f"('{self.config.served_model_name}' or '{self.config.model}')."
+                ),
+                "lora_name": lora_name,
+            }
+            return
+
+        lock = self._get_lora_lock(lora_name)
+        async with lock:
+            if lora_name in self.loaded_loras:
+                lora_id = self.loaded_loras[lora_name].id
+                yield {
+                    "status": "success",
+                    "message": f"LoRA adapter '{lora_name}' already loaded",
+                    "lora_name": lora_name,
+                    "lora_id": lora_id,
+                }
+                return
+
+            try:
+                if lora_uri.startswith("file://"):
+                    lora_path = self._local_path_from_uri(lora_uri)
+                    if not os.path.exists(lora_path):
+                        yield {
+                            "status": "error",
+                            "message": f"Local LoRA path does not exist: {lora_path}",
+                        }
+                        return
+                else:
+                    lora_manager = get_lora_manager()
+                    if lora_manager is None:
+                        yield {
+                            "status": "error",
+                            "message": "LoRAManager not initialized. Set DYN_LORA_ENABLED=true for URI-based LoRA loading.",
+                        }
+                        return
+                    download_result = await lora_manager.download_lora(lora_uri)
+                    if download_result.get("status") != "success":
+                        yield {
+                            "status": "error",
+                            "message": f"Failed to download LoRA: {download_result.get('message', 'Unknown error')}",
+                        }
+                        return
+                    lora_path = download_result["local_path"]
+
+                lora_id = lora_name_to_id(lora_name)
+                add_ok = await self.engine_client.add_lora(
+                    LoRARequest(
+                        lora_name=lora_name,
+                        lora_int_id=lora_id,
+                        lora_path=lora_path,
+                    )
+                )
+                if not add_ok:
+                    yield {
+                        "status": "error",
+                        "message": (
+                            "Engine rejected LoRA adapter. "
+                            "Adapter may be incompatible with this base model."
+                        ),
+                        "lora_name": lora_name,
+                    }
+                    return
+                self.loaded_loras[lora_name] = LoRAInfo(id=lora_id, path=lora_path)
+                logger.info("LoRA '%s' loaded and available for use", lora_name)
+
+                if self.generate_endpoint is not None:
+                    try:
+                        runtime_config = ModelRuntimeConfig()
+                        model_type = get_output_modalities(
+                            self.config.output_modalities,
+                            self.config.model,
+                        )
+                        if model_type is None:
+                            model_type = ModelType.Images
+
+                        await register_model(
+                            model_input=ModelInput.Text,
+                            model_type=model_type,
+                            endpoint=self.generate_endpoint,
+                            model_path=self.config.model,
+                            kv_cache_block_size=self.config.engine_args.block_size,
+                            runtime_config=runtime_config,
+                            user_data={"lora_adapter": True, "lora_id": lora_id},
+                            lora_name=lora_name,
+                            base_model_path=self.config.model,
+                            worker_type=WorkerType.Aggregated,
+                            needs=[],
+                        )
+                        logger.info(
+                            "Registered LoRA '%s' on endpoint %s",
+                            lora_name,
+                            self.generate_endpoint,
+                        )
+                    except Exception as reg_err:
+                        logger.exception(
+                            "Failed to register LoRA '%s' in discovery; rolling back",
+                            lora_name,
+                        )
+                        try:
+                            await self.engine_client.remove_lora(lora_id)
+                            self.loaded_loras.pop(lora_name, None)
+                        except Exception:
+                            logger.exception(
+                                "Failed to rollback LoRA '%s' after discovery registration failure",
+                                lora_name,
+                            )
+                        yield {
+                            "status": "error",
+                            "message": f"Failed to register LoRA '{lora_name}' in discovery registry: {str(reg_err)}",
+                            "lora_name": lora_name,
+                        }
+                        return
+
+                yield {
+                    "status": "success",
+                    "message": f"LoRA adapter '{lora_name}' loaded successfully",
+                    "lora_name": lora_name,
+                    "lora_id": lora_id,
+                }
+            except Exception as e:
+                logger.exception("Failed to load LoRA adapter: %s", e)
+                yield {"status": "error", "message": str(e)}
+            finally:
+                self._lora_state.cleanup_lock_if_not_loaded(lora_name, lock)
+
+    async def unload_lora(self, request=None):
+        lora_name = self._extract_lora_name_from_request(request)
+        if not lora_name:
+            yield {"status": "error", "message": "'lora_name' is required in request"}
+            return
+
+        lock = self._get_lora_lock(lora_name)
+        async with lock:
+            lora = self.loaded_loras.get(lora_name)
+            if lora is None:
+                yield {
+                    "status": "error",
+                    "message": f"LoRA adapter '{lora_name}' not found. Available LoRAs: {list(self.loaded_loras.keys())}",
+                }
+                return
+
+            try:
+                lora_id = lora.id
+
+                if self.generate_endpoint is not None:
+                    try:
+                        await unregister_model(
+                            endpoint=self.generate_endpoint,
+                            lora_name=lora_name,
+                        )
+                    except Exception as unreg_err:
+                        logger.exception(
+                            "Failed to unregister LoRA '%s' from discovery",
+                            lora_name,
+                        )
+                        yield {
+                            "status": "error",
+                            "message": f"Failed to unregister LoRA '{lora_name}' from discovery registry: {unreg_err!s}",
+                            "lora_name": lora_name,
+                        }
+                        return
+
+                try:
+                    await self.engine_client.remove_lora(lora_id)
+                except Exception as remove_err:
+                    if self.generate_endpoint is not None:
+                        try:
+                            runtime_config = ModelRuntimeConfig()
+                            model_type = get_output_modalities(
+                                self.config.output_modalities,
+                                self.config.model,
+                            )
+                            if model_type is None:
+                                model_type = ModelType.Images
+
+                            await register_model(
+                                model_input=ModelInput.Text,
+                                model_type=model_type,
+                                endpoint=self.generate_endpoint,
+                                model_path=self.config.model,
+                                kv_cache_block_size=self.config.engine_args.block_size,
+                                runtime_config=runtime_config,
+                                user_data={"lora_adapter": True, "lora_id": lora_id},
+                                lora_name=lora_name,
+                                base_model_path=self.config.model,
+                                worker_type=WorkerType.Aggregated,
+                                needs=[],
+                            )
+                            logger.info(
+                                "Re-registered LoRA '%s' in discovery after remove_lora failure",
+                                lora_name,
+                            )
+                        except Exception:
+                            logger.exception(
+                                "Failed to rollback discovery entry for LoRA '%s' after remove_lora failure",
+                                lora_name,
+                            )
+
+                    logger.exception(
+                        "Failed to remove LoRA '%s' from engine after discovery unregistration",
+                        lora_name,
+                    )
+                    yield {
+                        "status": "error",
+                        "message": f"Failed to unload LoRA '{lora_name}' from engine: {remove_err!s}",
+                        "lora_name": lora_name,
+                    }
+                    return
+
+                self.loaded_loras.pop(lora_name, None)
+                logger.info("LoRA '%s' unloaded", lora_name)
+
+                yield {
+                    "status": "success",
+                    "message": f"LoRA adapter '{lora_name}' unloaded successfully",
+                    "lora_name": lora_name,
+                }
+            except Exception as e:
+                logger.exception("Failed to unload LoRA adapter: %s", e)
+                yield {"status": "error", "message": str(e)}
+            finally:
+                self._lora_state.cleanup_lock_if_not_loaded(lora_name, lock)
+
+    async def list_loras(self, request=None):
+        async for response in super().list_loras(request):
+            yield response
 
     async def generate(
         self, request: Dict[str, Any], context: Context
@@ -180,6 +494,9 @@ class OmniHandler(BaseOmniHandler):
         }
         if inputs.sampling_params_list is not None:
             generate_kwargs["sampling_params_list"] = inputs.sampling_params_list
+        # Keep top-level LoRA only for paths that do not carry stage params.
+        if inputs.lora_request is not None and inputs.sampling_params_list is None:
+            generate_kwargs["lora_request"] = inputs.lora_request
 
         previous_text = ""
 
@@ -281,11 +598,17 @@ class OmniHandler(BaseOmniHandler):
             prompt = OmniTextPrompt(prompt=text_prompt)
             sampling_params_list = None
 
+        lora_request = self._resolve_and_apply_lora(
+            request.get("model"),
+            sampling_params_list,
+        )
+
         return EngineInputs(
             prompt=prompt,
             sampling_params_list=sampling_params_list,
             request_type=RequestType.CHAT_COMPLETION,
             fps=0,
+            lora_request=lora_request,
         )
 
     @staticmethod
@@ -326,9 +649,6 @@ class OmniHandler(BaseOmniHandler):
             height=height,
             width=width,
         )
-
-        # TODO: Apply LoRA Request params here and move to shared utilities for disaggregated stages to use as well.
-
         self._update_if_not_none(sp, "num_outputs_per_prompt", req.n)
 
         self._update_if_not_none(sp, "num_inference_steps", nvext.num_inference_steps)
@@ -341,11 +661,15 @@ class OmniHandler(BaseOmniHandler):
             nvext.seed if nvext.seed is not None else random.randint(0, 2**32 - 1)
         )
 
+        sampling_params_list = self._build_sampling_params_list(sp)
+        lora_request = self._resolve_and_apply_lora(req.model, sampling_params_list)
+
         return EngineInputs(
             prompt=prompt,
-            sampling_params_list=self._build_sampling_params_list(sp),
+            sampling_params_list=sampling_params_list,
             request_type=RequestType.IMAGE_GENERATION,
             response_format=req.response_format,
+            lora_request=lora_request,
         )
 
     def _engine_inputs_from_video(
@@ -398,6 +722,9 @@ class OmniHandler(BaseOmniHandler):
         self._update_if_not_none(sp, "guidance_scale_2", nvext.guidance_scale_2)
         self._update_if_not_none(sp, "fps", fps)
 
+        sampling_params_list = self._build_sampling_params_list(sp)
+        lora_request = self._resolve_and_apply_lora(req.model, sampling_params_list)
+
         logger.info(
             f"Video diffusion request: prompt='{req.prompt[:50]}...', "
             f"size={width}x{height}, frames={num_frames}, fps={fps}"
@@ -405,7 +732,8 @@ class OmniHandler(BaseOmniHandler):
 
         return EngineInputs(
             prompt=prompt,
-            sampling_params_list=self._build_sampling_params_list(sp),
+            sampling_params_list=sampling_params_list,
             request_type=RequestType.VIDEO_GENERATION,
             fps=fps,
+            lora_request=lora_request,
         )

--- a/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_handler.py
@@ -16,7 +16,9 @@ try:
     from dynamo.common.protocols.image_protocol import NvCreateImageRequest
     from dynamo.common.protocols.video_protocol import NvCreateVideoRequest, VideoNvExt
     from dynamo.common.utils.output_modalities import RequestType
+    from dynamo.vllm.lora_state import LoRAState
     from dynamo.vllm.omni.audio_handler import AudioGenerationHandler
+    from dynamo.vllm.omni.main import _register_lora_engine_routes
     from dynamo.vllm.omni.omni_handler import EngineInputs, OmniHandler
     from dynamo.vllm.omni.utils import build_original_prompt, parse_omni_request
 except ImportError:
@@ -57,6 +59,14 @@ def _make_handler(stage_types=("diffusion",)):
         stage_type=stage_types[i]
     )
     handler.engine_client = engine_client
+
+    # BaseOmniHandler.__init__ is mocked out in tests; recreate LoRA state attrs
+    # expected by BaseWorkerHandler helpers called by OmniHandler.
+    handler._lora_state = LoRAState()
+    handler.loaded_loras = handler._lora_state.loaded_loras
+    handler._lora_load_locks = handler._lora_state.lora_load_locks
+    handler._lora_load_locks_guard = handler._lora_state.lora_load_locks_guard
+
     return handler
 
 
@@ -246,6 +256,57 @@ class TestBuildSamplingParamsList:
         sp = OmniDiffusionSamplingParams()
         handler._build_sampling_params_list(sp)
         handler.engine_client.default_sampling_params_list[0].clone.assert_called_once()
+
+
+class TestLoraEngineRouteRegistration:
+    @pytest.mark.asyncio
+    async def test_register_lora_engine_routes_dispatches_each_handler(self):
+        runtime = MagicMock()
+        handler = SimpleNamespace(
+            load_lora=MagicMock(),
+            unload_lora=MagicMock(),
+            list_loras=MagicMock(),
+        )
+
+        async def _yield_once(payload):
+            yield {"status": "ok", "payload": payload}
+
+        handler.load_lora.side_effect = _yield_once
+        handler.unload_lora.side_effect = _yield_once
+        handler.list_loras.side_effect = _yield_once
+
+        _register_lora_engine_routes(runtime, handler)
+
+        registered = {
+            call.args[0]: call.args[1]
+            for call in runtime.register_engine_route.call_args_list
+        }
+
+        assert set(registered) == {"load_lora", "unload_lora", "list_loras"}
+
+        body = {"lora_name": "adapterA"}
+        assert await registered["load_lora"](body) == {"status": "ok", "payload": body}
+        assert await registered["unload_lora"](body) == {
+            "status": "ok",
+            "payload": body,
+        }
+        assert await registered["list_loras"](body) == {"status": "ok", "payload": body}
+
+
+class TestLoraRequestParsing:
+    def test_extract_lora_name_accepts_delete_route_alias_shape(self):
+        handler = _make_handler()
+
+        assert (
+            handler._extract_lora_name_from_request({"name": "adapterA"}) == "adapterA"
+        )
+        assert (
+            handler._extract_lora_name_from_request({"adapter_name": "adapterA"})
+            == "adapterA"
+        )
+        assert (
+            handler._extract_lora_name_from_request({"model": "adapterA"}) == "adapterA"
+        )
 
 
 class TestBuildOriginalPrompt:

--- a/examples/backends/vllm/launch/lora/omni/README.md
+++ b/examples/backends/vllm/launch/lora/omni/README.md
@@ -1,0 +1,126 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+---
+title: Omni LoRA (Image) with vLLM Backend
+---
+
+This example launches Dynamo frontend + vLLM-Omni worker in aggregated mode, with dynamic LoRA load/unload enabled for image generation.
+
+## Files
+
+- `omni_lora_agg.sh`: Launch frontend and Omni worker with `--enable-lora`
+- `validate_omni_lora_agg.sh`: Validate Omni LoRA endpoints and generation flow
+
+## Quick Start
+
+```bash
+cd examples/backends/vllm/launch/lora/omni
+./omni_lora_agg.sh
+```
+
+Default model is `stabilityai/stable-diffusion-xl-base-1.0`.
+
+## Load a LoRA Adapter
+
+```bash
+curl -s -X POST http://localhost:8081/v1/loras \
+  -H "Content-Type: application/json" \
+  -d '{
+    "lora_name": "sdxl-lora",
+    "source": {
+      "uri": "file:///path/to/adapter"
+    }
+  }' | jq .
+```
+
+Adapter folder must contain `adapter_config.json` and `adapter_model.safetensors`.
+
+## Compare LoRA vs Base Output
+
+```bash
+PROMPT="A red fox sitting on a snow-covered mountain at sunset, photorealistic"
+
+curl -sS -X POST http://localhost:8000/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"sdxl-lora\",
+    \"prompt\": \"${PROMPT}\",
+    \"size\": \"1024x1024\",
+    \"nvext\": {\"num_inference_steps\": 20, \"seed\": 42}
+  }" \
+| jq -e -r '.data[0].b64_json' \
+| base64 -d > sdxl_lora.png
+
+curl -sS -X POST http://localhost:8000/v1/images/generations \
+  -H "Content-Type: application/json" \
+  -d "{
+    \"model\": \"stabilityai/stable-diffusion-xl-base-1.0\",
+    \"prompt\": \"${PROMPT}\",
+    \"size\": \"1024x1024\",
+    \"nvext\": {\"num_inference_steps\": 20, \"seed\": 42}
+  }" \
+| jq -e -r '.data[0].b64_json' \
+| base64 -d > sdxl_base.png
+
+sha256sum sdxl_lora.png sdxl_base.png
+cmp -s sdxl_lora.png sdxl_base.png; echo "cmp_exit=$?"
+```
+
+`cmp_exit=0` means identical bytes; `cmp_exit=1` means different outputs.
+
+## List and Unload LoRAs
+
+```bash
+curl -s http://localhost:8081/v1/loras | jq .
+curl -s -X DELETE http://localhost:8081/v1/loras/sdxl-lora | jq .
+```
+
+## Configuration
+
+Environment variables:
+
+- `DYN_MODEL_NAME`: Base model (default `stabilityai/stable-diffusion-xl-base-1.0`)
+- `DYN_HTTP_PORT`: Frontend port (default `8000`)
+- `DYN_SYSTEM_PORT`: Omni system/admin port (default `8081`)
+- `DYN_TENSOR_PARALLEL_SIZE`: Tensor parallel size (default `1`)
+- `DYN_MEDIA_OUTPUT_FS_URL`: Media output path (default `file:///tmp/dynamo_media`)
+
+Extra Omni args:
+
+```bash
+./omni_lora_agg.sh --gpu-memory-utilization 0.8
+```
+
+```bash
+./omni_lora_agg.sh -- --gpu-memory-utilization 0.8
+```
+
+## Notes
+
+- For non-Omni LoRA examples, see `examples/backends/vllm/launch/lora/README.md`.
+
+## Validation Script
+
+Run the validator against a running Omni server:
+
+```bash
+# Terminal 1
+./omni_lora_agg.sh
+
+# Terminal 2 (basic endpoint and base model checks)
+./validate_omni_lora_agg.sh
+```
+
+Run full end-to-end LoRA lifecycle tests with a real adapter path:
+
+```bash
+./validate_omni_lora_agg.sh --lora-path /path/to/omni-lora-adapter
+```
+
+Optional arguments:
+
+```bash
+./validate_omni_lora_agg.sh --frontend-port 8000 --system-port 8081 --base-model stabilityai/stable-diffusion-xl-base-1.0
+```

--- a/examples/backends/vllm/launch/lora/omni/omni_lora_agg.sh
+++ b/examples/backends/vllm/launch/lora/omni/omni_lora_agg.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated vLLM-Omni image serving with dynamic LoRA support.
+
+set -euo pipefail
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../../../common/launch_utils.sh"
+source "$SCRIPT_DIR/../../../../../common/gpu_utils.sh"
+
+MODEL="${DYN_MODEL_NAME:-stabilityai/stable-diffusion-xl-base-1.0}"
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}"
+TP_SIZE="${DYN_TENSOR_PARALLEL_SIZE:-1}"
+MEDIA_OUTPUT_FS_URL="${DYN_MEDIA_OUTPUT_FS_URL:-file:///tmp/dynamo_media}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            cat <<USAGE
+Usage: $0 [--model <model_name>] [-- EXTRA_OMNI_ARGS]
+
+Options:
+  --model <model_name>  Base omni model to serve (default: stabilityai/stable-diffusion-xl-base-1.0)
+  -h, --help            Show help
+
+Environment variables:
+  DYN_MODEL_NAME            Base model name (default: stabilityai/stable-diffusion-xl-base-1.0)
+  DYN_HTTP_PORT             Frontend HTTP port (default: 8000)
+  DYN_SYSTEM_PORT           Omni system/admin port (default: 8081)
+  DYN_TENSOR_PARALLEL_SIZE  Tensor parallel size (default: 1)
+  DYN_MEDIA_OUTPUT_FS_URL   Media output filesystem URL (default: file:///tmp/dynamo_media)
+
+Any arguments after '--' are passed through to python -m dynamo.vllm.omni.
+USAGE
+            exit 0
+            ;;
+        --)
+            shift
+            EXTRA_ARGS+=("$@")
+            break
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+print_launch_banner --no-curl "Launching vLLM-Omni Image + LoRA (aggregated)" "$MODEL" "$HTTP_PORT"
+
+echo ""
+echo "Configuration:"
+echo "  model:        $MODEL"
+echo "  frontend:     http://localhost:$HTTP_PORT"
+echo "  system API:   http://localhost:$SYSTEM_PORT"
+echo "  tensor-par:   $TP_SIZE"
+echo "  gpu mem:      ${GPU_MEM_ARGS:-<default>}"
+echo ""
+echo "LoRA API examples:"
+echo "  curl -s -X POST http://localhost:${SYSTEM_PORT}/v1/loras \\"
+echo "    -H 'Content-Type: application/json' \\"
+echo "    -d '{\"lora_name\": \"my-lora\", \"source\": {\"uri\": \"file:///path/to/adapter\"}}' | jq ."
+echo "  curl -s http://localhost:${SYSTEM_PORT}/v1/loras | jq ."
+echo "  curl -s -X DELETE http://localhost:${SYSTEM_PORT}/v1/loras/my-lora | jq ."
+
+echo ""
+echo "Starting frontend..."
+python -m dynamo.frontend &
+FRONTEND_PID=$!
+
+if ! wait_for_ready "http://localhost:${HTTP_PORT}/health" 60; then
+    echo "Frontend failed to become ready; stopping launch." >&2
+    exit 1
+fi
+
+echo "Starting Omni worker..."
+DYN_SYSTEM_ENABLED=true \
+DYN_SYSTEM_PORT="$SYSTEM_PORT" \
+    python -m dynamo.vllm.omni \
+    --model "$MODEL" \
+    --output-modalities image \
+    --enable-lora \
+    --media-output-fs-url "$MEDIA_OUTPUT_FS_URL" \
+    --tensor-parallel-size "$TP_SIZE" \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+wait_any_exit

--- a/examples/backends/vllm/launch/lora/omni/validate_omni_lora_agg.sh
+++ b/examples/backends/vllm/launch/lora/omni/validate_omni_lora_agg.sh
@@ -1,0 +1,252 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Validation script for Omni image LoRA endpoints.
+#
+# Tests LoRA lifecycle (list, load, infer, unload) and basic error handling
+# against a running Omni worker.
+#
+# Prerequisites:
+#   A running Omni worker via omni_lora_agg.sh
+#
+# Usage:
+#   ./validate_omni_lora_agg.sh
+#   ./validate_omni_lora_agg.sh --lora-path /tmp/my-omni-lora
+
+set -euo pipefail
+
+FRONTEND_PORT="${DYN_HTTP_PORT:-8000}"
+SYSTEM_PORT="${DYN_SYSTEM_PORT:-8081}"
+BASE_MODEL_OVERRIDE=""
+LORA_PATH=""
+LORA_NAME="test-omni-lora"
+PROMPT="Portrait of a woman in a neon alley, mixed-media stylization, oil paint strokes, watercolor edges, ink outlines, posterized color blocks, cinematic contrast, surreal fashion editorial"
+SIZE="1024x1024"
+STEPS=50
+SEED=42
+CURL_TIMEOUT=90
+GUIDANCE_SCALE=7.5
+PASS=0
+FAIL=0
+SKIP=0
+TOTAL=0
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --frontend-port) FRONTEND_PORT=$2; shift 2 ;;
+        --system-port) SYSTEM_PORT=$2; shift 2 ;;
+        --base-model) BASE_MODEL_OVERRIDE=$2; shift 2 ;;
+        --lora-path) LORA_PATH=$2; shift 2 ;;
+        --lora-name) LORA_NAME=$2; shift 2 ;;
+        --prompt) PROMPT=$2; shift 2 ;;
+        --size) SIZE=$2; shift 2 ;;
+        --steps) STEPS=$2; shift 2 ;;
+        --guidance-scale) GUIDANCE_SCALE=$2; shift 2 ;;
+        --seed) SEED=$2; shift 2 ;;
+        --timeout) CURL_TIMEOUT=$2; shift 2 ;;
+        -h|--help)
+            cat <<USAGE
+Usage: $0 [OPTIONS]
+
+Options:
+  --frontend-port <port>  Frontend HTTP port (default: 8000)
+  --system-port <port>    Worker system/admin port (default: 8081)
+  --base-model <name>     Base model name override
+  --lora-path <path>      Local LoRA adapter path (file:// path source)
+  --lora-name <name>      LoRA name used for load test (default: test-omni-lora)
+  --prompt <text>         Prompt for generation checks
+  --size <WxH>            Image size for generation (default: 1024x1024)
+  --steps <int>           num_inference_steps (default: 50)
+  --guidance-scale <float> Guidance scale for generation (default: 7.5)
+  --seed <int>            Seed for deterministic checks (default: 42)
+  --timeout <seconds>     Curl timeout per request (default: 90)
+  -h, --help              Show this help message
+USAGE
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            exit 1
+            ;;
+    esac
+done
+
+FRONTEND="http://localhost:$FRONTEND_PORT"
+SYSTEM="http://localhost:$SYSTEM_PORT"
+
+pass() { PASS=$((PASS + 1)); TOTAL=$((TOTAL + 1)); echo "  PASS: $1"; }
+fail() { FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); echo "  FAIL: $1"; }
+skip() { SKIP=$((SKIP + 1)); TOTAL=$((TOTAL + 1)); echo "  SKIP: $1"; }
+
+check_json_field() {
+    local json=$1 field=$2 expected=$3 name=$4
+    local actual
+    actual=$(echo "$json" | python3 -c "import sys,json; print(json.load(sys.stdin).get('$field',''))" 2>/dev/null || echo "PARSE_ERROR")
+    if [[ "$actual" == "$expected" ]]; then
+        pass "$name"
+    else
+        fail "$name (expected '$expected', got '$actual')"
+    fi
+}
+
+api() {
+    curl -s --max-time "$CURL_TIMEOUT" "$@" 2>/dev/null
+}
+
+gen_image() {
+    local model_name=$1
+    local out_file=$2
+    local resp
+
+    resp=$(api -X POST "$FRONTEND/v1/images/generations" \
+        -H "Content-Type: application/json" \
+        -d "{
+          \"model\": \"$model_name\",
+          \"prompt\": \"$PROMPT\",
+          \"size\": \"$SIZE\",
+          \"nvext\": {
+            \"num_inference_steps\": $STEPS,
+            \"guidance_scale\": $GUIDANCE_SCALE,
+            \"seed\": $SEED
+          }
+        }" || echo '{"error":"request_failed"}')
+
+    if echo "$resp" | python3 -c "import sys,json; d=json.load(sys.stdin); assert 'data' in d and len(d['data'])>0 and d['data'][0].get('b64_json')" 2>/dev/null; then
+        echo "$resp" | python3 -c "import sys,json,base64,pathlib; d=json.load(sys.stdin); pathlib.Path('$out_file').write_bytes(base64.b64decode(d['data'][0]['b64_json']))"
+        return 0
+    fi
+
+    return 1
+}
+
+echo "=================================================="
+echo "Omni LoRA Endpoint Validation"
+echo "=================================================="
+echo "Frontend:   $FRONTEND"
+echo "System API: $SYSTEM"
+echo "LoRA path:  ${LORA_PATH:-<not set - load/infer/unload tests will be skipped>}"
+echo "Prompt:     $PROMPT"
+echo "=================================================="
+
+echo ""
+echo "[1/9] Checking frontend health..."
+if api "$FRONTEND/v1/models" > /dev/null; then
+    pass "Frontend is reachable"
+else
+    fail "Frontend is NOT reachable at $FRONTEND"
+    echo "Ensure omni_lora_agg.sh is running. Aborting."
+    exit 1
+fi
+
+if [[ -n "$BASE_MODEL_OVERRIDE" ]]; then
+    BASE_MODEL="$BASE_MODEL_OVERRIDE"
+else
+    BASE_MODEL=""
+    for _wait in $(seq 1 30); do
+        MODELS_JSON=$(api "$FRONTEND/v1/models" || echo '{}')
+        BASE_MODEL=$(echo "$MODELS_JSON" | python3 -c "import sys,json; d=json.load(sys.stdin); data=d.get('data') or []; print(data[0]['id'] if data else '')" 2>/dev/null || echo "")
+        if [[ -n "$BASE_MODEL" ]]; then
+            break
+        fi
+        sleep 1
+    done
+fi
+
+if [[ -n "$BASE_MODEL" ]]; then
+    pass "Detected base model: $BASE_MODEL"
+else
+    BASE_MODEL="${DYN_MODEL_NAME:-stabilityai/stable-diffusion-xl-base-1.0}"
+    pass "Using fallback base model: $BASE_MODEL"
+fi
+
+echo ""
+echo "[2/9] Testing list_loras (GET)..."
+RESP=$(api "$SYSTEM/v1/loras" || echo '{"status":"error"}')
+check_json_field "$RESP" "status" "success" "list_loras returns success"
+
+echo ""
+echo "[3/7] Testing unload_lora for non-existent adapter..."
+RESP=$(api -X DELETE "$SYSTEM/v1/loras/non-existent-lora" || echo '{"status":"error"}')
+check_json_field "$RESP" "status" "error" "unload_lora rejects non-existent adapter"
+
+echo ""
+echo "[4/7] Loading a real LoRA adapter..."
+if [[ -n "$LORA_PATH" && -d "$LORA_PATH" ]]; then
+    RESP=$(api -X POST "$SYSTEM/v1/loras" \
+        -H "Content-Type: application/json" \
+        -d "{\"lora_name\": \"$LORA_NAME\", \"source\": {\"uri\": \"file://$LORA_PATH\"}}" || echo '{"status":"error"}')
+    check_json_field "$RESP" "status" "success" "load_lora with real adapter"
+
+    LORA_VISIBLE=false
+    for _wait in $(seq 1 10); do
+        MODELS=$(api "$FRONTEND/v1/models" || echo '{}')
+        if echo "$MODELS" | python3 -c "import sys,json; ids=[m['id'] for m in json.load(sys.stdin).get('data',[])]; assert '$LORA_NAME' in ids" 2>/dev/null; then
+            LORA_VISIBLE=true
+            break
+        fi
+        sleep 1
+    done
+
+    if [[ "$LORA_VISIBLE" == "true" ]]; then
+        pass "LoRA appears in /v1/models"
+    else
+        fail "LoRA does NOT appear in /v1/models after 10s"
+    fi
+else
+    skip "No --lora-path provided, skipping real LoRA load"
+fi
+
+echo ""
+echo "[5/7] Testing image generation with LoRA adapter..."
+if [[ -n "$LORA_PATH" && -d "$LORA_PATH" ]]; then
+    TMP_LORA_IMG=$(mktemp /tmp/omni_lora_img.XXXXXX.png)
+    if gen_image "$LORA_NAME" "$TMP_LORA_IMG"; then
+        pass "LoRA image generation returned valid image"
+    else
+        fail "LoRA image generation failed"
+    fi
+else
+    skip "No --lora-path provided, skipping LoRA image generation"
+fi
+
+echo ""
+echo "[6/7] Testing image generation with base model..."
+TMP_BASE_IMG=$(mktemp /tmp/omni_base_img.XXXXXX.png)
+if gen_image "$BASE_MODEL" "$TMP_BASE_IMG"; then
+    pass "Base model image generation returned valid image"
+else
+    fail "Base model image generation failed"
+fi
+
+echo ""
+echo "[7/7] Unloading LoRA adapter..."
+if [[ -n "$LORA_PATH" && -d "$LORA_PATH" ]]; then
+    RESP=$(api -X DELETE "$SYSTEM/v1/loras/$LORA_NAME" || echo '{"status":"error"}')
+    check_json_field "$RESP" "status" "success" "unload_lora succeeds"
+
+    MODELS=$(api "$FRONTEND/v1/models" || echo '{}')
+    if echo "$MODELS" | python3 -c "import sys,json; ids=[m['id'] for m in json.load(sys.stdin).get('data',[])]; assert '$LORA_NAME' not in ids" 2>/dev/null; then
+        pass "LoRA removed from /v1/models"
+    else
+        fail "LoRA still present in /v1/models after unload"
+    fi
+
+    if [[ -f "${TMP_LORA_IMG:-}" && -f "$TMP_BASE_IMG" ]]; then
+        echo ""
+        echo "Deterministic compare summary (informational):"
+        sha256sum "$TMP_LORA_IMG" "$TMP_BASE_IMG" || true
+        cmp -s "$TMP_LORA_IMG" "$TMP_BASE_IMG" && echo "  byte_identical=true" || echo "  byte_identical=false"
+    fi
+else
+    skip "No --lora-path provided, skipping LoRA unload"
+fi
+
+echo ""
+echo "=================================================="
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped (out of $TOTAL)"
+echo "=================================================="
+
+if [[ $FAIL -gt 0 ]]; then
+    exit 1
+fi

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -32,6 +32,7 @@ use dynamo_runtime::{
         network::egress::push_router::RouterMode as RsRouterMode,
     },
     protocols::annotated::Annotated as RsAnnotated,
+    slug::Slug,
     traits::DistributedRuntimeProvider,
 };
 
@@ -537,6 +538,16 @@ fn register_model<'p>(
         if is_tensor_based || is_images || is_videos || is_realtime {
             let model_name = model_name.unwrap_or_else(|| source_path.clone());
             let mut card = llm_rs::model_card::ModelDeploymentCard::with_name_only(&model_name);
+            // Preserve source_path for compatibility checks (LoRA vs base model).
+            card.source_path = Some(source_path.clone());
+
+            // Populate lora_info if this is a LoRA registration.
+            if let Some(lora_name) = lora_identifier.clone() {
+                card.lora = Some(llm_rs::model_card::LoraInfo {
+                    name: lora_name,
+                    max_gpu_lora_count: None,
+                });
+            }
             card.model_type = model_type_obj;
             card.model_input = model_input;
             card.worker_type = worker_type_value;
@@ -549,11 +560,15 @@ fn register_model<'p>(
 
             // Register the Model Deployment Card via discovery interface
             let discovery = endpoint.inner.drt().discovery();
-            let spec = rs::discovery::DiscoverySpec::from_model(
+            let model_suffix = lora_identifier
+                .as_ref()
+                .map(|name| Slug::slugify(name).to_string());
+            let spec = rs::discovery::DiscoverySpec::from_model_with_suffix(
                 endpoint.inner.component().namespace().name().to_string(),
                 endpoint.inner.component().name().to_string(),
                 endpoint.inner.name().to_string(),
                 &card,
+                model_suffix,
             )
             .map_err(to_pyerr)?;
             discovery.register(spec).await.map_err(to_pyerr)?;

--- a/lib/bindings/python/tests/test_runtime_data_discovery.py
+++ b/lib/bindings/python/tests/test_runtime_data_discovery.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import json
+import pathlib
 
 import pytest
 
@@ -292,5 +293,57 @@ async def test_prefill_dual_emit_model_type_validation(temp_file_store):
                 worker_type=WorkerType.Prefill,
                 needs=[],
             )
+    finally:
+        rt.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_lora_registration_persists_base_and_lora_model_cards(temp_file_store):
+    rt = _runtime()
+    try:
+        ep = rt.endpoint("test.ns.generate")
+        await ep.register_endpoint_instance()
+
+        await register_model(
+            ModelInput.Tensor,
+            ModelType.TensorBased,
+            ep,
+            "base-model",
+            worker_type=WorkerType.Aggregated,
+        )
+        await register_model(
+            ModelInput.Tensor,
+            ModelType.TensorBased,
+            ep,
+            "base-model",
+            worker_type=WorkerType.Aggregated,
+            lora_name="adapterA",
+            base_model_path="base-model",
+        )
+
+        model_card_files = sorted(pathlib.Path(temp_file_store).glob("v1/mdc/**/*"))
+        model_card_json = [
+            json.loads(path.read_text()) for path in model_card_files if path.is_file()
+        ]
+
+        base_cards = [
+            card
+            for card in model_card_json
+            if card["card_json"]["display_name"] == "base-model"
+        ]
+        lora_cards = [
+            card
+            for card in model_card_json
+            if card["card_json"]["display_name"] == "adapterA"
+        ]
+
+        assert len(base_cards) == 1
+        assert len(lora_cards) == 1
+
+        assert base_cards[0]["card_json"]["source_path"] == "base-model"
+
+        assert lora_cards[0]["card_json"]["source_path"] == "base-model"
+        assert lora_cards[0]["card_json"]["lora"] == {"name": "adapterA"}
+        assert lora_cards[0]["model_suffix"] == "adaptera"
     finally:
         rt.shutdown()


### PR DESCRIPTION
## Overview:

This PR adds end-to-end dynamic LoRA support to the vLLM Omni aggregated worker path. It introduces runtime LoRA lifecycle APIs (load, unload, list), applies loaded adapters during image/video generation, and makes loaded LoRAs discoverable as frontend-visible models through model discovery. It also includes launch/validation documentation and scripts so the flow can be exercised from bring-up to teardown.

## Details:

1. Adds runtime lifecycle management for LoRAs in Omni:
- In-memory tracking of loaded adapters.
- Per-LoRA synchronization/locking.
- Load/unload/list API handlers with rollback behavior when registration steps fail.

2. Applies LoRA selection at request time:
- Resolves request model names to loaded LoRA adapters.
- Injects resolved LoRA request metadata into diffusion generation paths, including image and video requests.

3. Exposes LoRA admin surface from the Omni worker:
- Wires LoRA endpoints alongside existing generation endpoints when LoRA is enabled.
- Extends startup/shutdown handling to include LoRA lifecycle routing.

4. Updates discovery/model-card behavior for LoRA-backed models:
- Preserves base-model source compatibility while registering LoRA variants.
- Publishes LoRA metadata and suffix-aware model identities so adapters appear as distinct models in model discovery.

5. Reduces duplication in LoRA shared logic:
- Shared state/lock/resolve/list behavior is extracted into a common helper and reused by base and Omni handler paths.
- Omni keeps only the intentionally different orchestration logic for async multimodal lifecycle behavior.

6. Adds validation coverage and operational docs:

- Tests for route registration and LoRA model-name extraction.
- Discovery persistence tests for base + LoRA model-card behavior.
- Example launch and validation scripts for full lifecycle verification.

## Where should the reviewer start?

1. Start with the Omni handler lifecycle and request-routing logic.
Reason: this is the main behavioral change (load/unload/list, resolution, injection, rollback).

2. Then review worker entrypoint wiring for endpoint exposure and feature gating.
Reason: confirms how LoRA APIs are surfaced in runtime and tied to enablement flags.

3. Next review discovery registration changes.
Reason: this explains why loaded LoRAs show up as distinct, frontend-resolvable models.

4. Then check the shared LoRA helper refactor.
Reason: verifies drift-risk reduction and that shared behavior is consistently reused.

5. Finish with tests and example scripts.
Reason: validates intended behavior and gives an executable reviewer sanity-check path.

Model: stabilityai/stable-diffusion-xl-base-1.0
Lora: cosmic-tf/sdxl_finetuned_8styles [link](https://huggingface.co/cosmic-tf/sdxl_finetuned_8styles)

```
    prompt = (
        "Portrait of a woman in a neon alley, mixed-media stylization, oil paint strokes, "
        "watercolor edges, ink outlines, posterized color blocks, cinematic contrast, "
        "surreal fashion editorial"
    )
```
Model `stabilityai/stable-diffusion-xl-base-1.0` output image
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/07b6ff6c-f06c-4101-aeb3-cac7c7eef2b2" />


Lora 'cosmic-tf/sdxl_finetuned_8styles' [link](https://huggingface.co/cosmic-tf/sdxl_finetuned_8styles) output image.
<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/ba0f19e9-dd7e-4c1b-b38c-319eb55c62bc" />

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.


**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11426" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic LoRA support for Omni image serving with load, unload, and list actions (and automatic LoRA wiring for supported request types when enabled).
  * Introduced an Omni LoRA aggregated launch example and an end-to-end validation script for testing via the LoRA and image-generation APIs.

* **Bug Fixes**
  * Improved LoRA adapter lifecycle behavior and discovery compatibility so LoRA metadata is generated and tracked more reliably.
  * Enhanced LoRA state and request parsing to improve adapter unload and endpoint handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->