### PR TITLE
docs: add DynoSim Apple Silicon and trace-format notes

### DIFF
--- a/docs/dynosim/runs.md
+++ b/docs/dynosim/runs.md
@@ -586,7 +586,9 @@ If you violate those constraints, DynoSim fails immediately with a validation er
 - on Apple Silicon, run the `aarch64` wheel natively (`docker run --platform linux/arm64 ...`);
   amd64 emulation under Rosetta hits an Apple translation defect that segfaults multi-worker
   multi-turn runs ([issue #11228](https://github.com/ai-dynamo/dynamo/issues/11228)). To run
-  `linux/amd64` anyway, disable Docker Desktop's Rosetta option to fall back to QEMU
+  `linux/amd64` anyway, disable Docker Desktop's Rosetta option to fall back to QEMU. Bare
+  `docker run` defaults to the native arm64 image but silently reuses a previously pulled amd64
+  image under the same tag; pass `--platform linux/arm64` explicitly after running amd64 variants
 
 ## When To Use This vs AIPerf
 

--- a/docs/dynosim/runs.md
+++ b/docs/dynosim/runs.md
@@ -120,6 +120,11 @@ report JSON to disk.
 
 ## Input Format
 
+> [!NOTE]
+> The `mooncake-delta`, `agentic_mooncake`, and `dynamo` trace formats were added after the v1.2.1
+> release. The `ai-dynamo` 1.2.x wheels on PyPI accept only `--trace-format mooncake` and
+> `--trace-format applied_compute_agentic`.
+
 The trace file must be Mooncake-style JSONL. Each line should contain:
 
 - `timestamp` or `created_time`
@@ -251,6 +256,7 @@ The dedicated DynoSim CLI exposes:
 - `--arrival-interval-ms`
 - `--arrival-speedup-ratio`
 - `--trace-format mooncake|mooncake-delta|agentic_mooncake|applied_compute_agentic|dynamo`
+  (release availability differs; see the note in [Input Format](#input-format))
 - `--trace-block-size`
 - `--turns-per-session`
 - `--shared-prefix-ratio`
@@ -577,6 +583,10 @@ If you violate those constraints, DynoSim fails immediately with a validation er
 - trace-file workloads can use different values for `--trace-block-size` and engine `block_size`
 - Mooncake/toolagent traces typically use `--trace-block-size 512`, while engine `block_size`
   often stays `64`
+- on Apple Silicon, run the `aarch64` wheel natively (`docker run --platform linux/arm64 ...`);
+  amd64 emulation under Rosetta hits an Apple translation defect that segfaults multi-worker
+  multi-turn runs ([issue #11228](https://github.com/ai-dynamo/dynamo/issues/11228)). To run
+  `linux/amd64` anyway, disable Docker Desktop's Rosetta option to fall back to QEMU
 
 ## When To Use This vs AIPerf
 


### PR DESCRIPTION
## Overview

Two small additions to the DynoSim runs guide, both from [#11228](https://github.com/ai-dynamo/dynamo/issues/11228):

- **Apple Silicon note** (Practical Notes): run the `aarch64` wheel natively via `--platform linux/arm64`. Rosetta amd64 emulation hits an Apple translation defect that segfaults multi-worker multi-turn runs (root-caused in the issue thread); disabling Docker Desktop's Rosetta option to fall back to QEMU also works.
- **Trace-format release availability** (Input Format): `mooncake-delta`, `agentic_mooncake`, and `dynamo` were added after v1.2.1 — the 1.2.x PyPI wheels accept only `mooncake` and `applied_compute_agentic`. Docs previously described only the main-branch CLI, so pip users hit unknown-choice errors following them.


`fern check` and `fern docs broken-links` pass.

Closes #11228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11430" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which trace formats are available in different release versions and which options are supported by older wheels.
  * Added a note to the CLI usage guidance so readers can quickly check format availability.
  * Included Apple Silicon run instructions and a warning about potential instability when using emulation for multi-worker, multi-turn runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->