### PR TITLE
perf(kv-router): compact sparse CRTC children

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2493,6 +2493,7 @@ name = "dynamo-kv-router"
 version = "1.3.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "async-trait",
  "axum 0.8.4",
  "bytemuck",

--- a/lib/bench/kv_router/ckf_crossover/crtc.rs
+++ b/lib/bench/kv_router/ckf_crossover/crtc.rs
@@ -9,6 +9,7 @@ use anyhow::Context;
 use dynamo_kv_router::ConcurrentRadixTreeCompressed;
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::ThreadPoolIndexer;
+use dynamo_kv_router::indexer::concurrent_radix_tree_compressed::CrtcStructureStats;
 use dynamo_kv_router::indexer::{
     EventEnqueueCompletion, KvIndexerInterface, KvRouterError, SyncIndexer,
 };
@@ -117,6 +118,10 @@ impl CrtcBackend {
 
     pub fn touch_for_benchmark(&self) {
         self.indexer.backend().touch_for_benchmark();
+    }
+
+    pub fn structure_stats(&self) -> CrtcStructureStats {
+        self.indexer.backend().structure_stats()
     }
 
     pub async fn flush(&self) -> anyhow::Result<(QueueMetrics, CrtcCompletionMetrics)> {

--- a/lib/bench/kv_router/ckf_crossover/memory.rs
+++ b/lib/bench/kv_router/ckf_crossover/memory.rs
@@ -9,6 +9,7 @@ pub struct MemorySnapshot {
     pub rss_bytes: u64,
     pub pss_bytes: Option<u64>,
     pub uss_bytes: Option<u64>,
+    pub swap_bytes: Option<u64>,
 }
 
 pub fn memory_snapshot() -> anyhow::Result<MemorySnapshot> {
@@ -32,6 +33,7 @@ pub fn memory_snapshot() -> anyhow::Result<MemorySnapshot> {
             rss_bytes: value("Rss").unwrap_or(0),
             pss_bytes: value("Pss"),
             uss_bytes: Some(private_clean + private_dirty),
+            swap_bytes: value("Swap"),
         });
     }
 
@@ -45,6 +47,7 @@ pub fn memory_snapshot() -> anyhow::Result<MemorySnapshot> {
             rss_bytes: rss_kb * 1024,
             pss_bytes: None,
             uss_bytes: None,
+            swap_bytes: None,
         })
     }
 }

--- a/lib/bench/kv_router/ckf_crtc_crossover.rs
+++ b/lib/bench/kv_router/ckf_crtc_crossover.rs
@@ -20,6 +20,7 @@ use std::time::Duration;
 
 use anyhow::{Context, ensure};
 use clap::{Parser, Subcommand, ValueEnum};
+use dynamo_kv_router::indexer::concurrent_radix_tree_compressed::CrtcStructureStats;
 use dynamo_kv_router::indexer::cuckoo::{
     CuckooDcConfig, CuckooFrameEnvelope, CuckooFrameIndexer, CuckooIndexerConfig,
     CuckooIndexerMode, CuckooPublication, SnapshotProducer,
@@ -141,10 +142,12 @@ struct MemoryResult {
     rss_bytes: u64,
     pss_bytes: Option<u64>,
     uss_bytes: Option<u64>,
+    swap_bytes: Option<u64>,
     num_dcs: usize,
     memberships_per_dc: usize,
     authoritative_filter_bytes: u64,
     derived_transposed_bytes: u64,
+    crtc_structure: Option<CrtcStructureStats>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -288,6 +291,7 @@ async fn measure_memory(
             backend.touch_for_benchmark();
             trim_allocator();
             let snapshot = memory_snapshot()?;
+            let structure = backend.structure_stats();
             std::hint::black_box(&backend);
             Ok(memory_result(
                 measured_code_sha,
@@ -297,6 +301,7 @@ async fn measure_memory(
                 memberships_per_dc,
                 (0, 0),
                 snapshot,
+                Some(structure),
             ))
         }
         MemoryMode::CkfNative | MemoryMode::CkfTransposed => {
@@ -350,6 +355,7 @@ async fn measure_memory(
                     },
                 ),
                 snapshot,
+                None,
             ))
         }
         MemoryMode::RelayProducer => {
@@ -392,6 +398,7 @@ async fn measure_memory(
                 memberships_per_dc,
                 (filter_bytes, 0),
                 snapshot,
+                None,
             ))
         }
     }
@@ -405,6 +412,7 @@ fn memory_result(
     memberships_per_dc: usize,
     structure_bytes: (u64, u64),
     snapshot: memory::MemorySnapshot,
+    crtc_structure: Option<CrtcStructureStats>,
 ) -> MemoryResult {
     let (authoritative_filter_bytes, derived_transposed_bytes) = structure_bytes;
     MemoryResult {
@@ -415,10 +423,12 @@ fn memory_result(
         rss_bytes: snapshot.rss_bytes,
         pss_bytes: snapshot.pss_bytes,
         uss_bytes: snapshot.uss_bytes,
+        swap_bytes: snapshot.swap_bytes,
         num_dcs,
         memberships_per_dc,
         authoritative_filter_bytes,
         derived_transposed_bytes,
+        crtc_structure,
     }
 }
 

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -55,6 +55,7 @@ xxhash-rust = { workspace = true }
 flume = "0.12.0"
 parking_lot = { workspace = true }
 rmp-serde = { workspace = true }
+arc-swap = "1.9.1"
 
 rustc-hash = "2.1.1"
 

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/children.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/children.rs
@@ -1,0 +1,315 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use arc_swap::ArcSwap;
+use dashmap::DashMap;
+use rustc_hash::{FxBuildHasher, FxHashMap};
+
+use super::SharedNode;
+#[cfg(test)]
+use super::node::Node;
+use crate::protocols::LocalBlockHash;
+
+type ShardedChildren = DashMap<LocalBlockHash, SharedNode, FxBuildHasher>;
+
+pub(super) struct NodeChildren {
+    state: ArcSwap<CompactChildrenState>,
+}
+
+#[derive(Debug)]
+enum CompactChildrenState {
+    Inline(Option<(LocalBlockHash, SharedNode)>),
+    Sharded(ShardedChildren),
+}
+
+impl std::fmt::Debug for NodeChildren {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("NodeChildren")
+            .field("len", &self.len())
+            .field("promoted", &self.is_promoted())
+            .finish()
+    }
+}
+
+pub(super) enum ChildInsertResult {
+    Existing(SharedNode),
+    Inserted,
+}
+
+impl NodeChildren {
+    pub(super) fn from_entries(children: FxHashMap<LocalBlockHash, SharedNode>) -> Self {
+        match children.len() {
+            0 => Self {
+                state: ArcSwap::from_pointee(CompactChildrenState::Inline(None)),
+            },
+            1 => Self {
+                state: ArcSwap::from_pointee(CompactChildrenState::Inline(
+                    children.into_iter().next(),
+                )),
+            },
+            _ => {
+                let map = DashMap::with_hasher(FxBuildHasher);
+                for (key, child) in children {
+                    map.insert(key, child);
+                }
+                Self {
+                    state: ArcSwap::from_pointee(CompactChildrenState::Sharded(map)),
+                }
+            }
+        }
+    }
+
+    fn publish_if_current(
+        &self,
+        current: &Arc<CompactChildrenState>,
+        next: CompactChildrenState,
+    ) -> bool {
+        let previous = self.state.compare_and_swap(current, Arc::new(next));
+        Arc::ptr_eq(&previous, current)
+    }
+
+    pub(super) fn get_cloned(&self, key: LocalBlockHash) -> Option<SharedNode> {
+        let state = self.state.load();
+        match &**state {
+            CompactChildrenState::Inline(Some((entry_key, child))) if *entry_key == key => {
+                Some(child.clone())
+            }
+            CompactChildrenState::Inline(_) => None,
+            CompactChildrenState::Sharded(map) => map.get(&key).map(|entry| entry.value().clone()),
+        }
+    }
+
+    pub(super) fn insert_if_absent(
+        &self,
+        key: LocalBlockHash,
+        child: SharedNode,
+    ) -> ChildInsertResult {
+        loop {
+            let current = self.state.load_full();
+            match &*current {
+                CompactChildrenState::Inline(None) => {
+                    if self.publish_if_current(
+                        &current,
+                        CompactChildrenState::Inline(Some((key, child.clone()))),
+                    ) {
+                        return ChildInsertResult::Inserted;
+                    }
+                }
+                CompactChildrenState::Inline(Some((entry_key, existing))) if *entry_key == key => {
+                    return ChildInsertResult::Existing(existing.clone());
+                }
+                CompactChildrenState::Inline(Some((entry_key, existing))) => {
+                    let map = DashMap::with_hasher(FxBuildHasher);
+                    map.insert(*entry_key, existing.clone());
+                    map.insert(key, child.clone());
+                    if self.publish_if_current(&current, CompactChildrenState::Sharded(map)) {
+                        return ChildInsertResult::Inserted;
+                    }
+                }
+                CompactChildrenState::Sharded(map) => match map.entry(key) {
+                    dashmap::mapref::entry::Entry::Occupied(entry) => {
+                        return ChildInsertResult::Existing(entry.get().clone());
+                    }
+                    dashmap::mapref::entry::Entry::Vacant(entry) => {
+                        entry.insert(child);
+                        return ChildInsertResult::Inserted;
+                    }
+                },
+            }
+        }
+    }
+
+    pub(super) fn insert_or_replace(&self, key: LocalBlockHash, child: SharedNode) {
+        loop {
+            let current = self.state.load_full();
+            match &*current {
+                CompactChildrenState::Inline(None) => {
+                    if self.publish_if_current(
+                        &current,
+                        CompactChildrenState::Inline(Some((key, child.clone()))),
+                    ) {
+                        return;
+                    }
+                }
+                CompactChildrenState::Inline(Some((entry_key, _))) if *entry_key == key => {
+                    if self.publish_if_current(
+                        &current,
+                        CompactChildrenState::Inline(Some((key, child.clone()))),
+                    ) {
+                        return;
+                    }
+                }
+                CompactChildrenState::Inline(Some((entry_key, existing))) => {
+                    let map = DashMap::with_hasher(FxBuildHasher);
+                    map.insert(*entry_key, existing.clone());
+                    map.insert(key, child.clone());
+                    if self.publish_if_current(&current, CompactChildrenState::Sharded(map)) {
+                        return;
+                    }
+                }
+                CompactChildrenState::Sharded(map) => {
+                    map.insert(key, child);
+                    return;
+                }
+            }
+        }
+    }
+
+    pub(super) fn remove_if_same(&self, key: LocalBlockHash, child: &SharedNode) -> bool {
+        loop {
+            let current = self.state.load_full();
+            match &*current {
+                CompactChildrenState::Inline(Some((entry_key, existing)))
+                    if *entry_key == key && Arc::ptr_eq(existing, child) =>
+                {
+                    if self.publish_if_current(&current, CompactChildrenState::Inline(None)) {
+                        return true;
+                    }
+                }
+                CompactChildrenState::Inline(_) => return false,
+                CompactChildrenState::Sharded(map) => {
+                    return match map.entry(key) {
+                        dashmap::mapref::entry::Entry::Occupied(entry)
+                            if Arc::ptr_eq(entry.get(), child) =>
+                        {
+                            entry.remove();
+                            true
+                        }
+                        _ => false,
+                    };
+                }
+            }
+        }
+    }
+
+    pub(super) fn clear_children(&self) -> bool {
+        loop {
+            let current = self.state.load_full();
+            match &*current {
+                CompactChildrenState::Inline(None) => return false,
+                CompactChildrenState::Inline(Some(_)) => {
+                    if self.publish_if_current(&current, CompactChildrenState::Inline(None)) {
+                        return true;
+                    }
+                }
+                CompactChildrenState::Sharded(map) => {
+                    if map.is_empty() {
+                        return false;
+                    }
+                    map.clear();
+                    return true;
+                }
+            }
+        }
+    }
+
+    pub(super) fn entries_snapshot(&self) -> Vec<(LocalBlockHash, SharedNode)> {
+        let state = self.state.load();
+        match &**state {
+            CompactChildrenState::Inline(None) => Vec::new(),
+            CompactChildrenState::Inline(Some((key, child))) => {
+                vec![(*key, child.clone())]
+            }
+            CompactChildrenState::Sharded(map) => map
+                .iter()
+                .map(|entry| (*entry.key(), entry.value().clone()))
+                .collect(),
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        let state = self.state.load();
+        match &**state {
+            CompactChildrenState::Inline(None) => 0,
+            CompactChildrenState::Inline(Some(_)) => 1,
+            CompactChildrenState::Sharded(map) => map.len(),
+        }
+    }
+
+    pub(super) fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    pub(super) fn values_snapshot(&self) -> Vec<SharedNode> {
+        self.entries_snapshot()
+            .into_iter()
+            .map(|(_, child)| child)
+            .collect()
+    }
+
+    #[cfg(feature = "bench")]
+    pub(super) fn capacity(&self) -> usize {
+        let state = self.state.load();
+        match &**state {
+            CompactChildrenState::Inline(_) => 1,
+            CompactChildrenState::Sharded(map) => map.capacity(),
+        }
+    }
+
+    pub(super) fn is_promoted(&self) -> bool {
+        matches!(&**self.state.load(), CompactChildrenState::Sharded(_))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn node() -> SharedNode {
+        Arc::new(Node::new())
+    }
+
+    #[test]
+    fn second_distinct_child_promotes_and_clear_does_not_demote() {
+        let children = NodeChildren::from_entries(FxHashMap::default());
+        assert!(matches!(
+            children.insert_if_absent(LocalBlockHash(1), node()),
+            ChildInsertResult::Inserted
+        ));
+        assert!(!children.is_promoted());
+        assert!(matches!(
+            children.insert_if_absent(LocalBlockHash(2), node()),
+            ChildInsertResult::Inserted
+        ));
+        assert!(children.is_promoted());
+        assert!(children.clear_children());
+        assert!(children.is_promoted());
+    }
+
+    #[test]
+    fn concurrent_distinct_inserts_survive_singleton_promotion() {
+        let children = Arc::new(NodeChildren::from_entries(FxHashMap::default()));
+        let mut threads = Vec::new();
+        for key in 0..8 {
+            let children = children.clone();
+            threads.push(std::thread::spawn(move || {
+                children.insert_if_absent(LocalBlockHash(key), node());
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(children.len(), 8);
+        assert!(children.is_promoted());
+    }
+
+    #[test]
+    fn concurrent_duplicate_inserts_keep_one_unpromoted_child() {
+        let children = Arc::new(NodeChildren::from_entries(FxHashMap::default()));
+        let mut threads = Vec::new();
+        for _ in 0..8 {
+            let children = children.clone();
+            threads.push(std::thread::spawn(move || {
+                children.insert_if_absent(LocalBlockHash(1), node());
+            }));
+        }
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        assert_eq!(children.len(), 1);
+        assert!(!children.is_promoted());
+    }
+}

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -10,6 +10,8 @@ use std::sync::Arc;
 
 use dashmap::DashMap;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
+#[cfg(feature = "bench")]
+use serde::Serialize;
 use std::collections::VecDeque;
 #[cfg(feature = "bench")]
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -22,6 +24,7 @@ use crate::cleanup::{CleanupGuard, CleanupState};
 use crate::lookup_update::update_arc_lookup_for_keys;
 use crate::protocols::*;
 
+mod children;
 mod node;
 mod types;
 use node::*;
@@ -53,6 +56,75 @@ struct CrtcBenchMetrics {
     node_splits: AtomicU64,
     lookup_repair_scans: AtomicU64,
     lookup_repair_entries: AtomicU64,
+}
+
+#[cfg(feature = "bench")]
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CrtcCardinalityBuckets {
+    pub zero: u64,
+    pub one: u64,
+    pub two_to_four: u64,
+    pub five_to_sixteen: u64,
+    pub above_sixteen: u64,
+}
+
+#[cfg(feature = "bench")]
+impl CrtcCardinalityBuckets {
+    fn record(&mut self, value: usize) {
+        match value {
+            0 => self.zero += 1,
+            1 => self.one += 1,
+            2..=4 => self.two_to_four += 1,
+            5..=16 => self.five_to_sixteen += 1,
+            _ => self.above_sixteen += 1,
+        }
+    }
+}
+
+#[cfg(feature = "bench")]
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CrtcEdgeLengthBuckets {
+    pub zero: u64,
+    pub one: u64,
+    pub two_to_sixteen: u64,
+    pub seventeen_to_sixty_four: u64,
+    pub sixty_five_to_128: u64,
+    pub above_128: u64,
+}
+
+#[cfg(feature = "bench")]
+impl CrtcEdgeLengthBuckets {
+    fn record(&mut self, value: usize) {
+        match value {
+            0 => self.zero += 1,
+            1 => self.one += 1,
+            2..=16 => self.two_to_sixteen += 1,
+            17..=64 => self.seventeen_to_sixty_four += 1,
+            65..=128 => self.sixty_five_to_128 += 1,
+            _ => self.above_128 += 1,
+        }
+    }
+}
+
+#[cfg(feature = "bench")]
+#[derive(Clone, Debug, Default, Serialize)]
+pub struct CrtcStructureStats {
+    pub node_count: u64,
+    pub node_size_bytes: usize,
+    pub node_state_size_bytes: usize,
+    pub child_fanout: CrtcCardinalityBuckets,
+    pub edge_lengths: CrtcEdgeLengthBuckets,
+    pub full_worker_cardinality: CrtcCardinalityBuckets,
+    pub cutoff_cardinality: CrtcCardinalityBuckets,
+    pub promoted_child_maps: u64,
+    pub total_child_entries: u64,
+    pub total_child_capacity: u64,
+    pub total_edge_entries: u64,
+    pub total_edge_index_capacity: u64,
+    pub total_full_worker_entries: u64,
+    pub total_full_worker_capacity: u64,
+    pub total_cutoff_entries: u64,
+    pub total_cutoff_capacity: u64,
 }
 
 #[cfg(feature = "bench")]
@@ -112,6 +184,26 @@ impl ConcurrentRadixTreeCompressed {
         while let Some(node) = pending.pop() {
             node.touch_for_benchmark(&mut pending);
         }
+    }
+
+    #[cfg(feature = "bench")]
+    pub fn structure_stats(&self) -> CrtcStructureStats {
+        let mut stats = CrtcStructureStats {
+            node_size_bytes: std::mem::size_of::<Node>(),
+            node_state_size_bytes: std::mem::size_of::<crate::indexer::compressed_radix::NodeState>(
+            ),
+            ..CrtcStructureStats::default()
+        };
+        let mut pending = vec![self.root.clone()];
+        pending.extend(self.anchor_nodes.iter().map(|entry| entry.value().clone()));
+        let mut visited = FxHashSet::default();
+        while let Some(node) = pending.pop() {
+            if !visited.insert(Arc::as_ptr(&node) as usize) {
+                continue;
+            }
+            node.accumulate_structure_stats(&mut stats, &mut pending);
+        }
+        stats
     }
 
     #[cfg(test)]

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -5,15 +5,13 @@ use std::collections::VecDeque;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Weak};
 
-use dashmap::DashMap;
 use parking_lot::RwLock;
 use rustc_hash::{FxBuildHasher, FxHashMap, FxHashSet};
 
+use super::children::{ChildInsertResult, NodeChildren};
 use super::types::*;
 use crate::indexer::compressed_radix::NodeState;
 use crate::protocols::*;
-
-type NodeChildren = DashMap<LocalBlockHash, SharedNode, FxBuildHasher>;
 
 fn record_last_matched_hash(
     last_matched_hashes: &mut Option<&mut FxHashMap<WorkerWithDpRank, ExternalSequenceBlockHash>>,
@@ -107,15 +105,9 @@ impl Node {
         children: FxHashMap<LocalBlockHash, SharedNode>,
     ) -> Self {
         let internal = !children.is_empty();
-        // NOTE(perf): Reducing child-map sharding substantially lowered memory
-        // usage but regressed throughput. Treat custom sharding as an explicit
-        // memory tradeoff rather than a throughput optimization.
-        // NOTE(perf): Lazily allocating this map only after a node became
-        // internal also saved memory but regressed throughput under contention.
-        let children_map = DashMap::with_hasher(FxBuildHasher);
-        for (key, child) in children {
-            children_map.insert(key, child);
-        }
+        // Sparse nodes stay inline. Branching nodes promote once to the default
+        // sharded map and retain its existing concurrency model.
+        let children_map = NodeChildren::from_entries(children);
 
         Self {
             shape_gate: RwLock::new(()),
@@ -178,13 +170,8 @@ impl Node {
 
     pub(super) fn take_children(&self) -> Vec<SharedNode> {
         let _gate = self.shape_gate.write();
-        let children: Vec<_> = self
-            .children
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect();
-        if !children.is_empty() {
-            self.children.clear();
+        let children = self.children.values_snapshot();
+        if self.children.clear_children() {
             self.shape_version.fetch_add(1, Ordering::Release);
         }
         children
@@ -193,15 +180,12 @@ impl Node {
     #[cfg(test)]
     pub(super) fn children_snapshot(&self) -> Vec<SharedNode> {
         let _gate = self.shape_gate.read();
-        self.children
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect()
+        self.children.values_snapshot()
     }
 
     pub(super) fn push_children_into(&self, queue: &mut VecDeque<SharedNode>) {
         let _gate = self.shape_gate.read();
-        queue.extend(self.children.iter().map(|entry| entry.value().clone()));
+        queue.extend(self.children.values_snapshot());
     }
 
     #[cfg(feature = "bench")]
@@ -221,23 +205,47 @@ impl Node {
         for worker in &state.full_edge_workers {
             std::hint::black_box(worker);
         }
-        for child in &self.children {
-            std::hint::black_box(child.key());
-            queue.push(child.value().clone());
+        for (key, child) in self.children.entries_snapshot() {
+            std::hint::black_box(key);
+            queue.push(child);
         }
     }
 
+    #[cfg(feature = "bench")]
+    pub(super) fn accumulate_structure_stats(
+        &self,
+        stats: &mut super::CrtcStructureStats,
+        pending: &mut Vec<SharedNode>,
+    ) {
+        let _gate = self.shape_gate.read();
+        let state = self.state.read();
+        let children = self.children.entries_snapshot();
+
+        stats.node_count += 1;
+        stats.child_fanout.record(children.len());
+        stats.edge_lengths.record(state.edge.len());
+        stats
+            .full_worker_cardinality
+            .record(state.full_edge_workers.len());
+        stats.cutoff_cardinality.record(state.worker_cutoffs.len());
+        stats.promoted_child_maps += u64::from(self.children.is_promoted());
+        stats.total_child_entries += children.len() as u64;
+        stats.total_child_capacity += self.children.capacity() as u64;
+        stats.total_edge_entries += state.edge.len() as u64;
+        stats.total_edge_index_capacity += state.edge_index.capacity() as u64;
+        stats.total_full_worker_entries += state.full_edge_workers.len() as u64;
+        stats.total_full_worker_capacity += state.full_edge_workers.capacity() as u64;
+        stats.total_cutoff_entries += state.worker_cutoffs.len() as u64;
+        stats.total_cutoff_capacity += state.worker_cutoffs.capacity() as u64;
+        pending.extend(children.into_iter().map(|(_, child)| child));
+    }
+
     pub(super) fn child_edges_snapshot(&self) -> Vec<(LocalBlockHash, SharedNode)> {
-        self.children
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect()
+        self.children.entries_snapshot()
     }
 
     pub(super) fn child_snapshot(&self, local_hash: LocalBlockHash) -> Option<SharedNode> {
-        self.children
-            .get(&local_hash)
-            .map(|entry| entry.value().clone())
+        self.children.get_cloned(local_hash)
     }
 
     pub(super) fn contains_edge_hash(&self, hash: ExternalSequenceBlockHash) -> bool {
@@ -286,19 +294,14 @@ impl Node {
 
         // A concurrent split is either visible in this snapshot or starts after
         // the target coverage is gone and therefore cannot copy it forward.
-        let children = self
-            .children
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect();
+        let children = self.children.values_snapshot();
         drop(state);
         self.clear_children_if_unreachable(should_clear_children);
         children
     }
 
     fn clear_children_if_unreachable(&self, should_clear_children: bool) {
-        if should_clear_children && !self.children.is_empty() {
-            self.children.clear();
+        if should_clear_children && self.children.clear_children() {
             self.shape_version.fetch_add(1, Ordering::Release);
         }
     }
@@ -306,11 +309,11 @@ impl Node {
     pub(super) fn live_children(&self) -> Vec<SharedNode> {
         let _gate = self.shape_gate.read();
         self.children
-            .iter()
-            .filter_map(|entry| {
-                let child = entry.value();
+            .values_snapshot()
+            .into_iter()
+            .filter_map(|child| {
                 (child.state.read().has_any_workers() || !child.children.is_empty())
-                    .then(|| child.clone())
+                    .then_some(child)
             })
             .collect()
     }
@@ -320,11 +323,11 @@ impl Node {
         let state = self.state.read();
         let live_children: Vec<_> = self
             .children
-            .iter()
-            .filter_map(|entry| {
-                let child = entry.value();
+            .values_snapshot()
+            .into_iter()
+            .filter_map(|child| {
                 (child.state.read().has_any_workers() || !child.children.is_empty())
-                    .then(|| child.clone())
+                    .then_some(child)
             })
             .collect();
 
@@ -564,7 +567,7 @@ impl Node {
         self.apply_edge_shape_update(shape_version, |state, children| {
             let split = self.split_at_locked(state, split_pos);
             state.promote_to_full(worker);
-            children.insert(tail_first_local, tail_node.clone());
+            children.insert_or_replace(tail_first_local, tail_node.clone());
             (SplitStoreOutcome::Done { split, tail_node }, true)
         })
         .unwrap_or(SplitStoreOutcome::Stale)
@@ -611,10 +614,7 @@ impl Node {
                 return ParentChildPlan::StaleParent { hash };
             }
 
-            if let Some(child) = children
-                .get(&first_local)
-                .map(|entry| entry.value().clone())
-            {
+            if let Some(child) = children.get_cloned(first_local) {
                 return ParentChildPlan::Descend(child);
             }
 
@@ -635,14 +635,9 @@ impl Node {
                 return InsertChildOutcome::Stale;
             }
             if self.internal.load(Ordering::Acquire) {
-                return match self.children.entry(first_local) {
-                    dashmap::mapref::entry::Entry::Occupied(entry) => {
-                        InsertChildOutcome::Existing(entry.get().clone())
-                    }
-                    dashmap::mapref::entry::Entry::Vacant(entry) => {
-                        entry.insert(child.clone());
-                        InsertChildOutcome::Inserted(child)
-                    }
+                return match self.children.insert_if_absent(first_local, child.clone()) {
+                    ChildInsertResult::Existing(existing) => InsertChildOutcome::Existing(existing),
+                    ChildInsertResult::Inserted => InsertChildOutcome::Inserted(child),
                 };
             }
         }
@@ -651,12 +646,9 @@ impl Node {
         if self.shape_version.load(Ordering::Acquire) != shape_version {
             return InsertChildOutcome::Stale;
         }
-        match self.children.entry(first_local) {
-            dashmap::mapref::entry::Entry::Occupied(entry) => {
-                InsertChildOutcome::Existing(entry.get().clone())
-            }
-            dashmap::mapref::entry::Entry::Vacant(entry) => {
-                entry.insert(child.clone());
+        match self.children.insert_if_absent(first_local, child.clone()) {
+            ChildInsertResult::Existing(existing) => InsertChildOutcome::Existing(existing),
+            ChildInsertResult::Inserted => {
                 self.internal.store(true, Ordering::Release);
                 self.shape_version.fetch_add(1, Ordering::Release);
                 InsertChildOutcome::Inserted(child)
@@ -703,12 +695,9 @@ impl Node {
             state.full_edge_workers.insert(*worker);
         }
 
-        let suffix_children: FxHashMap<_, _> = self
-            .children
-            .iter()
-            .map(|entry| (*entry.key(), entry.value().clone()))
-            .collect();
-        self.children.clear();
+        let suffix_children: FxHashMap<_, _> =
+            self.children.entries_snapshot().into_iter().collect();
+        self.children.clear_children();
 
         let suffix = Arc::new(Node::from_state_and_children(
             NodeState {
@@ -719,7 +708,8 @@ impl Node {
             },
             suffix_children,
         ));
-        self.children.insert(suffix_first_local, suffix.clone());
+        self.children
+            .insert_or_replace(suffix_first_local, suffix.clone());
         self.internal.store(true, Ordering::Release);
 
         SplitLookupData { suffix }
@@ -846,8 +836,7 @@ impl Node {
             && input.seq_pos + edge_match_len < input.sequence.len()
         {
             self.children
-                .get(&input.sequence.at(input.seq_pos + edge_match_len))
-                .map(|entry| entry.value().clone())
+                .get_cloned(input.sequence.at(input.seq_pos + edge_match_len))
         } else {
             None
         };
@@ -863,13 +852,13 @@ impl Node {
 
     pub(super) fn remove_child_if_stale_leaf(&self, key: LocalBlockHash, child: &SharedNode) {
         let _parent_gate = self.shape_gate.write();
-        let still_attached = self
-            .children
-            .get(&key)
-            .is_some_and(|current| Arc::ptr_eq(current.value(), child));
-        if !still_attached {
+        let Some(current) = self.children.get_cloned(key) else {
+            return;
+        };
+        if !Arc::ptr_eq(&current, child) {
             return;
         }
+        drop(current);
 
         let Some(_child_gate) = child.shape_gate.try_write() else {
             return;
@@ -881,8 +870,9 @@ impl Node {
             return;
         }
 
-        self.children.remove(&key);
-        self.shape_version.fetch_add(1, Ordering::Release);
+        if self.children.remove_if_same(key, child) {
+            self.shape_version.fetch_add(1, Ordering::Release);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Replace each CRTC node's eagerly allocated child `DashMap` with a compact representation for zero or one child.
- Promote once, on insertion of a second distinct child, to the existing default-sharded `DashMap`; promoted nodes retain the existing concurrency model.
- Add targeted singleton/promotion race tests and extend the crossover harness with structural census data and swap accounting.

This is the CRTC child representation, not a feature-gated experiment.

The D=16 prototype matrix was based on `ffc344fc840f0b56c91e619efb149336f26b9971`. At the fixed 13.26M offered block-ops/s point, five fresh performance processes per arm measured:

| Variant | Achieved block-ops/s | Lookup p99 | Resident RSS |
| --- | ---: | ---: | ---: |
| Baseline | 13.257M | 5.352 us | 31.386 GiB |
| Compact children | 13.258M | 4.654 us | 12.293 GiB |

The resident-state column is from one separate fresh process per arm. Compact children saved 19.093 GiB RSS (60.83%). The census found 1,250,001 nodes, including 1,250,000 childless leaves; only the root promoted to a `DashMap`.

The measured prototype source was `c66de1eb1c0e19cceb1f7118a998bf12695e18ff`. This PR lands that compact-child design unconditionally while excluding the separate compact-worker experiment and local matrix runner/report.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-kv-router concurrent_radix_tree_compressed --lib` (29 passed)
- `cargo test -p dynamo-bench --bin ckf_crtc_crossover --no-default-features` (7 passed)
- `cargo clippy -p dynamo-kv-router --lib --features bench -- -D warnings`
