### PR TITLE
fix(ci): redirect CARGO_HOME to writable path in rust-gpu job

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -107,6 +107,11 @@ jobs:
         #   * torch._inductor calling getpass.getuser() -> pwd.getpwuid(1001) -> KeyError
         HOME: /__w/dynamo/dynamo
         USER: dynamo
+        # The image bakes CARGO_HOME=/usr/local/cargo owned by uid 1000, so cargo
+        # cannot write registry/{index,cache} as the uid-1001 runner and dies with
+        # "Permission denied (os error 13)" while downloading crates. Redirect
+        # CARGO_HOME to the runner-writable workspace so cargo owns its cache.
+        CARGO_HOME: /__w/dynamo/dynamo/.cargo
         CONTAINER_ID: test_${{ github.run_id }}_${{ github.run_attempt }}_rust_dynamo
     timeout-minutes: 30
     steps:


### PR DESCRIPTION
## Problem

The `rust-gpu` job in `dynamo-pipeline.yml` fails during dependency download with:

```
error: failed to open `/usr/local/cargo/registry/cache/index.crates.io-.../aligned-0.4.3.crate`
Caused by: Permission denied (os error 13)
```

The job dies before any Rust check runs. This is not a flake — it fails identically across re-runs (observed on `run_attempt: 4`).

## Root cause

This is the same uid mismatch already documented in the job's `HOME`/`USER` comment: the test image creates user `dynamo` at **uid 1000**, but the ARC k8s runner executes the job pod as **uid 1001**. The image bakes `CARGO_HOME=/usr/local/cargo` owned by uid 1000, so cargo cannot write `registry/{index,cache}` as uid 1001, giving `Permission denied (os error 13)`.

The existing `HOME`/`USER` override fixes the `.gitconfig` and `getpass.getuser()` symptoms of that mismatch, but it does **not** remap `CARGO_HOME`, so the registry write still lands in the root-owned baked directory.

## Fix

Set `CARGO_HOME: /__w/dynamo/dynamo/.cargo` (the runner-writable workspace, same base as the existing `HOME` override) in the `rust-gpu` job container `env` so cargo owns its download cache.

This is an environmental/CI-only change and does not touch any product code. Only the `rust-gpu` job is affected; the `mypy` job shares the same `HOME`/`USER` block but does not invoke cargo, so it is left unchanged.