### PR TITLE
feat(router): define queue admission strategy API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,23 @@
+@AGENTS.md
+
+## Policy-Class Admission Strategy API
+
+The public contract in `lib/kv-router/src/scheduling/queue_admission/` is the narrow boundary between the router and a policy-class admission algorithm. This layer defines vocabulary only; request storage, queue integration, lifecycle delivery, strategy registration, and concrete algorithms belong to the runtime host and composition layers.
+
+### Contract
+
+- `AdmissionId` is the only universal request fact. It is host-issued and must be the strategy's lifecycle key.
+- `AdmissionRequest` borrows optional session identity, full logical `context_tokens`, and a live `WorkerEligibility` capability. A strategy may ignore optional facts or return `Bypass` when they do not apply.
+- `WorkerEligibility` is read-only and may be retained by deferred work. Its snapshot distinguishes structurally legal workers from workers currently available after transient router conditions.
+- `Bypass` opts out of strategy lifecycle handling. `Ready(Any)` preserves ordinary routing, `Ready(Exact(worker))` adds a placement constraint, and `Defer` asks the runtime host to retain the request.
+- `AdmissionEvent` describes dispatch, successful completion, abort, and reconciliation. `Completed` carries the authoritative final logical context; `Aborted` commits no new context.
+- `MakeReady` releases a deferred admission ID with optional exact placement. Duplicate or unknown actions are harmless by contract.
+- `reconcile_interval` requests a maximum interval between reconsideration opportunities while work is deferred; it is not a dedicated strategy thread or timer.
+
+### Ownership and extension rules
+
+- A strategy owns algorithm state only. It must not own `SchedulingRequest`, request payloads, queue ordering, worker slots, or final selection.
+- Exact placement constrains the existing selector; it does not bypass structural validation, scoring, or booking.
+- Add request facts as typed accessors only after a concrete strategy proves they are necessary. Expose changing system state through a narrow read-only capability instead of copying actor state or adding an untyped metadata bag.
+- Keep algorithm-specific configuration in flattened `QueueAdmissionConfig::options`; the generic router validates only the strategy name and container shape.
+- This is a Rust dependency-inversion boundary, not a stable dynamic-plugin ABI. Built-in implementations should live outside `dynamo-kv-router` and use explicit registration at a composition root.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,5 +19,5 @@ The public contract in `lib/kv-router/src/scheduling/queue_admission/` is the na
 - A strategy owns algorithm state only. It must not own `SchedulingRequest`, request payloads, queue ordering, worker slots, or final selection.
 - Exact placement constrains the existing selector; it does not bypass structural validation, scoring, or booking.
 - Add request facts as typed accessors only after a concrete strategy proves they are necessary. Expose changing system state through a narrow read-only capability instead of copying actor state or adding an untyped metadata bag.
-- Keep algorithm-specific configuration in flattened `QueueAdmissionConfig::options`; the generic router validates only the strategy name and container shape.
+- Land algorithm-specific configuration and its concrete registration atomically; configuration must not accept strategy names or options that no composition root can validate.
 - This is a Rust dependency-inversion boundary, not a stable dynamic-plugin ABI. Built-in implementations should live outside `dynamo-kv-router` and use explicit registration at a composition root.

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -34,5 +34,8 @@ pub use prefill_load::{
     InvalidEffectivePrefillTokens, PrefillLoadEstimator, effective_prefill_tokens,
     prefill_load_hint_from_effective_tokens,
 };
-pub use queue_admission::{QueueAdmissionConfig, WorkerPlacement};
+pub use queue_admission::{
+    AdmissionAction, AdmissionDecision, AdmissionEvent, AdmissionId, AdmissionRequest,
+    PolicyClassAdmissionStrategy, QueueAdmissionConfig, WorkerPlacement,
+};
 pub use types::*;

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -36,6 +36,7 @@ pub use prefill_load::{
 };
 pub use queue_admission::{
     AdmissionAction, AdmissionDecision, AdmissionEvent, AdmissionId, AdmissionRequest,
-    PolicyClassAdmissionStrategy, QueueAdmissionConfig, WorkerPlacement,
+    PolicyClassAdmissionStrategy, QueueAdmissionConfig, WorkerEligibility,
+    WorkerEligibilitySnapshot, WorkerPlacement,
 };
 pub use types::*;

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -326,7 +326,6 @@ fn resolve_profile(
     let mut names = HashSet::with_capacity(profile.policy_classes.len());
     let mut classes = Vec::with_capacity(profile.policy_classes.len());
     let mut bindings = Vec::with_capacity(profile.policy_classes.len());
-    let mut has_queue_admission = false;
     for raw in profile.policy_classes {
         let resolved = resolve_policy_class(raw, &resolved_buckets.indices, location)?;
         if !names.insert(resolved.config.name.clone()) {
@@ -334,14 +333,6 @@ fn resolve_profile(
                 "{location} contains duplicate policy class {:?}",
                 resolved.config.name
             )));
-        }
-        if resolved.config.queue_admission.is_some() {
-            if has_queue_admission {
-                return Err(RouterPolicyConfigError::Validation(format!(
-                    "{location} must contain at most one capacity-reserving queue_admission class"
-                )));
-            }
-            has_queue_admission = true;
         }
         classes.push(resolved.config);
         bindings.push(resolved.binding);
@@ -463,11 +454,8 @@ fn resolve_policy_class(
             raw.name
         )));
     }
-    if raw.queue_admission.is_some() && raw.queue_policy != RouterQueuePolicy::Fcfs {
-        return Err(RouterPolicyConfigError::Validation(format!(
-            "{location} policy class {:?} queue_admission requires queue_policy fcfs",
-            raw.name
-        )));
+    if let Some(admission) = &raw.queue_admission {
+        validate_identifier(&admission.strategy, "queue admission strategy", location)?;
     }
     if raw
         .prefill_busy_threshold_frac
@@ -705,7 +693,7 @@ models:
     }
 
     #[test]
-    fn accepts_session_aware_admission_with_fcfs() {
+    fn accepts_generic_queue_admission_config() {
         let config = RouterPolicyConfig::from_yaml(
             r#"
 default_policy_family: standard
@@ -718,9 +706,10 @@ policy_classes:
     cache_bucket: all
     quantum: 1
   - name: agents
-    queue_policy: fcfs
+    queue_policy: wspt
     queue_admission:
       type: session_aware
+      pause_threshold: 0.7
     quantum: 1
 "#,
         )
@@ -728,10 +717,9 @@ policy_classes:
 
         let profile = config.resolve_profile(None, None, RouterQueuePolicy::Fcfs);
         let agents = profile.class(profile.resolve_class_index(Some("agents"), 0));
-        assert!(matches!(
-            agents.queue_admission,
-            Some(QueueAdmissionConfig::SessionAware {})
-        ));
+        let admission = agents.queue_admission.as_ref().unwrap();
+        assert_eq!(admission.strategy, "session_aware");
+        assert_eq!(admission.options["pause_threshold"], 0.7);
     }
 
     #[test]
@@ -741,27 +729,9 @@ policy_classes:
     }
 
     #[test]
-    fn rejects_duplicate_or_invalid_queue_admission() {
-        for (yaml, expected) in [
-            (
-                r#"
-default_policy_family: standard
-uncached_isl_buckets:
-  - min_tokens: 0
-    bucket: all
-policy_classes:
-  - name: agents
-    policy_family: standard
-    cache_bucket: all
-    queue_policy: wspt
-    queue_admission:
-      type: session_aware
-    quantum: 1
-"#,
-                "queue_admission requires queue_policy fcfs",
-            ),
-            (
-                r#"
+    fn accepts_multiple_queue_admission_classes() {
+        RouterPolicyConfig::from_yaml(
+            r#"
 default_policy_family: standard
 uncached_isl_buckets:
   - min_tokens: 0
@@ -780,10 +750,14 @@ policy_classes:
       type: session_aware
     quantum: 1
 "#,
-                "at most one capacity-reserving queue_admission class",
-            ),
-            (
-                r#"
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn rejects_invalid_queue_admission_strategy_name() {
+        let error = RouterPolicyConfig::from_yaml(
+            r#"
 default_policy_family: standard
 uncached_isl_buckets:
   - min_tokens: 0
@@ -793,16 +767,17 @@ policy_classes:
     policy_family: standard
     cache_bucket: all
     queue_admission:
-      type: session_aware
-      pause_threshold: 0.7
+      type: ""
     quantum: 1
 "#,
-                "unknown field",
-            ),
-        ] {
-            let error = RouterPolicyConfig::from_yaml(yaml).unwrap_err();
-            assert!(error.to_string().contains(expected), "{error}");
-        }
+        )
+        .unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("queue admission strategy name \"\" must match"),
+            "{error}"
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/policy_config.rs
+++ b/lib/kv-router/src/scheduling/policy_config.rs
@@ -454,9 +454,6 @@ fn resolve_policy_class(
             raw.name
         )));
     }
-    if let Some(admission) = &raw.queue_admission {
-        validate_identifier(&admission.strategy, "queue admission strategy", location)?;
-    }
     if raw
         .prefill_busy_threshold_frac
         .is_some_and(|value| !value.is_finite() || value < 0.0)
@@ -693,7 +690,7 @@ models:
     }
 
     #[test]
-    fn accepts_generic_queue_admission_config() {
+    fn accepts_session_aware_admission() {
         let config = RouterPolicyConfig::from_yaml(
             r#"
 default_policy_family: standard
@@ -709,7 +706,6 @@ policy_classes:
     queue_policy: wspt
     queue_admission:
       type: session_aware
-      pause_threshold: 0.7
     quantum: 1
 "#,
         )
@@ -717,9 +713,10 @@ policy_classes:
 
         let profile = config.resolve_profile(None, None, RouterQueuePolicy::Fcfs);
         let agents = profile.class(profile.resolve_class_index(Some("agents"), 0));
-        let admission = agents.queue_admission.as_ref().unwrap();
-        assert_eq!(admission.strategy, "session_aware");
-        assert_eq!(admission.options["pause_threshold"], 0.7);
+        assert!(matches!(
+            agents.queue_admission,
+            Some(QueueAdmissionConfig::SessionAware {})
+        ));
     }
 
     #[test]
@@ -755,9 +752,16 @@ policy_classes:
     }
 
     #[test]
-    fn rejects_invalid_queue_admission_strategy_name() {
-        let error = RouterPolicyConfig::from_yaml(
-            r#"
+    fn rejects_unknown_queue_admission_config() {
+        for (admission, expected) in [
+            ("type: misspelled", "unknown variant"),
+            (
+                "type: session_aware\n      pause_threshold: 0.7",
+                "unknown field `pause_threshold`",
+            ),
+        ] {
+            let yaml = format!(
+                r#"
 default_policy_family: standard
 uncached_isl_buckets:
   - min_tokens: 0
@@ -767,17 +771,13 @@ policy_classes:
     policy_family: standard
     cache_bucket: all
     queue_admission:
-      type: ""
+      {admission}
     quantum: 1
-"#,
-        )
-        .unwrap_err();
-        assert!(
-            error
-                .to_string()
-                .contains("queue admission strategy name \"\" must match"),
-            "{error}"
-        );
+"#
+            );
+            let error = RouterPolicyConfig::from_yaml(&yaml).unwrap_err();
+            assert!(error.to_string().contains(expected), "{error}");
+        }
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -101,7 +101,7 @@ impl WorkerEligibilitySnapshot {
 pub struct AdmissionRequest<'a> {
     id: AdmissionId,
     session_id: Option<&'a str>,
-    input_tokens: usize,
+    context_tokens: usize,
     worker_eligibility: WorkerEligibility,
 }
 
@@ -109,13 +109,13 @@ impl<'a> AdmissionRequest<'a> {
     pub fn new(
         id: AdmissionId,
         session_id: Option<&'a str>,
-        input_tokens: usize,
+        context_tokens: usize,
         worker_eligibility: WorkerEligibility,
     ) -> Self {
         Self {
             id,
             session_id,
-            input_tokens,
+            context_tokens,
             worker_eligibility,
         }
     }
@@ -128,8 +128,9 @@ impl<'a> AdmissionRequest<'a> {
         self.session_id
     }
 
-    pub fn input_tokens(&self) -> usize {
-        self.input_tokens
+    /// Full tokenized request context, not uncached prefill work.
+    pub fn context_tokens(&self) -> usize {
+        self.context_tokens
     }
 
     pub fn worker_eligibility(&self) -> &WorkerEligibility {
@@ -165,14 +166,13 @@ pub enum AdmissionEvent {
         id: AdmissionId,
         worker: WorkerWithDpRank,
     },
-    /// Best-effort cumulative generated tokens. Values are monotonic but may
-    /// be coalesced or dropped; `Finished::total_tokens` is authoritative.
-    OutputTokens { id: AdmissionId, cumulative: usize },
-    /// The request left the admission host, including cancellation at any stage.
-    Finished {
+    /// The response stream ended normally.
+    Completed {
         id: AdmissionId,
-        total_tokens: usize,
+        context_tokens: usize,
     },
+    /// The request ended without committing a new logical context.
+    Aborted { id: AdmissionId },
     /// The host is giving the strategy an opportunity to reconsider deferred work.
     Reconcile,
 }
@@ -191,13 +191,13 @@ pub enum AdmissionAction {
 /// The host calls [`Self::admit`] exactly once for each tracked request, using
 /// a unique ID. A bypassed request receives no lifecycle events. A ready
 /// request may receive one `Dispatched` event and every tracked request
-/// receives exactly one terminal `Finished` event while the host remains
-/// alive. A deferred request receives no `Dispatched` event until the first
-/// valid `MakeReady` action is accepted. Duplicate or unknown actions are
-/// ignored. While any request is deferred, `Reconcile` is delivered at least
-/// once per configured queue recheck interval and may also be delivered after
-/// lifecycle or capacity changes. Host shutdown drops the strategy and its
-/// requests together, so no terminal events are delivered after shutdown
+/// receives exactly one terminal `Completed` or `Aborted` event while the host
+/// remains alive. A deferred request receives no `Dispatched` event until the
+/// first valid `MakeReady` action is accepted. Duplicate or unknown actions
+/// are ignored. While any request is deferred, `Reconcile` is delivered at
+/// least once per configured queue recheck interval and may also be delivered
+/// after lifecycle or capacity changes. Host shutdown drops the strategy and
+/// its requests together, so no terminal events are delivered after shutdown
 /// begins.
 pub trait PolicyClassAdmissionStrategy: Send {
     fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision;
@@ -230,7 +230,7 @@ mod tests {
         fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
             assert_eq!(request.id(), AdmissionId::new(7));
             assert_eq!(request.session_id(), Some("session"));
-            assert_eq!(request.input_tokens(), 42);
+            assert_eq!(request.context_tokens(), 42);
             let worker = WorkerWithDpRank::new(3, 0);
             let eligibility = request.worker_eligibility().snapshot();
             assert!(eligibility.allows(worker));

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -1,18 +1,138 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::marker::PhantomData;
+
 use serde::Deserialize;
+use serde_yaml::Mapping;
 
 use crate::protocols::WorkerWithDpRank;
 
+/// Router-assigned identity for one request's admission lifecycle.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AdmissionId(u64);
+
+impl AdmissionId {
+    pub fn new(value: u64) -> Self {
+        Self(value)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Read-only request data exposed to admission strategies.
+///
+/// Accessors are added only when a strategy demonstrates a generic need for
+/// them; the actor-owned scheduling request is intentionally not exposed.
+#[derive(Debug, Clone, Copy)]
+pub struct AdmissionRequest<'a> {
+    id: AdmissionId,
+    _borrowed: PhantomData<&'a ()>,
+}
+
+impl AdmissionRequest<'_> {
+    pub fn new(id: AdmissionId) -> Self {
+        Self {
+            id,
+            _borrowed: PhantomData,
+        }
+    }
+
+    pub fn id(&self) -> AdmissionId {
+        self.id
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum WorkerPlacement {
+    /// Preserve the request's existing routing constraints.
     Any,
+    /// Add an exact-worker constraint. The router validates it against the
+    /// request's existing constraints before dispatch.
     Exact(WorkerWithDpRank),
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AdmissionDecision {
+    Ready(WorkerPlacement),
+    Defer,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AdmissionEvent {
+    /// The router selected and reserved a worker for the request.
+    Dispatched {
+        id: AdmissionId,
+        worker: WorkerWithDpRank,
+    },
+    /// The request left the admission host, including cancellation at any stage.
+    Finished { id: AdmissionId },
+    /// The host is giving the strategy an opportunity to reconsider deferred work.
+    Reconcile,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum AdmissionAction {
+    MakeReady {
+        id: AdmissionId,
+        placement: WorkerPlacement,
+    },
+}
+
+/// Policy-class admission behavior.
+///
+/// The host calls [`Self::admit`] exactly once with a unique ID. A ready
+/// request may receive one `Dispatched` event and every admitted request
+/// receives exactly one terminal `Finished` event while the host remains
+/// alive. A deferred request receives no `Dispatched` event until the first
+/// valid `MakeReady` action is accepted. Duplicate or unknown actions are
+/// ignored. While any request is deferred, `Reconcile` is delivered at least
+/// once per configured queue recheck interval and may also be delivered after
+/// lifecycle or capacity changes. Host shutdown drops the strategy and its
+/// requests together, so no terminal events are delivered after shutdown
+/// begins.
+pub trait PolicyClassAdmissionStrategy: Send {
+    fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision;
+
+    fn on_event(&mut self, _event: AdmissionEvent) -> Vec<AdmissionAction> {
+        Vec::new()
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
-pub enum QueueAdmissionConfig {
-    SessionAware {},
+pub struct QueueAdmissionConfig {
+    #[serde(rename = "type")]
+    pub strategy: String,
+    #[serde(flatten)]
+    pub options: Mapping,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ReadyStrategy;
+
+    impl PolicyClassAdmissionStrategy for ReadyStrategy {
+        fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+            assert_eq!(request.id(), AdmissionId::new(7));
+            AdmissionDecision::Ready(WorkerPlacement::Any)
+        }
+    }
+
+    #[test]
+    fn strategy_contract_is_object_safe() {
+        let mut strategy: Box<dyn PolicyClassAdmissionStrategy> = Box::new(ReadyStrategy);
+        assert_eq!(
+            strategy.admit(AdmissionRequest::new(AdmissionId::new(7))),
+            AdmissionDecision::Ready(WorkerPlacement::Any)
+        );
+        assert!(strategy.on_event(AdmissionEvent::Reconcile).is_empty());
+    }
 }

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -1,6 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
+use std::sync::Arc;
+use std::time::Duration;
+
 use serde::Deserialize;
 use serde_yaml::Mapping;
 
@@ -20,22 +24,116 @@ impl AdmissionId {
     }
 }
 
-/// Read-only request data exposed to admission strategies.
+/// Live worker eligibility for one admitted request.
 ///
-/// Accessors are added only when a strategy demonstrates a generic need for
-/// them; the actor-owned scheduling request is intentionally not exposed.
-#[derive(Debug, Clone, Copy)]
-pub struct AdmissionRequest {
-    id: AdmissionId,
+/// The host owns routing constraints and worker state. Strategies may retain
+/// this handle when deferred work must be reconsidered against current state.
+#[derive(Clone)]
+pub struct WorkerEligibility {
+    snapshot: Arc<dyn Fn() -> WorkerEligibilitySnapshot + Send + Sync>,
 }
 
-impl AdmissionRequest {
-    pub fn new(id: AdmissionId) -> Self {
-        Self { id }
+impl WorkerEligibility {
+    pub fn new(snapshot: impl Fn() -> WorkerEligibilitySnapshot + Send + Sync + 'static) -> Self {
+        Self {
+            snapshot: Arc::new(snapshot),
+        }
+    }
+
+    pub fn snapshot(&self) -> WorkerEligibilitySnapshot {
+        (self.snapshot)()
+    }
+}
+
+/// One consistent view of the workers eligible for a request.
+#[derive(Clone)]
+pub struct WorkerEligibilitySnapshot {
+    structural: Arc<HashSet<WorkerWithDpRank>>,
+    available: Arc<HashSet<WorkerWithDpRank>>,
+}
+
+impl WorkerEligibilitySnapshot {
+    pub fn new(workers: impl IntoIterator<Item = WorkerWithDpRank>) -> Self {
+        let workers: Arc<HashSet<_>> = Arc::new(workers.into_iter().collect());
+        Self {
+            structural: Arc::clone(&workers),
+            available: workers,
+        }
+    }
+
+    pub fn with_availability(
+        structural: HashSet<WorkerWithDpRank>,
+        mut available: HashSet<WorkerWithDpRank>,
+    ) -> Self {
+        available.retain(|worker| structural.contains(worker));
+        Self {
+            structural: Arc::new(structural),
+            available: Arc::new(available),
+        }
+    }
+
+    /// Whether routing constraints permit this worker right now.
+    pub fn allows(&self, worker: WorkerWithDpRank) -> bool {
+        self.available.contains(&worker)
+    }
+
+    /// Whether routing constraints permit this worker independent of
+    /// transient overload state.
+    pub fn structurally_allows(&self, worker: WorkerWithDpRank) -> bool {
+        self.structural.contains(&worker)
+    }
+
+    pub fn has_available_worker(&self) -> bool {
+        !self.available.is_empty()
+    }
+
+    pub fn has_structural_worker(&self) -> bool {
+        !self.structural.is_empty()
+    }
+}
+
+/// Read-only request facts exposed to admission strategies.
+///
+/// Only [`AdmissionId`] is universal. A strategy may ignore any other fact or
+/// return [`AdmissionDecision::Bypass`] when optional context does not apply.
+/// The actor-owned scheduling request is intentionally not exposed.
+#[derive(Clone)]
+pub struct AdmissionRequest<'a> {
+    id: AdmissionId,
+    session_id: Option<&'a str>,
+    input_tokens: usize,
+    worker_eligibility: WorkerEligibility,
+}
+
+impl<'a> AdmissionRequest<'a> {
+    pub fn new(
+        id: AdmissionId,
+        session_id: Option<&'a str>,
+        input_tokens: usize,
+        worker_eligibility: WorkerEligibility,
+    ) -> Self {
+        Self {
+            id,
+            session_id,
+            input_tokens,
+            worker_eligibility,
+        }
     }
 
     pub fn id(&self) -> AdmissionId {
         self.id
+    }
+
+    pub fn session_id(&self) -> Option<&'a str> {
+        self.session_id
+    }
+
+    pub fn input_tokens(&self) -> usize {
+        self.input_tokens
+    }
+
+    pub fn worker_eligibility(&self) -> &WorkerEligibility {
+        &self.worker_eligibility
     }
 }
 
@@ -52,6 +150,8 @@ pub enum WorkerPlacement {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum AdmissionDecision {
+    /// Continue through normal scheduling without a strategy lifecycle.
+    Bypass,
     Ready(WorkerPlacement),
     Defer,
 }
@@ -59,13 +159,20 @@ pub enum AdmissionDecision {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum AdmissionEvent {
-    /// The router selected and reserved a worker for the request.
+    /// The backend accepted the request after the router selected and reserved
+    /// its worker.
     Dispatched {
         id: AdmissionId,
         worker: WorkerWithDpRank,
     },
+    /// Best-effort cumulative generated tokens. Values are monotonic but may
+    /// be coalesced or dropped; `Finished::total_tokens` is authoritative.
+    OutputTokens { id: AdmissionId, cumulative: usize },
     /// The request left the admission host, including cancellation at any stage.
-    Finished { id: AdmissionId },
+    Finished {
+        id: AdmissionId,
+        total_tokens: usize,
+    },
     /// The host is giving the strategy an opportunity to reconsider deferred work.
     Reconcile,
 }
@@ -81,8 +188,9 @@ pub enum AdmissionAction {
 
 /// Policy-class admission behavior.
 ///
-/// The host calls [`Self::admit`] exactly once with a unique ID. A ready
-/// request may receive one `Dispatched` event and every admitted request
+/// The host calls [`Self::admit`] exactly once for each tracked request, using
+/// a unique ID. A bypassed request receives no lifecycle events. A ready
+/// request may receive one `Dispatched` event and every tracked request
 /// receives exactly one terminal `Finished` event while the host remains
 /// alive. A deferred request receives no `Dispatched` event until the first
 /// valid `MakeReady` action is accepted. Duplicate or unknown actions are
@@ -92,10 +200,15 @@ pub enum AdmissionAction {
 /// requests together, so no terminal events are delivered after shutdown
 /// begins.
 pub trait PolicyClassAdmissionStrategy: Send {
-    fn admit(&mut self, request: AdmissionRequest) -> AdmissionDecision;
+    fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision;
 
     fn on_event(&mut self, _event: AdmissionEvent) -> Vec<AdmissionAction> {
         Vec::new()
+    }
+
+    /// Maximum time requested between reconciliation opportunities.
+    fn reconcile_interval(&self) -> Option<Duration> {
+        None
     }
 }
 
@@ -114,8 +227,14 @@ mod tests {
     struct ReadyStrategy;
 
     impl PolicyClassAdmissionStrategy for ReadyStrategy {
-        fn admit(&mut self, request: AdmissionRequest) -> AdmissionDecision {
+        fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
             assert_eq!(request.id(), AdmissionId::new(7));
+            assert_eq!(request.session_id(), Some("session"));
+            assert_eq!(request.input_tokens(), 42);
+            let worker = WorkerWithDpRank::new(3, 0);
+            let eligibility = request.worker_eligibility().snapshot();
+            assert!(eligibility.allows(worker));
+            assert!(eligibility.structurally_allows(worker));
             AdmissionDecision::Ready(WorkerPlacement::Any)
         }
     }
@@ -123,10 +242,33 @@ mod tests {
     #[test]
     fn strategy_contract_is_object_safe() {
         let mut strategy: Box<dyn PolicyClassAdmissionStrategy> = Box::new(ReadyStrategy);
+        let worker = WorkerWithDpRank::new(3, 0);
+        let eligibility = WorkerEligibility::new(move || WorkerEligibilitySnapshot::new([worker]));
         assert_eq!(
-            strategy.admit(AdmissionRequest::new(AdmissionId::new(7))),
+            strategy.admit(AdmissionRequest::new(
+                AdmissionId::new(7),
+                Some("session"),
+                42,
+                eligibility,
+            )),
             AdmissionDecision::Ready(WorkerPlacement::Any)
         );
         assert!(strategy.on_event(AdmissionEvent::Reconcile).is_empty());
+    }
+
+    #[test]
+    fn worker_eligibility_distinguishes_structure_from_availability() {
+        let available = WorkerWithDpRank::new(1, 0);
+        let overloaded = WorkerWithDpRank::new(2, 0);
+        let snapshot = WorkerEligibilitySnapshot::with_availability(
+            HashSet::from([available, overloaded]),
+            HashSet::from([available]),
+        );
+
+        assert!(snapshot.allows(available));
+        assert!(!snapshot.allows(overloaded));
+        assert!(snapshot.structurally_allows(overloaded));
+        assert!(snapshot.has_available_worker());
+        assert!(snapshot.has_structural_worker());
     }
 }

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
+use rustc_hash::FxHashSet;
 use serde::Deserialize;
 use serde_yaml::Mapping;
 
@@ -48,13 +48,13 @@ impl WorkerEligibility {
 /// One consistent view of the workers eligible for a request.
 #[derive(Clone)]
 pub struct WorkerEligibilitySnapshot {
-    structural: Arc<HashSet<WorkerWithDpRank>>,
-    available: Arc<HashSet<WorkerWithDpRank>>,
+    structural: Arc<FxHashSet<WorkerWithDpRank>>,
+    available: Arc<FxHashSet<WorkerWithDpRank>>,
 }
 
 impl WorkerEligibilitySnapshot {
     pub fn new(workers: impl IntoIterator<Item = WorkerWithDpRank>) -> Self {
-        let workers: Arc<HashSet<_>> = Arc::new(workers.into_iter().collect());
+        let workers: Arc<FxHashSet<_>> = Arc::new(workers.into_iter().collect());
         Self {
             structural: Arc::clone(&workers),
             available: workers,
@@ -62,8 +62,8 @@ impl WorkerEligibilitySnapshot {
     }
 
     pub fn with_availability(
-        structural: HashSet<WorkerWithDpRank>,
-        mut available: HashSet<WorkerWithDpRank>,
+        structural: FxHashSet<WorkerWithDpRank>,
+        mut available: FxHashSet<WorkerWithDpRank>,
     ) -> Self {
         available.retain(|worker| structural.contains(worker));
         Self {
@@ -261,8 +261,8 @@ mod tests {
         let available = WorkerWithDpRank::new(1, 0);
         let overloaded = WorkerWithDpRank::new(2, 0);
         let snapshot = WorkerEligibilitySnapshot::with_availability(
-            HashSet::from([available, overloaded]),
-            HashSet::from([available]),
+            FxHashSet::from_iter([available, overloaded]),
+            FxHashSet::from_iter([available]),
         );
 
         assert!(snapshot.allows(available));

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -1,8 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::marker::PhantomData;
-
 use serde::Deserialize;
 use serde_yaml::Mapping;
 
@@ -27,17 +25,13 @@ impl AdmissionId {
 /// Accessors are added only when a strategy demonstrates a generic need for
 /// them; the actor-owned scheduling request is intentionally not exposed.
 #[derive(Debug, Clone, Copy)]
-pub struct AdmissionRequest<'a> {
+pub struct AdmissionRequest {
     id: AdmissionId,
-    _borrowed: PhantomData<&'a ()>,
 }
 
-impl AdmissionRequest<'_> {
+impl AdmissionRequest {
     pub fn new(id: AdmissionId) -> Self {
-        Self {
-            id,
-            _borrowed: PhantomData,
-        }
+        Self { id }
     }
 
     pub fn id(&self) -> AdmissionId {
@@ -98,7 +92,7 @@ pub enum AdmissionAction {
 /// requests together, so no terminal events are delivered after shutdown
 /// begins.
 pub trait PolicyClassAdmissionStrategy: Send {
-    fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision;
+    fn admit(&mut self, request: AdmissionRequest) -> AdmissionDecision;
 
     fn on_event(&mut self, _event: AdmissionEvent) -> Vec<AdmissionAction> {
         Vec::new()
@@ -120,7 +114,7 @@ mod tests {
     struct ReadyStrategy;
 
     impl PolicyClassAdmissionStrategy for ReadyStrategy {
-        fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+        fn admit(&mut self, request: AdmissionRequest) -> AdmissionDecision {
             assert_eq!(request.id(), AdmissionId::new(7));
             AdmissionDecision::Ready(WorkerPlacement::Any)
         }

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -6,7 +6,6 @@ use std::time::Duration;
 
 use rustc_hash::FxHashSet;
 use serde::Deserialize;
-use serde_yaml::Mapping;
 
 use crate::protocols::WorkerWithDpRank;
 
@@ -190,15 +189,15 @@ pub enum AdmissionAction {
 ///
 /// The host calls [`Self::admit`] exactly once for each tracked request, using
 /// a unique ID. A bypassed request receives no lifecycle events. A ready
-/// request may receive one `Dispatched` event and every tracked request
-/// receives exactly one terminal `Completed` or `Aborted` event while the host
-/// remains alive. A deferred request receives no `Dispatched` event until the
-/// first valid `MakeReady` action is accepted. Duplicate or unknown actions
-/// are ignored. While any request is deferred, `Reconcile` is delivered at
-/// least once per configured queue recheck interval and may also be delivered
-/// after lifecycle or capacity changes. Host shutdown drops the strategy and
-/// its requests together, so no terminal events are delivered after shutdown
-/// begins.
+/// request may receive one `Dispatched` event. Every request that returns
+/// `Ready` or `Defer` receives exactly one terminal `Completed` or `Aborted`
+/// event while the host remains alive. A deferred request receives no
+/// `Dispatched` event until the first valid `MakeReady` action is accepted.
+/// Duplicate or unknown actions are ignored. While any request is deferred,
+/// `Reconcile` is delivered at least once per configured queue recheck
+/// interval and may also be delivered after lifecycle or capacity changes.
+/// Host shutdown drops the strategy and its requests together, so no terminal
+/// events are delivered after shutdown begins.
 pub trait PolicyClassAdmissionStrategy: Send {
     fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision;
 
@@ -206,18 +205,17 @@ pub trait PolicyClassAdmissionStrategy: Send {
         Vec::new()
     }
 
-    /// Maximum time requested between reconciliation opportunities.
+    /// Maximum time requested between reconciliation opportunities. A returned
+    /// interval must be nonzero.
     fn reconcile_interval(&self) -> Option<Duration> {
         None
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Deserialize)]
-pub struct QueueAdmissionConfig {
-    #[serde(rename = "type")]
-    pub strategy: String,
-    #[serde(flatten)]
-    pub options: Mapping,
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+pub enum QueueAdmissionConfig {
+    SessionAware {},
 }
 
 #[cfg(test)]


### PR DESCRIPTION
<!-- codex-pr-description:start -->
This defines the minimal public contract for pluggable policy-class queue admission strategies. It keeps request payloads and scheduler ownership private while giving independently packaged Rust strategies typed request facts, live worker eligibility, admission decisions, and lifecycle vocabulary.

CLOSES: DYN-3231

### How This Was Implemented

- Adds an object-safe `PolicyClassAdmissionStrategy` with one admission method, one lifecycle-event method, and an optional reconciliation interval.
- Exposes an opaque host-issued ID, optional session identity, full logical context size, and a retained read-only `WorkerEligibility` capability.
- Defines `Bypass | Ready | Defer`, exact-or-any placement, `Dispatched | Completed | Aborted | Reconcile`, and `MakeReady` without exposing `SchedulingRequest`.
- Makes `queue_admission` configuration strategy-neutral and documents the ownership and extension rules in root `CLAUDE.md`.

<details>
<summary>Walkthrough</summary>

#### Mental model

The router host will own request payloads, queues, lifecycle delivery, worker selection, and booking. A strategy owns only algorithmic state and communicates through this typed contract; this PR defines that boundary without implementing the host or a concrete algorithm.

```mermaid
sequenceDiagram
    participant H as "Router admission host"
    participant S as "PolicyClassAdmissionStrategy"
    H->>S: "admit(borrowed request facts)"
    S-->>H: "Bypass, Ready(placement), or Defer"
    H->>S: "Dispatched / Completed / Aborted / Reconcile"
    S-->>H: "zero or more MakeReady actions"
```

#### State and ordering

The router assigns a copyable `AdmissionId`; strategies use it instead of client-controlled request identity. `Bypass` opts out of lifecycle handling, `Ready(Any)` preserves ordinary routing, and `Ready(Exact(worker))` adds a constraint without replacing selector validation, scoring, or booking. Deferred work may retain the live eligibility capability and requests reconsideration through `MakeReady`; duplicate and unknown actions are harmless by contract.

#### Request lifecycle

A future host calls `admit` once per tracked request. A bypassed request receives no strategy events; a ready or deferred request receives at most one accepted dispatch and exactly one `Completed` or `Aborted` terminal event while the host remains alive. `Completed { context_tokens }` supplies the authoritative final logical context, while `Aborted` commits no new context. Reconciliation is an opportunity delivered by the host, not a strategy-owned thread.

#### Boundaries and limitations

This phase contains no deferred-request storage, queue/selector integration, strategy registry, request-progress publisher, or ThunderAgent behavior. Optional `session_id` and `context_tokens` are typed facts rather than a session-specific policy or token-accounting implementation. The trait is a Rust dependency-inversion boundary, not a stable dynamic-plugin ABI; concrete built-ins and explicit registration belong outside `dynamo-kv-router`.

</details>

### Validation

- `cargo test -p dynamo-kv-router --lib queue_admission` (5 passed)
- `cargo test -p dynamo-kv-router --lib policy_config` (11 passed)
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- `git diff --check`
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Queue admission settings now support named strategies with flexible options in policy configuration.
  * Added broader admission lifecycle support, including admission decisions, events, and worker placement handling.

* **Bug Fixes**
  * Policy classes can now define queue admission more flexibly without requiring a specific queue policy.
  * Multiple policy classes with queue admission are now accepted, and invalid strategy names are properly rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->