### PR TITLE
feat(kv-router): add relay-shaped transposed CKF indexer [DYN-3584]

### DIFF
--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -11,6 +11,8 @@ use dynamo_bench::kv_router_common::args::CommonArgs;
 use dynamo_bench::kv_router_common::replay::{generate_replay_artifacts, process_mooncake_trace};
 use dynamo_bench::kv_router_common::sweep::compute_sweep_durations;
 use dynamo_kv_router::indexer::KvIndexerMetrics;
+use dynamo_kv_router::indexer::cuckoo::{CkfConfig, EventTransposedCkfIndexer};
+use dynamo_kv_router::protocols::WorkerWithDpRank;
 use dynamo_kv_router::{
     ConcurrentRadixTree, ConcurrentRadixTreeCompressed, PositionalIndexer, ThreadPoolIndexer,
 };
@@ -60,6 +62,17 @@ enum IndexerArgs {
         num_event_workers: usize,
     },
 
+    /// Fixed-D=16 bucket-major transposed Cuckoo-filter indexer.
+    TransposedCkf {
+        /// Number of OS threads that consume and apply KV cache events.
+        #[clap(long, default_value = "8")]
+        num_event_workers: usize,
+
+        /// Logical block capacity provisioned for each DC lane.
+        #[clap(long, default_value = "16384")]
+        expected_blocks_per_dc: usize,
+    },
+
     /// Branch-sharded CRTC: N independent CRTC shards routed by a bounded
     /// prefix trie with structural anchors for depth-boundary suffixes.
     /// find_matches touches at most one shard (no scatter-gather).
@@ -94,6 +107,10 @@ impl IndexerArgs {
             IndexerArgs::ConcurrentRadixTreeCompressed { num_event_workers } => {
                 MooncakeIndexerConfig::concurrent_radix_tree_compressed(*num_event_workers)
             }
+            IndexerArgs::TransposedCkf {
+                num_event_workers,
+                expected_blocks_per_dc,
+            } => MooncakeIndexerConfig::transposed_ckf(*num_event_workers, *expected_blocks_per_dc),
             IndexerArgs::BranchShardedCrtc {
                 num_shards,
                 num_event_workers_per_shard,
@@ -149,7 +166,7 @@ struct Args {
     /// Comma-separated list of indexer names to benchmark and compare on the
     /// same plot. Overrides the subcommand indexer when present. Valid names:
     /// radix-tree, nested-map, concurrent-radix-tree,
-    /// concurrent-radix-tree-compressed, branch-sharded-crtc.
+    /// concurrent-radix-tree-compressed, transposed-ckf, branch-sharded-crtc.
     #[clap(long, value_delimiter = ',')]
     compare: Vec<String>,
 
@@ -241,10 +258,23 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
             MooncakeIndexerKind::NestedMap
                 | MooncakeIndexerKind::ConcurrentRadixTree
                 | MooncakeIndexerKind::ConcurrentRadixTreeCompressed
+                | MooncakeIndexerKind::TransposedCkf
         ) {
             anyhow::bail!(
-                "corrected Mooncake replay supports only nested-map, concurrent-radix-tree, and concurrent-radix-tree-compressed; got {name}"
+                "corrected Mooncake replay supports only nested-map, concurrent-radix-tree, concurrent-radix-tree-compressed, and transposed-ckf; got {name}"
             );
+        }
+        if config.kind == MooncakeIndexerKind::TransposedCkf {
+            let total_workers = args
+                .common
+                .num_unique_inference_workers
+                .checked_mul(args.common.inference_worker_duplication_factor)
+                .ok_or_else(|| anyhow::anyhow!("simulated worker count overflow"))?;
+            if total_workers != 16 {
+                anyhow::bail!(
+                    "transposed-ckf requires exactly 16 simulated workers; got {total_workers}"
+                );
+            }
         }
     }
     Ok(())
@@ -262,7 +292,11 @@ fn indexer_config(args: &Args, name: &str) -> anyhow::Result<MooncakeIndexerConf
     if args.compare.is_empty() {
         Ok(args.get_indexer().to_config())
     } else {
-        MooncakeIndexerConfig::from_short_name(name, args.num_event_workers)
+        let mut config = MooncakeIndexerConfig::from_short_name(name, args.num_event_workers)?;
+        if config.kind == MooncakeIndexerKind::TransposedCkf {
+            config.expected_blocks_per_dc = args.common.num_gpu_blocks;
+        }
+        Ok(config)
     }
 }
 
@@ -345,6 +379,20 @@ async fn run_open_loop_for_config(
         MooncakeIndexerKind::ConcurrentRadixTreeCompressed => {
             let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
                 ConcurrentRadixTreeCompressed::new(),
+                config.num_event_workers,
+                args.common.block_size,
+                metrics(),
+            ));
+            run_backend(config.short_name(), indexer, trial, open_config).await
+        }
+        MooncakeIndexerKind::TransposedCkf => {
+            let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
+            let backend = EventTransposedCkfIndexer::new(
+                workers,
+                CkfConfig::new(config.expected_blocks_per_dc),
+            )?;
+            let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
+                backend,
                 config.num_event_workers,
                 args.common.block_size,
                 metrics(),

--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -11,8 +11,6 @@ use dynamo_bench::kv_router_common::args::CommonArgs;
 use dynamo_bench::kv_router_common::replay::{generate_replay_artifacts, process_mooncake_trace};
 use dynamo_bench::kv_router_common::sweep::compute_sweep_durations;
 use dynamo_kv_router::indexer::KvIndexerMetrics;
-use dynamo_kv_router::indexer::cuckoo::{CkfConfig, EventTransposedCkfIndexer};
-use dynamo_kv_router::protocols::WorkerWithDpRank;
 use dynamo_kv_router::{
     ConcurrentRadixTree, ConcurrentRadixTreeCompressed, PositionalIndexer, ThreadPoolIndexer,
 };
@@ -395,10 +393,7 @@ async fn run_open_loop_for_config(
             run_backend(config.short_name(), indexer, trial, open_config).await
         }
         MooncakeIndexerKind::TransposedCkf => {
-            let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
-            let mut ckf_config = CkfConfig::new(config.expected_blocks_per_dc);
-            ckf_config.publish_every_n_events = config.publish_every_n_events;
-            let backend = EventTransposedCkfIndexer::new(workers, ckf_config)?;
+            let backend = config.build_transposed_ckf_backend()?;
             let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
                 backend,
                 config.num_event_workers,

--- a/lib/bench/kv_router/mooncake_bench.rs
+++ b/lib/bench/kv_router/mooncake_bench.rs
@@ -71,6 +71,10 @@ enum IndexerArgs {
         /// Logical block capacity provisioned for each DC lane.
         #[clap(long, default_value = "16384")]
         expected_blocks_per_dc: usize,
+
+        /// Number of normalized events accumulated per DC lane before publication.
+        #[clap(long, default_value = "1")]
+        publish_every_n_events: usize,
     },
 
     /// Branch-sharded CRTC: N independent CRTC shards routed by a bounded
@@ -110,7 +114,9 @@ impl IndexerArgs {
             IndexerArgs::TransposedCkf {
                 num_event_workers,
                 expected_blocks_per_dc,
-            } => MooncakeIndexerConfig::transposed_ckf(*num_event_workers, *expected_blocks_per_dc),
+                publish_every_n_events,
+            } => MooncakeIndexerConfig::transposed_ckf(*num_event_workers, *expected_blocks_per_dc)
+                .with_publish_every_n_events(*publish_every_n_events),
             IndexerArgs::BranchShardedCrtc {
                 num_shards,
                 num_event_workers_per_shard,
@@ -265,6 +271,9 @@ fn validate_args(args: &Args) -> anyhow::Result<()> {
             );
         }
         if config.kind == MooncakeIndexerKind::TransposedCkf {
+            if config.publish_every_n_events == 0 {
+                anyhow::bail!("transposed-ckf publish cadence must be at least 1");
+            }
             let total_workers = args
                 .common
                 .num_unique_inference_workers
@@ -387,17 +396,18 @@ async fn run_open_loop_for_config(
         }
         MooncakeIndexerKind::TransposedCkf => {
             let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
-            let backend = EventTransposedCkfIndexer::new(
-                workers,
-                CkfConfig::new(config.expected_blocks_per_dc),
-            )?;
+            let mut ckf_config = CkfConfig::new(config.expected_blocks_per_dc);
+            ckf_config.publish_every_n_events = config.publish_every_n_events;
+            let backend = EventTransposedCkfIndexer::new(workers, ckf_config)?;
             let indexer = Arc::new(ThreadPoolIndexer::new_with_metrics(
                 backend,
                 config.num_event_workers,
                 args.common.block_size,
                 metrics(),
             ));
-            run_backend(config.short_name(), indexer, trial, open_config).await
+            let backend_name =
+                format!("{}-n{}", config.short_name(), config.publish_every_n_events);
+            run_backend(&backend_name, indexer, trial, open_config).await
         }
         MooncakeIndexerKind::RadixTree | MooncakeIndexerKind::BranchShardedCrtc => {
             anyhow::bail!(
@@ -455,6 +465,9 @@ fn print_open_loop_result(result: &OpenLoopResult) {
         result.issue_span_ns as f64 / 1e6,
         result.drain_ns as f64 / 1e6,
     );
+    if !result.backend_timing_report.is_empty() {
+        println!("{}", result.backend_timing_report);
+    }
 }
 
 fn open_loop_output_path(base: &str, backend: &str, duration_ms: Option<u64>) -> String {

--- a/lib/bench/kv_router/mooncake_open_loop.rs
+++ b/lib/bench/kv_router/mooncake_open_loop.rs
@@ -11,7 +11,7 @@ use std::time::Instant;
 
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::{
-    ObservationError, SyncIndexer, ThreadPoolIndexer, ThreadPoolObservationPlan,
+    KvIndexerInterface, ObservationError, SyncIndexer, ThreadPoolIndexer, ThreadPoolObservationPlan,
 };
 use dynamo_kv_router::protocols::{KvCacheEventData, RouterEvent};
 use serde::Serialize;
@@ -19,7 +19,7 @@ use tokio::sync::{Notify, oneshot};
 
 use super::mooncake_shared::{MooncakeTraceTotals, PreparedMooncakeBenchmark, WorkerTraceEntry};
 
-const RESULT_SCHEMA_VERSION: u32 = 1;
+const RESULT_SCHEMA_VERSION: u32 = 2;
 const EMPTY_OPERATION_ID: u32 = u32::MAX;
 
 #[derive(Clone, Debug)]
@@ -872,6 +872,7 @@ pub struct OpenLoopResult {
     pub generator_valid: bool,
     pub kept_up: bool,
     pub failure_reasons: Vec<String>,
+    pub backend_timing_report: String,
 }
 
 fn partition_dispatch(
@@ -1135,6 +1136,8 @@ pub async fn run_open_loop<T: SyncIndexer>(
         .unwrap_or(start_ns);
     let end_ns = query_drain_ns.max(sealed.latest_seal_ns());
     let snapshot = sealed.harvest().await?;
+    KvIndexerInterface::flush(indexer.as_ref()).await;
+    let backend_timing_report = KvIndexerInterface::timing_report(indexer.as_ref());
 
     Ok(analyze_result(
         backend_name,
@@ -1149,6 +1152,7 @@ pub async fn run_open_loop<T: SyncIndexer>(
         issuer_analysis,
         query_results,
         snapshot,
+        backend_timing_report,
     ))
 }
 
@@ -1166,6 +1170,7 @@ fn analyze_result(
     issuer: IssuerAnalysisInput,
     query_results: Vec<QueryLaneResult>,
     snapshot: dynamo_kv_router::indexer::ThreadPoolObservationSnapshot,
+    backend_timing_report: String,
 ) -> OpenLoopResult {
     let IssuerAnalysisInput {
         records,
@@ -1411,6 +1416,7 @@ fn analyze_result(
         generator_valid,
         kept_up,
         failure_reasons,
+        backend_timing_report,
     }
 }
 

--- a/lib/bench/kv_router/mooncake_open_loop.rs
+++ b/lib/bench/kv_router/mooncake_open_loop.rs
@@ -1134,9 +1134,10 @@ pub async fn run_open_loop<T: SyncIndexer>(
         .map(|result| result.drain_ns)
         .max()
         .unwrap_or(start_ns);
-    let end_ns = query_drain_ns.max(sealed.latest_seal_ns());
+    let observed_work_end_ns = query_drain_ns.max(sealed.latest_seal_ns());
     let snapshot = sealed.harvest().await?;
     KvIndexerInterface::flush(indexer.as_ref()).await;
+    let end_ns = observed_work_end_ns.max(clock.now_ns());
     let backend_timing_report = KvIndexerInterface::timing_report(indexer.as_ref());
 
     Ok(analyze_result(

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -37,6 +37,7 @@ pub struct MooncakeIndexerConfig {
     pub num_event_workers_per_shard: usize,
     pub prefix_depth: usize,
     pub expected_blocks_per_dc: usize,
+    pub publish_every_n_events: usize,
 }
 
 #[allow(dead_code)]
@@ -50,6 +51,7 @@ impl MooncakeIndexerConfig {
             num_event_workers_per_shard: 4,
             prefix_depth: 2,
             expected_blocks_per_dc: 16_384,
+            publish_every_n_events: 1,
         }
     }
 
@@ -85,6 +87,11 @@ impl MooncakeIndexerConfig {
             expected_blocks_per_dc,
             ..Self::radix_tree()
         }
+    }
+
+    pub fn with_publish_every_n_events(mut self, publish_every_n_events: usize) -> Self {
+        self.publish_every_n_events = publish_every_n_events;
+        self
     }
 
     pub fn branch_sharded_crtc(
@@ -167,10 +174,9 @@ impl MooncakeIndexerConfig {
             }
             MooncakeIndexerKind::TransposedCkf => {
                 let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
-                let backend = EventTransposedCkfIndexer::new(
-                    workers,
-                    CkfConfig::new(self.expected_blocks_per_dc),
-                )?;
+                let mut ckf_config = CkfConfig::new(self.expected_blocks_per_dc);
+                ckf_config.publish_every_n_events = self.publish_every_n_events;
+                let backend = EventTransposedCkfIndexer::new(workers, ckf_config)?;
                 Arc::new(ThreadPoolIndexer::new_with_metrics(
                     backend,
                     self.num_event_workers,

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -94,6 +94,13 @@ impl MooncakeIndexerConfig {
         self
     }
 
+    pub(crate) fn build_transposed_ckf_backend(&self) -> anyhow::Result<EventTransposedCkfIndexer> {
+        let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
+        let mut config = CkfConfig::new(self.expected_blocks_per_dc);
+        config.publish_every_n_events = self.publish_every_n_events;
+        Ok(EventTransposedCkfIndexer::new(workers, config)?)
+    }
+
     pub fn branch_sharded_crtc(
         num_shards: usize,
         num_event_workers_per_shard: usize,
@@ -173,10 +180,7 @@ impl MooncakeIndexerConfig {
                 ))
             }
             MooncakeIndexerKind::TransposedCkf => {
-                let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
-                let mut ckf_config = CkfConfig::new(self.expected_blocks_per_dc);
-                ckf_config.publish_every_n_events = self.publish_every_n_events;
-                let backend = EventTransposedCkfIndexer::new(workers, ckf_config)?;
+                let backend = self.build_transposed_ckf_backend()?;
                 Arc::new(ThreadPoolIndexer::new_with_metrics(
                     backend,
                     self.num_event_workers,

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -4,9 +4,10 @@
 use std::sync::Arc;
 
 use dynamo_kv_router::LocalBlockHash;
+use dynamo_kv_router::indexer::cuckoo::{CkfConfig, EventTransposedCkfIndexer};
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
-use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, StorageTier};
+use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, StorageTier, WorkerWithDpRank};
 use dynamo_kv_router::{
     BranchShardedIndexer, ConcurrentRadixTree, ConcurrentRadixTreeCompressed, PositionalIndexer,
     ThreadPoolIndexer,
@@ -23,6 +24,7 @@ pub enum MooncakeIndexerKind {
     NestedMap,
     ConcurrentRadixTree,
     ConcurrentRadixTreeCompressed,
+    TransposedCkf,
     BranchShardedCrtc,
 }
 
@@ -34,6 +36,7 @@ pub struct MooncakeIndexerConfig {
     pub num_shards: usize,
     pub num_event_workers_per_shard: usize,
     pub prefix_depth: usize,
+    pub expected_blocks_per_dc: usize,
 }
 
 #[allow(dead_code)]
@@ -46,6 +49,7 @@ impl MooncakeIndexerConfig {
             num_shards: 2,
             num_event_workers_per_shard: 4,
             prefix_depth: 2,
+            expected_blocks_per_dc: 16_384,
         }
     }
 
@@ -74,6 +78,15 @@ impl MooncakeIndexerConfig {
         }
     }
 
+    pub fn transposed_ckf(num_event_workers: usize, expected_blocks_per_dc: usize) -> Self {
+        Self {
+            kind: MooncakeIndexerKind::TransposedCkf,
+            num_event_workers,
+            expected_blocks_per_dc,
+            ..Self::radix_tree()
+        }
+    }
+
     pub fn branch_sharded_crtc(
         num_shards: usize,
         num_event_workers_per_shard: usize,
@@ -96,6 +109,7 @@ impl MooncakeIndexerConfig {
             MooncakeIndexerKind::ConcurrentRadixTreeCompressed => {
                 "concurrent-radix-tree-compressed"
             }
+            MooncakeIndexerKind::TransposedCkf => "transposed-ckf",
             MooncakeIndexerKind::BranchShardedCrtc => "branch-sharded-crtc",
         }
     }
@@ -108,9 +122,10 @@ impl MooncakeIndexerConfig {
             "concurrent-radix-tree-compressed" => {
                 Self::concurrent_radix_tree_compressed(num_event_workers)
             }
+            "transposed-ckf" => Self::transposed_ckf(num_event_workers, 16_384),
             "branch-sharded-crtc" => Self::branch_sharded_crtc(2, num_event_workers, 2),
             _ => anyhow::bail!(
-                "Unknown indexer '{}'. Valid names: radix-tree, nested-map, concurrent-radix-tree, concurrent-radix-tree-compressed, branch-sharded-crtc",
+                "Unknown indexer '{}'. Valid names: radix-tree, nested-map, concurrent-radix-tree, concurrent-radix-tree-compressed, transposed-ckf, branch-sharded-crtc",
                 name
             ),
         };
@@ -121,8 +136,8 @@ impl MooncakeIndexerConfig {
         &self,
         block_size: u32,
         metrics: Arc<KvIndexerMetrics>,
-    ) -> Arc<dyn KvIndexerInterface + Send + Sync> {
-        match self.kind {
+    ) -> anyhow::Result<Arc<dyn KvIndexerInterface + Send + Sync>> {
+        let indexer: Arc<dyn KvIndexerInterface + Send + Sync> = match self.kind {
             MooncakeIndexerKind::RadixTree => Arc::new(KvIndexer::new(
                 CancellationToken::new(),
                 block_size,
@@ -150,6 +165,19 @@ impl MooncakeIndexerConfig {
                     Some(metrics),
                 ))
             }
+            MooncakeIndexerKind::TransposedCkf => {
+                let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
+                let backend = EventTransposedCkfIndexer::new(
+                    workers,
+                    CkfConfig::new(self.expected_blocks_per_dc),
+                )?;
+                Arc::new(ThreadPoolIndexer::new_with_metrics(
+                    backend,
+                    self.num_event_workers,
+                    block_size,
+                    Some(metrics),
+                ))
+            }
             MooncakeIndexerKind::BranchShardedCrtc => {
                 let shards = (0..self.num_shards)
                     .map(|_| {
@@ -167,7 +195,8 @@ impl MooncakeIndexerConfig {
                     block_size,
                 ))
             }
-        }
+        };
+        Ok(indexer)
     }
 
     pub fn build_approximate_with_prune_config(
@@ -209,6 +238,9 @@ impl MooncakeIndexerConfig {
                     Some(metrics),
                     Some(prune_config),
                 ))
+            }
+            MooncakeIndexerKind::TransposedCkf => {
+                anyhow::bail!("transposed-ckf does not support approximate pruning")
             }
             MooncakeIndexerKind::BranchShardedCrtc => {
                 anyhow::bail!("branch-sharded-crtc does not support approximate pruning")

--- a/lib/bench/kv_router/mooncake_shared.rs
+++ b/lib/bench/kv_router/mooncake_shared.rs
@@ -4,7 +4,7 @@
 use std::sync::Arc;
 
 use dynamo_kv_router::LocalBlockHash;
-use dynamo_kv_router::indexer::cuckoo::{CkfConfig, EventTransposedCkfIndexer};
+use dynamo_kv_router::indexer::cuckoo::{CkfConfig, CkfMatchMode, EventTransposedCkfIndexer};
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{KvIndexer, KvIndexerInterface, KvIndexerMetrics};
 use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, StorageTier, WorkerWithDpRank};
@@ -38,6 +38,7 @@ pub struct MooncakeIndexerConfig {
     pub prefix_depth: usize,
     pub expected_blocks_per_dc: usize,
     pub publish_every_n_events: usize,
+    pub ckf_match_mode: CkfMatchMode,
 }
 
 #[allow(dead_code)]
@@ -52,6 +53,7 @@ impl MooncakeIndexerConfig {
             prefix_depth: 2,
             expected_blocks_per_dc: 16_384,
             publish_every_n_events: 1,
+            ckf_match_mode: CkfMatchMode::FullMap,
         }
     }
 
@@ -94,11 +96,20 @@ impl MooncakeIndexerConfig {
         self
     }
 
+    pub fn with_ckf_match_mode(mut self, ckf_match_mode: CkfMatchMode) -> Self {
+        self.ckf_match_mode = ckf_match_mode;
+        self
+    }
+
     pub(crate) fn build_transposed_ckf_backend(&self) -> anyhow::Result<EventTransposedCkfIndexer> {
         let workers = std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0));
         let mut config = CkfConfig::new(self.expected_blocks_per_dc);
         config.publish_every_n_events = self.publish_every_n_events;
-        Ok(EventTransposedCkfIndexer::new(workers, config)?)
+        Ok(EventTransposedCkfIndexer::new_with_match_mode(
+            workers,
+            config,
+            self.ckf_match_mode,
+        )?)
     }
 
     pub fn branch_sharded_crtc(
@@ -123,7 +134,10 @@ impl MooncakeIndexerConfig {
             MooncakeIndexerKind::ConcurrentRadixTreeCompressed => {
                 "concurrent-radix-tree-compressed"
             }
-            MooncakeIndexerKind::TransposedCkf => "transposed-ckf",
+            MooncakeIndexerKind::TransposedCkf => match self.ckf_match_mode {
+                CkfMatchMode::FullMap => "transposed-ckf",
+                CkfMatchMode::MaxDepthMatches => "transposed-ckf-max-depth",
+            },
             MooncakeIndexerKind::BranchShardedCrtc => "branch-sharded-crtc",
         }
     }

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -705,9 +705,11 @@ async fn measure_ckf_parity(
     artifact_sets: &[MockEngineReplayArtifacts],
     warning_count: &Arc<std::sync::atomic::AtomicUsize>,
     enforce_budgets: bool,
+    publish_every_n_events: usize,
 ) -> anyhow::Result<CkfParityStats> {
     let exact = MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS);
-    let ckf = MooncakeIndexerConfig::transposed_ckf(NUM_EVENT_WORKERS, NUM_GPU_BLOCKS);
+    let ckf = MooncakeIndexerConfig::transposed_ckf(NUM_EVENT_WORKERS, NUM_GPU_BLOCKS)
+        .with_publish_every_n_events(publish_every_n_events);
     assert_eq!(ckf.kind, MooncakeIndexerKind::TransposedCkf);
     let mut global = CkfParityStats::default();
 
@@ -740,7 +742,10 @@ async fn measure_ckf_parity(
         );
 
         let stats = compare_ckf_scores(artifact_set.engine_name, &actual, &expected);
-        println!("CKF_PARITY engine={} {stats:?}", artifact_set.engine_name);
+        println!(
+            "CKF_PARITY publish_every_n_events={} engine={} {stats:?}",
+            publish_every_n_events, artifact_set.engine_name
+        );
         assert_eq!(stats.under_reports, 0);
         assert_eq!(stats.under_report_magnitude, 0);
         if enforce_budgets {
@@ -755,7 +760,10 @@ async fn measure_ckf_parity(
         global.merge(stats);
     }
 
-    println!("CKF_PARITY global {global:?}");
+    println!(
+        "CKF_PARITY publish_every_n_events={} global {global:?}",
+        publish_every_n_events
+    );
     if enforce_budgets {
         assert_ckf_parity_budget("global", global, CKF_PARITY_GLOBAL_BUDGET);
     }
@@ -1222,12 +1230,14 @@ async fn mooncake_trace_replays_through_fixed_d16_ckf() -> anyhow::Result<()> {
     let traces = process_mooncake_trace(&fixture, BLOCK_SIZE, 1, 1, CKF_PARITY_WORKERS, 42)?;
     let mut artifact_sets = generate_mock_engine_parity_artifacts(&traces).await?;
     make_ckf_parity_corpus_quiescent(&mut artifact_sets);
-    let stats = measure_ckf_parity(&artifact_sets, &warning_count, true).await?;
+    let stats = measure_ckf_parity(&artifact_sets, &warning_count, true, 1).await?;
     assert!(stats.queries > 0);
     assert_eq!(
         stats.lane_observations,
         stats.queries * CKF_PARITY_WORKERS as u64
     );
+    let batched = measure_ckf_parity(&artifact_sets, &warning_count, true, 16).await?;
+    assert_eq!(batched.lane_observations, stats.lane_observations);
 
     Ok(())
 }
@@ -1240,7 +1250,7 @@ async fn mooncake_trace_measures_fixed_d16_ckf_tolerance() -> anyhow::Result<()>
     let traces = process_mooncake_trace(&fixture, BLOCK_SIZE, 1, 1, CKF_PARITY_WORKERS, 42)?;
     let mut artifact_sets = generate_mock_engine_parity_artifacts(&traces).await?;
     make_ckf_parity_corpus_quiescent(&mut artifact_sets);
-    let stats = measure_ckf_parity(&artifact_sets, &warning_count, false).await?;
+    let stats = measure_ckf_parity(&artifact_sets, &warning_count, false, 1).await?;
     assert!(stats.queries > 0);
     assert_eq!(
         stats.lane_observations,

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -26,6 +26,7 @@ use dynamo_bench::kv_router_common::replay::{
     generate_replay_artifacts_with_args_and_visibility, process_mooncake_trace,
 };
 use dynamo_kv_router::LocalBlockHash;
+use dynamo_kv_router::indexer::cuckoo::CkfMatchMode;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
 use dynamo_kv_router::indexer::{
     KvIndexerInterface, KvIndexerMetrics, METRIC_EVENT_CLEARED, METRIC_EVENT_REMOVED,
@@ -557,6 +558,50 @@ fn best_configured_lane(
         .map(|(lane, _)| lane)
 }
 
+fn max_depth_tie_projection(
+    scores: &NormalizedOverlapScores,
+    workers: &[WorkerWithDpRank; CKF_PARITY_WORKERS],
+) -> NormalizedOverlapScores {
+    let best = workers
+        .iter()
+        .filter_map(|worker| scores.get(worker).copied())
+        .max()
+        .unwrap_or(0);
+    if best == 0 {
+        return NormalizedOverlapScores::new();
+    }
+
+    workers
+        .iter()
+        .filter_map(|worker| (scores.get(worker).copied() == Some(best)).then_some((*worker, best)))
+        .collect()
+}
+
+fn assert_max_depth_matches_project_full_ckf(
+    engine_name: &str,
+    actual: &[ComparableOverlapScores],
+    full: &[ComparableOverlapScores],
+) {
+    assert_eq!(
+        actual.len(),
+        full.len(),
+        "{engine_name} maximum-depth CKF produced a different number of query results"
+    );
+    let workers = ckf_workers();
+    for (query_idx, (actual, full)) in actual.iter().zip(full).enumerate() {
+        assert_eq!(actual.query_len, full.query_len);
+        assert!(
+            actual.frequencies.is_empty(),
+            "{engine_name} maximum-depth CKF frequencies must remain empty at query {query_idx}"
+        );
+        assert_eq!(
+            actual.scores,
+            max_depth_tie_projection(&full.scores, &workers),
+            "{engine_name} maximum-depth CKF diverged from the full CKF tie-set projection at query {query_idx}"
+        );
+    }
+}
+
 fn compare_ckf_scores(
     engine_name: &str,
     actual: &[ComparableOverlapScores],
@@ -710,6 +755,9 @@ async fn measure_ckf_parity(
     let exact = MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS);
     let ckf = MooncakeIndexerConfig::transposed_ckf(NUM_EVENT_WORKERS, NUM_GPU_BLOCKS)
         .with_publish_every_n_events(publish_every_n_events);
+    let max_depth_ckf = ckf
+        .clone()
+        .with_ckf_match_mode(CkfMatchMode::MaxDepthMatches);
     assert_eq!(ckf.kind, MooncakeIndexerKind::TransposedCkf);
     let mut global = CkfParityStats::default();
 
@@ -740,6 +788,33 @@ async fn measure_ckf_parity(
             "{} CKF parity replay recorded event errors",
             artifact_set.engine_name
         );
+
+        support::reset_warning_count(warning_count);
+        let (max_depth, max_depth_metrics) = collect_prepared_corpus_overlap_scores_with_metrics(
+            &max_depth_ckf,
+            &artifact_set.artifacts,
+        )
+        .await?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert_eq!(
+            warning_count.load(Ordering::Relaxed),
+            0,
+            "{} maximum-depth CKF parity replay emitted warning/error logs",
+            artifact_set.engine_name
+        );
+        assert_eq!(
+            support::duplicate_store_warning_count(max_depth_metrics.as_ref()),
+            0,
+            "{} maximum-depth CKF parity replay recorded duplicate-store warnings",
+            artifact_set.engine_name
+        );
+        assert_eq!(
+            indexer_error_metric_count(max_depth_metrics.as_ref()),
+            0,
+            "{} maximum-depth CKF parity replay recorded event errors",
+            artifact_set.engine_name
+        );
+        assert_max_depth_matches_project_full_ckf(artifact_set.engine_name, &max_depth, &actual);
 
         let stats = compare_ckf_scores(artifact_set.engine_name, &actual, &expected);
         println!(

--- a/lib/bench/tests/mooncake_trace.rs
+++ b/lib/bench/tests/mooncake_trace.rs
@@ -27,7 +27,12 @@ use dynamo_bench::kv_router_common::replay::{
 };
 use dynamo_kv_router::LocalBlockHash;
 use dynamo_kv_router::indexer::pruning::PruneConfig;
-use dynamo_kv_router::indexer::{KvIndexerInterface, KvIndexerMetrics};
+use dynamo_kv_router::indexer::{
+    KvIndexerInterface, KvIndexerMetrics, METRIC_EVENT_CLEARED, METRIC_EVENT_REMOVED,
+    METRIC_EVENT_STORED, METRIC_STATUS_BLOCK_NOT_FOUND, METRIC_STATUS_CAPACITY_EXHAUSTED,
+    METRIC_STATUS_INDEXER_INVARIANT_VIOLATION, METRIC_STATUS_INVALID_BLOCK,
+    METRIC_STATUS_PARENT_NOT_FOUND,
+};
 use dynamo_kv_router::protocols::{
     ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
     KvCacheStoredBlockData, OverlapScores, StorageTier, TokensWithHashes, WorkerWithDpRank,
@@ -43,8 +48,8 @@ use mooncake_open_loop::{
     prepare_open_loop_trial, run_open_loop,
 };
 use mooncake_shared::{
-    MooncakeBenchmarkConfig, MooncakeIndexerConfig, PreparedMooncakeBenchmark, WorkerTraceEntry,
-    merge_worker_traces, prepare_scaled_benchmark,
+    MooncakeBenchmarkConfig, MooncakeIndexerConfig, MooncakeIndexerKind, PreparedMooncakeBenchmark,
+    WorkerTraceEntry, merge_worker_traces, prepare_scaled_benchmark,
 };
 use tempfile::NamedTempFile;
 use uuid::Uuid;
@@ -52,6 +57,7 @@ use uuid::Uuid;
 const BLOCK_SIZE: u32 = 128;
 const NUM_GPU_BLOCKS: usize = 16384;
 const NUM_UNIQUE_INFERENCE_WORKERS: usize = 10;
+const CKF_PARITY_WORKERS: usize = 16;
 const BENCHMARK_DURATION_MS: u64 = 2000;
 const NUM_EVENT_WORKERS: usize = 4;
 const PARITY_NUM_GPU_BLOCKS: usize = NUM_GPU_BLOCKS;
@@ -67,13 +73,15 @@ type NormalizedOverlapScores = BTreeMap<WorkerWithDpRank, u32>;
 struct ComparableOverlapScores {
     scores: NormalizedOverlapScores,
     frequencies: Vec<usize>,
+    query_len: usize,
 }
 
-impl From<OverlapScores> for ComparableOverlapScores {
-    fn from(overlap: OverlapScores) -> Self {
+impl ComparableOverlapScores {
+    fn new(overlap: OverlapScores, query_len: usize) -> Self {
         Self {
             scores: overlap.scores.into_iter().collect(),
             frequencies: overlap.frequencies,
+            query_len,
         }
     }
 }
@@ -224,6 +232,27 @@ async fn generate_mock_engine_parity_artifacts(
     Ok(artifact_sets)
 }
 
+fn make_ckf_parity_corpus_quiescent(artifact_sets: &mut [MockEngineReplayArtifacts]) {
+    for artifact_set in artifact_sets {
+        let first_query_timestamp = artifact_set
+            .artifacts
+            .iter()
+            .map(|artifact| artifact.kv_events.len())
+            .max()
+            .unwrap_or(0) as u64
+            + 1;
+
+        for artifact in &mut artifact_set.artifacts {
+            for (ordinal, event) in artifact.kv_events.iter_mut().enumerate() {
+                event.timestamp_us = ordinal as u64;
+            }
+            for (ordinal, request) in artifact.requests.iter_mut().enumerate() {
+                request.timestamp_us = first_query_timestamp + ordinal as u64;
+            }
+        }
+    }
+}
+
 fn original_prepared_query(
     prepared: &PreparedMooncakeBenchmark,
     benchmark: MooncakeBenchmarkConfig,
@@ -285,7 +314,7 @@ async fn collect_prepared_corpus_scores(
                         entry.id
                     );
                     let overlap = indexer.find_matches(request.to_vec()).await?;
-                    scores.push(overlap.into());
+                    scores.push(ComparableOverlapScores::new(overlap, request.len()));
                 }
                 MooncakeOperationPayload::Event(event) => indexer.apply_event(event.clone()).await,
             }
@@ -324,7 +353,7 @@ async fn collect_prepared_corpus_overlap_scores_with_metrics(
         benchmark.inference_worker_duplication_factor,
     )?;
     let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-    let indexer = config.build(BLOCK_SIZE, Arc::clone(&metrics));
+    let indexer = config.build(BLOCK_SIZE, Arc::clone(&metrics))?;
 
     Ok((
         collect_prepared_corpus_scores(indexer, &prepared, benchmark, &corpus).await?,
@@ -337,7 +366,7 @@ async fn collect_device_only_overlap_scores(
     config: &MooncakeIndexerConfig,
     artifacts: &[WorkerReplayArtifacts],
 ) -> anyhow::Result<Vec<NormalizedOverlapScores>> {
-    let indexer = config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()));
+    let indexer = config.build(BLOCK_SIZE, Arc::new(KvIndexerMetrics::new_unregistered()))?;
     let entries = collect_kv_event_replay_entries(artifacts);
     let mut scores = Vec::new();
     let mut idx = 0;
@@ -430,6 +459,307 @@ async fn assert_overlap_score_parity(
     }
 
     Ok(())
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+struct CkfParityStats {
+    queries: u64,
+    lane_observations: u64,
+    under_reports: u64,
+    under_report_magnitude: u64,
+    over_reports: u64,
+    total_inflation: u64,
+    maximum_inflation: u32,
+    full_map_mismatches: u64,
+    wrong_best: u64,
+}
+
+impl CkfParityStats {
+    fn merge(&mut self, other: Self) {
+        self.queries += other.queries;
+        self.lane_observations += other.lane_observations;
+        self.under_reports += other.under_reports;
+        self.under_report_magnitude += other.under_report_magnitude;
+        self.over_reports += other.over_reports;
+        self.total_inflation += other.total_inflation;
+        self.maximum_inflation = self.maximum_inflation.max(other.maximum_inflation);
+        self.full_map_mismatches += other.full_map_mismatches;
+        self.wrong_best += other.wrong_best;
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CkfParityBudget {
+    over_reports: u64,
+    total_inflation: u64,
+    maximum_inflation: u32,
+    full_map_mismatches: u64,
+    wrong_best: u64,
+}
+
+const CKF_PARITY_ENGINE_BUDGETS: [(&str, CkfParityBudget); 3] = [
+    (
+        "vllm",
+        CkfParityBudget {
+            over_reports: 0,
+            total_inflation: 0,
+            maximum_inflation: 0,
+            full_map_mismatches: 0,
+            wrong_best: 0,
+        },
+    ),
+    (
+        "sglang",
+        CkfParityBudget {
+            over_reports: 0,
+            total_inflation: 0,
+            maximum_inflation: 0,
+            full_map_mismatches: 0,
+            wrong_best: 0,
+        },
+    ),
+    (
+        "trtllm",
+        CkfParityBudget {
+            over_reports: 0,
+            total_inflation: 0,
+            maximum_inflation: 0,
+            full_map_mismatches: 0,
+            wrong_best: 0,
+        },
+    ),
+];
+
+const CKF_PARITY_GLOBAL_BUDGET: CkfParityBudget = CkfParityBudget {
+    over_reports: 0,
+    total_inflation: 0,
+    maximum_inflation: 0,
+    full_map_mismatches: 0,
+    wrong_best: 0,
+};
+
+fn ckf_workers() -> [WorkerWithDpRank; CKF_PARITY_WORKERS] {
+    std::array::from_fn(|lane| WorkerWithDpRank::new(lane as u64, 0))
+}
+
+fn best_configured_lane(
+    scores: &NormalizedOverlapScores,
+    workers: &[WorkerWithDpRank; CKF_PARITY_WORKERS],
+) -> Option<usize> {
+    workers
+        .iter()
+        .enumerate()
+        .filter_map(|(lane, worker)| scores.get(worker).copied().map(|depth| (lane, depth)))
+        .filter(|(_, depth)| *depth > 0)
+        .max_by(|(left_lane, left), (right_lane, right)| {
+            left.cmp(right).then_with(|| right_lane.cmp(left_lane))
+        })
+        .map(|(lane, _)| lane)
+}
+
+fn compare_ckf_scores(
+    engine_name: &str,
+    actual: &[ComparableOverlapScores],
+    expected: &[ComparableOverlapScores],
+) -> CkfParityStats {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "{engine_name} CKF produced a different number of query results than the exact baseline"
+    );
+
+    let workers = ckf_workers();
+    let configured: HashSet<_> = workers.into_iter().collect();
+    let mut stats = CkfParityStats::default();
+    for (query_idx, (actual, expected)) in actual.iter().zip(expected).enumerate() {
+        assert_eq!(
+            actual.query_len, expected.query_len,
+            "{engine_name} query length diverged at query {query_idx}"
+        );
+        assert!(
+            actual.frequencies.is_empty(),
+            "{engine_name} CKF frequencies must remain empty at query {query_idx}"
+        );
+        assert!(
+            actual
+                .scores
+                .keys()
+                .all(|worker| configured.contains(worker)),
+            "{engine_name} CKF returned an unconfigured identity at query {query_idx}: {:?}",
+            actual.scores
+        );
+        assert!(
+            actual.scores.values().all(|&depth| depth > 0),
+            "{engine_name} CKF must omit zero-depth scores at query {query_idx}: {:?}",
+            actual.scores
+        );
+        assert!(
+            actual
+                .scores
+                .values()
+                .all(|&depth| depth as usize <= actual.query_len),
+            "{engine_name} CKF depth exceeds query length at query {query_idx}: len={} scores={:?}",
+            actual.query_len,
+            actual.scores
+        );
+
+        stats.queries += 1;
+        stats.lane_observations += CKF_PARITY_WORKERS as u64;
+        let mut full_map_mismatch = false;
+        for worker in workers {
+            let expected_depth = expected.scores.get(&worker).copied().unwrap_or(0);
+            let actual_depth = actual.scores.get(&worker).copied().unwrap_or(0);
+            match actual_depth.cmp(&expected_depth) {
+                std::cmp::Ordering::Less => {
+                    stats.under_reports += 1;
+                    stats.under_report_magnitude += u64::from(expected_depth - actual_depth);
+                    full_map_mismatch = true;
+                }
+                std::cmp::Ordering::Greater => {
+                    let inflation = actual_depth - expected_depth;
+                    stats.over_reports += 1;
+                    stats.total_inflation += u64::from(inflation);
+                    stats.maximum_inflation = stats.maximum_inflation.max(inflation);
+                    full_map_mismatch = true;
+                }
+                std::cmp::Ordering::Equal => {}
+            }
+        }
+        stats.full_map_mismatches += u64::from(full_map_mismatch);
+        stats.wrong_best += u64::from(
+            best_configured_lane(&actual.scores, &workers)
+                != best_configured_lane(&expected.scores, &workers),
+        );
+    }
+
+    stats
+}
+
+fn indexer_error_metric_count(metrics: &KvIndexerMetrics) -> u64 {
+    let event_types = [
+        METRIC_EVENT_STORED,
+        METRIC_EVENT_REMOVED,
+        METRIC_EVENT_CLEARED,
+    ];
+    let error_statuses = [
+        METRIC_STATUS_PARENT_NOT_FOUND,
+        METRIC_STATUS_BLOCK_NOT_FOUND,
+        METRIC_STATUS_INVALID_BLOCK,
+        METRIC_STATUS_CAPACITY_EXHAUSTED,
+        METRIC_STATUS_INDEXER_INVARIANT_VIOLATION,
+    ];
+
+    event_types
+        .into_iter()
+        .flat_map(|event_type| {
+            error_statuses.into_iter().map(move |status| {
+                metrics
+                    .kv_cache_events_applied
+                    .get_metric_with_label_values(&[event_type, status])
+                    .map(|counter| counter.get())
+                    .unwrap_or(0)
+            })
+        })
+        .sum()
+}
+
+fn assert_ckf_parity_budget(scope: &str, stats: CkfParityStats, budget: CkfParityBudget) {
+    assert_eq!(stats.under_reports, 0, "{scope} CKF under-reported");
+    assert_eq!(
+        stats.under_report_magnitude, 0,
+        "{scope} CKF under-report magnitude must be zero"
+    );
+    assert!(
+        stats.over_reports <= budget.over_reports,
+        "{scope} CKF over-reports {} exceed budget {}",
+        stats.over_reports,
+        budget.over_reports
+    );
+    assert!(
+        stats.total_inflation <= budget.total_inflation,
+        "{scope} CKF total inflation {} exceeds budget {}",
+        stats.total_inflation,
+        budget.total_inflation
+    );
+    assert!(
+        stats.maximum_inflation <= budget.maximum_inflation,
+        "{scope} CKF maximum inflation {} exceeds budget {}",
+        stats.maximum_inflation,
+        budget.maximum_inflation
+    );
+    assert!(
+        stats.full_map_mismatches <= budget.full_map_mismatches,
+        "{scope} CKF full-map mismatches {} exceed budget {}",
+        stats.full_map_mismatches,
+        budget.full_map_mismatches
+    );
+    assert!(
+        stats.wrong_best <= budget.wrong_best,
+        "{scope} CKF wrong-best selections {} exceed budget {}",
+        stats.wrong_best,
+        budget.wrong_best
+    );
+}
+
+async fn measure_ckf_parity(
+    artifact_sets: &[MockEngineReplayArtifacts],
+    warning_count: &Arc<std::sync::atomic::AtomicUsize>,
+    enforce_budgets: bool,
+) -> anyhow::Result<CkfParityStats> {
+    let exact = MooncakeIndexerConfig::concurrent_radix_tree_compressed(NUM_EVENT_WORKERS);
+    let ckf = MooncakeIndexerConfig::transposed_ckf(NUM_EVENT_WORKERS, NUM_GPU_BLOCKS);
+    assert_eq!(ckf.kind, MooncakeIndexerKind::TransposedCkf);
+    let mut global = CkfParityStats::default();
+
+    for artifact_set in artifact_sets {
+        let expected =
+            collect_prepared_corpus_overlap_scores(&exact, &artifact_set.artifacts).await?;
+        support::reset_warning_count(warning_count);
+        let (actual, metrics) =
+            collect_prepared_corpus_overlap_scores_with_metrics(&ckf, &artifact_set.artifacts)
+                .await?;
+        tokio::time::sleep(Duration::from_millis(50)).await;
+
+        assert_eq!(
+            warning_count.load(Ordering::Relaxed),
+            0,
+            "{} CKF parity replay emitted warning/error logs",
+            artifact_set.engine_name
+        );
+        assert_eq!(
+            support::duplicate_store_warning_count(metrics.as_ref()),
+            0,
+            "{} CKF parity replay recorded duplicate-store warnings",
+            artifact_set.engine_name
+        );
+        assert_eq!(
+            indexer_error_metric_count(metrics.as_ref()),
+            0,
+            "{} CKF parity replay recorded event errors",
+            artifact_set.engine_name
+        );
+
+        let stats = compare_ckf_scores(artifact_set.engine_name, &actual, &expected);
+        println!("CKF_PARITY engine={} {stats:?}", artifact_set.engine_name);
+        assert_eq!(stats.under_reports, 0);
+        assert_eq!(stats.under_report_magnitude, 0);
+        if enforce_budgets {
+            let budget = CKF_PARITY_ENGINE_BUDGETS
+                .iter()
+                .find_map(|(engine, budget)| {
+                    (*engine == artifact_set.engine_name).then_some(*budget)
+                })
+                .expect("every parity engine must have a fixed CKF budget");
+            assert_ckf_parity_budget(artifact_set.engine_name, stats, budget);
+        }
+        global.merge(stats);
+    }
+
+    println!("CKF_PARITY global {global:?}");
+    if enforce_budgets {
+        assert_ckf_parity_budget("global", global, CKF_PARITY_GLOBAL_BUDGET);
+    }
+    Ok(global)
 }
 
 fn approx_tokens(seed: u32, num_blocks: usize) -> Vec<u32> {
@@ -881,6 +1211,41 @@ async fn mooncake_trace_replays_without_warnings_across_indexer_variants() -> an
     }
 
     assert_overlap_score_parity(&variants, &artifact_sets, Some(&warning_count)).await?;
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mooncake_trace_replays_through_fixed_d16_ckf() -> anyhow::Result<()> {
+    let warning_count = support::warning_counter(&["dynamo_kv_router::indexer", "dynamo_mocker"]);
+    let fixture = support::fixture_path("mooncake_trace_1000.jsonl")?;
+    let traces = process_mooncake_trace(&fixture, BLOCK_SIZE, 1, 1, CKF_PARITY_WORKERS, 42)?;
+    let mut artifact_sets = generate_mock_engine_parity_artifacts(&traces).await?;
+    make_ckf_parity_corpus_quiescent(&mut artifact_sets);
+    let stats = measure_ckf_parity(&artifact_sets, &warning_count, true).await?;
+    assert!(stats.queries > 0);
+    assert_eq!(
+        stats.lane_observations,
+        stats.queries * CKF_PARITY_WORKERS as u64
+    );
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "authoritative CKF false-positive tolerance measurement"]
+async fn mooncake_trace_measures_fixed_d16_ckf_tolerance() -> anyhow::Result<()> {
+    let warning_count = support::warning_counter(&["dynamo_kv_router::indexer", "dynamo_mocker"]);
+    let fixture = support::fixture_path("mooncake_trace_1000.jsonl")?;
+    let traces = process_mooncake_trace(&fixture, BLOCK_SIZE, 1, 1, CKF_PARITY_WORKERS, 42)?;
+    let mut artifact_sets = generate_mock_engine_parity_artifacts(&traces).await?;
+    make_ckf_parity_corpus_quiescent(&mut artifact_sets);
+    let stats = measure_ckf_parity(&artifact_sets, &warning_count, false).await?;
+    assert!(stats.queries > 0);
+    assert_eq!(
+        stats.lane_observations,
+        stats.queries * CKF_PARITY_WORKERS as u64
+    );
 
     Ok(())
 }

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -28,6 +28,16 @@ const DEFAULT_EXPECTED_BLOCKS_PER_DC: usize = 1;
 const DEFAULT_VERIFICATION_WINDOW: usize = 2;
 const DEFAULT_PUBLISH_EVERY_N_EVENTS: usize = 1;
 
+/// Output shape for CKF prefix lookups through [`EventTransposedCkfIndexer`].
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum CkfMatchMode {
+    /// Return every positive DC-lane depth.
+    #[default]
+    FullMap,
+    /// Return every positive lane tied at the greatest verified depth.
+    MaxDepthMatches,
+}
+
 /// Search behavior for CKF prefix lookups.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrefixSearchConfig {

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -18,7 +18,10 @@ pub use relay::{
     TransposedCkfReplica,
 };
 
-pub(crate) const DC_COUNT: usize = 16;
+/// Fixed number of DC lanes in the transposed CKF replica.
+pub const CKF_LANE_COUNT: usize = 16;
+
+pub(crate) const DC_COUNT: usize = CKF_LANE_COUNT;
 pub(crate) const MAX_KICKS: usize = 4096;
 pub(crate) const MAX_VERIFICATION_WINDOW: usize = 8;
 
@@ -96,6 +99,7 @@ impl Default for CkfConfig {
 }
 
 /// Construction failures for [`EventTransposedCkfIndexer`].
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error, PartialEq, Eq)]
 pub enum CkfBuildError {
     #[error("duplicate CKF worker identity: {worker:?}")]

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -19,12 +19,17 @@ pub(crate) const MAX_VERIFICATION_WINDOW: usize = 8;
 const DEFAULT_SEED: u64 = 0x5DEE_CE66_D1B5_4A33;
 const DEFAULT_MAX_KICKS: usize = 500;
 const DEFAULT_EXPECTED_BLOCKS_PER_DC: usize = 1;
-const DEFAULT_VERIFICATION_WINDOW: usize = 8;
+const DEFAULT_VERIFICATION_WINDOW: usize = 2;
 
 /// Search behavior for CKF prefix lookups.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrefixSearchConfig {
     /// Number of positions immediately before the tentative depth to verify linearly.
+    ///
+    /// If the first miss is the window's left edge, search may also scan the
+    /// previously discarded gap after the predecessor of the terminal lower bound.
+    /// Stable snapshots make that contradiction evidence of a false terminal branch;
+    /// concurrent mutation can instead expose temporary false negatives.
     pub verification_window: usize,
 }
 

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -5,12 +5,18 @@ mod addressing;
 mod bucket;
 mod event_indexer;
 mod mutator;
+mod relay;
 mod search;
 
 #[cfg(test)]
 mod tests;
 
 pub use event_indexer::EventTransposedCkfIndexer;
+pub use relay::{
+    CkfBucketImage, CkfDeltaBatch, CkfEventOutcome, CkfFormatIdentity, CkfMemorySnapshot,
+    CkfRelayAggregator, RelayLaneConfig, RelayManifest, RouterLocalCkfPipeline,
+    TransposedCkfReplica,
+};
 
 pub(crate) const DC_COUNT: usize = 16;
 pub(crate) const MAX_KICKS: usize = 4096;
@@ -20,6 +26,7 @@ const DEFAULT_SEED: u64 = 0x5DEE_CE66_D1B5_4A33;
 const DEFAULT_MAX_KICKS: usize = 500;
 const DEFAULT_EXPECTED_BLOCKS_PER_DC: usize = 1;
 const DEFAULT_VERIFICATION_WINDOW: usize = 2;
+const DEFAULT_PUBLISH_EVERY_N_EVENTS: usize = 1;
 
 /// Search behavior for CKF prefix lookups.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -52,6 +59,8 @@ pub struct CkfConfig {
     pub max_kicks: usize,
     /// Prefix-search behavior.
     pub search: PrefixSearchConfig,
+    /// Number of normalized mutation events accumulated per DC lane before publication.
+    pub publish_every_n_events: usize,
 }
 
 impl CkfConfig {
@@ -71,6 +80,7 @@ impl Default for CkfConfig {
             seed: DEFAULT_SEED,
             max_kicks: DEFAULT_MAX_KICKS,
             search: PrefixSearchConfig::default(),
+            publish_every_n_events: DEFAULT_PUBLISH_EVERY_N_EVENTS,
         }
     }
 }
@@ -94,9 +104,54 @@ pub enum CkfBuildError {
     )]
     InvalidVerificationWindow { value: usize },
 
+    #[error("publish_every_n_events must be greater than zero")]
+    InvalidPublishEveryNEvents,
+
     #[error("CKF capacity arithmetic overflowed")]
     CapacityOverflow,
 
     #[error("failed to allocate CKF storage")]
     AllocationFailed,
+
+    #[error("lane {lane} expected_contributions {value} is below the required minimum {minimum}")]
+    InvalidContributionCapacity {
+        lane: usize,
+        value: usize,
+        minimum: usize,
+    },
+
+    #[error("empty lane {lane} must have zero expected_contributions, got {value}")]
+    InvalidEmptyLaneContributionCapacity { lane: usize, value: usize },
+}
+
+pub(super) fn validate_config(config: CkfConfig) -> Result<(), CkfBuildError> {
+    if config.expected_blocks_per_dc == 0 {
+        return Err(CkfBuildError::ExpectedCapacityZero);
+    }
+    if !(1..=MAX_KICKS).contains(&config.max_kicks) {
+        return Err(CkfBuildError::InvalidMaxKicks {
+            value: config.max_kicks,
+            maximum: MAX_KICKS,
+        });
+    }
+    if !(1..=MAX_VERIFICATION_WINDOW).contains(&config.search.verification_window) {
+        return Err(CkfBuildError::InvalidVerificationWindow {
+            value: config.search.verification_window,
+        });
+    }
+    if config.publish_every_n_events == 0 {
+        return Err(CkfBuildError::InvalidPublishEveryNEvents);
+    }
+    Ok(())
+}
+
+pub(super) fn bucket_count(expected_blocks_per_dc: usize) -> Result<usize, CkfBuildError> {
+    let numerator = expected_blocks_per_dc
+        .checked_mul(5)
+        .and_then(|value| value.checked_add(15))
+        .ok_or(CkfBuildError::CapacityOverflow)?;
+    let required = (numerator / 16).max(2);
+    required
+        .checked_next_power_of_two()
+        .ok_or(CkfBuildError::CapacityOverflow)
 }

--- a/lib/kv-router/src/indexer/cuckoo.rs
+++ b/lib/kv-router/src/indexer/cuckoo.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod addressing;
+mod bucket;
+mod event_indexer;
+mod mutator;
+mod search;
+
+#[cfg(test)]
+mod tests;
+
+pub use event_indexer::EventTransposedCkfIndexer;
+
+pub(crate) const DC_COUNT: usize = 16;
+pub(crate) const MAX_KICKS: usize = 4096;
+pub(crate) const MAX_VERIFICATION_WINDOW: usize = 8;
+
+const DEFAULT_SEED: u64 = 0x5DEE_CE66_D1B5_4A33;
+const DEFAULT_MAX_KICKS: usize = 500;
+const DEFAULT_EXPECTED_BLOCKS_PER_DC: usize = 1;
+const DEFAULT_VERIFICATION_WINDOW: usize = 8;
+
+/// Search behavior for CKF prefix lookups.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct PrefixSearchConfig {
+    /// Number of positions immediately before the tentative depth to verify linearly.
+    pub verification_window: usize,
+}
+
+impl Default for PrefixSearchConfig {
+    fn default() -> Self {
+        Self {
+            verification_window: DEFAULT_VERIFICATION_WINDOW,
+        }
+    }
+}
+
+/// Capacity, addressing, and search configuration for the D=16 CKF indexer.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CkfConfig {
+    /// Logical blocks expected in each DC lane.
+    pub expected_blocks_per_dc: usize,
+    /// Shared deterministic addressing seed.
+    pub seed: u64,
+    /// Maximum relocation steps before one block insertion is rolled back.
+    pub max_kicks: usize,
+    /// Prefix-search behavior.
+    pub search: PrefixSearchConfig,
+}
+
+impl CkfConfig {
+    /// Create a configuration with the requested per-DC capacity and standard defaults.
+    pub fn new(expected_blocks_per_dc: usize) -> Self {
+        Self {
+            expected_blocks_per_dc,
+            ..Self::default()
+        }
+    }
+}
+
+impl Default for CkfConfig {
+    fn default() -> Self {
+        Self {
+            expected_blocks_per_dc: DEFAULT_EXPECTED_BLOCKS_PER_DC,
+            seed: DEFAULT_SEED,
+            max_kicks: DEFAULT_MAX_KICKS,
+            search: PrefixSearchConfig::default(),
+        }
+    }
+}
+
+/// Construction failures for [`EventTransposedCkfIndexer`].
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum CkfBuildError {
+    #[error("duplicate CKF worker identity: {worker:?}")]
+    DuplicateWorker {
+        worker: crate::protocols::WorkerWithDpRank,
+    },
+
+    #[error("expected_blocks_per_dc must be greater than zero")]
+    ExpectedCapacityZero,
+
+    #[error("max_kicks {value} is outside the supported range 1..={maximum}")]
+    InvalidMaxKicks { value: usize, maximum: usize },
+
+    #[error(
+        "verification_window {value} is outside the supported range 1..={MAX_VERIFICATION_WINDOW}"
+    )]
+    InvalidVerificationWindow { value: usize },
+
+    #[error("CKF capacity arithmetic overflowed")]
+    CapacityOverflow,
+
+    #[error("failed to allocate CKF storage")]
+    AllocationFailed,
+}

--- a/lib/kv-router/src/indexer/cuckoo/addressing.rs
+++ b/lib/kv-router/src/indexer/cuckoo/addressing.rs
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use xxhash_rust::xxh3;
+
+const ALTERNATE_BUCKET_DOMAIN: u64 = 0x9E37_79B9_7F4A_7C15;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct CkfProbe {
+    pub(super) fingerprint: u16,
+    pub(super) bucket_a: usize,
+    pub(super) bucket_b: usize,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct CkfAddressing {
+    bucket_mask: usize,
+    seed: u64,
+}
+
+impl CkfAddressing {
+    pub(super) fn new(bucket_count: usize, seed: u64) -> Self {
+        debug_assert!(bucket_count.is_power_of_two());
+        debug_assert!(bucket_count >= 2);
+        Self {
+            bucket_mask: bucket_count - 1,
+            seed,
+        }
+    }
+
+    #[inline]
+    pub(super) fn prepare(&self, sequence_hash: u64) -> CkfProbe {
+        let mixed = xxh3::xxh3_64_with_seed(&sequence_hash.to_le_bytes(), self.seed);
+        let fingerprint = nonzero_fingerprint(mixed as u16);
+        let bucket_a = ((mixed >> 16) as usize) & self.bucket_mask;
+        let bucket_b = self.alternate_bucket(bucket_a, fingerprint);
+        CkfProbe {
+            fingerprint,
+            bucket_a,
+            bucket_b,
+        }
+    }
+
+    #[inline]
+    pub(super) fn alternate_bucket(&self, bucket: usize, fingerprint: u16) -> usize {
+        bucket ^ self.bucket_delta(fingerprint)
+    }
+
+    #[inline]
+    fn bucket_delta(&self, fingerprint: u16) -> usize {
+        let mixed = xxh3::xxh3_64_with_seed(
+            &fingerprint.to_le_bytes(),
+            self.seed ^ ALTERNATE_BUCKET_DOMAIN,
+        );
+        let delta = (mixed as usize) & self.bucket_mask;
+        if delta == 0 { 1 } else { delta }
+    }
+}
+
+#[inline]
+fn nonzero_fingerprint(fingerprint: u16) -> u16 {
+    if fingerprint == 0 { 1 } else { fingerprint }
+}

--- a/lib/kv-router/src/indexer/cuckoo/addressing.rs
+++ b/lib/kv-router/src/indexer/cuckoo/addressing.rs
@@ -48,6 +48,8 @@ impl CkfAddressing {
 
     #[inline]
     fn bucket_delta(&self, fingerprint: u16) -> usize {
+        // TODO(perf): Benchmark a seed/mask-specific fingerprint delta table before replacing
+        // this hash, including its per-indexer memory and cache effects.
         let mixed = xxh3::xxh3_64_with_seed(
             &fingerprint.to_le_bytes(),
             self.seed ^ ALTERNATE_BUCKET_DOMAIN,

--- a/lib/kv-router/src/indexer/cuckoo/bucket.rs
+++ b/lib/kv-router/src/indexer/cuckoo/bucket.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::CkfBuildError;
+use super::addressing::CkfProbe;
+
+const SLOT_COUNT: usize = 4;
+const REPEATED_ONE: u64 = 0x0001_0001_0001_0001;
+const HIGH_BITS: u64 = 0x8000_8000_8000_8000;
+#[cfg(target_arch = "x86_64")]
+const CACHE_LINE_BYTES: usize = 64;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct PackedBucket(pub(super) u64);
+
+impl PackedBucket {
+    #[inline]
+    pub(super) fn contains(self, fingerprint: u16) -> bool {
+        debug_assert_ne!(fingerprint, 0);
+        let repeated = u64::from(fingerprint) * REPEATED_ONE;
+        let different = self.0 ^ repeated;
+        different.wrapping_sub(REPEATED_ONE) & !different & HIGH_BITS != 0
+    }
+
+    #[inline]
+    pub(super) fn first_empty(self) -> Option<usize> {
+        self.first(0)
+    }
+
+    #[inline]
+    pub(super) fn first(self, fingerprint: u16) -> Option<usize> {
+        if self.0 as u16 == fingerprint {
+            Some(0)
+        } else if (self.0 >> 16) as u16 == fingerprint {
+            Some(1)
+        } else if (self.0 >> 32) as u16 == fingerprint {
+            Some(2)
+        } else if (self.0 >> 48) as u16 == fingerprint {
+            Some(3)
+        } else {
+            None
+        }
+    }
+
+    #[inline]
+    pub(super) fn slot(self, slot: usize) -> u16 {
+        debug_assert!(slot < SLOT_COUNT);
+        (self.0 >> (slot * u16::BITS as usize)) as u16
+    }
+
+    #[inline]
+    pub(super) fn with_slot(self, slot: usize, fingerprint: u16) -> Self {
+        debug_assert!(slot < SLOT_COUNT);
+        let shift = slot * u16::BITS as usize;
+        let mask = u64::from(u16::MAX) << shift;
+        Self((self.0 & !mask) | (u64::from(fingerprint) << shift))
+    }
+
+    #[cfg(test)]
+    pub(super) fn scalar_contains(self, fingerprint: u16) -> bool {
+        (0..SLOT_COUNT).any(|slot| self.slot(slot) == fingerprint)
+    }
+}
+
+pub(super) trait CuckooBucketStore {
+    fn load_bucket(&self, bucket: usize) -> PackedBucket;
+    fn store_bucket(&self, bucket: usize, value: PackedBucket);
+    fn bucket_count(&self) -> usize;
+}
+
+#[derive(Debug)]
+pub(super) struct TransposedCkfTable<const D: usize> {
+    bucket_count: usize,
+    lanes: Box<[AtomicU64]>,
+}
+
+impl<const D: usize> TransposedCkfTable<D> {
+    pub(super) fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
+        debug_assert!((1..=16).contains(&D));
+        let lane_count = bucket_count
+            .checked_mul(D)
+            .ok_or(CkfBuildError::CapacityOverflow)?;
+        let allocation_bytes = lane_count
+            .checked_mul(std::mem::size_of::<AtomicU64>())
+            .ok_or(CkfBuildError::CapacityOverflow)?;
+        if allocation_bytes > isize::MAX as usize {
+            return Err(CkfBuildError::CapacityOverflow);
+        }
+
+        let mut lanes = Vec::new();
+        lanes
+            .try_reserve_exact(lane_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        lanes.extend((0..lane_count).map(|_| AtomicU64::new(0)));
+
+        Ok(Self {
+            bucket_count,
+            lanes: lanes.into_boxed_slice(),
+        })
+    }
+
+    pub(super) fn lane(&self, lane: usize) -> TransposedDcView<'_, D> {
+        debug_assert!(lane < D);
+        TransposedDcView { table: self, lane }
+    }
+
+    #[inline]
+    pub(super) fn probe(&self, probe: CkfProbe) -> u16 {
+        let mut present = 0u16;
+        for lane in 0..D {
+            let first = self.load(probe.bucket_a, lane);
+            let second = self.load(probe.bucket_b, lane);
+            let found = first.contains(probe.fingerprint) || second.contains(probe.fingerprint);
+            present |= u16::from(found) << lane;
+        }
+        present
+    }
+
+    pub(super) fn prefetch_probe(&self, probe: CkfProbe) {
+        self.prefetch_row(probe.bucket_a);
+        if probe.bucket_b != probe.bucket_a {
+            self.prefetch_row(probe.bucket_b);
+        }
+    }
+
+    #[inline]
+    fn load(&self, bucket: usize, lane: usize) -> PackedBucket {
+        let index = bucket * D + lane;
+        PackedBucket(self.lanes[index].load(Ordering::Relaxed))
+    }
+
+    #[inline]
+    fn store(&self, bucket: usize, lane: usize, value: PackedBucket) {
+        let index = bucket * D + lane;
+        self.lanes[index].store(value.0, Ordering::Relaxed);
+    }
+
+    fn prefetch_row(&self, bucket: usize) {
+        let index = bucket * D;
+        let row = self.lanes.as_ptr().wrapping_add(index).cast::<u8>();
+        prefetch_span(row, D * std::mem::size_of::<AtomicU64>());
+    }
+}
+
+pub(super) struct TransposedDcView<'a, const D: usize> {
+    table: &'a TransposedCkfTable<D>,
+    lane: usize,
+}
+
+impl<const D: usize> CuckooBucketStore for TransposedDcView<'_, D> {
+    #[inline]
+    fn load_bucket(&self, bucket: usize) -> PackedBucket {
+        self.table.load(bucket, self.lane)
+    }
+
+    #[inline]
+    fn store_bucket(&self, bucket: usize, value: PackedBucket) {
+        self.table.store(bucket, self.lane, value);
+    }
+
+    fn bucket_count(&self) -> usize {
+        self.table.bucket_count
+    }
+}
+
+#[cfg(target_arch = "x86_64")]
+fn prefetch_span(start: *const u8, len: usize) {
+    use std::arch::x86_64::{_MM_HINT_T0, _mm_prefetch};
+
+    if len == 0 {
+        return;
+    }
+
+    let address = start as usize;
+    let mut offset = 0usize;
+    loop {
+        // SAFETY: Every prefetched address is within the allocated row. Prefetch is a hint and
+        // does not dereference the pointer architecturally.
+        unsafe { _mm_prefetch(start.add(offset).cast::<i8>(), _MM_HINT_T0) };
+        let next = if offset == 0 {
+            CACHE_LINE_BYTES - (address & (CACHE_LINE_BYTES - 1))
+        } else {
+            offset + CACHE_LINE_BYTES
+        };
+        if next >= len {
+            break;
+        }
+        offset = next;
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn prefetch_span(_start: *const u8, _len: usize) {}

--- a/lib/kv-router/src/indexer/cuckoo/bucket.rs
+++ b/lib/kv-router/src/indexer/cuckoo/bucket.rs
@@ -4,8 +4,8 @@
 use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::CkfBuildError;
 use super::addressing::CkfProbe;
+use super::{CkfBuildError, DC_COUNT};
 
 const SLOT_COUNT: usize = 4;
 const REPEATED_ONE: u64 = 0x0001_0001_0001_0001;
@@ -130,7 +130,7 @@ pub(super) struct TransposedCkfTable<const D: usize> {
 
 impl<const D: usize> TransposedCkfTable<D> {
     pub(super) fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
-        debug_assert!((1..=16).contains(&D));
+        debug_assert!((1..=DC_COUNT).contains(&D));
         let lane_count = bucket_count
             .checked_mul(D)
             .ok_or(CkfBuildError::CapacityOverflow)?;

--- a/lib/kv-router/src/indexer/cuckoo/bucket.rs
+++ b/lib/kv-router/src/indexer/cuckoo/bucket.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::cell::Cell;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::CkfBuildError;
@@ -71,6 +72,57 @@ pub(super) trait CuckooBucketStore {
 }
 
 #[derive(Debug)]
+pub(super) struct OwnedPackedCkfLane {
+    buckets: Box<[Cell<u64>]>,
+}
+
+impl OwnedPackedCkfLane {
+    pub(super) fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
+        let allocation_bytes = bucket_count
+            .checked_mul(std::mem::size_of::<u64>())
+            .ok_or(CkfBuildError::CapacityOverflow)?;
+        if allocation_bytes > isize::MAX as usize {
+            return Err(CkfBuildError::CapacityOverflow);
+        }
+
+        let mut buckets = Vec::new();
+        buckets
+            .try_reserve_exact(bucket_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        buckets.extend((0..bucket_count).map(|_| Cell::new(0)));
+        Ok(Self {
+            buckets: buckets.into_boxed_slice(),
+        })
+    }
+
+    pub(super) fn clear(&mut self) {
+        for bucket in &mut self.buckets {
+            bucket.set(0);
+        }
+    }
+
+    pub(super) fn byte_len(&self) -> usize {
+        std::mem::size_of_val(self.buckets.as_ref())
+    }
+}
+
+impl CuckooBucketStore for OwnedPackedCkfLane {
+    #[inline]
+    fn load_bucket(&self, bucket: usize) -> PackedBucket {
+        PackedBucket(self.buckets[bucket].get())
+    }
+
+    #[inline]
+    fn store_bucket(&self, bucket: usize, value: PackedBucket) {
+        self.buckets[bucket].set(value.0);
+    }
+
+    fn bucket_count(&self) -> usize {
+        self.buckets.len()
+    }
+}
+
+#[derive(Debug)]
 pub(super) struct TransposedCkfTable<const D: usize> {
     bucket_count: usize,
     lanes: Box<[AtomicU64]>,
@@ -101,9 +153,33 @@ impl<const D: usize> TransposedCkfTable<D> {
         })
     }
 
+    #[cfg(test)]
     pub(super) fn lane(&self, lane: usize) -> TransposedDcView<'_, D> {
         debug_assert!(lane < D);
         TransposedDcView { table: self, lane }
+    }
+
+    pub(super) fn bucket_count(&self) -> usize {
+        self.bucket_count
+    }
+
+    pub(super) fn store_image(&self, bucket: usize, lane: usize, value: PackedBucket) {
+        debug_assert!(bucket < self.bucket_count);
+        debug_assert!(lane < D);
+        self.store(bucket, lane, value);
+    }
+
+    pub(super) fn load_image(&self, bucket: usize, lane: usize) -> PackedBucket {
+        debug_assert!(bucket < self.bucket_count);
+        debug_assert!(lane < D);
+        self.load(bucket, lane)
+    }
+
+    pub(super) fn clear_lane(&self, lane: usize) {
+        debug_assert!(lane < D);
+        for bucket in 0..self.bucket_count {
+            self.store(bucket, lane, PackedBucket::default());
+        }
     }
 
     #[inline]
@@ -144,11 +220,13 @@ impl<const D: usize> TransposedCkfTable<D> {
     }
 }
 
+#[cfg(test)]
 pub(super) struct TransposedDcView<'a, const D: usize> {
     table: &'a TransposedCkfTable<D>,
     lane: usize,
 }
 
+#[cfg(test)]
 impl<const D: usize> CuckooBucketStore for TransposedDcView<'_, D> {
     #[inline]
     fn load_bucket(&self, bucket: usize) -> PackedBucket {

--- a/lib/kv-router/src/indexer/cuckoo/bucket.rs
+++ b/lib/kv-router/src/indexer/cuckoo/bucket.rs
@@ -175,13 +175,6 @@ impl<const D: usize> TransposedCkfTable<D> {
         self.load(bucket, lane)
     }
 
-    pub(super) fn clear_lane(&self, lane: usize) {
-        debug_assert!(lane < D);
-        for bucket in 0..self.bucket_count {
-            self.store(bucket, lane, PackedBucket::default());
-        }
-    }
-
     #[inline]
     pub(super) fn probe(&self, probe: CkfProbe) -> u16 {
         let mut present = 0u16;

--- a/lib/kv-router/src/indexer/cuckoo/bucket.rs
+++ b/lib/kv-router/src/indexer/cuckoo/bucket.rs
@@ -175,6 +175,13 @@ impl<const D: usize> TransposedCkfTable<D> {
         self.load(bucket, lane)
     }
 
+    pub(super) fn clear_lane(&self, lane: usize) {
+        debug_assert!(lane < D);
+        for bucket in 0..self.bucket_count {
+            self.store(bucket, lane, PackedBucket::default());
+        }
+    }
+
     #[inline]
     pub(super) fn probe(&self, probe: CkfProbe) -> u16 {
         let mut present = 0u16;

--- a/lib/kv-router/src/indexer/cuckoo/bucket.rs
+++ b/lib/kv-router/src/indexer/cuckoo/bucket.rs
@@ -177,6 +177,9 @@ impl<const D: usize> TransposedCkfTable<D> {
 
     pub(super) fn clear_lane(&self, lane: usize) {
         debug_assert!(lane < D);
+        // A per-image atomic occupancy tracker won the reset microbenchmark but regressed the
+        // combined Relay workload by about 5.1% at N=1 and 3.0% at N=16. Keep the full scan
+        // unless a replacement avoids steady-state image bookkeeping and passes end-to-end.
         for bucket in 0..self.bucket_count {
             self.store(bucket, lane, PackedBucket::default());
         }

--- a/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
+++ b/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
@@ -21,14 +21,15 @@ use crate::protocols::{KvCacheEventError, LocalBlockHash, OverlapScores, WorkerW
 use super::CkfDeltaBatch;
 #[cfg(feature = "bench")]
 use super::relay::CkfBenchLocalTelemetry;
-#[cfg(not(feature = "metrics"))]
-use super::search::find_prefix_depths;
-#[cfg(feature = "metrics")]
-use super::search::find_prefix_depths_with_stats;
 #[cfg(any(test, feature = "bench"))]
 use super::search::linear_prefix_depths;
+#[cfg(not(feature = "metrics"))]
+use super::search::{find_max_depth_matches, find_prefix_depths};
+#[cfg(feature = "metrics")]
+use super::search::{find_max_depth_matches_with_stats, find_prefix_depths_with_stats};
 use super::{
-    CkfBuildError, CkfConfig, CkfEventOutcome, DC_COUNT, RelayManifest, RouterLocalCkfPipeline,
+    CkfBuildError, CkfConfig, CkfEventOutcome, CkfMatchMode, DC_COUNT, RelayManifest,
+    RouterLocalCkfPipeline,
 };
 
 #[cfg(test)]
@@ -39,6 +40,7 @@ pub(super) use super::bucket_count;
 pub struct EventTransposedCkfIndexer {
     pub(super) pipeline: RouterLocalCkfPipeline,
     workers: [WorkerWithDpRank; DC_COUNT],
+    match_mode: CkfMatchMode,
     #[cfg(feature = "metrics")]
     search_counters: Option<PreBoundCkfSearchCounters>,
 }
@@ -49,10 +51,20 @@ impl EventTransposedCkfIndexer {
         workers: [WorkerWithDpRank; DC_COUNT],
         config: CkfConfig,
     ) -> Result<Self, CkfBuildError> {
+        Self::new_with_match_mode(workers, config, CkfMatchMode::FullMap)
+    }
+
+    /// Construct the normal one-worker/rank-per-lane specialization with an output mode.
+    pub fn new_with_match_mode(
+        workers: [WorkerWithDpRank; DC_COUNT],
+        config: CkfConfig,
+        match_mode: CkfMatchMode,
+    ) -> Result<Self, CkfBuildError> {
         let manifest = RelayManifest::one_worker_per_lane(workers, config.expected_blocks_per_dc)?;
         Ok(Self {
             pipeline: RouterLocalCkfPipeline::new(manifest, config)?,
             workers,
+            match_mode,
             #[cfg(feature = "metrics")]
             search_counters: None,
         })
@@ -235,22 +247,40 @@ impl SyncIndexer for EventTransposedCkfIndexer {
         let replica = self.pipeline.replica();
         let probes = replica.prepared_probes(sequence);
         #[cfg(not(feature = "metrics"))]
-        let depths = find_prefix_depths::<DC_COUNT>(
-            probes.len(),
-            u16::MAX,
-            replica.config.search.verification_window,
-            |position| replica.table.prefetch_probe(probes[position]),
-            |position| replica.table.probe(probes[position]),
-        );
-        #[cfg(feature = "metrics")]
-        let depths = {
-            let result = find_prefix_depths_with_stats::<DC_COUNT>(
+        let depths = match self.match_mode {
+            CkfMatchMode::FullMap => find_prefix_depths::<DC_COUNT>(
                 probes.len(),
                 u16::MAX,
                 replica.config.search.verification_window,
                 |position| replica.table.prefetch_probe(probes[position]),
                 |position| replica.table.probe(probes[position]),
-            );
+            ),
+            CkfMatchMode::MaxDepthMatches => find_max_depth_matches::<DC_COUNT>(
+                probes.len(),
+                u16::MAX,
+                replica.config.search.verification_window,
+                |position| replica.table.prefetch_probe(probes[position]),
+                |position| replica.table.probe(probes[position]),
+            ),
+        };
+        #[cfg(feature = "metrics")]
+        let depths = {
+            let result = match self.match_mode {
+                CkfMatchMode::FullMap => find_prefix_depths_with_stats::<DC_COUNT>(
+                    probes.len(),
+                    u16::MAX,
+                    replica.config.search.verification_window,
+                    |position| replica.table.prefetch_probe(probes[position]),
+                    |position| replica.table.probe(probes[position]),
+                ),
+                CkfMatchMode::MaxDepthMatches => find_max_depth_matches_with_stats::<DC_COUNT>(
+                    probes.len(),
+                    u16::MAX,
+                    replica.config.search.verification_window,
+                    |position| replica.table.prefetch_probe(probes[position]),
+                    |position| replica.table.probe(probes[position]),
+                ),
+            };
             if let Some(counters) = &self.search_counters {
                 counters.record(
                     result.fallback.left_edge_lanes,

--- a/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
+++ b/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
@@ -100,17 +100,13 @@ impl EventTransposedCkfIndexer {
         match event.event.data {
             KvCacheEventData::Stored(store) => {
                 let lane = self.lane_for(worker, event_id)?;
+                if store.blocks.is_empty() {
+                    return Ok(());
+                }
+                let state = self.ensure_state(states, lane)?;
                 let mut first_error = None;
-                let mut entirely_duplicate = !store.blocks.is_empty();
+                let mut entirely_duplicate = true;
                 for block in store.blocks {
-                    let state = match self.ensure_state(states, lane) {
-                        Ok(state) => state,
-                        Err(error) => {
-                            entirely_duplicate = false;
-                            retain_first_error(&mut first_error, error);
-                            continue;
-                        }
-                    };
                     if !state.resident.insert(block.block_hash) {
                         continue;
                     }

--- a/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
+++ b/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
@@ -5,6 +5,8 @@ use std::sync::Arc;
 
 use rustc_hash::FxHashMap;
 
+#[cfg(feature = "metrics")]
+use crate::indexer::PreBoundCkfSearchCounters;
 #[cfg(feature = "bench")]
 use crate::indexer::WorkerObservationState;
 use crate::indexer::{
@@ -19,7 +21,10 @@ use crate::protocols::{
 use super::addressing::CkfAddressing;
 use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
 use super::mutator::{CuckooMutator, DcWriterState, DirtyBucket, lane_rng_seed};
+#[cfg(not(feature = "metrics"))]
 use super::search::find_prefix_depths;
+#[cfg(feature = "metrics")]
+use super::search::find_prefix_depths_with_stats;
 #[cfg(any(test, feature = "bench"))]
 use super::search::linear_prefix_depths;
 use super::{CkfBuildError, CkfConfig, DC_COUNT, MAX_KICKS, MAX_VERIFICATION_WINDOW};
@@ -33,6 +38,8 @@ pub struct EventTransposedCkfIndexer {
     worker_to_lane: FxHashMap<WorkerWithDpRank, usize>,
     worker_lane_masks: FxHashMap<WorkerId, u16>,
     pub(super) config: CkfConfig,
+    #[cfg(feature = "metrics")]
+    search_counters: Option<PreBoundCkfSearchCounters>,
 }
 
 impl EventTransposedCkfIndexer {
@@ -66,6 +73,8 @@ impl EventTransposedCkfIndexer {
             worker_to_lane,
             worker_lane_masks,
             config,
+            #[cfg(feature = "metrics")]
+            search_counters: None,
         })
     }
 
@@ -276,6 +285,15 @@ impl EventTransposedCkfIndexer {
 }
 
 impl SyncIndexer for EventTransposedCkfIndexer {
+    fn configure_metrics(&mut self, metrics: Option<&KvIndexerMetrics>) {
+        #[cfg(feature = "metrics")]
+        {
+            self.search_counters = metrics.map(KvIndexerMetrics::prebind_ckf_search);
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = metrics;
+    }
+
     fn worker(
         &self,
         event_receiver: flume::Receiver<WorkerTask>,
@@ -356,6 +374,7 @@ impl SyncIndexer for EventTransposedCkfIndexer {
         }
 
         let probes = self.prepared_probes(sequence);
+        #[cfg(not(feature = "metrics"))]
         let depths = find_prefix_depths::<DC_COUNT>(
             probes.len(),
             u16::MAX,
@@ -363,6 +382,26 @@ impl SyncIndexer for EventTransposedCkfIndexer {
             |position| self.table.prefetch_probe(probes[position]),
             |position| self.table.probe(probes[position]),
         );
+        #[cfg(feature = "metrics")]
+        let depths = {
+            let result = find_prefix_depths_with_stats::<DC_COUNT>(
+                probes.len(),
+                u16::MAX,
+                self.config.search.verification_window,
+                |position| self.table.prefetch_probe(probes[position]),
+                |position| self.table.probe(probes[position]),
+            );
+            if let Some(counters) = &self.search_counters {
+                counters.record(
+                    result.fallback.left_edge_lanes,
+                    result.fallback.activated_lanes,
+                    result.fallback.probe_calls,
+                    result.fallback.lane_probes,
+                    result.fallback.provenance_skips,
+                );
+            }
+            result.depths
+        };
 
         let mut scores = OverlapScores::new();
         scores

--- a/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
+++ b/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
@@ -194,28 +194,20 @@ impl SyncIndexer for EventTransposedCkfIndexer {
                 }
                 WorkerTask::Flush(sender) => {
                     #[cfg(feature = "bench")]
-                    let result = self
-                        .pipeline
+                    self.pipeline
                         .flush_pending_with_telemetry(&mut batch, &mut bench_telemetry);
                     #[cfg(not(feature = "bench"))]
-                    let result = self.pipeline.flush_pending(&mut batch);
-                    if let Err(error) = result {
-                        tracing::warn!(?error, "Failed to flush pending CKF publication");
-                    }
+                    self.pipeline.flush_pending(&mut batch);
                     #[cfg(feature = "bench")]
                     self.pipeline.merge_bench_telemetry(&mut bench_telemetry);
                     let _ = sender.send(());
                 }
                 WorkerTask::Terminate => {
                     #[cfg(feature = "bench")]
-                    let result = self
-                        .pipeline
+                    self.pipeline
                         .flush_pending_with_telemetry(&mut batch, &mut bench_telemetry);
                     #[cfg(not(feature = "bench"))]
-                    let result = self.pipeline.flush_pending(&mut batch);
-                    if let Err(error) = result {
-                        tracing::warn!(?error, "Failed to flush CKF publication at termination");
-                    }
+                    self.pipeline.flush_pending(&mut batch);
                     #[cfg(feature = "bench")]
                     self.pipeline.merge_bench_telemetry(&mut bench_telemetry);
                     break;
@@ -224,17 +216,10 @@ impl SyncIndexer for EventTransposedCkfIndexer {
         }
 
         #[cfg(feature = "bench")]
-        let result = self
-            .pipeline
+        self.pipeline
             .flush_pending_with_telemetry(&mut batch, &mut bench_telemetry);
         #[cfg(not(feature = "bench"))]
-        let result = self.pipeline.flush_pending(&mut batch);
-        if let Err(error) = result {
-            tracing::warn!(
-                ?error,
-                "Failed to flush CKF publication at receiver closure"
-            );
-        }
+        self.pipeline.flush_pending(&mut batch);
         #[cfg(feature = "bench")]
         self.pipeline.merge_bench_telemetry(&mut bench_telemetry);
 

--- a/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
+++ b/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
@@ -1,0 +1,443 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use rustc_hash::FxHashMap;
+
+#[cfg(feature = "bench")]
+use crate::indexer::WorkerObservationState;
+use crate::indexer::{
+    EventKind, EventWarningKind, KvIndexerMetrics, PreBoundEventCounters, SyncIndexer,
+    WorkerLookupStats, WorkerTask,
+};
+use crate::protocols::{
+    KvCacheEventData, KvCacheEventError, LocalBlockHash, OverlapScores, RouterEvent, WorkerId,
+    WorkerWithDpRank, compute_seq_hash_for_block,
+};
+
+use super::addressing::CkfAddressing;
+use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
+use super::mutator::{CuckooMutator, DcWriterState, DirtyBucket, lane_rng_seed};
+use super::search::find_prefix_depths;
+#[cfg(any(test, feature = "bench"))]
+use super::search::linear_prefix_depths;
+use super::{CkfBuildError, CkfConfig, DC_COUNT, MAX_KICKS, MAX_VERIFICATION_WINDOW};
+
+/// Fixed-D=16 event-driven transposed Cuckoo-filter indexer.
+#[derive(Debug)]
+pub struct EventTransposedCkfIndexer {
+    pub(super) table: TransposedCkfTable<DC_COUNT>,
+    pub(super) addressing: CkfAddressing,
+    workers: [WorkerWithDpRank; DC_COUNT],
+    worker_to_lane: FxHashMap<WorkerWithDpRank, usize>,
+    worker_lane_masks: FxHashMap<WorkerId, u16>,
+    pub(super) config: CkfConfig,
+}
+
+impl EventTransposedCkfIndexer {
+    /// Construct an indexer with one immutable lane assignment per worker/rank.
+    pub fn new(
+        workers: [WorkerWithDpRank; DC_COUNT],
+        config: CkfConfig,
+    ) -> Result<Self, CkfBuildError> {
+        validate_config(config)?;
+        let bucket_count = bucket_count(config.expected_blocks_per_dc)?;
+
+        let mut worker_to_lane = FxHashMap::default();
+        worker_to_lane
+            .try_reserve(DC_COUNT)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        let mut worker_lane_masks = FxHashMap::default();
+        worker_lane_masks
+            .try_reserve(DC_COUNT)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        for (lane, worker) in workers.iter().copied().enumerate() {
+            if worker_to_lane.insert(worker, lane).is_some() {
+                return Err(CkfBuildError::DuplicateWorker { worker });
+            }
+            *worker_lane_masks.entry(worker.worker_id).or_insert(0) |= 1u16 << lane;
+        }
+
+        Ok(Self {
+            table: TransposedCkfTable::new(bucket_count)?,
+            addressing: CkfAddressing::new(bucket_count, config.seed),
+            workers,
+            worker_to_lane,
+            worker_lane_masks,
+            config,
+        })
+    }
+
+    pub(super) fn apply_event(
+        &self,
+        states: &mut [Option<DcWriterState>; DC_COUNT],
+        event: RouterEvent,
+        counters: Option<&PreBoundEventCounters>,
+    ) -> Result<(), KvCacheEventError> {
+        self.apply_event_with_dirty(states, event, counters, |_, _| {})
+    }
+
+    pub(super) fn apply_event_with_dirty(
+        &self,
+        states: &mut [Option<DcWriterState>; DC_COUNT],
+        event: RouterEvent,
+        counters: Option<&PreBoundEventCounters>,
+        mut on_dirty: impl FnMut(usize, DirtyBucket),
+    ) -> Result<(), KvCacheEventError> {
+        let worker_id = event.worker_id;
+        let event_id = event.event.event_id;
+        let worker = WorkerWithDpRank::new(worker_id, event.event.dp_rank);
+        match event.event.data {
+            KvCacheEventData::Stored(store) => {
+                let lane = self.lane_for(worker, event_id)?;
+                let mut first_error = None;
+                let mut entirely_duplicate = !store.blocks.is_empty();
+                for block in store.blocks {
+                    let state = match self.ensure_state(states, lane) {
+                        Ok(state) => state,
+                        Err(error) => {
+                            entirely_duplicate = false;
+                            retain_first_error(&mut first_error, error);
+                            continue;
+                        }
+                    };
+                    if !state.resident.insert(block.block_hash) {
+                        continue;
+                    }
+                    entirely_duplicate = false;
+                    let view = self.table.lane(lane);
+                    let mutator =
+                        CuckooMutator::new(&view, &self.addressing, self.config.max_kicks);
+                    let result = mutator.insert(
+                        block.block_hash,
+                        &mut state.rng,
+                        &mut state.scratch,
+                        |dirty| on_dirty(lane, dirty),
+                    );
+                    if let Err(error) = result {
+                        let removed = state.resident.remove(&block.block_hash);
+                        debug_assert!(removed);
+                        retain_first_error(&mut first_error, error);
+                    }
+                }
+                if entirely_duplicate && let Some(counters) = counters {
+                    counters.inc_warning(EventWarningKind::DuplicateStore);
+                }
+                finish_event(first_error)
+            }
+            KvCacheEventData::Removed(remove) => {
+                let lane = self.lane_for(worker, event_id)?;
+                let mut first_error = None;
+                for hash in remove.block_hashes {
+                    let Some(state) = states[lane].as_mut() else {
+                        retain_first_error(&mut first_error, KvCacheEventError::BlockNotFound);
+                        continue;
+                    };
+                    if !state.resident.remove(&hash) {
+                        retain_first_error(&mut first_error, KvCacheEventError::BlockNotFound);
+                        continue;
+                    }
+                    let view = self.table.lane(lane);
+                    let mutator =
+                        CuckooMutator::new(&view, &self.addressing, self.config.max_kicks);
+                    match mutator.remove(hash, |dirty| on_dirty(lane, dirty)) {
+                        Ok(()) => {}
+                        Err(error) => {
+                            let inserted = state.resident.insert(hash);
+                            debug_assert!(inserted);
+                            retain_first_error(&mut first_error, error);
+                        }
+                    }
+                }
+                finish_event(first_error)
+            }
+            KvCacheEventData::Cleared => {
+                let Some(mask) = self.worker_lane_masks.get(&worker_id).copied() else {
+                    tracing::warn!(
+                        worker_id,
+                        event_id,
+                        "CKF event references an unknown worker"
+                    );
+                    return Err(KvCacheEventError::InvalidBlockSequence);
+                };
+                for (lane, state) in states.iter_mut().enumerate() {
+                    if mask & (1u16 << lane) == 0 {
+                        continue;
+                    }
+                    self.clear_lane(lane, |dirty| on_dirty(lane, dirty));
+                    *state = None;
+                }
+                Ok(())
+            }
+        }
+    }
+
+    fn lane_for(
+        &self,
+        worker: WorkerWithDpRank,
+        event_id: u64,
+    ) -> Result<usize, KvCacheEventError> {
+        let Some(lane) = self.worker_to_lane.get(&worker).copied() else {
+            tracing::warn!(
+                worker_id = worker.worker_id,
+                dp_rank = worker.dp_rank,
+                event_id,
+                "CKF event references an unknown worker/rank"
+            );
+            return Err(KvCacheEventError::InvalidBlockSequence);
+        };
+        Ok(lane)
+    }
+
+    fn ensure_state<'a>(
+        &self,
+        states: &'a mut [Option<DcWriterState>; DC_COUNT],
+        lane: usize,
+    ) -> Result<&'a mut DcWriterState, KvCacheEventError> {
+        if states[lane].is_none() {
+            states[lane] = Some(DcWriterState::new(
+                self.config.expected_blocks_per_dc,
+                self.config.max_kicks,
+                lane_rng_seed(self.config.seed, lane),
+            )?);
+        }
+        states[lane]
+            .as_mut()
+            .ok_or(KvCacheEventError::IndexerInvariantViolation)
+    }
+
+    fn clear_lane(&self, lane: usize, mut on_dirty: impl FnMut(DirtyBucket)) {
+        let view = self.table.lane(lane);
+        for bucket in 0..view.bucket_count() {
+            let before = view.load_bucket(bucket);
+            if before == PackedBucket::default() {
+                continue;
+            }
+            view.store_bucket(bucket, PackedBucket::default());
+            on_dirty(DirtyBucket {
+                bucket,
+                value: PackedBucket::default(),
+            });
+        }
+    }
+
+    fn clear_worker(&self, states: &mut [Option<DcWriterState>; DC_COUNT], worker_id: WorkerId) {
+        let Some(mask) = self.worker_lane_masks.get(&worker_id).copied() else {
+            return;
+        };
+        for (lane, state) in states.iter_mut().enumerate() {
+            if mask & (1u16 << lane) != 0 {
+                self.clear_lane(lane, |_| {});
+                *state = None;
+            }
+        }
+    }
+
+    fn clear_worker_rank(
+        &self,
+        states: &mut [Option<DcWriterState>; DC_COUNT],
+        worker: WorkerWithDpRank,
+    ) {
+        let Some(lane) = self.worker_to_lane.get(&worker).copied() else {
+            return;
+        };
+        self.clear_lane(lane, |_| {});
+        states[lane] = None;
+    }
+
+    fn worker_stats(&self, states: &[Option<DcWriterState>; DC_COUNT]) -> WorkerLookupStats {
+        WorkerLookupStats::from_worker_block_counts(states.iter().enumerate().filter_map(
+            |(lane, state)| {
+                state
+                    .as_ref()
+                    .map(|state| (self.workers[lane], state.resident.len()))
+            },
+        ))
+    }
+
+    pub(super) fn prepared_probes(
+        &self,
+        sequence: &[LocalBlockHash],
+    ) -> Vec<super::addressing::CkfProbe> {
+        compute_seq_hash_for_block(sequence)
+            .into_iter()
+            .map(|hash| self.addressing.prepare(hash))
+            .collect()
+    }
+
+    #[cfg(any(test, feature = "bench"))]
+    #[allow(dead_code)]
+    pub(super) fn linear_depths(&self, probes: &[super::addressing::CkfProbe]) -> [u32; DC_COUNT] {
+        linear_prefix_depths(probes.len(), u16::MAX, |position| {
+            self.table.probe(probes[position])
+        })
+    }
+}
+
+impl SyncIndexer for EventTransposedCkfIndexer {
+    fn worker(
+        &self,
+        event_receiver: flume::Receiver<WorkerTask>,
+        metrics: Option<Arc<KvIndexerMetrics>>,
+    ) -> anyhow::Result<()> {
+        let mut states: [Option<DcWriterState>; DC_COUNT] = std::array::from_fn(|_| None);
+        let counters = metrics.as_ref().map(|metrics| metrics.prebind());
+        #[cfg(feature = "bench")]
+        let mut observation = WorkerObservationState::default();
+
+        while let Ok(task) = event_receiver.recv() {
+            match task {
+                WorkerTask::Event(event) => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut states, event, counters.as_ref());
+                    record_worker_event_result(counters.as_ref(), kind, result);
+                }
+                WorkerTask::EventWithAck { event, resp } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut states, event, counters.as_ref());
+                    let applied = record_worker_event_result(counters.as_ref(), kind, result);
+                    let _ = resp.send(applied);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::InstallObservation { writer, resp } => {
+                    observation.install(writer, resp);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::ObservedEvent {
+                    event,
+                    correlation_id,
+                } => {
+                    let kind = EventKind::of(&event.event.data);
+                    let result = self.apply_event(&mut states, event, counters.as_ref());
+                    let applied = record_worker_event_result(counters.as_ref(), kind, result);
+                    observation.record(correlation_id, applied);
+                }
+                #[cfg(feature = "bench")]
+                WorkerTask::SealObservation(resp) => observation.seal(resp),
+                #[cfg(feature = "bench")]
+                WorkerTask::HarvestObservation(resp) => observation.harvest(resp),
+                WorkerTask::Anchor { worker, anchor } => {
+                    if let Err(error) = self.apply_anchor(worker, anchor) {
+                        tracing::warn!(?error, "CKF does not support structural anchors");
+                    }
+                }
+                WorkerTask::RemoveWorker { worker_id, .. } => {
+                    self.clear_worker(&mut states, worker_id);
+                }
+                WorkerTask::RemoveWorkerDpRank {
+                    worker_id, dp_rank, ..
+                } => {
+                    self.clear_worker_rank(&mut states, WorkerWithDpRank::new(worker_id, dp_rank));
+                }
+                WorkerTask::CleanupStaleChildren => {}
+                WorkerTask::DumpEvents(sender) => {
+                    let _ = sender.send(Err(anyhow::anyhow!(
+                        "CKF cannot reconstruct stored router events"
+                    )));
+                }
+                WorkerTask::Stats(sender) => {
+                    let _ = sender.send(self.worker_stats(&states));
+                }
+                WorkerTask::Flush(sender) => {
+                    let _ = sender.send(());
+                }
+                WorkerTask::Terminate => break,
+            }
+        }
+
+        tracing::debug!("EventTransposedCkfIndexer worker thread shutting down");
+        Ok(())
+    }
+
+    fn find_matches(&self, sequence: &[LocalBlockHash], _early_exit: bool) -> OverlapScores {
+        if sequence.is_empty() {
+            return OverlapScores::new();
+        }
+
+        let probes = self.prepared_probes(sequence);
+        let depths = find_prefix_depths::<DC_COUNT>(
+            probes.len(),
+            u16::MAX,
+            self.config.search.verification_window,
+            |position| self.table.prefetch_probe(probes[position]),
+            |position| self.table.probe(probes[position]),
+        );
+
+        let mut scores = OverlapScores::new();
+        scores
+            .scores
+            .reserve(depths.iter().filter(|&&depth| depth > 0).count());
+        for (lane, depth) in depths.into_iter().enumerate() {
+            if depth > 0 {
+                scores.scores.insert(self.workers[lane], depth);
+            }
+        }
+        scores
+    }
+
+    fn supports_event_dump(&self) -> bool {
+        false
+    }
+
+    fn supports_routing_decision_pruning(&self) -> bool {
+        false
+    }
+}
+
+fn validate_config(config: CkfConfig) -> Result<(), CkfBuildError> {
+    if config.expected_blocks_per_dc == 0 {
+        return Err(CkfBuildError::ExpectedCapacityZero);
+    }
+    if !(1..=MAX_KICKS).contains(&config.max_kicks) {
+        return Err(CkfBuildError::InvalidMaxKicks {
+            value: config.max_kicks,
+            maximum: MAX_KICKS,
+        });
+    }
+    if !(1..=MAX_VERIFICATION_WINDOW).contains(&config.search.verification_window) {
+        return Err(CkfBuildError::InvalidVerificationWindow {
+            value: config.search.verification_window,
+        });
+    }
+    Ok(())
+}
+
+pub(super) fn bucket_count(expected_blocks_per_dc: usize) -> Result<usize, CkfBuildError> {
+    let numerator = expected_blocks_per_dc
+        .checked_mul(5)
+        .and_then(|value| value.checked_add(15))
+        .ok_or(CkfBuildError::CapacityOverflow)?;
+    let required = (numerator / 16).max(2);
+    required
+        .checked_next_power_of_two()
+        .ok_or(CkfBuildError::CapacityOverflow)
+}
+
+fn retain_first_error(slot: &mut Option<KvCacheEventError>, error: KvCacheEventError) {
+    if slot.is_none() {
+        *slot = Some(error);
+    }
+}
+
+fn finish_event(error: Option<KvCacheEventError>) -> Result<(), KvCacheEventError> {
+    match error {
+        Some(error) => Err(error),
+        None => Ok(()),
+    }
+}
+
+fn record_worker_event_result(
+    counters: Option<&PreBoundEventCounters>,
+    kind: EventKind,
+    result: Result<(), KvCacheEventError>,
+) -> bool {
+    let applied = result.is_ok();
+    if let Err(error) = result.as_ref() {
+        tracing::warn!(?error, "Failed to apply CKF event");
+    }
+    if let Some(counters) = counters {
+        counters.inc(kind, result);
+    }
+    applied
+}

--- a/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
+++ b/lib/kv-router/src/indexer/cuckoo/event_indexer.rs
@@ -3,279 +3,95 @@
 
 use std::sync::Arc;
 
-use rustc_hash::FxHashMap;
+use rustc_hash::FxHashSet;
 
 #[cfg(feature = "metrics")]
 use crate::indexer::PreBoundCkfSearchCounters;
 #[cfg(feature = "bench")]
 use crate::indexer::WorkerObservationState;
 use crate::indexer::{
-    EventKind, EventWarningKind, KvIndexerMetrics, PreBoundEventCounters, SyncIndexer,
-    WorkerLookupStats, WorkerTask,
+    CkfMutationKind, EventKind, EventWarningKind, KvIndexerMetrics, PreBoundEventCounters,
+    SyncIndexer, WorkerTask,
 };
-use crate::protocols::{
-    KvCacheEventData, KvCacheEventError, LocalBlockHash, OverlapScores, RouterEvent, WorkerId,
-    WorkerWithDpRank, compute_seq_hash_for_block,
-};
+#[cfg(test)]
+use crate::protocols::RouterEvent;
+use crate::protocols::{KvCacheEventError, LocalBlockHash, OverlapScores, WorkerWithDpRank};
 
-use super::addressing::CkfAddressing;
-use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
-use super::mutator::{CuckooMutator, DcWriterState, DirtyBucket, lane_rng_seed};
+#[cfg(test)]
+use super::CkfDeltaBatch;
+#[cfg(feature = "bench")]
+use super::relay::CkfBenchLocalTelemetry;
 #[cfg(not(feature = "metrics"))]
 use super::search::find_prefix_depths;
 #[cfg(feature = "metrics")]
 use super::search::find_prefix_depths_with_stats;
 #[cfg(any(test, feature = "bench"))]
 use super::search::linear_prefix_depths;
-use super::{CkfBuildError, CkfConfig, DC_COUNT, MAX_KICKS, MAX_VERIFICATION_WINDOW};
+use super::{
+    CkfBuildError, CkfConfig, CkfEventOutcome, DC_COUNT, RelayManifest, RouterLocalCkfPipeline,
+};
+
+#[cfg(test)]
+pub(super) use super::bucket_count;
 
 /// Fixed-D=16 event-driven transposed Cuckoo-filter indexer.
 #[derive(Debug)]
 pub struct EventTransposedCkfIndexer {
-    pub(super) table: TransposedCkfTable<DC_COUNT>,
-    pub(super) addressing: CkfAddressing,
+    pub(super) pipeline: RouterLocalCkfPipeline,
     workers: [WorkerWithDpRank; DC_COUNT],
-    worker_to_lane: FxHashMap<WorkerWithDpRank, usize>,
-    worker_lane_masks: FxHashMap<WorkerId, u16>,
-    pub(super) config: CkfConfig,
     #[cfg(feature = "metrics")]
     search_counters: Option<PreBoundCkfSearchCounters>,
 }
 
 impl EventTransposedCkfIndexer {
-    /// Construct an indexer with one immutable lane assignment per worker/rank.
+    /// Construct the normal one-worker/rank-per-lane specialization.
     pub fn new(
         workers: [WorkerWithDpRank; DC_COUNT],
         config: CkfConfig,
     ) -> Result<Self, CkfBuildError> {
-        validate_config(config)?;
-        let bucket_count = bucket_count(config.expected_blocks_per_dc)?;
-
-        let mut worker_to_lane = FxHashMap::default();
-        worker_to_lane
-            .try_reserve(DC_COUNT)
-            .map_err(|_| CkfBuildError::AllocationFailed)?;
-        let mut worker_lane_masks = FxHashMap::default();
-        worker_lane_masks
-            .try_reserve(DC_COUNT)
-            .map_err(|_| CkfBuildError::AllocationFailed)?;
-        for (lane, worker) in workers.iter().copied().enumerate() {
-            if worker_to_lane.insert(worker, lane).is_some() {
-                return Err(CkfBuildError::DuplicateWorker { worker });
-            }
-            *worker_lane_masks.entry(worker.worker_id).or_insert(0) |= 1u16 << lane;
-        }
-
+        let manifest = RelayManifest::one_worker_per_lane(workers, config.expected_blocks_per_dc)?;
         Ok(Self {
-            table: TransposedCkfTable::new(bucket_count)?,
-            addressing: CkfAddressing::new(bucket_count, config.seed),
+            pipeline: RouterLocalCkfPipeline::new(manifest, config)?,
             workers,
-            worker_to_lane,
-            worker_lane_masks,
-            config,
             #[cfg(feature = "metrics")]
             search_counters: None,
         })
     }
 
+    #[cfg(test)]
     pub(super) fn apply_event(
         &self,
-        states: &mut [Option<DcWriterState>; DC_COUNT],
         event: RouterEvent,
         counters: Option<&PreBoundEventCounters>,
     ) -> Result<(), KvCacheEventError> {
-        self.apply_event_with_dirty(states, event, counters, |_, _| {})
+        let kind = EventKind::of(&event.event.data);
+        let mut batch = self.pipeline.new_batch();
+        let outcome = self.pipeline.apply_event(event, &mut batch);
+        record_worker_event_result(counters, kind, outcome)
     }
 
-    pub(super) fn apply_event_with_dirty(
+    #[cfg(test)]
+    pub(super) fn apply_event_with_batch(
         &self,
-        states: &mut [Option<DcWriterState>; DC_COUNT],
         event: RouterEvent,
-        counters: Option<&PreBoundEventCounters>,
-        mut on_dirty: impl FnMut(usize, DirtyBucket),
-    ) -> Result<(), KvCacheEventError> {
-        let worker_id = event.worker_id;
-        let event_id = event.event.event_id;
-        let worker = WorkerWithDpRank::new(worker_id, event.event.dp_rank);
-        match event.event.data {
-            KvCacheEventData::Stored(store) => {
-                let lane = self.lane_for(worker, event_id)?;
-                if store.blocks.is_empty() {
-                    return Ok(());
-                }
-                let state = self.ensure_state(states, lane)?;
-                let mut first_error = None;
-                let mut entirely_duplicate = true;
-                for block in store.blocks {
-                    if !state.resident.insert(block.block_hash) {
-                        continue;
-                    }
-                    entirely_duplicate = false;
-                    let view = self.table.lane(lane);
-                    let mutator =
-                        CuckooMutator::new(&view, &self.addressing, self.config.max_kicks);
-                    let result = mutator.insert(
-                        block.block_hash,
-                        &mut state.rng,
-                        &mut state.scratch,
-                        |dirty| on_dirty(lane, dirty),
-                    );
-                    if let Err(error) = result {
-                        let removed = state.resident.remove(&block.block_hash);
-                        debug_assert!(removed);
-                        retain_first_error(&mut first_error, error);
-                    }
-                }
-                if entirely_duplicate && let Some(counters) = counters {
-                    counters.inc_warning(EventWarningKind::DuplicateStore);
-                }
-                finish_event(first_error)
-            }
-            KvCacheEventData::Removed(remove) => {
-                let lane = self.lane_for(worker, event_id)?;
-                let mut first_error = None;
-                for hash in remove.block_hashes {
-                    let Some(state) = states[lane].as_mut() else {
-                        retain_first_error(&mut first_error, KvCacheEventError::BlockNotFound);
-                        continue;
-                    };
-                    if !state.resident.remove(&hash) {
-                        retain_first_error(&mut first_error, KvCacheEventError::BlockNotFound);
-                        continue;
-                    }
-                    let view = self.table.lane(lane);
-                    let mutator =
-                        CuckooMutator::new(&view, &self.addressing, self.config.max_kicks);
-                    match mutator.remove(hash, |dirty| on_dirty(lane, dirty)) {
-                        Ok(()) => {}
-                        Err(error) => {
-                            let inserted = state.resident.insert(hash);
-                            debug_assert!(inserted);
-                            retain_first_error(&mut first_error, error);
-                        }
-                    }
-                }
-                finish_event(first_error)
-            }
-            KvCacheEventData::Cleared => {
-                let Some(mask) = self.worker_lane_masks.get(&worker_id).copied() else {
-                    tracing::warn!(
-                        worker_id,
-                        event_id,
-                        "CKF event references an unknown worker"
-                    );
-                    return Err(KvCacheEventError::InvalidBlockSequence);
-                };
-                for (lane, state) in states.iter_mut().enumerate() {
-                    if mask & (1u16 << lane) == 0 {
-                        continue;
-                    }
-                    self.clear_lane(lane, |dirty| on_dirty(lane, dirty));
-                    *state = None;
-                }
-                Ok(())
-            }
-        }
+        batch: &mut CkfDeltaBatch,
+    ) -> CkfEventOutcome {
+        self.pipeline.apply_event(event, batch)
     }
 
-    fn lane_for(
-        &self,
-        worker: WorkerWithDpRank,
-        event_id: u64,
-    ) -> Result<usize, KvCacheEventError> {
-        let Some(lane) = self.worker_to_lane.get(&worker).copied() else {
-            tracing::warn!(
-                worker_id = worker.worker_id,
-                dp_rank = worker.dp_rank,
-                event_id,
-                "CKF event references an unknown worker/rank"
-            );
-            return Err(KvCacheEventError::InvalidBlockSequence);
-        };
-        Ok(lane)
-    }
-
-    fn ensure_state<'a>(
-        &self,
-        states: &'a mut [Option<DcWriterState>; DC_COUNT],
-        lane: usize,
-    ) -> Result<&'a mut DcWriterState, KvCacheEventError> {
-        if states[lane].is_none() {
-            states[lane] = Some(DcWriterState::new(
-                self.config.expected_blocks_per_dc,
-                self.config.max_kicks,
-                lane_rng_seed(self.config.seed, lane),
-            )?);
-        }
-        states[lane]
-            .as_mut()
-            .ok_or(KvCacheEventError::IndexerInvariantViolation)
-    }
-
-    fn clear_lane(&self, lane: usize, mut on_dirty: impl FnMut(DirtyBucket)) {
-        let view = self.table.lane(lane);
-        for bucket in 0..view.bucket_count() {
-            let before = view.load_bucket(bucket);
-            if before == PackedBucket::default() {
-                continue;
-            }
-            view.store_bucket(bucket, PackedBucket::default());
-            on_dirty(DirtyBucket {
-                bucket,
-                value: PackedBucket::default(),
-            });
-        }
-    }
-
-    fn clear_worker(&self, states: &mut [Option<DcWriterState>; DC_COUNT], worker_id: WorkerId) {
-        let Some(mask) = self.worker_lane_masks.get(&worker_id).copied() else {
-            return;
-        };
-        for (lane, state) in states.iter_mut().enumerate() {
-            if mask & (1u16 << lane) != 0 {
-                self.clear_lane(lane, |_| {});
-                *state = None;
-            }
-        }
-    }
-
-    fn clear_worker_rank(
-        &self,
-        states: &mut [Option<DcWriterState>; DC_COUNT],
-        worker: WorkerWithDpRank,
-    ) {
-        let Some(lane) = self.worker_to_lane.get(&worker).copied() else {
-            return;
-        };
-        self.clear_lane(lane, |_| {});
-        states[lane] = None;
-    }
-
-    fn worker_stats(&self, states: &[Option<DcWriterState>; DC_COUNT]) -> WorkerLookupStats {
-        WorkerLookupStats::from_worker_block_counts(states.iter().enumerate().filter_map(
-            |(lane, state)| {
-                state
-                    .as_ref()
-                    .map(|state| (self.workers[lane], state.resident.len()))
-            },
-        ))
-    }
-
+    #[cfg(test)]
     pub(super) fn prepared_probes(
         &self,
         sequence: &[LocalBlockHash],
     ) -> Vec<super::addressing::CkfProbe> {
-        compute_seq_hash_for_block(sequence)
-            .into_iter()
-            .map(|hash| self.addressing.prepare(hash))
-            .collect()
+        self.pipeline.replica().prepared_probes(sequence)
     }
 
     #[cfg(any(test, feature = "bench"))]
     #[allow(dead_code)]
     pub(super) fn linear_depths(&self, probes: &[super::addressing::CkfProbe]) -> [u32; DC_COUNT] {
         linear_prefix_depths(probes.len(), u16::MAX, |position| {
-            self.table.probe(probes[position])
+            self.pipeline.replica().table.probe(probes[position])
         })
     }
 }
@@ -295,22 +111,32 @@ impl SyncIndexer for EventTransposedCkfIndexer {
         event_receiver: flume::Receiver<WorkerTask>,
         metrics: Option<Arc<KvIndexerMetrics>>,
     ) -> anyhow::Result<()> {
-        let mut states: [Option<DcWriterState>; DC_COUNT] = std::array::from_fn(|_| None);
         let counters = metrics.as_ref().map(|metrics| metrics.prebind());
+        let mut batch = self.pipeline.new_batch();
+        let mut seen_worker_ids = FxHashSet::default();
         #[cfg(feature = "bench")]
         let mut observation = WorkerObservationState::default();
+        #[cfg(feature = "bench")]
+        let mut bench_telemetry = CkfBenchLocalTelemetry::default();
 
         while let Ok(task) = event_receiver.recv() {
             match task {
                 WorkerTask::Event(event) => {
+                    seen_worker_ids.insert(event.worker_id);
                     let kind = EventKind::of(&event.event.data);
-                    let result = self.apply_event(&mut states, event, counters.as_ref());
-                    record_worker_event_result(counters.as_ref(), kind, result);
+                    let outcome = self.pipeline.apply_event(event, &mut batch);
+                    #[cfg(feature = "bench")]
+                    bench_telemetry.absorb_outcome(&outcome);
+                    let _ = record_worker_event_result(counters.as_ref(), kind, outcome);
                 }
                 WorkerTask::EventWithAck { event, resp } => {
+                    seen_worker_ids.insert(event.worker_id);
                     let kind = EventKind::of(&event.event.data);
-                    let result = self.apply_event(&mut states, event, counters.as_ref());
-                    let applied = record_worker_event_result(counters.as_ref(), kind, result);
+                    let outcome = self.pipeline.apply_event(event, &mut batch);
+                    #[cfg(feature = "bench")]
+                    bench_telemetry.absorb_outcome(&outcome);
+                    let applied =
+                        record_worker_event_result(counters.as_ref(), kind, outcome).is_ok();
                     let _ = resp.send(applied);
                 }
                 #[cfg(feature = "bench")]
@@ -322,9 +148,12 @@ impl SyncIndexer for EventTransposedCkfIndexer {
                     event,
                     correlation_id,
                 } => {
+                    seen_worker_ids.insert(event.worker_id);
                     let kind = EventKind::of(&event.event.data);
-                    let result = self.apply_event(&mut states, event, counters.as_ref());
-                    let applied = record_worker_event_result(counters.as_ref(), kind, result);
+                    let outcome = self.pipeline.apply_event(event, &mut batch);
+                    bench_telemetry.absorb_outcome(&outcome);
+                    let applied =
+                        record_worker_event_result(counters.as_ref(), kind, outcome).is_ok();
                     observation.record(correlation_id, applied);
                 }
                 #[cfg(feature = "bench")]
@@ -337,12 +166,22 @@ impl SyncIndexer for EventTransposedCkfIndexer {
                     }
                 }
                 WorkerTask::RemoveWorker { worker_id, .. } => {
-                    self.clear_worker(&mut states, worker_id);
+                    seen_worker_ids.insert(worker_id);
+                    let outcome = self.pipeline.remove_worker(worker_id, &mut batch);
+                    #[cfg(feature = "bench")]
+                    bench_telemetry.absorb_outcome(&outcome);
+                    record_control_result(counters.as_ref(), outcome);
                 }
                 WorkerTask::RemoveWorkerDpRank {
                     worker_id, dp_rank, ..
                 } => {
-                    self.clear_worker_rank(&mut states, WorkerWithDpRank::new(worker_id, dp_rank));
+                    seen_worker_ids.insert(worker_id);
+                    let outcome = self
+                        .pipeline
+                        .remove_worker_rank(WorkerWithDpRank::new(worker_id, dp_rank), &mut batch);
+                    #[cfg(feature = "bench")]
+                    bench_telemetry.absorb_outcome(&outcome);
+                    record_control_result(counters.as_ref(), outcome);
                 }
                 WorkerTask::CleanupStaleChildren => {}
                 WorkerTask::DumpEvents(sender) => {
@@ -351,14 +190,53 @@ impl SyncIndexer for EventTransposedCkfIndexer {
                     )));
                 }
                 WorkerTask::Stats(sender) => {
-                    let _ = sender.send(self.worker_stats(&states));
+                    let _ = sender.send(self.pipeline.worker_stats(&seen_worker_ids));
                 }
                 WorkerTask::Flush(sender) => {
+                    #[cfg(feature = "bench")]
+                    let result = self
+                        .pipeline
+                        .flush_pending_with_telemetry(&mut batch, &mut bench_telemetry);
+                    #[cfg(not(feature = "bench"))]
+                    let result = self.pipeline.flush_pending(&mut batch);
+                    if let Err(error) = result {
+                        tracing::warn!(?error, "Failed to flush pending CKF publication");
+                    }
+                    #[cfg(feature = "bench")]
+                    self.pipeline.merge_bench_telemetry(&mut bench_telemetry);
                     let _ = sender.send(());
                 }
-                WorkerTask::Terminate => break,
+                WorkerTask::Terminate => {
+                    #[cfg(feature = "bench")]
+                    let result = self
+                        .pipeline
+                        .flush_pending_with_telemetry(&mut batch, &mut bench_telemetry);
+                    #[cfg(not(feature = "bench"))]
+                    let result = self.pipeline.flush_pending(&mut batch);
+                    if let Err(error) = result {
+                        tracing::warn!(?error, "Failed to flush CKF publication at termination");
+                    }
+                    #[cfg(feature = "bench")]
+                    self.pipeline.merge_bench_telemetry(&mut bench_telemetry);
+                    break;
+                }
             }
         }
+
+        #[cfg(feature = "bench")]
+        let result = self
+            .pipeline
+            .flush_pending_with_telemetry(&mut batch, &mut bench_telemetry);
+        #[cfg(not(feature = "bench"))]
+        let result = self.pipeline.flush_pending(&mut batch);
+        if let Err(error) = result {
+            tracing::warn!(
+                ?error,
+                "Failed to flush CKF publication at receiver closure"
+            );
+        }
+        #[cfg(feature = "bench")]
+        self.pipeline.merge_bench_telemetry(&mut bench_telemetry);
 
         tracing::debug!("EventTransposedCkfIndexer worker thread shutting down");
         Ok(())
@@ -369,23 +247,24 @@ impl SyncIndexer for EventTransposedCkfIndexer {
             return OverlapScores::new();
         }
 
-        let probes = self.prepared_probes(sequence);
+        let replica = self.pipeline.replica();
+        let probes = replica.prepared_probes(sequence);
         #[cfg(not(feature = "metrics"))]
         let depths = find_prefix_depths::<DC_COUNT>(
             probes.len(),
             u16::MAX,
-            self.config.search.verification_window,
-            |position| self.table.prefetch_probe(probes[position]),
-            |position| self.table.probe(probes[position]),
+            replica.config.search.verification_window,
+            |position| replica.table.prefetch_probe(probes[position]),
+            |position| replica.table.probe(probes[position]),
         );
         #[cfg(feature = "metrics")]
         let depths = {
             let result = find_prefix_depths_with_stats::<DC_COUNT>(
                 probes.len(),
                 u16::MAX,
-                self.config.search.verification_window,
-                |position| self.table.prefetch_probe(probes[position]),
-                |position| self.table.probe(probes[position]),
+                replica.config.search.verification_window,
+                |position| replica.table.prefetch_probe(probes[position]),
+                |position| replica.table.probe(probes[position]),
             );
             if let Some(counters) = &self.search_counters {
                 counters.record(
@@ -418,61 +297,52 @@ impl SyncIndexer for EventTransposedCkfIndexer {
     fn supports_routing_decision_pruning(&self) -> bool {
         false
     }
-}
 
-fn validate_config(config: CkfConfig) -> Result<(), CkfBuildError> {
-    if config.expected_blocks_per_dc == 0 {
-        return Err(CkfBuildError::ExpectedCapacityZero);
-    }
-    if !(1..=MAX_KICKS).contains(&config.max_kicks) {
-        return Err(CkfBuildError::InvalidMaxKicks {
-            value: config.max_kicks,
-            maximum: MAX_KICKS,
-        });
-    }
-    if !(1..=MAX_VERIFICATION_WINDOW).contains(&config.search.verification_window) {
-        return Err(CkfBuildError::InvalidVerificationWindow {
-            value: config.search.verification_window,
-        });
-    }
-    Ok(())
-}
-
-pub(super) fn bucket_count(expected_blocks_per_dc: usize) -> Result<usize, CkfBuildError> {
-    let numerator = expected_blocks_per_dc
-        .checked_mul(5)
-        .and_then(|value| value.checked_add(15))
-        .ok_or(CkfBuildError::CapacityOverflow)?;
-    let required = (numerator / 16).max(2);
-    required
-        .checked_next_power_of_two()
-        .ok_or(CkfBuildError::CapacityOverflow)
-}
-
-fn retain_first_error(slot: &mut Option<KvCacheEventError>, error: KvCacheEventError) {
-    if slot.is_none() {
-        *slot = Some(error);
-    }
-}
-
-fn finish_event(error: Option<KvCacheEventError>) -> Result<(), KvCacheEventError> {
-    match error {
-        Some(error) => Err(error),
-        None => Ok(()),
+    fn timing_report(&self) -> String {
+        #[cfg(feature = "bench")]
+        {
+            self.pipeline.timing_report()
+        }
+        #[cfg(not(feature = "bench"))]
+        {
+            String::new()
+        }
     }
 }
 
 fn record_worker_event_result(
     counters: Option<&PreBoundEventCounters>,
     kind: EventKind,
-    result: Result<(), KvCacheEventError>,
-) -> bool {
-    let applied = result.is_ok();
+    outcome: CkfEventOutcome,
+) -> Result<(), KvCacheEventError> {
+    if let Some(counters) = counters {
+        counters.inc_ckf_mutation(CkfMutationKind::UnknownRemove, outcome.unknown_removals());
+        counters.inc_ckf_mutation(
+            CkfMutationKind::CapacityExhausted,
+            outcome.capacity_failures(),
+        );
+        if outcome.duplicate_warning() {
+            counters.inc_warning(EventWarningKind::DuplicateStore);
+        }
+    }
+    let result = outcome.into_result();
     if let Err(error) = result.as_ref() {
         tracing::warn!(?error, "Failed to apply CKF event");
     }
     if let Some(counters) = counters {
         counters.inc(kind, result);
     }
-    applied
+    result
+}
+
+fn record_control_result(counters: Option<&PreBoundEventCounters>, outcome: CkfEventOutcome) {
+    if let Some(counters) = counters {
+        counters.inc_ckf_mutation(
+            CkfMutationKind::CapacityExhausted,
+            outcome.capacity_failures(),
+        );
+    }
+    if let Err(error) = outcome.into_result() {
+        tracing::warn!(?error, "Failed to apply CKF lifecycle operation");
+    }
 }

--- a/lib/kv-router/src/indexer/cuckoo/mutator.rs
+++ b/lib/kv-router/src/indexer/cuckoo/mutator.rs
@@ -1,0 +1,217 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use rustc_hash::FxHashSet;
+
+use super::addressing::CkfAddressing;
+use super::bucket::{CuckooBucketStore, PackedBucket};
+use crate::protocols::{ExternalSequenceBlockHash, KvCacheEventError};
+
+const SPLITMIX_INCREMENT: u64 = 0x9E37_79B9_7F4A_7C15;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct DirtyBucket {
+    pub(super) bucket: usize,
+    pub(super) value: PackedBucket,
+}
+
+pub(super) struct CuckooInsertionScratch {
+    touched: Vec<(usize, PackedBucket)>,
+    dirty_buckets: Vec<usize>,
+}
+
+impl CuckooInsertionScratch {
+    pub(super) fn new(max_kicks: usize) -> Result<Self, KvCacheEventError> {
+        let capacity = max_kicks
+            .checked_add(1)
+            .ok_or(KvCacheEventError::CapacityExhausted)?;
+        let mut touched = Vec::new();
+        let mut dirty_buckets = Vec::new();
+        touched
+            .try_reserve_exact(capacity)
+            .map_err(|_| KvCacheEventError::CapacityExhausted)?;
+        dirty_buckets
+            .try_reserve_exact(capacity)
+            .map_err(|_| KvCacheEventError::CapacityExhausted)?;
+        Ok(Self {
+            touched,
+            dirty_buckets,
+        })
+    }
+
+    fn clear(&mut self) {
+        self.touched.clear();
+        self.dirty_buckets.clear();
+    }
+}
+
+pub(super) struct DcWriterState {
+    pub(super) resident: FxHashSet<ExternalSequenceBlockHash>,
+    pub(super) rng: u64,
+    pub(super) scratch: CuckooInsertionScratch,
+}
+
+impl DcWriterState {
+    pub(super) fn new(
+        expected_blocks: usize,
+        max_kicks: usize,
+        rng: u64,
+    ) -> Result<Self, KvCacheEventError> {
+        let mut resident = FxHashSet::default();
+        resident
+            .try_reserve(expected_blocks)
+            .map_err(|_| KvCacheEventError::CapacityExhausted)?;
+        Ok(Self {
+            resident,
+            rng,
+            scratch: CuckooInsertionScratch::new(max_kicks)?,
+        })
+    }
+}
+
+pub(super) struct CuckooMutator<'a, S> {
+    store: &'a S,
+    addressing: &'a CkfAddressing,
+    max_kicks: usize,
+}
+
+impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
+    pub(super) fn new(store: &'a S, addressing: &'a CkfAddressing, max_kicks: usize) -> Self {
+        Self {
+            store,
+            addressing,
+            max_kicks,
+        }
+    }
+
+    pub(super) fn insert(
+        &self,
+        hash: ExternalSequenceBlockHash,
+        rng: &mut u64,
+        scratch: &mut CuckooInsertionScratch,
+        mut on_dirty: impl FnMut(DirtyBucket),
+    ) -> Result<(), KvCacheEventError> {
+        debug_assert!(self.store.bucket_count().is_power_of_two());
+        scratch.clear();
+        let probe = self.addressing.prepare(hash.0);
+
+        if self.insert_into_empty(probe.bucket_a, probe.fingerprint, scratch)
+            || self.insert_into_empty(probe.bucket_b, probe.fingerprint, scratch)
+        {
+            self.emit_final_dirty(scratch, &mut on_dirty);
+            return Ok(());
+        }
+
+        let mut bucket = if next_random(rng) & 1 == 0 {
+            probe.bucket_a
+        } else {
+            probe.bucket_b
+        };
+        let mut fingerprint = probe.fingerprint;
+
+        for _ in 0..self.max_kicks {
+            let before = self.store.load_bucket(bucket);
+            let slot = (next_random(rng) as usize) & 3;
+            let evicted = before.slot(slot);
+            self.write(bucket, before, before.with_slot(slot, fingerprint), scratch);
+            fingerprint = evicted;
+            bucket = self.addressing.alternate_bucket(bucket, fingerprint);
+
+            if self.insert_into_empty(bucket, fingerprint, scratch) {
+                self.emit_final_dirty(scratch, &mut on_dirty);
+                return Ok(());
+            }
+        }
+
+        self.rollback(scratch);
+        Err(KvCacheEventError::CapacityExhausted)
+    }
+
+    pub(super) fn remove(
+        &self,
+        hash: ExternalSequenceBlockHash,
+        mut on_dirty: impl FnMut(DirtyBucket),
+    ) -> Result<(), KvCacheEventError> {
+        let probe = self.addressing.prepare(hash.0);
+        for bucket in [probe.bucket_a, probe.bucket_b] {
+            let before = self.store.load_bucket(bucket);
+            let Some(slot) = before.first(probe.fingerprint) else {
+                continue;
+            };
+            let after = before.with_slot(slot, 0);
+            self.store.store_bucket(bucket, after);
+            on_dirty(DirtyBucket {
+                bucket,
+                value: after,
+            });
+            return Ok(());
+        }
+
+        Err(KvCacheEventError::IndexerInvariantViolation)
+    }
+
+    fn insert_into_empty(
+        &self,
+        bucket: usize,
+        fingerprint: u16,
+        scratch: &mut CuckooInsertionScratch,
+    ) -> bool {
+        let before = self.store.load_bucket(bucket);
+        let Some(slot) = before.first_empty() else {
+            return false;
+        };
+        self.write(bucket, before, before.with_slot(slot, fingerprint), scratch);
+        true
+    }
+
+    fn write(
+        &self,
+        bucket: usize,
+        before: PackedBucket,
+        after: PackedBucket,
+        scratch: &mut CuckooInsertionScratch,
+    ) {
+        scratch.touched.push((bucket, before));
+        scratch.dirty_buckets.push(bucket);
+        self.store.store_bucket(bucket, after);
+    }
+
+    fn rollback(&self, scratch: &mut CuckooInsertionScratch) {
+        for &(bucket, before) in scratch.touched.iter().rev() {
+            self.store.store_bucket(bucket, before);
+        }
+        scratch.clear();
+    }
+
+    fn emit_final_dirty(
+        &self,
+        scratch: &mut CuckooInsertionScratch,
+        on_dirty: &mut impl FnMut(DirtyBucket),
+    ) {
+        scratch.dirty_buckets.sort_unstable();
+        scratch.dirty_buckets.dedup();
+        for &bucket in &scratch.dirty_buckets {
+            on_dirty(DirtyBucket {
+                bucket,
+                value: self.store.load_bucket(bucket),
+            });
+        }
+        scratch.clear();
+    }
+}
+
+pub(super) fn lane_rng_seed(seed: u64, lane: usize) -> u64 {
+    let mut state = seed
+        ^ (lane as u64)
+            .wrapping_add(1)
+            .wrapping_mul(SPLITMIX_INCREMENT);
+    next_random(&mut state)
+}
+
+fn next_random(state: &mut u64) -> u64 {
+    *state = state.wrapping_add(SPLITMIX_INCREMENT);
+    let mut value = *state;
+    value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    value ^ (value >> 31)
+}

--- a/lib/kv-router/src/indexer/cuckoo/mutator.rs
+++ b/lib/kv-router/src/indexer/cuckoo/mutator.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
 use rustc_hash::FxHashSet;
 
 use super::addressing::CkfAddressing;
@@ -9,12 +10,14 @@ use crate::protocols::{ExternalSequenceBlockHash, KvCacheEventError};
 
 const SPLITMIX_INCREMENT: u64 = 0x9E37_79B9_7F4A_7C15;
 
+#[cfg(test)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct DirtyBucket {
     pub(super) bucket: usize,
     pub(super) value: PackedBucket,
 }
 
+#[derive(Debug)]
 pub(super) struct CuckooInsertionScratch {
     touched: Vec<(usize, PackedBucket)>,
     dirty_buckets: Vec<usize>,
@@ -43,14 +46,20 @@ impl CuckooInsertionScratch {
         self.touched.clear();
         self.dirty_buckets.clear();
     }
+
+    pub(super) fn capacity(&self) -> usize {
+        self.touched.capacity() + self.dirty_buckets.capacity()
+    }
 }
 
+#[cfg(test)]
 pub(super) struct DcWriterState {
     pub(super) resident: FxHashSet<ExternalSequenceBlockHash>,
     pub(super) rng: u64,
     pub(super) scratch: CuckooInsertionScratch,
 }
 
+#[cfg(test)]
 impl DcWriterState {
     pub(super) fn new(
         expected_blocks: usize,
@@ -84,12 +93,39 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn insert(
         &self,
         hash: ExternalSequenceBlockHash,
         rng: &mut u64,
         scratch: &mut CuckooInsertionScratch,
         mut on_dirty: impl FnMut(DirtyBucket),
+    ) -> Result<(), KvCacheEventError> {
+        self.insert_inner(hash, rng, scratch)?;
+        self.emit_final_dirty(scratch, &mut on_dirty);
+        Ok(())
+    }
+
+    pub(super) fn insert_touched(
+        &self,
+        hash: ExternalSequenceBlockHash,
+        rng: &mut u64,
+        scratch: &mut CuckooInsertionScratch,
+        mut on_touched: impl FnMut(usize),
+    ) -> Result<(), KvCacheEventError> {
+        self.insert_inner(hash, rng, scratch)?;
+        for &bucket in &scratch.dirty_buckets {
+            on_touched(bucket);
+        }
+        scratch.clear();
+        Ok(())
+    }
+
+    fn insert_inner(
+        &self,
+        hash: ExternalSequenceBlockHash,
+        rng: &mut u64,
+        scratch: &mut CuckooInsertionScratch,
     ) -> Result<(), KvCacheEventError> {
         debug_assert!(self.store.bucket_count().is_power_of_two());
         scratch.clear();
@@ -98,7 +134,6 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
         if self.insert_into_empty(probe.bucket_a, probe.fingerprint, scratch)
             || self.insert_into_empty(probe.bucket_b, probe.fingerprint, scratch)
         {
-            self.emit_final_dirty(scratch, &mut on_dirty);
             return Ok(());
         }
 
@@ -118,7 +153,6 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
             bucket = self.addressing.alternate_bucket(bucket, fingerprint);
 
             if self.insert_into_empty(bucket, fingerprint, scratch) {
-                self.emit_final_dirty(scratch, &mut on_dirty);
                 return Ok(());
             }
         }
@@ -127,6 +161,7 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
         Err(KvCacheEventError::CapacityExhausted)
     }
 
+    #[cfg(test)]
     pub(super) fn remove(
         &self,
         hash: ExternalSequenceBlockHash,
@@ -144,6 +179,25 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
                 bucket,
                 value: after,
             });
+            return Ok(());
+        }
+
+        Err(KvCacheEventError::IndexerInvariantViolation)
+    }
+
+    pub(super) fn remove_touched(
+        &self,
+        hash: ExternalSequenceBlockHash,
+        mut on_touched: impl FnMut(usize),
+    ) -> Result<(), KvCacheEventError> {
+        let probe = self.addressing.prepare(hash.0);
+        for bucket in [probe.bucket_a, probe.bucket_b] {
+            let before = self.store.load_bucket(bucket);
+            let Some(slot) = before.first(probe.fingerprint) else {
+                continue;
+            };
+            self.store.store_bucket(bucket, before.with_slot(slot, 0));
+            on_touched(bucket);
             return Ok(());
         }
 
@@ -183,6 +237,7 @@ impl<'a, S: CuckooBucketStore> CuckooMutator<'a, S> {
         scratch.clear();
     }
 
+    #[cfg(test)]
     fn emit_final_dirty(
         &self,
         scratch: &mut CuckooInsertionScratch,

--- a/lib/kv-router/src/indexer/cuckoo/relay.rs
+++ b/lib/kv-router/src/indexer/cuckoo/relay.rs
@@ -1,0 +1,1841 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Router-local validation of the eventual Relay-to-router CKF boundary.
+//!
+//! Publication windows currently close after a configured number of normalized events per
+//! DC lane. Event count is not a wall-clock freshness bound; a distributed publisher will also
+//! need a maximum-time trigger for low-traffic lanes. Its transport envelope must carry a Relay
+//! instance ID, model key, authoritative generation, state sequence, format identity, and a
+//! snapshot/delta/heartbeat kind. Heartbeats do not advance state sequence, gaps require a fresh
+//! complete snapshot, and recovery must validate and atomically publish a fully initialized table.
+//! This module deliberately implements none of that transport, fencing, or recovery machinery.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+#[cfg(feature = "bench")]
+use std::time::Instant;
+
+use parking_lot::{Mutex, MutexGuard};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use crate::indexer::WorkerLookupStats;
+use crate::protocols::{
+    ExternalSequenceBlockHash, KvCacheEventData, KvCacheEventError, RouterEvent, StorageTier,
+    WorkerId, WorkerWithDpRank,
+};
+
+use super::addressing::{CkfAddressing, CkfProbe};
+use super::bucket::{CuckooBucketStore, OwnedPackedCkfLane, PackedBucket, TransposedCkfTable};
+use super::mutator::{CuckooInsertionScratch, CuckooMutator, lane_rng_seed};
+use super::{CkfBuildError, CkfConfig, DC_COUNT, bucket_count, validate_config};
+
+const FORMAT_VERSION: u16 = 1;
+const FINGERPRINT_BITS: u8 = 16;
+const SLOTS_PER_BUCKET: u8 = 4;
+
+#[derive(Debug, Clone)]
+pub struct RelayLaneConfig {
+    members: Vec<WorkerWithDpRank>,
+    expected_contributions: usize,
+}
+
+impl RelayLaneConfig {
+    pub fn new(members: Vec<WorkerWithDpRank>, expected_contributions: usize) -> Self {
+        Self {
+            members,
+            expected_contributions,
+        }
+    }
+
+    pub fn empty() -> Self {
+        Self::new(Vec::new(), 0)
+    }
+
+    pub fn members(&self) -> &[WorkerWithDpRank] {
+        &self.members
+    }
+
+    pub fn expected_contributions(&self) -> usize {
+        self.expected_contributions
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct RelayManifest {
+    lanes: [RelayLaneConfig; DC_COUNT],
+    worker_to_lane: FxHashMap<WorkerWithDpRank, usize>,
+    worker_lane_masks: FxHashMap<WorkerId, u16>,
+    active_lanes: u16,
+}
+
+impl RelayManifest {
+    pub fn new(lanes: [RelayLaneConfig; DC_COUNT]) -> Result<Self, CkfBuildError> {
+        let member_count = lanes.iter().try_fold(0usize, |count, lane| {
+            count
+                .checked_add(lane.members.len())
+                .ok_or(CkfBuildError::CapacityOverflow)
+        })?;
+        let mut worker_to_lane = FxHashMap::default();
+        worker_to_lane
+            .try_reserve(member_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        let mut worker_lane_masks = FxHashMap::default();
+        worker_lane_masks
+            .try_reserve(member_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        let mut active_lanes = 0u16;
+
+        for (lane, config) in lanes.iter().enumerate() {
+            if !config.members.is_empty() {
+                active_lanes |= 1u16 << lane;
+            }
+            for &worker in &config.members {
+                if worker_to_lane.insert(worker, lane).is_some() {
+                    return Err(CkfBuildError::DuplicateWorker { worker });
+                }
+                *worker_lane_masks.entry(worker.worker_id).or_insert(0) |= 1u16 << lane;
+            }
+        }
+
+        Ok(Self {
+            lanes,
+            worker_to_lane,
+            worker_lane_masks,
+            active_lanes,
+        })
+    }
+
+    pub fn one_worker_per_lane(
+        workers: [WorkerWithDpRank; DC_COUNT],
+        expected_contributions: usize,
+    ) -> Result<Self, CkfBuildError> {
+        let mut lanes = Vec::new();
+        lanes
+            .try_reserve_exact(DC_COUNT)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        for worker in workers {
+            let mut members = Vec::new();
+            members
+                .try_reserve_exact(1)
+                .map_err(|_| CkfBuildError::AllocationFailed)?;
+            members.push(worker);
+            lanes.push(RelayLaneConfig::new(members, expected_contributions));
+        }
+        let lanes = lanes
+            .try_into()
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        Self::new(lanes)
+    }
+
+    pub fn lanes(&self) -> &[RelayLaneConfig; DC_COUNT] {
+        &self.lanes
+    }
+
+    fn lane_for(&self, worker: WorkerWithDpRank) -> Option<usize> {
+        self.worker_to_lane.get(&worker).copied()
+    }
+
+    fn lane_mask_for_worker(&self, worker_id: WorkerId) -> Option<u16> {
+        self.worker_lane_masks.get(&worker_id).copied()
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CkfFormatIdentity {
+    format_version: u16,
+    seed: u64,
+    bucket_count: usize,
+    fingerprint_bits: u8,
+    slots_per_bucket: u8,
+    lane_count: u8,
+}
+
+impl CkfFormatIdentity {
+    pub fn format_version(self) -> u16 {
+        self.format_version
+    }
+
+    pub fn seed(self) -> u64 {
+        self.seed
+    }
+
+    pub fn bucket_count(self) -> usize {
+        self.bucket_count
+    }
+
+    pub fn fingerprint_bits(self) -> u8 {
+        self.fingerprint_bits
+    }
+
+    pub fn slots_per_bucket(self) -> u8 {
+        self.slots_per_bucket
+    }
+
+    pub fn lane_count(self) -> u8 {
+        self.lane_count
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CkfBucketImage {
+    lane: u8,
+    bucket: usize,
+    value: u64,
+}
+
+impl CkfBucketImage {
+    pub fn lane(self) -> u8 {
+        self.lane
+    }
+
+    pub fn bucket(self) -> usize {
+        self.bucket
+    }
+
+    pub fn value(self) -> u64 {
+        self.value
+    }
+}
+
+#[derive(Debug)]
+pub struct CkfDeltaBatch {
+    format: CkfFormatIdentity,
+    reset_lanes: u16,
+    images: Vec<CkfBucketImage>,
+}
+
+impl CkfDeltaBatch {
+    pub fn format(&self) -> CkfFormatIdentity {
+        self.format
+    }
+
+    pub fn reset_lanes(&self) -> u16 {
+        self.reset_lanes
+    }
+
+    pub fn images(&self) -> &[CkfBucketImage] {
+        &self.images
+    }
+
+    fn new(format: CkfFormatIdentity) -> Self {
+        Self {
+            format,
+            reset_lanes: 0,
+            images: Vec::new(),
+        }
+    }
+
+    fn reset(&mut self, format: CkfFormatIdentity) {
+        self.format = format;
+        self.reset_lanes = 0;
+        self.images.clear();
+    }
+
+    fn try_reserve(&mut self, additional: usize) -> Result<(), KvCacheEventError> {
+        self.images
+            .try_reserve(additional)
+            .map_err(|_| KvCacheEventError::CapacityExhausted)
+    }
+}
+
+#[derive(Debug)]
+pub struct CkfEventOutcome {
+    first_error: Option<KvCacheEventError>,
+    batch_applied: bool,
+    unknown_removals: u64,
+    capacity_failures: u64,
+    duplicate_warning: bool,
+    #[cfg(feature = "bench")]
+    bench: CkfBenchLocalTelemetry,
+}
+
+impl CkfEventOutcome {
+    pub fn first_error(&self) -> Option<&KvCacheEventError> {
+        self.first_error.as_ref()
+    }
+
+    pub fn batch_applied(&self) -> bool {
+        self.batch_applied
+    }
+
+    pub fn into_result(self) -> Result<(), KvCacheEventError> {
+        match self.first_error {
+            Some(error) => Err(error),
+            None => Ok(()),
+        }
+    }
+
+    pub(super) fn unknown_removals(&self) -> u64 {
+        self.unknown_removals
+    }
+
+    pub(super) fn capacity_failures(&self) -> u64 {
+        self.capacity_failures
+    }
+
+    pub(super) fn duplicate_warning(&self) -> bool {
+        self.duplicate_warning
+    }
+
+    fn success(batch_applied: bool) -> Self {
+        Self {
+            first_error: None,
+            batch_applied,
+            unknown_removals: 0,
+            capacity_failures: 0,
+            duplicate_warning: false,
+            #[cfg(feature = "bench")]
+            bench: CkfBenchLocalTelemetry::default(),
+        }
+    }
+
+    fn failure(error: KvCacheEventError) -> Self {
+        Self {
+            first_error: Some(error),
+            batch_applied: false,
+            unknown_removals: 0,
+            capacity_failures: 0,
+            duplicate_warning: false,
+            #[cfg(feature = "bench")]
+            bench: CkfBenchLocalTelemetry::default(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+pub struct CkfMemorySnapshot {
+    pub configured_unique_capacity: usize,
+    pub configured_contribution_capacity: usize,
+    pub actual_contributions: usize,
+    pub member_set_capacity: usize,
+    pub dc_refcount_capacity: usize,
+    pub owned_filter_bytes: usize,
+    pub replica_bytes: usize,
+    pub dirty_tracking_bytes: usize,
+    pub aggregator_occupancy_bytes: usize,
+    pub replica_occupancy_bytes: usize,
+    pub insertion_scratch_capacity: usize,
+}
+
+#[derive(Debug)]
+struct DirtyBatchScratch {
+    words: Box<[u64]>,
+    buckets: Vec<usize>,
+}
+
+impl DirtyBatchScratch {
+    fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
+        let mut buckets = Vec::new();
+        buckets
+            .try_reserve_exact(bucket_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        Ok(Self {
+            words: zeroed_boxed_slice(bucket_count.div_ceil(u64::BITS as usize))?,
+            buckets,
+        })
+    }
+
+    fn begin_window(&self) {
+        debug_assert!(self.buckets.is_empty());
+    }
+
+    fn mark(&mut self, bucket: usize) {
+        let word = bucket / u64::BITS as usize;
+        let bit = 1u64 << (bucket % u64::BITS as usize);
+        if self.words[word] & bit == 0 {
+            self.words[word] |= bit;
+            self.buckets.push(bucket);
+        }
+    }
+
+    fn len(&self) -> usize {
+        self.buckets.len()
+    }
+
+    fn bucket(&self, index: usize) -> usize {
+        self.buckets[index]
+    }
+
+    fn clear(&mut self) {
+        for &bucket in &self.buckets {
+            let word = bucket / u64::BITS as usize;
+            self.words[word] &= !(1u64 << (bucket % u64::BITS as usize));
+        }
+        self.buckets.clear();
+    }
+
+    fn byte_len(&self) -> usize {
+        std::mem::size_of_val(self.words.as_ref())
+            + self.buckets.capacity() * std::mem::size_of::<usize>()
+    }
+}
+
+#[derive(Debug)]
+struct OccupiedBucketTracker {
+    words: Box<[u64]>,
+}
+
+impl OccupiedBucketTracker {
+    fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
+        Ok(Self {
+            words: zeroed_boxed_slice(bucket_count.div_ceil(u64::BITS as usize))?,
+        })
+    }
+
+    fn set(&mut self, bucket: usize, occupied: bool) {
+        let word = bucket / u64::BITS as usize;
+        let bit = 1u64 << (bucket % u64::BITS as usize);
+        if occupied {
+            self.words[word] |= bit;
+        } else {
+            self.words[word] &= !bit;
+        }
+    }
+
+    fn clear_filter(&mut self, filter: &OwnedPackedCkfLane) {
+        for (word_index, word) in self.words.iter_mut().enumerate() {
+            let mut remaining = *word;
+            while remaining != 0 {
+                let bit = remaining.trailing_zeros() as usize;
+                filter.store_bucket(
+                    word_index * u64::BITS as usize + bit,
+                    PackedBucket::default(),
+                );
+                remaining &= remaining - 1;
+            }
+            *word = 0;
+        }
+    }
+
+    fn byte_len(&self) -> usize {
+        std::mem::size_of_val(self.words.as_ref())
+    }
+}
+
+#[derive(Debug)]
+struct RelayLaneState {
+    member_blocks: FxHashMap<WorkerWithDpRank, FxHashSet<ExternalSequenceBlockHash>>,
+    dc_refcounts: FxHashMap<ExternalSequenceBlockHash, u32>,
+    filter: OwnedPackedCkfLane,
+    rng: u64,
+    insertion_scratch: CuckooInsertionScratch,
+    dirty_scratch: DirtyBatchScratch,
+    occupied_buckets: Option<OccupiedBucketTracker>,
+    member_remove_scratch: Vec<ExternalSequenceBlockHash>,
+    events_since_publish: usize,
+    published_nonempty: bool,
+    physical_touches_pending: u64,
+    #[cfg(feature = "bench")]
+    window_started_at: Option<Instant>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StoreMutation {
+    Duplicate,
+    Changed,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum RemoveMutation {
+    Unknown,
+    Changed,
+}
+
+#[derive(Debug, Default)]
+struct FinalizeImageStats {
+    distinct_touched: u64,
+    emitted_images: u64,
+    net_reverted: u64,
+}
+
+impl RelayLaneState {
+    fn new(
+        lane: usize,
+        lane_config: &RelayLaneConfig,
+        config: CkfConfig,
+        bucket_count: usize,
+        track_occupied: bool,
+    ) -> Result<Self, CkfBuildError> {
+        let member_count = lane_config.members.len();
+        let mut member_blocks = FxHashMap::default();
+        member_blocks
+            .try_reserve(member_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        let share = lane_config
+            .expected_contributions
+            .checked_div(member_count)
+            .unwrap_or(0);
+        let remainder = lane_config
+            .expected_contributions
+            .checked_rem(member_count)
+            .unwrap_or(0);
+        for (member_index, &member) in lane_config.members.iter().enumerate() {
+            let mut blocks = FxHashSet::default();
+            blocks
+                .try_reserve(share + usize::from(member_index < remainder))
+                .map_err(|_| CkfBuildError::AllocationFailed)?;
+            member_blocks.insert(member, blocks);
+        }
+
+        let mut dc_refcounts = FxHashMap::default();
+        dc_refcounts
+            .try_reserve(config.expected_blocks_per_dc)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        let mut member_remove_scratch = Vec::new();
+        member_remove_scratch
+            .try_reserve_exact(lane_config.expected_contributions)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+
+        Ok(Self {
+            member_blocks,
+            dc_refcounts,
+            filter: OwnedPackedCkfLane::new(bucket_count)?,
+            rng: lane_rng_seed(config.seed, lane),
+            insertion_scratch: CuckooInsertionScratch::new(config.max_kicks)
+                .map_err(|_| CkfBuildError::AllocationFailed)?,
+            dirty_scratch: DirtyBatchScratch::new(bucket_count)?,
+            occupied_buckets: track_occupied
+                .then(|| OccupiedBucketTracker::new(bucket_count))
+                .transpose()?,
+            member_remove_scratch,
+            events_since_publish: 0,
+            published_nonempty: false,
+            physical_touches_pending: 0,
+            #[cfg(feature = "bench")]
+            window_started_at: None,
+        })
+    }
+
+    fn advance_event(&mut self) {
+        if self.events_since_publish == 0 {
+            self.dirty_scratch.begin_window();
+            #[cfg(feature = "bench")]
+            {
+                self.window_started_at = Some(Instant::now());
+            }
+        }
+        self.events_since_publish = self.events_since_publish.saturating_add(1);
+    }
+
+    fn publication_due(&self, every_n_events: usize) -> bool {
+        self.events_since_publish >= every_n_events
+    }
+
+    fn has_pending_publication(&self) -> bool {
+        self.events_since_publish != 0
+    }
+
+    fn store(
+        &mut self,
+        worker: WorkerWithDpRank,
+        hash: ExternalSequenceBlockHash,
+        addressing: &CkfAddressing,
+        max_kicks: usize,
+    ) -> Result<StoreMutation, KvCacheEventError> {
+        let Some(member) = self.member_blocks.get_mut(&worker) else {
+            return Err(KvCacheEventError::InvalidBlockSequence);
+        };
+        if member.contains(&hash) {
+            return Ok(StoreMutation::Duplicate);
+        }
+
+        member
+            .try_reserve(1)
+            .map_err(|_| KvCacheEventError::CapacityExhausted)?;
+        let current = self.dc_refcounts.get(&hash).copied().unwrap_or(0);
+        if current == u32::MAX {
+            return Err(KvCacheEventError::IndexerInvariantViolation);
+        }
+        if current == 0 {
+            self.dc_refcounts
+                .try_reserve(1)
+                .map_err(|_| KvCacheEventError::CapacityExhausted)?;
+            let mutator = CuckooMutator::new(&self.filter, addressing, max_kicks);
+            let dirty = &mut self.dirty_scratch;
+            let physical_touches = &mut self.physical_touches_pending;
+            mutator.insert_touched(hash, &mut self.rng, &mut self.insertion_scratch, |bucket| {
+                *physical_touches = physical_touches.saturating_add(1);
+                dirty.mark(bucket);
+            })?;
+            self.dc_refcounts.insert(hash, 1);
+        } else {
+            let Some(refcount) = self.dc_refcounts.get_mut(&hash) else {
+                return Err(KvCacheEventError::IndexerInvariantViolation);
+            };
+            *refcount = current + 1;
+        }
+        let inserted = member.insert(hash);
+        debug_assert!(inserted);
+        Ok(StoreMutation::Changed)
+    }
+
+    fn remove(
+        &mut self,
+        worker: WorkerWithDpRank,
+        hash: ExternalSequenceBlockHash,
+        addressing: &CkfAddressing,
+        max_kicks: usize,
+    ) -> Result<RemoveMutation, KvCacheEventError> {
+        let Some(member) = self.member_blocks.get(&worker) else {
+            return Err(KvCacheEventError::InvalidBlockSequence);
+        };
+        if !member.contains(&hash) {
+            return Ok(RemoveMutation::Unknown);
+        }
+        let Some(current) = self.dc_refcounts.get(&hash).copied() else {
+            return Err(KvCacheEventError::IndexerInvariantViolation);
+        };
+        if current == 0 {
+            return Err(KvCacheEventError::IndexerInvariantViolation);
+        }
+
+        if current == 1 {
+            let mutator = CuckooMutator::new(&self.filter, addressing, max_kicks);
+            let dirty = &mut self.dirty_scratch;
+            let physical_touches = &mut self.physical_touches_pending;
+            mutator.remove_touched(hash, |bucket| {
+                *physical_touches = physical_touches.saturating_add(1);
+                dirty.mark(bucket);
+            })?;
+        }
+
+        let Some(member) = self.member_blocks.get_mut(&worker) else {
+            return Err(KvCacheEventError::IndexerInvariantViolation);
+        };
+        let removed = member.remove(&hash);
+        debug_assert!(removed);
+        if current == 1 {
+            self.dc_refcounts.remove(&hash);
+        } else {
+            let Some(refcount) = self.dc_refcounts.get_mut(&hash) else {
+                return Err(KvCacheEventError::IndexerInvariantViolation);
+            };
+            *refcount = current - 1;
+        }
+        Ok(RemoveMutation::Changed)
+    }
+
+    fn remove_member(
+        &mut self,
+        worker: WorkerWithDpRank,
+        addressing: &CkfAddressing,
+        max_kicks: usize,
+        first_error: &mut Option<KvCacheEventError>,
+    ) {
+        self.member_remove_scratch.clear();
+        let Some(member) = self.member_blocks.get(&worker) else {
+            return;
+        };
+        if self
+            .member_remove_scratch
+            .try_reserve(member.len())
+            .is_err()
+        {
+            retain_first_error(first_error, KvCacheEventError::CapacityExhausted);
+            return;
+        }
+        self.member_remove_scratch.extend(member.iter().copied());
+
+        for index in 0..self.member_remove_scratch.len() {
+            let hash = self.member_remove_scratch[index];
+            if let Err(error) = self.remove(worker, hash, addressing, max_kicks) {
+                retain_first_error(first_error, error);
+            }
+        }
+        self.member_remove_scratch.clear();
+    }
+
+    fn finalize_images(
+        &mut self,
+        lane: usize,
+        replica: &TransposedCkfReplica,
+        batch: &mut CkfDeltaBatch,
+    ) -> FinalizeImageStats {
+        let mut stats = FinalizeImageStats {
+            distinct_touched: self.dirty_scratch.len() as u64,
+            ..FinalizeImageStats::default()
+        };
+        for index in 0..self.dirty_scratch.len() {
+            let bucket = self.dirty_scratch.bucket(index);
+            let value = self.filter.load_bucket(bucket);
+            if let Some(occupied) = self.occupied_buckets.as_mut() {
+                occupied.set(bucket, value != PackedBucket::default());
+            }
+            if replica.table.load_image(bucket, lane) == value {
+                stats.net_reverted += 1;
+            } else {
+                batch.images.push(CkfBucketImage {
+                    lane: lane as u8,
+                    bucket,
+                    value: value.0,
+                });
+                stats.emitted_images += 1;
+            }
+        }
+        self.dirty_scratch.clear();
+        stats
+    }
+
+    fn reset_filter(&mut self) {
+        if let Some(occupied) = self.occupied_buckets.as_mut() {
+            occupied.clear_filter(&self.filter);
+        } else {
+            self.filter.clear();
+        }
+        self.dirty_scratch.clear();
+    }
+
+    fn finish_publication(&mut self) {
+        self.events_since_publish = 0;
+        self.published_nonempty = !self.dc_refcounts.is_empty();
+    }
+
+    fn contribution_count(&self) -> usize {
+        self.member_blocks.values().map(FxHashSet::len).sum()
+    }
+}
+
+#[derive(Debug)]
+pub struct CkfRelayAggregator {
+    manifest: RelayManifest,
+    lanes: [Option<Mutex<RelayLaneState>>; DC_COUNT],
+    addressing: CkfAddressing,
+    config: CkfConfig,
+    bucket_count: usize,
+    format: CkfFormatIdentity,
+}
+
+impl CkfRelayAggregator {
+    fn new(manifest: RelayManifest, config: CkfConfig) -> Result<Self, CkfBuildError> {
+        validate_config(config)?;
+        let bucket_count = bucket_count(config.expected_blocks_per_dc)?;
+        for (lane, lane_config) in manifest.lanes.iter().enumerate() {
+            if lane_config.members.is_empty() {
+                if lane_config.expected_contributions != 0 {
+                    return Err(CkfBuildError::InvalidEmptyLaneContributionCapacity {
+                        lane,
+                        value: lane_config.expected_contributions,
+                    });
+                }
+            } else if lane_config.expected_contributions < config.expected_blocks_per_dc {
+                return Err(CkfBuildError::InvalidContributionCapacity {
+                    lane,
+                    value: lane_config.expected_contributions,
+                    minimum: config.expected_blocks_per_dc,
+                });
+            }
+        }
+
+        let track_occupied = benchmark_flag("DYNAMO_CKF_AGGREGATOR_OCCUPANCY");
+        let mut lane_states = Vec::new();
+        lane_states
+            .try_reserve_exact(DC_COUNT)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        for (lane, lane_config) in manifest.lanes.iter().enumerate() {
+            let state = if lane_config.members.is_empty() {
+                None
+            } else {
+                Some(Mutex::new(RelayLaneState::new(
+                    lane,
+                    lane_config,
+                    config,
+                    bucket_count,
+                    track_occupied,
+                )?))
+            };
+            lane_states.push(state);
+        }
+        let lanes = lane_states
+            .try_into()
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        let format = CkfFormatIdentity {
+            format_version: FORMAT_VERSION,
+            seed: config.seed,
+            bucket_count,
+            fingerprint_bits: FINGERPRINT_BITS,
+            slots_per_bucket: SLOTS_PER_BUCKET,
+            lane_count: DC_COUNT as u8,
+        };
+
+        Ok(Self {
+            manifest,
+            lanes,
+            addressing: CkfAddressing::new(bucket_count, config.seed),
+            config,
+            bucket_count,
+            format,
+        })
+    }
+
+    fn lock_lanes(&self, mask: u16) -> [Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT] {
+        let mut guards = std::array::from_fn(|_| None);
+        for (lane, slot) in guards.iter_mut().enumerate() {
+            if mask & (1u16 << lane) == 0 {
+                continue;
+            }
+            *slot = self.lanes[lane].as_ref().map(Mutex::lock);
+        }
+        guards
+    }
+
+    fn lifecycle_batch_capacity(&self, mask: u16) -> Result<usize, KvCacheEventError> {
+        let lane_count = mask.count_ones() as usize;
+        self.bucket_count
+            .checked_mul(lane_count)
+            .ok_or(KvCacheEventError::CapacityExhausted)
+    }
+
+    fn stats_for_worker_ids(&self, worker_ids: &FxHashSet<WorkerId>) -> WorkerLookupStats {
+        let mut counts = Vec::new();
+        for lane in 0..DC_COUNT {
+            let Some(state) = self.lanes[lane].as_ref() else {
+                continue;
+            };
+            let state = state.lock();
+            counts.extend(state.member_blocks.iter().filter_map(|(&worker, blocks)| {
+                worker_ids
+                    .contains(&worker.worker_id)
+                    .then_some((worker, blocks.len()))
+            }));
+        }
+        WorkerLookupStats::from_worker_block_counts(counts)
+    }
+
+    fn memory_snapshot(&self, replica: &TransposedCkfReplica) -> CkfMemorySnapshot {
+        let mut snapshot = CkfMemorySnapshot {
+            configured_unique_capacity: self
+                .config
+                .expected_blocks_per_dc
+                .saturating_mul(self.manifest.active_lanes.count_ones() as usize),
+            configured_contribution_capacity: self
+                .manifest
+                .lanes
+                .iter()
+                .map(|lane| lane.expected_contributions)
+                .fold(0usize, usize::saturating_add),
+            replica_bytes: replica.byte_len(),
+            replica_occupancy_bytes: replica.occupancy_byte_len(),
+            ..CkfMemorySnapshot::default()
+        };
+        for state in self.lanes.iter().flatten() {
+            let state = state.lock();
+            snapshot.actual_contributions = snapshot
+                .actual_contributions
+                .saturating_add(state.contribution_count());
+            snapshot.member_set_capacity = snapshot.member_set_capacity.saturating_add(
+                state
+                    .member_blocks
+                    .values()
+                    .map(FxHashSet::capacity)
+                    .fold(0usize, usize::saturating_add),
+            );
+            snapshot.dc_refcount_capacity = snapshot
+                .dc_refcount_capacity
+                .saturating_add(state.dc_refcounts.capacity());
+            snapshot.owned_filter_bytes = snapshot
+                .owned_filter_bytes
+                .saturating_add(state.filter.byte_len());
+            snapshot.dirty_tracking_bytes = snapshot
+                .dirty_tracking_bytes
+                .saturating_add(state.dirty_scratch.byte_len());
+            snapshot.aggregator_occupancy_bytes =
+                snapshot.aggregator_occupancy_bytes.saturating_add(
+                    state
+                        .occupied_buckets
+                        .as_ref()
+                        .map_or(0, OccupiedBucketTracker::byte_len),
+                );
+            snapshot.insertion_scratch_capacity = snapshot
+                .insertion_scratch_capacity
+                .saturating_add(state.insertion_scratch.capacity());
+        }
+        snapshot
+    }
+}
+
+#[derive(Debug)]
+struct ReplicaOccupancy {
+    words_per_lane: usize,
+    words: Box<[AtomicU64]>,
+}
+
+impl ReplicaOccupancy {
+    fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
+        let words_per_lane = bucket_count.div_ceil(u64::BITS as usize);
+        let word_count = words_per_lane
+            .checked_mul(DC_COUNT)
+            .ok_or(CkfBuildError::CapacityOverflow)?;
+        let mut words = Vec::new();
+        words
+            .try_reserve_exact(word_count)
+            .map_err(|_| CkfBuildError::AllocationFailed)?;
+        words.extend((0..word_count).map(|_| AtomicU64::new(0)));
+        Ok(Self {
+            words_per_lane,
+            words: words.into_boxed_slice(),
+        })
+    }
+
+    fn set(&self, lane: usize, bucket: usize, occupied: bool) {
+        let index = lane * self.words_per_lane + bucket / u64::BITS as usize;
+        let bit = 1u64 << (bucket % u64::BITS as usize);
+        if occupied {
+            self.words[index].fetch_or(bit, Ordering::Relaxed);
+        } else {
+            self.words[index].fetch_and(!bit, Ordering::Relaxed);
+        }
+    }
+
+    fn clear_lane(&self, table: &TransposedCkfTable<DC_COUNT>, lane: usize) {
+        let start = lane * self.words_per_lane;
+        for word_index in 0..self.words_per_lane {
+            let mut remaining = self.words[start + word_index].swap(0, Ordering::Relaxed);
+            while remaining != 0 {
+                let bit = remaining.trailing_zeros() as usize;
+                let bucket = word_index * u64::BITS as usize + bit;
+                if bucket < table.bucket_count() {
+                    table.store_image(bucket, lane, PackedBucket::default());
+                }
+                remaining &= remaining - 1;
+            }
+        }
+    }
+
+    fn byte_len(&self) -> usize {
+        std::mem::size_of_val(self.words.as_ref())
+    }
+}
+
+#[derive(Debug)]
+pub struct TransposedCkfReplica {
+    pub(super) table: TransposedCkfTable<DC_COUNT>,
+    pub(super) addressing: CkfAddressing,
+    pub(super) config: CkfConfig,
+    format: CkfFormatIdentity,
+    occupied_buckets: Option<ReplicaOccupancy>,
+}
+
+impl TransposedCkfReplica {
+    fn new(format: CkfFormatIdentity, config: CkfConfig) -> Result<Self, CkfBuildError> {
+        Ok(Self {
+            table: TransposedCkfTable::new(format.bucket_count)?,
+            addressing: CkfAddressing::new(format.bucket_count, format.seed),
+            config,
+            format,
+            occupied_buckets: benchmark_flag("DYNAMO_CKF_REPLICA_OCCUPANCY")
+                .then(|| ReplicaOccupancy::new(format.bucket_count))
+                .transpose()?,
+        })
+    }
+
+    pub fn format(&self) -> CkfFormatIdentity {
+        self.format
+    }
+
+    /// Return one prefix depth for every configured DC lane.
+    pub fn find_prefix_depths(
+        &self,
+        sequence: &[crate::protocols::LocalBlockHash],
+    ) -> [u32; DC_COUNT] {
+        if sequence.is_empty() {
+            return [0; DC_COUNT];
+        }
+        let probes = self.prepared_probes(sequence);
+        #[cfg(not(feature = "metrics"))]
+        let depths = super::search::find_prefix_depths::<DC_COUNT>(
+            probes.len(),
+            u16::MAX,
+            self.config.search.verification_window,
+            |position| self.table.prefetch_probe(probes[position]),
+            |position| self.table.probe(probes[position]),
+        );
+        #[cfg(feature = "metrics")]
+        let depths = super::search::find_prefix_depths_with_stats::<DC_COUNT>(
+            probes.len(),
+            u16::MAX,
+            self.config.search.verification_window,
+            |position| self.table.prefetch_probe(probes[position]),
+            |position| self.table.probe(probes[position]),
+        )
+        .depths;
+        depths
+    }
+
+    pub(super) fn prepared_probes(
+        &self,
+        sequence: &[crate::protocols::LocalBlockHash],
+    ) -> Vec<CkfProbe> {
+        crate::protocols::compute_seq_hash_for_block(sequence)
+            .into_iter()
+            .map(|hash| self.addressing.prepare(hash))
+            .collect()
+    }
+
+    fn apply(&self, batch: &CkfDeltaBatch) {
+        debug_assert_eq!(batch.format, self.format);
+        for lane in 0..DC_COUNT {
+            if batch.reset_lanes & (1u16 << lane) == 0 {
+                continue;
+            }
+            if let Some(occupied) = &self.occupied_buckets {
+                occupied.clear_lane(&self.table, lane);
+            } else {
+                self.table.clear_lane(lane);
+            }
+        }
+        for image in &batch.images {
+            let lane = usize::from(image.lane);
+            let value = PackedBucket(image.value);
+            self.table.store_image(image.bucket, lane, value);
+            if let Some(occupied) = &self.occupied_buckets {
+                occupied.set(lane, image.bucket, value != PackedBucket::default());
+            }
+        }
+    }
+
+    fn byte_len(&self) -> usize {
+        self.table.bucket_count() * DC_COUNT * std::mem::size_of::<AtomicU64>()
+    }
+
+    fn occupancy_byte_len(&self) -> usize {
+        self.occupied_buckets
+            .as_ref()
+            .map_or(0, ReplicaOccupancy::byte_len)
+    }
+}
+
+#[derive(Debug)]
+pub struct RouterLocalCkfPipeline {
+    aggregator: CkfRelayAggregator,
+    replica: TransposedCkfReplica,
+    #[cfg(feature = "bench")]
+    bench_counters: CkfBenchCounters,
+}
+
+impl RouterLocalCkfPipeline {
+    pub fn new(manifest: RelayManifest, config: CkfConfig) -> Result<Self, CkfBuildError> {
+        let aggregator = CkfRelayAggregator::new(manifest, config)?;
+        let replica = TransposedCkfReplica::new(aggregator.format, config)?;
+        Ok(Self {
+            aggregator,
+            replica,
+            #[cfg(feature = "bench")]
+            bench_counters: CkfBenchCounters::default(),
+        })
+    }
+
+    pub fn replica(&self) -> &TransposedCkfReplica {
+        &self.replica
+    }
+
+    pub fn new_batch(&self) -> CkfDeltaBatch {
+        CkfDeltaBatch::new(self.aggregator.format)
+    }
+
+    pub fn apply_event(&self, event: RouterEvent, batch: &mut CkfDeltaBatch) -> CkfEventOutcome {
+        batch.reset(self.aggregator.format);
+        if event.storage_tier != StorageTier::Device
+            && !matches!(event.event.data, KvCacheEventData::Cleared)
+        {
+            return CkfEventOutcome::success(false);
+        }
+
+        let worker = WorkerWithDpRank::new(event.worker_id, event.event.dp_rank);
+        let mask = match &event.event.data {
+            KvCacheEventData::Stored(_) | KvCacheEventData::Removed(_) => {
+                let Some(lane) = self.aggregator.manifest.lane_for(worker) else {
+                    tracing::warn!(
+                        worker_id = worker.worker_id,
+                        dp_rank = worker.dp_rank,
+                        event_id = event.event.event_id,
+                        "CKF event references an unknown worker/rank"
+                    );
+                    return CkfEventOutcome::failure(KvCacheEventError::InvalidBlockSequence);
+                };
+                1u16 << lane
+            }
+            KvCacheEventData::Cleared => {
+                let Some(mask) = self
+                    .aggregator
+                    .manifest
+                    .lane_mask_for_worker(event.worker_id)
+                else {
+                    tracing::warn!(
+                        worker_id = event.worker_id,
+                        event_id = event.event.event_id,
+                        "CKF clear references an unknown worker"
+                    );
+                    return CkfEventOutcome::failure(KvCacheEventError::InvalidBlockSequence);
+                };
+                mask
+            }
+        };
+
+        let Some(capacity) = self
+            .aggregator
+            .bucket_count
+            .checked_mul(mask.count_ones() as usize)
+        else {
+            return CkfEventOutcome::failure(KvCacheEventError::CapacityExhausted);
+        };
+        if let Err(error) = batch.try_reserve(capacity) {
+            return CkfEventOutcome::failure(error);
+        }
+
+        #[cfg(feature = "bench")]
+        let event_started = Instant::now();
+        #[cfg(feature = "bench")]
+        let lock_started = Instant::now();
+        let event_id = event.event.event_id;
+        let mut outcome = CkfEventOutcome::success(false);
+        {
+            let mut guards = self.aggregator.lock_lanes(mask);
+            #[cfg(feature = "bench")]
+            let lock_acquired = Instant::now();
+            for state in guards.iter_mut().flatten() {
+                state.advance_event();
+            }
+            #[cfg(feature = "bench")]
+            let aggregation_started = Instant::now();
+
+            match event.event.data {
+                KvCacheEventData::Stored(store) => {
+                    let lane = mask.trailing_zeros() as usize;
+                    if let Some(state) = guards[lane].as_mut() {
+                        let mut entirely_duplicate = !store.blocks.is_empty();
+                        for block in store.blocks {
+                            match state.store(
+                                worker,
+                                block.block_hash,
+                                &self.aggregator.addressing,
+                                self.aggregator.config.max_kicks,
+                            ) {
+                                Ok(StoreMutation::Duplicate) => {}
+                                Ok(StoreMutation::Changed) => entirely_duplicate = false,
+                                Err(error) => {
+                                    entirely_duplicate = false;
+                                    if matches!(error, KvCacheEventError::CapacityExhausted) {
+                                        outcome.capacity_failures += 1;
+                                    }
+                                    retain_first_error(&mut outcome.first_error, error);
+                                }
+                            }
+                        }
+                        outcome.duplicate_warning = entirely_duplicate;
+                    } else {
+                        retain_first_error(
+                            &mut outcome.first_error,
+                            KvCacheEventError::IndexerInvariantViolation,
+                        );
+                    }
+                }
+                KvCacheEventData::Removed(remove) => {
+                    let lane = mask.trailing_zeros() as usize;
+                    if let Some(state) = guards[lane].as_mut() {
+                        for hash in remove.block_hashes {
+                            match state.remove(
+                                worker,
+                                hash,
+                                &self.aggregator.addressing,
+                                self.aggregator.config.max_kicks,
+                            ) {
+                                Ok(RemoveMutation::Unknown) => outcome.unknown_removals += 1,
+                                Ok(RemoveMutation::Changed) => {}
+                                Err(error) => retain_first_error(&mut outcome.first_error, error),
+                            }
+                        }
+                    } else {
+                        retain_first_error(
+                            &mut outcome.first_error,
+                            KvCacheEventError::IndexerInvariantViolation,
+                        );
+                    }
+                }
+                KvCacheEventData::Cleared => {
+                    for (lane, state) in guards.iter_mut().enumerate() {
+                        let Some(state) = state.as_mut() else {
+                            continue;
+                        };
+                        for member in self.aggregator.manifest.lanes[lane]
+                            .members
+                            .iter()
+                            .copied()
+                            .filter(|member| member.worker_id == event.worker_id)
+                        {
+                            state.remove_member(
+                                member,
+                                &self.aggregator.addressing,
+                                self.aggregator.config.max_kicks,
+                                &mut outcome.first_error,
+                            );
+                        }
+                    }
+                }
+            }
+
+            #[cfg(feature = "bench")]
+            let aggregation_ns = elapsed_ns(aggregation_started);
+
+            let due_mask =
+                due_lane_mask(&guards, mask, self.aggregator.config.publish_every_n_events);
+            if due_mask != 0 {
+                #[cfg(feature = "bench")]
+                let finalization_started = Instant::now();
+                let publication = publish_locked_lanes(&mut guards, due_mask, &self.replica, batch);
+                #[cfg(feature = "bench")]
+                let finalization_ns = elapsed_ns(finalization_started);
+                let has_replica_update = batch.reset_lanes != 0 || !batch.images.is_empty();
+                #[cfg(feature = "bench")]
+                let apply_started = Instant::now();
+                if has_replica_update {
+                    self.replica.apply(batch);
+                }
+                #[cfg(feature = "bench")]
+                outcome.bench.record_publication(
+                    &publication,
+                    has_replica_update
+                        .then(|| elapsed_ns(apply_started))
+                        .unwrap_or(0),
+                    !has_replica_update,
+                    finalization_ns,
+                );
+                #[cfg(not(feature = "bench"))]
+                let _ = publication;
+                outcome.batch_applied = has_replica_update;
+            }
+            #[cfg(feature = "bench")]
+            outcome.bench.record_event(
+                u64::from(mask.count_ones()),
+                elapsed_ns(event_started),
+                lock_acquired
+                    .saturating_duration_since(lock_started)
+                    .as_nanos()
+                    .min(u64::MAX as u128) as u64,
+                elapsed_ns(lock_acquired),
+                aggregation_ns,
+            );
+        }
+
+        if outcome.unknown_removals != 0 {
+            tracing::warn!(
+                worker_id = event.worker_id,
+                event_id,
+                unknown_removals = outcome.unknown_removals,
+                "Ignoring CKF removals for blocks not owned by the worker"
+            );
+        }
+        outcome
+    }
+
+    pub(super) fn remove_worker(
+        &self,
+        worker_id: WorkerId,
+        batch: &mut CkfDeltaBatch,
+    ) -> CkfEventOutcome {
+        let Some(mask) = self.aggregator.manifest.lane_mask_for_worker(worker_id) else {
+            batch.reset(self.aggregator.format);
+            return CkfEventOutcome::success(false);
+        };
+        self.remove_members(mask, batch, |member| member.worker_id == worker_id)
+    }
+
+    pub(super) fn remove_worker_rank(
+        &self,
+        worker: WorkerWithDpRank,
+        batch: &mut CkfDeltaBatch,
+    ) -> CkfEventOutcome {
+        let Some(lane) = self.aggregator.manifest.lane_for(worker) else {
+            batch.reset(self.aggregator.format);
+            return CkfEventOutcome::success(false);
+        };
+        self.remove_members(1u16 << lane, batch, |member| member == worker)
+    }
+
+    fn remove_members(
+        &self,
+        mask: u16,
+        batch: &mut CkfDeltaBatch,
+        mut selected: impl FnMut(WorkerWithDpRank) -> bool,
+    ) -> CkfEventOutcome {
+        batch.reset(self.aggregator.format);
+        let Ok(capacity) = self.aggregator.lifecycle_batch_capacity(mask) else {
+            return CkfEventOutcome::failure(KvCacheEventError::CapacityExhausted);
+        };
+        if let Err(error) = batch.try_reserve(capacity) {
+            return CkfEventOutcome::failure(error);
+        }
+
+        let mut outcome = CkfEventOutcome::success(false);
+        {
+            let mut guards = self.aggregator.lock_lanes(mask);
+            for state in guards.iter_mut().flatten() {
+                state.advance_event();
+            }
+            for (lane, state) in guards.iter_mut().enumerate() {
+                let Some(state) = state.as_mut() else {
+                    continue;
+                };
+                for member in self.aggregator.manifest.lanes[lane]
+                    .members
+                    .iter()
+                    .copied()
+                    .filter(|&member| selected(member))
+                {
+                    state.remove_member(
+                        member,
+                        &self.aggregator.addressing,
+                        self.aggregator.config.max_kicks,
+                        &mut outcome.first_error,
+                    );
+                }
+            }
+            #[cfg(feature = "bench")]
+            let finalization_started = Instant::now();
+            let publication = publish_locked_lanes(&mut guards, mask, &self.replica, batch);
+            #[cfg(feature = "bench")]
+            let finalization_ns = elapsed_ns(finalization_started);
+            let has_replica_update = batch.reset_lanes != 0 || !batch.images.is_empty();
+            #[cfg(feature = "bench")]
+            let apply_started = Instant::now();
+            if has_replica_update {
+                self.replica.apply(batch);
+            }
+            #[cfg(feature = "bench")]
+            outcome.bench.record_publication(
+                &publication,
+                has_replica_update
+                    .then(|| elapsed_ns(apply_started))
+                    .unwrap_or(0),
+                !has_replica_update,
+                finalization_ns,
+            );
+            #[cfg(not(feature = "bench"))]
+            let _ = publication;
+            outcome.batch_applied = has_replica_update;
+        }
+        outcome
+    }
+
+    #[cfg(any(test, not(feature = "bench")))]
+    pub(super) fn flush_pending(
+        &self,
+        batch: &mut CkfDeltaBatch,
+    ) -> Result<bool, KvCacheEventError> {
+        Ok(self.flush_pending_core(batch)?.applied)
+    }
+
+    #[cfg(feature = "bench")]
+    pub(super) fn flush_pending_with_telemetry(
+        &self,
+        batch: &mut CkfDeltaBatch,
+        telemetry: &mut CkfBenchLocalTelemetry,
+    ) -> Result<bool, KvCacheEventError> {
+        let result = self.flush_pending_core(batch)?;
+        if let Some(publication) = result.publication.as_ref() {
+            telemetry.record_publication(
+                publication,
+                result.replica_apply_ns,
+                !result.applied,
+                result.finalization_ns,
+            );
+        }
+        Ok(result.applied)
+    }
+
+    fn flush_pending_core(
+        &self,
+        batch: &mut CkfDeltaBatch,
+    ) -> Result<FlushPendingResult, KvCacheEventError> {
+        batch.reset(self.aggregator.format);
+        let mask = self.aggregator.manifest.active_lanes;
+        let capacity = self.aggregator.lifecycle_batch_capacity(mask)?;
+        batch.try_reserve(capacity)?;
+
+        let mut result = FlushPendingResult::default();
+        {
+            let mut guards = self.aggregator.lock_lanes(mask);
+            let pending_mask = pending_lane_mask(&guards, mask);
+            if pending_mask != 0 {
+                #[cfg(feature = "bench")]
+                let finalization_started = Instant::now();
+                let publication =
+                    publish_locked_lanes(&mut guards, pending_mask, &self.replica, batch);
+                #[cfg(feature = "bench")]
+                let finalization_ns = elapsed_ns(finalization_started);
+                let has_replica_update = batch.reset_lanes != 0 || !batch.images.is_empty();
+                #[cfg(feature = "bench")]
+                let apply_started = Instant::now();
+                if has_replica_update {
+                    self.replica.apply(batch);
+                }
+                #[cfg(feature = "bench")]
+                {
+                    result.replica_apply_ns = has_replica_update
+                        .then(|| elapsed_ns(apply_started))
+                        .unwrap_or(0);
+                    result.finalization_ns = finalization_ns;
+                }
+                result.applied = has_replica_update;
+                result.publication = Some(publication);
+            }
+        }
+        Ok(result)
+    }
+
+    pub(super) fn worker_stats(&self, worker_ids: &FxHashSet<WorkerId>) -> WorkerLookupStats {
+        self.aggregator.stats_for_worker_ids(worker_ids)
+    }
+
+    pub fn memory_snapshot(&self) -> CkfMemorySnapshot {
+        self.aggregator.memory_snapshot(&self.replica)
+    }
+
+    #[cfg(feature = "bench")]
+    pub(super) fn timing_report(&self) -> String {
+        self.bench_counters.report(
+            self.aggregator.config.publish_every_n_events,
+            self.aggregator.bucket_count,
+            self.memory_snapshot(),
+        )
+    }
+
+    #[cfg(feature = "bench")]
+    pub(super) fn merge_bench_telemetry(&self, telemetry: &mut CkfBenchLocalTelemetry) {
+        self.bench_counters.merge(telemetry);
+    }
+
+    #[cfg(test)]
+    pub(super) fn member_contains(
+        &self,
+        worker: WorkerWithDpRank,
+        hash: ExternalSequenceBlockHash,
+    ) -> bool {
+        let Some(lane) = self.aggregator.manifest.lane_for(worker) else {
+            return false;
+        };
+        self.aggregator.lanes[lane]
+            .as_ref()
+            .expect("active lane")
+            .lock()
+            .member_blocks
+            .get(&worker)
+            .is_some_and(|blocks| blocks.contains(&hash))
+    }
+
+    #[cfg(test)]
+    pub(super) fn clear_owned_representation(
+        &self,
+        worker: WorkerWithDpRank,
+        hash: ExternalSequenceBlockHash,
+    ) {
+        let lane = self
+            .aggregator
+            .manifest
+            .lane_for(worker)
+            .expect("test worker is manifested");
+        let state = self.aggregator.lanes[lane]
+            .as_ref()
+            .expect("test lane is active")
+            .lock();
+        let probe = self.aggregator.addressing.prepare(hash.0);
+        state
+            .filter
+            .store_bucket(probe.bucket_a, PackedBucket::default());
+        state
+            .filter
+            .store_bucket(probe.bucket_b, PackedBucket::default());
+    }
+}
+
+fn due_lane_mask(
+    guards: &[Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+    mask: u16,
+    every_n_events: usize,
+) -> u16 {
+    guards.iter().enumerate().fold(0u16, |due, (lane, state)| {
+        if mask & (1u16 << lane) != 0
+            && state
+                .as_ref()
+                .is_some_and(|state| state.publication_due(every_n_events))
+        {
+            due | (1u16 << lane)
+        } else {
+            due
+        }
+    })
+}
+
+fn pending_lane_mask(
+    guards: &[Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+    mask: u16,
+) -> u16 {
+    guards
+        .iter()
+        .enumerate()
+        .fold(0u16, |pending, (lane, state)| {
+            if mask & (1u16 << lane) != 0
+                && state
+                    .as_ref()
+                    .is_some_and(|state| state.has_pending_publication())
+            {
+                pending | (1u16 << lane)
+            } else {
+                pending
+            }
+        })
+}
+
+#[derive(Debug, Default)]
+struct PublicationStats {
+    lane_windows: u64,
+    lane_events: u64,
+    physical_touches: u64,
+    distinct_touched: u64,
+    final_images: u64,
+    net_reverted: u64,
+    reset_lanes: u64,
+    #[cfg(feature = "bench")]
+    staleness_ns: u64,
+    #[cfg(feature = "bench")]
+    maximum_staleness_ns: u64,
+}
+
+#[derive(Debug, Default)]
+struct FlushPendingResult {
+    applied: bool,
+    publication: Option<PublicationStats>,
+    #[cfg(feature = "bench")]
+    replica_apply_ns: u64,
+    #[cfg(feature = "bench")]
+    finalization_ns: u64,
+}
+
+fn publish_locked_lanes(
+    guards: &mut [Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+    mask: u16,
+    replica: &TransposedCkfReplica,
+    batch: &mut CkfDeltaBatch,
+) -> PublicationStats {
+    let mut stats = PublicationStats::default();
+    for (lane, state) in guards.iter_mut().enumerate() {
+        let Some(state) = state.as_mut() else {
+            continue;
+        };
+        if mask & (1u16 << lane) == 0 {
+            continue;
+        }
+        let images_before = batch.images.len();
+        let distinct_touched = state.dirty_scratch.len() as u64;
+        if state.dc_refcounts.is_empty() && state.published_nonempty {
+            state.reset_filter();
+            batch.reset_lanes |= 1u16 << lane;
+            stats.reset_lanes += 1;
+        } else if state.dc_refcounts.is_empty() {
+            stats.net_reverted = stats.net_reverted.saturating_add(distinct_touched);
+            state.dirty_scratch.clear();
+        } else {
+            let finalized = state.finalize_images(lane, replica, batch);
+            debug_assert_eq!(finalized.distinct_touched, distinct_touched);
+            stats.net_reverted = stats.net_reverted.saturating_add(finalized.net_reverted);
+            debug_assert_eq!(
+                finalized.emitted_images,
+                (batch.images.len() - images_before) as u64
+            );
+        }
+        stats.lane_windows += 1;
+        stats.lane_events = stats
+            .lane_events
+            .saturating_add(state.events_since_publish as u64);
+        stats.physical_touches = stats
+            .physical_touches
+            .saturating_add(state.physical_touches_pending);
+        stats.distinct_touched = stats.distinct_touched.saturating_add(distinct_touched);
+        stats.final_images = stats
+            .final_images
+            .saturating_add((batch.images.len() - images_before) as u64);
+        #[cfg(feature = "bench")]
+        if let Some(started_at) = state.window_started_at.take() {
+            let staleness = started_at.elapsed().as_nanos().min(u64::MAX as u128) as u64;
+            stats.staleness_ns = stats.staleness_ns.saturating_add(staleness);
+            stats.maximum_staleness_ns = stats.maximum_staleness_ns.max(staleness);
+        }
+        state.physical_touches_pending = 0;
+        state.finish_publication();
+    }
+    debug_assert_eq!(batch.reset_lanes & !mask, 0);
+    stats
+}
+
+#[cfg(feature = "bench")]
+#[derive(Debug, Default)]
+pub(super) struct CkfBenchLocalTelemetry {
+    normalized_events: u64,
+    affected_lane_events: u64,
+    event_ns: u64,
+    aggregation_ns: u64,
+    lock_wait_ns: u64,
+    lock_hold_ns: u64,
+    publications: u64,
+    unchanged_publications: u64,
+    published_lane_windows: u64,
+    published_lane_events: u64,
+    physical_touches: u64,
+    distinct_touched: u64,
+    final_images: u64,
+    net_reverted: u64,
+    reset_lanes: u64,
+    replica_apply_ns: u64,
+    finalization_ns: u64,
+    staleness_ns: u64,
+    maximum_staleness_ns: u64,
+}
+
+#[cfg(feature = "bench")]
+impl CkfBenchLocalTelemetry {
+    fn record_event(
+        &mut self,
+        affected_lanes: u64,
+        event_ns: u64,
+        wait_ns: u64,
+        hold_ns: u64,
+        aggregation_ns: u64,
+    ) {
+        self.normalized_events += 1;
+        self.affected_lane_events = self.affected_lane_events.saturating_add(affected_lanes);
+        self.event_ns = self.event_ns.saturating_add(event_ns);
+        self.aggregation_ns = self.aggregation_ns.saturating_add(aggregation_ns);
+        self.lock_wait_ns = self.lock_wait_ns.saturating_add(wait_ns);
+        self.lock_hold_ns = self.lock_hold_ns.saturating_add(hold_ns);
+    }
+
+    fn record_publication(
+        &mut self,
+        stats: &PublicationStats,
+        replica_apply_ns: u64,
+        unchanged: bool,
+        finalization_ns: u64,
+    ) {
+        self.publications += 1;
+        self.unchanged_publications = self
+            .unchanged_publications
+            .saturating_add(u64::from(unchanged));
+        self.published_lane_windows = self
+            .published_lane_windows
+            .saturating_add(stats.lane_windows);
+        self.published_lane_events = self.published_lane_events.saturating_add(stats.lane_events);
+        self.physical_touches = self.physical_touches.saturating_add(stats.physical_touches);
+        self.distinct_touched = self.distinct_touched.saturating_add(stats.distinct_touched);
+        self.final_images = self.final_images.saturating_add(stats.final_images);
+        self.net_reverted = self.net_reverted.saturating_add(stats.net_reverted);
+        self.reset_lanes = self.reset_lanes.saturating_add(stats.reset_lanes);
+        self.replica_apply_ns = self.replica_apply_ns.saturating_add(replica_apply_ns);
+        self.finalization_ns = self.finalization_ns.saturating_add(finalization_ns);
+        self.staleness_ns = self.staleness_ns.saturating_add(stats.staleness_ns);
+        self.maximum_staleness_ns = self.maximum_staleness_ns.max(stats.maximum_staleness_ns);
+    }
+
+    pub(super) fn absorb_outcome(&mut self, outcome: &CkfEventOutcome) {
+        self.absorb(&outcome.bench);
+    }
+
+    fn absorb(&mut self, other: &Self) {
+        self.normalized_events = self
+            .normalized_events
+            .saturating_add(other.normalized_events);
+        self.affected_lane_events = self
+            .affected_lane_events
+            .saturating_add(other.affected_lane_events);
+        self.event_ns = self.event_ns.saturating_add(other.event_ns);
+        self.aggregation_ns = self.aggregation_ns.saturating_add(other.aggregation_ns);
+        self.lock_wait_ns = self.lock_wait_ns.saturating_add(other.lock_wait_ns);
+        self.lock_hold_ns = self.lock_hold_ns.saturating_add(other.lock_hold_ns);
+        self.publications = self.publications.saturating_add(other.publications);
+        self.unchanged_publications = self
+            .unchanged_publications
+            .saturating_add(other.unchanged_publications);
+        self.published_lane_windows = self
+            .published_lane_windows
+            .saturating_add(other.published_lane_windows);
+        self.published_lane_events = self
+            .published_lane_events
+            .saturating_add(other.published_lane_events);
+        self.physical_touches = self.physical_touches.saturating_add(other.physical_touches);
+        self.distinct_touched = self.distinct_touched.saturating_add(other.distinct_touched);
+        self.final_images = self.final_images.saturating_add(other.final_images);
+        self.net_reverted = self.net_reverted.saturating_add(other.net_reverted);
+        self.reset_lanes = self.reset_lanes.saturating_add(other.reset_lanes);
+        self.replica_apply_ns = self.replica_apply_ns.saturating_add(other.replica_apply_ns);
+        self.finalization_ns = self.finalization_ns.saturating_add(other.finalization_ns);
+        self.staleness_ns = self.staleness_ns.saturating_add(other.staleness_ns);
+        self.maximum_staleness_ns = self.maximum_staleness_ns.max(other.maximum_staleness_ns);
+    }
+}
+
+#[cfg(feature = "bench")]
+#[derive(Debug, Default)]
+struct CkfBenchCounters {
+    normalized_events: AtomicU64,
+    affected_lane_events: AtomicU64,
+    event_ns: AtomicU64,
+    aggregation_ns: AtomicU64,
+    lock_wait_ns: AtomicU64,
+    lock_hold_ns: AtomicU64,
+    publications: AtomicU64,
+    unchanged_publications: AtomicU64,
+    published_lane_windows: AtomicU64,
+    published_lane_events: AtomicU64,
+    physical_touches: AtomicU64,
+    distinct_touched: AtomicU64,
+    final_images: AtomicU64,
+    net_reverted: AtomicU64,
+    reset_lanes: AtomicU64,
+    replica_apply_ns: AtomicU64,
+    finalization_ns: AtomicU64,
+    staleness_ns: AtomicU64,
+    maximum_staleness_ns: AtomicU64,
+}
+
+#[cfg(feature = "bench")]
+impl CkfBenchCounters {
+    fn merge(&self, local: &mut CkfBenchLocalTelemetry) {
+        self.normalized_events
+            .fetch_add(local.normalized_events, Ordering::Relaxed);
+        self.affected_lane_events
+            .fetch_add(local.affected_lane_events, Ordering::Relaxed);
+        self.event_ns.fetch_add(local.event_ns, Ordering::Relaxed);
+        self.aggregation_ns
+            .fetch_add(local.aggregation_ns, Ordering::Relaxed);
+        self.lock_wait_ns
+            .fetch_add(local.lock_wait_ns, Ordering::Relaxed);
+        self.lock_hold_ns
+            .fetch_add(local.lock_hold_ns, Ordering::Relaxed);
+        self.publications
+            .fetch_add(local.publications, Ordering::Relaxed);
+        self.unchanged_publications
+            .fetch_add(local.unchanged_publications, Ordering::Relaxed);
+        self.published_lane_windows
+            .fetch_add(local.published_lane_windows, Ordering::Relaxed);
+        self.published_lane_events
+            .fetch_add(local.published_lane_events, Ordering::Relaxed);
+        self.physical_touches
+            .fetch_add(local.physical_touches, Ordering::Relaxed);
+        self.distinct_touched
+            .fetch_add(local.distinct_touched, Ordering::Relaxed);
+        self.final_images
+            .fetch_add(local.final_images, Ordering::Relaxed);
+        self.net_reverted
+            .fetch_add(local.net_reverted, Ordering::Relaxed);
+        self.reset_lanes
+            .fetch_add(local.reset_lanes, Ordering::Relaxed);
+        self.replica_apply_ns
+            .fetch_add(local.replica_apply_ns, Ordering::Relaxed);
+        self.finalization_ns
+            .fetch_add(local.finalization_ns, Ordering::Relaxed);
+        self.staleness_ns
+            .fetch_add(local.staleness_ns, Ordering::Relaxed);
+        self.maximum_staleness_ns
+            .fetch_max(local.maximum_staleness_ns, Ordering::Relaxed);
+        *local = CkfBenchLocalTelemetry::default();
+    }
+
+    fn report(
+        &self,
+        publish_every_n_events: usize,
+        bucket_count: usize,
+        memory: CkfMemorySnapshot,
+    ) -> String {
+        let load = |counter: &AtomicU64| counter.load(Ordering::Relaxed);
+        let events = load(&self.normalized_events);
+        let publications = load(&self.publications);
+        let unchanged_publications = load(&self.unchanged_publications);
+        let lane_windows = load(&self.published_lane_windows);
+        let lane_events = load(&self.published_lane_events);
+        let touches = load(&self.physical_touches);
+        let distinct_touched = load(&self.distinct_touched);
+        let images = load(&self.final_images);
+        let net_reverted = load(&self.net_reverted);
+        format!(
+            "ckf_publish_every_n_events={publish_every_n_events} normalized_events={events} affected_lane_events={} publications={publications} unchanged_publications={unchanged_publications} published_lane_windows={lane_windows} events_per_publication={:.3} lane_events_per_lane_window={:.3} physical_touches={touches} distinct_touched={distinct_touched} final_images={images} cross_event_coalesced={} net_reverted={net_reverted} dirty_density={:.6} image_bytes={} bytes_per_event={:.3} bytes_per_publication={:.3} event_ns_per_event={:.3} aggregation_ns_per_event={:.3} finalization_ns_per_publication={:.3} lock_wait_ns_per_event={:.3} lock_hold_ns_per_event={:.3} replica_apply_ns={} staleness_ns_per_lane_window={:.3} maximum_staleness_ns={} reset_lanes={} actual_contributions={} member_set_capacity={} dc_refcount_capacity={} owned_filter_bytes={} replica_bytes={} dirty_tracking_bytes={} aggregator_occupancy_bytes={} replica_occupancy_bytes={}",
+            load(&self.affected_lane_events),
+            ratio(events, publications),
+            ratio(lane_events, lane_windows),
+            touches.saturating_sub(distinct_touched),
+            if lane_windows == 0 {
+                0.0
+            } else {
+                distinct_touched as f64 / (lane_windows as f64 * bucket_count.max(1) as f64)
+            },
+            images.saturating_mul(std::mem::size_of::<CkfBucketImage>() as u64),
+            ratio(
+                images.saturating_mul(std::mem::size_of::<CkfBucketImage>() as u64),
+                events,
+            ),
+            ratio(
+                images.saturating_mul(std::mem::size_of::<CkfBucketImage>() as u64),
+                publications,
+            ),
+            ratio(load(&self.event_ns), events),
+            ratio(load(&self.aggregation_ns), events),
+            ratio(load(&self.finalization_ns), publications),
+            ratio(load(&self.lock_wait_ns), events),
+            ratio(load(&self.lock_hold_ns), events),
+            load(&self.replica_apply_ns),
+            ratio(load(&self.staleness_ns), lane_windows),
+            load(&self.maximum_staleness_ns),
+            load(&self.reset_lanes),
+            memory.actual_contributions,
+            memory.member_set_capacity,
+            memory.dc_refcount_capacity,
+            memory.owned_filter_bytes,
+            memory.replica_bytes,
+            memory.dirty_tracking_bytes,
+            memory.aggregator_occupancy_bytes,
+            memory.replica_occupancy_bytes,
+        )
+    }
+}
+
+#[cfg(feature = "bench")]
+fn ratio(numerator: u64, denominator: u64) -> f64 {
+    if denominator == 0 {
+        0.0
+    } else {
+        numerator as f64 / denominator as f64
+    }
+}
+
+#[cfg(feature = "bench")]
+fn elapsed_ns(started: Instant) -> u64 {
+    started.elapsed().as_nanos().min(u64::MAX as u128) as u64
+}
+
+fn retain_first_error(slot: &mut Option<KvCacheEventError>, error: KvCacheEventError) {
+    if slot.is_none() {
+        *slot = Some(error);
+    }
+}
+
+#[cfg(any(test, feature = "bench"))]
+fn benchmark_flag(name: &str) -> bool {
+    std::env::var_os(name).is_some()
+}
+
+#[cfg(not(any(test, feature = "bench")))]
+fn benchmark_flag(_name: &str) -> bool {
+    false
+}
+
+fn zeroed_boxed_slice<T: Default>(len: usize) -> Result<Box<[T]>, CkfBuildError> {
+    let allocation_bytes = len
+        .checked_mul(std::mem::size_of::<T>())
+        .ok_or(CkfBuildError::CapacityOverflow)?;
+    if allocation_bytes > isize::MAX as usize {
+        return Err(CkfBuildError::CapacityOverflow);
+    }
+    let mut values = Vec::new();
+    values
+        .try_reserve_exact(len)
+        .map_err(|_| CkfBuildError::AllocationFailed)?;
+    values.resize_with(len, T::default);
+    Ok(values.into_boxed_slice())
+}

--- a/lib/kv-router/src/indexer/cuckoo/relay.rs
+++ b/lib/kv-router/src/indexer/cuckoo/relay.rs
@@ -204,6 +204,8 @@ pub struct CkfDeltaBatch {
     format: CkfFormatIdentity,
     reset_lanes: u16,
     images: Vec<CkfBucketImage>,
+    #[cfg(test)]
+    fail_reserve: bool,
 }
 
 impl CkfDeltaBatch {
@@ -224,6 +226,8 @@ impl CkfDeltaBatch {
             format,
             reset_lanes: 0,
             images: Vec::new(),
+            #[cfg(test)]
+            fail_reserve: false,
         }
     }
 
@@ -234,9 +238,23 @@ impl CkfDeltaBatch {
     }
 
     fn try_reserve(&mut self, additional: usize) -> Result<(), KvCacheEventError> {
+        #[cfg(test)]
+        if self.fail_reserve {
+            return Err(KvCacheEventError::CapacityExhausted);
+        }
         self.images
             .try_reserve(additional)
             .map_err(|_| KvCacheEventError::CapacityExhausted)
+    }
+
+    #[cfg(test)]
+    pub(super) fn image_capacity(&self) -> usize {
+        self.images.capacity()
+    }
+
+    #[cfg(test)]
+    pub(super) fn force_reserve_failure(&mut self) {
+        self.fail_reserve = true;
     }
 }
 
@@ -604,7 +622,7 @@ impl RelayLaneState {
         &mut self,
         lane: usize,
         replica: &TransposedCkfReplica,
-        batch: &mut CkfDeltaBatch,
+        mut emit: impl FnMut(CkfBucketImage),
     ) -> FinalizeImageStats {
         let mut stats = FinalizeImageStats {
             distinct_touched: self.dirty_scratch.len() as u64,
@@ -616,7 +634,7 @@ impl RelayLaneState {
             if replica.table.load_image(bucket, lane) == value {
                 stats.net_reverted += 1;
             } else {
-                batch.images.push(CkfBucketImage {
+                emit(CkfBucketImage {
                     lane: lane as u8,
                     bucket,
                     value: value.0,
@@ -722,13 +740,6 @@ impl CkfRelayAggregator {
             *slot = self.lanes[lane].as_ref().map(Mutex::lock);
         }
         guards
-    }
-
-    fn lifecycle_batch_capacity(&self, mask: u16) -> Result<usize, KvCacheEventError> {
-        let lane_count = mask.count_ones() as usize;
-        self.bucket_count
-            .checked_mul(lane_count)
-            .ok_or(KvCacheEventError::CapacityExhausted)
     }
 
     fn stats_for_worker_ids(&self, worker_ids: &FxHashSet<WorkerId>) -> WorkerLookupStats {
@@ -1052,29 +1063,15 @@ impl RouterLocalCkfPipeline {
             let due_mask =
                 due_lane_mask(&guards, mask, self.aggregator.config.publish_every_n_events);
             if due_mask != 0 {
-                #[cfg(feature = "bench")]
-                let finalization_started = Instant::now();
-                let publication = publish_locked_lanes(&mut guards, due_mask, &self.replica, batch);
-                #[cfg(feature = "bench")]
-                let finalization_ns = elapsed_ns(finalization_started);
-                let has_replica_update = batch.reset_lanes != 0 || !batch.images.is_empty();
-                #[cfg(feature = "bench")]
-                let apply_started = Instant::now();
-                if has_replica_update {
-                    self.replica.apply(batch);
-                }
+                let publication = self.publish_locked(&mut guards, due_mask, batch, true);
                 #[cfg(feature = "bench")]
                 outcome.bench.record_publication(
-                    &publication,
-                    has_replica_update
-                        .then(|| elapsed_ns(apply_started))
-                        .unwrap_or(0),
-                    !has_replica_update,
-                    finalization_ns,
+                    &publication.stats,
+                    publication.replica_apply_ns,
+                    !publication.applied,
+                    publication.finalization_ns,
                 );
-                #[cfg(not(feature = "bench"))]
-                let _ = publication;
-                outcome.batch_applied = has_replica_update;
+                outcome.batch_applied = publication.applied;
             }
             #[cfg(feature = "bench")]
             outcome.bench.record_event(
@@ -1124,23 +1121,59 @@ impl RouterLocalCkfPipeline {
         self.remove_members(1u16 << lane, batch, |member| member == worker)
     }
 
+    fn removal_image_capacity(
+        &self,
+        guards: &[Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+        mask: u16,
+        selected: impl Fn(WorkerWithDpRank) -> bool + Copy,
+    ) -> Option<usize> {
+        let mut total = 0usize;
+        for (lane, state) in guards.iter().enumerate() {
+            if mask & (1u16 << lane) == 0 {
+                continue;
+            }
+            let state = state.as_ref()?;
+            let member_blocks = self.aggregator.manifest.lanes[lane]
+                .members
+                .iter()
+                .copied()
+                .filter(|&member| selected(member))
+                .try_fold(0usize, |count, member| {
+                    count.checked_add(state.member_blocks.get(&member).map_or(0, FxHashSet::len))
+                })?;
+            let lane_capacity = state
+                .dirty_scratch
+                .len()
+                .checked_add(member_blocks)?
+                .min(self.aggregator.bucket_count);
+            total = total.checked_add(lane_capacity)?;
+        }
+        Some(total)
+    }
+
     fn remove_members(
         &self,
         mask: u16,
         batch: &mut CkfDeltaBatch,
-        mut selected: impl FnMut(WorkerWithDpRank) -> bool,
+        selected: impl Fn(WorkerWithDpRank) -> bool + Copy,
     ) -> CkfEventOutcome {
         batch.reset(self.aggregator.format);
-        let Ok(capacity) = self.aggregator.lifecycle_batch_capacity(mask) else {
-            return CkfEventOutcome::failure(KvCacheEventError::CapacityExhausted);
+        let requested_capacity = {
+            let guards = self.aggregator.lock_lanes(mask);
+            self.removal_image_capacity(&guards, mask, selected)
         };
-        if let Err(error) = batch.try_reserve(capacity) {
-            return CkfEventOutcome::failure(error);
-        }
+        let mut buffered = match requested_capacity {
+            Some(capacity) => batch.try_reserve(capacity).is_ok(),
+            None => false,
+        };
 
         let mut outcome = CkfEventOutcome::success(false);
         {
             let mut guards = self.aggregator.lock_lanes(mask);
+            buffered = buffered
+                && self
+                    .removal_image_capacity(&guards, mask, selected)
+                    .is_some_and(|required| batch.images.capacity() >= required);
             for state in guards.iter_mut().flatten() {
                 state.advance_event();
             }
@@ -1162,39 +1195,22 @@ impl RouterLocalCkfPipeline {
                     );
                 }
             }
-            #[cfg(feature = "bench")]
-            let finalization_started = Instant::now();
-            let publication = publish_locked_lanes(&mut guards, mask, &self.replica, batch);
-            #[cfg(feature = "bench")]
-            let finalization_ns = elapsed_ns(finalization_started);
-            let has_replica_update = batch.reset_lanes != 0 || !batch.images.is_empty();
-            #[cfg(feature = "bench")]
-            let apply_started = Instant::now();
-            if has_replica_update {
-                self.replica.apply(batch);
-            }
+            let publication = self.publish_locked(&mut guards, mask, batch, buffered);
             #[cfg(feature = "bench")]
             outcome.bench.record_publication(
-                &publication,
-                has_replica_update
-                    .then(|| elapsed_ns(apply_started))
-                    .unwrap_or(0),
-                !has_replica_update,
-                finalization_ns,
+                &publication.stats,
+                publication.replica_apply_ns,
+                !publication.applied,
+                publication.finalization_ns,
             );
-            #[cfg(not(feature = "bench"))]
-            let _ = publication;
-            outcome.batch_applied = has_replica_update;
+            outcome.batch_applied = publication.applied;
         }
         outcome
     }
 
     #[cfg(any(test, not(feature = "bench")))]
-    pub(super) fn flush_pending(
-        &self,
-        batch: &mut CkfDeltaBatch,
-    ) -> Result<bool, KvCacheEventError> {
-        Ok(self.flush_pending_core(batch)?.applied)
+    pub(super) fn flush_pending(&self, batch: &mut CkfDeltaBatch) -> bool {
+        self.flush_pending_core(batch).applied
     }
 
     #[cfg(feature = "bench")]
@@ -1202,8 +1218,8 @@ impl RouterLocalCkfPipeline {
         &self,
         batch: &mut CkfDeltaBatch,
         telemetry: &mut CkfBenchLocalTelemetry,
-    ) -> Result<bool, KvCacheEventError> {
-        let result = self.flush_pending_core(batch)?;
+    ) -> bool {
+        let result = self.flush_pending_core(batch);
         if let Some(publication) = result.publication.as_ref() {
             telemetry.record_publication(
                 publication,
@@ -1212,47 +1228,88 @@ impl RouterLocalCkfPipeline {
                 result.finalization_ns,
             );
         }
-        Ok(result.applied)
+        result.applied
     }
 
-    fn flush_pending_core(
-        &self,
-        batch: &mut CkfDeltaBatch,
-    ) -> Result<FlushPendingResult, KvCacheEventError> {
+    fn flush_pending_core(&self, batch: &mut CkfDeltaBatch) -> FlushPendingResult {
         batch.reset(self.aggregator.format);
         let mask = self.aggregator.manifest.active_lanes;
-        let capacity = self.aggregator.lifecycle_batch_capacity(mask)?;
-        batch.try_reserve(capacity)?;
+        let (initial_pending_mask, requested_capacity) = {
+            let guards = self.aggregator.lock_lanes(mask);
+            let pending_mask = pending_lane_mask(&guards, mask);
+            (pending_mask, pending_image_capacity(&guards, pending_mask))
+        };
+        if initial_pending_mask == 0 {
+            return FlushPendingResult::default();
+        }
+        let buffered =
+            requested_capacity.is_some_and(|capacity| batch.try_reserve(capacity).is_ok());
 
         let mut result = FlushPendingResult::default();
         {
             let mut guards = self.aggregator.lock_lanes(mask);
             let pending_mask = pending_lane_mask(&guards, mask);
             if pending_mask != 0 {
-                #[cfg(feature = "bench")]
-                let finalization_started = Instant::now();
-                let publication =
-                    publish_locked_lanes(&mut guards, pending_mask, &self.replica, batch);
-                #[cfg(feature = "bench")]
-                let finalization_ns = elapsed_ns(finalization_started);
-                let has_replica_update = batch.reset_lanes != 0 || !batch.images.is_empty();
-                #[cfg(feature = "bench")]
-                let apply_started = Instant::now();
-                if has_replica_update {
-                    self.replica.apply(batch);
-                }
+                let buffered = buffered
+                    && pending_image_capacity(&guards, pending_mask)
+                        .is_some_and(|required| batch.images.capacity() >= required);
+                let publication = self.publish_locked(&mut guards, pending_mask, batch, buffered);
+                result.applied = publication.applied;
                 #[cfg(feature = "bench")]
                 {
-                    result.replica_apply_ns = has_replica_update
-                        .then(|| elapsed_ns(apply_started))
-                        .unwrap_or(0);
-                    result.finalization_ns = finalization_ns;
+                    result.replica_apply_ns = publication.replica_apply_ns;
+                    result.finalization_ns = publication.finalization_ns;
                 }
-                result.applied = has_replica_update;
-                result.publication = Some(publication);
+                result.publication = Some(publication.stats);
             }
         }
-        Ok(result)
+        result
+    }
+
+    fn publish_locked(
+        &self,
+        guards: &mut [Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+        mask: u16,
+        batch: &mut CkfDeltaBatch,
+        buffered: bool,
+    ) -> AppliedPublication {
+        if buffered {
+            #[cfg(feature = "bench")]
+            let finalization_started = Instant::now();
+            let stats = publish_locked_lanes(guards, mask, &self.replica, batch);
+            #[cfg(feature = "bench")]
+            let finalization_ns = elapsed_ns(finalization_started);
+            let applied = stats.has_replica_update();
+            #[cfg(feature = "bench")]
+            let apply_started = Instant::now();
+            if applied {
+                self.replica.apply(batch);
+            }
+            return AppliedPublication {
+                stats,
+                applied,
+                #[cfg(feature = "bench")]
+                replica_apply_ns: if applied {
+                    elapsed_ns(apply_started)
+                } else {
+                    0
+                },
+                #[cfg(feature = "bench")]
+                finalization_ns,
+            };
+        }
+
+        #[cfg(feature = "bench")]
+        let started = Instant::now();
+        let stats = publish_locked_lanes_direct(guards, mask, &self.replica);
+        AppliedPublication {
+            applied: stats.has_replica_update(),
+            stats,
+            #[cfg(feature = "bench")]
+            replica_apply_ns: 0,
+            #[cfg(feature = "bench")]
+            finalization_ns: elapsed_ns(started),
+        }
     }
 
     pub(super) fn worker_stats(&self, worker_ids: &FxHashSet<WorkerId>) -> WorkerLookupStats {
@@ -1358,6 +1415,19 @@ fn pending_lane_mask(
         })
 }
 
+fn pending_image_capacity(
+    guards: &[Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+    mask: u16,
+) -> Option<usize> {
+    guards
+        .iter()
+        .enumerate()
+        .filter(|(lane, _)| mask & (1u16 << lane) != 0)
+        .try_fold(0usize, |capacity, (_, state)| {
+            capacity.checked_add(state.as_ref()?.dirty_scratch.len())
+        })
+}
+
 #[derive(Debug, Default)]
 struct PublicationStats {
     lane_windows: u64,
@@ -1373,6 +1443,21 @@ struct PublicationStats {
     maximum_staleness_ns: u64,
 }
 
+impl PublicationStats {
+    fn has_replica_update(&self) -> bool {
+        self.final_images != 0 || self.reset_lanes != 0
+    }
+}
+
+struct AppliedPublication {
+    stats: PublicationStats,
+    applied: bool,
+    #[cfg(feature = "bench")]
+    replica_apply_ns: u64,
+    #[cfg(feature = "bench")]
+    finalization_ns: u64,
+}
+
 #[derive(Debug, Default)]
 struct FlushPendingResult {
     applied: bool,
@@ -1383,11 +1468,55 @@ struct FlushPendingResult {
     finalization_ns: u64,
 }
 
+enum PublicationTarget<'a> {
+    Batch(&'a mut CkfDeltaBatch),
+    Replica(&'a TransposedCkfReplica),
+}
+
+impl PublicationTarget<'_> {
+    fn reset_lane(&mut self, lane: usize) {
+        match self {
+            Self::Batch(batch) => batch.reset_lanes |= 1u16 << lane,
+            Self::Replica(replica) => replica.table.clear_lane(lane),
+        }
+    }
+
+    fn emit(&mut self, image: CkfBucketImage) {
+        match self {
+            Self::Batch(batch) => batch.images.push(image),
+            Self::Replica(replica) => replica.table.store_image(
+                image.bucket,
+                usize::from(image.lane),
+                PackedBucket(image.value),
+            ),
+        }
+    }
+}
+
 fn publish_locked_lanes(
     guards: &mut [Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
     mask: u16,
     replica: &TransposedCkfReplica,
     batch: &mut CkfDeltaBatch,
+) -> PublicationStats {
+    let stats = publish_locked_lanes_to(guards, mask, replica, PublicationTarget::Batch(batch));
+    debug_assert_eq!(batch.reset_lanes & !mask, 0);
+    stats
+}
+
+fn publish_locked_lanes_direct(
+    guards: &mut [Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+    mask: u16,
+    replica: &TransposedCkfReplica,
+) -> PublicationStats {
+    publish_locked_lanes_to(guards, mask, replica, PublicationTarget::Replica(replica))
+}
+
+fn publish_locked_lanes_to(
+    guards: &mut [Option<MutexGuard<'_, RelayLaneState>>; DC_COUNT],
+    mask: u16,
+    replica: &TransposedCkfReplica,
+    mut target: PublicationTarget<'_>,
 ) -> PublicationStats {
     let mut stats = PublicationStats::default();
     for (lane, state) in guards.iter_mut().enumerate() {
@@ -1397,23 +1526,19 @@ fn publish_locked_lanes(
         if mask & (1u16 << lane) == 0 {
             continue;
         }
-        let images_before = batch.images.len();
         let distinct_touched = state.dirty_scratch.len() as u64;
         if state.dc_refcounts.is_empty() && state.published_nonempty {
             state.reset_filter();
-            batch.reset_lanes |= 1u16 << lane;
+            target.reset_lane(lane);
             stats.reset_lanes += 1;
         } else if state.dc_refcounts.is_empty() {
             stats.net_reverted = stats.net_reverted.saturating_add(distinct_touched);
             state.dirty_scratch.clear();
         } else {
-            let finalized = state.finalize_images(lane, replica, batch);
+            let finalized = state.finalize_images(lane, replica, |image| target.emit(image));
             debug_assert_eq!(finalized.distinct_touched, distinct_touched);
             stats.net_reverted = stats.net_reverted.saturating_add(finalized.net_reverted);
-            debug_assert_eq!(
-                finalized.emitted_images,
-                (batch.images.len() - images_before) as u64
-            );
+            stats.final_images = stats.final_images.saturating_add(finalized.emitted_images);
         }
         stats.lane_windows += 1;
         stats.lane_events = stats
@@ -1423,9 +1548,6 @@ fn publish_locked_lanes(
             .physical_touches
             .saturating_add(state.physical_touches_pending);
         stats.distinct_touched = stats.distinct_touched.saturating_add(distinct_touched);
-        stats.final_images = stats
-            .final_images
-            .saturating_add((batch.images.len() - images_before) as u64);
         #[cfg(feature = "bench")]
         if let Some(started_at) = state.window_started_at.take() {
             let staleness = started_at.elapsed().as_nanos().min(u64::MAX as u128) as u64;
@@ -1435,7 +1557,6 @@ fn publish_locked_lanes(
         state.physical_touches_pending = 0;
         state.finish_publication();
     }
-    debug_assert_eq!(batch.reset_lanes & !mask, 0);
     stats
 }
 

--- a/lib/kv-router/src/indexer/cuckoo/relay.rs
+++ b/lib/kv-router/src/indexer/cuckoo/relay.rs
@@ -337,6 +337,9 @@ pub struct CkfMemorySnapshot {
     pub insertion_scratch_capacity: usize,
 }
 
+// One bit per bucket plus first-touch order keeps publication-window draining O(touched).
+// Generation marks add per-bucket memory and wrap handling; reconsider them only for a measured
+// marking bottleneck.
 #[derive(Debug)]
 struct DirtyBatchScratch {
     words: Box<[u64]>,
@@ -445,6 +448,8 @@ impl RelayLaneState {
             .expected_contributions
             .checked_rem(member_count)
             .unwrap_or(0);
+        // Equal-share reservation is intentional. Use the capacity telemetry to demonstrate
+        // real ownership skew before introducing a weighted or lazy policy.
         for (member_index, &member) in lane_config.members.iter().enumerate() {
             let mut blocks = FxHashSet::default();
             blocks
@@ -628,6 +633,8 @@ impl RelayLaneState {
             distinct_touched: self.dirty_scratch.len() as u64,
             ..FinalizeImageStats::default()
         };
+        // First-touch order is intentional. Only revisit sorting or destination-store prefetch
+        // when replica_apply_ns is a measured hotspot, and validate it in the combined workload.
         for index in 0..self.dirty_scratch.len() {
             let bucket = self.dirty_scratch.bucket(index);
             let value = self.filter.load_bucket(bucket);
@@ -647,6 +654,8 @@ impl RelayLaneState {
     }
 
     fn reset_filter(&mut self) {
+        // Aggregator occupancy tracking added 1.44% without Clears and had no material benefit
+        // at one Clear per 1,000 events. This contiguous full clear is deliberate.
         self.filter.clear();
         self.dirty_scratch.clear();
     }
@@ -858,6 +867,8 @@ impl TransposedCkfReplica {
         &self,
         sequence: &[crate::protocols::LocalBlockHash],
     ) -> Vec<CkfProbe> {
+        // TODO(perf): Add a canonical sequence-hash sink or iterator so this can build probes
+        // without an intermediate Vec while preserving the shared hashing implementation.
         crate::protocols::compute_seq_hash_for_block(sequence)
             .into_iter()
             .map(|hash| self.addressing.prepare(hash))

--- a/lib/kv-router/src/indexer/cuckoo/relay.rs
+++ b/lib/kv-router/src/indexer/cuckoo/relay.rs
@@ -11,7 +11,9 @@
 //! complete snapshot, and recovery must validate and atomically publish a fully initialized table.
 //! This module deliberately implements none of that transport, fencing, or recovery machinery.
 
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::AtomicU64;
+#[cfg(feature = "bench")]
+use std::sync::atomic::Ordering;
 #[cfg(feature = "bench")]
 use std::time::Instant;
 
@@ -791,65 +793,11 @@ impl CkfRelayAggregator {
 }
 
 #[derive(Debug)]
-struct ReplicaOccupancy {
-    words_per_lane: usize,
-    words: Box<[AtomicU64]>,
-}
-
-impl ReplicaOccupancy {
-    fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
-        let words_per_lane = bucket_count.div_ceil(u64::BITS as usize);
-        let word_count = words_per_lane
-            .checked_mul(DC_COUNT)
-            .ok_or(CkfBuildError::CapacityOverflow)?;
-        let mut words = Vec::new();
-        words
-            .try_reserve_exact(word_count)
-            .map_err(|_| CkfBuildError::AllocationFailed)?;
-        words.extend((0..word_count).map(|_| AtomicU64::new(0)));
-        Ok(Self {
-            words_per_lane,
-            words: words.into_boxed_slice(),
-        })
-    }
-
-    fn set(&self, lane: usize, bucket: usize, occupied: bool) {
-        let index = lane * self.words_per_lane + bucket / u64::BITS as usize;
-        let bit = 1u64 << (bucket % u64::BITS as usize);
-        if occupied {
-            self.words[index].fetch_or(bit, Ordering::Relaxed);
-        } else {
-            self.words[index].fetch_and(!bit, Ordering::Relaxed);
-        }
-    }
-
-    fn clear_lane(&self, table: &TransposedCkfTable<DC_COUNT>, lane: usize) {
-        let start = lane * self.words_per_lane;
-        for word_index in 0..self.words_per_lane {
-            let mut remaining = self.words[start + word_index].swap(0, Ordering::Relaxed);
-            while remaining != 0 {
-                let bit = remaining.trailing_zeros() as usize;
-                let bucket = word_index * u64::BITS as usize + bit;
-                if bucket < table.bucket_count() {
-                    table.store_image(bucket, lane, PackedBucket::default());
-                }
-                remaining &= remaining - 1;
-            }
-        }
-    }
-
-    fn byte_len(&self) -> usize {
-        std::mem::size_of_val(self.words.as_ref())
-    }
-}
-
-#[derive(Debug)]
 pub struct TransposedCkfReplica {
     pub(super) table: TransposedCkfTable<DC_COUNT>,
     pub(super) addressing: CkfAddressing,
     pub(super) config: CkfConfig,
     format: CkfFormatIdentity,
-    occupied_buckets: ReplicaOccupancy,
 }
 
 impl TransposedCkfReplica {
@@ -859,7 +807,6 @@ impl TransposedCkfReplica {
             addressing: CkfAddressing::new(format.bucket_count, format.seed),
             config,
             format,
-            occupied_buckets: ReplicaOccupancy::new(format.bucket_count)?,
         })
     }
 
@@ -912,14 +859,12 @@ impl TransposedCkfReplica {
             if batch.reset_lanes & (1u16 << lane) == 0 {
                 continue;
             }
-            self.occupied_buckets.clear_lane(&self.table, lane);
+            self.table.clear_lane(lane);
         }
         for image in &batch.images {
             let lane = usize::from(image.lane);
             let value = PackedBucket(image.value);
             self.table.store_image(image.bucket, lane, value);
-            self.occupied_buckets
-                .set(lane, image.bucket, value != PackedBucket::default());
         }
     }
 
@@ -928,7 +873,7 @@ impl TransposedCkfReplica {
     }
 
     fn occupancy_byte_len(&self) -> usize {
-        self.occupied_buckets.byte_len()
+        0
     }
 }
 

--- a/lib/kv-router/src/indexer/cuckoo/relay.rs
+++ b/lib/kv-router/src/indexer/cuckoo/relay.rs
@@ -258,6 +258,7 @@ impl CkfDeltaBatch {
     }
 }
 
+#[must_use = "inspect the CKF event outcome for aggregation or publication failures"]
 #[derive(Debug)]
 pub struct CkfEventOutcome {
     first_error: Option<KvCacheEventError>,
@@ -322,19 +323,66 @@ impl CkfEventOutcome {
     }
 }
 
+#[non_exhaustive]
 #[derive(Debug, Clone, Copy, Default)]
 pub struct CkfMemorySnapshot {
-    pub configured_unique_capacity: usize,
-    pub configured_contribution_capacity: usize,
-    pub actual_contributions: usize,
-    pub member_set_capacity: usize,
-    pub dc_refcount_capacity: usize,
-    pub owned_filter_bytes: usize,
-    pub replica_bytes: usize,
-    pub dirty_tracking_bytes: usize,
-    pub aggregator_occupancy_bytes: usize,
-    pub replica_occupancy_bytes: usize,
-    pub insertion_scratch_capacity: usize,
+    configured_unique_capacity: usize,
+    configured_contribution_capacity: usize,
+    actual_contributions: usize,
+    member_set_capacity: usize,
+    dc_refcount_capacity: usize,
+    owned_filter_bytes: usize,
+    replica_bytes: usize,
+    dirty_tracking_bytes: usize,
+    aggregator_occupancy_bytes: usize,
+    replica_occupancy_bytes: usize,
+    insertion_scratch_capacity: usize,
+}
+
+impl CkfMemorySnapshot {
+    pub fn configured_unique_capacity(self) -> usize {
+        self.configured_unique_capacity
+    }
+
+    pub fn configured_contribution_capacity(self) -> usize {
+        self.configured_contribution_capacity
+    }
+
+    pub fn actual_contributions(self) -> usize {
+        self.actual_contributions
+    }
+
+    pub fn member_set_capacity(self) -> usize {
+        self.member_set_capacity
+    }
+
+    pub fn dc_refcount_capacity(self) -> usize {
+        self.dc_refcount_capacity
+    }
+
+    pub fn owned_filter_bytes(self) -> usize {
+        self.owned_filter_bytes
+    }
+
+    pub fn replica_bytes(self) -> usize {
+        self.replica_bytes
+    }
+
+    pub fn dirty_tracking_bytes(self) -> usize {
+        self.dirty_tracking_bytes
+    }
+
+    pub fn aggregator_occupancy_bytes(self) -> usize {
+        self.aggregator_occupancy_bytes
+    }
+
+    pub fn replica_occupancy_bytes(self) -> usize {
+        self.replica_occupancy_bytes
+    }
+
+    pub fn insertion_scratch_capacity(self) -> usize {
+        self.insertion_scratch_capacity
+    }
 }
 
 // One bit per bucket plus first-touch order keeps publication-window draining O(touched).
@@ -670,6 +718,10 @@ impl RelayLaneState {
     }
 }
 
+/// Exact aggregation state owned by the router-local Relay-shaped pipeline.
+///
+/// A standalone publisher API is intentionally deferred. Construct a
+/// [`RouterLocalCkfPipeline`] so aggregation and replica application remain ordered in-process.
 #[derive(Debug)]
 pub struct CkfRelayAggregator {
     manifest: RelayManifest,

--- a/lib/kv-router/src/indexer/cuckoo/relay.rs
+++ b/lib/kv-router/src/indexer/cuckoo/relay.rs
@@ -371,48 +371,6 @@ impl DirtyBatchScratch {
 }
 
 #[derive(Debug)]
-struct OccupiedBucketTracker {
-    words: Box<[u64]>,
-}
-
-impl OccupiedBucketTracker {
-    fn new(bucket_count: usize) -> Result<Self, CkfBuildError> {
-        Ok(Self {
-            words: zeroed_boxed_slice(bucket_count.div_ceil(u64::BITS as usize))?,
-        })
-    }
-
-    fn set(&mut self, bucket: usize, occupied: bool) {
-        let word = bucket / u64::BITS as usize;
-        let bit = 1u64 << (bucket % u64::BITS as usize);
-        if occupied {
-            self.words[word] |= bit;
-        } else {
-            self.words[word] &= !bit;
-        }
-    }
-
-    fn clear_filter(&mut self, filter: &OwnedPackedCkfLane) {
-        for (word_index, word) in self.words.iter_mut().enumerate() {
-            let mut remaining = *word;
-            while remaining != 0 {
-                let bit = remaining.trailing_zeros() as usize;
-                filter.store_bucket(
-                    word_index * u64::BITS as usize + bit,
-                    PackedBucket::default(),
-                );
-                remaining &= remaining - 1;
-            }
-            *word = 0;
-        }
-    }
-
-    fn byte_len(&self) -> usize {
-        std::mem::size_of_val(self.words.as_ref())
-    }
-}
-
-#[derive(Debug)]
 struct RelayLaneState {
     member_blocks: FxHashMap<WorkerWithDpRank, FxHashSet<ExternalSequenceBlockHash>>,
     dc_refcounts: FxHashMap<ExternalSequenceBlockHash, u32>,
@@ -420,7 +378,6 @@ struct RelayLaneState {
     rng: u64,
     insertion_scratch: CuckooInsertionScratch,
     dirty_scratch: DirtyBatchScratch,
-    occupied_buckets: Option<OccupiedBucketTracker>,
     member_remove_scratch: Vec<ExternalSequenceBlockHash>,
     events_since_publish: usize,
     published_nonempty: bool,
@@ -454,7 +411,6 @@ impl RelayLaneState {
         lane_config: &RelayLaneConfig,
         config: CkfConfig,
         bucket_count: usize,
-        track_occupied: bool,
     ) -> Result<Self, CkfBuildError> {
         let member_count = lane_config.members.len();
         let mut member_blocks = FxHashMap::default();
@@ -494,9 +450,6 @@ impl RelayLaneState {
             insertion_scratch: CuckooInsertionScratch::new(config.max_kicks)
                 .map_err(|_| CkfBuildError::AllocationFailed)?,
             dirty_scratch: DirtyBatchScratch::new(bucket_count)?,
-            occupied_buckets: track_occupied
-                .then(|| OccupiedBucketTracker::new(bucket_count))
-                .transpose()?,
             member_remove_scratch,
             events_since_publish: 0,
             published_nonempty: false,
@@ -658,9 +611,6 @@ impl RelayLaneState {
         for index in 0..self.dirty_scratch.len() {
             let bucket = self.dirty_scratch.bucket(index);
             let value = self.filter.load_bucket(bucket);
-            if let Some(occupied) = self.occupied_buckets.as_mut() {
-                occupied.set(bucket, value != PackedBucket::default());
-            }
             if replica.table.load_image(bucket, lane) == value {
                 stats.net_reverted += 1;
             } else {
@@ -677,11 +627,7 @@ impl RelayLaneState {
     }
 
     fn reset_filter(&mut self) {
-        if let Some(occupied) = self.occupied_buckets.as_mut() {
-            occupied.clear_filter(&self.filter);
-        } else {
-            self.filter.clear();
-        }
+        self.filter.clear();
         self.dirty_scratch.clear();
     }
 
@@ -726,7 +672,6 @@ impl CkfRelayAggregator {
             }
         }
 
-        let track_occupied = benchmark_flag("DYNAMO_CKF_AGGREGATOR_OCCUPANCY");
         let mut lane_states = Vec::new();
         lane_states
             .try_reserve_exact(DC_COUNT)
@@ -740,7 +685,6 @@ impl CkfRelayAggregator {
                     lane_config,
                     config,
                     bucket_count,
-                    track_occupied,
                 )?))
             };
             lane_states.push(state);
@@ -838,13 +782,6 @@ impl CkfRelayAggregator {
             snapshot.dirty_tracking_bytes = snapshot
                 .dirty_tracking_bytes
                 .saturating_add(state.dirty_scratch.byte_len());
-            snapshot.aggregator_occupancy_bytes =
-                snapshot.aggregator_occupancy_bytes.saturating_add(
-                    state
-                        .occupied_buckets
-                        .as_ref()
-                        .map_or(0, OccupiedBucketTracker::byte_len),
-                );
             snapshot.insertion_scratch_capacity = snapshot
                 .insertion_scratch_capacity
                 .saturating_add(state.insertion_scratch.capacity());
@@ -912,7 +849,7 @@ pub struct TransposedCkfReplica {
     pub(super) addressing: CkfAddressing,
     pub(super) config: CkfConfig,
     format: CkfFormatIdentity,
-    occupied_buckets: Option<ReplicaOccupancy>,
+    occupied_buckets: ReplicaOccupancy,
 }
 
 impl TransposedCkfReplica {
@@ -922,9 +859,7 @@ impl TransposedCkfReplica {
             addressing: CkfAddressing::new(format.bucket_count, format.seed),
             config,
             format,
-            occupied_buckets: benchmark_flag("DYNAMO_CKF_REPLICA_OCCUPANCY")
-                .then(|| ReplicaOccupancy::new(format.bucket_count))
-                .transpose()?,
+            occupied_buckets: ReplicaOccupancy::new(format.bucket_count)?,
         })
     }
 
@@ -977,19 +912,14 @@ impl TransposedCkfReplica {
             if batch.reset_lanes & (1u16 << lane) == 0 {
                 continue;
             }
-            if let Some(occupied) = &self.occupied_buckets {
-                occupied.clear_lane(&self.table, lane);
-            } else {
-                self.table.clear_lane(lane);
-            }
+            self.occupied_buckets.clear_lane(&self.table, lane);
         }
         for image in &batch.images {
             let lane = usize::from(image.lane);
             let value = PackedBucket(image.value);
             self.table.store_image(image.bucket, lane, value);
-            if let Some(occupied) = &self.occupied_buckets {
-                occupied.set(lane, image.bucket, value != PackedBucket::default());
-            }
+            self.occupied_buckets
+                .set(lane, image.bucket, value != PackedBucket::default());
         }
     }
 
@@ -998,9 +928,7 @@ impl TransposedCkfReplica {
     }
 
     fn occupancy_byte_len(&self) -> usize {
-        self.occupied_buckets
-            .as_ref()
-            .map_or(0, ReplicaOccupancy::byte_len)
+        self.occupied_buckets.byte_len()
     }
 }
 
@@ -1813,16 +1741,6 @@ fn retain_first_error(slot: &mut Option<KvCacheEventError>, error: KvCacheEventE
     if slot.is_none() {
         *slot = Some(error);
     }
-}
-
-#[cfg(any(test, feature = "bench"))]
-fn benchmark_flag(name: &str) -> bool {
-    std::env::var_os(name).is_some()
-}
-
-#[cfg(not(any(test, feature = "bench")))]
-fn benchmark_flag(_name: &str) -> bool {
-    false
 }
 
 fn zeroed_boxed_slice<T: Default>(len: usize) -> Result<Box<[T]>, CkfBuildError> {

--- a/lib/kv-router/src/indexer/cuckoo/search.rs
+++ b/lib/kv-router/src/indexer/cuckoo/search.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use super::MAX_VERIFICATION_WINDOW;
-
 #[cfg(test)]
 use std::cell::RefCell;
+
+use super::MAX_VERIFICATION_WINDOW;
 
 const MAX_LANES: usize = 16;
 const MAX_VERIFICATION_GROUPS: usize = MAX_LANES * MAX_VERIFICATION_WINDOW;
@@ -24,10 +24,28 @@ pub(super) struct FallbackStats {
     pub(super) provenance_skips: u64,
 }
 
+impl FallbackStats {
+    fn merge(&mut self, other: Self) {
+        self.left_edge_lanes += other.left_edge_lanes;
+        self.activated_lanes += other.activated_lanes;
+        self.probe_calls += other.probe_calls;
+        self.lane_probes += other.lane_probes;
+        self.provenance_skips += other.provenance_skips;
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct PrefixSearchResult<const D: usize> {
     pub(super) depths: [u32; D],
     pub(super) fallback: FallbackStats,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct PrefixSearchState<const D: usize> {
+    active: u16,
+    lower: [usize; D],
+    lower_predecessor: [usize; D],
+    upper: [usize; D],
 }
 
 #[cfg(test)]
@@ -110,6 +128,41 @@ pub(super) fn find_prefix_depths_with_stats<const D: usize>(
     )
 }
 
+#[cfg(any(not(feature = "metrics"), test))]
+pub(super) fn find_max_depth_matches<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> [u32; D] {
+    find_max_depth_matches_impl::<D, true, false>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    )
+    .depths
+}
+
+#[cfg(feature = "metrics")]
+pub(super) fn find_max_depth_matches_with_stats<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> PrefixSearchResult<D> {
+    find_max_depth_matches_impl::<D, true, false>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    )
+}
+
 #[cfg(test)]
 pub(super) fn fixed_window_prefix_depths<const D: usize>(
     sequence_len: usize,
@@ -153,17 +206,73 @@ pub(super) fn find_prefix_depths_with_test_trace<const D: usize>(
     prefetch: impl FnMut(usize),
     probe: impl FnMut(usize) -> u16,
 ) -> (PrefixSearchResult<D>, Vec<SearchTraceEvent>) {
+    trace_search(|| {
+        find_prefix_depths_impl::<D, true, true>(
+            sequence_len,
+            initial_mask,
+            verification_window,
+            prefetch,
+            probe,
+        )
+    })
+}
+
+#[cfg(test)]
+pub(super) fn find_max_depth_matches_with_test_trace<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> (PrefixSearchResult<D>, Vec<SearchTraceEvent>) {
+    trace_search(|| {
+        find_max_depth_matches_impl::<D, true, true>(
+            sequence_len,
+            initial_mask,
+            verification_window,
+            prefetch,
+            probe,
+        )
+    })
+}
+
+#[cfg(test)]
+pub(super) fn refine_binary_level_with_test_trace<const D: usize>(
+    lower: [usize; D],
+    upper: [usize; D],
+    selected: u16,
+    eligible: u16,
+    probe: impl FnMut(usize) -> u16,
+) -> ([usize; D], [usize; D], Vec<SearchTraceEvent>) {
+    let mut state = PrefixSearchState {
+        active: eligible,
+        lower,
+        lower_predecessor: [0; D],
+        upper,
+    };
+    let (_, trace) = trace_search(|| {
+        let mut probe = probe;
+        assert!(refine_binary_level::<D, true>(
+            &mut state,
+            selected,
+            eligible,
+            &mut |_| {},
+            &mut probe,
+        ));
+        empty_result::<D>()
+    });
+    (state.lower, state.upper, trace)
+}
+
+#[cfg(test)]
+fn trace_search<const D: usize>(
+    search: impl FnOnce() -> PrefixSearchResult<D>,
+) -> (PrefixSearchResult<D>, Vec<SearchTraceEvent>) {
     SEARCH_TRACE.with_borrow_mut(|trace| {
         assert!(trace.is_none(), "nested CKF search tracing is unsupported");
         *trace = Some(Vec::new());
     });
-    let result = find_prefix_depths_impl::<D, true, true>(
-        sequence_len,
-        initial_mask,
-        verification_window,
-        prefetch,
-        probe,
-    );
+    let result = search();
     let trace = SEARCH_TRACE.with_borrow_mut(|trace| {
         trace
             .take()
@@ -179,28 +288,190 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
     mut prefetch: impl FnMut(usize),
     mut probe: impl FnMut(usize) -> u16,
 ) -> PrefixSearchResult<D> {
-    let mut depths = [0u32; D];
-    let mut fallback = FallbackStats::default();
     if sequence_len == 0 {
-        return PrefixSearchResult { depths, fallback };
+        return empty_result();
     }
 
     debug_assert!((1..=MAX_LANES).contains(&D));
     debug_assert!((1..=MAX_VERIFICATION_WINDOW).contains(&verification_window));
-    let configured_mask = lane_mask::<D>();
-    let configured = initial_mask & configured_mask;
+    let mut state =
+        initialize_search::<D, TRACE>(sequence_len, initial_mask, &mut prefetch, &mut probe);
+    if state.active == 0 {
+        return empty_result();
+    }
+
+    let active = state.active;
+    while refine_binary_level::<D, TRACE>(&mut state, active, active, &mut prefetch, &mut probe) {}
+
+    finalize_lanes::<D, FALLBACK, TRACE>(
+        &state,
+        active,
+        verification_window,
+        &mut prefetch,
+        &mut probe,
+    )
+}
+
+fn find_max_depth_matches_impl<const D: usize, const FALLBACK: bool, const TRACE: bool>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    mut prefetch: impl FnMut(usize),
+    mut probe: impl FnMut(usize) -> u16,
+) -> PrefixSearchResult<D> {
+    if sequence_len == 0 {
+        return empty_result();
+    }
+
+    debug_assert!((1..=MAX_LANES).contains(&D));
+    debug_assert!((1..=MAX_VERIFICATION_WINDOW).contains(&verification_window));
+    let mut state =
+        initialize_search::<D, TRACE>(sequence_len, initial_mask, &mut prefetch, &mut probe);
+    if state.active == 0 {
+        return empty_result();
+    }
+    // Maximum-only search is not universally faster: equal ceilings provide no frontier to
+    // prune. Reuse the full scheduler for that case; see PR #11435 for workload benchmarks.
+    if active_lanes_share_ceiling(&state) {
+        let active = state.active;
+        while refine_binary_level::<D, TRACE>(&mut state, active, active, &mut prefetch, &mut probe)
+        {
+        }
+        return project_max_depths(finalize_lanes::<D, FALLBACK, TRACE>(
+            &state,
+            active,
+            verification_window,
+            &mut prefetch,
+            &mut probe,
+        ));
+    }
+    let mut unresolved = state.active;
+    let mut best_depth = 0u32;
+    let mut winners = 0u16;
+    let mut fallback = FallbackStats::default();
+
+    while unresolved != 0 {
+        for lane in 0..D {
+            let lane_bit = 1u16 << lane;
+            if unresolved & lane_bit != 0 && score_bound(state.upper[lane]) < best_depth {
+                unresolved &= !lane_bit;
+            }
+        }
+        if unresolved == 0 {
+            break;
+        }
+
+        let frontier_ceiling = (0..D)
+            .filter(|&lane| unresolved & (1u16 << lane) != 0)
+            .map(|lane| score_bound(state.upper[lane]))
+            .max()
+            .expect("at least one unresolved CKF lane");
+        let mut frontier = 0u16;
+        let mut terminal = 0u16;
+        for lane in 0..D {
+            let lane_bit = 1u16 << lane;
+            if unresolved & lane_bit == 0 || score_bound(state.upper[lane]) != frontier_ceiling {
+                continue;
+            }
+            frontier |= lane_bit;
+            if state.upper[lane] - state.lower[lane] <= 1 {
+                terminal |= lane_bit;
+            }
+        }
+
+        if terminal != 0 {
+            let result = finalize_lanes::<D, FALLBACK, TRACE>(
+                &state,
+                terminal,
+                verification_window,
+                &mut prefetch,
+                &mut probe,
+            );
+            fallback.merge(result.fallback);
+            for (lane, &depth) in result.depths.iter().enumerate() {
+                let lane_bit = 1u16 << lane;
+                if terminal & lane_bit == 0 || depth == 0 {
+                    continue;
+                }
+                if depth > best_depth {
+                    best_depth = depth;
+                    winners = lane_bit;
+                } else if depth == best_depth {
+                    winners |= lane_bit;
+                }
+            }
+            unresolved &= !terminal;
+            continue;
+        }
+
+        let refined = refine_binary_level::<D, TRACE>(
+            &mut state,
+            frontier,
+            unresolved,
+            &mut prefetch,
+            &mut probe,
+        );
+        debug_assert!(refined, "nonterminal CKF frontier must have a midpoint");
+    }
+
+    let mut depths = [0u32; D];
+    if best_depth != 0 {
+        for (lane, depth) in depths.iter_mut().enumerate() {
+            if winners & (1u16 << lane) != 0 {
+                *depth = best_depth;
+            }
+        }
+    }
+    PrefixSearchResult { depths, fallback }
+}
+
+fn active_lanes_share_ceiling<const D: usize>(state: &PrefixSearchState<D>) -> bool {
+    let mut ceiling = None;
+    for lane in 0..D {
+        if state.active & (1u16 << lane) == 0 {
+            continue;
+        }
+        let lane_ceiling = score_bound(state.upper[lane]);
+        if ceiling.is_some_and(|ceiling| ceiling != lane_ceiling) {
+            return false;
+        }
+        ceiling = Some(lane_ceiling);
+    }
+    true
+}
+
+fn project_max_depths<const D: usize>(mut result: PrefixSearchResult<D>) -> PrefixSearchResult<D> {
+    let best_depth = result.depths.iter().copied().max().unwrap_or(0);
+    for depth in &mut result.depths {
+        if *depth != best_depth {
+            *depth = 0;
+        }
+    }
+    result
+}
+
+fn initialize_search<const D: usize, const TRACE: bool>(
+    sequence_len: usize,
+    initial_mask: u16,
+    prefetch: &mut impl FnMut(usize),
+    probe: &mut impl FnMut(usize) -> u16,
+) -> PrefixSearchState<D> {
+    let configured = initial_mask & lane_mask::<D>();
     #[cfg(test)]
     if TRACE {
         record_trace(SearchTraceKind::Probe, SearchPhase::Initial, 0, configured);
     }
     let active = configured & probe(0);
+    let mut state = PrefixSearchState {
+        active,
+        lower: [0; D],
+        lower_predecessor: [0; D],
+        upper: [sequence_len; D],
+    };
     if active == 0 {
-        return PrefixSearchResult { depths, fallback };
+        return state;
     }
 
-    let mut lower = [0usize; D];
-    let mut lower_predecessor = [0usize; D];
-    let mut upper = [sequence_len; D];
     let mut sampling = active;
     let mut position = 1usize;
     if position < sequence_len {
@@ -244,10 +515,10 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
         for lane in 0..D {
             let lane_bit = 1u16 << lane;
             if hit_lanes & lane_bit != 0 {
-                lower_predecessor[lane] = lower[lane];
-                lower[lane] = position;
+                state.lower_predecessor[lane] = state.lower[lane];
+                state.lower[lane] = position;
             } else if miss_lanes & lane_bit != 0 {
-                upper[lane] = position;
+                state.upper[lane] = position;
             }
         }
         sampling &= hits;
@@ -258,71 +529,100 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
         position = next;
     }
 
-    loop {
-        let mut groups = [ProbeGroup::default(); MAX_LANES];
-        let mut group_count = 0usize;
+    state
+}
+
+fn refine_binary_level<const D: usize, const TRACE: bool>(
+    state: &mut PrefixSearchState<D>,
+    selected: u16,
+    eligible: u16,
+    prefetch: &mut impl FnMut(usize),
+    probe: &mut impl FnMut(usize) -> u16,
+) -> bool {
+    let mut groups = [ProbeGroup::default(); MAX_LANES];
+    let mut group_count = 0usize;
+    for lane in 0..D {
+        let lane_bit = 1u16 << lane;
+        if eligible & lane_bit == 0 || state.upper[lane] - state.lower[lane] <= 1 {
+            continue;
+        }
+        let midpoint = state.lower[lane] + (state.upper[lane] - state.lower[lane]) / 2;
+        add_group(&mut groups, &mut group_count, midpoint, lane_bit);
+    }
+
+    let has_selected_group = groups[..group_count]
+        .iter()
+        .any(|group| group.lanes & selected != 0);
+    if !has_selected_group {
+        return false;
+    }
+
+    for group in groups[..group_count]
+        .iter()
+        .filter(|group| group.lanes & selected != 0)
+    {
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Prefetch,
+                SearchPhase::Binary,
+                group.position,
+                group.lanes,
+            );
+        }
+        prefetch(group.position);
+    }
+    for group in groups[..group_count]
+        .iter()
+        .filter(|group| group.lanes & selected != 0)
+    {
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Probe,
+                SearchPhase::Binary,
+                group.position,
+                group.lanes,
+            );
+        }
+        let hits = probe(group.position);
         for lane in 0..D {
             let lane_bit = 1u16 << lane;
-            if active & lane_bit == 0 || upper[lane] - lower[lane] <= 1 {
+            if group.lanes & lane_bit == 0 {
                 continue;
             }
-            let midpoint = lower[lane] + (upper[lane] - lower[lane]) / 2;
-            add_group(&mut groups, &mut group_count, midpoint, lane_bit);
-        }
-        if group_count == 0 {
-            break;
-        }
-
-        for group in &groups[..group_count] {
-            #[cfg(test)]
-            if TRACE {
-                record_trace(
-                    SearchTraceKind::Prefetch,
-                    SearchPhase::Binary,
-                    group.position,
-                    group.lanes,
-                );
-            }
-            prefetch(group.position);
-        }
-        for group in &groups[..group_count] {
-            #[cfg(test)]
-            if TRACE {
-                record_trace(
-                    SearchTraceKind::Probe,
-                    SearchPhase::Binary,
-                    group.position,
-                    group.lanes,
-                );
-            }
-            let hits = probe(group.position);
-            for lane in 0..D {
-                let lane_bit = 1u16 << lane;
-                if group.lanes & lane_bit == 0 {
-                    continue;
-                }
-                if hits & lane_bit != 0 {
-                    lower_predecessor[lane] = lower[lane];
-                    lower[lane] = group.position;
-                } else {
-                    upper[lane] = group.position;
-                }
+            if hits & lane_bit != 0 {
+                state.lower_predecessor[lane] = state.lower[lane];
+                state.lower[lane] = group.position;
+            } else {
+                state.upper[lane] = group.position;
             }
         }
     }
+    true
+}
 
-    for (lane, (depth, &upper_bound)) in depths.iter_mut().zip(&upper).enumerate() {
-        if active & (1u16 << lane) != 0 {
-            *depth = upper_bound.min(u32::MAX as usize) as u32;
+fn finalize_lanes<const D: usize, const FALLBACK: bool, const TRACE: bool>(
+    state: &PrefixSearchState<D>,
+    lanes: u16,
+    verification_window: usize,
+    prefetch: &mut impl FnMut(usize),
+    probe: &mut impl FnMut(usize) -> u16,
+) -> PrefixSearchResult<D> {
+    let mut depths = [0u32; D];
+    let mut fallback = FallbackStats::default();
+    for (lane, depth) in depths.iter_mut().enumerate() {
+        if lanes & (1u16 << lane) != 0 {
+            *depth = score_bound(state.upper[lane]);
         }
     }
 
     let mut verification_groups = [ProbeGroup::default(); MAX_VERIFICATION_GROUPS];
     let mut verification_group_count = 0usize;
     let mut verification_start = [0usize; D];
-    for (lane, &depth) in upper.iter().enumerate() {
+    for (lane, &depth) in state.upper.iter().enumerate() {
         let lane_bit = 1u16 << lane;
-        if active & lane_bit == 0 {
+        if lanes & lane_bit == 0 {
             continue;
         }
         let start = depth.saturating_sub(verification_window);
@@ -338,7 +638,7 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
     }
     verification_groups[..verification_group_count].sort_unstable_by_key(|group| group.position);
 
-    let mut verifying = active;
+    let mut verifying = lanes;
     let mut fallback_lanes = 0u16;
     for group in &verification_groups[..verification_group_count] {
         let participants = group.lanes & verifying;
@@ -368,7 +668,7 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
         for (lane, depth) in depths.iter_mut().enumerate() {
             let lane_bit = 1u16 << lane;
             if misses & lane_bit != 0 {
-                *depth = group.position.min(u32::MAX as usize) as u32;
+                *depth = score_bound(group.position);
                 if group.position == verification_start[lane] {
                     fallback_lanes |= lane_bit;
                 }
@@ -391,9 +691,9 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
         if fallback_lanes & lane_bit == 0 {
             continue;
         }
-        let start = lower_predecessor[lane].saturating_add(1);
+        let start = state.lower_predecessor[lane].saturating_add(1);
         let end = verification_start[lane];
-        if lower_predecessor[lane] >= end {
+        if state.lower_predecessor[lane] >= end {
             fallback.provenance_skips += 1;
             fallback_lanes &= !lane_bit;
             continue;
@@ -406,9 +706,6 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
         fallback_end[lane] = end;
     }
     fallback.activated_lanes = u64::from(fallback_lanes.count_ones());
-    if fallback_lanes == 0 {
-        return PrefixSearchResult { depths, fallback };
-    }
 
     while fallback_lanes != 0 {
         let position = (0..D)
@@ -452,7 +749,7 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bo
                 continue;
             }
             if misses & lane_bit != 0 {
-                *depth = position.min(u32::MAX as usize) as u32;
+                *depth = score_bound(position);
                 fallback_lanes &= !lane_bit;
                 continue;
             }
@@ -482,11 +779,22 @@ pub(super) fn linear_prefix_depths<const D: usize>(
         active &= probe(position);
         for (lane, depth) in depths.iter_mut().enumerate() {
             if active & (1u16 << lane) != 0 {
-                *depth = (position + 1).min(u32::MAX as usize) as u32;
+                *depth = score_bound(position + 1);
             }
         }
     }
     depths
+}
+
+fn empty_result<const D: usize>() -> PrefixSearchResult<D> {
+    PrefixSearchResult {
+        depths: [0; D],
+        fallback: FallbackStats::default(),
+    }
+}
+
+fn score_bound(position: usize) -> u32 {
+    position.min(u32::MAX as usize) as u32
 }
 
 fn add_group<const N: usize>(

--- a/lib/kv-router/src/indexer/cuckoo/search.rs
+++ b/lib/kv-router/src/indexer/cuckoo/search.rs
@@ -1,0 +1,195 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::MAX_VERIFICATION_WINDOW;
+
+const MAX_LANES: usize = 16;
+const MAX_VERIFICATION_GROUPS: usize = MAX_LANES * MAX_VERIFICATION_WINDOW;
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+struct ProbeGroup {
+    position: usize,
+    lanes: u16,
+}
+
+pub(super) fn find_prefix_depths<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    mut prefetch: impl FnMut(usize),
+    mut probe: impl FnMut(usize) -> u16,
+) -> [u32; D] {
+    let mut depths = [0u32; D];
+    if sequence_len == 0 {
+        return depths;
+    }
+
+    debug_assert!((1..=MAX_LANES).contains(&D));
+    debug_assert!((1..=MAX_VERIFICATION_WINDOW).contains(&verification_window));
+    let configured_mask = lane_mask::<D>();
+    let active = initial_mask & configured_mask & probe(0);
+    if active == 0 {
+        return depths;
+    }
+
+    let mut lower = [0usize; D];
+    let mut upper = [sequence_len; D];
+    let mut sampling = active;
+    let mut position = 1usize;
+    if position < sequence_len {
+        prefetch(position);
+    }
+
+    while position < sequence_len && sampling != 0 {
+        if let Some(next) = position.checked_mul(2).filter(|&next| next < sequence_len) {
+            prefetch(next);
+        }
+        let hits = probe(position);
+        let hit_lanes = sampling & hits;
+        let miss_lanes = sampling & !hits;
+        for lane in 0..D {
+            let lane_bit = 1u16 << lane;
+            if hit_lanes & lane_bit != 0 {
+                lower[lane] = position;
+            } else if miss_lanes & lane_bit != 0 {
+                upper[lane] = position;
+            }
+        }
+        sampling &= hits;
+
+        let Some(next) = position.checked_mul(2) else {
+            break;
+        };
+        position = next;
+    }
+
+    loop {
+        let mut groups = [ProbeGroup::default(); MAX_LANES];
+        let mut group_count = 0usize;
+        for lane in 0..D {
+            let lane_bit = 1u16 << lane;
+            if active & lane_bit == 0 || upper[lane] - lower[lane] <= 1 {
+                continue;
+            }
+            let midpoint = lower[lane] + (upper[lane] - lower[lane]) / 2;
+            add_group(&mut groups, &mut group_count, midpoint, lane_bit);
+        }
+        if group_count == 0 {
+            break;
+        }
+
+        for group in &groups[..group_count] {
+            prefetch(group.position);
+        }
+        for group in &groups[..group_count] {
+            let hits = probe(group.position);
+            for lane in 0..D {
+                let lane_bit = 1u16 << lane;
+                if group.lanes & lane_bit == 0 {
+                    continue;
+                }
+                if hits & lane_bit != 0 {
+                    lower[lane] = group.position;
+                } else {
+                    upper[lane] = group.position;
+                }
+            }
+        }
+    }
+
+    for (lane, (depth, &upper_bound)) in depths.iter_mut().zip(&upper).enumerate() {
+        if active & (1u16 << lane) != 0 {
+            *depth = upper_bound.min(u32::MAX as usize) as u32;
+        }
+    }
+
+    let mut verification_groups = [ProbeGroup::default(); MAX_VERIFICATION_GROUPS];
+    let mut verification_group_count = 0usize;
+    for (lane, &depth) in upper.iter().enumerate() {
+        let lane_bit = 1u16 << lane;
+        if active & lane_bit == 0 {
+            continue;
+        }
+        for verify_position in depth.saturating_sub(verification_window)..depth {
+            add_group(
+                &mut verification_groups,
+                &mut verification_group_count,
+                verify_position,
+                lane_bit,
+            );
+        }
+    }
+    verification_groups[..verification_group_count].sort_unstable_by_key(|group| group.position);
+
+    let mut verifying = active;
+    for group in &verification_groups[..verification_group_count] {
+        let participants = group.lanes & verifying;
+        if participants == 0 {
+            continue;
+        }
+        prefetch(group.position);
+        let misses = participants & !probe(group.position);
+        for (lane, depth) in depths.iter_mut().enumerate() {
+            let lane_bit = 1u16 << lane;
+            if misses & lane_bit != 0 {
+                *depth = group.position.min(u32::MAX as usize) as u32;
+            }
+        }
+        verifying &= !misses;
+    }
+
+    depths
+}
+
+#[cfg(any(test, feature = "bench"))]
+#[allow(dead_code)]
+pub(super) fn linear_prefix_depths<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    mut probe: impl FnMut(usize) -> u16,
+) -> [u32; D] {
+    let mut depths = [0u32; D];
+    let mut active = initial_mask & lane_mask::<D>();
+    for position in 0..sequence_len {
+        if active == 0 {
+            break;
+        }
+        active &= probe(position);
+        for (lane, depth) in depths.iter_mut().enumerate() {
+            if active & (1u16 << lane) != 0 {
+                *depth = (position + 1).min(u32::MAX as usize) as u32;
+            }
+        }
+    }
+    depths
+}
+
+fn add_group<const N: usize>(
+    groups: &mut [ProbeGroup; N],
+    group_count: &mut usize,
+    position: usize,
+    lane: u16,
+) {
+    if let Some(group) = groups[..*group_count]
+        .iter_mut()
+        .find(|group| group.position == position)
+    {
+        group.lanes |= lane;
+        return;
+    }
+
+    debug_assert!(*group_count < N);
+    groups[*group_count] = ProbeGroup {
+        position,
+        lanes: lane,
+    };
+    *group_count += 1;
+}
+
+const fn lane_mask<const D: usize>() -> u16 {
+    if D >= u16::BITS as usize {
+        u16::MAX
+    } else {
+        (1u16 << D) - 1
+    }
+}

--- a/lib/kv-router/src/indexer/cuckoo/search.rs
+++ b/lib/kv-router/src/indexer/cuckoo/search.rs
@@ -27,6 +27,7 @@ pub(super) struct PrefixSearchResult<const D: usize> {
     pub(super) fallback: FallbackStats,
 }
 
+#[cfg(any(not(feature = "metrics"), test))]
 pub(super) fn find_prefix_depths<const D: usize>(
     sequence_len: usize,
     initial_mask: u16,

--- a/lib/kv-router/src/indexer/cuckoo/search.rs
+++ b/lib/kv-router/src/indexer/cuckoo/search.rs
@@ -12,16 +12,101 @@ struct ProbeGroup {
     lanes: u16,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct FallbackStats {
+    pub(super) left_edge_lanes: u64,
+    pub(super) activated_lanes: u64,
+    pub(super) probe_calls: u64,
+    pub(super) lane_probes: u64,
+    pub(super) provenance_skips: u64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct PrefixSearchResult<const D: usize> {
+    pub(super) depths: [u32; D],
+    pub(super) fallback: FallbackStats,
+}
+
 pub(super) fn find_prefix_depths<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> [u32; D] {
+    find_prefix_depths_impl::<D, true>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    )
+    .depths
+}
+
+#[cfg(feature = "metrics")]
+pub(super) fn find_prefix_depths_with_stats<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> PrefixSearchResult<D> {
+    find_prefix_depths_impl::<D, true>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    )
+}
+
+#[cfg(test)]
+pub(super) fn fixed_window_prefix_depths<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> [u32; D] {
+    find_prefix_depths_impl::<D, false>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    )
+    .depths
+}
+
+#[cfg(test)]
+pub(super) fn find_prefix_depths_with_test_stats<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> PrefixSearchResult<D> {
+    find_prefix_depths_impl::<D, true>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    )
+}
+
+fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
     sequence_len: usize,
     initial_mask: u16,
     verification_window: usize,
     mut prefetch: impl FnMut(usize),
     mut probe: impl FnMut(usize) -> u16,
-) -> [u32; D] {
+) -> PrefixSearchResult<D> {
     let mut depths = [0u32; D];
+    let mut fallback = FallbackStats::default();
     if sequence_len == 0 {
-        return depths;
+        return PrefixSearchResult { depths, fallback };
     }
 
     debug_assert!((1..=MAX_LANES).contains(&D));
@@ -29,10 +114,11 @@ pub(super) fn find_prefix_depths<const D: usize>(
     let configured_mask = lane_mask::<D>();
     let active = initial_mask & configured_mask & probe(0);
     if active == 0 {
-        return depths;
+        return PrefixSearchResult { depths, fallback };
     }
 
     let mut lower = [0usize; D];
+    let mut lower_predecessor = [0usize; D];
     let mut upper = [sequence_len; D];
     let mut sampling = active;
     let mut position = 1usize;
@@ -50,6 +136,7 @@ pub(super) fn find_prefix_depths<const D: usize>(
         for lane in 0..D {
             let lane_bit = 1u16 << lane;
             if hit_lanes & lane_bit != 0 {
+                lower_predecessor[lane] = lower[lane];
                 lower[lane] = position;
             } else if miss_lanes & lane_bit != 0 {
                 upper[lane] = position;
@@ -89,6 +176,7 @@ pub(super) fn find_prefix_depths<const D: usize>(
                     continue;
                 }
                 if hits & lane_bit != 0 {
+                    lower_predecessor[lane] = lower[lane];
                     lower[lane] = group.position;
                 } else {
                     upper[lane] = group.position;
@@ -105,12 +193,15 @@ pub(super) fn find_prefix_depths<const D: usize>(
 
     let mut verification_groups = [ProbeGroup::default(); MAX_VERIFICATION_GROUPS];
     let mut verification_group_count = 0usize;
+    let mut verification_start = [0usize; D];
     for (lane, &depth) in upper.iter().enumerate() {
         let lane_bit = 1u16 << lane;
         if active & lane_bit == 0 {
             continue;
         }
-        for verify_position in depth.saturating_sub(verification_window)..depth {
+        let start = depth.saturating_sub(verification_window);
+        verification_start[lane] = start;
+        for verify_position in start..depth {
             add_group(
                 &mut verification_groups,
                 &mut verification_group_count,
@@ -122,6 +213,7 @@ pub(super) fn find_prefix_depths<const D: usize>(
     verification_groups[..verification_group_count].sort_unstable_by_key(|group| group.position);
 
     let mut verifying = active;
+    let mut fallback_lanes = 0u16;
     for group in &verification_groups[..verification_group_count] {
         let participants = group.lanes & verifying;
         if participants == 0 {
@@ -133,12 +225,83 @@ pub(super) fn find_prefix_depths<const D: usize>(
             let lane_bit = 1u16 << lane;
             if misses & lane_bit != 0 {
                 *depth = group.position.min(u32::MAX as usize) as u32;
+                if group.position == verification_start[lane] {
+                    fallback_lanes |= lane_bit;
+                }
             }
         }
         verifying &= !misses;
     }
 
-    depths
+    if !FALLBACK {
+        return PrefixSearchResult { depths, fallback };
+    }
+    fallback.left_edge_lanes = u64::from(fallback_lanes.count_ones());
+
+    // A miss at the window's left edge can expose a false terminal branch. Scan only
+    // the previously unexamined gap after the terminal lower bound's predecessor.
+    let mut fallback_next = [0usize; D];
+    let mut fallback_end = [0usize; D];
+    for lane in 0..D {
+        let lane_bit = 1u16 << lane;
+        if fallback_lanes & lane_bit == 0 {
+            continue;
+        }
+        let start = lower_predecessor[lane].saturating_add(1);
+        let end = verification_start[lane];
+        if lower_predecessor[lane] >= end {
+            fallback.provenance_skips += 1;
+            fallback_lanes &= !lane_bit;
+            continue;
+        }
+        if start == end {
+            fallback_lanes &= !lane_bit;
+            continue;
+        }
+        fallback_next[lane] = start;
+        fallback_end[lane] = end;
+    }
+    fallback.activated_lanes = u64::from(fallback_lanes.count_ones());
+    if fallback_lanes == 0 {
+        return PrefixSearchResult { depths, fallback };
+    }
+
+    while fallback_lanes != 0 {
+        let position = (0..D)
+            .filter(|&lane| fallback_lanes & (1u16 << lane) != 0)
+            .map(|lane| fallback_next[lane])
+            .min()
+            .expect("at least one fallback lane");
+        let mut participants = 0u16;
+        for (lane, next) in fallback_next.iter().enumerate() {
+            let lane_bit = 1u16 << lane;
+            if fallback_lanes & lane_bit != 0 && *next == position {
+                participants |= lane_bit;
+            }
+        }
+
+        prefetch(position);
+        let misses = participants & !probe(position);
+        fallback.probe_calls += 1;
+        fallback.lane_probes += u64::from(participants.count_ones());
+        for (lane, depth) in depths.iter_mut().enumerate() {
+            let lane_bit = 1u16 << lane;
+            if participants & lane_bit == 0 {
+                continue;
+            }
+            if misses & lane_bit != 0 {
+                *depth = position.min(u32::MAX as usize) as u32;
+                fallback_lanes &= !lane_bit;
+                continue;
+            }
+            fallback_next[lane] += 1;
+            if fallback_next[lane] == fallback_end[lane] {
+                fallback_lanes &= !lane_bit;
+            }
+        }
+    }
+
+    PrefixSearchResult { depths, fallback }
 }
 
 #[cfg(any(test, feature = "bench"))]

--- a/lib/kv-router/src/indexer/cuckoo/search.rs
+++ b/lib/kv-router/src/indexer/cuckoo/search.rs
@@ -3,6 +3,9 @@
 
 use super::MAX_VERIFICATION_WINDOW;
 
+#[cfg(test)]
+use std::cell::RefCell;
+
 const MAX_LANES: usize = 16;
 const MAX_VERIFICATION_GROUPS: usize = MAX_LANES * MAX_VERIFICATION_WINDOW;
 
@@ -27,6 +30,51 @@ pub(super) struct PrefixSearchResult<const D: usize> {
     pub(super) fallback: FallbackStats,
 }
 
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SearchPhase {
+    Initial,
+    Exponential,
+    Binary,
+    Verification,
+    Fallback,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) enum SearchTraceKind {
+    Prefetch,
+    Probe,
+}
+
+#[cfg(test)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct SearchTraceEvent {
+    pub(super) kind: SearchTraceKind,
+    pub(super) phase: SearchPhase,
+    pub(super) position: usize,
+    pub(super) lanes: u16,
+}
+
+#[cfg(test)]
+thread_local! {
+    static SEARCH_TRACE: RefCell<Option<Vec<SearchTraceEvent>>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+fn record_trace(kind: SearchTraceKind, phase: SearchPhase, position: usize, lanes: u16) {
+    SEARCH_TRACE.with_borrow_mut(|trace| {
+        if let Some(trace) = trace {
+            trace.push(SearchTraceEvent {
+                kind,
+                phase,
+                position,
+                lanes,
+            });
+        }
+    });
+}
+
 #[cfg(any(not(feature = "metrics"), test))]
 pub(super) fn find_prefix_depths<const D: usize>(
     sequence_len: usize,
@@ -35,7 +83,7 @@ pub(super) fn find_prefix_depths<const D: usize>(
     prefetch: impl FnMut(usize),
     probe: impl FnMut(usize) -> u16,
 ) -> [u32; D] {
-    find_prefix_depths_impl::<D, true>(
+    find_prefix_depths_impl::<D, true, false>(
         sequence_len,
         initial_mask,
         verification_window,
@@ -53,7 +101,7 @@ pub(super) fn find_prefix_depths_with_stats<const D: usize>(
     prefetch: impl FnMut(usize),
     probe: impl FnMut(usize) -> u16,
 ) -> PrefixSearchResult<D> {
-    find_prefix_depths_impl::<D, true>(
+    find_prefix_depths_impl::<D, true, false>(
         sequence_len,
         initial_mask,
         verification_window,
@@ -70,7 +118,7 @@ pub(super) fn fixed_window_prefix_depths<const D: usize>(
     prefetch: impl FnMut(usize),
     probe: impl FnMut(usize) -> u16,
 ) -> [u32; D] {
-    find_prefix_depths_impl::<D, false>(
+    find_prefix_depths_impl::<D, false, false>(
         sequence_len,
         initial_mask,
         verification_window,
@@ -88,7 +136,7 @@ pub(super) fn find_prefix_depths_with_test_stats<const D: usize>(
     prefetch: impl FnMut(usize),
     probe: impl FnMut(usize) -> u16,
 ) -> PrefixSearchResult<D> {
-    find_prefix_depths_impl::<D, true>(
+    find_prefix_depths_impl::<D, true, false>(
         sequence_len,
         initial_mask,
         verification_window,
@@ -97,7 +145,34 @@ pub(super) fn find_prefix_depths_with_test_stats<const D: usize>(
     )
 }
 
-fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
+#[cfg(test)]
+pub(super) fn find_prefix_depths_with_test_trace<const D: usize>(
+    sequence_len: usize,
+    initial_mask: u16,
+    verification_window: usize,
+    prefetch: impl FnMut(usize),
+    probe: impl FnMut(usize) -> u16,
+) -> (PrefixSearchResult<D>, Vec<SearchTraceEvent>) {
+    SEARCH_TRACE.with_borrow_mut(|trace| {
+        assert!(trace.is_none(), "nested CKF search tracing is unsupported");
+        *trace = Some(Vec::new());
+    });
+    let result = find_prefix_depths_impl::<D, true, true>(
+        sequence_len,
+        initial_mask,
+        verification_window,
+        prefetch,
+        probe,
+    );
+    let trace = SEARCH_TRACE.with_borrow_mut(|trace| {
+        trace
+            .take()
+            .expect("CKF search trace must remain active through the search")
+    });
+    (result, trace)
+}
+
+fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool, const TRACE: bool>(
     sequence_len: usize,
     initial_mask: u16,
     verification_window: usize,
@@ -113,7 +188,12 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
     debug_assert!((1..=MAX_LANES).contains(&D));
     debug_assert!((1..=MAX_VERIFICATION_WINDOW).contains(&verification_window));
     let configured_mask = lane_mask::<D>();
-    let active = initial_mask & configured_mask & probe(0);
+    let configured = initial_mask & configured_mask;
+    #[cfg(test)]
+    if TRACE {
+        record_trace(SearchTraceKind::Probe, SearchPhase::Initial, 0, configured);
+    }
+    let active = configured & probe(0);
     if active == 0 {
         return PrefixSearchResult { depths, fallback };
     }
@@ -124,12 +204,39 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
     let mut sampling = active;
     let mut position = 1usize;
     if position < sequence_len {
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Prefetch,
+                SearchPhase::Exponential,
+                position,
+                sampling,
+            );
+        }
         prefetch(position);
     }
 
     while position < sequence_len && sampling != 0 {
         if let Some(next) = position.checked_mul(2).filter(|&next| next < sequence_len) {
+            #[cfg(test)]
+            if TRACE {
+                record_trace(
+                    SearchTraceKind::Prefetch,
+                    SearchPhase::Exponential,
+                    next,
+                    sampling,
+                );
+            }
             prefetch(next);
+        }
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Probe,
+                SearchPhase::Exponential,
+                position,
+                sampling,
+            );
         }
         let hits = probe(position);
         let hit_lanes = sampling & hits;
@@ -167,9 +274,27 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
         }
 
         for group in &groups[..group_count] {
+            #[cfg(test)]
+            if TRACE {
+                record_trace(
+                    SearchTraceKind::Prefetch,
+                    SearchPhase::Binary,
+                    group.position,
+                    group.lanes,
+                );
+            }
             prefetch(group.position);
         }
         for group in &groups[..group_count] {
+            #[cfg(test)]
+            if TRACE {
+                record_trace(
+                    SearchTraceKind::Probe,
+                    SearchPhase::Binary,
+                    group.position,
+                    group.lanes,
+                );
+            }
             let hits = probe(group.position);
             for lane in 0..D {
                 let lane_bit = 1u16 << lane;
@@ -220,7 +345,25 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
         if participants == 0 {
             continue;
         }
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Prefetch,
+                SearchPhase::Verification,
+                group.position,
+                participants,
+            );
+        }
         prefetch(group.position);
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Probe,
+                SearchPhase::Verification,
+                group.position,
+                participants,
+            );
+        }
         let misses = participants & !probe(group.position);
         for (lane, depth) in depths.iter_mut().enumerate() {
             let lane_bit = 1u16 << lane;
@@ -281,7 +424,25 @@ fn find_prefix_depths_impl<const D: usize, const FALLBACK: bool>(
             }
         }
 
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Prefetch,
+                SearchPhase::Fallback,
+                position,
+                participants,
+            );
+        }
         prefetch(position);
+        #[cfg(test)]
+        if TRACE {
+            record_trace(
+                SearchTraceKind::Probe,
+                SearchPhase::Fallback,
+                position,
+                participants,
+            );
+        }
         let misses = participants & !probe(position);
         fallback.probe_calls += 1;
         fallback.lane_probes += u64::from(participants.count_ones());

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -19,7 +19,10 @@ use super::addressing::{CkfAddressing, CkfProbe};
 use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
 use super::event_indexer::bucket_count;
 use super::mutator::{CuckooMutator, DcWriterState};
-use super::search::{find_prefix_depths, linear_prefix_depths};
+use super::search::{
+    find_prefix_depths, find_prefix_depths_with_test_stats, fixed_window_prefix_depths,
+    linear_prefix_depths,
+};
 use super::{CkfBuildError, CkfConfig, DC_COUNT, EventTransposedCkfIndexer};
 
 const TEST_SEED: u64 = 0x1234_5678_9ABC_DEF0;
@@ -462,9 +465,9 @@ fn window_eight_repairs_holes_at_offsets_two_through_eight() {
         let mut masks = [1u16; QUERY_LEN];
         masks[hole] = 0;
         let window_one =
-            find_prefix_depths::<1>(QUERY_LEN, 1, 1, |_| {}, |position| masks[position]);
+            fixed_window_prefix_depths::<1>(QUERY_LEN, 1, 1, |_| {}, |position| masks[position]);
         let window_eight =
-            find_prefix_depths::<1>(QUERY_LEN, 1, 8, |_| {}, |position| masks[position]);
+            fixed_window_prefix_depths::<1>(QUERY_LEN, 1, 8, |_| {}, |position| masks[position]);
         let linear = linear_prefix_depths::<1>(QUERY_LEN, 1, |position| masks[position]);
 
         assert_eq!(window_one, [QUERY_LEN as u32], "offset={offset}");
@@ -479,11 +482,121 @@ fn holes_beyond_the_terminal_window_remain_advisory() {
     const HOLE: usize = QUERY_LEN - 9;
     let mut masks = [1u16; QUERY_LEN];
     masks[HOLE] = 0;
-    let window_eight = find_prefix_depths::<1>(QUERY_LEN, 1, 8, |_| {}, |position| masks[position]);
+    let window_eight =
+        fixed_window_prefix_depths::<1>(QUERY_LEN, 1, 8, |_| {}, |position| masks[position]);
     let linear = linear_prefix_depths::<1>(QUERY_LEN, 1, |position| masks[position]);
 
     assert_eq!(window_eight, [QUERY_LEN as u32]);
     assert_eq!(linear, [HOLE as u32]);
+}
+
+#[test]
+fn terminal_branch_fallback_groups_lanes_and_repairs_a_clipped_false_pivot() {
+    const QUERY_LEN: usize = 65;
+    const LINEAR_MISS: usize = 40;
+    const FALSE_PIVOT: usize = 48;
+
+    let membership = |position: usize| {
+        if position < LINEAR_MISS || position == FALSE_PIVOT {
+            0b11
+        } else {
+            0
+        }
+    };
+    let mut probed = Vec::new();
+    let result = find_prefix_depths_with_test_stats::<2>(
+        QUERY_LEN,
+        0b11,
+        2,
+        |_| {},
+        |position| {
+            probed.push(position);
+            membership(position)
+        },
+    );
+    let linear = linear_prefix_depths::<2>(QUERY_LEN, 0b11, membership);
+
+    assert_eq!(result.depths, linear);
+    assert_eq!(result.depths, [LINEAR_MISS as u32; 2]);
+    assert!(!probed.contains(&17), "fallback must begin after B=32");
+    for fallback_position in 33..=LINEAR_MISS {
+        assert_eq!(
+            probed
+                .iter()
+                .filter(|&&position| position == fallback_position)
+                .count(),
+            1,
+            "fallback_position={fallback_position}"
+        );
+    }
+    assert_eq!(result.fallback.left_edge_lanes, 2);
+    assert_eq!(result.fallback.activated_lanes, 2);
+    assert_eq!(result.fallback.probe_calls, 8);
+    assert_eq!(result.fallback.lane_probes, 16);
+    assert_eq!(result.fallback.provenance_skips, 0);
+}
+
+#[test]
+fn terminal_branch_fallback_skips_second_order_provenance_without_an_inverted_range() {
+    const QUERY_LEN: usize = 65;
+    const LINEAR_MISS: usize = 41;
+
+    let membership =
+        |position: usize| u16::from(position < LINEAR_MISS || (48..=51).contains(&position));
+    let result = find_prefix_depths_with_test_stats::<1>(QUERY_LEN, 1, 8, |_| {}, membership);
+
+    assert_eq!(linear_prefix_depths::<1>(QUERY_LEN, 1, membership), [41]);
+    assert_eq!(result.depths, [44]);
+    assert_eq!(result.fallback.left_edge_lanes, 1);
+    assert_eq!(result.fallback.activated_lanes, 0);
+    assert_eq!(result.fallback.probe_calls, 0);
+    assert_eq!(result.fallback.provenance_skips, 1);
+}
+
+#[test]
+fn terminal_branch_fallback_documents_a_false_predecessor_residual() {
+    const QUERY_LEN: usize = 65;
+    const LINEAR_MISS: usize = 20;
+
+    let membership =
+        |position: usize| u16::from(position < LINEAR_MISS || position == 32 || position == 48);
+    let result = find_prefix_depths_with_test_stats::<1>(QUERY_LEN, 1, 8, |_| {}, membership);
+
+    assert_eq!(linear_prefix_depths::<1>(QUERY_LEN, 1, membership), [20]);
+    assert_eq!(result.depths, [33]);
+    assert_eq!(result.fallback.left_edge_lanes, 1);
+    assert_eq!(result.fallback.activated_lanes, 1);
+    assert_eq!(result.fallback.probe_calls, 1);
+    assert_eq!(result.fallback.provenance_skips, 0);
+}
+
+#[cfg(feature = "metrics")]
+#[test]
+fn provenance_fallback_metrics_record_prebound_lane_and_probe_counts() {
+    use crate::indexer::{
+        KvIndexerMetrics, METRIC_CKF_FALLBACK_ACTIVATED_LANES, METRIC_CKF_FALLBACK_LANE_PROBES,
+        METRIC_CKF_FALLBACK_LEFT_EDGE_LANES, METRIC_CKF_FALLBACK_PROBE_CALLS,
+        METRIC_CKF_FALLBACK_PROVENANCE_SKIPS,
+    };
+
+    let membership = |position: usize| u16::from(position < 40 || position == 48);
+    let result = find_prefix_depths_with_test_stats::<1>(65, 1, 2, |_| {}, membership);
+    let metrics = KvIndexerMetrics::new_unregistered();
+    let counters = metrics.prebind_ckf_search();
+    counters.record(
+        result.fallback.left_edge_lanes,
+        result.fallback.activated_lanes,
+        result.fallback.probe_calls,
+        result.fallback.lane_probes,
+        result.fallback.provenance_skips,
+    );
+
+    let value = |kind| metrics.ckf_search_fallback.with_label_values(&[kind]).get();
+    assert_eq!(value(METRIC_CKF_FALLBACK_LEFT_EDGE_LANES), 1);
+    assert_eq!(value(METRIC_CKF_FALLBACK_ACTIVATED_LANES), 1);
+    assert_eq!(value(METRIC_CKF_FALLBACK_PROBE_CALLS), 8);
+    assert_eq!(value(METRIC_CKF_FALLBACK_LANE_PROBES), 8);
+    assert_eq!(value(METRIC_CKF_FALLBACK_PROVENANCE_SKIPS), 0);
 }
 
 #[test]
@@ -780,8 +893,8 @@ fn study_corpus_contains_1024_distinct_queries_at_every_length() {
 }
 
 #[test]
-#[ignore = "deterministic million-observation CKF accuracy study"]
-fn verification_window_study() {
+#[ignore = "deterministic fixed-window CKF accuracy control"]
+fn fixed_verification_window_study() {
     const BUCKETS: usize = 16_384;
     const QUERIES_PER_CELL: usize = 1_024;
     const MAX_QUERY_LEN: usize = 512;
@@ -834,7 +947,7 @@ fn verification_window_study() {
                             table.probe(probes[position])
                         });
                     let mut window_one_probes = 0u64;
-                    let window_one = find_prefix_depths::<DC_COUNT>(
+                    let window_one = fixed_window_prefix_depths::<DC_COUNT>(
                         probes.len(),
                         u16::MAX,
                         1,
@@ -845,7 +958,7 @@ fn verification_window_study() {
                         },
                     );
                     let mut window_eight_probes = 0u64;
-                    let window_eight = find_prefix_depths::<DC_COUNT>(
+                    let window_eight = fixed_window_prefix_depths::<DC_COUNT>(
                         probes.len(),
                         u16::MAX,
                         8,
@@ -872,7 +985,7 @@ fn verification_window_study() {
     assert_eq!(totals.observations, 1_966_080);
     let expected_default = selected_verification_window(&totals);
     println!(
-        "queries={} distinct_queries={} observations={} expected_default={} paired_depth_differences={} paired_array_differences={} w1_full_map_mismatches={} w8_full_map_mismatches={} w1_lane_mismatches={} w8_lane_mismatches={} w1_inflation={} w8_inflation={} w1_inflation_magnitude={} w8_inflation_magnitude={} w1_under_reports={} w8_under_reports={} w1_wrong_best={} w8_wrong_best={} w1_probes={} w8_probes={}",
+        "FIXED_WINDOW_STUDY queries={} distinct_queries={} observations={} expected_fixed_window={} paired_depth_differences={} paired_array_differences={} w1_full_map_mismatches={} w8_full_map_mismatches={} w1_lane_mismatches={} w8_lane_mismatches={} w1_inflation={} w8_inflation={} w1_inflation_magnitude={} w8_inflation_magnitude={} w1_under_reports={} w8_under_reports={} w1_wrong_best={} w8_wrong_best={} w1_probes={} w8_probes={}",
         totals.queries,
         totals.distinct_queries,
         totals.observations,
@@ -894,10 +1007,224 @@ fn verification_window_study() {
         totals.window_one_probes,
         totals.window_eight_probes,
     );
+    assert_eq!(expected_default, 8);
+}
+
+#[derive(Debug, Default)]
+struct FallbackCandidateStats {
+    full_map_mismatches: u64,
+    lane_mismatches: u64,
+    inflation: u64,
+    inflation_magnitude: u64,
+    under_reports: u64,
+    wrong_best: u64,
+    probes: u64,
+    fallback_probes: u64,
+}
+
+impl FallbackCandidateStats {
+    fn record(
+        &mut self,
+        linear: [u32; DC_COUNT],
+        actual: [u32; DC_COUNT],
+        probes: u64,
+        fallback_probes: u64,
+    ) {
+        self.full_map_mismatches += u64::from(linear != actual);
+        self.wrong_best += u64::from(best_lane(linear) != best_lane(actual));
+        self.probes += probes;
+        self.fallback_probes += fallback_probes;
+        for (linear, actual) in linear.into_iter().zip(actual) {
+            match actual.cmp(&linear) {
+                std::cmp::Ordering::Greater => {
+                    self.lane_mismatches += 1;
+                    self.inflation += 1;
+                    self.inflation_magnitude += u64::from(actual - linear);
+                }
+                std::cmp::Ordering::Less => {
+                    self.lane_mismatches += 1;
+                    self.under_reports += 1;
+                }
+                std::cmp::Ordering::Equal => {}
+            }
+        }
+    }
+
+    fn matches_linear(&self) -> bool {
+        self.lane_mismatches == 0
+    }
+}
+
+#[derive(Debug, Default)]
+struct FallbackWindowStudyStats {
+    queries: u64,
+    distinct_queries: u64,
+    observations: u64,
+    window_one: FallbackCandidateStats,
+    window_two: FallbackCandidateStats,
+    window_eight: FallbackCandidateStats,
+}
+
+fn selected_fallback_window(stats: &FallbackWindowStudyStats) -> usize {
+    if stats.window_one.matches_linear() {
+        1
+    } else if stats.window_two.matches_linear() {
+        2
+    } else {
+        8
+    }
+}
+
+#[test]
+fn fallback_selection_prefers_the_smallest_linear_equivalent_window() {
+    let window_two = FallbackWindowStudyStats {
+        window_one: FallbackCandidateStats {
+            lane_mismatches: 1,
+            ..FallbackCandidateStats::default()
+        },
+        ..FallbackWindowStudyStats::default()
+    };
+    assert_eq!(selected_fallback_window(&window_two), 2);
+
+    let window_eight = FallbackWindowStudyStats {
+        window_one: FallbackCandidateStats {
+            lane_mismatches: 1,
+            ..FallbackCandidateStats::default()
+        },
+        window_two: FallbackCandidateStats {
+            lane_mismatches: 1,
+            ..FallbackCandidateStats::default()
+        },
+        ..FallbackWindowStudyStats::default()
+    };
+    assert_eq!(selected_fallback_window(&window_eight), 8);
+}
+
+#[test]
+#[ignore = "deterministic provenance-fallback window accuracy study"]
+fn provenance_fallback_window_study() {
+    const BUCKETS: usize = 16_384;
+    const QUERIES_PER_CELL: usize = 1_024;
+    const MAX_QUERY_LEN: usize = 512;
+    const MAX_RESIDENT_PREFIX: usize = 32;
+    const MAX_KICKS: usize = 4_096;
+    const OCCUPANCIES: [usize; 3] = [50, 80, 90];
+    const QUERY_LENGTHS: [usize; 5] = [1, 8, 32, 128, 512];
+    const SEEDS: usize = 8;
+
+    let mut totals = FallbackWindowStudyStats::default();
+    for seed_index in 0..SEEDS {
+        let seed = study_seed(seed_index);
+        let addressing = CkfAddressing::new(BUCKETS, seed);
+        let chains = study_chains(seed, addressing, QUERIES_PER_CELL, MAX_QUERY_LEN);
+        let query_hashes: HashSet<u64> = chains
+            .iter()
+            .flat_map(|chain| chain.sequence_hashes.iter().copied())
+            .collect();
+        let prefix_depths = study_prefix_depths(seed_index, QUERIES_PER_CELL, MAX_RESIDENT_PREFIX);
+        let distinct_queries: HashMap<usize, usize> = QUERY_LENGTHS
+            .into_iter()
+            .map(|query_len| (query_len, distinct_query_count(&chains, query_len)))
+            .collect();
+        assert!(
+            distinct_queries
+                .values()
+                .all(|&count| count == QUERIES_PER_CELL),
+            "seed_index={seed_index} distinct_queries={distinct_queries:?}"
+        );
+
+        for occupancy in OCCUPANCIES {
+            let table = TransposedCkfTable::<DC_COUNT>::new(BUCKETS).unwrap();
+            fill_study_table(
+                &table,
+                addressing,
+                &chains,
+                &prefix_depths,
+                &query_hashes,
+                occupancy,
+                MAX_KICKS,
+                seed,
+            );
+
+            for query_len in QUERY_LENGTHS {
+                totals.distinct_queries += distinct_queries[&query_len] as u64;
+                for chain in chains.iter().take(QUERIES_PER_CELL) {
+                    let probes = &chain.probes[..query_len];
+                    let linear =
+                        linear_prefix_depths::<DC_COUNT>(probes.len(), u16::MAX, |position| {
+                            table.probe(probes[position])
+                        });
+                    let (window_one, window_one_probes) = run_fallback_candidate(&table, probes, 1);
+                    let (window_two, window_two_probes) = run_fallback_candidate(&table, probes, 2);
+                    let (window_eight, window_eight_probes) =
+                        run_fallback_candidate(&table, probes, 8);
+
+                    totals.queries += 1;
+                    totals.observations += DC_COUNT as u64;
+                    totals.window_one.record(
+                        linear,
+                        window_one.depths,
+                        window_one_probes,
+                        window_one.fallback.probe_calls,
+                    );
+                    totals.window_two.record(
+                        linear,
+                        window_two.depths,
+                        window_two_probes,
+                        window_two.fallback.probe_calls,
+                    );
+                    totals.window_eight.record(
+                        linear,
+                        window_eight.depths,
+                        window_eight_probes,
+                        window_eight.fallback.probe_calls,
+                    );
+                }
+            }
+        }
+    }
+
+    assert_eq!(totals.queries, 122_880);
+    assert_eq!(totals.distinct_queries, totals.queries);
+    assert_eq!(totals.observations, 1_966_080);
+    let expected_default = selected_fallback_window(&totals);
+    println!(
+        "FALLBACK_WINDOW_STUDY queries={} distinct_queries={} observations={} expected_default={} w1={:?} w2={:?} w8={:?}",
+        totals.queries,
+        totals.distinct_queries,
+        totals.observations,
+        expected_default,
+        totals.window_one,
+        totals.window_two,
+        totals.window_eight,
+    );
+    assert!(!totals.window_one.matches_linear());
+    assert!(totals.window_two.matches_linear());
+    assert!(totals.window_eight.matches_linear());
+    assert_eq!(expected_default, 2);
     assert_eq!(
         CkfConfig::default().search.verification_window,
         expected_default
     );
+}
+
+fn run_fallback_candidate(
+    table: &TransposedCkfTable<DC_COUNT>,
+    probes: &[CkfProbe],
+    window: usize,
+) -> (super::search::PrefixSearchResult<DC_COUNT>, u64) {
+    let mut probe_calls = 0u64;
+    let result = find_prefix_depths_with_test_stats::<DC_COUNT>(
+        probes.len(),
+        u16::MAX,
+        window,
+        |position| table.prefetch_probe(probes[position]),
+        |position| {
+            probe_calls += 1;
+            table.probe(probes[position])
+        },
+    );
+    (result, probe_calls)
 }
 
 struct StudyChain {

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -215,14 +215,14 @@ fn due_net_reversion_is_unchanged_and_applies_no_batch() {
     let mut batch = index.pipeline.new_batch();
 
     index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
-    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.pipeline.flush_pending(&mut batch);
     index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
 
     assert!(!outcome.batch_applied());
     assert!(batch.images().is_empty());
     assert_eq!(batch.reset_lanes(), 0);
-    assert!(!index.pipeline.flush_pending(&mut batch).unwrap());
+    assert!(!index.pipeline.flush_pending(&mut batch));
 }
 
 #[test]
@@ -234,7 +234,7 @@ fn partially_net_reverted_window_emits_only_changed_buckets() {
     let mut batch = index.pipeline.new_batch();
 
     index.apply_event_with_batch(store_event(workers[0], &[10, 20], 1), &mut batch);
-    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.pipeline.flush_pending(&mut batch);
     index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
     index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
     let outcome = index.apply_event_with_batch(remove_event(workers[0], &[20]), &mut batch);
@@ -287,7 +287,7 @@ fn published_nonempty_lane_emptied_at_boundary_emits_reset() {
     let mut batch = index.pipeline.new_batch();
 
     index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
-    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.pipeline.flush_pending(&mut batch);
     index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 2), &mut batch);
 
@@ -339,7 +339,7 @@ fn flush_publishes_a_subthreshold_tail() {
 
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
     assert!(!outcome.batch_applied());
-    assert!(index.pipeline.flush_pending(&mut batch).unwrap());
+    assert!(index.pipeline.flush_pending(&mut batch));
     assert_ne!(
         index
             .pipeline
@@ -349,7 +349,44 @@ fn flush_publishes_a_subthreshold_tail() {
             & 1,
         0
     );
-    assert!(!index.pipeline.flush_pending(&mut batch).unwrap());
+    assert!(!index.pipeline.flush_pending(&mut batch));
+}
+
+#[test]
+fn flush_reserves_only_pending_images_and_empty_flush_stays_allocation_free() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 16;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut event_batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut event_batch);
+    index.apply_event_with_batch(store_event(workers[1], &[20], 2), &mut event_batch);
+
+    let mut flush_batch = index.pipeline.new_batch();
+    assert_eq!(flush_batch.image_capacity(), 0);
+    assert!(index.pipeline.flush_pending(&mut flush_batch));
+    assert_eq!(flush_batch.images().len(), 2);
+    assert!(flush_batch.image_capacity() <= bucket_count(32).unwrap());
+
+    let mut empty_batch = index.pipeline.new_batch();
+    assert!(!index.pipeline.flush_pending(&mut empty_batch));
+    assert_eq!(empty_batch.image_capacity(), 0);
+
+    index.apply_event_with_batch(store_event(workers[2], &[30], 3), &mut event_batch);
+    let mut direct_batch = index.pipeline.new_batch();
+    direct_batch.force_reserve_failure();
+    assert!(index.pipeline.flush_pending(&mut direct_batch));
+    assert!(direct_batch.images().is_empty());
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(30))
+            & (1 << 2),
+        0
+    );
 }
 
 #[test]
@@ -361,10 +398,35 @@ fn lifecycle_removal_forces_pending_publication() {
     let mut batch = index.pipeline.new_batch();
 
     index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
-    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.pipeline.flush_pending(&mut batch);
     let outcome = index.pipeline.remove_worker_rank(workers[0], &mut batch);
     assert!(outcome.batch_applied());
     assert_ne!(batch.reset_lanes() & 1, 0);
+    assert_eq!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn lifecycle_removal_uses_direct_publication_when_batch_reserve_fails() {
+    let workers = workers();
+    let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
+    let mut event_batch = index.pipeline.new_batch();
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut event_batch);
+
+    let mut lifecycle_batch = index.pipeline.new_batch();
+    lifecycle_batch.force_reserve_failure();
+    let outcome = index
+        .pipeline
+        .remove_worker_rank(workers[0], &mut lifecycle_batch);
+
+    assert!(outcome.into_result().is_ok());
     assert_eq!(
         index
             .pipeline
@@ -385,7 +447,7 @@ fn empty_then_repopulated_window_cancels_stale_reset() {
     let mut batch = index.pipeline.new_batch();
 
     index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
-    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.pipeline.flush_pending(&mut batch);
     index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
     index.apply_event_with_batch(store_event(workers[0], &[20], 2), &mut batch);
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 3), &mut batch);

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -1,0 +1,1172 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{
+    Arc, Barrier,
+    atomic::{AtomicBool, Ordering},
+};
+
+use crate::indexer::pruning::PruneConfig;
+use crate::indexer::{KvIndexerInterface, SyncIndexer, ThreadPoolIndexer, WorkerTask};
+use crate::protocols::{
+    ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData,
+    KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerWithDpRank,
+    compute_seq_hash_for_block,
+};
+
+use super::addressing::{CkfAddressing, CkfProbe};
+use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
+use super::event_indexer::bucket_count;
+use super::mutator::{CuckooMutator, DcWriterState};
+use super::search::{find_prefix_depths, linear_prefix_depths};
+use super::{CkfBuildError, CkfConfig, DC_COUNT, EventTransposedCkfIndexer};
+
+const TEST_SEED: u64 = 0x1234_5678_9ABC_DEF0;
+
+#[test]
+fn validates_config_and_worker_mapping() {
+    let workers = workers();
+    assert_eq!(bucket_count(1).unwrap(), 2);
+    assert_eq!(bucket_count(16).unwrap(), 8);
+
+    let zero_capacity = CkfConfig {
+        expected_blocks_per_dc: 0,
+        ..CkfConfig::default()
+    };
+    assert_eq!(
+        EventTransposedCkfIndexer::new(workers, zero_capacity).unwrap_err(),
+        CkfBuildError::ExpectedCapacityZero
+    );
+
+    let mut duplicate_workers = workers;
+    duplicate_workers[1] = duplicate_workers[0];
+    assert_eq!(
+        EventTransposedCkfIndexer::new(duplicate_workers, CkfConfig::default()).unwrap_err(),
+        CkfBuildError::DuplicateWorker {
+            worker: duplicate_workers[0]
+        }
+    );
+}
+
+#[test]
+fn packed_bucket_swar_matches_scalar_membership() {
+    let fingerprints = [1, 0x1234, 0x8000, u16::MAX];
+    let mut bucket = PackedBucket::default();
+    for (slot, fingerprint) in fingerprints.into_iter().enumerate() {
+        bucket = bucket.with_slot(slot, fingerprint);
+    }
+
+    for fingerprint in [1, 2, 0x1234, 0x1235, 0x8000, 0xFFFE, u16::MAX] {
+        assert_eq!(
+            bucket.contains(fingerprint),
+            bucket.scalar_contains(fingerprint),
+            "fingerprint={fingerprint:#06x}"
+        );
+    }
+
+    assert_eq!(bucket.first_empty(), None);
+    assert_eq!(bucket.first(1), Some(0));
+    assert_eq!(bucket.first(0x8000), Some(2));
+    assert_eq!(bucket.with_slot(1, 0).first_empty(), Some(1));
+}
+
+#[test]
+fn addressing_is_nonzero_and_alternate_bucket_is_an_involution() {
+    let addressing = CkfAddressing::new(1024, TEST_SEED);
+    assert_eq!(
+        compute_seq_hash_for_block(&[
+            LocalBlockHash(0x0123_4567_89AB_CDEF),
+            LocalBlockHash(0x1111_2222_3333_4444),
+            LocalBlockHash(0xDEAD_BEEF_CAFE_BABE),
+        ]),
+        [
+            0x0123_4567_89AB_CDEF,
+            0x98E7_E55F_299C_F592,
+            0x65D5_3B99_C525_2D19,
+        ]
+    );
+    assert_eq!(
+        [0u64, 1, 0x0123_4567_89AB_CDEF, u64::MAX].map(|hash| addressing.prepare(hash)),
+        [
+            CkfProbe {
+                fingerprint: 7_750,
+                bucket_a: 587,
+                bucket_b: 372,
+            },
+            CkfProbe {
+                fingerprint: 64_153,
+                bucket_a: 348,
+                bucket_b: 36,
+            },
+            CkfProbe {
+                fingerprint: 45_802,
+                bucket_a: 865,
+                bucket_b: 909,
+            },
+            CkfProbe {
+                fingerprint: 31_767,
+                bucket_a: 112,
+                bucket_b: 217,
+            },
+        ]
+    );
+    for hash in 0..10_000u64 {
+        let probe = addressing.prepare(hash);
+        assert_ne!(probe.fingerprint, 0);
+        assert_ne!(probe.bucket_a, probe.bucket_b);
+        assert_eq!(
+            addressing.alternate_bucket(probe.bucket_b, probe.fingerprint),
+            probe.bucket_a
+        );
+    }
+}
+
+#[test]
+fn bounded_relocation_rolls_back_every_write_and_emits_no_dirty_bucket() {
+    let table = TransposedCkfTable::<1>::new(2).unwrap();
+    let view = table.lane(0);
+    let full_a = PackedBucket::default()
+        .with_slot(0, 1)
+        .with_slot(1, 2)
+        .with_slot(2, 3)
+        .with_slot(3, 4);
+    let full_b = PackedBucket::default()
+        .with_slot(0, 5)
+        .with_slot(1, 6)
+        .with_slot(2, 7)
+        .with_slot(3, 8);
+    view.store_bucket(0, full_a);
+    view.store_bucket(1, full_b);
+
+    let addressing = CkfAddressing::new(2, TEST_SEED);
+    let mut state = DcWriterState::new(8, 1, TEST_SEED).unwrap();
+    let mut dirty = Vec::new();
+    let result = CuckooMutator::new(&view, &addressing, 1).insert(
+        ExternalSequenceBlockHash(999),
+        &mut state.rng,
+        &mut state.scratch,
+        |bucket| dirty.push(bucket),
+    );
+
+    assert!(matches!(
+        result,
+        Err(crate::protocols::KvCacheEventError::CapacityExhausted)
+    ));
+    assert_eq!(view.load_bucket(0), full_a);
+    assert_eq!(view.load_bucket(1), full_b);
+    assert!(dirty.is_empty());
+}
+
+#[test]
+fn distinct_hashes_with_one_ckf_representation_keep_separate_copies() {
+    let addressing = CkfAddressing::new(2, TEST_SEED);
+    let (first, second, representation) = colliding_hashes(addressing);
+    let table = TransposedCkfTable::<1>::new(2).unwrap();
+    let view = table.lane(0);
+    let mut state = DcWriterState::new(8, 20, TEST_SEED).unwrap();
+    let mutator = CuckooMutator::new(&view, &addressing, 20);
+
+    mutator
+        .insert(first, &mut state.rng, &mut state.scratch, |_| {})
+        .unwrap();
+    mutator
+        .insert(second, &mut state.rng, &mut state.scratch, |_| {})
+        .unwrap();
+    assert_eq!(fingerprint_copies(&view, representation), 2);
+
+    mutator.remove(first, |_| {}).unwrap();
+    assert_eq!(fingerprint_copies(&view, representation), 1);
+    assert_eq!(table.probe(representation), 1);
+}
+
+#[test]
+fn full_binary_search_and_terminal_window_follow_the_defined_contract() {
+    let masks = [1u16, 1, 1, 0, 1, 1, 1, 1];
+    let window_one = find_prefix_depths::<1>(masks.len(), 1, 1, |_| {}, |position| masks[position]);
+    let window_eight =
+        find_prefix_depths::<1>(masks.len(), 1, 8, |_| {}, |position| masks[position]);
+    let linear = linear_prefix_depths::<1>(masks.len(), 1, |position| masks[position]);
+
+    assert_eq!(window_one, [8]);
+    assert_eq!(window_eight, [3]);
+    assert_eq!(linear, [3]);
+}
+
+#[test]
+fn grouped_search_probes_each_binary_midpoint_once() {
+    let masks = [u16::MAX, u16::MAX, u16::MAX, 0, 0, 0, 0, 0];
+    let mut counts = [0usize; 8];
+    let depths = find_prefix_depths::<16>(
+        masks.len(),
+        u16::MAX,
+        1,
+        |_| {},
+        |position| {
+            counts[position] += 1;
+            masks[position]
+        },
+    );
+
+    assert!(depths.into_iter().all(|depth| depth == 3));
+    assert!(counts.into_iter().all(|count| count <= 2));
+}
+
+#[tokio::test]
+async fn thread_pool_uses_external_hashes_returns_full_map_and_clears_all_ranks() {
+    let workers = workers_with_shared_worker();
+    let index = ThreadPoolIndexer::new(
+        EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap(),
+        2,
+        32,
+    );
+    let local_hashes = vec![LocalBlockHash(11), LocalBlockHash(22)];
+    let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
+    assert!(index.backend().find_matches(&[], false).scores.is_empty());
+
+    KvIndexerInterface::apply_event(&index, store_event(workers[0], &sequence_hashes, 10_000))
+        .await;
+    KvIndexerInterface::apply_event(&index, store_event(workers[1], &sequence_hashes, 20_000))
+        .await;
+    KvIndexerInterface::flush(&index).await;
+
+    let scores = KvIndexerInterface::find_matches(&index, local_hashes.clone())
+        .await
+        .unwrap();
+    assert_eq!(scores.scores.get(&workers[0]), Some(&2));
+    assert_eq!(scores.scores.get(&workers[1]), Some(&2));
+    assert!(scores.frequencies.is_empty());
+
+    KvIndexerInterface::remove_worker_dp_rank(&index, workers[0].worker_id, workers[0].dp_rank)
+        .await;
+    KvIndexerInterface::flush(&index).await;
+    let scores = KvIndexerInterface::find_matches(&index, local_hashes.clone())
+        .await
+        .unwrap();
+    assert!(!scores.scores.contains_key(&workers[0]));
+    assert_eq!(scores.scores.get(&workers[1]), Some(&2));
+
+    KvIndexerInterface::apply_event(&index, store_event(workers[0], &sequence_hashes, 30_000))
+        .await;
+    KvIndexerInterface::flush(&index).await;
+
+    KvIndexerInterface::apply_event(&index, clear_event(workers[0].worker_id)).await;
+    KvIndexerInterface::flush(&index).await;
+    let scores = KvIndexerInterface::find_matches(&index, local_hashes)
+        .await
+        .unwrap();
+    assert!(!scores.scores.contains_key(&workers[0]));
+    assert!(!scores.scores.contains_key(&workers[1]));
+    let stats = index.worker_lookup_stats().await;
+    assert_eq!(stats.block_count_for_worker(workers[0]), None);
+    assert_eq!(stats.block_count_for_worker(workers[1]), None);
+    index.shutdown();
+}
+
+#[tokio::test]
+async fn thread_pool_reports_unsupported_dump_and_exact_stats() {
+    let workers = workers();
+    let index = ThreadPoolIndexer::new(
+        EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap(),
+        2,
+        32,
+    );
+    let hashes = [91u64, 92, 93];
+    KvIndexerInterface::apply_event(&index, store_event(workers[0], &hashes, 40_000)).await;
+    KvIndexerInterface::flush(&index).await;
+
+    let stats = index.worker_lookup_stats().await;
+    assert_eq!(stats.block_count_for_worker(workers[0]), Some(3));
+    assert!(matches!(
+        KvIndexerInterface::dump_events(&index).await,
+        Err(crate::indexer::KvRouterError::Unsupported(_))
+    ));
+    index.shutdown();
+}
+
+#[test]
+fn worker_acknowledges_partial_event_failure_and_continues_serving_tasks() {
+    let workers = workers();
+    let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
+    let (sender, receiver) = flume::unbounded();
+
+    std::thread::scope(|scope| {
+        let worker = scope.spawn(|| index.worker(receiver, None).unwrap());
+        sender
+            .send(WorkerTask::Event(store_event(workers[0], &[10, 20], 1000)))
+            .unwrap();
+
+        let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
+        sender
+            .send(WorkerTask::EventWithAck {
+                event: remove_event(workers[0], &[999, 20]),
+                resp: ack_tx,
+            })
+            .unwrap();
+        assert!(!ack_rx.blocking_recv().unwrap());
+
+        let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();
+        sender.send(WorkerTask::Stats(stats_tx)).unwrap();
+        let stats = stats_rx.blocking_recv().unwrap();
+        assert_eq!(stats.block_count_for_worker(workers[0]), Some(1));
+
+        let (flush_tx, flush_rx) = tokio::sync::oneshot::channel();
+        sender.send(WorkerTask::Flush(flush_tx)).unwrap();
+        flush_rx.blocking_recv().unwrap();
+        sender.send(WorkerTask::Terminate).unwrap();
+        worker.join().unwrap();
+    });
+}
+
+#[test]
+fn pruning_construction_is_rejected_before_threads_start() {
+    let backend = EventTransposedCkfIndexer::new(workers(), CkfConfig::new(32)).unwrap();
+    let result = std::panic::catch_unwind(|| {
+        ThreadPoolIndexer::new_with_pruning(backend, 1, 32, PruneConfig::default())
+    });
+    assert!(result.is_err());
+}
+
+#[test]
+fn removal_continues_after_a_missing_hash_and_retains_first_error() {
+    let workers = workers();
+    let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
+    let mut states = std::array::from_fn(|_| None);
+    index
+        .apply_event(&mut states, store_event(workers[0], &[10, 20], 1000), None)
+        .unwrap();
+
+    let result = index.apply_event(&mut states, remove_event(workers[0], &[999, 20]), None);
+    assert!(matches!(
+        result,
+        Err(crate::protocols::KvCacheEventError::BlockNotFound)
+    ));
+    assert!(
+        states[0]
+            .as_ref()
+            .expect("writer state")
+            .resident
+            .contains(&ExternalSequenceBlockHash(10))
+    );
+    assert!(
+        !states[0]
+            .as_ref()
+            .expect("writer state")
+            .resident
+            .contains(&ExternalSequenceBlockHash(20))
+    );
+}
+
+#[test]
+fn digest_updates_roll_back_when_ckf_mutation_fails() {
+    let workers = workers();
+    let mut config = CkfConfig::new(1);
+    config.max_kicks = 1;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut states = std::array::from_fn(|_| None);
+    index
+        .apply_event(
+            &mut states,
+            store_event(workers[0], &(0..8).collect::<Vec<_>>(), 1000),
+            None,
+        )
+        .unwrap();
+
+    assert!(matches!(
+        index.apply_event(&mut states, store_event(workers[0], &[8], 2000), None),
+        Err(crate::protocols::KvCacheEventError::CapacityExhausted)
+    ));
+    let state = states[0].as_ref().expect("writer state");
+    assert_eq!(state.resident.len(), 8);
+    assert!(!state.resident.contains(&ExternalSequenceBlockHash(8)));
+
+    let resident = ExternalSequenceBlockHash(0);
+    let probe = index.addressing.prepare(resident.0);
+    let view = index.table.lane(0);
+    view.store_bucket(probe.bucket_a, PackedBucket::default());
+    view.store_bucket(probe.bucket_b, PackedBucket::default());
+    assert!(matches!(
+        index.apply_event(&mut states, remove_event(workers[0], &[resident.0]), None),
+        Err(crate::protocols::KvCacheEventError::IndexerInvariantViolation)
+    ));
+    assert!(
+        states[0]
+            .as_ref()
+            .expect("writer state")
+            .resident
+            .contains(&resident)
+    );
+}
+
+#[test]
+fn invalid_representation_collision_removal_does_not_delete_the_resident_hash() {
+    let workers = workers();
+    let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(1)).unwrap();
+    let (resident, absent, probe) = colliding_hashes(index.addressing);
+    let mut states = std::array::from_fn(|_| None);
+    index
+        .apply_event(
+            &mut states,
+            store_event(workers[0], &[resident.0], 5000),
+            None,
+        )
+        .unwrap();
+
+    let result = index.apply_event(&mut states, remove_event(workers[0], &[absent.0]), None);
+    assert!(matches!(
+        result,
+        Err(crate::protocols::KvCacheEventError::BlockNotFound)
+    ));
+    assert_eq!(index.table.probe(probe) & 1, 1);
+    assert!(
+        states[0]
+            .as_ref()
+            .expect("writer state")
+            .resident
+            .contains(&resident)
+    );
+}
+
+#[test]
+fn successful_mutation_reports_each_final_dirty_image_once() {
+    let workers = workers();
+    let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
+    let mut states = std::array::from_fn(|_| None);
+    let mut dirty = Vec::new();
+    index
+        .apply_event_with_dirty(
+            &mut states,
+            store_event(workers[0], &[10], 6000),
+            None,
+            |lane, bucket| dirty.push((lane, bucket)),
+        )
+        .unwrap();
+
+    assert!(!dirty.is_empty());
+    let mut unique = HashSet::new();
+    for (lane, bucket) in dirty {
+        assert!(unique.insert((lane, bucket.bucket)));
+        assert_eq!(
+            index.table.lane(lane).load_bucket(bucket.bucket),
+            bucket.value
+        );
+    }
+}
+
+#[test]
+fn window_eight_repairs_holes_at_offsets_two_through_eight() {
+    const QUERY_LEN: usize = 33;
+
+    for offset in 2..=8 {
+        let hole = QUERY_LEN - offset;
+        let mut masks = [1u16; QUERY_LEN];
+        masks[hole] = 0;
+        let window_one =
+            find_prefix_depths::<1>(QUERY_LEN, 1, 1, |_| {}, |position| masks[position]);
+        let window_eight =
+            find_prefix_depths::<1>(QUERY_LEN, 1, 8, |_| {}, |position| masks[position]);
+        let linear = linear_prefix_depths::<1>(QUERY_LEN, 1, |position| masks[position]);
+
+        assert_eq!(window_one, [QUERY_LEN as u32], "offset={offset}");
+        assert_eq!(window_eight, [hole as u32], "offset={offset}");
+        assert_eq!(linear, [hole as u32], "offset={offset}");
+    }
+}
+
+#[test]
+fn holes_beyond_the_terminal_window_remain_advisory() {
+    const QUERY_LEN: usize = 33;
+    const HOLE: usize = QUERY_LEN - 9;
+    let mut masks = [1u16; QUERY_LEN];
+    masks[HOLE] = 0;
+    let window_eight = find_prefix_depths::<1>(QUERY_LEN, 1, 8, |_| {}, |position| masks[position]);
+    let linear = linear_prefix_depths::<1>(QUERY_LEN, 1, |position| masks[position]);
+
+    assert_eq!(window_eight, [QUERY_LEN as u32]);
+    assert_eq!(linear, [HOLE as u32]);
+}
+
+#[test]
+fn store_remove_churn_drains_every_physical_slot() {
+    let table = TransposedCkfTable::<1>::new(64).unwrap();
+    let view = table.lane(0);
+    let addressing = CkfAddressing::new(64, TEST_SEED);
+    let mut state = DcWriterState::new(128, 500, TEST_SEED).unwrap();
+    let hashes: Vec<_> = (0..128)
+        .map(|hash| ExternalSequenceBlockHash(10_000 + hash))
+        .collect();
+    let mutator = CuckooMutator::new(&view, &addressing, 500);
+    for &hash in &hashes {
+        mutator
+            .insert(hash, &mut state.rng, &mut state.scratch, |_| {})
+            .unwrap();
+        state.resident.insert(hash);
+    }
+    for &hash in hashes.iter().rev() {
+        mutator.remove(hash, |_| {}).unwrap();
+        state.resident.remove(&hash);
+    }
+
+    assert!(state.resident.is_empty());
+    assert!(
+        (0..view.bucket_count())
+            .all(|bucket| { view.load_bucket(bucket) == PackedBucket::default() })
+    );
+}
+
+#[tokio::test]
+async fn concurrent_queries_and_mutations_stay_bounded_and_drain_consistently() {
+    let workers = workers();
+    let index = Arc::new(ThreadPoolIndexer::new(
+        EventTransposedCkfIndexer::new(workers, CkfConfig::new(128)).unwrap(),
+        2,
+        32,
+    ));
+    let query: Vec<_> = (1..=64).map(LocalBlockHash).collect();
+    let sequence_hashes = compute_seq_hash_for_block(&query);
+    KvIndexerInterface::apply_event(
+        index.as_ref(),
+        store_event(workers[0], &sequence_hashes, 10_000),
+    )
+    .await;
+    KvIndexerInterface::flush(index.as_ref()).await;
+
+    let barrier = Arc::new(Barrier::new(2));
+    let stop = Arc::new(AtomicBool::new(false));
+    let query_index = Arc::clone(&index);
+    let query_barrier = Arc::clone(&barrier);
+    let query_stop = Arc::clone(&stop);
+    let query_copy = query.clone();
+    let reader = std::thread::spawn(move || {
+        query_barrier.wait();
+        while !query_stop.load(Ordering::Acquire) {
+            let scores = query_index.backend().find_matches(&query_copy, false);
+            assert!(scores.scores.keys().all(|worker| workers.contains(worker)));
+            assert!(
+                scores
+                    .scores
+                    .values()
+                    .all(|&depth| depth <= query_copy.len() as u32)
+            );
+        }
+    });
+
+    barrier.wait();
+    KvIndexerInterface::apply_event(
+        index.as_ref(),
+        remove_event(workers[0], &sequence_hashes[..16]),
+    )
+    .await;
+    KvIndexerInterface::apply_event(index.as_ref(), clear_event(workers[0].worker_id)).await;
+    KvIndexerInterface::apply_event(
+        index.as_ref(),
+        store_event(workers[0], &sequence_hashes, 20_000),
+    )
+    .await;
+    KvIndexerInterface::flush(index.as_ref()).await;
+    stop.store(true, Ordering::Release);
+    reader.join().unwrap();
+
+    let scores = index.backend().find_matches(&query, false);
+    assert_eq!(scores.scores.get(&workers[0]), Some(&(query.len() as u32)));
+    let probes = index.backend().prepared_probes(&query);
+    let linear = index.backend().linear_depths(&probes);
+    assert_eq!(linear[0], query.len() as u32);
+    let stats = index.worker_lookup_stats().await;
+    assert_eq!(stats.block_count_for_worker(workers[0]), Some(query.len()));
+    index.shutdown();
+}
+
+#[cfg(feature = "metrics")]
+#[test]
+fn new_event_errors_have_finite_metric_labels() {
+    use crate::indexer::{
+        KvIndexerMetrics, METRIC_EVENT_STORED, METRIC_STATUS_CAPACITY_EXHAUSTED,
+        METRIC_STATUS_INDEXER_INVARIANT_VIOLATION,
+    };
+
+    let metrics = KvIndexerMetrics::new_unregistered();
+    metrics.increment_event_applied(
+        METRIC_EVENT_STORED,
+        Err(crate::protocols::KvCacheEventError::CapacityExhausted),
+    );
+    metrics.increment_event_applied(
+        METRIC_EVENT_STORED,
+        Err(crate::protocols::KvCacheEventError::IndexerInvariantViolation),
+    );
+    assert_eq!(
+        metrics
+            .kv_cache_events_applied
+            .with_label_values(&[METRIC_EVENT_STORED, METRIC_STATUS_CAPACITY_EXHAUSTED])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .kv_cache_events_applied
+            .with_label_values(&[
+                METRIC_EVENT_STORED,
+                METRIC_STATUS_INDEXER_INVARIANT_VIOLATION,
+            ])
+            .get(),
+        1
+    );
+}
+
+#[cfg(feature = "metrics")]
+#[tokio::test]
+async fn duplicate_warning_and_partial_error_metrics_are_event_scoped() {
+    use crate::indexer::{
+        KvIndexerMetrics, METRIC_EVENT_REMOVED, METRIC_STATUS_BLOCK_NOT_FOUND,
+        METRIC_WARNING_DUPLICATE_STORE,
+    };
+
+    let workers = workers();
+    let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+    let index = ThreadPoolIndexer::new_with_metrics(
+        EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap(),
+        1,
+        32,
+        Some(Arc::clone(&metrics)),
+    );
+    KvIndexerInterface::apply_event(&index, store_event(workers[0], &[10, 20], 1000)).await;
+    KvIndexerInterface::apply_event(&index, store_event(workers[0], &[10, 20], 2000)).await;
+    KvIndexerInterface::apply_event(&index, store_event(workers[0], &[10, 30], 3000)).await;
+    KvIndexerInterface::apply_event(&index, remove_event(workers[0], &[999, 20])).await;
+    KvIndexerInterface::flush(&index).await;
+
+    assert_eq!(
+        metrics
+            .kv_cache_event_warnings
+            .with_label_values(&[METRIC_WARNING_DUPLICATE_STORE])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .kv_cache_events_applied
+            .with_label_values(&[METRIC_EVENT_REMOVED, METRIC_STATUS_BLOCK_NOT_FOUND])
+            .get(),
+        1
+    );
+    index.shutdown();
+}
+
+#[derive(Default)]
+struct StudyStats {
+    queries: u64,
+    distinct_queries: u64,
+    observations: u64,
+    paired_depth_differences: u64,
+    paired_array_differences: u64,
+    window_one_full_map_mismatches: u64,
+    window_eight_full_map_mismatches: u64,
+    window_one_mismatches: u64,
+    window_eight_mismatches: u64,
+    window_one_inflation: u64,
+    window_eight_inflation: u64,
+    window_one_inflation_magnitude: u64,
+    window_eight_inflation_magnitude: u64,
+    window_one_under_reports: u64,
+    window_eight_under_reports: u64,
+    window_one_wrong_best: u64,
+    window_eight_wrong_best: u64,
+    window_one_probes: u64,
+    window_eight_probes: u64,
+}
+
+impl StudyStats {
+    fn record(
+        &mut self,
+        linear: [u32; DC_COUNT],
+        window_one: [u32; DC_COUNT],
+        window_eight: [u32; DC_COUNT],
+        window_one_probes: u64,
+        window_eight_probes: u64,
+    ) {
+        self.queries += 1;
+        self.observations += DC_COUNT as u64;
+        self.window_one_probes += window_one_probes;
+        self.window_eight_probes += window_eight_probes;
+        if window_one != window_eight {
+            self.paired_array_differences += 1;
+        }
+        if linear != window_one {
+            self.window_one_full_map_mismatches += 1;
+        }
+        if linear != window_eight {
+            self.window_eight_full_map_mismatches += 1;
+        }
+        if best_lane(linear) != best_lane(window_one) {
+            self.window_one_wrong_best += 1;
+        }
+        if best_lane(linear) != best_lane(window_eight) {
+            self.window_eight_wrong_best += 1;
+        }
+
+        for lane in 0..DC_COUNT {
+            if window_one[lane] != window_eight[lane] {
+                self.paired_depth_differences += 1;
+            }
+            record_depth_error(
+                linear[lane],
+                window_one[lane],
+                &mut self.window_one_mismatches,
+                &mut self.window_one_inflation,
+                &mut self.window_one_inflation_magnitude,
+                &mut self.window_one_under_reports,
+            );
+            record_depth_error(
+                linear[lane],
+                window_eight[lane],
+                &mut self.window_eight_mismatches,
+                &mut self.window_eight_inflation,
+                &mut self.window_eight_inflation_magnitude,
+                &mut self.window_eight_under_reports,
+            );
+        }
+    }
+}
+
+fn selected_verification_window(stats: &StudyStats) -> usize {
+    if stats.paired_depth_differences == 0
+        && stats.window_one_mismatches <= stats.window_eight_mismatches
+    {
+        1
+    } else {
+        8
+    }
+}
+
+#[test]
+fn default_selection_decision_covers_both_outcomes() {
+    let no_window_difference = StudyStats {
+        window_one_mismatches: 4,
+        window_eight_mismatches: 4,
+        ..StudyStats::default()
+    };
+    assert_eq!(selected_verification_window(&no_window_difference), 1);
+
+    let paired_difference = StudyStats {
+        paired_depth_differences: 1,
+        ..StudyStats::default()
+    };
+    assert_eq!(selected_verification_window(&paired_difference), 8);
+
+    let additional_linear_disagreement = StudyStats {
+        window_one_mismatches: 1,
+        ..StudyStats::default()
+    };
+    assert_eq!(
+        selected_verification_window(&additional_linear_disagreement),
+        8
+    );
+}
+
+#[test]
+fn study_corpus_contains_1024_distinct_queries_at_every_length() {
+    const QUERIES: usize = 1_024;
+    const QUERY_LENGTHS: [usize; 5] = [1, 8, 32, 128, 512];
+    let addressing = CkfAddressing::new(16_384, study_seed(0));
+    let chains = study_chains(study_seed(0), addressing, QUERIES, 512);
+
+    for query_len in QUERY_LENGTHS {
+        assert_eq!(
+            distinct_query_count(&chains, query_len),
+            QUERIES,
+            "query_len={query_len}"
+        );
+    }
+}
+
+#[test]
+#[ignore = "deterministic million-observation CKF accuracy study"]
+fn verification_window_study() {
+    const BUCKETS: usize = 16_384;
+    const QUERIES_PER_CELL: usize = 1_024;
+    const MAX_QUERY_LEN: usize = 512;
+    const MAX_RESIDENT_PREFIX: usize = 32;
+    const MAX_KICKS: usize = 4_096;
+    const OCCUPANCIES: [usize; 3] = [50, 80, 90];
+    const QUERY_LENGTHS: [usize; 5] = [1, 8, 32, 128, 512];
+    const SEEDS: usize = 8;
+
+    let mut totals = StudyStats::default();
+    for seed_index in 0..SEEDS {
+        let seed = study_seed(seed_index);
+        let addressing = CkfAddressing::new(BUCKETS, seed);
+        let chains = study_chains(seed, addressing, QUERIES_PER_CELL, MAX_QUERY_LEN);
+        let query_hashes: HashSet<u64> = chains
+            .iter()
+            .flat_map(|chain| chain.sequence_hashes.iter().copied())
+            .collect();
+        let prefix_depths = study_prefix_depths(seed_index, QUERIES_PER_CELL, MAX_RESIDENT_PREFIX);
+        let distinct_queries: HashMap<usize, usize> = QUERY_LENGTHS
+            .into_iter()
+            .map(|query_len| (query_len, distinct_query_count(&chains, query_len)))
+            .collect();
+        assert!(
+            distinct_queries
+                .values()
+                .all(|&count| count == QUERIES_PER_CELL),
+            "seed_index={seed_index} distinct_queries={distinct_queries:?}"
+        );
+
+        for occupancy in OCCUPANCIES {
+            let table = TransposedCkfTable::<DC_COUNT>::new(BUCKETS).unwrap();
+            fill_study_table(
+                &table,
+                addressing,
+                &chains,
+                &prefix_depths,
+                &query_hashes,
+                occupancy,
+                MAX_KICKS,
+                seed,
+            );
+
+            for query_len in QUERY_LENGTHS {
+                totals.distinct_queries += distinct_queries[&query_len] as u64;
+                for chain in chains.iter().take(QUERIES_PER_CELL) {
+                    let probes = &chain.probes[..query_len];
+                    let linear =
+                        linear_prefix_depths::<DC_COUNT>(probes.len(), u16::MAX, |position| {
+                            table.probe(probes[position])
+                        });
+                    let mut window_one_probes = 0u64;
+                    let window_one = find_prefix_depths::<DC_COUNT>(
+                        probes.len(),
+                        u16::MAX,
+                        1,
+                        |position| table.prefetch_probe(probes[position]),
+                        |position| {
+                            window_one_probes += 1;
+                            table.probe(probes[position])
+                        },
+                    );
+                    let mut window_eight_probes = 0u64;
+                    let window_eight = find_prefix_depths::<DC_COUNT>(
+                        probes.len(),
+                        u16::MAX,
+                        8,
+                        |position| table.prefetch_probe(probes[position]),
+                        |position| {
+                            window_eight_probes += 1;
+                            table.probe(probes[position])
+                        },
+                    );
+                    totals.record(
+                        linear,
+                        window_one,
+                        window_eight,
+                        window_one_probes,
+                        window_eight_probes,
+                    );
+                }
+            }
+        }
+    }
+
+    assert_eq!(totals.queries, 122_880);
+    assert_eq!(totals.distinct_queries, totals.queries);
+    assert_eq!(totals.observations, 1_966_080);
+    let expected_default = selected_verification_window(&totals);
+    println!(
+        "queries={} distinct_queries={} observations={} expected_default={} paired_depth_differences={} paired_array_differences={} w1_full_map_mismatches={} w8_full_map_mismatches={} w1_lane_mismatches={} w8_lane_mismatches={} w1_inflation={} w8_inflation={} w1_inflation_magnitude={} w8_inflation_magnitude={} w1_under_reports={} w8_under_reports={} w1_wrong_best={} w8_wrong_best={} w1_probes={} w8_probes={}",
+        totals.queries,
+        totals.distinct_queries,
+        totals.observations,
+        expected_default,
+        totals.paired_depth_differences,
+        totals.paired_array_differences,
+        totals.window_one_full_map_mismatches,
+        totals.window_eight_full_map_mismatches,
+        totals.window_one_mismatches,
+        totals.window_eight_mismatches,
+        totals.window_one_inflation,
+        totals.window_eight_inflation,
+        totals.window_one_inflation_magnitude,
+        totals.window_eight_inflation_magnitude,
+        totals.window_one_under_reports,
+        totals.window_eight_under_reports,
+        totals.window_one_wrong_best,
+        totals.window_eight_wrong_best,
+        totals.window_one_probes,
+        totals.window_eight_probes,
+    );
+    assert_eq!(
+        CkfConfig::default().search.verification_window,
+        expected_default
+    );
+}
+
+struct StudyChain {
+    local_hashes: Vec<LocalBlockHash>,
+    sequence_hashes: Vec<u64>,
+    probes: Vec<CkfProbe>,
+}
+
+fn study_chains(
+    seed: u64,
+    addressing: CkfAddressing,
+    chain_count: usize,
+    chain_len: usize,
+) -> Vec<StudyChain> {
+    let mut rng = StudyRng(seed);
+    (0..chain_count)
+        .map(|_| {
+            let local_hashes: Vec<_> = (0..chain_len).map(|_| LocalBlockHash(rng.next())).collect();
+            let sequence_hashes = compute_seq_hash_for_block(&local_hashes);
+            let probes = sequence_hashes
+                .iter()
+                .copied()
+                .map(|hash| addressing.prepare(hash))
+                .collect();
+            StudyChain {
+                local_hashes,
+                sequence_hashes,
+                probes,
+            }
+        })
+        .collect()
+}
+
+fn distinct_query_count(chains: &[StudyChain], query_len: usize) -> usize {
+    chains
+        .iter()
+        .map(|chain| &chain.local_hashes[..query_len])
+        .collect::<HashSet<_>>()
+        .len()
+}
+
+fn study_prefix_depths(
+    seed_index: usize,
+    chain_count: usize,
+    max_query_len: usize,
+) -> Vec<[usize; DC_COUNT]> {
+    (0..chain_count)
+        .map(|chain| {
+            std::array::from_fn(|lane| {
+                (chain * 131 + lane * 37 + seed_index * 17) % (max_query_len + 1)
+            })
+        })
+        .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn fill_study_table(
+    table: &TransposedCkfTable<DC_COUNT>,
+    addressing: CkfAddressing,
+    chains: &[StudyChain],
+    prefix_depths: &[[usize; DC_COUNT]],
+    query_hashes: &HashSet<u64>,
+    occupancy: usize,
+    max_kicks: usize,
+    seed: u64,
+) {
+    let target = BUCKET_SLOTS_PER_LANE * occupancy / 100;
+    let mut noise = StudyRng(seed ^ (occupancy as u64).wrapping_mul(0xD1B5_4A32_D192_ED03));
+    let prefix_depths_by_lane: [Vec<_>; DC_COUNT] = std::array::from_fn(|lane| {
+        prefix_depths
+            .iter()
+            .map(|chain_depths| chain_depths[lane])
+            .collect()
+    });
+    for (lane, lane_prefix_depths) in prefix_depths_by_lane.iter().enumerate() {
+        let view = table.lane(lane);
+        let mut state = DcWriterState::new(target, max_kicks, seed ^ lane as u64).unwrap();
+        for (chain, &prefix_depth) in chains.iter().zip(lane_prefix_depths) {
+            for &hash in &chain.sequence_hashes[..prefix_depth] {
+                insert_study_hash(&view, &addressing, &mut state, hash, max_kicks);
+            }
+        }
+        while state.resident.len() < target {
+            let hash = noise.next();
+            if query_hashes.contains(&hash)
+                || state.resident.contains(&ExternalSequenceBlockHash(hash))
+            {
+                continue;
+            }
+            insert_study_hash(&view, &addressing, &mut state, hash, max_kicks);
+        }
+        assert_eq!(
+            state.resident.len(),
+            target,
+            "lane={lane} occupancy={occupancy}"
+        );
+    }
+}
+
+const BUCKET_SLOTS_PER_LANE: usize = 16_384 * 4;
+
+fn insert_study_hash<S: CuckooBucketStore>(
+    store: &S,
+    addressing: &CkfAddressing,
+    state: &mut DcWriterState,
+    hash: u64,
+    max_kicks: usize,
+) {
+    let hash = ExternalSequenceBlockHash(hash);
+    if state.resident.contains(&hash) {
+        return;
+    }
+    CuckooMutator::new(store, addressing, max_kicks)
+        .insert(hash, &mut state.rng, &mut state.scratch, |_| {})
+        .unwrap_or_else(|error| panic!("failed to reach study occupancy: {error}"));
+    state.resident.insert(hash);
+}
+
+fn record_depth_error(
+    expected: u32,
+    actual: u32,
+    mismatches: &mut u64,
+    inflation: &mut u64,
+    inflation_magnitude: &mut u64,
+    under_reports: &mut u64,
+) {
+    match actual.cmp(&expected) {
+        std::cmp::Ordering::Greater => {
+            *mismatches += 1;
+            *inflation += 1;
+            *inflation_magnitude += u64::from(actual - expected);
+        }
+        std::cmp::Ordering::Less => {
+            *mismatches += 1;
+            *under_reports += 1;
+        }
+        std::cmp::Ordering::Equal => {}
+    }
+}
+
+fn best_lane(depths: [u32; DC_COUNT]) -> Option<usize> {
+    depths
+        .into_iter()
+        .enumerate()
+        .filter(|(_, depth)| *depth > 0)
+        .max_by(|(left_lane, left), (right_lane, right)| {
+            left.cmp(right).then_with(|| right_lane.cmp(left_lane))
+        })
+        .map(|(lane, _)| lane)
+}
+
+fn study_seed(index: usize) -> u64 {
+    let mut rng = StudyRng(0x5DEE_CE66_D1B5_4A33 ^ index as u64);
+    rng.next()
+}
+
+struct StudyRng(u64);
+
+impl StudyRng {
+    fn next(&mut self) -> u64 {
+        self.0 = self.0.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut value = self.0;
+        value = (value ^ (value >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        value = (value ^ (value >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        value ^ (value >> 31)
+    }
+}
+
+fn workers() -> [WorkerWithDpRank; DC_COUNT] {
+    std::array::from_fn(|lane| WorkerWithDpRank::new(100 + lane as u64, 0))
+}
+
+fn workers_with_shared_worker() -> [WorkerWithDpRank; DC_COUNT] {
+    std::array::from_fn(|lane| match lane {
+        0 => WorkerWithDpRank::new(7, 0),
+        1 => WorkerWithDpRank::new(7, 1),
+        _ => WorkerWithDpRank::new(100 + lane as u64, 0),
+    })
+}
+
+fn store_event(
+    worker: WorkerWithDpRank,
+    sequence_hashes: &[u64],
+    token_hash_base: u64,
+) -> RouterEvent {
+    RouterEvent {
+        worker_id: worker.worker_id,
+        storage_tier: StorageTier::Device,
+        event: KvCacheEvent {
+            event_id: 1,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: Some(0),
+                blocks: sequence_hashes
+                    .iter()
+                    .copied()
+                    .enumerate()
+                    .map(|(index, hash)| KvCacheStoredBlockData {
+                        block_hash: ExternalSequenceBlockHash(hash),
+                        tokens_hash: LocalBlockHash(token_hash_base + index as u64),
+                        mm_extra_info: None,
+                    })
+                    .collect(),
+            }),
+            dp_rank: worker.dp_rank,
+        },
+    }
+}
+
+fn remove_event(worker: WorkerWithDpRank, hashes: &[u64]) -> RouterEvent {
+    RouterEvent {
+        worker_id: worker.worker_id,
+        storage_tier: StorageTier::Device,
+        event: KvCacheEvent {
+            event_id: 2,
+            data: KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: hashes
+                    .iter()
+                    .copied()
+                    .map(ExternalSequenceBlockHash)
+                    .collect(),
+            }),
+            dp_rank: worker.dp_rank,
+        },
+    }
+}
+
+fn clear_event(worker_id: u64) -> RouterEvent {
+    RouterEvent {
+        worker_id,
+        storage_tier: StorageTier::Device,
+        event: KvCacheEvent {
+            event_id: 3,
+            data: KvCacheEventData::Cleared,
+            dp_rank: 0,
+        },
+    }
+}
+
+fn colliding_hashes(
+    addressing: CkfAddressing,
+) -> (
+    ExternalSequenceBlockHash,
+    ExternalSequenceBlockHash,
+    CkfProbe,
+) {
+    let mut seen = HashMap::new();
+    for hash in 0..1_000_000u64 {
+        let probe = addressing.prepare(hash);
+        let key = (probe.fingerprint, probe.bucket_a, probe.bucket_b);
+        if let Some(first) = seen.insert(key, hash) {
+            return (
+                ExternalSequenceBlockHash(first),
+                ExternalSequenceBlockHash(hash),
+                probe,
+            );
+        }
+    }
+    panic!("failed to find deterministic CKF representation collision")
+}
+
+fn fingerprint_copies<S: CuckooBucketStore>(store: &S, probe: CkfProbe) -> usize {
+    [probe.bucket_a, probe.bucket_b]
+        .into_iter()
+        .map(|bucket| {
+            let bucket = store.load_bucket(bucket);
+            (0..4)
+                .filter(|&slot| bucket.slot(slot) == probe.fingerprint)
+                .count()
+        })
+        .sum()
+}

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -7,6 +7,8 @@ use std::sync::{
     atomic::{AtomicBool, Ordering},
 };
 
+use rustc_hash::FxHashSet;
+
 use crate::indexer::pruning::PruneConfig;
 use crate::indexer::{KvIndexerInterface, SyncIndexer, ThreadPoolIndexer, WorkerTask};
 use crate::protocols::{
@@ -23,9 +25,21 @@ use super::search::{
     find_prefix_depths, find_prefix_depths_with_test_stats, fixed_window_prefix_depths,
     linear_prefix_depths,
 };
-use super::{CkfBuildError, CkfConfig, DC_COUNT, EventTransposedCkfIndexer};
+use super::{
+    CkfBuildError, CkfConfig, DC_COUNT, EventTransposedCkfIndexer, RelayLaneConfig, RelayManifest,
+    RouterLocalCkfPipeline,
+};
 
 const TEST_SEED: u64 = 0x1234_5678_9ABC_DEF0;
+
+fn single_lane_manifest(
+    members: Vec<WorkerWithDpRank>,
+    expected_contributions: usize,
+) -> RelayManifest {
+    let mut lanes = std::array::from_fn(|_| RelayLaneConfig::empty());
+    lanes[0] = RelayLaneConfig::new(members, expected_contributions);
+    RelayManifest::new(lanes).unwrap()
+}
 
 #[test]
 fn validates_config_and_worker_mapping() {
@@ -50,6 +64,528 @@ fn validates_config_and_worker_mapping() {
             worker: duplicate_workers[0]
         }
     );
+}
+
+#[test]
+fn validates_publish_cadence_and_defaults_to_immediate_publication() {
+    assert_eq!(CkfConfig::default().publish_every_n_events, 1);
+
+    let config = CkfConfig {
+        publish_every_n_events: 0,
+        ..CkfConfig::default()
+    };
+    assert_eq!(
+        EventTransposedCkfIndexer::new(workers(), config).unwrap_err(),
+        CkfBuildError::InvalidPublishEveryNEvents
+    );
+}
+
+#[test]
+fn validates_manifest_contribution_capacity_and_rank_identity() {
+    let rank_zero = WorkerWithDpRank::new(100, 0);
+    let rank_one = WorkerWithDpRank::new(100, 1);
+    let manifest = single_lane_manifest(vec![rank_zero, rank_one], 31);
+    assert_eq!(
+        RouterLocalCkfPipeline::new(manifest, CkfConfig::new(32)).unwrap_err(),
+        CkfBuildError::InvalidContributionCapacity {
+            lane: 0,
+            value: 31,
+            minimum: 32,
+        }
+    );
+
+    let mut lanes = std::array::from_fn(|_| RelayLaneConfig::empty());
+    lanes[4] = RelayLaneConfig::new(Vec::new(), 1);
+    assert_eq!(
+        RouterLocalCkfPipeline::new(RelayManifest::new(lanes).unwrap(), CkfConfig::new(32))
+            .unwrap_err(),
+        CkfBuildError::InvalidEmptyLaneContributionCapacity { lane: 4, value: 1 }
+    );
+}
+
+#[test]
+fn publish_counters_are_lane_independent() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 2;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    let first = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    assert!(!first.batch_applied());
+    let second = index.apply_event_with_batch(store_event(workers[1], &[20], 2), &mut batch);
+    assert!(!second.batch_applied());
+
+    let lane_zero = index.apply_event_with_batch(store_event(workers[0], &[], 3), &mut batch);
+    assert!(lane_zero.batch_applied());
+    assert!(batch.images().iter().all(|image| image.lane() == 0));
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+    assert_eq!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(20))
+            & (1 << 1),
+        0
+    );
+
+    let lane_one = index.apply_event_with_batch(store_event(workers[1], &[], 4), &mut batch);
+    assert!(lane_one.batch_applied());
+    assert!(batch.images().iter().all(|image| image.lane() == 1));
+}
+
+#[test]
+fn sixteenth_event_publishes_fifteen_event_tail() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 16;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    let first = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    assert!(!first.batch_applied());
+    for event_id in 2..16 {
+        let outcome =
+            index.apply_event_with_batch(store_event(workers[0], &[10], event_id), &mut batch);
+        assert!(!outcome.batch_applied(), "event_id={event_id}");
+    }
+    assert_eq!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 16), &mut batch);
+    assert!(outcome.batch_applied());
+    assert_eq!(batch.images().len(), 1);
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn publication_window_coalesces_repeated_bucket_touches_across_events() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 3;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    assert!(
+        !index
+            .apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch)
+            .batch_applied()
+    );
+    assert!(
+        !index
+            .apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch)
+            .batch_applied()
+    );
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 3), &mut batch);
+    assert!(outcome.batch_applied());
+    assert_eq!(batch.images().len(), 1);
+    assert_eq!(batch.reset_lanes(), 0);
+}
+
+#[test]
+fn due_net_reversion_is_unchanged_and_applies_no_batch() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 2;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
+
+    assert!(!outcome.batch_applied());
+    assert!(batch.images().is_empty());
+    assert_eq!(batch.reset_lanes(), 0);
+    assert!(!index.pipeline.flush_pending(&mut batch).unwrap());
+}
+
+#[test]
+fn partially_net_reverted_window_emits_only_changed_buckets() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 3;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10, 20], 1), &mut batch);
+    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
+    let outcome = index.apply_event_with_batch(remove_event(workers[0], &[20]), &mut batch);
+
+    assert!(outcome.batch_applied());
+    assert_eq!(batch.reset_lanes(), 0);
+    assert_eq!(batch.images().len(), 1);
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+    assert_eq!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(20))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn unpublished_empty_populated_empty_window_emits_nothing() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 2;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    let outcome = index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+
+    assert!(!outcome.batch_applied());
+    assert!(batch.images().is_empty());
+    assert_eq!(batch.reset_lanes(), 0);
+}
+
+#[test]
+fn published_nonempty_lane_emptied_at_boundary_emits_reset() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 2;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 2), &mut batch);
+
+    assert!(outcome.batch_applied());
+    assert_ne!(batch.reset_lanes() & 1, 0);
+    assert!(batch.images().is_empty());
+}
+
+#[test]
+fn partial_failure_preserves_pending_successes_until_due_publication() {
+    let workers = workers();
+    let mut config = CkfConfig::new(1);
+    config.max_kicks = 1;
+    config.publish_every_n_events = 2;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    let first = index.apply_event_with_batch(
+        store_event(workers[0], &(0..7).collect::<Vec<_>>(), 1),
+        &mut batch,
+    );
+    assert!(!first.batch_applied());
+
+    let second = index.apply_event_with_batch(store_event(workers[0], &[7, 8], 2), &mut batch);
+    assert!(matches!(
+        second.first_error(),
+        Some(crate::protocols::KvCacheEventError::CapacityExhausted)
+    ));
+    assert!(second.batch_applied());
+    assert_eq!(index.pipeline.memory_snapshot().actual_contributions, 8);
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(7))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn flush_publishes_a_subthreshold_tail() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 16;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    assert!(!outcome.batch_applied());
+    assert!(index.pipeline.flush_pending(&mut batch).unwrap());
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+    assert!(!index.pipeline.flush_pending(&mut batch).unwrap());
+}
+
+#[test]
+fn lifecycle_removal_forces_pending_publication() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 16;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    index.pipeline.flush_pending(&mut batch).unwrap();
+    let outcome = index.pipeline.remove_worker_rank(workers[0], &mut batch);
+    assert!(outcome.batch_applied());
+    assert_ne!(batch.reset_lanes() & 1, 0);
+    assert_eq!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn empty_then_repopulated_window_cancels_stale_reset() {
+    let workers = workers();
+    let mut config = CkfConfig::new(32);
+    config.publish_every_n_events = 3;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+    let mut batch = index.pipeline.new_batch();
+
+    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    index.pipeline.flush_pending(&mut batch).unwrap();
+    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    index.apply_event_with_batch(store_event(workers[0], &[20], 2), &mut batch);
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 3), &mut batch);
+
+    assert!(outcome.batch_applied());
+    assert_eq!(batch.reset_lanes() & 1, 0);
+    assert_eq!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+    assert_ne!(
+        index
+            .pipeline
+            .replica()
+            .table
+            .probe(index.pipeline.replica().addressing.prepare(20))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn shared_dc_hash_survives_until_the_final_owner_is_removed() {
+    let first = WorkerWithDpRank::new(100, 0);
+    let second = WorkerWithDpRank::new(200, 0);
+    let manifest = single_lane_manifest(vec![first, second], 64);
+    let pipeline = RouterLocalCkfPipeline::new(manifest, CkfConfig::new(32)).unwrap();
+    let mut batch = pipeline.new_batch();
+
+    let first_store = pipeline.apply_event(store_event(first, &[10], 1), &mut batch);
+    assert!(first_store.batch_applied());
+    assert_eq!(batch.images().len(), 1);
+    let second_store = pipeline.apply_event(store_event(second, &[10], 2), &mut batch);
+    assert!(!second_store.batch_applied());
+    assert!(batch.images().is_empty());
+
+    pipeline.apply_event(remove_event(first, &[10]), &mut batch);
+    assert_ne!(
+        pipeline
+            .replica()
+            .table
+            .probe(pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+    pipeline.apply_event(remove_event(second, &[10]), &mut batch);
+    assert_ne!(batch.reset_lanes() & 1, 0);
+}
+
+#[test]
+fn clear_one_owner_preserves_another_owner_in_the_same_dc() {
+    let first = WorkerWithDpRank::new(100, 0);
+    let second = WorkerWithDpRank::new(200, 0);
+    let pipeline = RouterLocalCkfPipeline::new(
+        single_lane_manifest(vec![first, second], 64),
+        CkfConfig::new(32),
+    )
+    .unwrap();
+    let mut batch = pipeline.new_batch();
+
+    pipeline.apply_event(store_event(first, &[10], 1), &mut batch);
+    pipeline.apply_event(store_event(second, &[10], 2), &mut batch);
+    let outcome = pipeline.apply_event(clear_event(first.worker_id), &mut batch);
+
+    assert!(outcome.first_error().is_none());
+    assert!(!pipeline.member_contains(first, ExternalSequenceBlockHash(10)));
+    assert!(pipeline.member_contains(second, ExternalSequenceBlockHash(10)));
+    assert_eq!(batch.reset_lanes(), 0);
+    assert_ne!(
+        pipeline
+            .replica()
+            .table
+            .probe(pipeline.replica().addressing.prepare(10))
+            & 1,
+        0
+    );
+}
+
+#[test]
+fn worker_wide_clear_spans_lanes_and_preserves_unrelated_members() {
+    let rank_zero = WorkerWithDpRank::new(100, 0);
+    let rank_one = WorkerWithDpRank::new(100, 1);
+    let other = WorkerWithDpRank::new(200, 0);
+    let mut lanes = std::array::from_fn(|_| RelayLaneConfig::empty());
+    lanes[0] = RelayLaneConfig::new(vec![rank_zero, other], 64);
+    lanes[1] = RelayLaneConfig::new(vec![rank_one], 32);
+    let pipeline =
+        RouterLocalCkfPipeline::new(RelayManifest::new(lanes).unwrap(), CkfConfig::new(32))
+            .unwrap();
+    let mut batch = pipeline.new_batch();
+
+    pipeline.apply_event(store_event(rank_zero, &[10], 1), &mut batch);
+    pipeline.apply_event(store_event(other, &[10], 2), &mut batch);
+    pipeline.apply_event(store_event(rank_one, &[20], 3), &mut batch);
+    let mut clear = clear_event(rank_zero.worker_id);
+    clear.event.dp_rank = 999;
+    let outcome = pipeline.apply_event(clear, &mut batch);
+
+    assert!(outcome.first_error().is_none());
+    assert!(pipeline.member_contains(other, ExternalSequenceBlockHash(10)));
+    assert!(!pipeline.member_contains(rank_zero, ExternalSequenceBlockHash(10)));
+    assert!(!pipeline.member_contains(rank_one, ExternalSequenceBlockHash(20)));
+    assert_eq!(batch.reset_lanes() & 1, 0);
+    assert_ne!(batch.reset_lanes() & (1 << 1), 0);
+}
+
+#[test]
+fn non_device_events_are_ignored_and_unknown_clear_is_rejected() {
+    let worker = WorkerWithDpRank::new(100, 0);
+    let pipeline =
+        RouterLocalCkfPipeline::new(single_lane_manifest(vec![worker], 32), CkfConfig::new(32))
+            .unwrap();
+    let mut batch = pipeline.new_batch();
+    let mut host_store = store_event(worker, &[10], 1);
+    host_store.storage_tier = StorageTier::HostPinned;
+
+    let host_outcome = pipeline.apply_event(host_store, &mut batch);
+    assert!(!host_outcome.batch_applied());
+    assert!(!pipeline.member_contains(worker, ExternalSequenceBlockHash(10)));
+
+    let unknown = pipeline.apply_event(clear_event(999), &mut batch);
+    assert!(matches!(
+        unknown.first_error(),
+        Some(crate::protocols::KvCacheEventError::InvalidBlockSequence)
+    ));
+}
+
+#[test]
+fn shared_hash_stats_are_per_member_and_model_instances_are_isolated() {
+    let first = WorkerWithDpRank::new(100, 0);
+    let second = WorkerWithDpRank::new(200, 0);
+    let make_pipeline = || {
+        RouterLocalCkfPipeline::new(
+            single_lane_manifest(vec![first, second], 64),
+            CkfConfig::new(32),
+        )
+        .unwrap()
+    };
+    let first_model = make_pipeline();
+    let second_model = make_pipeline();
+    let mut batch = first_model.new_batch();
+    first_model.apply_event(store_event(first, &[10], 1), &mut batch);
+    first_model.apply_event(store_event(second, &[10], 2), &mut batch);
+
+    let worker_ids = FxHashSet::from_iter([first.worker_id, second.worker_id]);
+    let stats = first_model.worker_stats(&worker_ids);
+    assert_eq!(stats.block_count_for_worker(first), Some(1));
+    assert_eq!(stats.block_count_for_worker(second), Some(1));
+    assert_eq!(first_model.memory_snapshot().actual_contributions, 2);
+    assert_eq!(
+        second_model
+            .replica()
+            .table
+            .probe(second_model.replica().addressing.prepare(10)),
+        0
+    );
+}
+
+#[cfg(feature = "bench")]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[ignore = "temporary occupied-bucket tracking benchmark gate"]
+async fn occupied_tracking_study() {
+    const EVENTS_PER_CELL: usize = 30_000;
+    let replica_occupancy = std::env::var_os("DYNAMO_CKF_REPLICA_OCCUPANCY").is_some();
+    let aggregator_occupancy = std::env::var_os("DYNAMO_CKF_AGGREGATOR_OCCUPANCY").is_some();
+
+    for clear_every in [100usize, 1_000, 10_000] {
+        let workers = workers();
+        let index = ThreadPoolIndexer::new(
+            EventTransposedCkfIndexer::new(workers, CkfConfig::new(16_384)).unwrap(),
+            1,
+            32,
+        );
+        for event_index in 0..EVENTS_PER_CELL {
+            let hash = (event_index % clear_every) as u64 + 1;
+            KvIndexerInterface::apply_event(
+                &index,
+                store_event(workers[0], &[hash], event_index as u64 + 1),
+            )
+            .await;
+            if (event_index + 1) % clear_every == 0 {
+                KvIndexerInterface::apply_event(&index, clear_event(workers[0].worker_id)).await;
+            }
+        }
+        KvIndexerInterface::flush(&index).await;
+        println!(
+            "CKF_OCCUPANCY_STUDY replica_occupancy={} aggregator_occupancy={} clear_every={} events={} {}",
+            replica_occupancy,
+            aggregator_occupancy,
+            clear_every,
+            EVENTS_PER_CELL,
+            index.backend().timing_report(),
+        );
+        index.shutdown();
+    }
 }
 
 #[test]
@@ -290,19 +826,25 @@ async fn thread_pool_reports_unsupported_dump_and_exact_stats() {
 #[test]
 fn worker_acknowledges_partial_event_failure_and_continues_serving_tasks() {
     let workers = workers();
-    let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
+    let mut config = CkfConfig::new(1);
+    config.max_kicks = 1;
+    let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let (sender, receiver) = flume::unbounded();
 
     std::thread::scope(|scope| {
         let worker = scope.spawn(|| index.worker(receiver, None).unwrap());
         sender
-            .send(WorkerTask::Event(store_event(workers[0], &[10, 20], 1000)))
+            .send(WorkerTask::Event(store_event(
+                workers[0],
+                &(0..7).collect::<Vec<_>>(),
+                1000,
+            )))
             .unwrap();
 
         let (ack_tx, ack_rx) = tokio::sync::oneshot::channel();
         sender
             .send(WorkerTask::EventWithAck {
-                event: remove_event(workers[0], &[999, 20]),
+                event: store_event(workers[0], &[7, 8], 2000),
                 resp: ack_tx,
             })
             .unwrap();
@@ -311,7 +853,7 @@ fn worker_acknowledges_partial_event_failure_and_continues_serving_tasks() {
         let (stats_tx, stats_rx) = tokio::sync::oneshot::channel();
         sender.send(WorkerTask::Stats(stats_tx)).unwrap();
         let stats = stats_rx.blocking_recv().unwrap();
-        assert_eq!(stats.block_count_for_worker(workers[0]), Some(1));
+        assert_eq!(stats.block_count_for_worker(workers[0]), Some(8));
 
         let (flush_tx, flush_rx) = tokio::sync::oneshot::channel();
         sender.send(WorkerTask::Flush(flush_tx)).unwrap();
@@ -319,6 +861,51 @@ fn worker_acknowledges_partial_event_failure_and_continues_serving_tasks() {
         sender.send(WorkerTask::Terminate).unwrap();
         worker.join().unwrap();
     });
+}
+
+#[test]
+fn worker_termination_and_receiver_closure_drain_pending_publication() {
+    for terminate in [true, false] {
+        let workers = workers();
+        let mut config = CkfConfig::new(32);
+        config.publish_every_n_events = 16;
+        let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
+        let (sender, receiver) = flume::unbounded();
+
+        std::thread::scope(|scope| {
+            let worker = scope.spawn(|| index.worker(receiver, None).unwrap());
+            sender
+                .send(WorkerTask::Event(store_event(workers[0], &[10], 1)))
+                .unwrap();
+            let (flush_tx, flush_rx) = tokio::sync::oneshot::channel();
+            sender.send(WorkerTask::Stats(flush_tx)).unwrap();
+            flush_rx.blocking_recv().unwrap();
+            assert_eq!(
+                index
+                    .pipeline
+                    .replica()
+                    .table
+                    .probe(index.pipeline.replica().addressing.prepare(10))
+                    & 1,
+                0
+            );
+            if terminate {
+                sender.send(WorkerTask::Terminate).unwrap();
+            }
+            drop(sender);
+            worker.join().unwrap();
+        });
+
+        assert_ne!(
+            index
+                .pipeline
+                .replica()
+                .table
+                .probe(index.pipeline.replica().addressing.prepare(10))
+                & 1,
+            0
+        );
+    }
 }
 
 #[test]
@@ -331,32 +918,25 @@ fn pruning_construction_is_rejected_before_threads_start() {
 }
 
 #[test]
-fn removal_continues_after_a_missing_hash_and_retains_first_error() {
+fn unknown_removal_is_ignored_while_valid_removal_continues() {
     let workers = workers();
     let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
-    let mut states = std::array::from_fn(|_| None);
     index
-        .apply_event(&mut states, store_event(workers[0], &[10, 20], 1000), None)
+        .apply_event(store_event(workers[0], &[10, 20], 1000), None)
         .unwrap();
 
-    let result = index.apply_event(&mut states, remove_event(workers[0], &[999, 20]), None);
-    assert!(matches!(
-        result,
-        Err(crate::protocols::KvCacheEventError::BlockNotFound)
-    ));
+    index
+        .apply_event(remove_event(workers[0], &[999, 20]), None)
+        .unwrap();
     assert!(
-        states[0]
-            .as_ref()
-            .expect("writer state")
-            .resident
-            .contains(&ExternalSequenceBlockHash(10))
+        index
+            .pipeline
+            .member_contains(workers[0], ExternalSequenceBlockHash(10))
     );
     assert!(
-        !states[0]
-            .as_ref()
-            .expect("writer state")
-            .resident
-            .contains(&ExternalSequenceBlockHash(20))
+        !index
+            .pipeline
+            .member_contains(workers[0], ExternalSequenceBlockHash(20))
     );
 }
 
@@ -366,92 +946,72 @@ fn digest_updates_roll_back_when_ckf_mutation_fails() {
     let mut config = CkfConfig::new(1);
     config.max_kicks = 1;
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
-    let mut states = std::array::from_fn(|_| None);
     index
         .apply_event(
-            &mut states,
             store_event(workers[0], &(0..8).collect::<Vec<_>>(), 1000),
             None,
         )
         .unwrap();
 
     assert!(matches!(
-        index.apply_event(&mut states, store_event(workers[0], &[8], 2000), None),
+        index.apply_event(store_event(workers[0], &[8], 2000), None),
         Err(crate::protocols::KvCacheEventError::CapacityExhausted)
     ));
-    let state = states[0].as_ref().expect("writer state");
-    assert_eq!(state.resident.len(), 8);
-    assert!(!state.resident.contains(&ExternalSequenceBlockHash(8)));
+    assert_eq!(index.pipeline.memory_snapshot().actual_contributions, 8);
+    assert!(
+        !index
+            .pipeline
+            .member_contains(workers[0], ExternalSequenceBlockHash(8))
+    );
 
     let resident = ExternalSequenceBlockHash(0);
-    let probe = index.addressing.prepare(resident.0);
-    let view = index.table.lane(0);
-    view.store_bucket(probe.bucket_a, PackedBucket::default());
-    view.store_bucket(probe.bucket_b, PackedBucket::default());
+    index
+        .pipeline
+        .clear_owned_representation(workers[0], resident);
     assert!(matches!(
-        index.apply_event(&mut states, remove_event(workers[0], &[resident.0]), None),
+        index.apply_event(remove_event(workers[0], &[resident.0]), None),
         Err(crate::protocols::KvCacheEventError::IndexerInvariantViolation)
     ));
-    assert!(
-        states[0]
-            .as_ref()
-            .expect("writer state")
-            .resident
-            .contains(&resident)
-    );
+    assert!(index.pipeline.member_contains(workers[0], resident));
 }
 
 #[test]
 fn invalid_representation_collision_removal_does_not_delete_the_resident_hash() {
     let workers = workers();
     let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(1)).unwrap();
-    let (resident, absent, probe) = colliding_hashes(index.addressing);
-    let mut states = std::array::from_fn(|_| None);
+    let (resident, absent, probe) = colliding_hashes(index.pipeline.replica().addressing);
     index
-        .apply_event(
-            &mut states,
-            store_event(workers[0], &[resident.0], 5000),
-            None,
-        )
+        .apply_event(store_event(workers[0], &[resident.0], 5000), None)
         .unwrap();
 
-    let result = index.apply_event(&mut states, remove_event(workers[0], &[absent.0]), None);
-    assert!(matches!(
-        result,
-        Err(crate::protocols::KvCacheEventError::BlockNotFound)
-    ));
-    assert_eq!(index.table.probe(probe) & 1, 1);
-    assert!(
-        states[0]
-            .as_ref()
-            .expect("writer state")
-            .resident
-            .contains(&resident)
-    );
+    index
+        .apply_event(remove_event(workers[0], &[absent.0]), None)
+        .unwrap();
+    assert_eq!(index.pipeline.replica().table.probe(probe) & 1, 1);
+    assert!(index.pipeline.member_contains(workers[0], resident));
 }
 
 #[test]
 fn successful_mutation_reports_each_final_dirty_image_once() {
     let workers = workers();
     let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
-    let mut states = std::array::from_fn(|_| None);
-    let mut dirty = Vec::new();
-    index
-        .apply_event_with_dirty(
-            &mut states,
-            store_event(workers[0], &[10], 6000),
-            None,
-            |lane, bucket| dirty.push((lane, bucket)),
-        )
-        .unwrap();
+    let mut batch = index.pipeline.new_batch();
+    let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 6000), &mut batch);
+    assert!(outcome.first_error().is_none());
 
-    assert!(!dirty.is_empty());
+    assert!(!batch.images().is_empty());
     let mut unique = HashSet::new();
-    for (lane, bucket) in dirty {
-        assert!(unique.insert((lane, bucket.bucket)));
+    for image in batch.images() {
+        let lane = usize::from(image.lane());
+        assert!(unique.insert((lane, image.bucket())));
         assert_eq!(
-            index.table.lane(lane).load_bucket(bucket.bucket),
-            bucket.value
+            index
+                .pipeline
+                .replica()
+                .table
+                .lane(lane)
+                .load_bucket(image.bucket()),
+            PackedBucket(image.value())
         );
     }
 }
@@ -730,8 +1290,8 @@ fn new_event_errors_have_finite_metric_labels() {
 #[tokio::test]
 async fn duplicate_warning_and_partial_error_metrics_are_event_scoped() {
     use crate::indexer::{
-        KvIndexerMetrics, METRIC_EVENT_REMOVED, METRIC_STATUS_BLOCK_NOT_FOUND,
-        METRIC_WARNING_DUPLICATE_STORE,
+        KvIndexerMetrics, METRIC_CKF_MUTATION_UNKNOWN_REMOVE, METRIC_EVENT_REMOVED,
+        METRIC_STATUS_OK, METRIC_WARNING_DUPLICATE_STORE,
     };
 
     let workers = workers();
@@ -758,7 +1318,14 @@ async fn duplicate_warning_and_partial_error_metrics_are_event_scoped() {
     assert_eq!(
         metrics
             .kv_cache_events_applied
-            .with_label_values(&[METRIC_EVENT_REMOVED, METRIC_STATUS_BLOCK_NOT_FOUND])
+            .with_label_values(&[METRIC_EVENT_REMOVED, METRIC_STATUS_OK])
+            .get(),
+        1
+    );
+    assert_eq!(
+        metrics
+            .ckf_mutation
+            .with_label_values(&[METRIC_CKF_MUTATION_UNKNOWN_REMOVE])
             .get(),
         1
     );

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -1,13 +1,12 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::{HashMap, HashSet};
 use std::sync::{
     Arc, Barrier,
     atomic::{AtomicBool, Ordering},
 };
 
-use rustc_hash::FxHashSet;
+use rustc_hash::{FxHashMap, FxHashSet};
 
 use crate::indexer::pruning::PruneConfig;
 use crate::indexer::{KvIndexerInterface, SyncIndexer, ThreadPoolIndexer, WorkerTask};
@@ -1023,7 +1022,7 @@ fn successful_mutation_reports_each_final_dirty_image_once() {
     assert!(outcome.first_error().is_none());
 
     assert!(!batch.images().is_empty());
-    let mut unique = HashSet::new();
+    let mut unique = FxHashSet::default();
     for image in batch.images() {
         let lane = usize::from(image.lane());
         assert!(unique.insert((lane, image.bucket())));
@@ -1499,12 +1498,12 @@ fn fixed_verification_window_study() {
         let seed = study_seed(seed_index);
         let addressing = CkfAddressing::new(BUCKETS, seed);
         let chains = study_chains(seed, addressing, QUERIES_PER_CELL, MAX_QUERY_LEN);
-        let query_hashes: HashSet<u64> = chains
+        let query_hashes: FxHashSet<u64> = chains
             .iter()
             .flat_map(|chain| chain.sequence_hashes.iter().copied())
             .collect();
         let prefix_depths = study_prefix_depths(seed_index, QUERIES_PER_CELL, MAX_RESIDENT_PREFIX);
-        let distinct_queries: HashMap<usize, usize> = QUERY_LENGTHS
+        let distinct_queries: FxHashMap<usize, usize> = QUERY_LENGTHS
             .into_iter()
             .map(|query_len| (query_len, distinct_query_count(&chains, query_len)))
             .collect();
@@ -1707,12 +1706,12 @@ fn provenance_fallback_window_study() {
         let seed = study_seed(seed_index);
         let addressing = CkfAddressing::new(BUCKETS, seed);
         let chains = study_chains(seed, addressing, QUERIES_PER_CELL, MAX_QUERY_LEN);
-        let query_hashes: HashSet<u64> = chains
+        let query_hashes: FxHashSet<u64> = chains
             .iter()
             .flat_map(|chain| chain.sequence_hashes.iter().copied())
             .collect();
         let prefix_depths = study_prefix_depths(seed_index, QUERIES_PER_CELL, MAX_RESIDENT_PREFIX);
-        let distinct_queries: HashMap<usize, usize> = QUERY_LENGTHS
+        let distinct_queries: FxHashMap<usize, usize> = QUERY_LENGTHS
             .into_iter()
             .map(|query_len| (query_len, distinct_query_count(&chains, query_len)))
             .collect();
@@ -1852,7 +1851,7 @@ fn distinct_query_count(chains: &[StudyChain], query_len: usize) -> usize {
     chains
         .iter()
         .map(|chain| &chain.local_hashes[..query_len])
-        .collect::<HashSet<_>>()
+        .collect::<FxHashSet<_>>()
         .len()
 }
 
@@ -1876,7 +1875,7 @@ fn fill_study_table(
     addressing: CkfAddressing,
     chains: &[StudyChain],
     prefix_depths: &[[usize; DC_COUNT]],
-    query_hashes: &HashSet<u64>,
+    query_hashes: &FxHashSet<u64>,
     occupancy: usize,
     max_kicks: usize,
     seed: u64,
@@ -2061,7 +2060,7 @@ fn colliding_hashes(
     ExternalSequenceBlockHash,
     CkfProbe,
 ) {
-    let mut seen = HashMap::new();
+    let mut seen = FxHashMap::default();
     for hash in 0..1_000_000u64 {
         let probe = addressing.prepare(hash);
         let key = (probe.fingerprint, probe.bucket_a, probe.bucket_b);

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -21,13 +21,14 @@ use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
 use super::event_indexer::bucket_count;
 use super::mutator::{CuckooMutator, DcWriterState};
 use super::search::{
-    SearchPhase, SearchTraceEvent, SearchTraceKind, find_prefix_depths,
-    find_prefix_depths_with_test_stats, find_prefix_depths_with_test_trace,
-    fixed_window_prefix_depths, linear_prefix_depths,
+    SearchPhase, SearchTraceEvent, SearchTraceKind, find_max_depth_matches,
+    find_max_depth_matches_with_test_trace, find_prefix_depths, find_prefix_depths_with_test_stats,
+    find_prefix_depths_with_test_trace, fixed_window_prefix_depths, linear_prefix_depths,
+    refine_binary_level_with_test_trace,
 };
 use super::{
-    CkfBuildError, CkfConfig, DC_COUNT, EventTransposedCkfIndexer, RelayLaneConfig, RelayManifest,
-    RouterLocalCkfPipeline,
+    CkfBuildError, CkfConfig, CkfMatchMode, DC_COUNT, EventTransposedCkfIndexer, RelayLaneConfig,
+    RelayManifest, RouterLocalCkfPipeline,
 };
 
 const TEST_SEED: u64 = 0x1234_5678_9ABC_DEF0;
@@ -68,6 +69,11 @@ fn sequential_probe_events(phase: SearchPhase, groups: &[(usize, u16)]) -> Vec<S
             ]
         })
         .collect()
+}
+
+fn max_depth_projection<const D: usize>(depths: [u32; D]) -> [u32; D] {
+    let best = depths.into_iter().max().unwrap_or(0);
+    depths.map(|depth| u32::from(depth == best && best > 0) * depth)
 }
 
 fn single_lane_manifest(
@@ -854,6 +860,260 @@ fn divergent_lanes_group_binary_midpoints_once_per_level() {
     );
 }
 
+#[test]
+fn max_depth_terminal_demotion_allows_the_challenger_to_win() {
+    let membership = |position: usize| {
+        u16::from(position < 58 || position == 64) | (u16::from(position < 60) << 1)
+    };
+    let (result, trace) =
+        find_max_depth_matches_with_test_trace::<2>(65, 0b11, 8, |_| {}, membership);
+    let leader_miss = trace
+        .iter()
+        .position(|event| {
+            event.phase == SearchPhase::Verification
+                && event.kind == SearchTraceKind::Probe
+                && event.position == 58
+                && event.lanes == 0b01
+        })
+        .unwrap();
+    let challenger_verification = trace
+        .iter()
+        .rposition(|event| {
+            event.phase == SearchPhase::Verification
+                && event.kind == SearchTraceKind::Probe
+                && event.lanes & 0b10 != 0
+        })
+        .unwrap();
+
+    assert_eq!(result.depths, [0, 60]);
+    assert!(leader_miss < challenger_verification);
+}
+
+#[test]
+fn max_depth_provenance_demotion_reopens_the_frontier() {
+    let membership = |position: usize| {
+        u16::from(position < 20 || position == 32) | (u16::from(position < 28) << 1)
+    };
+    let (result, trace) =
+        find_max_depth_matches_with_test_trace::<2>(65, 0b11, 2, |_| {}, membership);
+    let repaired_leader = trace
+        .iter()
+        .position(|event| {
+            event.phase == SearchPhase::Fallback
+                && event.kind == SearchTraceKind::Probe
+                && event.position == 20
+                && event.lanes == 0b01
+        })
+        .unwrap();
+    let challenger_verification = trace
+        .iter()
+        .rposition(|event| {
+            event.phase == SearchPhase::Verification
+                && event.kind == SearchTraceKind::Probe
+                && event.lanes & 0b10 != 0
+        })
+        .unwrap();
+
+    assert_eq!(result.depths, [0, 28]);
+    assert_eq!(result.fallback.left_edge_lanes, 1);
+    assert_eq!(result.fallback.activated_lanes, 1);
+    assert!(repaired_leader < challenger_verification);
+}
+
+#[test]
+fn max_depth_matches_full_projection_for_second_order_provenance() {
+    let membership = |position: usize| {
+        u16::from(position < 20 || position == 32 || position == 48)
+            | (u16::from(position < 30) << 1)
+    };
+    let full = find_prefix_depths::<2>(65, 0b11, 8, |_| {}, membership);
+    let best = find_max_depth_matches::<2>(65, 0b11, 8, |_| {}, membership);
+
+    assert_eq!(full, [33, 30]);
+    assert_eq!(best, max_depth_projection(full));
+}
+
+#[test]
+fn max_depth_reuses_full_schedule_when_exponential_ceilings_match() {
+    let membership =
+        |position: usize| u16::from(position < 7) | (u16::from(position < 5 || position == 6) << 1);
+    let (full, full_trace) =
+        find_prefix_depths_with_test_trace::<2>(8, 0b11, 2, |_| {}, membership);
+    let (best, best_trace) =
+        find_max_depth_matches_with_test_trace::<2>(8, 0b11, 2, |_| {}, membership);
+
+    assert_eq!(best.depths, max_depth_projection(full.depths));
+    assert_eq!(best.fallback, full.fallback);
+    assert_eq!(best_trace, full_trace);
+}
+
+#[test]
+fn max_depth_mixed_d16_frontier_matches_full_projection() {
+    const PREFIX_DEPTHS: [usize; 16] = [
+        8, 12, 20, 20, 28, 36, 44, 52, 60, 24, 40, 16, 48, 56, 32, 18,
+    ];
+    let membership = |position: usize| {
+        PREFIX_DEPTHS
+            .iter()
+            .enumerate()
+            .fold(0u16, |mask, (lane, &depth)| {
+                let present = if lane == 15 {
+                    position < depth || matches!(position, 32 | 64)
+                } else {
+                    position < depth
+                };
+                mask | (u16::from(present) << lane)
+            })
+    };
+    let full = find_prefix_depths::<16>(65, u16::MAX, 2, |_| {}, membership);
+    let (best, trace) =
+        find_max_depth_matches_with_test_trace::<16>(65, u16::MAX, 2, |_| {}, membership);
+    let false_leader_fallback = trace
+        .iter()
+        .position(|event| {
+            event.phase == SearchPhase::Fallback
+                && event.kind == SearchTraceKind::Probe
+                && event.position == 33
+                && event.lanes == 1 << 15
+        })
+        .unwrap();
+    let winner_verification = trace
+        .iter()
+        .rposition(|event| {
+            event.phase == SearchPhase::Verification
+                && event.kind == SearchTraceKind::Probe
+                && event.lanes & (1 << 8) != 0
+        })
+        .unwrap();
+
+    assert_eq!(full[15], 33);
+    assert_eq!(best.depths, max_depth_projection(full));
+    assert_eq!(best.depths[8], 60);
+    assert!(false_leader_fallback < winner_verification);
+}
+
+#[test]
+fn max_depth_prunes_only_strictly_lower_ceilings() {
+    let membership = |position: usize| u16::from(position < 40) | (u16::from(position < 24) << 1);
+    let (result, trace) =
+        find_max_depth_matches_with_test_trace::<2>(65, 0b11, 2, |_| {}, membership);
+
+    assert_eq!(result.depths, [40, 0]);
+    assert!(trace.iter().all(|event| {
+        matches!(event.phase, SearchPhase::Initial | SearchPhase::Exponential)
+            || event.lanes & 0b10 == 0
+    }));
+}
+
+#[test]
+fn max_depth_retains_every_equal_ceiling_until_ties_are_resolved() {
+    const PREFIX_DEPTHS: [usize; 4] = [40, 40, 24, 0];
+    let membership = |position: usize| {
+        PREFIX_DEPTHS
+            .iter()
+            .enumerate()
+            .fold(0u16, |mask, (lane, &depth)| {
+                mask | (u16::from(position < depth) << lane)
+            })
+    };
+    let result = find_max_depth_matches::<4>(65, 0b1111, 2, |_| {}, membership);
+
+    assert_eq!(result, [40, 40, 0, 0]);
+}
+
+#[test]
+fn max_depth_midpoint_probe_advances_every_eligible_free_rider() {
+    let (lower, upper, trace) =
+        refine_binary_level_with_test_trace([32, 40], [64, 56], 0b01, 0b11, |position| {
+            assert_eq!(position, 48);
+            0b01
+        });
+
+    assert_eq!(lower, [48, 40]);
+    assert_eq!(upper, [64, 48]);
+    assert_eq!(
+        trace,
+        grouped_level_events(SearchPhase::Binary, &[(48, 0b11)])
+    );
+}
+
+#[test]
+fn max_depth_handles_empty_zero_single_and_all_lane_results() {
+    assert_eq!(
+        find_max_depth_matches::<4>(0, 0b1111, 2, |_| {}, |_| 0),
+        [0; 4]
+    );
+    assert_eq!(
+        find_max_depth_matches::<4>(8, 0b1111, 2, |_| {}, |_| 0),
+        [0; 4]
+    );
+
+    let single = find_max_depth_matches::<4>(
+        8,
+        0b1111,
+        2,
+        |_| {},
+        |position| u16::from(position < 5) | (u16::from(position < 3) << 1),
+    );
+    assert_eq!(single, [5, 0, 0, 0]);
+
+    let all = find_max_depth_matches::<16>(
+        8,
+        u16::MAX,
+        2,
+        |_| {},
+        |position| {
+            if position < 7 { u16::MAX } else { 0 }
+        },
+    );
+    assert_eq!(all, [7; 16]);
+}
+
+#[cfg(target_pointer_width = "64")]
+#[test]
+fn max_depth_uses_saturated_score_bounds_when_preserving_ties() {
+    let boundary = u32::MAX as usize;
+    let sequence_len = boundary + 9;
+    let membership = |position: usize| 0b01 | (u16::from(position < boundary + 4) << 1);
+    let full = find_prefix_depths::<2>(sequence_len, 0b11, 2, |_| {}, membership);
+    let best = find_max_depth_matches::<2>(sequence_len, 0b11, 2, |_| {}, membership);
+
+    assert_eq!(full, [u32::MAX, u32::MAX]);
+    assert_eq!(best, full);
+}
+
+#[test]
+fn max_depth_matches_full_projection_for_every_small_stable_mask() {
+    const D: usize = 2;
+    const QUERY_LEN: usize = 8;
+
+    for verification_window in 1..=8 {
+        for pattern in 0..=u16::MAX {
+            let membership = |position: usize| {
+                (0..D).fold(0u16, |mask, lane| {
+                    let pattern_bit = position * D + lane;
+                    mask | ((((u32::from(pattern) >> pattern_bit) & 1) as u16) << lane)
+                })
+            };
+            let full =
+                find_prefix_depths::<D>(QUERY_LEN, 0b11, verification_window, |_| {}, membership);
+            let best = find_max_depth_matches::<D>(
+                QUERY_LEN,
+                0b11,
+                verification_window,
+                |_| {},
+                membership,
+            );
+
+            assert_eq!(
+                best,
+                max_depth_projection(full),
+                "pattern={pattern:#06x} verification_window={verification_window}"
+            );
+        }
+    }
+}
+
 #[tokio::test]
 async fn thread_pool_uses_external_hashes_returns_full_map_and_clears_all_ranks() {
     let workers = workers_with_shared_worker();
@@ -903,6 +1163,36 @@ async fn thread_pool_uses_external_hashes_returns_full_map_and_clears_all_ranks(
     assert_eq!(stats.block_count_for_worker(workers[0]), None);
     assert_eq!(stats.block_count_for_worker(workers[1]), None);
     index.shutdown();
+}
+
+#[test]
+fn max_depth_adapter_returns_exact_tied_worker_identities() {
+    let workers = workers();
+    let index = EventTransposedCkfIndexer::new_with_match_mode(
+        workers,
+        CkfConfig::new(32),
+        CkfMatchMode::MaxDepthMatches,
+    )
+    .unwrap();
+    let query = vec![LocalBlockHash(11), LocalBlockHash(22), LocalBlockHash(33)];
+    let sequence_hashes = compute_seq_hash_for_block(&query);
+
+    index
+        .apply_event(store_event(workers[0], &sequence_hashes, 10_000), None)
+        .unwrap();
+    index
+        .apply_event(store_event(workers[1], &sequence_hashes, 20_000), None)
+        .unwrap();
+    index
+        .apply_event(store_event(workers[2], &sequence_hashes[..1], 30_000), None)
+        .unwrap();
+
+    let scores = index.find_matches(&query, false);
+    assert_eq!(scores.scores.len(), 2);
+    assert_eq!(scores.scores.get(&workers[0]), Some(&3));
+    assert_eq!(scores.scores.get(&workers[1]), Some(&3));
+    assert!(!scores.scores.contains_key(&workers[2]));
+    assert!(scores.frequencies.is_empty());
 }
 
 #[tokio::test]
@@ -1395,7 +1685,12 @@ fn store_remove_churn_drains_every_physical_slot() {
 async fn concurrent_queries_and_mutations_stay_bounded_and_drain_consistently() {
     let workers = workers();
     let index = Arc::new(ThreadPoolIndexer::new(
-        EventTransposedCkfIndexer::new(workers, CkfConfig::new(128)).unwrap(),
+        EventTransposedCkfIndexer::new_with_match_mode(
+            workers,
+            CkfConfig::new(128),
+            CkfMatchMode::MaxDepthMatches,
+        )
+        .unwrap(),
         2,
         32,
     ));

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -21,8 +21,9 @@ use super::bucket::{CuckooBucketStore, PackedBucket, TransposedCkfTable};
 use super::event_indexer::bucket_count;
 use super::mutator::{CuckooMutator, DcWriterState};
 use super::search::{
-    find_prefix_depths, find_prefix_depths_with_test_stats, fixed_window_prefix_depths,
-    linear_prefix_depths,
+    SearchPhase, SearchTraceEvent, SearchTraceKind, find_prefix_depths,
+    find_prefix_depths_with_test_stats, find_prefix_depths_with_test_trace,
+    fixed_window_prefix_depths, linear_prefix_depths,
 };
 use super::{
     CkfBuildError, CkfConfig, DC_COUNT, EventTransposedCkfIndexer, RelayLaneConfig, RelayManifest,
@@ -30,6 +31,44 @@ use super::{
 };
 
 const TEST_SEED: u64 = 0x1234_5678_9ABC_DEF0;
+
+const fn search_trace_event(
+    kind: SearchTraceKind,
+    phase: SearchPhase,
+    position: usize,
+    lanes: u16,
+) -> SearchTraceEvent {
+    SearchTraceEvent {
+        kind,
+        phase,
+        position,
+        lanes,
+    }
+}
+
+fn grouped_level_events(phase: SearchPhase, groups: &[(usize, u16)]) -> Vec<SearchTraceEvent> {
+    groups
+        .iter()
+        .map(|&(position, lanes)| {
+            search_trace_event(SearchTraceKind::Prefetch, phase, position, lanes)
+        })
+        .chain(groups.iter().map(|&(position, lanes)| {
+            search_trace_event(SearchTraceKind::Probe, phase, position, lanes)
+        }))
+        .collect()
+}
+
+fn sequential_probe_events(phase: SearchPhase, groups: &[(usize, u16)]) -> Vec<SearchTraceEvent> {
+    groups
+        .iter()
+        .flat_map(|&(position, lanes)| {
+            [
+                search_trace_event(SearchTraceKind::Prefetch, phase, position, lanes),
+                search_trace_event(SearchTraceKind::Probe, phase, position, lanes),
+            ]
+        })
+        .collect()
+}
 
 fn single_lane_manifest(
     members: Vec<WorkerWithDpRank>,
@@ -755,22 +794,64 @@ fn full_binary_search_and_terminal_window_follow_the_defined_contract() {
 }
 
 #[test]
-fn grouped_search_probes_each_binary_midpoint_once() {
-    let masks = [u16::MAX, u16::MAX, u16::MAX, 0, 0, 0, 0, 0];
-    let mut counts = [0usize; 8];
-    let depths = find_prefix_depths::<16>(
-        masks.len(),
-        u16::MAX,
-        1,
-        |_| {},
-        |position| {
-            counts[position] += 1;
-            masks[position]
-        },
-    );
+fn exponential_search_prefetches_exactly_one_sample_ahead() {
+    let (result, trace) = find_prefix_depths_with_test_trace::<1>(9, 1, 1, |_| {}, |_| 1);
+    let schedule: Vec<_> = trace
+        .into_iter()
+        .filter(|event| matches!(event.phase, SearchPhase::Initial | SearchPhase::Exponential))
+        .collect();
 
-    assert!(depths.into_iter().all(|depth| depth == 3));
-    assert!(counts.into_iter().all(|count| count <= 2));
+    assert_eq!(result.depths, [9]);
+    assert_eq!(
+        schedule,
+        vec![
+            search_trace_event(SearchTraceKind::Probe, SearchPhase::Initial, 0, 1),
+            search_trace_event(SearchTraceKind::Prefetch, SearchPhase::Exponential, 1, 1),
+            search_trace_event(SearchTraceKind::Prefetch, SearchPhase::Exponential, 2, 1),
+            search_trace_event(SearchTraceKind::Probe, SearchPhase::Exponential, 1, 1),
+            search_trace_event(SearchTraceKind::Prefetch, SearchPhase::Exponential, 4, 1),
+            search_trace_event(SearchTraceKind::Probe, SearchPhase::Exponential, 2, 1),
+            search_trace_event(SearchTraceKind::Prefetch, SearchPhase::Exponential, 8, 1),
+            search_trace_event(SearchTraceKind::Probe, SearchPhase::Exponential, 4, 1),
+            search_trace_event(SearchTraceKind::Probe, SearchPhase::Exponential, 8, 1),
+        ]
+    );
+}
+
+#[test]
+fn divergent_lanes_group_binary_midpoints_once_per_level() {
+    const PREFIX_DEPTHS: [usize; 16] = [3, 3, 6, 7, 11, 11, 15, 17, 3, 6, 11, 15, 17, 7, 3, 11];
+    let membership = |position: usize| {
+        PREFIX_DEPTHS
+            .iter()
+            .enumerate()
+            .fold(0u16, |mask, (lane, &depth)| {
+                mask | (u16::from(position < depth) << lane)
+            })
+    };
+    let (result, trace) =
+        find_prefix_depths_with_test_trace::<16>(17, u16::MAX, 1, |_| {}, membership);
+    let binary_schedule: Vec<_> = trace
+        .into_iter()
+        .filter(|event| event.phase == SearchPhase::Binary)
+        .collect();
+
+    assert_eq!(result.depths, PREFIX_DEPTHS.map(|depth| depth as u32));
+    assert_eq!(
+        binary_schedule,
+        [
+            grouped_level_events(
+                SearchPhase::Binary,
+                &[(3, 0x4103), (6, 0x220c), (12, 0x8c70)]
+            ),
+            grouped_level_events(
+                SearchPhase::Binary,
+                &[(5, 0x0204), (7, 0x2008), (10, 0x8430), (14, 0x0840)],
+            ),
+            grouped_level_events(SearchPhase::Binary, &[(11, 0x8430), (15, 0x0840)]),
+        ]
+        .concat()
+    );
 }
 
 #[tokio::test]
@@ -1039,6 +1120,43 @@ fn successful_mutation_reports_each_final_dirty_image_once() {
 }
 
 #[test]
+fn overlapping_verification_windows_isolate_lanes_and_retire_first_misses() {
+    const PREFIX_DEPTHS: [usize; 4] = [9, 10, 11, 12];
+    let membership = |position: usize| {
+        PREFIX_DEPTHS
+            .iter()
+            .enumerate()
+            .fold(0u16, |mask, (lane, &depth)| {
+                let hole = matches!((lane, position), (0, 5 | 7) | (1, 7) | (2, 6 | 9) | (3, 5));
+                mask | (u16::from(position < depth && !hole) << lane)
+            })
+    };
+    let (result, trace) =
+        find_prefix_depths_with_test_trace::<4>(17, 0b1111, 4, |_| {}, membership);
+    let verification_schedule: Vec<_> = trace
+        .into_iter()
+        .filter(|event| event.phase == SearchPhase::Verification)
+        .collect();
+
+    assert_eq!(result.depths, [5, 7, 9, 12]);
+    assert_eq!(
+        verification_schedule,
+        sequential_probe_events(
+            SearchPhase::Verification,
+            &[
+                (5, 0b0001),
+                (6, 0b0010),
+                (7, 0b0110),
+                (8, 0b1100),
+                (9, 0b1100),
+                (10, 0b1000),
+                (11, 0b1000),
+            ],
+        )
+    );
+}
+
+#[test]
 fn window_eight_repairs_holes_at_offsets_two_through_eight() {
     const QUERY_LEN: usize = 33;
 
@@ -1116,6 +1234,70 @@ fn terminal_branch_fallback_groups_lanes_and_repairs_a_clipped_false_pivot() {
     assert_eq!(result.fallback.probe_calls, 8);
     assert_eq!(result.fallback.lane_probes, 16);
     assert_eq!(result.fallback.provenance_skips, 0);
+}
+
+#[test]
+fn staggered_fallback_cursors_group_only_lanes_at_the_same_position() {
+    let membership = |position: usize| {
+        u16::from(position < 44 || position == 48)
+            | (u16::from(position < 42 || position == 44) << 1)
+    };
+    let (result, trace) = find_prefix_depths_with_test_trace::<2>(65, 0b11, 2, |_| {}, membership);
+    let fallback_schedule: Vec<_> = trace
+        .into_iter()
+        .filter(|event| event.phase == SearchPhase::Fallback)
+        .collect();
+    let expected_groups: Vec<_> = (33..=40)
+        .map(|position| (position, 0b01))
+        .chain((41..=42).map(|position| (position, 0b11)))
+        .chain((43..=44).map(|position| (position, 0b01)))
+        .collect();
+
+    assert_eq!(result.depths, [44, 42]);
+    assert_eq!(result.fallback.left_edge_lanes, 2);
+    assert_eq!(result.fallback.activated_lanes, 2);
+    assert_eq!(result.fallback.probe_calls, 12);
+    assert_eq!(result.fallback.lane_probes, 14);
+    assert_eq!(result.fallback.provenance_skips, 0);
+    assert_eq!(
+        fallback_schedule,
+        sequential_probe_events(SearchPhase::Fallback, &expected_groups)
+    );
+}
+
+#[test]
+fn valid_fallback_lane_progresses_while_second_order_lane_is_skipped() {
+    let membership = |position: usize| {
+        u16::from(position < 40 || position == 48)
+            | (u16::from(position < 41 || (48..=51).contains(&position)) << 1)
+    };
+    let (result, trace) = find_prefix_depths_with_test_trace::<2>(65, 0b11, 8, |_| {}, membership);
+    let fallback_probes: Vec<_> = trace
+        .into_iter()
+        .filter(|event| {
+            event.phase == SearchPhase::Fallback && event.kind == SearchTraceKind::Probe
+        })
+        .collect();
+
+    assert_eq!(result.depths, [40, 44]);
+    assert_eq!(result.fallback.left_edge_lanes, 2);
+    assert_eq!(result.fallback.activated_lanes, 1);
+    assert_eq!(result.fallback.probe_calls, 8);
+    assert_eq!(result.fallback.lane_probes, 8);
+    assert_eq!(result.fallback.provenance_skips, 1);
+    assert_eq!(
+        fallback_probes,
+        (33..=40)
+            .map(|position| {
+                search_trace_event(
+                    SearchTraceKind::Probe,
+                    SearchPhase::Fallback,
+                    position,
+                    0b01,
+                )
+            })
+            .collect::<Vec<_>>()
+    );
 }
 
 #[test]

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -549,58 +549,6 @@ fn shared_hash_stats_are_per_member_and_model_instances_are_isolated() {
     );
 }
 
-#[cfg(feature = "bench")]
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[ignore = "temporary occupied-bucket tracking benchmark gate"]
-async fn occupied_tracking_study() {
-    const EVENTS_PER_CELL: usize = 30_000;
-    let replica_occupancy = std::env::var_os("DYNAMO_CKF_REPLICA_OCCUPANCY").is_some();
-    let aggregator_occupancy = std::env::var_os("DYNAMO_CKF_AGGREGATOR_OCCUPANCY").is_some();
-
-    for clear_every in [Some(100usize), Some(1_000), Some(10_000), None] {
-        let workers = workers();
-        let index = ThreadPoolIndexer::new(
-            EventTransposedCkfIndexer::new(workers, CkfConfig::new(16_384)).unwrap(),
-            1,
-            32,
-        );
-        for event_index in 0..EVENTS_PER_CELL {
-            if let Some(clear_every) = clear_every {
-                let hash = (event_index % clear_every) as u64 + 1;
-                KvIndexerInterface::apply_event(
-                    &index,
-                    store_event(workers[0], &[hash], event_index as u64 + 1),
-                )
-                .await;
-            } else {
-                let event = if event_index == 0 {
-                    store_event(workers[0], &[1], 1)
-                } else if event_index % 2 == 1 {
-                    let hash = ((event_index + 3) / 2) as u64;
-                    store_event(workers[0], &[hash], event_index as u64 + 1)
-                } else {
-                    let hash = (event_index / 2) as u64;
-                    remove_event(workers[0], &[hash])
-                };
-                KvIndexerInterface::apply_event(&index, event).await;
-            }
-            if clear_every.is_some_and(|interval| (event_index + 1) % interval == 0) {
-                KvIndexerInterface::apply_event(&index, clear_event(workers[0].worker_id)).await;
-            }
-        }
-        KvIndexerInterface::flush(&index).await;
-        println!(
-            "CKF_OCCUPANCY_STUDY replica_occupancy={} aggregator_occupancy={} clear_every={} events={} {}",
-            replica_occupancy,
-            aggregator_occupancy,
-            clear_every.unwrap_or(0),
-            EVENTS_PER_CELL,
-            index.backend().timing_report(),
-        );
-        index.shutdown();
-    }
-}
-
 #[test]
 fn packed_bucket_swar_matches_scalar_membership() {
     let fingerprints = [1, 0x1234, 0x8000, u16::MAX];

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -557,7 +557,7 @@ async fn occupied_tracking_study() {
     let replica_occupancy = std::env::var_os("DYNAMO_CKF_REPLICA_OCCUPANCY").is_some();
     let aggregator_occupancy = std::env::var_os("DYNAMO_CKF_AGGREGATOR_OCCUPANCY").is_some();
 
-    for clear_every in [100usize, 1_000, 10_000] {
+    for clear_every in [Some(100usize), Some(1_000), Some(10_000), None] {
         let workers = workers();
         let index = ThreadPoolIndexer::new(
             EventTransposedCkfIndexer::new(workers, CkfConfig::new(16_384)).unwrap(),
@@ -565,13 +565,26 @@ async fn occupied_tracking_study() {
             32,
         );
         for event_index in 0..EVENTS_PER_CELL {
-            let hash = (event_index % clear_every) as u64 + 1;
-            KvIndexerInterface::apply_event(
-                &index,
-                store_event(workers[0], &[hash], event_index as u64 + 1),
-            )
-            .await;
-            if (event_index + 1) % clear_every == 0 {
+            if let Some(clear_every) = clear_every {
+                let hash = (event_index % clear_every) as u64 + 1;
+                KvIndexerInterface::apply_event(
+                    &index,
+                    store_event(workers[0], &[hash], event_index as u64 + 1),
+                )
+                .await;
+            } else {
+                let event = if event_index == 0 {
+                    store_event(workers[0], &[1], 1)
+                } else if event_index % 2 == 1 {
+                    let hash = ((event_index + 3) / 2) as u64;
+                    store_event(workers[0], &[hash], event_index as u64 + 1)
+                } else {
+                    let hash = (event_index / 2) as u64;
+                    remove_event(workers[0], &[hash])
+                };
+                KvIndexerInterface::apply_event(&index, event).await;
+            }
+            if clear_every.is_some_and(|interval| (event_index + 1) % interval == 0) {
                 KvIndexerInterface::apply_event(&index, clear_event(workers[0].worker_id)).await;
             }
         }
@@ -580,7 +593,7 @@ async fn occupied_tracking_study() {
             "CKF_OCCUPANCY_STUDY replica_occupancy={} aggregator_occupancy={} clear_every={} events={} {}",
             replica_occupancy,
             aggregator_occupancy,
-            clear_every,
+            clear_every.unwrap_or(0),
             EVENTS_PER_CELL,
             index.backend().timing_report(),
         );

--- a/lib/kv-router/src/indexer/cuckoo/tests.rs
+++ b/lib/kv-router/src/indexer/cuckoo/tests.rs
@@ -258,9 +258,9 @@ fn due_net_reversion_is_unchanged_and_applies_no_batch() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
     index.pipeline.flush_pending(&mut batch);
-    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    let _ = index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
 
     assert!(!outcome.batch_applied());
@@ -277,10 +277,10 @@ fn partially_net_reverted_window_emits_only_changed_buckets() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10, 20], 1), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10, 20], 1), &mut batch);
     index.pipeline.flush_pending(&mut batch);
-    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
-    index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
+    let _ = index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 2), &mut batch);
     let outcome = index.apply_event_with_batch(remove_event(workers[0], &[20]), &mut batch);
 
     assert!(outcome.batch_applied());
@@ -314,7 +314,7 @@ fn unpublished_empty_populated_empty_window_emits_nothing() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
     let outcome = index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
 
     assert!(!outcome.batch_applied());
@@ -330,9 +330,9 @@ fn published_nonempty_lane_emptied_at_boundary_emits_reset() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
     index.pipeline.flush_pending(&mut batch);
-    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    let _ = index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 2), &mut batch);
 
     assert!(outcome.batch_applied());
@@ -361,7 +361,7 @@ fn partial_failure_preserves_pending_successes_until_due_publication() {
         Some(crate::protocols::KvCacheEventError::CapacityExhausted)
     ));
     assert!(second.batch_applied());
-    assert_eq!(index.pipeline.memory_snapshot().actual_contributions, 8);
+    assert_eq!(index.pipeline.memory_snapshot().actual_contributions(), 8);
     assert_ne!(
         index
             .pipeline
@@ -404,8 +404,8 @@ fn flush_reserves_only_pending_images_and_empty_flush_stays_allocation_free() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut event_batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut event_batch);
-    index.apply_event_with_batch(store_event(workers[1], &[20], 2), &mut event_batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut event_batch);
+    let _ = index.apply_event_with_batch(store_event(workers[1], &[20], 2), &mut event_batch);
 
     let mut flush_batch = index.pipeline.new_batch();
     assert_eq!(flush_batch.image_capacity(), 0);
@@ -417,7 +417,7 @@ fn flush_reserves_only_pending_images_and_empty_flush_stays_allocation_free() {
     assert!(!index.pipeline.flush_pending(&mut empty_batch));
     assert_eq!(empty_batch.image_capacity(), 0);
 
-    index.apply_event_with_batch(store_event(workers[2], &[30], 3), &mut event_batch);
+    let _ = index.apply_event_with_batch(store_event(workers[2], &[30], 3), &mut event_batch);
     let mut direct_batch = index.pipeline.new_batch();
     direct_batch.force_reserve_failure();
     assert!(index.pipeline.flush_pending(&mut direct_batch));
@@ -441,7 +441,7 @@ fn lifecycle_removal_forces_pending_publication() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
     index.pipeline.flush_pending(&mut batch);
     let outcome = index.pipeline.remove_worker_rank(workers[0], &mut batch);
     assert!(outcome.batch_applied());
@@ -462,7 +462,7 @@ fn lifecycle_removal_uses_direct_publication_when_batch_reserve_fails() {
     let workers = workers();
     let index = EventTransposedCkfIndexer::new(workers, CkfConfig::new(32)).unwrap();
     let mut event_batch = index.pipeline.new_batch();
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut event_batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut event_batch);
 
     let mut lifecycle_batch = index.pipeline.new_batch();
     lifecycle_batch.force_reserve_failure();
@@ -490,10 +490,10 @@ fn empty_then_repopulated_window_cancels_stale_reset() {
     let index = EventTransposedCkfIndexer::new(workers, config).unwrap();
     let mut batch = index.pipeline.new_batch();
 
-    index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[10], 1), &mut batch);
     index.pipeline.flush_pending(&mut batch);
-    index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
-    index.apply_event_with_batch(store_event(workers[0], &[20], 2), &mut batch);
+    let _ = index.apply_event_with_batch(remove_event(workers[0], &[10]), &mut batch);
+    let _ = index.apply_event_with_batch(store_event(workers[0], &[20], 2), &mut batch);
     let outcome = index.apply_event_with_batch(store_event(workers[0], &[], 3), &mut batch);
 
     assert!(outcome.batch_applied());
@@ -533,7 +533,7 @@ fn shared_dc_hash_survives_until_the_final_owner_is_removed() {
     assert!(!second_store.batch_applied());
     assert!(batch.images().is_empty());
 
-    pipeline.apply_event(remove_event(first, &[10]), &mut batch);
+    let _ = pipeline.apply_event(remove_event(first, &[10]), &mut batch);
     assert_ne!(
         pipeline
             .replica()
@@ -542,7 +542,7 @@ fn shared_dc_hash_survives_until_the_final_owner_is_removed() {
             & 1,
         0
     );
-    pipeline.apply_event(remove_event(second, &[10]), &mut batch);
+    let _ = pipeline.apply_event(remove_event(second, &[10]), &mut batch);
     assert_ne!(batch.reset_lanes() & 1, 0);
 }
 
@@ -557,8 +557,8 @@ fn clear_one_owner_preserves_another_owner_in_the_same_dc() {
     .unwrap();
     let mut batch = pipeline.new_batch();
 
-    pipeline.apply_event(store_event(first, &[10], 1), &mut batch);
-    pipeline.apply_event(store_event(second, &[10], 2), &mut batch);
+    let _ = pipeline.apply_event(store_event(first, &[10], 1), &mut batch);
+    let _ = pipeline.apply_event(store_event(second, &[10], 2), &mut batch);
     let outcome = pipeline.apply_event(clear_event(first.worker_id), &mut batch);
 
     assert!(outcome.first_error().is_none());
@@ -588,9 +588,9 @@ fn worker_wide_clear_spans_lanes_and_preserves_unrelated_members() {
             .unwrap();
     let mut batch = pipeline.new_batch();
 
-    pipeline.apply_event(store_event(rank_zero, &[10], 1), &mut batch);
-    pipeline.apply_event(store_event(other, &[10], 2), &mut batch);
-    pipeline.apply_event(store_event(rank_one, &[20], 3), &mut batch);
+    let _ = pipeline.apply_event(store_event(rank_zero, &[10], 1), &mut batch);
+    let _ = pipeline.apply_event(store_event(other, &[10], 2), &mut batch);
+    let _ = pipeline.apply_event(store_event(rank_one, &[20], 3), &mut batch);
     let mut clear = clear_event(rank_zero.worker_id);
     clear.event.dp_rank = 999;
     let outcome = pipeline.apply_event(clear, &mut batch);
@@ -638,14 +638,14 @@ fn shared_hash_stats_are_per_member_and_model_instances_are_isolated() {
     let first_model = make_pipeline();
     let second_model = make_pipeline();
     let mut batch = first_model.new_batch();
-    first_model.apply_event(store_event(first, &[10], 1), &mut batch);
-    first_model.apply_event(store_event(second, &[10], 2), &mut batch);
+    let _ = first_model.apply_event(store_event(first, &[10], 1), &mut batch);
+    let _ = first_model.apply_event(store_event(second, &[10], 2), &mut batch);
 
     let worker_ids = FxHashSet::from_iter([first.worker_id, second.worker_id]);
     let stats = first_model.worker_stats(&worker_ids);
     assert_eq!(stats.block_count_for_worker(first), Some(1));
     assert_eq!(stats.block_count_for_worker(second), Some(1));
-    assert_eq!(first_model.memory_snapshot().actual_contributions, 2);
+    assert_eq!(first_model.memory_snapshot().actual_contributions(), 2);
     assert_eq!(
         second_model
             .replica()
@@ -1350,7 +1350,7 @@ fn digest_updates_roll_back_when_ckf_mutation_fails() {
         index.apply_event(store_event(workers[0], &[8], 2000), None),
         Err(crate::protocols::KvCacheEventError::CapacityExhausted)
     ));
-    assert_eq!(index.pipeline.memory_snapshot().actual_contributions, 8);
+    assert_eq!(index.pipeline.memory_snapshot().actual_contributions(), 8);
     assert!(
         !index
             .pipeline

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -140,6 +140,8 @@ pub const METRIC_STATUS_OK: &str = "ok";
 pub const METRIC_STATUS_PARENT_NOT_FOUND: &str = "parent_block_not_found";
 pub const METRIC_STATUS_BLOCK_NOT_FOUND: &str = "block_not_found";
 pub const METRIC_STATUS_INVALID_BLOCK: &str = "invalid_block";
+pub const METRIC_STATUS_CAPACITY_EXHAUSTED: &str = "capacity_exhausted";
+pub const METRIC_STATUS_INDEXER_INVARIANT_VIOLATION: &str = "indexer_invariant_violation";
 
 /// Metric event labels.
 pub const METRIC_EVENT_STORED: &str = "stored";
@@ -275,6 +277,10 @@ impl KvIndexerMetrics {
                         KvCacheEventError::ParentBlockNotFound => METRIC_STATUS_PARENT_NOT_FOUND,
                         KvCacheEventError::BlockNotFound => METRIC_STATUS_BLOCK_NOT_FOUND,
                         KvCacheEventError::InvalidBlockSequence => METRIC_STATUS_INVALID_BLOCK,
+                        KvCacheEventError::CapacityExhausted => METRIC_STATUS_CAPACITY_EXHAUSTED,
+                        KvCacheEventError::IndexerInvariantViolation => {
+                            METRIC_STATUS_INDEXER_INVARIANT_VIOLATION
+                        }
                     };
                     self.kv_cache_events_applied
                         .with_label_values(&[event_type, error_label])
@@ -330,6 +336,8 @@ struct ResultCounters {
     parent_not_found: IntCounter,
     block_not_found: IntCounter,
     invalid_block: IntCounter,
+    capacity_exhausted: IntCounter,
+    indexer_invariant_violation: IntCounter,
 }
 
 #[cfg(feature = "metrics")]
@@ -342,6 +350,10 @@ impl ResultCounters {
             block_not_found: counters
                 .with_label_values(&[event_type, METRIC_STATUS_BLOCK_NOT_FOUND]),
             invalid_block: counters.with_label_values(&[event_type, METRIC_STATUS_INVALID_BLOCK]),
+            capacity_exhausted: counters
+                .with_label_values(&[event_type, METRIC_STATUS_CAPACITY_EXHAUSTED]),
+            indexer_invariant_violation: counters
+                .with_label_values(&[event_type, METRIC_STATUS_INDEXER_INVARIANT_VIOLATION]),
         }
     }
 
@@ -351,6 +363,8 @@ impl ResultCounters {
             Err(KvCacheEventError::ParentBlockNotFound) => &self.parent_not_found,
             Err(KvCacheEventError::BlockNotFound) => &self.block_not_found,
             Err(KvCacheEventError::InvalidBlockSequence) => &self.invalid_block,
+            Err(KvCacheEventError::CapacityExhausted) => &self.capacity_exhausted,
+            Err(KvCacheEventError::IndexerInvariantViolation) => &self.indexer_invariant_violation,
         }
     }
 }

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -59,6 +59,21 @@ pub enum EventWarningKind {
     DuplicateStore,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum CkfMutationKind {
+    UnknownRemove,
+    CapacityExhausted,
+}
+
+impl std::fmt::Display for CkfMutationKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::UnknownRemove => f.write_str(METRIC_CKF_MUTATION_UNKNOWN_REMOVE),
+            Self::CapacityExhausted => f.write_str(METRIC_CKF_MUTATION_CAPACITY_EXHAUSTED),
+        }
+    }
+}
+
 impl std::fmt::Display for EventWarningKind {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -136,6 +151,9 @@ pub struct KvIndexerMetrics {
     /// Counters for CKF provenance-fallback behavior.
     #[cfg(feature = "metrics")]
     pub ckf_search_fallback: IntCounterVec,
+    /// Counters for CKF mutation outcomes that are finer-grained than event status.
+    #[cfg(feature = "metrics")]
+    pub ckf_mutation: IntCounterVec,
 }
 
 /// Metric status labels.
@@ -160,6 +178,10 @@ pub const METRIC_CKF_FALLBACK_ACTIVATED_LANES: &str = "activated_lanes";
 pub const METRIC_CKF_FALLBACK_PROBE_CALLS: &str = "probe_calls";
 pub const METRIC_CKF_FALLBACK_LANE_PROBES: &str = "lane_probes";
 pub const METRIC_CKF_FALLBACK_PROVENANCE_SKIPS: &str = "provenance_skips";
+
+/// CKF mutation metric labels.
+pub const METRIC_CKF_MUTATION_UNKNOWN_REMOVE: &str = "unknown_remove";
+pub const METRIC_CKF_MUTATION_CAPACITY_EXHAUSTED: &str = "capacity_exhausted";
 
 /// Metric name for KV cache events applied counter.
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
@@ -187,6 +209,14 @@ const CKF_SEARCH_FALLBACK_NAME: &str = "dynamo_kvrouter_ckf_search_fallback";
 const CKF_SEARCH_FALLBACK_HELP: &str = "CKF provenance-fallback activity and grouped probe cost";
 #[cfg(feature = "metrics")]
 const CKF_SEARCH_FALLBACK_LABELS: &[&str] = &["kind"];
+#[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
+const CKF_MUTATION_SUFFIX: &str = "ckf_mutation_total";
+#[cfg(feature = "metrics")]
+const CKF_MUTATION_NAME: &str = "dynamo_kvrouter_ckf_mutation_total";
+#[cfg(feature = "metrics")]
+const CKF_MUTATION_HELP: &str = "Total number of CKF block-level mutation outcomes";
+#[cfg(feature = "metrics")]
+const CKF_MUTATION_LABELS: &[&str] = &["outcome"];
 
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 static KV_INDEXER_METRICS: OnceLock<Arc<KvIndexerMetrics>> = OnceLock::new();
@@ -197,11 +227,13 @@ impl KvIndexerMetrics {
         kv_cache_events_applied: IntCounterVec,
         kv_cache_event_warnings: IntCounterVec,
         ckf_search_fallback: IntCounterVec,
+        ckf_mutation: IntCounterVec,
     ) -> Self {
         Self {
             kv_cache_events_applied,
             kv_cache_event_warnings,
             ckf_search_fallback,
+            ckf_mutation,
         }
     }
 
@@ -220,6 +252,10 @@ impl KvIndexerMetrics {
                 Opts::new(CKF_SEARCH_FALLBACK_NAME, CKF_SEARCH_FALLBACK_HELP),
                 CKF_SEARCH_FALLBACK_LABELS,
             )?,
+            IntCounterVec::new(
+                Opts::new(CKF_MUTATION_NAME, CKF_MUTATION_HELP),
+                CKF_MUTATION_LABELS,
+            )?,
         ))
     }
 
@@ -230,6 +266,7 @@ impl KvIndexerMetrics {
         registry.register(Box::new(metrics.kv_cache_events_applied.clone()))?;
         registry.register(Box::new(metrics.kv_cache_event_warnings.clone()))?;
         registry.register(Box::new(metrics.ckf_search_fallback.clone()))?;
+        registry.register(Box::new(metrics.ckf_mutation.clone()))?;
         Ok(metrics)
     }
 
@@ -260,17 +297,28 @@ impl KvIndexerMetrics {
                             CKF_SEARCH_FALLBACK_LABELS,
                             &[],
                         ),
+                        component.metrics().create_intcountervec(
+                            CKF_MUTATION_SUFFIX,
+                            CKF_MUTATION_HELP,
+                            CKF_MUTATION_LABELS,
+                            &[],
+                        ),
                     ) {
                         (
                             Ok(kv_cache_events_applied),
                             Ok(kv_cache_event_warnings),
                             Ok(ckf_search_fallback),
+                            Ok(ckf_mutation),
                         ) => Arc::new(Self::new(
                             kv_cache_events_applied,
                             kv_cache_event_warnings,
                             ckf_search_fallback,
+                            ckf_mutation,
                         )),
-                        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
+                        (Err(e), _, _, _)
+                        | (_, Err(e), _, _)
+                        | (_, _, Err(e), _)
+                        | (_, _, _, Err(e)) => {
                             tracing::warn!("Failed to create kv indexer metrics from component: {}. Using unregistered metrics as fallback.", e);
                             Arc::new(Self::new_unregistered())
                         }
@@ -424,6 +472,13 @@ struct PreBoundMetricCounters {
     removed: ResultCounters,
     cleared: ResultCounters,
     duplicate_store_warning: IntCounter,
+    ckf_mutation: CkfMutationCounters,
+}
+
+#[cfg(feature = "metrics")]
+struct CkfMutationCounters {
+    unknown_remove: IntCounter,
+    capacity_exhausted: IntCounter,
 }
 
 #[cfg(feature = "metrics")]
@@ -478,6 +533,14 @@ impl PreBoundEventCounters {
                     cleared: ResultCounters::new(cv, METRIC_EVENT_CLEARED),
                     duplicate_store_warning: warnings
                         .with_label_values(&[METRIC_WARNING_DUPLICATE_STORE]),
+                    ckf_mutation: CkfMutationCounters {
+                        unknown_remove: metrics
+                            .ckf_mutation
+                            .with_label_values(&[METRIC_CKF_MUTATION_UNKNOWN_REMOVE]),
+                        capacity_exhausted: metrics
+                            .ckf_mutation
+                            .with_label_values(&[METRIC_CKF_MUTATION_CAPACITY_EXHAUSTED]),
+                    },
                 },
             }
         }
@@ -517,5 +580,21 @@ impl PreBoundEventCounters {
         }
         #[cfg(not(feature = "metrics"))]
         let _ = (self, kind);
+    }
+
+    pub fn inc_ckf_mutation(&self, kind: CkfMutationKind, count: u64) {
+        #[cfg(feature = "metrics")]
+        {
+            if count == 0 {
+                return;
+            }
+            let counter = match kind {
+                CkfMutationKind::UnknownRemove => &self.inner.ckf_mutation.unknown_remove,
+                CkfMutationKind::CapacityExhausted => &self.inner.ckf_mutation.capacity_exhausted,
+            };
+            counter.inc_by(count);
+        }
+        #[cfg(not(feature = "metrics"))]
+        let _ = (self, kind, count);
     }
 }

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -133,6 +133,9 @@ pub struct KvIndexerMetrics {
     /// Counter of suspicious-but-valid KV events.
     #[cfg(feature = "metrics")]
     pub kv_cache_event_warnings: IntCounterVec,
+    /// Counters for CKF provenance-fallback behavior.
+    #[cfg(feature = "metrics")]
+    pub ckf_search_fallback: IntCounterVec,
 }
 
 /// Metric status labels.
@@ -150,6 +153,13 @@ pub const METRIC_EVENT_CLEARED: &str = "cleared";
 
 /// Metric warning labels.
 pub const METRIC_WARNING_DUPLICATE_STORE: &str = "duplicate_store";
+
+/// CKF search-fallback metric labels.
+pub const METRIC_CKF_FALLBACK_LEFT_EDGE_LANES: &str = "left_edge_lanes";
+pub const METRIC_CKF_FALLBACK_ACTIVATED_LANES: &str = "activated_lanes";
+pub const METRIC_CKF_FALLBACK_PROBE_CALLS: &str = "probe_calls";
+pub const METRIC_CKF_FALLBACK_LANE_PROBES: &str = "lane_probes";
+pub const METRIC_CKF_FALLBACK_PROVENANCE_SKIPS: &str = "provenance_skips";
 
 /// Metric name for KV cache events applied counter.
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
@@ -169,16 +179,29 @@ const KV_CACHE_EVENT_WARNINGS_HELP: &str =
     "Total number of suspicious KV cache events seen by the router indexer";
 #[cfg(feature = "metrics")]
 const KV_CACHE_EVENT_WARNINGS_LABELS: &[&str] = &["warning_kind"];
+#[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
+const CKF_SEARCH_FALLBACK_SUFFIX: &str = "ckf_search_fallback";
+#[cfg(feature = "metrics")]
+const CKF_SEARCH_FALLBACK_NAME: &str = "dynamo_kvrouter_ckf_search_fallback";
+#[cfg(feature = "metrics")]
+const CKF_SEARCH_FALLBACK_HELP: &str = "CKF provenance-fallback activity and grouped probe cost";
+#[cfg(feature = "metrics")]
+const CKF_SEARCH_FALLBACK_LABELS: &[&str] = &["kind"];
 
 #[cfg(all(feature = "metrics", feature = "runtime-protocols"))]
 static KV_INDEXER_METRICS: OnceLock<Arc<KvIndexerMetrics>> = OnceLock::new();
 
 impl KvIndexerMetrics {
     #[cfg(feature = "metrics")]
-    fn new(kv_cache_events_applied: IntCounterVec, kv_cache_event_warnings: IntCounterVec) -> Self {
+    fn new(
+        kv_cache_events_applied: IntCounterVec,
+        kv_cache_event_warnings: IntCounterVec,
+        ckf_search_fallback: IntCounterVec,
+    ) -> Self {
         Self {
             kv_cache_events_applied,
             kv_cache_event_warnings,
+            ckf_search_fallback,
         }
     }
 
@@ -193,6 +216,10 @@ impl KvIndexerMetrics {
                 Opts::new(KV_CACHE_EVENT_WARNINGS_NAME, KV_CACHE_EVENT_WARNINGS_HELP),
                 KV_CACHE_EVENT_WARNINGS_LABELS,
             )?,
+            IntCounterVec::new(
+                Opts::new(CKF_SEARCH_FALLBACK_NAME, CKF_SEARCH_FALLBACK_HELP),
+                CKF_SEARCH_FALLBACK_LABELS,
+            )?,
         ))
     }
 
@@ -202,6 +229,7 @@ impl KvIndexerMetrics {
         let metrics = Arc::new(Self::new_prometheus()?);
         registry.register(Box::new(metrics.kv_cache_events_applied.clone()))?;
         registry.register(Box::new(metrics.kv_cache_event_warnings.clone()))?;
+        registry.register(Box::new(metrics.ckf_search_fallback.clone()))?;
         Ok(metrics)
     }
 
@@ -226,11 +254,23 @@ impl KvIndexerMetrics {
                             KV_CACHE_EVENT_WARNINGS_LABELS,
                             &[],
                         ),
-                    ) {
-                        (Ok(kv_cache_events_applied), Ok(kv_cache_event_warnings)) => Arc::new(
-                            Self::new(kv_cache_events_applied, kv_cache_event_warnings),
+                        component.metrics().create_intcountervec(
+                            CKF_SEARCH_FALLBACK_SUFFIX,
+                            CKF_SEARCH_FALLBACK_HELP,
+                            CKF_SEARCH_FALLBACK_LABELS,
+                            &[],
                         ),
-                        (Err(e), _) | (_, Err(e)) => {
+                    ) {
+                        (
+                            Ok(kv_cache_events_applied),
+                            Ok(kv_cache_event_warnings),
+                            Ok(ckf_search_fallback),
+                        ) => Arc::new(Self::new(
+                            kv_cache_events_applied,
+                            kv_cache_event_warnings,
+                            ckf_search_fallback,
+                        )),
+                        (Err(e), _, _) | (_, Err(e), _) | (_, _, Err(e)) => {
                             tracing::warn!("Failed to create kv indexer metrics from component: {}. Using unregistered metrics as fallback.", e);
                             Arc::new(Self::new_unregistered())
                         }
@@ -309,6 +349,49 @@ impl KvIndexerMetrics {
     /// `with_label_values` hashmap lookup on every event.
     pub fn prebind(&self) -> PreBoundEventCounters {
         PreBoundEventCounters::new(self)
+    }
+
+    #[cfg(feature = "metrics")]
+    pub(crate) fn prebind_ckf_search(&self) -> PreBoundCkfSearchCounters {
+        PreBoundCkfSearchCounters::new(&self.ckf_search_fallback)
+    }
+}
+
+#[cfg(feature = "metrics")]
+#[derive(Clone, Debug)]
+pub(crate) struct PreBoundCkfSearchCounters {
+    left_edge_lanes: IntCounter,
+    activated_lanes: IntCounter,
+    probe_calls: IntCounter,
+    lane_probes: IntCounter,
+    provenance_skips: IntCounter,
+}
+
+#[cfg(feature = "metrics")]
+impl PreBoundCkfSearchCounters {
+    fn new(counters: &IntCounterVec) -> Self {
+        Self {
+            left_edge_lanes: counters.with_label_values(&[METRIC_CKF_FALLBACK_LEFT_EDGE_LANES]),
+            activated_lanes: counters.with_label_values(&[METRIC_CKF_FALLBACK_ACTIVATED_LANES]),
+            probe_calls: counters.with_label_values(&[METRIC_CKF_FALLBACK_PROBE_CALLS]),
+            lane_probes: counters.with_label_values(&[METRIC_CKF_FALLBACK_LANE_PROBES]),
+            provenance_skips: counters.with_label_values(&[METRIC_CKF_FALLBACK_PROVENANCE_SKIPS]),
+        }
+    }
+
+    pub(crate) fn record(
+        &self,
+        left_edge_lanes: u64,
+        activated_lanes: u64,
+        probe_calls: u64,
+        lane_probes: u64,
+        provenance_skips: u64,
+    ) {
+        self.left_edge_lanes.inc_by(left_edge_lanes);
+        self.activated_lanes.inc_by(activated_lanes);
+        self.probe_calls.inc_by(probe_calls);
+        self.lane_probes.inc_by(lane_probes);
+        self.provenance_skips.inc_by(provenance_skips);
     }
 }
 

--- a/lib/kv-router/src/indexer/metrics.rs
+++ b/lib/kv-router/src/indexer/metrics.rs
@@ -387,11 +387,24 @@ impl PreBoundCkfSearchCounters {
         lane_probes: u64,
         provenance_skips: u64,
     ) {
-        self.left_edge_lanes.inc_by(left_edge_lanes);
-        self.activated_lanes.inc_by(activated_lanes);
-        self.probe_calls.inc_by(probe_calls);
-        self.lane_probes.inc_by(lane_probes);
-        self.provenance_skips.inc_by(provenance_skips);
+        if left_edge_lanes | activated_lanes | probe_calls | lane_probes | provenance_skips == 0 {
+            return;
+        }
+        if left_edge_lanes != 0 {
+            self.left_edge_lanes.inc_by(left_edge_lanes);
+        }
+        if activated_lanes != 0 {
+            self.activated_lanes.inc_by(activated_lanes);
+        }
+        if probe_calls != 0 {
+            self.probe_calls.inc_by(probe_calls);
+        }
+        if lane_probes != 0 {
+            self.lane_probes.inc_by(lane_probes);
+        }
+        if provenance_skips != 0 {
+            self.provenance_skips.inc_by(provenance_skips);
+        }
     }
 }
 

--- a/lib/kv-router/src/indexer/mod.rs
+++ b/lib/kv-router/src/indexer/mod.rs
@@ -71,6 +71,7 @@ mod types;
 
 pub mod concurrent_radix_tree;
 pub mod concurrent_radix_tree_compressed;
+pub mod cuckoo;
 pub mod positional;
 pub mod pruning;
 pub mod radix_tree;

--- a/lib/kv-router/src/indexer/tests.rs
+++ b/lib/kv-router/src/indexer/tests.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashSet;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -11,16 +12,17 @@ use tokio_util::sync::CancellationToken;
 
 use super::concurrent_radix_tree::ConcurrentRadixTree;
 use super::concurrent_radix_tree_compressed::ConcurrentRadixTreeCompressed;
+use super::cuckoo::{CkfConfig, EventTransposedCkfIndexer};
 use super::positional::{PositionalIndexer, SearchMode};
 use super::*;
 use crate::indexer::pruning::PruneConfig;
 use crate::protocols::*;
 use crate::test_utils::{
-    assert_exact_scores, assert_no_scores, assert_overlap_scores_eq, assert_score,
-    flush_and_settle, make_clear_event, make_clear_event_with_dp_rank, make_remove_event,
-    make_remove_event_with_parent, make_store_event, make_store_event_with_dp_rank,
-    make_store_event_with_parent, make_store_event_with_start_position, query_scores, remove_event,
-    router_event, snapshot_events, snapshot_tree, stored_blocks_with_sequence_hashes,
+    assert_overlap_scores_eq, assert_score, flush_and_settle, make_clear_event,
+    make_clear_event_with_dp_rank, make_remove_event, make_remove_event_with_parent,
+    make_store_event, make_store_event_with_dp_rank, make_store_event_with_parent,
+    make_store_event_with_start_position, query_scores, remove_event, router_event,
+    snapshot_events, snapshot_tree, stored_blocks_with_sequence_hashes,
 };
 
 // ============================================================================
@@ -29,6 +31,8 @@ use crate::test_utils::{
 
 #[template]
 #[rstest]
+// CKF is added selectively through `matching_indexer_template`; this template also drives
+// dump/restore, parent-structure, and implementation-specific tests that CKF does not support.
 fn indexer_template(
     #[values("single", "flat", "flat_binary", "concurrent", "concurrent_compressed")] variant: &str,
 ) {
@@ -36,6 +40,22 @@ fn indexer_template(
 
 #[template]
 #[rstest]
+fn matching_indexer_template(
+    #[values(
+        "single",
+        "flat",
+        "flat_binary",
+        "concurrent",
+        "concurrent_compressed",
+        "ckf"
+    )]
+    variant: &str,
+) {
+}
+
+#[template]
+#[rstest]
+// CKF exposes logical resident counts through Stats, not tree node shape.
 fn tree_size_indexer_template(
     #[values("single", "concurrent", "concurrent_compressed")] variant: &str,
 ) {
@@ -43,6 +63,7 @@ fn tree_size_indexer_template(
 
 #[template]
 #[rstest]
+// CKF has no compressed-tree node representation.
 fn compressed_tree_size_indexer_template(
     #[values("single", "concurrent_compressed")] variant: &str,
 ) {
@@ -50,12 +71,166 @@ fn compressed_tree_size_indexer_template(
 
 #[template]
 #[rstest]
+// CKF intentionally rejects approximate routing and pruning construction.
 fn approx_indexer_template(
     #[values("single", "flat", "flat_binary", "concurrent", "concurrent_compressed")] variant: &str,
 ) {
 }
 
-fn make_indexer(variant: &str) -> Box<dyn KvIndexerInterface> {
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum MatchSemantics {
+    Exact,
+    ProbabilisticNoUnderreport,
+}
+
+fn padded_ckf_workers(
+    scenario_workers: &[WorkerWithDpRank],
+) -> [WorkerWithDpRank; super::cuckoo::DC_COUNT] {
+    assert!(
+        scenario_workers.len() <= super::cuckoo::DC_COUNT,
+        "CKF test scenario exceeds fixed lane count"
+    );
+    let mut seen = HashSet::with_capacity(super::cuckoo::DC_COUNT);
+    let mut workers = Vec::with_capacity(super::cuckoo::DC_COUNT);
+    for &worker in scenario_workers {
+        assert!(
+            seen.insert(worker),
+            "duplicate exact CKF test worker identity: {worker:?}"
+        );
+        workers.push(worker);
+    }
+
+    let mut padding_id = u64::MAX;
+    while workers.len() < super::cuckoo::DC_COUNT {
+        let candidate = WorkerWithDpRank::new(padding_id, 0);
+        padding_id = padding_id.wrapping_sub(1);
+        if seen.insert(candidate) {
+            workers.push(candidate);
+        }
+    }
+
+    workers
+        .try_into()
+        .unwrap_or_else(|_| unreachable!("CKF worker padding must produce exactly 16 lanes"))
+}
+
+#[test]
+fn ckf_test_worker_factory_preserves_ranks_pads_and_rejects_duplicates() {
+    let scenario = [WorkerWithDpRank::new(7, 0), WorkerWithDpRank::new(7, 1)];
+    let workers = padded_ckf_workers(&scenario);
+    assert_eq!(&workers[..scenario.len()], &scenario);
+    assert_eq!(workers[scenario.len()], WorkerWithDpRank::new(u64::MAX, 0));
+    assert_eq!(workers.into_iter().collect::<HashSet<_>>().len(), 16);
+
+    let duplicate = std::panic::catch_unwind(|| {
+        padded_ckf_workers(&[scenario[0], scenario[0]]);
+    });
+    assert!(duplicate.is_err());
+}
+
+fn make_matching_indexer(
+    variant: &str,
+    workers: &[WorkerWithDpRank],
+) -> Box<dyn KvIndexerInterface + Sync> {
+    let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
+    make_matching_indexer_with_metrics(variant, workers, metrics).0
+}
+
+fn make_matching_indexer_with_metrics(
+    variant: &str,
+    workers: &[WorkerWithDpRank],
+    metrics: Arc<KvIndexerMetrics>,
+) -> (Box<dyn KvIndexerInterface + Sync>, Arc<KvIndexerMetrics>) {
+    if variant != "ckf" {
+        return make_indexer_with_metrics(variant, metrics);
+    }
+
+    let backend =
+        EventTransposedCkfIndexer::new(padded_ckf_workers(workers), CkfConfig::new(16_384))
+            .expect("valid fixed-D CKF test configuration");
+    let index = ThreadPoolIndexer::new_with_metrics(backend, 4, 32, Some(Arc::clone(&metrics)));
+    (Box::new(index), metrics)
+}
+
+fn assert_scores_with_semantics(
+    variant: &str,
+    actual: &OverlapScores,
+    query_len: usize,
+    configured_workers: &[WorkerWithDpRank],
+    expected_scores: &[(WorkerWithDpRank, u32)],
+    ckf_semantics: MatchSemantics,
+) {
+    let expected: std::collections::HashMap<_, _> = expected_scores.iter().copied().collect();
+    if variant != "ckf" || ckf_semantics == MatchSemantics::Exact {
+        assert_eq!(actual.scores.len(), expected.len());
+        for (&worker, &expected_depth) in &expected {
+            assert_eq!(actual.scores.get(&worker), Some(&expected_depth));
+        }
+        if variant == "ckf" {
+            assert!(actual.frequencies.is_empty());
+        }
+        return;
+    }
+
+    let configured: HashSet<_> = configured_workers.iter().copied().collect();
+    assert_eq!(
+        configured.len(),
+        configured_workers.len(),
+        "probabilistic score assertion received duplicate workers"
+    );
+    assert!(actual.frequencies.is_empty());
+    assert!(
+        actual
+            .scores
+            .keys()
+            .all(|worker| configured.contains(worker)),
+        "CKF returned an unexpected identity: {:?}",
+        actual.scores
+    );
+    assert!(
+        actual.scores.values().all(|&depth| depth > 0),
+        "CKF must omit zero-depth scores: {:?}",
+        actual.scores
+    );
+    assert!(
+        actual
+            .scores
+            .values()
+            .all(|&depth| depth as usize <= query_len),
+        "CKF score exceeds query length {query_len}: {:?}",
+        actual.scores
+    );
+
+    for &worker in configured_workers {
+        let expected_depth = expected.get(&worker).copied().unwrap_or(0);
+        let actual_depth = actual.scores.get(&worker).copied().unwrap_or(0);
+        assert!(
+            actual_depth >= expected_depth,
+            "CKF under-reported {worker:?}: expected at least {expected_depth}, got {actual_depth}"
+        );
+    }
+}
+
+async fn assert_query_scores_with_semantics(
+    variant: &str,
+    index: &dyn KvIndexerInterface,
+    query: &[u64],
+    configured_workers: &[WorkerWithDpRank],
+    expected_scores: &[(WorkerWithDpRank, u32)],
+    ckf_semantics: MatchSemantics,
+) {
+    let scores = query_scores(index, query).await;
+    assert_scores_with_semantics(
+        variant,
+        &scores,
+        query.len(),
+        configured_workers,
+        expected_scores,
+        ckf_semantics,
+    );
+}
+
+fn make_indexer(variant: &str) -> Box<dyn KvIndexerInterface + Sync> {
     let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
     make_indexer_with_metrics(variant, metrics).0
 }
@@ -63,11 +238,11 @@ fn make_indexer(variant: &str) -> Box<dyn KvIndexerInterface> {
 fn make_indexer_with_metrics(
     variant: &str,
     metrics: Arc<KvIndexerMetrics>,
-) -> (Box<dyn KvIndexerInterface>, Arc<KvIndexerMetrics>) {
+) -> (Box<dyn KvIndexerInterface + Sync>, Arc<KvIndexerMetrics>) {
     let token = CancellationToken::new();
     let kv_block_size = 32;
 
-    let indexer: Box<dyn KvIndexerInterface> = match variant {
+    let indexer: Box<dyn KvIndexerInterface + Sync> = match variant {
         "single" => Box::new(KvIndexer::new(token, kv_block_size, metrics.clone())),
         // Pin the mode explicitly (not via `new`, which reads DYN_ROUTER_POSITIONAL_SEARCH_MODE)
         // so the matrix always exercises both strided and binary regardless of the ambient env.
@@ -384,11 +559,12 @@ mod interface_tests {
 
     #[cfg(feature = "metrics")]
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_continuation_store_does_not_warn(variant: &str) {
         let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
-        let (index, metrics) = make_indexer_with_metrics(variant, metrics);
         let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let (index, metrics) = make_matching_indexer_with_metrics(variant, &workers, metrics);
 
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
         flush_and_settle(index.as_ref()).await;
@@ -398,22 +574,40 @@ mod interface_tests {
             .await;
         flush_and_settle(index.as_ref()).await;
 
-        assert_score(index.as_ref(), &[1, 2, 3, 4, 5], worker, 5).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3, 4, 5],
+            &workers,
+            &[(worker, 5)],
+            MatchSemantics::Exact,
+        )
+        .await;
         assert_no_event_errors(metrics.as_ref());
         assert_no_event_warnings(metrics.as_ref());
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_store_and_find(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store a sequence for worker 0
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
 
         flush_and_settle(index.as_ref()).await;
 
-        assert_score(index.as_ref(), &[1, 2, 3], WorkerWithDpRank::new(0, 0), 3).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -651,22 +845,34 @@ mod interface_tests {
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_partial_match(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store [1, 2, 3] for worker 0
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
 
         flush_and_settle(index.as_ref()).await;
 
-        assert_score(index.as_ref(), &[1, 2, 999], WorkerWithDpRank::new(0, 0), 2).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 999],
+            &workers,
+            &[(worker, 2)],
+            MatchSemantics::ProbabilisticNoUnderreport,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_remove(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store sequence for worker 0
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -676,13 +882,24 @@ mod interface_tests {
 
         flush_and_settle(index.as_ref()).await;
 
-        assert_no_scores(index.as_ref(), &[1, 2, 3]).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_multiple_workers_shared_prefix(variant: &str) {
-        let index = make_indexer(variant);
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let workers = [worker0, worker1];
+        let index = make_matching_indexer(variant, &workers);
 
         // Worker 0 has [1, 2], Worker 1 has [1, 3]
         // Since sequence hashes are cumulative, [1] has same hash for both,
@@ -692,31 +909,34 @@ mod interface_tests {
 
         flush_and_settle(index.as_ref()).await;
 
-        assert_exact_scores(
+        assert_query_scores_with_semantics(
+            variant,
             index.as_ref(),
             &[1],
-            &[
-                (WorkerWithDpRank::new(0, 0), 1),
-                (WorkerWithDpRank::new(1, 0), 1),
-            ],
+            &workers,
+            &[(worker0, 1), (worker1, 1)],
+            MatchSemantics::Exact,
         )
         .await;
 
-        assert_exact_scores(
+        assert_query_scores_with_semantics(
+            variant,
             index.as_ref(),
             &[1, 2],
-            &[
-                (WorkerWithDpRank::new(0, 0), 2),
-                (WorkerWithDpRank::new(1, 0), 1),
-            ],
+            &workers,
+            &[(worker0, 2), (worker1, 1)],
+            MatchSemantics::ProbabilisticNoUnderreport,
         )
         .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_remove_worker(variant: &str) {
-        let index = make_indexer(variant);
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let workers = [worker0, worker1];
+        let index = make_matching_indexer(variant, &workers);
 
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
         index.apply_event(make_store_event(1, &[1, 2, 3])).await;
@@ -729,10 +949,13 @@ mod interface_tests {
         // Allow time for async remove_worker processing
         flush_and_settle(index.as_ref()).await;
 
-        assert_exact_scores(
+        assert_query_scores_with_semantics(
+            variant,
             index.as_ref(),
             &[1, 2, 3],
-            &[(WorkerWithDpRank::new(1, 0), 3)],
+            &workers,
+            &[(worker1, 3)],
+            MatchSemantics::Exact,
         )
         .await;
     }
@@ -767,9 +990,12 @@ mod interface_tests {
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_clear_all_blocks(variant: &str) {
-        let index = make_indexer(variant);
+        let worker0 = WorkerWithDpRank::new(0, 0);
+        let worker1 = WorkerWithDpRank::new(1, 0);
+        let workers = [worker0, worker1];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store some data for two workers
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -781,46 +1007,66 @@ mod interface_tests {
         flush_and_settle(index.as_ref()).await;
 
         // Worker 0's blocks should be gone, worker 1's remain
-        let scores = index
-            .find_matches(vec![
-                LocalBlockHash(1),
-                LocalBlockHash(2),
-                LocalBlockHash(3),
-            ])
-            .await
-            .unwrap();
-        assert_eq!(scores.scores.len(), 1);
-        assert!(scores.scores.contains_key(&WorkerWithDpRank::new(1, 0)));
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(worker1, 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_empty_query(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
 
         flush_and_settle(index.as_ref()).await;
 
-        assert_no_scores(index.as_ref(), &[]).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[],
+            &workers,
+            &[],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_miss_query(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
 
         flush_and_settle(index.as_ref()).await;
 
-        assert_no_scores(index.as_ref(), &[999, 998]).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[999, 998],
+            &workers,
+            &[],
+            MatchSemantics::ProbabilisticNoUnderreport,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_shutdown_idempotent(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let index = make_matching_indexer(variant, &[worker]);
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
         flush_and_settle(index.as_ref()).await;
         index.shutdown();
@@ -828,16 +1074,18 @@ mod interface_tests {
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_find_matches_for_request(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         let tokens: Vec<u32> = (1..=96).collect();
         let scores = index
             .find_matches_for_request(&tokens, None, None, None)
             .await
             .unwrap();
-        assert!(scores.scores.is_empty());
+        assert_scores_with_semantics(variant, &scores, 3, &workers, &[], MatchSemantics::Exact);
 
         let block_hashes = compute_block_hash_for_seq(&tokens, 32, BlockHashOptions::default());
         let sequence_hashes = compute_seq_hash_for_block(&block_hashes);
@@ -859,7 +1107,14 @@ mod interface_tests {
             .find_matches_for_request(&tokens, None, None, None)
             .await
             .unwrap();
-        assert_eq!(scores.scores.get(&WorkerWithDpRank::new(0, 0)), Some(&3));
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            3,
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        );
     }
 
     #[tokio::test]
@@ -1021,9 +1276,11 @@ mod interface_tests {
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_parent_hash_chains(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store initial sequence [1, 2, 3]
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -1036,16 +1293,26 @@ mod interface_tests {
         flush_and_settle(index.as_ref()).await;
 
         // Query for full sequence [1, 2, 3, 4, 5] should match all 5 blocks
-        assert_score(
+        assert_query_scores_with_semantics(
+            variant,
             index.as_ref(),
             &[1, 2, 3, 4, 5],
-            WorkerWithDpRank::new(0, 0),
-            5,
+            &workers,
+            &[(worker, 5)],
+            MatchSemantics::Exact,
         )
         .await;
 
         // Query for just [1, 2, 3] should match 3 blocks
-        assert_score(index.as_ref(), &[1, 2, 3], WorkerWithDpRank::new(0, 0), 3).await;
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
@@ -1089,9 +1356,14 @@ mod interface_tests {
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_multiple_dp_ranks(variant: &str) {
-        let index = make_indexer(variant);
+        let workers = [
+            WorkerWithDpRank::new(0, 0),
+            WorkerWithDpRank::new(0, 1),
+            WorkerWithDpRank::new(0, 2),
+        ];
+        let index = make_matching_indexer(variant, &workers);
 
         // Same worker_id but different dp_ranks should be tracked separately
         index
@@ -1107,19 +1379,50 @@ mod interface_tests {
         flush_and_settle(index.as_ref()).await;
 
         // Query should return all 3 dp_ranks as separate entries
-        let seq: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
-        let scores = index.find_matches(seq).await.unwrap();
-
-        assert_eq!(scores.scores.len(), 3);
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 3);
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 1)).unwrap(), 3);
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 2)).unwrap(), 3);
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(workers[0], 3), (workers[1], 3), (workers[2], 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
+    async fn test_remove_worker_dp_rank_only_clears_target_rank(variant: &str) {
+        let workers = [WorkerWithDpRank::new(7, 0), WorkerWithDpRank::new(7, 1)];
+        let index = make_matching_indexer(variant, &workers);
+        index
+            .apply_event(make_store_event_with_dp_rank(7, &[1, 2, 3], 0))
+            .await;
+        index
+            .apply_event(make_store_event_with_dp_rank(7, &[1, 2, 3], 1))
+            .await;
+        flush_and_settle(index.as_ref()).await;
+
+        index.remove_worker_dp_rank(7, 0).await;
+        flush_and_settle(index.as_ref()).await;
+
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(workers[1], 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
+    }
+
+    #[tokio::test]
+    #[apply(matching_indexer_template)]
     async fn test_partial_block_removal(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store [1, 2, 3]
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -1129,7 +1432,14 @@ mod interface_tests {
         // Verify all 3 blocks match
         let seq: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
         let scores = index.find_matches(seq.clone()).await.unwrap();
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 3);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            seq.len(),
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        );
 
         // Remove only the last block (block 3)
         // To do this correctly, we need to compute the seq_hash for block 3 specifically,
@@ -1145,12 +1455,26 @@ mod interface_tests {
 
         // Query [1, 2, 3] - should only match 2 blocks now (block 3 is removed)
         let scores = index.find_matches(seq).await.unwrap();
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 2);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            3,
+            &workers,
+            &[(worker, 2)],
+            MatchSemantics::ProbabilisticNoUnderreport,
+        );
 
         // Query [1, 2] - should still match 2 blocks
         let partial_seq: Vec<LocalBlockHash> = (1..=2).map(LocalBlockHash).collect();
         let scores = index.find_matches(partial_seq).await.unwrap();
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 2);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            2,
+            &workers,
+            &[(worker, 2)],
+            MatchSemantics::Exact,
+        );
     }
 
     #[tokio::test]
@@ -1209,9 +1533,11 @@ mod interface_tests {
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_remove_nonexistent_worker(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store data for worker 0
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -1225,16 +1551,23 @@ mod interface_tests {
         flush_and_settle(index.as_ref()).await;
 
         // Worker 0's data should still be there
-        let seq: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
-        let scores = index.find_matches(seq).await.unwrap();
-        assert_eq!(scores.scores.len(), 1);
-        assert!(scores.scores.contains_key(&WorkerWithDpRank::new(0, 0)));
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_remove_nonexistent_blocks(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store [1, 2, 3]
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -1245,15 +1578,23 @@ mod interface_tests {
         flush_and_settle(index.as_ref()).await;
 
         // Original data should still be there
-        let seq: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
-        let scores = index.find_matches(seq).await.unwrap();
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 3);
+        assert_query_scores_with_semantics(
+            variant,
+            index.as_ref(),
+            &[1, 2, 3],
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        )
+        .await;
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_clear_then_reuse(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store initial data
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -1266,7 +1607,14 @@ mod interface_tests {
         // Verify data is gone
         let seq: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
         let scores = index.find_matches(seq.clone()).await.unwrap();
-        assert!(scores.scores.is_empty());
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            seq.len(),
+            &workers,
+            &[],
+            MatchSemantics::Exact,
+        );
 
         // Store new data for the same worker
         index.apply_event(make_store_event(0, &[1, 2, 3])).await;
@@ -1275,14 +1623,22 @@ mod interface_tests {
 
         // Verify new data is accessible
         let scores = index.find_matches(seq).await.unwrap();
-        assert_eq!(scores.scores.len(), 1);
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 3);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            3,
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        );
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_multiple_sequences_per_worker(variant: &str) {
-        let index = make_indexer(variant);
+        let worker = WorkerWithDpRank::new(0, 0);
+        let workers = [worker];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store two disjoint sequences for the same worker
         // Sequence 1: [1, 2, 3]
@@ -1297,24 +1653,46 @@ mod interface_tests {
         // Query first sequence
         let seq1: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
         let scores = index.find_matches(seq1).await.unwrap();
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 3);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            3,
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        );
 
         // Query second sequence
         let seq2: Vec<LocalBlockHash> = (100..=102).map(LocalBlockHash).collect();
         let scores = index.find_matches(seq2).await.unwrap();
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 3);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            3,
+            &workers,
+            &[(worker, 3)],
+            MatchSemantics::Exact,
+        );
 
         // Query a mix that doesn't exist as a sequence - should only match first block
         let mixed: Vec<LocalBlockHash> = vec![LocalBlockHash(1), LocalBlockHash(100)];
         let scores = index.find_matches(mixed).await.unwrap();
-        // Only block 1 matches because [1, 100] is not a valid prefix
-        assert_eq!(*scores.scores.get(&WorkerWithDpRank::new(0, 0)).unwrap(), 1);
+        // Only block 1 is an exact match; CKF may over-report on the absent suffix.
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            2,
+            &workers,
+            &[(worker, 1)],
+            MatchSemantics::ProbabilisticNoUnderreport,
+        );
     }
 
     #[tokio::test]
-    #[apply(indexer_template)]
+    #[apply(matching_indexer_template)]
     async fn test_clear_clears_all_dp_ranks(variant: &str) {
-        let index = make_indexer(variant);
+        let workers = [WorkerWithDpRank::new(0, 0), WorkerWithDpRank::new(0, 1)];
+        let index = make_matching_indexer(variant, &workers);
 
         // Store same sequence for different dp_ranks
         index
@@ -1329,7 +1707,14 @@ mod interface_tests {
         // Verify both dp_ranks are present
         let seq: Vec<LocalBlockHash> = (1..=3).map(LocalBlockHash).collect();
         let scores = index.find_matches(seq.clone()).await.unwrap();
-        assert_eq!(scores.scores.len(), 2);
+        assert_scores_with_semantics(
+            variant,
+            &scores,
+            3,
+            &workers,
+            &[(workers[0], 3), (workers[1], 3)],
+            MatchSemantics::Exact,
+        );
 
         // Clear event clears ALL blocks for the worker_id, regardless of dp_rank
         index.apply_event(make_clear_event_with_dp_rank(0, 0)).await;
@@ -1338,10 +1723,7 @@ mod interface_tests {
 
         // Both dp_ranks should be cleared
         let scores = index.find_matches(seq).await.unwrap();
-        assert!(
-            scores.scores.is_empty(),
-            "Cleared event should clear all dp_ranks for a worker"
-        );
+        assert_scores_with_semantics(variant, &scores, 3, &workers, &[], MatchSemantics::Exact);
     }
 }
 

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -197,7 +197,7 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
     }
 
     pub fn new_with_metrics_and_pruning(
-        backend: T,
+        mut backend: T,
         num_workers: usize,
         kv_block_size: u32,
         metrics: Option<Arc<KvIndexerMetrics>>,
@@ -209,6 +209,7 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
             "backend does not support routing-decision pruning"
         );
         super::warn_on_unit_block_size("thread_pool", kv_block_size);
+        backend.configure_metrics(metrics.as_deref());
 
         let backend = Arc::new(backend);
         let mut worker_event_senders = Vec::new();

--- a/lib/kv-router/src/indexer/thread_pool.rs
+++ b/lib/kv-router/src/indexer/thread_pool.rs
@@ -204,6 +204,10 @@ impl<T: SyncIndexer> ThreadPoolIndexer<T> {
         prune_config: Option<PruneConfig>,
     ) -> Self {
         assert!(num_workers > 0, "Number of workers must be greater than 0");
+        assert!(
+            prune_config.is_none() || backend.supports_routing_decision_pruning(),
+            "backend does not support routing-decision pruning"
+        );
         super::warn_on_unit_block_size("thread_pool", kv_block_size);
 
         let backend = Arc::new(backend);
@@ -973,6 +977,12 @@ impl<T: SyncIndexer> KvIndexerInterface for ThreadPoolIndexer<T> {
     }
 
     async fn dump_events(&self) -> Result<Vec<RouterEvent>, KvRouterError> {
+        if !self.backend.supports_event_dump() {
+            return Err(KvRouterError::Unsupported(
+                "backend cannot reconstruct router events".to_string(),
+            ));
+        }
+
         // Send DumpEvents to every worker as a FIFO barrier: each worker must
         // finish processing all previously queued Events before it handles
         // DumpEvents, so by the time all workers respond we know the shared

--- a/lib/kv-router/src/indexer/traits.rs
+++ b/lib/kv-router/src/indexer/traits.rs
@@ -192,6 +192,16 @@ pub trait SyncIndexer: Send + Sync + 'static {
     /// Find matches for a sequence of block hashes.
     fn find_matches(&self, sequence: &[LocalBlockHash], early_exit: bool) -> OverlapScores;
 
+    /// Whether this backend can reconstruct its complete state as router events.
+    fn supports_event_dump(&self) -> bool {
+        true
+    }
+
+    /// Whether Boolean event acknowledgements are sufficient for pruning bookkeeping.
+    fn supports_routing_decision_pruning(&self) -> bool {
+        true
+    }
+
     /// Install a shared structural anchor for branch-sharded suffix routing.
     ///
     /// Backends that do not support anchored routing keep the default

--- a/lib/kv-router/src/indexer/traits.rs
+++ b/lib/kv-router/src/indexer/traits.rs
@@ -183,6 +183,9 @@ pub trait KvIndexerInterface {
 /// - Sticky event routing to N worker threads
 /// - Inline reads on the caller's thread (no channel dispatch for find_matches)
 pub trait SyncIndexer: Send + Sync + 'static {
+    /// Bind optional shared metrics before the backend is published to worker threads.
+    fn configure_metrics(&mut self, _metrics: Option<&KvIndexerMetrics>) {}
+
     fn worker(
         &self,
         event_receiver: flume::Receiver<WorkerTask>,

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -876,7 +876,7 @@ impl<'de> Deserialize<'de> for ExternalSequenceBlockHash {
 ///
 /// Indexer backends may introduce additional failure modes.
 #[non_exhaustive]
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum KvCacheEventError {
     #[error("Failed to find parent block")]
     ParentBlockNotFound,

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -873,6 +873,9 @@ impl<'de> Deserialize<'de> for ExternalSequenceBlockHash {
 // ------
 
 /// Errors that can occur during KV Cache Event processing.
+///
+/// Indexer backends may introduce additional failure modes.
+#[non_exhaustive]
 #[derive(Debug, thiserror::Error)]
 pub enum KvCacheEventError {
     #[error("Failed to find parent block")]

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -883,6 +883,12 @@ pub enum KvCacheEventError {
 
     #[error("Invalid block sequence")]
     InvalidBlockSequence,
+
+    #[error("Indexer capacity exhausted")]
+    CapacityExhausted,
+
+    #[error("Indexer invariant violated")]
+    IndexerInvariantViolation,
 }
 
 /// A [`KvCacheEvent`] on a specific LLM worker denoted by [`WorkerId`].

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -875,6 +875,7 @@ impl<'de> Deserialize<'de> for ExternalSequenceBlockHash {
 /// Errors that can occur during KV Cache Event processing.
 ///
 /// Indexer backends may introduce additional failure modes.
+/// Downstream matches must include a wildcard arm because this enum is non-exhaustive.
 #[non_exhaustive]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub enum KvCacheEventError {


### PR DESCRIPTION
## Summary

Refactors the fixed-D=16 transposed CKF backend into a production-shaped, router-local Relay boundary:

`Device RouterEvent -> exact per-DC aggregation -> absolute bucket images -> table-only transposed replica -> grouped/SWAR prefix search`

The aggregator supports multiple worker/rank identities per DC lane, exact shared-block refcounts, transactional physical mutations, Device-only residency, and safe worker lifecycle handling. A sparse touched-list publication window coalesces repeated bucket writes and suppresses net reversions against the current replica.

Publication cadence is configurable per lane with `publish_every_n_events >= 1`. The default remains `N=1`; `N>1` retains dirty state across events, while `Flush`, lifecycle barriers, termination, and receiver closure publish pending tails. The normal one-worker-per-lane `EventTransposedCkfIndexer` remains compatible with the existing non-pruning `ThreadPoolIndexer` path.

Compatibility note: this PR adds backend failure variants to the public `KvCacheEventError` and marks the enum `#[non_exhaustive]`. Downstream exhaustive matches must add a wildcard arm. That is an intentional one-time source break which prevents future backend additions from repeating the break.

## Attribution

The core CKF/Relay design, transposed bucket layout, and grouped overlap-search concepts were co-developed with [@Kaonael](https://github.com/Kaonael) through [DEP #11225](https://github.com/ai-dynamo/dynamo/issues/11225) and [Kaonael/dynamo#4](https://github.com/Kaonael/dynamo/pull/4). The squash merge commit credits Nikita as a co-author.

`Co-authored-by: Nikita Sukharev <kaonael@gmail.com>`

## Reviewer guide

The semantic core is concentrated in:

- `lib/kv-router/src/indexer/cuckoo/relay.rs`: manifest validation, exact per-DC aggregation, publication windows, local pipeline, and table-only replica;
- `lib/kv-router/src/indexer/cuckoo/mutator.rs`: transactional cuckoo insertion/removal and rollback;
- `lib/kv-router/src/indexer/cuckoo/bucket.rs`: packed buckets and the transposed D=16 replica layout;
- `lib/kv-router/src/indexer/cuckoo/event_indexer.rs`: ThreadPool adapter, lifecycle barriers, Stats, and result identity mapping;
- `lib/kv-router/src/indexer/cuckoo/search.rs`: grouped/SWAR prefix search and provenance verification;
- `lib/kv-router/src/indexer/cuckoo.rs`: public configuration and format contracts.

Most of `cuckoo/tests.rs` and `lib/bench` is permanent correctness/performance harness work. The metrics and protocol changes are integration plumbing around the core.

## Validation and correctness

The stable-snapshot search corpus covered 122,880 distinct queries and 1,966,080 lane observations. Window-2 provenance verification matched the linear first-CKF-miss oracle with zero mismatches and zero wrong-best selections. The CKF and linear oracle still shared 127 one-position boundary false positives relative to exact resident depth; those are intrinsic membership false positives, not binary-search errors.

The deterministic Mooncake parity corpus covered 3,000 queries and 48,000 lane observations across vLLM, SGLang, and TensorRT-LLM traces with zero full-map mismatches, inflation, under-reports, or wrong-best selections.

Relay-focused coverage includes shared hashes across workers, final-owner removal, unknown removal safety, partial commits, representation collisions, per-lane cadence, cross-event coalescing, net-revert suppression, reset cancellation, tail Flush, lifecycle publication, shutdown draining, direct-versus-Relay `N=1` parity after every event, and `N>1` parity at publication boundaries and after Flush.

The benchmarked candidate passed the focused CKF suites under default, bench, and metrics configurations, the indexer interface suite, and the Mooncake trace suite on both the development host and a clean Linux/x86_64 checkout. The follow-up Flush hardening passed the same focused suites locally and the Rust 1.96 Clippy target.

## Headline performance results

Seven paired fresh-process repetitions used the same 16-worker Mooncake corpus and offered load on an AMD EPYC 7702P, pinned to eight physical cores with a 32 GiB allocation:

| Path | Median block ops/s | Relative to direct | Query p50/p99 | Update p99 | Drain |
|---|---:|---:|---:|---:|---:|
| Direct mutation | 50.023M | 1.000x | 2.48/9.78 us | 13.38 ms | 56.63 ms |
| Relay `N=1` | 39.719M | 0.7948x | 2.40/9.30 us | 547.84 ms | 469.85 ms |
| Relay `N=16` probe | 41.983M | 0.8392x | 2.39/9.28 us | 429.36 ms | 362.21 ms |

All cells were generator-valid. Direct kept up in 7/7 repetitions; both Relay cells were intentionally measured beyond their sustainable update rate and accumulated backlog. `N=16` improved median throughput by 6.4% over `N=1`, but it is a batching probe, not a default selection; immediate `N=1` visibility remains the production default.

These campaign numbers predate a harness accounting correction: the old end timestamp captured event/query drain before the final `Flush`, so the `N=16` row can omit one partial publication tail. The harness now includes tail publication in elapsed and drain time for future runs; treat the reported `N=16` throughput as slightly optimistic rather than as a new default decision.

The campaign also rejected both occupied-bucket trackers. A replica tracker looked neutral in the isolated reset microbenchmark, but its per-image atomics regressed the combined workload by about 5.1% at `N=1` and 3.0% at `N=16`. Production therefore keeps full-scan lane resets. Touched-order images, no destination-store prefetch, and equal-share member reservation are also intentional.


## Maximum-depth match mode

This follow-up adds opt-in `MaxDepthMatches`; full-map output remains the default. It returns every positive lane tied at the greatest verified depth and matched the full-map maximum/tie-set projection query-for-query in deterministic `N=1` and `N=16` Mooncake parity runs.

The optimization is deliberately workload-dependent. On the ordinary non-prunable Mooncake cell, the initial controller regressed query-service p50 by 19.1%; the equal-ceiling full-schedule fallback reduced the final full/max medians to 1.233/1.242 us (+0.8%), while p99 moved from 3.447 to 3.346 us (-2.6%). On an AMD EPYC 7702P using a hierarchical sticky-session corpus with a shared eight-block system prefix, four-worker branch cohorts through block 24, and one 128-block deep winner, maximum-depth search reduced median query time from 3.891 to 3.482 us (10.6%) and improved throughput by 11.8%. It is therefore an explicit routing policy, not a universal replacement.

## Publisher/Relay integration and explicit deferrals

Everything is intentionally router-local in this PR: aggregation, absolute-image publication, and replica application are ordered in one process. That is useful as a complete indexer-side alternative to the current CRTC path and validates the ownership boundary, but it is not the final distributed integration.

The intended follow-up can move the event translator and exact aggregator to the Relay/publisher side while reusing the same absolute bucket-image contract; the router then retains only the transposed replica, format validation, and query path. This split is deliberately modular even though image consumption is local today.

This PR does **not** implement transport codecs, snapshots/deltas, epochs or state-sequence enforcement, checksums/chunking, replay buffers, snapshot-plus-catch-up, resubscription, publisher fencing, heartbeats/readiness, COW, process-restart recovery, Global Router plumbing, deployment selection, automatic resizing, D>16 sharding, pruning, native-filter fallback, or a wall-clock publication trigger. The local pipeline does not claim to survive publication loss, reordering, reconnect, or independent process restart.

The future transport seam remains documented around `relay_instance_id`, `model_key`, `generation`, `state_sequence`, format identity, and `snapshot | delta | heartbeat`.
