### PR TITLE
fix(benchmarks): run the in-cluster benchmark Job on the frontend image (DYN-3395)

### DIFF
--- a/benchmarks/incluster/benchmark_job.yaml
+++ b/benchmarks/incluster/benchmark_job.yaml
@@ -16,8 +16,12 @@ spec:
         fsGroup: 1000
       containers:
       - name: benchmark-runner
+        # aiperf only talks HTTP to the frontend service, so this CPU-only Job
+        # runs on the frontend image, which ships the benchmarks package (incl.
+        # aiperf, with the prebuilt arm64 crick wheel). Backend runtime images
+        # deliberately do not carry benchmark tooling.
         # TODO: update to latest public image in next release
-        image: nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.0
+        image: nvcr.io/nvidia/ai-dynamo/frontend:1.3.0
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:


### PR DESCRIPTION
## Summary

Cherry-pick of #11368 to release/1.3.0 -- the in-cluster benchmark Job now runs on the frontend image (which ships aiperf, including the arm64 crick wheel) instead of the vLLM serving runtime image, fixing `aiperf: command not found` (exit 127).

Conflict resolution (one hunk, documented): main carries the `:my-tag` placeholder convention while the release branch pins version tags, so the picked line was resolved to `nvcr.io/nvidia/ai-dynamo/frontend:1.3.0` -- the fix's image with the release branch's pinned tag.

Fixes DYN-3395
Fixes https://nvbugs/6418326

## Original PR

#11368, merge commit 98bbd86368 on main.

## Test plan

CI passes on this branch; the manifest parses and the Job image asserts to frontend:1.3.0. Repro (exit 127) and the fix (aiperf 0.10.0 from the frontend image) were proven against published images; QA verification on the first RC containing this fix is recorded on NVBug 6418326.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11436" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->