### PR TITLE
ci(docs): ignore flaky GitHub stargazers link in lychee

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -33,3 +33,7 @@
 # canonical release/support-matrix links added by the version bump 404 from CI
 # until then. Remove this entry once the v1.3.0 release is published.
 ^https://github\.com/ai-dynamo/dynamo/releases/tag/v1\.3\.0$
+
+# GitHub intermittently returns 404 to link checkers on the stargazers page
+# (valid public URL; fails lychee deterministically on CI runners)
+^https://github\.com/ai-dynamo/dynamo/stargazers$


### PR DESCRIPTION
## Overview:

The lychee docs link check fails deterministically on CI runners because GitHub returns 404 to link checkers on https://github.com/ai-dynamo/dynamo/stargazers -- a valid public URL (anti-bot behavior). Observed failing twice in a row on release/1.3.0 PR #11436 (runs 28977794521, jobs 85989105769 / 85989446073), flagging docs/contribution-guide.md, its zh-CN mirror, and the platform helm README -- none touched by that PR.

## Details:

Adds one anchored regex for the stargazers URL to .lycheeignore, with a comment explaining why. No other link coverage changes.

## Where should the reviewer start?

.lycheeignore -- the four added lines.

## Related Issues

Unblocks release-branch CP PR #11436; no tracker issue (CI hygiene).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11437" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved link-check reliability by skipping a flaky GitHub stargazers URL that can intermittently fail during CI runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->