### PR TITLE
perf(kv-router): skip empty child scans for leaf removals

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/node.rs
@@ -274,7 +274,11 @@ impl Node {
     }
 
     fn clear_children_if_unreachable(&self, should_clear_children: bool) {
-        if should_clear_children && !self.children.is_empty() {
+        // `internal` is sticky, so false proves this node never published a child.
+        if should_clear_children
+            && self.internal.load(Ordering::Acquire)
+            && !self.children.is_empty()
+        {
             self.children.clear();
             self.shape_version.fetch_add(1, Ordering::Release);
         }


### PR DESCRIPTION
## Summary

- skip `DashMap::is_empty()` when removing coverage from a CRTC node whose sticky `internal` flag proves it has never published a child
- preserve the existing child cleanup path for nodes that are or were internal
- avoid scanning and read-locking every empty DashMap shard on the leaf-removal hot path

`DashMap::is_empty()` is implemented through its length calculation, which visits every shard. The ToolAgent removal workload showed that scan dominating `Node::remove_worker_for_hashes`. The existing `internal` flag is sticky: `false` is therefore a safe proof that the physical child map is empty, while `true` remains intentionally inconclusive.

## Performance

Measured on commit `869348bb7bd1501deebf6f7f0ab69e1cd69acaba` using the public Mooncake ToolAgent trace, 16 inference workers, 8 CRTC event workers, and block size 128. Load generation and CRTC execution used disjoint CPU-affinity masks on an Intel Core Ultra 9 285K: event issuers were pinned to P-cores 0-6, the query issuer to P-core 7, and the CRTC backend to E-cores 8-23. Both arms were generator-valid, satisfied the harness keep-up gate, completed the full 109,892,041-block workload, and reported no failures.

A matched profile used this workload and CPU affinity. `perf` sampled only the E-core PMU with `cpu_atom/cycles/u` at 199 Hz using 16 KiB DWARF stacks. Sampling was gated to replay plus final drain. The baseline and candidate captures contained 6,903 and 6,002 samples respectively, with zero lost samples; both profiled processes remained generator-valid, passed the keep-up gate, completed all operations, and reported zero correctness failures.

| Profile metric | Baseline | This PR | Delta |
| --- | ---: | ---: | ---: |
| Approximate E-core cycles | 106.24B | 87.32B | -17.8% |
| `Node::remove_worker_for_hashes` cycle share | 21.68% | 9.07% | -58.2% |
| Achieved block ops/s | 15.470M | 15.500M | +0.2% |
| Lookup service p99 | 2.976 us | 2.809 us | -5.6% |
| Update accepted-to-finished p99 | 40.346 ms | 31.937 ms | -20.8% |
| Outstanding updates at stop | 56,351 | 41,205 | -26.9% |
| Final drain | 185.1 ms | 176.7 ms | -4.5% |

An initial 999 Hz attempt was excluded because perf observer overhead caused the baseline capture to lose 25.1% of its samples and materially perturbed the candidate. The longer replay allows 199 Hz to collect thousands of E-core samples without that observer overload.

## Reproduction

The trace below matches SHA-256 `48a2db1a13d3bc05e6330140c64f604ba366df20d3c9e128b5c35a01c1fa5f71`.

```bash
ROOT=$(git rev-parse --show-toplevel)
TRACE="$ROOT/lib/kv-router/traces/toolagent_trace.jsonl"

mkdir -p "$(dirname "$TRACE")"
curl -L \
  https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/traces/toolagent_trace.jsonl \
  -o "$TRACE"
echo '48a2db1a13d3bc05e6330140c64f604ba366df20d3c9e128b5c35a01c1fa5f71  '"$TRACE" \
  | sha256sum -c -

cargo bench --package dynamo-bench --bench mooncake_bench --no-run
BIN=$(find target/release/deps -maxdepth 1 -type f -perm /111 \
  -name 'mooncake_bench-*' -print -quit)

numactl --interleave=all "$BIN" "$TRACE" \
  --query-lanes 16 \
  --issuer-cpus 0-6 \
  --query-issuer-cpu 7 \
  --backend-cpus 8-23 \
  --issuer-spin-us 100 \
  --issue-lag-diagnostic-threshold-us 250 \
  --num-unique-inference-workers 16 \
  --trace-duplication-factor 100 \
  --trace-length-factor 1 \
  --benchmark-duration-ms 6868 \
  --result-json-output /path/to/result.json \
  concurrent-radix-tree-compressed \
  --num-event-workers 8
```

Adapt the CPU masks to the host while keeping issuer and backend masks disjoint. To compare the two arms, run the command in fresh processes at the parent and PR commits and compare the generated JSON.

## Validation

- `cargo fmt --all --check`
- `cargo test -p dynamo-kv-router --lib concurrent_radix_tree_compressed` (26 passed)
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- long ToolAgent replay at 16.0006M offered block ops/s on baseline and candidate binaries; generator-valid, keep-up true, zero failures
- matched E-core-only on-CPU profile at 199 Hz; zero lost samples, generator-valid, keep-up true, zero failures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved child cleanup logic to avoid clearing nodes that were never marked as having published children.
  * Added a safeguard so child maps are only cleared when the node is confirmed to be in the appropriate internal state.
  * Clarified the handling of nodes that should retain their children, reducing the chance of incorrect tree updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
