### PR TITLE
fix(tests): close gRPC streaming clients

### DIFF
--- a/tests/frontend/grpc/test_tensor_mocker_engine.py
+++ b/tests/frontend/grpc/test_tensor_mocker_engine.py
@@ -160,6 +160,7 @@ def test_model_infer_failure(start_services_with_echo_worker, request_params):
 @pytest.mark.pre_merge
 @pytest.mark.gpu_0  # Echo tensor worker is CPU-only (no GPU required)
 @pytest.mark.parallel
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize(
     "request_params",
     [
@@ -202,26 +203,30 @@ def test_model_stream_infer_failure(start_services_with_echo_worker, request_par
             user_data._completed_requests.put(result)
 
     user_data = UserData()
-    client.start_stream(
-        callback=partial(callback, user_data),
-    )
+    try:
+        client.start_stream(
+            callback=partial(callback, user_data),
+        )
 
-    client.async_stream_infer(
-        model_name="echo",
-        inputs=inputs,
-        parameters=request_params,
-    )
+        client.async_stream_infer(
+            model_name="echo",
+            inputs=inputs,
+            parameters=request_params,
+        )
 
-    # For stream infer, the exception and error will pass to the callback but not
-    # raised
-    with pytest.raises(Exception) as excinfo:
-        data_item = user_data._completed_requests.get(timeout=5)
-        if isinstance(data_item, Exception):
-            print("Raising exception received from stream infer callback")
-            raise data_item
-    if "malformed_response" in request_params:
-        assert "missing field `data_type`" in str(excinfo.value).lower()
-    elif "data_mismatch" in request_params:
-        assert "shape implies" in str(excinfo.value).lower()
-    elif "raise_exception" in request_params:
-        assert "intentional exception" in str(excinfo.value).lower()
+        # For stream infer, the exception and error will pass to the callback but not
+        # raised
+        with pytest.raises(Exception) as excinfo:
+            data_item = user_data._completed_requests.get(timeout=5)
+            if isinstance(data_item, Exception):
+                print("Raising exception received from stream infer callback")
+                raise data_item
+        if "malformed_response" in request_params:
+            assert "missing field `data_type`" in str(excinfo.value).lower()
+        elif "data_mismatch" in request_params:
+            assert "shape implies" in str(excinfo.value).lower()
+        elif "raise_exception" in request_params:
+            assert "intentional exception" in str(excinfo.value).lower()
+    finally:
+        client.stop_stream(cancel_requests=True)
+        client.close()

--- a/tests/frontend/grpc/test_tensor_mocker_engine.py
+++ b/tests/frontend/grpc/test_tensor_mocker_engine.py
@@ -125,6 +125,7 @@ def test_echo(start_services_with_echo_worker) -> None:
 @pytest.mark.pre_merge
 @pytest.mark.gpu_0  # Echo tensor worker is CPU-only (no GPU required)
 @pytest.mark.parallel
+@pytest.mark.timeout(60)
 @pytest.mark.parametrize(
     "request_params",
     [

--- a/tests/frontend/grpc/triton_echo_client.py
+++ b/tests/frontend/grpc/triton_echo_client.py
@@ -101,31 +101,35 @@ class TritonEchoClient:
                 user_data._completed_requests.put(result)
 
         user_data = UserData()
-        triton_client.start_stream(
-            callback=partial(callback, user_data),
-        )
+        try:
+            triton_client.start_stream(
+                callback=partial(callback, user_data),
+            )
 
-        triton_client.async_stream_infer(
-            model_name=model_name,
-            inputs=inputs,
-        )
+            triton_client.async_stream_infer(
+                model_name=model_name,
+                inputs=inputs,
+            )
 
-        data_item = user_data._completed_requests.get(timeout=5)
-        assert (
-            isinstance(data_item, Exception) is False
-        ), f"Stream inference failed: {data_item}"
+            data_item = user_data._completed_requests.get(timeout=5)
+            assert (
+                isinstance(data_item, Exception) is False
+            ), f"Stream inference failed: {data_item}"
 
-        output0_data = data_item.as_numpy("INPUT0")
-        output1_data = data_item.as_numpy("INPUT1")
+            output0_data = data_item.as_numpy("INPUT0")
+            output1_data = data_item.as_numpy("INPUT1")
 
-        assert (
-            output0_data is not None
-        ), "Expected response to include output tensor 'INPUT0'"
-        assert (
-            output1_data is not None
-        ), "Expected response to include output tensor 'INPUT1'"
-        assert np.array_equal(input0_data, output0_data)
-        assert np.array_equal(input1_data, output1_data)
+            assert (
+                output0_data is not None
+            ), "Expected response to include output tensor 'INPUT0'"
+            assert (
+                output1_data is not None
+            ), "Expected response to include output tensor 'INPUT1'"
+            assert np.array_equal(input0_data, output0_data)
+            assert np.array_equal(input1_data, output1_data)
+        finally:
+            triton_client.stop_stream(cancel_requests=True)
+            triton_client.close()
 
     def get_config(self) -> None:
         triton_client = self._client()


### PR DESCRIPTION
## Summary

- explicitly cancel and close Triton bidirectional gRPC streams in the tensor mocker tests
- clean up both the successful echo stream and failure-path streams so handler threads cannot accumulate across cases
- add a 60-second timeout to the parametrized streaming-failure test for actionable diagnostics

The test previously left each stream open after receiving its callback. Tritonclient could then wait indefinitely for its stream handler during shutdown, causing the arm64 runtime test job to time out.

## Validation

- `python -m pytest -xvv --basetemp=/tmp/pytest-grpc-fix --durations=0 tests/frontend/grpc/test_tensor_mocker_engine.py::test_echo tests/frontend/grpc/test_tensor_mocker_engine.py::test_model_stream_infer_failure`
  - 4 passed in 15.36s
  - teardown reduced from approximately 8.44s to 0.41s per case
- all commit-time pre-commit hooks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved streaming inference test reliability by adding a timeout and ensuring cleanup always runs, even if the test fails.
  * Strengthened the echo client’s stream test flow so streaming resources are consistently closed after execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->