### PR TITLE
feat(router): add ThunderAgent admission strategy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,3 +21,26 @@ The public contract in `lib/kv-router/src/scheduling/queue_admission/` is the na
 - Add request facts as typed accessors only after a concrete strategy proves they are necessary. Expose changing system state through a narrow read-only capability instead of copying actor state or adding an untyped metadata bag.
 - Keep algorithm-specific configuration in flattened `QueueAdmissionConfig::options`; the generic router validates only the strategy name and container shape.
 - This is a Rust dependency-inversion boundary, not a stable dynamic-plugin ABI. Built-in implementations should live outside `dynamo-kv-router` and use explicit registration at a composition root.
+
+## Policy-Class Admission Runtime
+
+The KV router hosts admission strategies behind the API above. The scheduler queue actor owns orchestration and lifecycle correlation; strategies own only algorithm state.
+
+```text
+request
+  -> scheduler queue actor
+  -> policy queue
+  -> configured policy-class admission strategy
+  -> ready/deferred storage owned by PolicyQueue
+  -> worker selector
+  -> engine
+```
+
+- `PolicyQueue` owns all request payloads. A strategy returns `Bypass`, `Ready`, or `Defer`; it never owns a `SchedulingRequest`.
+- The actor correlates admitted work by `AdmissionId`, delivers dispatch/completion/abort/reconcile events, and applies `MakeReady` actions.
+- Admission receives a live, read-only `RequestProgress` handle. The paired updater records monotonic logical context growth with one relaxed atomic operation on the response path; strategies read it during their own admission or reconciliation work.
+- `RequestGuard` owns terminal lifecycle delivery. Successful completion reports the authoritative final logical context; dropping a tracked request before completion reports an abort.
+- `free()` remains worker-slot cleanup. It does not terminate admission state and retains its existing public behavior.
+- `Ready(Exact(worker))` is a constraint on the normal selector, not a routing bypass. The selector still validates, scores, and books the worker.
+- Built-in strategies are registered explicitly in `dynamo-llm`. Caller-provided strategies use the same map and are not replaced by built-ins.
+- Do not add per-output-token actor messages. Changing request state should use a narrow capability such as `RequestProgress` only after an admission algorithm proves it needs the data.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2363,6 +2363,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynamo-admission-control"
+version = "1.3.0"
+dependencies = [
+ "dynamo-kv-router",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "dynamo-backend-common"
 version = "1.3.0"
 dependencies = [
@@ -2554,6 +2567,7 @@ dependencies = [
  "derive-getters",
  "derive_builder",
  "dialoguer",
+ "dynamo-admission-control",
  "dynamo-bench",
  "dynamo-kv-router",
  "dynamo-memory",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "lib/kv-hashing",
     "lib/mocker",
     "lib/kv-router",
+    "lib/admission-control",
     "lib/memory",
     "lib/kvbm-common",
     "lib/kvbm-config",
@@ -52,6 +53,7 @@ dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.3.0" }
 dynamo-memory = { path = "lib/memory", version = "1.3.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.3.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.3.0", features = ["metrics", "runtime-protocols"] }
+dynamo-admission-control = { path = "lib/admission-control", version = "1.3.0" }
 dynamo-protocols = { version = "=2.0.1" }
 dynamo-parsers = { version = "3.1.0" }
 # Published on crates.io. To see all available versions:

--- a/lib/admission-control/CLAUDE.md
+++ b/lib/admission-control/CLAUDE.md
@@ -1,0 +1,20 @@
+# lib/admission-control
+
+This crate contains built-in implementations of `PolicyClassAdmissionStrategy`. Keep the generic strategy contract and request ownership in `dynamo-kv-router`; keep algorithm-specific state and decisions in a submodule here.
+
+## Structure
+
+- `src/lib.rs` exposes strategy modules and preserves the crate's public convenience re-exports.
+- `src/thunderagent/` contains the complete ThunderAgent implementation and its local instructions.
+
+## Boundaries
+
+- Strategies receive read-only request facts and return `AdmissionDecision` or `AdmissionAction` values.
+- The KV-router admission controller owns queued requests, validates actions, applies placement, and delivers lifecycle events.
+- A strategy must not own `SchedulingRequest`, call the selector, reserve worker slots, or reproduce queue accounting.
+- Keep each concrete algorithm together. Do not split accounting, pressure, victim selection, packing, or placement into separate plug-ins without a second implementation that requires the seam.
+- Preserve root re-exports when moving implementation details so downstream users do not need import changes.
+
+## Validation
+
+Run `cargo test -p dynamo-admission-control` and `cargo clippy -p dynamo-admission-control --all-targets -- -D warnings` after changes.

--- a/lib/admission-control/Cargo.toml
+++ b/lib/admission-control/Cargo.toml
@@ -1,0 +1,21 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-admission-control"
+description = "Built-in queue admission strategies for Dynamo"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+
+[dependencies]
+dynamo-kv-router = { workspace = true }
+indexmap = { workspace = true }
+serde = { workspace = true }
+serde_yaml = "0.9.34"
+thiserror = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/lib/admission-control/README.md
+++ b/lib/admission-control/README.md
@@ -1,0 +1,12 @@
+# dynamo-admission-control
+
+`dynamo-admission-control` contains Dynamo's built-in policy-class queue admission strategies. The KV router owns request storage, lifecycle delivery, and final worker selection; this crate supplies the strategy-specific admission decisions.
+
+The currently implemented strategy is [ThunderAgent](src/thunderagent/), configured as `queue_admission.type: session_aware`.
+
+ThunderAgent retains quiescent completed sessions for `session_retention_seconds` (1,800 seconds by default) and then forgets their placement and accounting state. The inactivity lease resets after every successful turn, so clients do not need to emit a terminal signal. A later request for an expired session is admitted as a new program.
+
+## Known follow-ups
+
+- A resumed request released with `WorkerPlacement::Exact(worker)` can fail if that worker disappears before final selection. A future fix should retry normal selection for worker removal without weakening sticky placement during temporary overload.
+- A paused program whose assigned worker leaves the structurally eligible set cannot be greedily placed elsewhere until its resume timeout. A future fix should clear stale assignments before resume while preserving assignments during temporary overload.

--- a/lib/admission-control/src/lib.rs
+++ b/lib/admission-control/src/lib.rs
@@ -1,0 +1,10 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+pub mod thunderagent;
+
+pub use thunderagent::{
+    ConfigError, RegistrationError, STRATEGY_NAME, ThunderAgent, ThunderAgentConfig,
+    WatchWorkerCapacity, WorkerCapacity, WorkerCapacityProvider, register_builtin_strategies,
+    strategy_recheck_interval,
+};

--- a/lib/admission-control/src/lib.rs
+++ b/lib/admission-control/src/lib.rs
@@ -6,5 +6,4 @@ pub mod thunderagent;
 pub use thunderagent::{
     ConfigError, RegistrationError, STRATEGY_NAME, ThunderAgent, ThunderAgentConfig,
     WatchWorkerCapacity, WorkerCapacity, WorkerCapacityProvider, register_builtin_strategies,
-    strategy_recheck_interval,
 };

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -20,7 +20,7 @@ Each program has two independent state dimensions:
 - `Active`: its logical KV footprint counts against an assigned worker.
 - `Paused`: it has no reservation or assigned worker; a returning request remains deferred until resume.
 
-`RequestState` records the admission ID, initial context size, live request-progress and worker-eligibility handles, dispatch status, and the prior program snapshot used for rollback. `SessionRequests` serializes concurrent requests for one session: one current request and an ordered waiter set.
+`RequestState` records the admission ID, initial context size, live request-progress and worker-eligibility handles, and the prior program snapshot used for rollback. `SessionRequests` serializes concurrent requests for one session: one current request and an ordered waiter set.
 
 ## Request flow
 
@@ -56,11 +56,7 @@ Only active programs with an assigned worker contribute usage:
 normal usage = program tokens + buffer_per_program
 ```
 
-Reasoning programs read their full logical context from the retained `RequestProgress` handle during admission and reconciliation. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative. Acting programs apply `acting_token_weight` during normal pressure and resume calculations. A separate exponentially decayed Acting value is used only when choosing placement after `resume_timeout_seconds`:
-
-```text
-decayed tokens = token_total * 2^(-idle_seconds / acting_decay_tau_seconds)
-```
+Reasoning programs read their full logical context from the retained `RequestProgress` handle during admission and reconciliation. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative. Acting programs apply `acting_token_weight` during normal pressure and resume calculations.
 
 This is a logical projection, not live engine or indexer residency.
 
@@ -89,7 +85,7 @@ Sessions that cannot fit an eligible worker are skipped. The remaining candidate
 
 ### Forced resume
 
-A session deferred for `resume_timeout_seconds` bypasses the normal fit test. It is placed on the eligible worker with the greatest `capacity - decayed_usage`. A session waiting only because all structurally valid workers are temporarily overloaded remains deferred.
+A session deferred for `resume_timeout_seconds` bypasses the normal fit test and returns to normal worker selection. A session waiting only because all structurally valid workers are temporarily overloaded remains deferred.
 
 ### Pause
 

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -13,14 +13,13 @@ This module implements ThunderAgent as one `PolicyClassAdmissionStrategy`. It co
 
 ThunderAgent keys state by `session_id`.
 
-Each program has two independent state dimensions:
+Each retained program is in exactly one state:
 
-- `Reasoning`: a request is admitted or running. It cannot be paused mid-request.
-- `Acting`: the previous request completed and the agent is between turns.
-- `Active`: its logical KV footprint counts against an assigned worker.
-- `Paused`: it has no reservation or assigned worker; a returning request remains deferred until resume.
+- `Running { progress, pause_after_completion }`: one request is admitted or running. Its live progress handle supplies the current logical footprint. It cannot be suspended mid-request.
+- `IdleResident { footprint, last_activity }`: the previous request completed and its logical footprint remains resident on the assigned worker.
+- `Suspended { footprint, since }`: the logical footprint has no capacity reservation. A current request, when present, remains deferred until resume.
 
-`RequestState` records the admission ID, initial context size, live request-progress and worker-eligibility handles, and the prior program snapshot used for rollback. `SessionRequests` serializes concurrent requests for one session: one current request and an ordered waiter set.
+`New` is represented by no program entry. `Expired` is represented by removing the entry rather than retaining a tombstone. The worker assignment and completed-step count are common program fields. `RequestState` records the live request-progress and worker-eligibility handles plus the prior program snapshot used for rollback. `SessionRequests` serializes concurrent requests for one session: one current request and an ordered waiter set.
 
 ## Request flow
 
@@ -29,8 +28,8 @@ AdmissionRequest
   -> no session_id: Bypass
   -> another request for the session is current: Defer as a session waiter
   -> begin request
-       -> update logical context and mark Reasoning
-       -> paused session: Defer
+       -> create Running state from the request's live progress handle
+       -> suspended session: Defer
        -> valid sticky worker available: Ready(Exact)
        -> sticky worker temporarily overloaded: Defer without migration
        -> new session while any session is paused: Defer for fairness
@@ -39,7 +38,7 @@ AdmissionRequest
        -> otherwise: Defer
   -> router queue and selector
   -> Dispatched: commit the selected worker
-  -> Completed: store returned context size, mark Acting, apply deferred pause
+  -> Completed: store returned context size, become IdleResident, apply deferred suspension
   -> Aborted or pre-dispatch failure: restore the prior program snapshot
   -> promote the next request waiting for the same session
 ```
@@ -50,23 +49,23 @@ Worker eligibility is live. A deferred request retains `WorkerEligibility` and t
 
 Capacity is `total_kv_blocks * block_size + native_offloading_capacity_tokens` for each worker/rank. Workers with missing or zero device capacity are excluded from ThunderAgent capacity gating, with a one-time warning. If no worker reports usable metadata, capacity gating is disabled and requests continue through normal router selection.
 
-Only active programs with an assigned worker contribute usage:
+Only Running or IdleResident programs with an assigned worker contribute usage:
 
 ```text
 normal usage = program tokens + buffer_per_program
 ```
 
-Reasoning programs read their full logical context from the retained `RequestProgress` handle during admission and reconciliation. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative. Acting programs apply `acting_token_weight` during normal pressure and resume calculations.
+Running programs read their full logical context directly from the retained `RequestProgress` handle. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative. IdleResident programs apply `acting_token_weight` during normal pressure and resume calculations.
 
 This is a logical projection, not live engine or indexer residency.
 
-Completed sessions remain retained for `session_retention_seconds` (30 minutes by default). The clock resets after every successful turn. Once the retention lease expires, reconciliation removes an Acting session only when it has no current or waiting request. This approximates useful cache residence without requiring clients to emit a terminal signal; a later turn is treated as a new ThunderAgent program and still goes through normal KV-aware worker selection.
+Completed sessions remain retained for `session_retention_seconds` (30 minutes by default). The clock resets after every successful turn. Once the retention lease expires, reconciliation removes an IdleResident or Suspended session only when it has no current or waiting request. This approximates useful cache residence without requiring clients to emit a terminal signal; a later turn is treated as a new ThunderAgent program and still goes through normal KV-aware worker selection.
 
 ## Reconciliation algorithm
 
 Reconciliation runs no more often than `scheduler_interval_seconds` and always uses this order:
 
-1. Expire quiescent Acting sessions whose retention lease elapsed.
+1. Expire quiescent retained sessions whose retention lease elapsed.
 2. Greedy resume.
 3. Forced resume for timed-out sessions.
 4. Pause overloaded workers.
@@ -77,9 +76,9 @@ Resume-before-pause is intentional source behavior.
 
 The usable ceiling is `(pause_threshold - resume_hysteresis) * capacity`. Paused sessions are considered in these groups, then by increasing context size:
 
-1. Continuing Reasoning sessions after their first step.
+1. Continuing Running sessions after their first step.
 2. First-step sessions.
-3. Acting sessions.
+3. IdleResident sessions.
 
 Sessions that cannot fit an eligible worker are skipped. The remaining candidates are placed largest-context first onto the eligible worker with the most remaining capacity. Resuming a session with a deferred request emits `MakeReady`; resuming an idle session only changes its program state.
 
@@ -89,7 +88,7 @@ A session deferred for `resume_timeout_seconds` bypasses the normal fit test and
 
 ### Pause
 
-When a worker exceeds `pause_threshold * capacity`, ThunderAgent pauses the smallest Acting sessions until usage reaches `pause_target * capacity`. Reasoning sessions cannot be interrupted, so if Acting pauses are insufficient they are marked and become paused only after their current request completes.
+When a worker exceeds `pause_threshold * capacity`, ThunderAgent suspends the smallest IdleResident sessions until usage reaches `pause_target * capacity`. Running sessions cannot be interrupted, so if those suspensions are insufficient they are marked and become Suspended only after their current request completes.
 
 ## Primitive mapping
 
@@ -99,9 +98,9 @@ When a worker exceeds `pause_threshold * capacity`, ThunderAgent pauses the smal
 | Token accounting | Incoming and completed context sizes update one logical total per session. |
 | Block and resume | `Defer` keeps the request in the KV-router admission controller; `MakeReady` releases it. |
 | Retention capacity | Static device KV plus native-offload capacity from worker configuration. |
-| Pack and fairness | New-session fairness, grouped resume, largest-first placement, smallest-Acting pause, deferred Reasoning pause, hysteresis, and timeout. |
+| Pack and fairness | New-session fairness, grouped resume, largest-first placement, smallest-resident suspension, deferred Running suspension, hysteresis, and timeout. |
 | Sticky placement | `WorkerPlacement::Exact` preserves the selected worker/rank across turns. |
-| Session expiry | A quiescent Acting session is forgotten after `session_retention_seconds`; a later request starts a new program. |
+| Session expiry | A quiescent retained session is forgotten after `session_retention_seconds`; a later request starts a new program. |
 
 ## Invariants
 
@@ -112,7 +111,7 @@ When a worker exceeds `pause_threshold * capacity`, ThunderAgent pauses the smal
 - A request is released at most once.
 - Abort restores the exact program state that existed before admission.
 - Paused requests remain owned and accounted for by the KV-router queue, not this module.
-- Retention expiry never removes a Reasoning session or a session with a current or waiting request.
+- Retention expiry never removes a Running session or a session with a current or waiting request.
 
 ## Deliberately absent
 

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -49,8 +49,6 @@ Worker eligibility is live. A deferred request retains `WorkerEligibility` and t
 
 Capacity is `total_kv_blocks * block_size + native_offloading_capacity_tokens` for each worker/rank. Workers with missing or zero device capacity are excluded from ThunderAgent capacity gating, with a one-time warning. If no worker reports usable metadata, capacity gating is disabled and requests continue through normal router selection.
 
-Set `capacity_control: false` to retain session affinity and lifecycle tracking while disabling fit checks and pressure-driven suspend/resume. This is the affinity-only control for isolating whether capacity control earns its complexity.
-
 Only Running or IdleResident programs with an assigned worker contribute usage:
 
 ```text

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -55,7 +55,7 @@ Only Running or IdleResident programs with an assigned worker contribute usage:
 normal usage = program tokens + buffer_per_program
 ```
 
-Running programs read their full logical context directly from the retained `RequestProgress` handle. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative. IdleResident programs apply `acting_token_weight` during normal pressure and resume calculations.
+Running programs read their full logical context directly from the retained `RequestProgress` handle. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative.
 
 This is a logical projection, not live engine or indexer residency.
 

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -19,6 +19,19 @@ This module implements ThunderAgent as one `PolicyClassAdmissionStrategy`. It co
 | `session_retention_seconds` | `1800` | Retain quiescent placement and footprint state after the last successful turn. |
 | `scheduler_interval_seconds` | `5` | Minimum interval between reconciliation passes. |
 
+## Differences from upstream ThunderAgent
+
+The comparison target is `ThunderAgent-org/ThunderAgent` at `7ddc861027`, primarily `scheduler/router.py` and `backend/state.py`. This implementation retains upstream's global new-program fairness gate, smallest-ACTING-first and deferred-REASONING pause, three resume-priority groups, largest-first packing, and starvation timeout; the intentional differences are:
+
+| Change | Why |
+|---|---|
+| Require a stable `session_id`; bypass sessionless traffic instead of grouping it under a default program. | Identity is the working-set ownership key, and bypass keeps unrelated non-agent traffic out of ThunderAgent state. |
+| Preserve the assigned worker across normal pressure suspension; upstream clears the backend and BFD may resume elsewhere. Structural worker removal and the starvation timeout remain escape paths. | In the matched replay this removed 219 migrations, improved turns by 12.4%, and raised physical cache reuse by 2.26 percentage points. |
+| Trigger pressure at 0.95, drain to 0.80, and also use 0.80 as the resume ceiling; upstream pauses only after projected overflow and resumes against remaining capacity. | The proactive high/low pair avoids engine-cache saturation, while earlier pausing and a separate resume ceiling both lost throughput or reuse. |
+| Account exact live logical context from `RequestProgress` against device plus native-offload capacity; omit upstream's character estimate, shared-token discount, per-program buffer, ACTING weight, and optional decay. | Exact Dynamo observations remove interacting heuristics; the buffer ablation did not help, and no retained decision required decay or polled residency. |
+| Expire quiescent state after a 30-minute inactivity lease instead of requiring upstream's explicit `/programs/release` call. | Immediate terminal cleanup admitted too much live context and hurt reuse; the lease bounded retained state while matching or improving the no-expiry control. |
+| Encode only `Running`, `IdleResident`, and `Suspended`, with waiters and rollback owned by native queue admission. | This removes invalid status/lifecycle combinations and gives cancellation and same-session concurrency one authoritative owner without changing the retained pause/resume policy. |
+
 ## State model
 
 ThunderAgent keys state by `session_id`. The ID must remain stable across a trajectory's turns; a fresh per-request ID creates unrelated programs and defeats continuation admission and affinity.

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -9,9 +9,19 @@ This module implements ThunderAgent as one `PolicyClassAdmissionStrategy`. It co
 - `registration.rs` constructs the configured strategy for a policy class.
 - `strategy.rs` contains the session state machine, accounting, pause/resume policy, placement, and tests.
 
+## Current policy defaults
+
+| Field | Default | Role |
+|---|---:|---|
+| `pause_threshold` | `0.95` | Start pressure handling above this fraction of logical worker capacity. |
+| `pause_target` | `0.80` | Pause down to, and greedily resume up to, this fraction. There is no separate resume watermark. |
+| `resume_timeout_seconds` | `1800` | Bound starvation by releasing a timed-out request to normal worker selection. |
+| `session_retention_seconds` | `1800` | Retain quiescent placement and footprint state after the last successful turn. |
+| `scheduler_interval_seconds` | `5` | Minimum interval between reconciliation passes. |
+
 ## State model
 
-ThunderAgent keys state by `session_id`.
+ThunderAgent keys state by `session_id`. The ID must remain stable across a trajectory's turns; a fresh per-request ID creates unrelated programs and defeats continuation admission and affinity.
 
 Each retained program is in exactly one state:
 
@@ -32,8 +42,8 @@ AdmissionRequest
        -> suspended session: Defer
        -> valid sticky worker available: Ready(Exact)
        -> sticky worker temporarily overloaded: Defer without migration
-       -> new session while any session is paused: Defer for fairness
-       -> capacity unavailable: Ready(Any), letting the normal router fail open
+       -> new session while any session is suspended: Defer for fairness
+       -> no eligible worker has usable capacity metadata: Ready(Any), letting the normal router fail open
        -> enough projected capacity: Ready(Exact) on least-used eligible worker
        -> otherwise: Defer
   -> router queue and selector
@@ -74,17 +84,17 @@ Resume-before-pause is intentional source behavior.
 
 ### Greedy resume
 
-The usable ceiling is `pause_target * capacity`. Paused sessions are considered in these groups, then by increasing context size:
+The usable ceiling is `pause_target * capacity`. Suspended programs are considered in these groups, then by increasing context size:
 
-1. Continuing Running sessions after their first step.
-2. First-step sessions.
-3. IdleResident sessions.
+1. A waiting continuation after at least one completed turn.
+2. A first-step program, whether waiting or idle.
+3. An idle multi-step program with no waiting request.
 
 Sessions that cannot fit an eligible worker are skipped. The remaining candidates are placed largest-context first onto the eligible worker with the most remaining capacity. Resuming a session with a deferred request emits `MakeReady`; resuming an idle session only changes its program state.
 
 ### Forced resume
 
-A session deferred for `resume_timeout_seconds` bypasses the normal fit test and returns to normal worker selection. A session waiting only because all structurally valid workers are temporarily overloaded remains deferred.
+A current request suspended for `resume_timeout_seconds` bypasses the normal fit test, clears its assignment, and returns to normal worker selection with `WorkerPlacement::Any`. This is the starvation backstop and the only pressure-policy path that relaxes an otherwise structurally valid assignment. A session waiting only because every structurally valid worker is temporarily overloaded remains deferred.
 
 ### Pause
 
@@ -99,7 +109,7 @@ When a worker exceeds `pause_threshold * capacity`, ThunderAgent suspends the sm
 | Block and resume | `Defer` keeps the request in the KV-router admission controller; `MakeReady` releases it. |
 | Retention capacity | Static device KV plus native-offload capacity from worker configuration. |
 | Pack and fairness | New-session fairness, grouped resume, largest-first placement, smallest-resident suspension, deferred Running suspension, high/low watermarks, and timeout. |
-| Sticky placement | `WorkerPlacement::Exact` preserves the selected worker/rank across turns. |
+| Sticky placement | `WorkerPlacement::Exact` preserves the selected worker/rank across turns and pressure suspension. Structural worker removal or the starvation timeout can clear it. |
 | Session expiry | A quiescent retained session is forgotten after `session_retention_seconds`; a later request starts a new program. |
 
 ## Invariants
@@ -107,10 +117,10 @@ When a worker exceeds `pause_threshold * capacity`, ThunderAgent suspends the sm
 - Sessionless requests allocate no ThunderAgent state.
 - At most one request per session mutates program state at a time.
 - Placement never widens the request's router-owned eligibility.
-- Temporary overload does not silently migrate a sticky session.
+- Temporary overload does not migrate a sticky session before the configured starvation timeout.
 - A request is released at most once.
 - Abort restores the exact program state that existed before admission.
-- Paused requests remain owned and accounted for by the KV-router queue, not this module.
+- Deferred requests remain owned and accounted for by the KV-router queue, not this module.
 - Retention expiry never removes a Running session or a session with a current or waiting request.
 
 ## Deliberately absent

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -52,7 +52,7 @@ Capacity is `total_kv_blocks * block_size + native_offloading_capacity_tokens` f
 Only Running or IdleResident programs with an assigned worker contribute usage:
 
 ```text
-normal usage = program tokens + buffer_per_program
+normal usage = program tokens
 ```
 
 Running programs read their full logical context directly from the retained `RequestProgress` handle. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative.

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -49,6 +49,8 @@ Worker eligibility is live. A deferred request retains `WorkerEligibility` and t
 
 Capacity is `total_kv_blocks * block_size + native_offloading_capacity_tokens` for each worker/rank. Workers with missing or zero device capacity are excluded from ThunderAgent capacity gating, with a one-time warning. If no worker reports usable metadata, capacity gating is disabled and requests continue through normal router selection.
 
+Set `capacity_control: false` to retain session affinity and lifecycle tracking while disabling fit checks and pressure-driven suspend/resume. This is the affinity-only control for isolating whether capacity control earns its complexity.
+
 Only Running or IdleResident programs with an assigned worker contribute usage:
 
 ```text

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -1,0 +1,133 @@
+# ThunderAgent admission strategy
+
+This module implements ThunderAgent as one `PolicyClassAdmissionStrategy`. It controls whether a session's next request may enter the normal ready queue and, when ready, whether it must return to a specific worker. It does not own the queue, select the final worker, or communicate with engines.
+
+## Files
+
+- `capacity.rs` converts worker runtime configuration into per-worker/rank token capacity.
+- `config.rs` defines and validates ThunderAgent's tuning parameters.
+- `registration.rs` constructs the configured strategy for a policy class.
+- `strategy.rs` contains the session state machine, accounting, pause/resume policy, placement, and tests.
+
+## State model
+
+ThunderAgent keys state by `session_id`.
+
+Each program has two independent state dimensions:
+
+- `Reasoning`: a request is admitted or running. It cannot be paused mid-request.
+- `Acting`: the previous request completed and the agent is between turns.
+- `Active`: its logical KV footprint counts against an assigned worker.
+- `Paused`: it has no reservation or assigned worker; a returning request remains deferred until resume.
+
+`RequestState` records the admission ID, initial context size, live request-progress and worker-eligibility handles, dispatch status, and the prior program snapshot used for rollback. `SessionRequests` serializes concurrent requests for one session: one current request and an ordered waiter set.
+
+## Request flow
+
+```text
+AdmissionRequest
+  -> no session_id: Bypass
+  -> another request for the session is current: Defer as a session waiter
+  -> begin request
+       -> update logical context and mark Reasoning
+       -> paused session: Defer
+       -> valid sticky worker available: Ready(Exact)
+       -> sticky worker temporarily overloaded: Defer without migration
+       -> new session while any session is paused: Defer for fairness
+       -> capacity unavailable: Ready(Any), letting the normal router fail open
+       -> enough projected capacity: Ready(Exact) on least-used eligible worker
+       -> otherwise: Defer
+  -> router queue and selector
+  -> Dispatched: commit the selected worker
+  -> Completed: store returned context size, mark Acting, apply deferred pause
+  -> Aborted or pre-dispatch failure: restore the prior program snapshot
+  -> promote the next request waiting for the same session
+```
+
+Worker eligibility is live. A deferred request retains `WorkerEligibility` and takes a fresh snapshot during reconciliation, so worker churn and transient overload do not require copied router state.
+
+## Logical capacity accounting
+
+Capacity is `total_kv_blocks * block_size + native_offloading_capacity_tokens` for each worker/rank. Workers with missing or zero device capacity are excluded from ThunderAgent capacity gating, with a one-time warning. If no worker reports usable metadata, capacity gating is disabled and requests continue through normal router selection.
+
+Only active programs with an assigned worker contribute usage:
+
+```text
+normal usage = program tokens + buffer_per_program
+```
+
+Reasoning programs read their full logical context from the retained `RequestProgress` handle during admission and reconciliation. The response path updates that handle with one relaxed atomic operation and sends no per-output actor event. Completion remains authoritative. Acting programs apply `acting_token_weight` during normal pressure and resume calculations. A separate exponentially decayed Acting value is used only when choosing placement after `resume_timeout_seconds`:
+
+```text
+decayed tokens = token_total * 2^(-idle_seconds / acting_decay_tau_seconds)
+```
+
+This is a logical projection, not live engine or indexer residency.
+
+Completed sessions remain retained for `session_retention_seconds` (30 minutes by default). The clock resets after every successful turn. Once the retention lease expires, reconciliation removes an Acting session only when it has no current or waiting request. This approximates useful cache residence without requiring clients to emit a terminal signal; a later turn is treated as a new ThunderAgent program and still goes through normal KV-aware worker selection.
+
+## Reconciliation algorithm
+
+Reconciliation runs no more often than `scheduler_interval_seconds` and always uses this order:
+
+1. Expire quiescent Acting sessions whose retention lease elapsed.
+2. Greedy resume.
+3. Forced resume for timed-out sessions.
+4. Pause overloaded workers.
+
+Resume-before-pause is intentional source behavior.
+
+### Greedy resume
+
+The usable ceiling is `(pause_threshold - resume_hysteresis) * capacity`. Paused sessions are considered in these groups, then by increasing context size:
+
+1. Continuing Reasoning sessions after their first step.
+2. First-step sessions.
+3. Acting sessions.
+
+Sessions that cannot fit an eligible worker are skipped. The remaining candidates are placed largest-context first onto the eligible worker with the most remaining capacity. Resuming a session with a deferred request emits `MakeReady`; resuming an idle session only changes its program state.
+
+### Forced resume
+
+A session deferred for `resume_timeout_seconds` bypasses the normal fit test. It is placed on the eligible worker with the greatest `capacity - decayed_usage`. A session waiting only because all structurally valid workers are temporarily overloaded remains deferred.
+
+### Pause
+
+When a worker exceeds `pause_threshold * capacity`, ThunderAgent pauses the smallest Acting sessions until usage reaches `pause_target * capacity`. Reasoning sessions cannot be interrupted, so if Acting pauses are insufficient they are marked and become paused only after their current request completes.
+
+## Primitive mapping
+
+| Primitive | Current implementation |
+|---|---|
+| Session identity | `AdmissionRequest::session_id` keys program and request state. |
+| Token accounting | Incoming and completed context sizes update one logical total per session. |
+| Block and resume | `Defer` keeps the request in the KV-router admission controller; `MakeReady` releases it. |
+| Retention capacity | Static device KV plus native-offload capacity from worker configuration. |
+| Pack and fairness | New-session fairness, grouped resume, largest-first placement, smallest-Acting pause, deferred Reasoning pause, hysteresis, and timeout. |
+| Sticky placement | `WorkerPlacement::Exact` preserves the selected worker/rank across turns. |
+| Session expiry | A quiescent Acting session is forgotten after `session_retention_seconds`; a later request starts a new program. |
+
+## Invariants
+
+- Sessionless requests allocate no ThunderAgent state.
+- At most one request per session mutates program state at a time.
+- Placement never widens the request's router-owned eligibility.
+- Temporary overload does not silently migrate a sticky session.
+- A request is released at most once.
+- Abort restores the exact program state that existed before admission.
+- Paused requests remain owned and accounted for by the KV-router queue, not this module.
+- Retention expiry never removes a Reasoning session or a session with a current or waiting request.
+
+## Deliberately absent
+
+- Live indexer/cache residency queries.
+- Client-driven session-final cleanup; inactivity retention is the lifecycle mechanism.
+- In-flight decode preemption or migration.
+- Soft KV demotion, prefetch, or retention actions.
+- Separate plug-ins for accounting, pressure, victim selection, packing, decay, or placement.
+
+Add these only when an algorithm requiring them is being implemented and measured.
+
+## Validation
+
+Run `cargo test -p dynamo-admission-control`. The tests in `strategy.rs` cover admission, serialization, eligibility changes, pause/resume ordering, timeout, dispatch/abort rollback, and token accounting.

--- a/lib/admission-control/src/thunderagent/CLAUDE.md
+++ b/lib/admission-control/src/thunderagent/CLAUDE.md
@@ -74,7 +74,7 @@ Resume-before-pause is intentional source behavior.
 
 ### Greedy resume
 
-The usable ceiling is `(pause_threshold - resume_hysteresis) * capacity`. Paused sessions are considered in these groups, then by increasing context size:
+The usable ceiling is `pause_target * capacity`. Paused sessions are considered in these groups, then by increasing context size:
 
 1. Continuing Running sessions after their first step.
 2. First-step sessions.
@@ -98,7 +98,7 @@ When a worker exceeds `pause_threshold * capacity`, ThunderAgent suspends the sm
 | Token accounting | Incoming and completed context sizes update one logical total per session. |
 | Block and resume | `Defer` keeps the request in the KV-router admission controller; `MakeReady` releases it. |
 | Retention capacity | Static device KV plus native-offload capacity from worker configuration. |
-| Pack and fairness | New-session fairness, grouped resume, largest-first placement, smallest-resident suspension, deferred Running suspension, hysteresis, and timeout. |
+| Pack and fairness | New-session fairness, grouped resume, largest-first placement, smallest-resident suspension, deferred Running suspension, high/low watermarks, and timeout. |
 | Sticky placement | `WorkerPlacement::Exact` preserves the selected worker/rank across turns. |
 | Session expiry | A quiescent retained session is forgotten after `session_retention_seconds`; a later request starts a new program. |
 

--- a/lib/admission-control/src/thunderagent/capacity.rs
+++ b/lib/admission-control/src/thunderagent/capacity.rs
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use dynamo_kv_router::protocols::{WorkerConfigLike, WorkerId, WorkerWithDpRank};
+use tokio::sync::watch;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkerCapacity {
+    pub worker: WorkerWithDpRank,
+    pub tokens: usize,
+}
+
+pub trait WorkerCapacityProvider: Send {
+    fn snapshot(&mut self) -> Arc<[WorkerCapacity]>;
+}
+
+impl<F> WorkerCapacityProvider for F
+where
+    F: FnMut() -> Vec<WorkerCapacity> + Send,
+{
+    fn snapshot(&mut self) -> Arc<[WorkerCapacity]> {
+        self().into()
+    }
+}
+
+pub struct WatchWorkerCapacity<C> {
+    workers: watch::Receiver<HashMap<WorkerId, C>>,
+    block_size: u32,
+    cached: Option<Arc<[WorkerCapacity]>>,
+    warned_missing_capacity: bool,
+}
+
+impl<C> WatchWorkerCapacity<C> {
+    pub fn new(workers: watch::Receiver<HashMap<WorkerId, C>>, block_size: u32) -> Self {
+        Self {
+            workers,
+            block_size,
+            cached: None,
+            warned_missing_capacity: false,
+        }
+    }
+}
+
+impl<C> WorkerCapacityProvider for WatchWorkerCapacity<C>
+where
+    C: WorkerConfigLike + Send + Sync,
+{
+    fn snapshot(&mut self) -> Arc<[WorkerCapacity]> {
+        if let Some(cached) = &self.cached
+            && !self.workers.has_changed().unwrap_or(false)
+        {
+            return Arc::clone(cached);
+        }
+
+        let workers = self.workers.borrow_and_update();
+        let mut capacities = Vec::new();
+        let mut missing_capacity_workers = 0;
+        for (&worker_id, config) in workers.iter() {
+            let Some(blocks) = config.total_kv_blocks() else {
+                missing_capacity_workers += 1;
+                continue;
+            };
+            if blocks == 0 {
+                missing_capacity_workers += 1;
+                continue;
+            }
+            let tokens = blocks
+                .saturating_mul(u64::from(self.block_size))
+                .saturating_add(config.native_offloading_capacity_tokens().unwrap_or(0));
+            let tokens = usize::try_from(tokens).unwrap_or(usize::MAX);
+            let start = config.data_parallel_start_rank();
+            let end = start.saturating_add(config.data_parallel_size());
+            capacities.extend((start..end).map(|dp_rank| WorkerCapacity {
+                worker: WorkerWithDpRank::new(worker_id, dp_rank),
+                tokens,
+            }));
+        }
+        if missing_capacity_workers > 0 && !self.warned_missing_capacity {
+            tracing::warn!(
+                worker_count = workers.len(),
+                missing_capacity_workers,
+                "ThunderAgent capacity gating excludes workers without usable KV capacity"
+            );
+            self.warned_missing_capacity = true;
+        }
+        capacities.sort_unstable_by_key(|capacity| capacity.worker);
+        let capacities = Arc::from(capacities);
+        self.cached = Some(Arc::clone(&capacities));
+        capacities
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    struct Config;
+
+    impl WorkerConfigLike for Config {
+        fn data_parallel_start_rank(&self) -> u32 {
+            2
+        }
+
+        fn data_parallel_size(&self) -> u32 {
+            2
+        }
+
+        fn max_num_batched_tokens(&self) -> Option<u64> {
+            None
+        }
+
+        fn total_kv_blocks(&self) -> Option<u64> {
+            Some(10)
+        }
+
+        fn native_offloading_capacity_tokens(&self) -> Option<u64> {
+            Some(7)
+        }
+
+        fn taints(&self) -> &HashSet<String> {
+            static EMPTY: std::sync::LazyLock<HashSet<String>> =
+                std::sync::LazyLock::new(HashSet::new);
+            &EMPTY
+        }
+    }
+
+    struct ZeroConfig;
+
+    impl WorkerConfigLike for ZeroConfig {
+        fn data_parallel_start_rank(&self) -> u32 {
+            0
+        }
+
+        fn data_parallel_size(&self) -> u32 {
+            1
+        }
+
+        fn max_num_batched_tokens(&self) -> Option<u64> {
+            None
+        }
+
+        fn total_kv_blocks(&self) -> Option<u64> {
+            Some(0)
+        }
+
+        fn native_offloading_capacity_tokens(&self) -> Option<u64> {
+            Some(1_000)
+        }
+
+        fn taints(&self) -> &HashSet<String> {
+            static EMPTY: std::sync::LazyLock<HashSet<String>> =
+                std::sync::LazyLock::new(HashSet::new);
+            &EMPTY
+        }
+    }
+
+    #[test]
+    fn watch_provider_expands_dp_ranks_and_offload_capacity() {
+        let (_tx, rx) = watch::channel(HashMap::from([(11, Config)]));
+        let mut provider = WatchWorkerCapacity::new(rx, 16);
+        assert_eq!(
+            provider.snapshot().as_ref(),
+            &[
+                WorkerCapacity {
+                    worker: WorkerWithDpRank::new(11, 2),
+                    tokens: 167,
+                },
+                WorkerCapacity {
+                    worker: WorkerWithDpRank::new(11, 3),
+                    tokens: 167,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn watch_provider_treats_zero_kv_blocks_as_missing_capacity() {
+        let (_tx, rx) = watch::channel(HashMap::from([(11, ZeroConfig)]));
+        let mut provider = WatchWorkerCapacity::new(rx, 16);
+        assert!(provider.snapshot().is_empty());
+        assert!(provider.warned_missing_capacity);
+    }
+}

--- a/lib/admission-control/src/thunderagent/capacity.rs
+++ b/lib/admission-control/src/thunderagent/capacity.rs
@@ -29,15 +29,21 @@ where
 pub struct WatchWorkerCapacity<C> {
     workers: watch::Receiver<HashMap<WorkerId, C>>,
     block_size: u32,
+    enabled: bool,
     cached: Option<Arc<[WorkerCapacity]>>,
     warned_missing_capacity: bool,
 }
 
 impl<C> WatchWorkerCapacity<C> {
-    pub fn new(workers: watch::Receiver<HashMap<WorkerId, C>>, block_size: u32) -> Self {
+    pub fn new(
+        workers: watch::Receiver<HashMap<WorkerId, C>>,
+        block_size: u32,
+        enabled: bool,
+    ) -> Self {
         Self {
             workers,
             block_size,
+            enabled,
             cached: None,
             warned_missing_capacity: false,
         }
@@ -49,6 +55,9 @@ where
     C: WorkerConfigLike + Send + Sync,
 {
     fn snapshot(&mut self) -> Arc<[WorkerCapacity]> {
+        if !self.enabled {
+            return Arc::default();
+        }
         if let Some(cached) = &self.cached
             && !self.workers.has_changed().unwrap_or(false)
         {
@@ -162,7 +171,7 @@ mod tests {
     #[test]
     fn watch_provider_expands_dp_ranks_and_offload_capacity() {
         let (_tx, rx) = watch::channel(HashMap::from([(11, Config)]));
-        let mut provider = WatchWorkerCapacity::new(rx, 16);
+        let mut provider = WatchWorkerCapacity::new(rx, 16, true);
         assert_eq!(
             provider.snapshot().as_ref(),
             &[
@@ -181,8 +190,15 @@ mod tests {
     #[test]
     fn watch_provider_treats_zero_kv_blocks_as_missing_capacity() {
         let (_tx, rx) = watch::channel(HashMap::from([(11, ZeroConfig)]));
-        let mut provider = WatchWorkerCapacity::new(rx, 16);
+        let mut provider = WatchWorkerCapacity::new(rx, 16, true);
         assert!(provider.snapshot().is_empty());
         assert!(provider.warned_missing_capacity);
+    }
+
+    #[test]
+    fn disabled_provider_hides_capacity() {
+        let (_tx, rx) = watch::channel(HashMap::from([(11, Config)]));
+        let mut provider = WatchWorkerCapacity::new(rx, 16, false);
+        assert!(provider.snapshot().is_empty());
     }
 }

--- a/lib/admission-control/src/thunderagent/capacity.rs
+++ b/lib/admission-control/src/thunderagent/capacity.rs
@@ -29,21 +29,15 @@ where
 pub struct WatchWorkerCapacity<C> {
     workers: watch::Receiver<HashMap<WorkerId, C>>,
     block_size: u32,
-    enabled: bool,
     cached: Option<Arc<[WorkerCapacity]>>,
     warned_missing_capacity: bool,
 }
 
 impl<C> WatchWorkerCapacity<C> {
-    pub fn new(
-        workers: watch::Receiver<HashMap<WorkerId, C>>,
-        block_size: u32,
-        enabled: bool,
-    ) -> Self {
+    pub fn new(workers: watch::Receiver<HashMap<WorkerId, C>>, block_size: u32) -> Self {
         Self {
             workers,
             block_size,
-            enabled,
             cached: None,
             warned_missing_capacity: false,
         }
@@ -55,9 +49,6 @@ where
     C: WorkerConfigLike + Send + Sync,
 {
     fn snapshot(&mut self) -> Arc<[WorkerCapacity]> {
-        if !self.enabled {
-            return Arc::default();
-        }
         if let Some(cached) = &self.cached
             && !self.workers.has_changed().unwrap_or(false)
         {
@@ -171,7 +162,7 @@ mod tests {
     #[test]
     fn watch_provider_expands_dp_ranks_and_offload_capacity() {
         let (_tx, rx) = watch::channel(HashMap::from([(11, Config)]));
-        let mut provider = WatchWorkerCapacity::new(rx, 16, true);
+        let mut provider = WatchWorkerCapacity::new(rx, 16);
         assert_eq!(
             provider.snapshot().as_ref(),
             &[
@@ -190,15 +181,8 @@ mod tests {
     #[test]
     fn watch_provider_treats_zero_kv_blocks_as_missing_capacity() {
         let (_tx, rx) = watch::channel(HashMap::from([(11, ZeroConfig)]));
-        let mut provider = WatchWorkerCapacity::new(rx, 16, true);
+        let mut provider = WatchWorkerCapacity::new(rx, 16);
         assert!(provider.snapshot().is_empty());
         assert!(provider.warned_missing_capacity);
-    }
-
-    #[test]
-    fn disabled_provider_hides_capacity() {
-        let (_tx, rx) = watch::channel(HashMap::from([(11, Config)]));
-        let mut provider = WatchWorkerCapacity::new(rx, 16, false);
-        assert!(provider.snapshot().is_empty());
     }
 }

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -24,7 +24,6 @@ pub struct ThunderAgentConfig {
     pub resume_timeout_seconds: f64,
     pub session_retention_seconds: f64,
     pub scheduler_interval_seconds: f64,
-    pub acting_token_weight: f64,
     pub buffer_per_program: usize,
 }
 
@@ -37,7 +36,6 @@ impl Default for ThunderAgentConfig {
             resume_timeout_seconds: 1_800.0,
             session_retention_seconds: 1_800.0,
             scheduler_interval_seconds: 5.0,
-            acting_token_weight: 1.0,
             buffer_per_program: 100,
         }
     }
@@ -81,11 +79,6 @@ impl ThunderAgentConfig {
             self.scheduler_interval_seconds,
             "scheduler_interval_seconds must be a positive duration",
         )?;
-        if !self.acting_token_weight.is_finite() || self.acting_token_weight <= 0.0 {
-            return Err(ConfigError::Invalid(
-                "acting_token_weight must be finite and positive",
-            ));
-        }
         Ok(())
     }
 }
@@ -142,10 +135,6 @@ mod tests {
             },
             ThunderAgentConfig {
                 session_retention_seconds: 0.0,
-                ..Default::default()
-            },
-            ThunderAgentConfig {
-                acting_token_weight: 0.0,
                 ..Default::default()
             },
             ThunderAgentConfig {

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -24,7 +24,6 @@ pub struct ThunderAgentConfig {
     pub resume_timeout_seconds: f64,
     pub session_retention_seconds: f64,
     pub scheduler_interval_seconds: f64,
-    pub buffer_per_program: usize,
 }
 
 impl Default for ThunderAgentConfig {
@@ -36,7 +35,6 @@ impl Default for ThunderAgentConfig {
             resume_timeout_seconds: 1_800.0,
             session_retention_seconds: 1_800.0,
             scheduler_interval_seconds: 5.0,
-            buffer_per_program: 100,
         }
     }
 }

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -18,6 +18,7 @@ pub enum ConfigError {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ThunderAgentConfig {
+    pub capacity_control: bool,
     pub pause_threshold: f64,
     pub pause_target: f64,
     pub resume_hysteresis: f64,
@@ -31,6 +32,7 @@ pub struct ThunderAgentConfig {
 impl Default for ThunderAgentConfig {
     fn default() -> Self {
         Self {
+            capacity_control: true,
             pause_threshold: 0.95,
             pause_target: 0.80,
             resume_hysteresis: 0.10,
@@ -112,12 +114,13 @@ mod tests {
     #[test]
     fn options_use_defaults_and_reject_unknown_fields() {
         let options = serde_yaml::from_str::<Mapping>(
-            "pause_threshold: 0.7\npause_target: 0.6\nresume_hysteresis: 0.05",
+            "capacity_control: false\npause_threshold: 0.7\npause_target: 0.6\nresume_hysteresis: 0.05",
         )
         .unwrap();
         let config = ThunderAgentConfig::from_options(&options).unwrap();
         assert_eq!(config.pause_threshold, 0.7);
         assert_eq!(config.pause_target, 0.6);
+        assert!(!config.capacity_control);
         assert_eq!(config.session_retention_seconds, 1_800.0);
 
         let unknown = serde_yaml::from_str::<Mapping>("unknown: 1").unwrap();

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -25,7 +25,6 @@ pub struct ThunderAgentConfig {
     pub session_retention_seconds: f64,
     pub scheduler_interval_seconds: f64,
     pub acting_token_weight: f64,
-    pub acting_decay_tau_seconds: f64,
     pub buffer_per_program: usize,
 }
 
@@ -39,7 +38,6 @@ impl Default for ThunderAgentConfig {
             session_retention_seconds: 1_800.0,
             scheduler_interval_seconds: 5.0,
             acting_token_weight: 1.0,
-            acting_decay_tau_seconds: 1.0,
             buffer_per_program: 100,
         }
     }
@@ -86,11 +84,6 @@ impl ThunderAgentConfig {
         if !self.acting_token_weight.is_finite() || self.acting_token_weight <= 0.0 {
             return Err(ConfigError::Invalid(
                 "acting_token_weight must be finite and positive",
-            ));
-        }
-        if !self.acting_decay_tau_seconds.is_finite() || self.acting_decay_tau_seconds <= 0.0 {
-            return Err(ConfigError::Invalid(
-                "acting_decay_tau_seconds must be finite and positive",
             ));
         }
         Ok(())

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -18,7 +18,6 @@ pub enum ConfigError {
 #[derive(Debug, Clone, PartialEq, Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct ThunderAgentConfig {
-    pub capacity_control: bool,
     pub pause_threshold: f64,
     pub pause_target: f64,
     pub resume_hysteresis: f64,
@@ -32,7 +31,6 @@ pub struct ThunderAgentConfig {
 impl Default for ThunderAgentConfig {
     fn default() -> Self {
         Self {
-            capacity_control: true,
             pause_threshold: 0.95,
             pause_target: 0.80,
             resume_hysteresis: 0.10,
@@ -114,13 +112,12 @@ mod tests {
     #[test]
     fn options_use_defaults_and_reject_unknown_fields() {
         let options = serde_yaml::from_str::<Mapping>(
-            "capacity_control: false\npause_threshold: 0.7\npause_target: 0.6\nresume_hysteresis: 0.05",
+            "pause_threshold: 0.7\npause_target: 0.6\nresume_hysteresis: 0.05",
         )
         .unwrap();
         let config = ThunderAgentConfig::from_options(&options).unwrap();
         assert_eq!(config.pause_threshold, 0.7);
         assert_eq!(config.pause_target, 0.6);
-        assert!(!config.capacity_control);
         assert_eq!(config.session_retention_seconds, 1_800.0);
 
         let unknown = serde_yaml::from_str::<Mapping>("unknown: 1").unwrap();

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_yaml::{Mapping, Value};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ConfigError {
+    #[error("invalid ThunderAgent configuration: {0}")]
+    Invalid(&'static str),
+    #[error("failed to parse ThunderAgent configuration: {0}")]
+    Parse(#[from] serde_yaml::Error),
+}
+
+#[derive(Debug, Clone, PartialEq, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct ThunderAgentConfig {
+    pub pause_threshold: f64,
+    pub pause_target: f64,
+    pub resume_hysteresis: f64,
+    pub resume_timeout_seconds: f64,
+    pub session_retention_seconds: f64,
+    pub scheduler_interval_seconds: f64,
+    pub acting_token_weight: f64,
+    pub acting_decay_tau_seconds: f64,
+    pub buffer_per_program: usize,
+}
+
+impl Default for ThunderAgentConfig {
+    fn default() -> Self {
+        Self {
+            pause_threshold: 0.95,
+            pause_target: 0.80,
+            resume_hysteresis: 0.10,
+            resume_timeout_seconds: 1_800.0,
+            session_retention_seconds: 1_800.0,
+            scheduler_interval_seconds: 5.0,
+            acting_token_weight: 1.0,
+            acting_decay_tau_seconds: 1.0,
+            buffer_per_program: 100,
+        }
+    }
+}
+
+impl ThunderAgentConfig {
+    pub fn from_options(options: &Mapping) -> Result<Self, ConfigError> {
+        let config: Self = serde_yaml::from_value(Value::Mapping(options.clone()))?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    pub fn validate(&self) -> Result<(), ConfigError> {
+        validate_fraction(self.pause_threshold, "pause_threshold must be in [0, 1]")?;
+        validate_fraction(self.pause_target, "pause_target must be in [0, 1]")?;
+        if self.pause_target > self.pause_threshold {
+            return Err(ConfigError::Invalid(
+                "pause_target must not exceed pause_threshold",
+            ));
+        }
+        if !self.resume_hysteresis.is_finite()
+            || self.resume_hysteresis < 0.0
+            || self.resume_hysteresis > 1.0
+        {
+            return Err(ConfigError::Invalid("resume_hysteresis must be in [0, 1]"));
+        }
+        if self.resume_hysteresis > self.pause_threshold {
+            return Err(ConfigError::Invalid(
+                "resume_hysteresis must not exceed pause_threshold",
+            ));
+        }
+        validate_positive_duration(
+            self.resume_timeout_seconds,
+            "resume_timeout_seconds must be a positive duration",
+        )?;
+        validate_positive_duration(
+            self.session_retention_seconds,
+            "session_retention_seconds must be a positive duration",
+        )?;
+        validate_positive_duration(
+            self.scheduler_interval_seconds,
+            "scheduler_interval_seconds must be a positive duration",
+        )?;
+        if !self.acting_token_weight.is_finite() || self.acting_token_weight <= 0.0 {
+            return Err(ConfigError::Invalid(
+                "acting_token_weight must be finite and positive",
+            ));
+        }
+        if !self.acting_decay_tau_seconds.is_finite() || self.acting_decay_tau_seconds <= 0.0 {
+            return Err(ConfigError::Invalid(
+                "acting_decay_tau_seconds must be finite and positive",
+            ));
+        }
+        Ok(())
+    }
+}
+
+fn validate_fraction(value: f64, message: &'static str) -> Result<(), ConfigError> {
+    if value.is_finite() && (0.0..=1.0).contains(&value) {
+        Ok(())
+    } else {
+        Err(ConfigError::Invalid(message))
+    }
+}
+
+fn validate_positive_duration(value: f64, message: &'static str) -> Result<(), ConfigError> {
+    match Duration::try_from_secs_f64(value) {
+        Ok(duration) if !duration.is_zero() => Ok(()),
+        _ => Err(ConfigError::Invalid(message)),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn options_use_defaults_and_reject_unknown_fields() {
+        let options = serde_yaml::from_str::<Mapping>(
+            "pause_threshold: 0.7\npause_target: 0.6\nresume_hysteresis: 0.05",
+        )
+        .unwrap();
+        let config = ThunderAgentConfig::from_options(&options).unwrap();
+        assert_eq!(config.pause_threshold, 0.7);
+        assert_eq!(config.pause_target, 0.6);
+        assert_eq!(config.session_retention_seconds, 1_800.0);
+
+        let unknown = serde_yaml::from_str::<Mapping>("unknown: 1").unwrap();
+        assert!(ThunderAgentConfig::from_options(&unknown).is_err());
+    }
+
+    #[test]
+    fn rejects_inconsistent_or_zero_control_values() {
+        for config in [
+            ThunderAgentConfig {
+                pause_threshold: 0.7,
+                pause_target: 0.8,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                resume_hysteresis: 0.96,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                resume_timeout_seconds: 0.0,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                session_retention_seconds: 0.0,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                acting_token_weight: 0.0,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                scheduler_interval_seconds: 0.0,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                scheduler_interval_seconds: 1e-20,
+                ..Default::default()
+            },
+            ThunderAgentConfig {
+                resume_timeout_seconds: 1e-20,
+                ..Default::default()
+            },
+        ] {
+            assert!(config.validate().is_err());
+        }
+    }
+}

--- a/lib/admission-control/src/thunderagent/config.rs
+++ b/lib/admission-control/src/thunderagent/config.rs
@@ -20,7 +20,6 @@ pub enum ConfigError {
 pub struct ThunderAgentConfig {
     pub pause_threshold: f64,
     pub pause_target: f64,
-    pub resume_hysteresis: f64,
     pub resume_timeout_seconds: f64,
     pub session_retention_seconds: f64,
     pub scheduler_interval_seconds: f64,
@@ -31,7 +30,6 @@ impl Default for ThunderAgentConfig {
         Self {
             pause_threshold: 0.95,
             pause_target: 0.80,
-            resume_hysteresis: 0.10,
             resume_timeout_seconds: 1_800.0,
             session_retention_seconds: 1_800.0,
             scheduler_interval_seconds: 5.0,
@@ -52,17 +50,6 @@ impl ThunderAgentConfig {
         if self.pause_target > self.pause_threshold {
             return Err(ConfigError::Invalid(
                 "pause_target must not exceed pause_threshold",
-            ));
-        }
-        if !self.resume_hysteresis.is_finite()
-            || self.resume_hysteresis < 0.0
-            || self.resume_hysteresis > 1.0
-        {
-            return Err(ConfigError::Invalid("resume_hysteresis must be in [0, 1]"));
-        }
-        if self.resume_hysteresis > self.pause_threshold {
-            return Err(ConfigError::Invalid(
-                "resume_hysteresis must not exceed pause_threshold",
             ));
         }
         validate_positive_duration(
@@ -102,10 +89,8 @@ mod tests {
 
     #[test]
     fn options_use_defaults_and_reject_unknown_fields() {
-        let options = serde_yaml::from_str::<Mapping>(
-            "pause_threshold: 0.7\npause_target: 0.6\nresume_hysteresis: 0.05",
-        )
-        .unwrap();
+        let options =
+            serde_yaml::from_str::<Mapping>("pause_threshold: 0.7\npause_target: 0.6").unwrap();
         let config = ThunderAgentConfig::from_options(&options).unwrap();
         assert_eq!(config.pause_threshold, 0.7);
         assert_eq!(config.pause_target, 0.6);
@@ -121,10 +106,6 @@ mod tests {
             ThunderAgentConfig {
                 pause_threshold: 0.7,
                 pause_target: 0.8,
-                ..Default::default()
-            },
-            ThunderAgentConfig {
-                resume_hysteresis: 0.96,
                 ..Default::default()
             },
             ThunderAgentConfig {

--- a/lib/admission-control/src/thunderagent/mod.rs
+++ b/lib/admission-control/src/thunderagent/mod.rs
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+mod capacity;
+mod config;
+mod registration;
+mod strategy;
+
+pub use capacity::{WatchWorkerCapacity, WorkerCapacity, WorkerCapacityProvider};
+pub use config::{ConfigError, ThunderAgentConfig};
+pub use registration::{RegistrationError, register_builtin_strategies, strategy_recheck_interval};
+pub use strategy::ThunderAgent;
+
+pub const STRATEGY_NAME: &str = "session_aware";

--- a/lib/admission-control/src/thunderagent/mod.rs
+++ b/lib/admission-control/src/thunderagent/mod.rs
@@ -8,7 +8,7 @@ mod strategy;
 
 pub use capacity::{WatchWorkerCapacity, WorkerCapacity, WorkerCapacityProvider};
 pub use config::{ConfigError, ThunderAgentConfig};
-pub use registration::{RegistrationError, register_builtin_strategies, strategy_recheck_interval};
+pub use registration::{RegistrationError, register_builtin_strategies};
 pub use strategy::ThunderAgent;
 
 pub const STRATEGY_NAME: &str = "session_aware";

--- a/lib/admission-control/src/thunderagent/registration.rs
+++ b/lib/admission-control/src/thunderagent/registration.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::time::Duration;
 
 use dynamo_kv_router::RouterQueuePolicy;
 use dynamo_kv_router::protocols::{WorkerConfigLike, WorkerId};
@@ -27,8 +26,6 @@ pub enum RegistrationError {
     MultipleThunderAgentClasses { first: String, second: String },
     #[error(transparent)]
     ThunderAgentConfig(#[from] ConfigError),
-    #[error("admission strategy reconcile interval must be positive")]
-    ZeroReconcileInterval,
 }
 
 /// Register configured built-in strategies without replacing caller-provided ones.
@@ -76,24 +73,10 @@ where
     Ok(())
 }
 
-pub fn strategy_recheck_interval(
-    strategies: &PolicyClassAdmissionStrategies,
-) -> Result<Option<Duration>, RegistrationError> {
-    let mut minimum = None;
-    for interval in strategies
-        .values()
-        .filter_map(|strategy| strategy.reconcile_interval())
-    {
-        if interval.is_zero() {
-            return Err(RegistrationError::ZeroReconcileInterval);
-        }
-        minimum = Some(minimum.map_or(interval, |current: Duration| current.min(interval)));
-    }
-    Ok(minimum)
-}
-
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use super::*;
     use dynamo_kv_router::scheduling::{
         AdmissionDecision, AdmissionRequest, PolicyClassAdmissionStrategy, RouterPolicyConfig,
@@ -125,18 +108,6 @@ mod tests {
     impl PolicyClassAdmissionStrategy for CustomStrategy {
         fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
             AdmissionDecision::Ready(WorkerPlacement::Any)
-        }
-    }
-
-    struct ZeroIntervalStrategy;
-
-    impl PolicyClassAdmissionStrategy for ZeroIntervalStrategy {
-        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
-            AdmissionDecision::Bypass
-        }
-
-        fn reconcile_interval(&self) -> Option<Duration> {
-            Some(Duration::ZERO)
         }
     }
 
@@ -196,16 +167,5 @@ policy_classes:
         register_builtin_strategies(&profile("custom"), workers(), 16, &mut strategies).unwrap();
 
         assert_eq!(strategies["agents"].reconcile_interval(), None);
-    }
-
-    #[test]
-    fn rejects_zero_reconcile_interval() {
-        let mut strategies = PolicyClassAdmissionStrategies::new();
-        strategies.insert("agents".to_owned(), Box::new(ZeroIntervalStrategy));
-
-        assert!(matches!(
-            strategy_recheck_interval(&strategies),
-            Err(RegistrationError::ZeroReconcileInterval)
-        ));
     }
 }

--- a/lib/admission-control/src/thunderagent/registration.rs
+++ b/lib/admission-control/src/thunderagent/registration.rs
@@ -64,8 +64,7 @@ where
             });
         }
         let config = ThunderAgentConfig::from_options(&admission.options)?;
-        let capacity =
-            WatchWorkerCapacity::new(workers.clone(), block_size, config.capacity_control);
+        let capacity = WatchWorkerCapacity::new(workers.clone(), block_size);
         strategies.insert(
             class.name.clone(),
             Box::new(ThunderAgent::new(capacity, config)?),

--- a/lib/admission-control/src/thunderagent/registration.rs
+++ b/lib/admission-control/src/thunderagent/registration.rs
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use dynamo_kv_router::RouterQueuePolicy;
+use dynamo_kv_router::protocols::{WorkerConfigLike, WorkerId};
+use dynamo_kv_router::scheduling::{PolicyClassAdmissionStrategies, PolicyProfile};
+use thiserror::Error;
+use tokio::sync::watch;
+
+use super::{ConfigError, STRATEGY_NAME, ThunderAgent, ThunderAgentConfig, WatchWorkerCapacity};
+
+#[derive(Debug, Error)]
+pub enum RegistrationError {
+    #[error("unsupported queue admission strategy {strategy:?} for policy class {policy_class:?}")]
+    UnsupportedStrategy {
+        strategy: String,
+        policy_class: String,
+    },
+    #[error("ThunderAgent queue admission requires FCFS for policy class {0:?}")]
+    ThunderAgentRequiresFcfs(String),
+    #[error(
+        "ThunderAgent queue admission may be configured for only one policy class (found {first:?} and {second:?})"
+    )]
+    MultipleThunderAgentClasses { first: String, second: String },
+    #[error(transparent)]
+    ThunderAgentConfig(#[from] ConfigError),
+    #[error("admission strategy reconcile interval must be positive")]
+    ZeroReconcileInterval,
+}
+
+/// Register configured built-in strategies without replacing caller-provided ones.
+pub fn register_builtin_strategies<C>(
+    profile: &PolicyProfile,
+    workers: watch::Receiver<HashMap<WorkerId, C>>,
+    block_size: u32,
+    strategies: &mut PolicyClassAdmissionStrategies,
+) -> Result<(), RegistrationError>
+where
+    C: WorkerConfigLike + Send + Sync + 'static,
+{
+    let mut thunderagent_class = None;
+    for class in profile.classes() {
+        let Some(admission) = &class.queue_admission else {
+            continue;
+        };
+        if strategies.contains_key(&class.name) {
+            continue;
+        }
+        if admission.strategy != STRATEGY_NAME {
+            return Err(RegistrationError::UnsupportedStrategy {
+                strategy: admission.strategy.clone(),
+                policy_class: class.name.clone(),
+            });
+        }
+        if class.queue_policy != RouterQueuePolicy::Fcfs {
+            return Err(RegistrationError::ThunderAgentRequiresFcfs(
+                class.name.clone(),
+            ));
+        }
+        if let Some(first) = thunderagent_class.replace(class.name.clone()) {
+            return Err(RegistrationError::MultipleThunderAgentClasses {
+                first,
+                second: class.name.clone(),
+            });
+        }
+        let config = ThunderAgentConfig::from_options(&admission.options)?;
+        let capacity = WatchWorkerCapacity::new(workers.clone(), block_size);
+        strategies.insert(
+            class.name.clone(),
+            Box::new(ThunderAgent::new(capacity, config)?),
+        );
+    }
+    Ok(())
+}
+
+pub fn strategy_recheck_interval(
+    strategies: &PolicyClassAdmissionStrategies,
+) -> Result<Option<Duration>, RegistrationError> {
+    let mut minimum = None;
+    for interval in strategies
+        .values()
+        .filter_map(|strategy| strategy.reconcile_interval())
+    {
+        if interval.is_zero() {
+            return Err(RegistrationError::ZeroReconcileInterval);
+        }
+        minimum = Some(minimum.map_or(interval, |current: Duration| current.min(interval)));
+    }
+    Ok(minimum)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_kv_router::scheduling::{
+        AdmissionDecision, AdmissionRequest, PolicyClassAdmissionStrategy, RouterPolicyConfig,
+        WorkerPlacement,
+    };
+
+    struct TestWorkerConfig;
+
+    impl WorkerConfigLike for TestWorkerConfig {
+        fn data_parallel_start_rank(&self) -> u32 {
+            0
+        }
+
+        fn data_parallel_size(&self) -> u32 {
+            1
+        }
+
+        fn max_num_batched_tokens(&self) -> Option<u64> {
+            None
+        }
+
+        fn total_kv_blocks(&self) -> Option<u64> {
+            Some(1)
+        }
+    }
+
+    struct CustomStrategy;
+
+    impl PolicyClassAdmissionStrategy for CustomStrategy {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Ready(WorkerPlacement::Any)
+        }
+    }
+
+    struct ZeroIntervalStrategy;
+
+    impl PolicyClassAdmissionStrategy for ZeroIntervalStrategy {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Bypass
+        }
+
+        fn reconcile_interval(&self) -> Option<Duration> {
+            Some(Duration::ZERO)
+        }
+    }
+
+    fn profile(strategy: &str) -> PolicyProfile {
+        RouterPolicyConfig::from_yaml(&format!(
+            r#"
+default_policy_family: standard
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: agents
+    policy_family: standard
+    cache_bucket: all
+    queue_admission:
+      type: {strategy}
+    quantum: 1
+"#
+        ))
+        .unwrap()
+        .resolve_profile(None, None, RouterQueuePolicy::Fcfs)
+    }
+
+    fn workers() -> watch::Receiver<HashMap<WorkerId, TestWorkerConfig>> {
+        watch::channel(HashMap::new()).1
+    }
+
+    #[test]
+    fn builds_configured_thunderagent() {
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        register_builtin_strategies(&profile(STRATEGY_NAME), workers(), 16, &mut strategies)
+            .unwrap();
+
+        assert_eq!(
+            strategies["agents"].reconcile_interval(),
+            Some(Duration::from_secs(5))
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_strategy() {
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        let error = register_builtin_strategies(&profile("custom"), workers(), 16, &mut strategies)
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            RegistrationError::UnsupportedStrategy { .. }
+        ));
+    }
+
+    #[test]
+    fn preserves_caller_provided_strategy() {
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert("agents".to_owned(), Box::new(CustomStrategy));
+
+        register_builtin_strategies(&profile("custom"), workers(), 16, &mut strategies).unwrap();
+
+        assert_eq!(strategies["agents"].reconcile_interval(), None);
+    }
+
+    #[test]
+    fn rejects_zero_reconcile_interval() {
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert("agents".to_owned(), Box::new(ZeroIntervalStrategy));
+
+        assert!(matches!(
+            strategy_recheck_interval(&strategies),
+            Err(RegistrationError::ZeroReconcileInterval)
+        ));
+    }
+}

--- a/lib/admission-control/src/thunderagent/registration.rs
+++ b/lib/admission-control/src/thunderagent/registration.rs
@@ -64,7 +64,8 @@ where
             });
         }
         let config = ThunderAgentConfig::from_options(&admission.options)?;
-        let capacity = WatchWorkerCapacity::new(workers.clone(), block_size);
+        let capacity =
+            WatchWorkerCapacity::new(workers.clone(), block_size, config.capacity_control);
         strategies.insert(
             class.name.clone(),
             Box::new(ThunderAgent::new(capacity, config)?),

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -15,48 +15,100 @@ use indexmap::{IndexMap, IndexSet};
 
 use super::{ConfigError, ThunderAgentConfig, WorkerCapacity, WorkerCapacityProvider};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProgramStatus {
-    Reasoning,
-    Acting,
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ProgramLifecycle {
-    Active,
-    Paused,
+#[derive(Clone)]
+enum ProgramState {
+    Running {
+        progress: RequestProgress,
+        pause_after_completion: bool,
+    },
+    IdleResident {
+        footprint: usize,
+        last_activity: Instant,
+    },
+    Suspended {
+        footprint: usize,
+        since: Instant,
+    },
 }
 
 #[derive(Clone)]
 struct Program {
-    status: ProgramStatus,
-    lifecycle: ProgramLifecycle,
+    state: ProgramState,
     assigned_worker: Option<WorkerWithDpRank>,
-    token_total: usize,
     step_count: usize,
-    marked_for_pause: bool,
-    acting_since: Option<Instant>,
-    deferred_since: Option<Instant>,
 }
 
-impl Default for Program {
-    fn default() -> Self {
+impl Program {
+    fn running(
+        progress: RequestProgress,
+        assigned_worker: Option<WorkerWithDpRank>,
+        step_count: usize,
+    ) -> Self {
         Self {
-            status: ProgramStatus::Reasoning,
-            lifecycle: ProgramLifecycle::Active,
-            assigned_worker: None,
-            token_total: 0,
-            step_count: 0,
-            marked_for_pause: false,
-            acting_since: None,
-            deferred_since: None,
+            state: ProgramState::Running {
+                progress,
+                pause_after_completion: false,
+            },
+            assigned_worker,
+            step_count,
+        }
+    }
+
+    fn footprint(&self) -> usize {
+        match &self.state {
+            ProgramState::Running { progress, .. } => progress.context_tokens(),
+            ProgramState::IdleResident { footprint, .. }
+            | ProgramState::Suspended { footprint, .. } => *footprint,
+        }
+    }
+
+    fn is_idle_resident(&self) -> bool {
+        matches!(self.state, ProgramState::IdleResident { .. })
+    }
+
+    fn is_suspended(&self) -> bool {
+        matches!(self.state, ProgramState::Suspended { .. })
+    }
+
+    fn pause_after_completion(&self) -> bool {
+        matches!(
+            self.state,
+            ProgramState::Running {
+                pause_after_completion: true,
+                ..
+            }
+        )
+    }
+
+    fn mark_for_pause(&mut self) -> bool {
+        let ProgramState::Running {
+            pause_after_completion,
+            ..
+        } = &mut self.state
+        else {
+            return false;
+        };
+        !std::mem::replace(pause_after_completion, true)
+    }
+
+    fn retained_since(&self) -> Option<Instant> {
+        match self.state {
+            ProgramState::IdleResident { last_activity, .. } => Some(last_activity),
+            ProgramState::Suspended { since, .. } => Some(since),
+            ProgramState::Running { .. } => None,
+        }
+    }
+
+    fn suspended_since(&self) -> Option<Instant> {
+        match self.state {
+            ProgramState::Suspended { since, .. } => Some(since),
+            _ => None,
         }
     }
 }
 
 struct RequestState {
     session_id: String,
-    context_tokens: usize,
     progress: RequestProgress,
     worker_eligibility: WorkerEligibility,
     prior: Option<Program>,
@@ -134,7 +186,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             id,
             RequestState {
                 session_id: session_id.to_owned(),
-                context_tokens: request.context_tokens(),
                 progress: request.progress().clone(),
                 worker_eligibility: request.worker_eligibility().clone(),
                 prior: None,
@@ -158,11 +209,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         session_id: &str,
         now: Instant,
     ) -> AdmissionDecision {
-        self.refresh_reasoning_progress();
         let Some(request) = self.requests.get(&id) else {
             return AdmissionDecision::Defer;
         };
-        let context_tokens = request.context_tokens;
+        let context_tokens = request.progress.context_tokens();
+        let progress = request.progress.clone();
         let worker_eligibility = request.worker_eligibility.clone();
         let capacities = self.capacity.snapshot();
         let capacity_known = !capacities.is_empty();
@@ -171,6 +222,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let worker_is_structurally_allowed = |worker| eligibility.structurally_allows(worker);
         let prior = self.programs.get(session_id).cloned();
         let was_new = prior.is_none();
+        let was_suspended = prior.as_ref().is_some_and(Program::is_suspended);
+        let assigned_worker = prior.as_ref().and_then(|program| program.assigned_worker);
+        let step_count = prior
+            .as_ref()
+            .map_or(1, |program| program.step_count.saturating_add(1));
         let Some(request) = self.requests.get_mut(&id) else {
             return AdmissionDecision::Defer;
         };
@@ -186,27 +242,12 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 },
             );
         }
-        let (lifecycle, assigned_worker) = if let Some(program) = self.programs.get_mut(session_id)
-        {
-            program.step_count = program.step_count.saturating_add(1);
-            if context_tokens > 0 {
-                program.token_total = context_tokens;
-            }
-            program.status = ProgramStatus::Reasoning;
-            program.acting_since = None;
-            (program.lifecycle, program.assigned_worker)
-        } else {
-            let program = Program {
-                step_count: 1,
-                token_total: context_tokens,
-                ..Default::default()
-            };
-            let state = (program.lifecycle, program.assigned_worker);
-            self.programs.insert(session_id.to_owned(), program);
-            state
-        };
+        self.programs.insert(
+            session_id.to_owned(),
+            Program::running(progress, assigned_worker, step_count),
+        );
 
-        if lifecycle == ProgramLifecycle::Paused {
+        if was_suspended {
             self.defer_request(session_id, id, now, false);
             return AdmissionDecision::Defer;
         }
@@ -282,7 +323,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let Some(program) = self.programs.get_mut(session_id) else {
             return;
         };
-        program.lifecycle = ProgramLifecycle::Paused;
+        let footprint = program.footprint();
+        program.state = ProgramState::Suspended {
+            footprint,
+            since: now,
+        };
         if !preserve_assignment {
             program.assigned_worker = None;
         }
@@ -292,7 +337,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 .and_then(|requests| requests.current),
             Some(id)
         );
-        program.deferred_since = Some(now);
         self.paused.insert(session_id.to_owned());
     }
 
@@ -310,23 +354,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         }
         if let Some(program) = self.programs.get_mut(&request.session_id) {
             program.assigned_worker = Some(worker);
-        }
-    }
-
-    fn refresh_reasoning_progress(&mut self) {
-        for (session_id, requests) in &self.sessions {
-            let Some(id) = requests.current else {
-                continue;
-            };
-            let Some(request) = self.requests.get(&id) else {
-                continue;
-            };
-            let Some(program) = self.programs.get_mut(session_id) else {
-                continue;
-            };
-            if program.status == ProgramStatus::Reasoning {
-                program.token_total = request.progress.context_tokens();
-            }
         }
     }
 
@@ -360,16 +387,12 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         if let Some(requests) = self.sessions.get_mut(&request.session_id) {
             requests.current = None;
         }
-        if let Some(program) = self.programs.get_mut(&request.session_id) {
-            program.deferred_since = None;
-        }
-
         if completed_context_tokens.is_none() {
             match request.prior {
                 Some(prior) => {
-                    let lifecycle = prior.lifecycle;
+                    let suspended = prior.is_suspended();
                     self.programs.insert(request.session_id.clone(), prior);
-                    if lifecycle == ProgramLifecycle::Paused {
+                    if suspended {
                         self.paused.insert(request.session_id.clone());
                     } else {
                         self.paused.shift_remove(&request.session_id);
@@ -383,12 +406,13 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         } else if let Some(context_tokens) = completed_context_tokens
             && let Some(program) = self.programs.get_mut(&request.session_id)
         {
-            program.token_total = context_tokens;
-            program.status = ProgramStatus::Acting;
-            program.acting_since = Some(Instant::now());
-            let pause = std::mem::take(&mut program.marked_for_pause);
+            let pause = program.pause_after_completion();
+            program.state = ProgramState::IdleResident {
+                footprint: context_tokens,
+                last_activity: Instant::now(),
+            };
             if pause {
-                self.pause_acting(&request.session_id);
+                self.suspend_idle(&request.session_id);
             }
         }
 
@@ -418,13 +442,12 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             return Vec::new();
         }
         self.next_tick = now + Duration::from_secs_f64(self.config.scheduler_interval_seconds);
-        self.refresh_reasoning_progress();
         let expired_programs = self.expire_retained_programs(now);
         let paused_before = self.paused.len();
         let marked_before = self
             .programs
             .values()
-            .filter(|program| program.marked_for_pause)
+            .filter(|program| program.pause_after_completion())
             .count();
         let capacities = self.capacity.snapshot();
         let mut usage = self.worker_usage();
@@ -444,7 +467,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let marked = self
             .programs
             .values()
-            .filter(|program| program.marked_for_pause)
+            .filter(|program| program.pause_after_completion())
             .count();
         if greedy_resumes > 0
             || forced_resumes > 0
@@ -478,10 +501,9 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .programs
             .iter()
             .filter(|(session_id, program)| {
-                program.status == ProgramStatus::Acting
-                    && !self.sessions.contains_key(session_id.as_str())
+                !self.sessions.contains_key(session_id.as_str())
                     && program
-                        .acting_since
+                        .retained_since()
                         .is_some_and(|since| now.saturating_duration_since(since) >= retention)
             })
             .map(|(session_id, _)| session_id.clone())
@@ -495,16 +517,18 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     }
 
     fn program_tokens(&self, program: &Program) -> usize {
-        if program.status != ProgramStatus::Acting {
-            return program.token_total;
+        let tokens = program.footprint();
+        if program.is_idle_resident() {
+            scale_tokens(tokens, self.config.acting_token_weight)
+        } else {
+            tokens
         }
-        scale_tokens(program.token_total, self.config.acting_token_weight)
     }
 
     fn worker_usage(&self) -> HashMap<WorkerWithDpRank, WorkerUsage> {
         let mut usage = HashMap::<WorkerWithDpRank, WorkerUsage>::new();
         for program in self.programs.values() {
-            if program.lifecycle == ProgramLifecycle::Active
+            if !program.is_suspended()
                 && let Some(worker) = program.assigned_worker
             {
                 let worker_usage = usage.entry(worker).or_default();
@@ -535,12 +559,16 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             let program = &self.programs[session_id];
             let group = if program.step_count <= 1 {
                 1
-            } else if program.status == ProgramStatus::Reasoning {
+            } else if self
+                .sessions
+                .get(session_id)
+                .is_some_and(|requests| requests.current.is_some())
+            {
                 0
             } else {
                 2
             };
-            (group, program.token_total)
+            (group, program.footprint())
         });
 
         let ceiling = (self.config.pause_threshold - self.config.resume_hysteresis).max(0.0);
@@ -565,7 +593,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let mut resumable = Vec::new();
         for session_id in paused {
             let required = self.programs[&session_id]
-                .token_total
+                .footprint()
                 .saturating_add(self.config.buffer_per_program);
             if !backend_caps.iter().any(|(worker, remaining)| {
                 self.session_allows_worker(&session_id, *worker, eligibility)
@@ -578,7 +606,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 resumable.push(session_id);
             }
         }
-        resumable.sort_by_key(|session_id| Reverse(self.programs[session_id].token_total));
+        resumable.sort_by_key(|session_id| Reverse(self.programs[session_id].footprint()));
         let mut actions = Vec::new();
         let mut resumed = 0;
         for session_id in resumable {
@@ -589,7 +617,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     .find(|(_, (worker, remaining))| {
                         self.session_allows_worker(&session_id, *worker, eligibility)
                             && self.programs[&session_id]
-                                .token_total
+                                .footprint()
                                 .saturating_add(self.config.buffer_per_program)
                                 <= *remaining
                     })
@@ -597,7 +625,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 continue;
             };
             let required = self.programs[&session_id]
-                .token_total
+                .footprint()
                 .saturating_add(self.config.buffer_per_program);
             actions.extend(self.resume_program(&session_id, Some(worker)));
             resumed += 1;
@@ -625,10 +653,14 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .paused
             .iter()
             .filter(|session_id| {
-                self.programs
+                self.sessions
                     .get(*session_id)
-                    .and_then(|program| program.deferred_since)
-                    .is_some_and(|since| now.saturating_duration_since(since) >= timeout)
+                    .is_some_and(|requests| requests.current.is_some())
+                    && self
+                        .programs
+                        .get(*session_id)
+                        .and_then(Program::suspended_since)
+                        .is_some_and(|since| now.saturating_duration_since(since) >= timeout)
             })
             .cloned()
             .collect();
@@ -636,9 +668,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let mut actions = Vec::new();
         let mut resumed = 0;
         for session_id in timed_out {
-            if self.programs[&session_id].lifecycle != ProgramLifecycle::Paused {
-                continue;
-            }
             if self.session_waits_for_available_worker(&session_id, eligibility) {
                 continue;
             }
@@ -656,20 +685,21 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let mut acting = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
         let mut reasoning = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
         for (session_id, program) in &self.programs {
-            if program.lifecycle != ProgramLifecycle::Active || program.marked_for_pause {
+            if program.is_suspended() || program.pause_after_completion() {
                 continue;
             }
             let Some(worker) = program.assigned_worker else {
                 continue;
             };
-            let candidates = match program.status {
-                ProgramStatus::Acting => &mut acting,
-                ProgramStatus::Reasoning => &mut reasoning,
+            let candidates = match program.state {
+                ProgramState::IdleResident { .. } => &mut acting,
+                ProgramState::Running { .. } => &mut reasoning,
+                ProgramState::Suspended { .. } => continue,
             };
             candidates
                 .entry(worker)
                 .or_default()
-                .push((program.token_total, session_id.clone()));
+                .push((program.footprint(), session_id.clone()));
         }
         for candidates in acting.values_mut().chain(reasoning.values_mut()) {
             candidates.sort_by_key(|(tokens, _)| *tokens);
@@ -696,7 +726,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                         continue;
                     };
                     let used = self.program_tokens(program);
-                    self.pause_acting(session_id);
+                    self.suspend_idle(session_id);
                     paused += 1;
                     let worker_usage = usage.entry(capacity.worker).or_default();
                     worker_usage.remove_program(used, self.config.buffer_per_program);
@@ -707,8 +737,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             {
                 for (_, session_id) in candidates {
                     if let Some(program) = self.programs.get_mut(session_id) {
-                        program.marked_for_pause = true;
-                        marked += 1;
+                        marked += usize::from(program.mark_for_pause());
                     }
                 }
             }
@@ -732,10 +761,9 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     }
 
     fn deferred_eligibility_snapshots(&self) -> HashMap<AdmissionId, WorkerEligibilitySnapshot> {
-        self.programs
+        self.paused
             .iter()
-            .filter(|(_, program)| program.deferred_since.is_some())
-            .filter_map(|(session_id, _)| {
+            .filter_map(|session_id| {
                 let id = self.sessions.get(session_id)?.current?;
                 let request = self.requests.get(&id)?;
                 Some((id, request.worker_eligibility.snapshot()))
@@ -758,7 +786,12 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         {
             return false;
         }
-        if program.deferred_since.is_none() {
+        if !program.is_suspended()
+            || self
+                .sessions
+                .get(session_id)
+                .is_none_or(|requests| requests.current.is_none())
+        {
             return true;
         }
         self.sessions
@@ -776,7 +809,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let Some(program) = self.programs.get(session_id) else {
             return false;
         };
-        if program.deferred_since.is_none() {
+        if !program.is_suspended() {
             return false;
         }
         self.sessions
@@ -788,15 +821,21 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             })
     }
 
-    fn pause_acting(&mut self, session_id: &str) {
+    fn suspend_idle(&mut self, session_id: &str) {
         let Some(program) = self.programs.get_mut(session_id) else {
             return;
         };
-        if program.lifecycle != ProgramLifecycle::Active || program.status != ProgramStatus::Acting
-        {
+        let ProgramState::IdleResident {
+            footprint,
+            last_activity,
+        } = program.state
+        else {
             return;
-        }
-        program.lifecycle = ProgramLifecycle::Paused;
+        };
+        program.state = ProgramState::Suspended {
+            footprint,
+            since: last_activity,
+        };
         program.assigned_worker = None;
         self.paused.insert(session_id.to_owned());
     }
@@ -810,22 +849,39 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .sessions
             .get(session_id)
             .and_then(|requests| requests.current);
+        let deferred_progress = match deferred_id {
+            Some(id) => {
+                let Some(request) = self.requests.get(&id) else {
+                    return Vec::new();
+                };
+                Some(request.progress.clone())
+            }
+            None => None,
+        };
         let Some(program) = self.programs.get_mut(session_id) else {
             return Vec::new();
         };
-        if program.lifecycle != ProgramLifecycle::Paused {
+        let ProgramState::Suspended { footprint, since } = program.state else {
             return Vec::new();
-        }
-        program.lifecycle = ProgramLifecycle::Active;
+        };
+        program.state = match deferred_progress {
+            Some(progress) => ProgramState::Running {
+                progress,
+                pause_after_completion: false,
+            },
+            None => ProgramState::IdleResident {
+                footprint,
+                last_activity: since,
+            },
+        };
         program.assigned_worker = worker;
-        let was_deferred = program.deferred_since.take().is_some();
         self.paused.shift_remove(session_id);
-        match (was_deferred, deferred_id) {
-            (true, Some(id)) => vec![AdmissionAction::MakeReady {
+        match deferred_id {
+            Some(id) => vec![AdmissionAction::MakeReady {
                 id,
                 placement: worker.map_or(WorkerPlacement::Any, WorkerPlacement::Exact),
             }],
-            _ => Vec::new(),
+            None => Vec::new(),
         }
     }
 }
@@ -927,6 +983,46 @@ mod tests {
             .collect()
     }
 
+    fn idle_program(
+        assigned_worker: Option<WorkerWithDpRank>,
+        footprint: usize,
+        last_activity: Instant,
+        step_count: usize,
+    ) -> Program {
+        Program {
+            state: ProgramState::IdleResident {
+                footprint,
+                last_activity,
+            },
+            assigned_worker,
+            step_count,
+        }
+    }
+
+    fn suspended_program(footprint: usize, since: Instant, step_count: usize) -> Program {
+        Program {
+            state: ProgramState::Suspended { footprint, since },
+            assigned_worker: None,
+            step_count,
+        }
+    }
+
+    fn running_program(
+        assigned_worker: Option<WorkerWithDpRank>,
+        footprint: usize,
+        step_count: usize,
+    ) -> Program {
+        let (progress, _) = RequestProgress::new(footprint);
+        Program::running(progress, assigned_worker, step_count)
+    }
+
+    fn set_suspended_since(program: &mut Program, value: Instant) {
+        let ProgramState::Suspended { since, .. } = &mut program.state else {
+            panic!("program must be suspended");
+        };
+        *since = value;
+    }
+
     fn reconcile_now<P: WorkerCapacityProvider>(
         strategy: &mut ThunderAgent<P>,
     ) -> Vec<AdmissionAction> {
@@ -962,7 +1058,8 @@ mod tests {
             id: AdmissionId::new(1),
             context_tokens: 150,
         });
-        assert_eq!(strategy.programs["a"].token_total, 150);
+        assert!(strategy.programs["a"].is_idle_resident());
+        assert_eq!(strategy.programs["a"].footprint(), 150);
         assert_eq!(
             strategy.admit(request(2, Some("a"), 120)),
             AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
@@ -985,13 +1082,9 @@ mod tests {
         let allowed = Arc::new(AtomicBool::new(false));
         let mut strategy =
             ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
-        strategy.programs.insert(
-            "paused".to_owned(),
-            Program {
-                lifecycle: ProgramLifecycle::Paused,
-                ..Program::default()
-            },
-        );
+        strategy
+            .programs
+            .insert("paused".to_owned(), suspended_program(0, Instant::now(), 0));
         strategy.paused.insert("paused".to_owned());
         let live_allowed = Arc::clone(&allowed);
         assert_eq!(
@@ -1145,7 +1238,8 @@ mod tests {
             id: AdmissionId::new(1),
             context_tokens: 140,
         });
-        assert_eq!(strategy.programs["a"].token_total, 140);
+        assert!(strategy.programs["a"].is_idle_resident());
+        assert_eq!(strategy.programs["a"].footprint(), 140);
     }
 
     #[test]
@@ -1154,27 +1248,26 @@ mod tests {
             ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
         strategy.admit(request(1, Some("a"), 100));
         let (progress, updater) = RequestProgress::new(100);
-        strategy
-            .requests
-            .get_mut(&AdmissionId::new(1))
-            .unwrap()
-            .progress = progress;
+        strategy.programs["a"].state = ProgramState::Running {
+            progress,
+            pause_after_completion: false,
+        };
         strategy.on_event(AdmissionEvent::Dispatched {
             id: AdmissionId::new(1),
             worker: worker(1),
         });
         updater.update_context_tokens(128);
-        strategy.refresh_reasoning_progress();
 
         let program = &strategy.programs["a"];
-        assert_eq!(program.status, ProgramStatus::Reasoning);
-        assert_eq!(program.token_total, 128);
+        assert!(matches!(program.state, ProgramState::Running { .. }));
+        assert_eq!(program.footprint(), 128);
 
         strategy.on_event(AdmissionEvent::Completed {
             id: AdmissionId::new(1),
             context_tokens: 140,
         });
-        assert_eq!(strategy.programs["a"].token_total, 140);
+        assert!(strategy.programs["a"].is_idle_resident());
+        assert_eq!(strategy.programs["a"].footprint(), 140);
     }
 
     #[test]
@@ -1191,54 +1284,20 @@ mod tests {
         for (session_id, program) in [
             (
                 "expired-active",
-                Program {
-                    status: ProgramStatus::Acting,
-                    assigned_worker: Some(worker(1)),
-                    token_total: 100,
-                    acting_since: Some(expired_at),
-                    ..Program::default()
-                },
+                idle_program(Some(worker(1)), 100, expired_at, 0),
             ),
-            (
-                "expired-paused",
-                Program {
-                    status: ProgramStatus::Acting,
-                    lifecycle: ProgramLifecycle::Paused,
-                    token_total: 200,
-                    acting_since: Some(expired_at),
-                    ..Program::default()
-                },
-            ),
+            ("expired-paused", suspended_program(200, expired_at, 0)),
             (
                 "fresh",
-                Program {
-                    status: ProgramStatus::Acting,
-                    assigned_worker: Some(worker(1)),
-                    token_total: 300,
-                    acting_since: Some(expired_at + Duration::from_nanos(1)),
-                    ..Program::default()
-                },
+                idle_program(
+                    Some(worker(1)),
+                    300,
+                    expired_at + Duration::from_nanos(1),
+                    0,
+                ),
             ),
-            (
-                "reasoning",
-                Program {
-                    status: ProgramStatus::Reasoning,
-                    assigned_worker: Some(worker(1)),
-                    token_total: 400,
-                    acting_since: Some(expired_at),
-                    ..Program::default()
-                },
-            ),
-            (
-                "busy",
-                Program {
-                    status: ProgramStatus::Acting,
-                    assigned_worker: Some(worker(1)),
-                    token_total: 500,
-                    acting_since: Some(expired_at),
-                    ..Program::default()
-                },
-            ),
+            ("reasoning", running_program(Some(worker(1)), 400, 0)),
+            ("busy", idle_program(Some(worker(1)), 500, expired_at, 0)),
         ] {
             strategy.programs.insert(session_id.to_owned(), program);
         }
@@ -1272,14 +1331,12 @@ mod tests {
         let mut strategy = ThunderAgent::new(|| capacities(&[(1, 1_000)]), config).unwrap();
         strategy.programs.insert(
             "expired".to_owned(),
-            Program {
-                status: ProgramStatus::Acting,
-                assigned_worker: Some(worker(2)),
-                token_total: 700,
-                step_count: 4,
-                acting_since: Some(Instant::now() - Duration::from_secs(901)),
-                ..Program::default()
-            },
+            idle_program(
+                Some(worker(2)),
+                700,
+                Instant::now() - Duration::from_secs(901),
+                4,
+            ),
         );
 
         assert!(reconcile_now(&mut strategy).is_empty());
@@ -1322,15 +1379,9 @@ mod tests {
         }
 
         assert!(strategy.on_event(AdmissionEvent::Reconcile).is_empty());
-        assert_eq!(
-            strategy.programs["small"].lifecycle,
-            ProgramLifecycle::Active
-        );
+        assert!(strategy.programs["small"].is_idle_resident());
         assert!(reconcile_now(&mut strategy).is_empty());
-        assert_eq!(
-            strategy.programs["small"].lifecycle,
-            ProgramLifecycle::Paused
-        );
+        assert!(strategy.programs["small"].is_suspended());
         assert_eq!(
             strategy.admit(request(3, Some("small"), 110)),
             AdmissionDecision::Defer
@@ -1353,19 +1404,18 @@ mod tests {
             ..Default::default()
         };
         let mut strategy = ThunderAgent::new(Vec::<WorkerCapacity>::new, config).unwrap();
-        strategy.programs.insert(
-            "paused".to_owned(),
-            Program {
-                lifecycle: ProgramLifecycle::Paused,
-                ..Program::default()
-            },
-        );
+        strategy
+            .programs
+            .insert("paused".to_owned(), suspended_program(0, Instant::now(), 0));
         strategy.paused.insert("paused".to_owned());
         assert_eq!(
             strategy.admit(request(1, Some("paused"), 100)),
             AdmissionDecision::Defer
         );
-        strategy.programs["paused"].deferred_since = Some(Instant::now() - Duration::from_secs(2));
+        set_suspended_since(
+            &mut strategy.programs["paused"],
+            Instant::now() - Duration::from_secs(2),
+        );
         assert_eq!(
             reconcile_now(&mut strategy),
             vec![AdmissionAction::MakeReady {
@@ -1383,32 +1433,26 @@ mod tests {
             ..Default::default()
         };
         let mut strategy = ThunderAgent::new(|| capacities(&[(1, 100), (2, 100)]), config).unwrap();
-        for (session_id, assigned_worker, token_total) in
+        for (session_id, assigned_worker, footprint) in
             [("worker-1", worker(1), 300), ("worker-2", worker(2), 200)]
         {
             strategy.programs.insert(
                 session_id.to_owned(),
-                Program {
-                    status: ProgramStatus::Acting,
-                    assigned_worker: Some(assigned_worker),
-                    token_total,
-                    ..Program::default()
-                },
+                idle_program(Some(assigned_worker), footprint, Instant::now(), 0),
             );
         }
-        strategy.programs.insert(
-            "paused".to_owned(),
-            Program {
-                lifecycle: ProgramLifecycle::Paused,
-                ..Program::default()
-            },
-        );
+        strategy
+            .programs
+            .insert("paused".to_owned(), suspended_program(0, Instant::now(), 0));
         strategy.paused.insert("paused".to_owned());
         assert_eq!(
             strategy.admit(request(1, Some("paused"), 50)),
             AdmissionDecision::Defer
         );
-        strategy.programs["paused"].deferred_since = Some(Instant::now() - Duration::from_secs(2));
+        set_suspended_since(
+            &mut strategy.programs["paused"],
+            Instant::now() - Duration::from_secs(2),
+        );
 
         assert_eq!(
             reconcile_now(&mut strategy),
@@ -1425,12 +1469,7 @@ mod tests {
             ThunderAgent::new(Vec::<WorkerCapacity>::new, Default::default()).unwrap();
         strategy.programs.insert(
             "existing".to_owned(),
-            Program {
-                status: ProgramStatus::Acting,
-                token_total: 200,
-                step_count: 3,
-                ..Program::default()
-            },
+            idle_program(None, 200, Instant::now(), 3),
         );
         assert!(matches!(
             strategy.admit(request(1, Some("existing"), 300)),
@@ -1440,8 +1479,8 @@ mod tests {
             id: AdmissionId::new(1),
         });
         let program = &strategy.programs["existing"];
-        assert_eq!(program.status, ProgramStatus::Acting);
-        assert_eq!(program.token_total, 200);
+        assert!(program.is_idle_resident());
+        assert_eq!(program.footprint(), 200);
         assert_eq!(program.step_count, 3);
     }
 
@@ -1451,13 +1490,7 @@ mod tests {
             ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
         strategy.programs.insert(
             "existing".to_owned(),
-            Program {
-                status: ProgramStatus::Acting,
-                assigned_worker: Some(worker(1)),
-                token_total: 200,
-                step_count: 3,
-                ..Program::default()
-            },
+            idle_program(Some(worker(1)), 200, Instant::now(), 3),
         );
         strategy.admit(request(1, Some("existing"), 300));
         strategy.on_event(AdmissionEvent::Dispatched {
@@ -1469,8 +1502,8 @@ mod tests {
         });
 
         let program = &strategy.programs["existing"];
-        assert_eq!(program.status, ProgramStatus::Acting);
-        assert_eq!(program.token_total, 200);
+        assert!(program.is_idle_resident());
+        assert_eq!(program.footprint(), 200);
         assert_eq!(program.step_count, 3);
     }
 
@@ -1486,7 +1519,11 @@ mod tests {
             strategy.admit(request(2, Some("same"), 900)),
             AdmissionDecision::Defer
         );
-        assert_eq!(strategy.programs["same"].token_total, 100);
+        assert!(matches!(
+            strategy.programs["same"].state,
+            ProgramState::Running { .. }
+        ));
+        assert_eq!(strategy.programs["same"].footprint(), 100);
         assert_eq!(strategy.programs["same"].step_count, 1);
 
         assert!(
@@ -1504,7 +1541,8 @@ mod tests {
             id: AdmissionId::new(1),
             context_tokens: 150,
         });
-        assert_eq!(strategy.programs["same"].token_total, 150);
+        assert!(strategy.programs["same"].is_idle_resident());
+        assert_eq!(strategy.programs["same"].footprint(), 150);
         assert_eq!(strategy.programs["same"].step_count, 1);
     }
 
@@ -1530,7 +1568,11 @@ mod tests {
                 placement: WorkerPlacement::Exact(worker(1)),
             }]
         );
-        assert_eq!(strategy.programs["same"].token_total, 120);
+        assert!(matches!(
+            strategy.programs["same"].state,
+            ProgramState::Running { .. }
+        ));
+        assert_eq!(strategy.programs["same"].footprint(), 120);
         assert_eq!(strategy.programs["same"].step_count, 1);
         assert_eq!(strategy.sessions["same"].current, Some(AdmissionId::new(2)));
     }

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -121,21 +121,6 @@ struct SessionRequests {
     waiting: IndexSet<AdmissionId>,
 }
 
-#[derive(Debug, Default, Clone, Copy)]
-struct WorkerUsage {
-    used: usize,
-}
-
-impl WorkerUsage {
-    fn add_program(&mut self, tokens: usize) {
-        self.used = self.used.saturating_add(tokens);
-    }
-
-    fn remove_program(&mut self, tokens: usize) {
-        self.used = self.used.saturating_sub(tokens);
-    }
-}
-
 pub struct ThunderAgent<P> {
     capacity: P,
     config: ThunderAgentConfig,
@@ -212,7 +197,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let progress = request.progress.clone();
         let worker_eligibility = request.worker_eligibility.clone();
         let capacities = self.capacity.snapshot();
-        let capacity_known = !capacities.is_empty();
         let eligibility = worker_eligibility.snapshot();
         let worker_is_available = |worker| eligibility.allows(worker);
         let worker_is_structurally_allowed = |worker| eligibility.structurally_allows(worker);
@@ -274,10 +258,9 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             return AdmissionDecision::Defer;
         }
 
-        if !capacity_known
-            || !capacities
-                .iter()
-                .any(|capacity| worker_is_available(capacity.worker))
+        if !capacities
+            .iter()
+            .any(|capacity| worker_is_available(capacity.worker))
         {
             return AdmissionDecision::Ready(WorkerPlacement::Any);
         }
@@ -287,7 +270,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .iter()
             .filter(|capacity| worker_is_available(capacity.worker))
             .filter_map(|capacity| {
-                let used = usage.get(&capacity.worker).map_or(0, |usage| usage.used);
+                let used = usage.get(&capacity.worker).copied().unwrap_or(0);
                 capacity
                     .tokens
                     .checked_sub(used)
@@ -511,14 +494,14 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         expired.len()
     }
 
-    fn worker_usage(&self) -> HashMap<WorkerWithDpRank, WorkerUsage> {
-        let mut usage = HashMap::<WorkerWithDpRank, WorkerUsage>::new();
+    fn worker_usage(&self) -> HashMap<WorkerWithDpRank, usize> {
+        let mut usage = HashMap::<WorkerWithDpRank, usize>::new();
         for program in self.programs.values() {
             if !program.is_suspended()
                 && let Some(worker) = program.assigned_worker
             {
-                let worker_usage = usage.entry(worker).or_default();
-                worker_usage.add_program(program.footprint());
+                let used = usage.entry(worker).or_default();
+                *used = used.saturating_add(program.footprint());
             }
         }
         usage
@@ -527,7 +510,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     fn greedy_resume(
         &mut self,
         capacities: &[WorkerCapacity],
-        usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
+        usage: &mut HashMap<WorkerWithDpRank, usize>,
         eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
     ) -> (Vec<AdmissionAction>, usize) {
         let mut paused: Vec<String> = self
@@ -561,7 +544,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .filter_map(|capacity| {
                 let limit = scale_tokens(capacity.tokens, ceiling);
                 let remaining =
-                    limit.saturating_sub(usage.get(&capacity.worker).map_or(0, |usage| usage.used));
+                    limit.saturating_sub(usage.get(&capacity.worker).copied().unwrap_or(0));
                 (remaining > 0).then_some((capacity.worker, remaining))
             })
             .collect();
@@ -607,8 +590,8 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             actions.extend(self.resume_program(&session_id, Some(worker)));
             resumed += 1;
             let program = &self.programs[&session_id];
-            let worker_usage = usage.entry(worker).or_default();
-            worker_usage.add_program(program.footprint());
+            let used = usage.entry(worker).or_default();
+            *used = used.saturating_add(program.footprint());
             let updated = remaining - required;
             if updated > 0 {
                 backend_caps[position] = (worker, updated);
@@ -655,7 +638,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     fn pause_until_safe(
         &mut self,
         capacities: &[WorkerCapacity],
-        usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
+        usage: &mut HashMap<WorkerWithDpRank, usize>,
     ) -> (usize, usize) {
         let mut acting = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
         let mut reasoning = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
@@ -685,7 +668,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let mut marked_total = 0;
         for capacity in capacities {
             let threshold = scale_tokens(capacity.tokens, self.config.pause_threshold);
-            let worker_used = usage.get(&capacity.worker).map_or(0, |usage| usage.used);
+            let worker_used = usage.get(&capacity.worker).copied().unwrap_or(0);
             if worker_used <= threshold {
                 continue;
             }
@@ -694,7 +677,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             let mut marked = 0;
             if let Some(candidates) = acting.get(&capacity.worker) {
                 for (_, session_id) in candidates {
-                    if usage.get(&capacity.worker).map_or(0, |usage| usage.used) <= target {
+                    if usage.get(&capacity.worker).copied().unwrap_or(0) <= target {
                         break;
                     }
                     let Some(program) = self.programs.get(session_id) else {
@@ -703,11 +686,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     let used = program.footprint();
                     self.suspend_idle(session_id);
                     paused += 1;
-                    let worker_usage = usage.entry(capacity.worker).or_default();
-                    worker_usage.remove_program(used);
+                    let worker_used = usage.entry(capacity.worker).or_default();
+                    *worker_used = worker_used.saturating_sub(used);
                 }
             }
-            if usage.get(&capacity.worker).map_or(0, |usage| usage.used) > target
+            if usage.get(&capacity.worker).copied().unwrap_or(0) > target
                 && let Some(candidates) = reasoning.get(&capacity.worker)
             {
                 for (_, session_id) in candidates {
@@ -716,7 +699,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     }
                 }
             }
-            let used_after = usage.get(&capacity.worker).map_or(0, |usage| usage.used);
+            let used_after = usage.get(&capacity.worker).copied().unwrap_or(0);
             paused_total += paused;
             marked_total += marked;
             tracing::info!(
@@ -1288,7 +1271,7 @@ mod tests {
         assert!(strategy.programs.contains_key("busy"));
 
         let usage = strategy.worker_usage();
-        assert_eq!(usage[&worker(1)].used, 1_200);
+        assert_eq!(usage[&worker(1)], 1_200);
     }
 
     #[test]

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -151,7 +151,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         tracing::info!(
             pause_threshold = config.pause_threshold,
             pause_target = config.pause_target,
-            resume_hysteresis = config.resume_hysteresis,
             resume_timeout_seconds = config.resume_timeout_seconds,
             session_retention_seconds = config.session_retention_seconds,
             scheduler_interval_seconds = config.scheduler_interval_seconds,
@@ -556,7 +555,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             (group, program.footprint())
         });
 
-        let ceiling = (self.config.pause_threshold - self.config.resume_hysteresis).max(0.0);
+        let ceiling = self.config.pause_target;
         let mut backend_caps: Vec<(WorkerWithDpRank, usize)> = capacities
             .iter()
             .filter_map(|capacity| {

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -62,6 +62,7 @@ impl Program {
         }
     }
 
+    #[cfg(test)]
     fn is_idle_resident(&self) -> bool {
         matches!(self.state, ProgramState::IdleResident { .. })
     }
@@ -139,7 +140,6 @@ pub struct ThunderAgent<P> {
     capacity: P,
     config: ThunderAgentConfig,
     programs: IndexMap<String, Program>,
-    paused: IndexSet<String>,
     requests: HashMap<AdmissionId, RequestState>,
     sessions: HashMap<String, SessionRequests>,
     next_tick: Instant,
@@ -163,7 +163,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             capacity,
             config,
             programs: IndexMap::new(),
-            paused: IndexSet::new(),
             requests: HashMap::new(),
             sessions: HashMap::new(),
             next_tick,
@@ -272,7 +271,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         }
 
         // Preserve source fairness: a new program cannot bypass an already-paused one.
-        if was_new && !self.paused.is_empty() {
+        if was_new && self.programs.values().any(Program::is_suspended) {
             self.defer_request(session_id, id, now, false);
             return AdmissionDecision::Defer;
         }
@@ -336,7 +335,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 .and_then(|requests| requests.current),
             Some(id)
         );
-        self.paused.insert(session_id.to_owned());
     }
 
     fn dispatched(&mut self, id: AdmissionId, worker: WorkerWithDpRank) {
@@ -389,17 +387,10 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         if completed_context_tokens.is_none() {
             match request.prior {
                 Some(prior) => {
-                    let suspended = prior.is_suspended();
                     self.programs.insert(request.session_id.clone(), prior);
-                    if suspended {
-                        self.paused.insert(request.session_id.clone());
-                    } else {
-                        self.paused.shift_remove(&request.session_id);
-                    }
                 }
                 None => {
                     self.programs.shift_remove(&request.session_id);
-                    self.paused.shift_remove(&request.session_id);
                 }
             }
         } else if let Some(context_tokens) = completed_context_tokens
@@ -442,7 +433,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         }
         self.next_tick = now + Duration::from_secs_f64(self.config.scheduler_interval_seconds);
         let expired_programs = self.expire_retained_programs(now);
-        let paused_before = self.paused.len();
+        let paused_before = self
+            .programs
+            .values()
+            .filter(|program| program.is_suspended())
+            .count();
         let marked_before = self
             .programs
             .values()
@@ -468,18 +463,23 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .values()
             .filter(|program| program.pause_after_completion())
             .count();
+        let paused = self
+            .programs
+            .values()
+            .filter(|program| program.is_suspended())
+            .count();
         if greedy_resumes > 0
             || forced_resumes > 0
             || paused_now > 0
             || marked_now > 0
             || expired_programs > 0
-            || self.paused.len() != paused_before
+            || paused != paused_before
             || marked != marked_before
         {
             tracing::info!(
                 programs = self.programs.len(),
-                active = self.programs.len().saturating_sub(self.paused.len()),
-                paused = self.paused.len(),
+                active = self.programs.len().saturating_sub(paused),
+                paused,
                 marked,
                 greedy_resumed_programs = greedy_resumes,
                 forced_resumed_programs = forced_resumes,
@@ -510,7 +510,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
 
         for session_id in &expired {
             self.programs.shift_remove(session_id);
-            self.paused.shift_remove(session_id);
         }
         expired.len()
     }
@@ -534,16 +533,15 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
         eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
     ) -> (Vec<AdmissionAction>, usize) {
-        if self.paused.is_empty() {
+        let mut paused: Vec<String> = self
+            .programs
+            .iter()
+            .filter(|(_, program)| program.is_suspended())
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+        if paused.is_empty() {
             return (Vec::new(), 0);
         }
-
-        let mut paused: Vec<String> = self
-            .paused
-            .iter()
-            .filter(|session_id| self.programs.contains_key(*session_id))
-            .cloned()
-            .collect();
         paused.sort_by_key(|session_id| {
             let program = &self.programs[session_id];
             let group = if program.step_count <= 1 {
@@ -639,19 +637,17 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     ) -> (Vec<AdmissionAction>, usize) {
         let timeout = Duration::from_secs_f64(self.config.resume_timeout_seconds);
         let timed_out: Vec<String> = self
-            .paused
+            .programs
             .iter()
-            .filter(|session_id| {
+            .filter(|(session_id, program)| {
                 self.sessions
-                    .get(*session_id)
+                    .get(session_id.as_str())
                     .is_some_and(|requests| requests.current.is_some())
-                    && self
-                        .programs
-                        .get(*session_id)
-                        .and_then(Program::suspended_since)
+                    && program
+                        .suspended_since()
                         .is_some_and(|since| now.saturating_duration_since(since) >= timeout)
             })
-            .cloned()
+            .map(|(session_id, _)| session_id.clone())
             .collect();
 
         let mut actions = Vec::new();
@@ -750,9 +746,10 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     }
 
     fn deferred_eligibility_snapshots(&self) -> HashMap<AdmissionId, WorkerEligibilitySnapshot> {
-        self.paused
+        self.programs
             .iter()
-            .filter_map(|session_id| {
+            .filter(|(_, program)| program.is_suspended())
+            .filter_map(|(session_id, _)| {
                 let id = self.sessions.get(session_id)?.current?;
                 let request = self.requests.get(&id)?;
                 Some((id, request.worker_eligibility.snapshot()))
@@ -825,7 +822,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             footprint,
             since: last_activity,
         };
-        self.paused.insert(session_id.to_owned());
     }
 
     fn resume_program(
@@ -863,7 +859,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             },
         };
         program.assigned_worker = worker;
-        self.paused.shift_remove(session_id);
         match deferred_id {
             Some(id) => vec![AdmissionAction::MakeReady {
                 id,
@@ -1073,7 +1068,6 @@ mod tests {
         strategy
             .programs
             .insert("paused".to_owned(), suspended_program(0, Instant::now(), 0));
-        strategy.paused.insert("paused".to_owned());
         let live_allowed = Arc::clone(&allowed);
         assert_eq!(
             strategy.admit(filtered_request(1, Some("paused"), 100, move || {
@@ -1289,7 +1283,6 @@ mod tests {
         ] {
             strategy.programs.insert(session_id.to_owned(), program);
         }
-        strategy.paused.insert("expired-paused".to_owned());
         strategy.sessions.insert(
             "busy".to_owned(),
             SessionRequests {
@@ -1301,7 +1294,6 @@ mod tests {
         assert_eq!(strategy.expire_retained_programs(now), 2);
         assert!(!strategy.programs.contains_key("expired-active"));
         assert!(!strategy.programs.contains_key("expired-paused"));
-        assert!(!strategy.paused.contains("expired-paused"));
         assert!(strategy.programs.contains_key("fresh"));
         assert!(strategy.programs.contains_key("reasoning"));
         assert!(strategy.programs.contains_key("busy"));
@@ -1397,7 +1389,6 @@ mod tests {
         strategy
             .programs
             .insert("paused".to_owned(), suspended_program(0, Instant::now(), 0));
-        strategy.paused.insert("paused".to_owned());
         assert_eq!(
             strategy.admit(request(1, Some("paused"), 100)),
             AdmissionDecision::Defer
@@ -1434,7 +1425,6 @@ mod tests {
         strategy
             .programs
             .insert("paused".to_owned(), suspended_program(0, Instant::now(), 0));
-        strategy.paused.insert("paused".to_owned());
         assert_eq!(
             strategy.admit(request(1, Some("paused"), 50)),
             AdmissionDecision::Defer

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -1,0 +1,1587 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::cmp::Reverse;
+use std::collections::HashMap;
+use std::time::{Duration, Instant};
+
+use dynamo_kv_router::protocols::WorkerWithDpRank;
+use dynamo_kv_router::scheduling::{
+    AdmissionAction, AdmissionDecision, AdmissionEvent, AdmissionId, AdmissionRequest,
+    PolicyClassAdmissionStrategy, RequestProgress, WorkerEligibility, WorkerEligibilitySnapshot,
+    WorkerPlacement,
+};
+use indexmap::{IndexMap, IndexSet};
+
+use super::{ConfigError, ThunderAgentConfig, WorkerCapacity, WorkerCapacityProvider};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProgramStatus {
+    Reasoning,
+    Acting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ProgramLifecycle {
+    Active,
+    Paused,
+}
+
+#[derive(Clone)]
+struct Program {
+    status: ProgramStatus,
+    lifecycle: ProgramLifecycle,
+    assigned_worker: Option<WorkerWithDpRank>,
+    token_total: usize,
+    step_count: usize,
+    marked_for_pause: bool,
+    acting_since: Option<Instant>,
+    deferred_since: Option<Instant>,
+}
+
+impl Default for Program {
+    fn default() -> Self {
+        Self {
+            status: ProgramStatus::Reasoning,
+            lifecycle: ProgramLifecycle::Active,
+            assigned_worker: None,
+            token_total: 0,
+            step_count: 0,
+            marked_for_pause: false,
+            acting_since: None,
+            deferred_since: None,
+        }
+    }
+}
+
+struct RequestState {
+    session_id: String,
+    context_tokens: usize,
+    progress: RequestProgress,
+    worker_eligibility: WorkerEligibility,
+    dispatched: bool,
+    prior: Option<Program>,
+}
+
+#[derive(Default)]
+struct SessionRequests {
+    current: Option<AdmissionId>,
+    waiting: IndexSet<AdmissionId>,
+}
+
+#[derive(Debug, Default, Clone, Copy)]
+struct WorkerUsage {
+    used: usize,
+    decayed: usize,
+}
+
+impl WorkerUsage {
+    fn add_program(&mut self, normal: usize, decayed: usize, buffer: usize) {
+        self.used = self.used.saturating_add(normal).saturating_add(buffer);
+        self.decayed = self.decayed.saturating_add(decayed).saturating_add(buffer);
+    }
+
+    fn remove_program(&mut self, normal: usize, decayed: usize, buffer: usize) {
+        self.used = self.used.saturating_sub(normal).saturating_sub(buffer);
+        self.decayed = self.decayed.saturating_sub(decayed).saturating_sub(buffer);
+    }
+}
+
+pub struct ThunderAgent<P> {
+    capacity: P,
+    config: ThunderAgentConfig,
+    programs: IndexMap<String, Program>,
+    paused: IndexSet<String>,
+    requests: HashMap<AdmissionId, RequestState>,
+    sessions: HashMap<String, SessionRequests>,
+    next_tick: Instant,
+}
+
+impl<P: WorkerCapacityProvider> ThunderAgent<P> {
+    pub fn new(capacity: P, config: ThunderAgentConfig) -> Result<Self, ConfigError> {
+        config.validate()?;
+        tracing::info!(
+            pause_threshold = config.pause_threshold,
+            pause_target = config.pause_target,
+            resume_hysteresis = config.resume_hysteresis,
+            resume_timeout_seconds = config.resume_timeout_seconds,
+            session_retention_seconds = config.session_retention_seconds,
+            scheduler_interval_seconds = config.scheduler_interval_seconds,
+            acting_token_weight = config.acting_token_weight,
+            acting_decay_tau_seconds = config.acting_decay_tau_seconds,
+            buffer_per_program = config.buffer_per_program,
+            "ThunderAgent admission strategy configured"
+        );
+        let next_tick = Instant::now() + Duration::from_secs_f64(config.scheduler_interval_seconds);
+        Ok(Self {
+            capacity,
+            config,
+            programs: IndexMap::new(),
+            paused: IndexSet::new(),
+            requests: HashMap::new(),
+            sessions: HashMap::new(),
+            next_tick,
+        })
+    }
+
+    fn admit_request(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+        let Some(session_id) = request.session_id() else {
+            return AdmissionDecision::Bypass;
+        };
+
+        let now = Instant::now();
+        let id = request.id();
+        let session_is_busy = self
+            .sessions
+            .get(session_id)
+            .is_some_and(|requests| requests.current.is_some());
+        self.requests.insert(
+            id,
+            RequestState {
+                session_id: session_id.to_owned(),
+                context_tokens: request.context_tokens(),
+                progress: request.progress().clone(),
+                worker_eligibility: request.worker_eligibility().clone(),
+                dispatched: false,
+                prior: None,
+            },
+        );
+        if session_is_busy {
+            self.sessions
+                .get_mut(session_id)
+                .expect("busy session must exist")
+                .waiting
+                .insert(id);
+            return AdmissionDecision::Defer;
+        }
+
+        self.begin_request(id, session_id, now)
+    }
+
+    fn begin_request(
+        &mut self,
+        id: AdmissionId,
+        session_id: &str,
+        now: Instant,
+    ) -> AdmissionDecision {
+        self.refresh_reasoning_progress();
+        let Some(request) = self.requests.get(&id) else {
+            return AdmissionDecision::Defer;
+        };
+        let context_tokens = request.context_tokens;
+        let worker_eligibility = request.worker_eligibility.clone();
+        let capacities = self.capacity.snapshot();
+        let capacity_known = !capacities.is_empty();
+        let eligibility = worker_eligibility.snapshot();
+        let worker_is_available = |worker| eligibility.allows(worker);
+        let worker_is_structurally_allowed = |worker| eligibility.structurally_allows(worker);
+        let prior = self.programs.get(session_id).cloned();
+        let was_new = prior.is_none();
+        let Some(request) = self.requests.get_mut(&id) else {
+            return AdmissionDecision::Defer;
+        };
+        request.prior = prior;
+        if let Some(requests) = self.sessions.get_mut(session_id) {
+            requests.current = Some(id);
+        } else {
+            self.sessions.insert(
+                session_id.to_owned(),
+                SessionRequests {
+                    current: Some(id),
+                    ..Default::default()
+                },
+            );
+        }
+        let (lifecycle, assigned_worker) = if let Some(program) = self.programs.get_mut(session_id)
+        {
+            program.step_count = program.step_count.saturating_add(1);
+            if context_tokens > 0 {
+                program.token_total = context_tokens;
+            }
+            program.status = ProgramStatus::Reasoning;
+            program.acting_since = None;
+            (program.lifecycle, program.assigned_worker)
+        } else {
+            let program = Program {
+                step_count: 1,
+                token_total: context_tokens,
+                ..Default::default()
+            };
+            let state = (program.lifecycle, program.assigned_worker);
+            self.programs.insert(session_id.to_owned(), program);
+            state
+        };
+
+        if lifecycle == ProgramLifecycle::Paused {
+            self.defer_request(session_id, id, now, false);
+            return AdmissionDecision::Defer;
+        }
+
+        if let Some(worker) = assigned_worker {
+            if worker_is_structurally_allowed(worker) {
+                if worker_is_available(worker) {
+                    return AdmissionDecision::Ready(WorkerPlacement::Exact(worker));
+                }
+                self.defer_request(session_id, id, now, true);
+                return AdmissionDecision::Defer;
+            }
+            if let Some(program) = self.programs.get_mut(session_id) {
+                program.assigned_worker = None;
+            }
+        }
+
+        // Do not migrate a session just because every structurally valid worker
+        // is temporarily overloaded.
+        if eligibility.has_structural_worker() && !eligibility.has_available_worker() {
+            self.defer_request(session_id, id, now, false);
+            return AdmissionDecision::Defer;
+        }
+
+        // Preserve source fairness: a new program cannot bypass an already-paused one.
+        if was_new && !self.paused.is_empty() {
+            self.defer_request(session_id, id, now, false);
+            return AdmissionDecision::Defer;
+        }
+
+        if !capacity_known
+            || !capacities
+                .iter()
+                .any(|capacity| worker_is_available(capacity.worker))
+        {
+            return AdmissionDecision::Ready(WorkerPlacement::Any);
+        }
+
+        let required = context_tokens.saturating_add(self.config.buffer_per_program);
+        let usage = self.worker_usage(now);
+        let selected = capacities
+            .iter()
+            .filter(|capacity| worker_is_available(capacity.worker))
+            .filter_map(|capacity| {
+                let used = usage.get(&capacity.worker).map_or(0, |usage| usage.used);
+                capacity
+                    .tokens
+                    .checked_sub(used)
+                    .is_some_and(|remaining| remaining >= required)
+                    .then_some((capacity.worker, used))
+            })
+            .min_by_key(|(worker, used)| (*used, *worker))
+            .map(|(worker, _)| worker);
+
+        if let Some(worker) = selected {
+            if let Some(program) = self.programs.get_mut(session_id) {
+                program.assigned_worker = Some(worker);
+            }
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker))
+        } else {
+            self.defer_request(session_id, id, now, false);
+            AdmissionDecision::Defer
+        }
+    }
+
+    fn defer_request(
+        &mut self,
+        session_id: &str,
+        id: AdmissionId,
+        now: Instant,
+        preserve_assignment: bool,
+    ) {
+        let Some(program) = self.programs.get_mut(session_id) else {
+            return;
+        };
+        program.lifecycle = ProgramLifecycle::Paused;
+        if !preserve_assignment {
+            program.assigned_worker = None;
+        }
+        debug_assert_eq!(
+            self.sessions
+                .get(session_id)
+                .and_then(|requests| requests.current),
+            Some(id)
+        );
+        program.deferred_since = Some(now);
+        self.paused.insert(session_id.to_owned());
+    }
+
+    fn dispatched(&mut self, id: AdmissionId, worker: WorkerWithDpRank) {
+        let Some(request) = self.requests.get_mut(&id) else {
+            return;
+        };
+        if self
+            .sessions
+            .get(&request.session_id)
+            .and_then(|requests| requests.current)
+            != Some(id)
+        {
+            return;
+        }
+        request.dispatched = true;
+        if let Some(program) = self.programs.get_mut(&request.session_id) {
+            program.assigned_worker = Some(worker);
+        }
+    }
+
+    fn refresh_reasoning_progress(&mut self) {
+        for (session_id, requests) in &self.sessions {
+            let Some(id) = requests.current else {
+                continue;
+            };
+            let Some(request) = self.requests.get(&id) else {
+                continue;
+            };
+            let Some(program) = self.programs.get_mut(session_id) else {
+                continue;
+            };
+            if program.status == ProgramStatus::Reasoning {
+                program.token_total = request.progress.context_tokens();
+            }
+        }
+    }
+
+    fn completed(&mut self, id: AdmissionId, context_tokens: usize) -> Vec<AdmissionAction> {
+        self.finish_request(id, Some(context_tokens))
+    }
+
+    fn aborted(&mut self, id: AdmissionId) -> Vec<AdmissionAction> {
+        self.finish_request(id, None)
+    }
+
+    fn finish_request(
+        &mut self,
+        id: AdmissionId,
+        completed_context_tokens: Option<usize>,
+    ) -> Vec<AdmissionAction> {
+        let Some(request) = self.requests.remove(&id) else {
+            return Vec::new();
+        };
+        if self
+            .sessions
+            .get(&request.session_id)
+            .and_then(|requests| requests.current)
+            != Some(id)
+        {
+            if let Some(requests) = self.sessions.get_mut(&request.session_id) {
+                requests.waiting.shift_remove(&id);
+            }
+            return Vec::new();
+        }
+        if let Some(requests) = self.sessions.get_mut(&request.session_id) {
+            requests.current = None;
+        }
+        if let Some(program) = self.programs.get_mut(&request.session_id) {
+            program.deferred_since = None;
+        }
+
+        if !request.dispatched || completed_context_tokens.is_none() {
+            match request.prior {
+                Some(prior) => {
+                    let lifecycle = prior.lifecycle;
+                    self.programs.insert(request.session_id.clone(), prior);
+                    if lifecycle == ProgramLifecycle::Paused {
+                        self.paused.insert(request.session_id.clone());
+                    } else {
+                        self.paused.shift_remove(&request.session_id);
+                    }
+                }
+                None => {
+                    self.programs.shift_remove(&request.session_id);
+                    self.paused.shift_remove(&request.session_id);
+                }
+            }
+        } else if let Some(context_tokens) = completed_context_tokens
+            && let Some(program) = self.programs.get_mut(&request.session_id)
+        {
+            program.token_total = context_tokens;
+            program.status = ProgramStatus::Acting;
+            program.acting_since = Some(Instant::now());
+            let pause = std::mem::take(&mut program.marked_for_pause);
+            if pause {
+                self.pause_acting(&request.session_id);
+            }
+        }
+
+        self.promote_next(&request.session_id)
+    }
+
+    fn promote_next(&mut self, session_id: &str) -> Vec<AdmissionAction> {
+        let next = self
+            .sessions
+            .get_mut(session_id)
+            .and_then(|requests| requests.waiting.shift_remove_index(0));
+        let Some(id) = next else {
+            self.sessions.remove(session_id);
+            return Vec::new();
+        };
+        match self.begin_request(id, session_id, Instant::now()) {
+            AdmissionDecision::Ready(placement) => {
+                vec![AdmissionAction::MakeReady { id, placement }]
+            }
+            _ => Vec::new(),
+        }
+    }
+
+    fn reconcile(&mut self) -> Vec<AdmissionAction> {
+        let now = Instant::now();
+        if now < self.next_tick {
+            return Vec::new();
+        }
+        self.next_tick = now + Duration::from_secs_f64(self.config.scheduler_interval_seconds);
+        self.refresh_reasoning_progress();
+        let expired_programs = self.expire_retained_programs(now);
+        let paused_before = self.paused.len();
+        let marked_before = self
+            .programs
+            .values()
+            .filter(|program| program.marked_for_pause)
+            .count();
+        let capacities = self.capacity.snapshot();
+        let mut usage = self.worker_usage(now);
+        let eligibility = self.deferred_eligibility_snapshots();
+        let (mut actions, greedy_resumes) = if capacities.is_empty() {
+            (Vec::new(), 0)
+        } else {
+            self.greedy_resume(&capacities, &mut usage, &eligibility, now)
+        };
+        let (forced_actions, forced_resumes) =
+            self.force_timed_out(&capacities, &mut usage, &eligibility, now);
+        actions.extend(forced_actions);
+        let (paused_now, marked_now) = if capacities.is_empty() {
+            (0, 0)
+        } else {
+            self.pause_until_safe(&capacities, &mut usage, now)
+        };
+        let marked = self
+            .programs
+            .values()
+            .filter(|program| program.marked_for_pause)
+            .count();
+        if greedy_resumes > 0
+            || forced_resumes > 0
+            || paused_now > 0
+            || marked_now > 0
+            || expired_programs > 0
+            || self.paused.len() != paused_before
+            || marked != marked_before
+        {
+            tracing::info!(
+                programs = self.programs.len(),
+                active = self.programs.len().saturating_sub(self.paused.len()),
+                paused = self.paused.len(),
+                marked,
+                greedy_resumed_programs = greedy_resumes,
+                forced_resumed_programs = forced_resumes,
+                paused_programs = paused_now,
+                marked_programs = marked_now,
+                expired_programs,
+                released_requests = actions.len(),
+                capacity_workers = capacities.len(),
+                "ThunderAgent admission state changed"
+            );
+        }
+        actions
+    }
+
+    fn expire_retained_programs(&mut self, now: Instant) -> usize {
+        let retention = Duration::from_secs_f64(self.config.session_retention_seconds);
+        let expired: Vec<String> = self
+            .programs
+            .iter()
+            .filter(|(session_id, program)| {
+                program.status == ProgramStatus::Acting
+                    && !self.sessions.contains_key(session_id.as_str())
+                    && program
+                        .acting_since
+                        .is_some_and(|since| now.saturating_duration_since(since) >= retention)
+            })
+            .map(|(session_id, _)| session_id.clone())
+            .collect();
+
+        for session_id in &expired {
+            self.programs.shift_remove(session_id);
+            self.paused.shift_remove(session_id);
+        }
+        expired.len()
+    }
+
+    fn program_tokens(&self, program: &Program, decayed: bool, now: Instant) -> usize {
+        if program.status != ProgramStatus::Acting {
+            return program.token_total;
+        }
+        if !decayed {
+            return scale_tokens(program.token_total, self.config.acting_token_weight);
+        }
+        let idle = program
+            .acting_since
+            .map_or(Duration::ZERO, |since| now.saturating_duration_since(since));
+        let weight = 2.0_f64.powf(-idle.as_secs_f64() / self.config.acting_decay_tau_seconds);
+        scale_tokens(program.token_total, weight)
+    }
+
+    fn worker_usage(&self, now: Instant) -> HashMap<WorkerWithDpRank, WorkerUsage> {
+        let mut usage = HashMap::<WorkerWithDpRank, WorkerUsage>::new();
+        for program in self.programs.values() {
+            if program.lifecycle == ProgramLifecycle::Active
+                && let Some(worker) = program.assigned_worker
+            {
+                let worker_usage = usage.entry(worker).or_default();
+                worker_usage.add_program(
+                    self.program_tokens(program, false, now),
+                    self.program_tokens(program, true, now),
+                    self.config.buffer_per_program,
+                );
+            }
+        }
+        usage
+    }
+
+    fn greedy_resume(
+        &mut self,
+        capacities: &[WorkerCapacity],
+        usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
+        eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
+        now: Instant,
+    ) -> (Vec<AdmissionAction>, usize) {
+        if self.paused.is_empty() {
+            return (Vec::new(), 0);
+        }
+
+        let mut paused: Vec<String> = self
+            .paused
+            .iter()
+            .filter(|session_id| self.programs.contains_key(*session_id))
+            .cloned()
+            .collect();
+        paused.sort_by_key(|session_id| {
+            let program = &self.programs[session_id];
+            let group = if program.step_count <= 1 {
+                1
+            } else if program.status == ProgramStatus::Reasoning {
+                0
+            } else {
+                2
+            };
+            (group, program.token_total)
+        });
+
+        let ceiling = (self.config.pause_threshold - self.config.resume_hysteresis).max(0.0);
+        let mut backend_caps: Vec<(WorkerWithDpRank, usize)> = capacities
+            .iter()
+            .filter_map(|capacity| {
+                let limit = scale_tokens(capacity.tokens, ceiling);
+                let remaining =
+                    limit.saturating_sub(usage.get(&capacity.worker).map_or(0, |usage| usage.used));
+                (remaining > self.config.buffer_per_program).then_some((capacity.worker, remaining))
+            })
+            .collect();
+        sort_backend_caps(&mut backend_caps);
+        if backend_caps.is_empty() {
+            return (Vec::new(), 0);
+        }
+
+        let total_capacity = backend_caps.iter().fold(0usize, |total, (_, remaining)| {
+            total.saturating_add(*remaining)
+        });
+        let mut cumulative = 0usize;
+        let mut resumable = Vec::new();
+        for session_id in paused {
+            let required = self.programs[&session_id]
+                .token_total
+                .saturating_add(self.config.buffer_per_program);
+            if !backend_caps.iter().any(|(worker, remaining)| {
+                self.session_allows_worker(&session_id, *worker, eligibility)
+                    && required <= *remaining
+            }) {
+                continue;
+            }
+            if cumulative.saturating_add(required) <= total_capacity {
+                cumulative = cumulative.saturating_add(required);
+                resumable.push(session_id);
+            }
+        }
+        resumable.sort_by_key(|session_id| Reverse(self.programs[session_id].token_total));
+        let mut actions = Vec::new();
+        let mut resumed = 0;
+        for session_id in resumable {
+            let Some((position, &(worker, remaining))) =
+                backend_caps
+                    .iter()
+                    .enumerate()
+                    .find(|(_, (worker, remaining))| {
+                        self.session_allows_worker(&session_id, *worker, eligibility)
+                            && self.programs[&session_id]
+                                .token_total
+                                .saturating_add(self.config.buffer_per_program)
+                                <= *remaining
+                    })
+            else {
+                continue;
+            };
+            let required = self.programs[&session_id]
+                .token_total
+                .saturating_add(self.config.buffer_per_program);
+            actions.extend(self.resume_program(&session_id, Some(worker)));
+            resumed += 1;
+            let program = &self.programs[&session_id];
+            let worker_usage = usage.entry(worker).or_default();
+            worker_usage.add_program(
+                self.program_tokens(program, false, now),
+                self.program_tokens(program, true, now),
+                self.config.buffer_per_program,
+            );
+            let updated = remaining - required;
+            if updated > self.config.buffer_per_program {
+                backend_caps[position] = (worker, updated);
+                sort_backend_caps(&mut backend_caps);
+            } else {
+                backend_caps.remove(position);
+            }
+        }
+        (actions, resumed)
+    }
+
+    fn force_timed_out(
+        &mut self,
+        capacities: &[WorkerCapacity],
+        usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
+        eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
+        now: Instant,
+    ) -> (Vec<AdmissionAction>, usize) {
+        let timeout = Duration::from_secs_f64(self.config.resume_timeout_seconds);
+        let timed_out: Vec<String> = self
+            .paused
+            .iter()
+            .filter(|session_id| {
+                self.programs
+                    .get(*session_id)
+                    .and_then(|program| program.deferred_since)
+                    .is_some_and(|since| now.saturating_duration_since(since) >= timeout)
+            })
+            .cloned()
+            .collect();
+
+        let mut actions = Vec::new();
+        let mut resumed = 0;
+        for session_id in timed_out {
+            if self.programs[&session_id].lifecycle != ProgramLifecycle::Paused {
+                continue;
+            }
+            let target = capacities
+                .iter()
+                .filter(|capacity| {
+                    self.session_allows_worker(&session_id, capacity.worker, eligibility)
+                })
+                .max_by_key(|capacity| {
+                    (
+                        capacity.tokens as i128
+                            - usage.get(&capacity.worker).map_or(0, |usage| usage.decayed) as i128,
+                        Reverse(capacity.worker),
+                    )
+                })
+                .map(|capacity| capacity.worker);
+            if target.is_none() && self.session_waits_for_available_worker(&session_id, eligibility)
+            {
+                continue;
+            }
+            actions.extend(self.resume_program(&session_id, target));
+            resumed += 1;
+            if let Some(worker) = target {
+                let program = &self.programs[&session_id];
+                let worker_usage = usage.entry(worker).or_default();
+                worker_usage.add_program(
+                    self.program_tokens(program, false, now),
+                    self.program_tokens(program, true, now),
+                    self.config.buffer_per_program,
+                );
+            }
+        }
+        (actions, resumed)
+    }
+
+    fn pause_until_safe(
+        &mut self,
+        capacities: &[WorkerCapacity],
+        usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
+        now: Instant,
+    ) -> (usize, usize) {
+        let mut acting = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
+        let mut reasoning = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
+        for (session_id, program) in &self.programs {
+            if program.lifecycle != ProgramLifecycle::Active || program.marked_for_pause {
+                continue;
+            }
+            let Some(worker) = program.assigned_worker else {
+                continue;
+            };
+            let candidates = match program.status {
+                ProgramStatus::Acting => &mut acting,
+                ProgramStatus::Reasoning => &mut reasoning,
+            };
+            candidates
+                .entry(worker)
+                .or_default()
+                .push((program.token_total, session_id.clone()));
+        }
+        for candidates in acting.values_mut().chain(reasoning.values_mut()) {
+            candidates.sort_by_key(|(tokens, _)| *tokens);
+        }
+
+        let pause_target = self.config.pause_target;
+        let mut paused_total = 0;
+        let mut marked_total = 0;
+        for capacity in capacities {
+            let threshold = scale_tokens(capacity.tokens, self.config.pause_threshold);
+            let worker_used = usage.get(&capacity.worker).map_or(0, |usage| usage.used);
+            if worker_used <= threshold {
+                continue;
+            }
+            let target = scale_tokens(capacity.tokens, pause_target);
+            let mut paused = 0;
+            let mut marked = 0;
+            if let Some(candidates) = acting.get(&capacity.worker) {
+                for (_, session_id) in candidates {
+                    if usage.get(&capacity.worker).map_or(0, |usage| usage.used) <= target {
+                        break;
+                    }
+                    let Some(program) = self.programs.get(session_id) else {
+                        continue;
+                    };
+                    let used = self.program_tokens(program, false, now);
+                    let decayed = self.program_tokens(program, true, now);
+                    self.pause_acting(session_id);
+                    paused += 1;
+                    let worker_usage = usage.entry(capacity.worker).or_default();
+                    worker_usage.remove_program(used, decayed, self.config.buffer_per_program);
+                }
+            }
+            if usage.get(&capacity.worker).map_or(0, |usage| usage.used) > target
+                && let Some(candidates) = reasoning.get(&capacity.worker)
+            {
+                for (_, session_id) in candidates {
+                    if let Some(program) = self.programs.get_mut(session_id) {
+                        program.marked_for_pause = true;
+                        marked += 1;
+                    }
+                }
+            }
+            let used_after = usage.get(&capacity.worker).map_or(0, |usage| usage.used);
+            paused_total += paused;
+            marked_total += marked;
+            tracing::info!(
+                worker_id = capacity.worker.worker_id,
+                dp_rank = capacity.worker.dp_rank,
+                capacity_tokens = capacity.tokens,
+                used_before = worker_used,
+                used_after,
+                threshold_tokens = threshold,
+                target_tokens = target,
+                paused_programs = paused,
+                marked_programs = marked,
+                "ThunderAgent worker pressure handled"
+            );
+        }
+        (paused_total, marked_total)
+    }
+
+    fn deferred_eligibility_snapshots(&self) -> HashMap<AdmissionId, WorkerEligibilitySnapshot> {
+        self.programs
+            .iter()
+            .filter(|(_, program)| program.deferred_since.is_some())
+            .filter_map(|(session_id, _)| {
+                let id = self.sessions.get(session_id)?.current?;
+                let request = self.requests.get(&id)?;
+                Some((id, request.worker_eligibility.snapshot()))
+            })
+            .collect()
+    }
+
+    fn session_allows_worker(
+        &self,
+        session_id: &str,
+        worker: WorkerWithDpRank,
+        eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
+    ) -> bool {
+        let Some(program) = self.programs.get(session_id) else {
+            return false;
+        };
+        if program
+            .assigned_worker
+            .is_some_and(|assigned| assigned != worker)
+        {
+            return false;
+        }
+        if program.deferred_since.is_none() {
+            return true;
+        }
+        self.sessions
+            .get(session_id)
+            .and_then(|requests| requests.current)
+            .and_then(|id| eligibility.get(&id))
+            .is_none_or(|eligibility| eligibility.allows(worker))
+    }
+
+    fn session_waits_for_available_worker(
+        &self,
+        session_id: &str,
+        eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
+    ) -> bool {
+        let Some(program) = self.programs.get(session_id) else {
+            return false;
+        };
+        if program.deferred_since.is_none() {
+            return false;
+        }
+        self.sessions
+            .get(session_id)
+            .and_then(|requests| requests.current)
+            .and_then(|id| eligibility.get(&id))
+            .is_some_and(|snapshot| {
+                snapshot.has_structural_worker() && !snapshot.has_available_worker()
+            })
+    }
+
+    fn pause_acting(&mut self, session_id: &str) {
+        let Some(program) = self.programs.get_mut(session_id) else {
+            return;
+        };
+        if program.lifecycle != ProgramLifecycle::Active || program.status != ProgramStatus::Acting
+        {
+            return;
+        }
+        program.lifecycle = ProgramLifecycle::Paused;
+        program.assigned_worker = None;
+        self.paused.insert(session_id.to_owned());
+    }
+
+    fn resume_program(
+        &mut self,
+        session_id: &str,
+        worker: Option<WorkerWithDpRank>,
+    ) -> Vec<AdmissionAction> {
+        let deferred_id = self
+            .sessions
+            .get(session_id)
+            .and_then(|requests| requests.current);
+        let Some(program) = self.programs.get_mut(session_id) else {
+            return Vec::new();
+        };
+        if program.lifecycle != ProgramLifecycle::Paused {
+            return Vec::new();
+        }
+        program.lifecycle = ProgramLifecycle::Active;
+        program.assigned_worker = worker;
+        let was_deferred = program.deferred_since.take().is_some();
+        self.paused.shift_remove(session_id);
+        match (was_deferred, deferred_id) {
+            (true, Some(id)) => vec![AdmissionAction::MakeReady {
+                id,
+                placement: worker.map_or(WorkerPlacement::Any, WorkerPlacement::Exact),
+            }],
+            _ => Vec::new(),
+        }
+    }
+}
+
+impl<P: WorkerCapacityProvider> PolicyClassAdmissionStrategy for ThunderAgent<P> {
+    fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+        self.admit_request(request)
+    }
+
+    fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+        match event {
+            AdmissionEvent::Dispatched { id, worker } => {
+                self.dispatched(id, worker);
+                Vec::new()
+            }
+            AdmissionEvent::Completed { id, context_tokens } => self.completed(id, context_tokens),
+            AdmissionEvent::Aborted { id } => self.aborted(id),
+            AdmissionEvent::Reconcile => self.reconcile(),
+            _ => Vec::new(),
+        }
+    }
+
+    fn reconcile_interval(&self) -> Option<Duration> {
+        Some(Duration::from_secs_f64(
+            self.config.scheduler_interval_seconds,
+        ))
+    }
+}
+
+fn scale_tokens(tokens: usize, factor: f64) -> usize {
+    ((tokens as f64) * factor).clamp(0.0, usize::MAX as f64) as usize
+}
+
+fn sort_backend_caps(capacities: &mut [(WorkerWithDpRank, usize)]) {
+    capacities.sort_unstable_by_key(|(worker, remaining)| (Reverse(*remaining), *worker));
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    use super::*;
+
+    fn worker(id: u64) -> WorkerWithDpRank {
+        WorkerWithDpRank::new(id, 0)
+    }
+
+    fn request(id: u64, session_id: Option<&str>, context_tokens: usize) -> AdmissionRequest<'_> {
+        AdmissionRequest::new(
+            AdmissionId::new(id),
+            session_id,
+            context_tokens,
+            WorkerEligibility::new(|| WorkerEligibilitySnapshot::new([worker(1), worker(2)])),
+        )
+    }
+
+    fn filtered_request(
+        id: u64,
+        session_id: Option<&str>,
+        context_tokens: usize,
+        eligible_workers: impl Fn() -> Vec<WorkerWithDpRank> + Send + Sync + 'static,
+    ) -> AdmissionRequest<'_> {
+        AdmissionRequest::new(
+            AdmissionId::new(id),
+            session_id,
+            context_tokens,
+            WorkerEligibility::new(move || WorkerEligibilitySnapshot::new(eligible_workers())),
+        )
+    }
+
+    fn availability_request(
+        id: u64,
+        session_id: Option<&str>,
+        context_tokens: usize,
+        workers: impl Fn() -> (Vec<WorkerWithDpRank>, Vec<WorkerWithDpRank>) + Send + Sync + 'static,
+    ) -> AdmissionRequest<'_> {
+        AdmissionRequest::new(
+            AdmissionId::new(id),
+            session_id,
+            context_tokens,
+            WorkerEligibility::new(move || {
+                let (structural, available) = workers();
+                WorkerEligibilitySnapshot::with_availability(
+                    structural.into_iter().collect(),
+                    available.into_iter().collect(),
+                )
+            }),
+        )
+    }
+
+    fn capacities(values: &[(u64, usize)]) -> Vec<WorkerCapacity> {
+        values
+            .iter()
+            .map(|&(id, tokens)| WorkerCapacity {
+                worker: worker(id),
+                tokens,
+            })
+            .collect()
+    }
+
+    fn reconcile_now<P: WorkerCapacityProvider>(
+        strategy: &mut ThunderAgent<P>,
+    ) -> Vec<AdmissionAction> {
+        strategy.next_tick = Instant::now();
+        strategy.on_event(AdmissionEvent::Reconcile)
+    }
+
+    #[test]
+    fn sessionless_requests_do_not_create_program_state() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        assert_eq!(
+            strategy.admit(request(1, None, 100)),
+            AdmissionDecision::Bypass
+        );
+        assert!(strategy.programs.is_empty());
+    }
+
+    #[test]
+    fn new_session_uses_least_loaded_worker_and_sticks() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000), (2, 1_000)]), Default::default())
+                .unwrap();
+        assert_eq!(
+            strategy.admit(request(1, Some("a"), 100)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 150,
+        });
+        assert_eq!(strategy.programs["a"].token_total, 150);
+        assert_eq!(
+            strategy.admit(request(2, Some("a"), 120)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+    }
+
+    #[test]
+    fn placement_respects_request_worker_eligibility() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000), (2, 1_000)]), Default::default())
+                .unwrap();
+        assert_eq!(
+            strategy.admit(filtered_request(1, Some("a"), 100, || vec![worker(2)])),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(2)))
+        );
+    }
+
+    #[test]
+    fn deferred_request_rechecks_live_worker_eligibility() {
+        let allowed = Arc::new(AtomicBool::new(false));
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        strategy.programs.insert(
+            "paused".to_owned(),
+            Program {
+                lifecycle: ProgramLifecycle::Paused,
+                ..Program::default()
+            },
+        );
+        strategy.paused.insert("paused".to_owned());
+        let live_allowed = Arc::clone(&allowed);
+        assert_eq!(
+            strategy.admit(filtered_request(1, Some("paused"), 100, move || {
+                live_allowed
+                    .load(Ordering::Relaxed)
+                    .then(|| worker(1))
+                    .into_iter()
+                    .collect()
+            },)),
+            AdmissionDecision::Defer
+        );
+
+        assert!(reconcile_now(&mut strategy).is_empty());
+
+        allowed.store(true, Ordering::Relaxed);
+        assert_eq!(
+            reconcile_now(&mut strategy),
+            vec![AdmissionAction::MakeReady {
+                id: AdmissionId::new(1),
+                placement: WorkerPlacement::Exact(worker(1)),
+            }]
+        );
+    }
+
+    #[test]
+    fn sticky_session_reassigns_after_worker_removal() {
+        let current = Arc::new(Mutex::new(capacities(&[(1, 1_000), (2, 1_000)])));
+        let provider = {
+            let current = Arc::clone(&current);
+            move || current.lock().unwrap().clone()
+        };
+        let mut strategy = ThunderAgent::new(provider, Default::default()).unwrap();
+        assert_eq!(
+            strategy.admit(request(1, Some("a"), 100)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 150,
+        });
+
+        *current.lock().unwrap() = capacities(&[(2, 1_000)]);
+        assert_eq!(
+            strategy.admit(filtered_request(2, Some("a"), 120, || vec![worker(2)])),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(2)))
+        );
+    }
+
+    #[test]
+    fn sticky_session_waits_for_transiently_unavailable_worker() {
+        let available = Arc::new(AtomicBool::new(true));
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000), (2, 1_000)]), Default::default())
+                .unwrap();
+        let snapshot = {
+            let available = Arc::clone(&available);
+            move || {
+                let structural = vec![worker(1), worker(2)];
+                let available = if available.load(Ordering::Relaxed) {
+                    structural.clone()
+                } else {
+                    vec![worker(2)]
+                };
+                (structural, available)
+            }
+        };
+        assert_eq!(
+            strategy.admit(availability_request(1, Some("a"), 100, snapshot)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 150,
+        });
+
+        available.store(false, Ordering::Relaxed);
+        let snapshot = {
+            let available = Arc::clone(&available);
+            move || {
+                let structural = vec![worker(1), worker(2)];
+                let available = if available.load(Ordering::Relaxed) {
+                    structural.clone()
+                } else {
+                    vec![worker(2)]
+                };
+                (structural, available)
+            }
+        };
+        assert_eq!(
+            strategy.admit(availability_request(2, Some("a"), 160, snapshot)),
+            AdmissionDecision::Defer
+        );
+        assert_eq!(strategy.programs["a"].assigned_worker, Some(worker(1)));
+        assert!(reconcile_now(&mut strategy).is_empty());
+
+        available.store(true, Ordering::Relaxed);
+        assert_eq!(
+            reconcile_now(&mut strategy),
+            vec![AdmissionAction::MakeReady {
+                id: AdmissionId::new(2),
+                placement: WorkerPlacement::Exact(worker(1)),
+            }]
+        );
+    }
+
+    #[test]
+    fn sticky_session_drops_disallowed_worker_without_capacity_metadata() {
+        let current = Arc::new(Mutex::new(capacities(&[(1, 1_000)])));
+        let provider = {
+            let current = Arc::clone(&current);
+            move || current.lock().unwrap().clone()
+        };
+        let mut strategy = ThunderAgent::new(provider, Default::default()).unwrap();
+        strategy.admit(request(1, Some("a"), 100));
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 150,
+        });
+
+        current.lock().unwrap().clear();
+        assert_eq!(
+            strategy.admit(filtered_request(2, Some("a"), 120, || vec![worker(2)])),
+            AdmissionDecision::Ready(WorkerPlacement::Any)
+        );
+        assert_eq!(strategy.programs["a"].assigned_worker, None);
+    }
+
+    #[test]
+    fn completion_commits_authoritative_context_tokens() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        strategy.admit(request(1, Some("a"), 100));
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 140,
+        });
+        assert_eq!(strategy.programs["a"].token_total, 140);
+    }
+
+    #[test]
+    fn live_progress_updates_inflight_reasoning_context_tokens() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        strategy.admit(request(1, Some("a"), 100));
+        let (progress, updater) = RequestProgress::new(100);
+        strategy
+            .requests
+            .get_mut(&AdmissionId::new(1))
+            .unwrap()
+            .progress = progress;
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        updater.update_context_tokens(128);
+        strategy.refresh_reasoning_progress();
+
+        let program = &strategy.programs["a"];
+        assert_eq!(program.status, ProgramStatus::Reasoning);
+        assert_eq!(program.token_total, 128);
+
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 140,
+        });
+        assert_eq!(strategy.programs["a"].token_total, 140);
+    }
+
+    #[test]
+    fn retention_expiry_removes_only_quiescent_acting_programs() {
+        let config = ThunderAgentConfig {
+            session_retention_seconds: 900.0,
+            buffer_per_program: 0,
+            ..Default::default()
+        };
+        let mut strategy = ThunderAgent::new(Vec::<WorkerCapacity>::new, config).unwrap();
+        let now = Instant::now();
+        let expired_at = now - Duration::from_secs(900);
+
+        for (session_id, program) in [
+            (
+                "expired-active",
+                Program {
+                    status: ProgramStatus::Acting,
+                    assigned_worker: Some(worker(1)),
+                    token_total: 100,
+                    acting_since: Some(expired_at),
+                    ..Program::default()
+                },
+            ),
+            (
+                "expired-paused",
+                Program {
+                    status: ProgramStatus::Acting,
+                    lifecycle: ProgramLifecycle::Paused,
+                    token_total: 200,
+                    acting_since: Some(expired_at),
+                    ..Program::default()
+                },
+            ),
+            (
+                "fresh",
+                Program {
+                    status: ProgramStatus::Acting,
+                    assigned_worker: Some(worker(1)),
+                    token_total: 300,
+                    acting_since: Some(expired_at + Duration::from_nanos(1)),
+                    ..Program::default()
+                },
+            ),
+            (
+                "reasoning",
+                Program {
+                    status: ProgramStatus::Reasoning,
+                    assigned_worker: Some(worker(1)),
+                    token_total: 400,
+                    acting_since: Some(expired_at),
+                    ..Program::default()
+                },
+            ),
+            (
+                "busy",
+                Program {
+                    status: ProgramStatus::Acting,
+                    assigned_worker: Some(worker(1)),
+                    token_total: 500,
+                    acting_since: Some(expired_at),
+                    ..Program::default()
+                },
+            ),
+        ] {
+            strategy.programs.insert(session_id.to_owned(), program);
+        }
+        strategy.paused.insert("expired-paused".to_owned());
+        strategy.sessions.insert(
+            "busy".to_owned(),
+            SessionRequests {
+                current: Some(AdmissionId::new(99)),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(strategy.expire_retained_programs(now), 2);
+        assert!(!strategy.programs.contains_key("expired-active"));
+        assert!(!strategy.programs.contains_key("expired-paused"));
+        assert!(!strategy.paused.contains("expired-paused"));
+        assert!(strategy.programs.contains_key("fresh"));
+        assert!(strategy.programs.contains_key("reasoning"));
+        assert!(strategy.programs.contains_key("busy"));
+
+        let usage = strategy.worker_usage(now);
+        assert_eq!(usage[&worker(1)].used, 1_200);
+    }
+
+    #[test]
+    fn expired_session_returns_as_a_new_program() {
+        let config = ThunderAgentConfig {
+            session_retention_seconds: 900.0,
+            ..Default::default()
+        };
+        let mut strategy = ThunderAgent::new(|| capacities(&[(1, 1_000)]), config).unwrap();
+        strategy.programs.insert(
+            "expired".to_owned(),
+            Program {
+                status: ProgramStatus::Acting,
+                assigned_worker: Some(worker(2)),
+                token_total: 700,
+                step_count: 4,
+                acting_since: Some(Instant::now() - Duration::from_secs(901)),
+                ..Program::default()
+            },
+        );
+
+        assert!(reconcile_now(&mut strategy).is_empty());
+        assert!(!strategy.programs.contains_key("expired"));
+        assert_eq!(
+            strategy.admit(request(100, Some("expired"), 100)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+        assert_eq!(strategy.programs["expired"].step_count, 1);
+    }
+
+    #[test]
+    fn pressure_pauses_smallest_acting_program_then_resumes_deferred_turn() {
+        let current = Arc::new(Mutex::new(capacities(&[(1, 300)])));
+        let provider = {
+            let current = Arc::clone(&current);
+            move || current.lock().unwrap().clone()
+        };
+        let config = ThunderAgentConfig {
+            pause_threshold: 0.8,
+            pause_target: 0.5,
+            buffer_per_program: 0,
+            ..Default::default()
+        };
+        let mut strategy = ThunderAgent::new(provider, config).unwrap();
+
+        for (id, session, input, output) in [(1, "small", 80, 20), (2, "large", 150, 30)] {
+            assert!(matches!(
+                strategy.admit(request(id, Some(session), input)),
+                AdmissionDecision::Ready(_)
+            ));
+            strategy.on_event(AdmissionEvent::Dispatched {
+                id: AdmissionId::new(id),
+                worker: worker(1),
+            });
+            strategy.on_event(AdmissionEvent::Completed {
+                id: AdmissionId::new(id),
+                context_tokens: input + output,
+            });
+        }
+
+        assert!(strategy.on_event(AdmissionEvent::Reconcile).is_empty());
+        assert_eq!(
+            strategy.programs["small"].lifecycle,
+            ProgramLifecycle::Active
+        );
+        assert!(reconcile_now(&mut strategy).is_empty());
+        assert_eq!(
+            strategy.programs["small"].lifecycle,
+            ProgramLifecycle::Paused
+        );
+        assert_eq!(
+            strategy.admit(request(3, Some("small"), 110)),
+            AdmissionDecision::Defer
+        );
+
+        *current.lock().unwrap() = capacities(&[(1, 600)]);
+        assert_eq!(
+            reconcile_now(&mut strategy),
+            vec![AdmissionAction::MakeReady {
+                id: AdmissionId::new(3),
+                placement: WorkerPlacement::Exact(worker(1)),
+            }]
+        );
+    }
+
+    #[test]
+    fn timeout_forces_deferred_request_without_capacity_metadata() {
+        let config = ThunderAgentConfig {
+            resume_timeout_seconds: 1.0,
+            ..Default::default()
+        };
+        let mut strategy = ThunderAgent::new(Vec::<WorkerCapacity>::new, config).unwrap();
+        strategy.programs.insert(
+            "paused".to_owned(),
+            Program {
+                lifecycle: ProgramLifecycle::Paused,
+                ..Program::default()
+            },
+        );
+        strategy.paused.insert("paused".to_owned());
+        assert_eq!(
+            strategy.admit(request(1, Some("paused"), 100)),
+            AdmissionDecision::Defer
+        );
+        strategy.programs["paused"].deferred_since = Some(Instant::now() - Duration::from_secs(2));
+        assert_eq!(
+            reconcile_now(&mut strategy),
+            vec![AdmissionAction::MakeReady {
+                id: AdmissionId::new(1),
+                placement: WorkerPlacement::Any,
+            }]
+        );
+    }
+
+    #[test]
+    fn forced_resume_chooses_the_least_overfull_worker() {
+        let config = ThunderAgentConfig {
+            resume_timeout_seconds: 1.0,
+            buffer_per_program: 0,
+            ..Default::default()
+        };
+        let mut strategy = ThunderAgent::new(|| capacities(&[(1, 100), (2, 100)]), config).unwrap();
+        for (session_id, assigned_worker, token_total) in
+            [("worker-1", worker(1), 300), ("worker-2", worker(2), 200)]
+        {
+            strategy.programs.insert(
+                session_id.to_owned(),
+                Program {
+                    status: ProgramStatus::Acting,
+                    assigned_worker: Some(assigned_worker),
+                    token_total,
+                    ..Program::default()
+                },
+            );
+        }
+        strategy.programs.insert(
+            "paused".to_owned(),
+            Program {
+                lifecycle: ProgramLifecycle::Paused,
+                ..Program::default()
+            },
+        );
+        strategy.paused.insert("paused".to_owned());
+        assert_eq!(
+            strategy.admit(request(1, Some("paused"), 50)),
+            AdmissionDecision::Defer
+        );
+        strategy.programs["paused"].deferred_since = Some(Instant::now() - Duration::from_secs(2));
+
+        assert_eq!(
+            reconcile_now(&mut strategy),
+            vec![AdmissionAction::MakeReady {
+                id: AdmissionId::new(1),
+                placement: WorkerPlacement::Exact(worker(2)),
+            }]
+        );
+    }
+
+    #[test]
+    fn cancellation_before_dispatch_restores_prior_program_state() {
+        let mut strategy =
+            ThunderAgent::new(Vec::<WorkerCapacity>::new, Default::default()).unwrap();
+        strategy.programs.insert(
+            "existing".to_owned(),
+            Program {
+                status: ProgramStatus::Acting,
+                token_total: 200,
+                step_count: 3,
+                ..Program::default()
+            },
+        );
+        assert!(matches!(
+            strategy.admit(request(1, Some("existing"), 300)),
+            AdmissionDecision::Ready(_)
+        ));
+        strategy.on_event(AdmissionEvent::Aborted {
+            id: AdmissionId::new(1),
+        });
+        let program = &strategy.programs["existing"];
+        assert_eq!(program.status, ProgramStatus::Acting);
+        assert_eq!(program.token_total, 200);
+        assert_eq!(program.step_count, 3);
+    }
+
+    #[test]
+    fn cancellation_after_dispatch_restores_prior_program_state() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        strategy.programs.insert(
+            "existing".to_owned(),
+            Program {
+                status: ProgramStatus::Acting,
+                assigned_worker: Some(worker(1)),
+                token_total: 200,
+                step_count: 3,
+                ..Program::default()
+            },
+        );
+        strategy.admit(request(1, Some("existing"), 300));
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Aborted {
+            id: AdmissionId::new(1),
+        });
+
+        let program = &strategy.programs["existing"];
+        assert_eq!(program.status, ProgramStatus::Acting);
+        assert_eq!(program.token_total, 200);
+        assert_eq!(program.step_count, 3);
+    }
+
+    #[test]
+    fn concurrent_session_request_waits_without_mutating_program() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        assert_eq!(
+            strategy.admit(request(1, Some("same"), 100)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+        assert_eq!(
+            strategy.admit(request(2, Some("same"), 900)),
+            AdmissionDecision::Defer
+        );
+        assert_eq!(strategy.programs["same"].token_total, 100);
+        assert_eq!(strategy.programs["same"].step_count, 1);
+
+        assert!(
+            strategy
+                .on_event(AdmissionEvent::Aborted {
+                    id: AdmissionId::new(2),
+                })
+                .is_empty()
+        );
+        strategy.on_event(AdmissionEvent::Dispatched {
+            id: AdmissionId::new(1),
+            worker: worker(1),
+        });
+        strategy.on_event(AdmissionEvent::Completed {
+            id: AdmissionId::new(1),
+            context_tokens: 150,
+        });
+        assert_eq!(strategy.programs["same"].token_total, 150);
+        assert_eq!(strategy.programs["same"].step_count, 1);
+    }
+
+    #[test]
+    fn cancelling_current_session_request_promotes_one_waiter() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        assert!(matches!(
+            strategy.admit(request(1, Some("same"), 100)),
+            AdmissionDecision::Ready(_)
+        ));
+        assert_eq!(
+            strategy.admit(request(2, Some("same"), 120)),
+            AdmissionDecision::Defer
+        );
+
+        assert_eq!(
+            strategy.on_event(AdmissionEvent::Aborted {
+                id: AdmissionId::new(1),
+            }),
+            vec![AdmissionAction::MakeReady {
+                id: AdmissionId::new(2),
+                placement: WorkerPlacement::Exact(worker(1)),
+            }]
+        );
+        assert_eq!(strategy.programs["same"].token_total, 120);
+        assert_eq!(strategy.programs["same"].step_count, 1);
+        assert_eq!(strategy.sessions["same"].current, Some(AdmissionId::new(2)));
+    }
+}

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -149,7 +149,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     pub fn new(capacity: P, config: ThunderAgentConfig) -> Result<Self, ConfigError> {
         config.validate()?;
         tracing::info!(
-            capacity_control = config.capacity_control,
             pause_threshold = config.pause_threshold,
             pause_target = config.pause_target,
             resume_hysteresis = config.resume_hysteresis,

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -252,15 +252,8 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             return AdmissionDecision::Defer;
         }
 
-        // Preserve source fairness: a new program cannot bypass a paused continuation
-        // that is actually waiting to run. Idle suspended programs have no request to serve.
-        let suspended_continuation_waits = self
-            .sessions
-            .values()
-            .filter_map(|requests| requests.current)
-            .filter_map(|id| self.requests.get(&id))
-            .any(|request| request.prior.as_ref().is_some_and(Program::is_suspended));
-        if was_new && suspended_continuation_waits {
+        // Preserve source fairness: a new program cannot bypass an already-paused one.
+        if was_new && self.programs.values().any(Program::is_suspended) {
             self.defer_request(session_id, id, now, false);
             return AdmissionDecision::Defer;
         }
@@ -1026,40 +1019,6 @@ mod tests {
         assert_eq!(
             strategy.admit(request(2, Some("a"), 120)),
             AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
-        );
-    }
-
-    #[test]
-    fn new_session_does_not_wait_for_idle_suspended_program() {
-        let mut strategy =
-            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
-        strategy.programs.insert(
-            "paused".to_owned(),
-            suspended_program(100, Instant::now(), 1),
-        );
-
-        assert_eq!(
-            strategy.admit(request(1, Some("new"), 100)),
-            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
-        );
-    }
-
-    #[test]
-    fn new_session_waits_for_deferred_suspended_continuation() {
-        let mut strategy =
-            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
-        strategy.programs.insert(
-            "paused".to_owned(),
-            suspended_program(100, Instant::now(), 1),
-        );
-        assert_eq!(
-            strategy.admit(request(1, Some("paused"), 120)),
-            AdmissionDecision::Defer
-        );
-
-        assert_eq!(
-            strategy.admit(request(2, Some("new"), 100)),
-            AdmissionDecision::Defer
         );
     }
 

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -155,7 +155,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             resume_timeout_seconds = config.resume_timeout_seconds,
             session_retention_seconds = config.session_retention_seconds,
             scheduler_interval_seconds = config.scheduler_interval_seconds,
-            acting_token_weight = config.acting_token_weight,
             buffer_per_program = config.buffer_per_program,
             "ThunderAgent admission strategy configured"
         );
@@ -516,15 +515,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         expired.len()
     }
 
-    fn program_tokens(&self, program: &Program) -> usize {
-        let tokens = program.footprint();
-        if program.is_idle_resident() {
-            scale_tokens(tokens, self.config.acting_token_weight)
-        } else {
-            tokens
-        }
-    }
-
     fn worker_usage(&self) -> HashMap<WorkerWithDpRank, WorkerUsage> {
         let mut usage = HashMap::<WorkerWithDpRank, WorkerUsage>::new();
         for program in self.programs.values() {
@@ -532,8 +522,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 && let Some(worker) = program.assigned_worker
             {
                 let worker_usage = usage.entry(worker).or_default();
-                worker_usage
-                    .add_program(self.program_tokens(program), self.config.buffer_per_program);
+                worker_usage.add_program(program.footprint(), self.config.buffer_per_program);
             }
         }
         usage
@@ -631,7 +620,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             resumed += 1;
             let program = &self.programs[&session_id];
             let worker_usage = usage.entry(worker).or_default();
-            worker_usage.add_program(self.program_tokens(program), self.config.buffer_per_program);
+            worker_usage.add_program(program.footprint(), self.config.buffer_per_program);
             let updated = remaining - required;
             if updated > self.config.buffer_per_program {
                 backend_caps[position] = (worker, updated);
@@ -725,7 +714,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     let Some(program) = self.programs.get(session_id) else {
                         continue;
                     };
-                    let used = self.program_tokens(program);
+                    let used = program.footprint();
                     self.suspend_idle(session_id);
                     paused += 1;
                     let worker_usage = usage.entry(capacity.worker).or_default();

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -149,6 +149,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     pub fn new(capacity: P, config: ThunderAgentConfig) -> Result<Self, ConfigError> {
         config.validate()?;
         tracing::info!(
+            capacity_control = config.capacity_control,
             pause_threshold = config.pause_threshold,
             pause_target = config.pause_target,
             resume_hysteresis = config.resume_hysteresis,

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -59,7 +59,6 @@ struct RequestState {
     context_tokens: usize,
     progress: RequestProgress,
     worker_eligibility: WorkerEligibility,
-    dispatched: bool,
     prior: Option<Program>,
 }
 
@@ -72,18 +71,15 @@ struct SessionRequests {
 #[derive(Debug, Default, Clone, Copy)]
 struct WorkerUsage {
     used: usize,
-    decayed: usize,
 }
 
 impl WorkerUsage {
-    fn add_program(&mut self, normal: usize, decayed: usize, buffer: usize) {
-        self.used = self.used.saturating_add(normal).saturating_add(buffer);
-        self.decayed = self.decayed.saturating_add(decayed).saturating_add(buffer);
+    fn add_program(&mut self, tokens: usize, buffer: usize) {
+        self.used = self.used.saturating_add(tokens).saturating_add(buffer);
     }
 
-    fn remove_program(&mut self, normal: usize, decayed: usize, buffer: usize) {
-        self.used = self.used.saturating_sub(normal).saturating_sub(buffer);
-        self.decayed = self.decayed.saturating_sub(decayed).saturating_sub(buffer);
+    fn remove_program(&mut self, tokens: usize, buffer: usize) {
+        self.used = self.used.saturating_sub(tokens).saturating_sub(buffer);
     }
 }
 
@@ -108,7 +104,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             session_retention_seconds = config.session_retention_seconds,
             scheduler_interval_seconds = config.scheduler_interval_seconds,
             acting_token_weight = config.acting_token_weight,
-            acting_decay_tau_seconds = config.acting_decay_tau_seconds,
             buffer_per_program = config.buffer_per_program,
             "ThunderAgent admission strategy configured"
         );
@@ -142,7 +137,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 context_tokens: request.context_tokens(),
                 progress: request.progress().clone(),
                 worker_eligibility: request.worker_eligibility().clone(),
-                dispatched: false,
                 prior: None,
             },
         );
@@ -252,7 +246,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         }
 
         let required = context_tokens.saturating_add(self.config.buffer_per_program);
-        let usage = self.worker_usage(now);
+        let usage = self.worker_usage();
         let selected = capacities
             .iter()
             .filter(|capacity| worker_is_available(capacity.worker))
@@ -303,7 +297,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
     }
 
     fn dispatched(&mut self, id: AdmissionId, worker: WorkerWithDpRank) {
-        let Some(request) = self.requests.get_mut(&id) else {
+        let Some(request) = self.requests.get(&id) else {
             return;
         };
         if self
@@ -314,7 +308,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         {
             return;
         }
-        request.dispatched = true;
         if let Some(program) = self.programs.get_mut(&request.session_id) {
             program.assigned_worker = Some(worker);
         }
@@ -371,7 +364,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             program.deferred_since = None;
         }
 
-        if !request.dispatched || completed_context_tokens.is_none() {
+        if completed_context_tokens.is_none() {
             match request.prior {
                 Some(prior) => {
                     let lifecycle = prior.lifecycle;
@@ -434,20 +427,19 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             .filter(|program| program.marked_for_pause)
             .count();
         let capacities = self.capacity.snapshot();
-        let mut usage = self.worker_usage(now);
+        let mut usage = self.worker_usage();
         let eligibility = self.deferred_eligibility_snapshots();
         let (mut actions, greedy_resumes) = if capacities.is_empty() {
             (Vec::new(), 0)
         } else {
-            self.greedy_resume(&capacities, &mut usage, &eligibility, now)
+            self.greedy_resume(&capacities, &mut usage, &eligibility)
         };
-        let (forced_actions, forced_resumes) =
-            self.force_timed_out(&capacities, &mut usage, &eligibility, now);
+        let (forced_actions, forced_resumes) = self.force_timed_out(&eligibility, now);
         actions.extend(forced_actions);
         let (paused_now, marked_now) = if capacities.is_empty() {
             (0, 0)
         } else {
-            self.pause_until_safe(&capacities, &mut usage, now)
+            self.pause_until_safe(&capacities, &mut usage)
         };
         let marked = self
             .programs
@@ -502,32 +494,22 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         expired.len()
     }
 
-    fn program_tokens(&self, program: &Program, decayed: bool, now: Instant) -> usize {
+    fn program_tokens(&self, program: &Program) -> usize {
         if program.status != ProgramStatus::Acting {
             return program.token_total;
         }
-        if !decayed {
-            return scale_tokens(program.token_total, self.config.acting_token_weight);
-        }
-        let idle = program
-            .acting_since
-            .map_or(Duration::ZERO, |since| now.saturating_duration_since(since));
-        let weight = 2.0_f64.powf(-idle.as_secs_f64() / self.config.acting_decay_tau_seconds);
-        scale_tokens(program.token_total, weight)
+        scale_tokens(program.token_total, self.config.acting_token_weight)
     }
 
-    fn worker_usage(&self, now: Instant) -> HashMap<WorkerWithDpRank, WorkerUsage> {
+    fn worker_usage(&self) -> HashMap<WorkerWithDpRank, WorkerUsage> {
         let mut usage = HashMap::<WorkerWithDpRank, WorkerUsage>::new();
         for program in self.programs.values() {
             if program.lifecycle == ProgramLifecycle::Active
                 && let Some(worker) = program.assigned_worker
             {
                 let worker_usage = usage.entry(worker).or_default();
-                worker_usage.add_program(
-                    self.program_tokens(program, false, now),
-                    self.program_tokens(program, true, now),
-                    self.config.buffer_per_program,
-                );
+                worker_usage
+                    .add_program(self.program_tokens(program), self.config.buffer_per_program);
             }
         }
         usage
@@ -538,7 +520,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         capacities: &[WorkerCapacity],
         usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
         eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
-        now: Instant,
     ) -> (Vec<AdmissionAction>, usize) {
         if self.paused.is_empty() {
             return (Vec::new(), 0);
@@ -622,11 +603,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             resumed += 1;
             let program = &self.programs[&session_id];
             let worker_usage = usage.entry(worker).or_default();
-            worker_usage.add_program(
-                self.program_tokens(program, false, now),
-                self.program_tokens(program, true, now),
-                self.config.buffer_per_program,
-            );
+            worker_usage.add_program(self.program_tokens(program), self.config.buffer_per_program);
             let updated = remaining - required;
             if updated > self.config.buffer_per_program {
                 backend_caps[position] = (worker, updated);
@@ -640,8 +617,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
 
     fn force_timed_out(
         &mut self,
-        capacities: &[WorkerCapacity],
-        usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
         eligibility: &HashMap<AdmissionId, WorkerEligibilitySnapshot>,
         now: Instant,
     ) -> (Vec<AdmissionAction>, usize) {
@@ -664,34 +639,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             if self.programs[&session_id].lifecycle != ProgramLifecycle::Paused {
                 continue;
             }
-            let target = capacities
-                .iter()
-                .filter(|capacity| {
-                    self.session_allows_worker(&session_id, capacity.worker, eligibility)
-                })
-                .max_by_key(|capacity| {
-                    (
-                        capacity.tokens as i128
-                            - usage.get(&capacity.worker).map_or(0, |usage| usage.decayed) as i128,
-                        Reverse(capacity.worker),
-                    )
-                })
-                .map(|capacity| capacity.worker);
-            if target.is_none() && self.session_waits_for_available_worker(&session_id, eligibility)
-            {
+            if self.session_waits_for_available_worker(&session_id, eligibility) {
                 continue;
             }
-            actions.extend(self.resume_program(&session_id, target));
+            actions.extend(self.resume_program(&session_id, None));
             resumed += 1;
-            if let Some(worker) = target {
-                let program = &self.programs[&session_id];
-                let worker_usage = usage.entry(worker).or_default();
-                worker_usage.add_program(
-                    self.program_tokens(program, false, now),
-                    self.program_tokens(program, true, now),
-                    self.config.buffer_per_program,
-                );
-            }
         }
         (actions, resumed)
     }
@@ -700,7 +652,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         &mut self,
         capacities: &[WorkerCapacity],
         usage: &mut HashMap<WorkerWithDpRank, WorkerUsage>,
-        now: Instant,
     ) -> (usize, usize) {
         let mut acting = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
         let mut reasoning = HashMap::<WorkerWithDpRank, Vec<(usize, String)>>::new();
@@ -744,12 +695,11 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     let Some(program) = self.programs.get(session_id) else {
                         continue;
                     };
-                    let used = self.program_tokens(program, false, now);
-                    let decayed = self.program_tokens(program, true, now);
+                    let used = self.program_tokens(program);
                     self.pause_acting(session_id);
                     paused += 1;
                     let worker_usage = usage.entry(capacity.worker).or_default();
-                    worker_usage.remove_program(used, decayed, self.config.buffer_per_program);
+                    worker_usage.remove_program(used, self.config.buffer_per_program);
                 }
             }
             if usage.get(&capacity.worker).map_or(0, |usage| usage.used) > target
@@ -1309,7 +1259,7 @@ mod tests {
         assert!(strategy.programs.contains_key("reasoning"));
         assert!(strategy.programs.contains_key("busy"));
 
-        let usage = strategy.worker_usage(now);
+        let usage = strategy.worker_usage();
         assert_eq!(usage[&worker(1)].used, 1_200);
     }
 
@@ -1426,7 +1376,7 @@ mod tests {
     }
 
     #[test]
-    fn forced_resume_chooses_the_least_overfull_worker() {
+    fn forced_resume_delegates_worker_selection() {
         let config = ThunderAgentConfig {
             resume_timeout_seconds: 1.0,
             buffer_per_program: 0,
@@ -1464,7 +1414,7 @@ mod tests {
             reconcile_now(&mut strategy),
             vec![AdmissionAction::MakeReady {
                 id: AdmissionId::new(1),
-                placement: WorkerPlacement::Exact(worker(2)),
+                placement: WorkerPlacement::Any,
             }]
         );
     }

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -249,7 +249,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         );
 
         if was_suspended {
-            self.defer_request(session_id, id, now, false);
+            self.defer_request(session_id, id, now, true);
             return AdmissionDecision::Defer;
         }
 
@@ -837,7 +837,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             footprint,
             since: last_activity,
         };
-        program.assigned_worker = None;
         self.paused.insert(session_id.to_owned());
     }
 
@@ -1383,10 +1382,12 @@ mod tests {
         assert!(strategy.programs["small"].is_idle_resident());
         assert!(reconcile_now(&mut strategy).is_empty());
         assert!(strategy.programs["small"].is_suspended());
+        assert_eq!(strategy.programs["small"].assigned_worker, Some(worker(1)));
         assert_eq!(
             strategy.admit(request(3, Some("small"), 110)),
             AdmissionDecision::Defer
         );
+        assert_eq!(strategy.programs["small"].assigned_worker, Some(worker(1)));
 
         *current.lock().unwrap() = capacities(&[(1, 600)]);
         assert_eq!(

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -252,8 +252,15 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             return AdmissionDecision::Defer;
         }
 
-        // Preserve source fairness: a new program cannot bypass an already-paused one.
-        if was_new && self.programs.values().any(Program::is_suspended) {
+        // Preserve source fairness: a new program cannot bypass a paused continuation
+        // that is actually waiting to run. Idle suspended programs have no request to serve.
+        let suspended_continuation_waits = self
+            .sessions
+            .values()
+            .filter_map(|requests| requests.current)
+            .filter_map(|id| self.requests.get(&id))
+            .any(|request| request.prior.as_ref().is_some_and(Program::is_suspended));
+        if was_new && suspended_continuation_waits {
             self.defer_request(session_id, id, now, false);
             return AdmissionDecision::Defer;
         }
@@ -1019,6 +1026,40 @@ mod tests {
         assert_eq!(
             strategy.admit(request(2, Some("a"), 120)),
             AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+    }
+
+    #[test]
+    fn new_session_does_not_wait_for_idle_suspended_program() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        strategy.programs.insert(
+            "paused".to_owned(),
+            suspended_program(100, Instant::now(), 1),
+        );
+
+        assert_eq!(
+            strategy.admit(request(1, Some("new"), 100)),
+            AdmissionDecision::Ready(WorkerPlacement::Exact(worker(1)))
+        );
+    }
+
+    #[test]
+    fn new_session_waits_for_deferred_suspended_continuation() {
+        let mut strategy =
+            ThunderAgent::new(|| capacities(&[(1, 1_000)]), Default::default()).unwrap();
+        strategy.programs.insert(
+            "paused".to_owned(),
+            suspended_program(100, Instant::now(), 1),
+        );
+        assert_eq!(
+            strategy.admit(request(1, Some("paused"), 120)),
+            AdmissionDecision::Defer
+        );
+
+        assert_eq!(
+            strategy.admit(request(2, Some("new"), 100)),
+            AdmissionDecision::Defer
         );
     }
 

--- a/lib/admission-control/src/thunderagent/strategy.rs
+++ b/lib/admission-control/src/thunderagent/strategy.rs
@@ -127,12 +127,12 @@ struct WorkerUsage {
 }
 
 impl WorkerUsage {
-    fn add_program(&mut self, tokens: usize, buffer: usize) {
-        self.used = self.used.saturating_add(tokens).saturating_add(buffer);
+    fn add_program(&mut self, tokens: usize) {
+        self.used = self.used.saturating_add(tokens);
     }
 
-    fn remove_program(&mut self, tokens: usize, buffer: usize) {
-        self.used = self.used.saturating_sub(tokens).saturating_sub(buffer);
+    fn remove_program(&mut self, tokens: usize) {
+        self.used = self.used.saturating_sub(tokens);
     }
 }
 
@@ -155,7 +155,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             resume_timeout_seconds = config.resume_timeout_seconds,
             session_retention_seconds = config.session_retention_seconds,
             scheduler_interval_seconds = config.scheduler_interval_seconds,
-            buffer_per_program = config.buffer_per_program,
             "ThunderAgent admission strategy configured"
         );
         let next_tick = Instant::now() + Duration::from_secs_f64(config.scheduler_interval_seconds);
@@ -284,7 +283,6 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
             return AdmissionDecision::Ready(WorkerPlacement::Any);
         }
 
-        let required = context_tokens.saturating_add(self.config.buffer_per_program);
         let usage = self.worker_usage();
         let selected = capacities
             .iter()
@@ -294,7 +292,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 capacity
                     .tokens
                     .checked_sub(used)
-                    .is_some_and(|remaining| remaining >= required)
+                    .is_some_and(|remaining| remaining >= context_tokens)
                     .then_some((capacity.worker, used))
             })
             .min_by_key(|(worker, used)| (*used, *worker))
@@ -521,7 +519,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 && let Some(worker) = program.assigned_worker
             {
                 let worker_usage = usage.entry(worker).or_default();
-                worker_usage.add_program(program.footprint(), self.config.buffer_per_program);
+                worker_usage.add_program(program.footprint());
             }
         }
         usage
@@ -565,7 +563,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                 let limit = scale_tokens(capacity.tokens, ceiling);
                 let remaining =
                     limit.saturating_sub(usage.get(&capacity.worker).map_or(0, |usage| usage.used));
-                (remaining > self.config.buffer_per_program).then_some((capacity.worker, remaining))
+                (remaining > 0).then_some((capacity.worker, remaining))
             })
             .collect();
         sort_backend_caps(&mut backend_caps);
@@ -579,9 +577,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
         let mut cumulative = 0usize;
         let mut resumable = Vec::new();
         for session_id in paused {
-            let required = self.programs[&session_id]
-                .footprint()
-                .saturating_add(self.config.buffer_per_program);
+            let required = self.programs[&session_id].footprint();
             if !backend_caps.iter().any(|(worker, remaining)| {
                 self.session_allows_worker(&session_id, *worker, eligibility)
                     && required <= *remaining
@@ -603,24 +599,19 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     .enumerate()
                     .find(|(_, (worker, remaining))| {
                         self.session_allows_worker(&session_id, *worker, eligibility)
-                            && self.programs[&session_id]
-                                .footprint()
-                                .saturating_add(self.config.buffer_per_program)
-                                <= *remaining
+                            && self.programs[&session_id].footprint() <= *remaining
                     })
             else {
                 continue;
             };
-            let required = self.programs[&session_id]
-                .footprint()
-                .saturating_add(self.config.buffer_per_program);
+            let required = self.programs[&session_id].footprint();
             actions.extend(self.resume_program(&session_id, Some(worker)));
             resumed += 1;
             let program = &self.programs[&session_id];
             let worker_usage = usage.entry(worker).or_default();
-            worker_usage.add_program(program.footprint(), self.config.buffer_per_program);
+            worker_usage.add_program(program.footprint());
             let updated = remaining - required;
-            if updated > self.config.buffer_per_program {
+            if updated > 0 {
                 backend_caps[position] = (worker, updated);
                 sort_backend_caps(&mut backend_caps);
             } else {
@@ -714,7 +705,7 @@ impl<P: WorkerCapacityProvider> ThunderAgent<P> {
                     self.suspend_idle(session_id);
                     paused += 1;
                     let worker_usage = usage.entry(capacity.worker).or_default();
-                    worker_usage.remove_program(used, self.config.buffer_per_program);
+                    worker_usage.remove_program(used);
                 }
             }
             if usage.get(&capacity.worker).map_or(0, |usage| usage.used) > target
@@ -1256,7 +1247,6 @@ mod tests {
     fn retention_expiry_removes_only_quiescent_acting_programs() {
         let config = ThunderAgentConfig {
             session_retention_seconds: 900.0,
-            buffer_per_program: 0,
             ..Default::default()
         };
         let mut strategy = ThunderAgent::new(Vec::<WorkerCapacity>::new, config).unwrap();
@@ -1338,7 +1328,6 @@ mod tests {
         let config = ThunderAgentConfig {
             pause_threshold: 0.8,
             pause_target: 0.5,
-            buffer_per_program: 0,
             ..Default::default()
         };
         let mut strategy = ThunderAgent::new(provider, config).unwrap();
@@ -1410,7 +1399,6 @@ mod tests {
     fn forced_resume_delegates_worker_selection() {
         let config = ThunderAgentConfig {
             resume_timeout_seconds: 1.0,
-            buffer_per_program: 0,
             ..Default::default()
         };
         let mut strategy = ThunderAgent::new(|| capacities(&[(1, 100), (2, 100)]), config).unwrap();

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1513,6 +1513,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynamo-admission-control"
+version = "1.3.0"
+dependencies = [
+ "dynamo-kv-router",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "dynamo-data-gen"
 version = "1.3.0"
 dependencies = [
@@ -1590,6 +1603,7 @@ dependencies = [
  "derive-getters",
  "derive_builder",
  "dialoguer",
+ "dynamo-admission-control",
  "dynamo-kv-router",
  "dynamo-memory",
  "dynamo-mocker",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2087,6 +2087,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "dynamo-admission-control"
+version = "1.3.0"
+dependencies = [
+ "dynamo-kv-router",
+ "indexmap 2.14.0",
+ "serde",
+ "serde_yaml",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "dynamo-backend-common"
 version = "1.3.0"
 dependencies = [
@@ -2193,6 +2206,7 @@ dependencies = [
  "derive-getters",
  "derive_builder",
  "dialoguer",
+ "dynamo-admission-control",
  "dynamo-kv-router",
  "dynamo-memory",
  "dynamo-mocker",

--- a/lib/llm/Cargo.toml
+++ b/lib/llm/Cargo.toml
@@ -59,6 +59,7 @@ required-features = ["request-trace-bench"]
 [dependencies]
 # repo
 dynamo-kv-router = { workspace = true, features = ["metrics", "runtime-protocols"] }
+dynamo-admission-control = { workspace = true }
 dynamo-memory = { workspace = true }
 dynamo-mocker = { workspace = true }
 dynamo-rl = { workspace = true }

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -20,6 +20,7 @@ use super::sequence::{
 use crate::discovery::RuntimeConfigWatch;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use anyhow::Result;
+use dynamo_admission_control::{register_builtin_strategies, strategy_recheck_interval};
 use dynamo_kv_router::{
     PrefillLoadEstimator,
     config::{KvRouterConfig, RouterConfigOverride},
@@ -90,7 +91,7 @@ where
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         model_name: Option<&str>,
         worker_type: &'static str,
-        admission_strategies: PolicyClassAdmissionStrategies,
+        mut admission_strategies: PolicyClassAdmissionStrategies,
     ) -> Result<Self, KvSchedulerError> {
         let initial_workers: HashMap<WorkerId, ModelRuntimeConfig> =
             workers_with_configs.borrow().clone();
@@ -114,10 +115,15 @@ where
         let profile = kv_router_config
             .policy_profile(model_name)
             .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
-        let strategy_recheck_interval = admission_strategies
-            .values()
-            .filter_map(|strategy| strategy.reconcile_interval())
-            .min();
+        register_builtin_strategies(
+            &profile,
+            workers_with_configs.clone(),
+            block_size,
+            &mut admission_strategies,
+        )
+        .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
+        let strategy_recheck_interval = strategy_recheck_interval(&admission_strategies)
+            .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
         let queue_recheck_interval = strategy_recheck_interval.map_or_else(
             || kv_router_config.router_queue_recheck_interval(),
             |strategy_interval| {

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -20,7 +20,7 @@ use super::sequence::{
 use crate::discovery::RuntimeConfigWatch;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use anyhow::Result;
-use dynamo_admission_control::{register_builtin_strategies, strategy_recheck_interval};
+use dynamo_admission_control::register_builtin_strategies;
 use dynamo_kv_router::{
     PrefillLoadEstimator,
     config::{KvRouterConfig, RouterConfigOverride},
@@ -122,8 +122,10 @@ where
             &mut admission_strategies,
         )
         .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
-        let strategy_recheck_interval = strategy_recheck_interval(&admission_strategies)
-            .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
+        let strategy_recheck_interval = admission_strategies
+            .values()
+            .filter_map(|strategy| strategy.reconcile_interval())
+            .min();
         let queue_recheck_interval = strategy_recheck_interval.map_or_else(
             || kv_router_config.router_queue_recheck_interval(),
             |strategy_interval| {


### PR DESCRIPTION
<!-- codex-pr-description:start -->
PR #11434 defines the minimal policy-class admission API, and PR #11530 hosts its lifecycle plus a live request-progress capability. This stacked PR implements session-aware ThunderAgent in `dynamo-admission-control`. ThunderAgent retains quiescent sessions behind a 30-minute inactivity lease, preserving native performance without requiring clients to send a terminal-session request.

CLOSES: DYN-3231

### How This Was Implemented

- Keep the ThunderAgent algorithm, state, configuration, capacity accounting, and tests in the separate `dynamo-admission-control` crate.
- Reuse the policy queue and scheduler actor from the lower PRs for deferred storage, exact-worker readiness, cancellation, lifecycle correlation, and reconciliation.
- Retain the read-only `RequestProgress` capability from PR #11530 and sample it during admission/reconciliation; the response path performs one relaxed atomic update and sends no per-output actor messages.
- Implement sticky placement, capacity pressure, pause/mark/resume, timeout fallback, same-session serialization, and 30-minute inactivity retention inside the strategy.
- Register configured built-ins explicitly at LLM composition without replacing caller-provided strategies for the same policy class.

<details>
<summary>Walkthrough</summary>

#### Stack and ownership

```text
#11434 admission API
   -> #11530 queue host, lifecycle, live progress
      -> #11447 ThunderAgent strategy and composition
```

```mermaid
flowchart LR
  R["Tracked request"] --> H["Policy-class admission host"]
  H -->|"bypass / ready"| Q["Policy queue"]
  H -->|"defer"| D["Deferred queue entry"]
  D -->|"MakeReady"| Q
  Q --> S["Worker selector"]
  S --> W["Engine"]
  W -->|"atomic progress update"| P["RequestProgress"]
  W -->|"dispatch / finish"| H
  H --> T["dynamo-admission-control"]
  P -->|"read on reconcile"| T
  T -->|"30-minute inactivity"| X["Expire quiescent program"]
```

The queue actor owns request payloads and invokes a per-class strategy before ordinary worker selection. The strategy may bypass admission, make a request ready with optional placement, or defer it. It never owns scheduling requests, queue order, worker slots, or final selection.

#### State and ordering

ThunderAgent serializes concurrent requests for one session, preserves a structurally valid sticky worker through transient overload, and chooses capacity-aware placement when a new or resumed session becomes ready. Sessionless requests return `Bypass` and follow the ordinary queue and selector path. Workers without usable KV-capacity metadata are excluded with a one-time warning; if no usable metadata remains, admission fails open to normal router selection.

Reconciliation first expires retained programs, then greedily resumes, force-resumes timed-out work, and finally pauses overloaded workers. Expiry is conservative: only Acting programs whose successful-turn inactivity lease elapsed and which have no current or waiting request are removed; Reasoning programs cannot expire.

#### Request lifecycle

The queue actor assigns an opaque admission ID and owns lifecycle correlation. Dispatch and terminal events go to the strategy. In-flight logical context growth uses the retained `RequestProgress` handle from PR #11530 instead of actor messages. A successful turn commits its authoritative final context size, marks the program Acting, and resets the inactivity lease. Aborted work restores the prior program snapshot.

Clients send no terminal request. If a session returns after expiry, ThunderAgent admits it as a new program and normal KV-aware selection still applies.

#### Boundaries and limitations

Retention is a logical approximation of useful cache residence rather than a live indexer query. The crate performs explicit built-in registration rather than dynamic loading, and worker filtering plus final scoring/picking remain owned by the existing router selector. Live session-KV residency as a narrower future GC signal is tracked separately in DYN-3465.

</details>

### Validation

- `cargo test -p dynamo-admission-control` (26 passed)
- `cargo check -p dynamo-llm`
- `cargo fmt --all`
- `git diff --check`

### Benchmark Results

8x H100 NVL, two SGLang TP4 MiniMax-M2.7 workers, FP8 KV, HiCache ratio 4.0/write-back/kernel I/O, SWE-Bench Lite 300 x 3 attempts, Pi/Harbor, concurrency 256, 600-second warmup, then a 3,456.245-second measurement window.

| Metric | Native TA, 30-minute TTL | Old native, no expiry | Python TA |
|---|---:|---:|---:|
| Valid responses/min | 200.78 | 198.20 | 181.69 |
| Valid trials/min | 4.045 | 4.010 | 3.854 |
| Generation tokens/s | 727.66 | 736.59 | 679.69 |
| Device + host reuse | 94.09% | 93.19% | 89.23% |
| Recomputed prompt tokens | 10.71M | 12.03M | 18.44M |
| TTFT p50 / p95 | 39.87 / 80.63 s | 42.45 / 86.05 s | 50.40 / 100.43 s |
| Peak ProgramTable entries | 384 | 477 | N/A |
| Pause events | 356 | 410 | N/A |

<!-- codex-pr-description:end -->
