### PR TITLE
test(vllm): enable unified encoder-disaggregated topologies

### DIFF
--- a/components/src/dynamo/common/backend/README.md
+++ b/components/src/dynamo/common/backend/README.md
@@ -7,9 +7,9 @@ routing, health-check canaries, OpenTelemetry tracing, and request-side
 guided decoding / structural tag.
 
 > **Work in progress.** Multimodal support is backend-specific: vLLM supports
-> aggregated and prefill/decode image and video inference, while separate
-> encode workers and SGLang / TRT-LLM multimodal execution remain on their
-> non-unified paths. Diffusion (image/video/DLLM),
+> aggregated and prefill/decode image and video inference plus separate
+> image encode workers, while SGLang / TRT-LLM multimodal execution remains
+> on their non-unified paths. Diffusion (image/video/DLLM),
 > LoRA (SGLang / TRT-LLM — vLLM is supported),
 > engine routes (pause/resume, profiling, weight updates),
 > text-in-text-out, and snapshot/CRIU are still on the non-unified
@@ -571,8 +571,8 @@ Lifecycle and runtime:
 - **Multimodal (vLLM)** — image and video inference in aggregated and
   prefill/decode deployments, frontend-rendered `mm_kwargs` transfer over
   shared memory or NIXL, stable frontend hash forwarding, CPU embedding cache,
-  and Qwen-VL decode metadata reconstruction. Separate encode workers are not
-  supported by the unified vLLM entry point.
+  Qwen-VL decode metadata reconstruction, and separate URL-image Encode workers
+  with Local or NIXL embedding transfer.
 
 Observability:
 - **Health-check canary** — `health_check_payload()` + operator
@@ -618,7 +618,7 @@ Request handling:
 | Feature | Description |
 |---------|-------------|
 | Text-in-text-out mode | OpenAI-compatible chat/completion with engine-side tokenization. Unified hardcodes `ModelInput.Tokens`. |
-| Multimodal parity | The shared request and encoder-handoff contract are available. vLLM supports aggregated and prefill/decode image and video inference; SGLang / TRT-LLM execution and separate encode workers remain separate work. |
+| Multimodal parity | The shared request and encoder-handoff contract are available. vLLM supports aggregated and prefill/decode image and video inference plus separate URL-image Encode workers; SGLang / TRT-LLM execution remains separate work. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path. |
 | LoRA adapters (SGLang / TRT-LLM) | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading. **vLLM is supported on the unified path** — see [What works today](#what-works-today); SGLang and TRT-LLM advertise no LoRA updates yet. |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload. |
@@ -635,7 +635,7 @@ Request handling:
 | `KvConnectorProtocol` abstraction | Legacy abstracts NIXL pull / Mooncake push; unified uses vLLM's internal connector only |
 | `--benchmark-mode` family | The `--benchmark-*` flag family (mode, prefill/decode granularities, warmup, output path, timeout) injects into `vllm_config.additional_config` |
 | "Omni" alternative entry point | `dynamo.vllm.omni.*` parallel mode for alternative tensor workflows |
-| Separate multimodal encode worker | The unified entry point rejects `--disaggregation-mode encode` and `--route-to-encoder`. Encoder-managed embedding transfer remains on the legacy worker path. P/D video requests also reload raw media on decode because the handoff carries image metadata only. |
+| Separate encoder modalities | The separate Encode worker handles URL-based images only. Video and audio stay on the aggregated/prefill worker, and P/D video requests reload raw media on decode because the handoff carries image metadata only. |
 
 ### SGLang-specific gaps
 

--- a/docs/development/unified-backends.md
+++ b/docs/development/unified-backends.md
@@ -43,8 +43,8 @@ Supported today:
 
 Still use the lower-level Python worker path when you need a backend-specific
 feature that has not reached its unified engine, a separate multimodal encode
-worker, engine-specific routes, custom request handling, or direct control of
-the request payload.
+worker on a backend other than vLLM, engine-specific routes, custom request
+handling, or direct control of the request payload.
 
 After you implement the backend, package it into a runtime image with
 [Runtime Containers](custom-containers.md). For Kubernetes deployment, place the
@@ -159,8 +159,9 @@ Request handling:
 - Tool / reasoning parser configuration (`tool_call_parser`,
   `reasoning_parser`, `exclude_tools_when_tool_choice_none`)
 - vLLM image and video inference in aggregated and prefill/decode deployments,
-  including frontend-rendered multimodal input transfer and the CPU embedding
-  cache. See [vLLM Multimodal](../features/multimodal/multimodal-vllm.md#unified-vllm-backend).
+  including separate URL-image Encode workers, frontend-rendered multimodal
+  input transfer, and the CPU embedding cache. See
+  [vLLM Multimodal](../features/multimodal/multimodal-vllm.md#unified-vllm-backend).
 
 **Remaining Python unified-backend gaps**
 
@@ -168,7 +169,7 @@ Request handling:
 |---------|----------------|
 | Logprob response wire | Legacy handlers extract logprobs onto response chunks (vLLM `_extract_logprobs`, SGLang `_extract_logprobs` in `decode_handler`, TRT-LLM `_extract_logprobs` in `handler_base`); the unified `generate()` loops do not populate `log_probs` / `top_logprobs` / `cum_log_probs` on `GenerateChunk`. vLLM's `build_sampling_params` still passes `output_options.logprobs` to the engine on the unified path, so the engine computes them, but the values are dropped before they reach the chunk. SGLang and TRT-LLM unified `generate()` do not read `output_options.logprobs` at all. |
 | Text-in-text-out mode | Unified hardcodes `ModelInput.Tokens`; no engine-side tokenization or chat templating path |
-| Multimodal parity | vLLM supports aggregated and prefill/decode image and video inference. SGLang and TRT-LLM multimodal execution, separate encode workers, and the `ENCODE` role are not yet available through their unified engines. |
+| Multimodal parity | vLLM supports aggregated and prefill/decode image and video inference plus separate URL-image Encode workers. SGLang and TRT-LLM multimodal execution and the `ENCODE` role are not yet available through their unified engines. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
 | LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization locks, per-request adapter threading on prefill |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |
@@ -959,7 +960,7 @@ Request handling:
 |---------|----------------|
 | `cum_log_probs` response wire | Completion-side `log_probs` / `top_logprobs` are populated on the unified path for vLLM, SGLang, and TRT-LLM (shared helpers in `components/src/dynamo/common/backend/logprobs.py`). Prompt-side logprobs ride on the final chunk's `LLMEngineOutput.engine_data["prompt_logprobs"]` (consumed by `prompt_logprobs_from_engine_data` in the response builders). `cum_log_probs` is still not emitted. |
 | Text-in-text-out mode | `ModelInput::Text` is rejected at startup — `Tokens` only |
-| Native Rust multimodal engines | The shared request fields are available, but native Rust engines do not yet implement image, video, embedding transfer, or the `ENCODE` role. The Python unified vLLM engine supports aggregated and prefill/decode image and video inference. |
+| Native Rust multimodal engines | The shared request fields are available, but native Rust engines do not yet implement image, video, embedding transfer, or the `ENCODE` role. The Python unified vLLM engine supports aggregated and prefill/decode image and video inference plus separate URL-image Encode workers. |
 | Diffusion | Image (FLUX), video (Wan2.1), LLM diffusion (DLLM) workers; no diffusion engine, MediaOutput, or media scheduling on the unified path |
 | LoRA adapters | Dynamic load / unload / list, ModelDeploymentCard publishing, per-adapter serialization |
 | Snapshot / checkpoint | CRIU-based engine state save/restore + identity reload |

--- a/docs/features/multimodal/encoder-disaggregation.md
+++ b/docs/features/multimodal/encoder-disaggregation.md
@@ -62,9 +62,11 @@ cd $DYNAMO_HOME/examples/backends/vllm
 
 # E/PD
 bash launch/disagg_multimodal_e_pd.sh --model "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
+bash launch/disagg_multimodal_e_pd.sh --unified --model "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
 
 # E/P/D
 bash launch/disagg_multimodal_epd.sh --model "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
+bash launch/disagg_multimodal_epd.sh --unified --model "Qwen/Qwen3-VL-30B-A3B-Instruct-FP8"
 ```
 
 ### TRT-LLM

--- a/docs/features/multimodal/multimodal-vllm.md
+++ b/docs/features/multimodal/multimodal-vllm.md
@@ -20,7 +20,7 @@ base64 data).
 
 | Modality | Aggregated | P/D | Separate encode worker |
 | --- | --- | --- | --- |
-| **Image** | Yes | Yes | Legacy entry point only |
+| **Image** | Yes | Yes | Yes |
 | **Video** | Yes | Yes | Processed by the language-model worker |
 | **Audio** | Yes | Yes, with decode reload | Not routed to the separate encoder |
 
@@ -40,8 +40,8 @@ The main multimodal vLLM launchers in this repo are:
 | Aggregated | CUDA | `agg_multimodal.sh` | `--unified` | Simplest image/video serving from one worker |
 | Aggregated | XPU | `xpu/agg_multimodal_xpu.sh` | No | Image/video serving on XPU devices |
 | P/D | CUDA | `disagg_multimodal_p_d.sh` | `--unified` | Prefill/decode separation without a dedicated encoder |
-| E/PD (Encode + PD) | CUDA | `disagg_multimodal_e_pd.sh` | No | Separate encoder and embedding-cache workflows |
-| E/P/D (Full Disaggregation) | CUDA | `disagg_multimodal_epd.sh` | No | Separate encode, prefill, and decode workers |
+| E/PD (Encode + PD) | CUDA | `disagg_multimodal_e_pd.sh` | `--unified` | Separate encoder and embedding-cache workflows |
+| E/P/D (Full Disaggregation) | CUDA | `disagg_multimodal_epd.sh` | `--unified` | Separate encode, prefill, and decode workers |
 
 
 ## Image/Video Serving
@@ -182,11 +182,9 @@ failure after a full transfer does not currently have a raw-media fallback.
 P/D prefill deliberately uses the original media because it still needs
 raw-media-derived metadata for the decode handoff.
 
-<Warning>
-The unified vLLM entry point does not provide a separate Encode worker and
-rejects both `--disaggregation-mode encode` and `--route-to-encoder`. Use the
-legacy E/PD or E/P/D launchers when a dedicated encoder is required.
-</Warning>
+**Experimental in development builds.** The unified vLLM entry point supports
+separate Encode workers for URL-based images. It forwards a versioned transfer
+handoff through the frontend before the aggregated or prefill worker runs.
 
 ### E/PD Serving (Encode + PD)
 
@@ -201,6 +199,9 @@ cd $DYNAMO_HOME/examples/backends/vllm
 
 # Multi-GPU deployment
 bash launch/disagg_multimodal_e_pd.sh --model Qwen/Qwen3-VL-2B-Instruct
+
+# Unified backend
+bash launch/disagg_multimodal_e_pd.sh --unified --model Qwen/Qwen3-VL-2B-Instruct
 
 # Single-GPU (functional testing with small models)
 bash launch/disagg_multimodal_e_pd.sh --model Qwen/Qwen3-VL-2B-Instruct --single-gpu
@@ -220,6 +221,9 @@ cd $DYNAMO_HOME/examples/backends/vllm
 
 # Multi-GPU deployment
 bash launch/disagg_multimodal_epd.sh --model Qwen/Qwen3-VL-2B-Instruct
+
+# Unified backend
+bash launch/disagg_multimodal_epd.sh --unified --model Qwen/Qwen3-VL-2B-Instruct
 
 # Single-GPU (functional testing with small models)
 bash launch/disagg_multimodal_epd.sh --model Qwen/Qwen3-VL-2B-Instruct --single-gpu

--- a/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
+pick_worker_module dynamo.vllm dynamo.vllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
 # Use TCP transport for multimodal workloads (base64 images can exceed NATS 1MB limit)
 export DYN_REQUEST_PLANE=tcp
 
@@ -38,6 +41,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --model <model_name>          Specify the VLM model to use (default: $MODEL_NAME)"
             echo "                                LLaVA 1.5 7B, Qwen2.5-VL, and Phi3V models have predefined templates"
             echo "  --single-gpu                  Run encode and PD workers on the same GPU (for small models, e.g. 2B)"
+            echo "  --unified                     Use the unified vLLM backend"
             echo "  -h, --help                    Show this help message"
             echo ""
             echo "All additional arguments are passed through to the PD worker's dynamo.vllm."
@@ -127,7 +131,7 @@ fi
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utilization $DYN_ENCODE_GPU_MEM)..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
-python -m dynamo.vllm \
+python -m "$WORKER_MODULE" \
   --enable-multimodal \
   --disaggregation-mode encode \
   --model "$MODEL_NAME" \
@@ -138,7 +142,7 @@ python -m dynamo.vllm \
 echo "Starting PD worker on GPU $DYN_PD_WORKER_GPU (${PD_GPU_MEM_ARGS})..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 CUDA_VISIBLE_DEVICES=$DYN_PD_WORKER_GPU \
-python -m dynamo.vllm \
+python -m "$WORKER_MODULE" \
   --route-to-encoder \
   --enable-multimodal \
   --disaggregation-mode pd \

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -8,6 +8,9 @@ SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
 source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
+pick_worker_module dynamo.vllm dynamo.vllm.unified_main "$@"
+set -- "${REMAINING_ARGS[@]}"
+
 # Use TCP transport for multimodal workloads (base64 images can exceed NATS 1MB limit)
 export DYN_REQUEST_PLANE=tcp
 
@@ -59,6 +62,7 @@ while [[ $# -gt 0 ]]; do
             echo "                                LLaVA 1.5 7B, Qwen2.5-VL, and Phi3V models have predefined templates"
             echo "  --single-gpu                  Pack all 3 workers on 1 GPU (for small models, e.g. 2B)"
             echo "  --two-gpu                     Pack 3 workers on 2 GPUs (encode+prefill on GPU 0, decode on GPU 1)"
+            echo "  --unified                     Use the unified vLLM backend"
             echo "  -h, --help                    Show this help message"
             echo ""
             echo "Examples:"
@@ -203,19 +207,19 @@ echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utiliza
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_ENCODE \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
-python -m dynamo.vllm --enable-multimodal --disaggregation-mode encode --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &
+python -m "$WORKER_MODULE" --enable-multimodal --disaggregation-mode encode --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &
 
 # Start prefill worker (also handles encode routing via --route-to-encoder)
 echo "Starting prefill worker on GPU $DYN_PREFILL_WORKER_GPU (${PREFILL_GPU_MEM_ARGS})..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-8082} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_PREFILL \
-CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m dynamo.vllm --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $PREFILL_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_PREFILL}\"}" &
+CUDA_VISIBLE_DEVICES=$DYN_PREFILL_WORKER_GPU python -m "$WORKER_MODULE" --route-to-encoder --disaggregation-mode prefill --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $PREFILL_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_PREFILL}\"}" &
 
 # Start decode worker
 echo "Starting decode worker on GPU $DYN_DECODE_WORKER_GPU (${DECODE_GPU_MEM_ARGS})..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-8083} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_DECODE \
-CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m dynamo.vllm  --disaggregation-mode decode --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $DECODE_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_DECODE}\"}" &
+CUDA_VISIBLE_DEVICES=$DYN_DECODE_WORKER_GPU python -m "$WORKER_MODULE"  --disaggregation-mode decode --enable-multimodal --enable-mm-embeds --model $MODEL_NAME $DECODE_GPU_MEM_ARGS $EXTRA_ARGS $PD_EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_DECODE}\"}" &
 
 echo "=================================================="
 echo "All components started. Waiting for initialization..."

--- a/tests/serve/multimodal_profiles/vllm.py
+++ b/tests/serve/multimodal_profiles/vllm.py
@@ -52,7 +52,9 @@ VLLM_TOPOLOGY_SCRIPTS: dict[str, str] = {
     # config below toggles `--frontend-decoding` on the worker via env.
     "agg_router_frontend_decode": "agg_multimodal_router.sh",
     "e_pd": "disagg_multimodal_e_pd.sh",
+    "e_pd_unified": "disagg_multimodal_e_pd.sh",
     "epd": "disagg_multimodal_epd.sh",
+    "epd_unified": "disagg_multimodal_epd.sh",
     "epd_video": "disagg_multimodal_epd.sh",
     "p_d": "disagg_multimodal_p_d.sh",
     "p_d_unified": "disagg_multimodal_p_d.sh",
@@ -227,12 +229,37 @@ VLLM_MULTIMODAL_PROFILES: list[MultimodalModelProfile] = [
                 requested_vllm_kv_cache_bytes=4_096_361_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],
             ),
+            "e_pd_unified": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=340,
+                single_gpu=True,
+                profiled_vram_gib=15.0,
+                requested_vllm_kv_cache_bytes=4_096_361_000,
+                tests=[
+                    MmCase(
+                        payload=make_image_payload(["green"]),
+                        extra_script_args=["--unified"],
+                    )
+                ],
+            ),
             "epd": TopologyConfig(
                 marks=[pytest.mark.post_merge],
                 timeout_s=300,
                 single_gpu=True,
                 requested_vllm_kv_cache_bytes=1_714_881_000,
                 tests=[MmCase(payload=make_image_payload(["green"]))],
+            ),
+            "epd_unified": TopologyConfig(
+                marks=[pytest.mark.post_merge],
+                timeout_s=300,
+                single_gpu=True,
+                requested_vllm_kv_cache_bytes=1_714_881_000,
+                tests=[
+                    MmCase(
+                        payload=make_image_payload(["green"]),
+                        extra_script_args=["--unified"],
+                    )
+                ],
             ),
             "epd_video": TopologyConfig(
                 marks=[pytest.mark.post_merge],


### PR DESCRIPTION
## Overview:

Enable and document the unified vLLM E/PD and E/P/D deployment paths after the encoder routing, producer, and consumer layers are in place.

## Summary

- add `--unified` support to the vLLM E/PD and E/P/D launchers
- add single-GPU serve profiles for both unified encoder-disaggregated topologies
- document unified separate-encoder support and its URL-image limitation
- record end-to-end GPU validation for the completed stack

## Details:

This is stack PR 4 of 4 for [DIS-2034](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend), stacked on #11462.

The launchers select `dynamo.vllm.unified_main` for Encode, prefill/PD, and decode workers while preserving the legacy path by default. The serve profiles exercise both E/PD and full E/P/D with Qwen3-VL on one GPU.

## Where should the reviewer start?

- `examples/backends/vllm/launch/disagg_multimodal_e_pd.sh`
- `examples/backends/vllm/launch/disagg_multimodal_epd.sh`
- `tests/serve/multimodal_profiles/vllm.py`
- `docs/features/multimodal/multimodal-vllm.md`

## Validation

- computelab B200 GPU e2e, job `3034058`: 2 passed, 52 deselected
  - `mm_e_pd_unified_qwen3-vl-2b`
  - `mm_epd_unified_qwen3-vl-2b`
- focused Python validation in the vLLM dev image: 68 passed
- focused Rust validation: 4 passed
- `maturin develop --uv`
- `cargo fmt --all -- --check`
- `ruff check` on changed Python files
- `python3 -m py_compile` on changed Python files
- `bash -n` on both changed launch scripts
- `git diff --check`

## Stack

1. #11460 — generic encoder routing and discovery
2. #11461 — unified vLLM Encode engine
3. #11462 — unified vLLM encoder handoff consumer
4. **This PR:** launchers, GPU profiles, and documentation

## Related Issues

**🔗 This PR is linked to an issue:**

- [DIS-2034: vLLM: Add separate encode worker in unified backend](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend)
