### PR TITLE
feat(kv-router): coalesce worker KV events

### DIFF
--- a/components/src/dynamo/common/backend/worker.py
+++ b/components/src/dynamo/common/backend/worker.py
@@ -144,6 +144,7 @@ class WorkerConfig:
     route_to_encoder: bool = False
     media_decoder: Optional[MediaDecoder] = None
     media_fetcher: Optional[MediaFetcher] = None
+    kv_event_coalescing_block_size: Optional[int] = None
 
     @classmethod
     def from_runtime_config(
@@ -182,6 +183,9 @@ class WorkerConfig:
             ),
             "enable_local_indexer": getattr(runtime_cfg, "enable_local_indexer", True),
             "enable_kv_routing": getattr(runtime_cfg, "enable_kv_routing", True),
+            "kv_event_coalescing_block_size": getattr(
+                runtime_cfg, "kv_event_coalescing_block_size", None
+            ),
             "structural_tag_mode": (
                 "on"
                 if getattr(runtime_cfg, "dyn_enable_structural_tag", False)
@@ -267,6 +271,9 @@ class Worker:
             ),
             enable_local_indexer=self.config.enable_local_indexer,
             enable_kv_routing=self.config.enable_kv_routing,
+            kv_event_coalescing_block_size=(
+                self.config.kv_event_coalescing_block_size
+            ),
             metrics_labels=list(self.config.metrics_labels),
             disaggregation_mode=_to_rust_disaggregation_mode(
                 self.config.disaggregation_mode

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -32,6 +32,7 @@ class DynamoRuntimeConfig(ConfigBase):
     connector: list[str]
     enable_local_indexer: bool
     durable_kv_events: bool
+    kv_event_coalescing_block_size: Optional[int] = None
 
     dyn_tool_call_parser: Optional[str] = None
     dyn_reasoning_parser: Optional[str] = None
@@ -89,6 +90,14 @@ class DynamoRuntimeConfig(ConfigBase):
         if self.engine_request_limit is not None and self.engine_request_limit <= 0:
             raise ValueError(
                 f"--engine-request-limit must be a positive integer, got {self.engine_request_limit}"
+            )
+        if (
+            self.kv_event_coalescing_block_size is not None
+            and self.kv_event_coalescing_block_size <= 0
+        ):
+            raise ValueError(
+                "--kv-event-coalescing-block-size must be a positive integer, "
+                f"got {self.kv_event_coalescing_block_size}"
             )
 
     def _validate_output_modalities(self) -> None:
@@ -178,6 +187,15 @@ class DynamoRuntimeArgGroup(ArgGroup):
             env_var="DYN_DURABLE_KV_EVENTS",
             default=False,
             help="[Deprecated] Enable durable KV events using NATS JetStream instead of the local indexer. This option will be removed in a future release. The event-plane subscriber (local_indexer mode) is now the recommended path.",
+        )
+
+        add_argument(
+            g,
+            flag_name="--kv-event-coalescing-block-size",
+            env_var="DYN_KV_EVENT_COALESCING_BLOCK_SIZE",
+            default=None,
+            type=int,
+            help="Coalesce worker KV events into router-visible blocks of this many tokens. Must be a multiple of the engine KV block size.",
         )
 
         # Optional: tool/reasoning parsers (choices from dynamo._core when available)

--- a/components/src/dynamo/common/tests/configuration/test_runtime_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_runtime_args.py
@@ -111,3 +111,17 @@ def test_fpm_trace_help_lists_flag_and_env(monkeypatch):
     assert "--fpm-trace" in help_text
     assert "--no-fpm-trace" in help_text
     assert "DYN_FPM_TRACE" in help_text
+
+
+def test_kv_event_coalescing_block_size_from_cli():
+    config, help_text = _parse_runtime_args(
+        ["--kv-event-coalescing-block-size", "32"]
+    )
+
+    assert config.kv_event_coalescing_block_size == 32
+    assert "DYN_KV_EVENT_COALESCING_BLOCK_SIZE" in help_text
+
+
+def test_kv_event_coalescing_block_size_must_be_positive():
+    with pytest.raises(ValueError, match="must be a positive integer"):
+        _parse_runtime_args(["--kv-event-coalescing-block-size", "0"])

--- a/components/src/dynamo/sglang/capacity.py
+++ b/components/src/dynamo/sglang/capacity.py
@@ -56,6 +56,38 @@ def tokens_to_kv_blocks(tokens: int, page_size: int | None) -> int:
     return (tokens + page_size - 1) // page_size
 
 
+def kv_event_block_sizes(server_args: Any, dynamo_args: Any) -> tuple[int, int]:
+    """Return and validate physical and router-visible KV event block sizes."""
+    source = int(getattr(server_args, "page_size", 0) or 0)
+    target = int(
+        getattr(dynamo_args, "kv_event_coalescing_block_size", None) or source
+    )
+    if source <= 0:
+        raise ValueError(f"SGLang page_size must be positive, got {source}")
+    if target < source or target % source:
+        raise ValueError(
+            "kv_event_coalescing_block_size "
+            f"({target}) must be a multiple of SGLang page_size ({source}) "
+            "and cannot be smaller"
+        )
+    return source, target
+
+
+def scale_kv_block_capacity(
+    blocks: int | None, source: int, target: int
+) -> int | None:
+    """Convert a total capacity using floor division."""
+    if blocks is None:
+        return None
+    return blocks // (target // source)
+
+
+def scale_kv_block_usage(blocks: int, source: int, target: int) -> int:
+    """Convert an occupied-block measurement using ceiling division."""
+    ratio = target // source
+    return (blocks + ratio - 1) // ratio
+
+
 def runtime_capacity(
     server_args: Any, scheduler_info: dict[str, Any]
 ) -> RuntimeCapacity:

--- a/components/src/dynamo/sglang/publisher.py
+++ b/components/src/dynamo/sglang/publisher.py
@@ -26,7 +26,13 @@ from dynamo.llm import KvEventPublisher, WorkerMetricsPublisher
 from dynamo.runtime import Endpoint
 from dynamo.sglang._disagg import SGLANG_WORKER_GROUP_ID_KEY, get_sglang_worker_group_id
 from dynamo.sglang.args import Config
-from dynamo.sglang.capacity import kv_metrics_block_values, local_dp_rank_bounds
+from dynamo.sglang.capacity import (
+    kv_event_block_sizes,
+    kv_metrics_block_values,
+    local_dp_rank_bounds,
+    scale_kv_block_capacity,
+    scale_kv_block_usage,
+)
 
 
 def get_local_dp_rank_range(server_args) -> range:
@@ -220,6 +226,15 @@ class DynamoSglangPublisher:
                 active_decode_blocks, total_blocks = kv_metrics_block_values(
                     kv_metrics, self.server_args.page_size
                 )
+                source_block_size, routing_block_size = kv_event_block_sizes(
+                    self.server_args, self.dynamo_args
+                )
+                active_decode_blocks = scale_kv_block_usage(
+                    active_decode_blocks, source_block_size, routing_block_size
+                )
+                total_blocks = scale_kv_block_capacity(
+                    total_blocks, source_block_size, routing_block_size
+                )
                 self.metrics_publisher.publish(
                     dp_rank, kv_used_blocks=active_decode_blocks
                 )
@@ -338,6 +353,11 @@ class DynamoSglangPublisher:
                     zmq_topic="",
                     enable_local_indexer=self.dynamo_args.enable_local_indexer,
                     dp_rank=dp_rank,
+                    kv_event_coalescing_block_size=getattr(
+                        self.dynamo_args,
+                        "kv_event_coalescing_block_size",
+                        None,
+                    ),
                 )
                 self.kv_publishers.append(publisher)
 

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -30,8 +30,10 @@ from dynamo.sglang.args import DynamoConfig, use_modelexpress_remote_instance
 from dynamo.sglang.capacity import (
     get_hicache_native_offloading_capacity,
     get_spec_decode_runtime_data,
+    kv_event_block_sizes,
     model_card_dp_rank_bounds,
     runtime_capacity,
+    scale_kv_block_capacity,
 )
 
 SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
@@ -118,6 +120,7 @@ async def _register_model_with_runtime_config(
         True if registration succeeded, False otherwise.
     """
     runtime_config = await _get_runtime_config(engine, server_args, dynamo_args)
+    _, routing_block_size = kv_event_block_sizes(server_args, dynamo_args)
 
     if dynamo_args.use_sglang_tokenizer:
         logging.warning(
@@ -159,7 +162,7 @@ async def _register_model_with_runtime_config(
             endpoint,
             _register_model_source_path(engine, server_args),
             server_args.served_model_name,
-            kv_cache_block_size=server_args.page_size,
+            kv_cache_block_size=routing_block_size,
             runtime_config=runtime_config,
             custom_template_path=dynamo_args.custom_jinja_template,
             media_decoder=media_decoder,
@@ -457,11 +460,18 @@ async def _get_runtime_config(
     try:
         scheduler_info = engine._scheduler_init_result.scheduler_infos[0]
         capacity = runtime_capacity(server_args, scheduler_info)
+        source_block_size, routing_block_size = kv_event_block_sizes(
+            server_args, dynamo_args
+        )
         max_total_tokens = scheduler_info.get("max_total_num_tokens")
 
         if max_total_tokens:
             if capacity.total_kv_blocks is not None:
-                runtime_config.total_kv_blocks = capacity.total_kv_blocks
+                runtime_config.total_kv_blocks = scale_kv_block_capacity(
+                    capacity.total_kv_blocks,
+                    source_block_size,
+                    routing_block_size,
+                )
                 logging.info(
                     f"Got total KV blocks from scheduler: {runtime_config.total_kv_blocks} "
                     f"(max_total_tokens={max_total_tokens}, page_size={server_args.page_size})"

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -45,6 +45,7 @@ from dynamo.llm.exceptions import EngineShutdown
 from dynamo.runtime import DistributedRuntime
 from dynamo.sglang._compat import start_profile_compat
 from dynamo.sglang.args import Config
+from dynamo.sglang.capacity import kv_event_block_sizes
 from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import DynamoSglangPublisher
 
@@ -411,12 +412,16 @@ class LoraMixin:
                                 else:
                                     lora_worker_type = WorkerType.Aggregated
                                     lora_needs = []
+                            _, routing_block_size = kv_event_block_sizes(
+                                self.config.server_args,
+                                self.config.dynamo_args,
+                            )
                             await register_llm(
                                 model_input=ModelInput.Tokens,
                                 model_type=lora_model_type,
                                 endpoint=self.generate_endpoint,
                                 model_path=self.config.server_args.model_path,
-                                kv_cache_block_size=self.config.server_args.page_size,
+                                kv_cache_block_size=routing_block_size,
                                 user_data=user_data,
                                 lora_name=lora_name,
                                 base_model_path=self.config.server_args.model_path,

--- a/components/src/dynamo/sglang/tests/test_kv_event_coalescing.py
+++ b/components/src/dynamo/sglang/tests/test_kv_event_coalescing.py
@@ -1,0 +1,35 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.sglang.capacity import (
+    kv_event_block_sizes,
+    scale_kv_block_capacity,
+    scale_kv_block_usage,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
+
+
+def test_kv_event_block_sizes_preserve_physical_page_size():
+    server_args = SimpleNamespace(page_size=1)
+    dynamo_args = SimpleNamespace(kv_event_coalescing_block_size=16)
+
+    assert kv_event_block_sizes(server_args, dynamo_args) == (1, 16)
+    assert server_args.page_size == 1
+
+
+def test_kv_event_block_size_must_be_source_multiple():
+    with pytest.raises(ValueError, match="must be a multiple"):
+        kv_event_block_sizes(
+            SimpleNamespace(page_size=4),
+            SimpleNamespace(kv_event_coalescing_block_size=10),
+        )
+
+
+def test_kv_block_units_use_floor_capacity_and_ceiling_usage():
+    assert scale_kv_block_capacity(33, 1, 16) == 2
+    assert scale_kv_block_usage(33, 1, 16) == 3

--- a/lib/backend-common/src/publisher.rs
+++ b/lib/backend-common/src/publisher.rs
@@ -48,6 +48,7 @@ fn setup_kv_publishers(
     component: &Component,
     sources: Vec<KvEventSource>,
     kv_cache_block_size: u32,
+    coalescing_block_size: Option<u32>,
     enable_local_indexer: bool,
 ) -> Result<Vec<Arc<KvEventPublisher>>, DynamoError> {
     let mut publishers = Vec::with_capacity(sources.len());
@@ -66,9 +67,11 @@ fn setup_kv_publishers(
             ),
             KvEventSource::Push { on_ready, .. } => (None, Some(on_ready)),
         };
-        let publisher = KvEventPublisher::new_with_local_indexer(
+        let publisher = KvEventPublisher::new_with_local_indexer_worker_id_and_coalescing(
             component.clone(),
+            None,
             kv_cache_block_size,
+            coalescing_block_size,
             source_config,
             enable_local_indexer,
             dp_rank,
@@ -131,13 +134,20 @@ pub(crate) async fn setup_publishers(
     dp_ranks: Vec<u32>,
     on_publisher_ready: Option<crate::engine::OnSnapshotPublisherReady>,
     kv_cache_block_size: Option<u32>,
+    coalescing_block_size: Option<u32>,
     enable_local_indexer: bool,
 ) -> Result<PublisherHandles, DynamoError> {
     // KV event publishers require the engine's block size; without it, the
     // router can't translate token IDs into cache blocks. Snapshot publisher
     // is independent — load reporting works regardless of cache structure.
     let kv_publishers = if let Some(block_size) = kv_cache_block_size {
-        setup_kv_publishers(component, kv_sources, block_size, enable_local_indexer)?
+        setup_kv_publishers(
+            component,
+            kv_sources,
+            block_size,
+            coalescing_block_size,
+            enable_local_indexer,
+        )?
     } else {
         if !kv_sources.is_empty() {
             tracing::warn!(
@@ -153,7 +163,15 @@ pub(crate) async fn setup_publishers(
     } else {
         let router_publishers = build_router_publishers(component, &dp_ranks).await?;
         let gauges = Arc::new(ComponentGauges::new(engine_metrics, &dp_ranks)?);
-        let publisher = Arc::new(SnapshotPublisher::new(gauges, router_publishers));
+        let block_ratio = match (kv_cache_block_size, coalescing_block_size) {
+            (Some(source), Some(target)) => u64::from(target / source),
+            _ => 1,
+        };
+        let publisher = Arc::new(SnapshotPublisher::new_with_block_ratio(
+            gauges,
+            router_publishers,
+            block_ratio,
+        ));
         if let Some(on_ready) = on_publisher_ready {
             on_ready(publisher.clone())
                 .map_err(|e| publisher_err(format!("snapshot publisher on_ready: {e}")))?;

--- a/lib/backend-common/src/snapshot_publisher.rs
+++ b/lib/backend-common/src/snapshot_publisher.rs
@@ -37,6 +37,8 @@ pub struct SnapshotPublisher {
     /// First-failure log per rank; suppresses noise on sustained NATS
     /// outages.
     warned_ranks: Mutex<HashSet<u32>>,
+    /// Number of engine source blocks represented by one router block.
+    block_ratio: u64,
 }
 
 impl SnapshotPublisher {
@@ -48,6 +50,21 @@ impl SnapshotPublisher {
             gauges,
             router_publishers,
             warned_ranks: Mutex::new(HashSet::new()),
+            block_ratio: 1,
+        }
+    }
+
+    pub(crate) fn new_with_block_ratio(
+        gauges: Arc<ComponentGauges>,
+        router_publishers: HashMap<u32, Arc<WorkerMetricsPublisher>>,
+        block_ratio: u64,
+    ) -> Self {
+        debug_assert!(block_ratio > 0);
+        Self {
+            gauges,
+            router_publishers,
+            warned_ranks: Mutex::new(HashSet::new()),
+            block_ratio,
         }
     }
 
@@ -59,6 +76,7 @@ impl SnapshotPublisher {
     /// emitting for an unknown rank is a misconfiguration the framework
     /// can't recover from cleanly).
     pub fn publish(&self, dp_rank: u32, snap: ComponentSnapshot) {
+        let snap = self.scale_snapshot(snap);
         self.gauges.update(&snap);
         if let Some(rp) = self.router_publishers.get(&dp_rank)
             && let Err(e) = rp.publish(Some(dp_rank), None, Some(snap.kv_used_blocks))
@@ -69,6 +87,12 @@ impl SnapshotPublisher {
                 tracing::debug!(dp_rank, error = %e, "router signal publish failed");
             }
         }
+    }
+
+    fn scale_snapshot(&self, mut snap: ComponentSnapshot) -> ComponentSnapshot {
+        snap.kv_used_blocks = snap.kv_used_blocks.div_ceil(self.block_ratio);
+        snap.kv_total_blocks /= self.block_ratio;
+        snap
     }
 
     /// Declared dp_ranks. Stable for the publisher's lifetime.
@@ -89,6 +113,20 @@ mod tests {
         let metrics = EngineMetrics::from_hierarchy(TestHierarchy::new());
         let gauges = Arc::new(ComponentGauges::new(&metrics, &[0]).expect("component gauges"));
         SnapshotPublisher::new(gauges, HashMap::new())
+    }
+
+    #[test]
+    fn coalescing_scales_capacity_down_and_usage_up() {
+        let metrics = EngineMetrics::from_hierarchy(TestHierarchy::new());
+        let gauges = Arc::new(ComponentGauges::new(&metrics, &[0]).expect("component gauges"));
+        let publisher = SnapshotPublisher::new_with_block_ratio(gauges, HashMap::new(), 16);
+        let scaled = publisher.scale_snapshot(ComponentSnapshot {
+            kv_used_blocks: 33,
+            kv_total_blocks: 33,
+            ..ComponentSnapshot::default()
+        });
+        assert_eq!(scaled.kv_used_blocks, 3);
+        assert_eq!(scaled.kv_total_blocks, 2);
     }
 
     /// Publishing for an undeclared rank is a no-op (no panic, no crash).

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -150,6 +150,9 @@ pub struct WorkerConfig {
     /// Kill switch for KV-aware-routing publishers. When `false`, skip
     /// `engine.kv_event_sources()` and `SnapshotPublisher` setup.
     pub enable_kv_routing: bool,
+    /// Optional router-visible KV block size. The engine continues to emit
+    /// physical blocks at `EngineConfig.llm.kv_cache_block_size`.
+    pub kv_event_coalescing_block_size: Option<u32>,
     /// Per-endpoint Prometheus metric labels appended to every metric.
     /// Common labels: `("model", "<served-name>")`.
     pub metrics_labels: Vec<(String, String)>,
@@ -217,6 +220,7 @@ impl Default for WorkerConfig {
             exclude_tools_when_tool_choice_none: true,
             enable_local_indexer: true,
             enable_kv_routing: true,
+            kv_event_coalescing_block_size: None,
             metrics_labels: Vec::new(),
             disaggregation_mode: DisaggregationMode::Aggregated,
             health_check_payload: None,
@@ -657,11 +661,16 @@ impl Worker {
             .llm
             .as_ref()
             .and_then(|l| l.kv_cache_block_size);
+        let routing_kv_block_size = resolve_routing_kv_block_size(
+            kv_cache_block_size,
+            self.config.kv_event_coalescing_block_size,
+        )?;
         tracing::debug!(
             kv_sources = kv_sources.len(),
             snapshot_dp_ranks = bindings.dp_ranks.len(),
             enable_local_indexer,
             kv_cache_block_size = ?kv_cache_block_size,
+            routing_kv_block_size = ?routing_kv_block_size,
             "Starting KV-aware-routing publishers"
         );
         let handles = setup_publishers(
@@ -671,6 +680,7 @@ impl Worker {
             bindings.dp_ranks,
             bindings.on_publisher_ready,
             kv_cache_block_size,
+            self.config.kv_event_coalescing_block_size,
             enable_local_indexer,
         )
         .await?;
@@ -1595,6 +1605,31 @@ fn validate_model_input(model_input: ModelInput, engine: &EngineKind) -> Result<
     }
 }
 
+fn resolve_routing_kv_block_size(
+    source: Option<u32>,
+    configured: Option<u32>,
+) -> Result<Option<u32>, DynamoError> {
+    let Some(target) = configured else {
+        return Ok(source);
+    };
+    let Some(source) = source else {
+        return Err(err(
+            ErrorType::Backend(BackendError::InvalidArgument),
+            "kv_event_coalescing_block_size requires the engine to report kv_cache_block_size"
+                .to_string(),
+        ));
+    };
+    if source == 0 || target < source || target % source != 0 {
+        return Err(err(
+            ErrorType::Backend(BackendError::InvalidArgument),
+            format!(
+                "kv_event_coalescing_block_size ({target}) must be a multiple of the engine KV block size ({source}) and cannot be smaller"
+            ),
+        ));
+    }
+    Ok(Some(target))
+}
+
 async fn build_local_model(
     config: &WorkerConfig,
     engine_config: &EngineConfig,
@@ -1633,9 +1668,18 @@ async fn build_local_model(
         _ => None,
     };
 
+    let routing_kv_block_size = resolve_routing_kv_block_size(
+        llm.kv_cache_block_size,
+        config.kv_event_coalescing_block_size,
+    )?;
+    let block_ratio = match (llm.kv_cache_block_size, routing_kv_block_size) {
+        (Some(source), Some(target)) => u64::from(target / source),
+        _ => 1,
+    };
+
     let rt_cfg = ModelRuntimeConfig {
         context_length: llm.context_length,
-        total_kv_blocks: llm.total_kv_blocks,
+        total_kv_blocks: llm.total_kv_blocks.map(|blocks| blocks / block_ratio),
         max_num_seqs: llm.max_num_seqs,
         max_num_batched_tokens: llm.max_num_batched_tokens,
         data_parallel_size: llm.data_parallel_size.unwrap_or(1),
@@ -1655,7 +1699,7 @@ async fn build_local_model(
     let mut builder = LocalModelBuilder::default();
     builder
         .model_name(served_name)
-        .kv_cache_block_size(llm.kv_cache_block_size)
+        .kv_cache_block_size(routing_kv_block_size)
         .custom_template_path(config.custom_jinja_template.clone())
         .media_decoder(config.media_decoder.clone())
         .media_fetcher(config.media_fetcher.clone())
@@ -1697,6 +1741,20 @@ async fn build_local_model(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn routing_kv_block_size_validates_source_multiple() {
+        assert_eq!(
+            resolve_routing_kv_block_size(Some(1), None).unwrap(),
+            Some(1)
+        );
+        assert_eq!(
+            resolve_routing_kv_block_size(Some(4), Some(16)).unwrap(),
+            Some(16)
+        );
+        assert!(resolve_routing_kv_block_size(Some(4), Some(10)).is_err());
+        assert!(resolve_routing_kv_block_size(None, Some(16)).is_err());
+    }
 
     fn error_type_of(result: Result<ModelType, DynamoError>) -> ErrorType {
         result.unwrap_err().error_type()
@@ -1952,6 +2010,29 @@ mod tests {
                 .and_then(|value| value.as_str()),
             Some("group-a")
         );
+    }
+
+    #[tokio::test]
+    async fn build_local_model_advertises_coalesced_block_units() {
+        let config = WorkerConfig {
+            kv_event_coalescing_block_size: Some(16),
+            ..WorkerConfig::default()
+        };
+        let engine_config = EngineConfig {
+            model: "test/model".to_string(),
+            llm: Some(crate::engine::LlmRegistration {
+                kv_cache_block_size: Some(1),
+                total_kv_blocks: Some(33),
+                ..Default::default()
+            }),
+            ..EngineConfig::default()
+        };
+
+        let local_model = build_local_model(&config, &engine_config, true)
+            .await
+            .unwrap();
+        assert_eq!(local_model.card().kv_cache_block_size, 16);
+        assert_eq!(local_model.runtime_config().total_kv_blocks, Some(2));
     }
 
     #[tokio::test]

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -319,6 +319,7 @@ impl WorkerConfig {
         route_to_encoder = false,
         media_decoder = None,
         media_fetcher = None,
+        kv_event_coalescing_block_size = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -346,6 +347,7 @@ impl WorkerConfig {
         route_to_encoder: bool,
         media_decoder: Option<MediaDecoder>,
         media_fetcher: Option<MediaFetcher>,
+        kv_event_coalescing_block_size: Option<u32>,
     ) -> PyResult<Self> {
         // Delegating to the same conversion used by `register_model`.
         let model_input_rs = match model_input {
@@ -415,6 +417,7 @@ impl WorkerConfig {
                 exclude_tools_when_tool_choice_none,
                 enable_local_indexer,
                 enable_kv_routing,
+                kv_event_coalescing_block_size,
                 metrics_labels,
                 disaggregation_mode: disaggregation_mode.into(),
                 health_check_payload,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -39,7 +39,9 @@ use rs::protocols::annotated::Annotated as RsAnnotated;
 use tracing;
 
 use llm_rs::kv_router::KvPushRouter as RsKvPushRouter;
-use llm_rs::kv_router::publisher::{KvEventSourceConfig, create_stored_blocks};
+use llm_rs::kv_router::publisher::{
+    KvEventSourceConfig, create_stored_blocks, create_stored_blocks_with_input,
+};
 use llm_rs::protocols::common::timing::RequestTracker;
 use llm_rs::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 
@@ -862,6 +864,7 @@ pub(crate) struct KvEventPublisher {
     kv_block_size: usize,
     dp_rank: DpRank,
     warning_count: Arc<AtomicU32>,
+    coalescing_enabled: bool,
 }
 
 impl KvEventPublisher {
@@ -876,11 +879,13 @@ impl KvEventPublisher {
         dp_rank: DpRank,
     ) -> Self {
         let kv_block_size = inner.kv_block_size() as usize;
+        let coalescing_enabled = inner.routing_kv_block_size() != inner.kv_block_size();
         Self {
             inner,
             kv_block_size,
             dp_rank,
             warning_count: Arc::new(AtomicU32::new(0)),
+            coalescing_enabled,
         }
     }
 }
@@ -907,7 +912,7 @@ impl KvEventPublisher {
     ///         ``0`` is treated as ``None`` (also disables batching).
     ///         Maximum allowed is 15_000 (15 seconds); larger values are capped.
     #[new]
-    #[pyo3(signature = (endpoint, worker_id=None, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_ms=llm_rs::kv_router::publisher::DEFAULT_BATCHING_TIMEOUT_MS, image_token_id=None))]
+    #[pyo3(signature = (endpoint, worker_id=None, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_ms=llm_rs::kv_router::publisher::DEFAULT_BATCHING_TIMEOUT_MS, image_token_id=None, kv_event_coalescing_block_size=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         endpoint: Endpoint,
@@ -919,6 +924,7 @@ impl KvEventPublisher {
         zmq_topic: Option<String>,
         batching_timeout_ms: Option<u64>,
         image_token_id: Option<u32>,
+        kv_event_coalescing_block_size: Option<u32>,
     ) -> PyResult<Self> {
         let source_config = zmq_endpoint.map(|ep| KvEventSourceConfig::Zmq {
             endpoint: ep,
@@ -934,10 +940,11 @@ impl KvEventPublisher {
         let component = endpoint.inner.component().clone();
 
         let inner =
-            llm_rs::kv_router::publisher::KvEventPublisher::new_with_local_indexer_and_worker_id(
+            llm_rs::kv_router::publisher::KvEventPublisher::new_with_local_indexer_worker_id_and_coalescing(
                 component,
                 worker_id,
                 kv_block_size as u32,
+                kv_event_coalescing_block_size,
                 source_config,
                 enable_local_indexer,
                 dp_rank,
@@ -950,6 +957,8 @@ impl KvEventPublisher {
             kv_block_size,
             dp_rank,
             warning_count: Arc::new(AtomicU32::new(0)),
+            coalescing_enabled: kv_event_coalescing_block_size
+                .is_some_and(|target| target != kv_block_size as u32),
         })
     }
 
@@ -971,6 +980,7 @@ impl KvEventPublisher {
         let dp_rank = self.dp_rank;
         let warning_count = self.warning_count.clone();
         let inner = self.inner.clone();
+        let coalescing_enabled = self.coalescing_enabled;
 
         let event_id = inner.next_event_id();
 
@@ -981,12 +991,23 @@ impl KvEventPublisher {
 
         py.allow_threads(|| {
             let block_hashes_u64: Vec<u64> = block_hashes.iter().map(|&h| h as u64).collect();
-            let event = KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash: parent_hash.map(ExternalSequenceBlockHash::from),
-                    start_position: None,
-                    blocks: create_stored_blocks(
+            let (blocks, store_input) = if coalescing_enabled {
+                let (blocks, input) = create_stored_blocks_with_input(
+                    kv_block_size,
+                    &token_ids,
+                    &num_block_tokens,
+                    &block_hashes_u64,
+                    lora_name.as_deref(),
+                    cache_salt.as_deref(),
+                    &warning_count,
+                    mm_infos.as_deref(),
+                    is_eagle,
+                    None, // image_token_id: publish path keeps caller-supplied mm_infos
+                );
+                (blocks, Some(input))
+            } else {
+                (
+                    create_stored_blocks(
                         kv_block_size,
                         &token_ids,
                         &num_block_tokens,
@@ -996,13 +1017,28 @@ impl KvEventPublisher {
                         &warning_count,
                         mm_infos.as_deref(),
                         is_eagle,
-                        None, // image_token_id: publish path keeps caller-supplied mm_infos
+                        None,
                     ),
+                    None,
+                )
+            };
+            let event = KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: parent_hash.map(ExternalSequenceBlockHash::from),
+                    start_position: None,
+                    blocks,
                 }),
                 dp_rank,
             };
 
-            inner.publish(event).map_err(to_pyerr)
+            inner
+                .publish_with_storage_tier_and_input(
+                    event,
+                    StorageTier::Device,
+                    store_input,
+                )
+                .map_err(to_pyerr)
         })
     }
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1070,6 +1070,7 @@ class KvEventPublisher:
         zmq_topic: Optional[str] = None,
         batching_timeout_ms: Optional[int] = None,
         image_token_id: Optional[int] = None,
+        kv_event_coalescing_block_size: Optional[int] = None,
     ) -> None:
         """
         Create a `KvEventPublisher` object.
@@ -3284,6 +3285,7 @@ class backend:
             route_to_encoder: bool = ...,
             media_decoder: Optional[MediaDecoder] = None,
             media_fetcher: Optional[MediaFetcher] = None,
+            kv_event_coalescing_block_size: Optional[int] = None,
         ) -> None: ...
 
     class Worker:

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -413,6 +413,63 @@ pub struct PlacementEvent {
     pub event: KvCacheEvent,
 }
 
+/// Worker-local token context aligned with one stored source block.
+///
+/// This is deliberately not serialized with [`PlacementEvent`]. Publishers use
+/// it to build larger routing blocks before the event reaches either the local
+/// indexer or the event plane.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvCacheStoreBlockInput {
+    /// Canonical tokens used for routing-side hashing. EAGLE blocks contain
+    /// `source_block_size + 1` tokens; ordinary blocks contain exactly
+    /// `source_block_size` tokens.
+    pub token_ids: Vec<u32>,
+    pub lora_name: Option<String>,
+    pub cache_namespace: Option<String>,
+    pub is_eagle: bool,
+    /// Multimodal metadata to include in the token hash. This can differ from
+    /// the block's published `mm_extra_info`: image-token normalization replaces
+    /// placeholders with canonical pad values and therefore hashes without MM
+    /// metadata while still preserving that metadata on the stored block.
+    pub hash_mm_extra_info: Option<BlockExtraInfo>,
+}
+
+/// Worker-local store context, one entry per [`KvCacheStoreData::blocks`] item.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct KvCacheStoreInput {
+    pub blocks: Vec<KvCacheStoreBlockInput>,
+}
+
+/// Publisher ingress event. `store_input` is present only when a producer
+/// supplies token context for a stored event; it never crosses the network.
+#[derive(Debug, Clone, PartialEq)]
+pub struct PlacementEventInput {
+    pub event: PlacementEvent,
+    pub store_input: Option<KvCacheStoreInput>,
+}
+
+impl PlacementEventInput {
+    pub fn new(event: PlacementEvent, store_input: Option<KvCacheStoreInput>) -> Self {
+        Self { event, store_input }
+    }
+
+    pub fn without_store_input(event: PlacementEvent) -> Self {
+        Self::new(event, None)
+    }
+}
+
+impl From<PlacementEvent> for PlacementEventInput {
+    fn from(event: PlacementEvent) -> Self {
+        Self::without_store_input(event)
+    }
+}
+
+impl From<PlacementEventInput> for PlacementEvent {
+    fn from(input: PlacementEventInput) -> Self {
+        input.event
+    }
+}
+
 impl PlacementEvent {
     pub fn new(placement: Placement, event: KvCacheEvent) -> Self {
         Self { placement, event }

--- a/lib/kv-router/src/zmq_wire/convert.rs
+++ b/lib/kv-router/src/zmq_wire/convert.rs
@@ -7,8 +7,9 @@ use std::sync::atomic::{AtomicU32, Ordering};
 
 use crate::protocols::{
     BlockExtraInfo, BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData,
-    KvCacheRemoveData, KvCacheStoreData, KvCacheStoredBlockData, Placement, PlacementEvent,
-    StorageTier, WorkerWithDpRank, compute_block_hash_for_seq,
+    KvCacheRemoveData, KvCacheStoreBlockInput, KvCacheStoreData, KvCacheStoreInput,
+    KvCacheStoredBlockData, Placement, PlacementEvent, PlacementEventInput, StorageTier,
+    WorkerWithDpRank, compute_block_hash_for_seq,
 };
 
 use super::types::{BlockHashValue, RawKvEvent};
@@ -22,6 +23,49 @@ pub fn convert_event(
     warning_count: &Arc<AtomicU32>,
     image_token_id: Option<u32>,
 ) -> Option<PlacementEvent> {
+    convert_event_impl(
+        raw,
+        event_id,
+        kv_block_size,
+        worker,
+        warning_count,
+        image_token_id,
+        false,
+    )
+    .map(|input| input.event)
+}
+
+/// Convert a raw event while retaining worker-local token context for optional
+/// publisher-side block coalescing.
+pub fn convert_event_with_input(
+    raw: RawKvEvent,
+    event_id: u64,
+    kv_block_size: u32,
+    worker: WorkerWithDpRank,
+    warning_count: &Arc<AtomicU32>,
+    image_token_id: Option<u32>,
+) -> Option<PlacementEventInput> {
+    convert_event_impl(
+        raw,
+        event_id,
+        kv_block_size,
+        worker,
+        warning_count,
+        image_token_id,
+        true,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+fn convert_event_impl(
+    raw: RawKvEvent,
+    event_id: u64,
+    kv_block_size: u32,
+    worker: WorkerWithDpRank,
+    warning_count: &Arc<AtomicU32>,
+    image_token_id: Option<u32>,
+    capture_store_input: bool,
+) -> Option<PlacementEventInput> {
     let storage_tier = match &raw {
         RawKvEvent::BlockStored { medium, .. } | RawKvEvent::BlockRemoved { medium, .. } => {
             StorageTier::from_kv_medium_or_default(medium.as_deref())
@@ -60,15 +104,17 @@ pub fn convert_event(
                     // Return an empty Removed instead of Cleared to avoid nuking
                     // the worker's entire index state. An empty Removed is a no-op
                     // in the radix tree (zero iterations, returns Ok(())).
-                    return Some(PlacementEvent::new(
-                        Placement::local_worker(worker.worker_id, worker.dp_rank, storage_tier),
-                        KvCacheEvent {
-                            event_id,
-                            data: KvCacheEventData::Removed(KvCacheRemoveData {
-                                block_hashes: vec![],
-                            }),
-                            dp_rank,
-                        },
+                    return Some(PlacementEventInput::without_store_input(
+                        PlacementEvent::new(
+                            Placement::local_worker(worker.worker_id, worker.dp_rank, storage_tier),
+                            KvCacheEvent {
+                                event_id,
+                                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                                    block_hashes: vec![],
+                                }),
+                                dp_rank,
+                            },
+                        ),
                     ));
                 }
             }
@@ -78,14 +124,23 @@ pub fn convert_event(
                 .into_iter()
                 .map(BlockHashValue::into_u64)
                 .collect();
-            KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash: parent_block_hash
-                        .map(BlockHashValue::into_u64)
-                        .map(ExternalSequenceBlockHash::from),
-                    start_position: None,
-                    blocks: create_stored_blocks(
+            let (blocks, store_input) = if capture_store_input {
+                let (blocks, input) = create_stored_blocks_with_input(
+                    kv_block_size,
+                    &token_ids,
+                    &num_block_tokens,
+                    &block_hashes_u64,
+                    lora_name.as_deref(),
+                    cache_namespace.as_deref(),
+                    warning_count,
+                    block_mm_infos.as_deref(),
+                    is_eagle,
+                    image_token_id,
+                );
+                (blocks, Some(input))
+            } else {
+                (
+                    create_stored_blocks(
                         kv_block_size,
                         &token_ids,
                         &num_block_tokens,
@@ -97,9 +152,27 @@ pub fn convert_event(
                         is_eagle,
                         image_token_id,
                     ),
+                    None,
+                )
+            };
+            let event = KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: parent_block_hash
+                        .map(BlockHashValue::into_u64)
+                        .map(ExternalSequenceBlockHash::from),
+                    start_position: None,
+                    blocks,
                 }),
                 dp_rank,
-            }
+            };
+            return Some(PlacementEventInput::new(
+                PlacementEvent::new(
+                    Placement::local_worker(worker.worker_id, worker.dp_rank, storage_tier),
+                    event,
+                ),
+                store_input,
+            ));
         }
         RawKvEvent::BlockRemoved { block_hashes, .. } => {
             let hashes = block_hashes
@@ -123,9 +196,11 @@ pub fn convert_event(
         RawKvEvent::Ignored => unreachable!("ignored events return before conversion"),
     };
 
-    Some(PlacementEvent::new(
-        Placement::local_worker(worker.worker_id, worker.dp_rank, storage_tier),
-        event,
+    Some(PlacementEventInput::without_store_input(
+        PlacementEvent::new(
+            Placement::local_worker(worker.worker_id, worker.dp_rank, storage_tier),
+            event,
+        ),
     ))
 }
 
@@ -199,13 +274,6 @@ pub fn create_stored_block_from_parts(
         is_eagle,
         image_token_id,
     } = options;
-
-    // When the model has a routing image token and this block carries mm
-    // objects (vLLM events), normalize to the canonical pad_value scheme:
-    // substitute pad_value over the image_token_id runs and hash WITHOUT
-    // block_mm_infos, matching the frontend. sglang events carry no
-    // image_token_id tokens nor mm_extra_info, so they take the else branch
-    // unchanged.
     let tokens_hash = match (image_token_id, mm_extra_info.as_ref()) {
         (Some(img_tok), Some(info)) if !info.mm_objects.is_empty() => {
             let mm_hashes: Vec<u64> = info.mm_objects.iter().map(|o| o.mm_hash).collect();
@@ -235,7 +303,6 @@ pub fn create_stored_block_from_parts(
             )[0]
         }
     };
-
     tracing::trace!(
         "Creating stored block: external_block_hash={}, tokens_hash={}, token_ids={:?}, kv_block_size={}, mm_extra_info={:?}",
         block_hash,
@@ -251,6 +318,72 @@ pub fn create_stored_block_from_parts(
     }
 }
 
+pub fn create_stored_block_from_parts_with_input(
+    kv_block_size: u32,
+    block_hash: u64,
+    token_ids: &[u32],
+    options: StoredBlockOptions<'_>,
+) -> (KvCacheStoredBlockData, KvCacheStoreBlockInput) {
+    let StoredBlockOptions {
+        lora_name,
+        cache_namespace,
+        mm_extra_info,
+        is_eagle,
+        image_token_id,
+    } = options;
+
+    // When the model has a routing image token and this block carries mm
+    // objects (vLLM events), normalize to the canonical pad_value scheme:
+    // substitute pad_value over the image_token_id runs and hash WITHOUT
+    // block_mm_infos, matching the frontend. sglang events carry no
+    // image_token_id tokens nor mm_extra_info, so they take the else branch
+    // unchanged.
+    let (canonical_tokens, hash_mm_extra_info) = match (image_token_id, mm_extra_info.as_ref()) {
+        (Some(img_tok), Some(info)) if !info.mm_objects.is_empty() => {
+            let mm_hashes: Vec<u64> = info.mm_objects.iter().map(|o| o.mm_hash).collect();
+            let substituted = substitute_pad_values(token_ids, img_tok, &mm_hashes);
+            (substituted, None)
+        }
+        _ => (token_ids.to_vec(), mm_extra_info.clone()),
+    };
+    let block_mm_infos = hash_mm_extra_info
+        .as_ref()
+        .map(|info| vec![Some(info.clone())]);
+    let tokens_hash = compute_block_hash_for_seq(
+        &canonical_tokens,
+        kv_block_size,
+        BlockHashOptions {
+            block_mm_infos: block_mm_infos.as_deref(),
+            lora_name,
+            cache_namespace,
+            is_eagle,
+        },
+    )[0];
+
+    tracing::trace!(
+        "Creating stored block: external_block_hash={}, tokens_hash={}, token_ids={:?}, kv_block_size={}, mm_extra_info={:?}",
+        block_hash,
+        tokens_hash.0,
+        token_ids,
+        kv_block_size,
+        mm_extra_info
+    );
+    (
+        KvCacheStoredBlockData {
+            block_hash: ExternalSequenceBlockHash::from(block_hash),
+            tokens_hash,
+            mm_extra_info,
+        },
+        KvCacheStoreBlockInput {
+            token_ids: canonical_tokens,
+            lora_name: lora_name.map(ToOwned::to_owned),
+            cache_namespace: cache_namespace.map(ToOwned::to_owned),
+            is_eagle: is_eagle.unwrap_or(false),
+            hash_mm_extra_info,
+        },
+    )
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn create_stored_blocks(
     kv_block_size: u32,
@@ -264,7 +397,69 @@ pub fn create_stored_blocks(
     is_eagle: Option<bool>,
     image_token_id: Option<u32>,
 ) -> Vec<KvCacheStoredBlockData> {
+    let mut blocks = Vec::new();
+    let mut token_offset = 0usize;
+    let append = usize::from(is_eagle.unwrap_or(false));
+
+    for (block_idx, (num_tokens, block_hash)) in
+        num_block_tokens.iter().zip(block_hashes).enumerate()
+    {
+        if *num_tokens != u64::from(kv_block_size) {
+            if warning_count.fetch_add(1, Ordering::Relaxed) < 3 {
+                tracing::warn!(
+                    "Block not published. Block size must be {} tokens to be published. Block size is: {}",
+                    kv_block_size,
+                    *num_tokens
+                );
+            }
+            break;
+        }
+        let end = token_offset + append + *num_tokens as usize;
+        if end > token_ids.len() {
+            if warning_count.fetch_add(1, Ordering::Relaxed) < 3 {
+                tracing::warn!(
+                    "Block not published. token_ids too short: need {}, got {}",
+                    end,
+                    token_ids.len()
+                );
+            }
+            break;
+        }
+        let mm_extra_info = block_mm_infos
+            .and_then(|infos| infos.get(block_idx))
+            .and_then(Clone::clone);
+        blocks.push(create_stored_block_from_parts(
+            kv_block_size,
+            *block_hash,
+            &token_ids[token_offset..end],
+            StoredBlockOptions {
+                lora_name,
+                cache_namespace,
+                mm_extra_info,
+                is_eagle,
+                image_token_id,
+            },
+        ));
+        token_offset += *num_tokens as usize;
+    }
+    blocks
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn create_stored_blocks_with_input(
+    kv_block_size: u32,
+    token_ids: &[u32],
+    num_block_tokens: &[u64],
+    block_hashes: &[u64],
+    lora_name: Option<&str>,
+    cache_namespace: Option<&str>,
+    warning_count: &Arc<AtomicU32>,
+    block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+    is_eagle: Option<bool>,
+    image_token_id: Option<u32>,
+) -> (Vec<KvCacheStoredBlockData>, KvCacheStoreInput) {
     let mut blocks: Vec<KvCacheStoredBlockData> = Vec::new();
+    let mut inputs: Vec<KvCacheStoreBlockInput> = Vec::new();
 
     let mut token_offset: usize = 0;
     let append = is_eagle.unwrap_or(false) as usize;
@@ -300,7 +495,7 @@ pub fn create_stored_blocks(
             .and_then(|infos| infos.get(block_idx))
             .and_then(|opt| opt.clone());
 
-        blocks.push(create_stored_block_from_parts(
+        let (block, input) = create_stored_block_from_parts_with_input(
             kv_block_size,
             *block_hash_it,
             tokens,
@@ -311,11 +506,13 @@ pub fn create_stored_blocks(
                 is_eagle,
                 image_token_id,
             },
-        ));
+        );
+        blocks.push(block);
+        inputs.push(input);
         token_offset += *num_tokens_it as usize;
     }
 
-    blocks
+    (blocks, KvCacheStoreInput { blocks: inputs })
 }
 
 #[cfg(test)]
@@ -385,5 +582,37 @@ mod normalize_tests {
         let without =
             create_stored_block_from_parts(block_size, 0x1, &tokens, StoredBlockOptions::default());
         assert_eq!(with_img.tokens_hash, without.tokens_hash);
+    }
+
+    #[test]
+    fn sidecar_path_preserves_published_blocks() {
+        let warning_count = Arc::new(AtomicU32::new(0));
+        let standard = create_stored_blocks(
+            2,
+            &[10, 20, 30, 40],
+            &[2, 2],
+            &[100, 200],
+            Some("adapter"),
+            Some("namespace"),
+            &warning_count,
+            None,
+            None,
+            None,
+        );
+        let (with_sidecar, input) = create_stored_blocks_with_input(
+            2,
+            &[10, 20, 30, 40],
+            &[2, 2],
+            &[100, 200],
+            Some("adapter"),
+            Some("namespace"),
+            &warning_count,
+            None,
+            None,
+            None,
+        );
+        assert_eq!(with_sidecar, standard);
+        assert_eq!(input.blocks[0].token_ids, vec![10, 20]);
+        assert_eq!(input.blocks[1].token_ids, vec![30, 40]);
     }
 }

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -24,7 +24,9 @@ mod tests;
 mod types;
 
 pub use convert::{
-    StoredBlockOptions, convert_event, create_stored_block_from_parts, create_stored_blocks,
+    StoredBlockOptions, convert_event, convert_event_with_input, create_stored_block_from_parts,
+    create_stored_block_from_parts_with_input, create_stored_blocks,
+    create_stored_blocks_with_input,
 };
 pub use extra_keys::{
     extra_keys_to_block_mm_infos, extra_keys_to_cache_namespace, parse_mm_hash_from_extra_key,
@@ -145,6 +147,22 @@ impl ZmqEventNormalizer {
         worker: WorkerWithDpRank,
     ) -> Option<PlacementEvent> {
         convert_event(
+            raw,
+            event_id,
+            self.kv_block_size,
+            worker,
+            &self.warning_count,
+            self.image_token_id,
+        )
+    }
+
+    pub fn normalize_preprocessed_with_input(
+        &self,
+        raw: RawKvEvent,
+        event_id: u64,
+        worker: WorkerWithDpRank,
+    ) -> Option<crate::protocols::PlacementEventInput> {
+        convert_event_with_input(
             raw,
             event_id,
             self.kv_block_size,

--- a/lib/llm/src/kv_router/publisher/batching.rs
+++ b/lib/llm/src/kv_router/publisher/batching.rs
@@ -7,9 +7,11 @@ use std::time::{Duration, Instant};
 use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, StorageTier,
+    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, KvCacheStoreInput,
+    StorageTier,
 };
 
+use super::coalescer::EventCoalescer;
 use super::dedup::EventDedupFilter;
 use super::sinks::emit;
 
@@ -19,6 +21,7 @@ use super::sinks::emit;
 pub(super) struct BatchingState {
     pub(super) pending_removed: Option<KvCacheRemoveData>,
     pub(super) pending_stored: Option<KvCacheStoreData>,
+    pub(super) pending_stored_input: Option<KvCacheStoreInput>,
     pub(super) next_publish_id: u64,
     pub(super) last_dp_rank: u32,
     pub(super) last_storage_tier: StorageTier,
@@ -30,6 +33,7 @@ impl BatchingState {
         Self {
             pending_removed: None,
             pending_stored: None,
+            pending_stored_input: None,
             next_publish_id: 1,
             last_dp_rank: 0,
             last_storage_tier: StorageTier::Device,
@@ -77,48 +81,61 @@ impl BatchingState {
         local_indexer: &Option<Arc<LocalKvIndexer>>,
         worker_id: u64,
         dedup: &mut EventDedupFilter,
+        coalescer: &mut EventCoalescer,
     ) {
         if !self.has_pending() {
             return;
         }
         let dp_rank = self.last_dp_rank;
-        let mut emitted = false;
         if let Some(data) = self.pending_removed.take()
             && let Some(filtered) = dedup.filter_remove(dp_rank, self.last_storage_tier, data)
         {
-            emit(
-                publisher,
-                local_indexer,
-                worker_id,
+            for data in coalescer.process(
+                dp_rank,
                 self.last_storage_tier,
-                KvCacheEvent {
-                    event_id: self.next_publish_id,
-                    data: KvCacheEventData::Removed(filtered),
-                    dp_rank,
-                },
-            )
-            .await;
-            emitted = true;
+                KvCacheEventData::Removed(filtered),
+                None,
+            ) {
+                emit(
+                    publisher,
+                    local_indexer,
+                    worker_id,
+                    self.last_storage_tier,
+                    KvCacheEvent {
+                        event_id: self.next_publish_id,
+                        data,
+                        dp_rank,
+                    },
+                )
+                .await;
+                self.next_publish_id += 1;
+            }
         }
         if let Some(data) = self.pending_stored.take() {
             dedup.track_store(dp_rank, self.last_storage_tier, &data);
-            emit(
-                publisher,
-                local_indexer,
-                worker_id,
+            let input = self.pending_stored_input.take();
+            for data in coalescer.process(
+                dp_rank,
                 self.last_storage_tier,
-                KvCacheEvent {
-                    event_id: self.next_publish_id,
-                    data: KvCacheEventData::Stored(data),
-                    dp_rank,
-                },
-            )
-            .await;
-            emitted = true;
+                KvCacheEventData::Stored(data),
+                input,
+            ) {
+                emit(
+                    publisher,
+                    local_indexer,
+                    worker_id,
+                    self.last_storage_tier,
+                    KvCacheEvent {
+                        event_id: self.next_publish_id,
+                        data,
+                        dp_rank,
+                    },
+                )
+                .await;
+                self.next_publish_id += 1;
+            }
         }
-        if emitted {
-            self.next_publish_id += 1;
-        }
+        debug_assert!(self.pending_stored_input.is_none());
         self.record_flush_time();
     }
 }

--- a/lib/llm/src/kv_router/publisher/coalescer.rs
+++ b/lib/llm/src/kv_router/publisher/coalescer.rs
@@ -1,0 +1,907 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{HashMap, HashSet};
+
+use anyhow::{Result, bail};
+use dynamo_kv_router::protocols::{
+    BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, DpRank, ExternalSequenceBlockHash,
+    KvCacheEventData, KvCacheRemoveData, KvCacheStoreBlockInput, KvCacheStoreData,
+    KvCacheStoreInput, KvCacheStoredBlockData, StorageTier, compute_block_hash_for_seq,
+};
+
+#[derive(Debug, Clone)]
+struct SourceNode {
+    parent: Option<ExternalSequenceBlockHash>,
+    depth: usize,
+    source_position: Option<u32>,
+    block: KvCacheStoredBlockData,
+    input: KvCacheStoreBlockInput,
+    present_tiers: HashSet<StorageTier>,
+    children: HashSet<ExternalSequenceBlockHash>,
+    superblocks: HashSet<ExternalSequenceBlockHash>,
+}
+
+#[derive(Debug, Clone)]
+struct Superblock {
+    parent: Option<ExternalSequenceBlockHash>,
+    start_position: Option<u32>,
+    depth: usize,
+    members: Vec<ExternalSequenceBlockHash>,
+    block: KvCacheStoredBlockData,
+    active_tiers: HashSet<StorageTier>,
+}
+
+#[derive(Debug, Default)]
+struct RankState {
+    nodes: HashMap<ExternalSequenceBlockHash, SourceNode>,
+    superblocks: HashMap<ExternalSequenceBlockHash, Superblock>,
+}
+
+/// Coalesces engine-sized source blocks into larger router-visible blocks.
+///
+/// Source events have already been batched and source-hash removals have
+/// already passed through the publisher's refcounting deduplicator. The
+/// coalescer therefore treats repeated stores as idempotent and any removal as
+/// the final removal of that source placement.
+#[derive(Debug)]
+pub(super) struct EventCoalescer {
+    source_block_size: u32,
+    target_block_size: u32,
+    ratio: usize,
+    ranks: HashMap<DpRank, RankState>,
+}
+
+impl EventCoalescer {
+    pub(super) fn new(source_block_size: u32, target_block_size: u32) -> Result<Self> {
+        if source_block_size == 0 {
+            bail!("KV event source block size must be greater than zero");
+        }
+        if target_block_size < source_block_size {
+            bail!(
+                "KV event coalescing block size ({target_block_size}) cannot be smaller than the source block size ({source_block_size})"
+            );
+        }
+        if target_block_size % source_block_size != 0 {
+            bail!(
+                "KV event coalescing block size ({target_block_size}) must be a multiple of the source block size ({source_block_size})"
+            );
+        }
+        Ok(Self {
+            source_block_size,
+            target_block_size,
+            ratio: (target_block_size / source_block_size) as usize,
+            ranks: HashMap::new(),
+        })
+    }
+
+    pub(super) fn enabled(&self) -> bool {
+        self.ratio > 1
+    }
+
+    pub(super) fn process(
+        &mut self,
+        dp_rank: DpRank,
+        tier: StorageTier,
+        data: KvCacheEventData,
+        store_input: Option<KvCacheStoreInput>,
+    ) -> Vec<KvCacheEventData> {
+        if !self.enabled() {
+            return vec![data];
+        }
+
+        match data {
+            KvCacheEventData::Stored(store) => {
+                let Some(input) = store_input else {
+                    tracing::warn!(
+                        dp_rank,
+                        ?tier,
+                        "Dropping KV store event: coalescing requires source token context"
+                    );
+                    return self.fail_closed_store(dp_rank, tier, &store);
+                };
+                self.process_store(dp_rank, tier, store, input)
+            }
+            KvCacheEventData::Removed(remove) => self.process_remove(dp_rank, tier, remove),
+            KvCacheEventData::Cleared => {
+                self.ranks.clear();
+                vec![KvCacheEventData::Cleared]
+            }
+        }
+    }
+
+    fn process_store(
+        &mut self,
+        dp_rank: DpRank,
+        tier: StorageTier,
+        store: KvCacheStoreData,
+        input: KvCacheStoreInput,
+    ) -> Vec<KvCacheEventData> {
+        if store.blocks.len() != input.blocks.len() {
+            tracing::warn!(
+                dp_rank,
+                ?tier,
+                blocks = store.blocks.len(),
+                contexts = input.blocks.len(),
+                "Dropping KV store event: block/token context length mismatch"
+            );
+            return self.fail_closed_store(dp_rank, tier, &store);
+        }
+
+        let rank = self.ranks.entry(dp_rank).or_default();
+        let KvCacheStoreData {
+            parent_hash,
+            start_position,
+            blocks,
+        } = store;
+        let mut parent = parent_hash;
+        let mut candidates = HashSet::new();
+        let mut chain_valid = true;
+        let mut failed_hashes = Vec::new();
+
+        let pairs: Vec<_> = blocks.into_iter().zip(input.blocks.into_iter()).collect();
+        for (index, (block, block_input)) in pairs.iter().cloned().enumerate() {
+            if !chain_valid {
+                break;
+            }
+            let source_position =
+                start_position.and_then(|position| position.checked_add(index as u32));
+            let depth = if let Some(parent_hash) = parent {
+                let Some(parent_node) = rank.nodes.get(&parent_hash) else {
+                    tracing::warn!(
+                        dp_rank,
+                        ?tier,
+                        block_hash = block.block_hash.0,
+                        parent_hash = parent_hash.0,
+                        "Dropping KV store chain: coalescer does not know the parent block"
+                    );
+                    failed_hashes.extend(pairs[index..].iter().map(|(block, _)| block.block_hash));
+                    break;
+                };
+                parent_node.depth + 1
+            } else if let Some(position) = source_position {
+                position as usize + 1
+            } else {
+                1
+            };
+
+            let block_hash = block.block_hash;
+            if let Some(existing) = rank.nodes.get_mut(&block_hash) {
+                if existing.parent != parent
+                    || existing.depth != depth
+                    || existing.source_position != source_position
+                    || existing.block != block
+                    || existing.input != block_input
+                {
+                    tracing::warn!(
+                        dp_rank,
+                        ?tier,
+                        block_hash = block_hash.0,
+                        "Dropping conflicting duplicate KV source block"
+                    );
+                    chain_valid = false;
+                    failed_hashes.extend(pairs[index..].iter().map(|(block, _)| block.block_hash));
+                    continue;
+                }
+                existing.present_tiers.insert(tier);
+                candidates.extend(existing.superblocks.iter().copied());
+            } else {
+                rank.nodes.insert(
+                    block_hash,
+                    SourceNode {
+                        parent,
+                        depth,
+                        source_position,
+                        block,
+                        input: block_input,
+                        present_tiers: HashSet::from([tier]),
+                        children: HashSet::new(),
+                        superblocks: HashSet::new(),
+                    },
+                );
+                if let Some(parent_hash) = parent
+                    && let Some(parent_node) = rank.nodes.get_mut(&parent_hash)
+                {
+                    parent_node.children.insert(block_hash);
+                }
+            }
+
+            if depth % self.ratio == 0 && !rank.superblocks.contains_key(&block_hash) {
+                match build_superblock(
+                    rank,
+                    block_hash,
+                    self.source_block_size,
+                    self.target_block_size,
+                    self.ratio,
+                ) {
+                    Ok(superblock) => {
+                        for member in &superblock.members {
+                            if let Some(node) = rank.nodes.get_mut(member) {
+                                node.superblocks.insert(block_hash);
+                            }
+                        }
+                        rank.superblocks.insert(block_hash, superblock);
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            dp_rank,
+                            ?tier,
+                            block_hash = block_hash.0,
+                            %error,
+                            "Failed to build coalesced KV block"
+                        );
+                        failed_hashes.push(block_hash);
+                    }
+                }
+            }
+            if let Some(node) = rank.nodes.get(&block_hash) {
+                candidates.extend(node.superblocks.iter().copied());
+            }
+            parent = Some(block_hash);
+        }
+
+        let failed_removal = deactivate_sources(rank, tier, &failed_hashes);
+
+        let mut candidates: Vec<_> = candidates.into_iter().collect();
+        candidates.sort_unstable_by_key(|hash| {
+            (
+                rank.superblocks
+                    .get(hash)
+                    .map(|superblock| superblock.depth)
+                    .unwrap_or(usize::MAX),
+                hash.0,
+            )
+        });
+
+        let mut output = Vec::new();
+        if let Some(removal) = failed_removal {
+            output.push(KvCacheEventData::Removed(removal));
+        }
+        for endpoint in candidates {
+            let should_activate = rank.superblocks.get(&endpoint).is_some_and(|superblock| {
+                !superblock.active_tiers.contains(&tier)
+                    && superblock.members.iter().all(|member| {
+                        rank.nodes
+                            .get(member)
+                            .is_some_and(|node| node.present_tiers.contains(&tier))
+                    })
+            });
+            if !should_activate {
+                continue;
+            }
+            let superblock = rank.superblocks.get_mut(&endpoint).unwrap();
+            superblock.active_tiers.insert(tier);
+            output.push(KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: superblock.parent,
+                start_position: superblock.start_position,
+                blocks: vec![superblock.block.clone()],
+            }));
+        }
+        output
+    }
+
+    fn fail_closed_store(
+        &mut self,
+        dp_rank: DpRank,
+        tier: StorageTier,
+        store: &KvCacheStoreData,
+    ) -> Vec<KvCacheEventData> {
+        let Some(rank) = self.ranks.get_mut(&dp_rank) else {
+            return Vec::new();
+        };
+        let hashes: Vec<_> = store.blocks.iter().map(|block| block.block_hash).collect();
+        deactivate_sources(rank, tier, &hashes)
+            .map(KvCacheEventData::Removed)
+            .into_iter()
+            .collect()
+    }
+
+    fn process_remove(
+        &mut self,
+        dp_rank: DpRank,
+        tier: StorageTier,
+        remove: KvCacheRemoveData,
+    ) -> Vec<KvCacheEventData> {
+        let Some(rank) = self.ranks.get_mut(&dp_rank) else {
+            return Vec::new();
+        };
+        let mut removed_superblocks = HashSet::new();
+        let mut gc_candidates = Vec::new();
+
+        for source_hash in remove.block_hashes {
+            let memberships = match rank.nodes.get_mut(&source_hash) {
+                Some(node) => {
+                    if !node.present_tiers.remove(&tier) {
+                        continue;
+                    }
+                    node.superblocks.iter().copied().collect::<Vec<_>>()
+                }
+                None => continue,
+            };
+            for endpoint in memberships {
+                if rank
+                    .superblocks
+                    .get_mut(&endpoint)
+                    .is_some_and(|superblock| superblock.active_tiers.remove(&tier))
+                {
+                    removed_superblocks.insert(endpoint);
+                }
+            }
+            gc_candidates.push(source_hash);
+        }
+
+        for source_hash in gc_candidates {
+            gc_from(rank, source_hash);
+        }
+
+        if removed_superblocks.is_empty() {
+            Vec::new()
+        } else {
+            let mut block_hashes: Vec<_> = removed_superblocks.into_iter().collect();
+            block_hashes.sort_unstable_by_key(|hash| hash.0);
+            vec![KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes,
+            })]
+        }
+    }
+}
+
+fn deactivate_sources(
+    rank: &mut RankState,
+    tier: StorageTier,
+    source_hashes: &[ExternalSequenceBlockHash],
+) -> Option<KvCacheRemoveData> {
+    let mut removed_superblocks = HashSet::new();
+    for source_hash in source_hashes {
+        let memberships = match rank.nodes.get_mut(source_hash) {
+            Some(node) => {
+                node.present_tiers.remove(&tier);
+                node.superblocks.iter().copied().collect::<Vec<_>>()
+            }
+            None => continue,
+        };
+        for endpoint in memberships {
+            if rank
+                .superblocks
+                .get_mut(&endpoint)
+                .is_some_and(|superblock| superblock.active_tiers.remove(&tier))
+            {
+                removed_superblocks.insert(endpoint);
+            }
+        }
+    }
+    if removed_superblocks.is_empty() {
+        None
+    } else {
+        let mut block_hashes: Vec<_> = removed_superblocks.into_iter().collect();
+        block_hashes.sort_unstable_by_key(|hash| hash.0);
+        Some(KvCacheRemoveData { block_hashes })
+    }
+}
+
+fn build_superblock(
+    rank: &RankState,
+    endpoint: ExternalSequenceBlockHash,
+    source_block_size: u32,
+    target_block_size: u32,
+    ratio: usize,
+) -> Result<Superblock> {
+    let mut members = Vec::with_capacity(ratio);
+    let mut cursor = Some(endpoint);
+    for _ in 0..ratio {
+        let Some(hash) = cursor else {
+            bail!("source chain ended before a complete superblock was available");
+        };
+        let Some(node) = rank.nodes.get(&hash) else {
+            bail!("source chain contains an unknown block");
+        };
+        members.push(hash);
+        cursor = node.parent;
+    }
+    members.reverse();
+
+    let nodes: Vec<_> = members
+        .iter()
+        .map(|hash| rank.nodes.get(hash).unwrap())
+        .collect();
+    let first = nodes[0];
+    let lora_name = first.input.lora_name.as_deref();
+    let cache_namespace = first.input.cache_namespace.as_deref();
+    let is_eagle = first.input.is_eagle;
+    if nodes.iter().any(|node| {
+        node.input.lora_name.as_deref() != lora_name
+            || node.input.cache_namespace.as_deref() != cache_namespace
+            || node.input.is_eagle != is_eagle
+    }) {
+        bail!("source blocks in one superblock have incompatible hashing context");
+    }
+
+    let expected = source_block_size as usize + usize::from(is_eagle);
+    if nodes
+        .iter()
+        .any(|node| node.input.token_ids.len() != expected)
+    {
+        bail!("source block token count does not match the configured source block size");
+    }
+
+    let mut tokens = Vec::with_capacity(target_block_size as usize + usize::from(is_eagle));
+    for (index, node) in nodes.iter().enumerate() {
+        if is_eagle && index > 0 {
+            if tokens.last() != node.input.token_ids.first() {
+                bail!("adjacent EAGLE source blocks do not share their boundary token");
+            }
+            tokens.extend_from_slice(&node.input.token_ids[1..]);
+        } else {
+            tokens.extend_from_slice(&node.input.token_ids);
+        }
+    }
+
+    let hash_mm_extra_info = merge_mm_info(
+        nodes
+            .iter()
+            .map(|node| node.input.hash_mm_extra_info.as_ref()),
+        source_block_size as usize,
+    );
+    let block_mm_infos = hash_mm_extra_info
+        .as_ref()
+        .map(|info| vec![Some(info.clone())]);
+    let hashes = compute_block_hash_for_seq(
+        &tokens,
+        target_block_size,
+        BlockHashOptions {
+            block_mm_infos: block_mm_infos.as_deref(),
+            lora_name,
+            cache_namespace,
+            is_eagle: Some(is_eagle),
+        },
+    );
+    let Some(tokens_hash) = hashes.first().copied() else {
+        bail!("coalesced token sequence did not produce a target block hash");
+    };
+
+    let published_mm_extra_info = merge_mm_info(
+        nodes.iter().map(|node| node.block.mm_extra_info.as_ref()),
+        source_block_size as usize,
+    );
+    let start_position = first
+        .source_position
+        .map(|position| position / ratio as u32);
+
+    Ok(Superblock {
+        parent: cursor,
+        start_position,
+        depth: nodes.last().unwrap().depth,
+        members,
+        block: KvCacheStoredBlockData {
+            block_hash: endpoint,
+            tokens_hash,
+            mm_extra_info: published_mm_extra_info,
+        },
+        active_tiers: HashSet::new(),
+    })
+}
+
+fn merge_mm_info<'a>(
+    infos: impl Iterator<Item = Option<&'a BlockExtraInfo>>,
+    source_block_size: usize,
+) -> Option<BlockExtraInfo> {
+    let mut merged: Vec<BlockMmObjectInfo> = Vec::new();
+    for (block_index, info) in infos.enumerate() {
+        let Some(info) = info else {
+            continue;
+        };
+        let offset = block_index * source_block_size;
+        for object in &info.mm_objects {
+            let shifted: Vec<_> = object
+                .offsets
+                .iter()
+                .map(|(start, end)| (start + offset, end + offset))
+                .collect();
+            if let Some(existing) = merged
+                .iter_mut()
+                .find(|candidate| candidate.mm_hash == object.mm_hash)
+            {
+                existing.offsets.extend(shifted);
+            } else {
+                merged.push(BlockMmObjectInfo {
+                    mm_hash: object.mm_hash,
+                    offsets: shifted,
+                });
+            }
+        }
+    }
+    (!merged.is_empty()).then_some(BlockExtraInfo { mm_objects: merged })
+}
+
+fn gc_from(rank: &mut RankState, mut source_hash: ExternalSequenceBlockHash) {
+    loop {
+        let eligible = rank
+            .nodes
+            .get(&source_hash)
+            .is_some_and(|node| node.present_tiers.is_empty() && node.children.is_empty());
+        if !eligible {
+            return;
+        }
+        let node = rank.nodes.remove(&source_hash).unwrap();
+        for endpoint in node.superblocks {
+            let removable = rank
+                .superblocks
+                .get(&endpoint)
+                .is_some_and(|superblock| superblock.active_tiers.is_empty());
+            if !removable {
+                continue;
+            }
+            if let Some(superblock) = rank.superblocks.remove(&endpoint) {
+                for member in superblock.members {
+                    if let Some(member_node) = rank.nodes.get_mut(&member) {
+                        member_node.superblocks.remove(&endpoint);
+                    }
+                }
+            }
+        }
+        let Some(parent) = node.parent else {
+            return;
+        };
+        if let Some(parent_node) = rank.nodes.get_mut(&parent) {
+            parent_node.children.remove(&source_hash);
+        }
+        source_hash = parent;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_kv_router::protocols::{KvCacheStoreBlockInput, LocalBlockHash};
+
+    fn block(hash: u64, token: u32) -> (KvCacheStoredBlockData, KvCacheStoreBlockInput) {
+        (
+            KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(hash),
+                tokens_hash: LocalBlockHash(token as u64),
+                mm_extra_info: None,
+            },
+            KvCacheStoreBlockInput {
+                token_ids: vec![token],
+                lora_name: None,
+                cache_namespace: None,
+                is_eagle: false,
+                hash_mm_extra_info: None,
+            },
+        )
+    }
+
+    fn block_with_tokens(
+        hash: u64,
+        token_ids: Vec<u32>,
+        is_eagle: bool,
+    ) -> (KvCacheStoredBlockData, KvCacheStoreBlockInput) {
+        (
+            KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(hash),
+                tokens_hash: LocalBlockHash(hash),
+                mm_extra_info: None,
+            },
+            KvCacheStoreBlockInput {
+                token_ids,
+                lora_name: None,
+                cache_namespace: None,
+                is_eagle,
+                hash_mm_extra_info: None,
+            },
+        )
+    }
+
+    fn store(parent: Option<u64>, values: &[(u64, u32)]) -> (KvCacheEventData, KvCacheStoreInput) {
+        let (blocks, inputs): (Vec<_>, Vec<_>) = values
+            .iter()
+            .map(|(hash, token)| block(*hash, *token))
+            .unzip();
+        (
+            KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: parent.map(ExternalSequenceBlockHash),
+                start_position: None,
+                blocks,
+            }),
+            KvCacheStoreInput { blocks: inputs },
+        )
+    }
+
+    fn stored_hashes(output: &[KvCacheEventData]) -> Vec<u64> {
+        output
+            .iter()
+            .filter_map(|data| match data {
+                KvCacheEventData::Stored(store) => Some(store.blocks[0].block_hash.0),
+                _ => None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn emits_when_group_completes_and_removes_on_any_member() {
+        let mut coalescer = EventCoalescer::new(1, 4).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20), (3, 30)]);
+        assert!(
+            coalescer
+                .process(0, StorageTier::Device, data, Some(input))
+                .is_empty()
+        );
+        let (data, input) = store(Some(3), &[(4, 40)]);
+        let output = coalescer.process(0, StorageTier::Device, data, Some(input));
+        assert_eq!(stored_hashes(&output), vec![4]);
+
+        let output = coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(2)],
+            }),
+            None,
+        );
+        assert_eq!(
+            output,
+            vec![KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(4)]
+            })]
+        );
+    }
+
+    #[test]
+    fn restoring_member_reemits_superblock() {
+        let mut coalescer = EventCoalescer::new(1, 4).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20), (3, 30), (4, 40)]);
+        assert_eq!(
+            stored_hashes(&coalescer.process(0, StorageTier::Device, data, Some(input))),
+            vec![4]
+        );
+        coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(2)],
+            }),
+            None,
+        );
+        let (data, input) = store(Some(1), &[(2, 20)]);
+        assert_eq!(
+            stored_hashes(&coalescer.process(0, StorageTier::Device, data, Some(input))),
+            vec![4]
+        );
+    }
+
+    #[test]
+    fn shared_prefix_removal_invalidates_both_branches() {
+        let mut coalescer = EventCoalescer::new(1, 4).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20), (3, 30), (4, 40)]);
+        coalescer.process(0, StorageTier::Device, data, Some(input));
+        let (data, input) = store(Some(2), &[(5, 50), (6, 60)]);
+        assert_eq!(
+            stored_hashes(&coalescer.process(0, StorageTier::Device, data, Some(input))),
+            vec![6]
+        );
+
+        let output = coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(1)],
+            }),
+            None,
+        );
+        let KvCacheEventData::Removed(remove) = &output[0] else {
+            panic!("expected remove")
+        };
+        assert_eq!(
+            remove.block_hashes,
+            vec![ExternalSequenceBlockHash(4), ExternalSequenceBlockHash(6)]
+        );
+    }
+
+    #[test]
+    fn tiers_are_independent() {
+        let mut coalescer = EventCoalescer::new(1, 2).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20)]);
+        coalescer.process(0, StorageTier::Device, data.clone(), Some(input.clone()));
+        coalescer.process(
+            0,
+            StorageTier::HostPinned,
+            data.clone(),
+            Some(input.clone()),
+        );
+        coalescer.process(0, StorageTier::External, data, Some(input));
+
+        let output = coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(1)],
+            }),
+            None,
+        );
+        assert_eq!(output.len(), 1);
+        assert!(
+            coalescer.ranks[&0].superblocks[&ExternalSequenceBlockHash(2)]
+                .active_tiers
+                .contains(&StorageTier::HostPinned)
+        );
+        assert!(
+            coalescer.ranks[&0].superblocks[&ExternalSequenceBlockHash(2)]
+                .active_tiers
+                .contains(&StorageTier::External)
+        );
+    }
+
+    #[test]
+    fn several_member_removals_emit_one_superblock_removal() {
+        let mut coalescer = EventCoalescer::new(1, 4).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20), (3, 30), (4, 40)]);
+        coalescer.process(0, StorageTier::Device, data, Some(input));
+
+        let output = coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![
+                    ExternalSequenceBlockHash(1),
+                    ExternalSequenceBlockHash(3),
+                    ExternalSequenceBlockHash(4),
+                ],
+            }),
+            None,
+        );
+        assert_eq!(
+            output,
+            vec![KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(4)]
+            })]
+        );
+    }
+
+    #[test]
+    fn incomplete_group_removal_and_clear_emit_no_spurious_events() {
+        let mut coalescer = EventCoalescer::new(1, 4).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20)]);
+        assert!(
+            coalescer
+                .process(0, StorageTier::Device, data, Some(input))
+                .is_empty()
+        );
+        assert!(
+            coalescer
+                .process(
+                    0,
+                    StorageTier::Device,
+                    KvCacheEventData::Removed(KvCacheRemoveData {
+                        block_hashes: vec![ExternalSequenceBlockHash(2)],
+                    }),
+                    None,
+                )
+                .is_empty()
+        );
+        assert_eq!(
+            coalescer.process(0, StorageTier::Device, KvCacheEventData::Cleared, None),
+            vec![KvCacheEventData::Cleared]
+        );
+        assert!(coalescer.ranks.is_empty());
+    }
+
+    #[test]
+    fn missing_context_withdraws_an_active_superblock() {
+        let mut coalescer = EventCoalescer::new(1, 4).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20), (3, 30), (4, 40)]);
+        coalescer.process(0, StorageTier::Device, data.clone(), Some(input));
+
+        let output = coalescer.process(0, StorageTier::Device, data, None);
+        assert_eq!(
+            output,
+            vec![KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(4)]
+            })]
+        );
+    }
+
+    #[test]
+    fn computes_target_hash_from_combined_eagle_tokens() {
+        let mut coalescer = EventCoalescer::new(2, 4).unwrap();
+        let (first, mut first_input) = block_with_tokens(1, vec![10, 20, 30], true);
+        let (second, mut second_input) = block_with_tokens(2, vec![30, 40, 50], true);
+        for input in [&mut first_input, &mut second_input] {
+            input.lora_name = Some("adapter".to_string());
+            input.cache_namespace = Some("salt".to_string());
+        }
+        let output = coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: None,
+                blocks: vec![first, second],
+            }),
+            Some(KvCacheStoreInput {
+                blocks: vec![first_input, second_input],
+            }),
+        );
+        let KvCacheEventData::Stored(store) = &output[0] else {
+            panic!("expected store")
+        };
+        let expected = compute_block_hash_for_seq(
+            &[10, 20, 30, 40, 50],
+            4,
+            BlockHashOptions {
+                lora_name: Some("adapter"),
+                cache_namespace: Some("salt"),
+                is_eagle: Some(true),
+                ..BlockHashOptions::default()
+            },
+        )[0];
+        assert_eq!(store.blocks[0].tokens_hash, expected);
+    }
+
+    #[test]
+    fn emits_several_superblocks_from_one_source_batch() {
+        let mut coalescer = EventCoalescer::new(1, 2).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20), (3, 30), (4, 40)]);
+        let output = coalescer.process(0, StorageTier::Device, data, Some(input));
+        assert_eq!(stored_hashes(&output), vec![2, 4]);
+        let KvCacheEventData::Stored(second) = &output[1] else {
+            panic!("expected second store")
+        };
+        assert_eq!(second.parent_hash, Some(ExternalSequenceBlockHash(2)));
+    }
+
+    #[test]
+    fn dp_ranks_are_independent() {
+        let mut coalescer = EventCoalescer::new(1, 2).unwrap();
+        let (data, input) = store(None, &[(1, 10), (2, 20)]);
+        coalescer.process(0, StorageTier::Device, data.clone(), Some(input.clone()));
+        coalescer.process(1, StorageTier::Device, data, Some(input));
+        coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(1)],
+            }),
+            None,
+        );
+        assert!(
+            coalescer.ranks[&1].superblocks[&ExternalSequenceBlockHash(2)]
+                .active_tiers
+                .contains(&StorageTier::Device)
+        );
+    }
+
+    #[test]
+    fn merges_multimodal_metadata_at_target_offsets() {
+        let mut coalescer = EventCoalescer::new(2, 4).unwrap();
+        let mm_info = BlockExtraInfo {
+            mm_objects: vec![BlockMmObjectInfo {
+                mm_hash: 99,
+                offsets: vec![(0, 1)],
+            }],
+        };
+        let (mut first, mut first_input) = block_with_tokens(1, vec![10, 20], false);
+        let (mut second, mut second_input) = block_with_tokens(2, vec![30, 40], false);
+        first.mm_extra_info = Some(mm_info.clone());
+        second.mm_extra_info = Some(mm_info.clone());
+        first_input.hash_mm_extra_info = Some(mm_info.clone());
+        second_input.hash_mm_extra_info = Some(mm_info);
+
+        let output = coalescer.process(
+            0,
+            StorageTier::Device,
+            KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: None,
+                start_position: None,
+                blocks: vec![first, second],
+            }),
+            Some(KvCacheStoreInput {
+                blocks: vec![first_input, second_input],
+            }),
+        );
+        let KvCacheEventData::Stored(store) = &output[0] else {
+            panic!("expected store")
+        };
+        let merged = store.blocks[0].mm_extra_info.as_ref().unwrap();
+        assert_eq!(merged.mm_objects[0].offsets, vec![(0, 1), (2, 3)]);
+    }
+}

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -16,35 +16,76 @@ use crate::kv_router::metrics::kv_publisher_metrics;
 
 use super::DEFAULT_MAX_BATCH_BLOCKS;
 use super::batching::BatchingState;
+use super::coalescer::EventCoalescer;
 use super::dedup::EventDedupFilter;
 use super::sinks::{JetStreamPublisher, emit};
 
-pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 'static>(
+#[cfg(test)]
+pub(super) async fn run_event_processor_loop<
+    P: RouterEventSink + Send + Sync + 'static,
+    E: Into<PlacementEventInput>,
+>(
     publisher: P,
     worker_id: u64,
     cancellation_token: CancellationToken,
-    mut rx: mpsc::UnboundedReceiver<PlacementEvent>,
+    rx: mpsc::UnboundedReceiver<E>,
     local_indexer: Option<Arc<LocalKvIndexer>>,
     timeout_ms: Option<u64>,
     max_batch_blocks: usize,
 ) {
+    run_event_processor_loop_with_block_sizes(
+        publisher,
+        worker_id,
+        cancellation_token,
+        rx,
+        local_indexer,
+        timeout_ms,
+        max_batch_blocks,
+        1,
+        1,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_event_processor_loop_with_block_sizes<
+    P: RouterEventSink + Send + Sync + 'static,
+    E: Into<PlacementEventInput>,
+>(
+    publisher: P,
+    worker_id: u64,
+    cancellation_token: CancellationToken,
+    mut rx: mpsc::UnboundedReceiver<E>,
+    local_indexer: Option<Arc<LocalKvIndexer>>,
+    timeout_ms: Option<u64>,
+    max_batch_blocks: usize,
+    source_block_size: u32,
+    target_block_size: u32,
+) {
     let mut batching_state = BatchingState::new();
     let mut dedup = EventDedupFilter::new();
+    let mut coalescer = EventCoalescer::new(source_block_size, target_block_size)
+        .expect("publisher block sizes must be validated before starting");
     let mut last_raw_input_id: Option<u64> = None;
 
     loop {
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 tracing::info!("KV Event source received cancellation signal");
-                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
                 break;
             }
             event = rx.recv() => {
                 let Some(placement_event) = event else {
                     tracing::debug!("Event processor channel closed.");
-                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
                     break;
                 };
+
+                let PlacementEventInput {
+                    event: placement_event,
+                    store_input,
+                } = placement_event.into();
 
                 let raw_event_id = placement_event.event.event_id;
                 if let Some(last_id) = last_raw_input_id
@@ -89,7 +130,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                             || dp_rank_changed
                             || storage_tier_changed
                         {
-                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
                         }
                         match &mut batching_state.pending_removed {
                             Some(pending) => pending.block_hashes.extend(data.block_hashes),
@@ -106,31 +147,54 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                 data.parent_hash != p.blocks.last().map(|b| b.block_hash)
                             });
                         if should_flush {
-                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
                         }
                         match &mut batching_state.pending_stored {
-                            Some(pending) => pending.blocks.extend(data.blocks),
+                            Some(pending) => {
+                                pending.blocks.extend(data.blocks);
+                                match (&mut batching_state.pending_stored_input, store_input) {
+                                    (Some(pending_input), Some(input)) => {
+                                        pending_input.blocks.extend(input.blocks);
+                                    }
+                                    (None, None) => {}
+                                    _ => {
+                                        tracing::warn!(
+                                            worker_id,
+                                            "Dropping KV token sidecar for a mixed-context source batch"
+                                        );
+                                        batching_state.pending_stored_input = None;
+                                    }
+                                }
+                            }
                             None => {
                                 batching_state.pending_stored = Some(data);
+                                batching_state.pending_stored_input = store_input;
                             }
                         }
                     }
                     KvCacheEventData::Cleared => {
-                        batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                        batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
                         dedup.clear();
-                        emit(
-                            &publisher,
-                            &local_indexer,
-                            worker_id,
+                        for data in coalescer.process(
+                            event.dp_rank,
                             storage_tier,
-                            KvCacheEvent {
-                                event_id: batching_state.next_publish_id,
-                                data: KvCacheEventData::Cleared,
-                                dp_rank: event.dp_rank,
-                            },
-                        )
-                        .await;
-                        batching_state.next_publish_id += 1;
+                            KvCacheEventData::Cleared,
+                            None,
+                        ) {
+                            emit(
+                                &publisher,
+                                &local_indexer,
+                                worker_id,
+                                storage_tier,
+                                KvCacheEvent {
+                                    event_id: batching_state.next_publish_id,
+                                    data,
+                                    dp_rank: event.dp_rank,
+                                },
+                            )
+                            .await;
+                            batching_state.next_publish_id += 1;
+                        }
                     }
                 }
 
@@ -141,7 +205,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     && (timeout_ms.is_none_or(|ms| batching_state.is_timeout_elapsed(ms))
                         || batching_state.pending_block_count() > max_batch_blocks)
                 {
-                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
                 }
             }
             _ = tokio::time::sleep(
@@ -149,17 +213,21 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     .map(|ms| batching_state.remaining_timeout(ms))
                     .unwrap_or(Duration::from_secs(3600))
             ), if timeout_ms.is_some() && batching_state.has_pending() => {
-                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup, &mut coalescer).await;
             }
         }
     }
 }
 
-pub(super) async fn start_event_processor<P: RouterEventSink + Send + Sync + 'static>(
+#[cfg(test)]
+pub(super) async fn start_event_processor<
+    P: RouterEventSink + Send + Sync + 'static,
+    E: Into<PlacementEventInput>,
+>(
     publisher: P,
     worker_id: u64,
     cancellation_token: CancellationToken,
-    rx: mpsc::UnboundedReceiver<PlacementEvent>,
+    rx: mpsc::UnboundedReceiver<E>,
     local_indexer: Option<Arc<LocalKvIndexer>>,
     batching_timeout_ms: Option<u64>,
 ) {
@@ -175,15 +243,45 @@ pub(super) async fn start_event_processor<P: RouterEventSink + Send + Sync + 'st
     .await
 }
 
-pub(super) async fn start_event_processor_jetstream(
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn start_event_processor_with_coalescing<
+    P: RouterEventSink + Send + Sync + 'static,
+>(
+    publisher: P,
+    worker_id: u64,
+    cancellation_token: CancellationToken,
+    rx: mpsc::UnboundedReceiver<PlacementEventInput>,
+    local_indexer: Option<Arc<LocalKvIndexer>>,
+    batching_timeout_ms: Option<u64>,
+    source_block_size: u32,
+    target_block_size: u32,
+) {
+    run_event_processor_loop_with_block_sizes(
+        publisher,
+        worker_id,
+        cancellation_token,
+        rx,
+        local_indexer,
+        batching_timeout_ms,
+        DEFAULT_MAX_BATCH_BLOCKS,
+        source_block_size,
+        target_block_size,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn start_event_processor_jetstream_with_coalescing(
     publisher: NatsQueue,
     worker_id: u64,
     cancellation_token: CancellationToken,
-    rx: mpsc::UnboundedReceiver<PlacementEvent>,
+    rx: mpsc::UnboundedReceiver<PlacementEventInput>,
     local_indexer: Option<Arc<LocalKvIndexer>>,
     batching_timeout_ms: Option<u64>,
+    source_block_size: u32,
+    target_block_size: u32,
 ) {
-    run_event_processor_loop(
+    run_event_processor_loop_with_block_sizes(
         JetStreamPublisher(publisher),
         worker_id,
         cancellation_token,
@@ -191,6 +289,8 @@ pub(super) async fn start_event_processor_jetstream(
         local_indexer,
         batching_timeout_ms,
         DEFAULT_MAX_BATCH_BLOCKS,
+        source_block_size,
+        target_block_size,
     )
     .await
 }

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -10,9 +10,9 @@ use tokio_util::sync::CancellationToken;
 
 use dynamo_kv_router::indexer::{KvIndexerMetrics, LocalKvIndexer};
 use dynamo_kv_router::protocols::*;
-pub use dynamo_kv_router::zmq_wire::create_stored_blocks;
 #[cfg(test)]
 use dynamo_kv_router::zmq_wire::*;
+pub use dynamo_kv_router::zmq_wire::{create_stored_blocks, create_stored_blocks_with_input};
 use dynamo_runtime::config::environment_names::nats as env_nats;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_runtime::{
@@ -26,6 +26,7 @@ use crate::kv_router::{
 };
 
 mod batching;
+mod coalescer;
 mod dedup;
 mod event_processor;
 mod multimodal_embedding_cache;
@@ -40,15 +41,21 @@ use batching::BatchingState;
 #[cfg(test)]
 use dedup::EventDedupFilter;
 #[cfg(test)]
-use event_processor::run_event_processor_loop;
-use event_processor::{start_event_processor, start_event_processor_jetstream};
+use event_processor::{
+    run_event_processor_loop, run_event_processor_loop_with_block_sizes, start_event_processor,
+};
+use event_processor::{
+    start_event_processor_jetstream_with_coalescing, start_event_processor_with_coalescing,
+};
 pub use multimodal_embedding_cache::{
     MultimodalEmbeddingCacheEvent, MultimodalEmbeddingCachePublisher,
     MultimodalEmbeddingCacheUpdate,
 };
 use sinks::EventPlanePublisher;
 pub use worker_metrics::WorkerMetricsPublisher;
+#[cfg(test)]
 use zmq_listener::start_zmq_listener;
+use zmq_listener::start_zmq_listener_with_input;
 
 const MAX_BATCHING_TIMEOUT_MS: u64 = 15_000;
 pub const DEFAULT_BATCHING_TIMEOUT_MS: Option<u64> = None;
@@ -95,8 +102,9 @@ impl KvEventSource {
         kv_block_size: u32,
         source_config: KvEventSourceConfig,
         cancellation_token: CancellationToken,
-        tx: mpsc::UnboundedSender<PlacementEvent>,
+        tx: mpsc::UnboundedSender<PlacementEventInput>,
         next_event_id: Arc<AtomicU64>,
+        capture_store_input: bool,
     ) -> Result<Self> {
         match source_config {
             KvEventSourceConfig::Zmq {
@@ -104,20 +112,22 @@ impl KvEventSource {
                 topic,
                 image_token_id,
             } => {
-                let zmq_handle = component
-                    .drt()
-                    .runtime()
-                    .secondary()
-                    .spawn(start_zmq_listener(
-                        endpoint,
-                        topic,
-                        worker_id,
-                        tx,
-                        cancellation_token.clone(),
-                        kv_block_size,
-                        next_event_id,
-                        image_token_id,
-                    ));
+                let zmq_handle =
+                    component
+                        .drt()
+                        .runtime()
+                        .secondary()
+                        .spawn(start_zmq_listener_with_input(
+                            endpoint,
+                            topic,
+                            worker_id,
+                            tx,
+                            cancellation_token.clone(),
+                            kv_block_size,
+                            next_event_id,
+                            image_token_id,
+                            capture_store_input,
+                        ));
 
                 Ok(KvEventSource::Zmq { zmq_handle })
             }
@@ -135,8 +145,10 @@ impl KvEventSource {
 
 /// A publisher of KV events.
 pub struct KvEventPublisher {
-    /// The size of the KV block.
+    /// Physical block size emitted by the engine.
     kv_block_size: u32,
+    /// Router-visible block size after optional coalescing.
+    routing_kv_block_size: u32,
     /// The source of KV events.
     /// Can be `None` if all events provided through [`KvEventPublisher::publish`].
     source: Option<KvEventSource>,
@@ -145,7 +157,7 @@ pub struct KvEventPublisher {
     /// The ID of the local worker emitting placement events.
     worker_id: WorkerId,
     /// The channel to send events to.
-    tx: mpsc::UnboundedSender<PlacementEvent>,
+    tx: mpsc::UnboundedSender<PlacementEventInput>,
     /// Internal monotonic event ID counter. Shared with the ZMQ listener if present.
     next_event_id: Arc<AtomicU64>,
 }
@@ -194,6 +206,31 @@ impl KvEventPublisher {
         dp_rank: DpRank,
         batching_timeout_ms: Option<u64>,
     ) -> Result<Self> {
+        Self::new_with_local_indexer_worker_id_and_coalescing(
+            component,
+            worker_id,
+            kv_block_size,
+            None,
+            source_config,
+            enable_local_indexer,
+            dp_rank,
+            batching_timeout_ms,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_local_indexer_worker_id_and_coalescing(
+        component: Component,
+        worker_id: Option<WorkerId>,
+        kv_block_size: u32,
+        coalescing_block_size: Option<u32>,
+        source_config: Option<KvEventSourceConfig>,
+        enable_local_indexer: bool,
+        dp_rank: DpRank,
+        batching_timeout_ms: Option<u64>,
+    ) -> Result<Self> {
+        let routing_kv_block_size = coalescing_block_size.unwrap_or(kv_block_size);
+        let _ = coalescer::EventCoalescer::new(kv_block_size, routing_kv_block_size)?;
         let cancellation_token = CancellationToken::new();
         let batching_timeout_ms = batching_timeout_ms
             .filter(|&ms| {
@@ -208,7 +245,7 @@ impl KvEventPublisher {
             })
             .map(|ms| ms.min(MAX_BATCHING_TIMEOUT_MS));
 
-        let (tx, rx) = mpsc::unbounded_channel::<PlacementEvent>();
+        let (tx, rx) = mpsc::unbounded_channel::<PlacementEventInput>();
         let worker_id = worker_id.unwrap_or_else(|| component.drt().connection_id());
 
         let _ = KvPublisherMetrics::from_component(&component);
@@ -236,6 +273,7 @@ impl KvEventPublisher {
                 cancellation_token.clone(),
                 tx.clone(),
                 next_event_id.clone(),
+                routing_kv_block_size != kv_block_size,
             )?);
         }
 
@@ -243,7 +281,7 @@ impl KvEventPublisher {
             let metrics = Arc::new(KvIndexerMetrics::new_unregistered());
             Some(Arc::new(LocalKvIndexer::new(
                 cancellation_token.clone(),
-                kv_block_size,
+                routing_kv_block_size,
                 metrics,
                 WORKER_KV_INDEXER_BUFFER_SIZE,
             )))
@@ -288,13 +326,15 @@ impl KvEventPublisher {
                         }
                     };
 
-                start_event_processor(
+                start_event_processor_with_coalescing(
                     EventPlanePublisher(event_publisher),
                     worker_id,
                     cancellation_token_clone,
                     rx,
                     local_indexer_clone,
                     batching_timeout_ms,
+                    kv_block_size,
+                    routing_kv_block_size,
                 )
                 .await
             });
@@ -313,13 +353,15 @@ impl KvEventPublisher {
                     tracing::error!("Failed to connect NatsQueue: {e}");
                     return;
                 }
-                start_event_processor_jetstream(
+                start_event_processor_jetstream_with_coalescing(
                     nats_queue,
                     worker_id,
                     cancellation_token_clone,
                     rx,
                     local_indexer_clone,
                     batching_timeout_ms,
+                    kv_block_size,
+                    routing_kv_block_size,
                 )
                 .await
             });
@@ -327,6 +369,7 @@ impl KvEventPublisher {
 
         Ok(Self {
             kv_block_size,
+            routing_kv_block_size,
             source,
             cancellation_token,
             worker_id,
@@ -337,9 +380,12 @@ impl KvEventPublisher {
 
     pub fn publish(&self, event: KvCacheEvent) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
         let placement_event = PlacementEvent::local_gpu(self.worker_id, event);
-        match self.tx.send(placement_event) {
+        match self
+            .tx
+            .send(PlacementEventInput::without_store_input(placement_event))
+        {
             Ok(()) => Ok(()),
-            Err(err) => Err(mpsc::error::SendError(err.0.event)),
+            Err(err) => Err(mpsc::error::SendError(err.0.event.event)),
         }
     }
 
@@ -352,9 +398,31 @@ impl KvEventPublisher {
             Placement::local_worker(self.worker_id, event.dp_rank, storage_tier),
             event,
         );
-        match self.tx.send(placement_event) {
+        match self
+            .tx
+            .send(PlacementEventInput::without_store_input(placement_event))
+        {
             Ok(()) => Ok(()),
-            Err(err) => Err(mpsc::error::SendError(err.0.event)),
+            Err(err) => Err(mpsc::error::SendError(err.0.event.event)),
+        }
+    }
+
+    pub fn publish_with_storage_tier_and_input(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+        store_input: Option<KvCacheStoreInput>,
+    ) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
+        let placement_event = PlacementEvent::new(
+            Placement::local_worker(self.worker_id, event.dp_rank, storage_tier),
+            event,
+        );
+        match self
+            .tx
+            .send(PlacementEventInput::new(placement_event, store_input))
+        {
+            Ok(()) => Ok(()),
+            Err(err) => Err(mpsc::error::SendError(err.0.event.event)),
         }
     }
 
@@ -364,6 +432,10 @@ impl KvEventPublisher {
 
     pub fn kv_block_size(&self) -> u32 {
         self.kv_block_size
+    }
+
+    pub fn routing_kv_block_size(&self) -> u32 {
+        self.routing_kv_block_size
     }
 
     pub fn shutdown(&mut self) {

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1870,6 +1870,105 @@ mod event_processor_tests {
         )
     }
 
+    fn coalescing_store_input(
+        event_id: u64,
+        parent_hash: Option<u64>,
+        hashes: &[u64],
+        tokens: &[u32],
+    ) -> PlacementEventInput {
+        let warning_count = Arc::new(AtomicU32::new(0));
+        let block_sizes = vec![1; hashes.len()];
+        let (blocks, store_input) = create_stored_blocks_with_input(
+            1,
+            tokens,
+            &block_sizes,
+            hashes,
+            None,
+            None,
+            &warning_count,
+            None,
+            None,
+            None,
+        );
+        PlacementEventInput::new(
+            local_gpu_event(KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: parent_hash.map(ExternalSequenceBlockHash),
+                    start_position: None,
+                    blocks,
+                }),
+                dp_rank: 0,
+            }),
+            Some(store_input),
+        )
+    }
+
+    #[tokio::test]
+    async fn coalescing_runs_after_dedup_and_assigns_contiguous_output_ids() {
+        let (tx, rx) = mpsc::unbounded_channel::<PlacementEventInput>();
+        let publisher = MockPublisher::new();
+        let publisher_clone = publisher.clone();
+        let cancellation_token = CancellationToken::new();
+        let handle = tokio::spawn(async move {
+            run_event_processor_loop_with_block_sizes(
+                publisher_clone,
+                1,
+                cancellation_token,
+                rx,
+                None,
+                Some(10_000),
+                DEFAULT_MAX_BATCH_BLOCKS,
+                1,
+                4,
+            )
+            .await
+        });
+
+        tx.send(coalescing_store_input(
+            10,
+            None,
+            &[1, 2, 3, 4],
+            &[11, 22, 33, 44],
+        ))
+        .unwrap();
+        tx.send(coalescing_store_input(
+            11,
+            None,
+            &[1, 2, 3, 4],
+            &[11, 22, 33, 44],
+        ))
+        .unwrap();
+        for event_id in [12, 13] {
+            tx.send(PlacementEventInput::from(local_gpu_event(KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: vec![ExternalSequenceBlockHash(2)],
+                }),
+                dp_rank: 0,
+            })))
+            .unwrap();
+        }
+        drop(tx);
+        handle.await.unwrap();
+
+        let events = publisher.get_events();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].event.event_id, 1);
+        assert_eq!(events[1].event.event_id, 2);
+        let KvCacheEventData::Stored(stored) = &events[0].event.data else {
+            panic!("expected coalesced store")
+        };
+        assert_eq!(stored.blocks.len(), 1);
+        assert_eq!(stored.blocks[0].block_hash, ExternalSequenceBlockHash(4));
+        assert_eq!(
+            events[1].event.data,
+            KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: vec![ExternalSequenceBlockHash(4)]
+            })
+        );
+    }
+
     /// Test that pushing N removed events results in batched output
     /// Uses a 10ms timeout to ensure events are batched (events sent rapidly)
     #[tokio::test]

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -14,7 +14,7 @@ use dynamo_kv_router::zmq_wire::*;
 use crate::kv_router::metrics::kv_publisher_metrics;
 use crate::utils::zmq::{connect_sub_socket, multipart_message};
 
-#[allow(clippy::too_many_arguments)]
+#[cfg(test)]
 pub(super) async fn start_zmq_listener(
     zmq_endpoint: String,
     zmq_topic: String,
@@ -24,6 +24,58 @@ pub(super) async fn start_zmq_listener(
     kv_block_size: u32,
     next_event_id: Arc<AtomicU64>,
     image_token_id: Option<u32>,
+) {
+    start_zmq_listener_impl(
+        zmq_endpoint,
+        zmq_topic,
+        worker_id,
+        tx,
+        cancellation_token,
+        kv_block_size,
+        next_event_id,
+        image_token_id,
+        false,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn start_zmq_listener_with_input(
+    zmq_endpoint: String,
+    zmq_topic: String,
+    worker_id: WorkerId,
+    tx: mpsc::UnboundedSender<PlacementEventInput>,
+    cancellation_token: CancellationToken,
+    kv_block_size: u32,
+    next_event_id: Arc<AtomicU64>,
+    image_token_id: Option<u32>,
+    capture_store_input: bool,
+) {
+    start_zmq_listener_impl(
+        zmq_endpoint,
+        zmq_topic,
+        worker_id,
+        tx,
+        cancellation_token,
+        kv_block_size,
+        next_event_id,
+        image_token_id,
+        capture_store_input,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn start_zmq_listener_impl<E: From<PlacementEventInput>>(
+    zmq_endpoint: String,
+    zmq_topic: String,
+    worker_id: WorkerId,
+    tx: mpsc::UnboundedSender<E>,
+    cancellation_token: CancellationToken,
+    kv_block_size: u32,
+    next_event_id: Arc<AtomicU64>,
+    image_token_id: Option<u32>,
+    capture_store_input: bool,
 ) {
     tracing::debug!(
         "KVEventPublisher connecting to ZMQ endpoint {} (topic '{}')",
@@ -124,20 +176,25 @@ pub(super) async fn start_zmq_listener(
                         metrics.increment_zmq_event("accepted", event_type);
                     }
                     let event_id = next_event_id.fetch_add(1, Ordering::SeqCst);
-                    let Some(event) =
-                        normalizer.normalize_preprocessed(raw_event, event_id, worker)
-                    else {
+                    let event = if capture_store_input {
+                        normalizer.normalize_preprocessed_with_input(raw_event, event_id, worker)
+                    } else {
+                        normalizer
+                            .normalize_preprocessed(raw_event, event_id, worker)
+                            .map(PlacementEventInput::without_store_input)
+                    };
+                    let Some(event) = event else {
                         if let Some(metrics) = &metrics {
                             metrics.increment_zmq_conversion_issue(event_type, "conversion_none");
                         }
                         continue;
                     };
-                    if matches!(event.event.data, KvCacheEventData::Stored(ref data) if data.blocks.is_empty())
+                    if matches!(event.event.event.data, KvCacheEventData::Stored(ref data) if data.blocks.is_empty())
                         && let Some(metrics) = &metrics
                     {
                         metrics.increment_zmq_suspicious_event(event_type, "empty_store_blocks");
                     }
-                    if tx.send(event).is_err() {
+                    if tx.send(event.into()).is_err() {
                         tracing::warn!("Failed to send message to channel - receiver dropped");
                         break 'main String::from("channel receiver dropped");
                     }


### PR DESCRIPTION
## Summary

- add generic post-dedup KV event block coalescing in KvEventPublisher with worker-local canonical token sidecars
- invalidate active superblocks when any source member is finally removed, independently per DP rank and storage tier
- advertise and report router-visible block units through unified workers and legacy SGLang while preserving SGLang page_size
- add common CLI and environment configuration plus coalescer, pipeline, hashing, registration, and capacity tests

## Validation

- cargo test -p dynamo-llm kv_router::publisher:: --no-default-features
- cargo test -p dynamo-llm publisher::coalescer --no-default-features
- cargo test -p dynamo-kv-router zmq_wire::convert
- cargo test -p dynamo-backend-common
- cargo test -p dynamo-backend-common coalesc
- cargo test -p dynamo-backend-common routing_kv
- cargo check from lib/bindings/python
- python3 -m compileall -q components/src/dynamo/common components/src/dynamo/sglang
- focused Python pytest was not runnable in this checkout: system Python has no pytest and uv resolves incompatible vLLM and SGLang NIXL extras
- end-to-end 1-to-16 and 1-to-32 performance benchmarks were not run because the benchmark venv and request-plane harness are not provisioned in this worktree