### PR TITLE
fix(ci): repair reusable notify-slack workflow to fix post-merge startup_failure

### DIFF
--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -38,6 +38,11 @@ jobs:
     permissions:
       contents: read
       actions: read   # required to list this run's jobs via the Actions API
+    env:
+      # Bind the optional secret to an env var so the Notify Slack step can guard
+      # on it: the `secrets` context is unavailable in step `if` conditions, but
+      # `env` is. Absent secret -> empty string -> step is skipped, not failed.
+      SLACK_WEBHOOK_URL: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
     steps:
       - name: Get Failed jobs
         id: failed-jobs
@@ -87,10 +92,12 @@ jobs:
             echo "has_failures=false" >> "$GITHUB_OUTPUT"
           fi
       - name: Notify Slack
-        if: steps.failed-jobs.outputs.has_failures == 'true'
+        # Also require a non-empty webhook: with the secret optional, an absent
+        # webhook would otherwise fail this step (the Slack action rejects an empty URL).
+        if: steps.failed-jobs.outputs.has_failures == 'true' && env.SLACK_WEBHOOK_URL != ''
         uses: slackapi/slack-github-action@91efab103c0de0a537f72a35f6b8cda0ee76bf0a #v2.1.1
         with:
-          webhook: ${{ secrets.SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL }}
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             blocks:

--- a/.github/workflows/notify-slack.yml
+++ b/.github/workflows/notify-slack.yml
@@ -25,8 +25,11 @@ on:
           build-xpu
           test-xpu
     secrets:
+      # Keep optional: a `required: true` reusable-workflow secret gates the
+      # caller's startup even under `secrets: inherit`, failing the run at
+      # startup (0 jobs) when the secret is absent.
       SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL:
-        required: true
+        required: false
 
 jobs:
   notify-slack:


### PR DESCRIPTION
## Problem

The **Post-Merge CI Pipeline is currently down** — it fails to start (`startup_failure`, **0 jobs**, ~1s) on every commit that includes #11365 ("ci: extract shared Slack notifier into a reusable workflow").

Confirmed by recurrence:
- Run on #11365's merge commit (`f1de717b`) → `startup_failure`, 0 jobs
- Run on descendant commit #11390 (`88ddd8ae`) → `startup_failure`, 0 jobs
- Every post-merge run *started before* #11365 merged created jobs normally.

## Root cause

When #11365 moved the Slack notifier into the reusable `.github/workflows/notify-slack.yml`, it declared the webhook secret as `required: true`:

```yaml
    secrets:
      SLACK_NOTIFY_NIGHTLY_WEBHOOK_URL:
        required: true
```

A reusable workflow that marks a secret `required: true` makes GitHub **gate the caller's startup** on that secret being present — **even when the caller passes `secrets: inherit`**. If the secret isn't available in the calling context, GitHub aborts the entire calling run at compile time with `startup_failure` and 0 jobs. This is invisible to YAML parsing and to `actionlint` (both lint clean).

The pre-#11365 inline notifier referenced the same webhook *lazily inside a step*, where a missing secret simply resolves to empty at runtime — no startup gate. That single lazy→`required: true` change is the whole regression.

This also affects `nightly-ci.yml`, which uses the same reusable workflow with `secrets: inherit` and will hit the same startup gate on its next scheduled run.

## Fix

Declare the secret `required: false`. `secrets: inherit` still passes it through when present; when absent it resolves empty at runtime — matching the pre-#11365 inline behavior. This removes the startup gate and fixes **both** callers (post-merge and nightly).

## Validation

- YAML parses cleanly.
- `actionlint` on `notify-slack.yml` + `post-merge-ci.yml`: **exit 0, clean**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11452" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Made the nightly Slack webhook optional, so workflows no longer fail at startup when the secret isn’t provided.
  * Slack notifications will now proceed without error when the webhook value is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->