### PR TITLE
ci: grant actions: read to notify-slack caller jobs (fix reusable-workflow permission error)

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -842,6 +842,9 @@ jobs:
   notify-slack:
     if: always()
     needs: [vllm-test, vllm-multi-gpu-test, sglang-test, sglang-multi-gpu-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
+    permissions:
+      contents: read
+      actions: read   # grant the reusable notifier read access to list this run's jobs
     uses: ./.github/workflows/notify-slack.yml
     with:
       pipeline_name: Nightly

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -1260,6 +1260,9 @@ jobs:
   notify-slack:
     if: always() && github.event_name != 'workflow_dispatch'
     needs: [ deploy-status-check ]
+    permissions:
+      contents: read
+      actions: read   # grant the reusable notifier read access to list this run's jobs
     uses: ./.github/workflows/notify-slack.yml
     with:
       pipeline_name: Post-Merge


### PR DESCRIPTION
## Problem

After #11365 merged, `post-merge-ci.yml` (and `nightly-ci.yml`) fail validation:

```
Error calling workflow '.../notify-slack.yml@f1de717'. The nested job 'notify-slack'
is requesting 'actions: read', but is only allowed 'actions: none'.
```

The reusable `notify-slack.yml` job declares `permissions: { contents: read, actions: read }` (it needs `actions: read` to list the run's jobs). But both callers have top-level `permissions: contents: read` and the `notify-slack` calling job has no `permissions:` of its own, so it passes `actions: none` down — a called workflow can't exceed the caller's grant.

## Fix

Add a `permissions` block to each `notify-slack` **calling job** granting `contents: read` + `actions: read`. Job-level permissions can expand up to the repo's maximum token permissions (which allow `actions: read`), so the grant now reaches the reusable workflow.

```yaml
  notify-slack:
    ...
    permissions:
      contents: read
      actions: read
    uses: ./.github/workflows/notify-slack.yml
```

Applied to `post-merge-ci.yml` and `nightly-ci.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11456" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated two workflow jobs with explicit read-only access for repository contents and workflow actions, improving compatibility for run-status notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->