### PR TITLE
docs(trtllm): clarify NVENC requirement for MP4 video output

### DIFF
--- a/docs/backends/trtllm/trtllm-diffusion.md
+++ b/docs/backends/trtllm/trtllm-diffusion.md
@@ -21,7 +21,16 @@ image generation through `--modality image_diffusion` flag.
   pip install --no-binary imageio-ffmpeg "imageio[ffmpeg]"
   export IMAGEIO_FFMPEG_EXE=/path/to/your/ffmpeg
   ```
-  MP4 output requires an NVIDIA GPU at runtime (NVENC is a hardware encoder).
+
+- **NVENC-capable GPU for video output**: The TRT-LLM `/v1/videos` endpoint currently
+  supports only MP4 output and always encodes it with the NVENC H.264 hardware encoder
+  (`h264_nvenc`). An NVENC-capable NVIDIA GPU is mandatory. There is no software H.264
+  fallback, and the WebM/VP9 path (`libvpx-vp9`) is not exposed by the TRT-LLM video API.
+  GPUs without NVENC, including A100, H100, HGX B200, and GB200, cannot produce video
+  output. Examples of NVENC-capable data center GPUs include L4, L40, L40S, A10, A16,
+  A2, and T4. See the
+  [NVIDIA Video Encode and Decode Support Matrix](https://developer.nvidia.com/video-encode-decode-support-matrix).
+  NVENC capability alone does not guarantee sufficient VRAM or full model compatibility.
 
 ## Supported Models
 
@@ -106,3 +115,5 @@ curl -X POST http://localhost:8000/v1/images/generations \
 - Diffusion is experimental and not recommended for production use
 - Only text-to-video and text-to-image is supported in this release (image-to-video planned)
 - Requires GPU with sufficient VRAM for the diffusion model
+- MP4 video output requires an NVENC-capable GPU; GPUs without NVENC are unsupported for
+  TRT-LLM video output

--- a/docs/features/diffusion/README.md
+++ b/docs/features/diffusion/README.md
@@ -15,10 +15,13 @@ Dynamo supports serving diffusion models across multiple backends, enabling gene
 |----------|-----------|--------|---------|
 | Text-to-Text | ❌ | ✅ | ❌ |
 | Text-to-Image | ✅ | ✅ | ✅ |
-| Text-to-Video | ✅ | ✅ | ✅ |
+| Text-to-Video | ✅ | ✅ | ✅ (NVENC required) |
 | Image-to-Video | ✅ | ❌ | ❌ |
 
 **Status:** ✅ Supported | ❌ Not supported
+
+TRT-LLM video output currently supports MP4 only and requires an NVENC-capable GPU. GPUs
+without NVENC are not supported for TRT-LLM video output.
 
 ## Backend Documentation
 


### PR DESCRIPTION
## Overview

Clarifies the hardware requirement for experimental TRT-LLM video diffusion. The
`/v1/videos` endpoint currently accepts MP4 output only and encodes it with the
NVENC H.264 hardware encoder (`h264_nvenc`). An NVIDIA GPU alone is therefore not
sufficient; the GPU must include NVENC.

On GPUs without NVENC, frame generation can complete but the final encoding step
cannot produce a usable MP4. This documentation update makes that limitation
visible before users deploy on affected data center GPUs.

## Details

- Documents NVENC as mandatory for TRT-LLM MP4 video output.
- States that there is no software H.264 fallback and that the existing
  WebM/VP9 path is not exposed by the TRT-LLM video API.
- Lists representative GPUs with and without NVENC and links to NVIDIA's
  Video Encode and Decode Support Matrix.
- Adds the NVENC requirement to the TRT-LLM diffusion limitations and the
  top-level diffusion support matrix.
- Does not change runtime behavior.

Validation:

- `pre-commit run --files docs/backends/trtllm/trtllm-diffusion.md docs/features/diffusion/README.md`
- `git diff --check`
- Verified the NVIDIA support-matrix link.
- Ran a minimal real Wan2.1 1.3B smoke test on GB200 using 9 frames at
  480x272 and one inference step. Wan frame generation succeeded;
  `h264_nvenc` reported `unsupported device` and produced a zero-byte MP4,
  while software WebM/VP9 encoding succeeded on the same frames.

## Where should the reviewer start?

Start with the NVENC requirement in
`docs/backends/trtllm/trtllm-diffusion.md`, then review the conditional
TRT-LLM text-to-video support entry in `docs/features/diffusion/README.md`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Fixes DYN-3410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded diffusion feature docs with new support entries for text-to-video and image-to-video.
  * Clarified video output requirements: MP4-only output, NVENC-capable GPUs required, and non-NVENC GPUs are not supported.
  * Added more detailed guidance on supported and unsupported GPU families, including examples and limitations around VRAM and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->