### PR TITLE
feat(llm): route requests through encode workers

### DIFF
--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -154,6 +154,16 @@ impl Model {
         self.worker_sets.len()
     }
 
+    /// Snapshot all WorkerSets. Used by cross-role lifecycle coordination
+    /// where storage keys include role/surface suffixes but deployment
+    /// matching is based on `WorkerSet::namespace()`.
+    pub(crate) fn worker_sets(&self) -> Vec<Arc<WorkerSet>> {
+        self.worker_sets
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
     /// Check if this model has any decode engine (chat or completions) across any WorkerSet.
     pub fn has_decode_engine(&self) -> bool {
         self.worker_sets

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1354,22 +1354,6 @@ impl ModelManager {
     /// Publish an Encode endpoint and activate any waiting token pipeline.
     pub fn activate_encoder_router(&self, model_name: &str, namespace: &str, endpoint: Endpoint) {
         let key = Self::model_namespace_key(model_name, namespace);
-        let reactivate_if_needed = || {
-            if let Some(model) = self.get_model(model_name)
-                && let Some(ws) = model
-                    .worker_sets()
-                    .into_iter()
-                    .find(|ws| ws.namespace() == namespace && ws.encoder_router.is_some())
-                && let Some(ref router) = ws.encoder_router
-                && router.is_deactivated()
-            {
-                router.reactivate();
-                true
-            } else {
-                false
-            }
-        };
-
         let sender = match self.encoder_router_activators.entry(key) {
             Entry::Occupied(mut o) => {
                 let state = o.get_mut();
@@ -1396,15 +1380,35 @@ impl ModelManager {
                 );
             }
         } else {
-            reactivate_if_needed();
+            self.reactivate_encoder_routers(model_name, namespace);
+        }
+    }
+
+    fn reactivate_encoder_routers(&self, model_name: &str, namespace: &str) {
+        if let Some(model) = self.get_model(model_name) {
+            for ws in model.worker_sets() {
+                if ws.namespace() == namespace
+                    && let Some(ref router) = ws.encoder_router
+                    && router.is_deactivated()
+                {
+                    router.reactivate();
+                }
+            }
         }
     }
 
     /// Drop a stale Encode endpoint and make existing token pipelines bypass it.
     pub fn remove_encoder_activator(&self, model_name: &str, namespace: &str) {
         let key = Self::model_namespace_key(model_name, namespace);
-        if let Some(mut state) = self.encoder_router_activators.get_mut(&key) {
-            state.endpoint = None;
+        if let Entry::Occupied(mut o) = self.encoder_router_activators.entry(key) {
+            let should_remove = {
+                let state = o.get_mut();
+                state.endpoint = None;
+                state.consumer.is_none()
+            };
+            if should_remove {
+                o.remove();
+            }
         }
     }
 
@@ -2109,6 +2113,46 @@ mod tests {
         assert!(mm.register_encoder_router("llama", "ns2").is_some());
     }
 
+    #[test]
+    fn test_remove_encoder_activator_drops_stale_state_without_waiter() {
+        let mm = ModelManager::new();
+        let key = ModelManager::model_namespace_key("llama", "ns1");
+        mm.encoder_router_activators.insert(
+            key.clone(),
+            EncoderActivationState {
+                routing_enabled: true,
+                ..Default::default()
+            },
+        );
+
+        mm.remove_encoder_activator("llama", "ns1");
+
+        assert!(!mm.encoder_router_activators.contains_key(&key));
+        let _receiver = mm
+            .register_encoder_router("llama", "ns1")
+            .expect("registration after cleanup must succeed");
+        let state = mm.encoder_router_activators.get(&key).unwrap();
+        assert!(!state.routing_enabled);
+        assert!(state.consumer.is_some());
+    }
+
+    #[test]
+    fn test_remove_encoder_activator_preserves_waiting_consumer() {
+        let mm = ModelManager::new();
+        let key = ModelManager::model_namespace_key("llama", "ns1");
+        let _receiver = mm
+            .register_encoder_router("llama", "ns1")
+            .expect("consumer registration must succeed");
+        mm.enable_encoder_routing("llama", "ns1");
+
+        mm.remove_encoder_activator("llama", "ns1");
+
+        let state = mm.encoder_router_activators.get(&key).unwrap();
+        assert!(state.consumer.is_some());
+        assert!(state.endpoint.is_none());
+        assert!(state.routing_enabled);
+    }
+
     #[derive(Clone, Copy)]
     enum EncoderActivationSignal {
         Register,
@@ -2189,6 +2233,28 @@ mod tests {
 
         assert_eq!(receiver.await.unwrap(), endpoint);
         runtime.shutdown();
+    }
+
+    #[test]
+    fn test_encoder_router_reactivates_every_matching_worker_set() {
+        let router_a = crate::kv_router::EncoderRouter::disabled();
+        let router_b = crate::kv_router::EncoderRouter::disabled();
+        let mm = ModelManager::new();
+        let mut ws_a = make_worker_set("ns1", "checksum-a");
+        ws_a.encoder_router = Some(router_a.clone());
+        let mut ws_b = make_worker_set("ns1", "checksum-b");
+        ws_b.encoder_router = Some(router_b.clone());
+        mm.add_worker_set("llama", "ns1:chat:decode", ws_a);
+        mm.add_worker_set("llama", "ns1:completions:decode", ws_b);
+
+        mm.deactivate_encoder_router_for_consumers("llama", "ns1");
+        assert!(router_a.is_deactivated());
+        assert!(router_b.is_deactivated());
+
+        mm.reactivate_encoder_routers("llama", "ns1");
+
+        assert!(!router_a.is_deactivated());
+        assert!(!router_b.is_deactivated());
     }
 
     // -- remove_decode_prefill_waiter tests (stale-DecodeWaiting cleanup) --

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -66,6 +66,14 @@ enum PrefillActivationState {
     PrefillReady(Box<Endpoint>),
 }
 
+/// State for the optional Encode endpoint / token-pipeline rendezvous.
+#[derive(Default)]
+struct EncoderActivationState {
+    consumer: Option<oneshot::Sender<Endpoint>>,
+    endpoint: Option<Box<Endpoint>>,
+    routing_enabled: bool,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ModelManagerError {
     #[error("Model not found: {0}")]
@@ -100,6 +108,9 @@ pub struct ModelManager {
 
     /// Prefill router activation rendezvous, keyed by "model_name:namespace".
     prefill_router_activators: DashMap<String, PrefillActivationState>,
+
+    /// Encode router activation rendezvous, keyed by "model_name:namespace".
+    encoder_router_activators: DashMap<String, EncoderActivationState>,
 
     /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
@@ -138,6 +149,7 @@ impl ModelManager {
             models: DashMap::new(),
             cards: DashMap::new(),
             prefill_router_activators: DashMap::new(),
+            encoder_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
             lora_routing_table,
             lora_state_tracker,
@@ -1266,6 +1278,157 @@ impl ModelManager {
         }
     }
 
+    /// Register the optional encoder hop for a token-serving WorkerSet.
+    /// A cached Encode endpoint activates rebuilt consumers immediately.
+    pub fn register_encoder_router(
+        &self,
+        model_name: &str,
+        namespace: &str,
+    ) -> Option<oneshot::Receiver<Endpoint>> {
+        let key = Self::model_namespace_key(model_name, namespace);
+        match self.encoder_router_activators.entry(key) {
+            Entry::Occupied(mut o) => {
+                if o.get().consumer.is_some() {
+                    tracing::error!(
+                        model_name = %model_name,
+                        namespace = %namespace,
+                        "Token WorkerSet already registered for this encoder router"
+                    );
+                    return None;
+                }
+                let (tx, rx) = oneshot::channel();
+                let state = o.get_mut();
+                if state.routing_enabled {
+                    if let Some(endpoint) = state.endpoint.as_ref() {
+                        let _ = tx.send((**endpoint).clone());
+                    } else {
+                        state.consumer = Some(tx);
+                    }
+                } else {
+                    state.consumer = Some(tx);
+                }
+                Some(rx)
+            }
+            Entry::Vacant(v) => {
+                let (tx, rx) = oneshot::channel();
+                v.insert(EncoderActivationState {
+                    consumer: Some(tx),
+                    ..Default::default()
+                });
+                Some(rx)
+            }
+        }
+    }
+
+    /// Mark the model namespace as explicitly depending on an Encode worker.
+    /// Activation waits for both this signal and an Encode endpoint so worker
+    /// discovery order does not change routing behavior.
+    pub fn enable_encoder_routing(&self, model_name: &str, namespace: &str) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        // Option::zip would eagerly evaluate consumer.take(), dropping the
+        // waiter when the Encode endpoint has not arrived yet.
+        #[allow(clippy::manual_option_zip)]
+        let sender_and_endpoint = match self.encoder_router_activators.entry(key) {
+            Entry::Occupied(mut o) => {
+                let state = o.get_mut();
+                state.routing_enabled = true;
+                state
+                    .endpoint
+                    .as_ref()
+                    .map(|endpoint| (**endpoint).clone())
+                    .and_then(|endpoint| state.consumer.take().map(|sender| (sender, endpoint)))
+            }
+            Entry::Vacant(v) => {
+                v.insert(EncoderActivationState {
+                    routing_enabled: true,
+                    ..Default::default()
+                });
+                None
+            }
+        };
+        if let Some((sender, endpoint)) = sender_and_endpoint {
+            let _ = sender.send(endpoint);
+        }
+    }
+
+    /// Publish an Encode endpoint and activate any waiting token pipeline.
+    pub fn activate_encoder_router(&self, model_name: &str, namespace: &str, endpoint: Endpoint) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        let reactivate_if_needed = || {
+            if let Some(model) = self.get_model(model_name)
+                && let Some(ws) = model
+                    .worker_sets()
+                    .into_iter()
+                    .find(|ws| ws.namespace() == namespace && ws.encoder_router.is_some())
+                && let Some(ref router) = ws.encoder_router
+                && router.is_deactivated()
+            {
+                router.reactivate();
+                true
+            } else {
+                false
+            }
+        };
+
+        let sender = match self.encoder_router_activators.entry(key) {
+            Entry::Occupied(mut o) => {
+                let state = o.get_mut();
+                state.endpoint = Some(Box::new(endpoint.clone()));
+                state
+                    .routing_enabled
+                    .then(|| state.consumer.take())
+                    .flatten()
+            }
+            Entry::Vacant(v) => {
+                v.insert(EncoderActivationState {
+                    endpoint: Some(Box::new(endpoint.clone())),
+                    ..Default::default()
+                });
+                None
+            }
+        };
+        if let Some(sender) = sender {
+            if sender.send(endpoint).is_err() {
+                tracing::warn!(
+                    model_name = %model_name,
+                    namespace = %namespace,
+                    "Encoder router consumer disappeared before activation; endpoint remains cached"
+                );
+            }
+        } else {
+            reactivate_if_needed();
+        }
+    }
+
+    /// Drop a stale Encode endpoint and make existing token pipelines bypass it.
+    pub fn remove_encoder_activator(&self, model_name: &str, namespace: &str) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        if let Some(mut state) = self.encoder_router_activators.get_mut(&key) {
+            state.endpoint = None;
+        }
+    }
+
+    pub fn deactivate_encoder_router_for_consumers(&self, model_name: &str, namespace: &str) {
+        if let Some(model) = self.get_model(model_name) {
+            for ws in model.worker_sets() {
+                if ws.namespace() == namespace
+                    && let Some(ref router) = ws.encoder_router
+                {
+                    router.deactivate();
+                }
+            }
+        }
+    }
+
+    /// Remove a waiter owned by a token WorkerSet that failed or was removed,
+    /// while preserving a cached live Encode endpoint for rebuilds.
+    pub fn remove_consumer_encoder_waiter(&self, model_name: &str, namespace: &str) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        if let Some(mut state) = self.encoder_router_activators.get_mut(&key) {
+            state.consumer = None;
+        }
+    }
+
     // -- Worker monitoring --
 
     /// Gets or sets the load threshold config for a model's worker monitor.
@@ -1437,6 +1600,8 @@ fn has_required_kv_transfer_policy(configs: &HashMap<WorkerId, ModelRuntimeConfi
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
 
     use crate::local_model::runtime_config::ModelRuntimeConfig;
     use crate::model_card::ModelDeploymentCard;
@@ -1923,6 +2088,107 @@ mod tests {
         let mm = ModelManager::new();
         // Should not panic
         mm.remove_prefill_activator("llama", "ns1");
+    }
+
+    #[test]
+    fn test_encoder_router_registration_and_waiter_cleanup() {
+        let mm = ModelManager::new();
+        let rx = mm.register_encoder_router("llama", "ns1");
+        assert!(rx.is_some());
+        assert!(mm.register_encoder_router("llama", "ns1").is_none());
+
+        drop(rx);
+        mm.remove_consumer_encoder_waiter("llama", "ns1");
+        assert!(mm.register_encoder_router("llama", "ns1").is_some());
+    }
+
+    #[test]
+    fn test_encoder_router_different_namespaces_are_independent() {
+        let mm = ModelManager::new();
+        assert!(mm.register_encoder_router("llama", "ns1").is_some());
+        assert!(mm.register_encoder_router("llama", "ns2").is_some());
+    }
+
+    #[derive(Clone, Copy)]
+    enum EncoderActivationSignal {
+        Register,
+        Enable,
+        Activate,
+    }
+
+    #[tokio::test]
+    async fn test_encoder_router_activates_in_every_signal_order() {
+        use EncoderActivationSignal::{Activate, Enable, Register};
+
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("encoder-activation-orders".to_string())
+            .unwrap()
+            .component("encoder".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let orders = [
+            [Register, Enable, Activate],
+            [Register, Activate, Enable],
+            [Enable, Register, Activate],
+            [Enable, Activate, Register],
+            [Activate, Register, Enable],
+            [Activate, Enable, Register],
+        ];
+
+        for order in orders {
+            let mm = ModelManager::new();
+            let mut receiver = None;
+            for signal in order {
+                match signal {
+                    Register => {
+                        receiver = mm.register_encoder_router("llama", "ns1");
+                    }
+                    Enable => mm.enable_encoder_routing("llama", "ns1"),
+                    Activate => {
+                        mm.activate_encoder_router("llama", "ns1", endpoint.clone());
+                    }
+                }
+            }
+
+            let activated = receiver
+                .expect("every order registers a consumer")
+                .await
+                .expect("all three signals must activate the consumer");
+            assert_eq!(activated, endpoint);
+        }
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_encoder_router_repeated_enable_preserves_waiter() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("encoder-repeated-enable".to_string())
+            .unwrap()
+            .component("encoder".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let mm = ModelManager::new();
+        let receiver = mm
+            .register_encoder_router("llama", "ns1")
+            .expect("consumer registration must succeed");
+
+        mm.enable_encoder_routing("llama", "ns1");
+        mm.enable_encoder_routing("llama", "ns1");
+        mm.activate_encoder_router("llama", "ns1", endpoint.clone());
+
+        assert_eq!(receiver.await.unwrap(), endpoint);
+        runtime.shutdown();
     }
 
     // -- remove_decode_prefill_waiter tests (stale-DecodeWaiting cleanup) --

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -36,7 +36,7 @@ use crate::{
     discovery::{KvWorkerMonitor, WORKER_TYPE_DECODE, WorkerSet},
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
-    kv_router::PrefillRouter,
+    kv_router::{EncoderRouter, PrefillRouter},
     local_model::runtime_config::{TokenizerBackend, VLLM_INFERENCE_V1_GENERATE_CAPABILITY},
     model_card::ModelDeploymentCard,
     model_type::{ModelInput, ModelType},
@@ -144,6 +144,17 @@ fn supports_vllm_generate(card: &ModelDeploymentCard) -> bool {
         card.runtime_config
             .runtime_data
             .get(VLLM_INFERENCE_V1_GENERATE_CAPABILITY),
+        Some(serde_json::Value::Bool(true))
+    )
+}
+
+const ENCODER_RESULT_HANDOFF_CAPABILITY: &str = "encoder_result_handoff";
+
+fn supports_encoder_result_handoff(card: &ModelDeploymentCard) -> bool {
+    matches!(
+        card.runtime_config
+            .runtime_data
+            .get(ENCODER_RESULT_HANDOFF_CAPABILITY),
         Some(serde_json::Value::Bool(true))
     )
 }
@@ -1089,13 +1100,12 @@ impl ModelWatcher {
                         .deactivate_prefill_router_for_decode(&model_name, worker_namespace);
                 }
                 Some(WorkerType::Encode) if card.model_type.is_empty() => {
-                    // A surface-less encode helper (e.g. vLLM) never ran the
-                    // model_type pipeline chain, so it created no prefill/decode
-                    // activator state. Skip the decode waiter cleanup — that map
-                    // is keyed by (model, namespace) and clearing it on an
-                    // unrelated encode removal could drop a live DecodeWaiting
-                    // and recreate the stale-prefill-router rebuild failure
-                    // described above.
+                    if removed.is_some() {
+                        self.manager
+                            .remove_encoder_activator(&model_name, worker_namespace);
+                    }
+                    self.manager
+                        .deactivate_encoder_router_for_consumers(&model_name, worker_namespace);
                 }
                 Some(WorkerType::Decode)
                 | Some(WorkerType::Aggregated)
@@ -1116,6 +1126,8 @@ impl ModelWatcher {
                     // is a no-op.
                     self.manager
                         .remove_decode_prefill_waiter(&model_name, worker_namespace);
+                    self.manager
+                        .remove_consumer_encoder_waiter(&model_name, worker_namespace);
                 }
             }
         }
@@ -1367,6 +1379,37 @@ impl ModelWatcher {
         let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
         worker_set.set_instance_watcher(instance_watcher);
 
+        // A surface-less Encode worker is reached only through EncoderRouter.
+        // Register it for serving readiness, publish its endpoint to any
+        // waiting token pipeline, and do not build a public OpenAI surface.
+        if effective_worker_type(card.worker_type, card.model_type) == WorkerType::Encode
+            && card.model_type.is_empty()
+        {
+            if card.model_input != ModelInput::Tokens {
+                anyhow::bail!(
+                    "Encode workers must use ModelInput::Tokens, got {}",
+                    card.model_input.as_str()
+                );
+            }
+            self.manager
+                .add_worker_set(card.name(), &ws_key, worker_set);
+
+            if let Some(tx) = &self.model_update_tx {
+                tx.send(ModelUpdate::Added(card.clone())).await.ok();
+            }
+            self.manager.activate_encoder_router(
+                card.name(),
+                &namespace,
+                component.endpoint(&mcid.endpoint),
+            );
+            tracing::info!(
+                model_name = card.name(),
+                namespace = %namespace,
+                "Encode worker registered and router activated"
+            );
+            return Ok(());
+        }
+
         // worker_type-driven short circuit for Prefill.
         //
         // A prefill worker carries no OpenAI-style engine — it is reached only
@@ -1403,6 +1446,10 @@ impl ModelWatcher {
             // and go.
             self.manager
                 .add_worker_set(card.name(), &ws_key, worker_set);
+
+            if supports_encoder_result_handoff(card) {
+                self.manager.enable_encoder_routing(card.name(), &namespace);
+            }
 
             if let Some(tx) = &self.model_update_tx {
                 tx.send(ModelUpdate::Added(card.clone())).await.ok();
@@ -1548,12 +1595,24 @@ impl ModelWatcher {
                 None
             };
 
+            let encoder_chooser = if needs_preprocessed_routing {
+                if supports_encoder_result_handoff(card) {
+                    self.manager.enable_encoder_routing(&model_name, &namespace);
+                }
+                self.manager
+                    .register_encoder_router(&model_name, &namespace)
+                    .map(|rx| EncoderRouter::new(rx, model_name.clone(), namespace.clone()))
+            } else {
+                None
+            };
+
             // Store KV router, worker monitor, and prefill router on the WorkerSet.
             // The prefill router is stored so the watcher can deactivate/reactivate it
             // when prefill workers die or rejoin.
             worker_set.kv_router = kv_chooser.clone();
             worker_set.worker_monitor = worker_monitor.clone();
             worker_set.prefill_router = prefill_chooser.clone();
+            worker_set.encoder_router = encoder_chooser.clone();
 
             let preprocessed_routing = if needs_preprocessed_routing {
                 Some(
@@ -1564,6 +1623,7 @@ impl ModelWatcher {
                         worker_monitor.clone(),
                         kv_chooser.clone(),
                         prefill_chooser.clone(),
+                        encoder_chooser.clone(),
                         uses_multimodal_cache_routing(card),
                         router_config.session_affinity_ttl_secs,
                     )
@@ -1978,6 +2038,23 @@ mod tests {
             .set_engine_specific(VLLM_INFERENCE_V1_GENERATE_CAPABILITY, false)
             .unwrap();
         assert!(!supports_vllm_generate(&card));
+    }
+
+    #[test]
+    fn encoder_result_handoff_requires_explicit_worker_capability() {
+        let mut card = ModelDeploymentCard::with_name_only("model");
+        card.needs = vec![vec![WorkerType::Encode]];
+        assert!(!supports_encoder_result_handoff(&card));
+
+        card.runtime_config
+            .set_engine_specific(ENCODER_RESULT_HANDOFF_CAPABILITY, true)
+            .unwrap();
+        assert!(supports_encoder_result_handoff(&card));
+
+        card.runtime_config
+            .set_engine_specific(ENCODER_RESULT_HANDOFF_CAPABILITY, false)
+            .unwrap();
+        assert!(!supports_encoder_result_handoff(&card));
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch;
 
 use crate::{
     discovery::KvWorkerMonitor,
-    kv_router::{KvRouter, PrefillRouter},
+    kv_router::{EncoderRouter, KvRouter, PrefillRouter},
     model_card::ModelDeploymentCard,
     types::{
         RealtimeBidirectionalEngine,
@@ -58,6 +58,10 @@ pub struct WorkerSet {
     /// deactivate it when all prefill workers die, and reactivate when they rejoin.
     pub(crate) prefill_router: Option<Arc<PrefillRouter>>,
 
+    /// Optional multimodal encoder hop. Stored for discovery-driven
+    /// deactivation/reactivation when Encode workers leave or rejoin.
+    pub(crate) encoder_router: Option<Arc<EncoderRouter>>,
+
     /// Watcher for available instance IDs (from the Client's discovery watch).
     /// None for in-process models (http/grpc) which don't have a discovery client.
     instance_count_rx: Option<watch::Receiver<Vec<u64>>>,
@@ -81,6 +85,7 @@ impl WorkerSet {
             kv_router: None,
             worker_monitor: None,
             prefill_router: None,
+            encoder_router: None,
             instance_count_rx: None,
         }
     }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -13,7 +13,9 @@ use crate::{
     entrypoint::EngineConfig,
     http::service::metrics::Metrics,
     kv_router::indexer::try_build_cache_indexer,
-    kv_router::{KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics},
+    kv_router::{
+        EncoderRouter, KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics,
+    },
     lora::LoraFilteredRouter,
     migration::Migration,
     model_card::ModelDeploymentCard,
@@ -79,6 +81,7 @@ pub struct PreprocessedRouting {
     backend_engine:
         ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>,
     prefill_router: Arc<PrefillRouter>,
+    encoder_router: Arc<EncoderRouter>,
 }
 
 pub struct PreparedEngine {
@@ -237,6 +240,7 @@ pub async fn build_preprocessed_routing(
     worker_monitor: Option<KvWorkerMonitor>,
     chooser: Option<Arc<KvRouter>>,
     prefill_chooser: Option<Arc<PrefillRouter>>,
+    encoder_chooser: Option<Arc<EncoderRouter>>,
     enable_multimodal_cache_indexer: bool,
     session_affinity_ttl_secs: Option<u64>,
 ) -> anyhow::Result<PreprocessedRouting> {
@@ -291,6 +295,7 @@ pub async fn build_preprocessed_routing(
             session_affinity_ttl_secs,
         )
     });
+    let encoder_router = encoder_chooser.unwrap_or_else(EncoderRouter::disabled);
 
     let backend_engine = preprocessed_backend_engine(
         router,
@@ -302,6 +307,7 @@ pub async fn build_preprocessed_routing(
     Ok(PreprocessedRouting {
         backend_engine,
         prefill_router,
+        encoder_router,
     })
 }
 
@@ -479,15 +485,18 @@ impl PreprocessedRouting {
         let migration = Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics)
             .into_operator_for::<BackendOutput>();
         let prefill_op = self.prefill_router.into_operator();
+        let encoder_op = self.encoder_router.into_operator();
         let backend = ServiceBackend::from_engine(self.backend_engine.clone());
 
         let engine = frontend
             .link(preprocessor_op.forward_edge())?
             .link(migration.forward_edge())?
             .link(token_backend.forward_edge())?
+            .link(encoder_op.forward_edge())?
             .link(prefill_op.forward_edge())?
             .link(backend)?
             .link(prefill_op.backward_edge())?
+            .link(encoder_op.backward_edge())?
             .link(token_backend.backward_edge())?
             .link(migration.backward_edge())?
             .link(preprocessor_op.backward_edge())?
@@ -514,13 +523,16 @@ impl PreprocessedRouting {
         let migration = Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics)
             .into_operator_for::<LLMEngineOutput>();
         let prefill_op = self.prefill_router.into_operator();
+        let encoder_op = self.encoder_router.into_operator();
         let backend = ServiceBackend::from_engine(self.backend_engine.clone());
 
         let engine = frontend
             .link(migration.forward_edge())?
+            .link(encoder_op.forward_edge())?
             .link(prefill_op.forward_edge())?
             .link(backend)?
             .link(prefill_op.backward_edge())?
+            .link(encoder_op.backward_edge())?
             .link(migration.backward_edge())?
             .link(frontend)?;
 

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -43,6 +43,7 @@ pub use dynamo_kv_router::protocols;
 pub use dynamo_kv_router::scheduling;
 pub use dynamo_kv_router::selector;
 
+pub mod encoder_router;
 pub mod indexer;
 pub mod metrics;
 pub mod prefill_router;
@@ -56,6 +57,7 @@ pub mod shared_cache;
 pub use dynamo_kv_router::scheduling::{
     OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore,
 };
+pub use encoder_router::EncoderRouter;
 pub use indexer::{Indexer, ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub use prefill_router::PrefillRouter;
 pub use push_router::{DirectRoutingRouter, KvPushRouter};

--- a/lib/llm/src/kv_router/encoder_router.rs
+++ b/lib/llm/src/kv_router/encoder_router.rs
@@ -125,14 +125,32 @@ impl EncoderRouter {
             EncodePushRouter::from_client_with_monitor(client, RouterMode::RoundRobin, None)
                 .await?;
         let _ = self.router.set(Arc::new(router));
-        self.lifecycle
-            .store(EncoderLifecycleState::Active as u8, Ordering::Release);
-        tracing::info!(
-            model = %self.model_name,
-            namespace = %self.namespace,
-            "Encoder router activated"
-        );
+        if self.mark_active_if_pending() {
+            tracing::info!(
+                model = %self.model_name,
+                namespace = %self.namespace,
+                "Encoder router activated"
+            );
+        } else {
+            tracing::debug!(
+                model = %self.model_name,
+                namespace = %self.namespace,
+                state = ?self.lifecycle_state(),
+                "Encoder router initialized after its activation was superseded"
+            );
+        }
         Ok(())
+    }
+
+    fn mark_active_if_pending(&self) -> bool {
+        self.lifecycle
+            .compare_exchange(
+                EncoderLifecycleState::Pending as u8,
+                EncoderLifecycleState::Active as u8,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            )
+            .is_ok()
     }
 
     fn lifecycle_state(&self) -> EncoderLifecycleState {
@@ -140,17 +158,17 @@ impl EncoderRouter {
     }
 
     pub fn deactivate(&self) {
-        if self.router.get().is_some() {
-            self.lifecycle
-                .store(EncoderLifecycleState::Unavailable as u8, Ordering::Release);
-        }
+        self.lifecycle
+            .store(EncoderLifecycleState::Unavailable as u8, Ordering::Release);
     }
 
     pub fn reactivate(&self) {
-        if self.router.get().is_some() {
-            self.lifecycle
-                .store(EncoderLifecycleState::Active as u8, Ordering::Release);
-        }
+        let _ = self.lifecycle.compare_exchange(
+            EncoderLifecycleState::Unavailable as u8,
+            EncoderLifecycleState::Active as u8,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
     }
 
     pub fn is_deactivated(&self) -> bool {
@@ -211,33 +229,56 @@ impl
             return next.generate(context.map(|_| request)).await;
         }
 
-        let router = self
-            .router
-            .get()
-            .context("Encoder router is active but not initialized")?;
         let encode_context = Context::with_id_and_metadata(
             request.clone(),
             context.id().to_string(),
             context.metadata().clone(),
         );
-        let response = router.generate(encode_context).await?;
-        let (encoder_result, worker_link) = Self::consume_encode_stream(response).await?;
+        let encode_result = async {
+            let router = self
+                .router
+                .get()
+                .context("Encoder router is active but not initialized")?;
+            let response = router.generate(encode_context).await?;
+            Self::consume_encode_stream(response).await
+        }
+        .await;
 
-        // Once the Encode worker has emitted a transfer handle, always hand it
-        // to the downstream worker even if the caller disconnected. The
-        // receiver owns transfer completion and buffer release.
-        request.encoder_result = Some(encoder_result);
-        request.migration_link = worker_link;
+        match encode_result {
+            Ok((encoder_result, worker_link)) => {
+                // Once the Encode worker has emitted a transfer handle, always hand it
+                // to the downstream worker even if the caller disconnected. The
+                // receiver owns transfer completion and buffer release.
+                request.encoder_result = Some(encoder_result);
+                request.migration_link = worker_link;
+            }
+            Err(error) => {
+                tracing::error!(
+                    %error,
+                    model = %self.model_name,
+                    namespace = %self.namespace,
+                    "Encoder hop failed; falling back to downstream inline encoding"
+                );
+            }
+        }
         next.generate(context.map(|_| request)).await
     }
 }
 
 #[cfg(test)]
 mod tests {
+    use std::{collections::HashMap, sync::Mutex};
+
     use futures::stream;
     use serde_json::json;
 
-    use dynamo_runtime::pipeline::{ResponseStream, context::Controller};
+    use dynamo_runtime::{
+        engine::AsyncEngineContextProvider,
+        pipeline::{Error, ResponseStream, context::Controller},
+    };
+
+    use crate::protocols::common::preprocessor::MultimodalData;
+    use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 
     use super::*;
 
@@ -246,6 +287,47 @@ mod tests {
             Box::pin(stream::iter(items)),
             Arc::new(Controller::default()),
         )
+    }
+
+    #[derive(Default)]
+    struct CaptureEngine {
+        request: Mutex<Option<PreprocessedRequest>>,
+    }
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for CaptureEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> std::result::Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            self.request
+                .lock()
+                .unwrap()
+                .replace(request.content().clone());
+            Ok(ResponseStream::new(
+                Box::pin(stream::empty()),
+                request.context(),
+            ))
+        }
+    }
+
+    fn multimodal_request() -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("model".to_string())
+            .token_ids(vec![1, 2, 3])
+            .multi_modal_data(Some(HashMap::from([(
+                "image".to_string(),
+                vec![MultimodalData::RawUrl(
+                    "data:image/png;base64,cGF5bG9hZA==".to_string(),
+                )],
+            )])))
+            .stop_conditions(StopConditions::default())
+            .sampling_options(SamplingOptions::default())
+            .output_options(OutputOptions::default())
+            .build()
+            .unwrap()
     }
 
     #[tokio::test]
@@ -257,6 +339,41 @@ mod tests {
         drop(router);
 
         assert!(weak.upgrade().is_none());
+    }
+
+    #[test]
+    fn deactivation_wins_an_in_flight_activation() {
+        let router = EncoderRouter::disabled();
+
+        router.deactivate();
+
+        assert!(!router.mark_active_if_pending());
+        assert_eq!(router.lifecycle_state(), EncoderLifecycleState::Unavailable);
+    }
+
+    #[tokio::test]
+    async fn encoder_failure_falls_back_to_downstream() {
+        let router = EncoderRouter::disabled();
+        router
+            .lifecycle
+            .store(EncoderLifecycleState::Active as u8, Ordering::Release);
+        let downstream = Arc::new(CaptureEngine::default());
+        let next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>> =
+            downstream.clone();
+
+        let _response = router
+            .generate(SingleIn::new(multimodal_request()), next)
+            .await
+            .expect("encoder failure should fall through to downstream");
+
+        let request = downstream
+            .request
+            .lock()
+            .unwrap()
+            .take()
+            .expect("downstream must receive the original request");
+        assert!(request.encoder_result.is_none());
+        assert!(request.multi_modal_data.is_some());
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/encoder_router.rs
+++ b/lib/llm/src/kv_router/encoder_router.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Optional multimodal encoder hop for token-serving pipelines.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context as _, Result};
+use futures::StreamExt;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use dynamo_runtime::{
+    component::Endpoint,
+    engine::AsyncEngine,
+    pipeline::{
+        Context, ManyOut, Operator, PushRouter, RouterMode, ServerStreamingEngine, SingleIn,
+        async_trait,
+    },
+    protocols::{annotated::Annotated, maybe_error::MaybeError},
+};
+
+use crate::protocols::common::{
+    llm_backend::{LLMEngineOutput, PreprocessedRequest},
+    preprocessor::TraceLink,
+};
+
+type EncodePushRouter = PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum EncoderLifecycleState {
+    Pending = 0,
+    Active = 1,
+    Unavailable = 2,
+}
+
+impl EncoderLifecycleState {
+    fn load(value: u8) -> Self {
+        match value {
+            0 => Self::Pending,
+            1 => Self::Active,
+            2 => Self::Unavailable,
+            value => panic!("invalid encoder lifecycle state: {value}"),
+        }
+    }
+}
+
+/// Forward-only operator that optionally runs a multimodal Encode worker.
+///
+/// The router is present on every token pipeline but remains a passthrough
+/// until discovery supplies an Encode endpoint for the same model namespace.
+/// Encode workers are selected round-robin independently of the downstream
+/// token router mode; they do not participate in KV-aware routing.
+pub struct EncoderRouter {
+    router: OnceLock<Arc<EncodePushRouter>>,
+    cancel_token: CancellationToken,
+    lifecycle: AtomicU8,
+    model_name: String,
+    namespace: String,
+}
+
+impl Drop for EncoderRouter {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+    }
+}
+
+impl EncoderRouter {
+    /// Create a permanently-disabled passthrough router.
+    pub fn disabled() -> Arc<Self> {
+        Arc::new(Self {
+            router: OnceLock::new(),
+            cancel_token: CancellationToken::new(),
+            lifecycle: AtomicU8::new(EncoderLifecycleState::Pending as u8),
+            model_name: String::new(),
+            namespace: String::new(),
+        })
+    }
+
+    /// Create a router that activates when discovery observes an Encode peer.
+    pub fn new(
+        activation_rx: oneshot::Receiver<Endpoint>,
+        model_name: String,
+        namespace: String,
+    ) -> Arc<Self> {
+        let cancel_token = CancellationToken::new();
+        let router = Arc::new(Self {
+            router: OnceLock::new(),
+            cancel_token: cancel_token.clone(),
+            lifecycle: AtomicU8::new(EncoderLifecycleState::Pending as u8),
+            model_name,
+            namespace,
+        });
+
+        let router_weak = Arc::downgrade(&router);
+        tokio::spawn(async move {
+            tokio::select! {
+                result = activation_rx => {
+                    let Ok(endpoint) = result else {
+                        tracing::debug!("Encoder router activation channel closed");
+                        return;
+                    };
+                    let Some(router) = router_weak.upgrade() else {
+                        tracing::debug!("Encoder router dropped before activation");
+                        return;
+                    };
+                    if let Err(error) = router.activate(endpoint).await {
+                        tracing::error!(%error, "Failed to activate encoder router");
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Encoder router activation cancelled");
+                }
+            }
+        });
+
+        router
+    }
+
+    async fn activate(&self, endpoint: Endpoint) -> Result<()> {
+        let client = endpoint.client().await?;
+        let router =
+            EncodePushRouter::from_client_with_monitor(client, RouterMode::RoundRobin, None)
+                .await?;
+        let _ = self.router.set(Arc::new(router));
+        self.lifecycle
+            .store(EncoderLifecycleState::Active as u8, Ordering::Release);
+        tracing::info!(
+            model = %self.model_name,
+            namespace = %self.namespace,
+            "Encoder router activated"
+        );
+        Ok(())
+    }
+
+    fn lifecycle_state(&self) -> EncoderLifecycleState {
+        EncoderLifecycleState::load(self.lifecycle.load(Ordering::Acquire))
+    }
+
+    pub fn deactivate(&self) {
+        if self.router.get().is_some() {
+            self.lifecycle
+                .store(EncoderLifecycleState::Unavailable as u8, Ordering::Release);
+        }
+    }
+
+    pub fn reactivate(&self) {
+        if self.router.get().is_some() {
+            self.lifecycle
+                .store(EncoderLifecycleState::Active as u8, Ordering::Release);
+        }
+    }
+
+    pub fn is_deactivated(&self) -> bool {
+        self.lifecycle_state() == EncoderLifecycleState::Unavailable
+    }
+
+    fn should_encode(request: &PreprocessedRequest) -> bool {
+        !request.is_probe
+            && request.encoder_result.is_none()
+            && request
+                .multi_modal_data
+                .as_ref()
+                .is_some_and(|media| media.values().any(|items| !items.is_empty()))
+    }
+
+    async fn consume_encode_stream(
+        mut response: ManyOut<Annotated<LLMEngineOutput>>,
+    ) -> Result<(serde_json::Value, Option<TraceLink>)> {
+        let mut terminal = None;
+        while let Some(item) = response.next().await {
+            if let Some(error) = item.err() {
+                return Err(anyhow::anyhow!(error)).context("Encode worker returned an error");
+            }
+            let Some(output) = item.data else {
+                continue;
+            };
+            if output.finish_reason.is_some() {
+                terminal = Some(output);
+            }
+        }
+
+        let terminal = terminal.context("Encode worker stream ended without a terminal chunk")?;
+        let result = terminal
+            .encoder_result
+            .filter(serde_json::Value::is_object)
+            .context("Encode worker terminal is missing an object-shaped encoder_result")?;
+        Ok((result, terminal.worker_trace_link))
+    }
+}
+
+#[async_trait]
+impl
+    Operator<
+        SingleIn<PreprocessedRequest>,
+        ManyOut<Annotated<LLMEngineOutput>>,
+        SingleIn<PreprocessedRequest>,
+        ManyOut<Annotated<LLMEngineOutput>>,
+    > for EncoderRouter
+{
+    async fn generate(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
+        let (mut request, context) = request.into_parts();
+        if self.lifecycle_state() != EncoderLifecycleState::Active || !Self::should_encode(&request)
+        {
+            return next.generate(context.map(|_| request)).await;
+        }
+
+        let router = self
+            .router
+            .get()
+            .context("Encoder router is active but not initialized")?;
+        let encode_context = Context::with_id_and_metadata(
+            request.clone(),
+            context.id().to_string(),
+            context.metadata().clone(),
+        );
+        let response = router.generate(encode_context).await?;
+        let (encoder_result, worker_link) = Self::consume_encode_stream(response).await?;
+
+        // Once the Encode worker has emitted a transfer handle, always hand it
+        // to the downstream worker even if the caller disconnected. The
+        // receiver owns transfer completion and buffer release.
+        request.encoder_result = Some(encoder_result);
+        request.migration_link = worker_link;
+        next.generate(context.map(|_| request)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use serde_json::json;
+
+    use dynamo_runtime::pipeline::{ResponseStream, context::Controller};
+
+    use super::*;
+
+    fn stream_of(items: Vec<Annotated<LLMEngineOutput>>) -> ManyOut<Annotated<LLMEngineOutput>> {
+        ResponseStream::new(
+            Box::pin(stream::iter(items)),
+            Arc::new(Controller::default()),
+        )
+    }
+
+    #[tokio::test]
+    async fn pending_activation_does_not_keep_router_alive() {
+        let (_activation_tx, activation_rx) = oneshot::channel();
+        let router = EncoderRouter::new(activation_rx, "model".into(), "namespace".into());
+        let weak = Arc::downgrade(&router);
+
+        drop(router);
+
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn consumes_object_shaped_encode_terminal() {
+        let output = LLMEngineOutput::encode_terminal(
+            json!({"schema_version": 1}).as_object().unwrap().clone(),
+        );
+        let (result, _) =
+            EncoderRouter::consume_encode_stream(stream_of(vec![Annotated::from_data(output)]))
+                .await
+                .unwrap();
+        assert_eq!(result, json!({"schema_version": 1}));
+    }
+
+    #[tokio::test]
+    async fn rejects_terminal_without_encoder_result() {
+        let result = EncoderRouter::consume_encode_stream(stream_of(vec![Annotated::from_data(
+            LLMEngineOutput::stop(),
+        )]))
+        .await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Overview:

Add the backend-agnostic encoder routing hop that sends multimodal requests to a surface-less Encode worker before aggregated or prefill execution.

## Summary

- add an optional round-robin `EncoderRouter` to the preprocessed request pipeline
- activate and deactivate encoder routing through model discovery
- scope encoder endpoints and consumers by model namespace
- preserve passthrough behavior when no encoder is configured or available

## Details:

This is stack PR 1 of 4 for [DIS-2034](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend). It builds on the merged encoder-result contract in #10969 and Encode role/discovery foundation in #10970.

The router consumes the Encode worker's terminal `encoder_result`, attaches it to the downstream request, and carries the worker trace link forward. Discovery retains endpoint state across consumer rebuilds and deactivates the hop when Encode workers leave.

## Where should the reviewer start?

- `lib/llm/src/kv_router/encoder_router.rs`
- `lib/llm/src/discovery/model_manager.rs`
- `lib/llm/src/discovery/watcher.rs`
- `lib/llm/src/entrypoint/input/common.rs`

## Validation

- focused Rust tests: 4 passed
  - encoder router registration and waiter cleanup
  - model-namespace isolation
  - object-shaped Encode terminal consumption
  - rejection of terminals without `encoder_result`
- `cargo fmt --all -- --check`
- `git diff --check`
- full-stack GPU validation is recorded in #11449

## Stack

1. **This PR:** generic encoder routing and discovery
2. #11461 — unified vLLM Encode engine
3. #11462 — unified vLLM encoder handoff consumer
4. #11449 — launchers, GPU profiles, and documentation

## Related Issues

**🔗 This PR is linked to an issue:**

- [DIS-2034: vLLM: Add separate encode worker in unified backend](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for encoder-based routing in multimodal inference flows.
  * Improved handling for encode-only workers, including automatic routing setup and reactivation when needed.
  * Added a new routing stage so requests can pass through encoding before prefill when applicable.

* **Bug Fixes**
  * Better cleanup when workers are removed, preventing stale routing state.
  * Improved routing behavior across namespaces so encoder readiness is tracked more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->