### PR TITLE
feat(vllm): add unified encode engine

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -474,6 +474,7 @@ class DynamoVllmConfig(ConfigBase):
         self._resolve_embedding_transfer_mode()
         self._validate_multimodal_role_exclusivity()
         self._validate_multimodal_requires_flag()
+        self._validate_encoder_topology()
         self._validate_embedding_worker_exclusivity()
         self._validate_custom_encoder()
         self._resolve_legacy_benchmark_sampling()
@@ -727,6 +728,28 @@ class DynamoVllmConfig(ConfigBase):
         if self._count_multimodal_roles() == 1 and not self.enable_multimodal:
             raise ValueError(
                 "Use --enable-multimodal when enabling any multimodal component"
+            )
+
+    def _validate_encoder_topology(self) -> None:
+        """Validate explicit unified Encode roles and encoder routing."""
+        is_encode = self.disaggregation_mode == DisaggregationMode.ENCODE
+        if (is_encode or self.route_to_encoder) and not self.enable_multimodal:
+            raise ValueError(
+                "--disaggregation-mode=encode and --route-to-encoder require "
+                "--enable-multimodal"
+            )
+        if self.route_to_encoder and self.disaggregation_mode not in (
+            DisaggregationMode.AGGREGATED,
+            DisaggregationMode.PREFILL,
+        ):
+            raise ValueError(
+                "--route-to-encoder is only valid with "
+                "--disaggregation-mode=agg or prefill"
+            )
+        if (is_encode or self.route_to_encoder) and self.frontend_decoding:
+            raise ValueError(
+                "Separate vLLM encode workers are incompatible with "
+                "--frontend-decoding because they require image URLs"
             )
 
     def _validate_custom_encoder(self) -> None:

--- a/components/src/dynamo/vllm/encode_engine.py
+++ b/components/src/dynamo/vllm/encode_engine.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dedicated multimodal Encode engine for the unified vLLM backend."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from typing import Any, cast
+
+from vllm.sampling_params import SamplingParams
+
+from dynamo._core import Context
+from dynamo.common.backend.engine import (
+    EngineConfig,
+    GenerateChunk,
+    GenerateRequest,
+    LLMEngine,
+    LlmRegistration,
+)
+from dynamo.common.backend.multimodal import encoder_terminal_chunk
+from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
+from dynamo.llm import ModelInput
+from dynamo.vllm.args import Config, parse_args
+
+from .multimodal_handlers import EncodeWorkerHandler
+from .multimodal_utils.protocol import (
+    MultiModalGroup,
+    MultiModalInput,
+    PatchedTokensPrompt,
+    vLLMMultimodalRequest,
+)
+
+_IMAGE_URL_KEY = "image_url"
+_URL_VARIANT_KEY = "Url"
+_ENCODER_RESULT_SCHEMA_VERSION = 1
+
+
+def _image_urls(request: GenerateRequest) -> list[str]:
+    media = request.get("multi_modal_data") or {}
+    urls: list[str] = []
+    for item in media.get(_IMAGE_URL_KEY, []):
+        if isinstance(item, dict) and isinstance(item.get(_URL_VARIANT_KEY), str):
+            urls.append(item[_URL_VARIANT_KEY])
+            continue
+        raise ValueError(
+            "The separate vLLM encode worker supports URL-based images only; "
+            "decoded image payloads must be processed by an aggregated/prefill worker"
+        )
+    return urls
+
+
+class VllmEncodeEngine(LLMEngine):
+    """Image encoder that emits a versioned Local/NIXL transfer handoff."""
+
+    def __init__(self, config: Config):
+        self._config = config
+        self._handler: EncodeWorkerHandler | None = None
+
+    @classmethod
+    async def from_args(
+        cls, argv: list[str] | None = None, config: Config | None = None
+    ) -> tuple["VllmEncodeEngine", WorkerConfig]:
+        if config is None:
+            config = parse_args(argv, fpm_trace_relay_supported=False)
+        if config.disaggregation_mode != DisaggregationMode.ENCODE:
+            raise ValueError("VllmEncodeEngine requires --disaggregation-mode=encode")
+        if not config.enable_multimodal:
+            raise ValueError("The vLLM encode worker requires --enable-multimodal")
+        if config.route_to_encoder:
+            raise ValueError("--route-to-encoder is invalid on an encode worker")
+        if not config.served_model_name:
+            engine_served_names = config.engine_args.served_model_name
+            config.served_model_name = (
+                engine_served_names[0] if engine_served_names else config.model
+            )
+        if not config.engine_args.served_model_name:
+            config.engine_args.served_model_name = [config.served_model_name]
+
+        worker_config = WorkerConfig.from_runtime_config(
+            config,
+            model_name=config.model,
+            served_model_name=config.served_model_name,
+            model_input=ModelInput.Tokens,
+            enable_kv_routing=False,
+            enable_local_indexer=False,
+        )
+        return cls(config), worker_config
+
+    async def start(self, worker_id: int) -> EngineConfig:
+        del worker_id
+        # Config validation resolves the input union to the enum; narrow the
+        # declared field type for mypy at the handler boundary.
+        transfer_mode = cast(
+            EmbeddingTransferMode, self._config.embedding_transfer_mode
+        )
+        self._handler = EncodeWorkerHandler(
+            self._config.engine_args,
+            transfer_mode,
+        )
+        await self._handler.async_init_unified()
+        return EngineConfig(
+            model=self._config.model,
+            served_model_name=self._config.served_model_name,
+            # Encode cards do not use KV metadata, but LLMEngine registration
+            # remains token-shaped and expects an llm record.
+            llm=LlmRegistration(),
+        )
+
+    async def generate(
+        self, request: GenerateRequest, context: Context
+    ) -> AsyncGenerator[GenerateChunk, None]:
+        handler = self._handler
+        if handler is None:
+            raise RuntimeError(
+                "VllmEncodeEngine.start() must complete before generate()"
+            )
+
+        groups = [
+            MultiModalGroup(multimodal_input=MultiModalInput(image_url=url))
+            for url in _image_urls(request)
+        ]
+        encode_request = vLLMMultimodalRequest(
+            engine_prompt=PatchedTokensPrompt(prompt_token_ids=[]),
+            sampling_params=SamplingParams(),
+            request_id=context.id(),
+            multimodal_inputs=groups,
+        )
+
+        payload: dict[str, Any] | None = None
+        async for serialized in handler.generate(encode_request, context):
+            payload = json.loads(serialized)
+        if payload is None:
+            raise RuntimeError("vLLM encode handler returned no result")
+
+        multimodal_inputs = payload.get("multimodal_inputs")
+        if not isinstance(multimodal_inputs, list):
+            raise RuntimeError(
+                "vLLM encode handler returned malformed multimodal_inputs"
+            )
+        yield encoder_terminal_chunk(
+            {
+                "schema_version": _ENCODER_RESULT_SCHEMA_VERSION,
+                "multimodal_inputs": multimodal_inputs,
+            }
+        )
+
+    async def cleanup(self) -> None:
+        handler, self._handler = self._handler, None
+        if handler is None:
+            return
+        handler.cleanup()
+        await asyncio.gather(
+            handler.send_complete_checker_task,
+            return_exceptions=True,
+        )

--- a/components/src/dynamo/vllm/encode_engine.py
+++ b/components/src/dynamo/vllm/encode_engine.py
@@ -33,6 +33,7 @@ from .multimodal_utils.protocol import (
     PatchedTokensPrompt,
     vLLMMultimodalRequest,
 )
+from .multimodal_utils.request_processor import get_mm_processor_kwargs
 
 _IMAGE_URL_KEY = "image_url"
 _URL_VARIANT_KEY = "Url"
@@ -128,6 +129,7 @@ class VllmEncodeEngine(LLMEngine):
             sampling_params=SamplingParams(),
             request_id=context.id(),
             multimodal_inputs=groups,
+            mm_processor_kwargs=get_mm_processor_kwargs(request),
         )
 
         payload: dict[str, Any] | None = None

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -11,6 +12,7 @@ from typing import Any, AsyncIterator
 import torch
 from transformers import AutoImageProcessor
 from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.utils.func_utils import get_allowed_kwarg_only_overrides
 
 import dynamo.nixl_connect as connect
 from dynamo.common.multimodal import (
@@ -136,6 +138,34 @@ class EncodeWorkerHandler:
         """Initialize a unified engine, which does not own a Python runtime."""
         self._init_connector()
 
+    def _effective_mm_processor_kwargs(
+        self, request_kwargs: dict[str, Any] | None
+    ) -> dict[str, Any]:
+        """Merge engine defaults with request overrides using vLLM semantics."""
+        engine_kwargs = self.engine_args.mm_processor_kwargs or {}
+        merged_kwargs = dict(engine_kwargs) | dict(request_kwargs or {})
+        return get_allowed_kwarg_only_overrides(
+            self.image_processor,
+            merged_kwargs,
+            requires_kw_only=False,
+            allow_var_kwargs=True,
+        )
+
+    @staticmethod
+    def _embedding_cache_key(
+        image_url: str, mm_processor_kwargs: dict[str, Any]
+    ) -> str:
+        """Key an embedding by both its source and effective preprocessing."""
+        cache_identity = json.dumps(
+            {
+                "image_url": image_url,
+                "mm_processor_kwargs": mm_processor_kwargs,
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        return EmbeddingCache.generate_hash_key(cache_identity)
+
     @_nvtx.range_decorator("mm:encode_worker_generate", color="blue")
     async def generate(
         self, request: vLLMMultimodalRequest, context
@@ -151,6 +181,9 @@ class EncodeWorkerHandler:
         assert (
             request.multimodal_inputs is not None
         ), "multimodal_inputs must not be None for encode worker"
+        mm_processor_kwargs = self._effective_mm_processor_kwargs(
+            request.mm_processor_kwargs
+        )
 
         # The following steps encode the requested image and provided useful embeddings.
         # 1. Open the image from the provided URL.
@@ -178,7 +211,9 @@ class EncodeWorkerHandler:
 
                     image_url = group_input.image_url
                     # see if we have local cache
-                    embedding_key = EmbeddingCache.generate_hash_key(image_url)
+                    embedding_key = self._embedding_cache_key(
+                        image_url, mm_processor_kwargs
+                    )
                     if (
                         self.embedding_cache is not None
                         and self.embedding_cache.has_key(embedding_key)
@@ -237,7 +272,10 @@ class EncodeWorkerHandler:
                     f"[ENCODE] request: {request_id} image processing"
                 ):
                     image_embeds = await asyncio.to_thread(
-                        self.image_processor, images=loaded_images, return_tensors="pt"
+                        self.image_processor,
+                        images=loaded_images,
+                        return_tensors="pt",
+                        **mm_processor_kwargs,
                     )
 
                 with _nvtx.annotate(

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -119,13 +119,22 @@ class EncodeWorkerHandler:
             (None, None)
         )  # Send sentinel value to stop the checker
 
-    async def async_init(self, runtime: DistributedRuntime):
-        """Initialize the connector for RDMA transfers"""
+    def _init_connector(self) -> None:
+        """Initialize the connector shared by legacy and unified workers."""
         logger.info("Encode worker startup started.")
-        # Create and initialize a dynamo connector for this worker.
-        # We'll needs this to move data between this worker and remote workers efficiently.
+        # Create and initialize a Dynamo connector for moving embeddings
+        # between this worker and remote workers.
         self._connector = connect.Connector()
         logger.info("Encode worker startup completed.")
+
+    async def async_init(self, runtime: DistributedRuntime) -> None:
+        """Initialize a legacy worker while preserving its runtime contract."""
+        del runtime
+        self._init_connector()
+
+    async def async_init_unified(self) -> None:
+        """Initialize a unified engine, which does not own a Python runtime."""
+        self._init_connector()
 
     @_nvtx.range_decorator("mm:encode_worker_generate", color="blue")
     async def generate(

--- a/components/src/dynamo/vllm/multimodal_utils/protocol.py
+++ b/components/src/dynamo/vllm/multimodal_utils/protocol.py
@@ -192,6 +192,9 @@ class vLLMMultimodalRequest(vLLMGenerateRequest):
     # Add these fields for Qwen VL (mRoPE) decode-only worker
     image_grid_thw: Optional[List[List[int]]] = None
     embeddings_shape: Optional[List[int]] = None
+    # Per-request overrides for the multimodal processor. Encode workers merge
+    # these over their engine-level defaults before preprocessing the media.
+    mm_processor_kwargs: Optional[dict[str, Any]] = None
 
 
 class MyRequestOutput(BaseModel):

--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import pickle
+from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any, Optional
 
@@ -173,7 +174,9 @@ def compute_mm_uuids(
     return {modality: compute_mm_uuids_from_images(images)}
 
 
-def get_mm_processor_kwargs(request: dict[str, Any]) -> Optional[dict[str, Any]]:
+def get_mm_processor_kwargs(
+    request: Mapping[str, Any],
+) -> Optional[dict[str, Any]]:
     """Read processor kwargs from the canonical or router-compatible location."""
     value = request.get("mm_processor_kwargs")
     if value is None:

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_encode.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_encode.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("vllm.sampling_params")
+
+from dynamo.common.constants import DisaggregationMode  # noqa: E402
+from dynamo.vllm import encode_engine as encode_engine_mod  # noqa: E402
+from dynamo.vllm.encode_engine import VllmEncodeEngine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.unified,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _Context:
+    def id(self):
+        return "encode-request"
+
+
+class _Handler:
+    def __init__(self):
+        self.requests = []
+
+    async def generate(self, request, context):
+        self.requests.append((request, context))
+        yield json.dumps({"multimodal_inputs": []})
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_emits_versioned_terminal():
+    engine = VllmEncodeEngine(SimpleNamespace())
+    handler = _Handler()
+    engine._handler = handler
+
+    chunks = [
+        chunk
+        async for chunk in engine.generate(
+            {
+                "token_ids": [1],
+                "multi_modal_data": {
+                    "image_url": [{"Url": "https://example.com/image.png"}]
+                },
+            },
+            _Context(),
+        )
+    ]
+
+    assert chunks == [
+        {
+            "token_ids": [],
+            "index": 0,
+            "finish_reason": "stop",
+            "encoder_result": {
+                "schema_version": 1,
+                "multimodal_inputs": [],
+            },
+        }
+    ]
+    assert handler.requests[0][0].multimodal_inputs[0].multimodal_input.image_url == (
+        "https://example.com/image.png"
+    )
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_rejects_decoded_images():
+    engine = VllmEncodeEngine(SimpleNamespace())
+    engine._handler = _Handler()
+    with pytest.raises(ValueError, match="URL-based images only"):
+        _ = [
+            chunk
+            async for chunk in engine.generate(
+                {
+                    "token_ids": [1],
+                    "multi_modal_data": {
+                        "image_url": [{"Decoded": {"shape": [1, 1, 3]}}]
+                    },
+                },
+                _Context(),
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_from_args_builds_hidden_worker_config(monkeypatch):
+    config = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        enable_multimodal=True,
+        route_to_encoder=False,
+        served_model_name="model",
+        model="model",
+        engine_args=SimpleNamespace(served_model_name=["model"]),
+    )
+    worker_config = object()
+    from_runtime_config = MagicMock(return_value=worker_config)
+    monkeypatch.setattr(
+        encode_engine_mod.WorkerConfig, "from_runtime_config", from_runtime_config
+    )
+
+    engine, actual_worker_config = await VllmEncodeEngine.from_args([], config)
+
+    assert actual_worker_config is worker_config
+    assert engine._config is config
+    assert from_runtime_config.call_args.kwargs["enable_kv_routing"] is False
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_from_args_normalizes_served_name_fallback(monkeypatch):
+    config = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        enable_multimodal=True,
+        route_to_encoder=False,
+        served_model_name=None,
+        model="model",
+        engine_args=SimpleNamespace(served_model_name=None),
+    )
+    from_runtime_config = MagicMock(return_value=object())
+    monkeypatch.setattr(
+        encode_engine_mod.WorkerConfig, "from_runtime_config", from_runtime_config
+    )
+
+    await VllmEncodeEngine.from_args([], config)
+
+    assert config.served_model_name == "model"
+    assert config.engine_args.served_model_name == ["model"]
+    assert from_runtime_config.call_args.kwargs["served_model_name"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_cleanup_is_idempotent():
+    engine = VllmEncodeEngine(SimpleNamespace())
+    handler = SimpleNamespace(
+        cleanup=MagicMock(),
+        send_complete_checker_task=AsyncMock(return_value=None)(),
+    )
+    engine._handler = handler
+
+    await engine.cleanup()
+    await engine.cleanup()
+
+    handler.cleanup.assert_called_once_with()

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_encode.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_encode.py
@@ -12,6 +12,7 @@ pytest.importorskip("vllm.sampling_params")
 from dynamo.common.constants import DisaggregationMode  # noqa: E402
 from dynamo.vllm import encode_engine as encode_engine_mod  # noqa: E402
 from dynamo.vllm.encode_engine import VllmEncodeEngine  # noqa: E402
+from dynamo.vllm.multimodal_handlers import EncodeWorkerHandler  # noqa: E402
 
 pytestmark = [
     pytest.mark.unit,
@@ -51,6 +52,10 @@ async def test_encode_engine_emits_versioned_terminal():
                 "multi_modal_data": {
                     "image_url": [{"Url": "https://example.com/image.png"}]
                 },
+                "mm_processor_kwargs": {
+                    "min_pixels": 3136,
+                    "max_pixels": 1003520,
+                },
             },
             _Context(),
         )
@@ -70,6 +75,56 @@ async def test_encode_engine_emits_versioned_terminal():
     assert handler.requests[0][0].multimodal_inputs[0].multimodal_input.image_url == (
         "https://example.com/image.png"
     )
+    assert handler.requests[0][0].mm_processor_kwargs == {
+        "min_pixels": 3136,
+        "max_pixels": 1003520,
+    }
+
+
+def test_encode_worker_merges_and_filters_processor_kwargs():
+    class _ImageProcessor:
+        def __call__(
+            self,
+            images,
+            return_tensors=None,
+            *,
+            min_pixels=None,
+            max_pixels=None,
+        ):
+            del images, return_tensors, min_pixels, max_pixels
+
+    handler = object.__new__(EncodeWorkerHandler)
+    handler.engine_args = SimpleNamespace(
+        mm_processor_kwargs={
+            "min_pixels": 3136,
+            "max_pixels": 1003520,
+            "unsupported": True,
+        }
+    )
+    handler.image_processor = _ImageProcessor()
+
+    actual = handler._effective_mm_processor_kwargs(
+        {"max_pixels": 501760, "unsupported": False}
+    )
+
+    assert actual == {"min_pixels": 3136, "max_pixels": 501760}
+
+
+def test_encode_worker_cache_key_includes_processor_kwargs():
+    image_url = "https://example.com/image.png"
+
+    first = EncodeWorkerHandler._embedding_cache_key(
+        image_url, {"min_pixels": 3136, "max_pixels": 1003520}
+    )
+    reordered = EncodeWorkerHandler._embedding_cache_key(
+        image_url, {"max_pixels": 1003520, "min_pixels": 3136}
+    )
+    resized = EncodeWorkerHandler._embedding_cache_key(
+        image_url, {"min_pixels": 3136, "max_pixels": 501760}
+    )
+
+    assert first == reordered
+    assert first != resized
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
@@ -16,6 +16,8 @@ from dynamo.vllm.llm_engine import VllmLLMEngine  # noqa: E402
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
 
@@ -39,7 +41,9 @@ def test_main_routes_headless_to_run_dynamo_headless():
 @pytest.mark.asyncio
 async def test_main_routes_normal_node_to_run():
     """A non-headless node drives the unified Worker via run(VllmLLMEngine)."""
-    config = SimpleNamespace(headless=False)
+    config = SimpleNamespace(
+        headless=False, disaggregation_mode=DisaggregationMode.AGGREGATED
+    )
     with (
         patch.object(unified_main, "parse_args", return_value=config) as parse_args,
         patch.object(unified_main, "run_dynamo_headless") as run_headless,
@@ -63,6 +67,30 @@ async def test_main_routes_normal_node_to_run():
         assert await engine_factory(["--model", "test-model"]) == expected
 
     from_args.assert_awaited_once_with(["--model", "test-model"], config=config)
+
+
+@pytest.mark.asyncio
+async def test_main_routes_encode_node_to_dedicated_engine():
+    config = SimpleNamespace(
+        headless=False, disaggregation_mode=DisaggregationMode.ENCODE
+    )
+    with (
+        patch.object(unified_main, "parse_args", return_value=config),
+        patch.object(unified_main, "run") as run,
+    ):
+        unified_main.main()
+
+    assert run.call_args.args == (unified_main.VllmEncodeEngine,)
+    engine_factory = run.call_args.kwargs["engine_factory"]
+    expected = (MagicMock(), MagicMock())
+    with patch.object(
+        unified_main.VllmEncodeEngine,
+        "from_args",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as from_args:
+        assert await engine_factory([]) == expected
+    from_args.assert_awaited_once_with([], config=config)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -32,7 +32,7 @@ from dynamo.vllm.args import (
     parse_args,
     update_engine_config_with_dynamo,
 )
-from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.constants import DisaggregationMode, EmbeddingTransferMode
 from dynamo.vllm.headless import build_headless_namespace
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
 
@@ -367,6 +367,7 @@ def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
         enable_multimodal=False,
         frontend_decoding=False,
         multimodal_embedding_cache_capacity_gb=0.0,
+        embedding_transfer_mode=EmbeddingTransferMode.LOCAL,
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,
     )
@@ -663,6 +664,37 @@ def test_disaggregation_mode_decode(mock_vllm_cli):
     assert config.disaggregation_mode == DisaggregationMode.DECODE
     assert config.is_prefill_worker is False
     assert config.is_decode_worker is True
+
+
+def test_disaggregation_mode_encode_requires_multimodal_opt_in(mock_vllm_cli):
+    mock_vllm_cli("--model", "Qwen/Qwen3-0.6B", "--disaggregation-mode", "encode")
+    with pytest.raises(ValueError, match="require --enable-multimodal"):
+        parse_args()
+
+
+def test_disaggregation_mode_encode_accepts_multimodal_opt_in(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--disaggregation-mode",
+        "encode",
+        "--enable-multimodal",
+    )
+    config = parse_args()
+    assert config.disaggregation_mode == DisaggregationMode.ENCODE
+
+
+def test_route_to_encoder_rejects_decode_role(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--disaggregation-mode",
+        "decode",
+        "--enable-multimodal",
+        "--route-to-encoder",
+    )
+    with pytest.raises(ValueError, match="only valid"):
+        parse_args()
 
 
 def test_legacy_is_prefill_worker_emits_deprecation(mock_vllm_cli):

--- a/components/src/dynamo/vllm/unified_main.py
+++ b/components/src/dynamo/vllm/unified_main.py
@@ -10,9 +10,12 @@ See dynamo/common/backend/README.md for architecture, response contract,
 and feature gap details.
 """
 
+from dynamo.common.backend.engine import LLMEngine
 from dynamo.common.backend.run import run
 from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode
 from dynamo.vllm.args import parse_args
+from dynamo.vllm.encode_engine import VllmEncodeEngine
 from dynamo.vllm.headless import run_dynamo_headless
 from dynamo.vllm.llm_engine import VllmLLMEngine
 
@@ -27,14 +30,20 @@ def main():
         run_dynamo_headless(config)
         return
 
+    engine_cls = (
+        VllmEncodeEngine
+        if config.disaggregation_mode == DisaggregationMode.ENCODE
+        else VllmLLMEngine
+    )
+
     async def from_parsed_args(
         argv: list[str] | None = None,
-    ) -> tuple[VllmLLMEngine, WorkerConfig]:
-        return await VllmLLMEngine.from_args(argv, config=config)
+    ) -> tuple[LLMEngine, WorkerConfig]:
+        return await engine_cls.from_args(argv, config=config)
 
     # Construct from the already-parsed config without widening BaseEngine's
     # generic from_args(argv) contract with vLLM-specific arguments.
-    run(VllmLLMEngine, engine_factory=from_parsed_args)
+    run(engine_cls, engine_factory=from_parsed_args)
 
 
 if __name__ == "__main__":

--- a/tests/report_pytest_markers.py
+++ b/tests/report_pytest_markers.py
@@ -243,6 +243,7 @@ STUB_MODULES = [
     "vllm.tool_parsers.qwen3_engine_tool_parser",
     "vllm.utils",
     "vllm.utils.async_utils",
+    "vllm.utils.func_utils",
     "vllm.utils.hashing",
     "vllm.utils.system_utils",
     "vllm.v1",


### PR DESCRIPTION
## Overview:

Add a dedicated multimodal Encode engine to the unified vLLM entry point.

## Summary

- add `VllmEncodeEngine` as the producer of versioned `encoder_result` handoffs
- select the Encode engine from `dynamo.vllm.unified_main`
- initialize and clean up the existing vLLM encode handler through the unified engine lifecycle
- validate unified Encode topology and multimodal requirements

## Details:

This is stack PR 2 of 4 for [DIS-2034](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend), stacked on #11460.

The engine accepts URL-based images, runs the existing vLLM multimodal encoder, and emits an object-shaped, schema-versioned terminal handoff using the contract introduced in #10969. It remains surface-less and publishes no KV-routing metadata.

## Where should the reviewer start?

- `components/src/dynamo/vllm/encode_engine.py`
- `components/src/dynamo/vllm/unified_main.py`
- `components/src/dynamo/vllm/backend_args.py`
- `components/src/dynamo/vllm/tests/test_vllm_unified_encode.py`

## Validation

- included in the focused vLLM Python suite: 68 passed across the completed stack
- `ruff check` on changed Python files
- `python3 -m py_compile` on changed Python files
- `git diff --check`
- full-stack GPU validation is recorded in #11449

## Stack

1. #11460 — generic encoder routing and discovery
2. **This PR:** unified vLLM Encode engine
3. #11462 — unified vLLM encoder handoff consumer
4. #11449 — launchers, GPU profiles, and documentation

## Related Issues

**🔗 This PR is linked to an issue:**

- [DIS-2034: vLLM: Add separate encode worker in unified backend](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multimodal encode-mode support for image inputs in the unified vLLM backend.
  * Added request-level image preprocessing options, applied consistently during processing and caching.
  * Added routing between encode and decode engines based on the selected disaggregation mode.

* **Bug Fixes**
  * Added validation for incompatible multimodal, encoder-routing, and frontend-decoding configurations.
  * Improved embedding cache accuracy when image preprocessing settings change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->