### PR TITLE
feat(vllm): consume unified encoder handoffs

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -379,6 +379,7 @@ class DynamoVllmConfig(ConfigBase):
         self._resolve_embedding_transfer_mode()
         self._validate_multimodal_role_exclusivity()
         self._validate_multimodal_requires_flag()
+        self._validate_encoder_topology()
         self._validate_embedding_worker_exclusivity()
         self._validate_custom_encoder()
         self._validate_benchmark_config()
@@ -591,6 +592,28 @@ class DynamoVllmConfig(ConfigBase):
         if self._count_multimodal_roles() == 1 and not self.enable_multimodal:
             raise ValueError(
                 "Use --enable-multimodal when enabling any multimodal component"
+            )
+
+    def _validate_encoder_topology(self) -> None:
+        """Validate explicit unified Encode roles and encoder routing."""
+        is_encode = self.disaggregation_mode == DisaggregationMode.ENCODE
+        if (is_encode or self.route_to_encoder) and not self.enable_multimodal:
+            raise ValueError(
+                "--disaggregation-mode=encode and --route-to-encoder require "
+                "--enable-multimodal"
+            )
+        if self.route_to_encoder and self.disaggregation_mode not in (
+            DisaggregationMode.AGGREGATED,
+            DisaggregationMode.PREFILL,
+        ):
+            raise ValueError(
+                "--route-to-encoder is only valid with "
+                "--disaggregation-mode=agg or prefill"
+            )
+        if (is_encode or self.route_to_encoder) and self.frontend_decoding:
+            raise ValueError(
+                "Separate vLLM encode workers are incompatible with "
+                "--frontend-decoding because they require image URLs"
             )
 
     def _validate_custom_encoder(self) -> None:

--- a/components/src/dynamo/vllm/encode_engine.py
+++ b/components/src/dynamo/vllm/encode_engine.py
@@ -1,0 +1,159 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dedicated multimodal Encode engine for the unified vLLM backend."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncGenerator
+from typing import Any, cast
+
+from vllm.sampling_params import SamplingParams
+
+from dynamo._core import Context
+from dynamo.common.backend.engine import (
+    EngineConfig,
+    GenerateChunk,
+    GenerateRequest,
+    LLMEngine,
+    LlmRegistration,
+)
+from dynamo.common.backend.multimodal import encoder_terminal_chunk
+from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
+from dynamo.llm import ModelInput
+from dynamo.vllm.args import Config, parse_args
+
+from .multimodal_handlers import EncodeWorkerHandler
+from .multimodal_utils.protocol import (
+    MultiModalGroup,
+    MultiModalInput,
+    PatchedTokensPrompt,
+    vLLMMultimodalRequest,
+)
+
+_IMAGE_URL_KEY = "image_url"
+_URL_VARIANT_KEY = "Url"
+_ENCODER_RESULT_SCHEMA_VERSION = 1
+
+
+def _image_urls(request: GenerateRequest) -> list[str]:
+    media = request.get("multi_modal_data") or {}
+    urls: list[str] = []
+    for item in media.get(_IMAGE_URL_KEY, []):
+        if isinstance(item, dict) and isinstance(item.get(_URL_VARIANT_KEY), str):
+            urls.append(item[_URL_VARIANT_KEY])
+            continue
+        raise ValueError(
+            "The separate vLLM encode worker supports URL-based images only; "
+            "decoded image payloads must be processed by an aggregated/prefill worker"
+        )
+    return urls
+
+
+class VllmEncodeEngine(LLMEngine):
+    """Image encoder that emits a versioned Local/NIXL transfer handoff."""
+
+    def __init__(self, config: Config):
+        self._config = config
+        self._handler: EncodeWorkerHandler | None = None
+
+    @classmethod
+    async def from_args(
+        cls, argv: list[str] | None = None, config: Config | None = None
+    ) -> tuple["VllmEncodeEngine", WorkerConfig]:
+        if config is None:
+            config = parse_args(argv, fpm_trace_relay_supported=False)
+        if config.disaggregation_mode != DisaggregationMode.ENCODE:
+            raise ValueError("VllmEncodeEngine requires --disaggregation-mode=encode")
+        if not config.enable_multimodal:
+            raise ValueError("The vLLM encode worker requires --enable-multimodal")
+        if config.route_to_encoder:
+            raise ValueError("--route-to-encoder is invalid on an encode worker")
+        if not config.served_model_name:
+            engine_served_names = config.engine_args.served_model_name
+            config.served_model_name = (
+                engine_served_names[0] if engine_served_names else config.model
+            )
+        if not config.engine_args.served_model_name:
+            config.engine_args.served_model_name = [config.served_model_name]
+
+        worker_config = WorkerConfig.from_runtime_config(
+            config,
+            model_name=config.model,
+            served_model_name=config.served_model_name,
+            model_input=ModelInput.Tokens,
+            enable_kv_routing=False,
+            enable_local_indexer=False,
+        )
+        return cls(config), worker_config
+
+    async def start(self, worker_id: int) -> EngineConfig:
+        del worker_id
+        # Config validation resolves the input union to the enum; narrow the
+        # declared field type for mypy at the handler boundary.
+        transfer_mode = cast(
+            EmbeddingTransferMode, self._config.embedding_transfer_mode
+        )
+        self._handler = EncodeWorkerHandler(
+            self._config.engine_args,
+            transfer_mode,
+        )
+        await self._handler.async_init_unified()
+        return EngineConfig(
+            model=self._config.model,
+            served_model_name=self._config.served_model_name,
+            # Encode cards do not use KV metadata, but LLMEngine registration
+            # remains token-shaped and expects an llm record.
+            llm=LlmRegistration(),
+        )
+
+    async def generate(
+        self, request: GenerateRequest, context: Context
+    ) -> AsyncGenerator[GenerateChunk, None]:
+        handler = self._handler
+        if handler is None:
+            raise RuntimeError(
+                "VllmEncodeEngine.start() must complete before generate()"
+            )
+
+        groups = [
+            MultiModalGroup(multimodal_input=MultiModalInput(image_url=url))
+            for url in _image_urls(request)
+        ]
+        encode_request = vLLMMultimodalRequest(
+            engine_prompt=PatchedTokensPrompt(prompt_token_ids=[]),
+            sampling_params=SamplingParams(),
+            request_id=context.id(),
+            multimodal_inputs=groups,
+        )
+
+        payload: dict[str, Any] | None = None
+        async for serialized in handler.generate(encode_request, context):
+            payload = json.loads(serialized)
+        if payload is None:
+            raise RuntimeError("vLLM encode handler returned no result")
+
+        multimodal_inputs = payload.get("multimodal_inputs")
+        if not isinstance(multimodal_inputs, list):
+            raise RuntimeError(
+                "vLLM encode handler returned malformed multimodal_inputs"
+            )
+        yield encoder_terminal_chunk(
+            {
+                "schema_version": _ENCODER_RESULT_SCHEMA_VERSION,
+                "multimodal_inputs": multimodal_inputs,
+            }
+        )
+
+    async def cleanup(self) -> None:
+        handler, self._handler = self._handler, None
+        if handler is None:
+            return
+        handler.cleanup()
+        await asyncio.gather(
+            handler.send_complete_checker_task,
+            return_exceptions=True,
+        )

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -70,6 +70,7 @@ from dynamo.vllm.cache_info import (
 )
 from dynamo.vllm.capacity import per_rank_kv_blocks
 
+from .constants import EmbeddingTransferMode
 from .handlers import (
     VllmEnginePauseController,
     _apply_nvext_cache_salt,
@@ -84,12 +85,14 @@ from .logits_processing import (
 )
 from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.media_config import create_frontend_media_config
+from .multimodal_utils.prefill_worker_utils import EncoderResultEmbeddingLoader
 from .multimodal_utils.request_processor import VllmMultimodalRequestProcessor
 
 if TYPE_CHECKING:
     from dynamo._core.backend import EngineMetrics  # type: ignore[import-not-found]
 
 logger = logging.getLogger(__name__)
+_ENCODER_RESULT_HANDOFF_CAPABILITY = "encoder_result_handoff"
 
 
 class _UnifiedStatLogger(StatLoggerBase):
@@ -183,6 +186,8 @@ class VllmLLMEngine(LLMEngine):
         frontend_decoding: bool = False,
         multimodal_embedding_cache_capacity_gb: float = 0.0,
         namespace: str = "dynamo",
+        route_to_encoder: bool = False,
+        embedding_transfer_mode: EmbeddingTransferMode = EmbeddingTransferMode.LOCAL,
     ):
         self.engine_args = engine_args
         self.disaggregation_mode = disaggregation_mode
@@ -197,6 +202,8 @@ class VllmLLMEngine(LLMEngine):
             multimodal_embedding_cache_capacity_gb
         )
         self._namespace = namespace
+        self.route_to_encoder = route_to_encoder
+        self.embedding_transfer_mode = embedding_transfer_mode
         self.engine_client: AsyncLLM | None = None
         self._vllm_config: Any = None
         self._default_sampling_params: Any = None
@@ -252,9 +259,8 @@ class VllmLLMEngine(LLMEngine):
             config = parse_args(argv, fpm_trace_relay_supported=False)
 
         if config.disaggregation_mode == DisaggregationMode.ENCODE:
-            raise NotImplementedError(
-                "ENCODE is not supported by the unified vLLM entry point; "
-                "use `python -m dynamo.vllm` for multimodal encode workers"
+            raise ValueError(
+                "VllmLLMEngine cannot run in encode mode; use VllmEncodeEngine"
             )
 
         # Headless is handled by unified_main before engine construction; a
@@ -268,13 +274,6 @@ class VllmLLMEngine(LLMEngine):
                 "driving the unified Worker directly"
             )
 
-        if config.route_to_encoder:
-            raise NotImplementedError(
-                "--route-to-encoder is not supported by the unified vLLM entry "
-                "point yet; use `python -m dynamo.vllm` until the separate "
-                "unified encode worker is available"
-            )
-
         if not config.served_model_name:
             config.served_model_name = (
                 config.engine_args.served_model_name
@@ -282,11 +281,13 @@ class VllmLLMEngine(LLMEngine):
 
         configure_rl_logprobs_mode(config)
 
-        # _resolve_disaggregation_mode() in DynamoVllmConfig has already
-        # promoted the field to a DisaggregationMode enum; the field type
-        # is still the input union, so narrow it here for mypy (cast
-        # rather than assert so `-O` builds don't drop the narrowing).
+        # Config validation has already promoted both input unions to enums;
+        # narrow their declared field types for mypy (cast rather than assert
+        # so `-O` builds don't drop the narrowing).
         mode = cast(DisaggregationMode, config.disaggregation_mode)
+        embedding_transfer_mode = cast(
+            EmbeddingTransferMode, config.embedding_transfer_mode
+        )
         engine = cls(
             config.engine_args,
             mode,
@@ -301,6 +302,8 @@ class VllmLLMEngine(LLMEngine):
                 config.multimodal_embedding_cache_capacity_gb
             ),
             namespace=config.namespace,
+            route_to_encoder=config.route_to_encoder,
+            embedding_transfer_mode=embedding_transfer_mode,
         )
         media_decoder, media_fetcher = create_frontend_media_config(
             config.frontend_decoding
@@ -337,7 +340,7 @@ class VllmLLMEngine(LLMEngine):
 
         configure_multimodal_embedding_cache(
             self.engine_args,
-            route_to_encoder=False,
+            route_to_encoder=self.route_to_encoder,
             capacity_gb=self.multimodal_embedding_cache_capacity_gb,
             namespace=self._namespace,
             component=self._component,
@@ -359,11 +362,19 @@ class VllmLLMEngine(LLMEngine):
             usage_context=UsageContext.OPENAI_API_SERVER,
             stat_loggers=[self._stat_logger_factory],
         )
+        embedding_loader = (
+            EncoderResultEmbeddingLoader.from_transfer_mode(
+                self.embedding_transfer_mode
+            )
+            if self.route_to_encoder
+            else None
+        )
         self._multimodal_request_processor = VllmMultimodalRequestProcessor(
             model=self.engine_args.model,
             engine_client=self.engine_client,
             enable_multimodal=self.enable_multimodal,
             enable_frontend_decoding=self.frontend_decoding,
+            embedding_loader=embedding_loader,
         )
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             self._multimodal_request_processor.initialize_prefill_handoff()
@@ -392,6 +403,11 @@ class VllmLLMEngine(LLMEngine):
         return EngineConfig(
             model=self.engine_args.model,
             served_model_name=self._served_model_name,
+            runtime_data=(
+                {_ENCODER_RESULT_HANDOFF_CAPABILITY: True}
+                if self.route_to_encoder
+                else None
+            ),
             llm=LlmRegistration(
                 context_length=self._model_max_len,
                 kv_cache_block_size=block_size,

--- a/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
+++ b/components/src/dynamo/vllm/multimodal_handlers/encode_worker_handler.py
@@ -119,13 +119,22 @@ class EncodeWorkerHandler:
             (None, None)
         )  # Send sentinel value to stop the checker
 
-    async def async_init(self, runtime: DistributedRuntime):
-        """Initialize the connector for RDMA transfers"""
+    def _init_connector(self) -> None:
+        """Initialize the connector shared by legacy and unified workers."""
         logger.info("Encode worker startup started.")
-        # Create and initialize a dynamo connector for this worker.
-        # We'll needs this to move data between this worker and remote workers efficiently.
+        # Create and initialize a Dynamo connector for moving embeddings
+        # between this worker and remote workers.
         self._connector = connect.Connector()
         logger.info("Encode worker startup completed.")
+
+    async def async_init(self, runtime: DistributedRuntime) -> None:
+        """Initialize a legacy worker while preserving its runtime contract."""
+        del runtime
+        self._init_connector()
+
+    async def async_init_unified(self) -> None:
+        """Initialize a unified engine, which does not own a Python runtime."""
+        self._init_connector()
 
     @_nvtx.range_decorator("mm:encode_worker_generate", color="blue")
     async def generate(

--- a/components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py
+++ b/components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py
@@ -16,10 +16,13 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
 from dynamo.common.multimodal.embedding_transfer import (
     AbstractEmbeddingReceiver,
     LocalEmbeddingReceiver,
+    NixlReadEmbeddingReceiver,
+    NixlWriteEmbeddingReceiver,
 )
 from dynamo.common.utils.time_section import time_and_log_code_section
 from dynamo.runtime import Client
 
+from ..constants import EmbeddingTransferMode
 from .encode_utils import get_embedding_hash
 from .model import construct_mm_data
 from .protocol import (
@@ -38,12 +41,11 @@ SPLIT_ENCODE = int(os.getenv("DYN_SPLIT_ENCODE", 1))
 
 
 class _PendingRelease:
-    """Tracks NIXL tensor buffers that should be released after consumption.
+    """Tracks transferred tensors that should be released after consumption.
 
-    For NIXL receivers, embeddings are views into pre-allocated reusable
-    buffers.  Instead of cloning each embedding eagerly, we defer the
-    release until the caller has consumed the tensors (e.g. via
-    ``_accumulate_embeddings`` which copies data through ``torch.cat``).
+    NIXL releases return reusable buffers, while local releases remove the
+    temporary safetensors file. Instead of cloning every embedding eagerly,
+    release is deferred until the caller has consumed the tensors.
     """
 
     __slots__ = ("_receiver", "_tensor_ids")
@@ -349,3 +351,93 @@ class MultiModalEmbeddingLoader:
             pending.release_all()
 
         return multi_modal_data
+
+
+class EncoderResultEmbeddingLoader:
+    """Receive embeddings described by a unified ``encoder_result`` handoff."""
+
+    SCHEMA_VERSION = 1
+
+    def __init__(self, receiver: AbstractEmbeddingReceiver):
+        self._receiver = receiver
+
+    @classmethod
+    def from_transfer_mode(
+        cls, transfer_mode: EmbeddingTransferMode
+    ) -> "EncoderResultEmbeddingLoader":
+        if transfer_mode == EmbeddingTransferMode.LOCAL:
+            receiver: AbstractEmbeddingReceiver = LocalEmbeddingReceiver()
+        elif transfer_mode == EmbeddingTransferMode.NIXL_WRITE:
+            receiver = NixlWriteEmbeddingReceiver()
+        elif transfer_mode == EmbeddingTransferMode.NIXL_READ:
+            # Match the shared receiver factory and legacy vLLM path. Image
+            # embedding shapes vary, so fixed-size pre-registered descriptors
+            # cannot be reused safely; the default pool would also reserve
+            # roughly 8 GiB before the first request.
+            receiver = NixlReadEmbeddingReceiver(max_items=0)
+        else:
+            raise ValueError(f"Invalid embedding transfer mode: {transfer_mode}")
+        return cls(receiver)
+
+    async def load_encoder_result(
+        self,
+        encoder_result: dict[str, Any],
+        *,
+        model: str,
+        request_id: str,
+    ) -> Dict[str, Any]:
+        version = encoder_result.get("schema_version")
+        if version != self.SCHEMA_VERSION:
+            raise ValueError(
+                "Unsupported vLLM encoder_result schema_version "
+                f"{version!r}; expected {self.SCHEMA_VERSION}"
+            )
+        raw_groups = encoder_result.get("multimodal_inputs")
+        if not isinstance(raw_groups, list):
+            raise ValueError("encoder_result.multimodal_inputs must be a list")
+
+        groups = [MultiModalGroup.model_validate(group) for group in raw_groups]
+        receive_groups = [
+            group for group in groups if group.serialized_request is not None
+        ]
+        pending = _PendingRelease(self._receiver)
+        is_local = isinstance(self._receiver, LocalEmbeddingReceiver)
+
+        async def receive_group(group: MultiModalGroup) -> None:
+            assert group.serialized_request is not None
+            tensor_id, embedding = await self._receiver.receive_embeddings(
+                group.serialized_request
+            )
+            pending.track(tensor_id)
+            group.loaded_embedding = embedding
+
+        multi_modal_data: Dict[str, Any] = {}
+        try:
+            receive_results = await asyncio.gather(
+                *(receive_group(group) for group in receive_groups),
+                return_exceptions=True,
+            )
+            for result in receive_results:
+                if isinstance(result, BaseException):
+                    raise result
+
+            with time_and_log_code_section(
+                f"[PREFILL] request: {request_id} accumulate encoder_result"
+            ):
+                for group in groups:
+                    if group.loaded_embedding is None:
+                        raise ValueError(
+                            "encoder_result multimodal input is missing transfer metadata"
+                        )
+                    _accumulate_embeddings(
+                        multi_modal_data,
+                        model,
+                        group.loaded_embedding.dtype,
+                        group.loaded_embedding,
+                        group.image_grid_thw,
+                    )
+            if not is_local and len(groups) == 1:
+                _ensure_owned_tensors(multi_modal_data)
+            return multi_modal_data
+        finally:
+            pending.release_all()

--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -321,11 +321,35 @@ class VllmMultimodalRequestProcessor:
                 return None
 
             vllm_mm_data: dict[str, Any] = {}
+            encoder_result = request.get("encoder_result")
 
             # A separate encoder currently supports URL-based images only. Keep
             # processing other modalities locally so mixed image/video requests
             # preserve all of their inputs.
-            if self.embedding_loader is not None:
+            if encoder_result is not None:
+                if not isinstance(encoder_result, dict):
+                    raise ValueError("encoder_result must be a JSON object")
+                load_result = getattr(
+                    self.embedding_loader, "load_encoder_result", None
+                )
+                if load_result is None:
+                    raise ValueError(
+                        "Received encoder_result but no compatible embedding receiver "
+                        "is configured"
+                    )
+                vllm_mm_data = await load_result(
+                    encoder_result,
+                    model=self.model,
+                    request_id=request_id,
+                )
+            elif self.embedding_loader is not None:
+                load_multimodal_embeddings = getattr(
+                    self.embedding_loader, "load_multimodal_embeddings", None
+                )
+                if load_multimodal_embeddings is None:
+                    raise ValueError(
+                        "Received multimodal data but no encoder_result was provided"
+                    )
                 image_urls: list[str] = []
                 supported = True
                 for item in mm_map.get(IMAGE_URL_KEY, []):
@@ -334,18 +358,16 @@ class VllmMultimodalRequestProcessor:
                     elif isinstance(item, dict) and "Decoded" in item:
                         supported = False
                 if supported:
-                    vllm_mm_data = (
-                        await self.embedding_loader.load_multimodal_embeddings(
-                            image_urls,
-                            request_id,
-                            model=self.model,
-                            context=context,
-                        )
+                    vllm_mm_data = await load_multimodal_embeddings(
+                        image_urls,
+                        request_id,
+                        model=self.model,
+                        context=context,
                     )
 
             image_items = mm_map.get(IMAGE_URL_KEY, [])
             image_key = "vision_chunk" if self.use_unified_vision_chunk else "image"
-            if image_key not in vllm_mm_data and image_items:
+            if encoder_result is None and image_key not in vllm_mm_data and image_items:
                 with _nvtx.annotate("mm_backend:image_download", color="green"):
                     images = await self.image_loader.load_image_batch(image_items)
                 if images:

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
@@ -115,6 +115,59 @@ async def test_merges_encoder_images_with_local_video_and_decoded_fallback():
 
 
 @pytest.mark.asyncio
+async def test_consumes_unified_encoder_result_and_keeps_video_local():
+    processor = _processor()
+    encoded_image = {"image_embeds": object()}
+    video = object()
+    processor.embedding_loader = SimpleNamespace(
+        load_encoder_result=AsyncMock(return_value={"image": encoded_image})
+    )
+    processor.video_loader.load_video_batch.return_value = [video]
+    handoff = {"schema_version": 1, "multimodal_inputs": []}
+
+    result = await processor.extract_multimodal_data(
+        {
+            "encoder_result": handoff,
+            "multi_modal_data": {
+                "image_url": [{"Url": "https://example.com/image.png"}],
+                "video_url": [{"Url": "https://example.com/video.mp4"}],
+            },
+        },
+        "request-unified-encoder",
+        None,
+    )
+
+    assert result == {"image": encoded_image, "video": video}
+    processor.embedding_loader.load_encoder_result.assert_awaited_once_with(
+        handoff,
+        model=processor.model,
+        request_id="request-unified-encoder",
+    )
+    processor.image_loader.load_image_batch.assert_not_awaited()
+    processor.video_loader.load_video_batch.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unified_embedding_loader_requires_encoder_result():
+    processor = _processor()
+    processor.embedding_loader = SimpleNamespace(load_encoder_result=AsyncMock())
+
+    with pytest.raises(ValueError, match="no encoder_result was provided"):
+        await processor.extract_multimodal_data(
+            {
+                "multi_modal_data": {
+                    "image_url": [{"Url": "https://example.com/image.png"}]
+                }
+            },
+            "request-missing-encoder-result",
+            None,
+        )
+
+    processor.embedding_loader.load_encoder_result.assert_not_awaited()
+    processor.image_loader.load_image_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_rejects_media_when_multimodal_is_disabled():
     processor = _processor(enabled=False)
 

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_encode.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_encode.py
@@ -1,0 +1,151 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("vllm.sampling_params")
+
+from dynamo.common.constants import DisaggregationMode  # noqa: E402
+from dynamo.vllm import encode_engine as encode_engine_mod  # noqa: E402
+from dynamo.vllm.encode_engine import VllmEncodeEngine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.unified,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+class _Context:
+    def id(self):
+        return "encode-request"
+
+
+class _Handler:
+    def __init__(self):
+        self.requests = []
+
+    async def generate(self, request, context):
+        self.requests.append((request, context))
+        yield json.dumps({"multimodal_inputs": []})
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_emits_versioned_terminal():
+    engine = VllmEncodeEngine(SimpleNamespace())
+    handler = _Handler()
+    engine._handler = handler
+
+    chunks = [
+        chunk
+        async for chunk in engine.generate(
+            {
+                "token_ids": [1],
+                "multi_modal_data": {
+                    "image_url": [{"Url": "https://example.com/image.png"}]
+                },
+            },
+            _Context(),
+        )
+    ]
+
+    assert chunks == [
+        {
+            "token_ids": [],
+            "index": 0,
+            "finish_reason": "stop",
+            "encoder_result": {
+                "schema_version": 1,
+                "multimodal_inputs": [],
+            },
+        }
+    ]
+    assert handler.requests[0][0].multimodal_inputs[0].multimodal_input.image_url == (
+        "https://example.com/image.png"
+    )
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_rejects_decoded_images():
+    engine = VllmEncodeEngine(SimpleNamespace())
+    engine._handler = _Handler()
+    with pytest.raises(ValueError, match="URL-based images only"):
+        _ = [
+            chunk
+            async for chunk in engine.generate(
+                {
+                    "token_ids": [1],
+                    "multi_modal_data": {
+                        "image_url": [{"Decoded": {"shape": [1, 1, 3]}}]
+                    },
+                },
+                _Context(),
+            )
+        ]
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_from_args_builds_hidden_worker_config(monkeypatch):
+    config = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        enable_multimodal=True,
+        route_to_encoder=False,
+        served_model_name="model",
+        model="model",
+        engine_args=SimpleNamespace(served_model_name=["model"]),
+    )
+    worker_config = object()
+    from_runtime_config = MagicMock(return_value=worker_config)
+    monkeypatch.setattr(
+        encode_engine_mod.WorkerConfig, "from_runtime_config", from_runtime_config
+    )
+
+    engine, actual_worker_config = await VllmEncodeEngine.from_args([], config)
+
+    assert actual_worker_config is worker_config
+    assert engine._config is config
+    assert from_runtime_config.call_args.kwargs["enable_kv_routing"] is False
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_from_args_normalizes_served_name_fallback(monkeypatch):
+    config = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        enable_multimodal=True,
+        route_to_encoder=False,
+        served_model_name=None,
+        model="model",
+        engine_args=SimpleNamespace(served_model_name=None),
+    )
+    from_runtime_config = MagicMock(return_value=object())
+    monkeypatch.setattr(
+        encode_engine_mod.WorkerConfig, "from_runtime_config", from_runtime_config
+    )
+
+    await VllmEncodeEngine.from_args([], config)
+
+    assert config.served_model_name == "model"
+    assert config.engine_args.served_model_name == ["model"]
+    assert from_runtime_config.call_args.kwargs["served_model_name"] == "model"
+
+
+@pytest.mark.asyncio
+async def test_encode_engine_cleanup_is_idempotent():
+    engine = VllmEncodeEngine(SimpleNamespace())
+    handler = SimpleNamespace(
+        cleanup=MagicMock(),
+        send_complete_checker_task=AsyncMock(return_value=None)(),
+    )
+    engine._handler = handler
+
+    await engine.cleanup()
+    await engine.cleanup()
+
+    handler.cleanup.assert_called_once_with()

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_main.py
@@ -16,6 +16,8 @@ from dynamo.vllm.llm_engine import VllmLLMEngine  # noqa: E402
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
 
@@ -39,7 +41,9 @@ def test_main_routes_headless_to_run_dynamo_headless():
 @pytest.mark.asyncio
 async def test_main_routes_normal_node_to_run():
     """A non-headless node drives the unified Worker via run(VllmLLMEngine)."""
-    config = SimpleNamespace(headless=False)
+    config = SimpleNamespace(
+        headless=False, disaggregation_mode=DisaggregationMode.AGGREGATED
+    )
     with (
         patch.object(unified_main, "parse_args", return_value=config) as parse_args,
         patch.object(unified_main, "run_dynamo_headless") as run_headless,
@@ -63,6 +67,30 @@ async def test_main_routes_normal_node_to_run():
         assert await engine_factory(["--model", "test-model"]) == expected
 
     from_args.assert_awaited_once_with(["--model", "test-model"], config=config)
+
+
+@pytest.mark.asyncio
+async def test_main_routes_encode_node_to_dedicated_engine():
+    config = SimpleNamespace(
+        headless=False, disaggregation_mode=DisaggregationMode.ENCODE
+    )
+    with (
+        patch.object(unified_main, "parse_args", return_value=config),
+        patch.object(unified_main, "run") as run,
+    ):
+        unified_main.main()
+
+    assert run.call_args.args == (unified_main.VllmEncodeEngine,)
+    engine_factory = run.call_args.kwargs["engine_factory"]
+    expected = (MagicMock(), MagicMock())
+    with patch.object(
+        unified_main.VllmEncodeEngine,
+        "from_args",
+        new_callable=AsyncMock,
+        return_value=expected,
+    ) as from_args:
+        assert await engine_factory([]) == expected
+    from_args.assert_awaited_once_with([], config=config)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py
@@ -1,13 +1,27 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from dynamo.common.constants import DisaggregationMode
-from dynamo.vllm.multimodal_utils.request_processor import PreparedMultimodalPrompt
+pytest.importorskip("vllm.v1.engine.async_llm")
+pytest.importorskip("vllm.usage.usage_lib")
+
+from dynamo.common.constants import DisaggregationMode  # noqa: E402
+from dynamo.vllm import llm_engine as llm_engine_mod  # noqa: E402
+from dynamo.vllm.constants import EmbeddingTransferMode  # noqa: E402
+from dynamo.vllm.multimodal_utils import (  # noqa: E402
+    prefill_worker_utils as prefill_worker_utils_mod,
+)
+from dynamo.vllm.multimodal_utils.prefill_worker_utils import (  # noqa: E402
+    EncoderResultEmbeddingLoader,
+)
+from dynamo.vllm.multimodal_utils.request_processor import (  # noqa: E402
+    PreparedMultimodalPrompt,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -45,9 +59,7 @@ class _EngineClient:
 
 
 def _engine(mode=DisaggregationMode.AGGREGATED, responses=()):
-    from dynamo.vllm import llm_engine as mod
-
-    engine = mod.VllmLLMEngine(
+    engine = llm_engine_mod.VllmLLMEngine(
         SimpleNamespace(model="Qwen/Qwen3-VL-2B-Instruct"),
         mode,
         served_model_name="Qwen/Qwen3-VL-2B-Instruct",
@@ -67,8 +79,6 @@ def _sampling_params():
 
 @pytest.mark.asyncio
 async def test_generate_submits_prepared_multimodal_prompt(monkeypatch):
-    from dynamo.vllm import llm_engine as mod
-
     engine = _engine()
     prompt = {
         "prompt_token_ids": [1, 2, 3],
@@ -85,7 +95,7 @@ async def test_generate_submits_prepared_multimodal_prompt(monkeypatch):
     )
     engine._multimodal_request_processor = processor
     build_sampling_params = MagicMock(return_value=_sampling_params())
-    monkeypatch.setattr(mod, "build_sampling_params", build_sampling_params)
+    monkeypatch.setattr(llm_engine_mod, "build_sampling_params", build_sampling_params)
 
     chunks = [
         chunk
@@ -108,8 +118,6 @@ async def test_generate_submits_prepared_multimodal_prompt(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_prefill_terminal_adds_embedding_handoff(monkeypatch):
-    from dynamo.vllm import llm_engine as mod
-
     output = SimpleNamespace(
         index=0,
         token_ids=[42],
@@ -142,7 +150,9 @@ async def test_prefill_terminal_adds_embedding_handoff(monkeypatch):
     )
     engine._multimodal_request_processor = processor
     monkeypatch.setattr(
-        mod, "build_sampling_params", lambda *args, **kwargs: _sampling_params()
+        llm_engine_mod,
+        "build_sampling_params",
+        lambda *args, **kwargs: _sampling_params(),
     )
 
     chunks = [
@@ -173,37 +183,24 @@ async def test_prefill_terminal_adds_embedding_handoff(monkeypatch):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    ("mode", "route_to_encoder", "message"),
-    [
-        (DisaggregationMode.ENCODE, False, "ENCODE is not supported"),
-        (DisaggregationMode.AGGREGATED, True, "--route-to-encoder is not supported"),
-    ],
-)
-async def test_from_args_rejects_unsupported_multimodal_topologies(
-    monkeypatch, mode, route_to_encoder, message
-):
-    from dynamo.vllm import llm_engine as mod
-
+async def test_llm_engine_rejects_encode_role(monkeypatch):
     config = SimpleNamespace(
-        disaggregation_mode=mode,
-        route_to_encoder=route_to_encoder,
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        route_to_encoder=False,
         headless=False,
     )
     monkeypatch.setattr(
-        mod,
+        llm_engine_mod,
         "parse_args",
         lambda argv, fpm_trace_relay_supported=False: config,
     )
 
-    with pytest.raises(NotImplementedError, match=message):
-        await mod.VllmLLMEngine.from_args([])
+    with pytest.raises(ValueError, match="VllmEncodeEngine"):
+        await llm_engine_mod.VllmLLMEngine.from_args([])
 
 
 @pytest.mark.asyncio
 async def test_from_args_retains_multimodal_runtime_configuration(monkeypatch):
-    from dynamo.vllm import llm_engine as mod
-
     config = SimpleNamespace(
         disaggregation_mode=DisaggregationMode.AGGREGATED,
         route_to_encoder=False,
@@ -216,6 +213,7 @@ async def test_from_args_retains_multimodal_runtime_configuration(monkeypatch):
         enable_multimodal=True,
         frontend_decoding=True,
         multimodal_embedding_cache_capacity_gb=2.5,
+        embedding_transfer_mode=llm_engine_mod.EmbeddingTransferMode.LOCAL,
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,
         engine_args=SimpleNamespace(
@@ -225,23 +223,172 @@ async def test_from_args_retains_multimodal_runtime_configuration(monkeypatch):
     worker_config = object()
     from_runtime_config = MagicMock(return_value=worker_config)
     monkeypatch.setattr(
-        mod,
+        llm_engine_mod,
         "parse_args",
         lambda argv, fpm_trace_relay_supported=False: config,
     )
     monkeypatch.setattr(
-        mod.WorkerConfig,
+        llm_engine_mod.WorkerConfig,
         "from_runtime_config",
         from_runtime_config,
     )
 
-    engine, actual_worker_config = await mod.VllmLLMEngine.from_args([])
+    engine, actual_worker_config = await llm_engine_mod.VllmLLMEngine.from_args([])
 
     assert actual_worker_config is worker_config
     assert engine.enable_multimodal is True
     assert engine.frontend_decoding is True
     assert engine.multimodal_embedding_cache_capacity_gb == 2.5
     assert engine._namespace == "deployment"
+    assert engine.route_to_encoder is False
+    assert engine.embedding_transfer_mode == llm_engine_mod.EmbeddingTransferMode.LOCAL
     worker_overrides = from_runtime_config.call_args.kwargs
     assert worker_overrides["media_decoder"] is not None
     assert worker_overrides["media_fetcher"] is not None
+
+
+@pytest.mark.asyncio
+async def test_from_args_accepts_separate_encoder_routing(monkeypatch):
+    config = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.PREFILL,
+        route_to_encoder=True,
+        headless=False,
+        served_model_name="model",
+        model="model",
+        component="prefill",
+        namespace="deployment",
+        enable_rl=False,
+        enable_multimodal=True,
+        frontend_decoding=False,
+        multimodal_embedding_cache_capacity_gb=0.0,
+        embedding_transfer_mode=llm_engine_mod.EmbeddingTransferMode.NIXL_WRITE,
+        dyn_tool_call_parser=None,
+        dyn_reasoning_parser=None,
+        engine_args=SimpleNamespace(
+            model="model", served_model_name=["model"], logprobs_mode="raw_logprobs"
+        ),
+    )
+    monkeypatch.setattr(
+        llm_engine_mod,
+        "parse_args",
+        lambda argv, fpm_trace_relay_supported=False: config,
+    )
+    monkeypatch.setattr(
+        llm_engine_mod.WorkerConfig,
+        "from_runtime_config",
+        MagicMock(return_value=object()),
+    )
+
+    engine, _ = await llm_engine_mod.VllmLLMEngine.from_args([])
+
+    assert engine.route_to_encoder is True
+    assert (
+        engine.embedding_transfer_mode
+        == llm_engine_mod.EmbeddingTransferMode.NIXL_WRITE
+    )
+
+
+@pytest.mark.asyncio
+async def test_encoder_result_loader_validates_schema():
+    loader = EncoderResultEmbeddingLoader(AsyncMock())
+    with pytest.raises(ValueError, match="schema_version"):
+        await loader.load_encoder_result(
+            {"schema_version": 2, "multimodal_inputs": []},
+            model="model",
+            request_id="request",
+        )
+
+
+def test_encoder_result_loader_selects_matching_receiver(monkeypatch):
+    receiver = object()
+    constructor = MagicMock(return_value=receiver)
+    monkeypatch.setattr(
+        prefill_worker_utils_mod, "NixlWriteEmbeddingReceiver", constructor
+    )
+
+    loader = EncoderResultEmbeddingLoader.from_transfer_mode(
+        EmbeddingTransferMode.NIXL_WRITE
+    )
+
+    assert loader._receiver is receiver
+
+
+def _encoder_result(*serialized_requests):
+    return {
+        "schema_version": 1,
+        "multimodal_inputs": [
+            {
+                "serialized_request": {
+                    "embeddings_shape": [1, 1],
+                    "embedding_dtype_str": "float32",
+                    "serialized_request": serialized_request,
+                }
+            }
+            for serialized_request in serialized_requests
+        ],
+    }
+
+
+@pytest.mark.asyncio
+async def test_encoder_result_loader_releases_partial_receive_successes():
+    class PartiallyFailingReceiver:
+        def __init__(self):
+            self.received = asyncio.Event()
+            self.released = []
+
+        async def receive_embeddings(self, request):
+            if request.serialized_request == "success":
+                self.received.set()
+                return 7, prefill_worker_utils_mod.torch.ones((1, 1))
+            await self.received.wait()
+            raise RuntimeError("receive failed")
+
+        def release_tensor(self, tensor_id):
+            self.released.append(tensor_id)
+
+    receiver = PartiallyFailingReceiver()
+    loader = EncoderResultEmbeddingLoader(receiver)
+
+    with pytest.raises(RuntimeError, match="receive failed"):
+        await loader.load_encoder_result(
+            _encoder_result("success", "failure"),
+            model="model",
+            request_id="request",
+        )
+
+    assert receiver.released == [7]
+
+
+@pytest.mark.asyncio
+async def test_encoder_result_loader_releases_local_transfer(monkeypatch):
+    class RecordingLocalReceiver(prefill_worker_utils_mod.LocalEmbeddingReceiver):
+        def __init__(self):
+            self.embedding = prefill_worker_utils_mod.torch.ones((1, 1))
+            self.released = []
+
+        async def receive_embeddings(self, request):
+            return 11, self.embedding
+
+        def release_tensor(self, tensor_id):
+            self.released.append(tensor_id)
+
+    receiver = RecordingLocalReceiver()
+    ensure_owned = MagicMock()
+    monkeypatch.setattr(prefill_worker_utils_mod, "_ensure_owned_tensors", ensure_owned)
+    monkeypatch.setattr(
+        prefill_worker_utils_mod,
+        "_accumulate_embeddings",
+        lambda output, model, dtype, embedding, image_grid_thw: output.update(
+            image=embedding
+        ),
+    )
+
+    result = await EncoderResultEmbeddingLoader(receiver).load_encoder_result(
+        _encoder_result("local"),
+        model="model",
+        request_id="request",
+    )
+
+    assert result["image"] is receiver.embedding
+    assert receiver.released == [11]
+    ensure_owned.assert_not_called()

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -32,7 +32,7 @@ from dynamo.vllm.args import (
     parse_args,
     update_engine_config_with_dynamo,
 )
-from dynamo.vllm.constants import DisaggregationMode
+from dynamo.vllm.constants import DisaggregationMode, EmbeddingTransferMode
 from dynamo.vllm.headless import build_headless_namespace
 from dynamo.vllm.tests.conftest import make_cli_args_fixture
 
@@ -367,6 +367,7 @@ def test_unified_from_args_applies_rl_logprobs_default(monkeypatch):
         enable_multimodal=False,
         frontend_decoding=False,
         multimodal_embedding_cache_capacity_gb=0.0,
+        embedding_transfer_mode=EmbeddingTransferMode.LOCAL,
         dyn_tool_call_parser=None,
         dyn_reasoning_parser=None,
     )
@@ -663,6 +664,37 @@ def test_disaggregation_mode_decode(mock_vllm_cli):
     assert config.disaggregation_mode == DisaggregationMode.DECODE
     assert config.is_prefill_worker is False
     assert config.is_decode_worker is True
+
+
+def test_disaggregation_mode_encode_requires_multimodal_opt_in(mock_vllm_cli):
+    mock_vllm_cli("--model", "Qwen/Qwen3-0.6B", "--disaggregation-mode", "encode")
+    with pytest.raises(ValueError, match="require --enable-multimodal"):
+        parse_args()
+
+
+def test_disaggregation_mode_encode_accepts_multimodal_opt_in(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--disaggregation-mode",
+        "encode",
+        "--enable-multimodal",
+    )
+    config = parse_args()
+    assert config.disaggregation_mode == DisaggregationMode.ENCODE
+
+
+def test_route_to_encoder_rejects_decode_role(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--disaggregation-mode",
+        "decode",
+        "--enable-multimodal",
+        "--route-to-encoder",
+    )
+    with pytest.raises(ValueError, match="only valid"):
+        parse_args()
 
 
 def test_legacy_is_prefill_worker_emits_deprecation(mock_vllm_cli):

--- a/components/src/dynamo/vllm/unified_main.py
+++ b/components/src/dynamo/vllm/unified_main.py
@@ -10,9 +10,12 @@ See dynamo/common/backend/README.md for architecture, response contract,
 and feature gap details.
 """
 
+from dynamo.common.backend.engine import LLMEngine
 from dynamo.common.backend.run import run
 from dynamo.common.backend.worker import WorkerConfig
+from dynamo.common.constants import DisaggregationMode
 from dynamo.vllm.args import parse_args
+from dynamo.vllm.encode_engine import VllmEncodeEngine
 from dynamo.vllm.headless import run_dynamo_headless
 from dynamo.vllm.llm_engine import VllmLLMEngine
 
@@ -27,14 +30,20 @@ def main():
         run_dynamo_headless(config)
         return
 
+    engine_cls = (
+        VllmEncodeEngine
+        if config.disaggregation_mode == DisaggregationMode.ENCODE
+        else VllmLLMEngine
+    )
+
     async def from_parsed_args(
         argv: list[str] | None = None,
-    ) -> tuple[VllmLLMEngine, WorkerConfig]:
-        return await VllmLLMEngine.from_args(argv, config=config)
+    ) -> tuple[LLMEngine, WorkerConfig]:
+        return await engine_cls.from_args(argv, config=config)
 
     # Construct from the already-parsed config without widening BaseEngine's
     # generic from_args(argv) contract with vLLM-specific arguments.
-    run(VllmLLMEngine, engine_factory=from_parsed_args)
+    run(engine_cls, engine_factory=from_parsed_args)
 
 
 if __name__ == "__main__":

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -154,6 +154,16 @@ impl Model {
         self.worker_sets.len()
     }
 
+    /// Snapshot all WorkerSets. Used by cross-role lifecycle coordination
+    /// where storage keys include role/surface suffixes but deployment
+    /// matching is based on `WorkerSet::namespace()`.
+    pub(crate) fn worker_sets(&self) -> Vec<Arc<WorkerSet>> {
+        self.worker_sets
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+
     /// Check if this model has any decode engine (chat or completions) across any WorkerSet.
     pub fn has_decode_engine(&self) -> bool {
         self.worker_sets

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -66,6 +66,14 @@ enum PrefillActivationState {
     PrefillReady(Box<Endpoint>),
 }
 
+/// State for the optional Encode endpoint / token-pipeline rendezvous.
+#[derive(Default)]
+struct EncoderActivationState {
+    consumer: Option<oneshot::Sender<Endpoint>>,
+    endpoint: Option<Box<Endpoint>>,
+    routing_enabled: bool,
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum ModelManagerError {
     #[error("Model not found: {0}")]
@@ -100,6 +108,9 @@ pub struct ModelManager {
 
     /// Prefill router activation rendezvous, keyed by "model_name:namespace".
     prefill_router_activators: DashMap<String, PrefillActivationState>,
+
+    /// Encode router activation rendezvous, keyed by "model_name:namespace".
+    encoder_router_activators: DashMap<String, EncoderActivationState>,
 
     /// Per-endpoint runtime config watchers. Keyed by EndpointId (includes namespace).
     runtime_configs: DashMap<EndpointId, RuntimeConfigWatch>,
@@ -138,6 +149,7 @@ impl ModelManager {
             models: DashMap::new(),
             cards: DashMap::new(),
             prefill_router_activators: DashMap::new(),
+            encoder_router_activators: DashMap::new(),
             runtime_configs: DashMap::new(),
             lora_routing_table,
             lora_state_tracker,
@@ -1266,6 +1278,157 @@ impl ModelManager {
         }
     }
 
+    /// Register the optional encoder hop for a token-serving WorkerSet.
+    /// A cached Encode endpoint activates rebuilt consumers immediately.
+    pub fn register_encoder_router(
+        &self,
+        model_name: &str,
+        namespace: &str,
+    ) -> Option<oneshot::Receiver<Endpoint>> {
+        let key = Self::model_namespace_key(model_name, namespace);
+        match self.encoder_router_activators.entry(key) {
+            Entry::Occupied(mut o) => {
+                if o.get().consumer.is_some() {
+                    tracing::error!(
+                        model_name = %model_name,
+                        namespace = %namespace,
+                        "Token WorkerSet already registered for this encoder router"
+                    );
+                    return None;
+                }
+                let (tx, rx) = oneshot::channel();
+                let state = o.get_mut();
+                if state.routing_enabled {
+                    if let Some(endpoint) = state.endpoint.as_ref() {
+                        let _ = tx.send((**endpoint).clone());
+                    } else {
+                        state.consumer = Some(tx);
+                    }
+                } else {
+                    state.consumer = Some(tx);
+                }
+                Some(rx)
+            }
+            Entry::Vacant(v) => {
+                let (tx, rx) = oneshot::channel();
+                v.insert(EncoderActivationState {
+                    consumer: Some(tx),
+                    ..Default::default()
+                });
+                Some(rx)
+            }
+        }
+    }
+
+    /// Mark the model namespace as explicitly depending on an Encode worker.
+    /// Activation waits for both this signal and an Encode endpoint so worker
+    /// discovery order does not change routing behavior.
+    pub fn enable_encoder_routing(&self, model_name: &str, namespace: &str) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        // Option::zip would eagerly evaluate consumer.take(), dropping the
+        // waiter when the Encode endpoint has not arrived yet.
+        #[allow(clippy::manual_option_zip)]
+        let sender_and_endpoint = match self.encoder_router_activators.entry(key) {
+            Entry::Occupied(mut o) => {
+                let state = o.get_mut();
+                state.routing_enabled = true;
+                state
+                    .endpoint
+                    .as_ref()
+                    .map(|endpoint| (**endpoint).clone())
+                    .and_then(|endpoint| state.consumer.take().map(|sender| (sender, endpoint)))
+            }
+            Entry::Vacant(v) => {
+                v.insert(EncoderActivationState {
+                    routing_enabled: true,
+                    ..Default::default()
+                });
+                None
+            }
+        };
+        if let Some((sender, endpoint)) = sender_and_endpoint {
+            let _ = sender.send(endpoint);
+        }
+    }
+
+    /// Publish an Encode endpoint and activate any waiting token pipeline.
+    pub fn activate_encoder_router(&self, model_name: &str, namespace: &str, endpoint: Endpoint) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        let reactivate_if_needed = || {
+            if let Some(model) = self.get_model(model_name)
+                && let Some(ws) = model
+                    .worker_sets()
+                    .into_iter()
+                    .find(|ws| ws.namespace() == namespace && ws.encoder_router.is_some())
+                && let Some(ref router) = ws.encoder_router
+                && router.is_deactivated()
+            {
+                router.reactivate();
+                true
+            } else {
+                false
+            }
+        };
+
+        let sender = match self.encoder_router_activators.entry(key) {
+            Entry::Occupied(mut o) => {
+                let state = o.get_mut();
+                state.endpoint = Some(Box::new(endpoint.clone()));
+                state
+                    .routing_enabled
+                    .then(|| state.consumer.take())
+                    .flatten()
+            }
+            Entry::Vacant(v) => {
+                v.insert(EncoderActivationState {
+                    endpoint: Some(Box::new(endpoint.clone())),
+                    ..Default::default()
+                });
+                None
+            }
+        };
+        if let Some(sender) = sender {
+            if sender.send(endpoint).is_err() {
+                tracing::warn!(
+                    model_name = %model_name,
+                    namespace = %namespace,
+                    "Encoder router consumer disappeared before activation; endpoint remains cached"
+                );
+            }
+        } else {
+            reactivate_if_needed();
+        }
+    }
+
+    /// Drop a stale Encode endpoint and make existing token pipelines bypass it.
+    pub fn remove_encoder_activator(&self, model_name: &str, namespace: &str) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        if let Some(mut state) = self.encoder_router_activators.get_mut(&key) {
+            state.endpoint = None;
+        }
+    }
+
+    pub fn deactivate_encoder_router_for_consumers(&self, model_name: &str, namespace: &str) {
+        if let Some(model) = self.get_model(model_name) {
+            for ws in model.worker_sets() {
+                if ws.namespace() == namespace
+                    && let Some(ref router) = ws.encoder_router
+                {
+                    router.deactivate();
+                }
+            }
+        }
+    }
+
+    /// Remove a waiter owned by a token WorkerSet that failed or was removed,
+    /// while preserving a cached live Encode endpoint for rebuilds.
+    pub fn remove_consumer_encoder_waiter(&self, model_name: &str, namespace: &str) {
+        let key = Self::model_namespace_key(model_name, namespace);
+        if let Some(mut state) = self.encoder_router_activators.get_mut(&key) {
+            state.consumer = None;
+        }
+    }
+
     // -- Worker monitoring --
 
     /// Gets or sets the load threshold config for a model's worker monitor.
@@ -1437,6 +1600,8 @@ fn has_required_kv_transfer_policy(configs: &HashMap<WorkerId, ModelRuntimeConfi
 mod tests {
     use super::*;
     use std::collections::HashMap;
+
+    use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
 
     use crate::local_model::runtime_config::ModelRuntimeConfig;
     use crate::model_card::ModelDeploymentCard;
@@ -1923,6 +2088,107 @@ mod tests {
         let mm = ModelManager::new();
         // Should not panic
         mm.remove_prefill_activator("llama", "ns1");
+    }
+
+    #[test]
+    fn test_encoder_router_registration_and_waiter_cleanup() {
+        let mm = ModelManager::new();
+        let rx = mm.register_encoder_router("llama", "ns1");
+        assert!(rx.is_some());
+        assert!(mm.register_encoder_router("llama", "ns1").is_none());
+
+        drop(rx);
+        mm.remove_consumer_encoder_waiter("llama", "ns1");
+        assert!(mm.register_encoder_router("llama", "ns1").is_some());
+    }
+
+    #[test]
+    fn test_encoder_router_different_namespaces_are_independent() {
+        let mm = ModelManager::new();
+        assert!(mm.register_encoder_router("llama", "ns1").is_some());
+        assert!(mm.register_encoder_router("llama", "ns2").is_some());
+    }
+
+    #[derive(Clone, Copy)]
+    enum EncoderActivationSignal {
+        Register,
+        Enable,
+        Activate,
+    }
+
+    #[tokio::test]
+    async fn test_encoder_router_activates_in_every_signal_order() {
+        use EncoderActivationSignal::{Activate, Enable, Register};
+
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("encoder-activation-orders".to_string())
+            .unwrap()
+            .component("encoder".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let orders = [
+            [Register, Enable, Activate],
+            [Register, Activate, Enable],
+            [Enable, Register, Activate],
+            [Enable, Activate, Register],
+            [Activate, Register, Enable],
+            [Activate, Enable, Register],
+        ];
+
+        for order in orders {
+            let mm = ModelManager::new();
+            let mut receiver = None;
+            for signal in order {
+                match signal {
+                    Register => {
+                        receiver = mm.register_encoder_router("llama", "ns1");
+                    }
+                    Enable => mm.enable_encoder_routing("llama", "ns1"),
+                    Activate => {
+                        mm.activate_encoder_router("llama", "ns1", endpoint.clone());
+                    }
+                }
+            }
+
+            let activated = receiver
+                .expect("every order registers a consumer")
+                .await
+                .expect("all three signals must activate the consumer");
+            assert_eq!(activated, endpoint);
+        }
+
+        runtime.shutdown();
+    }
+
+    #[tokio::test]
+    async fn test_encoder_router_repeated_enable_preserves_waiter() {
+        let runtime = Runtime::from_current().unwrap();
+        let distributed =
+            DistributedRuntime::new(runtime.clone(), DistributedConfig::process_local())
+                .await
+                .unwrap();
+        let endpoint = distributed
+            .namespace("encoder-repeated-enable".to_string())
+            .unwrap()
+            .component("encoder".to_string())
+            .unwrap()
+            .endpoint("generate".to_string());
+        let mm = ModelManager::new();
+        let receiver = mm
+            .register_encoder_router("llama", "ns1")
+            .expect("consumer registration must succeed");
+
+        mm.enable_encoder_routing("llama", "ns1");
+        mm.enable_encoder_routing("llama", "ns1");
+        mm.activate_encoder_router("llama", "ns1", endpoint.clone());
+
+        assert_eq!(receiver.await.unwrap(), endpoint);
+        runtime.shutdown();
     }
 
     // -- remove_decode_prefill_waiter tests (stale-DecodeWaiting cleanup) --

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -36,7 +36,7 @@ use crate::{
     discovery::{KvWorkerMonitor, WORKER_TYPE_DECODE, WorkerSet},
     entrypoint::{self, ChatEngineFactoryCallback, RouterConfig},
     http::service::metrics::Metrics,
-    kv_router::PrefillRouter,
+    kv_router::{EncoderRouter, PrefillRouter},
     local_model::runtime_config::{TokenizerBackend, VLLM_INFERENCE_V1_GENERATE_CAPABILITY},
     model_card::ModelDeploymentCard,
     model_type::{ModelInput, ModelType},
@@ -144,6 +144,17 @@ fn supports_vllm_generate(card: &ModelDeploymentCard) -> bool {
         card.runtime_config
             .runtime_data
             .get(VLLM_INFERENCE_V1_GENERATE_CAPABILITY),
+        Some(serde_json::Value::Bool(true))
+    )
+}
+
+const ENCODER_RESULT_HANDOFF_CAPABILITY: &str = "encoder_result_handoff";
+
+fn supports_encoder_result_handoff(card: &ModelDeploymentCard) -> bool {
+    matches!(
+        card.runtime_config
+            .runtime_data
+            .get(ENCODER_RESULT_HANDOFF_CAPABILITY),
         Some(serde_json::Value::Bool(true))
     )
 }
@@ -1089,13 +1100,12 @@ impl ModelWatcher {
                         .deactivate_prefill_router_for_decode(&model_name, worker_namespace);
                 }
                 Some(WorkerType::Encode) if card.model_type.is_empty() => {
-                    // A surface-less encode helper (e.g. vLLM) never ran the
-                    // model_type pipeline chain, so it created no prefill/decode
-                    // activator state. Skip the decode waiter cleanup — that map
-                    // is keyed by (model, namespace) and clearing it on an
-                    // unrelated encode removal could drop a live DecodeWaiting
-                    // and recreate the stale-prefill-router rebuild failure
-                    // described above.
+                    if removed.is_some() {
+                        self.manager
+                            .remove_encoder_activator(&model_name, worker_namespace);
+                    }
+                    self.manager
+                        .deactivate_encoder_router_for_consumers(&model_name, worker_namespace);
                 }
                 Some(WorkerType::Decode)
                 | Some(WorkerType::Aggregated)
@@ -1116,6 +1126,8 @@ impl ModelWatcher {
                     // is a no-op.
                     self.manager
                         .remove_decode_prefill_waiter(&model_name, worker_namespace);
+                    self.manager
+                        .remove_consumer_encoder_waiter(&model_name, worker_namespace);
                 }
             }
         }
@@ -1367,6 +1379,37 @@ impl ModelWatcher {
         let mut worker_set = WorkerSet::new(namespace.clone(), checksum.to_string(), card.clone());
         worker_set.set_instance_watcher(instance_watcher);
 
+        // A surface-less Encode worker is reached only through EncoderRouter.
+        // Register it for serving readiness, publish its endpoint to any
+        // waiting token pipeline, and do not build a public OpenAI surface.
+        if effective_worker_type(card.worker_type, card.model_type) == WorkerType::Encode
+            && card.model_type.is_empty()
+        {
+            if card.model_input != ModelInput::Tokens {
+                anyhow::bail!(
+                    "Encode workers must use ModelInput::Tokens, got {}",
+                    card.model_input.as_str()
+                );
+            }
+            self.manager
+                .add_worker_set(card.name(), &ws_key, worker_set);
+
+            if let Some(tx) = &self.model_update_tx {
+                tx.send(ModelUpdate::Added(card.clone())).await.ok();
+            }
+            self.manager.activate_encoder_router(
+                card.name(),
+                &namespace,
+                component.endpoint(&mcid.endpoint),
+            );
+            tracing::info!(
+                model_name = card.name(),
+                namespace = %namespace,
+                "Encode worker registered and router activated"
+            );
+            return Ok(());
+        }
+
         // worker_type-driven short circuit for Prefill.
         //
         // A prefill worker carries no OpenAI-style engine — it is reached only
@@ -1403,6 +1446,10 @@ impl ModelWatcher {
             // and go.
             self.manager
                 .add_worker_set(card.name(), &ws_key, worker_set);
+
+            if supports_encoder_result_handoff(card) {
+                self.manager.enable_encoder_routing(card.name(), &namespace);
+            }
 
             if let Some(tx) = &self.model_update_tx {
                 tx.send(ModelUpdate::Added(card.clone())).await.ok();
@@ -1548,12 +1595,24 @@ impl ModelWatcher {
                 None
             };
 
+            let encoder_chooser = if needs_preprocessed_routing {
+                if supports_encoder_result_handoff(card) {
+                    self.manager.enable_encoder_routing(&model_name, &namespace);
+                }
+                self.manager
+                    .register_encoder_router(&model_name, &namespace)
+                    .map(|rx| EncoderRouter::new(rx, model_name.clone(), namespace.clone()))
+            } else {
+                None
+            };
+
             // Store KV router, worker monitor, and prefill router on the WorkerSet.
             // The prefill router is stored so the watcher can deactivate/reactivate it
             // when prefill workers die or rejoin.
             worker_set.kv_router = kv_chooser.clone();
             worker_set.worker_monitor = worker_monitor.clone();
             worker_set.prefill_router = prefill_chooser.clone();
+            worker_set.encoder_router = encoder_chooser.clone();
 
             let preprocessed_routing = if needs_preprocessed_routing {
                 Some(
@@ -1564,6 +1623,7 @@ impl ModelWatcher {
                         worker_monitor.clone(),
                         kv_chooser.clone(),
                         prefill_chooser.clone(),
+                        encoder_chooser.clone(),
                         uses_multimodal_cache_routing(card),
                         router_config.session_affinity_ttl_secs,
                     )
@@ -1978,6 +2038,23 @@ mod tests {
             .set_engine_specific(VLLM_INFERENCE_V1_GENERATE_CAPABILITY, false)
             .unwrap();
         assert!(!supports_vllm_generate(&card));
+    }
+
+    #[test]
+    fn encoder_result_handoff_requires_explicit_worker_capability() {
+        let mut card = ModelDeploymentCard::with_name_only("model");
+        card.needs = vec![vec![WorkerType::Encode]];
+        assert!(!supports_encoder_result_handoff(&card));
+
+        card.runtime_config
+            .set_engine_specific(ENCODER_RESULT_HANDOFF_CAPABILITY, true)
+            .unwrap();
+        assert!(supports_encoder_result_handoff(&card));
+
+        card.runtime_config
+            .set_engine_specific(ENCODER_RESULT_HANDOFF_CAPABILITY, false)
+            .unwrap();
+        assert!(!supports_encoder_result_handoff(&card));
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -11,7 +11,7 @@ use tokio::sync::watch;
 
 use crate::{
     discovery::KvWorkerMonitor,
-    kv_router::{KvRouter, PrefillRouter},
+    kv_router::{EncoderRouter, KvRouter, PrefillRouter},
     model_card::ModelDeploymentCard,
     types::{
         RealtimeBidirectionalEngine,
@@ -58,6 +58,10 @@ pub struct WorkerSet {
     /// deactivate it when all prefill workers die, and reactivate when they rejoin.
     pub(crate) prefill_router: Option<Arc<PrefillRouter>>,
 
+    /// Optional multimodal encoder hop. Stored for discovery-driven
+    /// deactivation/reactivation when Encode workers leave or rejoin.
+    pub(crate) encoder_router: Option<Arc<EncoderRouter>>,
+
     /// Watcher for available instance IDs (from the Client's discovery watch).
     /// None for in-process models (http/grpc) which don't have a discovery client.
     instance_count_rx: Option<watch::Receiver<Vec<u64>>>,
@@ -81,6 +85,7 @@ impl WorkerSet {
             kv_router: None,
             worker_monitor: None,
             prefill_router: None,
+            encoder_router: None,
             instance_count_rx: None,
         }
     }

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -13,7 +13,9 @@ use crate::{
     entrypoint::EngineConfig,
     http::service::metrics::Metrics,
     kv_router::indexer::try_build_cache_indexer,
-    kv_router::{KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics},
+    kv_router::{
+        EncoderRouter, KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics,
+    },
     lora::LoraFilteredRouter,
     migration::Migration,
     model_card::ModelDeploymentCard,
@@ -79,6 +81,7 @@ pub struct PreprocessedRouting {
     backend_engine:
         ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>,
     prefill_router: Arc<PrefillRouter>,
+    encoder_router: Arc<EncoderRouter>,
 }
 
 pub struct PreparedEngine {
@@ -237,6 +240,7 @@ pub async fn build_preprocessed_routing(
     worker_monitor: Option<KvWorkerMonitor>,
     chooser: Option<Arc<KvRouter>>,
     prefill_chooser: Option<Arc<PrefillRouter>>,
+    encoder_chooser: Option<Arc<EncoderRouter>>,
     enable_multimodal_cache_indexer: bool,
     session_affinity_ttl_secs: Option<u64>,
 ) -> anyhow::Result<PreprocessedRouting> {
@@ -291,6 +295,7 @@ pub async fn build_preprocessed_routing(
             session_affinity_ttl_secs,
         )
     });
+    let encoder_router = encoder_chooser.unwrap_or_else(EncoderRouter::disabled);
 
     let backend_engine = preprocessed_backend_engine(
         router,
@@ -302,6 +307,7 @@ pub async fn build_preprocessed_routing(
     Ok(PreprocessedRouting {
         backend_engine,
         prefill_router,
+        encoder_router,
     })
 }
 
@@ -479,15 +485,18 @@ impl PreprocessedRouting {
         let migration = Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics)
             .into_operator_for::<BackendOutput>();
         let prefill_op = self.prefill_router.into_operator();
+        let encoder_op = self.encoder_router.into_operator();
         let backend = ServiceBackend::from_engine(self.backend_engine.clone());
 
         let engine = frontend
             .link(preprocessor_op.forward_edge())?
             .link(migration.forward_edge())?
             .link(token_backend.forward_edge())?
+            .link(encoder_op.forward_edge())?
             .link(prefill_op.forward_edge())?
             .link(backend)?
             .link(prefill_op.backward_edge())?
+            .link(encoder_op.backward_edge())?
             .link(token_backend.backward_edge())?
             .link(migration.backward_edge())?
             .link(preprocessor_op.backward_edge())?
@@ -514,13 +523,16 @@ impl PreprocessedRouting {
         let migration = Migration::from_mdc(card, migration_limit, migration_max_seq_len, metrics)
             .into_operator_for::<LLMEngineOutput>();
         let prefill_op = self.prefill_router.into_operator();
+        let encoder_op = self.encoder_router.into_operator();
         let backend = ServiceBackend::from_engine(self.backend_engine.clone());
 
         let engine = frontend
             .link(migration.forward_edge())?
+            .link(encoder_op.forward_edge())?
             .link(prefill_op.forward_edge())?
             .link(backend)?
             .link(prefill_op.backward_edge())?
+            .link(encoder_op.backward_edge())?
             .link(migration.backward_edge())?
             .link(frontend)?;
 

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -43,6 +43,7 @@ pub use dynamo_kv_router::protocols;
 pub use dynamo_kv_router::scheduling;
 pub use dynamo_kv_router::selector;
 
+pub mod encoder_router;
 pub mod indexer;
 pub mod metrics;
 pub mod prefill_router;
@@ -56,6 +57,7 @@ pub mod shared_cache;
 pub use dynamo_kv_router::scheduling::{
     OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore,
 };
+pub use encoder_router::EncoderRouter;
 pub use indexer::{Indexer, ServedIndexerHandle, ServedIndexerMode, ensure_served_indexer_service};
 pub use prefill_router::PrefillRouter;
 pub use push_router::{DirectRoutingRouter, KvPushRouter};

--- a/lib/llm/src/kv_router/encoder_router.rs
+++ b/lib/llm/src/kv_router/encoder_router.rs
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Optional multimodal encoder hop for token-serving pipelines.
+
+use std::sync::atomic::{AtomicU8, Ordering};
+use std::sync::{Arc, OnceLock};
+
+use anyhow::{Context as _, Result};
+use futures::StreamExt;
+use tokio::sync::oneshot;
+use tokio_util::sync::CancellationToken;
+
+use dynamo_runtime::{
+    component::Endpoint,
+    engine::AsyncEngine,
+    pipeline::{
+        Context, ManyOut, Operator, PushRouter, RouterMode, ServerStreamingEngine, SingleIn,
+        async_trait,
+    },
+    protocols::{annotated::Annotated, maybe_error::MaybeError},
+};
+
+use crate::protocols::common::{
+    llm_backend::{LLMEngineOutput, PreprocessedRequest},
+    preprocessor::TraceLink,
+};
+
+type EncodePushRouter = PushRouter<PreprocessedRequest, Annotated<LLMEngineOutput>>;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[repr(u8)]
+enum EncoderLifecycleState {
+    Pending = 0,
+    Active = 1,
+    Unavailable = 2,
+}
+
+impl EncoderLifecycleState {
+    fn load(value: u8) -> Self {
+        match value {
+            0 => Self::Pending,
+            1 => Self::Active,
+            2 => Self::Unavailable,
+            value => panic!("invalid encoder lifecycle state: {value}"),
+        }
+    }
+}
+
+/// Forward-only operator that optionally runs a multimodal Encode worker.
+///
+/// The router is present on every token pipeline but remains a passthrough
+/// until discovery supplies an Encode endpoint for the same model namespace.
+/// Encode workers are selected round-robin independently of the downstream
+/// token router mode; they do not participate in KV-aware routing.
+pub struct EncoderRouter {
+    router: OnceLock<Arc<EncodePushRouter>>,
+    cancel_token: CancellationToken,
+    lifecycle: AtomicU8,
+    model_name: String,
+    namespace: String,
+}
+
+impl Drop for EncoderRouter {
+    fn drop(&mut self) {
+        self.cancel_token.cancel();
+    }
+}
+
+impl EncoderRouter {
+    /// Create a permanently-disabled passthrough router.
+    pub fn disabled() -> Arc<Self> {
+        Arc::new(Self {
+            router: OnceLock::new(),
+            cancel_token: CancellationToken::new(),
+            lifecycle: AtomicU8::new(EncoderLifecycleState::Pending as u8),
+            model_name: String::new(),
+            namespace: String::new(),
+        })
+    }
+
+    /// Create a router that activates when discovery observes an Encode peer.
+    pub fn new(
+        activation_rx: oneshot::Receiver<Endpoint>,
+        model_name: String,
+        namespace: String,
+    ) -> Arc<Self> {
+        let cancel_token = CancellationToken::new();
+        let router = Arc::new(Self {
+            router: OnceLock::new(),
+            cancel_token: cancel_token.clone(),
+            lifecycle: AtomicU8::new(EncoderLifecycleState::Pending as u8),
+            model_name,
+            namespace,
+        });
+
+        let router_weak = Arc::downgrade(&router);
+        tokio::spawn(async move {
+            tokio::select! {
+                result = activation_rx => {
+                    let Ok(endpoint) = result else {
+                        tracing::debug!("Encoder router activation channel closed");
+                        return;
+                    };
+                    let Some(router) = router_weak.upgrade() else {
+                        tracing::debug!("Encoder router dropped before activation");
+                        return;
+                    };
+                    if let Err(error) = router.activate(endpoint).await {
+                        tracing::error!(%error, "Failed to activate encoder router");
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Encoder router activation cancelled");
+                }
+            }
+        });
+
+        router
+    }
+
+    async fn activate(&self, endpoint: Endpoint) -> Result<()> {
+        let client = endpoint.client().await?;
+        let router =
+            EncodePushRouter::from_client_with_monitor(client, RouterMode::RoundRobin, None)
+                .await?;
+        let _ = self.router.set(Arc::new(router));
+        self.lifecycle
+            .store(EncoderLifecycleState::Active as u8, Ordering::Release);
+        tracing::info!(
+            model = %self.model_name,
+            namespace = %self.namespace,
+            "Encoder router activated"
+        );
+        Ok(())
+    }
+
+    fn lifecycle_state(&self) -> EncoderLifecycleState {
+        EncoderLifecycleState::load(self.lifecycle.load(Ordering::Acquire))
+    }
+
+    pub fn deactivate(&self) {
+        if self.router.get().is_some() {
+            self.lifecycle
+                .store(EncoderLifecycleState::Unavailable as u8, Ordering::Release);
+        }
+    }
+
+    pub fn reactivate(&self) {
+        if self.router.get().is_some() {
+            self.lifecycle
+                .store(EncoderLifecycleState::Active as u8, Ordering::Release);
+        }
+    }
+
+    pub fn is_deactivated(&self) -> bool {
+        self.lifecycle_state() == EncoderLifecycleState::Unavailable
+    }
+
+    fn should_encode(request: &PreprocessedRequest) -> bool {
+        !request.is_probe
+            && request.encoder_result.is_none()
+            && request
+                .multi_modal_data
+                .as_ref()
+                .is_some_and(|media| media.values().any(|items| !items.is_empty()))
+    }
+
+    async fn consume_encode_stream(
+        mut response: ManyOut<Annotated<LLMEngineOutput>>,
+    ) -> Result<(serde_json::Value, Option<TraceLink>)> {
+        let mut terminal = None;
+        while let Some(item) = response.next().await {
+            if let Some(error) = item.err() {
+                return Err(anyhow::anyhow!(error)).context("Encode worker returned an error");
+            }
+            let Some(output) = item.data else {
+                continue;
+            };
+            if output.finish_reason.is_some() {
+                terminal = Some(output);
+            }
+        }
+
+        let terminal = terminal.context("Encode worker stream ended without a terminal chunk")?;
+        let result = terminal
+            .encoder_result
+            .filter(serde_json::Value::is_object)
+            .context("Encode worker terminal is missing an object-shaped encoder_result")?;
+        Ok((result, terminal.worker_trace_link))
+    }
+}
+
+#[async_trait]
+impl
+    Operator<
+        SingleIn<PreprocessedRequest>,
+        ManyOut<Annotated<LLMEngineOutput>>,
+        SingleIn<PreprocessedRequest>,
+        ManyOut<Annotated<LLMEngineOutput>>,
+    > for EncoderRouter
+{
+    async fn generate(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        next: ServerStreamingEngine<PreprocessedRequest, Annotated<LLMEngineOutput>>,
+    ) -> Result<ManyOut<Annotated<LLMEngineOutput>>> {
+        let (mut request, context) = request.into_parts();
+        if self.lifecycle_state() != EncoderLifecycleState::Active || !Self::should_encode(&request)
+        {
+            return next.generate(context.map(|_| request)).await;
+        }
+
+        let router = self
+            .router
+            .get()
+            .context("Encoder router is active but not initialized")?;
+        let encode_context = Context::with_id_and_metadata(
+            request.clone(),
+            context.id().to_string(),
+            context.metadata().clone(),
+        );
+        let response = router.generate(encode_context).await?;
+        let (encoder_result, worker_link) = Self::consume_encode_stream(response).await?;
+
+        // Once the Encode worker has emitted a transfer handle, always hand it
+        // to the downstream worker even if the caller disconnected. The
+        // receiver owns transfer completion and buffer release.
+        request.encoder_result = Some(encoder_result);
+        request.migration_link = worker_link;
+        next.generate(context.map(|_| request)).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use futures::stream;
+    use serde_json::json;
+
+    use dynamo_runtime::pipeline::{ResponseStream, context::Controller};
+
+    use super::*;
+
+    fn stream_of(items: Vec<Annotated<LLMEngineOutput>>) -> ManyOut<Annotated<LLMEngineOutput>> {
+        ResponseStream::new(
+            Box::pin(stream::iter(items)),
+            Arc::new(Controller::default()),
+        )
+    }
+
+    #[tokio::test]
+    async fn pending_activation_does_not_keep_router_alive() {
+        let (_activation_tx, activation_rx) = oneshot::channel();
+        let router = EncoderRouter::new(activation_rx, "model".into(), "namespace".into());
+        let weak = Arc::downgrade(&router);
+
+        drop(router);
+
+        assert!(weak.upgrade().is_none());
+    }
+
+    #[tokio::test]
+    async fn consumes_object_shaped_encode_terminal() {
+        let output = LLMEngineOutput::encode_terminal(
+            json!({"schema_version": 1}).as_object().unwrap().clone(),
+        );
+        let (result, _) =
+            EncoderRouter::consume_encode_stream(stream_of(vec![Annotated::from_data(output)]))
+                .await
+                .unwrap();
+        assert_eq!(result, json!({"schema_version": 1}));
+    }
+
+    #[tokio::test]
+    async fn rejects_terminal_without_encoder_result() {
+        let result = EncoderRouter::consume_encode_stream(stream_of(vec![Annotated::from_data(
+            LLMEngineOutput::stop(),
+        )]))
+        .await;
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Overview:

Teach unified vLLM aggregated and prefill workers to consume Encode-worker handoffs.

## Summary

- enable `--route-to-encoder` on unified aggregated and prefill workers
- select Local, NIXL write, or NIXL read embedding receivers
- validate and materialize versioned `encoder_result` payloads
- preserve local processing for modalities not handled by the separate image encoder

## Details:

This is stack PR 3 of 4 for [DIS-2034](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend), stacked on #11461.

The receiving worker reconstructs vLLM multimodal inputs from transfer metadata and skips duplicate image downloads when an encoder result is present. Video and audio remain on the aggregated/prefill worker, so mixed-modality requests preserve their local inputs.

## Where should the reviewer start?

- `components/src/dynamo/vllm/multimodal_utils/prefill_worker_utils.py`
- `components/src/dynamo/vllm/multimodal_utils/request_processor.py`
- `components/src/dynamo/vllm/llm_engine.py`
- `components/src/dynamo/vllm/tests/test_vllm_unified_multimodal.py`

## Validation

- included in the focused vLLM Python suite: 68 passed across the completed stack
- `ruff check` on changed Python files
- `python3 -m py_compile` on changed Python files
- `git diff --check`
- full-stack GPU validation is recorded in #11449

## Stack

1. #11460 — generic encoder routing and discovery
2. #11461 — unified vLLM Encode engine
3. **This PR:** unified vLLM encoder handoff consumer
4. #11449 — launchers, GPU profiles, and documentation

## Related Issues

**🔗 This PR is linked to an issue:**

- [DIS-2034: vLLM: Add separate encode worker in unified backend](https://linear.app/nvidia/issue/DIS-2034/vllm-add-separate-encode-worker-in-unified-backend)
