### PR TITLE
feat(llm): Select reasoning output field via env var

### DIFF
--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -364,6 +364,37 @@ def test_load_aware_frontend_implies_kv_router_mode() -> None:
     assert config.router_assume_kv_reuse is False
 
 
+def test_frontend_reasoning_field_name_cli_and_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("DYN_REASONING_FIELD_NAME", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    assert config.reasoning_field_name == "reasoning_content"
+
+    monkeypatch.setenv("DYN_REASONING_FIELD_NAME", "reasoning")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    assert config.reasoning_field_name == "reasoning"
+
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(
+        parser.parse_args(["--reasoning-field-name", "reasoning_content"])
+    )
+    assert config.reasoning_field_name == "reasoning_content"
+
+
+def test_frontend_reasoning_field_name_rejects_invalid_choice() -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--reasoning-field-name", "invalid"])
+
+
 def test_frontend_rejection_thresholds_default_to_none(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -82,6 +82,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     debug_perf: bool
     enable_streaming_tool_dispatch: bool
     enable_streaming_reasoning_dispatch: bool
+    reasoning_field_name: str
     exclude_tools_when_tool_choice_none: bool
     preprocess_workers: int
     tokenizer_backend: str
@@ -437,6 +438,16 @@ class FrontendArgGroup(ArgGroup):
                 "with the complete reasoning block once thinking ends. "
                 "Can be combined with --enable-streaming-tool-dispatch."
             ),
+        )
+        add_argument(
+            g,
+            flag_name="--reasoning-field-name",
+            env_var="DYN_REASONING_FIELD_NAME",
+            default="reasoning_content",
+            help=(
+                "OpenAI-compatible response field used for emitted reasoning content."
+            ),
+            choices=["reasoning_content", "reasoning"],
         )
         # NOTE: This flag also exists in DynamoRuntimeArgGroup (runtime_args.py).
         # Both definitions are needed: runtime_args controls the Rust-native

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -410,6 +410,7 @@ async def async_main():
         "strip_anthropic_preamble": config.strip_anthropic_preamble,
         "enable_streaming_tool_dispatch": config.enable_streaming_tool_dispatch,
         "enable_streaming_reasoning_dispatch": config.enable_streaming_reasoning_dispatch,
+        "reasoning_field_name": config.reasoning_field_name,
         "tokenizer_backend": config.tokenizer_backend,
     }
     if config.migration_max_seq_len is not None:

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -29,6 +29,7 @@ use dynamo_llm::local_model::runtime_config::TokenizerBackend;
 use dynamo_llm::local_model::{LocalModel, LocalModelBuilder};
 use dynamo_llm::mocker::make_mocker_engine;
 use dynamo_llm::model_card::ModelDeploymentCard as RsModelDeploymentCard;
+use dynamo_llm::reasoning_field::ReasoningField;
 use dynamo_llm::types::openai::chat_completions::OpenAIChatCompletionsStreamingEngine;
 use dynamo_mocker::common::perf_model::PerfModel;
 
@@ -567,7 +568,7 @@ pub(crate) struct EntrypointArgs {
 impl EntrypointArgs {
     #[allow(clippy::too_many_arguments)]
     #[new]
-    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, mocker_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, is_decode=false, migration_limit=0, migration_max_seq_len=None, chat_engine_factory=None, aic_perf_config=None, *, metrics_prefix=None, enable_anthropic_api=None, strip_anthropic_preamble=None, enable_streaming_tool_dispatch=None, enable_streaming_reasoning_dispatch=None, tokenizer_backend=None))]
+    #[pyo3(signature = (engine_type, model_path=None, model_name=None, endpoint_id=None, template_file=None, router_config=None, kv_cache_block_size=None, http_host=None, http_port=None, http_metrics_port=None, tls_cert_path=None, tls_key_path=None, extra_engine_args=None, mocker_engine_args=None, runtime_config=None, namespace=None, namespace_prefix=None, is_prefill=false, is_decode=false, migration_limit=0, migration_max_seq_len=None, chat_engine_factory=None, aic_perf_config=None, *, metrics_prefix=None, enable_anthropic_api=None, strip_anthropic_preamble=None, enable_streaming_tool_dispatch=None, enable_streaming_reasoning_dispatch=None, reasoning_field_name=None, tokenizer_backend=None))]
     pub fn new(
         py: Python<'_>,
         engine_type: EngineType,
@@ -598,6 +599,7 @@ impl EntrypointArgs {
         strip_anthropic_preamble: Option<bool>,
         enable_streaming_tool_dispatch: Option<bool>,
         enable_streaming_reasoning_dispatch: Option<bool>,
+        reasoning_field_name: Option<String>,
         tokenizer_backend: Option<String>,
     ) -> PyResult<Self> {
         let endpoint_id_obj: Option<EndpointId> = endpoint_id.as_deref().map(EndpointId::from);
@@ -632,6 +634,12 @@ impl EntrypointArgs {
                     .map_err(PyValueError::new_err)
             })
             .transpose()?;
+        let reasoning_field = reasoning_field_name
+            .map(|name| {
+                name.parse::<ReasoningField>()
+                    .map_err(|err| PyValueError::new_err(err.to_string()))
+            })
+            .transpose()?;
 
         let mut runtime_config = runtime_config.unwrap_or_default();
         if let Some(tokenizer_backend) = tokenizer_backend {
@@ -658,6 +666,7 @@ impl EntrypointArgs {
                 strip_anthropic_preamble,
                 enable_streaming_tool_dispatch,
                 enable_streaming_reasoning_dispatch,
+                reasoning_field,
             ),
             tls_cert_path,
             tls_key_path,

--- a/lib/llm/src/frontend_config.rs
+++ b/lib/llm/src/frontend_config.rs
@@ -13,6 +13,8 @@ use dynamo_runtime::config::{
     environment_names::llm::{self as env_llm, metrics as env_metrics},
 };
 
+use crate::reasoning_field::ReasoningField;
+
 /// Metrics naming controls for frontend-owned services.
 ///
 /// Contains the optional metric name prefix resolved from `--metrics-prefix` or
@@ -137,23 +139,46 @@ impl Default for StreamingDispatchConfig {
     }
 }
 
+fn default_reasoning_field() -> ReasoningField {
+    match std::env::var(env_llm::DYN_REASONING_FIELD_NAME) {
+        Ok(value) => match value.parse::<ReasoningField>() {
+            Ok(field) => field,
+            Err(_) => {
+                tracing::warn!(
+                    "{}={value:?} is not \"reasoning\" or \"reasoning_content\"; defaulting to {}",
+                    env_llm::DYN_REASONING_FIELD_NAME,
+                    ReasoningField::default()
+                );
+                ReasoningField::default()
+            }
+        },
+        Err(_) => ReasoningField::default(),
+    }
+}
+
 /// Frontend API behavior consumed by the HTTP service.
 ///
 /// Groups endpoint-surface and streaming-behavior settings that originate from
 /// the frontend CLI/env contract. `EntrypointArgs` builds this from flat Python
 /// kwargs, `LocalModel` carries it, and `HttpServiceConfig` installs it into
 /// request-handler state.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FrontendApiConfig {
     anthropic: AnthropicApiConfig,
     streaming_dispatch: StreamingDispatchConfig,
+    reasoning_field: ReasoningField,
 }
 
 impl FrontendApiConfig {
-    pub fn new(anthropic: AnthropicApiConfig, streaming_dispatch: StreamingDispatchConfig) -> Self {
+    pub fn new(
+        anthropic: AnthropicApiConfig,
+        streaming_dispatch: StreamingDispatchConfig,
+        reasoning_field: ReasoningField,
+    ) -> Self {
         Self {
             anthropic,
             streaming_dispatch,
+            reasoning_field,
         }
     }
 
@@ -162,6 +187,7 @@ impl FrontendApiConfig {
         strip_anthropic_preamble: bool,
         enable_streaming_tool_dispatch: bool,
         enable_streaming_reasoning_dispatch: bool,
+        reasoning_field: ReasoningField,
     ) -> Self {
         Self {
             anthropic: AnthropicApiConfig::new(enable_anthropic_api, strip_anthropic_preamble),
@@ -169,6 +195,7 @@ impl FrontendApiConfig {
                 enable_streaming_tool_dispatch,
                 enable_streaming_reasoning_dispatch,
             ),
+            reasoning_field,
         }
     }
 
@@ -177,11 +204,13 @@ impl FrontendApiConfig {
         strip_anthropic_preamble: Option<bool>,
         enable_streaming_tool_dispatch: Option<bool>,
         enable_streaming_reasoning_dispatch: Option<bool>,
+        reasoning_field: Option<ReasoningField>,
     ) -> Option<Self> {
         if enable_anthropic_api.is_none()
             && strip_anthropic_preamble.is_none()
             && enable_streaming_tool_dispatch.is_none()
             && enable_streaming_reasoning_dispatch.is_none()
+            && reasoning_field.is_none()
         {
             return None;
         }
@@ -194,6 +223,7 @@ impl FrontendApiConfig {
                 .unwrap_or_else(|| defaults.streaming_dispatch().tool_dispatch()),
             enable_streaming_reasoning_dispatch
                 .unwrap_or_else(|| defaults.streaming_dispatch().reasoning_dispatch()),
+            reasoning_field.unwrap_or_else(|| defaults.reasoning_field()),
         ))
     }
 
@@ -212,6 +242,24 @@ impl FrontendApiConfig {
     pub fn streaming_dispatch_mut(&mut self) -> &mut StreamingDispatchConfig {
         &mut self.streaming_dispatch
     }
+
+    pub fn reasoning_field(&self) -> ReasoningField {
+        self.reasoning_field
+    }
+
+    pub fn set_reasoning_field(&mut self, reasoning_field: ReasoningField) {
+        self.reasoning_field = reasoning_field;
+    }
+}
+
+impl Default for FrontendApiConfig {
+    fn default() -> Self {
+        Self {
+            anthropic: Default::default(),
+            streaming_dispatch: Default::default(),
+            reasoning_field: default_reasoning_field(),
+        }
+    }
 }
 
 #[cfg(test)]
@@ -220,7 +268,7 @@ mod tests {
 
     #[test]
     fn optional_flags_return_none_when_all_values_are_unspecified() {
-        let config = FrontendApiConfig::from_optional_flags(None, None, None, None);
+        let config = FrontendApiConfig::from_optional_flags(None, None, None, None, None);
 
         assert_eq!(config, None);
     }
@@ -232,6 +280,7 @@ mod tests {
             Some(true),
             Some(false),
             Some(true),
+            Some(ReasoningField::Reasoning),
         )
         .expect("explicit flags should produce a config");
 
@@ -239,6 +288,7 @@ mod tests {
         assert!(config.anthropic().strip_preamble());
         assert!(!config.streaming_dispatch().tool_dispatch());
         assert!(config.streaming_dispatch().reasoning_dispatch());
+        assert_eq!(config.reasoning_field(), ReasoningField::Reasoning);
     }
 
     #[test]
@@ -249,17 +299,33 @@ mod tests {
                 (env_llm::DYN_STRIP_ANTHROPIC_PREAMBLE, Some("1")),
                 (env_llm::DYN_ENABLE_STREAMING_TOOL_DISPATCH, Some("1")),
                 (env_llm::DYN_ENABLE_STREAMING_REASONING_DISPATCH, Some("1")),
+                (env_llm::DYN_REASONING_FIELD_NAME, Some("reasoning")),
             ],
             || {
-                let config =
-                    FrontendApiConfig::from_optional_flags(Some(false), None, None, Some(false))
-                        .expect("partial flags should produce a config");
+                let config = FrontendApiConfig::from_optional_flags(
+                    Some(false),
+                    None,
+                    None,
+                    Some(false),
+                    None,
+                )
+                .expect("partial flags should produce a config");
 
                 assert!(!config.anthropic().enabled());
                 assert!(config.anthropic().strip_preamble());
                 assert!(config.streaming_dispatch().tool_dispatch());
                 assert!(!config.streaming_dispatch().reasoning_dispatch());
+                assert_eq!(config.reasoning_field(), ReasoningField::Reasoning);
             },
         );
+    }
+
+    #[test]
+    fn invalid_reasoning_field_env_defaults_to_reasoning_content() {
+        temp_env::with_var(env_llm::DYN_REASONING_FIELD_NAME, Some("invalid"), || {
+            let config = FrontendApiConfig::default();
+
+            assert_eq!(config.reasoning_field(), ReasoningField::ReasoningContent);
+        });
     }
 }

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -29,6 +29,7 @@ use crate::protocols::{
     common::metrics::{ANNOTATION_LLM_METRICS, LLMMetricAnnotation},
     openai::chat_completions::NvCreateChatCompletionStreamResponse,
 };
+use crate::reasoning_field::{ReasoningField, RoutedReasoning};
 use dynamo_runtime::metrics::prometheus_names::clamp_u64_to_i64;
 
 use dynamo_runtime::error::ErrorType as DynamoErrorType;
@@ -2115,6 +2116,7 @@ pub fn process_chat_response_using_event_converter_and_observe_metrics(
     annotated: EventConverter<NvCreateChatCompletionStreamResponse>,
     response_collector: &mut ResponseMetricCollector,
     http_queue_guard: &mut Option<HttpQueueGuard>,
+    reasoning_field: ReasoningField,
 ) -> Result<Option<Event>, axum::Error> {
     let mut annotated = annotated.0;
 
@@ -2142,10 +2144,10 @@ pub fn process_chat_response_using_event_converter_and_observe_metrics(
         annotated.data = None;
     }
 
-    // Route reasoning to the field selected by DYN_REASONING_FIELD_NAME at the
-    // SSE boundary. Internal representation stays `reasoning_content`.
+    // Route reasoning at the SSE boundary. Internal representation stays
+    // `reasoning_content`.
     let annotated =
-        annotated.map_data(|response| Ok(crate::reasoning_field::RoutedReasoning::new(response)));
+        annotated.map_data(|response| Ok(RoutedReasoning::new(response, reasoning_field)));
     annotated_to_sse_event(annotated)
 }
 
@@ -3120,6 +3122,7 @@ mod tests {
             EventConverter::from(annotated),
             &mut collector,
             &mut http_queue_guard,
+            ReasoningField::default(),
         );
 
         assert!(
@@ -3673,6 +3676,7 @@ mod tests {
             EventConverter::from(annotated),
             &mut collector,
             &mut http_queue_guard,
+            ReasoningField::default(),
         )
     }
 

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -2142,6 +2142,10 @@ pub fn process_chat_response_using_event_converter_and_observe_metrics(
         annotated.data = None;
     }
 
+    // Route reasoning to the field selected by DYN_REASONING_FIELD_NAME at the
+    // SSE boundary. Internal representation stays `reasoning_content`.
+    let annotated =
+        annotated.map_data(|response| Ok(crate::reasoning_field::RoutedReasoning::new(response)));
     annotated_to_sse_event(annotated)
 }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2269,7 +2269,7 @@ async fn chat_completions(
         if ctx.is_killed() {
             inflight_guard.mark_error(ErrorType::Cancelled);
         }
-        Ok(Json(response).into_response())
+        Ok(Json(crate::reasoning_field::RoutedReasoning::new(response)).into_response())
     }
 }
 

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -2149,6 +2149,7 @@ async fn chat_completions(
         let mut http_queue_guard = Some(http_queue_guard);
         let tool_dispatch_enabled = state.streaming_tool_dispatch_enabled();
         let reasoning_dispatch_enabled = state.streaming_reasoning_dispatch_enabled();
+        let reasoning_field = state.reasoning_field();
         let mut reasoning_buffer: HashMap<u32, String> = HashMap::new();
         let mut dispatched_tool_ids: HashSet<String> = HashSet::new();
 
@@ -2202,6 +2203,7 @@ async fn chat_completions(
                     EventConverter::from(response),
                     &mut response_collector,
                     &mut http_queue_guard,
+                    reasoning_field,
                 );
 
                 // Side-channel events come first, then the regular data event.
@@ -2269,7 +2271,11 @@ async fn chat_completions(
         if ctx.is_killed() {
             inflight_guard.mark_error(ErrorType::Cancelled);
         }
-        Ok(Json(crate::reasoning_field::RoutedReasoning::new(response)).into_response())
+        Ok(Json(crate::reasoning_field::RoutedReasoning::new(
+            response,
+            state.reasoning_field(),
+        ))
+        .into_response())
     }
 }
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -27,6 +27,7 @@ use crate::endpoint_type::EndpointType;
 use crate::kv_router::metrics::{
     RoutingOverheadMetrics, register_router_queue_metrics, register_worker_load_metrics,
 };
+use crate::reasoning_field::ReasoningField;
 use crate::request_template::RequestTemplate;
 use anyhow::Result;
 use axum_server::tls_rustls::RustlsConfig;
@@ -539,6 +540,11 @@ impl State {
         self.frontend_api_config
             .streaming_dispatch()
             .reasoning_dispatch()
+    }
+
+    /// Response field used for emitted OpenAI-compatible reasoning content.
+    pub fn reasoning_field(&self) -> ReasoningField {
+        self.frontend_api_config.reasoning_field()
     }
 }
 
@@ -1273,6 +1279,13 @@ impl HttpServiceConfigBuilder {
             .get_or_insert_with(FrontendApiConfig::default)
             .streaming_dispatch_mut()
             .set_reasoning_dispatch(enabled);
+        self
+    }
+
+    pub fn reasoning_field(mut self, reasoning_field: ReasoningField) -> Self {
+        self.frontend_api_config
+            .get_or_insert_with(FrontendApiConfig::default)
+            .set_reasoning_field(reasoning_field);
         self
     }
 

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -32,6 +32,7 @@ pub mod namespace;
 pub mod perf;
 pub mod preprocessor;
 pub mod protocols;
+pub mod reasoning_field;
 pub mod recorder;
 pub mod request_template;
 pub mod request_trace;

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -20,6 +20,7 @@ use crate::frontend_config::{FrontendApiConfig, MetricsConfig};
 use crate::model_card::{ModelDeploymentCard, is_weight_file};
 use crate::model_type::{ModelInput, ModelType};
 use crate::preprocessor::media::{MediaDecoder, MediaFetcher};
+use crate::reasoning_field::ReasoningField;
 use crate::request_template::RequestTemplate;
 
 pub mod runtime_config;
@@ -208,6 +209,12 @@ impl LocalModelBuilder {
         self.frontend_api_config
             .streaming_dispatch_mut()
             .set_reasoning_dispatch(enabled);
+        self
+    }
+
+    pub fn reasoning_field(&mut self, reasoning_field: ReasoningField) -> &mut Self {
+        self.frontend_api_config
+            .set_reasoning_field(reasoning_field);
         self
     }
 
@@ -550,6 +557,10 @@ impl LocalModel {
         self.frontend_api_config
             .streaming_dispatch()
             .reasoning_dispatch()
+    }
+
+    pub fn reasoning_field(&self) -> ReasoningField {
+        self.frontend_api_config.reasoning_field()
     }
 
     pub fn tls_cert_path(&self) -> Option<&Path> {

--- a/lib/llm/src/reasoning_field.rs
+++ b/lib/llm/src/reasoning_field.rs
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Per-deployment selector for the reasoning field name emitted by the OpenAI
+//! chat-completions HTTP API. Dynamo keeps `reasoning_content` as its internal
+//! canonical field; this module changes only the serialized response boundary.
+
+use std::sync::OnceLock;
+
+use serde::{Serialize, Serializer, ser::Error as _};
+use serde_json::Value;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ReasoningField {
+    Reasoning,
+    ReasoningContent,
+}
+
+fn reasoning_field_selection() -> ReasoningField {
+    static FIELD: OnceLock<ReasoningField> = OnceLock::new();
+    *FIELD.get_or_init(|| match std::env::var("DYN_REASONING_FIELD_NAME").as_deref() {
+        Ok("reasoning") => ReasoningField::Reasoning,
+        Ok("reasoning_content") | Err(_) => ReasoningField::ReasoningContent,
+        Ok(other) => {
+            tracing::warn!(
+                "DYN_REASONING_FIELD_NAME={other:?} is not \"reasoning\" or \"reasoning_content\"; defaulting to reasoning_content"
+            );
+            ReasoningField::ReasoningContent
+        }
+    })
+}
+
+/// Serialization wrapper that routes chat-completion reasoning to the field
+/// selected by `DYN_REASONING_FIELD_NAME`.
+///
+/// Keeping routing at the HTTP boundary is intentional: reasoning parsers,
+/// tool-call parsers, aggregators, request tracing, and gRPC continue to use
+/// Dynamo's canonical `reasoning_content` representation. That avoids
+/// teaching every internal producer about a wire-format compatibility option.
+#[derive(Debug, Clone)]
+pub struct RoutedReasoning<T>(T);
+
+impl<T> RoutedReasoning<T> {
+    pub fn new(inner: T) -> Self {
+        Self(inner)
+    }
+}
+
+impl<T: Serialize> Serialize for RoutedReasoning<T> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut value = serde_json::to_value(&self.0).map_err(S::Error::custom)?;
+        route_serialized_reasoning(&mut value, reasoning_field_selection());
+        value.serialize(serializer)
+    }
+}
+
+fn route_serialized_reasoning(value: &mut Value, field: ReasoningField) {
+    if field == ReasoningField::ReasoningContent {
+        return;
+    }
+
+    let Some(choices) = value.get_mut("choices").and_then(Value::as_array_mut) else {
+        return;
+    };
+
+    for choice in choices {
+        let Some(choice) = choice.as_object_mut() else {
+            continue;
+        };
+
+        // Unary chat completions use `message`; streamed chunks use `delta`.
+        for container_name in ["message", "delta"] {
+            let Some(container) = choice
+                .get_mut(container_name)
+                .and_then(Value::as_object_mut)
+            else {
+                continue;
+            };
+
+            if let Some(reasoning) = container.remove("reasoning_content") {
+                container.insert("reasoning".to_string(), reasoning);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn routes_unary_and_streaming_reasoning() {
+        let mut unary = json!({
+            "choices": [{
+                "message": {"content": null, "reasoning_content": "thinking"}
+            }]
+        });
+        route_serialized_reasoning(&mut unary, ReasoningField::Reasoning);
+        assert_eq!(unary["choices"][0]["message"]["reasoning"], "thinking");
+        assert!(
+            unary["choices"][0]["message"]
+                .get("reasoning_content")
+                .is_none()
+        );
+
+        let mut stream = json!({
+            "choices": [{
+                "delta": {"reasoning_content": "think"}
+            }]
+        });
+        route_serialized_reasoning(&mut stream, ReasoningField::Reasoning);
+        assert_eq!(stream["choices"][0]["delta"]["reasoning"], "think");
+        assert!(
+            stream["choices"][0]["delta"]
+                .get("reasoning_content")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn reasoning_content_mode_preserves_upstream_json() {
+        let mut value = json!({
+            "choices": [{
+                "message": {"reasoning_content": "thinking"}
+            }],
+            "nvext": {"reasoning_content": "unrelated"}
+        });
+        let original = value.clone();
+        route_serialized_reasoning(&mut value, ReasoningField::ReasoningContent);
+        assert_eq!(value, original);
+    }
+
+    #[test]
+    fn routing_does_not_rewrite_extension_fields_or_add_missing_fields() {
+        let mut value = json!({
+            "choices": [{"delta": {"content": "answer"}}],
+            "nvext": {"reasoning_content": "extension metadata"}
+        });
+        route_serialized_reasoning(&mut value, ReasoningField::Reasoning);
+        assert!(value["choices"][0]["delta"].get("reasoning").is_none());
+        assert_eq!(value["nvext"]["reasoning_content"], "extension metadata");
+    }
+}

--- a/lib/llm/src/reasoning_field.rs
+++ b/lib/llm/src/reasoning_field.rs
@@ -5,44 +5,87 @@
 //! chat-completions HTTP API. Dynamo keeps `reasoning_content` as its internal
 //! canonical field; this module changes only the serialized response boundary.
 
-use std::sync::OnceLock;
+use std::{fmt, str::FromStr};
 
 use serde::{Serialize, Serializer, ser::Error as _};
 use serde_json::Value;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum ReasoningField {
+pub enum ReasoningField {
     Reasoning,
     ReasoningContent,
 }
 
-fn reasoning_field_selection() -> ReasoningField {
-    static FIELD: OnceLock<ReasoningField> = OnceLock::new();
-    *FIELD.get_or_init(|| match std::env::var("DYN_REASONING_FIELD_NAME").as_deref() {
-        Ok("reasoning") => ReasoningField::Reasoning,
-        Ok("reasoning_content") | Err(_) => ReasoningField::ReasoningContent,
-        Ok(other) => {
-            tracing::warn!(
-                "DYN_REASONING_FIELD_NAME={other:?} is not \"reasoning\" or \"reasoning_content\"; defaulting to reasoning_content"
-            );
-            ReasoningField::ReasoningContent
+impl ReasoningField {
+    pub const DEFAULT: Self = Self::ReasoningContent;
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Reasoning => "reasoning",
+            Self::ReasoningContent => "reasoning_content",
         }
-    })
+    }
+}
+
+impl Default for ReasoningField {
+    fn default() -> Self {
+        Self::DEFAULT
+    }
+}
+
+impl fmt::Display for ReasoningField {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReasoningFieldParseError {
+    value: String,
+}
+
+impl fmt::Display for ReasoningFieldParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "reasoning field name {:?} is not \"reasoning\" or \"reasoning_content\"",
+            self.value
+        )
+    }
+}
+
+impl std::error::Error for ReasoningFieldParseError {}
+
+impl FromStr for ReasoningField {
+    type Err = ReasoningFieldParseError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "reasoning" => Ok(Self::Reasoning),
+            "reasoning_content" => Ok(Self::ReasoningContent),
+            other => Err(ReasoningFieldParseError {
+                value: other.to_string(),
+            }),
+        }
+    }
 }
 
 /// Serialization wrapper that routes chat-completion reasoning to the field
-/// selected by `DYN_REASONING_FIELD_NAME`.
+/// selected by frontend startup config.
 ///
 /// Keeping routing at the HTTP boundary is intentional: reasoning parsers,
 /// tool-call parsers, aggregators, request tracing, and gRPC continue to use
 /// Dynamo's canonical `reasoning_content` representation. That avoids
 /// teaching every internal producer about a wire-format compatibility option.
 #[derive(Debug, Clone)]
-pub struct RoutedReasoning<T>(T);
+pub struct RoutedReasoning<T> {
+    inner: T,
+    field: ReasoningField,
+}
 
 impl<T> RoutedReasoning<T> {
-    pub fn new(inner: T) -> Self {
-        Self(inner)
+    pub fn new(inner: T, field: ReasoningField) -> Self {
+        Self { inner, field }
     }
 }
 
@@ -51,8 +94,12 @@ impl<T: Serialize> Serialize for RoutedReasoning<T> {
     where
         S: Serializer,
     {
-        let mut value = serde_json::to_value(&self.0).map_err(S::Error::custom)?;
-        route_serialized_reasoning(&mut value, reasoning_field_selection());
+        if self.field == ReasoningField::ReasoningContent {
+            return self.inner.serialize(serializer);
+        }
+
+        let mut value = serde_json::to_value(&self.inner).map_err(S::Error::custom)?;
+        route_serialized_reasoning(&mut value, self.field);
         value.serialize(serializer)
     }
 }

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -360,6 +360,10 @@ pub mod llm {
     pub const DYN_ENABLE_STREAMING_REASONING_DISPATCH: &str =
         "DYN_ENABLE_STREAMING_REASONING_DISPATCH";
 
+    /// OpenAI-compatible response field used for emitted reasoning content.
+    /// Accepted values: "reasoning_content" (default) or "reasoning".
+    pub const DYN_REASONING_FIELD_NAME: &str = "DYN_REASONING_FIELD_NAME";
+
     /// \[EXPERIMENTAL\] Route supported tool-call families (Qwen3-Coder, DeepSeek-V4)
     /// through the `dynamo-parsers-v2` streaming parser for BOTH the batch and the
     /// streaming path, bypassing the v1 tool-call jail. Off by default; when set, the
@@ -865,6 +869,7 @@ mod tests {
             llm::DYN_ENABLE_FORCE_INCLUDE_USAGE,
             llm::DYN_ENABLE_STREAMING_TOOL_DISPATCH,
             llm::DYN_ENABLE_STREAMING_REASONING_DISPATCH,
+            llm::DYN_REASONING_FIELD_NAME,
             llm::DYN_ENABLE_EXPERIMENTAL_PARSERS_V2,
             llm::DYN_LORA_ALLOCATION_ENABLED,
             llm::DYN_LORA_ALLOCATION_ALGORITHM,


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

- Add `DYN_REASONING_FIELD_NAME` env var (reasoning | reasoning_content, default reasoning_content) — selects which wire key carries reasoning content on outbound chat completion responses.
- New lib/llm/src/reasoning_field.rs module: route_reasoning() returns a named `RoutedReasoning { reasoning, reasoning_content }` for struct-literal shorthand; `merge_and_route_stream_delta_reasoning()` idempotently combines existing content on a stream delta with new content and routes per env var. 
- Wire the router at every reasoning emit site — non-streaming aggregator (From<DeltaChoice>), audit/stream.rs one-chunk conversion, preprocessor.rs reasoning-parser output, jail.rs pending-release paths (both streaming and non-streaming paths respect the env var).
- Aggregator fold-body coalesces choice.delta.reasoning_content.or(choice.delta.reasoning) on ingest, and audit/stream.rs coalesces `message.reasoning_content.or_else(|| message.reasoning.clone())` before splitting — no reasoning is dropped if an upstream stage already routed to either wire field.
- `is_empty_stream_response` binds reasoning in its destructure and adds `reasoning.is_none()` to the emptiness predicate so reasoning-only stream chunks aren't dropped as "empty."
- Depends on the companion PR https://github.com/ai-dynamo/frontend-crates/pull/100 — the new reasoning field and reasoning_content alias
live in dynamo-protocols. Need to merge + release that crate first, then bump dynamo-protocols.

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

Fixes https://github.com/ai-dynamo/dynamo/issues/11203

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11464" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for reasoning output in chat responses and streamed updates, with reasoning preserved consistently across final and incremental results.
* **Bug Fixes**
  * Fixed streaming behavior so reasoning-only chunks are no longer dropped.
  * Improved handling of mixed reasoning formats so responses continue to show reasoning in the expected field.
* **Chores**
  * Updated internal test fixtures to match the current response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->