### PR TITLE
feat(kv-router): rename worker tenancy to routing groups [DYN-3584]

### DIFF
--- a/docs/components/router/standalone-indexer.md
+++ b/docs/components/router/standalone-indexer.md
@@ -24,13 +24,13 @@ The HTTP API follows the [Mooncake KV Indexer RFC](https://github.com/kvcache-ai
 standalone indexer waits for that many workers to register before opening its startup-ready
 gate, matching the frontend/router startup behavior.
 
-## Multi-Model and Multi-Tenant Support
+## Model and Routing Group Support
 
-The indexer maintains one radix tree per `(model_name, tenant_id)` pair. Workers registered with different model names or tenant IDs are isolated into separate indexers — queries against one model/tenant never return scores from another.
+The indexer maintains one radix tree per `(model_name, routing_group)` pair. Workers registered with different model names or routing groups are isolated into separate indexers. Queries against one pair never return scores from another.
 
 - **`model_name`** (required on `/register` and `/query`): Identifies the model. Workers serving different models get separate radix trees.
-- **`tenant_id`** (optional, defaults to `"default"`): Enables multi-tenant isolation within the same model. Omit for single-tenant deployments.
-- **`block_size`** is per-indexer: the first `/register` call for a given `(model_name, tenant_id)` sets the block size. Subsequent registrations for the same pair must use the same block size or the request will fail.
+- **`routing_group`** (optional, defaults to `"default"`): Identifies a statically assigned worker pool within the model. Omit it when the model does not need independently selectable pools.
+- **`block_size`** is per-indexer: the first `/register` call for a given `(model_name, routing_group)` sets the block size. Subsequent registrations for the same pair must use the same block size or the request will fail.
 
 ## Compatibility
 
@@ -115,7 +115,7 @@ This keeps the default `kv-indexer` build lean while still allowing Prometheus m
 ## CLI
 
 ```bash
-python -m dynamo.indexer --port 8090 [--threads 4] [--block-size 16 --model-name my-model --tenant-id default --workers "1=tcp://host:5557,2:1=tcp://host:5558"] [--peers "http://peer1:8090,http://peer2:8091"]
+python -m dynamo.indexer --port 8090 [--threads 4] [--block-size 16 --model-name my-model --routing-group default --workers "1=tcp://host:5557,2:1=tcp://host:5558"] [--peers "http://peer1:8090,http://peer2:8091"]
 ```
 
 | Flag | Default | Description |
@@ -125,7 +125,7 @@ python -m dynamo.indexer --port 8090 [--threads 4] [--block-size 16 --model-name
 | `--threads` | `4` | Number of indexer threads (1 = single-threaded, >1 = thread pool) |
 | `--workers` | (none) | Initial workers as `instance_id[:dp_rank]=zmq_address,...` pairs (dp_rank defaults to 0) |
 | `--model-name` | `default` | Model name for initial `--workers` |
-| `--tenant-id` | `default` | Tenant ID for initial `--workers` |
+| `--routing-group` | `default` | Routing group for initial `--workers` |
 | `--peers` | (none) | Comma-separated peer indexer URLs for P2P recovery on startup |
 
 ### Shared Startup Gate
@@ -157,13 +157,13 @@ curl http://localhost:8090/metrics
 | `dynamo_kvindexer_request_duration_seconds` | Histogram | `endpoint` | HTTP request latency |
 | `dynamo_kvindexer_requests_total` | Counter | `endpoint`, `method` | Total HTTP requests |
 | `dynamo_kvindexer_errors_total` | Counter | `endpoint`, `status_class` | HTTP error responses (4xx/5xx) |
-| `dynamo_kvindexer_models` | Gauge | — | Number of active model+tenant indexers |
+| `dynamo_kvindexer_models` | Gauge | — | Number of active model+routing-group indexers |
 | `dynamo_kvindexer_workers` | Gauge | — | Number of registered worker instances |
 | `dynamo_kvindexer_listeners` | Gauge | `status` | Number of ZMQ listeners by status (`pending`, `active`, `paused`, `failed`) |
 | `dynamo_kvrouter_kv_cache_events_applied` | Counter | `event_type`, `status` | Primary device-tier KV events applied, partitioned by event type and result |
 | `dynamo_kvrouter_kv_cache_event_warnings` | Counter | `warning_kind` | Suspicious-but-valid primary device-tier events, including duplicate STORE content |
 
-The core event counters aggregate process-wide across model and tenant indexers and
+The core event counters aggregate process-wide across model and routing-group indexers and
 across all indexer threads. A `duplicate_store` warning is not necessarily an error:
 peer recovery replay can reapply content already restored from a snapshot. Lower-tier
 events and listener transport or replay failures are not represented by these core
@@ -171,11 +171,11 @@ event counters; use the standalone service metrics and logs for those paths.
 
 ### `POST /register` — Register an endpoint
 
-Register a ZMQ endpoint for an instance. Each call creates or reuses the indexer for the given `(model_name, tenant_id)` pair.
+Register a ZMQ endpoint for an instance. Each call creates or reuses the indexer for the given `(model_name, routing_group)` pair.
 Registration is non-blocking: if the worker is not up yet, the listener is accepted in `pending` state and transitions to `active` once the initial ZMQ connection succeeds.
 
 ```bash
-# Single model, default tenant
+# Single model, default routing group
 curl -X POST http://localhost:8090/register \
   -H 'Content-Type: application/json' \
   -d '{
@@ -185,14 +185,14 @@ curl -X POST http://localhost:8090/register \
     "block_size": 16
   }'
 
-# With tenant isolation
+# With an explicit routing group
 curl -X POST http://localhost:8090/register \
   -H 'Content-Type: application/json' \
   -d '{
     "instance_id": 2,
     "endpoint": "tcp://127.0.0.1:5558",
     "model_name": "llama-3-8b",
-    "tenant_id": "customer-a",
+    "routing_group": "customer-a",
     "block_size": 16,
     "dp_rank": 0
   }'
@@ -204,47 +204,52 @@ curl -X POST http://localhost:8090/register \
 | `endpoint` | yes | — | ZMQ PUB address to subscribe to |
 | `model_name` | yes | — | Model name (used to select the indexer) |
 | `block_size` | yes | — | KV cache block size (must match the engine) |
-| `tenant_id` | no | `"default"` | Tenant identifier for isolation |
+| `routing_group` | no | `"default"` | Worker routing group |
 | `dp_rank` | no | `0` | Data parallel rank |
 | `replay_endpoint` | no | — | ZMQ ROUTER address for gap replay (e.g. `tcp://host:5560`) |
 | `additional_salt` | no | — | Per-tenant salt (Mooncake RFC #1403 `additionalsalt`, alias accepted). Currently parsed for forward compatibility — engines apply their own salting today. |
 
+For transition compatibility, indexer HTTP inputs also accept a string `tenant_id`, and the
+CLI accepts the hidden `--tenant-id` flag. These values are ignored. `routing_group` always
+controls worker eligibility; when it is omitted, the endpoint's normal default or all-groups
+behavior applies. Responses never include `tenant_id`.
+
 ### `POST /unregister` — Deregister an instance
 
-Remove an instance. Omitting `tenant_id` removes the instance from **all** tenants for the given model; providing it targets only that tenant's indexer.
+Remove an instance. Omitting `routing_group` removes the instance from every routing group for the given model; providing it targets one routing group.
 
 ```bash
-# Remove from all tenants
+# Remove from all routing groups
 curl -X POST http://localhost:8090/unregister \
   -H 'Content-Type: application/json' \
   -d '{"instance_id": 1, "model_name": "llama-3-8b"}'
 
-# Remove from a specific tenant
+# Remove from a specific routing group
 curl -X POST http://localhost:8090/unregister \
   -H 'Content-Type: application/json' \
-  -d '{"instance_id": 1, "model_name": "llama-3-8b", "tenant_id": "customer-a"}'
+  -d '{"instance_id": 1, "model_name": "llama-3-8b", "routing_group": "customer-a"}'
 
 # Remove a specific dp_rank
 curl -X POST http://localhost:8090/unregister \
   -H 'Content-Type: application/json' \
-  -d '{"instance_id": 1, "model_name": "llama-3-8b", "tenant_id": "default", "dp_rank": 0}'
+  -d '{"instance_id": 1, "model_name": "llama-3-8b", "routing_group": "default", "dp_rank": 0}'
 ```
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `instance_id` | yes | — | Worker instance to remove |
 | `model_name` | yes | — | Model name (identifies the indexer) |
-| `tenant_id` | no | — | Tenant identifier (omit to remove from all tenants) |
+| `routing_group` | no | — | Routing group (omit to remove from every group) |
 | `dp_rank` | no | — | Specific dp_rank to remove (omit to remove all) |
 
 ### `GET /workers` — List registered instances
 
-Returns all registered workers, optionally filtered by model and/or tenant.
+Returns all registered workers, optionally filtered by model and routing group.
 
 | Query parameter | Description |
 |-----------------|-------------|
 | `model_name` | Return only workers registered for this model. Omit to return all models. |
-| `tenant_id` | Return only workers registered for this tenant. Omit to return all tenants. |
+| `routing_group` | Return only workers registered for this routing group. Omit to return all groups. |
 
 ```bash
 # All workers
@@ -253,8 +258,8 @@ curl http://localhost:8090/workers
 # Workers for a specific model
 curl "http://localhost:8090/workers?model_name=llama-3-8b"
 
-# Workers for a specific model and tenant
-curl "http://localhost:8090/workers?model_name=llama-3-8b&tenant_id=customer-a"
+# Workers for a specific model and routing group
+curl "http://localhost:8090/workers?model_name=llama-3-8b&routing_group=customer-a"
 ```
 
 Returns:
@@ -265,7 +270,7 @@ Returns:
     "source": "zmq",
     "status": "active",
     "model_name": "llama-3-8b",
-    "tenant_id": "default",
+    "routing_group": "default",
     "block_size": 16,
     "endpoints": {
       "0": "tcp://127.0.0.1:5557",
@@ -291,12 +296,12 @@ Returns:
 | `source` | Always `"zmq"` for ZMQ-managed workers |
 | `status` | Aggregated listener status: `failed > pending > active > paused` |
 | `model_name` | Model this worker is registered under |
-| `tenant_id` | Tenant this worker is registered under |
-| `block_size` | KV cache block size for this worker's `(model_name, tenant_id)` indexer |
+| `routing_group` | Routing group this worker is registered under |
+| `block_size` | KV cache block size for this worker's `(model_name, routing_group)` indexer |
 | `endpoints` | Map of `dp_rank → zmq_address` |
 | `listeners` | Per-dp_rank listener detail; each entry may include a `last_error` field when the most recent startup or recv-loop attempt failed |
 
-Filters are independent — providing both `model_name` and `tenant_id` returns only workers matching both. An empty array is returned (not a 404) when no workers match the filter.
+Filters are independent — providing both `model_name` and `routing_group` returns only workers matching both. An empty array is returned (not a 404) when no workers match the filter.
 
 ### `POST /query` — Query overlap for token IDs
 
@@ -341,7 +346,7 @@ All counts are in **matched tokens** (block overlap count × block size).
 |-------|----------|---------|-------------|
 | `token_ids` | yes | — | Token sequence to query |
 | `model_name` | yes | — | Model name (selects the indexer) |
-| `tenant_id` | no | `"default"` | Tenant identifier |
+| `routing_group` | no | `"default"` | Worker routing group |
 | `lora_name` | no | — | LoRA adapter (overrides indexer-level lora_name for this query) |
 | `cache_salt` | no | — | Per-request cache salt (Mooncake RFC #1403). The indexer mixes it into hashes computed from `token_ids`; equal tokens with different salts do not match. |
 
@@ -359,7 +364,7 @@ Same response format as `/query`, including the per-instance `instances` map. Sc
 |-------|----------|---------|-------------|
 | `block_hashes` | yes | — | Pre-computed block hash array |
 | `model_name` | yes | — | Model name (selects the indexer) |
-| `tenant_id` | no | `"default"` | Tenant identifier |
+| `routing_group` | no | `"default"` | Worker routing group |
 | `cache_salt` | no | — | Must be omitted or `null`. Any string value, including an empty string, returns `400 Bad Request`. |
 
 `block_hashes` are opaque outputs of token hashing, so the indexer cannot apply or verify a salt
@@ -385,7 +390,7 @@ Legacy callers that only consume `scores` keep working: those values are equal t
 
 ### `GET /dump` — Dump all radix tree events
 
-Returns the full radix tree state as a JSON object keyed by `model_name:tenant_id`:
+Returns the full radix tree state as a JSON object keyed by `model_name:routing_group`:
 
 ```bash
 curl http://localhost:8090/dump
@@ -471,7 +476,7 @@ graph TD
     subgraph "Standalone Indexer (HTTP)"
         REG[Worker Registry]
         ZMQ[ZMQ SUB Listeners]
-        IDX["Indexer Map<br/>(model, tenant) → Radix Tree"]
+        IDX["Indexer Map<br/>(model, routing group) → Radix Tree"]
         HTTP[HTTP API<br/>/query /dump /register /health]
     end
 

--- a/docs/components/router/standalone-selection.md
+++ b/docs/components/router/standalone-selection.md
@@ -82,7 +82,7 @@ Content-Type: application/json
 {
   "worker_id": 1,
   "model_name": "model",
-  "tenant_id": "default",
+  "routing_group": "default",
   "endpoint": "http://worker:8000",
   "block_size": 16,
   "data_parallel_start_rank": 0,
@@ -97,7 +97,7 @@ Content-Type: application/json
 
 `POST /workers` returns `201`. `PATCH /workers/{worker_id}` updates supplied
 fields, `DELETE /workers/{worker_id}` removes the worker, and `GET /workers`
-lists catalog state. `model_name` and `tenant_id` scope all selection, indexer,
+lists catalog state. `model_name` and `routing_group` scope all selection, indexer,
 and load state; both default to `"default"` when omitted.
 
 `GET /health` is process liveness. `GET /ready` returns `200` only after at
@@ -113,7 +113,7 @@ Select a worker without booking active load:
 {
   "selection_id": "select-123",
   "model_name": "model",
-  "tenant_id": "default",
+  "routing_group": "default",
   "block_hashes": [11, 12, 13, 14, 15, 16, 17, 18],
   "sequence_hashes": [21, 22, 23, 24, 25, 26, 27, 28],
   "isl_tokens": 512
@@ -130,7 +130,7 @@ globally unique `reservation_id`, or allow the service to generate one:
   "selection_id": "select-123",
   "reservation_id": "request-123",
   "model_name": "model",
-  "tenant_id": "default",
+  "routing_group": "default",
   "block_hashes": [11, 12, 13, 14, 15, 16, 17, 18],
   "sequence_hashes": [21, 22, 23, 24, 25, 26, 27, 28],
   "isl_tokens": 512
@@ -144,7 +144,7 @@ Both endpoints return the same selection shape:
   "selection_id": "select-123",
   "reservation_id": "request-123",
   "model_name": "model",
-  "tenant_id": "default",
+  "routing_group": "default",
   "worker_id": 1,
   "dp_rank": 0,
   "endpoint": "http://worker:8000",
@@ -194,7 +194,7 @@ Content-Type: application/json
 {
   "reservation_id": "request-123",
   "model_name": "model",
-  "tenant_id": "default",
+  "routing_group": "default",
   "worker_id": 1,
   "dp_rank": 0,
   "sequence_hashes": [21, 22, 23, 24, 25, 26, 27, 28],
@@ -231,7 +231,7 @@ The selector has two independent peer configurations:
 | Plane | Transport | Flags | Purpose |
 |-------|-----------|-------|---------|
 | Indexer recovery | HTTP | `--indexer-peers` | Fetch a compatible `/dump` during startup and replay KV events into the local indexer. |
-| Replica synchronization | ZMQ | `--replica-sync-port`, `--replica-sync-peers` | Share admission, prefill-complete, and free events by model and tenant. |
+| Replica synchronization | ZMQ | `--replica-sync-port`, `--replica-sync-peers` | Share admission, prefill-complete, and free events by model and routing group. |
 
 Example:
 
@@ -268,8 +268,12 @@ replica-sync peers. They do not alter the HTTP indexer-recovery peers.
   dropped events, and temporary active-load divergence are accepted.
 - There is no sequencing, acknowledgement, replay, backpressure, or
   resynchronization for replica lifecycle events.
-- Unknown worker, model, tenant, DP-rank, and block-size events are dropped.
+- Unknown worker, model, routing-group, DP-rank, and block-size events are dropped.
   Register the same worker catalog on every selector before routing traffic.
+- The v1 replica envelope uses `routing_group` and is incompatible with binaries that
+  send `tenant_id`. Drain active reservations and lifecycle traffic, upgrade all connected
+  selectors together, re-register worker catalogs, and then resume traffic. Active advisory
+  state is not migrated.
 - Admission, prefill-complete, and free are synchronized. Output-block growth
   remains local to avoid excessive network bandwidth.
 - Startup recovery waits for recovered events to be submitted to the indexer,
@@ -283,7 +287,7 @@ replica-sync peers. They do not alter the HTTP indexer-recovery peers.
 ## Inspection APIs
 
 - `GET /loads` returns active-load snapshots, optionally filtered by
-  `model_name` and `tenant_id`.
+  `model_name` and `routing_group`.
 - `POST /potential_loads` estimates worker load for a prompt without selection.
 - `POST /overlap_scores` returns per-worker/per-rank tiered overlap rows.
 - `GET /dump` returns the compatible indexer recovery snapshot.

--- a/docs/components/router/standalone-slot-tracker.md
+++ b/docs/components/router/standalone-slot-tracker.md
@@ -63,7 +63,7 @@ neither the bind expression nor process identity is a configuration parameter.
 Peer connections are directional. For bidirectional synchronization, configure each
 replica with the other replica's reachable ZMQ endpoint. All replicas must independently
 receive the same worker registrations before lifecycle traffic begins. A replica event
-for an unknown `(model_name, tenant_id)`, block size, worker ID, or DP rank is dropped.
+for an unknown `(model_name, routing_group)`, block size, worker ID, or DP rank is dropped.
 Replica traffic never creates workers.
 
 The transport is bounded and best-effort. A full queue drops new events rather than
@@ -72,6 +72,12 @@ after peer registration. There is no acknowledgement, replay, snapshot, or gap r
 `/add`, `/prefill_complete`, and `/free` should normally remain sticky to the replica
 that accepted `/add`; replica synchronization provides advisory peer state rather than
 cross-replica lifecycle ownership.
+
+> [!WARNING]
+> The replica envelope uses `routing_group` on the existing v1 topic and is not compatible
+> with binaries that send `tenant_id`. Drain lifecycle traffic, stop all connected replicas,
+> upgrade them together, re-register worker catalogs, and then resume traffic. Active advisory
+> state is not migrated.
 
 Peers may also be managed dynamically:
 
@@ -103,7 +109,7 @@ methods, return:
 {"error": "concise description"}
 ```
 
-`tenant_id` defaults to `"default"` when omitted. Request bodies use Axum's default
+`routing_group` defaults to `"default"` when omitted. Request bodies use Axum's default
 bounded JSON handling.
 
 ## Topology API
@@ -116,7 +122,7 @@ Register one contiguous data-parallel range:
 {
   "worker_id": 7,
   "model_name": "llama-3-8b",
-  "tenant_id": "default",
+  "routing_group": "default",
   "block_size": 16,
   "dp_start": 0,
   "dp_size": 2
@@ -124,8 +130,8 @@ Register one contiguous data-parallel range:
 ```
 
 Returns `201`. `block_size` and `dp_size` must be positive, and the DP range must not
-overflow. Workers in the same `(model_name, tenant_id)` tracker must use the same block
-size. Worker IDs are scoped by `(model_name, tenant_id)`.
+overflow. Workers in the same `(model_name, routing_group)` tracker must use the same block
+size. Worker IDs are scoped by `(model_name, routing_group)`.
 
 ### `POST /unregister`
 
@@ -135,7 +141,7 @@ Remove a worker's full DP range and active requests immediately:
 {
   "worker_id": 7,
   "model_name": "llama-3-8b",
-  "tenant_id": "default"
+  "routing_group": "default"
 }
 ```
 
@@ -143,14 +149,14 @@ Returns `200`, or `404` if the registration does not exist.
 
 ### `GET /workers`
 
-List workers with independent optional `model_name` and `tenant_id` filters:
+List workers with independent optional `model_name` and `routing_group` filters:
 
 ```json
 [
   {
     "worker_id": 7,
     "model_name": "llama-3-8b",
-    "tenant_id": "default",
+    "routing_group": "default",
     "block_size": 16,
     "dp_start": 0,
     "dp_size": 2
@@ -169,7 +175,7 @@ Record prompt blocks on a registered worker rank:
 ```json
 {
   "model_name": "llama-3-8b",
-  "tenant_id": "default",
+  "routing_group": "default",
   "request_id": "req-123",
   "worker_id": 7,
   "dp_rank": 0,
@@ -189,7 +195,7 @@ Mark prompt processing complete:
 ```json
 {
   "model_name": "llama-3-8b",
-  "tenant_id": "default",
+  "routing_group": "default",
   "request_id": "req-123"
 }
 ```
@@ -204,12 +210,12 @@ Release prompt blocks and any remaining prefill state:
 ```json
 {
   "model_name": "llama-3-8b",
-  "tenant_id": "default",
+  "routing_group": "default",
   "request_id": "req-123"
 }
 ```
 
-Returns `200`. Free is idempotent while the model/tenant tracker exists, including for
+Returns `200`. Free is idempotent while the model/routing-group tracker exists, including for
 an unknown request. Unknown trackers return `404`.
 
 Lifecycle writes preserve the core slot tracker's arrival ordering. Consumers should
@@ -222,14 +228,14 @@ older than 300 seconds may be removed by inherited stale-request cleanup.
 
 ### `GET /loads`
 
-Read current load snapshots with independent optional `model_name` and `tenant_id`
+Read current load snapshots with independent optional `model_name` and `routing_group`
 filters:
 
 ```json
 [
   {
     "model_name": "llama-3-8b",
-    "tenant_id": "default",
+    "routing_group": "default",
     "worker_id": 7,
     "dp_rank": 0,
     "active_prefill_tokens": 48,
@@ -247,7 +253,7 @@ Project the loads for a new request:
 ```json
 {
   "model_name": "llama-3-8b",
-  "tenant_id": "default",
+  "routing_group": "default",
   "sequence_hashes": [101, -22, 303, 404],
   "new_isl_tokens": 48
 }

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -126,9 +126,13 @@ struct KvIndexerCli {
     #[arg(long, default_value = "default")]
     model_name: String,
 
-    /// Tenant ID for initial workers registered via --workers
+    /// Routing group for initial workers registered via --workers
     #[arg(long, default_value = "default")]
-    tenant_id: String,
+    routing_group: String,
+
+    /// Legacy compatibility input; accepted but ignored
+    #[arg(long = "tenant-id", default_value = "default", hide = true)]
+    _tenant_id: String,
 
     /// Comma-separated peer URLs for P2P recovery (e.g. "http://host1:8090,http://host2:8091")
     #[arg(long)]
@@ -174,7 +178,7 @@ where
             threads: cli.threads,
             workers: cli.workers,
             model_name: cli.model_name,
-            tenant_id: cli.tenant_id,
+            routing_group: cli.routing_group,
             peers: cli.peers,
             access_log: cli.access_log,
             trace_id_header,
@@ -483,17 +487,17 @@ impl SelectionService {
         })
     }
 
-    /// List catalog records, optionally filtered by model and tenant.
-    #[pyo3(signature = (*, model_name = None, tenant_id = None))]
+    /// List catalog records, optionally filtered by model and routing group.
+    #[pyo3(signature = (*, model_name = None, routing_group = None))]
     fn list_workers(
         &self,
         py: Python<'_>,
         model_name: Option<String>,
-        tenant_id: Option<String>,
+        routing_group: Option<String>,
     ) -> PyResult<PyObject> {
         let workers = self
             .inner
-            .list_workers(model_name.as_deref(), tenant_id.as_deref());
+            .list_workers(model_name.as_deref(), routing_group.as_deref());
         pythonize(py, &workers)
             .map(|o| o.unbind())
             .map_err(to_pyerr)
@@ -607,16 +611,16 @@ impl SelectionService {
     }
 
     /// Current per-model active load (pending counts + per-worker potential loads).
-    #[pyo3(signature = (*, model_name = None, tenant_id = None))]
+    #[pyo3(signature = (*, model_name = None, routing_group = None))]
     fn loads(
         &self,
         py: Python<'_>,
         model_name: Option<String>,
-        tenant_id: Option<String>,
+        routing_group: Option<String>,
     ) -> PyResult<PyObject> {
         let loads = self
             .inner
-            .loads(model_name.as_deref(), tenant_id.as_deref());
+            .loads(model_name.as_deref(), routing_group.as_deref());
         pythonize(py, &loads).map(|o| o.unbind()).map_err(to_pyerr)
     }
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -686,9 +686,9 @@ class SelectionService:
         ...
 
     def list_workers(
-        self, *, model_name: Optional[str] = None, tenant_id: Optional[str] = None
+        self, *, model_name: Optional[str] = None, routing_group: Optional[str] = None
     ) -> JsonLike:
-        """List catalog records, optionally filtered by model and tenant."""
+        """List catalog records, optionally filtered by model and routing group."""
         ...
 
     def ready(self) -> JsonLike:
@@ -726,7 +726,7 @@ class SelectionService:
         ...
 
     def loads(
-        self, *, model_name: Optional[str] = None, tenant_id: Optional[str] = None
+        self, *, model_name: Optional[str] = None, routing_group: Optional[str] = None
     ) -> JsonLike:
         """Current per-model active load (pending counts + per-worker potential loads)."""
         ...

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -24,7 +24,7 @@ const REPLICA_TOPIC: &[u8] = b"dynamo.slot-tracker.v1";
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) struct ScopedReplicaEvent {
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub block_size: u32,
     pub event: ActiveSequenceEvent,
 }
@@ -105,7 +105,7 @@ pub(crate) struct ScopedSequencePublisher {
 #[derive(Clone)]
 struct ScopedReplicaPublisher {
     model_name: Arc<str>,
-    tenant_id: Arc<str>,
+    routing_group: Arc<str>,
     block_size: u32,
     tx: ReplicaEventSender,
 }
@@ -117,14 +117,14 @@ impl ScopedSequencePublisher {
 
     pub(crate) fn enabled(
         model_name: Arc<str>,
-        tenant_id: Arc<str>,
+        routing_group: Arc<str>,
         block_size: u32,
         tx: ReplicaEventSender,
     ) -> Self {
         Self {
             replica: Some(ScopedReplicaPublisher {
                 model_name,
-                tenant_id,
+                routing_group,
                 block_size,
                 tx,
             }),
@@ -142,7 +142,7 @@ impl SequencePublisher for ScopedSequencePublisher {
         };
         let envelope = ScopedReplicaEvent {
             model_name: replica.model_name.to_string(),
-            tenant_id: replica.tenant_id.to_string(),
+            routing_group: replica.routing_group.to_string(),
             block_size: replica.block_size,
             event: event.clone(),
         };
@@ -151,7 +151,7 @@ impl SequencePublisher for ScopedSequencePublisher {
             Err(mpsc::error::TrySendError::Full(event)) => {
                 tracing::trace!(
                     model_name = %event.model_name,
-                    tenant_id = %event.tenant_id,
+                    routing_group = %event.routing_group,
                     request_id = %event.event.request_id,
                     "Replica publisher channel full; dropping event"
                 );
@@ -241,7 +241,7 @@ pub(crate) fn setup_replica_sync(
 pub(crate) fn setup_scoped_replica_sync(
     config: Option<&ReplicaSyncConfig>,
     model_name: &str,
-    tenant_id: &str,
+    routing_group: &str,
     block_size: u32,
 ) -> ScopedReplicaSync {
     let Some(config) = config else {
@@ -257,7 +257,7 @@ pub(crate) fn setup_scoped_replica_sync(
     ScopedReplicaSync {
         publisher: ScopedSequencePublisher::enabled(
             Arc::from(model_name),
-            Arc::from(tenant_id),
+            Arc::from(routing_group),
             block_size,
             config.outbound_tx.clone(),
         ),
@@ -535,7 +535,7 @@ mod tests {
     fn event() -> ScopedReplicaEvent {
         ScopedReplicaEvent {
             model_name: "model".to_string(),
-            tenant_id: "tenant".to_string(),
+            routing_group: "group".to_string(),
             block_size: 16,
             event: ActiveSequenceEvent {
                 request_id: "request".to_string(),
@@ -569,11 +569,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn replica_event_wire_schema_uses_routing_group() {
+        let payload = rmp_serde::to_vec_named(&event()).unwrap();
+        let value: serde_json::Value = rmp_serde::from_slice(&payload).unwrap();
+
+        assert_eq!(value["routing_group"], "group");
+        assert!(value.get("tenant_id").is_none());
+
+        let decoded: ScopedReplicaEvent = rmp_serde::from_slice(&payload).unwrap();
+        assert_eq!(decoded.routing_group, "group");
+    }
+
+    #[test]
+    fn legacy_replica_event_wire_schema_is_rejected() {
+        let legacy = serde_json::json!({
+            "model_name": "model",
+            "tenant_id": "tenant",
+            "block_size": 16,
+            "event": event().event,
+        });
+        let payload = rmp_serde::to_vec_named(&legacy).unwrap();
+
+        assert!(rmp_serde::from_slice::<ScopedReplicaEvent>(&payload).is_err());
+    }
+
     #[tokio::test]
     async fn scoped_publisher_drops_when_outbound_channel_is_full() {
         let (tx, mut rx) = mpsc::channel(1);
         let publisher =
-            ScopedSequencePublisher::enabled(Arc::from("model"), Arc::from("tenant"), 16, tx);
+            ScopedSequencePublisher::enabled(Arc::from("model"), Arc::from("group"), 16, tx);
         let event = event().event;
 
         publisher.publish_event(&event).await.unwrap();
@@ -653,7 +678,7 @@ mod tests {
                 dispatch_registry_b.dispatch_replica_event(event)
             })
             .unwrap();
-        let key = TrackerKey::new("model".to_string(), Some("tenant".to_string()));
+        let key = TrackerKey::new("model".to_string(), Some("group".to_string()));
         registry_a.register(key.clone(), 1, 16, 0, 1).unwrap();
         registry_b.register(key.clone(), 1, 16, 0, 1).unwrap();
         let worker = WorkerWithDpRank::new(1, 0);

--- a/lib/kv-router/src/services/indexer/logging.rs
+++ b/lib/kv-router/src/services/indexer/logging.rs
@@ -70,7 +70,7 @@ impl AccessLogSink {
         let mut inner = self.inner.lock();
         if let Err(e) = inner.writer.write_all(record.as_bytes()) {
             let prev = IO_ERRORS.fetch_add(1, Ordering::Relaxed);
-            if prev % 100 == 0 {
+            if prev.is_multiple_of(100) {
                 tracing::warn!(error = %e, total = prev + 1, "access log write failed");
             }
         }
@@ -161,7 +161,7 @@ pub async fn access_log_middleware(
 
 /// Parse and validate an HTTP header name at startup.
 pub fn parse_header_name(name: &str) -> Result<HeaderName, axum::http::Error> {
-    HeaderName::from_bytes(name.as_bytes()).map_err(|e| axum::http::Error::from(e))
+    HeaderName::from_bytes(name.as_bytes()).map_err(axum::http::Error::from)
 }
 
 #[cfg(test)]

--- a/lib/kv-router/src/services/indexer/metrics.rs
+++ b/lib/kv-router/src/services/indexer/metrics.rs
@@ -70,7 +70,7 @@ static METRICS: LazyLock<StandaloneIndexerMetrics> = LazyLock::new(|| Standalone
     .expect("valid counter"),
     models: IntGauge::new(
         format!("{METRICS_PREFIX}_{MODELS}"),
-        "Number of active model+tenant indexers",
+        "Number of active model+routing-group indexers",
     )
     .expect("valid gauge"),
     workers: IntGauge::new(
@@ -155,6 +155,18 @@ mod tests {
         register(&registry).expect("registration should succeed");
 
         set_worker_state(1, 2, [1, 1, 0, 0]);
+        METRICS
+            .request_duration
+            .with_label_values(&["/health"])
+            .observe(0.001);
+        METRICS
+            .requests_total
+            .with_label_values(&["/health", "GET"])
+            .inc();
+        METRICS
+            .errors_total
+            .with_label_values(&["/query", "4xx"])
+            .inc();
 
         let encoder = prometheus::TextEncoder::new();
         let mut buf = Vec::new();

--- a/lib/kv-router/src/services/indexer/mod.rs
+++ b/lib/kv-router/src/services/indexer/mod.rs
@@ -6,7 +6,7 @@
 //! Hosts an Axum HTTP server with `/register`, `/unregister`, `/query`,
 //! `/query_by_hash`, and peer-discovery routes that workers / gateways can
 //! call to drive cache-aware routing decisions. Each registered worker spawns
-//! a ZMQ listener that ingests its KV events into a per-(model, tenant)
+//! a ZMQ listener that ingests its KV events into a per-(model, routing group)
 //! [`backend::Indexer`].
 //!
 //! ## Multi-tier responses
@@ -51,7 +51,7 @@ pub struct IndexerConfig {
     pub threads: usize,
     pub workers: Option<String>,
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub peers: Option<String>,
     pub access_log: Option<PathBuf>,
     pub trace_id_header: HeaderName,
@@ -130,7 +130,7 @@ pub async fn run_server(config: IndexerConfig) -> anyhow::Result<()> {
         port = config.port,
         threads = config.threads,
         model_name = %config.model_name,
-        tenant_id = %config.tenant_id,
+        routing_group = %config.routing_group,
         num_peers = peers.len(),
         "Starting standalone KV cache indexer (HTTP-only mode)"
     );
@@ -198,7 +198,7 @@ async fn run_common(
                     endpoint,
                     dp_rank,
                     config.model_name.clone(),
-                    config.tenant_id.clone(),
+                    config.routing_group.clone(),
                     block_size,
                     None,
                 )

--- a/lib/kv-router/src/services/indexer/recovery.rs
+++ b/lib/kv-router/src/services/indexer/recovery.rs
@@ -59,16 +59,15 @@ async fn try_recover_from_peer(
 
     let dump: HashMap<String, DumpEntry> =
         resp.json().await.context("failed to parse dump response")?;
-
     let mut total_events = 0usize;
     for (map_key, entry) in dump {
-        let (model_name, tenant_id) = map_key
+        let (model_name, routing_group) = map_key
             .split_once(':')
             .ok_or_else(|| anyhow::anyhow!("invalid dump key format: {map_key}"))?;
 
         let key = IndexerKey {
             model_name: model_name.to_string(),
-            tenant_id: tenant_id.to_string(),
+            routing_group: routing_group.to_string(),
         };
 
         let indexer = registry.get_or_create_indexer(key, entry.block_size);

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -23,7 +23,7 @@ use super::listener::spawn_zmq_listener;
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct IndexerKey {
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
 }
 
 pub struct IndexerEntry {
@@ -110,7 +110,7 @@ pub struct WorkerInfo {
     source: WorkerSource,
     status: ListenerStatus,
     model_name: String,
-    tenant_id: String,
+    routing_group: String,
     block_size: u32,
     endpoints: HashMap<u32, String>,
     listeners: HashMap<u32, ListenerInfo>,
@@ -414,21 +414,21 @@ impl WorkerRegistry {
         endpoint: String,
         dp_rank: u32,
         model_name: String,
-        tenant_id: String,
+        routing_group: String,
         block_size: u32,
         replay_endpoint: Option<String>,
     ) -> Result<()> {
         let key = IndexerKey {
             model_name,
-            tenant_id,
+            routing_group,
         };
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
                 bail!(
-                    "instance {instance_id} is already registered for model={} tenant={}",
+                    "instance {instance_id} is already registered for model={} routing_group={}",
                     entry.key.model_name,
-                    entry.key.tenant_id
+                    entry.key.routing_group
                 );
             }
 
@@ -440,7 +440,7 @@ impl WorkerRegistry {
         let indexer_entry = self.indexers.entry(key.clone()).or_insert_with(|| {
             tracing::info!(
                 model_name = %key.model_name,
-                tenant_id = %key.tenant_id,
+                routing_group = %key.routing_group,
                 block_size,
                 "Creating new indexer"
             );
@@ -456,9 +456,9 @@ impl WorkerRegistry {
 
         if indexer_entry.block_size != block_size {
             bail!(
-                "block_size mismatch for model={} tenant={}: existing={}, requested={}",
+                "block_size mismatch for model={} routing_group={}: existing={}, requested={}",
                 key.model_name,
-                key.tenant_id,
+                key.routing_group,
                 indexer_entry.block_size,
                 block_size
             );
@@ -502,19 +502,19 @@ impl WorkerRegistry {
         &self,
         instance_id: WorkerId,
         model_name: &str,
-        tenant_id: &str,
+        routing_group: &str,
     ) -> Result<()> {
         let key = IndexerKey {
             model_name: model_name.to_string(),
-            tenant_id: tenant_id.to_string(),
+            routing_group: routing_group.to_string(),
         };
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
                 bail!(
-                    "instance {instance_id} is registered for model={} tenant={}",
+                    "instance {instance_id} is registered for model={} routing_group={}",
                     entry.key.model_name,
-                    entry.key.tenant_id
+                    entry.key.routing_group
                 );
             }
         } else {
@@ -544,11 +544,11 @@ impl WorkerRegistry {
         instance_id: WorkerId,
         dp_rank: u32,
         model_name: &str,
-        tenant_id: &str,
+        routing_group: &str,
     ) -> Result<()> {
         let key = IndexerKey {
             model_name: model_name.to_string(),
-            tenant_id: tenant_id.to_string(),
+            routing_group: routing_group.to_string(),
         };
 
         let (record, remove_worker) = {
@@ -559,9 +559,9 @@ impl WorkerRegistry {
 
             if entry.key != key {
                 bail!(
-                    "instance {instance_id} is registered for model={} tenant={}",
+                    "instance {instance_id} is registered for model={} routing_group={}",
                     entry.key.model_name,
-                    entry.key.tenant_id
+                    entry.key.routing_group
                 );
             }
 
@@ -595,7 +595,7 @@ impl WorkerRegistry {
         Ok(())
     }
 
-    pub async fn deregister_all_tenants(
+    pub async fn deregister_all_routing_groups(
         &self,
         instance_id: WorkerId,
         model_name: &str,
@@ -603,9 +603,9 @@ impl WorkerRegistry {
         let key = if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key.model_name != model_name {
                 bail!(
-                    "instance {instance_id} is registered for model={} tenant={}",
+                    "instance {instance_id} is registered for model={} routing_group={}",
                     entry.key.model_name,
-                    entry.key.tenant_id
+                    entry.key.routing_group
                 );
             }
             entry.key.clone()
@@ -680,7 +680,7 @@ impl WorkerRegistry {
     }
 
     /// Return registered workers, optionally filtered by `model_name` and/or
-    /// `tenant_id`.  Pass `None` for a field to skip that filter.
+    /// `routing_group`.  Pass `None` for a field to skip that filter.
     ///
     /// Workers that are mid-deregistration (listener map temporarily empty
     /// before the worker entry is removed) are silently omitted to avoid
@@ -688,7 +688,7 @@ impl WorkerRegistry {
     pub fn list_filtered(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<WorkerInfo> {
         self.workers
             .iter()
@@ -698,7 +698,7 @@ impl WorkerRegistry {
 
                 // Apply caller-supplied filters.
                 if model_name.is_some_and(|m| key.model_name != m)
-                    || tenant_id.is_some_and(|t| key.tenant_id != t)
+                    || routing_group.is_some_and(|t| key.routing_group != t)
                 {
                     return None;
                 }
@@ -732,7 +732,7 @@ impl WorkerRegistry {
                     source: WorkerSource::Zmq,
                     status,
                     model_name: key.model_name.clone(),
-                    tenant_id: key.tenant_id.clone(),
+                    routing_group: key.routing_group.clone(),
                     block_size,
                     endpoints,
                     listeners,
@@ -749,7 +749,7 @@ impl WorkerRegistry {
         let entry = self.indexers.entry(key.clone()).or_insert_with(|| {
             tracing::info!(
                 model_name = %key.model_name,
-                tenant_id = %key.tenant_id,
+                routing_group = %key.routing_group,
                 block_size,
                 "Creating indexer from recovery dump"
             );
@@ -765,7 +765,7 @@ impl WorkerRegistry {
         if entry.block_size != block_size {
             tracing::warn!(
                 model_name = %key.model_name,
-                tenant_id = %key.tenant_id,
+                routing_group = %key.routing_group,
                 existing_block_size = entry.block_size,
                 requested_block_size = block_size,
                 "Block size mismatch for existing indexer"
@@ -1014,7 +1014,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn deregister_all_tenants_removes_watermarks() {
+    async fn deregister_all_routing_groups_removes_watermarks() {
         let registry = test_registry();
         registry.signal_ready();
 
@@ -1034,13 +1034,13 @@ mod tests {
         assert!(registry.watermarks.contains_key(&(1, 0)));
 
         registry
-            .deregister_all_tenants(1, "test-model")
+            .deregister_all_routing_groups(1, "test-model")
             .await
             .unwrap();
 
         assert!(
             !registry.watermarks.contains_key(&(1, 0)),
-            "watermark should be removed after deregister_all_tenants"
+            "watermark should be removed after deregister_all_routing_groups"
         );
     }
 
@@ -1070,7 +1070,7 @@ mod tests {
                 "tcp://127.0.0.1:15571".to_string(),
                 0,
                 "mistral".to_string(),
-                "other-tenant".to_string(),
+                "other-group".to_string(),
                 8,
                 None,
             )
@@ -1082,11 +1082,11 @@ mod tests {
 
         let llama = workers.iter().find(|w| w.model_name == "llama3").unwrap();
         assert_eq!(llama.block_size, 4);
-        assert_eq!(llama.tenant_id, "acme");
+        assert_eq!(llama.routing_group, "acme");
 
         let mistral = workers.iter().find(|w| w.model_name == "mistral").unwrap();
         assert_eq!(mistral.block_size, 8);
-        assert_eq!(mistral.tenant_id, "other-tenant");
+        assert_eq!(mistral.routing_group, "other-group");
 
         let filtered = registry.list_filtered(Some("llama3"), None);
         assert_eq!(filtered.len(), 1);
@@ -1094,15 +1094,15 @@ mod tests {
 
         let acme = registry.list_filtered(None, Some("acme"));
         assert_eq!(acme.len(), 1);
-        assert_eq!(acme[0].tenant_id, "acme");
+        assert_eq!(acme[0].routing_group, "acme");
 
-        let other = registry.list_filtered(None, Some("other-tenant"));
+        let other = registry.list_filtered(None, Some("other-group"));
         assert_eq!(other.len(), 1);
-        assert_eq!(other[0].tenant_id, "other-tenant");
+        assert_eq!(other[0].routing_group, "other-group");
 
         assert!(
             registry
-                .list_filtered(Some("llama3"), Some("other-tenant"))
+                .list_filtered(Some("llama3"), Some("other-group"))
                 .is_empty()
         );
         assert!(registry.list_filtered(Some("nonexistent"), None).is_empty());
@@ -1125,7 +1125,7 @@ mod tests {
 
         let key = IndexerKey {
             model_name: "llama3".to_string(),
-            tenant_id: "acme".to_string(),
+            routing_group: "acme".to_string(),
         };
 
         // Inject the empty-listener WorkerEntry directly.

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -64,7 +64,7 @@ impl AppState {
             let prom_registry = prometheus::Registry::new();
             super::metrics::register(&prom_registry)?;
             let indexer_metrics = KvIndexerMetrics::new_registered(&prom_registry)?;
-            return Ok(Self {
+            Ok(Self {
                 registry: Arc::new(WorkerRegistry::new_with_indexer_metrics_and_cancel_token(
                     indexer_threads,
                     indexer_metrics,
@@ -72,7 +72,7 @@ impl AppState {
                 )),
                 access_log_sink: None,
                 prom_registry,
-            });
+            })
         }
 
         #[cfg(not(feature = "metrics"))]
@@ -86,62 +86,70 @@ impl AppState {
     }
 }
 
-fn default_tenant() -> String {
+fn default_routing_group() -> String {
     "default".to_string()
 }
 
 #[derive(Deserialize)]
-pub struct RegisterRequest {
-    pub instance_id: WorkerId,
-    pub endpoint: String,
-    pub model_name: String,
-    #[serde(default = "default_tenant")]
-    pub tenant_id: String,
-    pub block_size: u32,
+struct RegisterRequest {
+    instance_id: WorkerId,
+    endpoint: String,
+    model_name: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
+    #[serde(default = "default_routing_group", rename = "tenant_id")]
+    _tenant_id: String,
+    block_size: u32,
     #[serde(default)]
-    pub dp_rank: Option<u32>,
+    dp_rank: Option<u32>,
     #[serde(default)]
-    pub replay_endpoint: Option<String>,
+    replay_endpoint: Option<String>,
     /// Optional per-tenant salt (Mooncake RFC #1403 `additionalsalt`).
     /// Currently accepted but not yet mixed into hashes — engines apply
     /// their own salt internally. Plumbed for forward compatibility.
-    #[serde(default, alias = "additionalsalt")]
-    pub additional_salt: Option<String>,
+    #[serde(default, alias = "additionalsalt", rename = "additional_salt")]
+    _additional_salt: Option<String>,
 }
 
 #[derive(Deserialize)]
-pub struct UnregisterRequest {
-    pub instance_id: WorkerId,
-    pub model_name: String,
+struct UnregisterRequest {
+    instance_id: WorkerId,
+    model_name: String,
     #[serde(default)]
-    pub tenant_id: Option<String>,
+    routing_group: Option<String>,
+    #[serde(default, rename = "tenant_id")]
+    _tenant_id: Option<String>,
     #[serde(default)]
-    pub dp_rank: Option<u32>,
+    dp_rank: Option<u32>,
 }
 
 #[derive(Deserialize)]
-pub struct QueryRequest {
-    pub token_ids: Vec<u32>,
-    pub model_name: String,
-    #[serde(default = "default_tenant")]
-    pub tenant_id: String,
+struct QueryRequest {
+    token_ids: Vec<u32>,
+    model_name: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
+    #[serde(default = "default_routing_group", rename = "tenant_id")]
+    _tenant_id: String,
     #[serde(default)]
-    pub lora_name: Option<String>,
+    lora_name: Option<String>,
     /// Optional per-request cache salt (Mooncake RFC #1403), mixed into `/query` hashes.
     #[serde(default)]
-    pub cache_salt: Option<String>,
+    cache_salt: Option<String>,
 }
 
 #[derive(Deserialize)]
-pub struct QueryByHashRequest {
-    pub block_hashes: Vec<i64>,
-    pub model_name: String,
-    #[serde(default = "default_tenant")]
-    pub tenant_id: String,
+struct QueryByHashRequest {
+    block_hashes: Vec<i64>,
+    model_name: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
+    #[serde(default = "default_routing_group", rename = "tenant_id")]
+    _tenant_id: String,
     /// Invalid for `/query_by_hash`. Callers must precompute `block_hashes` with the intended
     /// cache salt and omit this field; a non-null value is rejected.
     #[serde(default)]
-    pub cache_salt: Option<String>,
+    cache_salt: Option<String>,
 }
 
 /// Response shape for `/query` and `/query_by_hash`.
@@ -183,7 +191,7 @@ async fn register(
             req.endpoint,
             req.dp_rank.unwrap_or(0),
             req.model_name,
-            req.tenant_id,
+            req.routing_group,
             req.block_size,
             req.replay_endpoint,
         )
@@ -210,25 +218,25 @@ async fn unregister(
     Json(req): Json<UnregisterRequest>,
 ) -> Response {
     let model = req.model_name.clone();
-    let result = match req.tenant_id {
-        Some(tenant_id) => match req.dp_rank {
+    let result = match req.routing_group {
+        Some(routing_group) => match req.dp_rank {
             Some(dp_rank) => {
                 state
                     .registry
-                    .deregister_dp_rank(req.instance_id, dp_rank, &req.model_name, &tenant_id)
+                    .deregister_dp_rank(req.instance_id, dp_rank, &req.model_name, &routing_group)
                     .await
             }
             None => {
                 state
                     .registry
-                    .deregister(req.instance_id, &req.model_name, &tenant_id)
+                    .deregister(req.instance_id, &req.model_name, &routing_group)
                     .await
             }
         },
         None => {
             state
                 .registry
-                .deregister_all_tenants(req.instance_id, &req.model_name)
+                .deregister_all_routing_groups(req.instance_id, &req.model_name)
                 .await
         }
     };
@@ -247,22 +255,23 @@ async fn unregister(
 /// Optional query parameters for `GET /workers`.
 ///
 /// Both fields are independent filters; omitting one skips that dimension.
-/// Example: `GET /workers?model_name=llama3&tenant_id=acme`
+/// Example: `GET /workers?model_name=llama3&routing_group=acme`
 #[derive(Deserialize)]
 struct WorkersQuery {
     model_name: Option<String>,
-    tenant_id: Option<String>,
+    routing_group: Option<String>,
+    #[serde(default, rename = "tenant_id")]
+    _tenant_id: Option<String>,
 }
 
 async fn list_workers(
     State(state): State<Arc<AppState>>,
     Query(params): Query<WorkersQuery>,
 ) -> impl IntoResponse {
-    Json(
-        state
-            .registry
-            .list_filtered(params.model_name.as_deref(), params.tenant_id.as_deref()),
-    )
+    Json(state.registry.list_filtered(
+        params.model_name.as_deref(),
+        params.routing_group.as_deref(),
+    ))
 }
 
 /// Build the [`ScoreResponse`] in both the flat (legacy) and per-instance
@@ -316,13 +325,16 @@ async fn query(State(state): State<Arc<AppState>>, Json(req): Json<QueryRequest>
     let model = req.model_name.clone();
     let key = IndexerKey {
         model_name: req.model_name,
-        tenant_id: req.tenant_id,
+        routing_group: req.routing_group,
     };
     let Some(ie) = state.registry.get_indexer(&key) else {
         let mut resp = (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
-                "error": format!("no indexer for model={} tenant={}", key.model_name, key.tenant_id)
+                "error": format!(
+                    "no indexer for model={} routing_group={}",
+                    key.model_name, key.routing_group
+                )
             })),
         )
             .into_response();
@@ -367,13 +379,16 @@ async fn query_by_hash(
 
     let key = IndexerKey {
         model_name: req.model_name,
-        tenant_id: req.tenant_id,
+        routing_group: req.routing_group,
     };
     let Some(ie) = state.registry.get_indexer(&key) else {
         let mut resp = (
             StatusCode::NOT_FOUND,
             Json(serde_json::json!({
-                "error": format!("no indexer for model={} tenant={}", key.model_name, key.tenant_id)
+                "error": format!(
+                    "no indexer for model={} routing_group={}",
+                    key.model_name, key.routing_group
+                )
             })),
         )
             .into_response();
@@ -497,7 +512,7 @@ pub(crate) async fn dump_registry(registry: &WorkerRegistry) -> serde_json::Valu
     for handle in handles {
         match handle.await {
             Ok((key, Ok(events), block_size)) => {
-                let map_key = format!("{}:{}", key.model_name, key.tenant_id);
+                let map_key = format!("{}:{}", key.model_name, key.routing_group);
                 result.insert(
                     map_key,
                     serde_json::json!({
@@ -507,7 +522,7 @@ pub(crate) async fn dump_registry(registry: &WorkerRegistry) -> serde_json::Valu
                 );
             }
             Ok((key, Err(e), _)) => {
-                let map_key = format!("{}:{}", key.model_name, key.tenant_id);
+                let map_key = format!("{}:{}", key.model_name, key.routing_group);
                 result.insert(map_key, serde_json::json!({"error": e.to_string()}));
             }
             Err(e) => {
@@ -741,14 +756,14 @@ mod tests {
             .await
             .unwrap();
 
-        // Worker 21: mistral / acme, block_size=8
+        // Worker 21: mistral / other, block_size=8
         registry
             .register(
                 21,
                 "tcp://127.0.0.1:15591".to_string(),
                 0,
                 "mistral".to_string(),
-                "acme".to_string(),
+                "other".to_string(),
                 8,
                 None,
             )
@@ -794,7 +809,43 @@ mod tests {
             .find(|w| w["model_name"] == "llama3")
             .unwrap();
         assert_eq!(llama["block_size"], 4);
-        assert_eq!(llama["tenant_id"], "acme");
+        assert_eq!(llama["routing_group"], "acme");
+        assert!(llama.get("tenant_id").is_none());
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/workers?tenant_id=acme")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let legacy_filtered: Vec<serde_json::Value> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(legacy_filtered.len(), 2);
+
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/workers?routing_group=acme")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let filtered_by_group: Vec<serde_json::Value> = serde_json::from_slice(&bytes).unwrap();
+        assert_eq!(filtered_by_group.len(), 1);
+        assert_eq!(filtered_by_group[0]["routing_group"], "acme");
 
         // Filtered by model_name=llama3: only one result
         let response = app

--- a/lib/kv-router/src/services/selection/catalog.rs
+++ b/lib/kv-router/src/services/selection/catalog.rs
@@ -68,7 +68,7 @@ impl WorkerCatalog {
     pub(super) fn list(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<WorkerCatalogRecord> {
         let mut records: Vec<_> = self
             .workers
@@ -76,14 +76,15 @@ impl WorkerCatalog {
             .values()
             .filter(|record| {
                 model_name.is_none_or(|model_name| record.model_name == model_name)
-                    && tenant_id.is_none_or(|tenant_id| record.tenant_id == tenant_id)
+                    && routing_group
+                        .is_none_or(|routing_group| record.routing_group == routing_group)
             })
             .cloned()
             .collect();
         records.sort_by_key(|record| {
             (
                 record.model_name.clone(),
-                record.tenant_id.clone(),
+                record.routing_group.clone(),
                 record.worker_id,
             )
         });
@@ -94,7 +95,7 @@ impl WorkerCatalog {
         self.workers.read().values().any(|record| {
             record.lifecycle == WorkerLifecycle::Schedulable
                 && record.model_name == key.model_name
-                && record.tenant_id == key.tenant_id
+                && record.routing_group == key.routing_group
         })
     }
 
@@ -108,7 +109,7 @@ impl WorkerCatalog {
             .filter(|record| {
                 record.lifecycle == WorkerLifecycle::Schedulable
                     && record.model_name == key.model_name
-                    && record.tenant_id == key.tenant_id
+                    && record.routing_group == key.routing_group
             })
             .filter_map(|record| {
                 record
@@ -135,7 +136,7 @@ impl WorkerCatalog {
         let record = workers.get(&worker_id)?;
         if record.lifecycle != WorkerLifecycle::Schedulable
             || record.model_name != key.model_name
-            || record.tenant_id != key.tenant_id
+            || record.routing_group != key.routing_group
         {
             return None;
         }

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -194,7 +194,7 @@ impl SelectionCore {
             return;
         }
 
-        let key = SelectionKey::new(envelope.model_name, envelope.tenant_id);
+        let key = SelectionKey::new(envelope.model_name, envelope.routing_group);
         let Some(entry) = self.entries.read().get(&key).cloned() else {
             tracing::trace!(%key, "Dropping replica event for unknown selector entry");
             return;
@@ -271,9 +271,9 @@ impl SelectionCore {
     pub fn list_workers(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<WorkerCatalogRecord> {
-        self.catalog.list(model_name, tenant_id)
+        self.catalog.list(model_name, routing_group)
     }
 
     pub fn ready(&self) -> ReadyResponse {
@@ -405,7 +405,7 @@ impl SelectionCore {
         let scoped_replica_sync = setup_scoped_replica_sync(
             self.replica_config.as_ref(),
             &key.model_name,
-            &key.tenant_id,
+            &key.routing_group,
             block_size,
         );
         let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
@@ -496,7 +496,7 @@ impl SelectionCore {
                     endpoint,
                     dp_rank,
                     record.model_name.clone(),
-                    record.tenant_id.clone(),
+                    record.routing_group.clone(),
                     block_size,
                     record.replay_endpoint.clone(),
                 )
@@ -510,7 +510,7 @@ impl SelectionCore {
         if self.kv_router_config.use_kv_events {
             if let Err(error) = self
                 .indexer_registry
-                .deregister(record.worker_id, &record.model_name, &record.tenant_id)
+                .deregister(record.worker_id, &record.model_name, &record.routing_group)
                 .await
             {
                 tracing::debug!(
@@ -573,7 +573,7 @@ impl SelectionCore {
     ) -> Result<SelectResponse, SelectionError> {
         self.schedule_selection(
             SelectionOperation {
-                key: SelectionKey::new(req.model_name, req.tenant_id),
+                key: SelectionKey::new(req.model_name, req.routing_group),
                 selection_id: req.selection_id,
                 reservation_id: None,
                 prompt: req.prompt,
@@ -609,7 +609,7 @@ impl SelectionCore {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         self.schedule_selection(
             SelectionOperation {
-                key: SelectionKey::new(req.model_name, req.tenant_id),
+                key: SelectionKey::new(req.model_name, req.routing_group),
                 selection_id: req.selection_id,
                 reservation_id: Some(reservation_id),
                 prompt: req.prompt,
@@ -713,7 +713,7 @@ impl SelectionCore {
             selection_id,
             reservation_id,
             model_name: key.model_name,
-            tenant_id: key.tenant_id,
+            routing_group: key.routing_group,
             worker_id: response.best_worker.worker_id,
             dp_rank: response.best_worker.dp_rank,
             endpoint,
@@ -728,7 +728,7 @@ impl SelectionCore {
         req: ReservationRequest,
     ) -> Result<ReservationResponse, SelectionError> {
         self.ensure_running()?;
-        let key = SelectionKey::new(req.model_name.clone(), req.tenant_id.clone());
+        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let normalized = req
             .prompt
@@ -773,7 +773,7 @@ impl SelectionCore {
         Ok(ReservationResponse {
             reservation_id: req.reservation_id,
             model_name: key.model_name,
-            tenant_id: key.tenant_id,
+            routing_group: key.routing_group,
             worker_id: worker.worker_id,
             dp_rank: worker.dp_rank,
             endpoint,
@@ -840,19 +840,20 @@ impl SelectionCore {
     pub fn loads(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<ModelLoadResponse> {
         let entries: Vec<_> = self.entries.read().values().cloned().collect();
         let mut loads = Vec::new();
         for entry in entries {
             if model_name.is_some_and(|model_name| entry.key.model_name != model_name)
-                || tenant_id.is_some_and(|tenant_id| entry.key.tenant_id != tenant_id)
+                || routing_group
+                    .is_some_and(|routing_group| entry.key.routing_group != routing_group)
             {
                 continue;
             }
             loads.push(ModelLoadResponse {
                 model_name: entry.key.model_name.clone(),
-                tenant_id: entry.key.tenant_id.clone(),
+                routing_group: entry.key.routing_group.clone(),
                 loads: entry
                     .scheduler
                     .get_potential_loads(None, 0, HashMap::new(), false),
@@ -860,7 +861,9 @@ impl SelectionCore {
                 pending_isl_tokens: entry.scheduler.pending_isl_tokens(),
             });
         }
-        loads.sort_by(|a, b| (&a.model_name, &a.tenant_id).cmp(&(&b.model_name, &b.tenant_id)));
+        loads.sort_by(|a, b| {
+            (&a.model_name, &a.routing_group).cmp(&(&b.model_name, &b.routing_group))
+        });
         loads
     }
 
@@ -868,7 +871,7 @@ impl SelectionCore {
         &self,
         req: PotentialLoadsRequest,
     ) -> Result<Vec<PotentialLoad>, SelectionError> {
-        let key = SelectionKey::new(req.model_name.clone(), req.tenant_id.clone());
+        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let prepared = self.prepare_selection_inputs(&entry, &req.prompt).await?;
         let track_prefill_tokens = req
@@ -888,7 +891,7 @@ impl SelectionCore {
         &self,
         req: OverlapScoresRequest,
     ) -> Result<OverlapScoresResponse, SelectionError> {
-        let key = SelectionKey::new(req.model_name.clone(), req.tenant_id.clone());
+        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let normalized = req
             .prompt
@@ -978,7 +981,7 @@ mod tests {
         WorkerRequest {
             worker_id,
             model_name: "model".to_string(),
-            tenant_id: "default".to_string(),
+            routing_group: "default".to_string(),
             endpoint: Some(format!("http://worker-{worker_id}:8000")),
             kv_events_endpoint: None,
             kv_events_endpoints: HashMap::new(),
@@ -1022,7 +1025,7 @@ mod tests {
     fn select_request() -> SelectRequest {
         SelectRequest {
             model_name: "model".to_string(),
-            tenant_id: "default".to_string(),
+            routing_group: "default".to_string(),
             selection_id: None,
             prompt: prompt(),
             router_config_override: None,
@@ -1039,7 +1042,7 @@ mod tests {
     fn reserve_request(reservation_id: &str) -> SelectAndReserveRequest {
         SelectAndReserveRequest {
             model_name: "model".to_string(),
-            tenant_id: "default".to_string(),
+            routing_group: "default".to_string(),
             selection_id: None,
             reservation_id: Some(reservation_id.to_string()),
             prompt: prompt(),
@@ -1113,6 +1116,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn upsert_moves_global_worker_id_between_routing_groups() {
+        let core = SelectionCore::new_local(test_config(true), 1, CancellationToken::new());
+        let mut group_a = worker_with_kv_events(1);
+        group_a.routing_group = "group-a".to_string();
+        core.upsert_worker(group_a).await.expect("group A upsert");
+        assert_eq!(
+            core.indexer_registry
+                .list_filtered(Some("model"), Some("group-a"))
+                .len(),
+            1
+        );
+
+        let mut group_b = worker_with_kv_events(1);
+        group_b.routing_group = "group-b".to_string();
+        core.upsert_worker(group_b).await.expect("group B upsert");
+
+        assert!(core.list_workers(Some("model"), Some("group-a")).is_empty());
+        assert_eq!(core.list_workers(Some("model"), Some("group-b")).len(), 1);
+        assert!(
+            core.indexer_registry
+                .list_filtered(Some("model"), Some("group-a"))
+                .is_empty()
+        );
+        assert_eq!(
+            core.indexer_registry
+                .list_filtered(Some("model"), Some("group-b"))
+                .len(),
+            1
+        );
+
+        let mut select_a = select_request();
+        select_a.routing_group = "group-a".to_string();
+        assert!(matches!(
+            core.select(select_a).await,
+            Err(SelectionError::NotReady(_))
+        ));
+        let mut select_b = select_request();
+        select_b.routing_group = "group-b".to_string();
+        assert_eq!(core.select(select_b).await.unwrap().worker_id, 1);
+
+        core.delete_worker(1).await.expect("delete group B worker");
+        assert!(
+            core.indexer_registry
+                .list_filtered(Some("model"), Some("group-b"))
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
     async fn shutdown_reports_not_ready_and_rejects_new_work() {
         let core = SelectionCore::new_local(test_config(false), 1, CancellationToken::new());
         core.upsert_worker(worker(1)).await.expect("worker upsert");
@@ -1149,7 +1201,7 @@ mod tests {
         let reservation_error = core
             .create_reservation(ReservationRequest {
                 model_name: "model".to_string(),
-                tenant_id: "default".to_string(),
+                routing_group: "default".to_string(),
                 reservation_id: "res-after-shutdown".to_string(),
                 worker_id: 1,
                 dp_rank: None,
@@ -1230,7 +1282,7 @@ mod tests {
         for worker_id in [1, 2] {
             core.create_reservation(ReservationRequest {
                 model_name: "model".to_string(),
-                tenant_id: "default".to_string(),
+                routing_group: "default".to_string(),
                 reservation_id: format!("occupy-{worker_id}"),
                 worker_id,
                 dp_rank: Some(0),
@@ -1258,7 +1310,7 @@ mod tests {
             queued_core
                 .select_and_reserve(SelectAndReserveRequest {
                     model_name: "model".to_string(),
-                    tenant_id: "default".to_string(),
+                    routing_group: "default".to_string(),
                     selection_id: Some("refresh-selection".to_string()),
                     reservation_id: Some("refreshed-request".to_string()),
                     prompt: PromptRequest {

--- a/lib/kv-router/src/services/selection/server.rs
+++ b/lib/kv-router/src/services/selection/server.rs
@@ -26,7 +26,7 @@ use super::types::{
 #[derive(Debug, Deserialize)]
 struct FilterQuery {
     model_name: Option<String>,
-    tenant_id: Option<String>,
+    routing_group: Option<String>,
 }
 
 pub struct AppState {
@@ -81,11 +81,10 @@ async fn list_workers(
     State(state): State<Arc<AppState>>,
     Query(params): Query<FilterQuery>,
 ) -> Response {
-    Json(
-        state
-            .service
-            .list_workers(params.model_name.as_deref(), params.tenant_id.as_deref()),
-    )
+    Json(state.service.list_workers(
+        params.model_name.as_deref(),
+        params.routing_group.as_deref(),
+    ))
     .into_response()
 }
 
@@ -193,11 +192,10 @@ async fn ready(State(state): State<Arc<AppState>>) -> Response {
 }
 
 async fn loads(State(state): State<Arc<AppState>>, Query(params): Query<FilterQuery>) -> Response {
-    Json(
-        state
-            .service
-            .loads(params.model_name.as_deref(), params.tenant_id.as_deref()),
-    )
+    Json(state.service.loads(
+        params.model_name.as_deref(),
+        params.routing_group.as_deref(),
+    ))
     .into_response()
 }
 

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -200,9 +200,9 @@ impl SelectionService {
     pub fn list_workers(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<WorkerCatalogRecord> {
-        self.core.list_workers(model_name, tenant_id)
+        self.core.list_workers(model_name, routing_group)
     }
 
     pub async fn select(&self, req: SelectRequest) -> Result<SelectResponse, SelectionError> {
@@ -264,9 +264,9 @@ impl SelectionService {
     pub fn loads(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<ModelLoadResponse> {
-        self.core.loads(model_name, tenant_id)
+        self.core.loads(model_name, routing_group)
     }
 
     pub async fn potential_loads(

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -286,6 +286,8 @@ async fn select_echoes_selection_id_and_does_not_book_load() {
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await;
     assert_eq!(body["selection_id"], "sel-a");
+    assert_eq!(body["routing_group"], "default");
+    assert!(body.get("tenant_id").is_none());
     assert_eq!(body["worker_id"], 1);
     assert_eq!(body["effective_prefill_tokens"], 4);
     assert_eq!(body["overlap"]["longest_matched"], 0);

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -18,7 +18,7 @@ use crate::services::overlap::MooncakeOverlapSummary;
 use super::input::PromptRequest;
 
 const DEFAULT_MODEL_NAME: &str = "default";
-const DEFAULT_TENANT_ID: &str = "default";
+const DEFAULT_ROUTING_GROUP: &str = "default";
 pub(super) const WORKER_TYPE: &str = "select";
 pub(super) const REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
@@ -26,35 +26,39 @@ fn default_model_name() -> String {
     DEFAULT_MODEL_NAME.to_string()
 }
 
-fn default_tenant_id() -> String {
-    DEFAULT_TENANT_ID.to_string()
+fn default_routing_group() -> String {
+    DEFAULT_ROUTING_GROUP.to_string()
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
 pub struct SelectionKey {
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
 }
 
 impl SelectionKey {
-    pub(super) fn new(model_name: impl Into<String>, tenant_id: impl Into<String>) -> Self {
+    pub(super) fn new(model_name: impl Into<String>, routing_group: impl Into<String>) -> Self {
         Self {
             model_name: model_name.into(),
-            tenant_id: tenant_id.into(),
+            routing_group: routing_group.into(),
         }
     }
 
     pub(super) fn indexer_key(&self) -> IndexerKey {
         IndexerKey {
             model_name: self.model_name.clone(),
-            tenant_id: self.tenant_id.clone(),
+            routing_group: self.routing_group.clone(),
         }
     }
 }
 
 impl fmt::Display for SelectionKey {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "model={} tenant={}", self.model_name, self.tenant_id)
+        write!(
+            f,
+            "model={} routing_group={}",
+            self.model_name, self.routing_group
+        )
     }
 }
 
@@ -131,7 +135,7 @@ impl WorkerConfigLike for SelectionWorkerConfig {
 pub struct WorkerCatalogRecord {
     pub worker_id: WorkerId,
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub lifecycle: WorkerLifecycle,
     pub endpoint: Option<String>,
     pub kv_events_endpoint: Option<String>,
@@ -161,7 +165,7 @@ impl WorkerCatalogRecord {
         Self {
             worker_id: req.worker_id,
             model_name: req.model_name,
-            tenant_id: req.tenant_id,
+            routing_group: req.routing_group,
             lifecycle: WorkerLifecycle::Incomplete,
             endpoint: req.endpoint,
             kv_events_endpoint: req.kv_events_endpoint,
@@ -184,7 +188,7 @@ impl WorkerCatalogRecord {
     }
 
     pub(super) fn key(&self) -> SelectionKey {
-        SelectionKey::new(self.model_name.clone(), self.tenant_id.clone())
+        SelectionKey::new(self.model_name.clone(), self.routing_group.clone())
     }
 
     pub(super) fn dp_start(&self) -> u32 {
@@ -270,8 +274,8 @@ pub struct WorkerRequest {
     pub worker_id: WorkerId,
     #[serde(default = "default_model_name")]
     pub model_name: String,
-    #[serde(default = "default_tenant_id")]
-    pub tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    pub routing_group: String,
     #[serde(default)]
     pub endpoint: Option<String>,
     #[serde(default)]
@@ -399,8 +403,8 @@ impl WorkerCatalogRecord {
 pub struct SelectRequest {
     #[serde(default = "default_model_name")]
     pub model_name: String,
-    #[serde(default = "default_tenant_id")]
-    pub tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    pub routing_group: String,
     #[serde(default)]
     pub selection_id: Option<String>,
     #[serde(flatten)]
@@ -427,8 +431,8 @@ pub struct SelectRequest {
 pub struct SelectAndReserveRequest {
     #[serde(default = "default_model_name")]
     pub model_name: String,
-    #[serde(default = "default_tenant_id")]
-    pub tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    pub routing_group: String,
     #[serde(default)]
     pub selection_id: Option<String>,
     #[serde(default)]
@@ -457,8 +461,8 @@ pub struct SelectAndReserveRequest {
 pub struct ReservationRequest {
     #[serde(default = "default_model_name")]
     pub model_name: String,
-    #[serde(default = "default_tenant_id")]
-    pub tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    pub routing_group: String,
     pub reservation_id: String,
     pub worker_id: WorkerId,
     #[serde(default)]
@@ -483,8 +487,8 @@ pub struct OutputBlockRequest {
 pub struct PotentialLoadsRequest {
     #[serde(default = "default_model_name")]
     pub model_name: String,
-    #[serde(default = "default_tenant_id")]
-    pub tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    pub routing_group: String,
     #[serde(flatten)]
     pub prompt: PromptRequest,
     #[serde(default)]
@@ -495,8 +499,8 @@ pub struct PotentialLoadsRequest {
 pub struct OverlapScoresRequest {
     #[serde(default = "default_model_name")]
     pub model_name: String,
-    #[serde(default = "default_tenant_id")]
-    pub tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    pub routing_group: String,
     #[serde(flatten)]
     pub prompt: PromptRequest,
     #[serde(default)]
@@ -510,7 +514,7 @@ pub struct SelectResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reservation_id: Option<String>,
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub worker_id: WorkerId,
     pub dp_rank: DpRank,
     pub endpoint: String,
@@ -523,7 +527,7 @@ pub struct SelectResponse {
 pub struct ReservationResponse {
     pub reservation_id: String,
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub worker_id: WorkerId,
     pub dp_rank: DpRank,
     pub endpoint: String,
@@ -539,7 +543,7 @@ pub struct ReadyResponse {
 #[derive(Debug, Serialize)]
 pub struct ModelLoadResponse {
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub loads: Vec<PotentialLoad>,
     pub pending_count: usize,
     pub pending_isl_tokens: usize,

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -24,21 +24,21 @@ use crate::services::common::replica_sync::{
     ReplicaSyncConfig, ScopedReplicaEvent, ScopedSequencePublisher, setup_scoped_replica_sync,
 };
 
-fn default_tenant() -> String {
+fn default_routing_group() -> String {
     "default".to_string()
 }
 
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
 pub struct TrackerKey {
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
 }
 
 impl TrackerKey {
-    pub fn new(model_name: String, tenant_id: Option<String>) -> Self {
+    pub fn new(model_name: String, routing_group: Option<String>) -> Self {
         Self {
             model_name,
-            tenant_id: tenant_id.unwrap_or_else(default_tenant),
+            routing_group: routing_group.unwrap_or_else(default_routing_group),
         }
     }
 }
@@ -47,7 +47,7 @@ impl TrackerKey {
 pub struct WorkerInfo {
     pub worker_id: WorkerId,
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub block_size: u32,
     pub dp_start: u32,
     pub dp_size: u32,
@@ -56,7 +56,7 @@ pub struct WorkerInfo {
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct ActiveLoadInfo {
     pub model_name: String,
-    pub tenant_id: String,
+    pub routing_group: String,
     pub worker_id: WorkerId,
     pub dp_rank: u32,
     pub active_prefill_tokens: usize,
@@ -75,33 +75,35 @@ pub enum RegistryError {
     InvalidDpRange { dp_start: u32, dp_size: u32 },
 
     #[error(
-        "block_size mismatch for model={model_name} tenant={tenant_id}: existing={existing}, requested={requested}"
+        "block_size mismatch for model={model_name} routing_group={routing_group}: existing={existing}, requested={requested}"
     )]
     BlockSizeMismatch {
         model_name: String,
-        tenant_id: String,
+        routing_group: String,
         existing: u32,
         requested: u32,
     },
 
-    #[error("worker {worker_id} already registered for model={model_name} tenant={tenant_id}")]
+    #[error(
+        "worker {worker_id} already registered for model={model_name} routing_group={routing_group}"
+    )]
     DuplicateWorker {
         worker_id: WorkerId,
         model_name: String,
-        tenant_id: String,
+        routing_group: String,
     },
 
-    #[error("worker {worker_id} not found for model={model_name} tenant={tenant_id}")]
+    #[error("worker {worker_id} not found for model={model_name} routing_group={routing_group}")]
     WorkerNotFound {
         worker_id: WorkerId,
         model_name: String,
-        tenant_id: String,
+        routing_group: String,
     },
 
-    #[error("no slot tracker for model={model_name} tenant={tenant_id}")]
+    #[error("no slot tracker for model={model_name} routing_group={routing_group}")]
     TrackerNotFound {
         model_name: String,
-        tenant_id: String,
+        routing_group: String,
     },
 }
 
@@ -121,8 +123,12 @@ impl TrackerEntry {
         replica_config: Option<&ReplicaSyncConfig>,
     ) -> Arc<Self> {
         let cancel_token = root_cancel_token.child_token();
-        let scoped_replica_sync =
-            setup_scoped_replica_sync(replica_config, &key.model_name, &key.tenant_id, block_size);
+        let scoped_replica_sync = setup_scoped_replica_sync(
+            replica_config,
+            &key.model_name,
+            &key.routing_group,
+            block_size,
+        );
         let tracker = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
             scoped_replica_sync.publisher,
             block_size as usize,
@@ -207,7 +213,7 @@ impl SlotTrackerRegistry {
             if entry.block_size != block_size {
                 return Err(RegistryError::BlockSizeMismatch {
                     model_name: key.model_name,
-                    tenant_id: key.tenant_id,
+                    routing_group: key.routing_group,
                     existing: entry.block_size,
                     requested: block_size,
                 });
@@ -231,7 +237,7 @@ impl SlotTrackerRegistry {
                 return Err(RegistryError::WorkerNotFound {
                     worker_id,
                     model_name: key.model_name.clone(),
-                    tenant_id: key.tenant_id.clone(),
+                    routing_group: key.routing_group.clone(),
                 });
             };
 
@@ -259,19 +265,19 @@ impl SlotTrackerRegistry {
     pub fn list_workers(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<WorkerInfo> {
         let mut workers = Vec::new();
         for entry in &self.trackers {
             let key = entry.key();
-            if !matches_filters(key, model_name, tenant_id) {
+            if !matches_filters(key, model_name, routing_group) {
                 continue;
             }
             for range in entry.value().tracker.worker_ranges() {
                 workers.push(WorkerInfo {
                     worker_id: range.worker_id,
                     model_name: key.model_name.clone(),
-                    tenant_id: key.tenant_id.clone(),
+                    routing_group: key.routing_group.clone(),
                     block_size: entry.value().block_size,
                     dp_start: range.dp_start,
                     dp_size: range.dp_size,
@@ -279,9 +285,9 @@ impl SlotTrackerRegistry {
             }
         }
         workers.sort_by(|a, b| {
-            (&a.model_name, &a.tenant_id, a.worker_id).cmp(&(
+            (&a.model_name, &a.routing_group, a.worker_id).cmp(&(
                 &b.model_name,
-                &b.tenant_id,
+                &b.routing_group,
                 b.worker_id,
             ))
         });
@@ -339,12 +345,12 @@ impl SlotTrackerRegistry {
     pub fn list_loads(
         &self,
         model_name: Option<&str>,
-        tenant_id: Option<&str>,
+        routing_group: Option<&str>,
     ) -> Vec<ActiveLoadInfo> {
         let mut loads = Vec::new();
         for entry in &self.trackers {
             let key = entry.key();
-            if !matches_filters(key, model_name, tenant_id) {
+            if !matches_filters(key, model_name, routing_group) {
                 continue;
             }
             let (decode_blocks, prefill_tokens, _) = entry
@@ -356,7 +362,7 @@ impl SlotTrackerRegistry {
             for worker in workers {
                 loads.push(ActiveLoadInfo {
                     model_name: key.model_name.clone(),
-                    tenant_id: key.tenant_id.clone(),
+                    routing_group: key.routing_group.clone(),
                     worker_id: worker.worker_id,
                     dp_rank: worker.dp_rank,
                     active_prefill_tokens: prefill_tokens.get(&worker).copied().unwrap_or(0),
@@ -365,9 +371,9 @@ impl SlotTrackerRegistry {
             }
         }
         loads.sort_by(|a, b| {
-            (&a.model_name, &a.tenant_id, a.worker_id, a.dp_rank).cmp(&(
+            (&a.model_name, &a.routing_group, a.worker_id, a.dp_rank).cmp(&(
                 &b.model_name,
-                &b.tenant_id,
+                &b.routing_group,
                 b.worker_id,
                 b.dp_rank,
             ))
@@ -409,7 +415,7 @@ impl SlotTrackerRegistry {
             return;
         }
 
-        let key = TrackerKey::new(envelope.model_name, Some(envelope.tenant_id));
+        let key = TrackerKey::new(envelope.model_name, Some(envelope.routing_group));
         let Some(entry) = self
             .trackers
             .get(&key)
@@ -417,7 +423,7 @@ impl SlotTrackerRegistry {
         else {
             tracing::trace!(
                 model_name = %key.model_name,
-                tenant_id = %key.tenant_id,
+                routing_group = %key.routing_group,
                 "Dropping replica event for unknown slot tracker"
             );
             return;
@@ -425,7 +431,7 @@ impl SlotTrackerRegistry {
         if entry.block_size != envelope.block_size {
             tracing::debug!(
                 model_name = %key.model_name,
-                tenant_id = %key.tenant_id,
+                routing_group = %key.routing_group,
                 expected_block_size = entry.block_size,
                 received_block_size = envelope.block_size,
                 "Dropping replica event with mismatched block size"
@@ -440,7 +446,7 @@ impl SlotTrackerRegistry {
             Err(mpsc::error::TrySendError::Full(event)) => {
                 tracing::trace!(
                     model_name = %key.model_name,
-                    tenant_id = %key.tenant_id,
+                    routing_group = %key.routing_group,
                     request_id = %event.request_id,
                     "Replica subscriber channel full; dropping event"
                 );
@@ -448,7 +454,7 @@ impl SlotTrackerRegistry {
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 tracing::debug!(
                     model_name = %key.model_name,
-                    tenant_id = %key.tenant_id,
+                    routing_group = %key.routing_group,
                     "Replica subscriber channel closed; dropping event"
                 );
             }
@@ -461,7 +467,7 @@ impl SlotTrackerRegistry {
             .map(|entry| Arc::clone(entry.value()))
             .ok_or_else(|| RegistryError::TrackerNotFound {
                 model_name: key.model_name.clone(),
-                tenant_id: key.tenant_id.clone(),
+                routing_group: key.routing_group.clone(),
             })
     }
 
@@ -497,19 +503,23 @@ fn topology_error(key: &TrackerKey, error: WorkerTopologyError) -> RegistryError
         WorkerTopologyError::DuplicateWorker { worker_id } => RegistryError::DuplicateWorker {
             worker_id,
             model_name: key.model_name.clone(),
-            tenant_id: key.tenant_id.clone(),
+            routing_group: key.routing_group.clone(),
         },
         WorkerTopologyError::WorkerNotFound { worker_id } => RegistryError::WorkerNotFound {
             worker_id,
             model_name: key.model_name.clone(),
-            tenant_id: key.tenant_id.clone(),
+            routing_group: key.routing_group.clone(),
         },
     }
 }
 
-fn matches_filters(key: &TrackerKey, model_name: Option<&str>, tenant_id: Option<&str>) -> bool {
+fn matches_filters(
+    key: &TrackerKey,
+    model_name: Option<&str>,
+    routing_group: Option<&str>,
+) -> bool {
     model_name.is_none_or(|model_name| key.model_name == model_name)
-        && tenant_id.is_none_or(|tenant_id| key.tenant_id == tenant_id)
+        && routing_group.is_none_or(|routing_group| key.routing_group == routing_group)
 }
 
 #[cfg(test)]
@@ -521,19 +531,19 @@ mod tests {
         SlotTrackerRegistry::new(CancellationToken::new())
     }
 
-    fn key(tenant_id: &str) -> TrackerKey {
-        TrackerKey::new("model".to_string(), Some(tenant_id.to_string()))
+    fn key(routing_group: &str) -> TrackerKey {
+        TrackerKey::new("model".to_string(), Some(routing_group.to_string()))
     }
 
     fn replica_event(
-        tenant_id: &str,
+        routing_group: &str,
         block_size: u32,
         worker: WorkerWithDpRank,
         router_id: u64,
     ) -> ScopedReplicaEvent {
         ScopedReplicaEvent {
             model_name: "model".to_string(),
-            tenant_id: tenant_id.to_string(),
+            routing_group: routing_group.to_string(),
             block_size,
             event: ActiveSequenceEvent {
                 request_id: "replica-request".to_string(),
@@ -578,7 +588,7 @@ mod tests {
             vec![
                 ActiveLoadInfo {
                     model_name: "model".to_string(),
-                    tenant_id: "default".to_string(),
+                    routing_group: "default".to_string(),
                     worker_id: 1,
                     dp_rank: 2,
                     active_prefill_tokens: 0,
@@ -586,7 +596,7 @@ mod tests {
                 },
                 ActiveLoadInfo {
                     model_name: "model".to_string(),
-                    tenant_id: "default".to_string(),
+                    routing_group: "default".to_string(),
                     worker_id: 1,
                     dp_rank: 3,
                     active_prefill_tokens: 0,
@@ -627,7 +637,7 @@ mod tests {
             registry.list_loads(None, None),
             vec![ActiveLoadInfo {
                 model_name: "model".to_string(),
-                tenant_id: "default".to_string(),
+                routing_group: "default".to_string(),
                 worker_id: 1,
                 dp_rank: 0,
                 active_prefill_tokens: 0,
@@ -700,6 +710,7 @@ mod tests {
             WorkerWithDpRank::new(1, 0),
             7,
         ));
+        registry.dispatch_replica_event(replica_event("other", 16, WorkerWithDpRank::new(1, 0), 8));
         tokio::task::yield_now().await;
         assert_eq!(registry.list_loads(None, None)[0].active_decode_blocks, 0);
 
@@ -722,7 +733,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn worker_ids_are_scoped_by_model_and_tenant() {
+    async fn worker_ids_are_scoped_by_model_and_routing_group() {
         let registry = registry();
         registry.register(key("a"), 1, 16, 0, 1).unwrap();
         registry.register(key("b"), 1, 16, 0, 1).unwrap();

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -25,7 +25,7 @@ pub struct AppState {
     pub registry: Arc<SlotTrackerRegistry>,
 }
 
-fn default_tenant() -> String {
+fn default_routing_group() -> String {
     "default".to_string()
 }
 
@@ -33,8 +33,8 @@ fn default_tenant() -> String {
 struct RegisterRequest {
     worker_id: u64,
     model_name: String,
-    #[serde(default = "default_tenant")]
-    tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
     block_size: u32,
     dp_start: u32,
     dp_size: u32,
@@ -44,15 +44,15 @@ struct RegisterRequest {
 struct UnregisterRequest {
     worker_id: u64,
     model_name: String,
-    #[serde(default = "default_tenant")]
-    tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
 }
 
 #[derive(Deserialize)]
 struct AddRequest {
     model_name: String,
-    #[serde(default = "default_tenant")]
-    tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
     request_id: String,
     worker_id: u64,
     dp_rank: u32,
@@ -65,16 +65,16 @@ struct AddRequest {
 #[derive(Deserialize)]
 struct LifecycleRequest {
     model_name: String,
-    #[serde(default = "default_tenant")]
-    tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
     request_id: String,
 }
 
 #[derive(Deserialize)]
 struct PotentialLoadsRequest {
     model_name: String,
-    #[serde(default = "default_tenant")]
-    tenant_id: String,
+    #[serde(default = "default_routing_group")]
+    routing_group: String,
     #[serde(deserialize_with = "deserialize_sequence_hashes")]
     sequence_hashes: Vec<SequenceHash>,
     #[serde(default)]
@@ -84,7 +84,7 @@ struct PotentialLoadsRequest {
 #[derive(Deserialize)]
 struct FilterQuery {
     model_name: Option<String>,
-    tenant_id: Option<String>,
+    routing_group: Option<String>,
 }
 
 fn deserialize_sequence_hashes<'de, D>(deserializer: D) -> Result<Vec<SequenceHash>, D::Error>
@@ -123,7 +123,7 @@ async fn register(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.tenant_id));
+    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
     match state.registry.register(
         key,
         req.worker_id,
@@ -144,7 +144,7 @@ async fn unregister(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.tenant_id));
+    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
     match state.registry.unregister(&key, req.worker_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => registry_error(error),
@@ -155,11 +155,10 @@ async fn list_workers(
     State(state): State<Arc<AppState>>,
     Query(params): Query<FilterQuery>,
 ) -> Response {
-    Json(
-        state
-            .registry
-            .list_workers(params.model_name.as_deref(), params.tenant_id.as_deref()),
-    )
+    Json(state.registry.list_workers(
+        params.model_name.as_deref(),
+        params.routing_group.as_deref(),
+    ))
     .into_response()
 }
 
@@ -171,7 +170,7 @@ async fn add(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.tenant_id));
+    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
 
     // Lifecycle delivery is intentionally arrival-ordered. Consumers should
     // normally await /add before sending /prefill_complete or /free.
@@ -195,7 +194,7 @@ async fn prefill_complete(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.tenant_id));
+    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
     match state.registry.mark_prefill_completed(&key, &req.request_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => service_error(error),
@@ -210,7 +209,7 @@ async fn free(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.tenant_id));
+    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
     match state.registry.free(&key, &req.request_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => service_error(error),
@@ -221,11 +220,10 @@ async fn list_loads(
     State(state): State<Arc<AppState>>,
     Query(params): Query<FilterQuery>,
 ) -> Response {
-    Json(
-        state
-            .registry
-            .list_loads(params.model_name.as_deref(), params.tenant_id.as_deref()),
-    )
+    Json(state.registry.list_loads(
+        params.model_name.as_deref(),
+        params.routing_group.as_deref(),
+    ))
     .into_response()
 }
 
@@ -237,7 +235,7 @@ async fn potential_loads(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.tenant_id));
+    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
     match state
         .registry
         .potential_loads(&key, &req.sequence_hashes, req.new_isl_tokens)

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -105,21 +105,32 @@ async fn wait_for_health(base_url: &str) {
     }
 }
 
-/// Build a registry seeded with one indexer for `(model, tenant)` and feed
+/// Build a registry seeded with one indexer for `(model, routing group)` and feed
 /// `events` through `apply_event_routed`. This bypasses the ZMQ listener path
 /// so we can drive HTTP queries against deterministic state.
 async fn registry_with_events(
     model: &str,
-    tenant: &str,
+    routing_group: &str,
     block_size: u32,
     events: Vec<RouterEvent>,
 ) -> Arc<WorkerRegistry> {
     let registry = Arc::new(WorkerRegistry::new(1));
     registry.signal_ready();
+    add_group_events(&registry, model, routing_group, block_size, events).await;
+    registry
+}
+
+async fn add_group_events(
+    registry: &WorkerRegistry,
+    model: &str,
+    routing_group: &str,
+    block_size: u32,
+    events: Vec<RouterEvent>,
+) {
     let indexer = registry.get_or_create_indexer(
         IndexerKey {
             model_name: model.to_string(),
-            tenant_id: tenant.to_string(),
+            routing_group: routing_group.to_string(),
         },
         block_size,
     );
@@ -130,14 +141,13 @@ async fn registry_with_events(
     // first query lands; otherwise the test races the indexer worker.
     if let Some(entry) = registry.get_indexer(&IndexerKey {
         model_name: model.to_string(),
-        tenant_id: tenant.to_string(),
+        routing_group: routing_group.to_string(),
     }) {
         let dump = entry.indexer.dump_events().await.expect("dump events");
         // dump_events provides the FIFO barrier we need; we don't care about
         // its contents here.
         drop(dump);
     }
-    registry
 }
 
 /// Spawn the HTTP server with `state` on a random localhost port and return
@@ -184,7 +194,7 @@ fn make_app_state(registry: Arc<WorkerRegistry>) -> Arc<AppState> {
 async fn query_by_hash_returns_per_instance_tier_breakdown() {
     const BLOCK_SIZE: u32 = 4;
     const MODEL: &str = "test-model";
-    const TENANT: &str = "default";
+    const ROUTING_GROUP: &str = "default";
 
     // Worker 7: 2 device blocks + 1 host-pinned extension.
     // Worker 8: 2 device blocks, no lower-tier.
@@ -193,7 +203,7 @@ async fn query_by_hash_returns_per_instance_tier_breakdown() {
         store_event(8, 0, 1, &[], &[11, 12], StorageTier::Device),
         store_event(7, 0, 2, &[11, 12], &[13], StorageTier::HostPinned),
     ];
-    let registry = registry_with_events(MODEL, TENANT, BLOCK_SIZE, events).await;
+    let registry = registry_with_events(MODEL, ROUTING_GROUP, BLOCK_SIZE, events).await;
     let state = make_app_state(registry);
     let (base_url, cancel, task) = spawn_indexer_http(state).await;
 
@@ -203,7 +213,7 @@ async fn query_by_hash_returns_per_instance_tier_breakdown() {
         .json(&json!({
             "block_hashes": [11_i64, 12, 13],
             "model_name": MODEL,
-            "tenant_id": TENANT,
+            "routing_group": ROUTING_GROUP,
         }))
         .send()
         .await
@@ -262,7 +272,7 @@ async fn query_by_hash_returns_per_instance_tier_breakdown() {
         .json(&json!({
             "block_hashes": [11_i64, 12, 13],
             "model_name": MODEL,
-            "tenant_id": TENANT,
+            "routing_group": ROUTING_GROUP,
             "cache_salt": null,
         }))
         .send()
@@ -274,13 +284,72 @@ async fn query_by_hash_returns_per_instance_tier_breakdown() {
     task.await.expect("server task join");
 }
 
+#[tokio::test]
+async fn query_by_hash_isolates_routing_groups_and_ignores_legacy_tenant_id() {
+    const BLOCK_SIZE: u32 = 4;
+    const MODEL: &str = "test-model";
+    let registry = registry_with_events(
+        MODEL,
+        "default",
+        BLOCK_SIZE,
+        vec![store_event(7, 0, 1, &[], &[11], StorageTier::Device)],
+    )
+    .await;
+    add_group_events(
+        &registry,
+        MODEL,
+        "group-b",
+        BLOCK_SIZE,
+        vec![store_event(8, 0, 1, &[], &[11], StorageTier::Device)],
+    )
+    .await;
+    let (base_url, cancel, task) = spawn_indexer_http(make_app_state(registry)).await;
+    let client = reqwest::Client::new();
+
+    let legacy_only: serde_json::Value = client
+        .post(format!("{base_url}/query_by_hash"))
+        .json(&json!({
+            "block_hashes": [11_i64],
+            "model_name": MODEL,
+            "tenant_id": "group-b",
+        }))
+        .send()
+        .await
+        .expect("legacy tenant-only query")
+        .json()
+        .await
+        .expect("legacy tenant-only response");
+    assert_eq!(legacy_only["scores"]["7"]["0"], BLOCK_SIZE);
+    assert!(legacy_only["scores"].get("8").is_none());
+
+    let explicit_group: serde_json::Value = client
+        .post(format!("{base_url}/query_by_hash"))
+        .json(&json!({
+            "block_hashes": [11_i64],
+            "model_name": MODEL,
+            "routing_group": "group-b",
+            "tenant_id": "default",
+        }))
+        .send()
+        .await
+        .expect("explicit routing-group query")
+        .json()
+        .await
+        .expect("explicit routing-group response");
+    assert_eq!(explicit_group["scores"]["8"]["0"], BLOCK_SIZE);
+    assert!(explicit_group["scores"].get("7").is_none());
+
+    cancel.cancel();
+    task.await.expect("server task join");
+}
+
 /// `/query` owns token hashing, so equal tokens under different cache salts must match only the
 /// worker whose stored blocks used the same salt.
 #[tokio::test]
 async fn query_isolates_cache_salts() {
     const BLOCK_SIZE: u32 = 4;
     const MODEL: &str = "test-model";
-    const TENANT: &str = "default";
+    const ROUTING_GROUP: &str = "default";
     let tokens = vec![1_u32, 2, 3, 4, 5, 6, 7, 8];
 
     let hashes_a = compute_block_hash_for_seq(
@@ -317,7 +386,7 @@ async fn query_isolates_cache_salts() {
             StorageTier::Device,
         ),
     ];
-    let registry = registry_with_events(MODEL, TENANT, BLOCK_SIZE, events).await;
+    let registry = registry_with_events(MODEL, ROUTING_GROUP, BLOCK_SIZE, events).await;
     let state = make_app_state(registry);
     let (base_url, cancel, task) = spawn_indexer_http(state).await;
     let client = reqwest::Client::new();
@@ -328,7 +397,7 @@ async fn query_isolates_cache_salts() {
             .json(&json!({
                 "token_ids": tokens.clone(),
                 "model_name": MODEL,
-                "tenant_id": TENANT,
+                "routing_group": ROUTING_GROUP,
                 "cache_salt": salt,
             }))
             .send()
@@ -348,8 +417,8 @@ async fn query_isolates_cache_salts() {
 #[tokio::test]
 async fn query_by_hash_rejects_cache_salt() {
     const MODEL: &str = "test-model";
-    const TENANT: &str = "default";
-    let registry = registry_with_events(MODEL, TENANT, 4, Vec::new()).await;
+    const ROUTING_GROUP: &str = "default";
+    let registry = registry_with_events(MODEL, ROUTING_GROUP, 4, Vec::new()).await;
     let state = make_app_state(registry);
     let (base_url, cancel, task) = spawn_indexer_http(state).await;
     let client = reqwest::Client::new();
@@ -360,7 +429,7 @@ async fn query_by_hash_rejects_cache_salt() {
             .json(&json!({
                 "block_hashes": [11_i64, 12],
                 "model_name": MODEL,
-                "tenant_id": TENANT,
+                "routing_group": ROUTING_GROUP,
                 "cache_salt": cache_salt,
             }))
             .send()
@@ -379,7 +448,7 @@ async fn query_by_hash_rejects_cache_salt() {
     task.await.expect("server task join");
 }
 
-/// `/query` against an unknown `(model, tenant)` must return 404 with an
+/// `/query` against an unknown `(model, routing group)` must return 404 with an
 /// error body, not 500 or a panic.
 #[tokio::test]
 async fn query_returns_404_for_unknown_model() {
@@ -418,14 +487,14 @@ async fn query_returns_404_for_unknown_model() {
 async fn duplicate_store_warning_is_exported() {
     const BLOCK_SIZE: u32 = 4;
     const MODEL: &str = "test-model";
-    const TENANT: &str = "default";
+    const ROUTING_GROUP: &str = "default";
 
     let state = Arc::new(AppState::new(4).expect("create app state"));
     state.registry.signal_ready();
 
     let key = IndexerKey {
         model_name: MODEL.to_string(),
-        tenant_id: TENANT.to_string(),
+        routing_group: ROUTING_GROUP.to_string(),
     };
     let indexer = state
         .registry
@@ -524,7 +593,7 @@ fn send_live_message(pub_socket: &zmq::Socket, seq: u64, payload: &[u8]) {
         .expect("send_multipart");
 }
 
-/// Poll `/query` against `(model, tenant)` until `instances[instance_id].cpu`
+/// Poll `/query` against `(model, routing group)` until `instances[instance_id].cpu`
 /// reaches `expected_cpu_tokens`, or panic on timeout. The listener applies
 /// events asynchronously after `/register`, so the first few queries may see
 /// the indexer still cold; this loop is the e2e-test equivalent of awaiting
@@ -532,7 +601,7 @@ fn send_live_message(pub_socket: &zmq::Socket, seq: u64, payload: &[u8]) {
 async fn await_instance_cpu(
     base_url: &str,
     model: &str,
-    tenant: &str,
+    routing_group: &str,
     instance_id: u64,
     token_ids: Vec<u32>,
     expected_cpu_tokens: u64,
@@ -542,7 +611,7 @@ async fn await_instance_cpu(
     let body = json!({
         "token_ids": token_ids,
         "model_name": model,
-        "tenant_id": tenant,
+        "routing_group": routing_group,
     });
     let deadline = tokio::time::Instant::now() + Duration::from_secs(5);
     let key = instance_id.to_string();
@@ -586,7 +655,7 @@ async fn await_instance_cpu(
 async fn zmq_published_tiered_events_appear_in_http_query() {
     const BLOCK_SIZE: u32 = 4;
     const MODEL: &str = "test-model";
-    const TENANT: &str = "default";
+    const ROUTING_GROUP: &str = "default";
     const INSTANCE_ID: u64 = 7;
 
     // Spin up the HTTP server with an empty registry.
@@ -613,7 +682,7 @@ async fn zmq_published_tiered_events_appear_in_http_query() {
             "instance_id": INSTANCE_ID,
             "endpoint": zmq_endpoint,
             "model_name": MODEL,
-            "tenant_id": TENANT,
+            "routing_group": ROUTING_GROUP,
             "block_size": BLOCK_SIZE,
             "dp_rank": 0,
         }))
@@ -663,7 +732,7 @@ async fn zmq_published_tiered_events_appear_in_http_query() {
     let body = await_instance_cpu(
         &base_url,
         MODEL,
-        TENANT,
+        ROUTING_GROUP,
         INSTANCE_ID,
         full_tokens,
         // Cumulative through host = 2 blocks * BLOCK_SIZE tokens.

--- a/tests/router/test_standalone_slot_tracker.py
+++ b/tests/router/test_standalone_slot_tracker.py
@@ -148,7 +148,7 @@ def test_shared_prefix_accounting_and_unregister(slot_tracker_url: str) -> None:
     assert _loads_by_rank(base_url, "llama-3-8b") == {
         (8, 0): {
             "model_name": "llama-3-8b",
-            "tenant_id": "default",
+            "routing_group": "default",
             "worker_id": 8,
             "dp_rank": 0,
             "active_prefill_tokens": 0,
@@ -204,7 +204,7 @@ def test_prefill_lifecycle_updates_both_load_dimensions(slot_tracker_url: str) -
 
     assert _loads_by_rank(base_url, "llama-3-8b")[(4, 0)] == {
         "model_name": "llama-3-8b",
-        "tenant_id": "default",
+        "routing_group": "default",
         "worker_id": 4,
         "dp_rank": 0,
         "active_prefill_tokens": 64,


### PR DESCRIPTION
## Summary
- Rename the runtime-free indexer, slot tracker, and selection partition key from `tenant_id` to `routing_group`, including HTTP APIs, Python bindings, replica messages, metrics, and docs.
- Keep request-level cache identity unchanged and accept `tenant_id` only as an ignored standalone-indexer compatibility input; mixed-version replica peers require a coordinated upgrade.

Review the private indexer wire DTOs in `services/indexer/server.rs`, the shared replica envelope in `services/common/replica_sync.rs`, and selector re-key cleanup in `services/selection/core/mod.rs` first.

## Validation
- `cargo test -p dynamo-kv-router --features standalone-selection,standalone-slot-tracker,metrics`
- Python binding and standalone slot-tracker tests: 23 passed
- `$clean` for `lib/kv-router` and `lib/bindings/python`
- `fern check` and `fern docs broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Routing is now organized by **routing group** instead of tenant across KV indexer, selection, and slot-tracker workflows.
  * Worker listings, loads, queries, and reservation-related responses now include routing-group scope.

* **Bug Fixes**
  * Improved isolation so results and worker state are filtered by the correct routing group.
  * Legacy tenant-based inputs are still accepted in some places for compatibility, while new behavior uses routing groups.

* **Documentation**
  * Updated standalone router docs and examples to reflect routing-group terminology and API fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->