### PR TITLE
refactor(operator): split startup config and webhooks

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -21,100 +21,507 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
+	semver "github.com/Masterminds/semver/v3"
+	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
+	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
-	_ "k8s.io/client-go/plugin/pkg/client/auth"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/scale"
 	k8sCache "k8s.io/client-go/tools/cache"
-	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsfilters "sigs.k8s.io/controller-runtime/pkg/metrics/filters"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
 	lwsscheme "sigs.k8s.io/lws/client-go/clientset/versioned/scheme"
 	volcanoscheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 
-	semver "github.com/Masterminds/semver/v3"
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	configvalidation "github.com/ai-dynamo/dynamo/deploy/operator/api/config/validation"
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	internalcert "github.com/ai-dynamo/dynamo/deploy/operator/internal/cert"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/config"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller"
-	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/namespace_scope"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/rbac"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secrets"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
-	webhookdefaulting "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
-	webhookmutation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/mutation"
-	webhookvalidation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/validation"
-	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
-	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/webhooks"
 	//+kubebuilder:scaffold:imports
 )
 
 var (
-	crdScheme    = k8sruntime.NewScheme()
-	setupLog     = ctrl.Log.WithName("setup")
-	configScheme = k8sruntime.NewScheme()
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
-// LoadAndValidateOperatorConfig loads the operator configuration from a file,
-// applies defaults via the scheme, and validates it.
-func LoadAndValidateOperatorConfig(path string) (*configv1alpha1.OperatorConfiguration, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
-	}
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	codecFactory := serializer.NewCodecFactory(configScheme)
-	cfg := &configv1alpha1.OperatorConfiguration{}
-	if err := k8sruntime.DecodeInto(codecFactory.UniversalDecoder(), data, cfg); err != nil {
-		return nil, fmt.Errorf("failed to decode config file %s: %w", path, err)
-	}
+	utilruntime.Must(nvidiacomv1alpha1.AddToScheme(scheme))
 
-	// Validate the configuration
-	if errs := configvalidation.ValidateOperatorConfiguration(cfg); len(errs) > 0 {
-		return nil, fmt.Errorf("config validation failed: %s", errs.ToAggregate().Error())
-	}
+	utilruntime.Must(nvidiacomv1beta1.AddToScheme(scheme))
 
-	return cfg, nil
+	utilruntime.Must(lwsscheme.AddToScheme(scheme))
+
+	utilruntime.Must(volcanoscheme.AddToScheme(scheme))
+
+	utilruntime.Must(grovev1alpha1.AddToScheme(scheme))
+
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
+
+	utilruntime.Must(istioclientsetscheme.AddToScheme(scheme))
+
+	utilruntime.Must(gaiev1.Install(scheme))
+
+	utilruntime.Must(configapi.AddToScheme(scheme))
 }
 
-func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
+// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
+// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
+
+//nolint:gocyclo
+func main() {
+	var configFile string
+	var operatorVersion string
+	var operatorImage string
+	var operatorImagePullPolicy string
+	flag.StringVar(&configFile, "config", "", "Path to operator configuration file (required)")
+	flag.StringVar(&operatorVersion, "operator-version", "unknown",
+		"Version of the operator (used in lease holder identity)")
+	flag.StringVar(
+		&operatorImage,
+		"operator-image",
+		"",
+		"Operator image used to deliver version-matched helper binaries for DGD overrides",
+	)
+	flag.StringVar(&operatorImagePullPolicy, "operator-image-pull-policy", string(corev1.PullIfNotPresent),
+		"Image pull policy for operator helper init containers")
+	opts := zap.Options{
+		Development: true,
+	}
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+
+	if configFile == "" {
+		setupLog.Error(nil, "--config flag is required")
+		os.Exit(1)
+	}
+
+	mgrOpts, cfg, err := apply(configFile)
+	if err != nil {
+		setupLog.Error(err, "Unable to load the configuration")
+		os.Exit(1)
+	}
+
+	// Validates the configuration after it has been loaded.
+	if err := config.Validate(&cfg).ToAggregate(); err != nil {
+		setupLog.Error(err, "Unable to validate the configuration")
+		os.Exit(1)
+	}
+
+	// Validate and normalize operator version to semver
+	if _, err := semver.NewVersion(operatorVersion); err != nil {
+		setupLog.Error(err, "operator-version is not valid semver",
+			"provided", operatorVersion, "error", err.Error())
+		os.Exit(1)
+	}
+	setupLog.Info("Operator version configured", "version", operatorVersion)
+
+	pullPolicy := corev1.PullPolicy(operatorImagePullPolicy)
+	switch pullPolicy {
+	case corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
+	default:
+		setupLog.Error(nil, "operator-image-pull-policy is invalid", "provided", operatorImagePullPolicy)
+		os.Exit(1)
+	}
+
+	ctx := ctrl.SetupSignalHandler()
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
+	}
+
+	// Initialize observability metrics
+	setupLog.Info("Initializing observability metrics")
+	observability.InitMetrics()
+
+	// Set up webhook certificate management.
+	// A direct (non-cached) client is needed because the manager's cache isn't started yet.
+	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: scheme})
+	if err != nil {
+		setupLog.Error(err, "unable to create direct client for cert management")
+		os.Exit(1)
+	}
+	certMgr, err := internalcert.NewCertManager(directClient, &cfg.Server.Webhook)
+	if err != nil {
+		setupLog.Error(err, "unable to create cert manager")
+		os.Exit(1)
+	}
+	// Auto mode runs one synchronous certificate refresh with the direct client,
+	// then registers the cert-controller with the not-yet-started manager.
+	if err = certMgr.SetupAndRunOnce(ctx, mgr); err != nil {
+		setupLog.Error(err, "failed to setup webhook certificate management")
+		os.Exit(1)
+	}
+
+	// Initialize namespace scope mechanism
+	restrictedNamespace := cfg.Namespace.Restricted
+	leaseWatcher, err := setupLease(ctx, mgr, &cfg, operatorVersion, restrictedNamespace)
+	if err != nil {
+		setupLog.Error(err, "unable to setup namespace scope lease mechanism")
+		os.Exit(1)
+	}
+
+	// Initialize runtime config (auto-detection of orchestrators and service mesh)
+	runtimeConfig, err := setupRuntimeConfig(ctx, mgr, &cfg, leaseWatcher)
+	if err != nil {
+		setupLog.Error(err, "unable to setup runtime config")
+		os.Exit(1)
+	}
+
+	dockerSecretRetriever, err := setupDockerSecretRetriever(ctx, mgr, restrictedNamespace)
+	if err != nil {
+		setupLog.Error(err, "unable to setup docker secret retriever")
+		os.Exit(1)
+	}
+
+	scaleClient, err := setupScalesGetter(mgr)
+	if err != nil {
+		setupLog.Error(err, "unable to create scale client")
+		os.Exit(1)
+	}
+
+	if err := setupProbeEndpoints(mgr); err != nil {
+		setupLog.Error(err, "Unable to setup probe endpoints")
+		os.Exit(1)
+	}
+
+	// Setup controllers synchronously before mgr.Start().
+	// Controllers don't depend on TLS certificates.
+	controllerOpts := controller.SetupControllersOpts{
+		RuntimeConfig:         runtimeConfig,
+		DockerSecretRetriever: dockerSecretRetriever,
+		SSHKeyManager:         secret.NewSSHKeyManager(mgr.GetClient(), cfg.MPI),
+		RBACManager:           rbac.NewManager(mgr.GetClient()),
+		ScaleClient:           scaleClient,
+		OperatorImage:         operatorImage,
+		OperatorPullPolicy:    pullPolicy,
+	}
+	if err := setupControllers(ctx, mgr, &cfg, controllerOpts); err != nil {
+		setupLog.Error(err, "Unable to setup controllers")
+		os.Exit(1)
+	}
+
+	if failedWebhook, err := webhooks.Setup(mgr, &cfg, runtimeConfig, operatorVersion); err != nil {
+		setupLog.Error(err, "Unable to create webhook", "webhook", failedWebhook)
+		os.Exit(1)
+	}
+
+	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS
+	// secrets before this point. Auto mode can therefore patch admission and
+	// conversion CAs immediately; manual mode waits for externally provided
+	// ca.crt and only patches conversion, leaving admission CA management
+	// out-of-band.
+	caInjector, err := internalcert.NewCABundleInjector(directClient, &cfg)
+	if err != nil {
+		setupLog.Error(err, "unable to create CA bundle injector")
+		os.Exit(1)
+	}
+	if cfg.Server.Webhook.CertProvisionMode == configapi.CertProvisionModeAuto {
+		if err := caInjector.InjectAll(ctx); err != nil {
+			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
+			os.Exit(1)
+		}
+	} else {
+		// Manual mode gets webhook CA material out-of-band. Missing ca.crt
+		// blocks startup instead of running with unauthenticated conversion.
+		if err := caInjector.InjectCRDConversionCA(ctx); err != nil {
+			setupLog.Error(err, "failed to inject CRD conversion CA bundle")
+			os.Exit(1)
+		}
+	}
+
+	// mgr.Start reads tls.crt and tls.key from the projected Secret volume
+	// synchronously. Secret API updates are not enough because kubelet projects
+	// them into already-running pods asynchronously.
+	if err := certMgr.WaitForMountedCertificate(ctx); err != nil {
+		setupLog.Error(err, "failed waiting for mounted webhook TLS certificate")
+		os.Exit(1)
+	}
+
+	// Kubernetes propagates webhook configuration asynchronously, especially
+	// with HA apiservers. A missing or stale CA must fail closed during manager
+	// cache startup rather than allowing the operator to run without conversion
+	// or admission.
+	setupLog.Info("starting manager")
+	if err := mgr.Start(ctx); err != nil {
+		setupLog.Error(err, "Could not run manager")
+		os.Exit(1)
+	}
+}
+
+func setupControllers(
+	_ context.Context,
+	mgr ctrl.Manager,
+	cfg *configapi.OperatorConfiguration,
+	opts controller.SetupControllersOpts,
+) error {
+	if failedCtrl, err := controller.SetupControllers(mgr, cfg, opts); err != nil {
+		return fmt.Errorf("unable to create controller %s: %w", failedCtrl, err)
+	}
+
+	// Register after ExcludedNamespaces is set so cluster-wide metrics skip restricted namespaces.
+	setupLog.Info("Registering resource counter")
+	if err := mgr.Add(observability.NewResourceCounter(
+		mgr.GetClient(),
+		opts.RuntimeConfig.ExcludedNamespaces,
+	)); err != nil {
+		setupLog.Error(err, "unable to register resource counter")
+		os.Exit(1)
+	}
+
+	return nil
+}
+
+// setupLease initializes the namespace scope lease mechanism based on the operator configuration.
+// It returns a LeaseWatcher if the operator is running in cluster-wide mode, or nil if running
+// in namespace-restricted mode.
+func setupLease(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	cfg *configapi.OperatorConfiguration,
+	operatorVersion string,
+	restrictedNamespace string,
+) (*namespace_scope.LeaseWatcher, error) {
+	if restrictedNamespace != "" {
+		// Namespace-restricted mode: Create and maintain namespace scope marker lease
+		setupLog.Info("Creating namespace scope marker lease manager",
+			"namespace", restrictedNamespace,
+			"leaseDuration", cfg.Namespace.Scope.LeaseDuration.Duration,
+			"renewInterval", cfg.Namespace.Scope.LeaseRenewInterval.Duration)
+
+		leaseManager, err := namespace_scope.NewLeaseManager(
+			mgr.GetConfig(),
+			restrictedNamespace,
+			operatorVersion,
+			cfg.Namespace.Scope.LeaseDuration.Duration,
+			cfg.Namespace.Scope.LeaseRenewInterval.Duration,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("unable to create namespace scope marker lease manager: %w", err)
+		}
+
+		// Start the lease manager
+		if err = leaseManager.Start(ctx); err != nil {
+			return nil, fmt.Errorf("unable to start namespace scope marker lease manager: %w", err)
+		}
+
+		// Monitor for fatal lease errors
+		// If lease renewal fails repeatedly, we must exit to prevent split-brain
+		go func() {
+			select {
+			case err := <-leaseManager.Errors():
+				setupLog.Error(err, "FATAL: Lease manager encountered unrecoverable error, shutting down to prevent split-brain")
+				os.Exit(1)
+			case <-ctx.Done():
+				// Normal shutdown, error channel monitoring no longer needed
+				return
+			}
+		}()
+
+		// Ensure lease is released on shutdown
+		defer func() {
+			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := leaseManager.Stop(shutdownCtx); err != nil {
+				setupLog.Error(err, "failed to stop lease manager cleanly")
+			}
+		}()
+
+		setupLog.Info("Namespace scope marker lease manager started successfully")
+		return nil, nil
+	}
+
+	// Cluster-wide mode: Watch for namespace scope marker leases
+	setupLog.Info("Setting up namespace scope marker lease watcher for cluster-wide mode")
+
+	leaseWatcher, err := namespace_scope.NewLeaseWatcher(mgr.GetConfig())
+	if err != nil {
+		return nil, fmt.Errorf("unable to create namespace scope marker lease watcher: %w", err)
+	}
+
+	// Start the lease watcher
+	if err = leaseWatcher.Start(ctx); err != nil {
+		return nil, fmt.Errorf("unable to start namespace scope marker lease watcher: %w", err)
+	}
+
+	setupLog.Info("Namespace scope marker lease watcher started successfully")
+	return leaseWatcher, nil
+}
+
+func setupRuntimeConfig(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	cfg *configapi.OperatorConfiguration,
+	excludedNamespaces commoncontroller.ExcludedNamespacesInterface,
+) (*commoncontroller.RuntimeConfig, error) {
+	runtimeConfig := &commoncontroller.RuntimeConfig{
+		ExcludedNamespaces: excludedNamespaces,
+	}
+
+	// Detect orchestrators availability using discovery client.
+	// Config overrides (*bool) take precedence over auto-detection:
+	//   nil   = auto-detect (backward compatible default)
+	//   false = forcibly disabled regardless of API availability
+	//   true  = forcibly enabled; hard exit if API is not available (misconfiguration)
+	setupLog.Info("Detecting Grove availability...")
+	groveDetected := commoncontroller.DetectGroveAvailability(ctx, mgr)
+	switch {
+	case cfg.Orchestrators.Grove.Enabled == nil:
+		runtimeConfig.GroveEnabled = groveDetected
+	case *cfg.Orchestrators.Grove.Enabled:
+		if !groveDetected {
+			return nil, fmt.Errorf(
+				"Grove is explicitly enabled in config but the Grove API group was not detected in the cluster",
+			)
+		}
+		runtimeConfig.GroveEnabled = true
+	default:
+		setupLog.Info("Grove is explicitly disabled via config override")
+		runtimeConfig.GroveEnabled = false
+	}
+
+	setupLog.Info("Detecting LWS availability...")
+	lwsDetected := commoncontroller.DetectLWSAvailability(ctx, mgr)
+	setupLog.Info("Detecting Volcano availability...")
+	volcanoDetected := commoncontroller.DetectVolcanoAvailability(ctx, mgr)
+	// LWS for multinode deployment usage depends on both LWS and Volcano availability
+	switch {
+	case cfg.Orchestrators.LWS.Enabled == nil:
+		runtimeConfig.LWSEnabled = lwsDetected && volcanoDetected
+	case *cfg.Orchestrators.LWS.Enabled:
+		if !lwsDetected {
+			return nil, fmt.Errorf("LWS is explicitly enabled in config but the LWS API group was not detected in the cluster")
+		}
+		if !volcanoDetected {
+			return nil, fmt.Errorf(
+				"LWS is explicitly enabled in config but the Volcano API group was not detected in the cluster",
+			)
+		}
+		runtimeConfig.LWSEnabled = true
+	default:
+		setupLog.Info("LWS is explicitly disabled via config override")
+		runtimeConfig.LWSEnabled = false
+	}
+
+	switch {
+	case cfg.Orchestrators.VolcanoScheduler.Enabled == nil:
+		runtimeConfig.VolcanoSchedulerEnabled = false
+	case *cfg.Orchestrators.VolcanoScheduler.Enabled:
+		if !volcanoDetected {
+			return nil, fmt.Errorf(
+				"Volcano scheduler integration is explicitly enabled in config but the Volcano API group " +
+					"was not detected in the cluster",
+			)
+		}
+		runtimeConfig.VolcanoSchedulerEnabled = true
+	default:
+		setupLog.Info("Volcano scheduler integration is explicitly disabled via config override")
+		runtimeConfig.VolcanoSchedulerEnabled = false
+	}
+
+	// Detect Kai-scheduler availability using discovery client
+	setupLog.Info("Detecting Kai-scheduler availability...")
+	kaiSchedulerDetected := commoncontroller.DetectKaiSchedulerAvailability(ctx, mgr)
+	switch {
+	case cfg.Orchestrators.KaiScheduler.Enabled == nil:
+		runtimeConfig.KaiSchedulerEnabled = kaiSchedulerDetected
+	case *cfg.Orchestrators.KaiScheduler.Enabled:
+		if !kaiSchedulerDetected {
+			return nil, fmt.Errorf(
+				"Kai-scheduler is explicitly enabled in config but the scheduling.run.ai API group was not detected in the cluster",
+			)
+		}
+		runtimeConfig.KaiSchedulerEnabled = true
+	default:
+		setupLog.Info("Kai-scheduler is explicitly disabled via config override")
+		runtimeConfig.KaiSchedulerEnabled = false
+	}
+
+	setupLog.Info("Detecting DRA (Dynamic Resource Allocation) availability...")
+	draDetected := commoncontroller.DetectDRAAvailability(ctx, mgr)
+	switch {
+	case cfg.DRA.Enabled == nil:
+		runtimeConfig.DRAEnabled = draDetected
+	case *cfg.DRA.Enabled:
+		if !draDetected {
+			return nil, fmt.Errorf("DRA is explicitly enabled in config but the resource.k8s.io/v1 API" +
+				" was not detected in the cluster (requires Kubernetes 1.34+)")
+		}
+		runtimeConfig.DRAEnabled = true
+	default:
+		setupLog.Info("DRA is explicitly disabled via config override")
+		runtimeConfig.DRAEnabled = false
+	}
+
+	setupLog.Info("Detecting Istio availability...")
+	switch {
+	case cfg.ServiceMesh.Enabled == nil:
+		setupLog.Info("Auto-detecting Istio availability")
+		runtimeConfig.IstioEnabled = commoncontroller.DetectIstioDestinationRuleAvailability(ctx, mgr)
+	case *cfg.ServiceMesh.Enabled:
+		setupLog.Info("Istio service mesh is explicitly enabled; verifying availability")
+		istioDetected := commoncontroller.DetectIstioDestinationRuleAvailability(ctx, mgr)
+		if !istioDetected {
+			return nil, fmt.Errorf("Service mesh is explicitly enabled but the networking.istio.io" +
+				" DestinationRule API group was not detected in the cluster")
+		}
+		runtimeConfig.IstioEnabled = true
+	default:
+		setupLog.Info("Istio service mesh is explicitly disabled via config override")
+		runtimeConfig.IstioEnabled = false
+	}
+
+	setupLog.Info("Detected orchestrators availability",
+		"grove", runtimeConfig.GroveEnabled,
+		"lws", runtimeConfig.LWSEnabled,
+		"volcano", volcanoDetected,
+		"volcano-scheduler", runtimeConfig.VolcanoSchedulerEnabled,
+		"kai-scheduler", runtimeConfig.KaiSchedulerEnabled,
+		"dra", runtimeConfig.DRAEnabled,
+		"istio", runtimeConfig.IstioEnabled,
+	)
+
+	return runtimeConfig, nil
+}
+
+func setupScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
 	config := mgr.GetConfig()
 
 	// Create kubernetes client for discovery
@@ -142,406 +549,13 @@ func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
 	return scalesGetter, nil
 }
 
-func initCRDSchemes() {
-	utilruntime.Must(clientgoscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(nvidiacomv1alpha1.AddToScheme(crdScheme))
-
-	utilruntime.Must(nvidiacomv1beta1.AddToScheme(crdScheme))
-
-	utilruntime.Must(lwsscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(volcanoscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(grovev1alpha1.AddToScheme(crdScheme))
-
-	utilruntime.Must(apiextensionsv1.AddToScheme(crdScheme))
-
-	utilruntime.Must(admissionregistrationv1.AddToScheme(crdScheme))
-
-	utilruntime.Must(istioclientsetscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(gaiev1.Install(crdScheme))
-	//+kubebuilder:scaffold:scheme
-}
-
-func initConfigScheme() {
-	utilruntime.Must(configv1alpha1.AddToScheme(configScheme))
-}
-
-// +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
-// +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
-
-//nolint:gocyclo
-func main() {
-	initCRDSchemes()
-	initConfigScheme()
-
-	var configFile string
-	var operatorVersion string
-	var operatorImage string
-	var operatorImagePullPolicy string
-	flag.StringVar(&configFile, "config", "", "Path to operator configuration file (required)")
-	flag.StringVar(&operatorVersion, "operator-version", "unknown",
-		"Version of the operator (used in lease holder identity)")
-	flag.StringVar(
-		&operatorImage,
-		"operator-image",
-		"",
-		"Operator image used to deliver version-matched helper binaries for DGD overrides",
-	)
-	flag.StringVar(&operatorImagePullPolicy, "operator-image-pull-policy", string(corev1.PullIfNotPresent),
-		"Image pull policy for operator helper init containers")
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
-
-	if configFile == "" {
-		setupLog.Error(nil, "--config flag is required")
-		os.Exit(1)
-	}
-	// Load, default, and validate operator configuration
-	operatorCfg, err := LoadAndValidateOperatorConfig(configFile)
-	if err != nil {
-		setupLog.Error(err, "failed to load operator configuration", "configFile", configFile)
-		os.Exit(1)
-	}
-	setupLog.Info("Operator configuration loaded successfully", "configFile", configFile)
-
-	// Validate and normalize operator version to semver
-	if _, err := semver.NewVersion(operatorVersion); err != nil {
-		setupLog.Error(err, "operator-version is not valid semver",
-			"provided", operatorVersion, "error", err.Error())
-		os.Exit(1)
-	}
-	setupLog.Info("Operator version configured", "version", operatorVersion)
-
-	pullPolicy := corev1.PullPolicy(operatorImagePullPolicy)
-	switch pullPolicy {
-	case corev1.PullAlways, corev1.PullIfNotPresent, corev1.PullNever:
-	default:
-		setupLog.Error(nil, "operator-image-pull-policy is invalid", "provided", operatorImagePullPolicy)
-		os.Exit(1)
-	}
-
-	// Initialize runtime config (will be populated after detection)
-	runtimeConfig := &commonController.RuntimeConfig{}
-
-	mainCtx := ctrl.SetupSignalHandler()
-
-	// if the enable-http2 flag is false (the default), http/2 should be disabled
-	// due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
-	}
-
-	tlsOpts := []func(*tls.Config){}
-	if !operatorCfg.Security.EnableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
-	}
-
-	webhookServer := webhook.NewServer(webhook.Options{
-		Host:    operatorCfg.Server.Webhook.Host,
-		Port:    operatorCfg.Server.Webhook.Port,
-		CertDir: operatorCfg.Server.Webhook.CertDir,
-		TLSOpts: tlsOpts,
-	})
-
-	metricsBindAddr := fmt.Sprintf("%s:%d", operatorCfg.Server.Metrics.BindAddress, operatorCfg.Server.Metrics.Port)
-	healthProbeAddr := fmt.Sprintf(
-		"%s:%d", operatorCfg.Server.HealthProbe.BindAddress, operatorCfg.Server.HealthProbe.Port,
-	)
-
-	mgrOpts := ctrl.Options{
-		Scheme: crdScheme,
-		Metrics: metricsserver.Options{
-			BindAddress:    metricsBindAddr,
-			SecureServing:  ptr.Deref(operatorCfg.Server.Metrics.Secure, true),
-			FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
-			TLSOpts:        tlsOpts,
-		},
-		WebhookServer:           webhookServer,
-		HealthProbeBindAddress:  healthProbeAddr,
-		LeaderElection:          operatorCfg.LeaderElection.Enabled,
-		LeaderElectionID:        operatorCfg.LeaderElection.ID,
-		LeaderElectionNamespace: operatorCfg.LeaderElection.Namespace,
-	}
-
-	restrictedNamespace := operatorCfg.Namespace.Restricted
-	if restrictedNamespace != "" {
-		mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
-			restrictedNamespace: {},
-		}
-		// PodSnapshotContent is cluster-scoped, so DefaultNamespaces does not cover it.
-		// Register it cluster-wide explicitly so the PodSnapshotReconciler can watch it.
-		mgrOpts.Cache.ByObject = map[client.Object]cache.ByObject{
-			&nvidiacomv1alpha1.PodSnapshotContent{}: {},
-		}
-		setupLog.Info("Restricted namespace configured, launching in restricted mode", "namespace", restrictedNamespace)
-
-		banner := strings.Repeat("=", 80)
-		setupLog.Error(nil, banner)
-		setupLog.Error(nil, "DEPRECATION WARNING: Namespace-restricted mode is deprecated "+
-			"and will be removed in a future release.")
-		setupLog.Error(nil, "The operator is running in namespace-restricted mode",
-			"namespace", restrictedNamespace)
-		setupLog.Error(nil, "Please migrate to cluster-wide mode "+
-			"by removing the namespaceRestriction configuration.")
-		setupLog.Error(nil, banner)
-	} else {
-		setupLog.Info("No restricted namespace configured, launching in cluster-wide mode")
-	}
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
-	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
-
-	// Initialize observability metrics
-	setupLog.Info("Initializing observability metrics")
-	observability.InitMetrics()
-
-	// Set up webhook certificate management.
-	// A direct (non-cached) client is needed because the manager's cache isn't started yet.
-	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: crdScheme})
-	if err != nil {
-		setupLog.Error(err, "unable to create direct client for cert management")
-		os.Exit(1)
-	}
-	certMgr, err := internalcert.NewCertManager(directClient, &operatorCfg.Server.Webhook)
-	if err != nil {
-		setupLog.Error(err, "unable to create cert manager")
-		os.Exit(1)
-	}
-	// Auto mode runs one synchronous certificate refresh with the direct client,
-	// then registers the cert-controller with the not-yet-started manager.
-	if err = certMgr.SetupAndRunOnce(mainCtx, mgr); err != nil {
-		setupLog.Error(err, "failed to setup webhook certificate management")
-		os.Exit(1)
-	}
-
-	// Initialize namespace scope mechanism
-	var leaseManager *namespace_scope.LeaseManager
-	var leaseWatcher *namespace_scope.LeaseWatcher
-
-	if restrictedNamespace != "" {
-		// Namespace-restricted mode: Create and maintain namespace scope marker lease
-		setupLog.Info("Creating namespace scope marker lease manager",
-			"namespace", restrictedNamespace,
-			"leaseDuration", operatorCfg.Namespace.Scope.LeaseDuration.Duration,
-			"renewInterval", operatorCfg.Namespace.Scope.LeaseRenewInterval.Duration)
-
-		leaseManager, err = namespace_scope.NewLeaseManager(
-			mgr.GetConfig(),
-			restrictedNamespace,
-			operatorVersion,
-			operatorCfg.Namespace.Scope.LeaseDuration.Duration,
-			operatorCfg.Namespace.Scope.LeaseRenewInterval.Duration,
-		)
-		if err != nil {
-			setupLog.Error(err, "unable to create namespace scope marker lease manager")
-			os.Exit(1)
-		}
-
-		// Start the lease manager
-		if err = leaseManager.Start(mainCtx); err != nil {
-			setupLog.Error(err, "unable to start namespace scope marker lease manager")
-			os.Exit(1)
-		}
-
-		// Monitor for fatal lease errors
-		// If lease renewal fails repeatedly, we must exit to prevent split-brain
-		go func() {
-			select {
-			case err := <-leaseManager.Errors():
-				setupLog.Error(err, "FATAL: Lease manager encountered unrecoverable error, shutting down to prevent split-brain")
-				os.Exit(1)
-			case <-mainCtx.Done():
-				// Normal shutdown, error channel monitoring no longer needed
-				return
-			}
-		}()
-
-		// Ensure lease is released on shutdown
-		defer func() {
-			shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-			defer cancel()
-			if err := leaseManager.Stop(shutdownCtx); err != nil {
-				setupLog.Error(err, "failed to stop lease manager cleanly")
-			}
-		}()
-
-		setupLog.Info("Namespace scope marker lease manager started successfully")
-	} else {
-		// Cluster-wide mode: Watch for namespace scope marker leases
-		setupLog.Info("Setting up namespace scope marker lease watcher for cluster-wide mode")
-
-		leaseWatcher, err = namespace_scope.NewLeaseWatcher(mgr.GetConfig())
-		if err != nil {
-			setupLog.Error(err, "unable to create namespace scope marker lease watcher")
-			os.Exit(1)
-		}
-
-		// Start the lease watcher
-		if err = leaseWatcher.Start(mainCtx); err != nil {
-			setupLog.Error(err, "unable to start namespace scope marker lease watcher")
-			os.Exit(1)
-		}
-
-		setupLog.Info("Namespace scope marker lease watcher started successfully")
-
-		// Pass leaseWatcher to runtime config for namespace exclusion filtering
-		runtimeConfig.ExcludedNamespaces = leaseWatcher
-	}
-
-	// Register after ExcludedNamespaces is set so cluster-wide metrics skip restricted namespaces.
-	setupLog.Info("Registering resource counter")
-	if err := mgr.Add(observability.NewResourceCounter(
-		mgr.GetClient(),
-		runtimeConfig.ExcludedNamespaces,
-	)); err != nil {
-		setupLog.Error(err, "unable to register resource counter")
-		os.Exit(1)
-	}
-
-	// Detect orchestrators availability using discovery client.
-	// Config overrides (*bool) take precedence over auto-detection:
-	//   nil   = auto-detect (backward compatible default)
-	//   false = forcibly disabled regardless of API availability
-	//   true  = forcibly enabled; hard exit if API is not available (misconfiguration)
-	setupLog.Info("Detecting Grove availability...")
-	groveDetected := commonController.DetectGroveAvailability(mainCtx, mgr)
-	switch {
-	case operatorCfg.Orchestrators.Grove.Enabled == nil:
-		runtimeConfig.GroveEnabled = groveDetected
-	case *operatorCfg.Orchestrators.Grove.Enabled:
-		if !groveDetected {
-			setupLog.Error(nil, "Grove is explicitly enabled in config but the Grove API group was not detected in the cluster")
-			os.Exit(1)
-		}
-		runtimeConfig.GroveEnabled = true
-	default:
-		setupLog.Info("Grove is explicitly disabled via config override")
-		runtimeConfig.GroveEnabled = false
-	}
-
-	setupLog.Info("Detecting LWS availability...")
-	lwsDetected := commonController.DetectLWSAvailability(mainCtx, mgr)
-	setupLog.Info("Detecting Volcano availability...")
-	volcanoDetected := commonController.DetectVolcanoAvailability(mainCtx, mgr)
-	// LWS for multinode deployment usage depends on both LWS and Volcano availability
-	switch {
-	case operatorCfg.Orchestrators.LWS.Enabled == nil:
-		runtimeConfig.LWSEnabled = lwsDetected && volcanoDetected
-	case *operatorCfg.Orchestrators.LWS.Enabled:
-		if !lwsDetected {
-			setupLog.Error(nil, "LWS is explicitly enabled in config but the LWS API group was not detected in the cluster")
-			os.Exit(1)
-		}
-		if !volcanoDetected {
-			setupLog.Error(nil, "LWS is explicitly enabled in config but the Volcano API group was not detected in the cluster")
-			os.Exit(1)
-		}
-		runtimeConfig.LWSEnabled = true
-	default:
-		setupLog.Info("LWS is explicitly disabled via config override")
-		runtimeConfig.LWSEnabled = false
-	}
-
-	switch {
-	case operatorCfg.Orchestrators.VolcanoScheduler.Enabled == nil:
-		runtimeConfig.VolcanoSchedulerEnabled = false
-	case *operatorCfg.Orchestrators.VolcanoScheduler.Enabled:
-		if !volcanoDetected {
-			setupLog.Error(nil,
-				"Volcano scheduler integration is explicitly enabled in config but "+
-					"the Volcano API group was not detected in the cluster",
-			)
-			os.Exit(1)
-		}
-		runtimeConfig.VolcanoSchedulerEnabled = true
-	default:
-		setupLog.Info("Volcano scheduler integration is explicitly disabled via config override")
-		runtimeConfig.VolcanoSchedulerEnabled = false
-	}
-
-	// Detect Kai-scheduler availability using discovery client
-	setupLog.Info("Detecting Kai-scheduler availability...")
-	kaiSchedulerDetected := commonController.DetectKaiSchedulerAvailability(mainCtx, mgr)
-	switch {
-	case operatorCfg.Orchestrators.KaiScheduler.Enabled == nil:
-		runtimeConfig.KaiSchedulerEnabled = kaiSchedulerDetected
-	case *operatorCfg.Orchestrators.KaiScheduler.Enabled:
-		if !kaiSchedulerDetected {
-			setupLog.Error(nil,
-				"Kai-scheduler is explicitly enabled in config but the scheduling.run.ai API group was not detected in the cluster",
-			)
-			os.Exit(1)
-		}
-		runtimeConfig.KaiSchedulerEnabled = true
-	default:
-		setupLog.Info("Kai-scheduler is explicitly disabled via config override")
-		runtimeConfig.KaiSchedulerEnabled = false
-	}
-
-	setupLog.Info("Detecting DRA (Dynamic Resource Allocation) availability...")
-	draDetected := commonController.DetectDRAAvailability(mainCtx, mgr)
-	switch {
-	case operatorCfg.DRA.Enabled == nil:
-		runtimeConfig.DRAEnabled = draDetected
-	case *operatorCfg.DRA.Enabled:
-		if !draDetected {
-			setupLog.Error(nil,
-				"DRA is explicitly enabled in config but the resource.k8s.io/v1 API"+
-					" was not detected in the cluster (requires Kubernetes 1.34+)",
-			)
-			os.Exit(1)
-		}
-		runtimeConfig.DRAEnabled = true
-	default:
-		setupLog.Info("DRA is explicitly disabled via config override")
-		runtimeConfig.DRAEnabled = false
-	}
-
-	setupLog.Info("Detecting Istio availability...")
-	switch {
-	case operatorCfg.ServiceMesh.Enabled == nil:
-		setupLog.Info("Auto-detecting Istio availability")
-		runtimeConfig.IstioEnabled = commonController.DetectIstioDestinationRuleAvailability(mainCtx, mgr)
-	case *operatorCfg.ServiceMesh.Enabled:
-		setupLog.Info("Istio service mesh is explicitly enabled; verifying availability")
-		istioDetected := commonController.DetectIstioDestinationRuleAvailability(mainCtx, mgr)
-		if !istioDetected {
-			setupLog.Error(nil,
-				"Service mesh is explicitly enabled but the networking.istio.io"+
-					" DestinationRule API group was not detected in the cluster",
-			)
-			os.Exit(1)
-		}
-		runtimeConfig.IstioEnabled = true
-	default:
-		setupLog.Info("Istio service mesh is explicitly disabled via config override")
-		runtimeConfig.IstioEnabled = false
-	}
-
-	setupLog.Info("Detected orchestrators availability",
-		"grove", runtimeConfig.GroveEnabled,
-		"lws", runtimeConfig.LWSEnabled,
-		"volcano", volcanoDetected,
-		"volcano-scheduler", runtimeConfig.VolcanoSchedulerEnabled,
-		"kai-scheduler", runtimeConfig.KaiSchedulerEnabled,
-		"dra", runtimeConfig.DRAEnabled,
-		"istio", runtimeConfig.IstioEnabled,
-	)
-
+// TODO: Consider moving this secret lookup into controller-runtime cache/indexing where possible.
+// Avoid periodic full-list refreshes.
+func setupDockerSecretRetriever(
+	ctx context.Context,
+	mgr ctrl.Manager,
+	restrictedNamespace string,
+) (*secrets.DockerSecretIndexer, error) {
 	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader(), restrictedNamespace)
 	// refresh whenever a secret is created/deleted/updated
 	// Set up informer
@@ -557,19 +571,18 @@ func main() {
 	}
 	secretInformer := factory.Core().V1().Secrets().Informer()
 	// Start the informer factory
-	go factory.Start(mainCtx.Done())
+	go factory.Start(ctx.Done())
 	// Wait for the initial sync
-	if !k8sCache.WaitForCacheSync(mainCtx.Done(), secretInformer.HasSynced) {
-		setupLog.Error(nil, "Failed to sync informer cache")
-		os.Exit(1)
+	if !k8sCache.WaitForCacheSync(ctx.Done(), secretInformer.HasSynced) {
+		return nil, fmt.Errorf("failed to sync informer cache")
 	}
 	setupLog.Info("Secret informer cache synced and ready")
-	_, err = secretInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
+	_, err := secretInformer.AddEventHandler(k8sCache.ResourceEventHandlerFuncs{
 		AddFunc: func(obj interface{}) {
 			secret := obj.(*corev1.Secret)
 			if secret.Type == corev1.SecretTypeDockerConfigJson {
 				setupLog.Info("refreshing docker secrets index after secret creation...")
-				err := dockerSecretRetriever.RefreshIndex(context.Background())
+				err := dockerSecretRetriever.RefreshIndex(ctx)
 				if err != nil {
 					setupLog.Error(err, "unable to refresh docker secrets index after secret creation")
 				} else {
@@ -581,7 +594,7 @@ func main() {
 			newSecret := new.(*corev1.Secret)
 			if newSecret.Type == corev1.SecretTypeDockerConfigJson {
 				setupLog.Info("refreshing docker secrets index after secret update...")
-				err := dockerSecretRetriever.RefreshIndex(context.Background())
+				err := dockerSecretRetriever.RefreshIndex(ctx)
 				if err != nil {
 					setupLog.Error(err, "unable to refresh docker secrets index after secret update")
 				} else {
@@ -593,7 +606,7 @@ func main() {
 			secret := obj.(*corev1.Secret)
 			if secret.Type == corev1.SecretTypeDockerConfigJson {
 				setupLog.Info("refreshing docker secrets index after secret deletion...")
-				err := dockerSecretRetriever.RefreshIndex(context.Background())
+				err := dockerSecretRetriever.RefreshIndex(ctx)
 				if err != nil {
 					setupLog.Error(err, "unable to refresh docker secrets index after secret deletion")
 				} else {
@@ -603,10 +616,9 @@ func main() {
 		},
 	})
 	if err != nil {
-		setupLog.Error(err, "unable to add event handler to secret informer")
-		os.Exit(1)
+		return nil, fmt.Errorf("unable to add event handler to secret informer: %w", err)
 	}
-	if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
+	if err := dockerSecretRetriever.RefreshIndex(ctx); err != nil {
 		setupLog.Error(err, "initial docker secrets index refresh completed with errors; continuing startup")
 	} else {
 		setupLog.Info("initial docker secrets index refreshed")
@@ -617,307 +629,42 @@ func main() {
 		defer ticker.Stop()
 		for {
 			select {
-			case <-mainCtx.Done():
+			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				if err := dockerSecretRetriever.RefreshIndex(mainCtx); err != nil {
+				if err := dockerSecretRetriever.RefreshIndex(ctx); err != nil {
 					setupLog.Error(err, "failed to refresh docker secrets index")
 				}
 			}
 		}
 	}()
+	return dockerSecretRetriever, nil
+}
 
-	sshKeyManager := secret.NewSSHKeyManager(mgr.GetClient(), operatorCfg.MPI)
+// setupProbeEndpoints registers the health endpoints
+func setupProbeEndpoints(mgr ctrl.Manager) error {
+	defer setupLog.Info("Probe endpoints are configured on healthz and readyz")
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up health check")
-		os.Exit(1)
+		return fmt.Errorf("unable to set up health check: %w", err)
 	}
+
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
-		setupLog.Error(err, "unable to set up ready check")
-		os.Exit(1)
+		return fmt.Errorf("unable to set up ready check: %w", err)
 	}
 
-	// Register controllers synchronously before mgr.Start().
-	// Controllers don't depend on TLS certificates.
-	if err := registerControllers(
-		mgr, operatorCfg, runtimeConfig,
-		dockerSecretRetriever, sshKeyManager,
-		operatorImage, pullPolicy,
-	); err != nil {
-		setupLog.Error(err, "failed to register controllers")
-		os.Exit(1)
-	}
-
-	if err := registerWebhookHandlers(mgr, operatorCfg, runtimeConfig, operatorVersion); err != nil {
-		setupLog.Error(err, "failed to register webhooks")
-		os.Exit(1)
-	}
-
-	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS
-	// secrets before this point. Auto mode can therefore patch admission and
-	// conversion CAs immediately; manual mode waits for externally provided
-	// ca.crt and only patches conversion, leaving admission CA management
-	// out-of-band.
-	caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
-	if err != nil {
-		setupLog.Error(err, "unable to create CA bundle injector")
-		os.Exit(1)
-	}
-	if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
-		if err := caInjector.InjectAll(mainCtx); err != nil {
-			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
-			os.Exit(1)
-		}
-	} else {
-		// Manual mode gets webhook CA material out-of-band. Missing ca.crt
-		// blocks startup instead of running with unauthenticated conversion.
-		if err := caInjector.InjectCRDConversionCA(mainCtx); err != nil {
-			setupLog.Error(err, "failed to inject CRD conversion CA bundle")
-			os.Exit(1)
-		}
-	}
-
-	// mgr.Start reads tls.crt and tls.key from the projected Secret volume
-	// synchronously. Secret API updates are not enough because kubelet projects
-	// them into already-running pods asynchronously.
-	if err := certMgr.WaitForMountedCertificate(mainCtx); err != nil {
-		setupLog.Error(err, "failed waiting for mounted webhook TLS certificate")
-		os.Exit(1)
-	}
-
-	// Kubernetes propagates webhook configuration asynchronously, especially
-	// with HA apiservers. A missing or stale CA must fail closed during manager
-	// cache startup rather than allowing the operator to run without conversion
-	// or admission.
-	setupLog.Info("starting manager")
-	if err := mgr.Start(mainCtx); err != nil {
-		setupLog.Error(err, "problem running manager")
-		os.Exit(1)
-	}
-}
-
-func registerControllers(
-	mgr ctrl.Manager,
-	operatorCfg *configv1alpha1.OperatorConfiguration,
-	runtimeConfig *commonController.RuntimeConfig,
-	dockerSecretRetriever *secrets.DockerSecretIndexer,
-	sshKeyManager *secret.SSHKeyManager,
-	operatorImage string,
-	operatorPullPolicy corev1.PullPolicy,
-) error {
-	if err := (&controller.DynamoComponentDeploymentReconciler{
-		Client:                mgr.GetClient(),
-		Recorder:              mgr.GetEventRecorderFor("dynamocomponentdeployment"),
-		Config:                operatorCfg,
-		RuntimeConfig:         runtimeConfig,
-		DockerSecretRetriever: dockerSecretRetriever,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoComponentDeployment controller: %w", err)
-	}
-
-	scaleClient, err := createScalesGetter(mgr)
-	if err != nil {
-		return fmt.Errorf("unable to create scale client: %w", err)
-	}
-
-	rbacManager := rbac.NewManager(mgr.GetClient())
-
-	if err = (&controller.DynamoGraphDeploymentReconciler{
-		Client:                mgr.GetClient(),
-		Recorder:              mgr.GetEventRecorderFor("dynamographdeployment"),
-		Config:                operatorCfg,
-		RuntimeConfig:         runtimeConfig,
-		RestConfig:            mgr.GetConfig(),
-		DockerSecretRetriever: dockerSecretRetriever,
-		ScaleClient:           scaleClient,
-		SSHKeyManager:         sshKeyManager,
-		RBACManager:           rbacManager,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoGraphDeployment controller: %w", err)
-	}
-
-	if err = (&controller.DynamoGraphDeploymentScalingAdapterReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("dgdscalingadapter"),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DGDScalingAdapter controller: %w", err)
-	}
-
-	if err = (&controller.DynamoGraphDeploymentRequestReconciler{
-		Client:                  mgr.GetClient(),
-		APIReader:               mgr.GetAPIReader(),
-		Recorder:                mgr.GetEventRecorderFor("dynamographdeploymentrequest"),
-		Config:                  operatorCfg,
-		RuntimeConfig:           runtimeConfig,
-		GPUDiscoveryCache:       gpu.NewGPUDiscoveryCache(),
-		GPUDiscovery:            gpu.NewGPUDiscovery(gpu.ScrapeMetricsEndpoint),
-		OperatorImage:           operatorImage,
-		OperatorImagePullPolicy: operatorPullPolicy,
-		RBACManager:             rbacManager,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoGraphDeploymentRequest controller: %w", err)
-	}
-
-	if err = (&controller.DynamoModelReconciler{
-		Client:         mgr.GetClient(),
-		Recorder:       mgr.GetEventRecorderFor("dynamomodel"),
-		EndpointClient: modelendpoint.NewClient(),
-		Config:         operatorCfg,
-		RuntimeConfig:  runtimeConfig,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoModel controller: %w", err)
-	}
-
-	if err = (&controller.CheckpointReconciler{
-		Client:        mgr.GetClient(),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-		Recorder:      mgr.GetEventRecorderFor("checkpoint"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoCheckpoint controller: %w", err)
-	}
-
-	if err = (&controller.PodSnapshotReconciler{
-		Client:        mgr.GetClient(),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-		Recorder:      mgr.GetEventRecorderFor("snapshot"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create PodSnapshot controller: %w", err)
-	}
-
-	if runtimeConfig.GroveEnabled {
-		if err = controller.NewFailoverCascadeReconciler(
-			mgr.GetClient(),
-			mgr.GetEventRecorderFor("gms-failover-cascade"),
-		).SetupWithManager(mgr); err != nil {
-			return fmt.Errorf("unable to create GMS FailoverCascade controller: %w", err)
-		}
-	}
-
-	if err = (&controller.TopologyLabelReconciler{
-		Client:        mgr.GetClient(),
-		NodeReader:    mgr.GetAPIReader(),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-		Recorder:      mgr.GetEventRecorderFor("topology-label"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create TopologyLabel controller: %w", err)
-	}
-
-	setupLog.Info("Controllers registered successfully")
 	return nil
 }
 
-func registerWebhookHandlers(
-	mgr ctrl.Manager,
-	operatorCfg *configv1alpha1.OperatorConfiguration,
-	runtimeConfig *commonController.RuntimeConfig,
-	operatorVersion string,
-) error {
-	isClusterWide := operatorCfg.Namespace.Restricted == ""
-	if isClusterWide {
-		setupLog.Info("Configuring webhooks with lease-based namespace exclusion for cluster-wide mode")
-		internalwebhook.SetExcludedNamespaces(runtimeConfig.ExcludedNamespaces)
-	} else {
-		setupLog.Info("Configuring webhooks for namespace-restricted mode (no lease checking)",
-			"restrictedNamespace", operatorCfg.Namespace.Restricted)
-		internalwebhook.SetExcludedNamespaces(nil)
+func apply(configFile string) (ctrl.Options, configapi.OperatorConfiguration, error) {
+	options, cfg, err := config.Load(scheme, configFile)
+	if err != nil {
+		return options, cfg, err
 	}
-
-	var operatorPrincipal string
-	if sa, ns := os.Getenv("POD_SERVICE_ACCOUNT"), os.Getenv("POD_NAMESPACE"); sa != "" && ns != "" {
-		operatorPrincipal = fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa)
-		setupLog.Info("Detected operator principal from downward API", "principal", operatorPrincipal)
-	} else {
-		setupLog.Info("POD_SERVICE_ACCOUNT/POD_NAMESPACE not set; operator SA self-identification disabled")
+	cfgStr, err := config.Encode(scheme, &cfg)
+	if err != nil {
+		return options, cfg, err
 	}
-
-	// Temporary internal gate for GMS + Snapshot.
-	if os.Getenv(consts.DynamoOperatorAllowGMSSnapshotEnvVar) == "1" {
-		setupLog.Info(
-			"INTERNAL OVERRIDE: GMS + Snapshot admission rule disabled via env var; do NOT enable in production",
-			"envVar", consts.DynamoOperatorAllowGMSSnapshotEnvVar,
-		)
-	}
-
-	setupLog.Info("Registering validation webhooks")
-
-	dcdHandler := webhookvalidation.NewDynamoComponentDeploymentHandler()
-	if err := dcdHandler.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoComponentDeployment webhook: %w", err)
-	}
-
-	dgdHandler := webhookvalidation.NewDynamoGraphDeploymentHandler(mgr, operatorPrincipal, runtimeConfig.GroveEnabled)
-	if err := dgdHandler.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeployment webhook: %w", err)
-	}
-
-	dckptHandler := webhookvalidation.NewDynamoCheckpointHandler()
-	if err := dckptHandler.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoCheckpoint webhook: %w", err)
-	}
-
-	dmHandler := webhookvalidation.NewDynamoModelHandler()
-	if err := dmHandler.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoModel webhook: %w", err)
-	}
-
-	dgdrHandler := webhookvalidation.NewDynamoGraphDeploymentRequestHandler(
-		isClusterWide, ptr.Deref(operatorCfg.GPU.DiscoveryEnabled, true),
-	)
-	if err := dgdrHandler.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest webhook: %w", err)
-	}
-
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest conversion webhook: %w", err)
-	}
-
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeployment{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeployment conversion webhook: %w", err)
-	}
-
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoComponentDeployment{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoComponentDeployment conversion webhook: %w", err)
-	}
-
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentScalingAdapter conversion webhook: %w", err)
-	}
-
-	setupLog.Info("Registering defaulting webhooks")
-
-	dcdDefaulter := webhookdefaulting.NewDCDDefaulter()
-	if err := dcdDefaulter.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoComponentDeployment defaulting webhook: %w", err)
-	}
-
-	dgdDefaulter := webhookdefaulting.NewDGDDefaulter(operatorVersion, runtimeConfig.GroveEnabled)
-	if err := dgdDefaulter.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeployment defaulting webhook: %w", err)
-	}
-
-	dgdrDefaulter := webhookdefaulting.NewDGDRDefaulter(operatorVersion)
-	if err := dgdrDefaulter.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest defaulting webhook: %w", err)
-	}
-
-	setupLog.Info("Registering mutation webhooks")
-
-	podCheckpointRestoreMutator := webhookmutation.NewPodCheckpointRestoreMutator(mgr.GetClient(), operatorCfg)
-	if err := podCheckpointRestoreMutator.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register Pod checkpoint restore mutating webhook: %w", err)
-	}
-
-	setupLog.Info("Webhooks registered successfully")
-	return nil
+	setupLog.Info("Configuration loaded", "config", cfgStr)
+	return options, cfg, nil
 }

--- a/deploy/operator/internal/config/config.go
+++ b/deploy/operator/internal/config/config.go
@@ -1,0 +1,139 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsfilters "sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+)
+
+// fromFile provides an alternative to the deprecated ctrl.ConfigFile().AtPath(path).OfKind(&cfg)
+func fromFile(path string, scheme *runtime.Scheme, cfg *configapi.OperatorConfiguration) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	codecs := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+
+	// Regardless of if the bytes are of any external version,
+	// it will be read successfully and converted into the internal version
+	return runtime.DecodeInto(codecs.UniversalDecoder(), content, cfg)
+}
+
+// addTo provides an alternative to the deprecated o.AndFrom(&cfg)
+func addTo(o *ctrl.Options, cfg *configapi.OperatorConfiguration) {
+	// if the enable-http2 flag is false (the default), http/2 should be disabled
+	// due to its vulnerabilities. More specifically, disabling http/2 will
+	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
+	// Rapid Reset CVEs. For more information see:
+	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+	// - https://github.com/advisories/GHSA-4374-p667-p6c8
+	disableHTTP2 := func(c *tls.Config) {
+		c.NextProtos = []string{"http/1.1"}
+	}
+
+	tlsOpts := []func(*tls.Config){}
+	if !cfg.Security.EnableHTTP2 {
+		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	webhookServer := webhook.NewServer(webhook.Options{
+		Host:    cfg.Server.Webhook.Host,
+		Port:    cfg.Server.Webhook.Port,
+		CertDir: cfg.Server.Webhook.CertDir,
+		TLSOpts: tlsOpts,
+	})
+
+	o.Metrics = metricsserver.Options{
+		BindAddress:    fmt.Sprintf("%s:%d", cfg.Server.Metrics.BindAddress, cfg.Server.Metrics.Port),
+		SecureServing:  ptr.Deref(cfg.Server.Metrics.Secure, true),
+		FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
+		TLSOpts:        tlsOpts,
+	}
+
+	o.WebhookServer = webhookServer
+	o.HealthProbeBindAddress = fmt.Sprintf("%s:%d", cfg.Server.HealthProbe.BindAddress, cfg.Server.HealthProbe.Port)
+	o.LeaderElection = cfg.LeaderElection.Enabled
+	o.LeaderElectionID = cfg.LeaderElection.ID
+	o.LeaderElectionNamespace = cfg.LeaderElection.Namespace
+
+	restrictedNamespace := cfg.Namespace.Restricted
+	if restrictedNamespace != "" {
+		o.Cache.DefaultNamespaces = map[string]cache.Config{
+			restrictedNamespace: {},
+		}
+		// PodSnapshotContent is cluster-scoped, so DefaultNamespaces does not cover it.
+		// Register it cluster-wide explicitly so the PodSnapshotReconciler can watch it.
+		o.Cache.ByObject = map[client.Object]cache.ByObject{
+			&nvidiacomv1alpha1.PodSnapshotContent{}: {},
+		}
+	}
+}
+
+// Load returns a set of controller options and configuration from the given file, if the config file path is empty
+// it used the default configapi values.
+func Load(scheme *runtime.Scheme, configFile string) (ctrl.Options, configapi.OperatorConfiguration, error) {
+	var err error
+	options := ctrl.Options{
+		Scheme: scheme,
+	}
+
+	cfg := configapi.OperatorConfiguration{}
+	if configFile == "" {
+		scheme.Default(&cfg)
+	} else {
+		err := fromFile(configFile, scheme, &cfg)
+		if err != nil {
+			return options, cfg, err
+		}
+	}
+	addTo(&options, &cfg)
+	return options, cfg, err
+}
+
+func Encode(scheme *runtime.Scheme, cfg *configapi.OperatorConfiguration) (string, error) {
+	codecs := serializer.NewCodecFactory(scheme)
+	const mediaType = runtime.ContentTypeYAML
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		return "", fmt.Errorf("unable to locate encoder -- %q is not a supported media type", mediaType)
+	}
+
+	encoder := codecs.EncoderForVersion(info.Serializer, configapi.SchemeGroupVersion)
+	buf := new(bytes.Buffer)
+	if err := encoder.Encode(cfg, buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/deploy/operator/internal/config/config_test.go
+++ b/deploy/operator/internal/config/config_test.go
@@ -1,0 +1,317 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert/yaml"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+)
+
+func TestEncode(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := configapi.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultConfig := &configapi.OperatorConfiguration{}
+	testScheme.Default(defaultConfig)
+
+	testcases := []struct {
+		name       string
+		scheme     *runtime.Scheme
+		cfg        *configapi.OperatorConfiguration
+		wantResult map[string]any
+	}{
+		{
+			name:   "empty",
+			scheme: testScheme,
+			cfg:    &configapi.OperatorConfiguration{},
+			wantResult: map[string]any{
+				"apiVersion": "operator.config.dynamo.nvidia.com/v1alpha1",
+				"kind":       "OperatorConfiguration",
+				"server": map[string]any{
+					"metrics": map[string]any{
+						"bindAddress": "",
+						"port":        0,
+					},
+					"healthProbe": map[string]any{
+						"bindAddress": "",
+						"port":        0,
+					},
+					"webhook": map[string]any{
+						"bindAddress":       "",
+						"port":              0,
+						"host":              "",
+						"certDir":           "",
+						"certProvisionMode": "",
+						"secretName":        "",
+						"serviceName":       "",
+					},
+				},
+				"leaderElection": map[string]any{
+					"enabled":   false,
+					"id":        "",
+					"namespace": "",
+				},
+				"namespace": map[string]any{
+					"restricted": "",
+					"scope": map[string]any{
+						"leaseDuration":      "0s",
+						"leaseRenewInterval": "0s",
+					},
+				},
+				"orchestrators": map[string]any{
+					"grove": map[string]any{
+						"terminationDelay": "0s",
+					},
+					"lws":              map[string]any{},
+					"kaiScheduler":     map[string]any{},
+					"volcanoScheduler": map[string]any{},
+				},
+				"dra": map[string]any{},
+				"infrastructure": map[string]any{
+					"natsAddress":        "",
+					"etcdAddress":        "",
+					"modelExpressURL":    "",
+					"prometheusEndpoint": "",
+				},
+				"ingress": map[string]any{
+					"virtualServiceGateway":   "",
+					"controllerClassName":     "",
+					"controllerTLSSecretName": "",
+					"hostSuffix":              "",
+				},
+				"serviceMesh": map[string]any{
+					"provider": "",
+				},
+				"rbac": map[string]any{
+					"plannerClusterRoleName":       "",
+					"dgdrProfilingClusterRoleName": "",
+					"eppClusterRoleName":           "",
+				},
+				"mpi": map[string]any{
+					"sshSecretName":      "",
+					"sshSecretNamespace": "",
+				},
+				"checkpoint": map[string]any{
+					"enabled": false,
+					"storage": map[string]any{
+						"type": "",
+						"pvc": map[string]any{
+							"pvcName":          "",
+							"basePath":         "",
+							"create":           false,
+							"size":             "",
+							"storageClassName": "",
+							"accessMode":       "",
+						},
+						"s3": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+						"oci": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+					},
+				},
+				"discovery": map[string]any{
+					"backend": "",
+				},
+				"gpu": map[string]any{},
+				"logging": map[string]any{
+					"level":  "",
+					"format": "",
+				},
+				"security": map[string]any{
+					"enableHTTP2": false,
+				},
+			},
+		},
+		{
+			name:   "default",
+			scheme: testScheme,
+			cfg:    defaultConfig,
+			wantResult: map[string]any{
+				"apiVersion": "operator.config.dynamo.nvidia.com/v1alpha1",
+				"kind":       "OperatorConfiguration",
+				"server": map[string]any{
+					"metrics": map[string]any{
+						"bindAddress": "0.0.0.0",
+						"port":        8080,
+						"secure":      true,
+					},
+					"healthProbe": map[string]any{
+						"bindAddress": "0.0.0.0",
+						"port":        8081,
+					},
+					"webhook": map[string]any{
+						"bindAddress":       "",
+						"port":              9443,
+						"host":              "0.0.0.0",
+						"certDir":           "/tmp/k8s-webhook-server/serving-certs",
+						"certProvisionMode": "auto",
+						"secretName":        "webhook-server-cert",
+						"serviceName":       "",
+					},
+				},
+				"leaderElection": map[string]any{
+					"enabled":   false,
+					"id":        "",
+					"namespace": "",
+				},
+				"namespace": map[string]any{
+					"restricted": "",
+					"scope": map[string]any{
+						"leaseDuration":      "30s",
+						"leaseRenewInterval": "10s",
+					},
+				},
+				"orchestrators": map[string]any{
+					"grove": map[string]any{
+						"terminationDelay": "15m0s",
+					},
+					"lws":              map[string]any{},
+					"kaiScheduler":     map[string]any{},
+					"volcanoScheduler": map[string]any{},
+				},
+				"dra": map[string]any{},
+				"infrastructure": map[string]any{
+					"natsAddress":        "",
+					"etcdAddress":        "",
+					"modelExpressURL":    "",
+					"prometheusEndpoint": "",
+				},
+				"ingress": map[string]any{
+					"virtualServiceGateway":   "",
+					"controllerClassName":     "",
+					"controllerTLSSecretName": "",
+					"hostSuffix":              "",
+				},
+				"serviceMesh": map[string]any{
+					"provider": "",
+				},
+				"rbac": map[string]any{
+					"plannerClusterRoleName":       "",
+					"dgdrProfilingClusterRoleName": "",
+					"eppClusterRoleName":           "",
+				},
+				"mpi": map[string]any{
+					"sshSecretName":      "",
+					"sshSecretNamespace": "",
+				},
+				"checkpoint": map[string]any{
+					"enabled": false,
+					"storage": map[string]any{
+						"type": "",
+						"pvc": map[string]any{
+							"pvcName":          "",
+							"basePath":         "",
+							"create":           false,
+							"size":             "",
+							"storageClassName": "",
+							"accessMode":       "",
+						},
+						"s3": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+						"oci": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+					},
+				},
+				"discovery": map[string]any{
+					"backend": "kubernetes",
+				},
+				"gpu": map[string]any{
+					"discoveryEnabled": true,
+				},
+				"logging": map[string]any{
+					"level":  "info",
+					"format": "json",
+				},
+				"security": map[string]any{
+					"enableHTTP2": false,
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Encode(tc.scheme, tc.cfg)
+			if err != nil {
+				t.Errorf("Unexpected error:%s", err)
+			}
+			gotMap := map[string]any{}
+			err = yaml.Unmarshal([]byte(got), &gotMap)
+			if err != nil {
+				t.Errorf("Unable to unmarshal result:%s", err)
+			}
+			if diff := cmp.Diff(tc.wantResult, gotMap); diff != "" {
+				t.Errorf("Unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := configapi.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// TODO: add test cases.
+	testcases := []struct {
+		name              string
+		configFile        string
+		wantConfiguration configapi.OperatorConfiguration
+		wantOptions       ctrl.Options
+		wantError         error
+	}{}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			options, cfg, err := Load(testScheme, tc.configFile)
+			if tc.wantError == nil {
+				if err != nil {
+					t.Errorf("Unexpected error:%s", err)
+				}
+				if diff := cmp.Diff(tc.wantConfiguration, cfg); diff != "" {
+					t.Errorf("Unexpected config (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tc.wantOptions, options); diff != "" {
+					t.Errorf("Unexpected options (-want +got):\n%s", diff)
+				}
+			} else {
+				if diff := cmp.Diff(tc.wantError.Error(), err.Error()); diff != "" {
+					t.Errorf("Unexpected error (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/config/validation.go
+++ b/deploy/operator/internal/config/validation.go
@@ -15,17 +15,17 @@
  * limitations under the License.
  */
 
-package validation
+package config
 
 import (
 	"net/url"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ValidateOperatorConfiguration validates an OperatorConfiguration object.
-func ValidateOperatorConfiguration(config *configv1alpha1.OperatorConfiguration) field.ErrorList {
+// Validate checks the configuration for invalid values.
+func Validate(config *configapi.OperatorConfiguration) field.ErrorList {
 	if config == nil {
 		return field.ErrorList{field.Required(field.NewPath(""), "operator configuration is required")}
 	}
@@ -45,7 +45,7 @@ func ValidateOperatorConfiguration(config *configv1alpha1.OperatorConfiguration)
 	return allErrs
 }
 
-func validateServer(server *configv1alpha1.ServerConfiguration, fldPath *field.Path) field.ErrorList {
+func validateServer(server *configapi.ServerConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if server.Metrics.Port < 0 || server.Metrics.Port > 65535 {
@@ -61,7 +61,7 @@ func validateServer(server *configv1alpha1.ServerConfiguration, fldPath *field.P
 	return allErrs
 }
 
-func validateLeaderElection(le *configv1alpha1.LeaderElectionConfiguration, fldPath *field.Path) field.ErrorList {
+func validateLeaderElection(le *configapi.LeaderElectionConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if le.Enabled && le.ID == "" {
@@ -71,7 +71,7 @@ func validateLeaderElection(le *configv1alpha1.LeaderElectionConfiguration, fldP
 	return allErrs
 }
 
-func validateNamespace(ns *configv1alpha1.NamespaceConfiguration, fldPath *field.Path) field.ErrorList {
+func validateNamespace(ns *configapi.NamespaceConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// Namespace-restricted mode validations
@@ -92,7 +92,7 @@ func validateNamespace(ns *configv1alpha1.NamespaceConfiguration, fldPath *field
 	return allErrs
 }
 
-func validateMPI(mpi *configv1alpha1.MPIConfiguration, fldPath *field.Path) field.ErrorList {
+func validateMPI(mpi *configapi.MPIConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if mpi.SSHSecretName == "" {
@@ -105,7 +105,7 @@ func validateMPI(mpi *configv1alpha1.MPIConfiguration, fldPath *field.Path) fiel
 	return allErrs
 }
 
-func validateInfrastructure(infra *configv1alpha1.InfrastructureConfiguration, fldPath *field.Path) field.ErrorList {
+func validateInfrastructure(infra *configapi.InfrastructureConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if infra.ModelExpressURL != "" {
@@ -117,10 +117,10 @@ func validateInfrastructure(infra *configv1alpha1.InfrastructureConfiguration, f
 	return allErrs
 }
 
-func validateDiscovery(discovery *configv1alpha1.DiscoveryConfiguration, fldPath *field.Path) field.ErrorList {
+func validateDiscovery(discovery *configapi.DiscoveryConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
-	if discovery.Backend != configv1alpha1.DiscoveryBackendKubernetes && discovery.Backend != configv1alpha1.DiscoveryBackendEtcd {
+	if discovery.Backend != configapi.DiscoveryBackendKubernetes && discovery.Backend != configapi.DiscoveryBackendEtcd {
 		allErrs = append(allErrs, field.NotSupported(fldPath.Child("backend"), discovery.Backend, []string{"kubernetes", "etcd"}))
 	}
 
@@ -128,7 +128,7 @@ func validateDiscovery(discovery *configv1alpha1.DiscoveryConfiguration, fldPath
 }
 
 // validateRBAC is mode-aware: validates RBAC fields based on namespace mode.
-func validateRBAC(config *configv1alpha1.OperatorConfiguration) field.ErrorList {
+func validateRBAC(config *configapi.OperatorConfiguration) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	// RBAC validation only applies in cluster-wide mode
@@ -150,7 +150,7 @@ func validateRBAC(config *configv1alpha1.OperatorConfiguration) field.ErrorList 
 	return allErrs
 }
 
-func validateOrchestrators(orch *configv1alpha1.OrchestratorConfiguration, fldPath *field.Path) field.ErrorList {
+func validateOrchestrators(orch *configapi.OrchestratorConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if orch.Grove.TerminationDelay.Duration < 0 {
@@ -160,7 +160,7 @@ func validateOrchestrators(orch *configv1alpha1.OrchestratorConfiguration, fldPa
 	return allErrs
 }
 
-func validateIngress(ingress *configv1alpha1.IngressConfiguration, fldPath *field.Path) field.ErrorList {
+func validateIngress(ingress *configapi.IngressConfiguration, fldPath *field.Path) field.ErrorList {
 	// No required fields — all ingress configuration is optional
 	_ = fldPath
 	_ = ingress
@@ -172,7 +172,7 @@ func validateIngress(ingress *configv1alpha1.IngressConfiguration, fldPath *fiel
 // private key (and optionally a CA certificates file); without them Istio's
 // validation webhook rejects the EPP DestinationRule and the operator can
 // never finish reconciling the DGD.
-func validateServiceMesh(sm *configv1alpha1.ServiceMeshConfiguration, fldPath *field.Path) field.ErrorList {
+func validateServiceMesh(sm *configapi.ServiceMeshConfiguration, fldPath *field.Path) field.ErrorList {
 	allErrs := field.ErrorList{}
 
 	if !sm.IsEnabled() {

--- a/deploy/operator/internal/config/validation_test.go
+++ b/deploy/operator/internal/config/validation_test.go
@@ -15,21 +15,21 @@
  * limitations under the License.
  */
 
-package validation
+package config
 
 import (
 	"encoding/json"
 	"testing"
 	"time"
 
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // validConfig returns a minimal valid OperatorConfiguration for cluster-wide mode.
-func validConfig() *configv1alpha1.OperatorConfiguration {
-	cfg := &configv1alpha1.OperatorConfiguration{}
-	configv1alpha1.SetDefaultsOperatorConfiguration(cfg)
+func validConfig() *configapi.OperatorConfiguration {
+	cfg := &configapi.OperatorConfiguration{}
+	configapi.SetDefaultsOperatorConfiguration(cfg)
 	cfg.MPI.SSHSecretName = "mpi-ssh"
 	cfg.MPI.SSHSecretNamespace = "default"
 	// Cluster-wide validation requires chart-provided RBAC names.
@@ -40,7 +40,7 @@ func validConfig() *configv1alpha1.OperatorConfiguration {
 }
 
 // validNamespaceScopedConfig returns a minimal valid OperatorConfiguration for namespace-restricted mode.
-func validNamespaceScopedConfig() *configv1alpha1.OperatorConfiguration {
+func validNamespaceScopedConfig() *configapi.OperatorConfiguration {
 	cfg := validConfig()
 	cfg.Namespace.Restricted = "my-namespace"
 	// RBAC not required in namespace mode
@@ -50,93 +50,93 @@ func validNamespaceScopedConfig() *configv1alpha1.OperatorConfiguration {
 	return cfg
 }
 
-func TestValidateOperatorConfiguration_Valid(t *testing.T) {
-	errs := ValidateOperatorConfiguration(validConfig())
+func TestValidate_Valid(t *testing.T) {
+	errs := Validate(validConfig())
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for valid config, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_ValidNamespaceScoped(t *testing.T) {
-	errs := ValidateOperatorConfiguration(validNamespaceScopedConfig())
+func TestValidate_ValidNamespaceScoped(t *testing.T) {
+	errs := Validate(validNamespaceScopedConfig())
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for valid namespace-scoped config, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_MissingMPISecret(t *testing.T) {
+func TestValidate_MissingMPISecret(t *testing.T) {
 	cfg := validConfig()
 	cfg.MPI.SSHSecretName = ""
 	cfg.MPI.SSHSecretNamespace = ""
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 2 {
 		t.Errorf("expected 2 errors for missing MPI secret, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_InvalidDiscoveryBackend(t *testing.T) {
+func TestValidate_InvalidDiscoveryBackend(t *testing.T) {
 	cfg := validConfig()
 	cfg.Discovery.Backend = "consul"
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid discovery backend, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_ClusterWideMissingPlannerRole(t *testing.T) {
+func TestValidate_ClusterWideMissingPlannerRole(t *testing.T) {
 	cfg := validConfig()
 	cfg.RBAC.PlannerClusterRoleName = ""
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for missing planner role in cluster-wide mode, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NamespaceScopedNoRBACRequired(t *testing.T) {
+func TestValidate_NamespaceScopedNoRBACRequired(t *testing.T) {
 	cfg := validNamespaceScopedConfig()
 	// Verify that RBAC is not required in namespace mode
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for namespace-scoped config without RBAC, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NamespaceScopedInvalidLease(t *testing.T) {
+func TestValidate_NamespaceScopedInvalidLease(t *testing.T) {
 	cfg := validNamespaceScopedConfig()
 	cfg.Namespace.Scope.LeaseDuration = metav1.Duration{Duration: 0}
 	cfg.Namespace.Scope.LeaseRenewInterval = metav1.Duration{Duration: 0}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 2 {
 		t.Errorf("expected 2 errors for zero lease values, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NamespaceScopedLeaseRenewExceedsDuration(t *testing.T) {
+func TestValidate_NamespaceScopedLeaseRenewExceedsDuration(t *testing.T) {
 	cfg := validNamespaceScopedConfig()
 	cfg.Namespace.Scope.LeaseDuration = metav1.Duration{Duration: 10 * time.Second}
 	cfg.Namespace.Scope.LeaseRenewInterval = metav1.Duration{Duration: 15 * time.Second}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for lease renew > duration, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_CheckpointEnabledRequiresNoStorageConfig(t *testing.T) {
+func TestValidate_CheckpointEnabledRequiresNoStorageConfig(t *testing.T) {
 	cfg := validConfig()
 	cfg.Checkpoint.Enabled = true
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for checkpoint config without storage settings, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_CheckpointDeprecatedStorageConfigIsAccepted(t *testing.T) {
+func TestValidate_CheckpointDeprecatedStorageConfigIsAccepted(t *testing.T) {
 	cfg := validConfig()
 	rawConfig := []byte(`{
 		"checkpoint": {
@@ -153,58 +153,58 @@ func TestValidateOperatorConfiguration_CheckpointDeprecatedStorageConfigIsAccept
 		t.Fatalf("failed to unmarshal compatibility config: %v", err)
 	}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for deprecated checkpoint storage config, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_CheckpointDisabledSkipsValidation(t *testing.T) {
+func TestValidate_CheckpointDisabledSkipsValidation(t *testing.T) {
 	cfg := validConfig()
 	cfg.Checkpoint.Enabled = false
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors when checkpoint is disabled, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_InvalidModelExpressURL(t *testing.T) {
+func TestValidate_InvalidModelExpressURL(t *testing.T) {
 	cfg := validConfig()
 	cfg.Infrastructure.ModelExpressURL = "://bad-url"
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid model express URL, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_InvalidPort(t *testing.T) {
+func TestValidate_InvalidPort(t *testing.T) {
 	cfg := validConfig()
 	cfg.Server.Metrics.Port = 99999
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid port, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_LeaderElectionEnabledMissingID(t *testing.T) {
+func TestValidate_LeaderElectionEnabledMissingID(t *testing.T) {
 	cfg := validConfig()
 	cfg.LeaderElection.Enabled = true
 	cfg.LeaderElection.ID = ""
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for missing leader election ID, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NegativeTerminationDelay(t *testing.T) {
+func TestValidate_NegativeTerminationDelay(t *testing.T) {
 	cfg := validConfig()
 	cfg.Orchestrators.Grove.TerminationDelay = metav1.Duration{Duration: -1 * time.Second}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := Validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for negative termination delay, got %d: %v", len(errs), errs)
 	}

--- a/deploy/operator/internal/controller/controller.go
+++ b/deploy/operator/internal/controller/controller.go
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/scale"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/rbac"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secrets"
+)
+
+// SetupControllersOpts holds optional dependencies for SetupControllers.
+type SetupControllersOpts struct {
+	RuntimeConfig         *commoncontroller.RuntimeConfig
+	DockerSecretRetriever *secrets.DockerSecretIndexer
+	SSHKeyManager         *secret.SSHKeyManager
+	RBACManager           *rbac.Manager
+	ScaleClient           scale.ScalesGetter
+	OperatorImage         string
+	OperatorPullPolicy    v1.PullPolicy
+}
+
+// SetupControllers sets up the core controllers. It returns the name of the
+// controller that failed to create and an error, if any.
+func SetupControllers(mgr ctrl.Manager, cfg *configapi.OperatorConfiguration, opts SetupControllersOpts) (string, error) {
+	if err := (&DynamoComponentDeploymentReconciler{
+		Client:                mgr.GetClient(),
+		Recorder:              mgr.GetEventRecorderFor("dynamocomponentdeployment"),
+		Config:                cfg,
+		RuntimeConfig:         opts.RuntimeConfig,
+		DockerSecretRetriever: opts.DockerSecretRetriever,
+	}).SetupWithManager(mgr); err != nil {
+		return "dynamocomponentdeployment", err
+	}
+
+	if err := (&DynamoGraphDeploymentReconciler{
+		Client:                mgr.GetClient(),
+		Recorder:              mgr.GetEventRecorderFor("dynamographdeployment"),
+		Config:                cfg,
+		RuntimeConfig:         opts.RuntimeConfig,
+		RestConfig:            mgr.GetConfig(),
+		DockerSecretRetriever: opts.DockerSecretRetriever,
+		ScaleClient:           opts.ScaleClient,
+		SSHKeyManager:         opts.SSHKeyManager,
+		RBACManager:           opts.RBACManager,
+	}).SetupWithManager(mgr); err != nil {
+		return "dynamographdeployment", err
+	}
+
+	if err := (&DynamoGraphDeploymentScalingAdapterReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor("dgdscalingadapter"),
+		Config:        cfg,
+		RuntimeConfig: opts.RuntimeConfig,
+	}).SetupWithManager(mgr); err != nil {
+		return "dgdscalingadapter", err
+	}
+
+	if err := (&DynamoGraphDeploymentRequestReconciler{
+		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
+		Recorder:                mgr.GetEventRecorderFor("dynamographdeploymentrequest"),
+		Config:                  cfg,
+		RuntimeConfig:           opts.RuntimeConfig,
+		GPUDiscoveryCache:       gpu.NewGPUDiscoveryCache(),
+		GPUDiscovery:            gpu.NewGPUDiscovery(gpu.ScrapeMetricsEndpoint),
+		OperatorImage:           opts.OperatorImage,
+		OperatorImagePullPolicy: opts.OperatorPullPolicy,
+		RBACManager:             opts.RBACManager,
+	}).SetupWithManager(mgr); err != nil {
+		return "dynamographdeploymentrequest", err
+	}
+
+	if err := (&DynamoModelReconciler{
+		Client:         mgr.GetClient(),
+		Recorder:       mgr.GetEventRecorderFor("dynamomodel"),
+		EndpointClient: modelendpoint.NewClient(),
+		Config:         cfg,
+		RuntimeConfig:  opts.RuntimeConfig,
+	}).SetupWithManager(mgr); err != nil {
+		return "dynamomodel", err
+	}
+
+	if err := (&CheckpointReconciler{
+		Client:        mgr.GetClient(),
+		Config:        cfg,
+		RuntimeConfig: opts.RuntimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("checkpoint"),
+	}).SetupWithManager(mgr); err != nil {
+		return "checkpoint", err
+	}
+
+	if err := (&PodSnapshotReconciler{
+		Client:        mgr.GetClient(),
+		Config:        cfg,
+		RuntimeConfig: opts.RuntimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("snapshot"),
+	}).SetupWithManager(mgr); err != nil {
+		return "podsnapshot", err
+	}
+
+	if opts.RuntimeConfig.GroveEnabled {
+		if err := NewFailoverCascadeReconciler(
+			mgr.GetClient(),
+			mgr.GetEventRecorderFor("gms-failover-cascade"),
+		).SetupWithManager(mgr); err != nil {
+			return "gms-failover-cascade", err
+		}
+	}
+
+	if err := (&TopologyLabelReconciler{
+		Client:        mgr.GetClient(),
+		NodeReader:    mgr.GetAPIReader(),
+		Config:        cfg,
+		RuntimeConfig: opts.RuntimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("topology-label"),
+	}).SetupWithManager(mgr); err != nil {
+		return "topology-label", err
+	}
+
+	return "", nil
+}

--- a/deploy/operator/internal/webhooks/webhooks.go
+++ b/deploy/operator/internal/webhooks/webhooks.go
@@ -1,0 +1,157 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package webhooks
+
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
+	webhookdefaulting "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
+	webhookmutation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/mutation"
+	webhookvalidation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/validation"
+)
+
+var log = ctrl.Log.WithName("webhooks")
+
+const (
+	dynamoComponentDeploymentWebhook        = "DynamoComponentDeployment"
+	dynamoGraphDeploymentWebhook            = "DynamoGraphDeployment"
+	dynamoGraphDeploymentRequestWebhook     = "DynamoGraphDeploymentRequest"
+	dynamoGraphDeploymentScalingAdapterHook = "DynamoGraphDeploymentScalingAdapter"
+	dynamoCheckpointWebhook                 = "DynamoCheckpoint"
+	dynamoModelWebhook                      = "DynamoModel"
+	podCheckpointRestoreWebhook             = "PodCheckpointRestore"
+)
+
+// Setup sets up the webhooks for core controllers. It returns the name of the
+// webhook that failed to create and an error, if any.
+func Setup(
+	mgr ctrl.Manager,
+	cfg *configapi.OperatorConfiguration,
+	runtimeConfig *commonController.RuntimeConfig,
+	operatorVersion string,
+) (string, error) {
+	isClusterWide := cfg.Namespace.Restricted == ""
+	if isClusterWide {
+		log.Info("Configuring webhooks with lease-based namespace exclusion for cluster-wide mode")
+		internalwebhook.SetExcludedNamespaces(runtimeConfig.ExcludedNamespaces)
+	} else {
+		log.Info("Configuring webhooks for namespace-restricted mode (no lease checking)",
+			"restrictedNamespace", cfg.Namespace.Restricted)
+		internalwebhook.SetExcludedNamespaces(nil)
+	}
+
+	var operatorPrincipal string
+	if sa, ns := os.Getenv("POD_SERVICE_ACCOUNT"), os.Getenv("POD_NAMESPACE"); sa != "" && ns != "" {
+		operatorPrincipal = fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa)
+		log.Info("Detected operator principal from downward API", "principal", operatorPrincipal)
+	} else {
+		log.Info("POD_SERVICE_ACCOUNT/POD_NAMESPACE not set; operator SA self-identification disabled")
+	}
+
+	// Temporary internal gate for GMS + Snapshot.
+	if os.Getenv(consts.DynamoOperatorAllowGMSSnapshotEnvVar) == "1" {
+		log.Info(
+			"INTERNAL OVERRIDE: GMS + Snapshot admission rule disabled via env var; do NOT enable in production",
+			"envVar", consts.DynamoOperatorAllowGMSSnapshotEnvVar,
+		)
+	}
+
+	log.Info("Registering validation webhooks")
+
+	dcdHandler := webhookvalidation.NewDynamoComponentDeploymentHandler()
+	if err := dcdHandler.RegisterWithManager(mgr); err != nil {
+		return dynamoComponentDeploymentWebhook, err
+	}
+
+	dgdHandler := webhookvalidation.NewDynamoGraphDeploymentHandler(mgr, operatorPrincipal, runtimeConfig.GroveEnabled)
+	if err := dgdHandler.RegisterWithManager(mgr); err != nil {
+		return dynamoGraphDeploymentWebhook, err
+	}
+
+	dckptHandler := webhookvalidation.NewDynamoCheckpointHandler()
+	if err := dckptHandler.RegisterWithManager(mgr); err != nil {
+		return dynamoCheckpointWebhook, err
+	}
+
+	dmHandler := webhookvalidation.NewDynamoModelHandler()
+	if err := dmHandler.RegisterWithManager(mgr); err != nil {
+		return dynamoModelWebhook, err
+	}
+
+	dgdrHandler := webhookvalidation.NewDynamoGraphDeploymentRequestHandler(
+		isClusterWide, ptr.Deref(cfg.GPU.DiscoveryEnabled, true),
+	)
+	if err := dgdrHandler.RegisterWithManager(mgr); err != nil {
+		return dynamoGraphDeploymentRequestWebhook, err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
+		Complete(); err != nil {
+		return dynamoGraphDeploymentRequestWebhook, err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeployment{}).
+		Complete(); err != nil {
+		return dynamoGraphDeploymentWebhook, err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoComponentDeployment{}).
+		Complete(); err != nil {
+		return dynamoComponentDeploymentWebhook, err
+	}
+
+	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}).
+		Complete(); err != nil {
+		return dynamoGraphDeploymentScalingAdapterHook, err
+	}
+
+	log.Info("Registering defaulting webhooks")
+
+	dcdDefaulter := webhookdefaulting.NewDCDDefaulter()
+	if err := dcdDefaulter.RegisterWithManager(mgr); err != nil {
+		return dynamoComponentDeploymentWebhook, err
+	}
+
+	dgdDefaulter := webhookdefaulting.NewDGDDefaulter(operatorVersion, runtimeConfig.GroveEnabled)
+	if err := dgdDefaulter.RegisterWithManager(mgr); err != nil {
+		return dynamoGraphDeploymentWebhook, err
+	}
+
+	dgdrDefaulter := webhookdefaulting.NewDGDRDefaulter(operatorVersion)
+	if err := dgdrDefaulter.RegisterWithManager(mgr); err != nil {
+		return dynamoGraphDeploymentRequestWebhook, err
+	}
+
+	log.Info("Registering mutation webhooks")
+
+	podCheckpointRestoreMutator := webhookmutation.NewPodCheckpointRestoreMutator(mgr.GetClient(), cfg)
+	if err := podCheckpointRestoreMutator.RegisterWithManager(mgr); err != nil {
+		return podCheckpointRestoreWebhook, err
+	}
+
+	return "", nil
+}


### PR DESCRIPTION
Summary
- Move operator configuration loading and validation into internal/config.
- Extract webhook setup into internal/webhooks.
- Keep cmd/main.go focused on startup orchestration and shared setup helpers.

Validation
- go test ./cmd ./internal/config ./internal/webhooks (from deploy/operator)
- go test ./... (from deploy/operator) was attempted, but sandbox restrictions blocked listener/network setup: envtest/httptest failed with bind: operation not permitted, and e2e kubectl network access was denied.