### PR TITLE
fix(operator): use global admission for namespace-restricted installs

### DIFF
--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -49,7 +49,7 @@ No action is required for most upgrades — the operator's built-in cert-control
 
 ---
 
-## ⚠️ Important: Cluster-Wide and Namespace-Restricted Deployment
+## ⚠️ DEVELOPMENT AND TESTING ONLY: Namespace-Restricted Deployment
 
 Deploy one cluster-wide operator per cluster. It owns the Custom Resource Definitions (CRDs),
 conversion webhook, and conversion certificate authority (CA).
@@ -57,9 +57,9 @@ conversion webhook, and conversion certificate authority (CA).
 > [!WARNING]
 > Namespace-restricted mode is only for development and testing. It is not supported for production.
 
-A namespace-restricted operator owns reconciliation, validation, and mutation only in its target
-namespace. Its Lease makes the cluster-wide operator skip that namespace. Install it alongside an
-existing cluster-wide operator with CRD management disabled:
+A namespace-restricted operator reconciles only its target namespace and serves no webhooks. Its
+Lease makes the cluster-wide reconcilers skip that namespace and provides feature gates to global
+admission. Install it alongside an existing cluster-wide operator with CRD management disabled:
 
 ```bash
 helm install dynamo-test dynamo-platform-${RELEASE_VERSION}.tgz \
@@ -105,7 +105,7 @@ Kubernetes: `>=1.30.0-0`
 | dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: `http://hostname:2379` or `https://hostname:2379` |
 | dynamo-operator.modelExpressURL | string | `""` | URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true). |
 | dynamo-operator.namespaceRestriction | object | `{"enabled":false,"lease":{"duration":"30s","renewInterval":"10s"},"targetNamespace":null}` | DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments. |
-| dynamo-operator.namespaceRestriction.enabled | bool | `false` | DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production. |
+| dynamo-operator.namespaceRestriction.enabled | bool | `false` | DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation. Not supported for production. |
 | dynamo-operator.namespaceRestriction.targetNamespace | string | `nil` | DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace. |
 | dynamo-operator.namespaceRestriction.lease | object | `{"duration":"30s","renewInterval":"10s"}` | DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease settings. |
 | dynamo-operator.namespaceRestriction.lease.duration | string | `"30s"` | DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease duration. |
@@ -152,7 +152,7 @@ Kubernetes: `>=1.30.0-0`
 | dynamo-operator.webhook.failurePolicy | string | `"Fail"` | Webhook failure policy controls how Kubernetes handles requests when the webhook is unavailable. 'Fail' (recommended for production) rejects requests if the webhook cannot be reached, ensuring strict validation. 'Ignore' allows requests through if the webhook is unavailable, providing availability over validation guarantees. |
 | dynamo-operator.webhook.podCheckpointRestoreFailurePolicy | string | `"Ignore"` | Failure policy for the Pod CREATE checkpoint-restore mutating webhook. Defaults to Ignore so a webhook outage falls back to cold-start instead of blocking workload Pods. |
 | dynamo-operator.webhook.timeoutSeconds | int | `10` | Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy. |
-| dynamo-operator.webhook.namespaceSelector | object | `{}` | Unsupported; must remain empty. Helm configures global admission for the cluster-wide operator and target-namespace admission for restricted operators. |
+| dynamo-operator.webhook.namespaceSelector | object | `{}` | Unsupported; must remain empty. Admission and conversion webhooks are always global and owned by the cluster-wide operator. Installation fails if set. |
 | dynamo-operator.webhook.certManager.enabled | bool | `false` | Whether to use cert-manager for automatic certificate management. Requires cert-manager to be installed in the cluster. When enabled, cert-manager will provision and rotate certificates instead of the operator's built-in cert-controller. |
 | dynamo-operator.webhook.certManager.certificate.duration | string | `"8760h"` | Certificate duration for webhook certificates managed by cert-manager (e.g., "8760h" for 1 year). cert-manager will automatically renew the certificate before it expires. |
 | dynamo-operator.webhook.certManager.certificate.renewBefore | string | `"360h"` | Time before certificate expiration to trigger renewal (e.g., "360h" for 15 days). cert-manager will attempt to renew the certificate when this threshold is reached. |

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -49,7 +49,7 @@ No action is required for most upgrades — the operator's built-in cert-control
 
 ---
 
-## ⚠️ Important: Cluster-Wide and Namespace-Restricted Deployment
+## ⚠️ DEVELOPMENT AND TESTING ONLY: Namespace-Restricted Deployment
 
 Deploy one cluster-wide operator per cluster. It owns the Custom Resource Definitions (CRDs),
 conversion webhook, and conversion certificate authority (CA).
@@ -57,9 +57,9 @@ conversion webhook, and conversion certificate authority (CA).
 > [!WARNING]
 > Namespace-restricted mode is only for development and testing. It is not supported for production.
 
-A namespace-restricted operator owns reconciliation, validation, and mutation only in its target
-namespace. Its Lease makes the cluster-wide operator skip that namespace. Install it alongside an
-existing cluster-wide operator with CRD management disabled:
+A namespace-restricted operator reconciles only its target namespace and serves no webhooks. Its
+Lease makes the cluster-wide reconcilers skip that namespace and provides feature gates to global
+admission. Install it alongside an existing cluster-wide operator with CRD management disabled:
 
 ```bash
 helm install dynamo-test dynamo-platform-${RELEASE_VERSION}.tgz \

--- a/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
@@ -98,7 +98,7 @@ Validation for configuration consistency
   {{- fail "VALIDATION ERROR: namespaceRestriction.enabled=true is incompatible with upgradeCRD=true. Set upgradeCRD=false so the namespaced release does not install or update cluster-wide CRDs." -}}
 {{- end -}}
 {{- if not (empty .Values.webhook.namespaceSelector) -}}
-  {{- fail "VALIDATION ERROR: webhook.namespaceSelector must be empty. Helm manages admission scope: cluster-wide webhooks cover every namespace and namespace-restricted webhooks cover only their target namespace." -}}
+  {{- fail "VALIDATION ERROR: webhook.namespaceSelector must be empty. Admission and conversion webhooks are always global and owned by the cluster-wide operator." -}}
 {{- end -}}
 {{/* Validate leader election namespace setting */}}
 {{- if and (not .Values.namespaceRestriction.enabled) .Values.controllerManager.leaderElection.namespace -}}

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-certificates.yaml
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-{{- if .Values.webhook.certManager.enabled }}
+{{- if and (not .Values.namespaceRestriction.enabled) .Values.webhook.certManager.enabled }}
 ---
 # Self-signed issuer to bootstrap the CA
 apiVersion: cert-manager.io/v1

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if not .Values.namespaceRestriction.enabled }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
@@ -361,3 +362,4 @@ webhooks:
     - pods
   sideEffects: None
   timeoutSeconds: {{ .Values.webhook.timeoutSeconds }}
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if not .Values.namespaceRestriction.enabled }}
 ---
 # Role to manage the webhook certificate secret (create placeholder, read, update)
 apiVersion: rbac.authorization.k8s.io/v1
@@ -117,3 +118,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-service.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-service.yaml
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{{- if not .Values.namespaceRestriction.enabled }}
 ---
 apiVersion: v1
 kind: Service
@@ -34,3 +35,4 @@ spec:
     control-plane: controller-manager
   {{- include "dynamo-operator.selectorLabels" . | nindent 4 }}
 
+{{- end }}

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -33,7 +33,7 @@ env: []
 
 # -- DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments.
 namespaceRestriction:
-  # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production.
+  # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation. Not supported for production.
   enabled: false
   # -- DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace.
   targetNamespace: ""
@@ -219,8 +219,8 @@ webhook:
   # Timeout for webhook calls (in seconds)
   timeoutSeconds: 10
 
-  # -- Unsupported; must remain empty. Helm configures global admission for the
-  # cluster-wide operator and target-namespace admission for restricted operators.
+  # -- Unsupported; must remain empty. Admission and conversion webhooks are always
+  # global and owned by the cluster-wide operator. Installation fails if set.
   namespaceSelector: {}
 
   # cert-manager integration (optional, alternative to built-in cert-controller)

--- a/deploy/helm/charts/platform/tests/namespace_restriction_webhook_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/namespace_restriction_webhook_rbac_test.yaml
@@ -24,28 +24,14 @@ tests:
               - patch
         documentIndex: 2
 
-  - it: prevents a namespace-restricted operator from patching CRDs
+  - it: renders no webhook RBAC for a namespaced operator
     template: charts/dynamo-operator/templates/webhook-rbac.yaml
     set:
       dynamo-operator.namespaceRestriction.enabled: true
       dynamo-operator.upgradeCRD: false
     asserts:
       - hasDocuments:
-          count: 4
-      - notContains:
-          path: rules
-          content:
-            apiGroups:
-              - apiextensions.k8s.io
-            resources:
-              - customresourcedefinitions
-            verbs:
-              - get
-              - list
-              - watch
-              - update
-              - patch
-        documentIndex: 2
+          count: 0
 
   - it: omits cluster-scoped admission and CRD rules from the namespace-restricted manager Role
     template: charts/dynamo-operator/templates/manager-rbac.yaml

--- a/deploy/helm/charts/platform/tests/namespace_restriction_webhooks_test.yaml
+++ b/deploy/helm/charts/platform/tests/namespace_restriction_webhooks_test.yaml
@@ -40,63 +40,25 @@ tests:
           path: webhooks[3].namespaceSelector
         documentIndex: 1
 
-  - it: scopes namespace-restricted admission to the target namespace
+  - it: renders no admission configuration for a namespaced installation
     template: charts/dynamo-operator/templates/webhook-configuration.yaml
     set:
       dynamo-operator.namespaceRestriction.enabled: true
-      # Exercise a YAML boolean-like namespace to ensure the rendered selector stays a string.
-      dynamo-operator.namespaceRestriction.targetNamespace: "true"
       dynamo-operator.upgradeCRD: false
     asserts:
       - hasDocuments:
-          count: 2
-      - equal:
-          path: webhooks[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 0
-      - equal:
-          path: webhooks[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 0
-      - equal:
-          path: webhooks[2].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 0
-      - equal:
-          path: webhooks[3].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 0
-      - equal:
-          path: webhooks[4].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 0
-      - equal:
-          path: webhooks[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 1
-      - equal:
-          path: webhooks[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 1
-      - equal:
-          path: webhooks[2].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 1
-      - equal:
-          path: webhooks[3].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
-          value: "true"
-        documentIndex: 1
+          count: 0
 
-  - it: renders a webhook service for a namespace-restricted installation
+  - it: renders no webhook service for a namespaced installation
     template: charts/dynamo-operator/templates/webhook-service.yaml
     set:
       dynamo-operator.namespaceRestriction.enabled: true
       dynamo-operator.upgradeCRD: false
     asserts:
       - hasDocuments:
-          count: 1
+          count: 0
 
-  - it: renders webhook certificates for a namespace-restricted installation
+  - it: renders no webhook certificates for a namespaced installation
     template: charts/dynamo-operator/templates/webhook-certificates.yaml
     set:
       dynamo-operator.namespaceRestriction.enabled: true
@@ -104,4 +66,4 @@ tests:
       dynamo-operator.webhook.certManager.enabled: true
     asserts:
       - hasDocuments:
-          count: 4
+          count: 0

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -83,7 +83,7 @@ dynamo-operator:
   modelExpressURL: ""
   # -- DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments.
   namespaceRestriction:
-    # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production.
+    # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation. Not supported for production.
     enabled: false
     # -- DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace.
     targetNamespace:
@@ -238,7 +238,7 @@ dynamo-operator:
     # -- Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy.
     timeoutSeconds: 10
 
-    # -- Unsupported; must remain empty. Helm configures global admission for the cluster-wide operator and target-namespace admission for restricted operators.
+    # -- Unsupported; must remain empty. Admission and conversion webhooks are always global and owned by the cluster-wide operator. Installation fails if set.
     namespaceSelector: {}
 
     # cert-manager integration for automated certificate lifecycle management

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -309,23 +309,36 @@ func main() {
 	setupLog.Info("Initializing observability metrics")
 	observability.InitMetrics()
 
-	// Set up webhook certificate management.
-	// A direct (non-cached) client is needed because the manager's cache isn't started yet.
-	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: crdScheme})
+	gates, err := features.New(mainCtx, mgr, operatorCfg)
 	if err != nil {
-		setupLog.Error(err, "unable to create direct client for cert management")
+		setupLog.Error(err, "unable to resolve operator feature gates")
 		os.Exit(1)
 	}
-	certMgr, err := internalcert.NewCertManager(directClient, &operatorCfg.Server.Webhook)
-	if err != nil {
-		setupLog.Error(err, "unable to create cert manager")
-		os.Exit(1)
+	runtimeConfig.Gate = gates
+
+	var operatorPrincipal string
+	if sa, ns := os.Getenv("POD_SERVICE_ACCOUNT"), os.Getenv("POD_NAMESPACE"); sa != "" && ns != "" {
+		operatorPrincipal = fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa)
 	}
-	// Auto mode runs one synchronous certificate refresh with the direct client,
-	// then registers the cert-controller with the not-yet-started manager.
-	if err = certMgr.SetupAndRunOnce(mainCtx, mgr); err != nil {
-		setupLog.Error(err, "failed to setup webhook certificate management")
-		os.Exit(1)
+
+	// Only the cluster-wide operator owns webhook certificates.
+	var directClient client.Client
+	var certMgr *internalcert.CertManager
+	if isClusterWide {
+		directClient, err = client.New(mgr.GetConfig(), client.Options{Scheme: crdScheme})
+		if err != nil {
+			setupLog.Error(err, "unable to create direct client for cert management")
+			os.Exit(1)
+		}
+		certMgr, err = internalcert.NewCertManager(directClient, &operatorCfg.Server.Webhook)
+		if err != nil {
+			setupLog.Error(err, "unable to create cert manager")
+			os.Exit(1)
+		}
+		if err = certMgr.SetupAndRunOnce(mainCtx, mgr); err != nil {
+			setupLog.Error(err, "failed to setup webhook certificate management")
+			os.Exit(1)
+		}
 	}
 
 	// Initialize namespace scope mechanism
@@ -345,6 +358,8 @@ func main() {
 			operatorVersion,
 			operatorCfg.Namespace.Scope.LeaseDuration.Duration,
 			operatorCfg.Namespace.Scope.LeaseRenewInterval.Duration,
+			gates,
+			operatorPrincipal,
 		)
 		if err != nil {
 			setupLog.Error(err, "unable to create namespace scope marker lease manager")
@@ -411,13 +426,6 @@ func main() {
 		setupLog.Error(err, "unable to register resource counter")
 		os.Exit(1)
 	}
-
-	gates, err := features.New(mainCtx, mgr, operatorCfg)
-	if err != nil {
-		setupLog.Error(err, "unable to resolve operator feature gates")
-		os.Exit(1)
-	}
-	runtimeConfig.Gate = gates
 
 	dockerSecretRetriever := secrets.NewDockerSecretIndexer(mgr.GetAPIReader(), restrictedNamespace)
 	// refresh whenever a secret is created/deleted/updated
@@ -526,44 +534,34 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := registerWebhookHandlers(mgr, operatorCfg, runtimeConfig, operatorVersion, gates); err != nil {
-		setupLog.Error(err, "failed to register webhooks")
-		os.Exit(1)
-	}
-
-	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS secrets.
-	// Auto mode patches admission and, for cluster-wide operators, conversion CAs.
-	// Manual mode patches only cluster-wide conversion CAs; admission stays out-of-band.
-	caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
-	if err != nil {
-		setupLog.Error(err, "unable to create CA bundle injector")
-		os.Exit(1)
-	}
-	if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
-		if isClusterWide {
-			err = caInjector.InjectAll(mainCtx)
-		} else {
-			err = caInjector.InjectAdmission(mainCtx)
-		}
-		if err != nil {
-			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
+	if isClusterWide {
+		internalwebhook.SetExcludedNamespaces(nil)
+		internalwebhook.SetFeatureResolver(features.NewResolver(gates, leaseWatcher.AdmissionGateSnapshot))
+		internalwebhook.SetNamespaceOperatorPrincipalResolver(leaseWatcher.OperatorPrincipal)
+		if err := registerWebhookHandlers(mgr, operatorCfg, operatorVersion, operatorPrincipal, gates); err != nil {
+			setupLog.Error(err, "failed to register webhooks")
 			os.Exit(1)
 		}
-	} else if isClusterWide {
-		// Manual mode gets webhook CA material out-of-band. Missing ca.crt
-		// blocks startup instead of running with unauthenticated conversion.
-		if err := caInjector.InjectCRDConversionCA(mainCtx); err != nil {
+
+		caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
+		if err != nil {
+			setupLog.Error(err, "unable to create CA bundle injector")
+			os.Exit(1)
+		}
+		if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
+			if err := caInjector.InjectAll(mainCtx); err != nil {
+				setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
+				os.Exit(1)
+			}
+		} else if err := caInjector.InjectCRDConversionCA(mainCtx); err != nil {
 			setupLog.Error(err, "failed to inject CRD conversion CA bundle")
 			os.Exit(1)
 		}
-	}
 
-	// mgr.Start reads tls.crt and tls.key from the projected Secret volume
-	// synchronously. Secret API updates are not enough because kubelet projects
-	// them into already-running pods asynchronously.
-	if err := certMgr.WaitForMountedCertificate(mainCtx); err != nil {
-		setupLog.Error(err, "failed waiting for mounted webhook TLS certificate")
-		os.Exit(1)
+		if err := certMgr.WaitForMountedCertificate(mainCtx); err != nil {
+			setupLog.Error(err, "failed waiting for mounted webhook TLS certificate")
+			os.Exit(1)
+		}
 	}
 
 	// Kubernetes propagates webhook configuration asynchronously, especially
@@ -696,27 +694,11 @@ func registerControllers(
 func registerWebhookHandlers(
 	mgr ctrl.Manager,
 	operatorCfg *configv1alpha1.OperatorConfiguration,
-	runtimeConfig *commonController.RuntimeConfig,
 	operatorVersion string,
+	operatorPrincipal string,
 	gate features.Gate,
 ) error {
 	isClusterWide := operatorCfg.Namespace.Restricted == ""
-	if isClusterWide {
-		setupLog.Info("Configuring webhooks with lease-based namespace exclusion for cluster-wide mode")
-		internalwebhook.SetExcludedNamespaces(runtimeConfig.ExcludedNamespaces)
-	} else {
-		setupLog.Info("Configuring webhooks for namespace-restricted mode (no lease checking)",
-			"restrictedNamespace", operatorCfg.Namespace.Restricted)
-		internalwebhook.SetExcludedNamespaces(nil)
-	}
-
-	var operatorPrincipal string
-	if sa, ns := os.Getenv("POD_SERVICE_ACCOUNT"), os.Getenv("POD_NAMESPACE"); sa != "" && ns != "" {
-		operatorPrincipal = fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa)
-		setupLog.Info("Detected operator principal from downward API", "principal", operatorPrincipal)
-	} else {
-		setupLog.Info("POD_SERVICE_ACCOUNT/POD_NAMESPACE not set; operator SA self-identification disabled")
-	}
 
 	// Temporary internal gate for GMS + Snapshot.
 	if gate.Enabled(features.GMSSnapshot) {

--- a/deploy/operator/internal/features/namespace.go
+++ b/deploy/operator/internal/features/namespace.go
@@ -1,0 +1,72 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package features
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+)
+
+// LeaseAnnotation stores the namespaced operator's effective feature gates.
+const LeaseAnnotation = "nvidia.com/dynamo-operator-admission-feature-gates"
+
+// Resolver returns the effective gates and compatibility warnings for a namespace.
+type Resolver interface {
+	ForNamespace(namespace string) (Gate, []string)
+}
+
+type namespaceResolver struct {
+	base   Gates
+	source func(namespace string) (string, bool)
+}
+
+// NewResolver creates a namespace-aware gate resolver.
+func NewResolver(base Gates, source func(namespace string) (string, bool)) Resolver {
+	return &namespaceResolver{base: base, source: source}
+}
+
+func (r *namespaceResolver) ForNamespace(namespace string) (Gate, []string) {
+	snapshot, found := r.source(namespace)
+	if !found {
+		return r.base, nil
+	}
+
+	resolved, unknown, err := resolveSnapshot(r.base, snapshot)
+	if err != nil {
+		return r.base, []string{fmt.Sprintf("ignoring invalid admission feature gates published for namespace %q: %v", namespace, err)}
+	}
+	if unknown == "" {
+		return resolved, nil
+	}
+	return resolved, []string{fmt.Sprintf("namespace operator requested feature gate unknown to the cluster-wide operator: %s", unknown)}
+}
+
+// resolveSnapshot overlays a JSON gate snapshot onto base. Missing fields inherit base,
+// allowing an older namespaced operator to coexist with a newer global operator.
+func resolveSnapshot(base Gates, snapshot string) (Gates, string, error) {
+	if snapshot == "" {
+		return base, "", nil
+	}
+
+	resolved := base
+	if err := json.Unmarshal([]byte(snapshot), &resolved); err != nil {
+		return base, "", fmt.Errorf("decoding admission feature gates: %w", err)
+	}
+
+	decoder := json.NewDecoder(strings.NewReader(snapshot))
+	decoder.DisallowUnknownFields()
+	strict := base
+	if err := decoder.Decode(&strict); err != nil {
+		const prefix = "json: unknown field \""
+		if message := err.Error(); strings.HasPrefix(message, prefix) && strings.HasSuffix(message, "\"") {
+			return resolved, strings.TrimSuffix(strings.TrimPrefix(message, prefix), "\""), nil
+		}
+		return base, "", fmt.Errorf("decoding admission feature gates: %w", err)
+	}
+
+	return resolved, "", nil
+}

--- a/deploy/operator/internal/namespace_scope/lease_manager.go
+++ b/deploy/operator/internal/namespace_scope/lease_manager.go
@@ -21,10 +21,12 @@ package namespace_scope
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/go-logr/logr"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -37,6 +39,8 @@ import (
 const (
 	// LeaseName is the well-known name for namespace scope marker leases
 	LeaseName = "dynamo-operator-namespace-scope"
+	// OperatorPrincipalAnnotation stores the namespaced operator's Kubernetes username.
+	OperatorPrincipalAnnotation = "nvidia.com/dynamo-operator-principal"
 )
 
 // Deprecated: LeaseManager manages the namespace scope marker lease for the deprecated
@@ -54,10 +58,21 @@ type LeaseManager struct {
 	failureCount    int
 	maxFailures     int
 	logger          logr.Logger
+
+	admissionGatesJSON string
+	operatorPrincipal  string
 }
 
 // NewLeaseManager creates a new lease manager for namespace scope marking
-func NewLeaseManager(config *rest.Config, namespace string, operatorVersion string, leaseDuration time.Duration, renewInterval time.Duration) (*LeaseManager, error) {
+func NewLeaseManager(
+	config *rest.Config,
+	namespace string,
+	operatorVersion string,
+	leaseDuration time.Duration,
+	renewInterval time.Duration,
+	admissionGates features.Gates,
+	operatorPrincipal string,
+) (*LeaseManager, error) {
 	// Validate inputs
 	if leaseDuration <= 0 {
 		return nil, fmt.Errorf("lease duration must be greater than zero, got %v", leaseDuration)
@@ -92,6 +107,11 @@ func NewLeaseManager(config *rest.Config, namespace string, operatorVersion stri
 		maxFailures = 1 // Always allow at least 1 failure for transient issues
 	}
 
+	admissionGatesJSON, err := json.Marshal(admissionGates)
+	if err != nil {
+		return nil, fmt.Errorf("failed to encode admission feature gates: %w", err)
+	}
+
 	return &LeaseManager{
 		client:          client,
 		namespace:       namespace,
@@ -101,6 +121,9 @@ func NewLeaseManager(config *rest.Config, namespace string, operatorVersion stri
 		operatorVersion: operatorVersion,
 		stopCh:          make(chan struct{}),
 		maxFailures:     maxFailures,
+
+		admissionGatesJSON: string(admissionGatesJSON),
+		operatorPrincipal:  operatorPrincipal,
 	}, nil
 }
 
@@ -176,6 +199,10 @@ func (lm *LeaseManager) createOrUpdateLease(ctx context.Context) error {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      LeaseName,
 			Namespace: lm.namespace,
+			Annotations: map[string]string{
+				features.LeaseAnnotation:    lm.admissionGatesJSON,
+				OperatorPrincipalAnnotation: lm.operatorPrincipal,
+			},
 		},
 		Spec: coordinationv1.LeaseSpec{
 			HolderIdentity:       &lm.holderIdentity,
@@ -204,6 +231,11 @@ func (lm *LeaseManager) createOrUpdateLease(ctx context.Context) error {
 	existingLease.Spec.HolderIdentity = &lm.holderIdentity
 	existingLease.Spec.LeaseDurationSeconds = &leaseDurationSeconds
 	existingLease.Spec.RenewTime = &now
+	if existingLease.Annotations == nil {
+		existingLease.Annotations = make(map[string]string)
+	}
+	existingLease.Annotations[features.LeaseAnnotation] = lm.admissionGatesJSON
+	existingLease.Annotations[OperatorPrincipalAnnotation] = lm.operatorPrincipal
 
 	_, err = lm.client.CoordinationV1().Leases(lm.namespace).Update(ctx, existingLease, metav1.UpdateOptions{})
 	if err != nil {

--- a/deploy/operator/internal/namespace_scope/lease_manager_test.go
+++ b/deploy/operator/internal/namespace_scope/lease_manager_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -71,6 +72,9 @@ func TestLeaseManager_CreateOrUpdateLease(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			const admissionGatesJSON = `{"grove":false}`
+			const operatorPrincipal = "system:serviceaccount:test-ns:dynamo-operator"
+
 			// Create fake client with or without existing lease
 			var client *fake.Clientset
 			if tt.existingLease != nil {
@@ -88,6 +92,9 @@ func TestLeaseManager_CreateOrUpdateLease(t *testing.T) {
 				holderIdentity:  "namespace-restricted-operator-" + tt.operatorVersion,
 				operatorVersion: tt.operatorVersion,
 				stopCh:          make(chan struct{}),
+
+				admissionGatesJSON: admissionGatesJSON,
+				operatorPrincipal:  operatorPrincipal,
 			}
 
 			// Call createOrUpdateLease
@@ -128,6 +135,12 @@ func TestLeaseManager_CreateOrUpdateLease(t *testing.T) {
 			}
 			if *lease.Spec.LeaseDurationSeconds != 30 {
 				t.Errorf("lease duration = %v, want %v", *lease.Spec.LeaseDurationSeconds, 30)
+			}
+			if got := lease.Annotations[features.LeaseAnnotation]; got != admissionGatesJSON {
+				t.Errorf("admission gates = %q, want %q", got, admissionGatesJSON)
+			}
+			if got := lease.Annotations[OperatorPrincipalAnnotation]; got != operatorPrincipal {
+				t.Errorf("operator principal = %q, want %q", got, operatorPrincipal)
 			}
 
 			if lease.Spec.RenewTime == nil {

--- a/deploy/operator/internal/namespace_scope/lease_watcher.go
+++ b/deploy/operator/internal/namespace_scope/lease_watcher.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/go-logr/logr"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	"k8s.io/client-go/informers"
@@ -89,6 +90,33 @@ func (lw *LeaseWatcher) Contains(namespace string) bool {
 	}
 
 	return true
+}
+
+// AdmissionGateSnapshot returns the active namespaced operator's serialized gates.
+func (lw *LeaseWatcher) AdmissionGateSnapshot(namespace string) (string, bool) {
+	return lw.leaseAnnotation(namespace, features.LeaseAnnotation)
+}
+
+// OperatorPrincipal returns the active namespaced operator's Kubernetes username.
+func (lw *LeaseWatcher) OperatorPrincipal(namespace string) (string, bool) {
+	principal, found := lw.leaseAnnotation(namespace, OperatorPrincipalAnnotation)
+	return principal, found && principal != ""
+}
+
+func (lw *LeaseWatcher) leaseAnnotation(namespace, name string) (string, bool) {
+	if !lw.Contains(namespace) {
+		return "", false
+	}
+	value, exists := lw.excludedNamespaces.Load(namespace)
+	if !exists {
+		return "", false
+	}
+	lease, ok := value.(*coordinationv1.Lease)
+	if !ok || lease.Annotations == nil {
+		return "", false
+	}
+	annotation, found := lease.Annotations[name]
+	return annotation, found
 }
 
 // Start starts watching for namespace scope marker leases

--- a/deploy/operator/internal/namespace_scope/lease_watcher_test.go
+++ b/deploy/operator/internal/namespace_scope/lease_watcher_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/go-logr/logr"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,6 +135,32 @@ func TestLeaseWatcher_HandleLeaseUpdate(t *testing.T) {
 	// Verify namespace is still excluded
 	if !lw.Contains("test-ns") {
 		t.Error("namespace should still be excluded after second update")
+	}
+}
+
+func TestLeaseWatcher_AdmissionGateSnapshot(t *testing.T) {
+	lease := &coordinationv1.Lease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      LeaseName,
+			Namespace: "test-ns",
+			Annotations: map[string]string{
+				features.LeaseAnnotation:    `{"grove":true}`,
+				OperatorPrincipalAnnotation: "system:serviceaccount:test-ns:dev-operator",
+			},
+		},
+		Spec: coordinationv1.LeaseSpec{
+			LeaseDurationSeconds: ptr.To[int32](30),
+			RenewTime:            &metav1.MicroTime{Time: time.Now()},
+		},
+	}
+	lw := &LeaseWatcher{logger: logr.Discard()}
+	lw.handleLeaseAdd(lease)
+
+	if got, found := lw.AdmissionGateSnapshot("test-ns"); !found || got != `{"grove":true}` {
+		t.Fatalf("AdmissionGateSnapshot() = %q, %v", got, found)
+	}
+	if got, found := lw.OperatorPrincipal("test-ns"); !found || got != "system:serviceaccount:test-ns:dev-operator" {
+		t.Fatalf("OperatorPrincipal() = %q, %v", got, found)
 	}
 }
 

--- a/deploy/operator/internal/webhook/common.go
+++ b/deploy/operator/internal/webhook/common.go
@@ -19,7 +19,6 @@ package webhook
 
 import (
 	"context"
-	"net/http"
 	"strings"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
@@ -43,6 +42,8 @@ type ExcludedNamespacesChecker interface {
 // webhookExcludedNamespaces holds the excluded namespaces checker (usually leaseWatcher).
 // This is set by main.go and shared across admission handlers.
 var webhookExcludedNamespaces ExcludedNamespacesChecker
+var webhookFeatureResolver features.Resolver
+var namespaceOperatorPrincipal func(string) (string, bool)
 
 // SetExcludedNamespaces sets the excluded namespaces checker for all webhooks.
 // This should be called from main.go before starting the webhook server.
@@ -53,6 +54,16 @@ func SetExcludedNamespaces(checker ExcludedNamespacesChecker) {
 // GetExcludedNamespaces returns the current excluded namespaces checker.
 func GetExcludedNamespaces() ExcludedNamespacesChecker {
 	return webhookExcludedNamespaces
+}
+
+// SetFeatureResolver configures per-namespace feature gates for admission.
+func SetFeatureResolver(resolver features.Resolver) {
+	webhookFeatureResolver = resolver
+}
+
+// SetNamespaceOperatorPrincipalResolver configures namespaced operator authorization.
+func SetNamespaceOperatorPrincipalResolver(resolver func(string) (string, bool)) {
+	namespaceOperatorPrincipal = resolver
 }
 
 // LeaseAwareValidator wraps a CustomValidator and adds lease-based namespace exclusion logic.
@@ -76,12 +87,15 @@ type LeaseAwareDefaulter struct {
 func WithGate(webhook *admission.Webhook, gate features.Gate) *admission.Webhook {
 	handler := webhook.Handler
 	webhook.Handler = admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
-		features.MustGateFrom(ctx)
-		return handler.Handle(ctx, req)
+		effectiveGate := gate
+		var warnings admission.Warnings
+		if webhookFeatureResolver != nil {
+			effectiveGate, warnings = webhookFeatureResolver.ForNamespace(req.Namespace)
+		}
+		response := handler.Handle(features.WithGate(ctx, effectiveGate), req)
+		response.Warnings = append(warnings, response.Warnings...)
+		return response
 	})
-	webhook.WithContextFunc = func(ctx context.Context, _ *http.Request) context.Context {
-		return features.WithGate(ctx, gate)
-	}
 	return webhook
 }
 
@@ -190,6 +204,14 @@ func CanModifyDGDReplicas(operatorPrincipal string, userInfo authenticationv1.Us
 	}
 
 	parts := strings.Split(username, ":")
+	if len(parts) == 4 && namespaceOperatorPrincipal != nil {
+		if principal, found := namespaceOperatorPrincipal(parts[2]); found && principal == username {
+			webhookCommonLog.V(1).Info("allowing DGD replicas modification",
+				"username", username,
+				"matchType", "namespaceOperatorPrincipal")
+			return true
+		}
+	}
 	if len(parts) == 4 && parts[3] == consts.PlannerServiceAccountName {
 		webhookCommonLog.V(1).Info("allowing DGD replicas modification",
 			"username", username,

--- a/deploy/operator/internal/webhook/common_test.go
+++ b/deploy/operator/internal/webhook/common_test.go
@@ -7,10 +7,10 @@ package webhook
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -65,31 +65,42 @@ func TestLeaseAwareDefaulterWithoutChecker(t *testing.T) {
 }
 
 func TestWithGate(t *testing.T) {
-	webhook := WithGate(&admission.Webhook{Handler: admission.HandlerFunc(func(context.Context, admission.Request) admission.Response {
+	SetFeatureResolver(features.NewResolver(features.Gates{Grove: true}, func(namespace string) (string, bool) {
+		switch namespace {
+		case "claimed":
+			return `{"grove":false,"futureGate":true}`, true
+		case "invalid":
+			return `{"grove":"yes"}`, true
+		default:
+			return "", false
+		}
+	}))
+	t.Cleanup(func() { SetFeatureResolver(nil) })
+
+	webhook := WithGate(&admission.Webhook{Handler: admission.HandlerFunc(func(ctx context.Context, req admission.Request) admission.Response {
+		wantGrove := req.Namespace != "claimed"
+		if got := features.MustGateFrom(ctx).Enabled(features.Grove); got != wantGrove {
+			t.Fatalf("Grove gate = %v, want %v", got, wantGrove)
+		}
 		return admission.Allowed("handled")
 	})}, features.Gates{Grove: true})
-	ctx := webhook.WithContextFunc(context.Background(), &http.Request{})
-	if !features.MustGateFrom(ctx).Enabled(features.Grove) {
-		t.Fatal("Grove gate missing from webhook context")
-	}
-	if response := webhook.Handler.Handle(ctx, admission.Request{}); !response.Allowed {
-		t.Fatal("handler rejected request with gate context")
-	}
-}
 
-func TestWithGateRequiresGateContext(t *testing.T) {
-	webhook := WithGate(&admission.Webhook{Handler: admission.HandlerFunc(func(context.Context, admission.Request) admission.Response {
-		return admission.Allowed("handled")
-	})}, features.Defaults())
-	defer func() {
-		if recover() == nil {
-			t.Fatal("handler did not panic without gate context")
+	for namespace, wantWarnings := range map[string]int{"claimed": 1, "invalid": 1, "unclaimed": 0} {
+		response := webhook.Handler.Handle(context.Background(), admission.Request{AdmissionRequest: admissionv1.AdmissionRequest{
+			Namespace: namespace,
+		}})
+		if !response.Allowed || len(response.Warnings) != wantWarnings {
+			t.Fatalf("response for %q = %#v", namespace, response)
 		}
-	}()
-	webhook.Handler.Handle(context.Background(), admission.Request{})
+	}
 }
 
 func TestCanModifyDGDReplicas(t *testing.T) {
+	SetNamespaceOperatorPrincipalResolver(func(namespace string) (string, bool) {
+		return "system:serviceaccount:tenant-a:dev-operator-controller-manager", namespace == "tenant-a"
+	})
+	t.Cleanup(func() { SetNamespaceOperatorPrincipalResolver(nil) })
+
 	tests := []struct {
 		name          string
 		principal     string
@@ -112,6 +123,12 @@ func TestCanModifyDGDReplicas(t *testing.T) {
 			name:          "operator SA auto-detected from downward API",
 			principal:     "system:serviceaccount:custom-ns:my-release-controller-manager",
 			username:      "system:serviceaccount:custom-ns:my-release-controller-manager",
+			expectAllowed: true,
+		},
+		{
+			name:          "active namespaced operator SA",
+			principal:     "system:serviceaccount:dynamo-system:dynamo-operator-controller-manager",
+			username:      "system:serviceaccount:tenant-a:dev-operator-controller-manager",
 			expectAllowed: true,
 		},
 		{

--- a/deploy/operator/internal/webhook/defaulting/AGENTS.md
+++ b/deploy/operator/internal/webhook/defaulting/AGENTS.md
@@ -1,0 +1,15 @@
+# Defaulting package
+
+## Feature-gated defaulting
+
+**Gate-dependent defaults must use the request namespace's effective `features.Gate`.**
+
+- Resolve gates through the shared `features.Resolver`. Do not read operator
+  configuration booleans, environment variables, runtime capability detection,
+  namespace Leases, or installation mode directly from a defaulter.
+- Namespace Lease values override global values in either direction.
+- Keep defaults that are not feature-dependent stable across namespaces.
+- Test the global value and namespace overrides in both directions for every
+  gate-dependent default.
+
+The Grove-dependent `minAvailable` default follows this contract.

--- a/docs/kubernetes/dynamo-operator.md
+++ b/docs/kubernetes/dynamo-operator.md
@@ -49,10 +49,9 @@ certificate authority (CA). Deploy exactly one cluster-wide operator per cluster
 > [!WARNING]
 > Namespace-restricted mode is only for development and testing. It is not supported for production.
 
-A namespace-restricted operator reconciles, validates, and mutates resources only in its target
-namespace. It creates a Lease that makes the cluster-wide operator skip reconciliation and
-admission in that namespace. The namespace-restricted operator serves its own admission webhooks
-using its local feature settings.
+A namespace-restricted operator reconciles only its target namespace and serves no webhooks. It
+creates a Lease that makes the cluster-wide operator skip reconciliation in that namespace and
+provides its feature gates to global admission.
 
 Use this mode to test controller changes or feature settings in one namespace on a development
 cluster. It is not a multi-tenancy boundary.
@@ -60,18 +59,10 @@ cluster. It is not a multi-tenancy boundary.
 **How It Works:**
 
 1. The namespace-restricted operator creates a Lease named `dynamo-operator-namespace-scope`.
-2. The cluster-wide operator watches these Leases and skips the claimed namespace.
-3. The namespace-restricted ValidatingWebhookConfiguration and MutatingWebhookConfiguration select
-   only the target namespace.
-4. The namespace-restricted operator manages the TLS certificate and CA bundles for its own
-   admission configurations.
-5. The cluster-wide operator remains the only owner of CRDs, conversion, and conversion CA bundles.
-
-If the namespace-restricted Pod becomes unavailable, Lease expiration lets the cluster-wide operator
-resume reconciliation, but does not remove the namespace-restricted webhook configurations. Admission
-continues to target the unavailable Service. Recover the Pod to restore namespace-restricted admission,
-or uninstall the release to remove its webhook configurations. Cluster-wide admission resumes after the
-Lease is deleted or expires.
+2. The cluster-wide operator watches these Leases and skips reconciliation in the claimed namespace.
+3. The cluster-wide operator remains the only owner of CRDs and all webhooks.
+4. Global admission uses the feature-gate snapshot from the Lease for the claimed namespace.
+5. If no successor renews the Lease, it expires and cluster-wide reconciliation resumes.
 
 > [!CAUTION]
 > Set `dynamo-operator.upgradeCRD=false`. Namespace-restricted operators use the CRDs installed and
@@ -98,10 +89,10 @@ release namespace.
 Install every operator Helm release in a separate namespace. Multiple Dynamo operator releases in
 the same Helm release namespace are not supported.
 
-Run the same operator version in parallel whenever possible. The cluster-wide operator should be
-the same version or newer and must provide the newest APIs in the cluster. A newer namespaced
-controller can be used for development when it does not require CRD fields absent from the
-cluster-wide installation.
+Run the same operator version in parallel whenever possible. The cluster-wide operator must be the
+same version or newer and provide the newest APIs in the cluster. A 1.3 namespaced operator is not
+supported with a 1.2 cluster-wide operator. Newer namespaced controller code can be used for
+development when it remains compatible with the cluster-wide CRDs and webhooks.
 
 **Observability:**
 


### PR DESCRIPTION
## Summary

- remove the separate admission webhooks, webhook Service, certificate resources, and webhook RBAC from namespace-restricted installations
- run webhook registration, certificate management, and CA injection only in the cluster-wide operator
- publish the namespace-restricted operator's effective feature gates and service-account principal on its existing ownership Lease
- make the global admission stack resolve feature gates per request namespace and authorize the namespace-restricted controller from that Lease
- keep the existing Lease-based reconciliation exclusion unchanged

Namespace-restricted mode remains development/test only and unsupported for production. Running different operator versions in parallel is strongly discouraged. The cluster-wide operator must be the same version or newer and ship the newest APIs.

## Validation

- `go test ./cmd/... ./internal/features/... ./internal/namespace_scope/... ./internal/webhook/...`
- Helm `make test` (30 tests passed)
- Helm `make lint`
- Helm `make generate-helm-docs`
- pre-commit hooks

Linear: [DYN-3412](https://linear.app/nvidia/issue/DYN-3412/dynamorelease130operatorwebhook-multi-operator-cluster-wide-defaulter)
