### PR TITLE
refactor(validation): make DCD validation structural

### DIFF
--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -44,7 +44,7 @@ webhooks:
     service:
       name: {{ include "dynamo-operator.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate/nvidia.com/v1beta1/dynamocomponentdeployments
+      path: /validate-nvidia-com-v1alpha1-dynamocomponentdeployment
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamocomponentdeployment.kb.io
   {{- if .Values.webhook.namespaceSelector }}
@@ -59,7 +59,7 @@ webhooks:
   - apiGroups:
     - nvidia.com
     apiVersions:
-    - v1beta1
+    - v1alpha1
     operations:
     - CREATE
     - UPDATE

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -44,7 +44,7 @@ webhooks:
     service:
       name: {{ include "dynamo-operator.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-nvidia-com-v1alpha1-dynamocomponentdeployment
+      path: /validate/nvidia.com/v1beta1/dynamocomponentdeployments
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamocomponentdeployment.kb.io
   {{- if .Values.webhook.namespaceSelector }}
@@ -59,7 +59,7 @@ webhooks:
   - apiGroups:
     - nvidia.com
     apiVersions:
-    - v1alpha1
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -21,42 +21,123 @@ import (
 	"context"
 	"fmt"
 
-	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
 
-// DynamoComponentDeploymentValidator validates DynamoComponentDeployment resources.
-// This validator can be used by both webhooks and controllers for consistent validation.
-type DynamoComponentDeploymentValidator struct {
-	deployment *nvidiacomv1alpha1.DynamoComponentDeployment
+// DynamoComponentDeploymentValidator validates v1beta1 DynamoComponentDeployment resources.
+type DynamoComponentDeploymentValidator struct{}
+
+// NewDynamoComponentDeploymentValidator creates a validator for v1beta1 DynamoComponentDeployment.
+func NewDynamoComponentDeploymentValidator() *DynamoComponentDeploymentValidator {
+	return &DynamoComponentDeploymentValidator{}
 }
 
-// NewDynamoComponentDeploymentValidator creates a new validator for DynamoComponentDeployment.
-func NewDynamoComponentDeploymentValidator(deployment *nvidiacomv1alpha1.DynamoComponentDeployment) *DynamoComponentDeploymentValidator {
-	return &DynamoComponentDeploymentValidator{
-		deployment: deployment,
-	}
+// dynamoComponentDeploymentValidation carries DCD-specific request state.
+// API values and derived traversal state remain explicit validator arguments.
+type dynamoComponentDeploymentValidation struct {
+	sharedValidation
 }
 
-// Validate performs stateless validation on the DynamoComponentDeployment.
-// Context is required for operations that may need to query the cluster (e.g., CRD checks).
-// Returns warnings and error.
-func (v *DynamoComponentDeploymentValidator) Validate(ctx context.Context) (admission.Warnings, error) {
-	// Validate shared spec fields using SharedSpecValidatorV1Alpha1
-	calculatedNamespace := v.deployment.GetDynamoNamespace()
-	sharedValidator := NewSharedSpecValidatorV1Alpha1(&v.deployment.Spec.DynamoComponentDeploymentSharedSpec, "spec", calculatedNamespace, false)
-
-	return sharedValidator.Validate(ctx)
-}
-
-// ValidateUpdate performs stateful validation comparing old and new DynamoComponentDeployment.
-// Returns warnings and error.
-func (v *DynamoComponentDeploymentValidator) ValidateUpdate(old *nvidiacomv1alpha1.DynamoComponentDeployment) (admission.Warnings, error) {
-	// Validate that BackendFramework is not changed (immutable)
-	if v.deployment.Spec.BackendFramework != old.Spec.BackendFramework {
-		warning := "Changing spec.backendFramework may cause unexpected behavior"
-		return admission.Warnings{warning}, fmt.Errorf("spec.backendFramework is immutable and cannot be changed after creation")
+// Validate performs stateless validation on the v1beta1 DynamoComponentDeployment.
+// ctx and dcd must not be nil.
+func (v *DynamoComponentDeploymentValidator) Validate(
+	ctx context.Context,
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+) (admission.Warnings, error) {
+	validation := &dynamoComponentDeploymentValidation{
+		sharedValidation: sharedValidation{ctx: ctx},
 	}
 
-	return nil, nil
+	allErrs := validation.validateDynamoComponentDeployment(dcd)
+	alpha, err := alphaDynamoComponentDeploymentForValidation(dcd)
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate preserved v1alpha1 DynamoComponentDeployment fields: %w", err)
+	}
+	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentV1alpha1(alpha)...)
+
+	return validation.warnings, invalidDynamoComponentDeploymentError(dcd, allErrs)
+}
+
+// ValidateUpdate performs stateful validation comparing old and new v1beta1 DCD objects.
+// ctx, oldDCD, and newDCD must not be nil.
+func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
+	ctx context.Context,
+	oldDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+) (admission.Warnings, error) {
+	validation := &dynamoComponentDeploymentValidation{
+		sharedValidation: sharedValidation{ctx: ctx},
+	}
+
+	allErrs := validation.validateDynamoComponentDeploymentUpdate(newDCD, oldDCD)
+	return validation.warnings, invalidDynamoComponentDeploymentError(newDCD, allErrs)
+}
+
+// validateDynamoComponentDeployment validates dcd. dcd must not be nil.
+func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeployment(
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+) field.ErrorList {
+	return v.validateDynamoComponentDeploymentSpec(&dcd.Spec, field.NewPath("spec"))
+}
+
+// validateDynamoComponentDeploymentSpec validates spec. spec and fldPath must not be nil.
+func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentSpec(
+	spec *nvidiacomv1beta1.DynamoComponentDeploymentSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	// Standalone DCDs use neither Grove nor live InferencePool discovery.
+	const (
+		grovePathway                      = false
+		validateInferencePoolAvailability = false
+	)
+	return v.validateDynamoComponentDeploymentSharedSpec(
+		&spec.DynamoComponentDeploymentSharedSpec,
+		fldPath,
+		grovePathway,
+		validateInferencePoolAvailability,
+	)
+}
+
+// validateDynamoComponentDeploymentUpdate validates an update. newDCD and oldDCD must not be nil.
+func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentUpdate(
+	newDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+	oldDCD *nvidiacomv1beta1.DynamoComponentDeployment,
+) field.ErrorList {
+	return v.validateDynamoComponentDeploymentSpecUpdate(
+		&newDCD.Spec,
+		&oldDCD.Spec,
+		field.NewPath("spec"),
+	)
+}
+
+// validateDynamoComponentDeploymentSpecUpdate validates a spec update.
+// newSpec, oldSpec, and fldPath must not be nil.
+func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentSpecUpdate(
+	newSpec *nvidiacomv1beta1.DynamoComponentDeploymentSpec,
+	oldSpec *nvidiacomv1beta1.DynamoComponentDeploymentSpec,
+	fldPath *field.Path,
+) field.ErrorList {
+	// Standalone DCD updates preserve direct replica modification.
+	const canModifyReplicas = true
+
+	allErrs := field.ErrorList{}
+	if newSpec.BackendFramework != oldSpec.BackendFramework {
+		v.warn("Changing spec.backendFramework may cause unexpected behavior")
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("backendFramework"),
+			newSpec.BackendFramework,
+			"is immutable and cannot be changed after creation",
+		))
+	}
+
+	allErrs = append(allErrs, v.validateDynamoComponentDeploymentSharedSpecUpdate(
+		&newSpec.DynamoComponentDeploymentSharedSpec,
+		&oldSpec.DynamoComponentDeploymentSharedSpec,
+		fldPath,
+		canModifyReplicas,
+		nvidiacomv1beta1.DynamoComponentDeploymentGVK.GroupKind(),
+	)...)
+	return allErrs
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go
@@ -60,7 +60,8 @@ func (v *DynamoComponentDeploymentValidator) Validate(
 	return validation.warnings, invalidDynamoComponentDeploymentError(dcd, allErrs)
 }
 
-// ValidateUpdate performs stateful validation comparing old and new v1beta1 DCD objects.
+// ValidateUpdate performs complete validation of an updated v1beta1 DCD and
+// compares its state with the previous object.
 // ctx, oldDCD, and newDCD must not be nil.
 func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
 	ctx context.Context,
@@ -71,7 +72,13 @@ func (v *DynamoComponentDeploymentValidator) ValidateUpdate(
 		sharedValidation: sharedValidation{ctx: ctx},
 	}
 
-	allErrs := validation.validateDynamoComponentDeploymentUpdate(newDCD, oldDCD)
+	allErrs := validation.validateDynamoComponentDeployment(newDCD)
+	alpha, err := alphaDynamoComponentDeploymentForValidation(newDCD)
+	if err != nil {
+		return nil, fmt.Errorf("cannot validate preserved v1alpha1 DynamoComponentDeployment fields: %w", err)
+	}
+	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentV1alpha1(alpha)...)
+	allErrs = append(allErrs, validation.validateDynamoComponentDeploymentUpdate(newDCD, oldDCD)...)
 	return validation.warnings, invalidDynamoComponentDeploymentError(newDCD, allErrs)
 }
 

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
@@ -19,13 +19,14 @@ package validation
 
 import (
 	"context"
-	"fmt"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
@@ -33,13 +34,21 @@ import (
 
 const (
 	// DynamoComponentDeploymentWebhookName is the name of the validating webhook handler for DynamoComponentDeployment.
-	DynamoComponentDeploymentWebhookName = "dynamocomponentdeployment-validating-webhook"
-	dynamoComponentDeploymentWebhookPath = "/validate-nvidia-com-v1alpha1-dynamocomponentdeployment"
+	DynamoComponentDeploymentWebhookName         = "dynamocomponentdeployment-validating-webhook"
+	dynamoComponentDeploymentV1Alpha1WebhookPath = "/validate-nvidia-com-v1alpha1-dynamocomponentdeployment"
+	dynamoComponentDeploymentV1Beta1WebhookPath  = "/validate/nvidia.com/v1beta1/dynamocomponentdeployments"
 )
 
 // DynamoComponentDeploymentHandler is a handler for validating DynamoComponentDeployment resources.
 // It is a thin wrapper around DynamoComponentDeploymentValidator.
 type DynamoComponentDeploymentHandler struct{}
+
+// dynamoComponentDeploymentV1Alpha1Handler keeps the previous endpoint available
+// during the v1alpha1-to-v1beta1 admission migration. It converts the spoke
+// request to the v1beta1 hub before invoking the shared validation logic.
+type dynamoComponentDeploymentV1Alpha1Handler struct {
+	handler *DynamoComponentDeploymentHandler
+}
 
 // NewDynamoComponentDeploymentHandler creates a new handler for DynamoComponentDeployment Webhook.
 func NewDynamoComponentDeploymentHandler() *DynamoComponentDeploymentHandler {
@@ -48,9 +57,17 @@ func NewDynamoComponentDeploymentHandler() *DynamoComponentDeploymentHandler {
 
 // ValidateCreate validates a DynamoComponentDeployment create request.
 func (h *DynamoComponentDeploymentHandler) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return h.validateCreate(ctx, obj, nvidiacomv1beta1.DynamoComponentDeploymentGVK)
+}
+
+func (h *DynamoComponentDeploymentHandler) validateCreate(
+	ctx context.Context,
+	obj runtime.Object,
+	expectedGVK schema.GroupVersionKind,
+) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName(DynamoComponentDeploymentWebhookName)
 
-	if err := internalwebhook.ValidateAdmissionGVK(ctx, nvidiacomv1alpha1.DynamoComponentDeploymentGVK); err != nil {
+	if err := internalwebhook.ValidateAdmissionGVK(ctx, expectedGVK); err != nil {
 		return nil, err
 	}
 
@@ -61,16 +78,23 @@ func (h *DynamoComponentDeploymentHandler) ValidateCreate(ctx context.Context, o
 
 	logger.Info("validate create", "name", deployment.Name, "namespace", deployment.Namespace)
 
-	// Create validator and perform validation
-	validator := NewDynamoComponentDeploymentValidator(deployment)
-	return validator.Validate(ctx)
+	validator := NewDynamoComponentDeploymentValidator()
+	return validator.Validate(ctx, deployment)
 }
 
 // ValidateUpdate validates a DynamoComponentDeployment update request.
 func (h *DynamoComponentDeploymentHandler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	return h.validateUpdate(ctx, oldObj, newObj, nvidiacomv1beta1.DynamoComponentDeploymentGVK)
+}
+
+func (h *DynamoComponentDeploymentHandler) validateUpdate(
+	ctx context.Context,
+	oldObj, newObj runtime.Object,
+	expectedGVK schema.GroupVersionKind,
+) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName(DynamoComponentDeploymentWebhookName)
 
-	if err := internalwebhook.ValidateAdmissionGVK(ctx, nvidiacomv1alpha1.DynamoComponentDeploymentGVK); err != nil {
+	if err := internalwebhook.ValidateAdmissionGVK(ctx, expectedGVK); err != nil {
 		return nil, err
 	}
 
@@ -81,7 +105,7 @@ func (h *DynamoComponentDeploymentHandler) ValidateUpdate(ctx context.Context, o
 
 	logger.Info("validate update", "name", newDeployment.Name, "namespace", newDeployment.Namespace)
 
-	// Skip validation if the resource is being deleted (to allow finalizer removal)
+	// Skip validation if the resource is being deleted to allow finalizer removal.
 	if !newDeployment.DeletionTimestamp.IsZero() {
 		logger.Info("skipping validation for resource being deleted", "name", newDeployment.Name)
 		return nil, nil
@@ -92,42 +116,43 @@ func (h *DynamoComponentDeploymentHandler) ValidateUpdate(ctx context.Context, o
 		return nil, err
 	}
 
-	// Create validator and perform validation
-	validator := NewDynamoComponentDeploymentValidator(newDeployment)
-
-	// Validate stateless rules
-	warnings, err := validator.Validate(ctx)
+	validator := NewDynamoComponentDeploymentValidator()
+	warnings, err := validator.Validate(ctx, newDeployment)
 	if err != nil {
 		return warnings, err
 	}
 
-	// Validate stateful rules (immutability)
-	updateWarnings, err := validator.ValidateUpdate(oldDeployment)
+	updateWarnings, err := validator.ValidateUpdate(ctx, oldDeployment, newDeployment)
 	if err != nil {
 		return updateWarnings, err
 	}
 
-	// Combine warnings
 	warnings = append(warnings, updateWarnings...)
 	return warnings, nil
 }
 
 // ValidateDelete validates a DynamoComponentDeployment delete request.
 func (h *DynamoComponentDeploymentHandler) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return h.validateDelete(ctx, obj, nvidiacomv1beta1.DynamoComponentDeploymentGVK)
+}
+
+func (h *DynamoComponentDeploymentHandler) validateDelete(
+	ctx context.Context,
+	obj runtime.Object,
+	expectedGVK schema.GroupVersionKind,
+) (admission.Warnings, error) {
 	logger := log.FromContext(ctx).WithName(DynamoComponentDeploymentWebhookName)
 
-	if err := internalwebhook.ValidateAdmissionGVK(ctx, nvidiacomv1alpha1.DynamoComponentDeploymentGVK); err != nil {
+	if err := internalwebhook.ValidateAdmissionGVK(ctx, expectedGVK); err != nil {
 		return nil, err
 	}
 
-	deployment, err := castToDynamoComponentDeployment(obj)
+	deployment, err := dynamoComponentDeploymentMetadata(obj)
 	if err != nil {
 		return nil, err
 	}
 
-	logger.Info("validate delete", "name", deployment.Name, "namespace", deployment.Namespace)
-
-	// No special validation needed for deletion
+	logger.Info("validate delete", "name", deployment.GetName(), "namespace", deployment.GetNamespace())
 	return nil, nil
 }
 
@@ -135,24 +160,48 @@ func (h *DynamoComponentDeploymentHandler) ValidateDelete(ctx context.Context, o
 // The handler is automatically wrapped with LeaseAwareValidator to add namespace exclusion logic
 // and ObservedValidator to add metrics collection.
 func (h *DynamoComponentDeploymentHandler) RegisterWithManager(mgr manager.Manager) error {
-	// Wrap the handler with lease-aware logic for cluster-wide coordination
-	leaseAwareValidator := internalwebhook.NewLeaseAwareValidator(h, internalwebhook.GetExcludedNamespaces())
+	h.registerWithManager(
+		mgr,
+		&nvidiacomv1beta1.DynamoComponentDeployment{},
+		dynamoComponentDeploymentV1Beta1WebhookPath,
+		h,
+	)
 
-	// Wrap with metrics collection
-	observedValidator := observability.NewObservedValidator(leaseAwareValidator, consts.ResourceTypeDynamoComponentDeployment)
-
-	webhook := admission.
-		WithCustomValidator(mgr.GetScheme(), &nvidiacomv1alpha1.DynamoComponentDeployment{}, observedValidator).
-		WithRecoverPanic(true)
-	mgr.GetWebhookServer().Register(dynamoComponentDeploymentWebhookPath, webhook)
+	// TODO(1.5): Remove the v1alpha1 endpoint and handler after 1.3 is no longer
+	// a supported upgrade or rollback target.
+	alphaHandler := &dynamoComponentDeploymentV1Alpha1Handler{handler: h}
+	h.registerWithManager(
+		mgr,
+		&nvidiacomv1alpha1.DynamoComponentDeployment{},
+		dynamoComponentDeploymentV1Alpha1WebhookPath,
+		alphaHandler,
+	)
 	return nil
 }
 
-// castToDynamoComponentDeployment attempts to cast a runtime.Object to a DynamoComponentDeployment.
-func castToDynamoComponentDeployment(obj runtime.Object) (*nvidiacomv1alpha1.DynamoComponentDeployment, error) {
-	deployment, ok := obj.(*nvidiacomv1alpha1.DynamoComponentDeployment)
-	if !ok {
-		return nil, fmt.Errorf("expected DynamoComponentDeployment but got %T", obj)
-	}
-	return deployment, nil
+func (h *DynamoComponentDeploymentHandler) registerWithManager(
+	mgr manager.Manager,
+	object runtime.Object,
+	path string,
+	validator admission.CustomValidator,
+) {
+	leaseAwareValidator := internalwebhook.NewLeaseAwareValidator(validator, internalwebhook.GetExcludedNamespaces())
+	observedValidator := observability.NewObservedValidator(leaseAwareValidator, consts.ResourceTypeDynamoComponentDeployment)
+
+	webhook := admission.
+		WithCustomValidator(mgr.GetScheme(), object, observedValidator).
+		WithRecoverPanic(true)
+	mgr.GetWebhookServer().Register(path, webhook)
+}
+
+func (h *dynamoComponentDeploymentV1Alpha1Handler) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return h.handler.validateCreate(ctx, obj, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
+}
+
+func (h *dynamoComponentDeploymentV1Alpha1Handler) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
+	return h.handler.validateUpdate(ctx, oldObj, newObj, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
+}
+
+func (h *dynamoComponentDeploymentV1Alpha1Handler) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
+	return h.handler.validateDelete(ctx, obj, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
 }

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go
@@ -117,18 +117,7 @@ func (h *DynamoComponentDeploymentHandler) validateUpdate(
 	}
 
 	validator := NewDynamoComponentDeploymentValidator()
-	warnings, err := validator.Validate(ctx, newDeployment)
-	if err != nil {
-		return warnings, err
-	}
-
-	updateWarnings, err := validator.ValidateUpdate(ctx, oldDeployment, newDeployment)
-	if err != nil {
-		return updateWarnings, err
-	}
-
-	warnings = append(warnings, updateWarnings...)
-	return warnings, nil
+	return validator.ValidateUpdate(ctx, oldDeployment, newDeployment)
 }
 
 // ValidateDelete validates a DynamoComponentDeployment delete request.

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler_test.go
@@ -1,0 +1,94 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	admissionv1 "k8s.io/api/admission/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+)
+
+func TestDynamoComponentDeploymentV1Alpha1HandlerConvertsRequest(t *testing.T) {
+	handler := &dynamoComponentDeploymentV1Alpha1Handler{
+		handler: NewDynamoComponentDeploymentHandler(),
+	}
+	ctx := dgdAdmissionContext(admissionv1.Create, nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
+	dcd := alphaDCDForAdmission(nil)
+
+	warnings, err := handler.ValidateCreate(ctx, dcd)
+	if err != nil {
+		t.Fatalf("ValidateCreate() error = %v", err)
+	}
+	if len(warnings) != 0 {
+		t.Fatalf("ValidateCreate() warnings = %v, want none", warnings)
+	}
+}
+
+func TestCastToDynamoComponentDeployment(t *testing.T) {
+	beta := betaDCDForAdmission(nil)
+	got, err := castToDynamoComponentDeployment(beta)
+	if err != nil || got != beta {
+		t.Fatalf("castToDynamoComponentDeployment() = (%v, %v), want original DCD", got, err)
+	}
+
+	alpha := alphaDCDForAdmission(nil)
+	got, err = castToDynamoComponentDeployment(alpha)
+	if err != nil {
+		t.Fatalf("castToDynamoComponentDeployment() error = %v", err)
+	}
+	if got.Spec.ComponentName != alpha.Spec.ServiceName {
+		t.Fatalf("converted component name = %q, want %q", got.Spec.ComponentName, alpha.Spec.ServiceName)
+	}
+
+	if _, err := castToDynamoComponentDeployment(nil); err == nil {
+		t.Fatal("castToDynamoComponentDeployment() error = nil, want type mismatch")
+	}
+}
+
+func TestDynamoComponentDeploymentHandlerRegisterWithManager(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := nvidiacomv1alpha1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1alpha1 scheme: %v", err)
+	}
+	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add v1beta1 scheme: %v", err)
+	}
+
+	server := ctrlwebhook.NewServer(ctrlwebhook.Options{})
+	mgr := &fakeManager{scheme: scheme, webhookServer: server}
+	handler := NewDynamoComponentDeploymentHandler()
+	if err := handler.RegisterWithManager(mgr); err != nil {
+		t.Fatalf("RegisterWithManager() error = %v", err)
+	}
+
+	for _, path := range []string{
+		dynamoComponentDeploymentV1Alpha1WebhookPath,
+		dynamoComponentDeploymentV1Beta1WebhookPath,
+	} {
+		request := httptest.NewRequest("POST", path, nil)
+		_, pattern := server.WebhookMux().Handler(request)
+		if pattern != path {
+			t.Fatalf("registered pattern = %q, want %q", pattern, path)
+		}
+	}
+}

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_helpers.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_helpers.go
@@ -1,0 +1,100 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"fmt"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// invalidDynamoComponentDeploymentError converts allErrs for dcd into an API error.
+// dcd must not be nil.
+func invalidDynamoComponentDeploymentError(
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+	allErrs field.ErrorList,
+) error {
+	if len(allErrs) == 0 {
+		return nil
+	}
+	return k8serrors.NewInvalid(nvidiacomv1beta1.DynamoComponentDeploymentGVK.GroupKind(), dcd.Name, allErrs)
+}
+
+// alphaDynamoComponentDeploymentForValidation reconstructs the compatibility view.
+// dcd must not be nil.
+func alphaDynamoComponentDeploymentForValidation(
+	dcd *nvidiacomv1beta1.DynamoComponentDeployment,
+) (*nvidiacomv1alpha1.DynamoComponentDeployment, error) {
+	alpha := &nvidiacomv1alpha1.DynamoComponentDeployment{}
+	if err := alpha.ConvertFrom(dcd); err != nil {
+		return nil, fmt.Errorf("failed to reconstruct compatibility view: %w", err)
+	}
+	return alpha, nil
+}
+
+func hasDynamoComponentDeploymentV1alpha1CompatibilityFields(
+	dcd *nvidiacomv1alpha1.DynamoComponentDeployment,
+) bool {
+	spec := &dcd.Spec.DynamoComponentDeploymentSharedSpec
+	hasDeprecatedAutoscaling := false
+	//nolint:staticcheck // SA1019: Intentionally checking a deprecated field preserved by conversion.
+	if spec.Autoscaling != nil {
+		hasDeprecatedAutoscaling = true
+	}
+	return len(spec.Annotations) > 0 ||
+		spec.DynamoNamespace != nil ||
+		hasDeprecatedAutoscaling ||
+		spec.Ingress != nil ||
+		len(spec.VolumeMounts) > 0 ||
+		spec.EPPConfig != nil ||
+		spec.FrontendSidecar != nil ||
+		spec.Failover != nil
+}
+
+// castToDynamoComponentDeployment converts the v1alpha1 spoke to the v1beta1
+// hub used by the DCD validator, or returns a v1beta1 object unchanged.
+func castToDynamoComponentDeployment(obj runtime.Object) (*nvidiacomv1beta1.DynamoComponentDeployment, error) {
+	switch deployment := obj.(type) {
+	case *nvidiacomv1beta1.DynamoComponentDeployment:
+		return deployment, nil
+	case *nvidiacomv1alpha1.DynamoComponentDeployment:
+		converted := &nvidiacomv1beta1.DynamoComponentDeployment{}
+		if err := deployment.ConvertTo(converted); err != nil {
+			return nil, fmt.Errorf("convert v1alpha1 DynamoComponentDeployment to v1beta1: %w", err)
+		}
+		return converted, nil
+	default:
+		return nil, fmt.Errorf("expected v1alpha1 or v1beta1 DynamoComponentDeployment but got %T", obj)
+	}
+}
+
+func dynamoComponentDeploymentMetadata(obj runtime.Object) (metav1.Object, error) {
+	switch deployment := obj.(type) {
+	case *nvidiacomv1beta1.DynamoComponentDeployment:
+		return deployment, nil
+	case *nvidiacomv1alpha1.DynamoComponentDeployment:
+		return deployment, nil
+	default:
+		return nil, fmt.Errorf("expected DynamoComponentDeployment but got %T", obj)
+	}
+}

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
@@ -18,14 +18,15 @@
 package validation
 
 import (
+	"fmt"
 	"slices"
-	"strings"
 	"testing"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
+	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -46,6 +47,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 		validReplicas    = int32(3)
 		negativeReplicas = int32(-1)
 		validMinAvail    = int32(2)
+		negativeSHMSize  = resource.MustParse("-1Gi")
 		workerGPU        = &nvidiacomv1alpha1.Resources{
 			Limits: &nvidiacomv1alpha1.ResourceItem{GPU: "1"},
 		}
@@ -81,7 +83,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Replicas = &validReplicas
 				dcd.Spec.MinAvailable = &validMinAvail
 			}),
-			wantWebhookErrs: []string{"spec.minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components"},
+			wantWebhookErrs: []string{"spec.minAvailable: Forbidden: is currently supported only for Grove-backed DynamoGraphDeployment components"},
 		},
 		{
 			name: "v1beta1 minAvailable reaches the standalone DCD webhook",
@@ -89,21 +91,38 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Replicas = &validReplicas
 				dcd.Spec.MinAvailable = &validMinAvail
 			}),
-			wantWebhookErrs: []string{"spec.minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components"},
+			wantWebhookErrs: []string{"spec.minAvailable: Forbidden: is currently supported only for Grove-backed DynamoGraphDeployment components"},
+		},
+		{
+			name: "v1beta1 structural validation aggregates independent shared-spec errors",
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.ComponentType = nvidiacomv1beta1.ComponentTypeFrontend
+				dcd.Spec.SharedMemorySize = &negativeSHMSize
+				dcd.Spec.FrontendSidecar = k8sptr.To("frontend")
+				dcd.Spec.Experimental = &nvidiacomv1beta1.ExperimentalSpec{
+					GPUMemoryService: &nvidiacomv1beta1.GPUMemoryServiceSpec{},
+				}
+			}),
+			wantWebhookErrs: []string{
+				`spec.sharedMemorySize: Invalid value: "-1Gi": must be non-negative`,
+				"spec.podTemplate.spec.containers: Required value: is required when frontendSidecar is set",
+				"spec.experimental.gpuMemoryService: Forbidden: GPU memory service is only supported for worker, prefill, or decode components",
+				"spec.experimental.gpuMemoryService: Forbidden: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1",
+			},
 		},
 		{
 			name: "invalid ingress",
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.Ingress = &nvidiacomv1alpha1.IngressSpec{Enabled: true}
 			}),
-			wantWebhookErrs: []string{"spec.ingress.host is required when ingress is enabled"},
+			wantWebhookErrs: []string{"spec.ingress.host: Required value: is required when ingress is enabled"},
 		},
 		{
 			name: "invalid volume mount",
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.VolumeMounts = []nvidiacomv1alpha1.VolumeMount{{Name: "data"}}
 			}),
-			wantWebhookErrs: []string{"spec.volumeMounts[0].mountPoint is required when useAsCompilationCache is false"},
+			wantWebhookErrs: []string{"spec.volumeMounts[0].mountPoint: Required value: is required when useAsCompilationCache is false"},
 		},
 		{
 			name: "invalid shared memory",
@@ -276,7 +295,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				Annotations: map[string]string{consts.KubeAnnotationVLLMDistributedExecutorBackend: "invalid"},
 			}),
-			wantWebhookErrs: []string{`spec.annotations[nvidia.com/vllm-distributed-executor-backend] has invalid value "invalid": must be "mp" or "ray"`},
+			wantWebhookErrs: []string{`spec.annotations[nvidia.com/vllm-distributed-executor-backend]: Invalid value: "invalid": must be "mp" or "ray"`},
 		},
 		{
 			name: "checkpoint without GMS is accepted",
@@ -381,7 +400,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				},
 			}),
-			wantWebhookErrs: []string{"spec.checkpoint.job.gmsClientContainers requires gpuMemoryService to be enabled"},
+			wantWebhookErrs: []string{"spec.experimental.checkpoint.job.gmsClientContainers: Forbidden: requires gpuMemoryService to be set"},
 		},
 		{
 			name: "checkpoint GMS client names are validated by the source schema",
@@ -417,7 +436,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					Containers: []corev1.Container{{Name: consts.FrontendSidecarContainerName, Image: "conflict:latest"}},
 				}},
 			}),
-			wantWebhookErrs: []string{`spec: cannot inject frontend sidecar: a container named "sidecar-frontend" already exists in extraPodSpec.containers`},
+			wantWebhookErrs: []string{`spec.frontendSidecar: Forbidden: cannot inject frontend sidecar: a container named "sidecar-frontend" already exists in extraPodSpec.containers`},
 		},
 		{
 			name: "frontend sidecar with non-conflicting containers is accepted",
@@ -439,7 +458,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					Enabled: true,
 				},
 			}),
-			wantWebhookErrs: []string{"spec.gpuMemoryService: GPU memory service is only supported for worker components (componentType must be worker, prefill, or decode)"},
+			wantWebhookErrs: []string{"spec.experimental.gpuMemoryService: Forbidden: GPU memory service is only supported for worker, prefill, or decode components"},
 		},
 		{
 			name: "GMS requires a GPU",
@@ -447,7 +466,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				ComponentType:    consts.ComponentTypeWorker,
 				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true},
 			}),
-			wantWebhookErrs: []string{"spec.gpuMemoryService: GPU memory service requires resources.limits.gpu >= 1"},
+			wantWebhookErrs: []string{"spec.experimental.gpuMemoryService: Forbidden: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1"},
 		},
 		{
 			name: "GMS accepts GPU requests when limits are unset",
@@ -468,7 +487,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				},
 				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{Enabled: true},
 			}),
-			wantWebhookErrs: []string{"spec.gpuMemoryService: GPU memory service requires resources.limits.gpu >= 1"},
+			wantWebhookErrs: []string{"spec.experimental.gpuMemoryService: Forbidden: GPU memory service requires podTemplate.spec.containers[main].resources.limits.nvidia.com/gpu >= 1"},
 		},
 		{
 			name: "checkpoint GMS clients reject inter-pod GMS",
@@ -490,7 +509,10 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				},
 			}),
-			wantWebhookErrs: []string{"spec.checkpoint.job.gmsClientContainers is only supported with gpuMemoryService.mode=IntraPod"},
+			wantWebhookErrs: []string{
+				"spec.experimental.checkpoint.job.gmsClientContainers: Forbidden: is only supported with gpuMemoryService.mode=IntraPod",
+				"spec.experimental.checkpoint: Forbidden: GMS + Snapshot is temporarily disabled; disable gpuMemoryService or enable the internal GMS + Snapshot gate",
+			},
 		},
 		{
 			name: "checkpoint GMS clients accept intra-pod GMS",
@@ -553,7 +575,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 1,
 				},
 			}),
-			wantWebhookErrs: []string{`spec.failover: interPod failover requires gpuMemoryService.enabled=true and gpuMemoryService.mode="interPod"`},
+			wantWebhookErrs: []string{`spec.experimental.failover: Forbidden: gpuMemoryService is required when failover mode is "InterPod"`},
 		},
 		{
 			name: "inter-pod failover requires matching GMS mode",
@@ -570,7 +592,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 1,
 				},
 			}),
-			wantWebhookErrs: []string{`spec.failover: interPod failover requires gpuMemoryService.mode="interPod" (got "intraPod")`},
+			wantWebhookErrs: []string{`spec.experimental.failover.mode: Invalid value: "InterPod": must match gpuMemoryService.mode "IntraPod"`},
 		},
 		{
 			name: "matching inter-pod GMS failover is accepted",
@@ -615,7 +637,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					NumShadows: 2,
 				},
 			}),
-			wantWebhookErrs: []string{`spec.failover.numShadows=2 is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`},
+			wantWebhookErrs: []string{`spec.failover.numShadows: Invalid value: 2: is invalid for mode="intraPod": intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode="interPod" to configure numShadows`},
 		},
 		{
 			name: "single-shadow intra-pod failover is accepted",
@@ -655,7 +677,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.OwnerReferences = []metav1.OwnerReference{{Kind: "DynamoGraphDeployment", Name: "trtllm-disagg"}}
 				dcd.Spec.DynamoNamespace = k8sptr.To("my-custom-namespace")
 			}),
-			wantWarnings: []string{"spec.dynamoNamespace is deprecated and ignored. Value 'my-custom-namespace' will be replaced with 'hannahz-trtllm-disagg'. Remove this field from your configuration"},
+			wantWarnings: []string{`spec.dynamoNamespace is deprecated and ignored. Value "my-custom-namespace" will be replaced with "hannahz-trtllm-disagg". Remove this field from your configuration`},
 		},
 
 		// EPP rules and their source-version ownership.
@@ -665,7 +687,10 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				ComponentType: consts.ComponentTypeEPP,
 				Multinode:     &nvidiacomv1alpha1.MultinodeSpec{NodeCount: 2},
 			}),
-			wantWebhookErrs: []string{"spec: EPP component cannot be multinode (multinode field must be nil or nodeCount must be 1)"},
+			wantWebhookErrs: []string{
+				"spec.multinode: Forbidden: EPP component cannot be multinode",
+				"spec.eppConfig: Required value: is required for EPP components",
+			},
 		},
 		{
 			name: "v1alpha1 EPP requires one replica",
@@ -673,21 +698,24 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				ComponentType: consts.ComponentTypeEPP,
 				Replicas:      &validMinAvail,
 			}),
-			wantWebhookErrs: []string{"spec: EPP component must have exactly 1 replica (found 2 replicas)"},
+			wantWebhookErrs: []string{
+				"spec.replicas: Invalid value: 2: EPP component must have exactly 1 replica",
+				"spec.eppConfig: Required value: is required for EPP components",
+			},
 		},
 		{
 			name: "v1alpha1 EPP requires configuration",
 			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
 				ComponentType: consts.ComponentTypeEPP,
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig is required for EPP components"},
+			wantWebhookErrs: []string{"spec.eppConfig: Required value: is required for EPP components"},
 		},
 		{
-			name: "v1beta1 EPP without configuration reaches and is rejected by the converted webhook",
+			name: "v1beta1 EPP without configuration reaches and is rejected by the v1beta1 webhook",
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig is required for EPP components"},
+			wantWebhookErrs: []string{"spec.eppConfig: Required value: is required for EPP components"},
 		},
 		{
 			name: "v1alpha1 empty EPP config reaches and is rejected by the webhook",
@@ -695,7 +723,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				ComponentType: consts.ComponentTypeEPP,
 				EPPConfig:     &nvidiacomv1alpha1.EPPConfig{},
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig: either configMapRef or config must be specified (no default configuration provided)"},
+			wantWebhookErrs: []string{"spec.eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "v1beta1 empty EPP config is rejected by source CEL",
@@ -717,7 +745,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				},
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig: configMapRef and config are mutually exclusive, only one can be specified"},
+			wantWebhookErrs: []string{"spec.eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "v1beta1 conflicting EPP config is rejected by source CEL",
@@ -741,7 +769,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					ConfigMapRef: &corev1.ConfigMapKeySelector{},
 				},
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig.configMapRef.name is required"},
+			wantWebhookErrs: []string{"spec.eppConfig.configMapRef.name: Required value: is required"},
 		},
 		{
 			name: "valid v1alpha1 EPP config reaches the webhook",
@@ -754,7 +782,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name: "valid v1beta1 EPP config reaches the converted webhook",
+			name: "valid v1beta1 EPP config reaches the v1beta1 webhook",
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
 				dcd.Spec.Replicas = &oneReplica
@@ -832,7 +860,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name:       "valid v1beta1 deployment reaches the converted webhook",
+			name:       "valid v1beta1 deployment reaches the v1beta1 webhook",
 			deployment: betaDCDForAdmission(nil),
 		},
 		{
@@ -845,7 +873,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name:          "v1beta1 update without changes reaches the converted webhook",
+			name:          "v1beta1 update without changes reaches the v1beta1 webhook",
 			oldDeployment: betaDCDForAdmission(nil),
 			deployment:    betaDCDForAdmission(nil),
 		},
@@ -857,18 +885,18 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.BackendFramework = dcdAdmissionVLLMBackend
 			}),
-			wantWebhookErrs: []string{"spec.backendFramework is immutable and cannot be changed after creation"},
+			wantWebhookErrs: []string{`spec.backendFramework: Invalid value: "vllm": is immutable and cannot be changed after creation`},
 			wantWarnings:    []string{"Changing spec.backendFramework may cause unexpected behavior"},
 		},
 		{
-			name: "v1beta1 backend framework update reaches and is rejected by the converted webhook",
+			name: "v1beta1 backend framework update reaches and is rejected by the v1beta1 webhook",
 			oldDeployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.BackendFramework = dcdAdmissionSGLangBackend
 			}),
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.BackendFramework = dcdAdmissionVLLMBackend
 			}),
-			wantWebhookErrs: []string{"spec.backendFramework is immutable and cannot be changed after creation"},
+			wantWebhookErrs: []string{`spec.backendFramework: Invalid value: "vllm": is immutable and cannot be changed after creation`},
 			wantWarnings:    []string{"Changing spec.backendFramework may cause unexpected behavior"},
 		},
 		{
@@ -883,13 +911,21 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}),
 		},
 		{
-			name: "v1beta1 replicas update reaches the converted webhook",
+			name: "v1beta1 replicas update reaches the v1beta1 webhook",
 			oldDeployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.Replicas = &oneReplica
 			}),
 			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
 				dcd.Spec.Replicas = &validReplicas
 			}),
+		},
+		{
+			name:          "v1beta1 multinode layout change is rejected by the shared update validator",
+			oldDeployment: betaDCDForAdmission(nil),
+			deployment: betaDCDForAdmission(func(dcd *nvidiacomv1beta1.DynamoComponentDeployment) {
+				dcd.Spec.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
+			}),
+			wantWebhookErrs: []string{`spec.multinode: Invalid value: {"nodeCount":2}: cannot change node topology between single-node and multi-node after creation`},
 		},
 	}
 
@@ -935,16 +971,16 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			}
 
 			handler := NewDynamoComponentDeploymentHandler()
-			ctx := dgdAdmissionContext(dgdAdmissionOperation(tt.oldDeployment), nvidiacomv1alpha1.DynamoComponentDeploymentGVK)
+			ctx := dgdAdmissionContext(dgdAdmissionOperation(tt.oldDeployment), nvidiacomv1beta1.DynamoComponentDeploymentGVK)
 			var warnings []string
 			var err error
 			if tt.oldDeployment == nil {
-				warnings, err = handler.ValidateCreate(ctx, dcdAdmissionAlpha(t, tt.deployment))
+				warnings, err = handler.ValidateCreate(ctx, dcdAdmissionBeta(t, tt.deployment))
 			} else {
 				warnings, err = handler.ValidateUpdate(
 					ctx,
-					dcdAdmissionAlpha(t, tt.oldDeployment),
-					dcdAdmissionAlpha(t, tt.deployment),
+					dcdAdmissionBeta(t, tt.oldDeployment),
+					dcdAdmissionBeta(t, tt.deployment),
 				)
 			}
 			assertDCDWebhookErrors(t, err, tt.wantWebhookErrs)
@@ -966,7 +1002,22 @@ func assertDCDWebhookErrors(t *testing.T, err error, want []string) {
 	if err == nil {
 		t.Fatalf("webhook errors = nil, want %v", want)
 	}
-	got := strings.Split(err.Error(), "\n")
+	statusErr, ok := err.(*k8serrors.StatusError)
+	if !ok || !k8serrors.IsInvalid(err) {
+		t.Fatalf("error = %T %v, want typed Kubernetes invalid error", err, err)
+	}
+	if statusErr.ErrStatus.Details == nil {
+		t.Fatalf("error = %v, want typed field causes", err)
+	}
+
+	causes := statusErr.ErrStatus.Details.Causes
+	got := make([]string, len(causes))
+	for i, cause := range causes {
+		if cause.Field == "" {
+			t.Fatalf("error cause = %#v, want an exact field path", cause)
+		}
+		got[i] = fmt.Sprintf("%s: %s", cause.Field, cause.Message)
+	}
 	if !slices.Equal(got, want) {
 		t.Fatalf("webhook errors = %v, want %v", got, want)
 	}
@@ -1026,17 +1077,17 @@ func betaDCDForAdmission(
 	return dcd
 }
 
-func dcdAdmissionAlpha(t *testing.T, deployment runtime.Object) *nvidiacomv1alpha1.DynamoComponentDeployment {
+func dcdAdmissionBeta(t *testing.T, deployment runtime.Object) *nvidiacomv1beta1.DynamoComponentDeployment {
 	t.Helper()
 	switch deployment := deployment.(type) {
 	case *nvidiacomv1alpha1.DynamoComponentDeployment:
-		return deployment.DeepCopy()
-	case *nvidiacomv1beta1.DynamoComponentDeployment:
-		alpha := &nvidiacomv1alpha1.DynamoComponentDeployment{}
-		if err := alpha.ConvertFrom(deployment); err != nil {
-			t.Fatalf("convert v1beta1 DCD to v1alpha1: %v", err)
+		beta := &nvidiacomv1beta1.DynamoComponentDeployment{}
+		if err := deployment.ConvertTo(beta); err != nil {
+			t.Fatalf("convert v1alpha1 DCD to v1beta1: %v", err)
 		}
-		return alpha
+		return beta
+	case *nvidiacomv1beta1.DynamoComponentDeployment:
+		return deployment.DeepCopy()
 	default:
 		t.Fatalf("unsupported DCD type %T", deployment)
 		return nil

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
@@ -723,7 +723,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				ComponentType: consts.ComponentTypeEPP,
 				EPPConfig:     &nvidiacomv1alpha1.EPPConfig{},
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
+			wantWebhookErrs: []string{"spec.eppConfig: Forbidden: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "v1beta1 empty EPP config is rejected by source CEL",
@@ -745,7 +745,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				},
 			}),
-			wantWebhookErrs: []string{"spec.eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
+			wantWebhookErrs: []string{"spec.eppConfig: Forbidden: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "v1beta1 conflicting EPP config is rejected by source CEL",
@@ -926,6 +926,43 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Multinode = &nvidiacomv1beta1.MultinodeSpec{NodeCount: 2}
 			}),
 			wantWebhookErrs: []string{`spec.multinode: Invalid value: {"nodeCount":2}: cannot change node topology between single-node and multi-node after creation`},
+		},
+		{
+			name: "v1alpha1 update aggregates create and DCD-specific update errors",
+			oldDeployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Replicas:      &oneReplica,
+				MinAvailable:  &oneReplica,
+				Resources:     workerGPU,
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+				},
+				Failover: &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeInterPod,
+					NumShadows: 1,
+				},
+			}),
+			deployment: alphaDCDWithSharedSpec(nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec{
+				ComponentType: consts.ComponentTypeWorker,
+				Replicas:      &oneReplica,
+				MinAvailable:  &oneReplica,
+				Resources:     workerGPU,
+				GPUMemoryService: &nvidiacomv1alpha1.GPUMemoryServiceSpec{
+					Enabled: true,
+					Mode:    nvidiacomv1alpha1.GMSModeInterPod,
+				},
+				Failover: &nvidiacomv1alpha1.FailoverSpec{
+					Enabled:    true,
+					Mode:       nvidiacomv1alpha1.GMSModeInterPod,
+					NumShadows: 2,
+				},
+			}),
+			wantWebhookErrs: []string{
+				"spec.minAvailable: Forbidden: is currently supported only for Grove-backed DynamoGraphDeployment components",
+				"spec.experimental.failover.numShadows: Invalid value: 2: is immutable for inter-pod GMS failover; delete and recreate the DynamoComponentDeployment to change it",
+			},
 		},
 	}
 

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_v1alpha1.go
@@ -1,0 +1,50 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+)
+
+// validateDynamoComponentDeploymentV1alpha1 validates dcd. dcd must not be nil.
+func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentV1alpha1(
+	dcd *nvidiacomv1alpha1.DynamoComponentDeployment,
+) field.ErrorList {
+	if !hasDynamoComponentDeploymentV1alpha1CompatibilityFields(dcd) {
+		return nil
+	}
+	return v.validateDynamoComponentDeploymentSpecV1alpha1(
+		&dcd.Spec,
+		field.NewPath("spec"),
+		dcd.GetDynamoNamespace(),
+	)
+}
+
+// validateDynamoComponentDeploymentSpecV1alpha1 validates spec. spec and fldPath must not be nil.
+func (v *dynamoComponentDeploymentValidation) validateDynamoComponentDeploymentSpecV1alpha1(
+	spec *nvidiacomv1alpha1.DynamoComponentDeploymentSpec,
+	fldPath *field.Path,
+	dynamoNamespace string,
+) field.ErrorList {
+	return v.validateDynamoComponentDeploymentSharedSpecV1alpha1(
+		&spec.DynamoComponentDeploymentSharedSpec,
+		fldPath,
+		dynamoNamespace,
+	)
+}

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment.go
@@ -199,6 +199,8 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 	fldPath *field.Path,
 	opts dynamoGraphDeploymentSpecValidationOptions,
 ) field.ErrorList {
+	const validateInferencePoolAvailability = true
+
 	allErrs := field.ErrorList{}
 
 	if spec.PriorityClassName != "" && !opts.grovePathway {
@@ -255,6 +257,7 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpec(
 			component,
 			componentPath,
 			opts.grovePathway,
+			validateInferencePoolAvailability,
 		)...)
 	}
 
@@ -543,6 +546,7 @@ func (v *dynamoGraphDeploymentValidation) validateDynamoGraphDeploymentSpecUpdat
 			oldComponent,
 			componentsPath.Index(i),
 			canModifyReplicas,
+			nvidiacomv1beta1.DynamoGraphDeploymentGVK.GroupKind(),
 		)...)
 	}
 

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -776,7 +776,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
+			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Forbidden: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "alpha intra-pod failover shadow maximum is preserved structurally",
@@ -926,7 +926,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker.ComponentType = consts.ComponentTypeEPP
 				worker.EPPConfig = &nvidiacomv1alpha1.EPPConfig{}
 			}),
-			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Invalid value: null: exactly one of configMapRef or config is required"},
+			wantWebhookErrs: []string{"spec.services[worker].eppConfig: Forbidden: exactly one of configMapRef or config is required"},
 		},
 		{
 			name: "v1beta1 EPP config without a source is rejected by CEL",

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -161,7 +161,7 @@ func TestValidateDynamoComponentDeploymentSharedSpecFieldPaths(t *testing.T) {
 	}
 	validation := &sharedValidation{ctx: context.Background(), mgr: newGroveTopologyTestManager(t)}
 
-	errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, field.NewPath("spec", "components").Index(0), false)
+	errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, field.NewPath("spec", "components").Index(0), false, true)
 	assertFieldPaths(t, errs, []string{
 		"spec.components[0].minAvailable",
 		"spec.components[0].sharedMemorySize",
@@ -180,7 +180,7 @@ func TestValidateDynamoComponentDeploymentSharedSpecFrontendSidecar(t *testing.T
 	t.Run("requires pod template", func(t *testing.T) {
 		name := "frontend"
 		spec := &nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec{FrontendSidecar: &name}
-		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true)
+		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true, true)
 		assertFieldPaths(t, errs, []string{
 			"spec.components[0].podTemplate.spec.containers",
 		})
@@ -192,7 +192,7 @@ func TestValidateDynamoComponentDeploymentSharedSpecFrontendSidecar(t *testing.T
 			PodTemplate:     &corev1.PodTemplateSpec{},
 			FrontendSidecar: &name,
 		}
-		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true)
+		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true, true)
 		assertFieldPaths(t, errs, []string{
 			"spec.components[0].frontendSidecar",
 		})
@@ -206,7 +206,7 @@ func TestValidateDynamoComponentDeploymentSharedSpecFrontendSidecar(t *testing.T
 			},
 			FrontendSidecar: &name,
 		}
-		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true)
+		errs := validation.validateDynamoComponentDeploymentSharedSpec(spec, componentPath, true, true)
 		assertFieldPaths(t, errs, nil)
 	})
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -112,9 +112,8 @@ func (v *sharedValidation) validateEPPConfigV1alpha1(
 	if (config.ConfigMapRef == nil) != (config.Config == nil) {
 		return nil
 	}
-	return field.ErrorList{field.Invalid(
+	return field.ErrorList{field.Forbidden(
 		fldPath,
-		nil,
 		"exactly one of configMapRef or config is required",
 	)}
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1alpha1.go
@@ -18,478 +18,12 @@
 package validation
 
 import (
-	"context"
-	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/checkpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
-	controllercommon "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo/epp"
-	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 )
-
-// SharedSpecValidatorV1Alpha1 validates DynamoComponentDeploymentSharedSpec fields.
-// This validator is used by DynamoComponentDeploymentValidator to provide
-// consistent validation logic for v1alpha1 shared spec fields.
-type SharedSpecValidatorV1Alpha1 struct {
-	spec                *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec
-	fieldPath           string       // e.g., "spec" for DCD
-	calculatedNamespace string       // Namespace the operator will use for this component
-	mgr                 ctrl.Manager // Optional: for API group detection via discovery client
-	grovePathway        bool         // Whether the component is backed by Grove
-}
-
-// NewSharedSpecValidatorV1Alpha1 creates a validator for v1alpha1 DynamoComponentDeploymentSharedSpec.
-// fieldPath is used to provide context in error messages (e.g., "spec").
-// calculatedNamespace is the namespace the operator will use:
-//   - If GlobalDynamoNamespace is true: "dynamo" (global constant)
-//   - Otherwise: {k8s_namespace}-{dgd_name}
-func NewSharedSpecValidatorV1Alpha1(spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec, fieldPath string, calculatedNamespace string, grovePathway bool) *SharedSpecValidatorV1Alpha1 {
-	return &SharedSpecValidatorV1Alpha1{
-		spec:                spec,
-		fieldPath:           fieldPath,
-		calculatedNamespace: calculatedNamespace,
-		mgr:                 nil,
-		grovePathway:        grovePathway,
-	}
-}
-
-// NewSharedSpecValidatorV1Alpha1WithManager creates a validator with a manager for API group detection.
-// This allows the validator to check for API group availability (e.g., inference.networking.k8s.io) when validating EPP components.
-func NewSharedSpecValidatorV1Alpha1WithManager(spec *nvidiacomv1alpha1.DynamoComponentDeploymentSharedSpec, fieldPath string, calculatedNamespace string, mgr ctrl.Manager, grovePathway bool) *SharedSpecValidatorV1Alpha1 {
-	return &SharedSpecValidatorV1Alpha1{
-		spec:                spec,
-		fieldPath:           fieldPath,
-		calculatedNamespace: calculatedNamespace,
-		mgr:                 mgr,
-		grovePathway:        grovePathway,
-	}
-}
-
-// Validate performs validation on the shared spec fields.
-// Context is required for any operations that may need to query the cluster (e.g., CRD checks).
-// Returns warnings (e.g., deprecation notices) and error if validation fails.
-func (v *SharedSpecValidatorV1Alpha1) Validate(ctx context.Context) (admission.Warnings, error) {
-	var warnings admission.Warnings
-
-	if v.spec.DynamoNamespace != nil && *v.spec.DynamoNamespace != "" {
-		warnings = append(warnings, fmt.Sprintf(
-			"%s.dynamoNamespace is deprecated and ignored. Value '%s' will be replaced with '%s'. "+
-				"Remove this field from your configuration",
-			v.fieldPath, *v.spec.DynamoNamespace, v.calculatedNamespace))
-	}
-	//nolint:staticcheck // SA1019: Intentionally checking deprecated field to warn users
-	if v.spec.Autoscaling != nil {
-		warnings = append(warnings, fmt.Sprintf(
-			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter "+
-				"with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
-			v.fieldPath))
-	}
-
-	if v.spec.Replicas != nil && *v.spec.Replicas < 0 {
-		return nil, fmt.Errorf("%s.replicas must be non-negative", v.fieldPath)
-	}
-	if err := v.validateMinAvailable(); err != nil {
-		return nil, err
-	}
-	if v.spec.SharedMemory != nil {
-		if err := v.validateSharedMemory(); err != nil {
-			return nil, err
-		}
-	}
-	if err := v.validateCheckpointConfig(); err != nil {
-		return nil, err
-	}
-	if err := v.validateGMSClientContainerNames(); err != nil {
-		return nil, err
-	}
-	if err := v.validateServiceAnnotations(); err != nil {
-		return nil, err
-	}
-	if err := v.validateEPPConfig(ctx); err != nil {
-		return nil, err
-	}
-	if err := v.validateGPUMemoryService(); err != nil {
-		return nil, err
-	}
-	if err := v.validateFailover(); err != nil {
-		return nil, err
-	}
-	if err := v.validateSnapshotWithGPUMemoryService(); err != nil {
-		return nil, err
-	}
-
-	if v.spec.Ingress != nil && v.spec.Ingress.Enabled {
-		if err := v.validateIngress(); err != nil {
-			return nil, err
-		}
-	}
-	if err := v.validateVolumeMounts(); err != nil {
-		return nil, err
-	}
-	if err := v.validateFrontendSidecar(); err != nil {
-		return nil, err
-	}
-
-	return warnings, nil
-}
-
-// implied non Grove pathway because Grove does not create DCDs
-func (v *SharedSpecValidatorV1Alpha1) validateMinAvailable() error {
-	if v.spec.MinAvailable != nil && !v.grovePathway {
-		return fmt.Errorf("spec.minAvailable is currently supported only for Grove-backed DynamoGraphDeployment components")
-	}
-	return nil
-}
-
-// validateSharedMemory validates the shared memory configuration.
-func (v *SharedSpecValidatorV1Alpha1) validateSharedMemory() error {
-	// If disabled is false (i.e., shared memory is enabled), size is required
-	if !v.spec.SharedMemory.Disabled && v.spec.SharedMemory.Size.IsZero() {
-		return fmt.Errorf("%s.sharedMemory.size is required when disabled is false", v.fieldPath)
-	}
-	return nil
-}
-
-func (v *SharedSpecValidatorV1Alpha1) validateCheckpointConfig() error {
-	if v.spec.Checkpoint == nil {
-		return nil
-	}
-	if v.spec.Checkpoint.Job != nil &&
-		v.spec.Checkpoint.CheckpointRef != nil &&
-		*v.spec.Checkpoint.CheckpointRef != "" {
-		return fmt.Errorf("%s.checkpoint.job cannot be set when checkpointRef is specified", v.fieldPath)
-	}
-	if v.spec.Checkpoint.TargetContainerName != "" {
-		if errs := k8svalidation.IsDNS1123Label(v.spec.Checkpoint.TargetContainerName); len(errs) > 0 {
-			return fmt.Errorf(
-				"%s.checkpoint.targetContainerName %q is not a valid Kubernetes container name: %s",
-				v.fieldPath,
-				v.spec.Checkpoint.TargetContainerName,
-				strings.Join(errs, "; "),
-			)
-		}
-	}
-	if v.spec.Checkpoint.Job != nil {
-		if len(v.spec.Checkpoint.Job.GMSClientContainers) > 0 {
-			if v.spec.GPUMemoryService == nil || !v.spec.GPUMemoryService.Enabled {
-				return fmt.Errorf("%s.checkpoint.job.gmsClientContainers requires gpuMemoryService to be enabled", v.fieldPath)
-			}
-			if v.spec.GPUMemoryService.Mode == nvidiacomv1alpha1.GMSModeInterPod {
-				return fmt.Errorf("%s.checkpoint.job.gmsClientContainers is only supported with gpuMemoryService.mode=IntraPod", v.fieldPath)
-			}
-		}
-		for i, name := range v.spec.Checkpoint.Job.GMSClientContainers {
-			if errs := k8svalidation.IsDNS1123Label(name); len(errs) > 0 {
-				return fmt.Errorf(
-					"%s.checkpoint.job.gmsClientContainers[%d] %q is not a valid Kubernetes container name: %s",
-					v.fieldPath,
-					i,
-					name,
-					strings.Join(errs, "; "),
-				)
-			}
-		}
-	}
-	return nil
-}
-
-func (v *SharedSpecValidatorV1Alpha1) validateGMSClientContainerNames() error {
-	if v.spec.GPUMemoryService == nil {
-		return nil
-	}
-	for i, name := range v.spec.GPUMemoryService.ExtraClientContainers {
-		if errs := k8svalidation.IsDNS1123Label(name); len(errs) > 0 {
-			return fmt.Errorf(
-				"%s.gpuMemoryService.extraClientContainers[%d] %q is not a valid Kubernetes container name: %s",
-				v.fieldPath,
-				i,
-				name,
-				strings.Join(errs, "; "),
-			)
-		}
-	}
-	return nil
-}
-
-// validateServiceAnnotations validates known annotations on the service-level spec.
-func (v *SharedSpecValidatorV1Alpha1) validateServiceAnnotations() error {
-	annotationsPath := ""
-	if v.fieldPath != "" {
-		annotationsPath = v.fieldPath + ".annotations"
-	}
-	return vllmDistributedExecutorBackendAnnotationError(annotationsPath, v.spec.Annotations)
-}
-
-// validateEPPConfig validates EPP-specific configuration constraints.
-func (v *SharedSpecValidatorV1Alpha1) validateEPPConfig(ctx context.Context) error {
-	// Only validate if this is an EPP component
-	if v.spec.ComponentType != consts.ComponentTypeEPP {
-		return nil
-	}
-
-	// Check if InferencePool API group is available in the cluster (if manager is provided)
-	if v.mgr != nil {
-		if err := v.checkInferencePoolAPIAvailability(ctx); err != nil {
-			return fmt.Errorf("%s: cannot deploy EPP component: %w", v.fieldPath, err)
-		}
-	}
-
-	// EPP must be single-node (cannot be multinode)
-	if v.spec.IsMultinode() {
-		return fmt.Errorf("%s: EPP component cannot be multinode (multinode field must be nil or nodeCount must be 1)", v.fieldPath)
-	}
-
-	// EPP should have exactly 1 replica (optional constraint - can be relaxed if needed)
-	if v.spec.Replicas != nil && *v.spec.Replicas != 1 {
-		return fmt.Errorf("%s: EPP component must have exactly 1 replica (found %d replicas)", v.fieldPath, *v.spec.Replicas)
-	}
-
-	// EPP components MUST have EPPConfig
-	if v.spec.EPPConfig == nil {
-		return fmt.Errorf("%s.eppConfig is required for EPP components", v.fieldPath)
-	}
-
-	// Either ConfigMapRef or Config must be specified (no default)
-	if v.spec.EPPConfig.ConfigMapRef == nil && v.spec.EPPConfig.Config == nil {
-		return fmt.Errorf("%s.eppConfig: either configMapRef or config must be specified (no default configuration provided)", v.fieldPath)
-	}
-
-	// ConfigMapRef and Config are mutually exclusive
-	if v.spec.EPPConfig.ConfigMapRef != nil && v.spec.EPPConfig.Config != nil {
-		return fmt.Errorf("%s.eppConfig: configMapRef and config are mutually exclusive, only one can be specified", v.fieldPath)
-	}
-
-	// If ConfigMapRef is provided, validate it
-	if v.spec.EPPConfig.ConfigMapRef != nil {
-		if v.spec.EPPConfig.ConfigMapRef.Name == "" {
-			return fmt.Errorf("%s.eppConfig.configMapRef.name is required", v.fieldPath)
-		}
-	}
-
-	return nil
-}
-
-// checkInferencePoolAPIAvailability checks if the inference.networking.k8s.io API group is available in the cluster.
-// Returns an error if the API group is not available, which prevents EPP deployment.
-// This reuses the controller_common.DetectInferencePoolAvailability function.
-func (v *SharedSpecValidatorV1Alpha1) checkInferencePoolAPIAvailability(ctx context.Context) error {
-	if v.mgr == nil {
-		// No manager provided, skip the check (e.g., in controller without webhooks)
-		return nil
-	}
-
-	if !controllercommon.DetectInferencePoolAvailability(ctx, v.mgr) {
-		return fmt.Errorf(
-			"InferencePool API group (%s) is not available in the cluster. "+
-				"EPP requires the Gateway API Inference Extension to be installed. "+
-				"Please install the Gateway API Inference Extension before deploying EPP components",
-			epp.InferencePoolGroup)
-	}
-
-	return nil
-}
-
-// parseGPUCount extracts the GPU count from a Resources block, preferring
-// Limits then Requests. Returns (0, nil) when no GPU is requested, or an
-// error if the value is non-numeric.
-func parseGPUCount(r *nvidiacomv1alpha1.Resources) (int, error) {
-	gpuStr := ""
-	switch {
-	case r != nil && r.Limits != nil && r.Limits.GPU != "":
-		gpuStr = r.Limits.GPU
-	case r != nil && r.Requests != nil && r.Requests.GPU != "":
-		gpuStr = r.Requests.GPU
-	}
-	if gpuStr == "" {
-		return 0, nil
-	}
-	n, err := strconv.Atoi(gpuStr)
-	if err != nil {
-		return 0, fmt.Errorf("invalid value %q: %w", gpuStr, err)
-	}
-	return n, nil
-}
-
-// validateGPUMemoryService validates gpuMemoryService constraints.
-//
-// gpuMemoryService declares the GMS layout (intra-pod sidecar vs. inter-pod
-// dedicated weight-server pod) and may be enabled independently of failover:
-// the intra-pod layout gives the engine a GMS sidecar in the same pod, and
-// the inter-pod layout gives it a dedicated weight-server pod paired with one
-// engine pod. Failover adds shadow engine pods on top of the declared layout
-// (see validateFailover); it is not the sole way to request the inter-pod
-// layout.
-func (v *SharedSpecValidatorV1Alpha1) validateGPUMemoryService() error {
-	if v.spec.GPUMemoryService == nil || !v.spec.GPUMemoryService.Enabled {
-		return nil
-	}
-
-	isWorker := v.spec.ComponentType == consts.ComponentTypeWorker ||
-		v.spec.ComponentType == consts.ComponentTypePrefill ||
-		v.spec.ComponentType == consts.ComponentTypeDecode
-	if !isWorker {
-		return fmt.Errorf(
-			"%s.gpuMemoryService: GPU memory service is only supported for worker components (componentType must be worker, prefill, or decode)",
-			v.fieldPath)
-	}
-
-	gpuCount, err := parseGPUCount(v.spec.Resources)
-	if err != nil || gpuCount < 1 {
-		return fmt.Errorf(
-			"%s.gpuMemoryService: GPU memory service requires resources.limits.gpu >= 1",
-			v.fieldPath)
-	}
-
-	return nil
-}
-
-// validateFailover validates GMS failover configuration constraints.
-//
-// The layout (intra-pod sidecar vs. inter-pod weight-server pod) is declared
-// by gpuMemoryService.mode. failover is an independent toggle: when enabled,
-// failover.mode MUST match gpuMemoryService.mode so the two knobs describe a
-// consistent topology. It is also valid to configure gpuMemoryService without
-// failover (no shadows; a single engine + GMS server pair) — see
-// validateGPUMemoryService below.
-func (v *SharedSpecValidatorV1Alpha1) validateFailover() error {
-	if v.spec.Failover == nil || !v.spec.Failover.Enabled {
-		// When failover.enabled is false the sub-fields (mode, numShadows)
-		// are dormant configuration and the render path ignores them
-		// (GetNumShadows returns 0). We deliberately do not validate them
-		// here so users can stage a failover config before flipping
-		// enabled=true — matching the K8s convention that fields on a
-		// disabled feature are not constrained.
-		return nil
-	}
-
-	var errs []error
-
-	// For intra-pod mode: require gpuMemoryService.enabled and validate mode matching.
-	if v.spec.Failover.Mode == nvidiacomv1alpha1.GMSModeIntraPod {
-		if v.spec.GPUMemoryService == nil || !v.spec.GPUMemoryService.Enabled {
-			errs = append(errs, fmt.Errorf(
-				"%s.failover: intraPod failover requires gpuMemoryService.enabled to be true",
-				v.fieldPath))
-		} else if v.spec.GPUMemoryService.Mode != "" &&
-			v.spec.GPUMemoryService.Mode != nvidiacomv1alpha1.GMSModeIntraPod {
-			errs = append(errs, fmt.Errorf(
-				"%s.failover: failover.mode %q must match gpuMemoryService.mode %q",
-				v.fieldPath, v.spec.Failover.Mode, v.spec.GPUMemoryService.Mode))
-		}
-
-		// intraPod is a fixed 1 primary + 1 shadow sidecar layout; numShadows
-		// is meaningless here and any value other than the implicit 1 is
-		// almost certainly a configuration error (user probably wanted
-		// mode=interPod).
-		if v.spec.Failover.NumShadows != 0 && v.spec.Failover.NumShadows != 1 {
-			errs = append(errs, fmt.Errorf(
-				"%s.failover.numShadows=%d is invalid for mode=%q: intraPod uses a fixed 1 primary + 1 shadow sidecar; "+
-					"use failover.mode=%q to configure numShadows",
-				v.fieldPath, v.spec.Failover.NumShadows, nvidiacomv1alpha1.GMSModeIntraPod, nvidiacomv1alpha1.GMSModeInterPod))
-		}
-	}
-
-	// For inter-pod mode: require the inter-pod GMS layout (gpuMemoryService
-	// with mode=interPod) so failover hot-spares are added on top of an
-	// already-declared weight-server pod layout.
-	if v.spec.Failover.Mode == nvidiacomv1alpha1.GMSModeInterPod {
-		if v.spec.GPUMemoryService == nil || !v.spec.GPUMemoryService.Enabled {
-			errs = append(errs, fmt.Errorf(
-				"%s.failover: interPod failover requires gpuMemoryService.enabled=true and gpuMemoryService.mode=%q",
-				v.fieldPath, nvidiacomv1alpha1.GMSModeInterPod))
-		} else if v.spec.GPUMemoryService.Mode != nvidiacomv1alpha1.GMSModeInterPod {
-			// An unset gpuMemoryService.mode defaults to the intra-pod sidecar
-			// layout, which is incompatible with inter-pod failover; the user
-			// must set gpuMemoryService.mode=interPod explicitly.
-			detected := string(v.spec.GPUMemoryService.Mode)
-			if detected == "" {
-				detected = unsetValue
-			}
-			errs = append(errs, fmt.Errorf(
-				"%s.failover: interPod failover requires gpuMemoryService.mode=%q (got %q)",
-				v.fieldPath, nvidiacomv1alpha1.GMSModeInterPod, detected))
-		}
-
-		if v.spec.Failover.NumShadows < 1 {
-			errs = append(errs, fmt.Errorf("%s.failover.numShadows must be >= 1", v.fieldPath))
-		}
-
-		gpuCount, err := parseGPUCount(v.spec.Resources)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("%s.resources.limits.gpu: %w", v.fieldPath, err))
-		} else if gpuCount < 1 {
-			errs = append(errs, fmt.Errorf("%s: GMS failover requires at least 1 GPU in resources.limits.gpu", v.fieldPath))
-		}
-
-		switch v.spec.ComponentType {
-		case consts.ComponentTypeEPP, consts.ComponentTypeFrontend, consts.ComponentTypePlanner:
-			errs = append(errs, fmt.Errorf("%s: GMS failover is not supported for componentType %q", v.fieldPath, v.spec.ComponentType))
-		}
-	}
-
-	return errors.Join(errs...)
-}
-
-func (v *SharedSpecValidatorV1Alpha1) validateSnapshotWithGPUMemoryService() error {
-	return checkpoint.ValidateGMSSnapshotGate(
-		fmt.Sprintf("%s.checkpoint", v.fieldPath),
-		v.spec.Checkpoint != nil && v.spec.Checkpoint.Enabled,
-		v.spec.GPUMemoryService)
-}
-
-// validateIngress validates the ingress configuration.
-func (v *SharedSpecValidatorV1Alpha1) validateIngress() error {
-	if v.spec.Ingress.Host == "" {
-		return fmt.Errorf("%s.ingress.host is required when ingress is enabled", v.fieldPath)
-	}
-	return nil
-}
-
-// validateVolumeMounts validates the volume mount configurations.
-func (v *SharedSpecValidatorV1Alpha1) validateVolumeMounts() error {
-	for i, volumeMount := range v.spec.VolumeMounts {
-		if err := v.validateVolumeMount(i, &volumeMount); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// validateVolumeMount validates a single volume mount configuration.
-func (v *SharedSpecValidatorV1Alpha1) validateVolumeMount(index int, volumeMount *nvidiacomv1alpha1.VolumeMount) error {
-	// If useAsCompilationCache is false, mountPoint is required
-	if !volumeMount.UseAsCompilationCache && volumeMount.MountPoint == "" {
-		return fmt.Errorf("%s.volumeMounts[%d].mountPoint is required when useAsCompilationCache is false", v.fieldPath, index)
-	}
-	return nil
-}
-
-// validateFrontendSidecar checks that extraPodSpec.containers does not already
-// contain a container whose name collides with the auto-generated frontend sidecar.
-func (v *SharedSpecValidatorV1Alpha1) validateFrontendSidecar() error {
-	if v.spec.FrontendSidecar == nil {
-		return nil
-	}
-	if v.spec.ExtraPodSpec == nil || v.spec.ExtraPodSpec.PodSpec == nil {
-		return nil
-	}
-	for _, c := range v.spec.ExtraPodSpec.PodSpec.Containers {
-		if c.Name == consts.FrontendSidecarContainerName {
-			return fmt.Errorf(
-				"%s: cannot inject frontend sidecar: a container named %q already exists in extraPodSpec.containers",
-				v.fieldPath, consts.FrontendSidecarContainerName)
-		}
-	}
-	return nil
-}
 
 // validateDynamoComponentDeploymentSharedSpecV1alpha1 validates spec. spec and fldPath must not be nil.
 func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
@@ -498,6 +32,14 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 	dynamoNamespace string,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
+	if value, invalid := invalidVLLMDistributedExecutorBackendAnnotation(spec.Annotations); invalid {
+		allErrs = append(allErrs, field.Invalid(
+			fldPath.Child("annotations").Key(consts.KubeAnnotationVLLMDistributedExecutorBackend),
+			value,
+			`must be "mp" or "ray"`,
+		))
+	}
+
 	if spec.DynamoNamespace != nil && *spec.DynamoNamespace != "" {
 		v.warnf(
 			"%s.dynamoNamespace is deprecated and ignored. Value %q will be replaced with %q. Remove this field from your configuration",
@@ -512,14 +54,6 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecV1alpha1(
 			"%s.autoscaling is deprecated and ignored. Use DynamoGraphDeploymentScalingAdapter with HPA, KEDA, or Planner for autoscaling instead. See docs/kubernetes/autoscaling.md",
 			fldPath,
 		)
-	}
-
-	if value, invalid := invalidVLLMDistributedExecutorBackendAnnotation(spec.Annotations); invalid {
-		allErrs = append(allErrs, field.Invalid(
-			fldPath.Child("annotations").Key(consts.KubeAnnotationVLLMDistributedExecutorBackend),
-			value,
-			`must be "mp" or "ray"`,
-		))
 	}
 
 	volumeMountsPath := fldPath.Child("volumeMounts")
@@ -550,14 +84,13 @@ func (v *sharedValidation) validateVolumeMountV1alpha1(
 	volumeMount *nvidiacomv1alpha1.VolumeMount,
 	fldPath *field.Path,
 ) field.ErrorList {
-	allErrs := field.ErrorList{}
-	if !volumeMount.UseAsCompilationCache && volumeMount.MountPoint == "" {
-		allErrs = append(allErrs, field.Required(
-			fldPath.Child("mountPoint"),
-			"is required when useAsCompilationCache is false",
-		))
+	if volumeMount.UseAsCompilationCache || volumeMount.MountPoint != "" {
+		return nil
 	}
-	return allErrs
+	return field.ErrorList{field.Required(
+		fldPath.Child("mountPoint"),
+		"is required when useAsCompilationCache is false",
+	)}
 }
 
 // validateIngressSpecV1alpha1 validates ingress. ingress and fldPath must not be nil.
@@ -576,17 +109,14 @@ func (v *sharedValidation) validateEPPConfigV1alpha1(
 	config *nvidiacomv1alpha1.EPPConfig,
 	fldPath *field.Path,
 ) field.ErrorList {
-	if (config.ConfigMapRef == nil) == (config.Config == nil) {
-		return field.ErrorList{field.Invalid(
-			fldPath,
-			nil,
-			"exactly one of configMapRef or config is required",
-		)}
-	}
-	if config.ConfigMapRef == nil || config.ConfigMapRef.Name != "" {
+	if (config.ConfigMapRef == nil) != (config.Config == nil) {
 		return nil
 	}
-	return field.ErrorList{field.Required(fldPath.Child("configMapRef", "name"), "is required")}
+	return field.ErrorList{field.Invalid(
+		fldPath,
+		nil,
+		"exactly one of configMapRef or config is required",
+	)}
 }
 
 // validateFailoverSpecV1alpha1 validates failover. failover and fldPath must not be nil.
@@ -594,10 +124,8 @@ func (v *sharedValidation) validateFailoverSpecV1alpha1(
 	failover *nvidiacomv1alpha1.FailoverSpec,
 	fldPath *field.Path,
 ) field.ErrorList {
-	if !failover.Enabled || failover.Mode != nvidiacomv1alpha1.GMSModeIntraPod {
-		return nil
-	}
-	if failover.NumShadows == 0 || failover.NumShadows == 1 {
+	if !failover.Enabled || failover.Mode != nvidiacomv1alpha1.GMSModeIntraPod ||
+		failover.NumShadows == 0 || failover.NumShadows == 1 {
 		return nil
 	}
 	return field.ErrorList{field.Invalid(
@@ -605,17 +133,4 @@ func (v *sharedValidation) validateFailoverSpecV1alpha1(
 		failover.NumShadows,
 		fmt.Sprintf("is invalid for mode=%q: intraPod uses a fixed 1 primary + 1 shadow sidecar; use failover.mode=%q to configure numShadows", nvidiacomv1alpha1.GMSModeIntraPod, nvidiacomv1alpha1.GMSModeInterPod),
 	)}
-}
-
-func vllmDistributedExecutorBackendAnnotationError(fieldPath string, annotations map[string]string) error {
-	value, invalid := invalidVLLMDistributedExecutorBackendAnnotation(annotations)
-	if !invalid {
-		return nil
-	}
-	if fieldPath == "" {
-		return fmt.Errorf("annotation %s has invalid value %q: must be \"mp\" or \"ray\"",
-			consts.KubeAnnotationVLLMDistributedExecutorBackend, value)
-	}
-	return fmt.Errorf("%s[%s] has invalid value %q: must be \"mp\" or \"ray\"",
-		fieldPath, consts.KubeAnnotationVLLMDistributedExecutorBackend, value)
 }

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -440,7 +440,7 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("failover", "numShadows"),
 			newFailover.NumShadows,
-			"is immutable for inter-pod GMS failover; delete and recreate the DynamoGraphDeployment to change it",
+			fmt.Sprintf("is immutable for inter-pod GMS failover; delete and recreate the %s to change it", ownerKind.Kind),
 		))
 	}
 	return allErrs

--- a/deploy/operator/internal/webhook/validation/shared_v1beta1.go
+++ b/deploy/operator/internal/webhook/validation/shared_v1beta1.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dra"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/dynamo"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	k8sptr "k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -50,10 +51,12 @@ func (v *sharedValidation) warnf(format string, args ...any) {
 }
 
 // validateDynamoComponentDeploymentSharedSpec validates spec. spec and fldPath must not be nil.
+// grovePathway and validateInferencePoolAvailability are supplied by the owning resource.
 func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpec(
 	spec *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
 	grovePathway bool,
+	validateInferencePoolAvailability bool,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 
@@ -72,8 +75,10 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpec(
 	}
 
 	if spec.ComponentType == nvidiacomv1beta1.ComponentTypeEPP {
-		if err := inferencePoolAvailabilityError(v.ctx, v.mgr); err != nil {
-			allErrs = append(allErrs, field.Forbidden(fldPath.Child("type"), fmt.Sprintf("cannot deploy EPP component: %v", err)))
+		if validateInferencePoolAvailability {
+			if err := inferencePoolAvailabilityError(v.ctx, v.mgr); err != nil {
+				allErrs = append(allErrs, field.Forbidden(fldPath.Child("type"), fmt.Sprintf("cannot deploy EPP component: %v", err)))
+			}
 		}
 		if spec.IsMultinode() {
 			allErrs = append(allErrs, field.Forbidden(fldPath.Child("multinode"), "EPP component cannot be multinode"))
@@ -315,12 +320,13 @@ func (v *sharedValidation) validateComponentCheckpointJobConfig(
 }
 
 // validateDynamoComponentDeploymentSharedSpecUpdate validates a component update.
-// newComponent, oldComponent, and fldPath must not be nil.
+// newComponent, oldComponent, and fldPath must not be nil; ownerKind.Kind must not be empty.
 func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 	newComponent *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	oldComponent *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec,
 	fldPath *field.Path,
 	canModifyReplicas bool,
+	ownerKind schema.GroupKind,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 	if (newComponent.ScalingAdapter != nil || oldComponent.ScalingAdapter != nil) && !canModifyReplicas &&
@@ -345,12 +351,13 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			newComponent.TopologyConstraint,
 			oldComponent.TopologyConstraint,
 			topologyPath,
+			ownerKind,
 		)...)
 	} else if oldComponent.TopologyConstraint != nil {
 		allErrs = append(allErrs, field.Invalid(
 			topologyPath,
 			newComponent.TopologyConstraint,
-			"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints",
+			fmt.Sprintf("is immutable and cannot be added, removed, or changed after creation; delete and recreate the %s to change topology constraints", ownerKind.Kind),
 		))
 	}
 
@@ -359,6 +366,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			newComponent.Experimental,
 			oldComponent.Experimental,
 			fldPath.Child("experimental"),
+			ownerKind,
 		)...)
 	} else if oldComponent.Experimental != nil {
 		oldGMS := gpuMemoryServiceForExperimental(oldComponent.Experimental)
@@ -366,7 +374,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			allErrs = append(allErrs, field.Invalid(
 				fldPath.Child("experimental", "gpuMemoryService", "mode"),
 				nil,
-				"the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+				fmt.Sprintf("the inter-pod GMS layout cannot be toggled after creation; delete and recreate the %s", ownerKind.Kind),
 			))
 		}
 		oldFailover := failoverForExperimental(oldComponent.Experimental)
@@ -374,7 +382,7 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 			allErrs = append(allErrs, field.Invalid(
 				fldPath.Child("experimental", "failover"),
 				nil,
-				"inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+				fmt.Sprintf("inter-pod GMS failover cannot be toggled after creation; delete and recreate the %s", ownerKind.Kind),
 			))
 		}
 	}
@@ -382,11 +390,12 @@ func (v *sharedValidation) validateDynamoComponentDeploymentSharedSpecUpdate(
 }
 
 // validateTopologyConstraintUpdate validates a topology constraint update.
-// newConstraint and fldPath must not be nil; oldConstraint may be nil for an addition.
+// newConstraint and fldPath must not be nil; oldConstraint may be nil for an addition and ownerKind.Kind must not be empty.
 func (v *sharedValidation) validateTopologyConstraintUpdate(
 	newConstraint *nvidiacomv1beta1.TopologyConstraint,
 	oldConstraint *nvidiacomv1beta1.TopologyConstraint,
 	fldPath *field.Path,
+	ownerKind schema.GroupKind,
 ) field.ErrorList {
 	if oldConstraint != nil && newConstraint.PackDomain == oldConstraint.PackDomain {
 		return nil
@@ -394,16 +403,17 @@ func (v *sharedValidation) validateTopologyConstraintUpdate(
 	return field.ErrorList{field.Invalid(
 		fldPath,
 		newConstraint,
-		"is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change topology constraints",
+		fmt.Sprintf("is immutable and cannot be added, removed, or changed after creation; delete and recreate the %s to change topology constraints", ownerKind.Kind),
 	)}
 }
 
 // validateExperimentalSpecUpdate validates an experimental spec update.
-// newExperimental and fldPath must not be nil; oldExperimental may be nil for an addition.
+// newExperimental and fldPath must not be nil; oldExperimental may be nil for an addition and ownerKind.Kind must not be empty.
 func (v *sharedValidation) validateExperimentalSpecUpdate(
 	newExperimental *nvidiacomv1beta1.ExperimentalSpec,
 	oldExperimental *nvidiacomv1beta1.ExperimentalSpec,
 	fldPath *field.Path,
+	ownerKind schema.GroupKind,
 ) field.ErrorList {
 	allErrs := field.ErrorList{}
 	newGMS := newExperimental.GPUMemoryService
@@ -412,7 +422,7 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("gpuMemoryService", "mode"),
 			k8sptr.Deref(newGMS, nvidiacomv1beta1.GPUMemoryServiceSpec{}).Mode,
-			"the inter-pod GMS layout cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+			fmt.Sprintf("the inter-pod GMS layout cannot be toggled after creation; delete and recreate the %s", ownerKind.Kind),
 		))
 	}
 
@@ -422,7 +432,7 @@ func (v *sharedValidation) validateExperimentalSpecUpdate(
 		allErrs = append(allErrs, field.Invalid(
 			fldPath.Child("failover"),
 			newFailover,
-			"inter-pod GMS failover cannot be toggled after creation; delete and recreate the DynamoGraphDeployment",
+			fmt.Sprintf("inter-pod GMS failover cannot be toggled after creation; delete and recreate the %s", ownerKind.Kind),
 		))
 	}
 	if isInterPodFailover(newFailover) && isInterPodFailover(oldFailover) &&


### PR DESCRIPTION
## Overview:

Refactor DynamoComponentDeployment validation to follow the v1beta1 Go API structure while preserving the effective validation contract for served v1alpha1 requests.

## Details:

- make v1beta1 the primary DynamoComponentDeployment validation type and recurse structurally through its Go API types
- retain sparse v1alpha1 compatibility validation through the real conversion methods and fail hard on conversion errors
- reuse shared component create and update validators from both DCD and DGD while preserving standalone replica-update behavior
- register both validating webhook endpoints in the binary, while keeping the Helm registration on v1alpha1 for the staged migration
- aggregate independent create and update failures and retain typed Kubernetes field errors
- preserve every existing admission case and extend aggregation and endpoint coverage

## Where should the reviewer start?

- `deploy/operator/internal/webhook/validation/dynamocomponentdeployment.go` for the structural recursion and update aggregation
- `deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go` for the unified schema, CEL, conversion, and webhook admission chain
- `deploy/operator/internal/webhook/validation/dynamocomponentdeployment_handler.go` for the dual endpoint registration and alpha-to-beta conversion boundary

## Related Issues

- [x] Confirmed — no related GitHub issue
- Linear: DEP-1068

## Summary

DCD validation now follows the v1beta1 API tree without changing the currently active v1alpha1 Helm admission endpoint. Source-version schema gaps remain explicitly covered during alpha-to-beta admission.

## Validation

- `go test ./internal/webhook/validation -count=1 -coverprofile=/private/tmp/dcd-structural-final.cover` (81.3%; baseline 81.1%)
- `GOCACHE=/private/tmp/dynamo-go-cache go test ./api/... -count=1`
- `GOCACHE=/private/tmp/dynamo-go-cache go test ./api -run TestFuzzRoundTrip -roundtrip-fuzz-iters=3000 -count=1 -v`
- `go test ./internal/webhook/... -count=1`
- `go test ./cmd/... -count=1`
- `go vet ./internal/webhook/validation`
- `bin/golangci-lint-v1.64.8 run ./internal/webhook/validation/...`
- `helm lint . --set discoveryBackend=kubernetes`
- `helm template dcd-validation . --set discoveryBackend=kubernetes --show-only templates/webhook-configuration.yaml`