### PR TITLE
perf(frontend): reduce generate request copies

### DIFF
--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -208,23 +208,30 @@ impl<'a> VllmTitoEnvelope<'a> {
 /// `extra_args.vllm_tito`. The backend remains the authority for interpreting
 /// every vLLM-specific field.
 fn preprocessed_from_generate(
-    request: &GenerateRequest,
+    request: GenerateRequest,
     model: &str,
     data_parallel_rank: Option<u32>,
     request_id: &str,
 ) -> anyhow::Result<PreprocessedRequest> {
     let sampling = &request.sampling_params;
     let max_tokens = sampling.max_tokens();
+    let min_tokens = sampling.min_tokens();
+    let ignore_eos = sampling.ignore_eos();
     let routing_priority = dynamo_routing_priority(request.priority);
-    let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(request, request_id))?;
+    let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(&request, request_id))?;
+    let GenerateRequest {
+        token_ids,
+        cache_salt,
+        ..
+    } = request;
 
     PreprocessedRequest::builder()
         .model(model.to_string())
-        .token_ids(request.token_ids.clone())
+        .token_ids(token_ids)
         .stop_conditions(StopConditions {
             max_tokens,
-            min_tokens: sampling.min_tokens(),
-            ignore_eos: Some(sampling.ignore_eos()),
+            min_tokens,
+            ignore_eos: Some(ignore_eos),
             ..Default::default()
         })
         .sampling_options(SamplingOptions {
@@ -235,7 +242,7 @@ fn preprocessed_from_generate(
         .routing(Some(crate::protocols::common::preprocessor::RoutingHints {
             dp_rank: data_parallel_rank,
             expected_output_tokens: max_tokens,
-            cache_namespace: request.cache_salt.clone(),
+            cache_namespace: cache_salt,
             // `priority_jump` is a boost-only scheduler input. Preserve penalties
             // in signed `priority`, matching the standard preprocessor projection.
             priority_jump: Some(routing_priority.max(0) as f64),
@@ -318,7 +325,7 @@ async fn handler_generate(
 
     let request_context = resolve_generate_request_context(&headers, request.request_id.as_deref());
     let preprocessed = match preprocessed_from_generate(
-        &request,
+        request,
         &model,
         request_context.data_parallel_rank,
         &request_context.request_id,
@@ -837,7 +844,7 @@ mod tests {
             serde_json::from_value(raw.clone()).expect("deserialize request");
 
         let preprocessed =
-            preprocessed_from_generate(&request, "test-model", None, "resolved-request")
+            preprocessed_from_generate(request, "test-model", None, "resolved-request")
                 .expect("build request");
         assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
         assert_eq!(preprocessed.stop_conditions.min_tokens, None);
@@ -898,7 +905,7 @@ mod tests {
         .expect("deserialize request");
 
         let preprocessed =
-            preprocessed_from_generate(&request, "test-model", None, "resolved-request")
+            preprocessed_from_generate(request, "test-model", None, "resolved-request")
                 .expect("build request");
         assert_eq!(preprocessed.stop_conditions.max_tokens, None);
         assert_eq!(preprocessed.stop_conditions.min_tokens, None);
@@ -921,7 +928,7 @@ mod tests {
         .expect("deserialize request");
 
         let preprocessed =
-            preprocessed_from_generate(&request, "test-model", None, "resolved-request")
+            preprocessed_from_generate(request, "test-model", None, "resolved-request")
                 .expect("build request");
         assert_eq!(preprocessed.stop_conditions.min_tokens, Some(0));
     }
@@ -1128,7 +1135,7 @@ mod tests {
         .expect("deserialize request");
 
         let preprocessed =
-            preprocessed_from_generate(&request, "test-model", Some(3), "resolved-request")
+            preprocessed_from_generate(request, "test-model", Some(3), "resolved-request")
                 .expect("build request");
         let routing = preprocessed.routing.as_ref().expect("routing hints");
 

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -348,6 +348,8 @@ impl GenerateChoiceAcc {
             }
         }
         if options.include_logprobs {
+            // Keep `None` until a logprob-bearing delta arrives: `into_response`
+            // distinguishes missing logprobs from an empty content array.
             let has_logprobs = if let Some(content) = self.logprobs.as_mut() {
                 append_completion_logprobs_from_output(output, content)?
             } else {
@@ -855,6 +857,113 @@ mod tests {
         assert_eq!(round.choices.len(), 1);
         assert_eq!(round.choices[0].token_ids, None);
         assert_eq!(round.choices[0].finish_reason, None);
+    }
+
+    #[test]
+    fn completion_logprobs_match_typed_wire_shape() {
+        let output = LLMEngineOutput {
+            token_ids: vec![100],
+            log_probs: Some(vec![-1.0e30]),
+            top_logprobs: Some(vec![vec![
+                crate::protocols::common::llm_backend::TopLogprob {
+                    rank: 1,
+                    token_id: 7,
+                    token: None,
+                    logprob: -1.0e30,
+                    bytes: None,
+                },
+            ]]),
+            ..Default::default()
+        };
+        let mut content = Vec::new();
+
+        assert!(
+            append_completion_logprobs_from_output(&output, &mut content)
+                .expect("build completion logprobs")
+        );
+
+        let expected = dynamo_protocols::types::ChatCompletionTokenLogprob {
+            token: "token_id:100".to_string(),
+            logprob: -9999.0,
+            bytes: Some(b"token_id:100".to_vec()),
+            top_logprobs: vec![
+                dynamo_protocols::types::TopLogprobs {
+                    token: "token_id:7".to_string(),
+                    logprob: -9999.0,
+                    bytes: Some(b"token_id:7".to_vec()),
+                },
+                dynamo_protocols::types::TopLogprobs {
+                    token: "token_id:100".to_string(),
+                    logprob: -9999.0,
+                    bytes: Some(b"token_id:100".to_vec()),
+                },
+            ],
+        };
+
+        assert_eq!(
+            content,
+            vec![serde_json::to_value(expected).expect("serialize typed logprob")]
+        );
+    }
+
+    #[test]
+    fn completion_logprobs_reject_malformed_output() {
+        let cases = [
+            (
+                LLMEngineOutput {
+                    token_ids: vec![100],
+                    top_logprobs: Some(vec![vec![]]),
+                    ..Default::default()
+                },
+                "top_logprobs without selected-token logprobs",
+            ),
+            (
+                LLMEngineOutput {
+                    token_ids: vec![100, 101],
+                    log_probs: Some(vec![-0.25]),
+                    ..Default::default()
+                },
+                "1 selected-token logprobs for 2 tokens",
+            ),
+            (
+                LLMEngineOutput {
+                    token_ids: vec![100, 101],
+                    log_probs: Some(vec![-0.25, -0.5]),
+                    top_logprobs: Some(vec![vec![]]),
+                    ..Default::default()
+                },
+                "1 top-logprob positions for 2 tokens",
+            ),
+        ];
+
+        for (output, expected_error) in cases {
+            let mut content = vec![json!("existing")];
+
+            let error = append_completion_logprobs_from_output(&output, &mut content)
+                .expect_err("malformed output must fail");
+
+            assert!(
+                error.to_string().contains(expected_error),
+                "unexpected error: {error}"
+            );
+            assert_eq!(content, vec![json!("existing")]);
+        }
+    }
+
+    #[test]
+    fn empty_completion_logprobs_do_not_modify_content() {
+        let output = LLMEngineOutput {
+            log_probs: Some(vec![]),
+            top_logprobs: Some(vec![]),
+            ..Default::default()
+        };
+        let mut content = vec![json!("existing")];
+
+        assert!(
+            !append_completion_logprobs_from_output(&output, &mut content)
+                .expect("empty output is valid")
+        );
+        assert_eq!(content, vec![json!("existing")]);
     }
 
     #[tokio::test]

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -321,7 +321,7 @@ pub(crate) struct GenerateResponseOptions {
 struct GenerateChoiceAcc {
     index: u32,
     token_ids: Vec<crate::protocols::TokenIdType>,
-    logprobs: Option<Vec<dynamo_protocols::types::ChatCompletionTokenLogprob>>,
+    logprobs: Option<Vec<Value>>,
     finish_reason: Option<String>,
     routed_experts: Option<String>,
 }
@@ -348,16 +348,21 @@ impl GenerateChoiceAcc {
             }
         }
         if options.include_logprobs {
-            match completion_logprobs_from_output(output)? {
-                Some(mut chunk_logprobs) => self
-                    .logprobs
-                    .get_or_insert_with(Vec::new)
-                    .append(&mut chunk_logprobs),
-                None if !output.token_ids.is_empty() => anyhow::bail!(
+            let has_logprobs = if let Some(content) = self.logprobs.as_mut() {
+                append_completion_logprobs_from_output(output, content)?
+            } else {
+                let mut content = Vec::new();
+                let has_logprobs = append_completion_logprobs_from_output(output, &mut content)?;
+                if has_logprobs {
+                    self.logprobs = Some(content);
+                }
+                has_logprobs
+            };
+            if !has_logprobs && !output.token_ids.is_empty() {
+                anyhow::bail!(
                     "generate choice {} requested logprobs but a token-bearing delta returned none",
                     self.index
-                ),
-                None => {}
+                );
             }
         }
         self.token_ids.extend_from_slice(&output.token_ids);
@@ -382,7 +387,9 @@ impl GenerateChoiceAcc {
                 content.len(),
                 token_ids.len()
             );
-            Some(serde_json::json!({"content": content}))
+            let mut logprobs = Map::with_capacity(1);
+            logprobs.insert("content".to_string(), Value::Array(content));
+            Some(Value::Object(logprobs))
         } else {
             None
         };
@@ -401,15 +408,16 @@ fn clamp_vllm_logprob(logprob: f32) -> f32 {
     logprob.max(-9999.0)
 }
 
-fn completion_logprobs_from_output(
+fn append_completion_logprobs_from_output(
     output: &LLMEngineOutput,
-) -> Result<Option<Vec<dynamo_protocols::types::ChatCompletionTokenLogprob>>> {
+    content: &mut Vec<Value>,
+) -> Result<bool> {
     let Some(log_probs) = output.log_probs.as_ref() else {
         anyhow::ensure!(
             output.top_logprobs.is_none(),
             "generate output returned top_logprobs without selected-token logprobs"
         );
-        return Ok(None);
+        return Ok(false);
     };
     anyhow::ensure!(
         log_probs.len() == output.token_ids.len(),
@@ -426,40 +434,48 @@ fn completion_logprobs_from_output(
         );
     }
     if output.token_ids.is_empty() {
-        return Ok(None);
+        return Ok(false);
     }
 
-    let content = output
-        .token_ids
-        .iter()
-        .zip(log_probs)
-        .enumerate()
-        .map(|(position, (token_id, logprob))| {
-            let token = format!("token_id:{token_id}");
-            let top_logprobs = output
-                .top_logprobs
-                .as_ref()
-                .map_or(&[][..], |all| all[position].as_slice());
-            let top_logprobs = top_logprobs
-                .iter()
-                .cloned()
-                .map(|mut entry| {
-                    entry.logprob = f64::from(clamp_vllm_logprob(entry.logprob as f32));
-                    entry
-                })
-                .collect::<Vec<_>>();
-            let logprob = clamp_vllm_logprob(*logprob as f32);
-            let top_logprobs =
-                convert_backend_top_logprobs(&top_logprobs, &token, *token_id, logprob, true);
-            dynamo_protocols::types::ChatCompletionTokenLogprob {
-                bytes: token_to_utf8_bytes(&token),
-                token,
-                logprob,
-                top_logprobs,
-            }
-        })
-        .collect();
-    Ok(Some(content))
+    content.reserve(output.token_ids.len());
+    for (position, (token_id, logprob)) in output.token_ids.iter().zip(log_probs).enumerate() {
+        let token = format!("token_id:{token_id}");
+        let backend_top_logprobs = output
+            .top_logprobs
+            .as_ref()
+            .map_or(&[][..], |all| all[position].as_slice());
+        let logprob = clamp_vllm_logprob(*logprob as f32);
+        let mut top_logprobs =
+            convert_backend_top_logprobs(backend_top_logprobs, &token, *token_id, logprob, true);
+        for entry in &mut top_logprobs {
+            entry.logprob = clamp_vllm_logprob(entry.logprob);
+        }
+        let bytes = bytes_value(token_to_utf8_bytes(&token));
+        let mut token_logprob = Map::with_capacity(4);
+        token_logprob.insert("token".to_string(), Value::String(token));
+        token_logprob.insert("logprob".to_string(), Value::from(logprob));
+        token_logprob.insert("bytes".to_string(), bytes);
+        token_logprob.insert(
+            "top_logprobs".to_string(),
+            Value::Array(top_logprobs.into_iter().map(top_logprob_value).collect()),
+        );
+        content.push(Value::Object(token_logprob));
+    }
+    Ok(true)
+}
+
+fn top_logprob_value(entry: dynamo_protocols::types::TopLogprobs) -> Value {
+    let mut value = Map::with_capacity(3);
+    value.insert("token".to_string(), Value::String(entry.token));
+    value.insert("logprob".to_string(), Value::from(entry.logprob));
+    value.insert("bytes".to_string(), bytes_value(entry.bytes));
+    Value::Object(value)
+}
+
+fn bytes_value(bytes: Option<Vec<u8>>) -> Value {
+    bytes.map_or(Value::Null, |bytes| {
+        Value::Array(bytes.into_iter().map(Value::from).collect())
+    })
 }
 
 fn prompt_logprobs_from_output(output: &LLMEngineOutput) -> Result<Option<PromptLogprobs>> {


### PR DESCRIPTION
## Overview:

Reduce CPU and allocation overhead in the opt-in `/inference/v1/generate` frontend path without changing its JSON contract or cancellation behavior.

## Details:

- Move the deserialized prompt-token vector and cache salt into `PreprocessedRequest` instead of cloning them.
- Build completion-logprob JSON values directly while folding worker deltas, avoiding a temporary vector per delta, clones of backend top-logprob entries, and a second typed-to-JSON serialization pass.
- Preserve request identity, forward-compatible opaque fields, cache namespace, priority/DP-rank routing, logprob clamping, transfer metadata, choice ordering, and terminal/cancellation checks.

## Where should the reviewer start?

Start with `append_completion_logprobs_from_output` in `lib/llm/src/protocols/openai/generate.rs`, then review `preprocessed_from_generate` in `lib/llm/src/http/service/generate.rs`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Performance

The primary workload drove the real unary HTTP route with an in-process synthetic Generate engine returning 256 one-token deltas. Each token had the selected token plus four alternative logprobs. The prompt contained 8 token IDs, concurrency was 1, each process warmed up with 64 requests, and then measured 1,024 requests. Nine process runs were interleaved A/B/B/A between base `cc5cf40db46a673bd0087dd1a34eda7a80000813` and candidate `f19adbfc929821b81dc42ca829b81c2554e987ca`; values are medians with observed ranges.

| Metric | Base | Candidate | Change |
|---|---:|---:|---:|
| Throughput | 357.56 req/s (345.52–359.29) | 385.38 req/s (378.04–388.56) | +27.82 req/s, +7.78% |
| Process CPU/request | 2.600 ms (2.583–2.685) | 2.410 ms (2.387–2.458) | -0.190 ms, -7.30% |
| Allocations/request | 30,640.01 | 28,589.93 | -2,050.08, -6.69% |
| Allocated bytes/request | 7,639,878 | 7,489,899 | -149,979, -1.96% |
| p50 latency | 1.742 ms | 1.504 ms | -0.238 ms, -13.64% |
| p99 latency | 2.250 ms | 1.977 ms | -0.273 ms, -12.11% |

At concurrency 32, median process CPU fell from 6.196 to 5.725 ms/request (-7.59%), but throughput was noisy and moved from 537.81 to 526.34 req/s (-2.13%). This supports CPU efficiency/headroom, not a high-concurrency throughput claim.

For a 32,768-token prompt with a one-token response, moving request ownership reduced median allocated bytes from 1,526,064 to 1,397,527 bytes/request (-128,537, -8.42%). CPU moved from 0.986 to 0.979 ms/request (-0.74%), so this supports an allocation reduction but not a material speed claim. A concurrency-256 guardrail was effectively flat (49,136.6 to 49,555.8 req/s). Peak RSS was also flat within noise (397,132 versus 399,032 KiB); the prebuilt output pool dominates that measurement.

Base `perf` attributed 37.3% of sampled core cycles to the final typed-logprob-to-`serde_json::Value` conversion in `GenerateChoiceAcc::into_response`, plus 6.3% directly to `GenerateAggregator::apply_output`. The candidate removes the former stack.

The harness preserves HTTP deserialization, validation, routing projection, request context creation, disconnect monitoring, dispatch scheduling, aggregation, response serialization, and client HTTP I/O. It replaces only worker transport/model execution with prebuilt `LLMEngineOutput` batches matching the vLLM-Rust backend shape (`token: None`, `bytes: None`). No GPU model was run, so these results do not predict model-dominated end-to-end latency. The endpoint is experimental and opt-in, and production logprob/delta distributions are unknown.

Validity: valid for the isolated frontend mechanism and tested revisions described here. Caveats: the worker/model boundary is synthetic, no GPU model was run, production logprob and delta distributions are unknown, and the concurrency-32 throughput result was noisy and did not improve.

## Benchmark methodology

### Prerequisites and environment

- Ubuntu 24.04.2, Linux 6.17.0-35-generic, glibc 2.39.
- Rust and Cargo 1.96.1; network access for public Cargo and Git dependencies.
- Install the repository system prerequisites from `docs/contribution-guide.md`. No Python package installation is required for this Rust test target.
- Intel Core Ultra 9 285K; processes pinned with `taskset -c 0-7` to eight P-cores. Intel P-state was active with the `powersave` governor.
- No NATS, etcd, model files, GPUs, or external services. The test binds an ephemeral loopback port.
- Repository release profile (`thin` LTO, one codegen unit, `x86-64-v3`, frame pointers). `--no-default-features` excludes unrelated block-manager code; the Generate path is unchanged.

Install the pinned toolchain, fetch dependencies, and create worktrees:

```bash
rustup toolchain install 1.96.1
cargo fetch --locked
git worktree add ../dynamo-generate-base cc5cf40db46a673bd0087dd1a34eda7a80000813
git worktree add ../dynamo-generate-candidate 4e01d1e65032ad51a6dbe3d6b4006b1fd4881c7a
```

The reported measurements were captured at base `cc5cf40db46a673bd0087dd1a34eda7a80000813` and tested candidate `f19adbfc929821b81dc42ca829b81c2554e987ca`. Published commit `4e01d1e65032ad51a6dbe3d6b4006b1fd4881c7a` is that candidate patch rebased without conflict onto `d64f3986282d4625bfedd2606802ba51fc19f95f`; both candidate commits have stable patch ID `42a2130c4bcdc2acde410cff637eb59cd2f7491f`.

Save the following one-off harness as `lib/llm/tests/generate_frontend_benchmark.rs` in both worktrees:

```rust
// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
// SPDX-License-Identifier: Apache-2.0
use std::alloc::{GlobalAlloc, Layout, System};
use std::sync::atomic::{AtomicU64, Ordering};
use std::sync::{Arc, Mutex};
use std::time::{Duration, Instant};
use dynamo_llm::http::service::service_v2::HttpService;
use dynamo_llm::model_card::ModelDeploymentCard;
use dynamo_llm::protocols::{Annotated, common::{FinishReason, llm_backend::{LLMEngineOutput, TopLogprob}, preprocessor::PreprocessedRequest}};
use dynamo_runtime::{CancellationToken, engine::{AsyncEngine, ResponseStream}, pipeline::{AsyncEngineContextProvider, Error, ManyOut, SingleIn}};
use futures::{StreamExt, stream};
use serde::Serialize;
use serde_json::{Value, json};
struct CountingAllocator;
static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);
unsafe impl GlobalAlloc for CountingAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 { ALLOCATIONS.fetch_add(1, Ordering::Relaxed); ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed); unsafe { System.alloc(layout) } }
    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 { ALLOCATIONS.fetch_add(1, Ordering::Relaxed); ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed); unsafe { System.alloc_zeroed(layout) } }
    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) { unsafe { System.dealloc(ptr, layout) } }
    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, size: usize) -> *mut u8 { ALLOCATIONS.fetch_add(1, Ordering::Relaxed); ALLOCATED_BYTES.fetch_add(size as u64, Ordering::Relaxed); unsafe { System.realloc(ptr, layout, size) } }
}
#[global_allocator] static GLOBAL: CountingAllocator = CountingAllocator;
#[derive(Clone, Copy)]
struct Case { prompt: usize, output: usize, deltas: usize, top_k: usize, opaque: usize, concurrency: usize, warmup: usize, measured: usize }
fn env(name: &str, default: usize) -> usize { std::env::var(name).ok().map(|v| v.parse().unwrap()).unwrap_or(default) }
impl Case { fn load() -> Self { Self { prompt: env("PERF_PROMPT_TOKENS",8), output: env("PERF_OUTPUT_TOKENS",1), deltas: env("PERF_DELTAS",1), top_k: env("PERF_TOP_K",0), opaque: env("PERF_OPAQUE_BYTES",0), concurrency: env("PERF_CONCURRENCY",1), warmup: env("PERF_WARMUP_REQUESTS",128), measured: env("PERF_MEASURED_REQUESTS",512) } } }
struct PoolEngine { batches: Mutex<Vec<Vec<Annotated<LLMEngineOutput>>>> }
#[async_trait::async_trait]
impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error> for PoolEngine {
    async fn generate(&self, request: SingleIn<PreprocessedRequest>) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
        let batch = self.batches.lock().unwrap().pop().unwrap();
        Ok(ResponseStream::new(Box::pin(stream::iter(batch)), request.context()))
    }
}
fn batch(c: Case) -> Vec<Annotated<LLMEngineOutput>> {
    assert!(c.output > 0 && c.deltas > 0 && c.deltas <= c.output);
    let base = c.output / c.deltas; let rem = c.output % c.deltas; let mut next = 10_000u32;
    (0..c.deltas).map(|i| { let n = base + usize::from(i < rem); let ids: Vec<u32> = (next..next+n as u32).collect(); next += n as u32;
        let (lp, top) = if c.top_k == 0 {(None,None)} else {(Some(vec![-0.25;n]), Some(ids.iter().map(|&id| (0..c.top_k).map(|r| TopLogprob { rank:r as u32, token_id:id+r as u32, token:None, logprob:-0.25-r as f64, bytes:None }).collect()).collect()))};
        Annotated::from_data(LLMEngineOutput { token_ids:ids, log_probs:lp, top_logprobs:top, index:Some(0), finish_reason:(i+1==c.deltas).then_some(FinishReason::Length), ..Default::default() }) }).collect()
}
fn body(c: Case) -> Value { let mut sampling=serde_json::Map::new(); sampling.insert("max_tokens".into(),json!(c.output)); if c.top_k>0 { sampling.insert("logprobs".into(),json!(c.top_k-1)); } json!({"request_id":"benchmark-request","model":"benchmark-model","token_ids":(0..c.prompt as u32).collect::<Vec<_>>(),"sampling_params":sampling,"future_opaque_field":"x".repeat(c.opaque)}) }
async fn request(client:&reqwest::Client,url:&str,body:&Value,c:Case)->(u64,usize){ let start=Instant::now(); let r=client.post(url).json(body).send().await.unwrap(); assert!(r.status().is_success()); let bytes=r.bytes().await.unwrap(); let ns=start.elapsed().as_nanos() as u64; let v:Value=serde_json::from_slice(&bytes).unwrap(); assert_eq!(v["choices"][0]["token_ids"].as_array().unwrap().len(),c.output); assert_eq!(v["choices"][0]["finish_reason"],"length"); if c.top_k>0 {assert_eq!(v["choices"][0]["logprobs"]["content"].as_array().unwrap().len(),c.output);} (ns,bytes.len()) }
async fn run(client:&reqwest::Client,url:&str,body:&Value,c:Case,n:usize)->Vec<(u64,usize)>{stream::iter(0..n).map(|_|request(client,url,body,c)).buffer_unordered(c.concurrency).collect().await}
#[repr(C)] struct Timespec{tv_sec:i64,tv_nsec:i64}
unsafe extern "C" {fn clock_gettime(id:i32,tp:*mut Timespec)->i32;}
fn cpu_ns()->u64{let mut t=Timespec{tv_sec:0,tv_nsec:0};assert_eq!(unsafe{clock_gettime(2,&mut t)},0);t.tv_sec as u64*1_000_000_000+t.tv_nsec as u64}
fn pct(v:&[u64],p:f64)->u64{v[((v.len()-1)as f64*p).round()as usize]}
#[derive(Serialize)] struct Measurement{revision:String,prompt_tokens:usize,output_tokens:usize,deltas:usize,top_k:usize,opaque_bytes:usize,concurrency:usize,warmup_requests:usize,measured_requests:usize,wall_time_ns:u64,process_cpu_time_ns:u64,requests_per_second:f64,cpu_time_ns_per_request:f64,allocations_per_request:f64,allocated_bytes_per_request:f64,latency_p50_ns:u64,latency_p95_ns:u64,latency_p99_ns:u64,response_bytes:usize}
#[tokio::test(flavor="multi_thread",worker_threads=8)]
async fn generate_frontend_benchmark(){let c=Case::load();let batches=(0..c.warmup+c.measured).map(|_|batch(c)).collect();let engine=Arc::new(PoolEngine{batches:Mutex::new(batches)});let listener=tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();let port=listener.local_addr().unwrap().port();let service=HttpService::builder().port(port).host("127.0.0.1").enable_chat_endpoints(false).enable_cmpl_endpoints(false).enable_embeddings_endpoints(false).enable_responses_endpoints(false).enable_engine_apis(true).build().unwrap();let card=ModelDeploymentCard::with_name_only("benchmark-model");service.model_manager().add_generate_model("benchmark-model",card.mdcsum(),engine).unwrap();let cancel=CancellationToken::new();let server=service.spawn_with_listener(cancel.clone(),listener).await;let client=reqwest::Client::builder().no_proxy().pool_max_idle_per_host(c.concurrency).build().unwrap();tokio::time::sleep(Duration::from_millis(20)).await;let url=format!("http://127.0.0.1:{port}/inference/v1/generate");let b=body(c);assert_eq!(run(&client,&url,&b,c,c.warmup).await.len(),c.warmup);ALLOCATIONS.store(0,Ordering::SeqCst);ALLOCATED_BYTES.store(0,Ordering::SeqCst);let cpu=cpu_ns();let wall=Instant::now();let out=run(&client,&url,&b,c,c.measured).await;let wall_ns=wall.elapsed().as_nanos()as u64;let cpu_ns=cpu_ns()-cpu;let mut lat:Vec<u64>=out.iter().map(|x|x.0).collect();lat.sort_unstable();let n=c.measured as f64;let m=Measurement{revision:std::env::var("PERF_REVISION").unwrap_or_default(),prompt_tokens:c.prompt,output_tokens:c.output,deltas:c.deltas,top_k:c.top_k,opaque_bytes:c.opaque,concurrency:c.concurrency,warmup_requests:c.warmup,measured_requests:c.measured,wall_time_ns:wall_ns,process_cpu_time_ns:cpu_ns,requests_per_second:n*1e9/wall_ns as f64,cpu_time_ns_per_request:cpu_ns as f64/n,allocations_per_request:ALLOCATIONS.load(Ordering::SeqCst)as f64/n,allocated_bytes_per_request:ALLOCATED_BYTES.load(Ordering::SeqCst)as f64/n,latency_p50_ns:pct(&lat,.50),latency_p95_ns:pct(&lat,.95),latency_p99_ns:pct(&lat,.99),response_bytes:out.iter().map(|x|x.1).sum()};println!("PERF_RESULT {}",serde_json::to_string(&m).unwrap());cancel.cancel();server.await.unwrap().unwrap();}
```

Build each arm before measuring:

```bash
cd ../dynamo-generate-base
CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --test generate_frontend_benchmark --no-run
BASE_BIN=$(find "$PWD/target/release/deps" -maxdepth 1 -type f -name 'generate_frontend_benchmark-*' -perm -111 | head -1)
cd ../dynamo-generate-candidate
CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --test generate_frontend_benchmark --no-run
CANDIDATE_BIN=$(find "$PWD/target/release/deps" -maxdepth 1 -type f -name 'generate_frontend_benchmark-*' -perm -111 | head -1)
```

Run nine times per revision, alternating A/B/B/A:

```bash
taskset -c 0-7 env PERF_REVISION=cc5cf40db46a673bd0087dd1a34eda7a80000813 PERF_PROMPT_TOKENS=8 PERF_OUTPUT_TOKENS=256 PERF_DELTAS=256 PERF_TOP_K=5 PERF_OPAQUE_BYTES=0 PERF_CONCURRENCY=1 PERF_WARMUP_REQUESTS=64 PERF_MEASURED_REQUESTS=1024 "$BASE_BIN" --exact generate_frontend_benchmark --nocapture
taskset -c 0-7 env PERF_REVISION=4e01d1e65032ad51a6dbe3d6b4006b1fd4881c7a PERF_PROMPT_TOKENS=8 PERF_OUTPUT_TOKENS=256 PERF_DELTAS=256 PERF_TOP_K=5 PERF_OPAQUE_BYTES=0 PERF_CONCURRENCY=1 PERF_WARMUP_REQUESTS=64 PERF_MEASURED_REQUESTS=1024 "$CANDIDATE_BIN" --exact generate_frontend_benchmark --nocapture
```

Expected output is one `PERF_RESULT` JSON object. The harness checks HTTP success, token/logprob counts, and terminal finish reason. Use the median of nine process-level values. Throughput change is `(candidate/base-1)*100`; reductions use `(1-candidate/base)*100`.

Other arms change only these variables:

```bash
# Concurrency 32
PERF_CONCURRENCY=32 PERF_WARMUP_REQUESTS=128 PERF_MEASURED_REQUESTS=1024
# 32K prompt
PERF_PROMPT_TOKENS=32768 PERF_OUTPUT_TOKENS=1 PERF_DELTAS=1 PERF_TOP_K=0 PERF_CONCURRENCY=1 PERF_WARMUP_REQUESTS=128 PERF_MEASURED_REQUESTS=2048
# High-concurrency guardrail
PERF_PROMPT_TOKENS=8 PERF_OUTPUT_TOKENS=1 PERF_DELTAS=1 PERF_TOP_K=0 PERF_CONCURRENCY=256 PERF_WARMUP_REQUESTS=256 PERF_MEASURED_REQUESTS=8192
```

Profile with:

```bash
perf record -F 999 --call-graph dwarf -o perf.data -- taskset -c 0-7 env PERF_PROMPT_TOKENS=8 PERF_OUTPUT_TOKENS=256 PERF_DELTAS=256 PERF_TOP_K=5 PERF_CONCURRENCY=32 PERF_WARMUP_REQUESTS=128 PERF_MEASURED_REQUESTS=1024 "$BASE_BIN" --exact generate_frontend_benchmark --nocapture
perf report -i perf.data --stdio --no-children --sort symbol
```

Correctness validation:

```bash
CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --lib protocols::openai::generate::tests -- --test-threads=1
CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --lib http::service::generate::tests -- --test-threads=1
CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --lib http::service::disconnect::tests -- --test-threads=1
```

The candidate passed 23 protocol, 19 Generate HTTP/dispatch, and 8 disconnect/cancellation tests.

## Validation

Published commit `4e01d1e65032ad51a6dbe3d6b4006b1fd4881c7a` passed:

- `cargo fmt --all -- --check`
- `CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --lib protocols::openai::generate::tests -- --test-threads=1` (23 passed)
- `CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --lib http::service::generate::tests -- --test-threads=1` (19 passed)
- `CARGO_INCREMENTAL=0 cargo test -p dynamo-llm --no-default-features --release --lib http::service::disconnect::tests -- --test-threads=1` (8 passed)

<!-- perf-agent-investigation:fb77a01f-60f6-485e-9e19-37ea63aa38bc -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved completion logprob output in responses, making streamed and non-streamed results more consistent.
  * Preserved the expected behavior when logprobs are requested but no token-level data is available.
  * Updated request preprocessing to reduce unnecessary copying, improving efficiency during request handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->