### PR TITLE
perf(router): avoid rebuilding blocked lane index

### DIFF
--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -195,6 +195,7 @@ struct PolicyClassQueue<T> {
     ready_by_worker: FxHashMap<WorkerWithDpRank, BinaryHeap<PolicyQueueEntry<T>>>,
     blocked_workers: FxHashSet<WorkerWithDpRank>,
     candidate_worker_heads: BTreeSet<WorkerLaneHead>,
+    needs_blocked_worker_recheck: bool,
 }
 
 impl<T> PolicyClassQueue<T> {
@@ -260,6 +261,29 @@ impl<T> PolicyClassQueue<T> {
         class_index: usize,
         is_dispatchable: &mut impl FnMut(usize, &PolicyClassConfig, &T) -> bool,
     ) -> Option<DispatchCandidate> {
+        if self.needs_blocked_worker_recheck {
+            self.needs_blocked_worker_recheck = false;
+            let Self {
+                config,
+                ready_by_worker,
+                blocked_workers,
+                candidate_worker_heads,
+                ..
+            } = self;
+            blocked_workers.retain(|worker| {
+                let ready = ready_by_worker
+                    .get(worker)
+                    .expect("blocked worker lane vanished");
+                let head = ready.peek().expect("blocked worker lane is empty");
+                if is_dispatchable(class_index, config, head.payload()) {
+                    candidate_worker_heads.insert(WorkerLaneHead::new(*worker, head));
+                    false
+                } else {
+                    true
+                }
+            });
+        }
+
         let shared = self
             .pending
             .peek()
@@ -364,21 +388,7 @@ impl<T> PolicyClassQueue<T> {
     }
 
     fn recheck_all_workers(&mut self) {
-        let Self {
-            ready_by_worker,
-            blocked_workers,
-            candidate_worker_heads,
-            ..
-        } = self;
-        for worker in blocked_workers.drain() {
-            let ready = ready_by_worker
-                .get(&worker)
-                .expect("blocked worker lane vanished");
-            candidate_worker_heads.insert(WorkerLaneHead::new(
-                worker,
-                ready.peek().expect("blocked worker lane is empty"),
-            ));
-        }
+        self.needs_blocked_worker_recheck = true;
     }
 
     fn rebuild_worker_heads(&mut self) {
@@ -419,6 +429,7 @@ impl<T> PolicyQueue<T> {
                     ready_by_worker: FxHashMap::default(),
                     blocked_workers: FxHashSet::default(),
                     candidate_worker_heads: BTreeSet::new(),
+                    needs_blocked_worker_recheck: false,
                     stats: PolicyQueueStats::default(),
                     deficit: 0,
                 })
@@ -1009,6 +1020,46 @@ policy_classes:
         assert_eq!(popped, LANES / 2);
         assert_eq!(checks, LANES);
         assert_eq!(queue.pending_count(), LANES / 2);
+    }
+
+    #[test]
+    fn global_recheck_dispatches_workers_as_they_become_available() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        for lane in 0..3 {
+            queue
+                .enqueue(
+                    0,
+                    3,
+                    QueueSnapshot::new(1, 0),
+                    lane as f64,
+                    0.0,
+                    0,
+                    WorkerPlacement::Exact(WorkerWithDpRank::new(lane, 0)),
+                    lane,
+                )
+                .unwrap();
+        }
+
+        assert!(queue.pop_next(|_, _, _| false).is_none());
+
+        let mut available = [false, true, false];
+        queue.recheck_all_workers();
+        let entry = queue
+            .pop_next(|_, _, lane| available[*lane as usize])
+            .expect("newly available worker should dispatch");
+        assert_eq!(entry.into_payload(), 1);
+        assert!(
+            queue
+                .pop_next(|_, _, lane| available[*lane as usize])
+                .is_none()
+        );
+
+        available[2] = true;
+        queue.recheck_all_workers();
+        let entry = queue
+            .pop_next(|_, _, lane| available[*lane as usize])
+            .expect("later worker availability should dispatch on the next recheck");
+        assert_eq!(entry.into_payload(), 2);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -242,6 +242,10 @@ impl<T> PolicyClassQueue<T> {
         is_dispatchable: &mut impl FnMut(usize, &PolicyClassConfig, &T) -> bool,
     ) -> Option<DispatchCandidate> {
         if self.ready_by_worker.is_empty() {
+            debug_assert!(
+                self.blocked_workers.is_empty(),
+                "blocked workers must have a ready lane"
+            );
             return self
                 .pending
                 .peek()
@@ -263,6 +267,8 @@ impl<T> PolicyClassQueue<T> {
     ) -> Option<DispatchCandidate> {
         if self.needs_blocked_worker_recheck {
             self.needs_blocked_worker_recheck = false;
+            // Defer the scan until dispatch, when `is_dispatchable` is meaningful.
+            // Re-peeking here also observes head changes from intervening `push_ready` calls.
             let Self {
                 config,
                 ready_by_worker,
@@ -541,6 +547,8 @@ impl<T> PolicyQueue<T> {
 
     /// Runs one DRR ring pass over dispatchable class heads. If no head has
     /// enough credit, bulk-adds the minimum complete rounds needed for progress.
+    /// `is_dispatchable` may be evaluated more than once for the same entry
+    /// during one call; callers must not rely on an exact invocation count.
     pub fn pop_next(
         &mut self,
         mut is_dispatchable: impl FnMut(usize, &PolicyClassConfig, &T) -> bool,
@@ -1060,6 +1068,68 @@ policy_classes:
             .pop_next(|_, _, lane| available[*lane as usize])
             .expect("later worker availability should dispatch on the next recheck");
         assert_eq!(entry.into_payload(), 2);
+        assert_eq!(queue.pending_count(), 1);
+    }
+
+    #[test]
+    fn global_recheck_preserves_priority_for_multiple_available_workers() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        for (worker, strict_priority, payload) in [(1, 0, "low"), (2, 1, "high")] {
+            queue
+                .enqueue(
+                    0,
+                    2,
+                    QueueSnapshot::new(1, 0),
+                    0.0,
+                    0.0,
+                    strict_priority,
+                    WorkerPlacement::Exact(WorkerWithDpRank::new(worker, 0)),
+                    payload,
+                )
+                .unwrap();
+        }
+
+        assert!(queue.pop_next(|_, _, _| false).is_none());
+
+        queue.recheck_all_workers();
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "high"
+        );
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "low"
+        );
+    }
+
+    #[test]
+    fn pending_global_recheck_survives_retain_removing_blocked_lane() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        for (worker, payload) in [(1, "remove"), (2, "keep")] {
+            queue
+                .enqueue(
+                    0,
+                    2,
+                    QueueSnapshot::new(1, 0),
+                    0.0,
+                    0.0,
+                    0,
+                    WorkerPlacement::Exact(WorkerWithDpRank::new(worker, 0)),
+                    payload,
+                )
+                .unwrap();
+        }
+
+        assert!(queue.pop_next(|_, _, _| false).is_none());
+        queue.recheck_all_workers();
+        queue.retain(|payload| *payload == "keep");
+
+        assert_eq!(queue.pending_count(), 1);
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "keep"
+        );
+        assert_eq!(queue.pending_count(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Avoid rebuilding the ordered exact-worker lane index when a global queue update finds that blocked workers are still blocked. The queue now defers the full recheck until dispatch, scans the blocked set once, and inserts only lane heads that are actually dispatchable. Targeted worker rechecks and ordinary dispatch remain unchanged.

## Overview:

The exact-worker lane index prevents one busy pinned worker from blocking work for every other worker. A periodic or remote-state full recheck previously drained every blocked lane into the `BTreeSet`, after which `next_dispatchable_worker` removed those same entries again when the workers remained busy. At 10,000 fully blocked lanes this produced a millisecond-scale scheduler-actor stall.

This follow-up keeps blocked lanes out of the ordered candidate index until the dispatchability predicate confirms that they can run. It also adds a behavior test covering workers that become available across successive global rechecks.

## Details:

- Record a pending full recheck with a per-policy-class boolean.
- Evaluate blocked lane heads directly from the `FxHashSet` on the next dispatch attempt.
- Insert only newly dispatchable heads into the `BTreeSet`; leave the others blocked.
- Preserve worker-targeted rechecks, FCFS/priority ordering, DRR accounting, and lane-head replacement.

## Where should the reviewer start?

Start with `PolicyClassQueue::next_dispatchable_worker` and `PolicyClassQueue::recheck_all_workers` in `lib/kv-router/src/scheduling/policy_queue.rs`. The new unit test in the same file exercises the observable recheck behavior.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Performance

On an Intel Core Ultra 9 285K, eight order-balanced single-core runs of the **10,000-lane fully blocked full-recheck workload** reduced the median latency from **1,043.065 µs** at base revision `cc5cf40db46a673bd0087dd1a34eda7a80000813` to **30.864 µs** at candidate revision `947464445554d1acf77b05ec166a3094f2c6e7dc`. Using the unrounded medians, that is an absolute reduction of **1,012.200 µs**, or **97.04%** (**33.80×** faster).

| Revision label | Full-recheck latency samples (µs) | Median | Range | CV |
| --- | --- | ---: | ---: | ---: |
| Base `cc5cf40db46a673bd0087dd1a34eda7a80000813` | 1051.876, 1045.222, 1039.116, 1044.140, 1042.739, 1041.310, 1043.390, 1041.085 | 1043.065 | 1039.116–1051.876 | 0.37% |
| Candidate `947464445554d1acf77b05ec166a3094f2c6e7dc` | 30.447, 30.399, 31.141, 30.555, 31.212, 30.655, 31.074, 31.546 | 30.864 | 30.399–31.546 | 1.36% |

The median of each run's p99 operation latency fell from **1,092.598 µs** to **32.127 µs** (97.06%). The all-available 10,000-lane turnover control remained flat: **150.930 ns/dispatch** at the base versus **150.645 ns/dispatch** with the candidate, a 0.19% difference. Checksums, dispatch counts, and final queue depths matched on both revisions. Additional fully blocked scaling points improved from **4.221 µs to 0.316 µs** at 128 lanes and from **56.790 µs to 2.724 µs** at 1,024 lanes.

Validity: **valid for this focused scheduler benchmark**. The published commit `89f03aaf0323cc02495ed47e9eb1d80a6a70b398` applies the byte-identical `policy_queue.rs` change on target revision `68a791296f08a49e4e7fc2febfc503571b1717d1`; the intervening target commits do not touch the scheduler file or its mechanism. Performance was therefore not rerun after the clean rebase.

Caveats: this is not an end-to-end serving result. It executes the production `PolicyQueue`, including exact-worker lane maps, blocked-worker bookkeeping, `BTreeSet` maintenance, priority ordering, and full rechecks. A boolean vector replaces the scheduler actor's worker-capacity predicate; the async admission channel, active-token snapshot construction, tokenizer, network, and backend are outside the measured boundary.

The production path is routing hints or affinity → `KvPushRouter::select_worker` → `KvRouter::find_best_match_details_with_policy_class` → `SchedulerQueueActor::handle_enqueue` → `WorkerPlacement::Exact` → `PolicyQueue`. Full rechecks come from remote state changes and the periodic queue task. The periodic interval is 60 seconds by default and 100 ms when queueing is combined with the prefill-load model. At the 100 ms interval, the measured worst-case workload occupies about 1.043% of one scheduler core before this change and 0.031% after it, saving about 1.012 percentage points and removing a roughly 1 ms actor stall. At the default 60-second interval, the CPU share is negligible. System-level impact therefore depends on having a large blocked exact-worker backlog and frequent global rechecks; no broader throughput claim is made.

## Benchmark methodology

### Prerequisites and environment

- Linux x86_64 with `taskset`, Git, Python 3, and the [repository's Rust prerequisites](https://github.com/ai-dynamo/dynamo/blob/main/docs/contribution-guide.md).
- Network access for the lockfile-pinned Cargo dependencies on the first build.
- Rust 1.96.1 and Cargo 1.96.1; `rust-toolchain.toml` selects this toolchain.
- No frontend, NATS, etcd, GPU, model, generated dataset, or inference backend is required. The harness generates all queue input in memory.

The reported host was Ubuntu 24.04.2 LTS, kernel 6.17.0-35-generic, glibc 2.39, with 128 GiB RAM and an Intel Core Ultra 9 285K. CPU 2 was pinned with `taskset`; `intel_pstate` used the `powersave` governor with an 800 MHz–5.6 GHz configured range. No CPU isolation was applied. Both arms used the system allocator and the same dependency cache. Builds were complete before measurements began.

The measured SHAs were base `cc5cf40db46a673bd0087dd1a34eda7a80000813` and candidate `947464445554d1acf77b05ec166a3094f2c6e7dc`. The commands below reconstruct that candidate source tree from this pull request's byte-identical file patch, so they require only a clone with commit `89f03aaf0323cc02495ed47e9eb1d80a6a70b398` available.

### Prepare source trees and dependencies

```bash
git fetch origin main

BASE_SHA=cc5cf40db46a673bd0087dd1a34eda7a80000813
PUBLISHED_SHA=89f03aaf0323cc02495ed47e9eb1d80a6a70b398

git worktree add --detach /tmp/dynamo-recheck-base "$BASE_SHA"
git worktree add --detach /tmp/dynamo-recheck-fix "$BASE_SHA"

# Apply only this PR's scheduler-file change to recreate the measured candidate tree.
git diff "${BASE_SHA}...${PUBLISHED_SHA}" -- \
  lib/kv-router/src/scheduling/policy_queue.rs \
  | git -C /tmp/dynamo-recheck-fix apply

# Confirm the reconstructed candidate file is byte-identical to the published file.
test "$(git -C /tmp/dynamo-recheck-fix hash-object \
  lib/kv-router/src/scheduling/policy_queue.rs)" = \
  "$(git rev-parse \
  "${PUBLISHED_SHA}:lib/kv-router/src/scheduling/policy_queue.rs")"

rustup show
cargo fetch --locked
```

Save the following complete temporary benchmark harness as `/tmp/policy_queue_perf.rs`. It is intentionally not part of the source diff.

```rust
use super::*;
use crate::scheduling::RouterPolicyConfig;
use std::hint::black_box;
use std::time::Instant;

#[derive(Debug, Clone, Copy)]
struct TraceRequest {
    id: u64,
    worker: usize,
}

#[derive(Debug)]
struct TraceResult {
    wall_ns: u128,
    dispatches: u64,
    checksum: u64,
    latencies_ns: Vec<u64>,
    pending: usize,
}

fn profile() -> PolicyProfile {
    RouterPolicyConfig::from_yaml(
        r#"
default_policy_family: trace
uncached_isl_buckets:
  - min_tokens: 0
    bucket: all
policy_classes:
  - name: trace
    policy_family: trace
    cache_bucket: all
    quantum: 1000000
"#,
    )
    .unwrap()
    .resolve_profile(None, None, RouterQueuePolicy::Fcfs)
}

fn enqueue(queue: &mut PolicyQueue<TraceRequest>, lanes: usize, next_id: &mut u64, worker: usize) {
    let id = *next_id;
    *next_id += 1;
    queue
        .enqueue(
            0,
            lanes,
            QueueSnapshot::new(1, 0),
            id as f64,
            0.0,
            0,
            WorkerPlacement::Exact(WorkerWithDpRank::new(worker as u64, 0)),
            TraceRequest { id, worker },
        )
        .unwrap();
}

fn build_queue(lanes: usize) -> (PolicyQueue<TraceRequest>, u64) {
    let mut queue = PolicyQueue::new(profile());
    let mut next_id = 0;
    for worker in 0..lanes {
        enqueue(&mut queue, lanes, &mut next_id, worker);
    }
    (queue, next_id)
}

fn pop(
    queue: &mut PolicyQueue<TraceRequest>,
    available: &[bool],
) -> Option<PolicyQueueEntry<TraceRequest>> {
    queue.pop_next(|_, _, request| available[request.worker])
}

fn run_turnover(lanes: usize, events: usize) -> TraceResult {
    let (mut queue, mut next_id) = build_queue(lanes);
    let available = vec![true; lanes];
    let mut latencies_ns = Vec::with_capacity(events);
    let mut checksum = 0_u64;
    let start = Instant::now();
    for _ in 0..events {
        let op_start = Instant::now();
        let request = pop(&mut queue, &available)
            .expect("all lanes are available")
            .into_payload();
        checksum = checksum.wrapping_add(request.id);
        enqueue(&mut queue, lanes, &mut next_id, request.worker);
        latencies_ns.push(op_start.elapsed().as_nanos() as u64);
    }
    let wall_ns = start.elapsed().as_nanos();
    assert_eq!(queue.pending_count(), lanes);
    TraceResult {
        wall_ns,
        dispatches: events as u64,
        checksum,
        latencies_ns,
        pending: queue.pending_count(),
    }
}

fn run_fully_blocked(lanes: usize, events: usize) -> TraceResult {
    let (mut queue, _) = build_queue(lanes);
    let available = vec![false; lanes];
    assert!(pop(&mut queue, &available).is_none());
    let mut latencies_ns = Vec::with_capacity(events);
    let start = Instant::now();
    for _ in 0..events {
        let op_start = Instant::now();
        queue.recheck_all_workers();
        assert!(pop(&mut queue, &available).is_none());
        latencies_ns.push(op_start.elapsed().as_nanos() as u64);
    }
    let wall_ns = start.elapsed().as_nanos();
    TraceResult {
        wall_ns,
        dispatches: 0,
        checksum: 0,
        latencies_ns,
        pending: queue.pending_count(),
    }
}

fn execute(scenario: &str, lanes: usize, events: usize) -> TraceResult {
    match scenario {
        "turnover" => run_turnover(lanes, events),
        "fully_blocked" => run_fully_blocked(lanes, events),
        other => panic!("unknown scenario {other}"),
    }
}

fn percentile(sorted: &[u64], numerator: usize, denominator: usize) -> u64 {
    sorted[(sorted.len() - 1) * numerator / denominator]
}

#[test]
#[ignore]
fn candidate_scale_trace() {
    let scenario = std::env::var("DYN_TRACE_SCENARIO").unwrap_or_else(|_| "fully_blocked".into());
    let lanes = std::env::var("DYN_TRACE_LANES")
        .unwrap_or_else(|_| "10000".into())
        .parse::<usize>()
        .unwrap();
    let events = std::env::var("DYN_TRACE_EVENTS")
        .unwrap_or_else(|_| "2000".into())
        .parse::<usize>()
        .unwrap();
    black_box(execute(&scenario, lanes, (events / 10).clamp(100, 10_000)));
    let mut result = execute(&scenario, lanes, events);
    result.latencies_ns.sort_unstable();
    println!(
        "TRACE_RESULT revision={} scenario={} lanes={} events={} shared_percent=0 wall_ns={} ns_per_event={:.3} events_per_second={:.3} dispatches={} dispatches_per_second={:.3} p50_ns={} p95_ns={} p99_ns={} checksum={} pending={}",
        env!("GIT_REVISION"), scenario, lanes, events, result.wall_ns,
        result.wall_ns as f64 / events as f64,
        events as f64 * 1e9 / result.wall_ns as f64,
        result.dispatches,
        result.dispatches as f64 * 1e9 / result.wall_ns as f64,
        percentile(&result.latencies_ns, 50, 100),
        percentile(&result.latencies_ns, 95, 100),
        percentile(&result.latencies_ns, 99, 100),
        result.checksum,
        result.pending,
    );
}
```

Install the harness in both temporary worktrees:

```bash
for wt in /tmp/dynamo-recheck-base /tmp/dynamo-recheck-fix; do
  cp /tmp/policy_queue_perf.rs \
    "$wt/lib/kv-router/src/scheduling/policy_queue_perf.rs"
  sed -i '23i\
#[cfg(test)]\
#[path = "policy_queue_perf.rs"]\
mod perf_candidate_trace;\
' "$wt/lib/kv-router/src/scheduling/policy_queue.rs"
done
```

Build sequentially and copy each test binary before building the other arm. No build should run concurrently with measurement.

```bash
export CARGO_TARGET_DIR=/tmp/dynamo-recheck-target

cd /tmp/dynamo-recheck-base
GIT_REVISION=cc5cf40db46a673bd0087dd1a34eda7a80000813 \
  cargo test --locked -p dynamo-kv-router --lib --release --no-run
base_bin=$(find "$CARGO_TARGET_DIR/release/deps" -maxdepth 1 -type f -executable \
  -name 'dynamo_kv_router-*' -printf '%T@ %p\n' \
  | sort -nr | head -1 | cut -d' ' -f2-)
cp "$base_bin" /tmp/policy-queue-base

cd /tmp/dynamo-recheck-fix
GIT_REVISION=947464445554d1acf77b05ec166a3094f2c6e7dc \
  cargo test --locked -p dynamo-kv-router --lib --release --no-run
fix_bin=$(find "$CARGO_TARGET_DIR/release/deps" -maxdepth 1 -type f -executable \
  -name 'dynamo_kv_router-*' -printf '%T@ %p\n' \
  | sort -nr | head -1 | cut -d' ' -f2-)
cp "$fix_bin" /tmp/policy-queue-fix
```

### Run workloads

The primary workload uses 10,000 exact-worker lanes with every worker unavailable. Each fresh process builds a new queue, performs 200 warm-up rechecks, then measures 2,000 rechecks. Run eight processes per arm and alternate the arm order to balance time-dependent effects. `taskset -c 2` pins every process to the same core.

```bash
run_arm() {
  local binary=$1 output=$2 scenario=$3 lanes=$4 events=$5
  env DYN_TRACE_SCENARIO="$scenario" \
      DYN_TRACE_LANES="$lanes" \
      DYN_TRACE_EVENTS="$events" \
    taskset -c 2 "$binary" perf_candidate_trace::candidate_scale_trace \
      --ignored --nocapture --test-threads=1 | tee -a "$output"
}

run_balanced() {
  local scenario=$1 lanes=$2 events=$3 base_output=$4 fix_output=$5
  : > "$base_output"
  : > "$fix_output"
  for repetition in 1 2 3 4 5 6 7 8; do
    if (( repetition % 2 )); then
      run_arm /tmp/policy-queue-base "$base_output" "$scenario" "$lanes" "$events"
      run_arm /tmp/policy-queue-fix "$fix_output" "$scenario" "$lanes" "$events"
    else
      run_arm /tmp/policy-queue-fix "$fix_output" "$scenario" "$lanes" "$events"
      run_arm /tmp/policy-queue-base "$base_output" "$scenario" "$lanes" "$events"
    fi
  done
}

run_balanced fully_blocked 10000 2000 \
  /tmp/base-results.txt /tmp/fix-results.txt
```

The all-available turnover control uses the same 10,000 lanes and eight-run alternating order, with 10,000 warm-up dispatches and 2,000,000 measured dispatches per process:

```bash
run_balanced turnover 10000 2000000 \
  /tmp/base-turnover-results.txt /tmp/fix-turnover-results.txt
```

For the additional fully blocked scaling points, repeat `run_balanced` with 128 lanes and 100,000 measured rechecks, then 1,024 lanes and 20,000 measured rechecks:

```bash
run_balanced fully_blocked 128 100000 \
  /tmp/base-128-results.txt /tmp/fix-128-results.txt
run_balanced fully_blocked 1024 20000 \
  /tmp/base-1024-results.txt /tmp/fix-1024-results.txt
```

### Calculate statistics and verify output

The summary statistic is the median across the eight process-level `ns_per_event` values. CV is the sample standard deviation divided by the arithmetic mean. The absolute and percentage changes and speedup use the unrounded medians. The p99 summary is the median of the eight process-level `p99_ns` values.

```bash
python3 - <<'PY'
import re
import statistics

def records(path):
    rows = []
    with open(path, encoding="utf-8") as stream:
        for line in stream:
            if "TRACE_RESULT" not in line:
                continue
            rows.append(dict(re.findall(r"(\w+)=([^\s]+)", line)))
    return rows

def report(label, base_path, fix_path):
    base_rows = records(base_path)
    fix_rows = records(fix_path)
    assert len(base_rows) == len(fix_rows) == 8
    base = [float(row["ns_per_event"]) for row in base_rows]
    fix = [float(row["ns_per_event"]) for row in fix_rows]
    for name, values, rows in [("base", base, base_rows), ("fix", fix, fix_rows)]:
        cv = statistics.stdev(values) / statistics.mean(values) * 100
        p99_median = statistics.median(float(row["p99_ns"]) for row in rows)
        print(label, name, values)
        print("median", statistics.median(values), "range", min(values), max(values),
              "cv_percent", cv, "median_p99_ns", p99_median)
        print("correctness", [(row["dispatches"], row["checksum"], row["pending"])
                              for row in rows])
    base_median = statistics.median(base)
    fix_median = statistics.median(fix)
    print("absolute_change_ns", fix_median - base_median)
    print("percent_change", (fix_median - base_median) / base_median * 100)
    print("speedup", base_median / fix_median)

report("fully_blocked_10000", "/tmp/base-results.txt", "/tmp/fix-results.txt")
report("turnover_10000", "/tmp/base-turnover-results.txt",
       "/tmp/fix-turnover-results.txt")
report("fully_blocked_128", "/tmp/base-128-results.txt", "/tmp/fix-128-results.txt")
report("fully_blocked_1024", "/tmp/base-1024-results.txt", "/tmp/fix-1024-results.txt")
PY
```

For the primary workload, expected correctness fields on every run are `dispatches=0 checksum=0 pending=10000`; medians should be near the reported 1,043.065 µs base and 30.864 µs candidate values. For turnover, expected fields are `dispatches=2000000 checksum=1999999000000 pending=10000`; medians should be near 150.930 ns/dispatch base and 150.645 ns/dispatch candidate. Timing varies with hardware, CPU frequency, and background load, but the correctness fields must match exactly.

## Validation

```bash
cargo fmt --all -- --check
cargo test -p dynamo-kv-router --lib --release
cargo clippy -p dynamo-kv-router --lib --tests -- -D warnings
```

The measured candidate passed all three checks: 626 tests passed with no failures or ignored tests, and formatting and clippy passed. After the clean rebase onto `68a791296f08a49e4e7fc2febfc503571b1717d1`, formatting, strict clippy, and all 626 release library tests passed again. The final commit contains only the production change and behavior test; the temporary benchmark harness is excluded from the source diff.

<!-- perf-agent-investigation:39382f3b-2fae-4ee6-a76f-e3ea741730a3 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved scheduling behavior so workers that are blocked are only re-evaluated when a recheck is triggered, avoiding premature dispatch.
  * Blocked workers now become eligible for processing as soon as they become available, with the change taking effect after the next recheck cycle.

* **Tests**
  * Added a unit test covering that blocked lanes do not dispatch until recheck runs, and that subsequent availability changes apply only after the next recheck.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->