### PR TITLE
fix(mocker): fall back when AIC memory estimator is unavailable

### DIFF
--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -3,17 +3,21 @@
 
 import argparse
 import json
+import logging
 import os
 import socket
 
 from dynamo._internal.aic import (
     DEFAULT_GPU_MEMORY_UTILIZATION,
     DEFAULT_MEM_FRACTION_STATIC,
+    AicMemoryEstimatorUnavailableError,
     estimate_num_gpu_blocks,
 )
 from dynamo.common.utils.topology import apply_topology_config
 from dynamo.llm import ModelRuntimeConfig
 from dynamo.mocker import MockEngineArgs, ReasoningConfig, SglangArgs, TrtllmArgs
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_NUM_GPU_BLOCKS = 16384
 _DEFAULT_MAX_NUM_SEQS = 256
@@ -106,34 +110,44 @@ def _estimate_aic_num_gpu_blocks(
     resolved_block_size = _resolve_block_size_for_capacity(
         engine_type, block_size, sglang_page_size
     )
-    return estimate_num_gpu_blocks(
-        backend_name=aic_backend,
-        system=aic_system or _DEFAULT_AIC_SYSTEM,
-        model_path=aic_model_path,
-        tp_size=aic_tp_size if aic_tp_size is not None else 1,
-        block_size=resolved_block_size,
-        max_num_batched_tokens=(
-            max_num_batched_tokens
-            if max_num_batched_tokens is not None
-            else _DEFAULT_MAX_NUM_BATCHED_TOKENS
-        ),
-        gpu_memory_utilization=(
-            gpu_memory_utilization
-            if gpu_memory_utilization is not None
-            else DEFAULT_GPU_MEMORY_UTILIZATION
-        ),
-        mem_fraction_static=(
-            mem_fraction_static
-            if mem_fraction_static is not None
-            else DEFAULT_MEM_FRACTION_STATIC
-        ),
-        # None -> aic.py applies the TRT-LLM default (0.9).
-        free_gpu_memory_fraction=free_gpu_memory_fraction,
-        backend_version=aic_backend_version,
-        moe_tp_size=aic_moe_tp_size,
-        moe_ep_size=aic_moe_ep_size,
-        attention_dp_size=aic_attention_dp_size,
-    )
+    try:
+        return estimate_num_gpu_blocks(
+            backend_name=aic_backend,
+            system=aic_system or _DEFAULT_AIC_SYSTEM,
+            model_path=aic_model_path,
+            tp_size=aic_tp_size if aic_tp_size is not None else 1,
+            block_size=resolved_block_size,
+            max_num_batched_tokens=(
+                max_num_batched_tokens
+                if max_num_batched_tokens is not None
+                else _DEFAULT_MAX_NUM_BATCHED_TOKENS
+            ),
+            gpu_memory_utilization=(
+                gpu_memory_utilization
+                if gpu_memory_utilization is not None
+                else DEFAULT_GPU_MEMORY_UTILIZATION
+            ),
+            mem_fraction_static=(
+                mem_fraction_static
+                if mem_fraction_static is not None
+                else DEFAULT_MEM_FRACTION_STATIC
+            ),
+            # None -> aic.py applies the TRT-LLM default (0.9).
+            free_gpu_memory_fraction=free_gpu_memory_fraction,
+            backend_version=aic_backend_version,
+            moe_tp_size=aic_moe_tp_size,
+            moe_ep_size=aic_moe_ep_size,
+            attention_dp_size=aic_attention_dp_size,
+        )
+    except AicMemoryEstimatorUnavailableError as exc:
+        logger.warning(
+            "AIC KV-cache capacity estimation is unavailable: %s. Falling back "
+            "to default num_gpu_blocks=%d; upgrade aiconfigurator or set "
+            "--num-gpu-blocks-override explicitly.",
+            exc,
+            _DEFAULT_NUM_GPU_BLOCKS,
+        )
+        return _DEFAULT_NUM_GPU_BLOCKS
 
 
 def _resolve_num_gpu_blocks(

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -4,7 +4,6 @@
 import argparse
 import importlib.util
 import json
-import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -614,7 +613,10 @@ def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):
 def test_build_mocker_engine_args_falls_back_when_aic_estimator_missing(
     monkeypatch, caplog
 ):
-    monkeypatch.setitem(sys.modules, "aiconfigurator.sdk", None)
+    def missing_memory(module_name):
+        raise ModuleNotFoundError(name=module_name)
+
+    monkeypatch.setattr("dynamo._internal.aic.importlib.import_module", missing_memory)
 
     engine_args = CONFIG.build_mocker_engine_args(
         make_args(aic_perf_model=True, model_path="/models/mock")

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -4,6 +4,7 @@
 import argparse
 import importlib.util
 import json
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -608,6 +609,20 @@ def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):
             "attention_dp_size": None,
         }
     ]
+
+
+def test_build_mocker_engine_args_falls_back_when_aic_estimator_missing(
+    monkeypatch, caplog
+):
+    monkeypatch.setitem(sys.modules, "aiconfigurator.sdk", None)
+
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(aic_perf_model=True, model_path="/models/mock")
+    )
+
+    assert engine_args.num_gpu_blocks == 16384
+    assert "Falling back to default num_gpu_blocks=16384" in caplog.text
+    assert "--num-gpu-blocks-override" in caplog.text
 
 
 def test_aic_capacity_estimation_preserves_explicit_zero_inputs(monkeypatch):

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -28,6 +28,10 @@ DEFAULT_MEM_FRACTION_STATIC = 0.88
 DEFAULT_FREE_GPU_MEMORY_FRACTION = 0.9
 
 
+class AicMemoryEstimatorUnavailableError(RuntimeError):
+    """Raised when the optional AIC KV-cache estimator cannot be imported."""
+
+
 def _validate_kv_capacity_backend(backend_name: str) -> None:
     if backend_name not in _KV_CAPACITY_BACKENDS:
         supported = ", ".join(sorted(_KV_CAPACITY_BACKENDS))
@@ -454,20 +458,18 @@ def estimate_num_gpu_blocks(
 
     # Imported lazily: aiconfigurator is an optional dependency (the `mocker`
     # extra), so importing it at module scope would break callers that never run
-    # AIC estimation. Estimation is opt-in (only reached when an AIC backend is
-    # configured), so a missing install is a hard error -- fail loudly with an
-    # actionable message rather than silently using the default block count.
-    # Mirrors `_load_aiconfigurator`.
+    # AIC estimation. Report a typed error so callers can choose their policy:
+    # mocker warns and uses its existing default block count, while direct callers
+    # still receive an actionable error. Mirrors `_load_aiconfigurator`.
     # TODO: account for whether specdec is enabled (pass `nextn=...`). Currently
     #   omitted due to a downstream AIC bug where `_get_memory_usage` predicts
     #   negative KV capacity with Eagle.
     try:
         from aiconfigurator.sdk import memory
     except ImportError as exc:
-        raise RuntimeError(
-            "aiconfigurator is required for AIC KV-cache estimation but is not "
-            "installed; install the 'mocker' extra or set num_gpu_blocks "
-            "explicitly (e.g. --num-gpu-blocks-override)"
+        raise AicMemoryEstimatorUnavailableError(
+            "aiconfigurator.sdk.memory is required for AIC KV-cache estimation; "
+            "install a compatible aiconfigurator version"
         ) from exc
 
     # AIC's non-KV memory is independent of batch size (activations track

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import math
 import os
@@ -465,12 +466,20 @@ def estimate_num_gpu_blocks(
     #   omitted due to a downstream AIC bug where `_get_memory_usage` predicts
     #   negative KV capacity with Eagle.
     try:
-        from aiconfigurator.sdk import memory
-    except ImportError as exc:
-        raise AicMemoryEstimatorUnavailableError(
-            "aiconfigurator.sdk.memory is required for AIC KV-cache estimation; "
-            "install a compatible aiconfigurator version"
-        ) from exc
+        memory = importlib.import_module("aiconfigurator.sdk.memory")
+    except ModuleNotFoundError as exc:
+        if exc.name == "aiconfigurator.sdk.memory":
+            raise AicMemoryEstimatorUnavailableError(
+                "aiconfigurator.sdk.memory is required for AIC KV-cache estimation; "
+                "install a compatible aiconfigurator version"
+            ) from exc
+        if exc.name in {"aiconfigurator", "aiconfigurator.sdk"}:
+            raise RuntimeError(
+                "aiconfigurator is required for AIC KV-cache estimation but is not "
+                "installed; install the 'mocker' extra or set num_gpu_blocks "
+                "explicitly (e.g. --num-gpu-blocks-override)"
+            ) from exc
+        raise
 
     # AIC's non-KV memory is independent of batch size (activations track
     # max_num_tokens), so the fixed max_batch_size here does not affect the result.

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -173,9 +173,11 @@ def test_estimate_num_gpu_blocks_rejects_unsupported_backend():
 def test_estimate_num_gpu_blocks_reports_unavailable_estimator(monkeypatch):
     # The low-level helper reports a typed, actionable error so mocker can apply
     # its fallback without masking unrelated estimator failures.
-    import sys
+    def missing_memory(module_name):
+        raise ModuleNotFoundError(name=module_name)
 
-    monkeypatch.setitem(sys.modules, "aiconfigurator.sdk", None)
+    monkeypatch.setattr("dynamo._internal.aic.importlib.import_module", missing_memory)
+
     with pytest.raises(
         AicMemoryEstimatorUnavailableError,
         match=r"aiconfigurator\.sdk\.memory is required",
@@ -188,6 +190,29 @@ def test_estimate_num_gpu_blocks_reports_unavailable_estimator(monkeypatch):
             block_size=10,
             max_num_batched_tokens=128,
         )
+
+
+def test_estimate_num_gpu_blocks_propagates_transitive_import_error(monkeypatch):
+    missing_dependency = ModuleNotFoundError(name="aiconfigurator_core")
+
+    def broken_memory_module(_module_name):
+        raise missing_dependency
+
+    monkeypatch.setattr(
+        "dynamo._internal.aic.importlib.import_module", broken_memory_module
+    )
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        estimate_num_gpu_blocks(
+            backend_name="vllm",
+            system="h200_sxm",
+            model_path="some/model",
+            tp_size=1,
+            block_size=10,
+            max_num_batched_tokens=128,
+        )
+
+    assert exc_info.value is missing_dependency
 
 
 def test_trtllm_version_resolution():

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -10,6 +10,7 @@ from dynamo._internal.aic import (
     _NEXTN_ACCEPT_RATES_LEN,
     DEFAULT_FREE_GPU_MEMORY_FRACTION,
     DEFAULT_MEM_FRACTION_STATIC,
+    AicMemoryEstimatorUnavailableError,
     _normalize_aic_quant_mode,
     _pad_nextn_accept_rates,
     _resolve_quant_mode,
@@ -169,14 +170,16 @@ def test_estimate_num_gpu_blocks_rejects_unsupported_backend():
         )
 
 
-def test_estimate_num_gpu_blocks_errors_clearly_when_aic_missing(monkeypatch):
-    # Estimation is opt-in; if it is reached without aiconfigurator installed,
-    # fail loudly with an actionable message (not a raw ModuleNotFoundError, and
-    # not a silent fallback to the default block count).
+def test_estimate_num_gpu_blocks_reports_unavailable_estimator(monkeypatch):
+    # The low-level helper reports a typed, actionable error so mocker can apply
+    # its fallback without masking unrelated estimator failures.
     import sys
 
     monkeypatch.setitem(sys.modules, "aiconfigurator.sdk", None)
-    with pytest.raises(RuntimeError, match="aiconfigurator is required"):
+    with pytest.raises(
+        AicMemoryEstimatorUnavailableError,
+        match=r"aiconfigurator\.sdk\.memory is required",
+    ):
         estimate_num_gpu_blocks(
             backend_name="vllm",
             system="h200_sxm",


### PR DESCRIPTION
## Summary

- classify a missing `aiconfigurator.sdk.memory` estimator with a dedicated exception
- let mocker fall back to the existing default `num_gpu_blocks=16384` instead of crashing
- warn users to upgrade aiconfigurator or set `--num-gpu-blocks-override` explicitly
- cover the AIC 0.9-style missing-module path

Fixes [DYN-3358](https://linear.app/nvidia/issue/DYN-3358/dynamo130dgdr-dynamomocker-crashes-on-startup-when-launched-with-aic).

## Validation

- `PYTHONPATH="$PWD/lib/bindings/python/src:$PWD/components/src" .venv/bin/python -m pytest -xvv components/src/dynamo/mocker/tests/unit/test_config.py` (35 passed)
- `SKIP=pytest-marker-report .venv/bin/pre-commit run --files lib/bindings/python/src/dynamo/_internal/aic.py components/src/dynamo/mocker/config.py lib/bindings/python/tests/test_aic_capacity.py components/src/dynamo/mocker/tests/unit/test_config.py`
- direct missing-module assertion for `estimate_num_gpu_blocks` passed

The full `pytest-marker-report` hook cannot collect in this local environment because `tests/kvbm_integration/test_consolidator_config_unit.py` imports unavailable `kvbm.trtllm_integration`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved fallback behavior when GPU block estimation is unavailable, so configuration now uses a safe default instead of failing.
  * Added clearer warning messages to help identify when automatic estimation could not be used and what to do next.
* **Tests**
  * Expanded coverage for the fallback path and missing dependency scenario to verify the default value is applied correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->