### PR TITLE
fix(mocker): fall back when AIC memory estimator is unavailable

### DIFF
--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -3,17 +3,21 @@
 
 import argparse
 import json
+import logging
 import os
 import socket
 
 from dynamo._internal.aic import (
     DEFAULT_GPU_MEMORY_UTILIZATION,
     DEFAULT_MEM_FRACTION_STATIC,
+    AicMemoryEstimatorUnavailableError,
     estimate_num_gpu_blocks,
 )
 from dynamo.common.utils.topology import apply_topology_config
 from dynamo.llm import ModelRuntimeConfig
 from dynamo.mocker import MockEngineArgs, ReasoningConfig, SglangArgs, TrtllmArgs
+
+logger = logging.getLogger(__name__)
 
 _DEFAULT_NUM_GPU_BLOCKS = 16384
 _DEFAULT_MAX_NUM_SEQS = 256
@@ -106,34 +110,44 @@ def _estimate_aic_num_gpu_blocks(
     resolved_block_size = _resolve_block_size_for_capacity(
         engine_type, block_size, sglang_page_size
     )
-    return estimate_num_gpu_blocks(
-        backend_name=aic_backend,
-        system=aic_system or _DEFAULT_AIC_SYSTEM,
-        model_path=aic_model_path,
-        tp_size=aic_tp_size if aic_tp_size is not None else 1,
-        block_size=resolved_block_size,
-        max_num_batched_tokens=(
-            max_num_batched_tokens
-            if max_num_batched_tokens is not None
-            else _DEFAULT_MAX_NUM_BATCHED_TOKENS
-        ),
-        gpu_memory_utilization=(
-            gpu_memory_utilization
-            if gpu_memory_utilization is not None
-            else DEFAULT_GPU_MEMORY_UTILIZATION
-        ),
-        mem_fraction_static=(
-            mem_fraction_static
-            if mem_fraction_static is not None
-            else DEFAULT_MEM_FRACTION_STATIC
-        ),
-        # None -> aic.py applies the TRT-LLM default (0.9).
-        free_gpu_memory_fraction=free_gpu_memory_fraction,
-        backend_version=aic_backend_version,
-        moe_tp_size=aic_moe_tp_size,
-        moe_ep_size=aic_moe_ep_size,
-        attention_dp_size=aic_attention_dp_size,
-    )
+    try:
+        return estimate_num_gpu_blocks(
+            backend_name=aic_backend,
+            system=aic_system or _DEFAULT_AIC_SYSTEM,
+            model_path=aic_model_path,
+            tp_size=aic_tp_size if aic_tp_size is not None else 1,
+            block_size=resolved_block_size,
+            max_num_batched_tokens=(
+                max_num_batched_tokens
+                if max_num_batched_tokens is not None
+                else _DEFAULT_MAX_NUM_BATCHED_TOKENS
+            ),
+            gpu_memory_utilization=(
+                gpu_memory_utilization
+                if gpu_memory_utilization is not None
+                else DEFAULT_GPU_MEMORY_UTILIZATION
+            ),
+            mem_fraction_static=(
+                mem_fraction_static
+                if mem_fraction_static is not None
+                else DEFAULT_MEM_FRACTION_STATIC
+            ),
+            # None -> aic.py applies the TRT-LLM default (0.9).
+            free_gpu_memory_fraction=free_gpu_memory_fraction,
+            backend_version=aic_backend_version,
+            moe_tp_size=aic_moe_tp_size,
+            moe_ep_size=aic_moe_ep_size,
+            attention_dp_size=aic_attention_dp_size,
+        )
+    except AicMemoryEstimatorUnavailableError as exc:
+        logger.warning(
+            "AIC KV-cache capacity estimation is unavailable: %s. Falling back "
+            "to default num_gpu_blocks=%d; upgrade aiconfigurator or set "
+            "--num-gpu-blocks-override explicitly.",
+            exc,
+            _DEFAULT_NUM_GPU_BLOCKS,
+        )
+        return _DEFAULT_NUM_GPU_BLOCKS
 
 
 def _resolve_num_gpu_blocks(

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -542,6 +542,23 @@ def test_build_mocker_engine_args_estimates_aic_blocks(monkeypatch):
     ]
 
 
+def test_build_mocker_engine_args_falls_back_when_aic_estimator_missing(
+    monkeypatch, caplog
+):
+    def missing_memory(module_name):
+        raise ModuleNotFoundError(name=module_name)
+
+    monkeypatch.setattr("dynamo._internal.aic.importlib.import_module", missing_memory)
+
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(aic_perf_model=True, model_path="/models/mock")
+    )
+
+    assert engine_args.num_gpu_blocks == 16384
+    assert "Falling back to default num_gpu_blocks=16384" in caplog.text
+    assert "--num-gpu-blocks-override" in caplog.text
+
+
 def test_aic_capacity_estimation_preserves_explicit_zero_inputs(monkeypatch):
     calls = []
 

--- a/lib/bindings/python/src/dynamo/_internal/aic.py
+++ b/lib/bindings/python/src/dynamo/_internal/aic.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import importlib
 import logging
 import math
 import os
@@ -26,6 +27,10 @@ DEFAULT_STATIC_STRIDE = 32
 DEFAULT_GPU_MEMORY_UTILIZATION = 0.9
 DEFAULT_MEM_FRACTION_STATIC = 0.88
 DEFAULT_FREE_GPU_MEMORY_FRACTION = 0.9
+
+
+class AicMemoryEstimatorUnavailableError(RuntimeError):
+    """Raised when the optional AIC KV-cache estimator cannot be imported."""
 
 
 def _validate_kv_capacity_backend(backend_name: str) -> None:
@@ -454,21 +459,27 @@ def estimate_num_gpu_blocks(
 
     # Imported lazily: aiconfigurator is an optional dependency (the `mocker`
     # extra), so importing it at module scope would break callers that never run
-    # AIC estimation. Estimation is opt-in (only reached when an AIC backend is
-    # configured), so a missing install is a hard error -- fail loudly with an
-    # actionable message rather than silently using the default block count.
-    # Mirrors `_load_aiconfigurator`.
+    # AIC estimation. Report a typed error so callers can choose their policy:
+    # mocker warns and uses its existing default block count, while direct callers
+    # still receive an actionable error. Mirrors `_load_aiconfigurator`.
     # TODO: account for whether specdec is enabled (pass `nextn=...`). Currently
     #   omitted due to a downstream AIC bug where `_get_memory_usage` predicts
     #   negative KV capacity with Eagle.
     try:
-        from aiconfigurator.sdk import memory
-    except ImportError as exc:
-        raise RuntimeError(
-            "aiconfigurator is required for AIC KV-cache estimation but is not "
-            "installed; install the 'mocker' extra or set num_gpu_blocks "
-            "explicitly (e.g. --num-gpu-blocks-override)"
-        ) from exc
+        memory = importlib.import_module("aiconfigurator.sdk.memory")
+    except ModuleNotFoundError as exc:
+        if exc.name == "aiconfigurator.sdk.memory":
+            raise AicMemoryEstimatorUnavailableError(
+                "aiconfigurator.sdk.memory is required for AIC KV-cache estimation; "
+                "install a compatible aiconfigurator version"
+            ) from exc
+        if exc.name in {"aiconfigurator", "aiconfigurator.sdk"}:
+            raise RuntimeError(
+                "aiconfigurator is required for AIC KV-cache estimation but is not "
+                "installed; install the 'mocker' extra or set num_gpu_blocks "
+                "explicitly (e.g. --num-gpu-blocks-override)"
+            ) from exc
+        raise
 
     # AIC's non-KV memory is independent of batch size (activations track
     # max_num_tokens), so the fixed max_batch_size here does not affect the result.

--- a/lib/bindings/python/tests/test_aic_capacity.py
+++ b/lib/bindings/python/tests/test_aic_capacity.py
@@ -10,6 +10,7 @@ from dynamo._internal.aic import (
     _NEXTN_ACCEPT_RATES_LEN,
     DEFAULT_FREE_GPU_MEMORY_FRACTION,
     DEFAULT_MEM_FRACTION_STATIC,
+    AicMemoryEstimatorUnavailableError,
     _normalize_aic_quant_mode,
     _pad_nextn_accept_rates,
     _resolve_quant_mode,
@@ -169,14 +170,18 @@ def test_estimate_num_gpu_blocks_rejects_unsupported_backend():
         )
 
 
-def test_estimate_num_gpu_blocks_errors_clearly_when_aic_missing(monkeypatch):
-    # Estimation is opt-in; if it is reached without aiconfigurator installed,
-    # fail loudly with an actionable message (not a raw ModuleNotFoundError, and
-    # not a silent fallback to the default block count).
-    import sys
+def test_estimate_num_gpu_blocks_reports_unavailable_estimator(monkeypatch):
+    # The low-level helper reports a typed, actionable error so mocker can apply
+    # its fallback without masking unrelated estimator failures.
+    def missing_memory(module_name):
+        raise ModuleNotFoundError(name=module_name)
 
-    monkeypatch.setitem(sys.modules, "aiconfigurator.sdk", None)
-    with pytest.raises(RuntimeError, match="aiconfigurator is required"):
+    monkeypatch.setattr("dynamo._internal.aic.importlib.import_module", missing_memory)
+
+    with pytest.raises(
+        AicMemoryEstimatorUnavailableError,
+        match=r"aiconfigurator\.sdk\.memory is required",
+    ):
         estimate_num_gpu_blocks(
             backend_name="vllm",
             system="h200_sxm",
@@ -185,6 +190,29 @@ def test_estimate_num_gpu_blocks_errors_clearly_when_aic_missing(monkeypatch):
             block_size=10,
             max_num_batched_tokens=128,
         )
+
+
+def test_estimate_num_gpu_blocks_propagates_transitive_import_error(monkeypatch):
+    missing_dependency = ModuleNotFoundError(name="aiconfigurator_core")
+
+    def broken_memory_module(_module_name):
+        raise missing_dependency
+
+    monkeypatch.setattr(
+        "dynamo._internal.aic.importlib.import_module", broken_memory_module
+    )
+
+    with pytest.raises(ModuleNotFoundError) as exc_info:
+        estimate_num_gpu_blocks(
+            backend_name="vllm",
+            system="h200_sxm",
+            model_path="some/model",
+            tp_size=1,
+            block_size=10,
+            max_num_batched_tokens=128,
+        )
+
+    assert exc_info.value is missing_dependency
 
 
 def test_trtllm_version_resolution():


### PR DESCRIPTION
## Summary

- cherry-pick #11490 into `release/1.3.0`
- fall back to the existing mocker default `num_gpu_blocks=16384` when AIC 0.9.0 lacks `aiconfigurator.sdk.memory`
- preserve hard failures for missing AIC installations and transitive import failures
- warn users to upgrade AIC or set an explicit block count

Fixes [DYN-3358](https://linear.app/nvidia/issue/DYN-3358/dynamo130dgdr-dynamomocker-crashes-on-startup-when-launched-with-aic).

Main PR: #11490

## Validation

- `PYTHONPATH="$PWD/lib/bindings/python/src:$PWD/components/src" .venv/bin/python -m pytest -xvv components/src/dynamo/mocker/tests/unit/test_config.py` (28 passed)
- real `aiconfigurator==0.9.0` fallback smoke check
- transitive `ModuleNotFoundError` propagation smoke check
- `SKIP=pytest-marker-report .venv/bin/pre-commit run --files lib/bindings/python/src/dynamo/_internal/aic.py components/src/dynamo/mocker/config.py lib/bindings/python/tests/test_aic_capacity.py components/src/dynamo/mocker/tests/unit/test_config.py`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11495" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->