### PR TITLE
fix(trtllm): preserve reasoning for guided tool calls

### DIFF
--- a/components/src/dynamo/common/backend/tests/test_backend_bindings.py
+++ b/components/src/dynamo/common/backend/tests/test_backend_bindings.py
@@ -141,6 +141,16 @@ def test_worker_config_accepts_disaggregation_mode():
         backend.WorkerConfig(namespace="dynamo", disaggregation_mode=mode)
 
 
+def test_worker_config_accepts_reasoning_required_structural_tag_mode():
+    backend.WorkerConfig(namespace="dynamo", structural_tag_mode="reasoning_required")
+
+
+def test_model_runtime_config_accepts_reasoning_required_structural_tag_mode():
+    from dynamo._core import ModelRuntimeConfig
+
+    ModelRuntimeConfig().set_structural_tag_mode("reasoning_required")
+
+
 @pytest.mark.unified
 def test_python_worker_config_from_runtime_config_copies_parser_settings():
     from dynamo.common.backend.worker import WorkerConfig

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -96,6 +96,12 @@ _IDLE_SLEEP_S = 0.01
 # publish KV cache events. Without this, `get_kv_cache_events` returns empty.
 _DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
 
+_LLGUIDANCE_REASONING_ERROR = (
+    "TRT-LLM llguidance cannot preserve reasoning for required or named "
+    "tool_choice; use xgrammar or set "
+    "chat_template_kwargs.enable_thinking=false"
+)
+
 # Note: `metrics_dict` is set per-instance on `GenerationResult` (only
 # when TRT-LLM's perf-stats collection is enabled and the request
 # finished). Check `hasattr(res, "metrics_dict")` on each instance —
@@ -122,6 +128,19 @@ def _to_signed_i64(value: int | None) -> int | None:
     return value
 
 
+def _resolve_structural_tag_mode(config: Any, guided_decoding_backend: object) -> str:
+    """Resolve the structural-tag policy published by the unified worker."""
+    if config.dyn_enable_structural_tag:
+        return "on"
+    if (
+        guided_decoding_backend == "xgrammar"
+        and config.dyn_reasoning_parser
+        and config.dyn_tool_call_parser
+    ):
+        return "reasoning_required"
+    return "off"
+
+
 class TrtllmLLMEngine(LLMEngine):
     def __init__(
         self,
@@ -137,6 +156,7 @@ class TrtllmLLMEngine(LLMEngine):
         publish_events_and_metrics: bool = False,
     ):
         self.engine_args = engine_args
+        self._guided_decoding_backend = engine_args.get("guided_decoding_backend")
         self.model_name = model_name
         self.served_model_name = served_model_name
         self.max_seq_len = max_seq_len
@@ -320,12 +340,16 @@ class TrtllmLLMEngine(LLMEngine):
             component=config.component,
             publish_events_and_metrics=config.publish_events_and_metrics,
         )
+        structural_tag_mode = _resolve_structural_tag_mode(
+            config, engine._guided_decoding_backend
+        )
         worker_config = WorkerConfig.from_runtime_config(
             config,
             model_name=config.model,
             served_model_name=config.served_model_name,
             model_input=ModelInput.Tokens,
             disaggregation_mode=_TRTLLM_TO_COMMON_DISAGG[config.disaggregation_mode],
+            structural_tag_mode=structural_tag_mode,
         )
         return engine, worker_config
 
@@ -758,6 +782,7 @@ class TrtllmLLMEngine(LLMEngine):
         self, request: GenerateRequest, context: Context
     ) -> AsyncGenerator[GenerateChunk, None]:
         assert self._engine is not None, "Engine not initialized"
+        self._validate_guided_reasoning_support(request)
 
         # Tag the request as structured-output / image so the per-type
         # counters split traffic correctly in Prometheus.
@@ -1100,6 +1125,18 @@ class TrtllmLLMEngine(LLMEngine):
         if self._engine is not None:
             await self._engine.cleanup()
             logger.info("TensorRT-LLM engine shutdown")
+
+    @staticmethod
+    def _validate_guided_reasoning_support_for_backend(
+        guided_decoding_backend: object, request: GenerateRequest
+    ) -> None:
+        if request.get("require_reasoning") and guided_decoding_backend == "llguidance":
+            raise ValueError(_LLGUIDANCE_REASONING_ERROR)
+
+    def _validate_guided_reasoning_support(self, request: GenerateRequest) -> None:
+        self._validate_guided_reasoning_support_for_backend(
+            self._guided_decoding_backend, request
+        )
 
     @staticmethod
     def _override_sampling_params(

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import json
 import re as re_mod
 from dataclasses import dataclass
 from typing import Any, ClassVar
@@ -257,6 +258,20 @@ class TestLLMEngineOverrideSamplingParams:
         expected = "(" + "|".join(re_mod.escape(choice) for choice in choices) + ")"
         assert result.guided_decoding.regex == expected
 
+    def test_guided_decoding_structural_tag_is_serialized(self):
+        sampling_params = MockSamplingParams()
+        structural_tag = {
+            "type": "structural_tag",
+            "format": {"type": "json_schema", "json_schema": self.JSON_SCHEMA},
+        }
+        request = {
+            "sampling_options": {"guided_decoding": {"structural_tag": structural_tag}}
+        }
+
+        result = TrtllmLLMEngine._override_sampling_params(sampling_params, request)
+
+        assert json.loads(result.guided_decoding.structural_tag) == structural_tag
+
 
 @pytest.mark.parametrize(
     ("override", "expected"),
@@ -279,6 +294,99 @@ def test_unified_guided_decoding_backend_matches_legacy(override, expected):
     engine, _ = asyncio.run(TrtllmLLMEngine.from_args(argv))
 
     assert engine.engine_args["guided_decoding_backend"] == expected
+    assert engine._guided_decoding_backend == expected
+
+
+@pytest.mark.parametrize(
+    (
+        "reasoning_parser",
+        "tool_parser",
+        "override",
+        "explicit_structural_tag",
+        "expected_mode",
+    ),
+    [
+        ("qwen3", "hermes", None, False, "reasoning_required"),
+        (
+            "qwen3",
+            "hermes",
+            '{"guided_decoding_backend": "llguidance"}',
+            False,
+            "off",
+        ),
+        ("qwen3", None, None, False, "off"),
+        (None, "hermes", None, False, "off"),
+        ("qwen3", "hermes", None, True, "on"),
+        (
+            "qwen3",
+            "hermes",
+            '{"guided_decoding_backend": "llguidance"}',
+            True,
+            "on",
+        ),
+    ],
+    ids=[
+        "xgrammar-with-both-parsers",
+        "effective-llguidance-override",
+        "missing-tool-parser",
+        "missing-reasoning-parser",
+        "explicit-structural-tags",
+        "explicit-structural-tags-with-llguidance",
+    ],
+)
+def test_unified_guided_reasoning_structural_tag_mode(
+    reasoning_parser,
+    tool_parser,
+    override,
+    explicit_structural_tag,
+    expected_mode,
+):
+    argv = [
+        "--model-path",
+        "Qwen/Qwen3-0.6B",
+        "--guided-decoding-backend",
+        "xgrammar",
+    ]
+    if reasoning_parser is not None:
+        argv.extend(["--dyn-reasoning-parser", reasoning_parser])
+    if tool_parser is not None:
+        argv.extend(["--dyn-tool-call-parser", tool_parser])
+    if override is not None:
+        argv.extend(["--override-engine-args", override])
+    if explicit_structural_tag:
+        argv.append("--dyn-enable-structural-tag")
+
+    _, worker_config = asyncio.run(TrtllmLLMEngine.from_args(argv))
+
+    assert worker_config.structural_tag_mode == expected_mode
+
+
+@pytest.mark.parametrize(
+    ("backend", "require_reasoning", "raises"),
+    [
+        ("llguidance", True, True),
+        ("llguidance", False, False),
+        ("xgrammar", True, False),
+    ],
+)
+def test_unified_llguidance_rejects_reasoning_required_tool_choice(
+    backend, require_reasoning, raises
+):
+    request = {"require_reasoning": require_reasoning}
+
+    if raises:
+        with pytest.raises(
+            ValueError,
+            match=(
+                "TRT-LLM llguidance cannot preserve reasoning for required or "
+                "named tool_choice"
+            ),
+        ):
+            TrtllmLLMEngine._validate_guided_reasoning_support_for_backend(
+                backend, request
+            )
+    else:
+        TrtllmLLMEngine._validate_guided_reasoning_support_for_backend(backend, request)
 
 
 class TestGuidedDecodingFromToolChoice:

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -376,9 +376,10 @@ impl WorkerConfig {
         let st_mode = match structural_tag_mode.as_str() {
             "off" => RsStructuralTagMode::Off,
             "on" => RsStructuralTagMode::On,
+            "reasoning_required" => RsStructuralTagMode::ReasoningRequired,
             other => {
                 return Err(PyErr::new::<pyo3::exceptions::PyValueError, _>(format!(
-                    "Invalid structural_tag_mode: {other}. Expected 'off' or 'on'."
+                    "Invalid structural_tag_mode: {other}. Expected 'off', 'on', or 'reasoning_required'."
                 )));
             }
         };

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -256,9 +256,10 @@ impl ModelRuntimeConfig {
         self.inner.structural_tag_mode = match mode {
             "off" => RsStructuralTagMode::Off,
             "on" => RsStructuralTagMode::On,
+            "reasoning_required" => RsStructuralTagMode::ReasoningRequired,
             _ => {
                 return Err(PyErr::new::<PyException, _>(format!(
-                    "Invalid structural_tag_mode: {mode}. Expected 'off' or 'on'."
+                    "Invalid structural_tag_mode: {mode}. Expected 'off', 'on', or 'reasoning_required'."
                 )));
             }
         };

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -34,6 +34,9 @@ pub enum StructuralTagMode {
     #[default]
     Off,
     On,
+    /// Apply structural tags only when a forced tool choice must preserve a
+    /// reasoning phase before the schema-constrained tool call.
+    ReasoningRequired,
 }
 
 /// Controls when structural tags are activated based on `tool_choice`.
@@ -651,6 +654,26 @@ mod tests {
         assert!(json.contains("\"tokenizer_backend\":\"fastokens\""));
         let parsed: ModelRuntimeConfig = serde_json::from_str(&json).unwrap();
         assert_eq!(parsed.tokenizer_backend, Some(TokenizerBackend::Fastokens));
+    }
+
+    #[test]
+    fn reasoning_required_structural_tag_mode_roundtrips_through_serde_json() {
+        assert_eq!(
+            ModelRuntimeConfig::default().structural_tag_mode,
+            StructuralTagMode::Off
+        );
+        let cfg = ModelRuntimeConfig {
+            structural_tag_mode: StructuralTagMode::ReasoningRequired,
+            ..Default::default()
+        };
+
+        let json = serde_json::to_string(&cfg).unwrap();
+        assert!(json.contains("\"structural_tag_mode\":\"reasoning_required\""));
+        let parsed: ModelRuntimeConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(
+            parsed.structural_tag_mode,
+            StructuralTagMode::ReasoningRequired
+        );
     }
 
     #[test]

--- a/lib/llm/src/preprocessor/structural_tag.rs
+++ b/lib/llm/src/preprocessor/structural_tag.rs
@@ -3,7 +3,9 @@
 
 //! Structural tag policy for chat tool-call guided decoding.
 
-use crate::local_model::runtime_config::{StructuralTagMode, StructuralTagScope};
+use crate::local_model::runtime_config::{
+    StructuralTagMode, StructuralTagSchemaMode, StructuralTagScope,
+};
 use crate::preprocessor::{OpenAIPreprocessor, PreprocessedRequest};
 
 use dynamo_parsers::tool_calling::{ToolChoice, ToolDefinition};
@@ -19,11 +21,25 @@ impl OpenAIPreprocessor {
         prompt_injected_reasoning: bool,
         preprocessed_request: &mut PreprocessedRequest,
     ) -> Result<bool, DynamoError> {
-        if self.runtime_config.structural_tag_mode == StructuralTagMode::Off {
+        let mode = self.runtime_config.structural_tag_mode;
+        let reasoning_required = Self::should_use_reasoning_structural_tag(
+            mode,
+            tool_choice,
+            preprocessed_request.require_reasoning,
+        );
+
+        if mode == StructuralTagMode::Off
+            || (mode == StructuralTagMode::ReasoningRequired && !reasoning_required)
+        {
             return Ok(false);
         }
 
         let Some(parser_name) = self.tool_call_parser.as_deref() else {
+            if reasoning_required {
+                return Err(Self::reasoning_structural_tag_error(
+                    "the deployment does not configure --dyn-tool-call-parser",
+                ));
+            }
             tracing::warn!(
                 "Structural tag is enabled but --dyn-tool-call-parser is not set; \
                  structural tags will not be applied"
@@ -31,7 +47,9 @@ impl OpenAIPreprocessor {
             return Ok(false);
         };
 
-        let Some(builder) = Self::structural_tag_builder_for_parser(parser_name) else {
+        let Some(builder) =
+            Self::structural_tag_builder_for_parser(parser_name, reasoning_required)?
+        else {
             return Ok(false);
         };
 
@@ -55,23 +73,50 @@ impl OpenAIPreprocessor {
             tool_choice,
             tools,
             parallel_tool_calls,
-            schema_mode: self.runtime_config.structural_tag_schema,
-            starts_in_reasoning: prompt_injected_reasoning,
+            schema_mode: if reasoning_required {
+                StructuralTagSchemaMode::Strict
+            } else {
+                self.runtime_config.structural_tag_schema
+            },
+            starts_in_reasoning: reasoning_required || prompt_injected_reasoning,
         };
 
-        Self::apply_tool_call_format(parser_name, builder, &ctx, preprocessed_request)
+        Self::apply_tool_call_format(
+            parser_name,
+            builder,
+            &ctx,
+            reasoning_required,
+            preprocessed_request,
+        )
+    }
+
+    fn should_use_reasoning_structural_tag(
+        mode: StructuralTagMode,
+        tool_choice: &ToolChoice,
+        require_reasoning: bool,
+    ) -> bool {
+        mode != StructuralTagMode::Off
+            && require_reasoning
+            && matches!(tool_choice, ToolChoice::Required | ToolChoice::Named(_))
     }
 
     /// Find the structural tag builder for a parser, if supported.
     fn structural_tag_builder_for_parser(
         parser_name: &str,
-    ) -> Option<&'static dynamo_parsers::tool_calling::StructuralTagBuilder> {
+        reasoning_required: bool,
+    ) -> Result<Option<&'static dynamo_parsers::tool_calling::StructuralTagBuilder>, DynamoError>
+    {
         let parser_map = dynamo_parsers::tool_calling::parsers::get_tool_parser_map();
         let builder = parser_map
             .get(parser_name)
             .and_then(|tc| tc.structural_tag_builder.as_ref());
 
         if builder.is_none() {
+            if reasoning_required {
+                return Err(Self::reasoning_structural_tag_error(format!(
+                    "tool-call parser '{parser_name}' does not provide a structural-tag builder"
+                )));
+            }
             tracing::warn!(
                 parser = parser_name,
                 "Structural tag enabled but parser does not support it; \
@@ -79,7 +124,16 @@ impl OpenAIPreprocessor {
             );
         }
 
-        builder
+        Ok(builder)
+    }
+
+    fn reasoning_structural_tag_error(reason: impl std::fmt::Display) -> DynamoError {
+        DynamoError::builder()
+            .error_type(ErrorType::InvalidArgument)
+            .message(format!(
+                "cannot preserve reasoning before the guided tool call because {reason}"
+            ))
+            .build()
     }
 
     /// Apply the `tool_choice=none` ban tag, if configured.
@@ -109,6 +163,7 @@ impl OpenAIPreprocessor {
         parser_name: &str,
         builder: &dynamo_parsers::tool_calling::StructuralTagBuilder,
         ctx: &dynamo_parsers::tool_calling::ToolCallFormatBuildContext<'_>,
+        reasoning_required: bool,
         common_request: &mut PreprocessedRequest,
     ) -> Result<bool, DynamoError> {
         let structural_tag = match builder.build_tool_call_format(ctx) {
@@ -122,6 +177,11 @@ impl OpenAIPreprocessor {
                 return Ok(false);
             }
             Err(e) => {
+                if reasoning_required {
+                    return Err(Self::reasoning_structural_tag_error(format!(
+                        "tool-call parser '{parser_name}' cannot build a reasoning-aware structural tag: {e}"
+                    )));
+                }
                 return Err(DynamoError::builder()
                     .error_type(ErrorType::Unknown)
                     .message(format!(
@@ -157,5 +217,169 @@ impl OpenAIPreprocessor {
                 }
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
+    use dynamo_parsers::tool_calling::{StructuralTagBuilder, TriggeredTagsConfig};
+    use serde_json::json;
+
+    fn request(require_reasoning: bool) -> PreprocessedRequest {
+        PreprocessedRequest::builder()
+            .model("test".to_string())
+            .token_ids(vec![1])
+            .stop_conditions(StopConditions::default())
+            .sampling_options(SamplingOptions::default())
+            .output_options(OutputOptions::default())
+            .require_reasoning(require_reasoning)
+            .build()
+            .unwrap()
+    }
+
+    fn tools() -> Vec<ToolDefinition> {
+        vec![ToolDefinition {
+            name: "get_weather".to_string(),
+            parameters: Some(json!({
+                "type": "object",
+                "properties": {"location": {"type": "string"}},
+                "required": ["location"]
+            })),
+            strict: Some(false),
+        }]
+    }
+
+    #[test]
+    fn reasoning_required_mode_only_activates_for_forced_reasoning_tool_choices() {
+        let named = ToolChoice::Named("get_weather".to_string());
+
+        assert!(OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::ReasoningRequired,
+            &ToolChoice::Required,
+            true,
+        ));
+        assert!(OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::ReasoningRequired,
+            &named,
+            true,
+        ));
+        assert!(!OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::ReasoningRequired,
+            &ToolChoice::Required,
+            false,
+        ));
+        assert!(!OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::ReasoningRequired,
+            &ToolChoice::Auto,
+            true,
+        ));
+        assert!(!OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::ReasoningRequired,
+            &ToolChoice::None,
+            true,
+        ));
+        assert!(!OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::Off,
+            &ToolChoice::Required,
+            true,
+        ));
+        assert!(OpenAIPreprocessor::should_use_reasoning_structural_tag(
+            StructuralTagMode::On,
+            &ToolChoice::Required,
+            true,
+        ));
+    }
+
+    #[test]
+    fn forced_reasoning_structural_tags_use_strict_schema_and_reasoning_prefix() {
+        let tools = tools();
+        let builder = OpenAIPreprocessor::structural_tag_builder_for_parser("hermes", true)
+            .unwrap()
+            .unwrap();
+        for tool_choice in [
+            ToolChoice::Required,
+            ToolChoice::Named("get_weather".to_string()),
+        ] {
+            let ctx = dynamo_parsers::tool_calling::ToolCallFormatBuildContext {
+                tool_choice: &tool_choice,
+                tools: &tools,
+                parallel_tool_calls: Some(false),
+                schema_mode: StructuralTagSchemaMode::Strict,
+                starts_in_reasoning: true,
+            };
+            let mut request = request(true);
+
+            assert!(
+                OpenAIPreprocessor::apply_tool_call_format(
+                    "hermes",
+                    builder,
+                    &ctx,
+                    true,
+                    &mut request,
+                )
+                .unwrap()
+            );
+
+            let tag = request
+                .sampling_options
+                .guided_decoding
+                .unwrap()
+                .structural_tag
+                .unwrap();
+            assert_eq!(tag["format"]["type"], "sequence");
+            assert_eq!(tag["format"]["elements"][0]["end"], "</think>");
+            assert_eq!(
+                tag["format"]["elements"][1]["tags"][0]["content"]["json_schema"]["required"][0],
+                "location"
+            );
+        }
+    }
+
+    #[test]
+    fn reasoning_structural_tag_rejects_parser_without_builder() {
+        let err = OpenAIPreprocessor::structural_tag_builder_for_parser("llama3_json", true)
+            .expect_err("llama3_json has no structural-tag builder");
+
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        let message = err.to_string();
+        assert!(message.contains("llama3_json"), "{message}");
+        assert!(message.contains("structural-tag builder"), "{message}");
+    }
+
+    #[test]
+    fn reasoning_structural_tag_rejects_builder_without_reasoning_terminator() {
+        let builder = StructuralTagBuilder::TriggeredTags(TriggeredTagsConfig {
+            begin_template: "<tool_call>{}".to_string(),
+            end_template: "</tool_call>".to_string(),
+            triggers: vec!["<tool_call>".to_string()],
+            content_style: Default::default(),
+            tool_call_ban_tokens: vec![],
+            reasoning_end: None,
+        });
+        let tools = tools();
+        let ctx = dynamo_parsers::tool_calling::ToolCallFormatBuildContext {
+            tool_choice: &ToolChoice::Required,
+            tools: &tools,
+            parallel_tool_calls: None,
+            schema_mode: StructuralTagSchemaMode::Strict,
+            starts_in_reasoning: true,
+        };
+        let mut request = request(true);
+
+        let err = OpenAIPreprocessor::apply_tool_call_format(
+            "test_parser",
+            &builder,
+            &ctx,
+            true,
+            &mut request,
+        )
+        .expect_err("reasoning-aware tags require a terminator");
+
+        assert_eq!(err.error_type(), ErrorType::InvalidArgument);
+        let message = err.to_string();
+        assert!(message.contains("test_parser"), "{message}");
+        assert!(message.contains("reasoning end tag"), "{message}");
     }
 }

--- a/tests/serve/test_trtllm.py
+++ b/tests/serve/test_trtllm.py
@@ -29,7 +29,11 @@ from tests.utils.payload_builder import (
     multimodal_payload_default,
     router_selection_chat_payload_default,
 )
-from tests.utils.payloads import ImageGenerationPayload, VideoGenerationPayload
+from tests.utils.payloads import (
+    ImageGenerationPayload,
+    ToolCallingChatPayload,
+    VideoGenerationPayload,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -54,6 +58,52 @@ qwen3_vl_engine_config_files = (
     "encode.yaml",
     "prefill.yaml",
 )
+
+
+def reasoning_tool_call_payload(
+    tool_choice: str | dict, enable_thinking: bool
+) -> ToolCallingChatPayload:
+    return ToolCallingChatPayload(
+        body={
+            "messages": [
+                {
+                    "role": "user",
+                    "content": (
+                        "What is the weather in San Francisco? Use get_weather."
+                    ),
+                }
+            ],
+            "tools": [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "get_weather",
+                        "description": "Get the current weather for a location.",
+                        "parameters": {
+                            "type": "object",
+                            "properties": {
+                                "location": {"type": "string"},
+                            },
+                            "required": ["location"],
+                            "additionalProperties": False,
+                        },
+                    },
+                }
+            ],
+            "tool_choice": tool_choice,
+            "parallel_tool_calls": False,
+            "chat_template_kwargs": {"enable_thinking": enable_thinking},
+            "max_tokens": 512,
+            "temperature": 0.0,
+        },
+        repeat_count=1,
+        expected_log=[],
+        expected_response=["San Francisco"],
+        expected_tool_name="get_weather",
+        expected_reasoning=enable_thinking,
+        expected_finish_reason="tool_calls",
+    )
+
 
 # TensorRT-LLM test configurations
 # NOTE: pytest.mark.gpu_1 tests take ~442s (7m 22s) total to run sequentially (with models pre-cached)
@@ -100,7 +150,15 @@ trtllm_configs = {
         name="aggregated_unified",
         directory=trtllm_dir,
         script_name="agg.sh",
-        script_args=["--unified", "--guided-decoding-backend", "xgrammar"],
+        script_args=[
+            "--unified",
+            "--guided-decoding-backend",
+            "xgrammar",
+            "--dyn-reasoning-parser",
+            "qwen3",
+            "--dyn-tool-call-parser",
+            "hermes",
+        ],
         marks=[
             pytest.mark.core,
             pytest.mark.gpu_1,
@@ -118,6 +176,15 @@ trtllm_configs = {
             chat_payload_default(),
             completion_payload_default(),
             guided_decoding_chat_payload_default(),
+            reasoning_tool_call_payload("required", enable_thinking=True),
+            reasoning_tool_call_payload(
+                {
+                    "type": "function",
+                    "function": {"name": "get_weather"},
+                },
+                enable_thinking=True,
+            ),
+            reasoning_tool_call_payload("required", enable_thinking=False),
         ],
     ),
     "disaggregated": TRTLLMConfig(

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -290,9 +290,18 @@ class ChatPayloadWithLogprobs(ChatPayload):
 class ToolCallingChatPayload(ChatPayload):
     """ChatPayload that validates tool calls in the response."""
 
-    def __init__(self, *args, expected_tool_name: Optional[str] = None, **kwargs):
+    def __init__(
+        self,
+        *args,
+        expected_tool_name: Optional[str] = None,
+        expected_reasoning: Optional[bool] = None,
+        expected_finish_reason: Optional[str] = None,
+        **kwargs,
+    ):
         super().__init__(*args, **kwargs)
         self.expected_tool_name = expected_tool_name
+        self.expected_reasoning = expected_reasoning
+        self.expected_finish_reason = expected_finish_reason
 
     def validate(self, response, content: str) -> None:
         """Validate that tool calls exist in the response.
@@ -307,7 +316,8 @@ class ToolCallingChatPayload(ChatPayload):
         choices = response_data.get("choices", [])
         assert choices, "Response missing choices"
 
-        message = choices[0].get("message", {})
+        choice = choices[0]
+        message = choice.get("message", {})
         tool_calls = message.get("tool_calls", [])
 
         assert tool_calls, "Expected model to generate tool calls but none found"
@@ -333,6 +343,21 @@ class ToolCallingChatPayload(ChatPayload):
                 self.expected_tool_name in tool_names
             ), f"Expected tool '{self.expected_tool_name}' not found. Available tools: {tool_names}"
             logger.info(f"Expected tool '{self.expected_tool_name}' was called")
+
+        reasoning = message.get("reasoning_content")
+        has_reasoning = bool(reasoning and str(reasoning).strip())
+        if self.expected_reasoning is True:
+            assert has_reasoning, "Expected non-empty reasoning_content"
+        elif self.expected_reasoning is False:
+            assert (
+                not has_reasoning
+            ), f"Expected empty reasoning_content, got: {reasoning!r}"
+
+        if self.expected_finish_reason is not None:
+            assert choice.get("finish_reason") == self.expected_finish_reason, (
+                f"Expected finish_reason={self.expected_finish_reason!r}, "
+                f"got {choice.get('finish_reason')!r}"
+            )
 
         # Check expected_response keywords against tool call arguments (OR logic)
         if self.expected_response:


### PR DESCRIPTION
## Overview:

Preserves reasoning for required and named tool calls in unified TRT-LLM by selecting an internal `reasoning_required` xgrammar structural-tag mode. The generated constraint accepts reasoning through the parser-specific terminator and then enforces the schema-constrained tool call in the same generation request.

## Summary

- Automatically selects `reasoning_required` for the effective xgrammar backend when both Dynamo reasoning and tool parsers are configured.
- Uses strict parser-native tool schemas for required and named choices while leaving auto, none, ordinary JSON/regex/grammar/choice constraints, and thinking-disabled requests unchanged.
- Returns an explicit unsupported-combination error for reasoning-required llguidance requests.
- Adds Rust policy/binding coverage, focused unified TRT-LLM unit tests, and required/named/thinking-disabled GPU regression payloads.

## Details:

The Rust preprocessor now supports a serialized `StructuralTagMode::ReasoningRequired` policy. When `require_reasoning=true` is derived for a forced tool choice, it builds:

```text
<any reasoning text> </think> <schema-constrained tool call>
```

Unified TRT-LLM resolves the effective guided-decoding backend after engine argument overrides. Explicit structural-tag configuration retains precedence. Missing structural-tag builders or reasoning terminators return `InvalidArgument` errors naming the incompatible parser.

## Where should the reviewer start?

1. `lib/llm/src/preprocessor/structural_tag.rs` for activation, strict-schema construction, and error handling.
2. `components/src/dynamo/trtllm/llm_engine.py` for effective-backend mode selection and llguidance rejection.
3. `tests/serve/test_trtllm.py` for required, named, and thinking-disabled regression payloads.

## Validation:

- `cargo fmt --all -- --check` — passed.
- `cargo test -p dynamo-llm structural_tag` — passed.
- `pytest -q components/src/dynamo/common/backend/tests/test_backend_bindings.py components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py` — 76 passed.
- `pre-commit run --files components/src/dynamo/common/backend/tests/test_backend_bindings.py components/src/dynamo/trtllm/llm_engine.py components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py lib/bindings/python/rust/backend.rs lib/bindings/python/rust/llm/local_model.rs lib/llm/src/local_model/runtime_config.rs lib/llm/src/preprocessor/structural_tag.rs tests/serve/test_trtllm.py tests/utils/payloads.py` — passed after rebasing onto merged #11423.
- `pytest -m "e2e and trtllm and gpu_1" tests/serve/test_trtllm.py -k aggregated_unified` — not run locally because the computelab session service was unresponsive; required GPU CI coverage before marking ready for review.

## Related Issues

**🔗 This PR is linked to issues:**

- Closes [DIS-2373: Preserve forced reasoning with TRT-LLM guided tool decoding](https://linear.app/nvidia/issue/DIS-2373/preserve-forced-reasoning-with-trt-llm-guided-tool-decoding)
- Relates to [DIS-1988: Add guided decoding to unified backends](https://linear.app/nvidia/issue/DIS-1988/add-guided-decoding-to-unified-backends)
- Builds on [PR #11205](https://github.com/ai-dynamo/dynamo/pull/11205) and merged prerequisite [PR #11423](https://github.com/ai-dynamo/dynamo/pull/11423).
