### PR TITLE
feat(router): expose local indexer publisher endpoint

### DIFF
--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -1365,7 +1365,7 @@ impl LLMEngine for PyLLMEngine {
             let list = bound.downcast::<pyo3::types::PyList>()?;
             let mut sources = Vec::with_capacity(list.len());
             for item in list.iter() {
-                sources.push(depythonize_kv_source(&item)?);
+                sources.push(depythonize_kv_source(&item, self.core.event_loop.clone())?);
             }
             Ok(sources)
         })
@@ -1560,7 +1560,10 @@ fn class_name(item: &Bound<'_, PyAny>) -> PyResult<String> {
     item.get_type().getattr("__name__")?.extract::<String>()
 }
 
-fn depythonize_kv_source(item: &Bound<'_, PyAny>) -> PyResult<RsKvEventSource> {
+fn depythonize_kv_source(
+    item: &Bound<'_, PyAny>,
+    event_loop: Arc<PyObject>,
+) -> PyResult<RsKvEventSource> {
     let cls = class_name(item)?;
     let dp_rank: u32 = item.getattr("dp_rank")?.extract()?;
     match cls.as_str() {
@@ -1580,8 +1583,13 @@ fn depythonize_kv_source(item: &Bound<'_, PyAny>) -> PyResult<RsKvEventSource> {
             // round-trip is needed here.
             let on_ready_obj: PyObject = item.getattr("on_ready")?.into();
             let on_ready: OnPublisherReady = Box::new(move |publisher| {
+                let event_loop = event_loop.clone();
                 Python::with_gil(|py| -> PyResult<()> {
-                    let py_pub = Py::new(py, PyKvEventPublisher::from_arc(publisher, dp_rank))?;
+                    let event_loop = event_loop.bind(py).clone().unbind();
+                    let py_pub = Py::new(
+                        py,
+                        PyKvEventPublisher::from_arc(publisher, dp_rank, event_loop),
+                    )?;
                     on_ready_obj.call1(py, (py_pub,))?;
                     Ok(())
                 })

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -1028,6 +1028,7 @@ pub(crate) struct KvEventPublisher {
     dp_rank: DpRank,
     warning_count: Arc<AtomicU32>,
     image_token_id: Option<u32>,
+    event_loop: PyObject,
 }
 
 #[derive(Deserialize)]
@@ -1063,6 +1064,7 @@ impl KvEventPublisher {
     pub(crate) fn from_arc(
         inner: Arc<llm_rs::kv_router::publisher::KvEventPublisher>,
         dp_rank: DpRank,
+        event_loop: PyObject,
     ) -> Self {
         let kv_block_size = inner.kv_block_size() as usize;
         Self {
@@ -1074,6 +1076,7 @@ impl KvEventPublisher {
             // carries no image marker; the non-unified path sets it via the
             // constructor.
             image_token_id: None,
+            event_loop,
         }
     }
 
@@ -1177,6 +1180,7 @@ impl KvEventPublisher {
             return Err(to_pyerr(anyhow::anyhow!("kv_block_size cannot be 0")));
         }
 
+        let event_loop = endpoint.event_loop.clone();
         let inner =
             llm_rs::kv_router::publisher::KvEventPublisher::new_with_local_indexer_and_worker_id_at(
                 endpoint.inner.clone(),
@@ -1199,7 +1203,18 @@ impl KvEventPublisher {
             dp_rank,
             warning_count: Arc::new(AtomicU32::new(0)),
             image_token_id,
+            event_loop,
         })
+    }
+
+    #[getter]
+    fn local_indexer_endpoint(&self) -> Option<Endpoint> {
+        self.inner
+            .local_indexer_query_endpoint()
+            .map(|inner| Endpoint {
+                inner,
+                event_loop: self.event_loop.clone(),
+            })
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1195,6 +1195,13 @@ class KvEventPublisher:
             kv_state_endpoint: KV event ownership endpoint; defaults to endpoint.
         """
 
+    @property
+    def local_indexer_endpoint(self) -> Optional[Endpoint]:
+        """
+        Worker-local KV indexer query endpoint created by this publisher, if enabled.
+        """
+        ...
+
     def publish_stored(
         self,
         token_ids: List[int],

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -42,7 +42,9 @@ pub(crate) use recovery::{
 };
 #[cfg(test)]
 pub(crate) use recovery::{WorkerQueryClient, WorkerQueryTransport};
-pub(crate) use recovery::{start_subscriber, start_worker_kv_query_endpoint};
+pub(crate) use recovery::{
+    start_subscriber, start_worker_kv_query_endpoint, worker_kv_query_endpoint,
+};
 
 /// `approx` is the optional predict-on-route side indexer. It is always local
 /// to this router, even when the primary indexer is served or consumed

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -20,6 +20,6 @@ pub(crate) use worker_query::TargetFaultDisposition;
 pub(crate) use worker_query::WorkerQueryClient;
 #[cfg(feature = "ckf-diagnostics")]
 pub(crate) use worker_query::WorkerQueryHealthSnapshot;
-pub(crate) use worker_query_endpoint::start_worker_kv_query_endpoint;
+pub(crate) use worker_query_endpoint::{start_worker_kv_query_endpoint, worker_kv_query_endpoint};
 #[cfg(test)]
 pub(crate) use worker_query_transport::WorkerQueryTransport;

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query_endpoint.rs
@@ -19,6 +19,17 @@ use dynamo_runtime::{
 };
 use tokio::sync::Semaphore;
 
+/// Return the address used by this publisher's recovery service.
+///
+/// This is only an address; it does not imply that the endpoint has finished
+/// registering or is ready to serve requests.
+pub(crate) fn worker_kv_query_endpoint(
+    component: &Component,
+    publisher_id: u64,
+) -> dynamo_runtime::component::Endpoint {
+    component.endpoint(format!("worker_kv_query_source_{publisher_id:x}"))
+}
+
 /// Worker-side endpoint registration for Router -> LocalKvIndexer query service
 pub(crate) async fn start_worker_kv_query_endpoint(
     component: Component,
@@ -37,14 +48,14 @@ pub(crate) async fn start_worker_kv_query_endpoint(
     let ingress = Ingress::for_engine(engine)?;
 
     let route_worker_id = component.drt().connection_id();
-    let endpoint_name = format!("worker_kv_query_source_{publisher_id:x}");
+    let endpoint = worker_kv_query_endpoint(&component, publisher_id);
+    let endpoint_name = endpoint.name().to_string();
     tracing::info!(
         "WorkerKvQuery endpoint starting for worker {worker_id} dp_rank {dp_rank} \
          routed by instance {route_worker_id} on endpoint '{endpoint_name}'"
     );
 
-    component
-        .endpoint(&endpoint_name)
+    endpoint
         .endpoint_builder()
         .handler(ingress)
         .graceful_shutdown(true)

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -1,8 +1,8 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, RwLock};
 
 use anyhow::Result;
 use tokio::sync::mpsc;
@@ -20,7 +20,8 @@ use dynamo_runtime::traits::DistributedRuntimeProvider;
 
 use crate::discovery::KvEventSource as DiscoveredKvEventSource;
 use crate::kv_router::{
-    KV_EVENT_SUBJECT, WORKER_KV_INDEXER_BUFFER_SIZE, indexer::start_worker_kv_query_endpoint,
+    KV_EVENT_SUBJECT, WORKER_KV_INDEXER_BUFFER_SIZE,
+    indexer::{start_worker_kv_query_endpoint, worker_kv_query_endpoint},
     metrics::KvPublisherMetrics,
 };
 
@@ -191,6 +192,8 @@ pub struct KvEventPublisher {
     tx: mpsc::UnboundedSender<Vec<PlacementEvent>>,
     /// Internal monotonic event ID counter. Shared with the ZMQ listener if present.
     next_event_id: Arc<AtomicU64>,
+    /// Address of the worker-local recovery endpoint once its publisher ID is known.
+    local_indexer_query_endpoint: Arc<RwLock<Option<Endpoint>>>,
 }
 
 impl KvEventPublisher {
@@ -344,6 +347,8 @@ impl KvEventPublisher {
 
         let cancellation_token_clone = cancellation_token.clone();
         let local_indexer_clone = local_indexer.clone();
+        let local_indexer_query_endpoint = Arc::new(RwLock::new(None));
+        let local_indexer_query_endpoint_clone = local_indexer_query_endpoint.clone();
 
         tracing::info!("Using event plane for KV event publishing");
         let endpoint_clone = endpoint.clone();
@@ -365,6 +370,10 @@ impl KvEventPublisher {
             let publisher_id = event_publisher.publisher_id();
 
             let recovery_endpoint = if let Some(local_indexer) = local_indexer_clone.as_ref() {
+                let endpoint = worker_kv_query_endpoint(&component, publisher_id);
+                if let Ok(mut stored_endpoint) = local_indexer_query_endpoint_clone.write() {
+                    *stored_endpoint = Some(endpoint);
+                }
                 match start_worker_kv_query_endpoint(
                     component.clone(),
                     publisher_id,
@@ -465,7 +474,19 @@ impl KvEventPublisher {
             worker_id,
             tx,
             next_event_id,
+            local_indexer_query_endpoint,
         })
+    }
+
+    /// Return the worker-local recovery endpoint address once it has been assigned.
+    ///
+    /// `Some` identifies the address selected by the publisher, but does not by
+    /// itself guarantee that endpoint registration has completed.
+    pub fn local_indexer_query_endpoint(&self) -> Option<Endpoint> {
+        self.local_indexer_query_endpoint
+            .read()
+            .ok()
+            .and_then(|endpoint| endpoint.clone())
     }
 
     pub fn publish(&self, event: KvCacheEvent) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -30,6 +30,7 @@ mod test_event_processing {
             worker_id: 7,
             tx,
             next_event_id: Arc::new(AtomicU64::new(0)),
+            local_indexer_query_endpoint: Arc::new(RwLock::new(None)),
         };
 
         publisher.publish_batch(Vec::new()).unwrap();
@@ -70,6 +71,7 @@ mod test_event_processing {
             worker_id: 7,
             tx,
             next_event_id: Arc::new(AtomicU64::new(0)),
+            local_indexer_query_endpoint: Arc::new(RwLock::new(None)),
         };
         drop(rx);
 
@@ -105,6 +107,7 @@ mod test_event_processing {
             worker_id: 7,
             tx,
             next_event_id: Arc::new(AtomicU64::new(0)),
+            local_indexer_query_endpoint: Arc::new(RwLock::new(None)),
         };
 
         publisher


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

```
Expose the worker-local KV indexer query endpoint from `KvEventPublisher` through the Python binding. When local indexer mode
  is enabled, `publisher.local_indexer_endpoint` returns the underlying `Endpoint` so applications can explicitly unregister it during
  graceful shutdown. When local indexer mode is disabled, it returns `None`.
```

Goal is to reach this line of code in the indexer 1-2 seconds before the worker 7587895284999313111 actually stops accepting TCP traffic on its endpoint. This helps with smooth scale down. 
```
 router logs:
     WorkerQueryClient: all dp_ranks gone for worker 7587895284999313111, removing
```



## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use Relates to #11494`when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

Closes #11494


<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11498" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Extended the KV event publisher API to expose an optional `endpoint` for the worker-local KV indexer query, when local-indexer mode is enabled.
  * Improved local KV routing so the worker-specific KV query endpoint is retained by the publisher and available via a new getter.

* **API Updates**
  * Updated the underlying local-indexer startup/wiring to use the resolved worker query endpoint consistently across the publisher and routing logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->