### PR TITLE
feat(frontend): enable tokenizer cache for tiktoken

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2880,8 +2880,7 @@ dependencies = [
 [[package]]
 name = "dynamo-tokenizers"
 version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda65fd29fa8fc5395fc9430155d68d67a7eef216415a152cbf85e9916aa0bbf"
+source = "git+https://github.com/ai-dynamo/frontend-crates.git?rev=1cef80a2d789a0f1f43cbce78c6139ab89e0e30e#1cef80a2d789a0f1f43cbce78c6139ab89e0e30e"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2879,8 +2879,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.4.0"
-source = "git+https://github.com/ai-dynamo/frontend-crates.git?rev=1cef80a2d789a0f1f43cbce78c6139ab89e0e30e#1cef80a2d789a0f1f43cbce78c6139ab89e0e30e"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61fb9c031ea19d99d1faf8ff304fe666eb2dbd4666fcb416af3f08ae88f5be80"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ keywords = ["llm", "genai", "inference", "nvidia", "distributed"]
 dynamo-runtime = { path = "lib/runtime", version = "1.3.0" }
 dynamo-llm = { path = "lib/llm", version = "1.3.0" }
 dynamo-rl = { path = "lib/rl", version = "1.3.0" }
-dynamo-tokenizers = { version = "=1.4.0" }
+dynamo-tokenizers = { version = "=1.5.0" }
 dynamo-renderer = { version = "=1.3.5" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.3.0" }
@@ -197,8 +197,3 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
-
-# Remove this override and bump the exact workspace dependency after
-# https://github.com/ai-dynamo/frontend-crates/pull/103 is released.
-[patch.crates-io]
-dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates.git", rev = "1cef80a2d789a0f1f43cbce78c6139ab89e0e30e" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -197,3 +197,8 @@ lto = "thin"
 inherits = "release"
 debug = true
 strip = false
+
+# Remove this override and bump the exact workspace dependency after
+# https://github.com/ai-dynamo/frontend-crates/pull/103 is released.
+[patch.crates-io]
+dynamo-tokenizers = { git = "https://github.com/ai-dynamo/frontend-crates.git", rev = "1cef80a2d789a0f1f43cbce78c6139ab89e0e30e" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1862,9 +1862,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda65fd29fa8fc5395fc9430155d68d67a7eef216415a152cbf85e9916aa0bbf"
+checksum = "61fb9c031ea19d99d1faf8ff304fe666eb2dbd4666fcb416af3f08ae88f5be80"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2514,9 +2514,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-tokenizers"
-version = "1.4.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda65fd29fa8fc5395fc9430155d68d67a7eef216415a152cbf85e9916aa0bbf"
+checksum = "61fb9c031ea19d99d1faf8ff304fe666eb2dbd4666fcb416af3f08ae88f5be80"
 dependencies = [
  "aho-corasick",
  "anyhow",

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -1188,18 +1188,18 @@ impl ModelDeploymentCard {
                         format!("Failed to load tiktoken tokenizer from {}", p.display())
                     })?;
 
+                let specials = tokenizer.special_tokens().to_vec();
                 let raw: Arc<dyn crate::tokenizers::traits::Tokenizer> = Arc::new(tokenizer);
                 if cache_enabled {
-                    // Empty specials disable L1, so the wrapper bypasses cache observers.
-                    // The instrumentation helper still binds zero-valued per-model token
-                    // series, ready for future tiktoken special-token extraction.
                     tracing::info!(
                         cache_bytes,
-                        "wrapping tiktoken tokenizer in L1 cache (no special tokens registered; L1 is disabled until tiktoken special-token extraction is added)",
+                        cache_extend,
+                        boundaries = specials.len(),
+                        "wrapping tiktoken tokenizer in L1 prefix cache",
                     );
                     instrumented_tokenizer_cache(
                         raw,
-                        Vec::new(),
+                        specials,
                         cache_bytes,
                         cache_extend,
                         self.name(),

--- a/lib/llm/tests/model_card.rs
+++ b/lib/llm/tests/model_card.rs
@@ -2,9 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_llm::model_card::{ModelDeploymentCard, PromptFormatterArtifact, TokenizerKind};
+use dynamo_llm::tokenizers::{TikTokenTokenizer, traits::Encoder};
 use tempfile::tempdir;
 
 const HF_PATH: &str = "tests/data/sample-models/TinyLlama_v1.1";
+const TIKTOKEN_PATH: &str = "tests/data/sample-models/mock-tiktoken";
 
 #[tokio::test]
 async fn test_model_info_from_hf_like_local_repo() {
@@ -35,6 +37,52 @@ async fn test_tokenizer_from_hf_like_local_repo() {
         TokenizerKind::HfTokenizerJson(_) => (),
         TokenizerKind::TikTokenModel(_) => panic!("Expected HfTokenizerJson, got TikTokenModel"),
     }
+}
+
+#[test]
+fn test_tiktoken_model_card_cache_matches_direct_tokenizer_and_records_tokens() {
+    let model = "model-card-tiktoken-cache-integration";
+    let mut mdc = ModelDeploymentCard::load_from_disk(TIKTOKEN_PATH, None).unwrap();
+    mdc.set_name(model);
+
+    let production = mdc.tokenizer().unwrap();
+    let direct =
+        TikTokenTokenizer::from_file_auto(&format!("{TIKTOKEN_PATH}/tiktoken.model")).unwrap();
+
+    let cached_tokens = dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_CACHED_TOKENS_TOTAL
+        .with_label_values(&[model]);
+    let uncached_tokens =
+        dynamo_runtime::metrics::frontend_perf::TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL
+            .with_label_values(&[model]);
+    let cached_before = cached_tokens.get();
+    let uncached_before = uncached_tokens.get();
+
+    let prompts = [
+        "<|im_start|>system\nYou are concise.<|im_end|><|im_start|>user\nExplain prefix caching.<|im_end|>",
+        "<|im_start|>system\nYou are concise.<|im_end|><|im_start|>user\nNow include Unicode: 北京 😀.<|im_end|>",
+    ];
+    let mut returned_tokens = 0_u64;
+    for prompt in prompts {
+        let actual = production.encode(prompt).unwrap().token_ids().to_vec();
+        let expected = direct.encode(prompt).unwrap().token_ids().to_vec();
+        assert_eq!(
+            actual, expected,
+            "cached production path must remain token-exact"
+        );
+        returned_tokens += actual.len() as u64;
+    }
+
+    let cached_delta = cached_tokens.get() - cached_before;
+    let uncached_delta = uncached_tokens.get() - uncached_before;
+    assert!(
+        cached_delta > 0,
+        "the second request should reuse the shared chat prefix"
+    );
+    assert_eq!(
+        cached_delta + uncached_delta,
+        returned_tokens,
+        "cache token accounting must cover every returned token"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- enable the existing default-on L1 tokenizer cache for supported TikToken models by forwarding the exact registered special-token boundaries
- preserve the existing cache controls and metrics while reporting the number of TikToken boundaries at startup
- add a production `ModelDeploymentCard` integration test covering token exactness, shared-prefix reuse, and cached/uncached token accounting
- bump the exact `dynamo-tokenizers` pin to the officially published `1.5.0` release from https://github.com/ai-dynamo/frontend-crates/pull/103

## Validation

Official `dynamo-tokenizers` 1.5.0 release:

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-llm --test model_card --test tokenizers --locked`
- `cargo metadata --locked --format-version 1 --no-deps`
- `cd lib/bindings/kvbm && cargo metadata --locked --format-version 1 --no-deps`
- `cd lib/bindings/python && cargo metadata --locked --format-version 1 --no-deps`

Pre-release validation against the same upstream tokenizer source:

- `cargo test -p dynamo-llm`
- `cargo clippy -p dynamo-llm --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prefix caching for TikToken models by correctly recognizing special tokens as cache boundaries.
  * Ensured cached tokenization matches direct TikToken encoding results.
  * Improved accuracy of tokenizer cache metrics for returned tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->