### PR TITLE
perf(trtllm): skip duplicate text prompt metadata on DSV4

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -628,12 +628,19 @@ class HandlerBase(BaseGenerativeHandler):
         # Serialize first_gen_log_probs for the Rust transport layer.
         DisaggregatedParamsCodec.serialize_first_gen_log_probs(params_dict)
 
+        # Text-only decode requests already carry the original token_ids.
+        # Prompt metadata is only needed to avoid reprocessing multimodal input.
+        if not self._request_has_multimodal(request) and not any(
+            key in request for key in ("_epd_processed_prompt", "_epd_prompt_token_ids")
+        ):
+            return params_dict
+
         # Pack prefill metadata for DECODE worker optimization
         # The frontend only forwards disaggregated_params from prefill response
         # Note: max_tokens is already handled by Rust frontend's PrefillRouter
         prefill_metadata = {}
 
-        # ALWAYS pack prompt info for DECODE to skip re-processing
+        # Pack prompt info for DECODE to skip re-processing
         # Per TRT-LLM team: DECODE never needs to reload images - KV cache has the context
         # Use processed_input['prompt'] (from process_openai_request) which is the actual
         # multimodal prompt used by TRT-LLM, not res.prompt which might be raw

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -18,6 +18,7 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
+from tensorrt_llm.llmapi import DisaggregatedParams
 
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.trtllm.constants import DisaggregationMode
@@ -562,6 +563,76 @@ class TestMultimodalGuard:
         assert result["prompt"] == "describe image"
         assert result["prompt_token_ids"] == [1, 2, 3]
         assert result["multi_modal_data"] is None
+
+
+class TestPrefillPromptMetadata:
+    """Tests for prompt metadata in the legacy prefill handoff."""
+
+    def _make_handler(self) -> HandlerBase:
+        config = MagicMock()
+        config.multimodal_processor = MagicMock()
+        config.shutdown_event = None
+        return _ConcreteHandler(config)
+
+    def _pack_metadata(self, request, processed_input, prompt, prompt_token_ids):
+        params = DisaggregatedParams(request_type="context_only")
+        output = MagicMock(disaggregated_params=params)
+        result = MagicMock(prompt=prompt, prompt_token_ids=prompt_token_ids)
+
+        return self._make_handler()._encode_and_pack_disaggregated_params(
+            output,
+            params,
+            request,
+            result,
+            processed_input,
+        )
+
+    def test_text_only_prefill_omits_prompt_metadata(self):
+        result = self._pack_metadata(
+            request={"token_ids": [1, 2, 3]},
+            processed_input=[1, 2, 3],
+            prompt="text prompt",
+            prompt_token_ids=[1, 2, 3],
+        )
+
+        assert "_epd_metadata" not in result
+
+    def test_multimodal_prefill_preserves_prompt_metadata(self):
+        result = self._pack_metadata(
+            request={
+                "token_ids": [1, 2, 3],
+                "multi_modal_data": {
+                    "image_url": [{"Url": "http://example.com/image.jpg"}]
+                },
+            },
+            processed_input={"prompt": "describe image"},
+            prompt="raw prompt",
+            prompt_token_ids=[1, 2, 3],
+        )
+
+        assert result["_epd_metadata"] == {
+            "_prefill_prompt": "describe image",
+            "_prefill_prompt_token_ids": [1, 2, 3],
+        }
+
+    def test_epd_prefill_preserves_encoder_metadata(self):
+        result = self._pack_metadata(
+            request={
+                "token_ids": [1, 2, 3],
+                "_epd_processed_prompt": "encoder prompt",
+                "_epd_prompt_token_ids": [1, 2, 3],
+            },
+            processed_input={"prompt": "encoder prompt"},
+            prompt="engine prompt",
+            prompt_token_ids=[4, 5, 6],
+        )
+
+        assert result["_epd_metadata"] == {
+            "_prefill_prompt": "encoder prompt",
+            "_prefill_prompt_token_ids": [4, 5, 6],
+            "_epd_processed_prompt": "engine prompt",
+            "_epd_prompt_token_ids": [4, 5, 6],
+        }
 
 
 class TestDisaggRequestId:


### PR DESCRIPTION
## Summary

- apply the text-only prefill-handoff optimization from #11202 to `feat/deepseek_v4_aa`
- omit duplicate prompt metadata for text-only requests, since decode already receives the original top-level `token_ids`
- preserve existing multimodal and EPD prompt metadata behavior
- include the focused text, multimodal, and EPD regression coverage from the source PR

The transplanted commit has the same stable patch ID as `29ef95d7e8bbee710098590375d8ca9f3b0880a9` from #11202.

## Validation

- `uvx --from ruff==0.5.2 ruff check components/src/dynamo/trtllm/request_handlers/handler_base.py components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py`
- `python3 -m py_compile components/src/dynamo/trtllm/request_handlers/handler_base.py components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py`
- `git diff --check origin/feat/deepseek_v4_aa...HEAD`
- `python3 -m pytest -q components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py -k TestPrefillPromptMetadata` (skipped as expected because CUDA/TRT-LLM GPU collection is unavailable locally)

Source PR: #11202