### PR TITLE
perf(runtime): batch large TCP request payloads

### DIFF
--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -71,6 +71,10 @@ const WRITER_SPIN_LIMIT: u32 = 64;
 /// Soft limit for queued bytes in the TCP writer buffer.
 const WRITER_SOFT_WRITE_BUF_LIMIT: usize = 65_535;
 
+/// Larger byte limit used while a batch contains only payloads that are at
+/// least as large as the default soft limit.
+const WRITER_LARGE_PAYLOAD_WRITE_BUF_LIMIT: usize = 1024 * 1024;
+
 /// Buffers smaller than this are coalesced into the writer's flattened buffer.
 const WRITE_FLATTEN_THRESHOLD: usize = 4096;
 
@@ -165,6 +169,7 @@ struct TcpWriteBuffer {
     write_buf: VecDeque<Bytes>,
     flattened_writes: BytesMut,
     write_buf_len: usize,
+    only_large_payloads: bool,
 }
 
 impl TcpWriteBuffer {
@@ -173,6 +178,7 @@ impl TcpWriteBuffer {
             write_buf: VecDeque::with_capacity(WRITE_VECTORED_CHUNKS),
             flattened_writes: BytesMut::new(),
             write_buf_len: 0,
+            only_large_payloads: true,
         }
     }
 
@@ -181,7 +187,12 @@ impl TcpWriteBuffer {
     }
 
     fn is_full(&self) -> bool {
-        self.write_buf_len >= WRITER_SOFT_WRITE_BUF_LIMIT
+        let limit = if self.only_large_payloads {
+            WRITER_LARGE_PAYLOAD_WRITE_BUF_LIMIT
+        } else {
+            WRITER_SOFT_WRITE_BUF_LIMIT
+        };
+        self.write_buf_len >= limit
     }
 
     fn queued_len(&self) -> usize {
@@ -192,9 +203,11 @@ impl TcpWriteBuffer {
         self.write_buf.clear();
         self.flattened_writes.clear();
         self.write_buf_len = 0;
+        self.only_large_payloads = true;
     }
 
     fn push_frame(&mut self, frame: TcpRequestFrame) {
+        self.only_large_payloads &= frame.payload.len() >= WRITER_SOFT_WRITE_BUF_LIMIT;
         self.write(frame.header);
         self.write(frame.payload);
     }
@@ -1828,6 +1841,32 @@ mod tests {
         assert_eq!(written, queued_len);
         assert_eq!(writer.written, expected);
         assert!(write_buf.is_empty());
+    }
+
+    #[test]
+    fn test_tcp_write_buffer_extends_batch_only_for_large_payloads() {
+        let frame = |payload_len| TcpRequestFrame {
+            header: Bytes::from_static(b"h"),
+            payload: Bytes::from(vec![b'p'; payload_len]),
+        };
+
+        let mut large_batch = TcpWriteBuffer::new();
+        for _ in 0..15 {
+            large_batch.push_frame(frame(WRITER_SOFT_WRITE_BUF_LIMIT));
+            assert!(!large_batch.is_full());
+        }
+        large_batch.push_frame(frame(WRITER_SOFT_WRITE_BUF_LIMIT));
+        assert!(large_batch.is_full());
+
+        let mut mixed_batch = TcpWriteBuffer::new();
+        mixed_batch.push_frame(frame(WRITER_SOFT_WRITE_BUF_LIMIT));
+        assert!(!mixed_batch.is_full());
+        mixed_batch.push_frame(frame(WRITE_FLATTEN_THRESHOLD));
+        assert!(mixed_batch.is_full());
+
+        mixed_batch.clear();
+        mixed_batch.push_frame(frame(WRITER_SOFT_WRITE_BUF_LIMIT));
+        assert!(!mixed_batch.is_full());
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Increase the TCP writer's byte-bounded batch while every request added so far has a large payload. All-large batches may grow to 1 MiB; encountering a smaller payload switches the batch back to the existing 65,535-byte threshold and ends that drain after the smaller frame. This amortizes writer wakeups and `writev` calls without reintroducing payload copies.

## Details:

- Track whether every payload added to the current batch is at least as large as the existing soft limit.
- Use a 1 MiB soft cap while that remains true, then stop extending the batch after the first smaller payload.
- Keep the 4,096-byte flattening threshold and 64-iovec syscall cap unchanged.
- Add a focused unit test for large-only, mixed, and cleared-buffer behavior.

## Where should the reviewer start?

`lib/runtime/src/pipeline/network/egress/tcp_client.rs`, specifically `TcpWriteBuffer::push_frame`, `TcpWriteBuffer::is_full`, and `test_tcp_write_buffer_extends_batch_only_for_large_payloads`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Performance

The comparison uses the median of five fresh-process runs on base `cc5cf40db46a673bd0087dd1a34eda7a80000813` and benchmark candidate `8352277293c557e27bb1e81405958654527a57f0`. The published PR commit `73e3a146bb` contains the same one-file change rebased onto current `main`; the reproduction steps below apply that published diff to the original base. Each run sends 250,000 requests after 12,500 warm-up requests through one real `TcpRequestClient` connection to a protocol-correct loopback ACK responder.

At a 65,536-byte payload and concurrency 256:

- Throughput: 160,006.15 to 192,078.77 requests/s, +32,072.62 requests/s (+20.04%).
- Client CPU: 9.2333 to 6.9221 µs/request, -2.3112 µs/request (-25.03%).
- p99 latency: 13.871 to 1.673 ms, -12.198 ms (-87.94%).
- p95 latency: 3.101 to 1.557 ms, -1.544 ms (-49.79%).
- p50 latency: 1.178 to 1.325 ms, +0.148 ms (+12.53%). This is the batching tradeoff at the highest tested concurrency.

At concurrency 32, throughput increased from 149,751.39 to 181,741.52 requests/s (+21.36%), client CPU fell from 9.8805 to 7.5321 µs/request (-23.77%), and p99 fell from 413.75 to 340.24 µs (-17.77%).

A diagnostic `strace` run over 5,000 requests at concurrency 256 reduced client socket-send attempts from 5,005 (1.001/request) to 945 (0.189/request). Median iovec occupancy rose from 2 to 19. Positive partial writes rose from 3 to 624 because each call covered more bytes; the existing partial-write loop handled them correctly. Syscall tracing was not used for throughput numbers.

The 1 MiB/concurrency-32 guard used 100,000 measured requests per run. Its five-run medians were not distinguishable within uncertainty: 12,272.44 versus 12,510.53 requests/s, with ranges of 12,208.98–12,344.58 and 12,037.86–12,608.04 requests/s. A separate seven-run check produced 12,244.54 versus 12,234.59 requests/s (-0.08%).

An additional five-run sweep covered payloads 64, 1,024, 4,095, 4,096, 4,097, 16,384, 65,536, and 1,048,576 bytes at concurrency 1, 32, and 256. Small and threshold-adjacent groups stayed within run-to-run uncertainty. All measured requests completed with the expected empty ACK and zero errors.

These are focused request-plane measurements, not full model-serving results. The real client framing, allocation, lock-free queue, writer batching, socket writes, response decoding, and waiter delivery execute unchanged. The mock replaces the worker at the TCP protocol boundary. Both processes run on one host over loopback; no tokenizer, model backend, GPU execution, or network fabric is included. Payload-size prevalence in production is unknown, so the 65,536-byte gains should not be extrapolated to aggregate deployment throughput without a representative payload distribution.

## Benchmark methodology

Prerequisites are Linux with `taskset`, Python 3, Git, and the Rust toolchain pinned by `rust-toolchain.toml`. Use separate Cargo target directories and do not build during measurement. The reported host was an Intel Core Ultra 9 285K with 24 CPUs and no SMT, Ubuntu 24.04.2 LTS, Linux 6.17.0-35-generic, glibc's allocator, Rust/Cargo 1.96.1, and the `powersave` governor. Client threads were pinned to CPUs 2-3 and the responder to CPUs 4-7.

Create the worktrees and decode the complete one-off harness embedded below:

```bash
export PERF_WORK=/tmp/dynamo-tcp-large-batch
export BASE_SHA=cc5cf40db46a673bd0087dd1a34eda7a80000813
export FIX_SHA=73e3a146bb
mkdir -p "$PERF_WORK"/{bin,results}
git worktree add --detach "$PERF_WORK/base" "$BASE_SHA"
git worktree add --detach "$PERF_WORK/fix" "$BASE_SHA"
git show "$FIX_SHA" --format= -- \
  lib/runtime/src/pipeline/network/egress/tcp_client.rs | \
  git -C "$PERF_WORK/fix" apply
base64 -d <<'B64' | gzip -d > "$PERF_WORK/tcp_request_plane_bench.rs"
H4sIAAAAAAACA60baXPctvW7fgW0napce5em7ojyyiPbcquJE3tsJ23Go2GwJFbLiEsyBKkjsv5738NBAjxW8rTOxBKBd+Hh4V2AX7wgnz++/c/0XZywN1l+V8SXy/ILuy19Un8SJxyTHW/ngPz86/nb81Py5sOnjx8+nX45//Az2SKn796dvz8//XL22SWnSUIEDicF46y4ZpG78ULxeB+HLOVseh6xtIwXMSt8cprTcMmmO663AXCb5F0WVpxFZM7ScLmixRVZZAV5e5fSVfYPTvIii6qwjLOUfHnzEXj8WTFekjCJgSRy2hRUviyZGiOrLGKE3bIijDnj5PcvYf5JYr0RAL8TlkakzPDHhMRpmFRRnF5q0oLcoqArGJsQGq1izoH7hMBsxcTgTRGXrCBzWoZLMVAC94LRhCRZls9peCVk5Vl4xcqJIAi6yTNQBYlYmEWSNEhxQwWliCXxNSvuXLEOocVCrqNgeUJDWAayuMmKK1YIekvATgCIlmIG2YGmyizMEjLPqjSixR25icsloQRWEq9AOA0wDbOiYGFJTt/8aAgXATmeCbYJ6i+shNZRTFwSKo3DzkVVgtqKMpJmJfwA6rRkKIWiJbQ4BbFTRlYsBEljviKVoF/ClLuxARtO5nfw4fv3r6vFhLzGD/Xjp6p8OBYgkTCCoKjAeFbM9/M4B0Wl8FvKSlSG77NLEB7IlGEeyP0Hku0dnxBjJEsX8eX3M6hStN+oYfIvRmFFILQi/BEXLPkp6rCPEQv+4Fnq+/i3Gi0joJpeG19xZnwAZ9//LEznNIoKY4bfpaHvnxahMSblvn9bFbQUVnqe8pLWIpTZVZwhA4A5RfxPIPXZLWhEfP0bDRk+bWghASrxfcxLlrJC6O9zCRa+siFrxb2u4gS0YU1KcV/ToohxZuNvXwECzNx5y+bV5fhig5dFhVZYXHJyv0HgD9qeT4ATHhAxQkEFMFKrQ46WS5Al4j6pePwXk2M5vUsyGgXSrsyZMEvDCiw+De+scWWqNvANLVZVHvTO5VmWBPhpkwcLT1kSzKvFAh2cxeE6Rudhrymhc5bYQ/LIB7iqAI4fvQsqZH2wN9l42NiIV3liqmmRwmoLzpwxmZ6QzyxZqAlBnZXkmiYVKuFXFr6UbE7IDPzdte9TIOOMXX4V58722AV3kIArcMbHXQKA8g3OB6x2C7ZqAl5qQauklJ/fBGtB22COfyRzawj/uDdxGmU33NkZd+cWMBesaO58y2kMtB388dW7ILMZQRHGLviX1Pn2jYiJ7Qs3TLIUFDDuIValNwXNg6wIWAJKAiQluVtmARciOwbeg710odnHly52uW/lDuLVGD3iqa17XO4AV5vG4aYzilOgHUdqXzBA3iObh5G9jvr3lk00Z0uKOJpO8XM0ISPpz0bjiQUsj10NjJ8IvL1z6Hrw37a/e+Ttb4++Z3XsNkdDq5eiqLYY1ydb0gHeagTZ77ShW2e+xlHjUzGOmHve0UEb2XILNaoxioi7HZ6NZ6hx9JBQkYd/2kgdr1Ljypkuic5SG9/TLBPGpjgmsDrra/mlZolyYionJMedve46te+qzUAPIUqVXqXZTdrGUr6tRhHfa+D7HV+NLqenOD0V09NKqMj7H02vl64h2sOG/PvBCFtv0ONMRJI8ISKG4Q95yutg9gunl9otQCwsAg75XooGvUBnLpZ8B1F11TMBmRScfUEQhuN6mP7RN3ydJRB9Ic0LgE4J+XvAId+DBM0EghU/Bqbjiyk5BJiQ5mVVDIeYVVXCAhFlJjORFVv5/k/0bs5+SSHhhBTiZRLPQ0wSEOxEpFAwboYarBNO3519+c0nl6yUgASBYtinv1TWy6s8BycVETUPOSmvQsiJuWtJVIQgSpVyuoBlEMm7purI70+/fD7951nw+ez9u4kU36U8gLUEeVlAUDCDAeWwf2XA/tx0inBCPDC7RsgFhfIp8sn9A5gjZjtnRZEVvp9QXgYZDxh+AsHetUrKsCK1jkWVNKumMuueZ9fMXp/Wdr1ELT+vViyQqjXl74kBtkVi6gYHQg84kl5RBRXOtA9qy2oHkXkPsm3ZNSgML5KyBWpZewNK/+iArjPtGjG9DvmNjbf+UDSYsY2qfYI+IRxKR+Zw0PKEMFokorpFpfcdmUc3A+m45hCZaqrW8PpdEVTsQYOOPbFuiwQdc8igYg6v2ztJwxgyaRjDT99UQXEYoOP4G37DSN9jGoL/OpA1EqxD6407YGHtMybCoq9cm5oUxgYhRBmXAHHLa8QBPyNmnjejlTH8gmwHkGjg/66nOIYZhAJWsgAbICxIIOeGLAHS3q/VDxeC1Ycc/dNLkf6eKKbxggCUi9Bj8pLsGIZeMIgiKfkZQufxRrNC9GcsjfIsTkvkgm5t+8D3F0W2CuZMJnTOV6AKRcAEqUPODwKA6ILzcU1lKctwJBJkiwWHoRnZEUAu6BbqxiiARNMxuY1fHffJ3UPq+VMXY+CSWY0wtKYuJ7XIXhEGVq6TX2vlXQK1MJY6dsav+icMAgNq6uH7nOw9TU0GLm757k5HPTUVVEeX1cXkEQChrycA7TwFaFcB9eq/zEo4m3IlXex+7e4Nqd0goNXuNEo/mTXcZCkc8GzFnGYQzy/FjouITJjdopdJmeicOpiscdG/8ZtWzoQ0WbdPdAdJHHJMaD4xDt75pTPWp1wScGFtQZoJLAeyIabF1UlhwUIG6TIoRXfzfB8bkQFklDSMyztnjzwjWHGoH2Mbn4ZYKEBydclWUJlyIPQrCzs0oKDTiFmWG9YH1qokFcsDJTpbhlxjl2LT9RV2FrxWRFaG++HKsTK3B5P2ZqM0N+bBX6zIYINsOqoBJltjPGEsdxosJYBJvpNYw9ZhUhfB2j3D6kwQ4aB5D8DNEjJTAfYZTaR25GOA7XHvW0ovXzVP171or6cW5/mM1JjHFogSBwC27QlQWbOamd4FZdf3nYA5B0Vd2RQe+jeiprrZt5GSC42uKSZpGnZoU5X0PZQgaz+j4ZKwVV7eyTaybOT/BHm7qFY4oWSRVYVoNoAXjy+nEGtimhK0Ddduq7Rs2w0TyA/MiqgXqmC4xY6S8hnZg2qkhaNMXtxMBDRJnK02FW34x33JRu06igpciyiOHewUQuTHvuOwU0A7S1SbGAzMaBr7/jxOI0HFxU6PzT8vIBYn6aYz+nR2+vY3WUdpQm6SheDXEMsZvzL8gzhAwEY7KxU9VnFYZFyy6mso9DsKJOhw5QoDPB41fwplWQ7lVEdlurWd05vUkUpbQaHWMhqwKCQOJaEj6kCk3fHJmrPpFHoOBGs0pe6FGhpEUIciVPx8GI0HD874uKeh0erDf6H8Su6v3lsK2ghjxoNU9ZKrg70TGREFx6Y73jYh3c5yZIdc3pmQ0yJ82b6bOWn6/HjPImBUy9rq6/vqjkiMqSRFQquLmJPvbPYLm3bqValh0tykiIbI2LDzubzKgM0EtnhNcuOo2w35YbDGLGTcCmwl6HcgmhmYBlIOdoxIZFZLD0m7AduAFmxFY3HDZsD+vQuLnWMkGSDwLZQ7xHNdU277eIQZVCyY3mhJnks1yXPnGJReNiK0rhLUrexMX9mqxr0NpLYfoNRv/WDKFpqEqx9MmUeTDveDNfupfuuCiT1z84ovnacdfb3Z5tkZ2nPQbevEamx5unqCuwiRSlh0GE4nm9C7HNSbi1vY9SvIikM1ijuj7gzBirObdjCSdT2UqWr/OpMileUQ8vShd5xnahPHWqGT9n5NiPNM7U0NNO4nLdbXmbrvBYbMTV+0j9EL6w/M1EQEh5xjBqHrYQgbwsA34bcDAaj2AbOaSQelS8TcdGk0QsMuePicswg3C6ZoCrFKFhQHe4MuG/90PPIQs65wUvLJYDyoA8KG1V6EQgyMB5N34f18v24DN75mndUM2+bTD4b2Xy332XsmtD9DY5f+1XZghdTeTExKcerbAOWY5KMKSUVct0FJZkZSa1PZLXxEjiTrmlMGRmM1Ck4OdPof0ipE/9yykuONdsu3vRmu7D2aW6awHMsstBloXqrnPVbdHnDrIT7MSZjDM2xIi0bPwd7FxJgSFxStLhPWWALBPFidBoDneu01FzTFcOYofqoMmEKw1F2pZwbrsVvgUxanXX1L5K9I7KLVzZKdLCsXkfvcSWdperfMbnpSWtmd35TppBkbT8QdgHVFCJbJIZAwkmc8LiGp0pZjEakjMtTxbapAscwysmA3deAeGRYQiucqMrO2XrBY6hbjAdabGZTb7fSYs5A7u57RkzcuE4U89XcDorLM9UT3DZrt60a5UGtQAj8Yq9O5QZ1QtdND7RzEmh35wyoJmsyhpgHHASIWJMz3Dy/AmBYv6qdlUGM09ci400rTPQuV3lyzcPOrd7tPj5WWzNvmi3GnB2nKoJJSRanpajkj/UAqjkbmewSwA5RVXwRbc4aWHcujj8qCQqVCC7zCt6jZYJ433ZsvjnYWu/uHh/PdvYge0N2QHe0cRR7z2N7h7sHU8xbewSGl3pweeTvzw6m3PUByWJzbKSw3RRc5xYxgWvJpytcJtn34A4i0f3jk1X/WM73AbdvQlTk4zjkUbUtxT2jURSqK4d36tMrxVZsxycE75Vi3g1nzOGKa2jwrlzUKvnpbMcrB3a7EQ0MjosiHfLN2QvR/ToKs2lM7K5aiRJtOT2Ij7thlbIOgkmbpVPYsTt/8ONI6A78tLLn1HAE9W7swDprgEajyuFvY1WffSu27T0mMhL73AUf/ZCt5b5Ft+9HubGuV7oredpy6aWEt1Rs3wS3t61RkJgKCrL75Q207tVrlJfGom2s5ViY0GKYHdS713YiudGw4eKnXZkDp0kAZ1J8VsuSwVI2VzmnhXQzGQZWKo2jliWFe1XeQM3Wtal1wPleD9rWk0WBfQvi/XOYVRgg7kNZBX2kME2uMSAGMOl3HHqzieZDXrDEfbGg/6/HuDQMHW9Sup3rVrmdmpYymQcWN+55GK/isF/I08aRtS1y/fVOPtyRlSOGqle+/hF9PIL95YaDKnKid1qgTXHeDap4jbJ3VX/jOdNOxq4URPttd0eAaDABf7/jtamYkX+momC0+WgD1yx9fb4T8boFZOtSw1mALwXxt5T9ypkd1fuT32WgN1jr2Gro13JZcZ0Cj4ZRISmxlNKM1eU4TpNULNgWrPltAypD1KQDgXtPuklZmXC/MsHMg0gAMbJV9Mkb+wJHpGAxa612gjgCgqd8G4PJ9T4IZJceW4QA9d98bD+Ee7T+Ce7Q/jHv0GO7REC6Ei7W4225HZHR5posb+T1+rwfH9oA11rr3GiPDvQKC8dUDp1YQQByFVLpgNsKQGxU+D1xPD0HZcZfowkp02moTfmY+MQA2fU68Rd18XVIrYvjJych8SdLADz4vGQ2/wqixn/pYZLTuTUdN7WkPP6QPEGkAHv1W9+ZBBuBxfzI4kI6o9DUaykfkNadqBWDv1llfF4tqCx+hz8RbdN9X7y2NLrT85wBYRsl/DyBqoWAFdOJAuj3jeaYrOy9qQl3fqA8DiqWYWIg7LWN0jgwcffcsG5SCAL5rFmaM7/mMpFbdnoywrafkdOdJFl7BoXCMW68tpDIWkRsf8TnnaYn/gAL+Ng67fjU9SEz1HBSxBlH8m55Zo+Q57AgUqpA+VXkuuhpEPs0m9/j3g36Tihc3/wXDjCiouTUAAA==
B64
echo 'b78cfe1ace0c7589f5862016785b84a0119d490000d80245fc0b7af5504b6ec0  '"$PERF_WORK/tcp_request_plane_bench.rs" | sha256sum -c -
```

Build independently with the repository lockfile and release profile:

```bash
for arm in base fix; do
  mkdir -p "$PERF_WORK/$arm/lib/runtime/examples"
  cp "$PERF_WORK/tcp_request_plane_bench.rs" "$PERF_WORK/$arm/lib/runtime/examples/"
  CARGO_TARGET_DIR="$PERF_WORK/target-$arm" cargo build \
    --manifest-path "$PERF_WORK/$arm/Cargo.toml" --release --locked \
    -p dynamo-runtime --example tcp_request_plane_bench
  cp "$PERF_WORK/target-$arm/release/examples/tcp_request_plane_bench" \
    "$PERF_WORK/bin/tcp-request-$arm"
done
```

For every sample, start a fresh base responder, wait for `READY`, run one client arm, then terminate that responder:

```bash
taskset -c 4-7 "$PERF_WORK/bin/tcp-request-base" --mode server \
  --addr 127.0.0.1:39051 --threads 4 --server-read-delay-us 0 >server.log 2>&1 &
server_pid=$!
until grep -q '^READY ' server.log; do sleep 0.02; done

taskset -c 2-3 "$PERF_WORK/bin/tcp-request-$ARM" --mode client \
  --addr 127.0.0.1:39051 --threads 2 --payload-bytes 65536 \
  --concurrency 256 --requests 250000 --warmup-requests 12500 \
  --pool-size 1 --channel-buffer 1024 --revision "$ARM" --label "$ARM-$REP" \
  >>raw.jsonl
kill "$server_pid"; wait "$server_pid" 2>/dev/null || true
```

Use `ARM` order `base fix fix base fix base base fix base fix`, five samples per arm. Repeat with concurrency 32. For the 1 MiB guard use payload 1,048,576, concurrency 32, 100,000 measured requests, and 5,000 warm-up requests. The broad guard matrix uses payloads `64 1024 4095 4096 4097 16384 65536 1048576` at concurrency `1 32 256`.

Each successful run emits one JSON object. Require `errors == 0`; the harness also fails on a non-empty ACK. Compute each arm's median from the five raw values with Python's `statistics.median`. Expected 65,536-byte/concurrency-256 medians are approximately 160k versus 192k requests/s, 9.23 versus 6.92 µs CPU/request, and 13.9 versus 1.67 ms p99. Retain outliers and report the observed range.

## Validation

Passed on refreshed `origin/main`:

```bash
cargo fmt --all --check
cargo test --release -p dynamo-runtime \
  pipeline::network::egress::tcp_client::tests -- --nocapture
```

The focused release suite completed with 27 tests passed and no failures.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP write buffering so batches of larger messages can queue more data before sending, reducing unnecessary flushes.
  * Mixed message batches still follow the standard buffer limit, preserving existing behavior for smaller payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->