### PR TITLE
perf(kv-router): share request block ownership chains

### DIFF
--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -5,47 +5,181 @@ use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
 use std::sync::{Arc, Weak};
 
+/// One node in a persistent request block chain.
+///
+/// Sequence hashes identify their lineage, so a live tail transitively owns the
+/// entire prompt prefix through these parent references.
 #[derive(Debug)]
-pub(super) struct BlockAcquire {
-    pub(super) rc: Arc<()>,
-    pub(super) became_present_on_worker: bool,
+struct BlockNode {
+    hash: SequenceHash,
+    depth: usize,
+    parent: Option<Arc<BlockNode>>,
+}
+
+/// The single strong block owner retained by a request.
+///
+/// This type intentionally does not implement `Clone`. New request owners must
+/// be acquired through [`BlockTracker::acquire_prompt`], which also maintains
+/// the weak block index and membership transitions.
+#[derive(Debug, Default)]
+pub(super) struct RequestBlockChain {
+    tail: Option<Arc<BlockNode>>,
+    prompt_depth: usize,
+}
+
+impl RequestBlockChain {
+    fn new(tail: Option<Arc<BlockNode>>, prompt_depth: usize) -> Self {
+        Self { tail, prompt_depth }
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    fn nodes_from_tail(&self) -> impl Iterator<Item = &BlockNode> {
+        std::iter::successors(self.tail.as_deref(), |node| node.parent.as_deref())
+    }
+
+    #[cfg(test)]
+    pub(super) fn prompt_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
+        self.nodes_from_tail()
+            .filter(|node| node.depth <= self.prompt_depth)
+            .map(|node| node.hash)
+    }
+}
+
+impl Drop for RequestBlockChain {
+    fn drop(&mut self) {
+        let Some(mut current) = self.tail.take() else {
+            return;
+        };
+
+        // A block-size-1 prompt can contain tens of thousands of nodes. Unwrap
+        // an exclusively owned suffix iteratively so dropping the parent chain
+        // cannot overflow the stack.
+        loop {
+            match Arc::try_unwrap(current) {
+                Ok(mut node) => match node.parent.take() {
+                    Some(parent) => current = parent,
+                    None => break,
+                },
+                Err(shared) => {
+                    drop(shared);
+                    break;
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
-    pub(super) unique_blocks: FxHashMap<SequenceHash, Weak<()>>,
-    pub(super) fractional_blocks: FxHashMap<SequenceHash, f64>,
+    unique_blocks: FxHashMap<SequenceHash, Weak<BlockNode>>,
+    fractional_blocks: FxHashMap<SequenceHash, f64>,
 }
 
 impl BlockTracker {
-    pub(super) fn touch_block(&mut self, block: &SequenceHash) -> BlockAcquire {
-        if let Some(weak) = self.unique_blocks.get(block)
-            && let Some(rc) = weak.upgrade()
-        {
-            return BlockAcquire {
-                rc,
-                became_present_on_worker: false,
-            };
+    /// Acquire one strong tail for a prompt and return the first newly present
+    /// prompt index, if any.
+    pub(super) fn acquire_prompt(
+        &mut self,
+        sequence: &[SequenceHash],
+    ) -> (RequestBlockChain, Option<usize>) {
+        let Some(&tail_hash) = sequence.last() else {
+            return (RequestBlockChain::default(), None);
+        };
+
+        if let Some(tail) = self.upgrade_live_node(tail_hash) {
+            Self::debug_assert_lineage(&tail, sequence);
+            return (RequestBlockChain::new(Some(tail), sequence.len()), None);
         }
 
-        let rc = Arc::new(());
-        self.unique_blocks.insert(*block, Arc::downgrade(&rc));
-        BlockAcquire {
-            rc,
-            became_present_on_worker: true,
+        let mut parent = None;
+        let mut first_new_idx = 0;
+
+        // Prompt liveness is prefix-closed. Search backward for the deepest
+        // live prefix, then construct only the missing suffix.
+        for idx in (0..sequence.len().saturating_sub(1)).rev() {
+            if let Some(node) = self.upgrade_live_node(sequence[idx]) {
+                Self::debug_assert_lineage(&node, &sequence[..=idx]);
+                parent = Some(node);
+                first_new_idx = idx + 1;
+                break;
+            }
         }
+
+        for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
+            let node = Arc::new(BlockNode {
+                hash,
+                depth: first_new_idx + idx + 1,
+                parent,
+            });
+            self.unique_blocks.insert(hash, Arc::downgrade(&node));
+            parent = Some(node);
+        }
+
+        (
+            RequestBlockChain::new(parent, sequence.len()),
+            Some(first_new_idx),
+        )
     }
 
-    pub(super) fn try_remove_block(&mut self, block: &SequenceHash) -> bool {
-        if let Some(weak) = self.unique_blocks.get(block)
-            && weak.strong_count() == 0
-        {
-            self.unique_blocks.remove(block);
-            self.fractional_blocks.remove(block);
-            return true;
+    /// Append a unique output block to an existing request chain.
+    pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
+        debug_assert!(
+            self.upgrade_live_node(hash).is_none(),
+            "random output hash unexpectedly collided with a live block"
+        );
+
+        let parent = chain.tail.take();
+        let depth = parent.as_ref().map_or(1, |node| node.depth + 1);
+        let node = Arc::new(BlockNode {
+            hash,
+            depth,
+            parent,
+        });
+        self.unique_blocks.insert(hash, Arc::downgrade(&node));
+        chain.tail = Some(node);
+    }
+
+    /// Release a request chain and return the prompt suffix that became absent
+    /// from the worker.
+    pub(super) fn release(&mut self, chain: RequestBlockChain) -> Vec<SequenceHash> {
+        let mut dead_nodes = Vec::new();
+        let mut current = chain.tail.as_ref();
+
+        while let Some(node) = current {
+            if Arc::strong_count(node) != 1 {
+                break;
+            }
+            dead_nodes.push((node.hash, node.depth));
+            current = node.parent.as_ref();
         }
 
-        false
+        for &(hash, _) in &dead_nodes {
+            self.unique_blocks.remove(&hash);
+            self.fractional_blocks.remove(&hash);
+        }
+
+        let mut prompt_remove = dead_nodes
+            .into_iter()
+            .filter_map(|(hash, depth)| (depth <= chain.prompt_depth).then_some(hash))
+            .collect::<Vec<_>>();
+        prompt_remove.reverse();
+        prompt_remove
+    }
+
+    /// Mark the request's exclusively owned suffix as fractional.
+    pub(super) fn set_unique_suffix_fractional(
+        &mut self,
+        chain: &RequestBlockChain,
+        fraction: f64,
+    ) {
+        let mut current = chain.tail.as_ref();
+        while let Some(node) = current {
+            if Arc::strong_count(node) != 1 {
+                break;
+            }
+            self.fractional_blocks.insert(node.hash, fraction);
+            current = node.parent.as_ref();
+        }
     }
 
     pub(super) fn active_blocks(&self) -> usize {
@@ -57,6 +191,55 @@ impl BlockTracker {
         }
         count.round() as usize
     }
+
+    pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
+        self.unique_blocks.contains_key(hash)
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn fractional_hashes_are_active(&self) -> bool {
+        self.fractional_blocks
+            .keys()
+            .all(|hash| self.unique_blocks.contains_key(hash))
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn contains_chain(&self, chain: &RequestBlockChain) -> bool {
+        chain
+            .nodes_from_tail()
+            .all(|node| self.unique_blocks.contains_key(&node.hash))
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
+        self.unique_blocks.keys().copied()
+    }
+
+    fn upgrade_live_node(&mut self, hash: SequenceHash) -> Option<Arc<BlockNode>> {
+        let weak = self.unique_blocks.get(&hash)?;
+        let node = weak.upgrade();
+        if node.is_none() {
+            self.unique_blocks.remove(&hash);
+            self.fractional_blocks.remove(&hash);
+        }
+        node
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    fn debug_assert_lineage(tail: &Arc<BlockNode>, sequence: &[SequenceHash]) {
+        assert_eq!(tail.depth, sequence.len(), "sequence tail depth mismatch");
+        let mut current = Some(tail.as_ref());
+        for (expected_depth, &expected_hash) in sequence.iter().enumerate().rev() {
+            let node = current.expect("live sequence chain ended before its expected root");
+            assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
+            assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
+            current = node.parent.as_deref();
+        }
+    }
+
+    #[cfg(not(any(test, debug_assertions)))]
+    #[inline]
+    fn debug_assert_lineage(_tail: &Arc<BlockNode>, _sequence: &[SequenceHash]) {}
 }
 
 #[cfg(test)]
@@ -64,43 +247,72 @@ mod tests {
     use super::*;
 
     #[test]
-    fn first_touch_and_last_remove_report_presence_transitions() {
+    fn first_acquire_and_last_release_report_presence_transitions() {
         let mut tracker = BlockTracker::default();
 
-        let first = tracker.touch_block(&1);
-        let second = tracker.touch_block(&1);
+        let (first, first_new) = tracker.acquire_prompt(&[1]);
+        let (second, second_new) = tracker.acquire_prompt(&[1]);
 
-        assert!(first.became_present_on_worker);
-        assert!(!second.became_present_on_worker);
+        assert_eq!(first_new, Some(0));
+        assert_eq!(second_new, None);
         assert_eq!(tracker.active_blocks(), 1);
 
-        drop(first.rc);
-        assert!(!tracker.try_remove_block(&1));
+        assert!(tracker.release(first).is_empty());
         assert_eq!(tracker.active_blocks(), 1);
 
-        drop(second.rc);
-        assert!(tracker.try_remove_block(&1));
+        assert_eq!(tracker.release(second), vec![1]);
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn release_only_removes_unique_branch_suffix() {
+        let mut tracker = BlockTracker::default();
+        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
+
+        assert_eq!(first_new, Some(2));
+        assert_eq!(tracker.active_blocks(), 4);
+        assert_eq!(tracker.release(left), vec![3]);
+        assert_eq!(tracker.active_blocks(), 3);
+        assert_eq!(tracker.release(right), vec![1, 2, 4]);
         assert_eq!(tracker.active_blocks(), 0);
     }
 
     #[test]
     fn fractional_blocks_adjust_active_block_count() {
         let mut tracker = BlockTracker::default();
-        let first = tracker.touch_block(&1);
-        let second = tracker.touch_block(&2);
+        let (chain, _) = tracker.acquire_prompt(&[1, 2]);
 
-        tracker.fractional_blocks.insert(1, 0.5);
-        tracker.fractional_blocks.insert(2, 0.5);
+        tracker.set_unique_suffix_fractional(&chain, 0.5);
         assert_eq!(tracker.active_blocks(), 1);
 
-        drop(first.rc);
-        assert!(tracker.try_remove_block(&1));
-        assert!(!tracker.fractional_blocks.contains_key(&1));
-        assert_eq!(tracker.active_blocks(), 1);
-
-        drop(second.rc);
-        assert!(tracker.try_remove_block(&2));
+        assert_eq!(tracker.release(chain), vec![1, 2]);
         assert!(tracker.fractional_blocks.is_empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn output_only_chain_releases_without_prompt_membership() {
+        let mut tracker = BlockTracker::default();
+        let (mut chain, first_new) = tracker.acquire_prompt(&[]);
+
+        assert_eq!(first_new, None);
+        tracker.append_output(&mut chain, 42);
+        assert_eq!(tracker.active_blocks(), 1);
+        assert!(tracker.release(chain).is_empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn long_chain_release_is_iterative() {
+        const DEPTH: usize = 65_536;
+        let sequence = (1..=DEPTH as u64).collect::<Vec<_>>();
+        let mut tracker = BlockTracker::default();
+        let (chain, first_new) = tracker.acquire_prompt(&sequence);
+
+        assert_eq!(first_new, Some(0));
+        assert_eq!(tracker.active_blocks(), DEPTH);
+        assert_eq!(tracker.release(chain), sequence);
         assert_eq!(tracker.active_blocks(), 0);
     }
 }

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -78,6 +78,12 @@ pub(super) struct BlockTracker {
 impl BlockTracker {
     /// Acquire one strong tail for a prompt and return the first newly present
     /// prompt index, if any.
+    ///
+    /// # Lineage contract
+    ///
+    /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
+    /// depth. As with the KV indexer, this tracker trusts callers to maintain
+    /// that invariant and does not validate the hash recurrence in production.
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],
@@ -124,7 +130,10 @@ impl BlockTracker {
     /// Append a unique output block to an existing request chain.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
         debug_assert!(
-            self.upgrade_live_node(hash).is_none(),
+            self.unique_blocks
+                .get(&hash)
+                .and_then(Weak::upgrade)
+                .is_none(),
             "random output hash unexpectedly collided with a live block"
         );
 
@@ -288,6 +297,25 @@ mod tests {
 
         assert_eq!(tracker.release(chain), vec![1, 2]);
         assert!(tracker.fractional_blocks.is_empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn release_cleans_fractional_unique_suffix_above_shared_prefix() {
+        let mut tracker = BlockTracker::default();
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (shared_prefix, _) = tracker.acquire_prompt(&[1, 2]);
+
+        tracker.set_unique_suffix_fractional(&longer, 0.5);
+        assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
+        assert!(!tracker.fractional_blocks.contains_key(&1));
+        assert!(!tracker.fractional_blocks.contains_key(&2));
+
+        assert_eq!(tracker.release(longer), vec![3]);
+        assert!(tracker.fractional_blocks.is_empty());
+        assert_eq!(tracker.active_blocks(), 2);
+
+        assert_eq!(tracker.release(shared_prefix), vec![1, 2]);
         assert_eq!(tracker.active_blocks(), 0);
     }
 

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -20,7 +20,6 @@
 
 use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -28,7 +27,7 @@ use uuid::Uuid;
 #[cfg(test)]
 use rustc_hash::FxHashSet;
 
-use super::block_tracker::BlockTracker;
+use super::block_tracker::{BlockTracker, RequestBlockChain};
 use super::prefill_tracker::{PrefillLoadState, PrefillLoadTracker};
 use super::prompt_registry::WorkerLoadSnapshot;
 use crate::protocols::PrefillLoadHint;
@@ -45,16 +44,9 @@ pub type RequestId = String;
 
 #[derive(Debug)]
 pub(super) struct RequestState {
-    prompt_blocks: Vec<(SequenceHash, Arc<()>)>,
-    output_blocks: Vec<(SequenceHash, Arc<()>)>,
+    blocks: RequestBlockChain,
     started_at: Instant,
     expected_output_tokens: Option<u32>,
-}
-
-impl RequestState {
-    fn all_blocks(&self) -> impl Iterator<Item = &(SequenceHash, Arc<()>)> {
-        self.prompt_blocks.iter().chain(self.output_blocks.iter())
-    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -143,11 +135,14 @@ impl ActiveSequences {
             "prefill tracker cannot reference missing request state",
         );
         assert!(
-            self.blocks
-                .fractional_blocks
-                .keys()
-                .all(|hash| self.blocks.unique_blocks.contains_key(hash)),
+            self.blocks.fractional_hashes_are_active(),
             "fractional_blocks cannot reference non-active blocks",
+        );
+        assert!(
+            self.requests
+                .values()
+                .all(|state| self.blocks.contains_chain(&state.blocks)),
+            "request block chain cannot reference an unindexed block",
         );
     }
 
@@ -185,41 +180,22 @@ impl ActiveSequences {
         let mut outcome = self.force_expiry();
         let started_at = Instant::now();
 
-        let prompt_blocks = match token_sequence {
-            Some(sequence) => {
-                let mut first_new_prompt_idx = None;
-                let prompt_blocks: Vec<_> = sequence
-                    .into_iter()
-                    .enumerate()
-                    .map(|(idx, block)| {
-                        let acquire = self.blocks.touch_block(&block);
-                        if acquire.became_present_on_worker && first_new_prompt_idx.is_none() {
-                            first_new_prompt_idx = Some(idx);
-                        }
-                        (block, acquire.rc)
-                    })
-                    .collect();
+        let prompt_hashes = token_sequence.unwrap_or_default();
+        let (blocks, first_new_prompt_idx) = self.blocks.acquire_prompt(&prompt_hashes);
 
-                if let Some(first_new_prompt_idx) = first_new_prompt_idx {
-                    debug_assert!(
-                        prompt_blocks[first_new_prompt_idx..]
-                            .iter()
-                            .all(|(hash, _)| self.blocks.unique_blocks.contains_key(hash))
-                    );
-                    let parent = first_new_prompt_idx
-                        .checked_sub(1)
-                        .map(|idx| prompt_blocks[idx].0);
-                    let hashes = prompt_blocks[first_new_prompt_idx..]
-                        .iter()
-                        .map(|(hash, _)| *hash)
-                        .collect();
-                    outcome.membership_delta.push_store(parent, hashes);
-                }
-
-                prompt_blocks
-            }
-            None => Vec::new(),
-        };
+        if let Some(first_new_prompt_idx) = first_new_prompt_idx {
+            debug_assert!(
+                prompt_hashes[first_new_prompt_idx..]
+                    .iter()
+                    .all(|hash| self.blocks.contains_block(hash))
+            );
+            let parent = first_new_prompt_idx
+                .checked_sub(1)
+                .map(|idx| prompt_hashes[idx]);
+            outcome
+                .membership_delta
+                .push_store(parent, prompt_hashes[first_new_prompt_idx..].to_vec());
+        }
 
         let prefill = if track_prefill_tokens {
             prefill_load_hint.and_then(|hint| {
@@ -235,8 +211,7 @@ impl ActiveSequences {
         self.requests.insert(
             request_id.clone(),
             RequestState {
-                prompt_blocks,
-                output_blocks: Vec::new(),
+                blocks,
                 started_at,
                 expected_output_tokens,
             },
@@ -272,22 +247,14 @@ impl ActiveSequences {
             return PromptMembershipDelta::default();
         };
 
-        let _ = request_state.expected_output_tokens;
+        let RequestState {
+            blocks,
+            expected_output_tokens,
+            ..
+        } = request_state;
+        let _ = expected_output_tokens;
         let mut membership_delta = PromptMembershipDelta::default();
-        let mut prompt_remove = Vec::new();
-
-        for (block_hash, rc) in request_state.prompt_blocks {
-            drop(rc);
-            if self.blocks.try_remove_block(&block_hash) || !prompt_remove.is_empty() {
-                prompt_remove.push(block_hash);
-            }
-        }
-        membership_delta.push_remove(prompt_remove);
-
-        for (block_hash, rc) in request_state.output_blocks {
-            drop(rc);
-            self.blocks.try_remove_block(&block_hash);
-        }
+        membership_delta.push_remove(self.blocks.release(blocks));
 
         self.validate_state();
         membership_delta
@@ -301,27 +268,24 @@ impl ActiveSequences {
         request_id: &RequestId,
         decay_fraction: Option<f64>,
     ) -> Option<SequenceHash> {
-        if !self.requests.contains_key(request_id) {
+        let Some(request_state) = self.requests.get_mut(request_id) else {
             tracing::warn!("Request {request_id} not found for add_output_block");
             return None;
-        }
+        };
 
         // TODO: Output blocks still use random hashes, so indexing them mainly simplifies
         // generic block bookkeeping and usually adds little real reuse signal.
         let random_hash: SequenceHash = Uuid::new_v4().as_u64_pair().0;
-        let acquire = self.blocks.touch_block(&random_hash);
-        self.requests
-            .get_mut(request_id)
-            .expect("request existence was checked above")
-            .output_blocks
-            .push((random_hash, acquire.rc));
+        self.blocks
+            .append_output(&mut request_state.blocks, random_hash);
 
         if let Some(frac) = decay_fraction {
-            self.set_single_ref_blocks_as_fractional(request_id, frac);
+            self.blocks
+                .set_unique_suffix_fractional(&request_state.blocks, frac);
         }
 
         self.validate_state();
-        acquire.became_present_on_worker.then_some(random_hash)
+        Some(random_hash)
     }
 
     /// Force expiry of stale requests if the timer has elapsed.
@@ -359,23 +323,6 @@ impl ActiveSequences {
         outcome
     }
 
-    /// Find all blocks in a request that have only a single strong reference (only used by this request)
-    /// and insert them into fractional_blocks with the given fraction value.
-    fn set_single_ref_blocks_as_fractional(&mut self, request_id: &RequestId, fraction: f64) {
-        let Some(request_state) = self.requests.get(request_id) else {
-            tracing::warn!(
-                "Request {request_id} not found for set_single_ref_blocks_as_fractional"
-            );
-            return;
-        };
-
-        for (hash, rc) in request_state.all_blocks() {
-            if Arc::strong_count(rc) == 1 {
-                self.blocks.fractional_blocks.insert(*hash, fraction);
-            }
-        }
-    }
-
     pub(super) fn worker_load_snapshot(&self) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
             active_blocks: self.active_blocks(),
@@ -386,14 +333,14 @@ impl ActiveSequences {
 
     #[cfg(test)]
     pub(super) fn active_block_hashes(&self) -> FxHashSet<SequenceHash> {
-        self.blocks.unique_blocks.keys().copied().collect()
+        self.blocks.active_hashes().collect()
     }
 
     #[cfg(test)]
     pub(super) fn active_prompt_hashes(&self) -> FxHashSet<SequenceHash> {
         self.requests
             .values()
-            .flat_map(|state| state.prompt_blocks.iter().map(|(hash, _)| *hash))
+            .flat_map(|state| state.blocks.prompt_hashes())
             .collect()
     }
 }
@@ -415,6 +362,12 @@ mod tests {
             initial_effective_prefill_tokens: tokens,
             expected_prefill_duration: None,
         })
+    }
+
+    #[test]
+    fn active_sequences_remains_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ActiveSequences>();
     }
 
     #[test]
@@ -543,7 +496,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "request_2".to_string(),
-            Some(vec![4]),
+            Some(vec![5]),
             None,
             true,
             tracking_hint(4),
@@ -560,7 +513,7 @@ mod tests {
             tracking_hint(0),
             decay_now,
         );
-        assert_eq!(seq_manager.active_blocks(), 4);
+        assert_eq!(seq_manager.active_blocks(), 5);
         assert_eq!(seq_manager.active_tokens(decay_now), 16);
 
         seq_manager.free(&"request_2".to_string(), decay_now);


### PR DESCRIPTION
## Summary

- replace per-request `Vec<(SequenceHash, Arc<()>)>` ownership with one tail `Arc` into an immutable persistent block chain
- reuse a live prompt tail directly and allocate nodes only for a missing suffix
- release only the uniquely owned suffix, stopping at the first shared node
- preserve prompt-membership events, fractional accounting, output-block behavior, and compile-time `Send + Sync` guarantees
- destroy long unique chains iteratively to avoid recursive-drop stack overflow at block size 1

## Details:

This keeps Arc-based liveness while removing per-block `Weak::upgrade`/Arc cloning on shared prompt acquisition and full-chain scans on release. Each `SequenceHash` is trusted to identify one prefix ancestry and depth, matching the KV indexer's engine-to-router contract; this PR does not add runtime recurrence validation.

The review follow-up documents that contract, makes the output-hash debug assertion side-effect-free, and covers fractional cleanup of a unique suffix above a shared prefix. Public APIs, event schemas, routing behavior, and PromptRegistry behavior are unchanged.

## Where should the reviewer start?

Start with `lib/kv-router/src/sequences/block_tracker.rs`, especially `acquire_prompt`, `release`, and `RequestBlockChain::drop`. Then inspect `lib/kv-router/src/sequences/single.rs` for the request-lifecycle integration.

## Related Issues

**This PR is NOT linked to an issue:**

- [x] Confirmed — no related issue

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- `cargo test -p dynamo-kv-router block_tracker --lib` — 6 passed
- `cargo test -p dynamo-kv-router --lib` — 726 passed, 2 ignored
- `cargo test -p dynamo-bench --test active_sequences_trace` — 9 passed

### Frontend profile

Matched frontend profiles were collected from baseline and candidate builds at `e7ba0adbb99c4fed9fdf77971dbc2e41cf031458`:

- frontend on CPUs 0-1; KV routing; block size 1; fastokens; 1 GiB tokenizer cache; frontend-only jemalloc
- eight SGLang FIFO mockers and AIPerf on CPUs 2-23
- AgentX/Weka trace; speedup ratio 1,000,000; concurrency 256
- 40-second frontend-only `perf record -e cycles:u -F 99 --call-graph dwarf` capture after a 40-second settle

The inclusive BlockTracker lifecycle fell from 25.36% (806/3178 samples, 95% CI 23.88%-26.90%) to 17.04% (511/2999 samples, 95% CI 15.74%-18.43%). Weighted-cycle share fell from 26.21% to 17.59%, and frontend CPU per completed request fell from 14.249 ms to 13.665 ms.

Profiled throughput was diagnostic only and remained effectively flat (14.379 vs 14.250 req/s). The mocker side saturated individual cores, so this is not presented as a maximum frontend-capacity result. Both comparison arms used the same AIPerf 0.8.0 client on the non-frontend CPU partition.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved request tracking for prompt and output blocks, with smoother handling of shared prefixes and extended sequences.
  * Added more reliable support for long-running request chains without risking stack overflow.

* **Bug Fixes**
  * Fixed block cleanup so released request data is removed more consistently.
  * Improved active-block counting for fractional/shared blocks.
  * Strengthened consistency checks to better detect invalid request state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->