### PR TITLE
docs: require KV events for cache-aware routing

### DIFF
--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -76,6 +76,7 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 > ```bash
 > python -m dynamo.vllm \
 >   --model Qwen/Qwen3-0.6B \
+>   --enable-prefix-caching \
 >   --kv-events-config '{"enable_kv_cache_events":true,"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
 > ```
 >

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -80,8 +80,10 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 >   --kv-events-config '{"enable_kv_cache_events":true,"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
 > ```
 >
-> Use a unique port for each worker process that shares a host or network
-> namespace. If workers will not publish events, start the frontend with
+> `endpoint` is the base ZMQ port, and vLLM offsets it by data-parallel rank.
+> For worker processes that share a host or network namespace, reserve one port
+> per rank and choose base ports whose resulting ranges do not overlap. If
+> workers will not publish events, start the frontend with
 > `--no-router-kv-events` for approximate cache prediction or `--load-aware` for
 > load-only routing.
 

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -80,8 +80,7 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 > ```
 >
 > Use a unique port for each worker process that shares a host or network
-> namespace. vLLM workers started with `--disaggregation-mode decode` do not
-> publish KV events. If workers will not publish events, start the frontend with
+> namespace. If workers will not publish events, start the frontend with
 > `--no-router-kv-events` for approximate cache prediction or `--load-aware` for
 > load-only routing.
 

--- a/docs/backends/vllm/README.md
+++ b/docs/backends/vllm/README.md
@@ -53,7 +53,7 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 | Feature | Status | Notes |
 |---------|--------|-------|
 | [**Disaggregated Serving**](../../design-docs/disagg-serving.md) | ✅ | Prefill/decode separation with NIXL KV transfer |
-| [**KV-Aware Routing**](../../components/router/README.md) | ✅ | |
+| [**KV-Aware Routing**](../../components/router/README.md) | ✅ | Requires explicit KV event publishing on workers for event-driven cache state |
 | [**SLA-Based Planner**](../../components/planner/planner-guide.md) | ✅ | |
 | [**KVBM**](../../components/kvbm/README.md) | ✅ | |
 | [**LMCache**](../../integrations/lmcache-integration.md) | ✅ | CUDA 12.9 and arm64/aarch64 containers may require building LMCache from source |
@@ -64,6 +64,26 @@ For development, use the [devcontainer](https://github.com/ai-dynamo/dynamo/tree
 | **DP Rank Routing** | ✅ | [Hybrid load balancing](https://docs.vllm.ai/en/stable/serving/data_parallel_deployment/?h=external+dp#hybrid-load-balancing) via external DP rank control |
 | [**LoRA**](https://github.com/ai-dynamo/dynamo/tree/main/examples/backends/vllm/launch/lora/README.md) | ✅ | Dynamic loading/unloading from S3-compatible storage |
 | **GB200 Support** | ✅ | Container functional on main |
+
+## KV Routing Requirements
+
+> [!IMPORTANT]
+> Starting the frontend with `--router-mode kv` does not enable KV event
+> publishing on vLLM workers. For event-driven cache-aware routing, enable
+> publishing on every aggregated or prefill worker whose cache state the router
+> should track:
+>
+> ```bash
+> python -m dynamo.vllm \
+>   --model Qwen/Qwen3-0.6B \
+>   --kv-events-config '{"enable_kv_cache_events":true,"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+> ```
+>
+> Use a unique port for each worker process that shares a host or network
+> namespace. vLLM workers started with `--disaggregation-mode decode` do not
+> publish KV events. If workers will not publish events, start the frontend with
+> `--no-router-kv-events` for approximate cache prediction or `--load-aware` for
+> load-only routing.
 
 ## Quick Start
 

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -15,7 +15,15 @@ To launch the Dynamo frontend with the KV Router:
 python -m dynamo.frontend --router-mode kv --http-port 8000
 ```
 
-For Kubernetes, set `DYN_ROUTER_MODE=kv` on the Frontend service. For event-driven KV state, configure backend workers to publish KV cache events using the backend-specific flags described in [Router Operations](router-operations.md#additional-notes). Use `--no-router-kv-events` only when you want approximate cache-state prediction.
+> [!IMPORTANT]
+> `--router-mode kv` (or `DYN_ROUTER_MODE=kv`) enables KV routing on the
+> frontend, but it does not enable KV event publishing on backend workers. With
+> the default `--router-kv-events` setting, missing publishers leave the router
+> in event-driven mode without real cache state; the router does not
+> automatically switch to approximate prediction. Configure the backend-specific
+> publishing flags in [Router Operations](router-operations.md#additional-notes).
+> If workers will not publish events, use `--no-router-kv-events` for approximate
+> cache prediction or `--load-aware` for load-only routing.
 
 | Argument | Default | Description |
 |----------|---------|-------------|
@@ -23,7 +31,7 @@ For Kubernetes, set `DYN_ROUTER_MODE=kv` on the Frontend service. For event-driv
 | `--load-aware` | disabled | Use KV active-load routing without cache-reuse signals; implies `--router-mode kv` on the frontend |
 | `--router-kv-overlap-score-credit` | `1.0` | Credit multiplier for device-local prefix overlap, from 0.0 to 1.0 |
 | `--router-prefill-load-scale` | `1.0` | Scale adjusted prompt-side prefill load before adding decode blocks |
-| `--router-kv-events` / `--no-router-kv-events` | `--router-kv-events` | Consume worker KV events, or fall back to approximate routing without events |
+| `--router-kv-events` / `--no-router-kv-events` | `--router-kv-events` | Consume worker KV events, or explicitly disable them to use approximate routing |
 | `--router-queue-threshold` | `16.0` | Backpressure queue threshold; priority hints only reorder requests while this queue is non-empty |
 | `--router-queue-policy` | `fcfs` | Queue scheduling policy: `fcfs` (tail TTFT), `wspt` (avg TTFT), or `lcfs` (comparison-only reverse ordering) |
 | `--no-router-track-prefill-tokens` | disabled | Ignore prompt-side prefill tokens in router load accounting; useful for decode-only routing paths |

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -36,6 +36,8 @@ python -m dynamo.frontend --router-mode kv --http-port 8000
 > If workers will not publish events, use `--no-router-kv-events` for approximate
 > cache prediction or `--load-aware` for load-only routing.
 
+For Kubernetes, set `DYN_ROUTER_MODE=kv` on the Frontend service.
+
 ### Standalone Router
 
 You can also run the KV router as a standalone service (without the Dynamo frontend). See the [Standalone Router component](https://github.com/ai-dynamo/dynamo/tree/main/components/src/dynamo/router/) for more details.

--- a/docs/components/router/README.md
+++ b/docs/components/router/README.md
@@ -15,16 +15,6 @@ To launch the Dynamo frontend with the KV Router:
 python -m dynamo.frontend --router-mode kv --http-port 8000
 ```
 
-> [!IMPORTANT]
-> `--router-mode kv` (or `DYN_ROUTER_MODE=kv`) enables KV routing on the
-> frontend, but it does not enable KV event publishing on backend workers. With
-> the default `--router-kv-events` setting, missing publishers leave the router
-> in event-driven mode without real cache state; the router does not
-> automatically switch to approximate prediction. Configure the backend-specific
-> publishing flags in [Router Operations](router-operations.md#additional-notes).
-> If workers will not publish events, use `--no-router-kv-events` for approximate
-> cache prediction or `--load-aware` for load-only routing.
-
 | Argument | Default | Description |
 |----------|---------|-------------|
 | `--router-mode kv` | `round-robin` | Enable KV cache-aware routing |
@@ -35,6 +25,16 @@ python -m dynamo.frontend --router-mode kv --http-port 8000
 | `--router-queue-threshold` | `16.0` | Backpressure queue threshold; priority hints only reorder requests while this queue is non-empty |
 | `--router-queue-policy` | `fcfs` | Queue scheduling policy: `fcfs` (tail TTFT), `wspt` (avg TTFT), or `lcfs` (comparison-only reverse ordering) |
 | `--no-router-track-prefill-tokens` | disabled | Ignore prompt-side prefill tokens in router load accounting; useful for decode-only routing paths |
+
+> [!IMPORTANT]
+> `--router-mode kv` (or `DYN_ROUTER_MODE=kv`) enables KV routing on the
+> frontend, but it does not enable KV event publishing on backend workers. With
+> the default `--router-kv-events` setting, missing publishers leave the router
+> in event-driven mode without real cache state; the router does not
+> automatically switch to approximate prediction. Configure the backend-specific
+> publishing flags in [Router Operations](router-operations.md#additional-notes).
+> If workers will not publish events, use `--no-router-kv-events` for approximate
+> cache prediction or `--load-aware` for load-only routing.
 
 ### Standalone Router
 


### PR DESCRIPTION
## Summary

- Clarify that `--router-mode kv` enables KV routing on the frontend but does not enable worker-side KV event publishing.
- Document the explicit vLLM `--kv-events-config` required for event-driven cache state.
- Distinguish missing publishers from the explicit approximate (`--no-router-kv-events`) and load-only (`--load-aware`) modes.

## Why

Worker KV event publishing is independent of router event consumption. A deployment can therefore enable KV routing on the frontend while leaving the event-driven index without real cache state. The runtime now reports this mismatch, but the primary router and vLLM entry docs should prevent the configuration error up front.

This PR intentionally limits the first change to the two high-level documentation entry points. Recipe and example corrections will follow separately.

Relates to #11473.

## Validation

- `git diff --check`
- Documentation-applicable pre-commit checks passed, including codespell, case-conflict, merge-conflict, line-ending, executable, and trailing-whitespace checks.
- The repository-wide `pytest-marker-report` hook was skipped for the commit after failing to collect the unrelated full test suite because the temporary port allocator could not reserve a port.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified vLLM KV-aware routing requirements, including worker event publishing and unique port configuration.
  * Added setup examples for enabling KV cache events.
  * Documented fallback options for approximate or load-aware routing when workers do not publish events.
  * Updated router CLI guidance to distinguish frontend KV routing from backend KV event publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->