### PR TITLE
perf(kv-router): use arena block ownership counts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2514,6 +2514,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "slotmap",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1558,6 +1558,7 @@ dependencies = [
  "seqlock",
  "serde",
  "serde_yaml",
+ "slotmap",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2159,6 +2159,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "slotmap",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -58,6 +58,7 @@ parking_lot = { workspace = true }
 rmp-serde = { workspace = true }
 
 rustc-hash = "2.1.1"
+slotmap = "1"
 
 # standalone-indexer (optional)
 axum = { workspace = true, optional = true }

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -127,9 +127,6 @@ impl BlockTracker {
             "random output hash unexpectedly collided with a live block"
         );
 
-        self.nodes.reserve(1);
-        self.unique_blocks.reserve(1);
-
         let parent = chain.tail;
         let depth = parent.map_or(1, |node_id| {
             self.nodes

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -5,47 +5,181 @@ use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
 use std::sync::{Arc, Weak};
 
+/// One node in a persistent request block chain.
+///
+/// Sequence hashes identify their lineage, so a live tail transitively owns the
+/// entire prompt prefix through these parent references.
 #[derive(Debug)]
-pub(super) struct BlockAcquire {
-    pub(super) rc: Arc<()>,
-    pub(super) became_present_on_worker: bool,
+struct BlockNode {
+    hash: SequenceHash,
+    depth: usize,
+    parent: Option<Arc<BlockNode>>,
+}
+
+/// The single strong block owner retained by a request.
+///
+/// This type intentionally does not implement `Clone`. New request owners must
+/// be acquired through [`BlockTracker::acquire_prompt`], which also maintains
+/// the weak block index and membership transitions.
+#[derive(Debug, Default)]
+pub(super) struct RequestBlockChain {
+    tail: Option<Arc<BlockNode>>,
+    prompt_depth: usize,
+}
+
+impl RequestBlockChain {
+    fn new(tail: Option<Arc<BlockNode>>, prompt_depth: usize) -> Self {
+        Self { tail, prompt_depth }
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    fn nodes_from_tail(&self) -> impl Iterator<Item = &BlockNode> {
+        std::iter::successors(self.tail.as_deref(), |node| node.parent.as_deref())
+    }
+
+    #[cfg(test)]
+    pub(super) fn prompt_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
+        self.nodes_from_tail()
+            .filter(|node| node.depth <= self.prompt_depth)
+            .map(|node| node.hash)
+    }
+}
+
+impl Drop for RequestBlockChain {
+    fn drop(&mut self) {
+        let Some(mut current) = self.tail.take() else {
+            return;
+        };
+
+        // A block-size-1 prompt can contain tens of thousands of nodes. Unwrap
+        // an exclusively owned suffix iteratively so dropping the parent chain
+        // cannot overflow the stack.
+        loop {
+            match Arc::try_unwrap(current) {
+                Ok(mut node) => match node.parent.take() {
+                    Some(parent) => current = parent,
+                    None => break,
+                },
+                Err(shared) => {
+                    drop(shared);
+                    break;
+                }
+            }
+        }
+    }
 }
 
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
-    pub(super) unique_blocks: FxHashMap<SequenceHash, Weak<()>>,
-    pub(super) fractional_blocks: FxHashMap<SequenceHash, f64>,
+    unique_blocks: FxHashMap<SequenceHash, Weak<BlockNode>>,
+    fractional_blocks: FxHashMap<SequenceHash, f64>,
 }
 
 impl BlockTracker {
-    pub(super) fn touch_block(&mut self, block: &SequenceHash) -> BlockAcquire {
-        if let Some(weak) = self.unique_blocks.get(block)
-            && let Some(rc) = weak.upgrade()
-        {
-            return BlockAcquire {
-                rc,
-                became_present_on_worker: false,
-            };
+    /// Acquire one strong tail for a prompt and return the first newly present
+    /// prompt index, if any.
+    pub(super) fn acquire_prompt(
+        &mut self,
+        sequence: &[SequenceHash],
+    ) -> (RequestBlockChain, Option<usize>) {
+        let Some(&tail_hash) = sequence.last() else {
+            return (RequestBlockChain::default(), None);
+        };
+
+        if let Some(tail) = self.upgrade_live_node(tail_hash) {
+            Self::debug_assert_lineage(&tail, sequence);
+            return (RequestBlockChain::new(Some(tail), sequence.len()), None);
         }
 
-        let rc = Arc::new(());
-        self.unique_blocks.insert(*block, Arc::downgrade(&rc));
-        BlockAcquire {
-            rc,
-            became_present_on_worker: true,
+        let mut parent = None;
+        let mut first_new_idx = 0;
+
+        // Prompt liveness is prefix-closed. Search backward for the deepest
+        // live prefix, then construct only the missing suffix.
+        for idx in (0..sequence.len().saturating_sub(1)).rev() {
+            if let Some(node) = self.upgrade_live_node(sequence[idx]) {
+                Self::debug_assert_lineage(&node, &sequence[..=idx]);
+                parent = Some(node);
+                first_new_idx = idx + 1;
+                break;
+            }
         }
+
+        for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
+            let node = Arc::new(BlockNode {
+                hash,
+                depth: first_new_idx + idx + 1,
+                parent,
+            });
+            self.unique_blocks.insert(hash, Arc::downgrade(&node));
+            parent = Some(node);
+        }
+
+        (
+            RequestBlockChain::new(parent, sequence.len()),
+            Some(first_new_idx),
+        )
     }
 
-    pub(super) fn try_remove_block(&mut self, block: &SequenceHash) -> bool {
-        if let Some(weak) = self.unique_blocks.get(block)
-            && weak.strong_count() == 0
-        {
-            self.unique_blocks.remove(block);
-            self.fractional_blocks.remove(block);
-            return true;
+    /// Append a unique output block to an existing request chain.
+    pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
+        debug_assert!(
+            self.upgrade_live_node(hash).is_none(),
+            "random output hash unexpectedly collided with a live block"
+        );
+
+        let parent = chain.tail.take();
+        let depth = parent.as_ref().map_or(1, |node| node.depth + 1);
+        let node = Arc::new(BlockNode {
+            hash,
+            depth,
+            parent,
+        });
+        self.unique_blocks.insert(hash, Arc::downgrade(&node));
+        chain.tail = Some(node);
+    }
+
+    /// Release a request chain and return the prompt suffix that became absent
+    /// from the worker.
+    pub(super) fn release(&mut self, chain: RequestBlockChain) -> Vec<SequenceHash> {
+        let mut dead_nodes = Vec::new();
+        let mut current = chain.tail.as_ref();
+
+        while let Some(node) = current {
+            if Arc::strong_count(node) != 1 {
+                break;
+            }
+            dead_nodes.push((node.hash, node.depth));
+            current = node.parent.as_ref();
         }
 
-        false
+        for &(hash, _) in &dead_nodes {
+            self.unique_blocks.remove(&hash);
+            self.fractional_blocks.remove(&hash);
+        }
+
+        let mut prompt_remove = dead_nodes
+            .into_iter()
+            .filter_map(|(hash, depth)| (depth <= chain.prompt_depth).then_some(hash))
+            .collect::<Vec<_>>();
+        prompt_remove.reverse();
+        prompt_remove
+    }
+
+    /// Mark the request's exclusively owned suffix as fractional.
+    pub(super) fn set_unique_suffix_fractional(
+        &mut self,
+        chain: &RequestBlockChain,
+        fraction: f64,
+    ) {
+        let mut current = chain.tail.as_ref();
+        while let Some(node) = current {
+            if Arc::strong_count(node) != 1 {
+                break;
+            }
+            self.fractional_blocks.insert(node.hash, fraction);
+            current = node.parent.as_ref();
+        }
     }
 
     pub(super) fn active_blocks(&self) -> usize {
@@ -57,6 +191,55 @@ impl BlockTracker {
         }
         count.round() as usize
     }
+
+    pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
+        self.unique_blocks.contains_key(hash)
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn fractional_hashes_are_active(&self) -> bool {
+        self.fractional_blocks
+            .keys()
+            .all(|hash| self.unique_blocks.contains_key(hash))
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn contains_chain(&self, chain: &RequestBlockChain) -> bool {
+        chain
+            .nodes_from_tail()
+            .all(|node| self.unique_blocks.contains_key(&node.hash))
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
+        self.unique_blocks.keys().copied()
+    }
+
+    fn upgrade_live_node(&mut self, hash: SequenceHash) -> Option<Arc<BlockNode>> {
+        let weak = self.unique_blocks.get(&hash)?;
+        let node = weak.upgrade();
+        if node.is_none() {
+            self.unique_blocks.remove(&hash);
+            self.fractional_blocks.remove(&hash);
+        }
+        node
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    fn debug_assert_lineage(tail: &Arc<BlockNode>, sequence: &[SequenceHash]) {
+        assert_eq!(tail.depth, sequence.len(), "sequence tail depth mismatch");
+        let mut current = Some(tail.as_ref());
+        for (expected_depth, &expected_hash) in sequence.iter().enumerate().rev() {
+            let node = current.expect("live sequence chain ended before its expected root");
+            assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
+            assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
+            current = node.parent.as_deref();
+        }
+    }
+
+    #[cfg(not(any(test, debug_assertions)))]
+    #[inline]
+    fn debug_assert_lineage(_tail: &Arc<BlockNode>, _sequence: &[SequenceHash]) {}
 }
 
 #[cfg(test)]
@@ -64,43 +247,72 @@ mod tests {
     use super::*;
 
     #[test]
-    fn first_touch_and_last_remove_report_presence_transitions() {
+    fn first_acquire_and_last_release_report_presence_transitions() {
         let mut tracker = BlockTracker::default();
 
-        let first = tracker.touch_block(&1);
-        let second = tracker.touch_block(&1);
+        let (first, first_new) = tracker.acquire_prompt(&[1]);
+        let (second, second_new) = tracker.acquire_prompt(&[1]);
 
-        assert!(first.became_present_on_worker);
-        assert!(!second.became_present_on_worker);
+        assert_eq!(first_new, Some(0));
+        assert_eq!(second_new, None);
         assert_eq!(tracker.active_blocks(), 1);
 
-        drop(first.rc);
-        assert!(!tracker.try_remove_block(&1));
+        assert!(tracker.release(first).is_empty());
         assert_eq!(tracker.active_blocks(), 1);
 
-        drop(second.rc);
-        assert!(tracker.try_remove_block(&1));
+        assert_eq!(tracker.release(second), vec![1]);
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn release_only_removes_unique_branch_suffix() {
+        let mut tracker = BlockTracker::default();
+        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
+
+        assert_eq!(first_new, Some(2));
+        assert_eq!(tracker.active_blocks(), 4);
+        assert_eq!(tracker.release(left), vec![3]);
+        assert_eq!(tracker.active_blocks(), 3);
+        assert_eq!(tracker.release(right), vec![1, 2, 4]);
         assert_eq!(tracker.active_blocks(), 0);
     }
 
     #[test]
     fn fractional_blocks_adjust_active_block_count() {
         let mut tracker = BlockTracker::default();
-        let first = tracker.touch_block(&1);
-        let second = tracker.touch_block(&2);
+        let (chain, _) = tracker.acquire_prompt(&[1, 2]);
 
-        tracker.fractional_blocks.insert(1, 0.5);
-        tracker.fractional_blocks.insert(2, 0.5);
+        tracker.set_unique_suffix_fractional(&chain, 0.5);
         assert_eq!(tracker.active_blocks(), 1);
 
-        drop(first.rc);
-        assert!(tracker.try_remove_block(&1));
-        assert!(!tracker.fractional_blocks.contains_key(&1));
-        assert_eq!(tracker.active_blocks(), 1);
-
-        drop(second.rc);
-        assert!(tracker.try_remove_block(&2));
+        assert_eq!(tracker.release(chain), vec![1, 2]);
         assert!(tracker.fractional_blocks.is_empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn output_only_chain_releases_without_prompt_membership() {
+        let mut tracker = BlockTracker::default();
+        let (mut chain, first_new) = tracker.acquire_prompt(&[]);
+
+        assert_eq!(first_new, None);
+        tracker.append_output(&mut chain, 42);
+        assert_eq!(tracker.active_blocks(), 1);
+        assert!(tracker.release(chain).is_empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn long_chain_release_is_iterative() {
+        const DEPTH: usize = 65_536;
+        let sequence = (1..=DEPTH as u64).collect::<Vec<_>>();
+        let mut tracker = BlockTracker::default();
+        let (chain, first_new) = tracker.acquire_prompt(&sequence);
+
+        assert_eq!(first_new, Some(0));
+        assert_eq!(tracker.active_blocks(), DEPTH);
+        assert_eq!(tracker.release(chain), sequence);
         assert_eq!(tracker.active_blocks(), 0);
     }
 }

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_tokens::{PositionalLineageHash, SequenceHash};
+use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
 #[cfg(debug_assertions)]
 use rustc_hash::FxHashSet;
@@ -15,30 +15,14 @@ new_key_type! {
 
 /// One node in a persistent request block chain.
 ///
-/// Positional lineage hashes distinguish the same sequence hash at different
-/// positions or beneath different parent-hash fragments. Parent IDs are
-/// generational arena keys, while `incoming` counts direct request-tail and
-/// child-to-parent edges.
+/// Sequence hashes identify their lineage. Parent IDs are generational arena
+/// keys, while `incoming` counts direct request-tail and child-to-parent edges.
 #[derive(Debug)]
 struct BlockNode {
-    lineage_hash: PositionalLineageHash,
+    hash: SequenceHash,
+    depth: usize,
     parent: Option<BlockNodeId>,
     incoming: NonZeroU32,
-}
-
-impl BlockNode {
-    #[inline]
-    fn sequence_hash(&self) -> SequenceHash {
-        self.lineage_hash.current_sequence_hash()
-    }
-
-    #[inline]
-    fn depth(&self) -> usize {
-        usize::try_from(self.lineage_hash.position())
-            .expect("block position does not fit usize")
-            .checked_add(1)
-            .expect("block chain depth overflowed")
-    }
 }
 
 /// The single block-chain tail retained by a request.
@@ -62,25 +46,26 @@ impl RequestBlockChain {
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
     nodes: SlotMap<BlockNodeId, BlockNode>,
-    unique_blocks: FxHashMap<PositionalLineageHash, BlockNodeId>,
-    fractional_blocks: FxHashMap<PositionalLineageHash, f64>,
+    unique_blocks: FxHashMap<SequenceHash, BlockNodeId>,
+    fractional_blocks: FxHashMap<SequenceHash, f64>,
 }
 
 impl BlockTracker {
     /// Acquire one request tail for a prompt and return the first newly present
     /// prompt index, if any.
     ///
-    /// The internal index augments each [`SequenceHash`] with its position and
-    /// parent-hash fragment. Public membership events continue to use the raw
-    /// sequence hashes.
+    /// # Lineage contract
+    ///
+    /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
+    /// depth. As with the KV indexer, this tracker trusts callers to maintain
+    /// that invariant and does not validate the hash recurrence in production.
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],
     ) -> (RequestBlockChain, Option<usize>) {
-        let Some(tail_idx) = sequence.len().checked_sub(1) else {
+        let Some(&tail_hash) = sequence.last() else {
             return (RequestBlockChain::default(), None);
         };
-        let tail_hash = Self::prompt_lineage_hash(sequence, tail_idx);
 
         if let Some(tail) = self.live_node_id(tail_hash) {
             self.debug_assert_lineage(tail, sequence);
@@ -94,8 +79,7 @@ impl BlockTracker {
         // Prompt liveness is prefix-closed. Search backward for the deepest
         // live prefix, then construct only the missing suffix.
         for idx in (0..sequence.len().saturating_sub(1)).rev() {
-            let lineage_hash = Self::prompt_lineage_hash(sequence, idx);
-            if let Some(node_id) = self.live_node_id(lineage_hash) {
+            if let Some(node_id) = self.live_node_id(sequence[idx]) {
                 self.debug_assert_lineage(node_id, &sequence[..=idx]);
                 parent = Some(node_id);
                 first_new_idx = idx + 1;
@@ -106,7 +90,7 @@ impl BlockTracker {
         let missing = sequence.len() - first_new_idx;
         self.nodes.reserve(missing);
         self.unique_blocks.reserve(missing);
-        self.debug_assert_new_hashes(sequence, first_new_idx);
+        self.debug_assert_new_hashes(&sequence[first_new_idx..]);
 
         // Adding the first new child contributes one new incoming edge to the
         // reused prefix. Subsequent construction transfers the provisional
@@ -115,14 +99,14 @@ impl BlockTracker {
             self.increment_incoming(parent_id);
         }
 
-        for idx in first_new_idx..sequence.len() {
-            let lineage_hash = Self::prompt_lineage_hash(sequence, idx);
+        for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
             let node_id = self.nodes.insert(BlockNode {
-                lineage_hash,
+                hash,
+                depth: first_new_idx + idx + 1,
                 parent,
                 incoming: NonZeroU32::MIN,
             });
-            let previous = self.unique_blocks.insert(lineage_hash, node_id);
+            let previous = self.unique_blocks.insert(hash, node_id);
             debug_assert!(
                 previous.is_none(),
                 "new block unexpectedly replaced a live index entry"
@@ -138,32 +122,27 @@ impl BlockTracker {
 
     /// Append a unique output block to an existing request chain.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
-        let parent = chain.tail;
-        let (parent_hash, position) = parent.map_or((None, 0), |node_id| {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("request tail references a missing block node");
-            let position = node
-                .lineage_hash
-                .position()
-                .checked_add(1)
-                .expect("block position overflowed");
-            (Some(node.sequence_hash()), position)
-        });
-        let lineage_hash = PositionalLineageHash::new(hash, parent_hash, position);
-
         debug_assert!(
-            !self.unique_blocks.contains_key(&lineage_hash),
+            !self.unique_blocks.contains_key(&hash),
             "random output hash unexpectedly collided with a live block"
         );
 
+        let parent = chain.tail;
+        let depth = parent.map_or(1, |node_id| {
+            self.nodes
+                .get(node_id)
+                .expect("request tail references a missing block node")
+                .depth
+                .checked_add(1)
+                .expect("block chain depth overflowed")
+        });
         let node_id = self.nodes.insert(BlockNode {
-            lineage_hash,
+            hash,
+            depth,
             parent,
             incoming: NonZeroU32::MIN,
         });
-        let previous = self.unique_blocks.insert(lineage_hash, node_id);
+        let previous = self.unique_blocks.insert(hash, node_id);
         debug_assert!(
             previous.is_none(),
             "new output unexpectedly replaced a live index entry"
@@ -198,12 +177,11 @@ impl BlockTracker {
                 .nodes
                 .get(node_id)
                 .expect("request chain references a missing block node");
-            let lineage_hash = node.lineage_hash;
-            let hash = node.sequence_hash();
-            let depth = node.depth();
+            let hash = node.hash;
+            let depth = node.depth;
             let parent = node.parent;
 
-            match self.unique_blocks.entry(lineage_hash) {
+            match self.unique_blocks.entry(hash) {
                 Entry::Occupied(entry) => {
                     assert_eq!(
                         *entry.get(),
@@ -214,7 +192,7 @@ impl BlockTracker {
                 }
                 Entry::Vacant(_) => panic!("live block node is missing from the hash index"),
             }
-            self.fractional_blocks.remove(&lineage_hash);
+            self.fractional_blocks.remove(&hash);
             self.nodes
                 .remove(node_id)
                 .expect("validated block node disappeared before removal");
@@ -244,7 +222,7 @@ impl BlockTracker {
             if node.incoming.get() != 1 {
                 break;
             }
-            self.fractional_blocks.insert(node.lineage_hash, fraction);
+            self.fractional_blocks.insert(node.hash, fraction);
             current = node.parent;
         }
     }
@@ -259,9 +237,8 @@ impl BlockTracker {
         count.round() as usize
     }
 
-    pub(super) fn contains_prompt_block(&self, sequence: &[SequenceHash], index: usize) -> bool {
-        self.live_node_id(Self::prompt_lineage_hash(sequence, index))
-            .is_some()
+    pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
+        self.live_node_id(*hash).is_some()
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -282,9 +259,9 @@ impl BlockTracker {
                 "arena yielded a duplicate node ID"
             );
             assert_eq!(
-                self.unique_blocks.get(&node.lineage_hash),
+                self.unique_blocks.get(&node.hash),
                 Some(&node_id),
-                "live arena node is missing its exact lineage-index entry"
+                "live arena node is missing its exact hash-index entry"
             );
 
             if let Some(parent_id) = node.parent {
@@ -293,23 +270,23 @@ impl BlockTracker {
                     .get(parent_id)
                     .expect("block node references a missing parent");
                 assert_eq!(
-                    parent.depth() + 1,
-                    node.depth(),
+                    parent.depth + 1,
+                    node.depth,
                     "child block depth must immediately follow its parent"
                 );
             } else {
-                assert_eq!(node.depth(), 1, "root block depth must be one");
+                assert_eq!(node.depth, 1, "root block depth must be one");
             }
         }
 
-        for (&lineage_hash, &node_id) in &self.unique_blocks {
+        for (&hash, &node_id) in &self.unique_blocks {
             let node = self
                 .nodes
                 .get(node_id)
-                .expect("lineage index references a missing arena node");
+                .expect("hash index references a missing arena node");
             assert_eq!(
-                node.lineage_hash, lineage_hash,
-                "lineage index key does not match its arena node"
+                node.hash, hash,
+                "hash index key does not match its arena node"
             );
         }
 
@@ -331,7 +308,7 @@ impl BlockTracker {
                     .get(tail_id)
                     .expect("request tail references a missing arena node");
                 assert!(
-                    chain.prompt_depth <= tail.depth(),
+                    chain.prompt_depth <= tail.depth,
                     "request prompt depth cannot exceed its full block-chain depth"
                 );
                 let count = expected_incoming
@@ -366,9 +343,7 @@ impl BlockTracker {
 
     #[cfg(test)]
     pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
-        self.unique_blocks
-            .keys()
-            .map(PositionalLineageHash::current_sequence_hash)
+        self.unique_blocks.keys().copied()
     }
 
     #[cfg(test)]
@@ -378,29 +353,21 @@ impl BlockTracker {
     ) -> impl Iterator<Item = SequenceHash> + 'a {
         self.node_ids_from_tail(chain).filter_map(|node_id| {
             let node = &self.nodes[node_id];
-            (node.depth() <= chain.prompt_depth).then(|| node.sequence_hash())
+            (node.depth <= chain.prompt_depth).then_some(node.hash)
         })
     }
 
-    fn live_node_id(&self, lineage_hash: PositionalLineageHash) -> Option<BlockNodeId> {
-        let &node_id = self.unique_blocks.get(&lineage_hash)?;
+    fn live_node_id(&self, hash: SequenceHash) -> Option<BlockNodeId> {
+        let &node_id = self.unique_blocks.get(&hash)?;
         let node = self
             .nodes
             .get(node_id)
-            .expect("live lineage index references a stale arena ID");
+            .expect("live block index references a stale arena ID");
         assert_eq!(
-            node.lineage_hash, lineage_hash,
-            "live lineage index key does not match its arena node"
+            node.hash, hash,
+            "live block index key does not match its arena node"
         );
         Some(node_id)
-    }
-
-    #[inline]
-    fn prompt_lineage_hash(sequence: &[SequenceHash], index: usize) -> PositionalLineageHash {
-        let current = sequence[index];
-        let parent = index.checked_sub(1).map(|parent_idx| sequence[parent_idx]);
-        let position = u64::try_from(index).expect("block position does not fit u64");
-        PositionalLineageHash::new(current, parent, position)
     }
 
     fn increment_incoming(&mut self, node_id: BlockNodeId) {
@@ -417,16 +384,15 @@ impl BlockTracker {
     }
 
     #[cfg(debug_assertions)]
-    fn debug_assert_new_hashes(&self, sequence: &[SequenceHash], first_new_idx: usize) {
+    fn debug_assert_new_hashes(&self, hashes: &[SequenceHash]) {
         let mut seen = FxHashSet::default();
-        for idx in first_new_idx..sequence.len() {
-            let lineage_hash = Self::prompt_lineage_hash(sequence, idx);
+        for hash in hashes {
             assert!(
-                !self.unique_blocks.contains_key(&lineage_hash),
+                !self.unique_blocks.contains_key(hash),
                 "sequence lineage hash unexpectedly aliases a live block"
             );
             assert!(
-                seen.insert(lineage_hash),
+                seen.insert(*hash),
                 "sequence lineage repeats a hash in one missing suffix"
             );
         }
@@ -434,7 +400,7 @@ impl BlockTracker {
 
     #[cfg(not(debug_assertions))]
     #[inline]
-    fn debug_assert_new_hashes(&self, _sequence: &[SequenceHash], _first_new_idx: usize) {}
+    fn debug_assert_new_hashes(&self, _hashes: &[SequenceHash]) {}
 
     #[cfg(any(test, debug_assertions))]
     fn debug_assert_lineage(&self, tail: BlockNodeId, sequence: &[SequenceHash]) {
@@ -443,7 +409,7 @@ impl BlockTracker {
             .get(tail)
             .expect("live sequence tail references a missing arena node");
         assert_eq!(
-            tail_node.depth(),
+            tail_node.depth,
             sequence.len(),
             "sequence tail depth mismatch"
         );
@@ -454,17 +420,8 @@ impl BlockTracker {
                 .nodes
                 .get(node_id)
                 .expect("live sequence chain references a missing arena node");
-            assert_eq!(node.depth(), expected_depth + 1, "sequence depth mismatch");
-            assert_eq!(
-                node.lineage_hash,
-                Self::prompt_lineage_hash(sequence, expected_depth),
-                "positional sequence lineage hash mismatch"
-            );
-            assert_eq!(
-                node.sequence_hash(),
-                expected_hash,
-                "sequence lineage hash mismatch"
-            );
+            assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
+            assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
             current = node.parent;
         }
     }
@@ -492,27 +449,13 @@ impl BlockTracker {
 
     #[cfg(test)]
     fn incoming_for(&self, hash: SequenceHash) -> u32 {
-        let node_id = self.node_id_for(hash);
+        let node_id = self.live_node_id(hash).expect("expected live block hash");
         self.nodes[node_id].incoming.get()
     }
 
     #[cfg(test)]
     fn node_id_for(&self, hash: SequenceHash) -> BlockNodeId {
-        let mut matches = self.unique_blocks.iter().filter_map(|(lineage, &node_id)| {
-            (lineage.current_sequence_hash() == hash).then_some(node_id)
-        });
-        let node_id = matches.next().expect("expected live block hash");
-        assert!(
-            matches.next().is_none(),
-            "expected raw block hash to identify exactly one live lineage"
-        );
-        node_id
-    }
-
-    #[cfg(test)]
-    fn node_id_for_prompt(&self, sequence: &[SequenceHash], index: usize) -> BlockNodeId {
-        self.live_node_id(Self::prompt_lineage_hash(sequence, index))
-            .expect("expected live prompt lineage")
+        self.live_node_id(hash).expect("expected live block hash")
     }
 }
 
@@ -609,60 +552,8 @@ mod tests {
 
         assert_eq!(tracker.incoming_for(2), before);
         assert_eq!(tracker.incoming_for(42), 1);
-        let output = &tracker.nodes[tracker.node_id_for(42)];
-        assert_eq!(output.lineage_hash.position(), 2);
-        assert_eq!(output.lineage_hash.current_sequence_hash(), 42);
-        assert_eq!(output.lineage_hash.parent_hash_fragment(), 2);
         tracker.assert_consistent([&chain]);
         assert_eq!(tracker.release(chain), vec![1, 2]);
-    }
-
-    #[test]
-    fn same_tail_hash_under_different_parents_has_independent_lineages() {
-        let left_sequence = [1, 9];
-        let right_sequence = [2, 9];
-        let mut tracker = BlockTracker::default();
-        let (left, left_first_new) = tracker.acquire_prompt(&left_sequence);
-        let (right, right_first_new) = tracker.acquire_prompt(&right_sequence);
-
-        assert_eq!(left_first_new, Some(0));
-        assert_eq!(right_first_new, Some(0));
-        assert_ne!(
-            tracker.node_id_for_prompt(&left_sequence, 1),
-            tracker.node_id_for_prompt(&right_sequence, 1)
-        );
-        assert_eq!(tracker.active_blocks(), 4);
-
-        tracker.set_unique_suffix_fractional(&left, 0.5);
-        assert_eq!(tracker.active_blocks(), 3);
-        tracker.assert_consistent([&left, &right]);
-
-        assert_eq!(tracker.release(left), vec![1, 9]);
-        assert_eq!(tracker.active_blocks(), 2);
-        tracker.assert_consistent([&right]);
-        assert_eq!(tracker.release(right), vec![2, 9]);
-        tracker.assert_consistent(std::iter::empty());
-    }
-
-    #[test]
-    fn same_hash_at_different_depths_has_independent_lineages() {
-        let root_sequence = [9];
-        let nested_sequence = [1, 9];
-        let mut tracker = BlockTracker::default();
-        let (root, _) = tracker.acquire_prompt(&root_sequence);
-        let (nested, nested_first_new) = tracker.acquire_prompt(&nested_sequence);
-
-        assert_eq!(nested_first_new, Some(0));
-        assert_ne!(
-            tracker.node_id_for_prompt(&root_sequence, 0),
-            tracker.node_id_for_prompt(&nested_sequence, 1)
-        );
-        assert_eq!(tracker.active_blocks(), 3);
-        tracker.assert_consistent([&root, &nested]);
-
-        assert_eq!(tracker.release(root), vec![9]);
-        tracker.assert_consistent([&nested]);
-        assert_eq!(tracker.release(nested), vec![1, 9]);
     }
 
     #[test]
@@ -715,23 +606,9 @@ mod tests {
         let (shared_prefix, _) = tracker.acquire_prompt(&[1, 2]);
 
         tracker.set_unique_suffix_fractional(&longer, 0.5);
-        let sequence = [1, 2, 3];
-        assert_eq!(
-            tracker
-                .fractional_blocks
-                .get(&BlockTracker::prompt_lineage_hash(&sequence, 2)),
-            Some(&0.5)
-        );
-        assert!(
-            !tracker
-                .fractional_blocks
-                .contains_key(&BlockTracker::prompt_lineage_hash(&sequence, 0))
-        );
-        assert!(
-            !tracker
-                .fractional_blocks
-                .contains_key(&BlockTracker::prompt_lineage_hash(&sequence, 1))
-        );
+        assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
+        assert!(!tracker.fractional_blocks.contains_key(&1));
+        assert!(!tracker.fractional_blocks.contains_key(&2));
         tracker.assert_consistent([&longer, &shared_prefix]);
 
         assert_eq!(tracker.release(longer), vec![3]);
@@ -772,7 +649,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "live lineage index references a stale arena ID")]
+    #[should_panic(expected = "live block index references a stale arena ID")]
     fn stale_generation_in_index_is_rejected() {
         let mut tracker = BlockTracker::default();
         let (first, _) = tracker.acquire_prompt(&[1]);
@@ -780,39 +657,21 @@ mod tests {
         assert_eq!(tracker.release(first), vec![1]);
         let (second, _) = tracker.acquire_prompt(&[2]);
 
-        let wrong_lineage = BlockTracker::prompt_lineage_hash(&[99], 0);
-        tracker.unique_blocks.insert(wrong_lineage, old_id);
-        let _ = tracker.live_node_id(wrong_lineage);
+        tracker.unique_blocks.insert(99, old_id);
+        let _ = tracker.contains_block(&99);
         drop(second);
     }
 
     #[test]
-    #[should_panic(expected = "live lineage index key does not match its arena node")]
+    #[should_panic(expected = "live block index key does not match its arena node")]
     fn live_id_with_the_wrong_hash_is_rejected() {
         let mut tracker = BlockTracker::default();
         let (chain, _) = tracker.acquire_prompt(&[1]);
         let node_id = tracker.node_id_for(1);
 
-        let wrong_lineage = BlockTracker::prompt_lineage_hash(&[2], 0);
-        tracker.unique_blocks.insert(wrong_lineage, node_id);
-        let _ = tracker.live_node_id(wrong_lineage);
+        tracker.unique_blocks.insert(2, node_id);
+        let _ = tracker.contains_block(&2);
         drop(chain);
-    }
-
-    #[test]
-    fn positional_lineage_modes_cover_prompt_size_boundaries() {
-        let sequence = (1..=65_537_u64).collect::<Vec<_>>();
-
-        assert_eq!(BlockTracker::prompt_lineage_hash(&sequence, 255).mode(), 0);
-        assert_eq!(BlockTracker::prompt_lineage_hash(&sequence, 256).mode(), 1);
-        assert_eq!(
-            BlockTracker::prompt_lineage_hash(&sequence, 65_535).mode(),
-            1
-        );
-        assert_eq!(
-            BlockTracker::prompt_lineage_hash(&sequence, 65_536).mode(),
-            2
-        );
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -3,80 +3,55 @@
 
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
-use std::sync::{Arc, Weak};
+#[cfg(debug_assertions)]
+use rustc_hash::FxHashSet;
+use slotmap::{SlotMap, new_key_type};
+use std::collections::hash_map::Entry;
+use std::num::NonZeroU32;
+
+new_key_type! {
+    struct BlockNodeId;
+}
 
 /// One node in a persistent request block chain.
 ///
-/// Sequence hashes identify their lineage, so a live tail transitively owns the
-/// entire prompt prefix through these parent references.
+/// Sequence hashes identify their lineage. Parent IDs are generational arena
+/// keys, while `incoming` counts direct request-tail and child-to-parent edges.
 #[derive(Debug)]
 struct BlockNode {
     hash: SequenceHash,
     depth: usize,
-    parent: Option<Arc<BlockNode>>,
+    parent: Option<BlockNodeId>,
+    incoming: NonZeroU32,
 }
 
-/// The single strong block owner retained by a request.
+/// The single block-chain tail retained by a request.
 ///
 /// This type intentionally does not implement `Clone`. New request owners must
 /// be acquired through [`BlockTracker::acquire_prompt`], which also maintains
-/// the weak block index and membership transitions.
+/// the arena ownership counts and block index.
 #[derive(Debug, Default)]
+#[must_use = "request block chains must be retained by a request and released through BlockTracker"]
 pub(super) struct RequestBlockChain {
-    tail: Option<Arc<BlockNode>>,
+    tail: Option<BlockNodeId>,
     prompt_depth: usize,
 }
 
 impl RequestBlockChain {
-    fn new(tail: Option<Arc<BlockNode>>, prompt_depth: usize) -> Self {
+    fn new(tail: Option<BlockNodeId>, prompt_depth: usize) -> Self {
         Self { tail, prompt_depth }
-    }
-
-    #[cfg(any(test, debug_assertions))]
-    fn nodes_from_tail(&self) -> impl Iterator<Item = &BlockNode> {
-        std::iter::successors(self.tail.as_deref(), |node| node.parent.as_deref())
-    }
-
-    #[cfg(test)]
-    pub(super) fn prompt_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
-        self.nodes_from_tail()
-            .filter(|node| node.depth <= self.prompt_depth)
-            .map(|node| node.hash)
-    }
-}
-
-impl Drop for RequestBlockChain {
-    fn drop(&mut self) {
-        let Some(mut current) = self.tail.take() else {
-            return;
-        };
-
-        // A block-size-1 prompt can contain tens of thousands of nodes. Unwrap
-        // an exclusively owned suffix iteratively so dropping the parent chain
-        // cannot overflow the stack.
-        loop {
-            match Arc::try_unwrap(current) {
-                Ok(mut node) => match node.parent.take() {
-                    Some(parent) => current = parent,
-                    None => break,
-                },
-                Err(shared) => {
-                    drop(shared);
-                    break;
-                }
-            }
-        }
     }
 }
 
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
-    unique_blocks: FxHashMap<SequenceHash, Weak<BlockNode>>,
+    nodes: SlotMap<BlockNodeId, BlockNode>,
+    unique_blocks: FxHashMap<SequenceHash, BlockNodeId>,
     fractional_blocks: FxHashMap<SequenceHash, f64>,
 }
 
 impl BlockTracker {
-    /// Acquire one strong tail for a prompt and return the first newly present
+    /// Acquire one request tail for a prompt and return the first newly present
     /// prompt index, if any.
     ///
     /// # Lineage contract
@@ -92,8 +67,9 @@ impl BlockTracker {
             return (RequestBlockChain::default(), None);
         };
 
-        if let Some(tail) = self.upgrade_live_node(tail_hash) {
-            Self::debug_assert_lineage(&tail, sequence);
+        if let Some(tail) = self.live_node_id(tail_hash) {
+            self.debug_assert_lineage(tail, sequence);
+            self.increment_incoming(tail);
             return (RequestBlockChain::new(Some(tail), sequence.len()), None);
         }
 
@@ -103,22 +79,39 @@ impl BlockTracker {
         // Prompt liveness is prefix-closed. Search backward for the deepest
         // live prefix, then construct only the missing suffix.
         for idx in (0..sequence.len().saturating_sub(1)).rev() {
-            if let Some(node) = self.upgrade_live_node(sequence[idx]) {
-                Self::debug_assert_lineage(&node, &sequence[..=idx]);
-                parent = Some(node);
+            if let Some(node_id) = self.live_node_id(sequence[idx]) {
+                self.debug_assert_lineage(node_id, &sequence[..=idx]);
+                parent = Some(node_id);
                 first_new_idx = idx + 1;
                 break;
             }
         }
 
+        let missing = sequence.len() - first_new_idx;
+        self.nodes.reserve(missing);
+        self.unique_blocks.reserve(missing);
+        self.debug_assert_new_hashes(&sequence[first_new_idx..]);
+
+        // Adding the first new child contributes one new incoming edge to the
+        // reused prefix. Subsequent construction transfers the provisional
+        // request-tail edge into a child-to-parent edge without changing it.
+        if let Some(parent_id) = parent {
+            self.increment_incoming(parent_id);
+        }
+
         for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
-            let node = Arc::new(BlockNode {
+            let node_id = self.nodes.insert(BlockNode {
                 hash,
                 depth: first_new_idx + idx + 1,
                 parent,
+                incoming: NonZeroU32::MIN,
             });
-            self.unique_blocks.insert(hash, Arc::downgrade(&node));
-            parent = Some(node);
+            let previous = self.unique_blocks.insert(hash, node_id);
+            debug_assert!(
+                previous.is_none(),
+                "new block unexpectedly replaced a live index entry"
+            );
+            parent = Some(node_id);
         }
 
         (
@@ -130,47 +123,89 @@ impl BlockTracker {
     /// Append a unique output block to an existing request chain.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
         debug_assert!(
-            self.unique_blocks
-                .get(&hash)
-                .and_then(Weak::upgrade)
-                .is_none(),
+            !self.unique_blocks.contains_key(&hash),
             "random output hash unexpectedly collided with a live block"
         );
 
-        let parent = chain.tail.take();
-        let depth = parent.as_ref().map_or(1, |node| node.depth + 1);
-        let node = Arc::new(BlockNode {
+        self.nodes.reserve(1);
+        self.unique_blocks.reserve(1);
+
+        let parent = chain.tail;
+        let depth = parent.map_or(1, |node_id| {
+            self.nodes
+                .get(node_id)
+                .expect("request tail references a missing block node")
+                .depth
+                .checked_add(1)
+                .expect("block chain depth overflowed")
+        });
+        let node_id = self.nodes.insert(BlockNode {
             hash,
             depth,
             parent,
+            incoming: NonZeroU32::MIN,
         });
-        self.unique_blocks.insert(hash, Arc::downgrade(&node));
-        chain.tail = Some(node);
+        let previous = self.unique_blocks.insert(hash, node_id);
+        debug_assert!(
+            previous.is_none(),
+            "new output unexpectedly replaced a live index entry"
+        );
+        chain.tail = Some(node_id);
     }
 
     /// Release a request chain and return the prompt suffix that became absent
     /// from the worker.
     pub(super) fn release(&mut self, chain: RequestBlockChain) -> Vec<SequenceHash> {
-        let mut dead_nodes = Vec::new();
-        let mut current = chain.tail.as_ref();
+        let RequestBlockChain { tail, prompt_depth } = chain;
+        let mut prompt_remove = Vec::new();
+        let mut current = tail;
 
-        while let Some(node) = current {
-            if Arc::strong_count(node) != 1 {
+        while let Some(node_id) = current {
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("request chain references a missing block node");
+            let incoming = node.incoming.get();
+
+            if incoming > 1 {
+                self.nodes
+                    .get_mut(node_id)
+                    .expect("request chain references a missing block node")
+                    .incoming = NonZeroU32::new(incoming - 1)
+                    .expect("shared block ownership count cannot become zero");
                 break;
             }
-            dead_nodes.push((node.hash, node.depth));
-            current = node.parent.as_ref();
-        }
 
-        for &(hash, _) in &dead_nodes {
-            self.unique_blocks.remove(&hash);
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("request chain references a missing block node");
+            let hash = node.hash;
+            let depth = node.depth;
+            let parent = node.parent;
+
+            match self.unique_blocks.entry(hash) {
+                Entry::Occupied(entry) => {
+                    assert_eq!(
+                        *entry.get(),
+                        node_id,
+                        "block hash index references a different live node"
+                    );
+                    entry.remove();
+                }
+                Entry::Vacant(_) => panic!("live block node is missing from the hash index"),
+            }
             self.fractional_blocks.remove(&hash);
+            self.nodes
+                .remove(node_id)
+                .expect("validated block node disappeared before removal");
+
+            if depth <= prompt_depth {
+                prompt_remove.push(hash);
+            }
+            current = parent;
         }
 
-        let mut prompt_remove = dead_nodes
-            .into_iter()
-            .filter_map(|(hash, depth)| (depth <= chain.prompt_depth).then_some(hash))
-            .collect::<Vec<_>>();
         prompt_remove.reverse();
         prompt_remove
     }
@@ -181,13 +216,17 @@ impl BlockTracker {
         chain: &RequestBlockChain,
         fraction: f64,
     ) {
-        let mut current = chain.tail.as_ref();
-        while let Some(node) = current {
-            if Arc::strong_count(node) != 1 {
+        let mut current = chain.tail;
+        while let Some(node_id) = current {
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("request chain references a missing block node");
+            if node.incoming.get() != 1 {
                 break;
             }
             self.fractional_blocks.insert(node.hash, fraction);
-            current = node.parent.as_ref();
+            current = node.parent;
         }
     }
 
@@ -202,21 +241,107 @@ impl BlockTracker {
     }
 
     pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
-        self.unique_blocks.contains_key(hash)
+        self.live_node_id(*hash).is_some()
     }
 
     #[cfg(any(test, debug_assertions))]
-    pub(super) fn fractional_hashes_are_active(&self) -> bool {
-        self.fractional_blocks
-            .keys()
-            .all(|hash| self.unique_blocks.contains_key(hash))
-    }
+    pub(super) fn assert_consistent<'a>(
+        &self,
+        chains: impl IntoIterator<Item = &'a RequestBlockChain>,
+    ) {
+        assert_eq!(
+            self.nodes.len(),
+            self.unique_blocks.len(),
+            "arena and live block index must have identical cardinality"
+        );
 
-    #[cfg(any(test, debug_assertions))]
-    pub(super) fn contains_chain(&self, chain: &RequestBlockChain) -> bool {
-        chain
-            .nodes_from_tail()
-            .all(|node| self.unique_blocks.contains_key(&node.hash))
+        let mut expected_incoming = FxHashMap::default();
+        for (node_id, node) in &self.nodes {
+            assert!(
+                expected_incoming.insert(node_id, 0_u32).is_none(),
+                "arena yielded a duplicate node ID"
+            );
+            assert_eq!(
+                self.unique_blocks.get(&node.hash),
+                Some(&node_id),
+                "live arena node is missing its exact hash-index entry"
+            );
+
+            if let Some(parent_id) = node.parent {
+                let parent = self
+                    .nodes
+                    .get(parent_id)
+                    .expect("block node references a missing parent");
+                assert_eq!(
+                    parent.depth + 1,
+                    node.depth,
+                    "child block depth must immediately follow its parent"
+                );
+            } else {
+                assert_eq!(node.depth, 1, "root block depth must be one");
+            }
+        }
+
+        for (&hash, &node_id) in &self.unique_blocks {
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("hash index references a missing arena node");
+            assert_eq!(
+                node.hash, hash,
+                "hash index key does not match its arena node"
+            );
+        }
+
+        for (_, node) in &self.nodes {
+            if let Some(parent_id) = node.parent {
+                let count = expected_incoming
+                    .get_mut(&parent_id)
+                    .expect("block node references a missing parent");
+                *count = count
+                    .checked_add(1)
+                    .expect("reconstructed child ownership count overflowed");
+            }
+        }
+
+        for chain in chains {
+            if let Some(tail_id) = chain.tail {
+                let tail = self
+                    .nodes
+                    .get(tail_id)
+                    .expect("request tail references a missing arena node");
+                assert!(
+                    chain.prompt_depth <= tail.depth,
+                    "request prompt depth cannot exceed its full block-chain depth"
+                );
+                let count = expected_incoming
+                    .get_mut(&tail_id)
+                    .expect("request tail references a missing arena node");
+                *count = count
+                    .checked_add(1)
+                    .expect("reconstructed request ownership count overflowed");
+            } else {
+                assert_eq!(
+                    chain.prompt_depth, 0,
+                    "an empty request chain cannot retain prompt depth"
+                );
+            }
+        }
+
+        for (node_id, node) in &self.nodes {
+            assert_eq!(
+                expected_incoming[&node_id],
+                node.incoming.get(),
+                "stored incoming ownership count differs from reconstructed edges"
+            );
+        }
+
+        assert!(
+            self.fractional_blocks
+                .keys()
+                .all(|hash| self.unique_blocks.contains_key(hash)),
+            "fractional blocks cannot reference non-active blocks"
+        );
     }
 
     #[cfg(test)]
@@ -224,36 +349,124 @@ impl BlockTracker {
         self.unique_blocks.keys().copied()
     }
 
-    fn upgrade_live_node(&mut self, hash: SequenceHash) -> Option<Arc<BlockNode>> {
-        let weak = self.unique_blocks.get(&hash)?;
-        let node = weak.upgrade();
-        if node.is_none() {
-            self.unique_blocks.remove(&hash);
-            self.fractional_blocks.remove(&hash);
-        }
-        node
+    #[cfg(test)]
+    pub(super) fn prompt_hashes<'a>(
+        &'a self,
+        chain: &'a RequestBlockChain,
+    ) -> impl Iterator<Item = SequenceHash> + 'a {
+        self.node_ids_from_tail(chain).filter_map(|node_id| {
+            let node = &self.nodes[node_id];
+            (node.depth <= chain.prompt_depth).then_some(node.hash)
+        })
     }
 
+    fn live_node_id(&self, hash: SequenceHash) -> Option<BlockNodeId> {
+        let &node_id = self.unique_blocks.get(&hash)?;
+        let node = self
+            .nodes
+            .get(node_id)
+            .expect("live block index references a stale arena ID");
+        assert_eq!(
+            node.hash, hash,
+            "live block index key does not match its arena node"
+        );
+        Some(node_id)
+    }
+
+    fn increment_incoming(&mut self, node_id: BlockNodeId) {
+        let node = self
+            .nodes
+            .get_mut(node_id)
+            .expect("cannot acquire ownership of a missing block node");
+        let incoming = node
+            .incoming
+            .get()
+            .checked_add(1)
+            .expect("block ownership count overflowed");
+        node.incoming = NonZeroU32::new(incoming).expect("incremented ownership cannot be zero");
+    }
+
+    #[cfg(debug_assertions)]
+    fn debug_assert_new_hashes(&self, hashes: &[SequenceHash]) {
+        let mut seen = FxHashSet::default();
+        for hash in hashes {
+            assert!(
+                !self.unique_blocks.contains_key(hash),
+                "sequence lineage hash unexpectedly aliases a live block"
+            );
+            assert!(
+                seen.insert(*hash),
+                "sequence lineage repeats a hash in one missing suffix"
+            );
+        }
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[inline]
+    fn debug_assert_new_hashes(&self, _hashes: &[SequenceHash]) {}
+
     #[cfg(any(test, debug_assertions))]
-    fn debug_assert_lineage(tail: &Arc<BlockNode>, sequence: &[SequenceHash]) {
-        assert_eq!(tail.depth, sequence.len(), "sequence tail depth mismatch");
-        let mut current = Some(tail.as_ref());
+    fn debug_assert_lineage(&self, tail: BlockNodeId, sequence: &[SequenceHash]) {
+        let tail_node = self
+            .nodes
+            .get(tail)
+            .expect("live sequence tail references a missing arena node");
+        assert_eq!(
+            tail_node.depth,
+            sequence.len(),
+            "sequence tail depth mismatch"
+        );
+        let mut current = Some(tail);
         for (expected_depth, &expected_hash) in sequence.iter().enumerate().rev() {
-            let node = current.expect("live sequence chain ended before its expected root");
+            let node_id = current.expect("live sequence chain ended before its expected root");
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("live sequence chain references a missing arena node");
             assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
             assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
-            current = node.parent.as_deref();
+            current = node.parent;
         }
     }
 
     #[cfg(not(any(test, debug_assertions)))]
     #[inline]
-    fn debug_assert_lineage(_tail: &Arc<BlockNode>, _sequence: &[SequenceHash]) {}
+    fn debug_assert_lineage(&self, _tail: BlockNodeId, _sequence: &[SequenceHash]) {}
+
+    #[cfg(test)]
+    fn node_ids_from_tail<'a>(
+        &'a self,
+        chain: &'a RequestBlockChain,
+    ) -> impl Iterator<Item = BlockNodeId> + 'a {
+        let mut current = chain.tail;
+        std::iter::from_fn(move || {
+            let node_id = current?;
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("request chain references a missing arena node");
+            current = node.parent;
+            Some(node_id)
+        })
+    }
+
+    #[cfg(test)]
+    fn incoming_for(&self, hash: SequenceHash) -> u32 {
+        let node_id = self.live_node_id(hash).expect("expected live block hash");
+        self.nodes[node_id].incoming.get()
+    }
+
+    #[cfg(test)]
+    fn node_id_for(&self, hash: SequenceHash) -> BlockNodeId {
+        self.live_node_id(hash).expect("expected live block hash")
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use rand::{Rng, SeedableRng, rngs::StdRng};
+    use rustc_hash::FxHashSet;
 
     #[test]
     fn first_acquire_and_last_release_report_presence_transitions() {
@@ -264,13 +477,52 @@ mod tests {
 
         assert_eq!(first_new, Some(0));
         assert_eq!(second_new, None);
+        assert_eq!(tracker.incoming_for(1), 2);
+        tracker.assert_consistent([&first, &second]);
         assert_eq!(tracker.active_blocks(), 1);
 
         assert!(tracker.release(first).is_empty());
+        assert_eq!(tracker.incoming_for(1), 1);
+        tracker.assert_consistent([&second]);
         assert_eq!(tracker.active_blocks(), 1);
 
         assert_eq!(tracker.release(second), vec![1]);
+        tracker.assert_consistent(std::iter::empty());
         assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn shorter_request_adds_only_a_tail_edge() {
+        let mut tracker = BlockTracker::default();
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (shorter, first_new) = tracker.acquire_prompt(&[1, 2]);
+
+        assert_eq!(first_new, None);
+        assert_eq!(tracker.incoming_for(1), 1);
+        assert_eq!(tracker.incoming_for(2), 2);
+        assert_eq!(tracker.incoming_for(3), 1);
+        tracker.assert_consistent([&longer, &shorter]);
+
+        assert!(tracker.release(shorter).is_empty());
+        tracker.assert_consistent([&longer]);
+        assert_eq!(tracker.release(longer), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn longer_request_adds_one_child_edge_to_a_shorter_tail() {
+        let mut tracker = BlockTracker::default();
+        let (shorter, _) = tracker.acquire_prompt(&[1, 2]);
+        let (longer, first_new) = tracker.acquire_prompt(&[1, 2, 3]);
+
+        assert_eq!(first_new, Some(2));
+        assert_eq!(tracker.incoming_for(1), 1);
+        assert_eq!(tracker.incoming_for(2), 2);
+        assert_eq!(tracker.incoming_for(3), 1);
+        tracker.assert_consistent([&shorter, &longer]);
+
+        assert_eq!(tracker.release(longer), vec![3]);
+        tracker.assert_consistent([&shorter]);
+        assert_eq!(tracker.release(shorter), vec![1, 2]);
     }
 
     #[test]
@@ -280,11 +532,59 @@ mod tests {
         let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
 
         assert_eq!(first_new, Some(2));
+        assert_eq!(tracker.incoming_for(1), 1);
+        assert_eq!(tracker.incoming_for(2), 2);
+        tracker.assert_consistent([&left, &right]);
         assert_eq!(tracker.active_blocks(), 4);
+
         assert_eq!(tracker.release(left), vec![3]);
+        tracker.assert_consistent([&right]);
         assert_eq!(tracker.active_blocks(), 3);
         assert_eq!(tracker.release(right), vec![1, 2, 4]);
+        tracker.assert_consistent(std::iter::empty());
         assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn output_append_transfers_tail_ownership_to_the_child_edge() {
+        let mut tracker = BlockTracker::default();
+        let (mut chain, _) = tracker.acquire_prompt(&[1, 2]);
+
+        let before = tracker.incoming_for(2);
+        tracker.append_output(&mut chain, 42);
+
+        assert_eq!(tracker.incoming_for(2), before);
+        assert_eq!(tracker.incoming_for(42), 1);
+        tracker.assert_consistent([&chain]);
+        assert_eq!(tracker.release(chain), vec![1, 2]);
+    }
+
+    #[test]
+    fn output_append_preserves_a_shared_tail_count() {
+        let mut tracker = BlockTracker::default();
+        let (mut generating, _) = tracker.acquire_prompt(&[1, 2]);
+        let (shared, _) = tracker.acquire_prompt(&[1, 2]);
+
+        assert_eq!(tracker.incoming_for(2), 2);
+        tracker.append_output(&mut generating, 42);
+        assert_eq!(tracker.incoming_for(2), 2);
+        tracker.assert_consistent([&generating, &shared]);
+
+        assert!(tracker.release(generating).is_empty());
+        assert_eq!(tracker.incoming_for(2), 1);
+        tracker.assert_consistent([&shared]);
+        assert_eq!(tracker.release(shared), vec![1, 2]);
+    }
+
+    #[test]
+    fn either_branch_can_be_released_first() {
+        let mut tracker = BlockTracker::default();
+        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (right, _) = tracker.acquire_prompt(&[1, 2, 4]);
+
+        assert_eq!(tracker.release(right), vec![4]);
+        tracker.assert_consistent([&left]);
+        assert_eq!(tracker.release(left), vec![1, 2, 3]);
     }
 
     #[test]
@@ -293,10 +593,12 @@ mod tests {
         let (chain, _) = tracker.acquire_prompt(&[1, 2]);
 
         tracker.set_unique_suffix_fractional(&chain, 0.5);
+        tracker.assert_consistent([&chain]);
         assert_eq!(tracker.active_blocks(), 1);
 
         assert_eq!(tracker.release(chain), vec![1, 2]);
         assert!(tracker.fractional_blocks.is_empty());
+        tracker.assert_consistent(std::iter::empty());
         assert_eq!(tracker.active_blocks(), 0);
     }
 
@@ -310,9 +612,11 @@ mod tests {
         assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
         assert!(!tracker.fractional_blocks.contains_key(&1));
         assert!(!tracker.fractional_blocks.contains_key(&2));
+        tracker.assert_consistent([&longer, &shared_prefix]);
 
         assert_eq!(tracker.release(longer), vec![3]);
         assert!(tracker.fractional_blocks.is_empty());
+        tracker.assert_consistent([&shared_prefix]);
         assert_eq!(tracker.active_blocks(), 2);
 
         assert_eq!(tracker.release(shared_prefix), vec![1, 2]);
@@ -326,8 +630,155 @@ mod tests {
 
         assert_eq!(first_new, None);
         tracker.append_output(&mut chain, 42);
+        tracker.assert_consistent([&chain]);
         assert_eq!(tracker.active_blocks(), 1);
         assert!(tracker.release(chain).is_empty());
+        tracker.assert_consistent(std::iter::empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn removed_slot_generation_cannot_resolve_after_reuse() {
+        let mut tracker = BlockTracker::default();
+        let (first, _) = tracker.acquire_prompt(&[1]);
+        let old_id = tracker.node_id_for(1);
+        assert_eq!(tracker.release(first), vec![1]);
+
+        let (second, _) = tracker.acquire_prompt(&[2]);
+        assert!(tracker.nodes.get(old_id).is_none());
+        assert_ne!(old_id, tracker.node_id_for(2));
+        tracker.assert_consistent([&second]);
+        assert_eq!(tracker.release(second), vec![2]);
+    }
+
+    #[test]
+    #[should_panic(expected = "live block index references a stale arena ID")]
+    fn stale_generation_in_index_is_rejected() {
+        let mut tracker = BlockTracker::default();
+        let (first, _) = tracker.acquire_prompt(&[1]);
+        let old_id = tracker.node_id_for(1);
+        assert_eq!(tracker.release(first), vec![1]);
+        let (second, _) = tracker.acquire_prompt(&[2]);
+
+        tracker.unique_blocks.insert(99, old_id);
+        let _ = tracker.contains_block(&99);
+        drop(second);
+    }
+
+    #[test]
+    #[should_panic(expected = "live block index key does not match its arena node")]
+    fn live_id_with_the_wrong_hash_is_rejected() {
+        let mut tracker = BlockTracker::default();
+        let (chain, _) = tracker.acquire_prompt(&[1]);
+        let node_id = tracker.node_id_for(1);
+
+        tracker.unique_blocks.insert(2, node_id);
+        let _ = tracker.contains_block(&2);
+        drop(chain);
+    }
+
+    #[test]
+    #[should_panic(expected = "block ownership count overflowed")]
+    fn ownership_count_overflow_panics() {
+        let mut tracker = BlockTracker::default();
+        let (chain, _) = tracker.acquire_prompt(&[1]);
+        let node_id = tracker.node_id_for(1);
+        tracker.nodes[node_id].incoming = NonZeroU32::MAX;
+        let _ = tracker.acquire_prompt(&[1]);
+        drop(chain);
+    }
+
+    #[test]
+    fn randomized_lifecycle_matches_reference_model() {
+        const SLOTS: usize = 32;
+        const STEPS: usize = 10_000;
+        let prompts = [
+            vec![1, 2, 3, 4],
+            vec![1, 2, 3, 5],
+            vec![1, 2, 6],
+            vec![1, 7],
+            vec![8, 9, 10],
+            vec![8, 9, 11],
+            vec![12],
+        ];
+        let mut rng = StdRng::seed_from_u64(0x5eed_51a7);
+        let mut tracker = BlockTracker::default();
+        let mut chains = (0..SLOTS).map(|_| None).collect::<Vec<_>>();
+        let mut reference = (0..SLOTS)
+            .map(|_| None::<(Vec<SequenceHash>, usize)>)
+            .collect::<Vec<_>>();
+        let mut counts = FxHashMap::<SequenceHash, usize>::default();
+        let mut next_output = 1_000_000_u64;
+
+        for _ in 0..STEPS {
+            let slot = rng.random_range(0..SLOTS);
+            match (&mut chains[slot], &mut reference[slot]) {
+                (chain @ None, reference @ None) => {
+                    let prompt = &prompts[rng.random_range(0..prompts.len())];
+                    let expected_first_new =
+                        prompt.iter().position(|hash| !counts.contains_key(hash));
+                    let (new_chain, first_new) = tracker.acquire_prompt(prompt);
+                    assert_eq!(first_new, expected_first_new);
+                    for &hash in prompt {
+                        *counts.entry(hash).or_default() += 1;
+                    }
+                    *chain = Some(new_chain);
+                    *reference = Some((prompt.clone(), prompt.len()));
+                }
+                (Some(chain), Some((blocks, _prompt_depth))) if rng.random_bool(0.35) => {
+                    let hash = next_output;
+                    next_output += 1;
+                    tracker.append_output(chain, hash);
+                    blocks.push(hash);
+                    counts.insert(hash, 1);
+                }
+                (chain @ Some(_), reference @ Some(_)) => {
+                    let chain = chain.take().expect("matched active chain");
+                    let (blocks, prompt_depth) = reference.take().expect("matched reference");
+                    let expected_remove = blocks[..prompt_depth]
+                        .iter()
+                        .copied()
+                        .filter(|hash| counts[hash] == 1)
+                        .collect::<Vec<_>>();
+                    assert_eq!(tracker.release(chain), expected_remove);
+                    for hash in blocks {
+                        let count = counts.get_mut(&hash).expect("reference block is active");
+                        *count -= 1;
+                        if *count == 0 {
+                            counts.remove(&hash);
+                        }
+                    }
+                }
+                _ => unreachable!("tracker and reference occupancy diverged"),
+            }
+
+            tracker.assert_consistent(chains.iter().filter_map(Option::as_ref));
+            let actual = tracker.active_hashes().collect::<FxHashSet<_>>();
+            let expected = counts.keys().copied().collect::<FxHashSet<_>>();
+            assert_eq!(actual, expected);
+        }
+
+        for slot in 0..SLOTS {
+            if let Some(chain) = chains[slot].take() {
+                let (blocks, prompt_depth) = reference[slot].take().expect("active reference");
+                let expected_remove = blocks[..prompt_depth]
+                    .iter()
+                    .copied()
+                    .filter(|hash| counts[hash] == 1)
+                    .collect::<Vec<_>>();
+                assert_eq!(tracker.release(chain), expected_remove);
+                for hash in blocks {
+                    let count = counts.get_mut(&hash).expect("reference block is active");
+                    *count -= 1;
+                    if *count == 0 {
+                        counts.remove(&hash);
+                    }
+                }
+            }
+        }
+
+        tracker.assert_consistent(std::iter::empty());
+        assert!(counts.is_empty());
         assert_eq!(tracker.active_blocks(), 0);
     }
 
@@ -339,8 +790,10 @@ mod tests {
         let (chain, first_new) = tracker.acquire_prompt(&sequence);
 
         assert_eq!(first_new, Some(0));
+        tracker.assert_consistent([&chain]);
         assert_eq!(tracker.active_blocks(), DEPTH);
         assert_eq!(tracker.release(chain), sequence);
+        tracker.assert_consistent(std::iter::empty());
         assert_eq!(tracker.active_blocks(), 0);
     }
 }

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_tokens::SequenceHash;
+use dynamo_tokens::{PositionalLineageHash, SequenceHash};
 use rustc_hash::FxHashMap;
 #[cfg(debug_assertions)]
 use rustc_hash::FxHashSet;
@@ -15,14 +15,30 @@ new_key_type! {
 
 /// One node in a persistent request block chain.
 ///
-/// Sequence hashes identify their lineage. Parent IDs are generational arena
-/// keys, while `incoming` counts direct request-tail and child-to-parent edges.
+/// Positional lineage hashes distinguish the same sequence hash at different
+/// positions or beneath different parent-hash fragments. Parent IDs are
+/// generational arena keys, while `incoming` counts direct request-tail and
+/// child-to-parent edges.
 #[derive(Debug)]
 struct BlockNode {
-    hash: SequenceHash,
-    depth: usize,
+    lineage_hash: PositionalLineageHash,
     parent: Option<BlockNodeId>,
     incoming: NonZeroU32,
+}
+
+impl BlockNode {
+    #[inline]
+    fn sequence_hash(&self) -> SequenceHash {
+        self.lineage_hash.current_sequence_hash()
+    }
+
+    #[inline]
+    fn depth(&self) -> usize {
+        usize::try_from(self.lineage_hash.position())
+            .expect("block position does not fit usize")
+            .checked_add(1)
+            .expect("block chain depth overflowed")
+    }
 }
 
 /// The single block-chain tail retained by a request.
@@ -46,26 +62,25 @@ impl RequestBlockChain {
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
     nodes: SlotMap<BlockNodeId, BlockNode>,
-    unique_blocks: FxHashMap<SequenceHash, BlockNodeId>,
-    fractional_blocks: FxHashMap<SequenceHash, f64>,
+    unique_blocks: FxHashMap<PositionalLineageHash, BlockNodeId>,
+    fractional_blocks: FxHashMap<PositionalLineageHash, f64>,
 }
 
 impl BlockTracker {
     /// Acquire one request tail for a prompt and return the first newly present
     /// prompt index, if any.
     ///
-    /// # Lineage contract
-    ///
-    /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
-    /// depth. As with the KV indexer, this tracker trusts callers to maintain
-    /// that invariant and does not validate the hash recurrence in production.
+    /// The internal index augments each [`SequenceHash`] with its position and
+    /// parent-hash fragment. Public membership events continue to use the raw
+    /// sequence hashes.
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],
     ) -> (RequestBlockChain, Option<usize>) {
-        let Some(&tail_hash) = sequence.last() else {
+        let Some(tail_idx) = sequence.len().checked_sub(1) else {
             return (RequestBlockChain::default(), None);
         };
+        let tail_hash = Self::prompt_lineage_hash(sequence, tail_idx);
 
         if let Some(tail) = self.live_node_id(tail_hash) {
             self.debug_assert_lineage(tail, sequence);
@@ -79,7 +94,8 @@ impl BlockTracker {
         // Prompt liveness is prefix-closed. Search backward for the deepest
         // live prefix, then construct only the missing suffix.
         for idx in (0..sequence.len().saturating_sub(1)).rev() {
-            if let Some(node_id) = self.live_node_id(sequence[idx]) {
+            let lineage_hash = Self::prompt_lineage_hash(sequence, idx);
+            if let Some(node_id) = self.live_node_id(lineage_hash) {
                 self.debug_assert_lineage(node_id, &sequence[..=idx]);
                 parent = Some(node_id);
                 first_new_idx = idx + 1;
@@ -90,7 +106,7 @@ impl BlockTracker {
         let missing = sequence.len() - first_new_idx;
         self.nodes.reserve(missing);
         self.unique_blocks.reserve(missing);
-        self.debug_assert_new_hashes(&sequence[first_new_idx..]);
+        self.debug_assert_new_hashes(sequence, first_new_idx);
 
         // Adding the first new child contributes one new incoming edge to the
         // reused prefix. Subsequent construction transfers the provisional
@@ -99,14 +115,14 @@ impl BlockTracker {
             self.increment_incoming(parent_id);
         }
 
-        for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
+        for idx in first_new_idx..sequence.len() {
+            let lineage_hash = Self::prompt_lineage_hash(sequence, idx);
             let node_id = self.nodes.insert(BlockNode {
-                hash,
-                depth: first_new_idx + idx + 1,
+                lineage_hash,
                 parent,
                 incoming: NonZeroU32::MIN,
             });
-            let previous = self.unique_blocks.insert(hash, node_id);
+            let previous = self.unique_blocks.insert(lineage_hash, node_id);
             debug_assert!(
                 previous.is_none(),
                 "new block unexpectedly replaced a live index entry"
@@ -122,27 +138,32 @@ impl BlockTracker {
 
     /// Append a unique output block to an existing request chain.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
+        let parent = chain.tail;
+        let (parent_hash, position) = parent.map_or((None, 0), |node_id| {
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("request tail references a missing block node");
+            let position = node
+                .lineage_hash
+                .position()
+                .checked_add(1)
+                .expect("block position overflowed");
+            (Some(node.sequence_hash()), position)
+        });
+        let lineage_hash = PositionalLineageHash::new(hash, parent_hash, position);
+
         debug_assert!(
-            !self.unique_blocks.contains_key(&hash),
+            !self.unique_blocks.contains_key(&lineage_hash),
             "random output hash unexpectedly collided with a live block"
         );
 
-        let parent = chain.tail;
-        let depth = parent.map_or(1, |node_id| {
-            self.nodes
-                .get(node_id)
-                .expect("request tail references a missing block node")
-                .depth
-                .checked_add(1)
-                .expect("block chain depth overflowed")
-        });
         let node_id = self.nodes.insert(BlockNode {
-            hash,
-            depth,
+            lineage_hash,
             parent,
             incoming: NonZeroU32::MIN,
         });
-        let previous = self.unique_blocks.insert(hash, node_id);
+        let previous = self.unique_blocks.insert(lineage_hash, node_id);
         debug_assert!(
             previous.is_none(),
             "new output unexpectedly replaced a live index entry"
@@ -177,11 +198,12 @@ impl BlockTracker {
                 .nodes
                 .get(node_id)
                 .expect("request chain references a missing block node");
-            let hash = node.hash;
-            let depth = node.depth;
+            let lineage_hash = node.lineage_hash;
+            let hash = node.sequence_hash();
+            let depth = node.depth();
             let parent = node.parent;
 
-            match self.unique_blocks.entry(hash) {
+            match self.unique_blocks.entry(lineage_hash) {
                 Entry::Occupied(entry) => {
                     assert_eq!(
                         *entry.get(),
@@ -192,7 +214,7 @@ impl BlockTracker {
                 }
                 Entry::Vacant(_) => panic!("live block node is missing from the hash index"),
             }
-            self.fractional_blocks.remove(&hash);
+            self.fractional_blocks.remove(&lineage_hash);
             self.nodes
                 .remove(node_id)
                 .expect("validated block node disappeared before removal");
@@ -222,7 +244,7 @@ impl BlockTracker {
             if node.incoming.get() != 1 {
                 break;
             }
-            self.fractional_blocks.insert(node.hash, fraction);
+            self.fractional_blocks.insert(node.lineage_hash, fraction);
             current = node.parent;
         }
     }
@@ -237,8 +259,9 @@ impl BlockTracker {
         count.round() as usize
     }
 
-    pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
-        self.live_node_id(*hash).is_some()
+    pub(super) fn contains_prompt_block(&self, sequence: &[SequenceHash], index: usize) -> bool {
+        self.live_node_id(Self::prompt_lineage_hash(sequence, index))
+            .is_some()
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -259,9 +282,9 @@ impl BlockTracker {
                 "arena yielded a duplicate node ID"
             );
             assert_eq!(
-                self.unique_blocks.get(&node.hash),
+                self.unique_blocks.get(&node.lineage_hash),
                 Some(&node_id),
-                "live arena node is missing its exact hash-index entry"
+                "live arena node is missing its exact lineage-index entry"
             );
 
             if let Some(parent_id) = node.parent {
@@ -270,23 +293,23 @@ impl BlockTracker {
                     .get(parent_id)
                     .expect("block node references a missing parent");
                 assert_eq!(
-                    parent.depth + 1,
-                    node.depth,
+                    parent.depth() + 1,
+                    node.depth(),
                     "child block depth must immediately follow its parent"
                 );
             } else {
-                assert_eq!(node.depth, 1, "root block depth must be one");
+                assert_eq!(node.depth(), 1, "root block depth must be one");
             }
         }
 
-        for (&hash, &node_id) in &self.unique_blocks {
+        for (&lineage_hash, &node_id) in &self.unique_blocks {
             let node = self
                 .nodes
                 .get(node_id)
-                .expect("hash index references a missing arena node");
+                .expect("lineage index references a missing arena node");
             assert_eq!(
-                node.hash, hash,
-                "hash index key does not match its arena node"
+                node.lineage_hash, lineage_hash,
+                "lineage index key does not match its arena node"
             );
         }
 
@@ -308,7 +331,7 @@ impl BlockTracker {
                     .get(tail_id)
                     .expect("request tail references a missing arena node");
                 assert!(
-                    chain.prompt_depth <= tail.depth,
+                    chain.prompt_depth <= tail.depth(),
                     "request prompt depth cannot exceed its full block-chain depth"
                 );
                 let count = expected_incoming
@@ -343,7 +366,9 @@ impl BlockTracker {
 
     #[cfg(test)]
     pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
-        self.unique_blocks.keys().copied()
+        self.unique_blocks
+            .keys()
+            .map(PositionalLineageHash::current_sequence_hash)
     }
 
     #[cfg(test)]
@@ -353,21 +378,29 @@ impl BlockTracker {
     ) -> impl Iterator<Item = SequenceHash> + 'a {
         self.node_ids_from_tail(chain).filter_map(|node_id| {
             let node = &self.nodes[node_id];
-            (node.depth <= chain.prompt_depth).then_some(node.hash)
+            (node.depth() <= chain.prompt_depth).then(|| node.sequence_hash())
         })
     }
 
-    fn live_node_id(&self, hash: SequenceHash) -> Option<BlockNodeId> {
-        let &node_id = self.unique_blocks.get(&hash)?;
+    fn live_node_id(&self, lineage_hash: PositionalLineageHash) -> Option<BlockNodeId> {
+        let &node_id = self.unique_blocks.get(&lineage_hash)?;
         let node = self
             .nodes
             .get(node_id)
-            .expect("live block index references a stale arena ID");
+            .expect("live lineage index references a stale arena ID");
         assert_eq!(
-            node.hash, hash,
-            "live block index key does not match its arena node"
+            node.lineage_hash, lineage_hash,
+            "live lineage index key does not match its arena node"
         );
         Some(node_id)
+    }
+
+    #[inline]
+    fn prompt_lineage_hash(sequence: &[SequenceHash], index: usize) -> PositionalLineageHash {
+        let current = sequence[index];
+        let parent = index.checked_sub(1).map(|parent_idx| sequence[parent_idx]);
+        let position = u64::try_from(index).expect("block position does not fit u64");
+        PositionalLineageHash::new(current, parent, position)
     }
 
     fn increment_incoming(&mut self, node_id: BlockNodeId) {
@@ -384,15 +417,16 @@ impl BlockTracker {
     }
 
     #[cfg(debug_assertions)]
-    fn debug_assert_new_hashes(&self, hashes: &[SequenceHash]) {
+    fn debug_assert_new_hashes(&self, sequence: &[SequenceHash], first_new_idx: usize) {
         let mut seen = FxHashSet::default();
-        for hash in hashes {
+        for idx in first_new_idx..sequence.len() {
+            let lineage_hash = Self::prompt_lineage_hash(sequence, idx);
             assert!(
-                !self.unique_blocks.contains_key(hash),
+                !self.unique_blocks.contains_key(&lineage_hash),
                 "sequence lineage hash unexpectedly aliases a live block"
             );
             assert!(
-                seen.insert(*hash),
+                seen.insert(lineage_hash),
                 "sequence lineage repeats a hash in one missing suffix"
             );
         }
@@ -400,7 +434,7 @@ impl BlockTracker {
 
     #[cfg(not(debug_assertions))]
     #[inline]
-    fn debug_assert_new_hashes(&self, _hashes: &[SequenceHash]) {}
+    fn debug_assert_new_hashes(&self, _sequence: &[SequenceHash], _first_new_idx: usize) {}
 
     #[cfg(any(test, debug_assertions))]
     fn debug_assert_lineage(&self, tail: BlockNodeId, sequence: &[SequenceHash]) {
@@ -409,7 +443,7 @@ impl BlockTracker {
             .get(tail)
             .expect("live sequence tail references a missing arena node");
         assert_eq!(
-            tail_node.depth,
+            tail_node.depth(),
             sequence.len(),
             "sequence tail depth mismatch"
         );
@@ -420,8 +454,17 @@ impl BlockTracker {
                 .nodes
                 .get(node_id)
                 .expect("live sequence chain references a missing arena node");
-            assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
-            assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
+            assert_eq!(node.depth(), expected_depth + 1, "sequence depth mismatch");
+            assert_eq!(
+                node.lineage_hash,
+                Self::prompt_lineage_hash(sequence, expected_depth),
+                "positional sequence lineage hash mismatch"
+            );
+            assert_eq!(
+                node.sequence_hash(),
+                expected_hash,
+                "sequence lineage hash mismatch"
+            );
             current = node.parent;
         }
     }
@@ -449,13 +492,27 @@ impl BlockTracker {
 
     #[cfg(test)]
     fn incoming_for(&self, hash: SequenceHash) -> u32 {
-        let node_id = self.live_node_id(hash).expect("expected live block hash");
+        let node_id = self.node_id_for(hash);
         self.nodes[node_id].incoming.get()
     }
 
     #[cfg(test)]
     fn node_id_for(&self, hash: SequenceHash) -> BlockNodeId {
-        self.live_node_id(hash).expect("expected live block hash")
+        let mut matches = self.unique_blocks.iter().filter_map(|(lineage, &node_id)| {
+            (lineage.current_sequence_hash() == hash).then_some(node_id)
+        });
+        let node_id = matches.next().expect("expected live block hash");
+        assert!(
+            matches.next().is_none(),
+            "expected raw block hash to identify exactly one live lineage"
+        );
+        node_id
+    }
+
+    #[cfg(test)]
+    fn node_id_for_prompt(&self, sequence: &[SequenceHash], index: usize) -> BlockNodeId {
+        self.live_node_id(Self::prompt_lineage_hash(sequence, index))
+            .expect("expected live prompt lineage")
     }
 }
 
@@ -552,8 +609,60 @@ mod tests {
 
         assert_eq!(tracker.incoming_for(2), before);
         assert_eq!(tracker.incoming_for(42), 1);
+        let output = &tracker.nodes[tracker.node_id_for(42)];
+        assert_eq!(output.lineage_hash.position(), 2);
+        assert_eq!(output.lineage_hash.current_sequence_hash(), 42);
+        assert_eq!(output.lineage_hash.parent_hash_fragment(), 2);
         tracker.assert_consistent([&chain]);
         assert_eq!(tracker.release(chain), vec![1, 2]);
+    }
+
+    #[test]
+    fn same_tail_hash_under_different_parents_has_independent_lineages() {
+        let left_sequence = [1, 9];
+        let right_sequence = [2, 9];
+        let mut tracker = BlockTracker::default();
+        let (left, left_first_new) = tracker.acquire_prompt(&left_sequence);
+        let (right, right_first_new) = tracker.acquire_prompt(&right_sequence);
+
+        assert_eq!(left_first_new, Some(0));
+        assert_eq!(right_first_new, Some(0));
+        assert_ne!(
+            tracker.node_id_for_prompt(&left_sequence, 1),
+            tracker.node_id_for_prompt(&right_sequence, 1)
+        );
+        assert_eq!(tracker.active_blocks(), 4);
+
+        tracker.set_unique_suffix_fractional(&left, 0.5);
+        assert_eq!(tracker.active_blocks(), 3);
+        tracker.assert_consistent([&left, &right]);
+
+        assert_eq!(tracker.release(left), vec![1, 9]);
+        assert_eq!(tracker.active_blocks(), 2);
+        tracker.assert_consistent([&right]);
+        assert_eq!(tracker.release(right), vec![2, 9]);
+        tracker.assert_consistent(std::iter::empty());
+    }
+
+    #[test]
+    fn same_hash_at_different_depths_has_independent_lineages() {
+        let root_sequence = [9];
+        let nested_sequence = [1, 9];
+        let mut tracker = BlockTracker::default();
+        let (root, _) = tracker.acquire_prompt(&root_sequence);
+        let (nested, nested_first_new) = tracker.acquire_prompt(&nested_sequence);
+
+        assert_eq!(nested_first_new, Some(0));
+        assert_ne!(
+            tracker.node_id_for_prompt(&root_sequence, 0),
+            tracker.node_id_for_prompt(&nested_sequence, 1)
+        );
+        assert_eq!(tracker.active_blocks(), 3);
+        tracker.assert_consistent([&root, &nested]);
+
+        assert_eq!(tracker.release(root), vec![9]);
+        tracker.assert_consistent([&nested]);
+        assert_eq!(tracker.release(nested), vec![1, 9]);
     }
 
     #[test]
@@ -606,9 +715,23 @@ mod tests {
         let (shared_prefix, _) = tracker.acquire_prompt(&[1, 2]);
 
         tracker.set_unique_suffix_fractional(&longer, 0.5);
-        assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
-        assert!(!tracker.fractional_blocks.contains_key(&1));
-        assert!(!tracker.fractional_blocks.contains_key(&2));
+        let sequence = [1, 2, 3];
+        assert_eq!(
+            tracker
+                .fractional_blocks
+                .get(&BlockTracker::prompt_lineage_hash(&sequence, 2)),
+            Some(&0.5)
+        );
+        assert!(
+            !tracker
+                .fractional_blocks
+                .contains_key(&BlockTracker::prompt_lineage_hash(&sequence, 0))
+        );
+        assert!(
+            !tracker
+                .fractional_blocks
+                .contains_key(&BlockTracker::prompt_lineage_hash(&sequence, 1))
+        );
         tracker.assert_consistent([&longer, &shared_prefix]);
 
         assert_eq!(tracker.release(longer), vec![3]);
@@ -649,7 +772,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "live block index references a stale arena ID")]
+    #[should_panic(expected = "live lineage index references a stale arena ID")]
     fn stale_generation_in_index_is_rejected() {
         let mut tracker = BlockTracker::default();
         let (first, _) = tracker.acquire_prompt(&[1]);
@@ -657,21 +780,39 @@ mod tests {
         assert_eq!(tracker.release(first), vec![1]);
         let (second, _) = tracker.acquire_prompt(&[2]);
 
-        tracker.unique_blocks.insert(99, old_id);
-        let _ = tracker.contains_block(&99);
+        let wrong_lineage = BlockTracker::prompt_lineage_hash(&[99], 0);
+        tracker.unique_blocks.insert(wrong_lineage, old_id);
+        let _ = tracker.live_node_id(wrong_lineage);
         drop(second);
     }
 
     #[test]
-    #[should_panic(expected = "live block index key does not match its arena node")]
+    #[should_panic(expected = "live lineage index key does not match its arena node")]
     fn live_id_with_the_wrong_hash_is_rejected() {
         let mut tracker = BlockTracker::default();
         let (chain, _) = tracker.acquire_prompt(&[1]);
         let node_id = tracker.node_id_for(1);
 
-        tracker.unique_blocks.insert(2, node_id);
-        let _ = tracker.contains_block(&2);
+        let wrong_lineage = BlockTracker::prompt_lineage_hash(&[2], 0);
+        tracker.unique_blocks.insert(wrong_lineage, node_id);
+        let _ = tracker.live_node_id(wrong_lineage);
         drop(chain);
+    }
+
+    #[test]
+    fn positional_lineage_modes_cover_prompt_size_boundaries() {
+        let sequence = (1..=65_537_u64).collect::<Vec<_>>();
+
+        assert_eq!(BlockTracker::prompt_lineage_hash(&sequence, 255).mode(), 0);
+        assert_eq!(BlockTracker::prompt_lineage_hash(&sequence, 256).mode(), 1);
+        assert_eq!(
+            BlockTracker::prompt_lineage_hash(&sequence, 65_535).mode(),
+            1
+        );
+        assert_eq!(
+            BlockTracker::prompt_lineage_hash(&sequence, 65_536).mode(),
+            2
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -78,6 +78,12 @@ pub(super) struct BlockTracker {
 impl BlockTracker {
     /// Acquire one strong tail for a prompt and return the first newly present
     /// prompt index, if any.
+    ///
+    /// # Lineage contract
+    ///
+    /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
+    /// depth. As with the KV indexer, this tracker trusts callers to maintain
+    /// that invariant and does not validate the hash recurrence in production.
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],
@@ -124,7 +130,10 @@ impl BlockTracker {
     /// Append a unique output block to an existing request chain.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
         debug_assert!(
-            self.upgrade_live_node(hash).is_none(),
+            self.unique_blocks
+                .get(&hash)
+                .and_then(Weak::upgrade)
+                .is_none(),
             "random output hash unexpectedly collided with a live block"
         );
 
@@ -288,6 +297,25 @@ mod tests {
 
         assert_eq!(tracker.release(chain), vec![1, 2]);
         assert!(tracker.fractional_blocks.is_empty());
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn release_cleans_fractional_unique_suffix_above_shared_prefix() {
+        let mut tracker = BlockTracker::default();
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (shared_prefix, _) = tracker.acquire_prompt(&[1, 2]);
+
+        tracker.set_unique_suffix_fractional(&longer, 0.5);
+        assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
+        assert!(!tracker.fractional_blocks.contains_key(&1));
+        assert!(!tracker.fractional_blocks.contains_key(&2));
+
+        assert_eq!(tracker.release(longer), vec![3]);
+        assert!(tracker.fractional_blocks.is_empty());
+        assert_eq!(tracker.active_blocks(), 2);
+
+        assert_eq!(tracker.release(shared_prefix), vec![1, 2]);
         assert_eq!(tracker.active_blocks(), 0);
     }
 

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -59,6 +59,16 @@ impl BlockTracker {
     /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
     /// depth. As with the KV indexer, this tracker trusts callers to maintain
     /// that invariant and does not validate the hash recurrence in production.
+    ///
+    /// # Collision scope
+    ///
+    /// `SequenceHash` is a probabilistic 64-bit identifier, so collisions are
+    /// possible but very unlikely. A collision matters here only when both
+    /// blocks are live in the same `WorkerWithDpRank` tracker: each worker and
+    /// DP rank owns a separate `BlockTracker` and hash index. Assuming uniform
+    /// hashes, an active set of `n` blocks has collision probability of roughly
+    /// `n * (n - 1) / 2^65`. Replica sync may reproduce the same collision for
+    /// that worker on peer routers, but cannot alias arena nodes across workers.
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -177,9 +177,8 @@ impl ActiveSequences {
 
         if let Some(first_new_prompt_idx) = first_new_prompt_idx {
             debug_assert!(
-                prompt_hashes[first_new_prompt_idx..]
-                    .iter()
-                    .all(|hash| self.blocks.contains_block(hash))
+                (first_new_prompt_idx..prompt_hashes.len())
+                    .all(|idx| self.blocks.contains_prompt_block(&prompt_hashes, idx))
             );
             let parent = first_new_prompt_idx
                 .checked_sub(1)
@@ -375,6 +374,31 @@ mod tests {
     }
 
     #[test]
+    fn active_worker_teardown_with_colliding_raw_tail_hashes() {
+        let mut sequences = ActiveSequences::new_without_expiry(1);
+        let now = Instant::now();
+        sequences.add_request_with_prefill_tracking(
+            "left".to_string(),
+            Some(vec![1, 9]),
+            None,
+            false,
+            None,
+            now,
+        );
+        sequences.add_request_with_prefill_tracking(
+            "right".to_string(),
+            Some(vec![2, 9]),
+            None,
+            false,
+            None,
+            now,
+        );
+
+        assert_eq!(sequences.active_blocks(), 4);
+        drop(sequences);
+    }
+
+    #[test]
     fn test_prompt_membership_delta_only_reports_first_add_and_last_remove() {
         let mut seq_manager = ActiveSequences::new(4);
         let decay_now = Instant::now();
@@ -430,6 +454,61 @@ mod tests {
                 hashes: vec![1, 2, 3],
             }]
         );
+    }
+
+    #[test]
+    fn colliding_raw_tail_hashes_keep_membership_lineages_independent() {
+        let mut seq_manager = ActiveSequences::new_without_expiry(1);
+        let decay_now = Instant::now();
+
+        let left = seq_manager.add_request_with_prefill_tracking(
+            "left".to_string(),
+            Some(vec![1, 9]),
+            None,
+            false,
+            None,
+            decay_now,
+        );
+        let right = seq_manager.add_request_with_prefill_tracking(
+            "right".to_string(),
+            Some(vec![2, 9]),
+            None,
+            false,
+            None,
+            decay_now,
+        );
+
+        assert_eq!(
+            left.membership_delta.stores,
+            vec![PromptMembershipStore {
+                parent: None,
+                hashes: vec![1, 9],
+            }]
+        );
+        assert_eq!(
+            right.membership_delta.stores,
+            vec![PromptMembershipStore {
+                parent: None,
+                hashes: vec![2, 9],
+            }]
+        );
+        assert_eq!(seq_manager.active_blocks(), 4);
+
+        assert_eq!(
+            seq_manager.free(&"left".to_string(), decay_now).removes,
+            vec![PromptMembershipRemove { hashes: vec![1, 9] }]
+        );
+        assert_eq!(seq_manager.active_blocks(), 2);
+        assert_eq!(
+            seq_manager.active_prompt_hashes(),
+            [2, 9].into_iter().collect()
+        );
+
+        assert_eq!(
+            seq_manager.free(&"right".to_string(), decay_now).removes,
+            vec![PromptMembershipRemove { hashes: vec![2, 9] }]
+        );
+        assert_eq!(seq_manager.active_blocks(), 0);
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -239,12 +239,8 @@ impl ActiveSequences {
             return PromptMembershipDelta::default();
         };
 
-        let RequestState {
-            blocks,
-            expected_output_tokens,
-            ..
-        } = request_state;
-        let _ = expected_output_tokens;
+        let blocks = request_state.blocks;
+        let _ = request_state.expected_output_tokens;
         let mut membership_delta = PromptMembershipDelta::default();
         membership_delta.push_remove(self.blocks.release(blocks));
 

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -134,16 +134,8 @@ impl ActiveSequences {
             active_prefills.is_subset(&active_requests),
             "prefill tracker cannot reference missing request state",
         );
-        assert!(
-            self.blocks.fractional_hashes_are_active(),
-            "fractional_blocks cannot reference non-active blocks",
-        );
-        assert!(
-            self.requests
-                .values()
-                .all(|state| self.blocks.contains_chain(&state.blocks)),
-            "request block chain cannot reference an unindexed block",
-        );
+        self.blocks
+            .assert_consistent(self.requests.values().map(|state| &state.blocks));
     }
 
     #[inline]
@@ -340,7 +332,7 @@ impl ActiveSequences {
     pub(super) fn active_prompt_hashes(&self) -> FxHashSet<SequenceHash> {
         self.requests
             .values()
-            .flat_map(|state| state.blocks.prompt_hashes())
+            .flat_map(|state| self.blocks.prompt_hashes(&state.blocks))
             .collect()
     }
 }
@@ -368,6 +360,22 @@ mod tests {
     fn active_sequences_remains_send_and_sync() {
         fn assert_send_sync<T: Send + Sync>() {}
         assert_send_sync::<ActiveSequences>();
+    }
+
+    #[test]
+    fn active_worker_teardown_with_a_live_long_chain_is_iterative() {
+        const DEPTH: usize = 65_536;
+        let mut sequences = ActiveSequences::new_without_expiry(1);
+        sequences.add_request_with_prefill_tracking(
+            "long-lived".to_string(),
+            Some((1..=DEPTH as u64).collect()),
+            None,
+            false,
+            None,
+            Instant::now(),
+        );
+
+        drop(sequences);
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -20,7 +20,6 @@
 
 use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -28,7 +27,7 @@ use uuid::Uuid;
 #[cfg(test)]
 use rustc_hash::FxHashSet;
 
-use super::block_tracker::BlockTracker;
+use super::block_tracker::{BlockTracker, RequestBlockChain};
 use super::prefill_tracker::{PrefillLoadState, PrefillLoadTracker};
 use super::prompt_registry::WorkerLoadSnapshot;
 use crate::protocols::PrefillLoadHint;
@@ -45,16 +44,9 @@ pub type RequestId = String;
 
 #[derive(Debug)]
 pub(super) struct RequestState {
-    prompt_blocks: Vec<(SequenceHash, Arc<()>)>,
-    output_blocks: Vec<(SequenceHash, Arc<()>)>,
+    blocks: RequestBlockChain,
     started_at: Instant,
     expected_output_tokens: Option<u32>,
-}
-
-impl RequestState {
-    fn all_blocks(&self) -> impl Iterator<Item = &(SequenceHash, Arc<()>)> {
-        self.prompt_blocks.iter().chain(self.output_blocks.iter())
-    }
 }
 
 #[derive(Debug, Default, Clone, PartialEq, Eq)]
@@ -143,11 +135,14 @@ impl ActiveSequences {
             "prefill tracker cannot reference missing request state",
         );
         assert!(
-            self.blocks
-                .fractional_blocks
-                .keys()
-                .all(|hash| self.blocks.unique_blocks.contains_key(hash)),
+            self.blocks.fractional_hashes_are_active(),
             "fractional_blocks cannot reference non-active blocks",
+        );
+        assert!(
+            self.requests
+                .values()
+                .all(|state| self.blocks.contains_chain(&state.blocks)),
+            "request block chain cannot reference an unindexed block",
         );
     }
 
@@ -185,41 +180,22 @@ impl ActiveSequences {
         let mut outcome = self.force_expiry();
         let started_at = Instant::now();
 
-        let prompt_blocks = match token_sequence {
-            Some(sequence) => {
-                let mut first_new_prompt_idx = None;
-                let prompt_blocks: Vec<_> = sequence
-                    .into_iter()
-                    .enumerate()
-                    .map(|(idx, block)| {
-                        let acquire = self.blocks.touch_block(&block);
-                        if acquire.became_present_on_worker && first_new_prompt_idx.is_none() {
-                            first_new_prompt_idx = Some(idx);
-                        }
-                        (block, acquire.rc)
-                    })
-                    .collect();
+        let prompt_hashes = token_sequence.unwrap_or_default();
+        let (blocks, first_new_prompt_idx) = self.blocks.acquire_prompt(&prompt_hashes);
 
-                if let Some(first_new_prompt_idx) = first_new_prompt_idx {
-                    debug_assert!(
-                        prompt_blocks[first_new_prompt_idx..]
-                            .iter()
-                            .all(|(hash, _)| self.blocks.unique_blocks.contains_key(hash))
-                    );
-                    let parent = first_new_prompt_idx
-                        .checked_sub(1)
-                        .map(|idx| prompt_blocks[idx].0);
-                    let hashes = prompt_blocks[first_new_prompt_idx..]
-                        .iter()
-                        .map(|(hash, _)| *hash)
-                        .collect();
-                    outcome.membership_delta.push_store(parent, hashes);
-                }
-
-                prompt_blocks
-            }
-            None => Vec::new(),
-        };
+        if let Some(first_new_prompt_idx) = first_new_prompt_idx {
+            debug_assert!(
+                prompt_hashes[first_new_prompt_idx..]
+                    .iter()
+                    .all(|hash| self.blocks.contains_block(hash))
+            );
+            let parent = first_new_prompt_idx
+                .checked_sub(1)
+                .map(|idx| prompt_hashes[idx]);
+            outcome
+                .membership_delta
+                .push_store(parent, prompt_hashes[first_new_prompt_idx..].to_vec());
+        }
 
         let prefill = if track_prefill_tokens {
             prefill_load_hint.and_then(|hint| {
@@ -235,8 +211,7 @@ impl ActiveSequences {
         self.requests.insert(
             request_id.clone(),
             RequestState {
-                prompt_blocks,
-                output_blocks: Vec::new(),
+                blocks,
                 started_at,
                 expected_output_tokens,
             },
@@ -272,22 +247,14 @@ impl ActiveSequences {
             return PromptMembershipDelta::default();
         };
 
-        let _ = request_state.expected_output_tokens;
+        let RequestState {
+            blocks,
+            expected_output_tokens,
+            ..
+        } = request_state;
+        let _ = expected_output_tokens;
         let mut membership_delta = PromptMembershipDelta::default();
-        let mut prompt_remove = Vec::new();
-
-        for (block_hash, rc) in request_state.prompt_blocks {
-            drop(rc);
-            if self.blocks.try_remove_block(&block_hash) || !prompt_remove.is_empty() {
-                prompt_remove.push(block_hash);
-            }
-        }
-        membership_delta.push_remove(prompt_remove);
-
-        for (block_hash, rc) in request_state.output_blocks {
-            drop(rc);
-            self.blocks.try_remove_block(&block_hash);
-        }
+        membership_delta.push_remove(self.blocks.release(blocks));
 
         self.validate_state();
         membership_delta
@@ -301,27 +268,24 @@ impl ActiveSequences {
         request_id: &RequestId,
         decay_fraction: Option<f64>,
     ) -> Option<SequenceHash> {
-        if !self.requests.contains_key(request_id) {
+        let Some(request_state) = self.requests.get_mut(request_id) else {
             tracing::warn!("Request {request_id} not found for add_output_block");
             return None;
-        }
+        };
 
         // TODO: Output blocks still use random hashes, so indexing them mainly simplifies
         // generic block bookkeeping and usually adds little real reuse signal.
         let random_hash: SequenceHash = Uuid::new_v4().as_u64_pair().0;
-        let acquire = self.blocks.touch_block(&random_hash);
-        self.requests
-            .get_mut(request_id)
-            .expect("request existence was checked above")
-            .output_blocks
-            .push((random_hash, acquire.rc));
+        self.blocks
+            .append_output(&mut request_state.blocks, random_hash);
 
         if let Some(frac) = decay_fraction {
-            self.set_single_ref_blocks_as_fractional(request_id, frac);
+            self.blocks
+                .set_unique_suffix_fractional(&request_state.blocks, frac);
         }
 
         self.validate_state();
-        acquire.became_present_on_worker.then_some(random_hash)
+        Some(random_hash)
     }
 
     /// Force expiry of stale requests if the timer has elapsed.
@@ -359,23 +323,6 @@ impl ActiveSequences {
         outcome
     }
 
-    /// Find all blocks in a request that have only a single strong reference (only used by this request)
-    /// and insert them into fractional_blocks with the given fraction value.
-    fn set_single_ref_blocks_as_fractional(&mut self, request_id: &RequestId, fraction: f64) {
-        let Some(request_state) = self.requests.get(request_id) else {
-            tracing::warn!(
-                "Request {request_id} not found for set_single_ref_blocks_as_fractional"
-            );
-            return;
-        };
-
-        for (hash, rc) in request_state.all_blocks() {
-            if Arc::strong_count(rc) == 1 {
-                self.blocks.fractional_blocks.insert(*hash, fraction);
-            }
-        }
-    }
-
     pub(super) fn worker_load_snapshot(&self) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
             active_blocks: self.active_blocks(),
@@ -386,14 +333,14 @@ impl ActiveSequences {
 
     #[cfg(test)]
     pub(super) fn active_block_hashes(&self) -> FxHashSet<SequenceHash> {
-        self.blocks.unique_blocks.keys().copied().collect()
+        self.blocks.active_hashes().collect()
     }
 
     #[cfg(test)]
     pub(super) fn active_prompt_hashes(&self) -> FxHashSet<SequenceHash> {
         self.requests
             .values()
-            .flat_map(|state| state.prompt_blocks.iter().map(|(hash, _)| *hash))
+            .flat_map(|state| state.blocks.prompt_hashes())
             .collect()
     }
 }
@@ -415,6 +362,12 @@ mod tests {
             initial_effective_prefill_tokens: tokens,
             expected_prefill_duration: None,
         })
+    }
+
+    #[test]
+    fn active_sequences_remains_send_and_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<ActiveSequences>();
     }
 
     #[test]
@@ -543,7 +496,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "request_2".to_string(),
-            Some(vec![4]),
+            Some(vec![5]),
             None,
             true,
             tracking_hint(4),
@@ -560,7 +513,7 @@ mod tests {
             tracking_hint(0),
             decay_now,
         );
-        assert_eq!(seq_manager.active_blocks(), 4);
+        assert_eq!(seq_manager.active_blocks(), 5);
         assert_eq!(seq_manager.active_tokens(decay_now), 16);
 
         seq_manager.free(&"request_2".to_string(), decay_now);

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -177,8 +177,9 @@ impl ActiveSequences {
 
         if let Some(first_new_prompt_idx) = first_new_prompt_idx {
             debug_assert!(
-                (first_new_prompt_idx..prompt_hashes.len())
-                    .all(|idx| self.blocks.contains_prompt_block(&prompt_hashes, idx))
+                prompt_hashes[first_new_prompt_idx..]
+                    .iter()
+                    .all(|hash| self.blocks.contains_block(hash))
             );
             let parent = first_new_prompt_idx
                 .checked_sub(1)
@@ -374,31 +375,6 @@ mod tests {
     }
 
     #[test]
-    fn active_worker_teardown_with_colliding_raw_tail_hashes() {
-        let mut sequences = ActiveSequences::new_without_expiry(1);
-        let now = Instant::now();
-        sequences.add_request_with_prefill_tracking(
-            "left".to_string(),
-            Some(vec![1, 9]),
-            None,
-            false,
-            None,
-            now,
-        );
-        sequences.add_request_with_prefill_tracking(
-            "right".to_string(),
-            Some(vec![2, 9]),
-            None,
-            false,
-            None,
-            now,
-        );
-
-        assert_eq!(sequences.active_blocks(), 4);
-        drop(sequences);
-    }
-
-    #[test]
     fn test_prompt_membership_delta_only_reports_first_add_and_last_remove() {
         let mut seq_manager = ActiveSequences::new(4);
         let decay_now = Instant::now();
@@ -454,61 +430,6 @@ mod tests {
                 hashes: vec![1, 2, 3],
             }]
         );
-    }
-
-    #[test]
-    fn colliding_raw_tail_hashes_keep_membership_lineages_independent() {
-        let mut seq_manager = ActiveSequences::new_without_expiry(1);
-        let decay_now = Instant::now();
-
-        let left = seq_manager.add_request_with_prefill_tracking(
-            "left".to_string(),
-            Some(vec![1, 9]),
-            None,
-            false,
-            None,
-            decay_now,
-        );
-        let right = seq_manager.add_request_with_prefill_tracking(
-            "right".to_string(),
-            Some(vec![2, 9]),
-            None,
-            false,
-            None,
-            decay_now,
-        );
-
-        assert_eq!(
-            left.membership_delta.stores,
-            vec![PromptMembershipStore {
-                parent: None,
-                hashes: vec![1, 9],
-            }]
-        );
-        assert_eq!(
-            right.membership_delta.stores,
-            vec![PromptMembershipStore {
-                parent: None,
-                hashes: vec![2, 9],
-            }]
-        );
-        assert_eq!(seq_manager.active_blocks(), 4);
-
-        assert_eq!(
-            seq_manager.free(&"left".to_string(), decay_now).removes,
-            vec![PromptMembershipRemove { hashes: vec![1, 9] }]
-        );
-        assert_eq!(seq_manager.active_blocks(), 2);
-        assert_eq!(
-            seq_manager.active_prompt_hashes(),
-            [2, 9].into_iter().collect()
-        );
-
-        assert_eq!(
-            seq_manager.free(&"right".to_string(), decay_now).removes,
-            vec![PromptMembershipRemove { hashes: vec![2, 9] }]
-        );
-        assert_eq!(seq_manager.active_blocks(), 0);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace per-request, per-block `Arc` ownership with a persistent request block chain backed by a typed `SlotMap` arena.
- Track request-tail and child-parent ownership with checked, non-atomic `NonZeroU32` counts. Keep request chains private and non-`Clone`, validate arena generations and hashes on every index hit, and reconstruct all ownership counts in debug/test consistency checks.
- Preserve eager removal from the hash and fractional indexes, fractional accounting, active hashes, prompt-membership events, output hashes, replica behavior, routing semantics, and public interfaces.
- Keep release iterative, including 65,536-node request chains. This is Phase 1 only; the optional stale-index/deferred-deletion optimization is not included.

This draft targets `main` directly and includes the persistent-chain change from #11503 as well as the arena conversion.

### Main to arena profile

The retained main capture was pinned at `e7ba0adbb99c4fed9fdf77971dbc2e41cf031458`; the arena capture used `0d758f56fd51d0d90db2e22d84f522ade4cf1872`. Both used the AgentX/Weka trace, frontend CPUs `0-1`, eight SGLang FIFO mockers plus AIPerf on CPUs `2-23`, KV block size 1, speedup ratio 1,000,000, concurrency 256, fastokens, a 1 GiB tokenizer cache, frontend jemalloc, and a 40-second 99 Hz DWARF user-space cycles capture after settling.

| Metric | Main | Arena | Change |
|---|---:|---:|---:|
| BlockTracker inclusive weighted cycles | 26.21% | 15.04% | -42.62% |
| BlockTracker inclusive samples | 806/3,178 (25.36%) | 438/2,955 (14.82%) | -41.56% |
| Sample-level 95% Wilson interval | 23.88%-26.90% | 13.59%-16.15% | non-overlapping |

These are single, non-contemporaneous captures. The intervals quantify perf sample uncertainty, not run-to-run variance. CPU time per request is not compared across these two captures because capture-window accounting was corrected in the newer harness.

For the contemporaneous Phase 1 Arc-chain-to-arena comparison, BlockTracker weighted cycles fell from 18.27% to 15.04% (-17.66%), frontend CPU time per capture-window completion fell from 65.215 ms to 59.175 ms (-9.26%), and peak frontend RSS fell from 4,410,300 KiB to 4,335,552 KiB (-1.69%). Diagnostic throughput was 14.368 versus 14.188 requests/s; the mocker-side partition remained limiting, so this fixed-concurrency profiled throughput is not a frontend-capacity result.

One fresh-process `active_sequences_bench` run per arm at equivalent chain length measured:

| Metric | Arc chain | Arena | Change |
|---|---:|---:|---:|
| Logical block visits/s | 98,482,783 | 148,245,979 | +50.53% |
| Free p50 | 192.7 us | 110.5 us | -42.66% |
| Free p99 | 3,016.9 us | 1,751.8 us | -41.93% |
| Peak RSS | 7,779,496 KiB | 7,596,536 KiB | -2.35% |

## Validation

- `cargo fmt --all --check`
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- Focused BlockTracker tests: 16 passed
- Focused ActiveSequences tests: 11 passed
- `cargo test -p dynamo-kv-router`: 737 passed, 2 ignored
- `cargo test -p dynamo-bench --test active_sequences_trace`: 9 passed
- Randomized 10,000-step ownership-model test
- SlotMap stale-generation and wrong-hash tests
- Checked ownership-overflow test
- 65,536-node explicit-release and worker-teardown tests
- One fresh-process microbenchmark and one frontend perf capture per arm



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Improved request block tracking for prompt reuse and output generation.
  * Added more efficient cleanup of long request sequences.
  * Strengthened handling of shared, fractional, stale, and invalid blocks.

* **Bug Fixes**
  * Improved block ownership and lifecycle management.
  * Added safeguards against inconsistent block state and overflow conditions.

* **Tests**
  * Expanded coverage for request lifecycle behavior, concurrency, and long-chain teardown.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->