### PR TITLE
fix(vllm): reject over-budget max tokens

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -549,6 +549,71 @@ def _prompt_token_ids_for_engine_data(
     return list(prompt_token_ids or [])
 
 
+def _prompt_token_count_for_validation(
+    request: Dict[str, Any],
+    embedding_sequence_length: int | None = None,
+    prompt_token_count: int | None = None,
+) -> int | None:
+    """Return the prompt length used for max-model-length validation."""
+    if prompt_token_count is not None:
+        return prompt_token_count
+    if embedding_sequence_length is not None:
+        return embedding_sequence_length
+
+    extra_args = request.get("extra_args") or {}
+    if isinstance(extra_args, dict):
+        expanded_token_ids = extra_args.get("expanded_token_ids")
+        if expanded_token_ids:
+            return len(expanded_token_ids)
+    if "token_ids" in request:
+        return len(request.get("token_ids") or [])
+    return None
+
+
+def _explicit_max_tokens_budget_error(
+    request: Dict[str, Any],
+    model_max_len: int | None,
+    embedding_sequence_length: int | None = None,
+    prompt_token_count: int | None = None,
+) -> str | None:
+    if model_max_len is None or model_max_len <= 0:
+        return None
+
+    stop_conditions = request.get("stop_conditions") or {}
+    max_tokens = stop_conditions.get("max_tokens")
+    if max_tokens is None:
+        max_tokens = request.get("max_tokens")
+    if not isinstance(max_tokens, int) or isinstance(max_tokens, bool):
+        return None
+
+    prompt_tokens = _prompt_token_count_for_validation(
+        request,
+        embedding_sequence_length=embedding_sequence_length,
+        prompt_token_count=prompt_token_count,
+    )
+    if prompt_tokens is None:
+        return None
+
+    requested_tokens = prompt_tokens + max_tokens
+    if requested_tokens <= model_max_len:
+        return None
+
+    return (
+        f"This model's maximum context length is {model_max_len} tokens. "
+        f"However, you requested {requested_tokens} tokens "
+        f"({prompt_tokens} in the messages, {max_tokens} in the completion). "
+        "Please reduce the length of the messages or completion."
+    )
+
+
+def _prompt_token_count_for_text_mode(
+    input_param_manager: InputParamManager, input_data: Any
+) -> int:
+    if isinstance(input_data, list):
+        return len(input_data)
+    return len(input_param_manager.tokenizer.encode(input_data))
+
+
 def _flatten_logprobs(
     log_probs: Any,
 ) -> Optional[list[float]]:
@@ -814,8 +879,7 @@ def build_sampling_params(
 
     # If max_tokens wasn't provided (None or missing), compute a dynamic default
     provided_max_tokens = request.get("stop_conditions", {}).get("max_tokens", None)
-    token_ids = request.get("token_ids", [])
-    input_length = len(token_ids)
+    input_length = _prompt_token_count_for_validation(request) or 0
     if model_max_len is not None and provided_max_tokens is None:
         # Ensure at least 1 token generation by default when possible
         dynamic_default = max(1, model_max_len - input_length)
@@ -3309,6 +3373,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
 
         _apply_nvext_cache_salt(request, prompt)
 
+        budget_error = _explicit_max_tokens_budget_error(
+            request,
+            self.model_max_len,
+            embedding_sequence_length=embedding_sequence_length,
+        )
+        if budget_error is not None:
+            logger.error("Request %s: %s", request_id, budget_error)
+            yield {
+                "finish_reason": f"error: {budget_error}",
+                "index": 0,
+                "token_ids": [],
+            }
+            return
+
         # Build sampling params from request
         sampling_params = build_sampling_params(
             request,
@@ -3428,6 +3506,35 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             prompt = TokensPrompt(prompt_token_ids=input_data)
         else:
             prompt = TextPrompt(prompt=input_data)
+
+        request_max_tokens = request.get("max_tokens")
+        prompt_token_count = (
+            _prompt_token_count_for_text_mode(self.input_param_manager, input_data)
+            if isinstance(request_max_tokens, int)
+            and not isinstance(request_max_tokens, bool)
+            else None
+        )
+        budget_error = _explicit_max_tokens_budget_error(
+            request,
+            self.model_max_len,
+            prompt_token_count=prompt_token_count,
+        )
+        if budget_error is not None:
+            logger.error("Request %s: %s", request_id, budget_error)
+            yield {
+                "id": request.get("id") or request.get("request_id", request_id),
+                "created": int(time.time()),
+                "object": "chat.completion.chunk",
+                "model": request.get("model", "unknown"),
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {"role": "assistant", "content": ""},
+                        "finish_reason": f"error: {budget_error}",
+                    }
+                ],
+            }
+            return
 
         # Build sampling params from OpenAI-style request
         sampling_params = build_sampling_params_openai(

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -9,6 +9,7 @@ import re
 import socket
 import sys
 import warnings
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -1070,6 +1071,40 @@ def test_build_sampling_params_caps_omitted_max_tokens_to_generation_default():
     assert sp.max_tokens == remaining
 
 
+def test_explicit_max_tokens_budget_error_uses_prompt_and_completion_budget():
+    from dynamo.vllm.handlers import _explicit_max_tokens_budget_error
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 98},
+        "output_options": {},
+    }
+
+    error = _explicit_max_tokens_budget_error(request, model_max_len=100)
+
+    assert error is not None
+    assert "maximum context length is 100 tokens" in error
+    assert "requested 101 tokens (3 in the messages, 98 in the completion)" in error
+
+
+def test_explicit_max_tokens_budget_error_uses_expanded_prompt_tokens():
+    from dynamo.vllm.handlers import _explicit_max_tokens_budget_error
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "sampling_options": {},
+        "stop_conditions": {"max_tokens": 6},
+        "output_options": {},
+        "extra_args": {"expanded_token_ids": list(range(95))},
+    }
+
+    error = _explicit_max_tokens_budget_error(request, model_max_len=100)
+
+    assert error is not None
+    assert "requested 101 tokens (95 in the messages, 6 in the completion)" in error
+
+
 def _make_dynamo_config(**overrides):
     """Build a minimal fake DynamoConfig for update_engine_config_with_dynamo tests."""
     defaults = {
@@ -1228,3 +1263,127 @@ def test_build_sampling_params_openai_maps_max_thinking_tokens():
     }
     sp = build_sampling_params_openai(request, default_sampling_params={})
     assert sp.thinking_token_budget == 1024
+
+
+@pytest.mark.asyncio
+async def test_generate_text_mode_rejects_explicit_max_tokens_over_context():
+    from dynamo.vllm.handlers import DecodeWorkerHandler
+
+    class InputParams:
+        def get_input_param(self, request, use_tokenizer):
+            assert use_tokenizer is True
+            return [1, 2, 3]
+
+    class EngineClient:
+        def __init__(self):
+            self.generate_called = False
+
+        def generate(self, *args, **kwargs):
+            self.generate_called = True
+            raise AssertionError("engine should not be called")
+
+    @asynccontextmanager
+    async def abort_monitor(*args, **kwargs):
+        yield
+
+    engine_client = EngineClient()
+    handler = SimpleNamespace(
+        input_param_manager=InputParams(),
+        default_sampling_params={},
+        model_max_len=100,
+        config=SimpleNamespace(disaggregation_mode=DisaggregationMode.AGGREGATED),
+        engine_client=engine_client,
+        _deferred_aborts={},
+        _shutdown_on_engine_dead=lambda exc: None,
+        _abort_monitor=abort_monitor,
+        _to_local_dp_rank=lambda rank: None,
+    )
+    context = SimpleNamespace(trace_headers=lambda: {})
+    request = {
+        "id": "chatcmpl-test",
+        "model": "test-model",
+        "prompt": "ignored after tokenization",
+        "max_tokens": 98,
+    }
+
+    chunks = [
+        chunk
+        async for chunk in DecodeWorkerHandler._generate_text_mode(
+            handler, request, context, "req-1"
+        )
+    ]
+
+    assert len(chunks) == 1
+    assert chunks[0]["id"] == "chatcmpl-test"
+    assert chunks[0]["model"] == "test-model"
+    assert chunks[0]["choices"][0]["finish_reason"] == (
+        "error: This model's maximum context length is 100 tokens. "
+        "However, you requested 101 tokens "
+        "(3 in the messages, 98 in the completion). "
+        "Please reduce the length of the messages or completion."
+    )
+    assert engine_client.generate_called is False
+
+
+@pytest.mark.asyncio
+async def test_generate_text_mode_rejects_string_prompt_over_context():
+    from dynamo.vllm.handlers import DecodeWorkerHandler
+
+    class Tokenizer:
+        def encode(self, text):
+            assert text == "rendered chat prompt"
+            return [1, 2, 3]
+
+    class InputParams:
+        tokenizer = Tokenizer()
+
+        def get_input_param(self, request, use_tokenizer):
+            assert use_tokenizer is True
+            return "rendered chat prompt"
+
+    class EngineClient:
+        def __init__(self):
+            self.generate_called = False
+
+        def generate(self, *args, **kwargs):
+            self.generate_called = True
+            raise AssertionError("engine should not be called")
+
+    @asynccontextmanager
+    async def abort_monitor(*args, **kwargs):
+        yield
+
+    engine_client = EngineClient()
+    handler = SimpleNamespace(
+        input_param_manager=InputParams(),
+        default_sampling_params={},
+        model_max_len=100,
+        config=SimpleNamespace(disaggregation_mode=DisaggregationMode.AGGREGATED),
+        engine_client=engine_client,
+        _deferred_aborts={},
+        _shutdown_on_engine_dead=lambda exc: None,
+        _abort_monitor=abort_monitor,
+        _to_local_dp_rank=lambda rank: None,
+    )
+    context = SimpleNamespace(trace_headers=lambda: {})
+    request = {
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "hello"}],
+        "max_tokens": 98,
+    }
+
+    chunks = [
+        chunk
+        async for chunk in DecodeWorkerHandler._generate_text_mode(
+            handler, request, context, "req-1"
+        )
+    ]
+
+    assert len(chunks) == 1
+    assert chunks[0]["choices"][0]["finish_reason"] == (
+        "error: This model's maximum context length is 100 tokens. "
+        "However, you requested 101 tokens "
+        "(3 in the messages, 98 in the completion). "
+        "Please reduce the length of the messages or completion."
+    )
+    assert engine_client.generate_called is False

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -783,6 +783,36 @@ class TestDecodeWorkerMultimodalBranching:
         assert len(chunks) == 1
         assert chunks[0]["message"] == "test stop"
 
+    async def test_over_budget_explicit_max_tokens_returns_error_before_engine(self):
+        handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
+        handler.model_max_len = 100
+        handler.engine_client = MagicMock()
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "sampling_options": {},
+            "stop_conditions": {"max_tokens": 98},
+            "output_options": {},
+        }
+        context = MagicMock()
+        chunks = []
+        async for chunk in handler._generate_token_mode(request, context, "req-1"):
+            chunks.append(chunk)
+
+        assert chunks == [
+            {
+                "finish_reason": (
+                    "error: This model's maximum context length is 100 tokens. "
+                    "However, you requested 101 tokens "
+                    "(3 in the messages, 98 in the completion). "
+                    "Please reduce the length of the messages or completion."
+                ),
+                "index": 0,
+                "token_ids": [],
+            }
+        ]
+        handler.engine_client.generate.assert_not_called()
+
     async def test_aggregated_mode_calls_extract_multimodal_data(self):
         """Aggregated mode handler calls _extract_multimodal_data normally."""
         handler = _make_decode_handler(disaggregation_mode="AGGREGATED")


### PR DESCRIPTION
## Summary

- Cherry-pick of #11384 to `release/1.3.0`.
- Reject explicit `max_tokens` when the prompt plus requested completion exceeds the model context length.
- Preserve the dynamic output cap when `max_tokens` is omitted.
- Use expanded multimodal prompt tokens when validating the request budget.

Fixes DIS-2377

## Original PR

- Main PR: #11384
- Main merge commit: `485c298fff259ea228d4d86e23fe4153aead3c8a`
- Backport commit: `9a57acd512e55d094473d469619104730c5496dd`

## Conflict resolution

- `handlers.py`: retained release-branch text-mode behavior and inserted only the request-budget validation from #11384.
- `test_vllm_unit.py`: omitted the unrelated main-only cache-salt test and added the new validation tests plus the required release-only import.
- `test_vllm_worker_handler.py`: applied cleanly.

## Validation

- [x] Repository pre-commit hooks pass on all three changed files.
- [x] Python syntax compilation passes on all three changed files.
- [x] Eight focused request-budget helper behavior cases pass.
- [x] `git diff --check origin/release/1.3.0...HEAD` passes.
- [x] Commit has a valid GPG signature and both DCO sign-offs.
- Focused vLLM pytest was not run locally because the CUDA vLLM stack is unavailable on ARM64 macOS. The source PR passed the full Linux vLLM CI matrix.
- [ ] Release PR CI passes.