### PR TITLE
fix(llm): route structured JSON responses to content with reasoning parser

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -25,7 +25,7 @@ use anyhow::{Result, bail};
 use dynamo_protocols::types::{
     ChatCompletionMessageContent, ChatCompletionRequestMessage,
     ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
-    ChatCompletionToolChoiceOption, EncodingFormat, ResponseFormat,
+    ChatCompletionToolChoiceOption, EncodingFormat,
 };
 use dynamo_renderer::OAIPromptFormatter;
 use dynamo_runtime::error::{DynamoError, ErrorType};
@@ -438,12 +438,7 @@ impl OpenAIPreprocessor {
                 None => true,
             }
         });
-        let is_structured_response = request.response_format().is_some_and(|format| {
-            format
-                .get_attr("type")
-                .ok()
-                .is_some_and(|kind| kind.as_str().is_some_and(|kind| kind != "text"))
-        });
+        let is_structured_response = Self::has_structured_response_format(request);
         if !is_guided_tool_choice
             && !(is_structured_response
                 && Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser))
@@ -462,11 +457,13 @@ impl OpenAIPreprocessor {
         !matches!(reasoning_parser, Some("gpt_oss"))
     }
 
-    fn has_structured_response_format(request: &NvCreateChatCompletionRequest) -> bool {
-        matches!(
-            request.inner.response_format,
-            Some(ResponseFormat::JsonObject | ResponseFormat::JsonSchema { .. })
-        )
+    fn has_structured_response_format<R: OAIChatLikeRequest>(request: &R) -> bool {
+        request.response_format().is_some_and(|format| {
+            format
+                .get_attr("type")
+                .ok()
+                .is_some_and(|kind| kind.as_str().is_some_and(|kind| kind != "text"))
+        })
     }
 
     /// Match the rendered prompt's reasoning mode before selecting SGLang NativeGrammar.

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -4191,8 +4191,21 @@ mod tests {
             }))
             .unwrap()
         };
+        let json_object_request = |enable_thinking: bool| {
+            serde_json::from_value::<NvCreateChatCompletionRequest>(serde_json::json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "return json"}],
+                "chat_template_kwargs": {"enable_thinking": enable_thinking},
+                "response_format": {"type": "json_object"}
+            }))
+            .unwrap()
+        };
         assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &structured_request(true),
+            Some("qwen3")
+        ));
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
+            &json_object_request(true),
             Some("qwen3")
         ));
         assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
@@ -4201,6 +4214,10 @@ mod tests {
         ));
         assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &structured_request(true),
+            Some("gpt_oss")
+        ));
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &json_object_request(true),
             Some("gpt_oss")
         ));
         assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -172,6 +172,8 @@ struct ReasoningState {
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
     reasoning_parser: Option<Box<dyn ReasoningParser>>,
     bypass_bare_guided_json: bool,
+    // TODO: Track this per choice.index for n > 1. The current bypass
+    // decision and parser state are shared across all streamed choices.
     guided_json_bypass_decision: Option<bool>,
 }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -444,11 +444,22 @@ impl OpenAIPreprocessor {
                 .ok()
                 .is_some_and(|kind| kind.as_str().is_some_and(|kind| kind != "text"))
         });
-        if !is_guided_tool_choice && !is_structured_response {
+        if !is_guided_tool_choice
+            && !(is_structured_response
+                && Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser))
+        {
             return false;
         }
 
         Self::sglang_effective_reasoning_enabled(reasoning_parser, request.chat_template_args())
+    }
+
+    fn structured_response_supports_sglang_reasoning_gate(reasoning_parser: Option<&str>) -> bool {
+        // GPT-OSS/Harmony must skip SGLang's `require_reasoning + json_schema`
+        // path for structured output until upstream fixes malformed Harmony:
+        // https://github.com/sgl-project/sglang/issues/31019
+        // Tool calling still uses `require_reasoning`.
+        !matches!(reasoning_parser, Some("gpt_oss"))
     }
 
     fn has_structured_response_format(request: &NvCreateChatCompletionRequest) -> bool {
@@ -2064,8 +2075,12 @@ impl OpenAIPreprocessor {
             && (Self::skips_guided_json_when_prompt_injected(reasoning_parser)
                 || (is_structured_response
                     && Self::skips_structured_response_when_prompt_injected(reasoning_parser)));
-        let bypass_reasoning_for_bare_guided_json =
-            inspect_force_reasoning_guided_output || inspect_prompt_injected_guided_output;
+        let inspect_gpt_oss_structured_response = is_structured_response
+            && !uses_tool_call_structural_tag
+            && matches!(reasoning_parser, Some("gpt_oss"));
+        let bypass_reasoning_for_bare_guided_json = inspect_force_reasoning_guided_output
+            || inspect_prompt_injected_guided_output
+            || inspect_gpt_oss_structured_response;
         // Preserve the legacy bypass for force-reasoning parsers not yet opted in.
         let skip_reasoning_for_guided_json = is_guided_output
             && !uses_tool_call_structural_tag
@@ -4187,6 +4202,18 @@ mod tests {
             &structured_request(false),
             Some("qwen3")
         ));
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &structured_request(true),
+            Some("gpt_oss")
+        ));
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &structured_request(false),
+            Some("gpt_oss")
+        ));
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
+            &request(serde_json::json!("required"), None),
+            Some("gpt_oss")
+        ));
     }
 
     /// Verifies SGLang's effective reasoning mode for each parser family.
@@ -4253,6 +4280,17 @@ mod tests {
                 "minimax_m3",
                 serde_json::json!({"thinking_mode": "disabled"}),
                 false,
+            ),
+            ("gpt_oss", serde_json::json!({}), true),
+            (
+                "gpt_oss",
+                serde_json::json!({"enable_thinking": true}),
+                true,
+            ),
+            (
+                "gpt_oss",
+                serde_json::json!({"enable_thinking": false}),
+                true,
             ),
             ("deepseek_r1", serde_json::json!({}), true),
             ("minimax_append_think", serde_json::json!({}), false),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -2072,12 +2072,12 @@ impl OpenAIPreprocessor {
             && (Self::skips_guided_json_when_prompt_injected(reasoning_parser)
                 || (is_structured_response
                     && Self::skips_structured_response_when_prompt_injected(reasoning_parser)));
-        let inspect_gpt_oss_structured_response = is_structured_response
+        let inspect_unsupported_structured_response_reasoning_gate = is_structured_response
             && !uses_tool_call_structural_tag
-            && matches!(reasoning_parser, Some("gpt_oss"));
+            && !Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser);
         let bypass_reasoning_for_bare_guided_json = inspect_force_reasoning_guided_output
             || inspect_prompt_injected_guided_output
-            || inspect_gpt_oss_structured_response;
+            || inspect_unsupported_structured_response_reasoning_gate;
         // Preserve the legacy bypass for force-reasoning parsers not yet opted in.
         let skip_reasoning_for_guided_json = is_guided_output
             && !uses_tool_call_structural_tag

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -25,7 +25,7 @@ use anyhow::{Result, bail};
 use dynamo_protocols::types::{
     ChatCompletionMessageContent, ChatCompletionRequestMessage,
     ChatCompletionRequestUserMessageContent, ChatCompletionRequestUserMessageContentPart,
-    ChatCompletionToolChoiceOption, EncodingFormat,
+    ChatCompletionToolChoiceOption, EncodingFormat, ResponseFormat,
 };
 use dynamo_renderer::OAIPromptFormatter;
 use dynamo_runtime::error::{DynamoError, ErrorType};
@@ -422,7 +422,7 @@ impl OpenAIPreprocessor {
         }
     }
 
-    fn guided_tool_choice_requires_reasoning<R: OAIChatLikeRequest>(
+    fn guided_output_requires_reasoning<R: OAIChatLikeRequest>(
         request: &R,
         reasoning_parser: Option<&str>,
     ) -> bool {
@@ -438,11 +438,24 @@ impl OpenAIPreprocessor {
                 None => true,
             }
         });
-        if !is_guided_tool_choice {
+        let is_structured_response = request.response_format().is_some_and(|format| {
+            format
+                .get_attr("type")
+                .ok()
+                .is_some_and(|kind| kind.as_str().is_some_and(|kind| kind != "text"))
+        });
+        if !is_guided_tool_choice && !is_structured_response {
             return false;
         }
 
         Self::sglang_effective_reasoning_enabled(reasoning_parser, request.chat_template_args())
+    }
+
+    fn has_structured_response_format(request: &NvCreateChatCompletionRequest) -> bool {
+        matches!(
+            request.inner.response_format,
+            Some(ResponseFormat::JsonObject | ResponseFormat::JsonSchema { .. })
+        )
     }
 
     /// Match the rendered prompt's reasoning mode before selecting SGLang NativeGrammar.
@@ -1014,7 +1027,7 @@ impl OpenAIPreprocessor {
 
         // SGLang needs this request-scoped signal in addition to its native
         // reasoning parser so guided JSON starts after the reasoning boundary.
-        builder.require_reasoning(Self::guided_tool_choice_requires_reasoning(
+        builder.require_reasoning(Self::guided_output_requires_reasoning(
             request,
             self.runtime_config.reasoning_parser.as_deref(),
         ));
@@ -2037,20 +2050,24 @@ impl OpenAIPreprocessor {
             Some(ChatCompletionToolChoiceOption::Required)
                 | Some(ChatCompletionToolChoiceOption::Named(_))
         );
+        let is_structured_response = Self::has_structured_response_format(request);
+        let is_guided_output = is_guided_tool_choice || is_structured_response;
         let reasoning_parser = self.runtime_config.reasoning_parser.as_deref();
         // Force parsers opt in by capability; prompt-seeded parsers opt in per request.
         // Structural-tag tool formats do not use this guided-JSON detection path.
-        let inspect_force_reasoning_guided_output = is_guided_tool_choice
+        let inspect_force_reasoning_guided_output = is_guided_output
             && !uses_tool_call_structural_tag
             && Self::supports_reasoning_before_guided_json(reasoning_parser);
-        let inspect_prompt_injected_guided_output = is_guided_tool_choice
+        let inspect_prompt_injected_guided_output = is_guided_output
             && prompt_injected_reasoning
             && !uses_tool_call_structural_tag
-            && Self::skips_guided_json_when_prompt_injected(reasoning_parser);
+            && (Self::skips_guided_json_when_prompt_injected(reasoning_parser)
+                || (is_structured_response
+                    && Self::skips_structured_response_when_prompt_injected(reasoning_parser)));
         let bypass_reasoning_for_bare_guided_json =
             inspect_force_reasoning_guided_output || inspect_prompt_injected_guided_output;
         // Preserve the legacy bypass for force-reasoning parsers not yet opted in.
-        let skip_reasoning_for_guided_json = is_guided_tool_choice
+        let skip_reasoning_for_guided_json = is_guided_output
             && !uses_tool_call_structural_tag
             && Self::is_force_reasoning_parser(reasoning_parser)
             && !inspect_force_reasoning_guided_output;
@@ -2834,6 +2851,11 @@ impl OpenAIPreprocessor {
                     | "minimax-m3"
             )
         )
+    }
+
+    fn skips_structured_response_when_prompt_injected(reasoning_parser: Option<&str>) -> bool {
+        matches!(reasoning_parser, Some("qwen3"))
+            || Self::skips_guided_json_when_prompt_injected(reasoning_parser)
     }
 
     fn prompt_injected_reasoning_start(
@@ -4062,10 +4084,10 @@ mod tests {
         assert!(OpenAIPreprocessor::backend_extra_args(&request, true).is_none());
     }
 
-    /// Verifies the SGLang reasoning gate is limited to forced guided tool
-    /// choices and honors the public per-request thinking override.
+    /// Verifies the SGLang reasoning gate covers forced tool JSON and
+    /// structured assistant output while honoring per-request thinking controls.
     #[test]
-    fn test_guided_tool_choice_requires_reasoning() {
+    fn test_guided_output_requires_reasoning() {
         let request = |tool_choice: serde_json::Value, enable_thinking: Option<bool>| {
             let mut value = serde_json::json!({
                 "model": "test-model",
@@ -4088,7 +4110,7 @@ mod tests {
         };
 
         let required = request(serde_json::json!("required"), Some(true));
-        assert!(OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &required,
             Some("nemotron_v3")
         ));
@@ -4100,46 +4122,70 @@ mod tests {
             }),
             None,
         );
-        assert!(OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &named,
             Some("nemotron_v3")
         ));
 
         let disabled = request(serde_json::json!("required"), Some(false));
-        assert!(!OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &disabled,
             Some("nemotron_v3")
         ));
-        assert!(!OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &required, None
         ));
 
         let automatic = request(serde_json::json!("auto"), Some(true));
-        assert!(!OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &automatic,
             Some("nemotron_v3")
         ));
 
         let gemma_without_opt_in = request(serde_json::json!("required"), None);
-        assert!(!OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &gemma_without_opt_in,
             Some("gemma4")
         ));
         let gemma_with_opt_in = request(serde_json::json!("required"), Some(true));
-        assert!(OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &gemma_with_opt_in,
             Some("gemma4")
         ));
 
         let deepseek_default = request(serde_json::json!("required"), None);
-        assert!(OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
             &deepseek_default,
             Some("deepseek_v4")
         ));
         let deepseek_disabled = request(serde_json::json!("required"), Some(false));
-        assert!(!OpenAIPreprocessor::guided_tool_choice_requires_reasoning(
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
             &deepseek_disabled,
             Some("deepseek_v4")
+        ));
+
+        let structured_request = |enable_thinking: bool| {
+            serde_json::from_value::<NvCreateChatCompletionRequest>(serde_json::json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "return json"}],
+                "chat_template_kwargs": {"enable_thinking": enable_thinking},
+                "response_format": {
+                    "type": "json_schema",
+                    "json_schema": {
+                        "name": "result",
+                        "schema": {"type": "object"}
+                    }
+                }
+            }))
+            .unwrap()
+        };
+        assert!(OpenAIPreprocessor::guided_output_requires_reasoning(
+            &structured_request(true),
+            Some("qwen3")
+        ));
+        assert!(!OpenAIPreprocessor::guided_output_requires_reasoning(
+            &structured_request(false),
+            Some("qwen3")
         ));
     }
 

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -439,14 +439,14 @@ impl OpenAIPreprocessor {
             }
         });
         let is_structured_response = Self::has_structured_response_format(request);
-        if !is_guided_tool_choice
-            && !(is_structured_response
-                && Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser))
-        {
-            return false;
-        }
+        let structured_response_requires_reasoning = is_structured_response
+            && Self::structured_response_supports_sglang_reasoning_gate(reasoning_parser);
 
-        Self::sglang_effective_reasoning_enabled(reasoning_parser, request.chat_template_args())
+        (is_guided_tool_choice || structured_response_requires_reasoning)
+            && Self::sglang_effective_reasoning_enabled(
+                reasoning_parser,
+                request.chat_template_args(),
+            )
     }
 
     fn structured_response_supports_sglang_reasoning_gate(reasoning_parser: Option<&str>) -> bool {

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1889,6 +1889,33 @@ async fn response_format_gemma4_bare_json_stays_content() {
     assert_eq!(content, json);
 }
 
+/// MiniMax append-think is a force-reasoning parser that is not yet proven to
+/// preserve native reasoning before guided JSON. Structured bare JSON should
+/// therefore use the legacy guided-output bypass and remain assistant content.
+#[tokio::test]
+async fn response_format_minimax_append_think_bare_json_stays_content() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let preprocessor = build_preprocessor(Some("minimax_append_think"), Some("minimax_m2"));
+    let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert!(
+        reasoning.is_empty(),
+        "response_format JSON must not be reasoning_content, got: {reasoning:?}"
+    );
+    assert_eq!(content, json);
+}
+
 /// GPT-OSS/Harmony guided structured output may be emitted as bare JSON from
 /// token 0. The reasoning parser should preserve that JSON as assistant
 /// content instead of dropping it while waiting for Harmony channel markers.

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1266,6 +1266,33 @@ fn streaming_tool_request(
     request
 }
 
+/// Streaming chat completion request with OpenAI structured output.
+fn streaming_json_schema_request(enable_thinking: bool) -> NvCreateChatCompletionRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Return a country and its capital."}],
+        "stream": true,
+        "temperature": 0.0,
+        "chat_template_kwargs": {"enable_thinking": enable_thinking},
+        "response_format": {
+            "type": "json_schema",
+            "json_schema": {
+                "name": "capital",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "country": {"type": "string"},
+                        "capital": {"type": "string"}
+                    },
+                    "required": ["country", "capital"],
+                    "additionalProperties": false
+                }
+            }
+        }
+    }))
+    .unwrap()
+}
+
 fn enable_opt_in_reasoning(request: &mut NvCreateChatCompletionRequest, reasoning_parser: &str) {
     if matches!(reasoning_parser, "deepseek_v3" | "deepseek_v3_1") {
         request.chat_template_args =
@@ -1761,6 +1788,79 @@ async fn tool_choice_matrix_non_force_required_prompt_injected_bare_json_contrac
         reasoning.contains("get_weather"),
         "{case}: parser pins the JSON in reasoning_content under the broken contract, got: {reasoning:?}"
     );
+}
+
+/// `enable_thinking=true` still preserves genuine reasoning followed by a
+/// response_format JSON payload in their respective OpenAI fields.
+#[tokio::test]
+async fn response_format_qwen3_prompt_injected_reasoning_then_json_preserves_channels() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let stream_text = format!("France is a country in Europe.</think>{json}");
+    let preprocessor = build_preprocessor(Some("qwen3"), None);
+    let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(&stream_text), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert_eq!(reasoning.trim(), "France is a country in Europe.");
+    assert_eq!(content, json);
+}
+
+/// If SGLang emits response_format JSON immediately after a prompt-injected
+/// Qwen `<think>`, Dynamo must recover the structured answer as assistant
+/// content instead of classifying the JSON as reasoning.
+#[tokio::test]
+async fn response_format_qwen3_prompt_injected_bare_json_stays_content() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let preprocessor = build_preprocessor(Some("qwen3"), None);
+    let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, true, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert!(
+        reasoning.is_empty(),
+        "response_format JSON must not be reasoning_content, got: {reasoning:?}"
+    );
+    assert_eq!(content, json);
+}
+
+/// With thinking disabled, response_format JSON is ordinary assistant content.
+#[tokio::test]
+async fn response_format_qwen3_no_thinking_json_stays_content() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let preprocessor = build_preprocessor(Some("qwen3"), None);
+    let request = streaming_json_schema_request(false);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert!(reasoning.is_empty());
+    assert_eq!(content, json);
 }
 
 /// DeepSeek V4 + required + `prompt_injected_reasoning=true` + bare JSON.

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1863,6 +1863,85 @@ async fn response_format_qwen3_no_thinking_json_stays_content() {
     assert_eq!(content, json);
 }
 
+/// Gemma4 structured output without visible reasoning markers should remain
+/// assistant content even when the reasoning parser is configured.
+#[tokio::test]
+async fn response_format_gemma4_bare_json_stays_content() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let preprocessor = build_preprocessor(Some("gemma4"), None);
+    let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert!(
+        reasoning.is_empty(),
+        "response_format JSON must not be reasoning_content, got: {reasoning:?}"
+    );
+    assert_eq!(content, json);
+}
+
+/// GPT-OSS/Harmony guided structured output may be emitted as bare JSON from
+/// token 0. The reasoning parser should preserve that JSON as assistant
+/// content instead of dropping it while waiting for Harmony channel markers.
+#[tokio::test]
+async fn response_format_gpt_oss_bare_json_stays_content() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let preprocessor = build_preprocessor(Some("gpt_oss"), None);
+    let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert!(
+        reasoning.is_empty(),
+        "response_format JSON must not be reasoning_content, got: {reasoning:?}"
+    );
+    assert_eq!(content, json);
+}
+
+/// If GPT-OSS emits native Harmony reasoning before the structured payload,
+/// shape detection must fall back to the parser path and preserve channels.
+#[tokio::test]
+async fn response_format_gpt_oss_reasoning_then_json_preserves_channels() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let stream_text = format!(
+        "<|channel|>analysis<|message|>Need answer as JSON.<|end|><|start|>assistant<|channel|>final<|message|>{json}"
+    );
+    let preprocessor = build_preprocessor(Some("gpt_oss"), None);
+    let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(&stream_text), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert_eq!(reasoning, "Need answer as JSON.");
+    assert_eq!(content, json);
+}
+
 /// DeepSeek V4 + required + `prompt_injected_reasoning=true` + bare JSON.
 ///
 /// This is the production failure shape from DeepSeek V4 Pro: the V4 formatter

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -1293,6 +1293,21 @@ fn streaming_json_schema_request(enable_thinking: bool) -> NvCreateChatCompletio
     .unwrap()
 }
 
+/// Streaming chat completion request with OpenAI JSON object response format.
+fn streaming_json_object_request(enable_thinking: bool) -> NvCreateChatCompletionRequest {
+    serde_json::from_value(serde_json::json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Return a JSON object."}],
+        "stream": true,
+        "temperature": 0.0,
+        "chat_template_kwargs": {"enable_thinking": enable_thinking},
+        "response_format": {
+            "type": "json_object"
+        }
+    }))
+    .unwrap()
+}
+
 fn enable_opt_in_reasoning(request: &mut NvCreateChatCompletionRequest, reasoning_parser: &str) {
     if matches!(reasoning_parser, "deepseek_v3" | "deepseek_v3_1") {
         request.chat_template_args =
@@ -1924,6 +1939,32 @@ async fn response_format_gpt_oss_bare_json_stays_content() {
     let json = r#"{"country":"France","capital":"Paris"}"#;
     let preprocessor = build_preprocessor(Some("gpt_oss"), None);
     let request = streaming_json_schema_request(true);
+    let input_stream = stream::iter(
+        vec![mock_content_chunk(json), mock_final_chunk()]
+            .into_iter()
+            .map(Annotated::from_data),
+    );
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let DrainOutput {
+        reasoning, content, ..
+    } = drain_stream(output_stream).await;
+
+    assert!(
+        reasoning.is_empty(),
+        "response_format JSON must not be reasoning_content, got: {reasoning:?}"
+    );
+    assert_eq!(content, json);
+}
+
+/// `json_object` response_format is also translated to guided JSON. It should
+/// follow the same GPT-OSS structured-output bypass as `json_schema`.
+#[tokio::test]
+async fn response_format_gpt_oss_json_object_bare_json_stays_content() {
+    let json = r#"{"country":"France","capital":"Paris"}"#;
+    let preprocessor = build_preprocessor(Some("gpt_oss"), None);
+    let request = streaming_json_object_request(true);
     let input_stream = stream::iter(
         vec![mock_content_chunk(json), mock_final_chunk()]
             .into_iter()


### PR DESCRIPTION

## Overview:

Fixes an issue reported in DIS-2376 where `response_format: { "type": "json_schema" }` output could be placed in `reasoning_content` instead of `content` when using Dynamo frontend + SGLang backend with reasoning enabled.

This was reproduced locally on latest Dynamo main with SGLang backend and `qwen/qwen3.6-35b-a3b`.

## Details:

Root cause:
Dynamo has special handling for guided JSON output when reasoning parsing is enabled, but that handling was only applied to forced/named tool-call requests. `response_format=json_schema` also uses guided JSON decoding, but Dynamo did not classify it as guided output in the reasoning parser path.

For Qwen-style thinking, the rendered prompt can put the parser into an initial reasoning state. If the model then emits the structured JSON answer directly, without an explicit reasoning end marker before it, Dynamo treats that bare JSON as reasoning text. As a result, the final JSON answer is placed in `reasoning_content` instead of the assistant `content` field.

Fix:
Updated the Rust frontend/postprocessor path to include structured `response_format` as guided output, so `response_format=json_schema` is routed through the same reasoning/content separation logic as guided JSON tool output.

Output before fix:

```json
{
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": null,
        "reasoning_content": "{\"country\":\"France\",\"capital\":\"Paris\"}",
        "tool_calls": []
      },
      "finish_reason": "stop"
    }
  ]
}
```

Output after fix:

```json
{
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "{\"country\":\"France\",\"capital\":\"Paris\"}",
        "reasoning_content": "Thinking process: ...",
        "tool_calls": []
      },
      "finish_reason": "stop"
    }
  ]
}
```

Also validated with `enable_thinking=false`:

```json
{
  "choices": [
    {
      "message": {
        "role": "assistant",
        "content": "{\"country\":\"France\",\"capital\":\"Paris\"}",
        "reasoning_content": null,
        "tool_calls": []
      },
      "finish_reason": "stop"
    }
  ]
}
```
Note that in current dynamo guided decoding, both `--dyn-reasoning-parser qwen3` and `--reasoning-parser qwen3` need to be passed, otherwise reasoning_content will be `null`.

Tests added/updated:
- Added Rust postprocessor coverage for `response_format=json_schema` with Qwen3 reasoning parser.
- Updated guided-output reasoning gate tests to cover structured response format.

## Where should the reviewer start?

Start with:

- `lib/llm/src/preprocessor.rs`
  - Main logic change: treat structured `response_format` as guided output in the reasoning parser path.

Then review:

- `lib/llm/tests/postprocessor_parsing_stream.rs`
  - Regression coverage for `response_format=json_schema` with Qwen3 thinking enabled/disabled.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to DIS-2376


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reasoning handling for structured JSON responses and forced tool calls.
  * Ensured streamed JSON is correctly placed in assistant content rather than reasoning content.
  * Preserved genuine reasoning text across multiple reasoning formats and model configurations.
  * Added support for scenarios where thinking is enabled, omitted, or injected into prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->