### PR TITLE
fix(trtllm): size omitted max_tokens for multimodal via expanded prompt length

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -113,7 +113,7 @@ class MultimodalRequestProcessor:
             )
             return len(token_ids) - num_placeholders + image_tokens
         except Exception as e:
-            logging.debug("Could not compute expanded prompt length: %s", e)
+            logging.warning("Could not compute expanded prompt length: %s", e)
             return None
 
     def is_url(self, path: str) -> bool:

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -90,7 +90,7 @@ class MultimodalRequestProcessor:
 
             self.input_processor = create_input_processor(model_dir, self.tokenizer)
         except Exception as e:
-            logging.debug("Input processor unavailable for max_tokens sizing: %s", e)
+            logging.warning("Input processor unavailable for max_tokens sizing: %s", e)
 
     def _expanded_prompt_len(
         self, token_ids: List[int], images: Optional[List[Any]]

--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -81,6 +81,41 @@ class MultimodalRequestProcessor:
             enable_frontend_decoding=enable_frontend_decoding
         )
 
+        # Input processor used only to size an omitted max_tokens (see
+        # _expanded_prompt_len). Optional: unavailable for models without a
+        # registered processor, in which case max_tokens sizing is left to the engine.
+        self.input_processor = None
+        try:
+            from tensorrt_llm.inputs import create_input_processor
+
+            self.input_processor = create_input_processor(model_dir, self.tokenizer)
+        except Exception as e:
+            logging.debug("Input processor unavailable for max_tokens sizing: %s", e)
+
+    def _expanded_prompt_len(
+        self, token_ids: List[int], images: Optional[List[Any]]
+    ) -> Optional[int]:
+        """Post-expansion prompt length: text tokens plus per-image tokens, with
+        image placeholders in token_ids replaced by their expanded token counts.
+
+        Returns None when it cannot be computed, so callers fall back to the
+        engine default instead of an over/underestimate.
+        """
+        if not self.input_processor or not images or not token_ids:
+            return None
+        try:
+            mm_ids = self.input_processor.get_mm_token_ids()
+            mm_id_set = set(mm_ids.tolist()) if mm_ids is not None else set()
+            num_placeholders = sum(1 for t in token_ids if t in mm_id_set)
+            image_tokens = sum(
+                int(self.input_processor.get_num_tokens_per_image(image=img))
+                for img in images
+            )
+            return len(token_ids) - num_placeholders + image_tokens
+        except Exception as e:
+            logging.debug("Could not compute expanded prompt length: %s", e)
+            return None
+
     def is_url(self, path: str) -> bool:
         """Check if a path is a URL."""
         parsed = urlparse(path)
@@ -403,6 +438,15 @@ class MultimodalRequestProcessor:
             logging.warning("No token_ids in request")
             return None
         processed_inputs["prompt_token_ids"] = token_ids
+
+        # Post-expansion prompt length, so an omitted max_tokens can be sized
+        # against the real context usage rather than the unexpanded placeholders.
+        mm_data = processed_inputs.get("multi_modal_data")
+        expanded_len = self._expanded_prompt_len(
+            token_ids, mm_data.get("image") if mm_data else None
+        )
+        if expanded_len is not None:
+            processed_inputs["expanded_prompt_len"] = expanded_len
 
         return processed_inputs
 

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1057,9 +1057,16 @@ class HandlerBase(BaseGenerativeHandler):
                 if isinstance(processed_input, dict)
                 else None
             )
+            prompt_token_ids = (
+                processed_input.get("prompt_token_ids")
+                if isinstance(processed_input, dict)
+                else None
+            )
             default_max_tokens = self._default_max_tokens(
                 self.max_seq_len,
-                request.get("token_ids", []),
+                prompt_token_ids
+                if prompt_token_ids is not None
+                else request.get("token_ids", []),
                 has_images,
                 expanded_prompt_len,
             )
@@ -1421,7 +1428,7 @@ class HandlerBase(BaseGenerativeHandler):
         if max_seq_len is None:
             return None
         if has_images:
-            if not expanded_prompt_len:
+            if expanded_prompt_len is None:
                 return None
             return max(1, max_seq_len - expanded_prompt_len)
         return max(1, max_seq_len - len(token_ids))

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1050,16 +1050,21 @@ class HandlerBase(BaseGenerativeHandler):
         max_tokens = request["stop_conditions"]["max_tokens"]
         if max_tokens is not None:
             sampling_params.max_tokens = max_tokens
-        elif self.max_seq_len is not None:
-            if self.multimodal_processor and processed_input is not None:
-                logging.debug(
-                    "Skipping dynamic max_tokens default for multimodal request..."
-                )
-            else:
-                token_ids = request.get("token_ids", [])
-                input_length = len(token_ids)
-                dynamic_default = max(1, self.max_seq_len - input_length)
-                sampling_params.max_tokens = dynamic_default
+        else:
+            has_images = self._request_has_images(processed_input)
+            expanded_prompt_len = (
+                processed_input.get("expanded_prompt_len")
+                if isinstance(processed_input, dict)
+                else None
+            )
+            default_max_tokens = self._default_max_tokens(
+                self.max_seq_len,
+                request.get("token_ids", []),
+                has_images,
+                expanded_prompt_len,
+            )
+            if default_max_tokens is not None:
+                sampling_params.max_tokens = default_max_tokens
 
         stop_conditions = request["stop_conditions"]
         ignore_eos = stop_conditions.get("ignore_eos")
@@ -1379,6 +1384,47 @@ class HandlerBase(BaseGenerativeHandler):
 
             # Initiate graceful shutdown
             await self._initiate_shutdown(e)
+
+    @staticmethod
+    def _request_has_images(processed_input) -> bool:
+        """Whether the processed input carries image content, as opposed to a
+        text-only request served by a multimodal worker.
+
+        This distinction drives max_tokens sizing: only image requests have
+        unexpanded placeholders in token_ids, so only they need the expanded
+        length; text requests use len(token_ids) directly.
+        """
+        return bool(
+            isinstance(processed_input, dict)
+            and (
+                processed_input.get("multi_modal_data")
+                or processed_input.get("multi_modal_embeddings")
+            )
+        )
+
+    @staticmethod
+    def _default_max_tokens(
+        max_seq_len: Optional[int],
+        token_ids: list,
+        has_images: bool,
+        expanded_prompt_len: Optional[int],
+    ) -> Optional[int]:
+        """Default for an omitted max_tokens: fill the model's remaining context.
+
+        For image requests, token_ids hold unexpanded placeholders, so sizing uses
+        expanded_prompt_len (placeholders replaced by their per-image token counts);
+        when that is unavailable, returns None to defer to the engine default rather
+        than overestimate. Text requests (including text-only requests to a
+        multimodal worker) use len(token_ids) directly. Returns None when no default
+        applies.
+        """
+        if max_seq_len is None:
+            return None
+        if has_images:
+            if not expanded_prompt_len:
+                return None
+            return max(1, max_seq_len - expanded_prompt_len)
+        return max(1, max_seq_len - len(token_ids))
 
     @staticmethod
     def _override_sampling_params(sampling_params, request: dict) -> SamplingParams:

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -1047,16 +1047,17 @@ class HandlerBase(BaseGenerativeHandler):
                         sampling_params, "prompt_logprobs", int(prompt_logprobs_value)
                     )
 
+        expanded_prompt_len = (
+            processed_input.pop("expanded_prompt_len", None)
+            if isinstance(processed_input, dict)
+            else None
+        )
+
         max_tokens = request["stop_conditions"]["max_tokens"]
         if max_tokens is not None:
             sampling_params.max_tokens = max_tokens
         else:
             has_images = self._request_has_images(processed_input)
-            expanded_prompt_len = (
-                processed_input.get("expanded_prompt_len")
-                if isinstance(processed_input, dict)
-                else None
-            )
             prompt_token_ids = (
                 processed_input.get("prompt_token_ids")
                 if isinstance(processed_input, dict)

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -805,6 +805,32 @@ class TestHealthCheckPriority:
         assert kwargs["priority"] == DEFAULT_REQUEST_PRIORITY
 
     @pytest.mark.asyncio
+    async def test_default_max_tokens_uses_processed_prompt_token_ids(self):
+        """DECODE-style processed tokens size the remaining context correctly."""
+        handler = self._make_handler()
+        handler.max_seq_len = 100
+        handler._prepare_input_for_generation = mock.AsyncMock(
+            return_value={"prompt_token_ids": list(range(40))}
+        )
+        generation_result = self._make_mock_generation_result()
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {"max_tokens": None},
+            "sampling_options": {},
+        }
+
+        chunks = [
+            chunk
+            async for chunk in handler.generate_locally(request, self._make_context())
+        ]
+        assert chunks
+
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        assert kwargs["sampling_params"].max_tokens == 60
+
+    @pytest.mark.asyncio
     async def test_routing_cache_salt_forwarded_to_generate_async(self):
         handler = self._make_handler()
         generation_result = self._make_mock_generation_result()
@@ -849,6 +875,9 @@ class TestDefaultMaxTokens:
     def test_image_without_expanded_defers(self):
         # No expanded length available -> defer to engine default (None)
         assert HandlerBase._default_max_tokens(100, [1, 2, 3], True, None) is None
+
+    def test_image_zero_expanded_len_is_valid(self):
+        assert HandlerBase._default_max_tokens(100, [], True, 0) == 100
 
     def test_floors_at_one(self):
         # Prompt already at/over context -> never returns <= 0

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -18,12 +18,12 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
-from tensorrt_llm.llmapi import DisaggregatedParams
 
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.trtllm.constants import DisaggregationMode
 from dynamo.trtllm.health_check import TrtllmHealthCheckPayload
 from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+from dynamo.trtllm.multimodal_processor import MultimodalRequestProcessor
 from dynamo.trtllm.request_handlers.handler_base import HandlerBase
 
 pytestmark = [
@@ -636,76 +636,6 @@ class TestMultimodalGuard:
         assert result["multi_modal_data"] is None
 
 
-class TestPrefillPromptMetadata:
-    """Tests for prompt metadata in the legacy prefill handoff."""
-
-    def _make_handler(self) -> HandlerBase:
-        config = MagicMock()
-        config.multimodal_processor = MagicMock()
-        config.shutdown_event = None
-        return _ConcreteHandler(config)
-
-    def _pack_metadata(self, request, processed_input, prompt, prompt_token_ids):
-        params = DisaggregatedParams(request_type="context_only")
-        output = MagicMock(disaggregated_params=params)
-        result = MagicMock(prompt=prompt, prompt_token_ids=prompt_token_ids)
-
-        return self._make_handler()._encode_and_pack_disaggregated_params(
-            output,
-            params,
-            request,
-            result,
-            processed_input,
-        )
-
-    def test_text_only_prefill_omits_prompt_metadata(self):
-        result = self._pack_metadata(
-            request={"token_ids": [1, 2, 3]},
-            processed_input=[1, 2, 3],
-            prompt="text prompt",
-            prompt_token_ids=[1, 2, 3],
-        )
-
-        assert "_epd_metadata" not in result
-
-    def test_multimodal_prefill_preserves_prompt_metadata(self):
-        result = self._pack_metadata(
-            request={
-                "token_ids": [1, 2, 3],
-                "multi_modal_data": {
-                    "image_url": [{"Url": "http://example.com/image.jpg"}]
-                },
-            },
-            processed_input={"prompt": "describe image"},
-            prompt="raw prompt",
-            prompt_token_ids=[1, 2, 3],
-        )
-
-        assert result["_epd_metadata"] == {
-            "_prefill_prompt": "describe image",
-            "_prefill_prompt_token_ids": [1, 2, 3],
-        }
-
-    def test_epd_prefill_preserves_encoder_metadata(self):
-        result = self._pack_metadata(
-            request={
-                "token_ids": [1, 2, 3],
-                "_epd_processed_prompt": "encoder prompt",
-                "_epd_prompt_token_ids": [1, 2, 3],
-            },
-            processed_input={"prompt": "encoder prompt"},
-            prompt="engine prompt",
-            prompt_token_ids=[4, 5, 6],
-        )
-
-        assert result["_epd_metadata"] == {
-            "_prefill_prompt": "encoder prompt",
-            "_prefill_prompt_token_ids": [4, 5, 6],
-            "_epd_processed_prompt": "engine prompt",
-            "_epd_prompt_token_ids": [4, 5, 6],
-        }
-
-
 class TestDisaggRequestId:
     """Tests for disagg_request_id population in _setup_disaggregated_params_for_mode."""
 
@@ -897,181 +827,108 @@ class TestHealthCheckPriority:
         assert kwargs["cache_salt"] == "tenant-a"
 
 
-class _FakeConversationParams:
-    """Stand-in for tensorrt_llm.llmapi.ConversationParams. Only ``conversation_id``
-    is read back by the assertions."""
+class TestDefaultMaxTokens:
+    """Unit tests for HandlerBase._default_max_tokens (omitted max_tokens sizing)."""
 
-    def __init__(self, conversation_id):
-        self.conversation_id = conversation_id
+    def test_text_fills_remaining_context(self):
+        # 100 - len([1,2,3]) = 97
+        assert HandlerBase._default_max_tokens(100, [1, 2, 3], False, None) == 97
+
+    def test_text_on_multimodal_worker_ignores_expanded(self):
+        # A text request (no images) uses len(token_ids) even if an expanded
+        # length is somehow present; it must not defer like an image request.
+        assert HandlerBase._default_max_tokens(100, [1, 2, 3], False, 40) == 97
+
+    def test_returns_none_without_max_seq_len(self):
+        assert HandlerBase._default_max_tokens(None, [1, 2, 3], False, None) is None
+
+    def test_image_uses_expanded_len(self):
+        # 100 - 40 = 60; token_ids ignored in favor of the expanded length
+        assert HandlerBase._default_max_tokens(100, [1, 2, 3], True, 40) == 60
+
+    def test_image_without_expanded_defers(self):
+        # No expanded length available -> defer to engine default (None)
+        assert HandlerBase._default_max_tokens(100, [1, 2, 3], True, None) is None
+
+    def test_floors_at_one(self):
+        # Prompt already at/over context -> never returns <= 0
+        assert HandlerBase._default_max_tokens(3, [1, 2, 3, 4, 5], False, None) == 1
 
 
-class TestConversationAffinity:
-    """Verify generate_locally's conversation-affinity branching on the legacy path.
+class TestExpandedPromptLen:
+    """Unit tests for MultimodalRequestProcessor._expanded_prompt_len."""
 
-    When engine-owned conversation-affinity ADP routing is enabled, the handler
-    must (a) NOT force ``attention_dp_rank`` and (b) forward the frontend's
-    ``agent_context.session_id`` as ``ConversationParams`` to
-    ``generate_async``. When disabled, the router's ``dp_rank`` still drives
-    ``SchedulingParams`` as before.
+    def _processor(self, mm_token_ids, tokens_per_image):
+        # Bypass __init__ (which would build a real input processor) and inject a mock.
+        proc = MultimodalRequestProcessor.__new__(MultimodalRequestProcessor)
+        ip = MagicMock()
+        ip.get_mm_token_ids.return_value = (
+            torch.tensor(mm_token_ids) if mm_token_ids is not None else None
+        )
+        ip.get_num_tokens_per_image.side_effect = lambda image: tokens_per_image
+        proc.input_processor = ip
+        return proc
+
+    def test_replaces_placeholders_with_image_tokens(self):
+        # token_ids has one placeholder (99); one image expands to 256 tokens.
+        # 4 tokens - 1 placeholder + 256 = 259
+        proc = self._processor(mm_token_ids=[99], tokens_per_image=256)
+        assert proc._expanded_prompt_len([1, 2, 99, 3], images=["img"]) == 259
+
+    def test_multiple_images_sum(self):
+        # Two placeholders, two images x 10 tokens: 5 - 2 + 20 = 23
+        proc = self._processor(mm_token_ids=[99], tokens_per_image=10)
+        assert proc._expanded_prompt_len([1, 99, 2, 99, 3], ["a", "b"]) == 23
+
+    def test_none_without_input_processor(self):
+        proc = MultimodalRequestProcessor.__new__(MultimodalRequestProcessor)
+        proc.input_processor = None
+        assert proc._expanded_prompt_len([1, 2, 3], ["img"]) is None
+
+    def test_none_without_images(self):
+        proc = self._processor(mm_token_ids=[99], tokens_per_image=256)
+        assert proc._expanded_prompt_len([1, 2, 3], None) is None
+
+    def test_none_on_processor_error(self):
+        proc = MultimodalRequestProcessor.__new__(MultimodalRequestProcessor)
+        ip = MagicMock()
+        ip.get_mm_token_ids.side_effect = RuntimeError("boom")
+        proc.input_processor = ip
+        assert proc._expanded_prompt_len([1, 2, 3], ["img"]) is None
+
+
+class TestRequestHasImages:
+    """Unit tests for HandlerBase._request_has_images (image-vs-text classification).
+
+    Regression coverage for the bug where a text request to a multimodal worker
+    was mis-classified as multimodal and its omitted max_tokens deferred to the
+    engine default (32) instead of filling from len(token_ids).
     """
 
-    def _make_handler(self, *, conversation_affinity: bool) -> HandlerBase:
-        config = MagicMock()
-        config.shutdown_event = None
-        config.disaggregation_mode = DisaggregationMode.AGGREGATED
-        handler = _ConcreteHandler(config)
-        handler.publisher = None
-        handler.multimodal_processor = None
-        handler.additional_metrics = None
-        handler.max_seq_len = None
-        handler.default_sampling_params = MockSamplingParams()
-        # Pre-resolve the gate so the lazy path in _generate_locally_impl is a
-        # no-op — the branching under test happens downstream.
-        handler._conversation_affinity = conversation_affinity
-        return handler
+    def test_text_request_has_no_images(self):
+        # processed_input for text on a multimodal worker: no mm keys.
+        assert HandlerBase._request_has_images({"prompt_token_ids": [1, 2, 3]}) is False
 
-    def _make_mock_generation_result(self):
-        output = MagicMock()
-        output.token_ids = [42]
-        output.finish_reason = "stop"
-        output.stop_reason = None
-        output.request_perf_metrics = None
-
-        res = MagicMock()
-        res.outputs = [output]
-        res.finished = True
-
-        generation_result = MagicMock()
-        generation_result.abort = MagicMock()
-
-        async def mock_aiter(self_mock):
-            yield res
-
-        generation_result.__aiter__ = mock_aiter
-        return generation_result
-
-    def _make_context(self):
-        context = MagicMock()
-        never_resolve = asyncio.get_event_loop().create_future()
-        context.async_killed_or_stopped.return_value = never_resolve
-        context.id.return_value = "conv-affinity-test"
-        return context
-
-    async def _drive(self, handler, request):
-        generation_result = self._make_mock_generation_result()
-        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
-        chunks = [
-            c async for c in handler.generate_locally(request, self._make_context())
-        ]
-        assert len(chunks) > 0
-        handler.engine.llm.generate_async.assert_called_once()
-        _, kwargs = handler.engine.llm.generate_async.call_args
-        return kwargs
-
-    @pytest.mark.asyncio
-    async def test_affinity_off_forwards_router_dp_rank(self):
-        """affinity=False + router dp_rank → SchedulingParams with that rank."""
-        handler = self._make_handler(conversation_affinity=False)
-        kwargs = await self._drive(
-            handler,
-            {
-                "token_ids": [1, 2, 3],
-                "stop_conditions": {"max_tokens": 10},
-                "sampling_options": {"temperature": 0.7},
-                "routing": {"dp_rank": 3},
-            },
+    def test_multi_modal_data_is_images(self):
+        assert (
+            HandlerBase._request_has_images({"multi_modal_data": {"image": ["x"]}})
+            is True
         )
-        scheduling_params = kwargs["scheduling_params"]
-        assert scheduling_params is not None
-        assert scheduling_params.attention_dp_rank == 3
-        assert scheduling_params.attention_dp_relax is False
-        assert "conversation_params" not in kwargs
 
-    @pytest.mark.asyncio
-    async def test_affinity_off_no_rank_leaves_scheduling_params_none(self):
-        """affinity=False + no router rank → scheduling_params=None, no conv kwarg."""
-        handler = self._make_handler(conversation_affinity=False)
-        kwargs = await self._drive(
-            handler,
-            {
-                "token_ids": [1, 2, 3],
-                "stop_conditions": {"max_tokens": 10},
-                "sampling_options": {"temperature": 0.7},
-            },
+    def test_multi_modal_embeddings_is_images(self):
+        assert (
+            HandlerBase._request_has_images(
+                {"multi_modal_embeddings": {"image": ["x"]}}
+            )
+            is True
         )
-        assert kwargs["scheduling_params"] is None
-        assert "conversation_params" not in kwargs
 
-    @pytest.mark.asyncio
-    async def test_affinity_on_with_session_id_suppresses_rank(self, monkeypatch):
-        """affinity=True + session id → scheduling_params=None + ConversationParams."""
-        monkeypatch.setattr(
-            "dynamo.trtllm.conversation_affinity.ConversationParams",
-            _FakeConversationParams,
-        )
-        handler = self._make_handler(conversation_affinity=True)
-        # Router still stamps a rank; affinity mode must ignore it — an explicit
-        # rank would bypass the engine's ConversationAwareADPRouter.
-        kwargs = await self._drive(
-            handler,
-            {
-                "token_ids": [1, 2, 3],
-                "stop_conditions": {"max_tokens": 10},
-                "sampling_options": {"temperature": 0.7},
-                "routing": {"dp_rank": 3},
-                "agent_context": {"session_id": "run-42:agent-0"},
-            },
-        )
-        assert kwargs["scheduling_params"] is None
-        conv_params = kwargs["conversation_params"]
-        assert conv_params is not None
-        assert conv_params.conversation_id == "run-42:agent-0"
+    def test_empty_mm_data_is_not_images(self):
+        # mm key present but falsy (text path sets these to None) -> not images.
+        assert HandlerBase._request_has_images({"multi_modal_data": None}) is False
 
-    @pytest.mark.asyncio
-    async def test_affinity_on_without_session_id_passes_none_conversation_params(
-        self, monkeypatch
-    ):
-        """affinity=True + no session id → scheduling_params=None,
-        conversation_params kwarg present with value None (no-id balancing)."""
-        monkeypatch.setattr(
-            "dynamo.trtllm.conversation_affinity.ConversationParams",
-            _FakeConversationParams,
-        )
-        handler = self._make_handler(conversation_affinity=True)
-        kwargs = await self._drive(
-            handler,
-            {
-                "token_ids": [1, 2, 3],
-                "stop_conditions": {"max_tokens": 10},
-                "sampling_options": {"temperature": 0.7},
-            },
-        )
-        assert kwargs["scheduling_params"] is None
-        assert "conversation_params" in kwargs
-        assert kwargs["conversation_params"] is None
+    def test_none_is_not_images(self):
+        assert HandlerBase._request_has_images(None) is False
 
-    @pytest.mark.asyncio
-    async def test_lazy_resolution_raises_when_api_missing(self, monkeypatch):
-        """Startup gate: engine has affinity ON but ConversationParams API is
-        missing → RuntimeError on first request, before generate_async is called."""
-        monkeypatch.setattr(
-            "dynamo.trtllm.request_handlers.handler_base.CONVERSATION_PARAMS_AVAILABLE",
-            False,
-        )
-        handler = self._make_handler(conversation_affinity=False)
-        # Trigger the lazy path with an engine config that enables affinity.
-        handler._conversation_affinity = None
-        handler.engine.llm.args.attention_dp_config = {
-            "kv_cache_routing_conversation_affinity": True
-        }
-        handler.engine.llm.generate_async = MagicMock()
-
-        request = {
-            "token_ids": [1, 2, 3],
-            "stop_conditions": {"max_tokens": 10},
-            "sampling_options": {"temperature": 0.7},
-        }
-        with pytest.raises(RuntimeError, match="ConversationParams API"):
-            async for _ in handler.generate_locally(request, self._make_context()):
-                pass
-        handler.engine.llm.generate_async.assert_not_called()
+    def test_non_dict_is_not_images(self):
+        assert HandlerBase._request_has_images([1, 2, 3]) is False

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -831,6 +831,33 @@ class TestHealthCheckPriority:
         assert kwargs["sampling_params"].max_tokens == 60
 
     @pytest.mark.asyncio
+    async def test_expanded_prompt_len_is_not_forwarded_to_engine(self):
+        handler = self._make_handler()
+        handler._prepare_input_for_generation = mock.AsyncMock(
+            return_value={
+                "prompt_token_ids": [1, 2, 3],
+                "expanded_prompt_len": 42,
+            }
+        )
+        generation_result = self._make_mock_generation_result()
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {"max_tokens": 10},
+            "sampling_options": {},
+        }
+
+        chunks = [
+            chunk
+            async for chunk in handler.generate_locally(request, self._make_context())
+        ]
+        assert chunks
+
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        assert "expanded_prompt_len" not in kwargs["inputs"]
+
+    @pytest.mark.asyncio
     async def test_routing_cache_salt_forwarded_to_generate_async(self):
         handler = self._make_handler()
         generation_result = self._make_mock_generation_result()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -18,6 +18,7 @@ if not torch.cuda.is_available():
         allow_module_level=True,
     )
 from tensorrt_llm.executor.request import DEFAULT_REQUEST_PRIORITY
+from tensorrt_llm.llmapi import DisaggregatedParams
 
 from dynamo.llm.exceptions import EngineShutdown
 from dynamo.trtllm.constants import DisaggregationMode
@@ -636,6 +637,76 @@ class TestMultimodalGuard:
         assert result["multi_modal_data"] is None
 
 
+class TestPrefillPromptMetadata:
+    """Tests for prompt metadata in the legacy prefill handoff."""
+
+    def _make_handler(self) -> HandlerBase:
+        config = MagicMock()
+        config.multimodal_processor = MagicMock()
+        config.shutdown_event = None
+        return _ConcreteHandler(config)
+
+    def _pack_metadata(self, request, processed_input, prompt, prompt_token_ids):
+        params = DisaggregatedParams(request_type="context_only")
+        output = MagicMock(disaggregated_params=params)
+        result = MagicMock(prompt=prompt, prompt_token_ids=prompt_token_ids)
+
+        return self._make_handler()._encode_and_pack_disaggregated_params(
+            output,
+            params,
+            request,
+            result,
+            processed_input,
+        )
+
+    def test_text_only_prefill_omits_prompt_metadata(self):
+        result = self._pack_metadata(
+            request={"token_ids": [1, 2, 3]},
+            processed_input=[1, 2, 3],
+            prompt="text prompt",
+            prompt_token_ids=[1, 2, 3],
+        )
+
+        assert "_epd_metadata" not in result
+
+    def test_multimodal_prefill_preserves_prompt_metadata(self):
+        result = self._pack_metadata(
+            request={
+                "token_ids": [1, 2, 3],
+                "multi_modal_data": {
+                    "image_url": [{"Url": "http://example.com/image.jpg"}]
+                },
+            },
+            processed_input={"prompt": "describe image"},
+            prompt="raw prompt",
+            prompt_token_ids=[1, 2, 3],
+        )
+
+        assert result["_epd_metadata"] == {
+            "_prefill_prompt": "describe image",
+            "_prefill_prompt_token_ids": [1, 2, 3],
+        }
+
+    def test_epd_prefill_preserves_encoder_metadata(self):
+        result = self._pack_metadata(
+            request={
+                "token_ids": [1, 2, 3],
+                "_epd_processed_prompt": "encoder prompt",
+                "_epd_prompt_token_ids": [1, 2, 3],
+            },
+            processed_input={"prompt": "encoder prompt"},
+            prompt="engine prompt",
+            prompt_token_ids=[4, 5, 6],
+        )
+
+        assert result["_epd_metadata"] == {
+            "_prefill_prompt": "encoder prompt",
+            "_prefill_prompt_token_ids": [4, 5, 6],
+            "_epd_processed_prompt": "engine prompt",
+            "_epd_prompt_token_ids": [4, 5, 6],
+        }
+
+
 class TestDisaggRequestId:
     """Tests for disagg_request_id population in _setup_disaggregated_params_for_mode."""
 
@@ -988,3 +1059,184 @@ class TestRequestHasImages:
 
     def test_non_dict_is_not_images(self):
         assert HandlerBase._request_has_images([1, 2, 3]) is False
+
+
+class _FakeConversationParams:
+
+    """Stand-in for tensorrt_llm.llmapi.ConversationParams. Only ``conversation_id``
+    is read back by the assertions."""
+
+    def __init__(self, conversation_id):
+        self.conversation_id = conversation_id
+
+
+class TestConversationAffinity:
+    """Verify generate_locally's conversation-affinity branching on the legacy path.
+
+    When engine-owned conversation-affinity ADP routing is enabled, the handler
+    must (a) NOT force ``attention_dp_rank`` and (b) forward the frontend's
+    ``agent_context.session_id`` as ``ConversationParams`` to
+    ``generate_async``. When disabled, the router's ``dp_rank`` still drives
+    ``SchedulingParams`` as before.
+    """
+
+    def _make_handler(self, *, conversation_affinity: bool) -> HandlerBase:
+        config = MagicMock()
+        config.shutdown_event = None
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        handler = _ConcreteHandler(config)
+        handler.publisher = None
+        handler.multimodal_processor = None
+        handler.additional_metrics = None
+        handler.max_seq_len = None
+        handler.default_sampling_params = MockSamplingParams()
+        # Pre-resolve the gate so the lazy path in _generate_locally_impl is a
+        # no-op — the branching under test happens downstream.
+        handler._conversation_affinity = conversation_affinity
+        return handler
+
+    def _make_mock_generation_result(self):
+        output = MagicMock()
+        output.token_ids = [42]
+        output.finish_reason = "stop"
+        output.stop_reason = None
+        output.request_perf_metrics = None
+
+        res = MagicMock()
+        res.outputs = [output]
+        res.finished = True
+
+        generation_result = MagicMock()
+        generation_result.abort = MagicMock()
+
+        async def mock_aiter(self_mock):
+            yield res
+
+        generation_result.__aiter__ = mock_aiter
+        return generation_result
+
+    def _make_context(self):
+        context = MagicMock()
+        never_resolve = asyncio.get_event_loop().create_future()
+        context.async_killed_or_stopped.return_value = never_resolve
+        context.id.return_value = "conv-affinity-test"
+        return context
+
+    async def _drive(self, handler, request):
+        generation_result = self._make_mock_generation_result()
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+        chunks = [
+            c async for c in handler.generate_locally(request, self._make_context())
+        ]
+        assert len(chunks) > 0
+        handler.engine.llm.generate_async.assert_called_once()
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        return kwargs
+
+    @pytest.mark.asyncio
+    async def test_affinity_off_forwards_router_dp_rank(self):
+        """affinity=False + router dp_rank → SchedulingParams with that rank."""
+        handler = self._make_handler(conversation_affinity=False)
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+                "routing": {"dp_rank": 3},
+            },
+        )
+        scheduling_params = kwargs["scheduling_params"]
+        assert scheduling_params is not None
+        assert scheduling_params.attention_dp_rank == 3
+        assert scheduling_params.attention_dp_relax is False
+        assert "conversation_params" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_affinity_off_no_rank_leaves_scheduling_params_none(self):
+        """affinity=False + no router rank → scheduling_params=None, no conv kwarg."""
+        handler = self._make_handler(conversation_affinity=False)
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+            },
+        )
+        assert kwargs["scheduling_params"] is None
+        assert "conversation_params" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_affinity_on_with_session_id_suppresses_rank(self, monkeypatch):
+        """affinity=True + session id → scheduling_params=None + ConversationParams."""
+        monkeypatch.setattr(
+            "dynamo.trtllm.conversation_affinity.ConversationParams",
+            _FakeConversationParams,
+        )
+        handler = self._make_handler(conversation_affinity=True)
+        # Router still stamps a rank; affinity mode must ignore it — an explicit
+        # rank would bypass the engine's ConversationAwareADPRouter.
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+                "routing": {"dp_rank": 3},
+                "agent_context": {"session_id": "run-42:agent-0"},
+            },
+        )
+        assert kwargs["scheduling_params"] is None
+        conv_params = kwargs["conversation_params"]
+        assert conv_params is not None
+        assert conv_params.conversation_id == "run-42:agent-0"
+
+    @pytest.mark.asyncio
+    async def test_affinity_on_without_session_id_passes_none_conversation_params(
+        self, monkeypatch
+    ):
+        """affinity=True + no session id → scheduling_params=None,
+        conversation_params kwarg present with value None (no-id balancing)."""
+        monkeypatch.setattr(
+            "dynamo.trtllm.conversation_affinity.ConversationParams",
+            _FakeConversationParams,
+        )
+        handler = self._make_handler(conversation_affinity=True)
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+            },
+        )
+        assert kwargs["scheduling_params"] is None
+        assert "conversation_params" in kwargs
+        assert kwargs["conversation_params"] is None
+
+    @pytest.mark.asyncio
+    async def test_lazy_resolution_raises_when_api_missing(self, monkeypatch):
+        """Startup gate: engine has affinity ON but ConversationParams API is
+        missing → RuntimeError on first request, before generate_async is called."""
+        monkeypatch.setattr(
+            "dynamo.trtllm.request_handlers.handler_base.CONVERSATION_PARAMS_AVAILABLE",
+            False,
+        )
+        handler = self._make_handler(conversation_affinity=False)
+        # Trigger the lazy path with an engine config that enables affinity.
+        handler._conversation_affinity = None
+        handler.engine.llm.args.attention_dp_config = {
+            "kv_cache_routing_conversation_affinity": True
+        }
+        handler.engine.llm.generate_async = MagicMock()
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {"max_tokens": 10},
+            "sampling_options": {"temperature": 0.7},
+        }
+        with pytest.raises(RuntimeError, match="ConversationParams API"):
+            async for _ in handler.generate_locally(request, self._make_context()):
+                pass
+        handler.engine.llm.generate_async.assert_not_called()


### PR DESCRIPTION
## Summary

On the TensorRT-LLM backend, a chat request that omits `max_tokens` on a **multimodal** worker falls back to TRT-LLM's `SamplingParams` default of **32**, truncating the response to near-empty (`finish_reason: "length"`). It is especially visible on reasoning models, whose hidden reasoning alone exceeds 32 tokens. It affects **both text and image** requests to such a worker.

## Root cause

`HandlerBase` fills a dynamic default for an omitted `max_tokens` as `max_seq_len - len(token_ids)`, but skips multimodal requests:

```python
elif self.max_seq_len is not None:
    if self.multimodal_processor and processed_input is not None:
        logging.debug("Skipping dynamic max_tokens default for multimodal request...")
    else:
        # text: max_seq_len - len(token_ids)
```

For an **image** request, `token_ids` holds unexpanded image placeholders, so `len(token_ids)` understates the prompt and the text formula would overestimate the budget. But skipping entirely leaves the engine default of 32. And because `processed_input` is non-None for *every* request on a multimodal worker, even **text** requests took the skip and got 32.

## Fix

- Compute the **post-expansion** prompt length in `MultimodalRequestProcessor` via TRT-LLM's own input processor (`get_mm_token_ids` + `get_num_tokens_per_image`), attach it as `expanded_prompt_len`.
- Classify each request by **actual image content** (`_request_has_images`) rather than by whether the worker is multimodal.
- Size the default in `_default_max_tokens`:
  - **image** request → `max_seq_len - expanded_prompt_len` (defer to engine default if the length can't be computed, rather than overestimate),
  - **text** request → `max_seq_len - len(token_ids)`.

No hardcoded limits; only TRT-LLM's public API and the model's own `max_seq_len`. Requests that pass an explicit `max_tokens` are unaffected.

## Verified on a live multimodal TRT-LLM deployment

A reasoning VLM served with `--modality multimodal`, omitting `max_tokens`:

| Request | Before | After |
|---|---|---|
| **text** (`"Say hello in one word."`) | `finish_reason: length`, `completion_tokens: 32`, `content: null` | `finish_reason: stop`, 117 tok, `content: "Hello"` |
| **image** (`"What color?"` + PNG) | `finish_reason: length`, 32 tok, empty | `finish_reason: stop`, 105 tok, `content: "Green"` |

Explicit `max_tokens` was correct throughout.

## Tests (`test_trtllm_handler_base.py`)

- `_default_max_tokens`: text fills remaining context; image uses the expanded length; image without an expanded length defers; `None` when `max_seq_len` unset; result floored at 1; **text ignores a stray expanded length** (does not defer).
- `_request_has_images`: text (no mm keys) → False; `multi_modal_data`/`multi_modal_embeddings` → True; empty mm value → False; `None`/non-dict → False. *(Regression coverage for the text-on-multimodal-worker mis-classification the live test surfaced.)*
- `_expanded_prompt_len`: placeholder tokens replaced by per-image counts (single and multi-image); `None` without a processor, without images, or on processor error.

Closes DIS-2389

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved maximum token calculations for multimodal prompts containing images.
  * Prevented token overestimation when image token sizing cannot be determined.
  * Improved handling of text-only and image-based requests, including edge cases.

* **Tests**
  * Added coverage for multimodal prompt expansion, token limits, missing metadata, and processing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->