### PR TITLE
test(vllm): fix omni 0.23 contract guards (regressed by #11374)

### DIFF
--- a/components/src/dynamo/vllm/tests/omni/test_omni_base_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_base_handler.py
@@ -30,6 +30,9 @@ _SKIP_FIELDS = {
     "sequence_parallel_size",
     "enable_expert_parallel",
     "ulysses_mode",
+    # Diffusion sequence-parallel mask padding; internal SP detail, defaults False
+    # and is not a benchmark-facing knob (same rationale as sequence_parallel_size).
+    "mask_sp_padding",
 }
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_api_contract.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_api_contract.py
@@ -129,7 +129,17 @@ def test_request_exposes_all_token_ids():
     private attribute so a rename is caught here, not at runtime."""
     from vllm.v1.request import Request
 
-    assert "_all_token_ids" in inspect.getsource(Request), (
+    # vllm-omni monkeypatches vllm.v1.request.Request with its OmniRequest subclass,
+    # whose body does not redeclare `_all_token_ids` (it inherits it). Walk the MRO so
+    # the inherited attribute is still detected, while a real rename in vLLM still fails.
+    sources = []
+    for klass in Request.__mro__:
+        try:
+            sources.append(inspect.getsource(klass))
+        except (OSError, TypeError):
+            continue
+
+    assert any("_all_token_ids" in src for src in sources), (
         "vllm.v1.request.Request no longer exposes `_all_token_ids` — "
         "InstrumentedScheduler relies on it for NewRequestData.prefill_token_ids."
     )

--- a/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_renderer_api.py
@@ -431,9 +431,11 @@ class TestVllmRendererApi:
             "routed_experts",
             "num_nans_in_logits",
         )
-        # vllm-omni extends EngineCoreOutput with streaming segment metadata
-        # (only installed on amd64, not arm64).
+        # vllm-omni's bundled vLLM adds `multimodal_output`, and vllm-omni extends
+        # EngineCoreOutput with streaming segment metadata (only installed on amd64,
+        # not arm64).
         omni_output_extra_fields = (
+            "multimodal_output",
             "is_segment_finished",
             "new_prompt_len_snapshot",
         )


### PR DESCRIPTION
## Overview

PR #11374 (vllm-omni `v0.21.0rc1` → `v0.23.0rc1`) turned the `vllm-runtime / Test` CPU jobs **red on `release/1.3.0`** — the parent commit was green, the merge commit failed all four jobs, and every subsequent cherry-pick (e.g. #11455) inherits it.

Three `pre_merge` contract-guard tests reacted to omni 0.23 internals. In all three the **guarded runtime path still works** — only the guards are over-strict — so this PR updates the guards, with no product-code change.

## Root cause per test

- **`test_engine_core_struct_contract`** — omni 0.23's bundled vLLM adds a trailing `multimodal_output` field to `EngineCoreOutput`. The CI assertion printed:
  ```
  Actual: (... 'num_nans_in_logits', 'multimodal_output', 'is_segment_finished', 'new_prompt_len_snapshot')
  ```
  `vllm_processor.py` constructs `EngineCoreOutput` **by keyword** and only sets fields it knows (`output_kwargs` + `if "…" in __struct_fields__`), so the new optional field just defaults — construction is unaffected. Fix: add `multimodal_output` to the omni field variants.

- **`test_request_exposes_all_token_ids`** — omni monkeypatches `vllm.v1.request.Request` → `OmniRequest`, whose body doesn't redeclare `_all_token_ids` (it **inherits** it), so the `inspect.getsource(Request)` text check fails. The attribute still exists at runtime; `InstrumentedScheduler` is fine. Fix: walk the MRO so the inherited attribute is detected, while a genuine rename in vLLM still fails.

- **`test_all_diffusion_parallel_config_fields_covered`** — omni 0.23 adds `DiffusionParallelConfig.mask_sp_padding` (internal sequence-parallel detail, defaults `False`, not a benchmark-facing knob). Fix: add to `_SKIP_FIELDS`, consistent with the existing `sequence_parallel_size` / `enable_expert_parallel` skips.

## Verification (on the real `vllm-omni 0.23.0rc1` / `vllm 0.23.0` release/1.3.0 image)

- Contract guards: **3 failed** with the baked test files (reproduces CI) → **3 passed** with this PR's files.
- Full `test_omni_base_handler.py`: **3 passed**.
- Runtime introspection confirmed the *why*: `EngineCoreOutput` really has `multimodal_output` and keyword-constructs with it defaulting to `None`; `Request` is monkeypatched to `OmniRequest` with `_all_token_ids` resolvable via the MRO; `DiffusionParallelConfig.mask_sp_padding` present.
- End-to-end sanity on the omni image: text serving (`Qwen3-0.6B`, valid `/v1/chat/completions`) and diffusion generation (`Z-Image-Turbo`, valid 512×512 PNG via `/v1/images/generations`) both succeeded with no errors in the guarded paths.

## Not addressed

The GPU `test_omni_serve_deployment[omni_i2v]` failure on the same run is a separate ffmpeg / "No valid H.264 encoder" environment issue, unrelated to the pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11516" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->