### PR TITLE
feat(frontend): make fastokens the default tokenizer

### DIFF
--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -459,6 +459,32 @@ def test_load_aware_frontend_implies_kv_router_mode() -> None:
     assert config.router_assume_kv_reuse is False
 
 
+def test_frontend_tokenizer_defaults_to_fastokens(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_TOKENIZER", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args([])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.tokenizer_backend == "fastokens"
+
+
+def test_frontend_tokenizer_env_and_cli_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_TOKENIZER", "default")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--tokenizer", "fastokens"])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.tokenizer_backend == "fastokens"
+
+
 def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
     """Default --admission-control is 'none': busy thresholds are cleared
     even though the underlying threshold flags have non-None defaults."""

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -477,11 +477,11 @@ class FrontendArgGroup(ArgGroup):
             g,
             flag_name="--tokenizer",
             env_var="DYN_TOKENIZER",
-            default="default",
+            default="fastokens",
             dest="tokenizer_backend",
             help=(
-                "Tokenizer backend for BPE models: 'default' (HuggingFace tokenizers library) "
-                "or 'fastokens' (fastokens crate for high-performance BPE encoding). "
+                "Tokenizer backend for BPE models: 'fastokens' (fastokens crate for high-performance BPE encoding) "
+                "or 'default' (HuggingFace tokenizers library). "
                 "Decoding always uses HuggingFace. Has no effect on TikToken models."
             ),
             choices=["default", "fastokens"],

--- a/docs/components/frontend/Tokenizer.md
+++ b/docs/components/frontend/Tokenizer.md
@@ -2,23 +2,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Tokenizer
+subtitle: Selects between the default fastokens and HuggingFace tokenizer backends for BPE models served through the Dynamo Frontend.
 ---
 
-The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: both the default HuggingFace path and the `fastokens` path can serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.
+The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: both the HuggingFace path and the default `fastokens` path can serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.
 
 ## Tokenizer Backends
 
-#### `default` HuggingFace Tokenizers
-
-The default backend uses the [HuggingFace `tokenizers`](https://github.com/huggingface/tokenizers) library (Rust).
-It supports features in `tokenizer.json` files (normalizers, pre-tokenizers, post-processors, decoders, added tokens with special-token flags, and byte-fallback).
-
 #### `fastokens` High-Performance Encoder
 
-The `fastokens` backend uses the [`fastokens`](https://github.com/Atero-ai/fastokens) crate, a purpose-built encoder optimized for throughput on supported BPE `tokenizer.json` models.
+The default `fastokens` backend uses the [`fastokens`](https://github.com/Atero-ai/fastokens) crate, a purpose-built encoder optimized for throughput on supported BPE `tokenizer.json` models.
 It is a _hybrid_ backend: encoding uses `fastokens` while decoding falls back to HuggingFace so that incremental detokenization, byte-fallback, and special-token handling work correctly.
 
-Use this backend when tokenization is a measurable bottleneck, for example on high-concurrency prefill-heavy workloads.
+#### `default` HuggingFace Tokenizers
+
+The HuggingFace backend uses the [HuggingFace `tokenizers`](https://github.com/huggingface/tokenizers) library (Rust).
+It supports features in `tokenizer.json` files (normalizers, pre-tokenizers, post-processors, decoders, added tokens with special-token flags, and byte-fallback).
+
+Use this backend when validating a new or unusual tokenizer and you want maximum compatibility first.
 
 #### Compatibility notes:
 
@@ -32,22 +33,22 @@ Set the backend with a CLI flag or environment variable. The CLI flag takes prec
 
 | CLI Argument | Env Var | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `default`, `fastokens` | `default` |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `default` | `fastokens` |
 
 **Examples:**
 
 ```bash
-# CLI flag
-python -m dynamo.frontend --tokenizer fastokens
+# Default fastokens backend
+python -m dynamo.frontend
 
-# Environment variable
-export DYN_TOKENIZER=fastokens
+# Explicit environment variable
+export DYN_TOKENIZER=default
 python -m dynamo.frontend
 ```
 
 ## Dynamo Frontend Behavior
 
-When `DYN_TOKENIZER=fastokens` is set:
+When `fastokens` is selected by default, by `--tokenizer fastokens`, or by `DYN_TOKENIZER=fastokens`:
 
 1. The frontend passes the environment variable to the Rust runtime.
 2. When building the tokenizer for a model, `ModelDeploymentCard::tokenizer()` attempts to load `fastokens::Tokenizer` from the same `tokenizer.json` file.

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -116,7 +116,7 @@ See the [Frontend Guide](frontend-guide.md) for KServe message formats and integ
 
 | CLI Argument | Env Var | Default | Description |
 |-------------|---------|---------|-------------|
-| `--tokenizer` | `DYN_TOKENIZER` | `default` | Tokenizer: `default` (HuggingFace) or `fastokens` (high-performance Rust tokenizer). See [Tokenizer](Tokenizer.md) |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens` | Tokenizer: `fastokens` (high-performance Rust tokenizer) or `default` (HuggingFace). See [Tokenizer](Tokenizer.md) |
 
 ## Experimental
 

--- a/docs/features/tokenizer/README.md
+++ b/docs/features/tokenizer/README.md
@@ -7,9 +7,9 @@ subtitle: Reduce frontend tokenization latency for long-context BPE models
 
 The Dynamo frontend tokenizes every incoming prompt before it sends the request to an inference backend. For short prompts, that cost is usually small. For agentic, RAG, and long-context workloads, tokenization can become a meaningful part of time-to-first-token (TTFT), especially when KV cache hit rates are high and the model path is already fast.
 
-`fastokens` is an optional tokenizer backend for BPE `tokenizer.json` models. It uses the Rust encoder from the [`fastokens` GitHub repository](https://github.com/crusoecloud/fastokens) for text-to-token-ID conversion while Dynamo continues to use HuggingFace `tokenizers` for decoding and streaming output.
+`fastokens` is the default tokenizer backend for BPE `tokenizer.json` models. It uses the Rust encoder from the [`fastokens` GitHub repository](https://github.com/crusoecloud/fastokens) for text-to-token-ID conversion while Dynamo continues to use HuggingFace `tokenizers` for decoding and streaming output.
 
-Use it when tokenization is visible in your frontend latency profile and your model uses a supported BPE tokenizer.
+Use the `default` HuggingFace backend when validating a new or unusual tokenizer and you want maximum compatibility first.
 
 ## Why Use Fastokens?
 
@@ -29,11 +29,11 @@ Dynamo exposes `fastokens` as a frontend tokenizer backend. The integration is h
 - **Encoding**: `fastokens` converts prompt text to token IDs.
 - **Decoding**: HuggingFace `tokenizers` converts generated token IDs back to text.
 
-Both backends load from the same `tokenizer.json`, so supported tokenizers should produce the same token IDs as the default HuggingFace path. If `fastokens` cannot load the tokenizer file, Dynamo logs a warning and falls back to the default backend instead of dropping requests.
+Both backends load from the same `tokenizer.json`, so supported tokenizers should produce the same token IDs as the HuggingFace path. If `fastokens` cannot load the tokenizer file, Dynamo logs a warning and falls back to the HuggingFace backend instead of dropping requests.
 
 ```mermaid
 flowchart TD
-    Start["Frontend starts with<br/>--tokenizer fastokens"] --> Kind{"Tokenizer file type"}
+    Start["Frontend starts with<br/>fastokens selected"] --> Kind{"Tokenizer file type"}
     Kind -->|BPE tokenizer.json| Load{"fastokens loads?"}
     Kind -->|.model / .tiktoken| Other["Use existing TikToken backend"]
     Load -->|Yes| Fast["Encode with fastokens<br/>Decode with HuggingFace"]
@@ -45,7 +45,7 @@ flowchart TD
 
 ## When to Enable It
 
-Enable `fastokens` when:
+Use the default `fastokens` backend when:
 
 - Prompts are long, commonly thousands to tens of thousands of tokens.
 - Your workload is prefill-heavy, agentic, or RAG-heavy.
@@ -53,7 +53,7 @@ Enable `fastokens` when:
 - Frontend tokenizer latency shows up in metrics, traces, or profiling.
 - Your model uses a BPE `tokenizer.json`.
 
-Stay on the default backend if:
+Select the HuggingFace backend with `--tokenizer default` or `DYN_TOKENIZER=default` if:
 
 - Prompts are short and tokenization is not on the critical path.
 - You are validating a new or unusual tokenizer and want maximum compatibility first.
@@ -62,21 +62,22 @@ Stay on the default backend if:
 
 ## Quick Start
 
-Enable `fastokens` on the frontend with either the CLI flag or the environment variable. The CLI flag takes precedence.
+The frontend uses `fastokens` by default. Set the HuggingFace backend explicitly with either the CLI flag or the environment variable when you need it. The CLI flag takes precedence.
 
 ```bash
-# CLI flag
-python -m dynamo.frontend --tokenizer fastokens
+# Default fastokens backend
+python -m dynamo.frontend
 
-# Environment variable
-export DYN_TOKENIZER=fastokens
+# Explicit HuggingFace backend
+export DYN_TOKENIZER=default
 python -m dynamo.frontend
 ```
 
-To return to the default HuggingFace tokenizer backend, omit the flag or set `DYN_TOKENIZER=default`.
+You can also select either backend with the CLI flag:
 
 ```bash
 python -m dynamo.frontend --tokenizer default
+python -m dynamo.frontend --tokenizer fastokens
 ```
 
 No client changes are required. Request payloads, OpenAI-compatible API behavior, and streamed responses remain the same.
@@ -85,7 +86,7 @@ No client changes are required. Request payloads, OpenAI-compatible API behavior
 
 | CLI argument | Environment variable | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `default`, `fastokens` | `default` |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `default` | `fastokens` |
 
 ## Compatibility
 
@@ -108,7 +109,7 @@ The `fastokens` repository maintains the current [tested models list](https://gi
 - `mistralai/Devstral-Small-2-24B-Instruct-2512`
 - `zai-org/GLM-4.7`, `zai-org/GLM-5`
 
-For any new model, validate on representative prompts before rolling out broadly. The safest check is to compare token IDs against the default backend and confirm the frontend logs show the fast path was selected.
+For any new model, validate on representative prompts before rolling out broadly. The safest check is to compare token IDs against the HuggingFace backend and confirm the frontend logs show the fast path was selected.
 
 ## Verify the Backend
 
@@ -120,7 +121,7 @@ When `fastokens` is active, look for:
 Using fastokens tokenizer backend
 ```
 
-If the tokenizer is unsupported, Dynamo keeps serving with the default backend and logs:
+If the tokenizer is unsupported, Dynamo keeps serving with the HuggingFace backend and logs:
 
 ```text
 Failed to load fastokens, falling back to HuggingFace
@@ -147,8 +148,8 @@ See the [frontend benchmarking guide](https://github.com/ai-dynamo/dynamo/tree/m
 
 ## Troubleshooting
 
-**I enabled `fastokens`, but the logs do not show `Using fastokens tokenizer backend`.**
-Make sure the setting is applied to the frontend process, not only to the backend worker. For local launches, pass `--tokenizer fastokens` to `python -m dynamo.frontend` or set `DYN_TOKENIZER=fastokens` before starting the frontend. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
+**I expected `fastokens`, but the logs do not show `Using fastokens tokenizer backend`.**
+Make sure the setting is not overridden to `default` on the frontend process. For local launches, omit `--tokenizer` or pass `--tokenizer fastokens` to `python -m dynamo.frontend`; for environment configuration, unset `DYN_TOKENIZER` or set `DYN_TOKENIZER=fastokens`. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
 
 **The frontend logs `Failed to load fastokens, falling back to HuggingFace`.**
 The model's tokenizer file uses a feature that `fastokens` does not support, or it is not a BPE `tokenizer.json` path. Dynamo has already fallen back to HuggingFace and should keep serving traffic. Check the tokenizer format, compare against the [tested models list](https://github.com/crusoecloud/fastokens#tested-models), and use `--tokenizer default` if you want to avoid the warning.
@@ -169,7 +170,7 @@ Inspect each run artifact and frontend log to confirm the backend actually chang
 Do not roll out that model with `fastokens`. Reproduce the mismatch with a minimal prompt and file an issue with the model name, tokenizer file, prompt, and whether the model appears on the tested models list.
 
 **Decoded output looks wrong.**
-Decoding still uses HuggingFace, so this is usually not caused by the `fastokens` flag. Verify that the tokenizer files match the model weights and that the default backend produces the expected output.
+Decoding still uses HuggingFace, so this is usually not caused by the `fastokens` flag. Verify that the tokenizer files match the model weights and that the HuggingFace backend produces the expected output.
 
 ## See Also
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -948,7 +948,7 @@ impl ModelDeploymentCard {
     /// This supports both HuggingFace `tokenizer.json` and tiktoken `.model`/`.tiktoken` files.
     ///
     /// Env-var controls:
-    /// - `DYN_TOKENIZER=fastokens` — use `fastokens` as the encoding backend
+    /// - `DYN_TOKENIZER=default` — use HuggingFace encoding instead of the default `fastokens` backend
     /// - `DYN_TOKENIZER_CACHE=1` — wrap the tokenizer in an L1 prefix cache that records
     ///   tokenizations at special-token boundaries (massive speed-up for shared chat
     ///   prefixes; default off, zero cost when unset)
@@ -960,16 +960,16 @@ impl ModelDeploymentCard {
     ///   fall back to the original hit-without-insert behavior.
     pub fn tokenizer(&self) -> anyhow::Result<crate::tokenizers::Tokenizer> {
         let use_fast = match std::env::var("DYN_TOKENIZER") {
-            Ok(v) if v == "fastokens" => true,
-            Ok(v) if v == "default" || v.is_empty() => false,
+            Ok(v) if v == "default" => false,
+            Ok(v) if v == "fastokens" || v.is_empty() => true,
             Ok(v) => {
                 tracing::warn!(
                     value = %v,
-                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'default'; falling back to default"
+                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'default'; falling back to fastokens"
                 );
-                false
+                true
             }
-            Err(_) => false,
+            Err(_) => true,
         };
 
         let cache_enabled = matches!(


### PR DESCRIPTION
Makes `fastokens` the default tokenizer backend for Dynamo frontend BPE tokenization.

Assigned target: https://github.com/ai-dynamo/dynamo

## Summary
- Defaults frontend `--tokenizer` / `DYN_TOKENIZER` to `fastokens`.
- Defaults the Rust tokenizer selection to `fastokens` when `DYN_TOKENIZER` is unset, empty, or invalid.
- Keeps `--tokenizer default` / `DYN_TOKENIZER=default` as the explicit HuggingFace opt-out.
- Updates tokenizer docs and configuration tests for the new default.

## Validation
- `python3 -m py_compile components/src/dynamo/frontend/frontend_args.py components/src/dynamo/common/tests/configuration/test_kv_router_args.py`
- `git diff --check HEAD~1..HEAD`
- Static Python assertions for frontend and Rust tokenizer fallback defaults.

## Notes
- Could not run Rust tests because `cargo` is not installed in the runner.
- Could not run pytest because dependency resolution failed for the repository extras (`ai-dynamo[sglang]` conflicts with `ai-dynamo[vllm]` on `nixl[cu13]`).

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11517" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The Dynamo Frontend now uses the high-performance `fastokens` tokenizer backend by default for BPE models.
  * Explicitly selecting `default` continues to use HuggingFace tokenizers.
  * If `fastokens` cannot load a tokenizer, the frontend logs a warning and falls back to HuggingFace without dropping requests.
  * CLI options take precedence over the `DYN_TOKENIZER` environment variable.

* **Documentation**
  * Updated tokenizer configuration, compatibility, fallback, and troubleshooting guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->