### PR TITLE
refactor(frontend): rename tokenizer default option

### DIFF
--- a/benchmarks/frontend/dgd/templates/mocker.yaml
+++ b/benchmarks/frontend/dgd/templates/mocker.yaml
@@ -6,7 +6,7 @@
 # Template variables (substituted by sweep_runner.py --deploy-template):
 #   ${DGD_NAME}              - DynamoGraphDeployment name
 #   ${IMAGE}                 - Container image
-#   ${DYN_TOKENIZER}         - "default" (hf) or "fastokens"
+#   ${DYN_TOKENIZER}         - "huggingface" (hf) or "fastokens"
 #   ${FRONTEND_PORT}         - Frontend HTTP port
 #   ${ROUTER_MODE}           - Frontend router mode
 #   ${MODEL_PATH}            - HF model ID

--- a/benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm-gpt-oss-20b.yaml
@@ -12,7 +12,7 @@
 # Template variables (substituted by sweep_runner.py --deploy-template):
 #   ${DGD_NAME}              - DynamoGraphDeployment name
 #   ${IMAGE}                 - Container image
-#   ${DYN_TOKENIZER}         - "default" (hf) or "fastokens"
+#   ${DYN_TOKENIZER}         - "huggingface" (hf) or "fastokens"
 #   ${FRONTEND_PORT}         - Frontend HTTP port (default: 8000)
 #   ${ROUTER_MODE}           - Frontend router mode (default: round-robin)
 #   ${MODEL}                 - Model path (HF ID or local path on PVC)

--- a/benchmarks/frontend/dgd/templates/vllm.yaml
+++ b/benchmarks/frontend/dgd/templates/vllm.yaml
@@ -6,7 +6,7 @@
 # Template variables (substituted by sweep_runner.py --deploy-template):
 #   ${DGD_NAME}              - DynamoGraphDeployment name
 #   ${IMAGE}                 - Container image
-#   ${DYN_TOKENIZER}         - "default" (hf) or "fastokens"
+#   ${DYN_TOKENIZER}         - "huggingface" (hf) or "fastokens"
 #   ${FRONTEND_PORT}         - Frontend HTTP port
 #   ${ROUTER_MODE}           - Frontend router mode
 #   ${MODEL}                 - HF model ID

--- a/benchmarks/frontend/scripts/run_perf.sh
+++ b/benchmarks/frontend/scripts/run_perf.sh
@@ -127,7 +127,7 @@ Service Options:
   --event-plane PLANE       nats|zmq (default: nats)
   --frontend-port PORT      Frontend HTTP port (default: 8000)
   --planner-profile PATH    Planner profile data path
-  --tokenizer-backend NAME  Tokenizer backend: "fast" or "hf" (default: unset, uses HF)
+  --tokenizer-backend NAME  Tokenizer backend: "fast" or "hf" (default: unset, uses fastokens)
   --fast-tokens             Shorthand for --tokenizer-backend fast
   --num-models N            Number of model instances (default: 1). Each gets --workers workers
                             with names model-1, model-2, ...
@@ -212,7 +212,7 @@ echo "║          Unified Observability Capture                      ║"
 echo "╚══════════════════════════════════════════════════════════════╝"
 echo ""
 echo "Output:    $OUTPUT_DIR"
-echo "Tokenizer: ${TOKENIZER_BACKEND:-hf (default)}"
+echo "Tokenizer: ${TOKENIZER_BACKEND:-fastokens (default)}"
 echo ""
 
 # ─── Pre-flight: detect available tools ──────────────────────────────────────
@@ -433,10 +433,10 @@ FRONTEND_ENV=(
 
 if [[ -n "$TOKENIZER_BACKEND" ]]; then
     # Map human-readable CLI values to DYN_TOKENIZER env var values
-    # (Rust model_card.rs reads DYN_TOKENIZER, expects "fastokens" or "default")
+    # (Rust model_card.rs reads DYN_TOKENIZER, expects "fastokens" or "huggingface")
     case "$TOKENIZER_BACKEND" in
         fast|fastokens) _DYN_TOK_VAL="fastokens" ;;
-        hf|default|"")  _DYN_TOK_VAL="default" ;;
+        hf|huggingface|"")  _DYN_TOK_VAL="huggingface" ;;
         *)               _DYN_TOK_VAL="$TOKENIZER_BACKEND" ;;
     esac
     FRONTEND_ENV+=(DYN_TOKENIZER="$_DYN_TOK_VAL")

--- a/benchmarks/frontend/scripts/scaling-test.md
+++ b/benchmarks/frontend/scripts/scaling-test.md
@@ -129,7 +129,7 @@ spec:
           args: ["python3 -m dynamo.frontend --router-mode round-robin --http-port 8000"]
           env:
             - name: DYN_TOKENIZER
-              value: "default"
+              value: "huggingface"
             - name: DYN_PERF_DIAG
               value: "1"
             - name: HF_HOME

--- a/benchmarks/frontend/scripts/sweep_k8s/dgd.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/dgd.py
@@ -28,10 +28,10 @@ from sweep_k8s.kubectl import (
 )
 
 # Tokenizer name mapping for DGD env vars (DYN_TOKENIZER accepts
-# "default" or "fastokens")
+# "huggingface" or "fastokens")
 TOKENIZER_BACKEND_MAP = {
-    "hf": "default",
-    "default": "default",
+    "hf": "huggingface",
+    "huggingface": "huggingface",
     "fast": "fastokens",
     "fastokens": "fastokens",
 }

--- a/benchmarks/frontend/scripts/sweep_k8s/template.py
+++ b/benchmarks/frontend/scripts/sweep_k8s/template.py
@@ -18,10 +18,10 @@ from sweep_core.models import DeployDimension, SweepConfig
 from sweep_k8s.kubectl import apply_yaml
 
 # Tokenizer name mapping for template substitution (DYN_TOKENIZER accepts
-# "default" or "fastokens")
+# "huggingface" or "fastokens")
 TOKENIZER_TEMPLATE_MAP = {
-    "hf": "default",
-    "default": "default",
+    "hf": "huggingface",
+    "huggingface": "huggingface",
     "fast": "fastokens",
     "fastokens": "fastokens",
 }

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -459,6 +459,32 @@ def test_load_aware_frontend_implies_kv_router_mode() -> None:
     assert config.router_assume_kv_reuse is False
 
 
+def test_frontend_tokenizer_defaults_to_fastokens(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_TOKENIZER", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args([])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.tokenizer_backend == "fastokens"
+
+
+def test_frontend_tokenizer_env_and_cli_precedence(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_TOKENIZER", "default")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(["--tokenizer", "fastokens"])
+
+    config = FrontendConfig.from_cli_args(args)
+    config.validate()
+
+    assert config.tokenizer_backend == "fastokens"
+
+
 def test_frontend_admission_control_defaults_to_none(monkeypatch) -> None:
     """Default --admission-control is 'none': busy thresholds are cleared
     even though the underlying threshold flags have non-None defaults."""

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -473,7 +473,7 @@ def test_frontend_tokenizer_defaults_to_fastokens(monkeypatch) -> None:
 
 
 def test_frontend_tokenizer_env_and_cli_precedence(monkeypatch) -> None:
-    monkeypatch.setenv("DYN_TOKENIZER", "default")
+    monkeypatch.setenv("DYN_TOKENIZER", "huggingface")
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
 

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -477,11 +477,11 @@ class FrontendArgGroup(ArgGroup):
             g,
             flag_name="--tokenizer",
             env_var="DYN_TOKENIZER",
-            default="default",
+            default="fastokens",
             dest="tokenizer_backend",
             help=(
-                "Tokenizer backend for BPE models: 'default' (HuggingFace tokenizers library) "
-                "or 'fastokens' (fastokens crate for high-performance BPE encoding). "
+                "Tokenizer backend for BPE models: 'fastokens' (fastokens crate for high-performance BPE encoding) "
+                "or 'default' (HuggingFace tokenizers library). "
                 "Decoding always uses HuggingFace. Has no effect on TikToken models."
             ),
             choices=["default", "fastokens"],

--- a/components/src/dynamo/frontend/frontend_args.py
+++ b/components/src/dynamo/frontend/frontend_args.py
@@ -86,7 +86,7 @@ class FrontendConfig(RouterConfigBase, KvRouterConfigBase, AicPerfConfigBase):
     tokenizer_backend: str
     trust_remote_code: bool
 
-    _VALID_TOKENIZER_BACKENDS = {"default", "fastokens"}
+    _VALID_TOKENIZER_BACKENDS = {"huggingface", "fastokens"}
 
     def validate(self) -> None:
         if self.load_aware:
@@ -481,10 +481,10 @@ class FrontendArgGroup(ArgGroup):
             dest="tokenizer_backend",
             help=(
                 "Tokenizer backend for BPE models: 'fastokens' (fastokens crate for high-performance BPE encoding) "
-                "or 'default' (HuggingFace tokenizers library). "
+                "or 'huggingface' (HuggingFace tokenizers library). "
                 "Decoding always uses HuggingFace. Has no effect on TikToken models."
             ),
-            choices=["default", "fastokens"],
+            choices=["huggingface", "fastokens"],
         )
 
         add_negatable_bool_argument(

--- a/docs/components/frontend/Tokenizer.md
+++ b/docs/components/frontend/Tokenizer.md
@@ -14,7 +14,7 @@ The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenize
 The default `fastokens` backend uses the [`fastokens`](https://github.com/Atero-ai/fastokens) crate, a purpose-built encoder optimized for throughput on supported BPE `tokenizer.json` models.
 It is a _hybrid_ backend: encoding uses `fastokens` while decoding falls back to HuggingFace so that incremental detokenization, byte-fallback, and special-token handling work correctly.
 
-#### `default` HuggingFace Tokenizers
+#### `huggingface` Tokenizers
 
 The HuggingFace backend uses the [HuggingFace `tokenizers`](https://github.com/huggingface/tokenizers) library (Rust).
 It supports features in `tokenizer.json` files (normalizers, pre-tokenizers, post-processors, decoders, added tokens with special-token flags, and byte-fallback).
@@ -33,7 +33,7 @@ Set the backend with a CLI flag or environment variable. The CLI flag takes prec
 
 | CLI Argument | Env Var | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `default` | `fastokens` |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `huggingface` | `fastokens` |
 
 **Examples:**
 
@@ -42,7 +42,7 @@ Set the backend with a CLI flag or environment variable. The CLI flag takes prec
 python -m dynamo.frontend
 
 # Explicit environment variable
-export DYN_TOKENIZER=default
+export DYN_TOKENIZER=huggingface
 python -m dynamo.frontend
 ```
 
@@ -53,4 +53,4 @@ When `fastokens` is selected by default, by `--tokenizer fastokens`, or by `DYN_
 1. The frontend passes the environment variable to the Rust runtime.
 2. When building the tokenizer for a model, `ModelDeploymentCard::tokenizer()` attempts to load `fastokens::Tokenizer` from the same `tokenizer.json` file.
 3. If loading succeeds, a hybrid `FastTokenizer` is created that encodes with `fastokens` and decodes with HuggingFace.
-4. If loading fails (unsupported tokenizer features, missing file, etc.), the frontend logs a warning and falls back to the standard HuggingFace backend; no operator intervention is needed.
+4. If loading fails (unsupported tokenizer features, missing file, etc.), the frontend logs a warning and falls back to the `huggingface` backend; no operator intervention is needed.

--- a/docs/components/frontend/Tokenizer.md
+++ b/docs/components/frontend/Tokenizer.md
@@ -2,23 +2,24 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: Tokenizer
+subtitle: Selects between the default fastokens and HuggingFace tokenizer backends for BPE models served through the Dynamo Frontend.
 ---
 
-The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: both the default HuggingFace path and the `fastokens` path can serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.
+The Dynamo Frontend supports multiple tokenizer backends for BPE-based `tokenizer.json` models. `BPE` is the underlying tokenization algorithm, not a backend-specific feature: both the HuggingFace path and the default `fastokens` path can serve these models. The backend choice controls which implementation performs tokenization before requests are sent to the inference engine.
 
 ## Tokenizer Backends
 
-#### `default` HuggingFace Tokenizers
-
-The default backend uses the [HuggingFace `tokenizers`](https://github.com/huggingface/tokenizers) library (Rust).
-It supports features in `tokenizer.json` files (normalizers, pre-tokenizers, post-processors, decoders, added tokens with special-token flags, and byte-fallback).
-
 #### `fastokens` High-Performance Encoder
 
-The `fastokens` backend uses the [`fastokens`](https://github.com/Atero-ai/fastokens) crate, a purpose-built encoder optimized for throughput on supported BPE `tokenizer.json` models.
+The default `fastokens` backend uses the [`fastokens`](https://github.com/Atero-ai/fastokens) crate, a purpose-built encoder optimized for throughput on supported BPE `tokenizer.json` models.
 It is a _hybrid_ backend: encoding uses `fastokens` while decoding falls back to HuggingFace so that incremental detokenization, byte-fallback, and special-token handling work correctly.
 
-Use this backend when tokenization is a measurable bottleneck, for example on high-concurrency prefill-heavy workloads.
+#### `default` HuggingFace Tokenizers
+
+The HuggingFace backend uses the [HuggingFace `tokenizers`](https://github.com/huggingface/tokenizers) library (Rust).
+It supports features in `tokenizer.json` files (normalizers, pre-tokenizers, post-processors, decoders, added tokens with special-token flags, and byte-fallback).
+
+Use this backend when validating a new or unusual tokenizer and you want maximum compatibility first.
 
 #### Compatibility notes:
 
@@ -32,22 +33,22 @@ Set the backend with a CLI flag or environment variable. The CLI flag takes prec
 
 | CLI Argument | Env Var | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `default`, `fastokens` | `default` |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `default` | `fastokens` |
 
 **Examples:**
 
 ```bash
-# CLI flag
-python -m dynamo.frontend --tokenizer fastokens
+# Default fastokens backend
+python -m dynamo.frontend
 
-# Environment variable
-export DYN_TOKENIZER=fastokens
+# Explicit environment variable
+export DYN_TOKENIZER=default
 python -m dynamo.frontend
 ```
 
 ## Dynamo Frontend Behavior
 
-When `DYN_TOKENIZER=fastokens` is set:
+When `fastokens` is selected by default, by `--tokenizer fastokens`, or by `DYN_TOKENIZER=fastokens`:
 
 1. The frontend passes the environment variable to the Rust runtime.
 2. When building the tokenizer for a model, `ModelDeploymentCard::tokenizer()` attempts to load `fastokens::Tokenizer` from the same `tokenizer.json` file.

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -116,7 +116,7 @@ See the [Frontend Guide](frontend-guide.md) for KServe message formats and integ
 
 | CLI Argument | Env Var | Default | Description |
 |-------------|---------|---------|-------------|
-| `--tokenizer` | `DYN_TOKENIZER` | `default` | Tokenizer: `default` (HuggingFace) or `fastokens` (high-performance Rust tokenizer). See [Tokenizer](Tokenizer.md) |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens` | Tokenizer: `fastokens` (high-performance Rust tokenizer) or `default` (HuggingFace). See [Tokenizer](Tokenizer.md) |
 
 ## Experimental
 

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -116,7 +116,7 @@ See the [Frontend Guide](frontend-guide.md) for KServe message formats and integ
 
 | CLI Argument | Env Var | Default | Description |
 |-------------|---------|---------|-------------|
-| `--tokenizer` | `DYN_TOKENIZER` | `fastokens` | Tokenizer: `fastokens` (high-performance Rust tokenizer) or `default` (HuggingFace). See [Tokenizer](Tokenizer.md) |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens` | Tokenizer: `fastokens` (high-performance Rust tokenizer) or `huggingface` (HuggingFace). See [Tokenizer](Tokenizer.md) |
 
 ## Experimental
 

--- a/docs/features/tokenizer/README.md
+++ b/docs/features/tokenizer/README.md
@@ -9,7 +9,7 @@ The Dynamo frontend tokenizes every incoming prompt before it sends the request 
 
 `fastokens` is the default tokenizer backend for BPE `tokenizer.json` models. It uses the Rust encoder from the [`fastokens` GitHub repository](https://github.com/crusoecloud/fastokens) for text-to-token-ID conversion while Dynamo continues to use HuggingFace `tokenizers` for decoding and streaming output.
 
-Use the `default` HuggingFace backend when validating a new or unusual tokenizer and you want maximum compatibility first.
+Use the `huggingface` backend when validating a new or unusual tokenizer and you want maximum compatibility first.
 
 ## Why Use Fastokens?
 
@@ -29,7 +29,7 @@ Dynamo exposes `fastokens` as a frontend tokenizer backend. The integration is h
 - **Encoding**: `fastokens` converts prompt text to token IDs.
 - **Decoding**: HuggingFace `tokenizers` converts generated token IDs back to text.
 
-Both backends load from the same `tokenizer.json`, so supported tokenizers should produce the same token IDs as the HuggingFace path. If `fastokens` cannot load the tokenizer file, Dynamo logs a warning and falls back to the HuggingFace backend instead of dropping requests.
+Both backends load from the same `tokenizer.json`, so supported tokenizers should produce the same token IDs as the HuggingFace path. If `fastokens` cannot load the tokenizer file, Dynamo logs a warning and falls back to the `huggingface` backend instead of dropping requests.
 
 ```mermaid
 flowchart TD
@@ -53,7 +53,7 @@ Use the default `fastokens` backend when:
 - Frontend tokenizer latency shows up in metrics, traces, or profiling.
 - Your model uses a BPE `tokenizer.json`.
 
-Select the HuggingFace backend with `--tokenizer default` or `DYN_TOKENIZER=default` if:
+Select the HuggingFace backend with `--tokenizer huggingface` or `DYN_TOKENIZER=huggingface` if:
 
 - Prompts are short and tokenization is not on the critical path.
 - You are validating a new or unusual tokenizer and want maximum compatibility first.
@@ -69,14 +69,14 @@ The frontend uses `fastokens` by default. Set the HuggingFace backend explicitly
 python -m dynamo.frontend
 
 # Explicit HuggingFace backend
-export DYN_TOKENIZER=default
+export DYN_TOKENIZER=huggingface
 python -m dynamo.frontend
 ```
 
 You can also select either backend with the CLI flag:
 
 ```bash
-python -m dynamo.frontend --tokenizer default
+python -m dynamo.frontend --tokenizer huggingface
 python -m dynamo.frontend --tokenizer fastokens
 ```
 
@@ -86,7 +86,7 @@ No client changes are required. Request payloads, OpenAI-compatible API behavior
 
 | CLI argument | Environment variable | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `default` | `fastokens` |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `huggingface` | `fastokens` |
 
 ## Compatibility
 
@@ -149,13 +149,13 @@ See the [frontend benchmarking guide](https://github.com/ai-dynamo/dynamo/tree/m
 ## Troubleshooting
 
 **I expected `fastokens`, but the logs do not show `Using fastokens tokenizer backend`.**
-Make sure the setting is not overridden to `default` on the frontend process. For local launches, omit `--tokenizer` or pass `--tokenizer fastokens` to `python -m dynamo.frontend`; for environment configuration, unset `DYN_TOKENIZER` or set `DYN_TOKENIZER=fastokens`. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
+Make sure the setting is not overridden to `huggingface` on the frontend process. For local launches, omit `--tokenizer` or pass `--tokenizer fastokens` to `python -m dynamo.frontend`; for environment configuration, unset `DYN_TOKENIZER` or set `DYN_TOKENIZER=fastokens`. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
 
 **The frontend logs `Failed to load fastokens, falling back to HuggingFace`.**
-The model's tokenizer file uses a feature that `fastokens` does not support, or it is not a BPE `tokenizer.json` path. Dynamo has already fallen back to HuggingFace and should keep serving traffic. Check the tokenizer format, compare against the [tested models list](https://github.com/crusoecloud/fastokens#tested-models), and use `--tokenizer default` if you want to avoid the warning.
+The model's tokenizer file uses a feature that `fastokens` does not support, or it is not a BPE `tokenizer.json` path. Dynamo has already fallen back to HuggingFace and should keep serving traffic. Check the tokenizer format, compare against the [tested models list](https://github.com/crusoecloud/fastokens#tested-models), and use `--tokenizer huggingface` if you want to avoid the warning.
 
 **The frontend logs `Unrecognized DYN_TOKENIZER value`.**
-Use only `fastokens` or `default` for `DYN_TOKENIZER`. Values such as `fast`, `hf`, or `huggingface` are benchmark-runner aliases, not valid values for the frontend environment variable.
+Use only `fastokens` or `huggingface` for `DYN_TOKENIZER`. Values such as `fast`, `hf`, or `default` are benchmark-runner aliases, not valid values for the frontend environment variable.
 
 **The model uses `.model` or `.tiktoken` files.**
 The `fastokens` flag has no effect for TikToken-format tokenizers. Dynamo uses the existing TikToken backend, so you should not expect the `Using fastokens tokenizer backend` log or a `fastokens` speedup.

--- a/docs/features/tokenizer/README.md
+++ b/docs/features/tokenizer/README.md
@@ -7,9 +7,9 @@ subtitle: Reduce frontend tokenization latency for long-context BPE models
 
 The Dynamo frontend tokenizes every incoming prompt before it sends the request to an inference backend. For short prompts, that cost is usually small. For agentic, RAG, and long-context workloads, tokenization can become a meaningful part of time-to-first-token (TTFT), especially when KV cache hit rates are high and the model path is already fast.
 
-`fastokens` is an optional tokenizer backend for BPE `tokenizer.json` models. It uses the Rust encoder from the [`fastokens` GitHub repository](https://github.com/crusoecloud/fastokens) for text-to-token-ID conversion while Dynamo continues to use HuggingFace `tokenizers` for decoding and streaming output.
+`fastokens` is the default tokenizer backend for BPE `tokenizer.json` models. It uses the Rust encoder from the [`fastokens` GitHub repository](https://github.com/crusoecloud/fastokens) for text-to-token-ID conversion while Dynamo continues to use HuggingFace `tokenizers` for decoding and streaming output.
 
-Use it when tokenization is visible in your frontend latency profile and your model uses a supported BPE tokenizer.
+Use the `default` HuggingFace backend when validating a new or unusual tokenizer and you want maximum compatibility first.
 
 ## Why Use Fastokens?
 
@@ -29,11 +29,11 @@ Dynamo exposes `fastokens` as a frontend tokenizer backend. The integration is h
 - **Encoding**: `fastokens` converts prompt text to token IDs.
 - **Decoding**: HuggingFace `tokenizers` converts generated token IDs back to text.
 
-Both backends load from the same `tokenizer.json`, so supported tokenizers should produce the same token IDs as the default HuggingFace path. If `fastokens` cannot load the tokenizer file, Dynamo logs a warning and falls back to the default backend instead of dropping requests.
+Both backends load from the same `tokenizer.json`, so supported tokenizers should produce the same token IDs as the HuggingFace path. If `fastokens` cannot load the tokenizer file, Dynamo logs a warning and falls back to the HuggingFace backend instead of dropping requests.
 
 ```mermaid
 flowchart TD
-    Start["Frontend starts with<br/>--tokenizer fastokens"] --> Kind{"Tokenizer file type"}
+    Start["Frontend starts with<br/>fastokens selected"] --> Kind{"Tokenizer file type"}
     Kind -->|BPE tokenizer.json| Load{"fastokens loads?"}
     Kind -->|.model / .tiktoken| Other["Use existing TikToken backend"]
     Load -->|Yes| Fast["Encode with fastokens<br/>Decode with HuggingFace"]
@@ -45,7 +45,7 @@ flowchart TD
 
 ## When to Enable It
 
-Enable `fastokens` when:
+Use the default `fastokens` backend when:
 
 - Prompts are long, commonly thousands to tens of thousands of tokens.
 - Your workload is prefill-heavy, agentic, or RAG-heavy.
@@ -53,7 +53,7 @@ Enable `fastokens` when:
 - Frontend tokenizer latency shows up in metrics, traces, or profiling.
 - Your model uses a BPE `tokenizer.json`.
 
-Stay on the default backend if:
+Select the HuggingFace backend with `--tokenizer default` or `DYN_TOKENIZER=default` if:
 
 - Prompts are short and tokenization is not on the critical path.
 - You are validating a new or unusual tokenizer and want maximum compatibility first.
@@ -62,21 +62,22 @@ Stay on the default backend if:
 
 ## Quick Start
 
-Enable `fastokens` on the frontend with either the CLI flag or the environment variable. The CLI flag takes precedence.
+The frontend uses `fastokens` by default. Set the HuggingFace backend explicitly with either the CLI flag or the environment variable when you need it. The CLI flag takes precedence.
 
 ```bash
-# CLI flag
-python -m dynamo.frontend --tokenizer fastokens
+# Default fastokens backend
+python -m dynamo.frontend
 
-# Environment variable
-export DYN_TOKENIZER=fastokens
+# Explicit HuggingFace backend
+export DYN_TOKENIZER=default
 python -m dynamo.frontend
 ```
 
-To return to the default HuggingFace tokenizer backend, omit the flag or set `DYN_TOKENIZER=default`.
+You can also select either backend with the CLI flag:
 
 ```bash
 python -m dynamo.frontend --tokenizer default
+python -m dynamo.frontend --tokenizer fastokens
 ```
 
 No client changes are required. Request payloads, OpenAI-compatible API behavior, and streamed responses remain the same.
@@ -85,7 +86,7 @@ No client changes are required. Request payloads, OpenAI-compatible API behavior
 
 | CLI argument | Environment variable | Valid values | Default |
 |---|---|---|---|
-| `--tokenizer` | `DYN_TOKENIZER` | `default`, `fastokens` | `default` |
+| `--tokenizer` | `DYN_TOKENIZER` | `fastokens`, `default` | `fastokens` |
 
 ## Compatibility
 
@@ -108,7 +109,7 @@ The `fastokens` repository maintains the current [tested models list](https://gi
 - `mistralai/Devstral-Small-2-24B-Instruct-2512`
 - `zai-org/GLM-4.7`, `zai-org/GLM-5`
 
-For any new model, validate on representative prompts before rolling out broadly. The safest check is to compare token IDs against the default backend and confirm the frontend logs show the fast path was selected.
+For any new model, validate on representative prompts before rolling out broadly. The safest check is to compare token IDs against the HuggingFace backend and confirm the frontend logs show the fast path was selected.
 
 ## Verify the Backend
 
@@ -120,7 +121,7 @@ When `fastokens` is active, look for:
 Using fastokens tokenizer backend
 ```
 
-If the tokenizer is unsupported, Dynamo keeps serving with the default backend and logs:
+If the tokenizer is unsupported, Dynamo keeps serving with the HuggingFace backend and logs:
 
 ```text
 Failed to load fastokens, falling back to HuggingFace
@@ -147,8 +148,8 @@ See the [frontend benchmarking guide](https://github.com/ai-dynamo/dynamo/tree/m
 
 ## Troubleshooting
 
-**I enabled `fastokens`, but the logs do not show `Using fastokens tokenizer backend`.**
-Make sure the setting is applied to the frontend process, not only to the backend worker. For local launches, pass `--tokenizer fastokens` to `python -m dynamo.frontend` or set `DYN_TOKENIZER=fastokens` before starting the frontend. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
+**I expected `fastokens`, but the logs do not show `Using fastokens tokenizer backend`.**
+Make sure the setting is not overridden to `default` on the frontend process. For local launches, omit `--tokenizer` or pass `--tokenizer fastokens` to `python -m dynamo.frontend`; for environment configuration, unset `DYN_TOKENIZER` or set `DYN_TOKENIZER=fastokens`. For benchmark DGD templates, use `DYN_TOKENIZER=fastokens`; the sweep runner maps `--tokenizers fastokens` to that value and restarts the frontend pod.
 
 **The frontend logs `Failed to load fastokens, falling back to HuggingFace`.**
 The model's tokenizer file uses a feature that `fastokens` does not support, or it is not a BPE `tokenizer.json` path. Dynamo has already fallen back to HuggingFace and should keep serving traffic. Check the tokenizer format, compare against the [tested models list](https://github.com/crusoecloud/fastokens#tested-models), and use `--tokenizer default` if you want to avoid the warning.
@@ -169,7 +170,7 @@ Inspect each run artifact and frontend log to confirm the backend actually chang
 Do not roll out that model with `fastokens`. Reproduce the mismatch with a minimal prompt and file an issue with the model name, tokenizer file, prompt, and whether the model appears on the tested models list.
 
 **Decoded output looks wrong.**
-Decoding still uses HuggingFace, so this is usually not caused by the `fastokens` flag. Verify that the tokenizer files match the model weights and that the default backend produces the expected output.
+Decoding still uses HuggingFace, so this is usually not caused by the `fastokens` flag. Verify that the tokenizer files match the model weights and that the HuggingFace backend produces the expected output.
 
 ## See Also
 

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -948,7 +948,7 @@ impl ModelDeploymentCard {
     /// This supports both HuggingFace `tokenizer.json` and tiktoken `.model`/`.tiktoken` files.
     ///
     /// Env-var controls:
-    /// - `DYN_TOKENIZER=default` — use HuggingFace encoding instead of the default `fastokens` backend
+    /// - `DYN_TOKENIZER=huggingface` — use HuggingFace encoding instead of the default `fastokens` backend
     /// - `DYN_TOKENIZER_CACHE=1` — wrap the tokenizer in an L1 prefix cache that records
     ///   tokenizations at special-token boundaries (massive speed-up for shared chat
     ///   prefixes; default off, zero cost when unset)
@@ -960,12 +960,12 @@ impl ModelDeploymentCard {
     ///   fall back to the original hit-without-insert behavior.
     pub fn tokenizer(&self) -> anyhow::Result<crate::tokenizers::Tokenizer> {
         let use_fast = match std::env::var("DYN_TOKENIZER") {
-            Ok(v) if v == "default" => false,
+            Ok(v) if v == "huggingface" => false,
             Ok(v) if v == "fastokens" || v.is_empty() => true,
             Ok(v) => {
                 tracing::warn!(
                     value = %v,
-                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'default'; falling back to fastokens"
+                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'huggingface'; falling back to fastokens"
                 );
                 true
             }

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -948,7 +948,7 @@ impl ModelDeploymentCard {
     /// This supports both HuggingFace `tokenizer.json` and tiktoken `.model`/`.tiktoken` files.
     ///
     /// Env-var controls:
-    /// - `DYN_TOKENIZER=fastokens` — use `fastokens` as the encoding backend
+    /// - `DYN_TOKENIZER=default` — use HuggingFace encoding instead of the default `fastokens` backend
     /// - `DYN_TOKENIZER_CACHE=1` — wrap the tokenizer in an L1 prefix cache that records
     ///   tokenizations at special-token boundaries (massive speed-up for shared chat
     ///   prefixes; default off, zero cost when unset)
@@ -960,16 +960,16 @@ impl ModelDeploymentCard {
     ///   fall back to the original hit-without-insert behavior.
     pub fn tokenizer(&self) -> anyhow::Result<crate::tokenizers::Tokenizer> {
         let use_fast = match std::env::var("DYN_TOKENIZER") {
-            Ok(v) if v == "fastokens" => true,
-            Ok(v) if v == "default" || v.is_empty() => false,
+            Ok(v) if v == "default" => false,
+            Ok(v) if v == "fastokens" || v.is_empty() => true,
             Ok(v) => {
                 tracing::warn!(
                     value = %v,
-                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'default'; falling back to default"
+                    "Unrecognized DYN_TOKENIZER value, expected 'fastokens' or 'default'; falling back to fastokens"
                 );
-                false
+                true
             }
-            Err(_) => false,
+            Err(_) => true,
         };
 
         let cache_enabled = matches!(


### PR DESCRIPTION
Renames the explicit HuggingFace tokenizer selection from `default` to `huggingface` and documents fastokens fallback behavior.

Assigned target: https://github.com/ai-dynamo/dynamo

## Summary
- Replaces the `DYN_TOKENIZER=default` / `--tokenizer default` option with `huggingface`.
- Updates tokenizer docs to state that unsupported `fastokens` tokenizers fall back to HuggingFace.
- Keeps benchmark helper aliases (`hf`) mapped to the new `huggingface` environment value.

## Validation
- `python3 -m py_compile components/src/dynamo/frontend/frontend_args.py components/src/dynamo/common/tests/configuration/test_kv_router_args.py benchmarks/frontend/scripts/sweep_k8s/dgd.py benchmarks/frontend/scripts/sweep_k8s/template.py benchmarks/frontend/scripts/sweep_executors/local.py`
- `bash -n benchmarks/frontend/scripts/run_perf.sh`
- `git diff --check`
- Static tokenizer rename checks via Python script

## Notes
- This is layered on top of #11517, which makes `fastokens` the default tokenizer backend.
- `python3 -m pytest components/src/dynamo/common/tests/configuration/test_kv_router_args.py -k tokenizer -q` could not run because `pytest`, `pip`, and `ensurepip` are not installed in the runner.
- `cargo test -p dynamo-llm tokenizer --lib` could not run because `cargo` is not installed in the runner.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11518" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Fastokens is now the default tokenizer backend.
  * HuggingFace tokenization can be selected explicitly with `huggingface`.

* **Bug Fixes**
  * Updated benchmark and deployment configuration to use the supported tokenizer names.
  * Invalid tokenizer values now fall back to fastokens with a warning.

* **Documentation**
  * Updated tokenizer configuration, backend guidance, examples, fallback behavior, and troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->