### PR TITLE
fix: XPU marker composition for post-merge and nightly

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -473,7 +473,7 @@ jobs:
     uses: ./.github/workflows/xpu-ci.yaml
     with:
       framework: vllm
-      pytest_markers: 'vllm and xpu_1'
+      pytest_markers: 'vllm'
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
 
   # ============================================================================

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -591,7 +591,7 @@ jobs:
     uses: ./.github/workflows/xpu-ci.yaml
     with:
       framework: vllm
-      pytest_markers: '(pre_merge or post_merge) and vllm and xpu_1'
+      pytest_markers: '(pre_merge or post_merge) and vllm'
 
   # ============================================================================
   # IMAGE COMPLIANCE


### PR DESCRIPTION
## Overview:

Fix XPU CI marker composition for post-merge and nightly runs. The vllm XPU workflow was receiving xpu_1 too early from the caller, which made xpu-ci.yaml append xpu_1 / xpu_2 again and could produce an impossible marker expression during test selection.

## Details:

- Remove the pre-applied xpu_1 hardware marker from the post-merge XPU caller.
- Remove the pre-applied xpu_1 hardware marker from the nightly XPU caller.
- Let xpu-ci.yaml append the correct hardware marker per job (xpu_1 for the single-card job, xpu_2 for the 2-card job).

## Where should the reviewer start?

Start with:
- [dynamo/.github/workflows/post-merge-ci.yml](dynamo/.github/workflows/post-merge-ci.yml#L591)
- [dynamo/.github/workflows/nightly-ci.yml](dynamo/.github/workflows/nightly-ci.yml#L473)
- [dynamo/.github/workflows/xpu-ci.yaml](dynamo/.github/workflows/xpu-ci.yaml#L181)

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11519" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded XPU nightly test coverage to include all tests marked for vLLM.
  * Updated post-merge and pre-merge XPU validation to run all applicable vLLM tests, rather than only the previously selected subset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->