### PR TITLE
perf(kv-router): add fast path for empty-token PotentialLoads requests

### DIFF
--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -78,3 +78,8 @@ tower = { version = "0.5", features = ["util"] }
 [[bench]]
 name = "policy_queue"
 harness = false
+
+[[bench]]
+name = "potential_loads"
+harness = false
+required-features = ["standalone-selection"]

--- a/lib/kv-router/benches/potential_loads.rs
+++ b/lib/kv-router/benches/potential_loads.rs
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! `SelectionCore::potential_loads` empty-token fast path vs. a non-empty
+//! control, across representative worker counts.
+//!
+//! Run with: `cargo bench -p dynamo-kv-router --bench potential_loads`
+//!
+//! To compare before/after a change to the empty-token fast path, run this
+//! same file at two revisions (it only depends on the stable
+//! `SelectionCore::potential_loads` public entrypoint) and diff with
+//! criterion's baselines:
+//!   cargo bench -p dynamo-kv-router --bench potential_loads -- --save-baseline before
+//!   # checkout the other revision
+//!   cargo bench -p dynamo-kv-router --bench potential_loads -- --baseline before
+
+use std::time::Duration;
+
+use criterion::{BenchmarkId, Criterion, black_box, criterion_group, criterion_main};
+use dynamo_kv_router::config::KvRouterConfig;
+use dynamo_kv_router::services::selection::{PotentialLoadsRequest, SelectionCore, WorkerRequest};
+use tokio::runtime::Runtime;
+use tokio_util::sync::CancellationToken;
+
+const WORKER_COUNTS: [u64; 4] = [1, 8, 32, 128];
+const CONTROL_TOKEN_COUNT: usize = 64;
+
+fn router_config() -> KvRouterConfig {
+    KvRouterConfig {
+        use_kv_events: false,
+        router_queue_threshold: None,
+        ..Default::default()
+    }
+}
+
+fn build_runtime() -> Runtime {
+    tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .build()
+        .expect("build tokio runtime")
+}
+
+fn build_core(rt: &Runtime, num_workers: u64) -> SelectionCore {
+    let core = SelectionCore::new_local(router_config(), 1, CancellationToken::new());
+    rt.block_on(async {
+        for worker_id in 0..num_workers {
+            let req: WorkerRequest = serde_json::from_value(serde_json::json!({
+                "worker_id": worker_id,
+                "model_name": "model",
+                "endpoint": format!("http://worker-{worker_id}:8000"),
+                "block_size": 4,
+            }))
+            .expect("valid worker request");
+            core.upsert_worker(req).await.expect("register worker");
+        }
+    });
+    core
+}
+
+fn empty_tokens_request() -> PotentialLoadsRequest {
+    serde_json::from_value(serde_json::json!({
+        "model_name": "model",
+        "token_ids": [],
+    }))
+    .expect("valid potential-loads request")
+}
+
+fn control_tokens_request() -> PotentialLoadsRequest {
+    let token_ids: Vec<u32> = (0..CONTROL_TOKEN_COUNT as u32).collect();
+    serde_json::from_value(serde_json::json!({
+        "model_name": "model",
+        "token_ids": token_ids,
+    }))
+    .expect("valid potential-loads request")
+}
+
+fn bench_group(c: &mut Criterion, group_name: &str, request: fn() -> PotentialLoadsRequest) {
+    let rt = build_runtime();
+    let mut group = c.benchmark_group(group_name);
+    for &workers in &WORKER_COUNTS {
+        let core = build_core(&rt, workers);
+        group.bench_with_input(BenchmarkId::from_parameter(workers), &workers, |b, _| {
+            b.iter(|| {
+                rt.block_on(async {
+                    black_box(core.potential_loads(request()).await.expect("ok"));
+                });
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_empty_tokens(c: &mut Criterion) {
+    bench_group(c, "potential_loads/empty_tokens", empty_tokens_request);
+}
+
+fn bench_control_tokens(c: &mut Criterion) {
+    bench_group(
+        c,
+        "potential_loads/control_64_tokens",
+        control_tokens_request,
+    );
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+    .sample_size(200)
+    .warm_up_time(Duration::from_secs(2))
+    .measurement_time(Duration::from_secs(8))
+    .noise_threshold(0.03);
+    targets = bench_empty_tokens, bench_control_tokens
+}
+
+criterion_main!(benches);

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -536,6 +536,13 @@ where
         loads
     }
 
+    /// Fast path for empty-token potential-load queries.
+    /// Returns current active load per worker without touching the indexer or
+    /// computing cache-hit overlap.
+    pub fn get_current_loads(&self) -> Vec<PotentialLoad> {
+        self.get_potential_loads(None, 0, HashMap::new(), false)
+    }
+
     pub fn get_active_lora_counts(&self) -> HashMap<String, usize> {
         self.slots.get_active_lora_counts()
     }
@@ -855,6 +862,44 @@ mod tests {
 
         let loads = scheduler.get_potential_loads(None, 0, HashMap::new(), false);
         assert_eq!(loads[0].active_requests, 0);
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn test_get_current_loads_matches_empty_potential_loads() {
+        let workers = HashMap::from([
+            (0, SimpleWorkerConfig::default()),
+            (1, SimpleWorkerConfig::default()),
+        ]);
+        let (scheduler, _slots, _cfg_tx, cancel_token) = make_scheduler(workers, None, true, None);
+
+        // Book a request so active_requests and potential_decode_blocks are non-zero,
+        // pinning the semantics rather than trivially comparing all-zero fields.
+        scheduler
+            .schedule_request(request(ScheduleMode::Tracked {
+                request_id: ("test-req-1".to_string()),
+            }))
+            .await
+            .unwrap();
+
+        let mut current = scheduler.get_current_loads();
+        let mut expected = scheduler.get_potential_loads(None, 0, HashMap::new(), false);
+
+        current.sort_by_key(|l| (l.worker_id, l.dp_rank));
+        expected.sort_by_key(|l| (l.worker_id, l.dp_rank));
+
+        assert_eq!(current.len(), expected.len());
+        for (c, e) in current.iter().zip(expected.iter()) {
+            assert_eq!(c.worker_id, e.worker_id);
+            assert_eq!(c.dp_rank, e.dp_rank);
+            assert_eq!(c.potential_decode_blocks, e.potential_decode_blocks);
+            assert_eq!(c.active_requests, e.active_requests);
+            assert_eq!(c.potential_prefill_tokens, e.potential_prefill_tokens);
+        }
+
+        // Verify at least one worker has active load from the booked request
+        assert!(current.iter().any(|f| f.active_requests > 0));
+
         cancel_token.cancel();
     }
 

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -873,6 +873,29 @@ impl SelectionCore {
     ) -> Result<Vec<PotentialLoad>, SelectionError> {
         let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
+
+        // Fast path: empty token list -> skip indexer/cache-hit work and return
+        // current load snapshot directly
+        let tokens_empty = req.prompt.token_ids.as_ref().is_some_and(|t| t.is_empty())
+            && req
+                .prompt
+                .mm_routing_info
+                .as_ref()
+                .map_or(true, |mm| mm.routing_token_ids.is_empty())
+            && req
+                .prompt
+                .block_hashes
+                .as_ref()
+                .map_or(true, |hashes| hashes.is_empty())
+            && req
+                .prompt
+                .sequence_hashes
+                .as_ref()
+                .map_or(true, |hashes| hashes.is_empty());
+        if tokens_empty {
+            return Ok(entry.scheduler.get_current_loads());
+        }
+
         let prepared = self.prepare_selection_inputs(&entry, &req.prompt).await?;
         let track_prefill_tokens = req
             .router_config_override

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -357,6 +357,31 @@ async fn overlap_scores_returns_all_schedulable_worker_ranks() {
 }
 
 #[tokio::test]
+async fn potential_loads_empty_tokens_returns_ok() {
+    let app = app();
+    assert_eq!(
+        register_worker(app.clone(), None).await.status(),
+        StatusCode::CREATED
+    );
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/potential_loads")
+                .header(header::CONTENT_TYPE, "application/json")
+                .body(Body::from(r#"{"model_name": "model", "token_ids": []}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = response_json(response).await;
+    assert!(body.is_array(), "expected array of potential loads");
+}
+
+#[tokio::test]
 async fn select_and_reserve_books_and_duplicate_reservation_conflicts() {
     let app = app();
     assert_eq!(


### PR DESCRIPTION
## Overview:

Adds a fast path in the KV router for `PotentialLoads` requests with empty token lists. Previously, empty-token requests went through the full projection pipeline: token normalization, block hash computation,and overlap analysis construction, despite none of that work being meaningful for an empty sequence. The fast path skips all of it and returns the current per-worker load snapshot directly.

## Details:

- `lib/kv-router/src/scheduling/local.rs`: adds `LocalScheduler::get_current_loads()`: delegates to `get_potential_loads(None, 0, HashMap::new(), false)` to return the current active load per worker with no projected request.
- `lib/kv-router/src/services/selection/core/mod.rs`: adds an early return in `SelectionCore::potential_loads` when `token_ids` is empty and no block/sequence hashes are provided, returns `get_current_loads()` directly without calling
`prepare_selection_inputs`.
- `lib/kv-router/src/scheduling/local.rs` (tests): adds `test_get_current_loads_matches_empty_potential_loads` verifying `get_current_loads()` matches `get_potential_loads(None, 0, HashMap::new(), false)` field-by-field for every worker and that `potential_prefill_tokens == 0`.

## Where should the reviewer start?

- `lib/kv-router/src/services/selection/core/mod.rs`: the fast path early return
- `lib/kv-router/src/scheduling/local.rs`: `get_current_loads()` helper and the new test

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #10566 

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11521" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for retrieving current worker load snapshots through the potential-loads service.
  - Requests with no token or sequence inputs now return an immediate snapshot of current loads.

- **Bug Fixes**
  - Improved handling of empty token requests, ensuring they return a successful response with a valid JSON array.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->