### PR TITLE
refactor(operator): move config loading to internal package

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -396,6 +396,7 @@ areas:
   - deploy/operator/internal/
   - deploy/operator/internal/cert/
   - deploy/operator/internal/common/
+  - deploy/operator/internal/config/
   - deploy/operator/internal/consts/
   - deploy/operator/internal/controller/
   - deploy/operator/internal/controller_common/

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -21,7 +21,6 @@ package main
 
 import (
 	"context"
-	"crypto/tls"
 	"flag"
 	"fmt"
 	"os"
@@ -43,29 +42,24 @@ import (
 	"k8s.io/client-go/scale"
 	k8sCache "k8s.io/client-go/tools/cache"
 	"k8s.io/utils/ptr"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	k8sruntime "k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-	metricsfilters "sigs.k8s.io/controller-runtime/pkg/metrics/filters"
-	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
-	"sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	lwsscheme "sigs.k8s.io/lws/client-go/clientset/versioned/scheme"
 	volcanoscheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 
 	semver "github.com/Masterminds/semver/v3"
-	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
-	configvalidation "github.com/ai-dynamo/dynamo/deploy/operator/api/config/validation"
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	internalcert "github.com/ai-dynamo/dynamo/deploy/operator/internal/cert"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/config"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
@@ -87,31 +81,32 @@ import (
 )
 
 var (
-	crdScheme    = k8sruntime.NewScheme()
-	setupLog     = ctrl.Log.WithName("setup")
-	configScheme = k8sruntime.NewScheme()
+	scheme   = runtime.NewScheme()
+	setupLog = ctrl.Log.WithName("setup")
 )
 
-// LoadAndValidateOperatorConfig loads the operator configuration from a file,
-// applies defaults via the scheme, and validates it.
-func LoadAndValidateOperatorConfig(path string) (*configv1alpha1.OperatorConfiguration, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read config file %s: %w", path, err)
-	}
+func init() {
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	codecFactory := serializer.NewCodecFactory(configScheme)
-	cfg := &configv1alpha1.OperatorConfiguration{}
-	if err := k8sruntime.DecodeInto(codecFactory.UniversalDecoder(), data, cfg); err != nil {
-		return nil, fmt.Errorf("failed to decode config file %s: %w", path, err)
-	}
+	utilruntime.Must(nvidiacomv1alpha1.AddToScheme(scheme))
 
-	// Validate the configuration
-	if errs := configvalidation.ValidateOperatorConfiguration(cfg); len(errs) > 0 {
-		return nil, fmt.Errorf("config validation failed: %s", errs.ToAggregate().Error())
-	}
+	utilruntime.Must(nvidiacomv1beta1.AddToScheme(scheme))
 
-	return cfg, nil
+	utilruntime.Must(lwsscheme.AddToScheme(scheme))
+
+	utilruntime.Must(volcanoscheme.AddToScheme(scheme))
+
+	utilruntime.Must(grovev1alpha1.AddToScheme(scheme))
+
+	utilruntime.Must(apiextensionsv1.AddToScheme(scheme))
+
+	utilruntime.Must(admissionregistrationv1.AddToScheme(scheme))
+
+	utilruntime.Must(istioclientsetscheme.AddToScheme(scheme))
+
+	utilruntime.Must(gaiev1.Install(scheme))
+
+	utilruntime.Must(configapi.AddToScheme(scheme))
 }
 
 func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
@@ -142,42 +137,12 @@ func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
 	return scalesGetter, nil
 }
 
-func initCRDSchemes() {
-	utilruntime.Must(clientgoscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(nvidiacomv1alpha1.AddToScheme(crdScheme))
-
-	utilruntime.Must(nvidiacomv1beta1.AddToScheme(crdScheme))
-
-	utilruntime.Must(lwsscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(volcanoscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(grovev1alpha1.AddToScheme(crdScheme))
-
-	utilruntime.Must(apiextensionsv1.AddToScheme(crdScheme))
-
-	utilruntime.Must(admissionregistrationv1.AddToScheme(crdScheme))
-
-	utilruntime.Must(istioclientsetscheme.AddToScheme(crdScheme))
-
-	utilruntime.Must(gaiev1.Install(crdScheme))
-	//+kubebuilder:scaffold:scheme
-}
-
-func initConfigScheme() {
-	utilruntime.Must(configv1alpha1.AddToScheme(configScheme))
-}
-
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create
 // +kubebuilder:rbac:groups=authorization.k8s.io,resources=subjectaccessreviews,verbs=create
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update
 
 //nolint:gocyclo
 func main() {
-	initCRDSchemes()
-	initConfigScheme()
-
 	var configFile string
 	var operatorVersion string
 	var operatorImage string
@@ -200,18 +165,6 @@ func main() {
 	flag.Parse()
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 
-	if configFile == "" {
-		setupLog.Error(nil, "--config flag is required")
-		os.Exit(1)
-	}
-	// Load, default, and validate operator configuration
-	operatorCfg, err := LoadAndValidateOperatorConfig(configFile)
-	if err != nil {
-		setupLog.Error(err, "failed to load operator configuration", "configFile", configFile)
-		os.Exit(1)
-	}
-	setupLog.Info("Operator configuration loaded successfully", "configFile", configFile)
-
 	// Validate and normalize operator version to semver
 	if _, err := semver.NewVersion(operatorVersion); err != nil {
 		setupLog.Error(err, "operator-version is not valid semver",
@@ -233,59 +186,25 @@ func main() {
 
 	mainCtx := ctrl.SetupSignalHandler()
 
-	// if the enable-http2 flag is false (the default), http/2 should be disabled
-	// due to its vulnerabilities. More specifically, disabling http/2 will
-	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
-	// Rapid Reset CVEs. For more information see:
-	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
-	// - https://github.com/advisories/GHSA-4374-p667-p6c8
-	disableHTTP2 := func(c *tls.Config) {
-		setupLog.Info("disabling http/2")
-		c.NextProtos = []string{"http/1.1"}
+	if configFile == "" {
+		setupLog.Error(nil, "--config flag is required")
+		os.Exit(1)
 	}
 
-	tlsOpts := []func(*tls.Config){}
-	if !operatorCfg.Security.EnableHTTP2 {
-		tlsOpts = append(tlsOpts, disableHTTP2)
+	mgrOpts, operatorCfg, err := apply(configFile)
+	if err != nil {
+		setupLog.Error(err, "unable to load the configuration")
+		os.Exit(1)
 	}
 
-	webhookServer := webhook.NewServer(webhook.Options{
-		Host:    operatorCfg.Server.Webhook.Host,
-		Port:    operatorCfg.Server.Webhook.Port,
-		CertDir: operatorCfg.Server.Webhook.CertDir,
-		TLSOpts: tlsOpts,
-	})
-
-	metricsBindAddr := fmt.Sprintf("%s:%d", operatorCfg.Server.Metrics.BindAddress, operatorCfg.Server.Metrics.Port)
-	healthProbeAddr := fmt.Sprintf(
-		"%s:%d", operatorCfg.Server.HealthProbe.BindAddress, operatorCfg.Server.HealthProbe.Port,
-	)
-
-	mgrOpts := ctrl.Options{
-		Scheme: crdScheme,
-		Metrics: metricsserver.Options{
-			BindAddress:    metricsBindAddr,
-			SecureServing:  ptr.Deref(operatorCfg.Server.Metrics.Secure, true),
-			FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
-			TLSOpts:        tlsOpts,
-		},
-		WebhookServer:           webhookServer,
-		HealthProbeBindAddress:  healthProbeAddr,
-		LeaderElection:          operatorCfg.LeaderElection.Enabled,
-		LeaderElectionID:        operatorCfg.LeaderElection.ID,
-		LeaderElectionNamespace: operatorCfg.LeaderElection.Namespace,
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
+	if err != nil {
+		setupLog.Error(err, "unable to start manager")
+		os.Exit(1)
 	}
 
 	restrictedNamespace := operatorCfg.Namespace.Restricted
 	if restrictedNamespace != "" {
-		mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
-			restrictedNamespace: {},
-		}
-		// PodSnapshotContent is cluster-scoped, so DefaultNamespaces does not cover it.
-		// Register it cluster-wide explicitly so the PodSnapshotReconciler can watch it.
-		mgrOpts.Cache.ByObject = map[client.Object]cache.ByObject{
-			&nvidiacomv1alpha1.PodSnapshotContent{}: {},
-		}
 		setupLog.Info("Restricted namespace configured, launching in restricted mode", "namespace", restrictedNamespace)
 
 		banner := strings.Repeat("=", 80)
@@ -300,11 +219,6 @@ func main() {
 	} else {
 		setupLog.Info("No restricted namespace configured, launching in cluster-wide mode")
 	}
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), mgrOpts)
-	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
-	}
 
 	// Initialize observability metrics
 	setupLog.Info("Initializing observability metrics")
@@ -312,7 +226,7 @@ func main() {
 
 	// Set up webhook certificate management.
 	// A direct (non-cached) client is needed because the manager's cache isn't started yet.
-	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: crdScheme})
+	directClient, err := client.New(mgr.GetConfig(), client.Options{Scheme: scheme})
 	if err != nil {
 		setupLog.Error(err, "unable to create direct client for cert management")
 		os.Exit(1)
@@ -642,7 +556,7 @@ func main() {
 	// Register controllers synchronously before mgr.Start().
 	// Controllers don't depend on TLS certificates.
 	if err := registerControllers(
-		mgr, operatorCfg, runtimeConfig,
+		mgr, &operatorCfg, runtimeConfig,
 		dockerSecretRetriever, sshKeyManager,
 		operatorImage, pullPolicy,
 	); err != nil {
@@ -650,7 +564,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err := registerWebhookHandlers(mgr, operatorCfg, runtimeConfig, operatorVersion); err != nil {
+	if err := registerWebhookHandlers(mgr, &operatorCfg, runtimeConfig, operatorVersion); err != nil {
 		setupLog.Error(err, "failed to register webhooks")
 		os.Exit(1)
 	}
@@ -660,12 +574,12 @@ func main() {
 	// conversion CAs immediately; manual mode waits for externally provided
 	// ca.crt and only patches conversion, leaving admission CA management
 	// out-of-band.
-	caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
+	caInjector, err := internalcert.NewCABundleInjector(directClient, &operatorCfg)
 	if err != nil {
 		setupLog.Error(err, "unable to create CA bundle injector")
 		os.Exit(1)
 	}
-	if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
+	if operatorCfg.Server.Webhook.CertProvisionMode == configapi.CertProvisionModeAuto {
 		if err := caInjector.InjectAll(mainCtx); err != nil {
 			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
 			os.Exit(1)
@@ -700,7 +614,7 @@ func main() {
 
 func registerControllers(
 	mgr ctrl.Manager,
-	operatorCfg *configv1alpha1.OperatorConfiguration,
+	operatorCfg *configapi.OperatorConfiguration,
 	runtimeConfig *commonController.RuntimeConfig,
 	dockerSecretRetriever *secrets.DockerSecretIndexer,
 	sshKeyManager *secret.SSHKeyManager,
@@ -816,7 +730,7 @@ func registerControllers(
 
 func registerWebhookHandlers(
 	mgr ctrl.Manager,
-	operatorCfg *configv1alpha1.OperatorConfiguration,
+	operatorCfg *configapi.OperatorConfiguration,
 	runtimeConfig *commonController.RuntimeConfig,
 	operatorVersion string,
 ) error {
@@ -921,4 +835,18 @@ func registerWebhookHandlers(
 
 	setupLog.Info("Webhooks registered successfully")
 	return nil
+}
+
+func apply(configFile string) (ctrl.Options, configapi.OperatorConfiguration, error) {
+	options, cfg, err := config.Load(scheme, configFile)
+	if err != nil {
+		return options, cfg, err
+	}
+	cfgStr, err := config.Encode(scheme, &cfg)
+	if err != nil {
+		return options, cfg, err
+	}
+
+	setupLog.Info("Configuration loaded", "config", cfgStr)
+	return options, cfg, nil
 }

--- a/deploy/operator/internal/config/config.go
+++ b/deploy/operator/internal/config/config.go
@@ -1,0 +1,140 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package config
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	metricsfilters "sigs.k8s.io/controller-runtime/pkg/metrics/filters"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+)
+
+// fromFile reads the configuration from the given file and decodes it into the internal cfg.
+func fromFile(path string, scheme *runtime.Scheme, cfg *configapi.OperatorConfiguration) error {
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	codecs := serializer.NewCodecFactory(scheme, serializer.EnableStrict)
+
+	// Regardless of if the bytes are of any external version,
+	// it will be read successfully and converted into the internal version
+	return runtime.DecodeInto(codecs.UniversalDecoder(), content, cfg)
+}
+
+// addTo applies the configuration from cfg to the controller-runtime Options o.
+func addTo(o *ctrl.Options, cfg *configapi.OperatorConfiguration) {
+	addLeaderElectionTo(o, cfg)
+	addCacheByObjectTo(o, cfg)
+
+	o.HealthProbeBindAddress = fmt.Sprintf("%s:%d", cfg.Server.HealthProbe.BindAddress, cfg.Server.HealthProbe.Port)
+
+	// if the enable-http2 flag is false (the default), http/2 should be disabled
+	// due to its vulnerabilities. More specifically, disabling http/2 will
+	// prevent from being vulnerable to the HTTP/2 Stream Cancellation and
+	// Rapid Reset CVEs. For more information see:
+	// - https://github.com/advisories/GHSA-qppj-fm5r-hxr3
+	// - https://github.com/advisories/GHSA-4374-p667-p6c8
+	disableHTTP2 := func(c *tls.Config) {
+		c.NextProtos = []string{"http/1.1"}
+	}
+
+	tlsOpts := []func(*tls.Config){}
+	if !cfg.Security.EnableHTTP2 {
+		tlsOpts = append(tlsOpts, disableHTTP2)
+	}
+
+	o.Metrics = metricsserver.Options{
+		BindAddress:    fmt.Sprintf("%s:%d", cfg.Server.Metrics.BindAddress, cfg.Server.Metrics.Port),
+		SecureServing:  ptr.Deref(cfg.Server.Metrics.Secure, true),
+		FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
+		TLSOpts:        tlsOpts,
+	}
+
+	webhookServer := webhook.NewServer(webhook.Options{
+		Host:    cfg.Server.Webhook.Host,
+		Port:    cfg.Server.Webhook.Port,
+		CertDir: cfg.Server.Webhook.CertDir,
+		TLSOpts: tlsOpts,
+	})
+
+	o.WebhookServer = webhookServer
+
+}
+
+func addLeaderElectionTo(o *ctrl.Options, cfg *configapi.OperatorConfiguration) {
+	o.LeaderElection = cfg.LeaderElection.Enabled
+	o.LeaderElectionID = cfg.LeaderElection.ID
+	o.LeaderElectionNamespace = cfg.LeaderElection.Namespace
+}
+
+func addCacheByObjectTo(o *ctrl.Options, cfg *configapi.OperatorConfiguration) {
+	restrictedNamespace := cfg.Namespace.Restricted
+	if restrictedNamespace != "" {
+		o.Cache.DefaultNamespaces = map[string]cache.Config{
+			restrictedNamespace: {},
+		}
+		// PodSnapshotContent is cluster-scoped, so DefaultNamespaces does not cover it.
+		// Register it cluster-wide explicitly so the PodSnapshotReconciler can watch it.
+		o.Cache.ByObject = map[client.Object]cache.ByObject{
+			&nvidiacomv1alpha1.PodSnapshotContent{}: {},
+		}
+	}
+}
+
+// Load returns a set of controller options and configuration from the given file, if the config file path is empty
+// it used the default configapi values.
+func Load(scheme *runtime.Scheme, configFile string) (ctrl.Options, configapi.OperatorConfiguration, error) {
+	var err error
+	options := ctrl.Options{
+		Scheme: scheme,
+	}
+
+	cfg := configapi.OperatorConfiguration{}
+	if configFile == "" {
+		scheme.Default(&cfg)
+	} else {
+		err := fromFile(configFile, scheme, &cfg)
+		if err != nil {
+			return options, cfg, err
+		}
+	}
+	if err := validate(&cfg).ToAggregate(); err != nil {
+		return options, cfg, err
+	}
+	addTo(&options, &cfg)
+	return options, cfg, err
+}
+
+func Encode(scheme *runtime.Scheme, cfg *configapi.OperatorConfiguration) (string, error) {
+	codecs := serializer.NewCodecFactory(scheme)
+	const mediaType = runtime.ContentTypeYAML
+	info, ok := runtime.SerializerInfoForMediaType(codecs.SupportedMediaTypes(), mediaType)
+	if !ok {
+		return "", fmt.Errorf("unable to locate encoder -- %q is not a supported media type", mediaType)
+	}
+
+	encoder := codecs.EncoderForVersion(info.Serializer, configapi.SchemeGroupVersion)
+	buf := new(bytes.Buffer)
+	if err := encoder.Encode(cfg, buf); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/deploy/operator/internal/config/config_test.go
+++ b/deploy/operator/internal/config/config_test.go
@@ -1,0 +1,439 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	ctrlcache "sigs.k8s.io/controller-runtime/pkg/cache"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+)
+
+func TestEncode(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := configapi.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultConfig := &configapi.OperatorConfiguration{}
+	testScheme.Default(defaultConfig)
+
+	testcases := []struct {
+		name       string
+		scheme     *runtime.Scheme
+		cfg        *configapi.OperatorConfiguration
+		wantResult map[string]any
+	}{
+		{
+			name:   "empty",
+			scheme: testScheme,
+			cfg:    &configapi.OperatorConfiguration{},
+			wantResult: map[string]any{
+				"apiVersion": "operator.config.dynamo.nvidia.com/v1alpha1",
+				"kind":       "OperatorConfiguration",
+				"server": map[string]any{
+					"metrics": map[string]any{
+						"bindAddress": "",
+						"port":        0,
+					},
+					"healthProbe": map[string]any{
+						"bindAddress": "",
+						"port":        0,
+					},
+					"webhook": map[string]any{
+						"bindAddress":       "",
+						"port":              0,
+						"host":              "",
+						"certDir":           "",
+						"certProvisionMode": "",
+						"secretName":        "",
+						"serviceName":       "",
+					},
+				},
+				"leaderElection": map[string]any{
+					"enabled":   false,
+					"id":        "",
+					"namespace": "",
+				},
+				"namespace": map[string]any{
+					"restricted": "",
+					"scope": map[string]any{
+						"leaseDuration":      "0s",
+						"leaseRenewInterval": "0s",
+					},
+				},
+				"orchestrators": map[string]any{
+					"grove": map[string]any{
+						"terminationDelay": "0s",
+					},
+					"lws":              map[string]any{},
+					"kaiScheduler":     map[string]any{},
+					"volcanoScheduler": map[string]any{},
+				},
+				"dra": map[string]any{},
+				"infrastructure": map[string]any{
+					"natsAddress":        "",
+					"etcdAddress":        "",
+					"modelExpressURL":    "",
+					"prometheusEndpoint": "",
+				},
+				"ingress": map[string]any{
+					"virtualServiceGateway":   "",
+					"controllerClassName":     "",
+					"controllerTLSSecretName": "",
+					"hostSuffix":              "",
+				},
+				"serviceMesh": map[string]any{
+					"provider": "",
+				},
+				"rbac": map[string]any{
+					"plannerClusterRoleName":       "",
+					"dgdrProfilingClusterRoleName": "",
+					"eppClusterRoleName":           "",
+				},
+				"mpi": map[string]any{
+					"sshSecretName":      "",
+					"sshSecretNamespace": "",
+				},
+				"checkpoint": map[string]any{
+					"enabled": false,
+					"storage": map[string]any{
+						"type": "",
+						"pvc": map[string]any{
+							"pvcName":          "",
+							"basePath":         "",
+							"create":           false,
+							"size":             "",
+							"storageClassName": "",
+							"accessMode":       "",
+						},
+						"s3": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+						"oci": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+					},
+				},
+				"discovery": map[string]any{
+					"backend": "",
+				},
+				"gpu": map[string]any{},
+				"logging": map[string]any{
+					"level":  "",
+					"format": "",
+				},
+				"security": map[string]any{
+					"enableHTTP2": false,
+				},
+			},
+		},
+		{
+			name:   "default",
+			scheme: testScheme,
+			cfg:    defaultConfig,
+			wantResult: map[string]any{
+				"apiVersion": "operator.config.dynamo.nvidia.com/v1alpha1",
+				"kind":       "OperatorConfiguration",
+				"server": map[string]any{
+					"metrics": map[string]any{
+						"bindAddress": "0.0.0.0",
+						"port":        8080,
+						"secure":      true,
+					},
+					"healthProbe": map[string]any{
+						"bindAddress": "0.0.0.0",
+						"port":        8081,
+					},
+					"webhook": map[string]any{
+						"bindAddress":       "",
+						"port":              9443,
+						"host":              "0.0.0.0",
+						"certDir":           "/tmp/k8s-webhook-server/serving-certs",
+						"certProvisionMode": "auto",
+						"secretName":        "webhook-server-cert",
+						"serviceName":       "",
+					},
+				},
+				"leaderElection": map[string]any{
+					"enabled":   false,
+					"id":        "",
+					"namespace": "",
+				},
+				"namespace": map[string]any{
+					"restricted": "",
+					"scope": map[string]any{
+						"leaseDuration":      "30s",
+						"leaseRenewInterval": "10s",
+					},
+				},
+				"orchestrators": map[string]any{
+					"grove": map[string]any{
+						"terminationDelay": "15m0s",
+					},
+					"lws":              map[string]any{},
+					"kaiScheduler":     map[string]any{},
+					"volcanoScheduler": map[string]any{},
+				},
+				"dra": map[string]any{},
+				"infrastructure": map[string]any{
+					"natsAddress":        "",
+					"etcdAddress":        "",
+					"modelExpressURL":    "",
+					"prometheusEndpoint": "",
+				},
+				"ingress": map[string]any{
+					"virtualServiceGateway":   "",
+					"controllerClassName":     "",
+					"controllerTLSSecretName": "",
+					"hostSuffix":              "",
+				},
+				"serviceMesh": map[string]any{
+					"provider": "",
+				},
+				"rbac": map[string]any{
+					"plannerClusterRoleName":       "",
+					"dgdrProfilingClusterRoleName": "",
+					"eppClusterRoleName":           "",
+				},
+				"mpi": map[string]any{
+					"sshSecretName":      "",
+					"sshSecretNamespace": "",
+				},
+				"checkpoint": map[string]any{
+					"enabled": false,
+					"storage": map[string]any{
+						"type": "",
+						"pvc": map[string]any{
+							"pvcName":          "",
+							"basePath":         "",
+							"create":           false,
+							"size":             "",
+							"storageClassName": "",
+							"accessMode":       "",
+						},
+						"s3": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+						"oci": map[string]any{
+							"uri":                  "",
+							"credentialsSecretRef": "",
+						},
+					},
+				},
+				"discovery": map[string]any{
+					"backend": "kubernetes",
+				},
+				"gpu": map[string]any{
+					"discoveryEnabled": true,
+				},
+				"logging": map[string]any{
+					"level":  "info",
+					"format": "json",
+				},
+				"security": map[string]any{
+					"enableHTTP2": false,
+				},
+			},
+		},
+	}
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := Encode(tc.scheme, tc.cfg)
+			if err != nil {
+				t.Errorf("Unexpected error:%s", err)
+			}
+			gotMap := map[string]any{}
+			err = yaml.Unmarshal([]byte(got), &gotMap)
+			if err != nil {
+				t.Errorf("Unable to unmarshal result:%s", err)
+			}
+			if diff := cmp.Diff(tc.wantResult, gotMap); diff != "" {
+				t.Errorf("Unexpected result (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	testScheme := runtime.NewScheme()
+	err := configapi.AddToScheme(testScheme)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	validConfigFile := t.TempDir() + "/config.yaml"
+	err = os.WriteFile(validConfigFile, []byte(`apiVersion: operator.config.dynamo.nvidia.com/v1alpha1
+kind: OperatorConfiguration
+rbac:
+  plannerClusterRoleName: planner-role
+  dgdrProfilingClusterRoleName: dgdr-profiling-role
+  eppClusterRoleName: epp-role
+mpi:
+  sshSecretName: mpi-ssh
+  sshSecretNamespace: default
+`), 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defaultCfg := configapi.OperatorConfiguration{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: configapi.SchemeGroupVersion.String(),
+			Kind:       "OperatorConfiguration",
+		},
+		Server: configapi.ServerConfiguration{
+			Metrics: configapi.MetricsServer{
+				Server: configapi.Server{
+					BindAddress: "0.0.0.0",
+					Port:        8080,
+				},
+				Secure: ptr.To(true),
+			},
+			HealthProbe: configapi.Server{
+				BindAddress: "0.0.0.0",
+				Port:        8081,
+			},
+			Webhook: configapi.WebhookServer{
+				Server: configapi.Server{
+					Port: 9443,
+				},
+				Host:              "0.0.0.0",
+				CertDir:           "/tmp/k8s-webhook-server/serving-certs",
+				CertProvisionMode: configapi.CertProvisionModeAuto,
+				SecretName:        "webhook-server-cert",
+			},
+		},
+		Namespace: configapi.NamespaceConfiguration{
+			Scope: configapi.NamespaceScopeConfiguration{
+				LeaseDuration:      metav1.Duration{Duration: 30 * time.Second},
+				LeaseRenewInterval: metav1.Duration{Duration: 10 * time.Second},
+			},
+		},
+		Orchestrators: configapi.OrchestratorConfiguration{
+			Grove: configapi.GroveConfiguration{
+				TerminationDelay: metav1.Duration{Duration: 15 * time.Minute},
+			},
+		},
+		Discovery: configapi.DiscoveryConfiguration{
+			Backend: configapi.DiscoveryBackendKubernetes,
+		},
+		GPU: configapi.GPUConfiguration{
+			DiscoveryEnabled: ptr.To(true),
+		},
+		Logging: configapi.LoggingConfiguration{
+			Level:  "info",
+			Format: "json",
+		},
+	}
+
+	defaultControlOptions := ctrl.Options{
+		Metrics: metricsserver.Options{
+			BindAddress:   "0.0.0.0:8080",
+			SecureServing: true,
+		},
+		HealthProbeBindAddress: "0.0.0.0:8081",
+	}
+
+	configCmpOpts := []cmp.Option{}
+
+	ctrlOptsCmpOpts := []cmp.Option{
+		cmpopts.IgnoreUnexported(ctrl.Options{}),
+		cmpopts.IgnoreUnexported(webhook.DefaultServer{}),
+		cmpopts.IgnoreUnexported(ctrlcache.Options{}),
+		cmpopts.IgnoreUnexported(net.ListenConfig{}),
+		cmpopts.IgnoreFields(metricsserver.Options{}, "FilterProvider", "TLSOpts"),
+		cmpopts.IgnoreFields(ctrl.Options{}, "Scheme", "Logger", "WebhookServer"),
+		cmpopts.IgnoreFields(ctrl.Options{}, "Controller", "Logger"),
+	}
+
+	testcases := []struct {
+		name              string
+		configFile        string
+		wantConfiguration configapi.OperatorConfiguration
+		wantOptions       ctrl.Options
+		wantError         error
+	}{
+		{
+			name:              "default config",
+			configFile:        "",
+			wantConfiguration: defaultCfg,
+			wantOptions:       defaultControlOptions,
+			wantError: errors.New("[mpi.sshSecretName: Required value: MPI SSH secret name is required, " +
+				"mpi.sshSecretNamespace: Required value: MPI SSH secret namespace is required, " +
+				"rbac.plannerClusterRoleName: Required value: planner ClusterRole name is required in cluster-wide mode, " +
+				"rbac.dgdrProfilingClusterRoleName: Required value: DGDR profiling ClusterRole name is required in cluster-wide mode, " +
+				"rbac.eppClusterRoleName: Required value: EPP ClusterRole name is required in cluster-wide mode]"),
+		},
+		{
+			name:       "minimal valid",
+			configFile: validConfigFile,
+			wantConfiguration: func() configapi.OperatorConfiguration {
+				cfg := (&defaultCfg).DeepCopy()
+				cfg.RBAC = configapi.RBACConfiguration{
+					PlannerClusterRoleName:       "planner-role",
+					DGDRProfilingClusterRoleName: "dgdr-profiling-role",
+					EPPClusterRoleName:           "epp-role",
+				}
+				cfg.MPI = configapi.MPIConfiguration{
+					SSHSecretName:      "mpi-ssh",
+					SSHSecretNamespace: "default",
+				}
+				return *cfg
+			}(),
+			wantOptions: defaultControlOptions,
+		},
+		{
+			name:       "bad path",
+			configFile: ".",
+			wantError: &fs.PathError{
+				Op:   "read",
+				Path: ".",
+				Err:  errors.New("is a directory"),
+			},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			options, cfg, err := Load(testScheme, tc.configFile)
+			if tc.wantError == nil {
+				if err != nil {
+					t.Errorf("Unexpected error:%s", err)
+				}
+				if diff := cmp.Diff(tc.wantConfiguration, cfg, configCmpOpts...); diff != "" {
+					t.Errorf("Unexpected config (-want +got):\n%s", diff)
+				}
+				if diff := cmp.Diff(tc.wantOptions, options, ctrlOptsCmpOpts...); diff != "" {
+					t.Errorf("Unexpected options (-want +got):\n%s", diff)
+				}
+			} else {
+				if diff := cmp.Diff(tc.wantError.Error(), err.Error()); diff != "" {
+					t.Errorf("Unexpected error (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/config/validation.go
+++ b/deploy/operator/internal/config/validation.go
@@ -1,21 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
-package validation
+package config
 
 import (
 	"net/url"
@@ -24,8 +12,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-// ValidateOperatorConfiguration validates an OperatorConfiguration object.
-func ValidateOperatorConfiguration(config *configv1alpha1.OperatorConfiguration) field.ErrorList {
+// validate checks the configuration for invalid values.
+func validate(config *configv1alpha1.OperatorConfiguration) field.ErrorList {
 	if config == nil {
 		return field.ErrorList{field.Required(field.NewPath(""), "operator configuration is required")}
 	}

--- a/deploy/operator/internal/config/validation_test.go
+++ b/deploy/operator/internal/config/validation_test.go
@@ -1,21 +1,9 @@
 /*
- * SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
  * SPDX-License-Identifier: Apache-2.0
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
  */
 
-package validation
+package config
 
 import (
 	"encoding/json"
@@ -50,93 +38,93 @@ func validNamespaceScopedConfig() *configv1alpha1.OperatorConfiguration {
 	return cfg
 }
 
-func TestValidateOperatorConfiguration_Valid(t *testing.T) {
-	errs := ValidateOperatorConfiguration(validConfig())
+func TestValidate_Valid(t *testing.T) {
+	errs := validate(validConfig())
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for valid config, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_ValidNamespaceScoped(t *testing.T) {
-	errs := ValidateOperatorConfiguration(validNamespaceScopedConfig())
+func TestValidate_ValidNamespaceScoped(t *testing.T) {
+	errs := validate(validNamespaceScopedConfig())
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for valid namespace-scoped config, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_MissingMPISecret(t *testing.T) {
+func TestValidate_MissingMPISecret(t *testing.T) {
 	cfg := validConfig()
 	cfg.MPI.SSHSecretName = ""
 	cfg.MPI.SSHSecretNamespace = ""
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 2 {
 		t.Errorf("expected 2 errors for missing MPI secret, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_InvalidDiscoveryBackend(t *testing.T) {
+func TestValidate_InvalidDiscoveryBackend(t *testing.T) {
 	cfg := validConfig()
 	cfg.Discovery.Backend = "consul"
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid discovery backend, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_ClusterWideMissingPlannerRole(t *testing.T) {
+func TestValidate_ClusterWideMissingPlannerRole(t *testing.T) {
 	cfg := validConfig()
 	cfg.RBAC.PlannerClusterRoleName = ""
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for missing planner role in cluster-wide mode, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NamespaceScopedNoRBACRequired(t *testing.T) {
+func TestValidate_NamespaceScopedNoRBACRequired(t *testing.T) {
 	cfg := validNamespaceScopedConfig()
 	// Verify that RBAC is not required in namespace mode
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for namespace-scoped config without RBAC, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NamespaceScopedInvalidLease(t *testing.T) {
+func TestValidate_NamespaceScopedInvalidLease(t *testing.T) {
 	cfg := validNamespaceScopedConfig()
 	cfg.Namespace.Scope.LeaseDuration = metav1.Duration{Duration: 0}
 	cfg.Namespace.Scope.LeaseRenewInterval = metav1.Duration{Duration: 0}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 2 {
 		t.Errorf("expected 2 errors for zero lease values, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NamespaceScopedLeaseRenewExceedsDuration(t *testing.T) {
+func TestValidate_NamespaceScopedLeaseRenewExceedsDuration(t *testing.T) {
 	cfg := validNamespaceScopedConfig()
 	cfg.Namespace.Scope.LeaseDuration = metav1.Duration{Duration: 10 * time.Second}
 	cfg.Namespace.Scope.LeaseRenewInterval = metav1.Duration{Duration: 15 * time.Second}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for lease renew > duration, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_CheckpointEnabledRequiresNoStorageConfig(t *testing.T) {
+func TestValidate_CheckpointEnabledRequiresNoStorageConfig(t *testing.T) {
 	cfg := validConfig()
 	cfg.Checkpoint.Enabled = true
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for checkpoint config without storage settings, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_CheckpointDeprecatedStorageConfigIsAccepted(t *testing.T) {
+func TestValidate_CheckpointDeprecatedStorageConfigIsAccepted(t *testing.T) {
 	cfg := validConfig()
 	rawConfig := []byte(`{
 		"checkpoint": {
@@ -153,58 +141,58 @@ func TestValidateOperatorConfiguration_CheckpointDeprecatedStorageConfigIsAccept
 		t.Fatalf("failed to unmarshal compatibility config: %v", err)
 	}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors for deprecated checkpoint storage config, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_CheckpointDisabledSkipsValidation(t *testing.T) {
+func TestValidate_CheckpointDisabledSkipsValidation(t *testing.T) {
 	cfg := validConfig()
 	cfg.Checkpoint.Enabled = false
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 0 {
 		t.Errorf("expected no errors when checkpoint is disabled, got: %v", errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_InvalidModelExpressURL(t *testing.T) {
+func TestValidate_InvalidModelExpressURL(t *testing.T) {
 	cfg := validConfig()
 	cfg.Infrastructure.ModelExpressURL = "://bad-url"
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid model express URL, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_InvalidPort(t *testing.T) {
+func TestValidate_InvalidPort(t *testing.T) {
 	cfg := validConfig()
 	cfg.Server.Metrics.Port = 99999
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for invalid port, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_LeaderElectionEnabledMissingID(t *testing.T) {
+func TestValidate_LeaderElectionEnabledMissingID(t *testing.T) {
 	cfg := validConfig()
 	cfg.LeaderElection.Enabled = true
 	cfg.LeaderElection.ID = ""
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for missing leader election ID, got %d: %v", len(errs), errs)
 	}
 }
 
-func TestValidateOperatorConfiguration_NegativeTerminationDelay(t *testing.T) {
+func TestValidate_NegativeTerminationDelay(t *testing.T) {
 	cfg := validConfig()
 	cfg.Orchestrators.Grove.TerminationDelay = metav1.Duration{Duration: -1 * time.Second}
 
-	errs := ValidateOperatorConfiguration(cfg)
+	errs := validate(cfg)
 	if len(errs) != 1 {
 		t.Errorf("expected 1 error for negative termination delay, got %d: %v", len(errs), errs)
 	}


### PR DESCRIPTION
## Summary
- move operator configuration loading, validation, encoding, and controller-runtime option wiring into deploy/operator/internal/config
- update operator main to consume the internal config loader
- add focused tests for encoding and manager option construction

## Validation
- go test ./internal/config ./cmd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added unified operator configuration loading from files or defaults.
  - Configuration now supports clearer control of leader election, caching, metrics, health probes, webhooks, and HTTP/2 security settings.
  - Improved automatic webhook certificate and CA bundle handling.

- **Bug Fixes**
  - Improved configuration validation and error reporting for invalid settings.

- **Tests**
  - Added coverage for configuration loading, encoding, defaults, validation, and invalid configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->