### PR TITLE
fix(sglang): warm every prefill DP rank before serving

### DIFF
--- a/components/src/dynamo/sglang/_disagg.py
+++ b/components/src/dynamo/sglang/_disagg.py
@@ -14,9 +14,9 @@
   `dist_init_addr` into a runtime-data key that non-leader workers can use
   to discover the leader endpoint.
 
-* :func:`warmup_prefill_engine` — drive one request through the disagg
-  path with SGLang's `FAKE_BOOTSTRAP_HOST` so the first real request
-  doesn't pay the JIT/CUDA-graph compile cost.
+* :func:`warmup_prefill_engine` — drive one request per DP rank through
+  the disagg path with SGLang's `FAKE_BOOTSTRAP_HOST` so the first real
+  request doesn't pay the JIT/CUDA-graph compile cost.
 """
 
 from __future__ import annotations
@@ -123,29 +123,37 @@ def get_sglang_worker_group_id(server_args) -> Optional[str]:
 
 
 async def warmup_prefill_engine(engine: sgl.Engine, bootstrap_port: int) -> None:
-    """Drive one request through the prefill disagg path with SGLang's
-    `FAKE_BOOTSTRAP_HOST` so JIT/CUDA-graph compile happens before the
-    first real request. Raises on timeout/failure — an unwarmed prefill
-    silently drops production requests."""
+    """Warm every prefill DP rank through the disagg path.
+
+    Uses SGLang's `FAKE_BOOTSTRAP_HOST` so JIT/CUDA-graph compile happens
+    before the first real request. Raises on timeout/failure — an unwarmed
+    prefill silently drops production requests.
+    """
     from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 
+    server_args = engine.tokenizer_manager.server_args
+    dp_size = server_args.dp_size
     sampling_params = {
         "temperature": 0.0,
         "max_new_tokens": 8,
         "ignore_eos": True,
     }
 
-    async def _do_warmup() -> None:
+    async def _warmup_dp_rank(dp_rank: int) -> None:
         results = await engine.async_generate(
-            input_ids=[0, 1, 2, 3],
+            input_ids=[10, 11, 12, 13],
             sampling_params=sampling_params,
             stream=True,
             bootstrap_host=FAKE_BOOTSTRAP_HOST,
             bootstrap_port=bootstrap_port,
-            bootstrap_room=999999,
+            bootstrap_room=dp_rank,
+            routed_dp_rank=dp_rank,
         )
         async for _ in results:
             pass
+
+    async def _do_warmup() -> None:
+        await asyncio.gather(*(_warmup_dp_rank(i) for i in range(dp_size)))
 
     logging.info("SGLang prefill warmup starting...")
     await asyncio.wait_for(_do_warmup(), timeout=_PREFILL_WARMUP_TIMEOUT_S)

--- a/components/src/dynamo/sglang/tests/test_sglang_disagg.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_disagg.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for SGLang disaggregated serving helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("sglang", reason="sglang not installed in this container")
+
+from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST  # noqa: E402
+
+from dynamo.sglang._disagg import warmup_prefill_engine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.sglang,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.mark.asyncio
+async def test_prefill_warmup_covers_every_dp_rank():
+    calls = []
+    consumed_dp_ranks = []
+
+    async def async_generate(**kwargs):
+        calls.append(kwargs)
+
+        async def results():
+            dp_rank = kwargs["routed_dp_rank"]
+            consumed_dp_ranks.append(dp_rank)
+            yield {"meta_info": {"dp_rank": dp_rank}}
+
+        return results()
+
+    engine = SimpleNamespace(
+        async_generate=async_generate,
+        tokenizer_manager=SimpleNamespace(server_args=SimpleNamespace(dp_size=8)),
+    )
+
+    await warmup_prefill_engine(engine, bootstrap_port=8998)
+
+    assert len(calls) == 8
+    calls.sort(key=lambda call: call["routed_dp_rank"])
+    for dp_rank, call in enumerate(calls):
+        assert call["input_ids"] == [10, 11, 12, 13]
+        assert call["bootstrap_host"] == FAKE_BOOTSTRAP_HOST
+        assert call["bootstrap_port"] == 8998
+        assert call["bootstrap_room"] == dp_rank
+        assert call["routed_dp_rank"] == dp_rank
+    assert sorted(consumed_dp_ranks) == list(range(8))


### PR DESCRIPTION
## Summary

Dynamo embedded SGLang prefill warmup currently sends one fake-transfer request through automatic load balancing. In a multinode DP deployment, this warms only one DP rank and leaves the remaining ranks to compile request-time kernels after the worker registers.

Using one Engine API batch of DP-size requests is not sufficient for DP-attention deployments. SGLang intentionally takes the sequential tokenization path when DP attention is enabled, so the API batch is emitted as individual scheduler dispatches. With the total-tokens balancer, load-snapshot refreshes can overwrite speculative dispatch counters before the scheduler publishes the new load; an observed DP8 startup routed two warmup requests to DP0 and none to DP7.

Send one concurrent warmup request per DP rank, route each request explicitly with `routed_dp_rank`, assign a unique bootstrap room, and drain every stream before registration. The public `routed_dp_rank` type remains scalar.

## Validation

- All repository pre-commit hooks and PR checks pass.
- A two-node DP8/TP8/EP8 startup logged exactly one warmup prefill request on each of DP0 through DP7 within a 1 ms window.
- Concurrently warming all eight ranks took 135.12 seconds, essentially unchanged from the 135.40-second single-rank embedded warmup.
- The 377-request AIPerf warmup completed with zero errors in 1109.42 seconds, down from 1268.64 seconds for the single-rank baseline: 159.22 seconds, or 12.6%, faster.
- A full 30-minute agentic replay passed with 16,383 measured requests, zero request errors, and a 96.84% theoretical prefix-cache hit rate versus 96.78% for the baseline.
- The change only runs before worker registration. The full replay is treated as correctness and production-path no-regression evidence; single-run throughput differences are not attributed to this warmup change.

similar fix in sglang: https://github.com/sgl-project/sglang/pull/30748