### PR TITLE
test(operator): exercise Helm admission through envtest

### DIFF
--- a/.github/actions/check-deploy-component/action.yml
+++ b/.github/actions/check-deploy-component/action.yml
@@ -30,11 +30,16 @@ runs:
       shell: bash
       working-directory: ./deploy/${{ inputs.component }}
       run: |
+        OPERATOR_CHART_CONTEXT=()
+        if [[ "${{ inputs.component }}" == "operator" ]]; then
+          OPERATOR_CHART_CONTEXT=(--build-context operator-chart=../helm/charts/platform/components/operator)
+        fi
         docker buildx build \
           --platform ${{ inputs.platform }} \
           --target tester \
           --progress=plain \
           --build-context snapshot=../snapshot \
+          "${OPERATOR_CHART_CONTEXT[@]}" \
           .
 
     - name: Set up Go

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -44,7 +44,7 @@ webhooks:
     service:
       name: {{ include "dynamo-operator.fullname" . }}-webhook-service
       namespace: {{ .Release.Namespace }}
-      path: /validate-nvidia-com-v1alpha1-dynamocomponentdeployment
+      path: /validate/nvidia.com/v1beta1/dynamocomponentdeployments
   failurePolicy: {{ .Values.webhook.failurePolicy }}
   name: vdynamocomponentdeployment.kb.io
   {{- if .Values.webhook.namespaceSelector }}
@@ -59,7 +59,7 @@ webhooks:
   - apiGroups:
     - nvidia.com
     apiVersions:
-    - v1alpha1
+    - v1beta1
     operations:
     - CREATE
     - UPDATE

--- a/deploy/operator/Dockerfile
+++ b/deploy/operator/Dockerfile
@@ -40,6 +40,10 @@ RUN golangci-lint run --timeout=5m
 # Test stage
 FROM base AS tester
 
+# The operator CI uses deploy/operator as its build context, so provide the chart separately.
+COPY --from=operator-chart . /operator-chart
+ENV DYNAMO_OPERATOR_HELM_CHART=/operator-chart
+
 # Install make if not present
 RUN apt-get update && apt-get install -y --no-install-recommends make && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/operator/Makefile
+++ b/deploy/operator/Makefile
@@ -301,8 +301,8 @@ vet: ## Run go vet against code.
 	go vet ./...
 
 .PHONY: test
-test: manifests generate fmt vet envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /test | grep -v /cmd) -coverprofile cover.out
+test: manifests generate fmt vet envtest helm ## Run tests.
+	HELM="$(HELM)" KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e | grep -v /test | grep -v /cmd) -coverprofile cover.out
 
 # Utilize Kind or modify the e2e tests to load the image locally, enabling compatibility with other vendors.
 .PHONY: test-e2e  # Run the e2e tests against a Kind k8s instance that is spun up.

--- a/deploy/operator/internal/webhook/validation/admission_test.go
+++ b/deploy/operator/internal/webhook/validation/admission_test.go
@@ -228,7 +228,12 @@ func renderHelmValidatingWebhook(operatorRoot string) (*admissionregistrationv1.
 			return nil, fmt.Errorf("find helm binary: %w", err)
 		}
 	}
-	chartPath := filepath.Join(operatorRoot, "..", "helm", "charts", "platform", "components", "operator")
+	chartPath := os.Getenv("DYNAMO_OPERATOR_HELM_CHART")
+	if chartPath == "" {
+		chartPath = filepath.Join(operatorRoot, "..", "helm", "charts", "platform", "components", "operator")
+	} else if !filepath.IsAbs(chartPath) {
+		chartPath = filepath.Join(operatorRoot, chartPath)
+	}
 	command := exec.Command(
 		helmBinary,
 		"template",

--- a/deploy/operator/internal/webhook/validation/admission_test.go
+++ b/deploy/operator/internal/webhook/validation/admission_test.go
@@ -1,0 +1,668 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package validation
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	authenticationv1 "k8s.io/api/authentication/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/wait"
+	utilyaml "k8s.io/apimachinery/pkg/util/yaml"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
+	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+var apiAdmissionTestEnvironment *admissionTestEnvironment
+
+func TestMain(m *testing.M) {
+	testEnvironment, err := startAdmissionTestEnvironment()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "start admission test environment: %v\n", err)
+		os.Exit(1)
+	}
+	apiAdmissionTestEnvironment = testEnvironment
+
+	code := m.Run()
+	if err := testEnvironment.Stop(); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "stop admission test environment: %v\n", err)
+		if code == 0 {
+			code = 1
+		}
+	}
+	os.Exit(code)
+}
+
+type admissionTestEnvironment struct {
+	environment *envtest.Environment
+	client      dynamic.Interface
+	cancel      context.CancelFunc
+	managerDone <-chan error
+	warnings    *admissionWarningCollector
+	dcdBeta     *validatorSlot
+	dgdBeta     *validatorSlot
+}
+
+func startAdmissionTestEnvironment() (*admissionTestEnvironment, error) {
+	operatorRoot, err := admissionTestOperatorRoot()
+	if err != nil {
+		return nil, err
+	}
+	validatingWebhook, err := renderHelmValidatingWebhook(operatorRoot)
+	if err != nil {
+		return nil, err
+	}
+	scheme := runtime.NewScheme()
+	if err := nvidiacomv1alpha1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add v1alpha1 scheme: %w", err)
+	}
+	if err := nvidiacomv1beta1.AddToScheme(scheme); err != nil {
+		return nil, fmt.Errorf("add v1beta1 scheme: %w", err)
+	}
+
+	testEnvironment := &envtest.Environment{
+		Scheme:                scheme,
+		CRDDirectoryPaths:     []string{filepath.Join(operatorRoot, "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+		BinaryAssetsDirectory: filepath.Join(
+			operatorRoot,
+			"bin",
+			"k8s",
+			fmt.Sprintf("1.30.0-%s-%s", goruntime.GOOS, goruntime.GOARCH),
+		),
+		WebhookInstallOptions: envtest.WebhookInstallOptions{
+			ValidatingWebhooks: []*admissionregistrationv1.ValidatingWebhookConfiguration{validatingWebhook},
+		},
+	}
+	config, err := testEnvironment.Start()
+	if err != nil {
+		return nil, err
+	}
+
+	webhookServer := ctrlwebhook.NewServer(ctrlwebhook.Options{
+		Host:    testEnvironment.WebhookInstallOptions.LocalServingHost,
+		Port:    testEnvironment.WebhookInstallOptions.LocalServingPort,
+		CertDir: testEnvironment.WebhookInstallOptions.LocalServingCertDir,
+	})
+	manager, err := ctrl.NewManager(config, ctrl.Options{
+		Scheme:        scheme,
+		Metrics:       metricsserver.Options{BindAddress: "0"},
+		WebhookServer: webhookServer,
+	})
+	if err != nil {
+		_ = testEnvironment.Stop()
+		return nil, fmt.Errorf("create webhook manager: %w", err)
+	}
+
+	for _, object := range []runtime.Object{
+		&nvidiacomv1beta1.DynamoGraphDeployment{},
+		&nvidiacomv1beta1.DynamoComponentDeployment{},
+		&nvidiacomv1beta1.DynamoGraphDeploymentRequest{},
+		&nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{},
+	} {
+		if err := ctrl.NewWebhookManagedBy(manager, object).Complete(); err != nil {
+			_ = testEnvironment.Stop()
+			return nil, fmt.Errorf("register conversion webhook for %T: %w", object, err)
+		}
+	}
+
+	harness := &admissionTestEnvironment{
+		environment: testEnvironment,
+		warnings:    &admissionWarningCollector{},
+		dcdBeta:     newValidatorSlot(),
+		dgdBeta:     newValidatorSlot(),
+	}
+	dcdRegistration := NewDynamoComponentDeploymentHandler()
+	dcdRegistration.registerWithManager(
+		manager,
+		&nvidiacomv1beta1.DynamoComponentDeployment{},
+		dynamoComponentDeploymentV1Beta1WebhookPath,
+		harness.dcdBeta,
+	)
+	dgdRegistration := &DynamoGraphDeploymentHandler{}
+	dgdRegistration.registerWithManager(
+		manager,
+		&nvidiacomv1beta1.DynamoGraphDeployment{},
+		dynamoGraphDeploymentV1Beta1WebhookPath,
+		harness.dgdBeta,
+	)
+	clientConfig := rest.CopyConfig(config)
+	clientConfig.WarningHandler = harness.warnings
+	harness.client, err = dynamic.NewForConfig(clientConfig)
+	if err != nil {
+		_ = testEnvironment.Stop()
+		return nil, fmt.Errorf("create dynamic client: %w", err)
+	}
+
+	managerContext, cancel := context.WithCancel(context.Background())
+	managerDone := make(chan error, 1)
+	harness.cancel = cancel
+	harness.managerDone = managerDone
+	go func() {
+		managerDone <- manager.Start(managerContext)
+	}()
+	if err := wait.PollUntilContextTimeout(
+		context.Background(),
+		10*time.Millisecond,
+		10*time.Second,
+		true,
+		func(context.Context) (bool, error) {
+			return webhookServer.StartedChecker()(nil) == nil, nil
+		},
+	); err != nil {
+		cancel()
+		_ = testEnvironment.Stop()
+		return nil, fmt.Errorf("wait for webhook server: %w", err)
+	}
+
+	return harness, nil
+}
+
+func (e *admissionTestEnvironment) Stop() error {
+	e.cancel()
+	managerErr := <-e.managerDone
+	environmentErr := e.environment.Stop()
+	if managerErr != nil {
+		return fmt.Errorf("stop webhook manager: %w", managerErr)
+	}
+	if environmentErr != nil {
+		return fmt.Errorf("stop envtest: %w", environmentErr)
+	}
+	return nil
+}
+
+func admissionTestOperatorRoot() (string, error) {
+	_, filename, _, ok := goruntime.Caller(0)
+	if !ok {
+		return "", fmt.Errorf("resolve admission test source path")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(filename), "..", "..", "..")), nil
+}
+
+func renderHelmValidatingWebhook(operatorRoot string) (*admissionregistrationv1.ValidatingWebhookConfiguration, error) {
+	helmBinary := os.Getenv("HELM")
+	if helmBinary == "" {
+		var err error
+		helmBinary, err = exec.LookPath("helm")
+		if err != nil {
+			return nil, fmt.Errorf("find helm binary: %w", err)
+		}
+	}
+	chartPath := filepath.Join(operatorRoot, "..", "helm", "charts", "platform", "components", "operator")
+	command := exec.Command(
+		helmBinary,
+		"template",
+		"admission-test",
+		chartPath,
+		"--namespace", "default",
+		"--show-only", "templates/webhook-configuration.yaml",
+		"--set", "discoveryBackend=kubernetes",
+	)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("render Helm webhook configuration: %w: %s", err, output)
+	}
+
+	decoder := utilyaml.NewYAMLOrJSONDecoder(bytes.NewReader(output), 4096)
+	var validatingWebhooks []*admissionregistrationv1.ValidatingWebhookConfiguration
+	for {
+		var document map[string]any
+		if err := decoder.Decode(&document); err != nil {
+			if err == io.EOF {
+				break
+			}
+			return nil, fmt.Errorf("decode rendered Helm webhook configuration: %w", err)
+		}
+		if document["kind"] != "ValidatingWebhookConfiguration" {
+			continue
+		}
+		encoded, err := json.Marshal(document)
+		if err != nil {
+			return nil, fmt.Errorf("encode rendered validating webhook configuration: %w", err)
+		}
+		webhook := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+		if err := json.Unmarshal(encoded, webhook); err != nil {
+			return nil, fmt.Errorf("decode rendered validating webhook configuration: %w", err)
+		}
+		validatingWebhooks = append(validatingWebhooks, webhook)
+	}
+	if len(validatingWebhooks) != 1 {
+		return nil, fmt.Errorf("rendered Helm chart contains %d validating webhook configurations, want 1", len(validatingWebhooks))
+	}
+	return validatingWebhooks[0], nil
+}
+
+func (e *admissionTestEnvironment) useDynamoComponentDeploymentHandler(handler *DynamoComponentDeploymentHandler) {
+	e.dcdBeta.Set(handler)
+}
+
+func (e *admissionTestEnvironment) allowDynamoComponentDeployments() {
+	e.dcdBeta.Set(allowingValidator{})
+}
+
+func (e *admissionTestEnvironment) useDynamoGraphDeploymentHandler(handler *DynamoGraphDeploymentHandler) {
+	e.dgdBeta.Set(handler)
+}
+
+func (e *admissionTestEnvironment) allowDynamoGraphDeployments() {
+	e.dgdBeta.Set(allowingValidator{})
+}
+
+func (e *admissionTestEnvironment) Admit(
+	t *testing.T,
+	oldObject runtime.Object,
+	object runtime.Object,
+	mutateRequest func(*testing.T, map[string]any),
+	userInfo *authenticationv1.UserInfo,
+	allow func(),
+	configure func(),
+) ([]string, error) {
+	t.Helper()
+
+	request := admissionUnstructured(t, object)
+	if mutateRequest != nil {
+		mutateRequest(t, request)
+	}
+	resourceInfo, err := admissionTarget(request)
+	if err != nil {
+		t.Fatal(err)
+	}
+	e.ensureNamespace(t, resourceInfo.namespace)
+	resource := resourceInfo.ForClient(e.client)
+
+	if oldObject != nil {
+		if admissionSourceVersion(t, oldObject) != admissionSourceVersion(t, object) {
+			t.Fatal("old and current source versions differ")
+		}
+		allow()
+		oldRequest := admissionUnstructured(t, oldObject)
+		seedRequest := (&unstructured.Unstructured{Object: oldRequest}).DeepCopy()
+
+		// Restart is update-only, so reproduce its two-step API lifecycle when seeding old state.
+		_, hasRestart, err := unstructured.NestedFieldNoCopy(seedRequest.Object, "spec", "restart")
+		if err != nil {
+			t.Fatalf("inspect old admission restart: %v", err)
+		}
+		if hasRestart {
+			unstructured.RemoveNestedField(seedRequest.Object, "spec", "restart")
+		}
+		created, err := resource.Create(t.Context(), seedRequest, metav1.CreateOptions{})
+		if err != nil {
+			t.Fatalf("seed old admission object: %v", err)
+		}
+		e.cleanup(t, resource, created.GetName())
+		if hasRestart {
+			desiredOld := &unstructured.Unstructured{Object: oldRequest}
+			desiredOld.SetResourceVersion(created.GetResourceVersion())
+			created, err = resource.Update(t.Context(), desiredOld, metav1.UpdateOptions{})
+			if err != nil {
+				t.Fatalf("seed old admission restart: %v", err)
+			}
+		}
+		created = e.updateStatus(t, resource, created, oldObject)
+		if err := unstructured.SetNestedField(request, created.GetResourceVersion(), "metadata", "resourceVersion"); err != nil {
+			t.Fatalf("set update resource version: %v", err)
+		}
+	}
+
+	configure()
+	client, err := e.clientForUser(userInfo)
+	if err != nil {
+		t.Fatalf("create admission client: %v", err)
+	}
+	resource = resourceInfo.ForClient(client)
+	e.warnings.Reset()
+	if oldObject == nil {
+		created, err := resource.Create(t.Context(), &unstructured.Unstructured{Object: request}, metav1.CreateOptions{})
+		if err == nil {
+			e.cleanup(t, resource, created.GetName())
+		}
+		return e.warnings.List(), err
+	}
+	_, err = resource.Update(t.Context(), &unstructured.Unstructured{Object: request}, metav1.UpdateOptions{})
+	return e.warnings.List(), err
+}
+
+type admissionResourceTarget struct {
+	groupVersionResource schema.GroupVersionResource
+	namespace            string
+}
+
+func (r admissionResourceTarget) ForClient(client dynamic.Interface) dynamic.ResourceInterface {
+	return client.Resource(r.groupVersionResource).Namespace(r.namespace)
+}
+
+func admissionTarget(object map[string]any) (admissionResourceTarget, error) {
+	apiVersion, _, err := unstructured.NestedString(object, "apiVersion")
+	if err != nil || apiVersion == "" {
+		return admissionResourceTarget{}, fmt.Errorf("admission object has no apiVersion")
+	}
+	groupVersion, err := schema.ParseGroupVersion(apiVersion)
+	if err != nil {
+		return admissionResourceTarget{}, fmt.Errorf("parse admission apiVersion %q: %w", apiVersion, err)
+	}
+	kind, _, err := unstructured.NestedString(object, "kind")
+	if err != nil || kind == "" {
+		return admissionResourceTarget{}, fmt.Errorf("admission object has no kind")
+	}
+	var resource string
+	switch kind {
+	case "DynamoComponentDeployment":
+		resource = "dynamocomponentdeployments"
+	case "DynamoGraphDeployment":
+		resource = "dynamographdeployments"
+	default:
+		return admissionResourceTarget{}, fmt.Errorf("unsupported admission kind %q", kind)
+	}
+	namespace, _, err := unstructured.NestedString(object, "metadata", "namespace")
+	if err != nil || namespace == "" {
+		return admissionResourceTarget{}, fmt.Errorf("admission object has no namespace")
+	}
+	groupVersionResource := groupVersion.WithResource(resource)
+	return admissionResourceTarget{
+		groupVersionResource: groupVersionResource,
+		namespace:            namespace,
+	}, nil
+}
+
+func (e *admissionTestEnvironment) updateStatus(
+	t *testing.T,
+	resource dynamic.ResourceInterface,
+	created *unstructured.Unstructured,
+	oldObject runtime.Object,
+) *unstructured.Unstructured {
+	t.Helper()
+	oldWithStatus, err := runtime.DefaultUnstructuredConverter.ToUnstructured(oldObject)
+	if err != nil {
+		t.Fatalf("convert old admission status: %v", err)
+	}
+	status, found := oldWithStatus["status"]
+	if !found || !hasNonZeroAdmissionStatus(status) {
+		return created
+	}
+	withStatus := created.DeepCopy()
+	withStatus.Object["status"] = status
+	updated, err := resource.UpdateStatus(t.Context(), withStatus, metav1.UpdateOptions{})
+	if err != nil {
+		t.Fatalf("seed old admission status: %v", err)
+	}
+	return updated
+}
+
+func hasNonZeroAdmissionStatus(value any) bool {
+	switch value := value.(type) {
+	case nil:
+		return false
+	case map[string]any:
+		for _, child := range value {
+			if hasNonZeroAdmissionStatus(child) {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, child := range value {
+			if hasNonZeroAdmissionStatus(child) {
+				return true
+			}
+		}
+		return false
+	case string:
+		return value != ""
+	case bool:
+		return value
+	case int:
+		return value != 0
+	case int8:
+		return value != 0
+	case int16:
+		return value != 0
+	case int32:
+		return value != 0
+	case int64:
+		return value != 0
+	case uint:
+		return value != 0
+	case uint8:
+		return value != 0
+	case uint16:
+		return value != 0
+	case uint32:
+		return value != 0
+	case uint64:
+		return value != 0
+	case float32:
+		return value != 0
+	case float64:
+		return value != 0
+	default:
+		return true
+	}
+}
+
+func (e *admissionTestEnvironment) ensureNamespace(t *testing.T, namespace string) {
+	t.Helper()
+	namespaces := e.client.Resource(schema.GroupVersionResource{Version: "v1", Resource: "namespaces"})
+	if _, err := namespaces.Get(t.Context(), namespace, metav1.GetOptions{}); err == nil {
+		return
+	} else if !apierrors.IsNotFound(err) {
+		t.Fatalf("get admission namespace %q: %v", namespace, err)
+	}
+	_, err := namespaces.Create(t.Context(), &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "v1",
+		"kind":       "Namespace",
+		"metadata": map[string]any{
+			"name": namespace,
+		},
+	}}, metav1.CreateOptions{})
+	if err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("create admission namespace %q: %v", namespace, err)
+	}
+}
+
+func (e *admissionTestEnvironment) cleanup(t *testing.T, resource dynamic.ResourceInterface, name string) {
+	t.Helper()
+	t.Cleanup(func() {
+		if err := resource.Delete(context.Background(), name, metav1.DeleteOptions{}); err != nil {
+			if apierrors.IsNotFound(err) {
+				return
+			}
+			t.Errorf("delete admitted object %q: %v", name, err)
+		}
+	})
+}
+
+func assertAdmissionErrors(t *testing.T, err error, schemaErr, celErr string, webhookErrs []string) {
+	t.Helper()
+
+	want := webhookErrs
+	if schemaErr != "" {
+		if celErr != "" || len(webhookErrs) != 0 {
+			t.Fatal("schema rejection cannot have downstream expectations")
+		}
+		want = []string{schemaErr}
+	} else if celErr != "" {
+		if len(webhookErrs) != 0 {
+			t.Fatal("CEL rejection cannot have webhook expectations")
+		}
+		want = []string{celErr}
+	}
+
+	if len(want) == 0 {
+		if err != nil {
+			t.Fatalf("admission error = %v, want none", err)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatalf("admission errors = nil, want %v", want)
+	}
+	statusErr, ok := err.(*apierrors.StatusError)
+	if !ok || !apierrors.IsInvalid(err) {
+		t.Fatalf("error = %T %v, want typed Kubernetes invalid error", err, err)
+	}
+	if statusErr.ErrStatus.Details == nil {
+		t.Fatalf("error = %v, want typed field causes", err)
+	}
+
+	causes := statusErr.ErrStatus.Details.Causes
+	got := make([]string, 0, len(causes))
+	for _, cause := range causes {
+		// Ignore the API server's unfielded cascade notice after a primary schema error.
+		if strings.Contains(cause.Message, "some validation rules were not checked because the object was invalid") {
+			continue
+		}
+		if cause.Field == "" {
+			t.Fatalf("error cause = %#v, want an exact field path", cause)
+		}
+		got = append(got, fmt.Sprintf("%s: %s", cause.Field, cause.Message))
+	}
+	if !slices.Equal(got, want) {
+		t.Fatalf("admission errors = %v, want %v", got, want)
+	}
+}
+
+func assertBetaValidationErrors(t *testing.T, err error, want []string) {
+	t.Helper()
+	assertAdmissionErrors(t, err, "", "", want)
+}
+
+func (e *admissionTestEnvironment) clientForUser(userInfo *authenticationv1.UserInfo) (dynamic.Interface, error) {
+	if userInfo == nil {
+		return e.client, nil
+	}
+	if userInfo.UID != "" || len(userInfo.Extra) != 0 {
+		return nil, fmt.Errorf("envtest admission users support username and groups only")
+	}
+	groups := append([]string{}, userInfo.Groups...)
+	groups = append(groups, "system:masters")
+	user, err := e.environment.AddUser(envtest.User{Name: userInfo.Username, Groups: groups}, nil)
+	if err != nil {
+		return nil, err
+	}
+	config := rest.CopyConfig(user.Config())
+	config.WarningHandler = e.warnings
+	return dynamic.NewForConfig(config)
+}
+
+type admissionWarningCollector struct {
+	lock     sync.Mutex
+	warnings []string
+}
+
+func (c *admissionWarningCollector) HandleWarningHeader(_ int, _ string, text string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.warnings = append(c.warnings, text)
+}
+
+func (c *admissionWarningCollector) Reset() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.warnings = nil
+}
+
+func (c *admissionWarningCollector) List() []string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	warnings := make([]string, 0, len(c.warnings))
+	for _, warning := range c.warnings {
+		// The matrices assert webhook warnings, not Kubernetes' built-in API deprecation warning.
+		if strings.HasPrefix(warning, "nvidia.com/v1alpha1 ") && strings.Contains(warning, " is deprecated; use nvidia.com/v1beta1 ") {
+			continue
+		}
+		warnings = append(warnings, warning)
+	}
+	return warnings
+}
+
+type validatorSlot struct {
+	lock      sync.RWMutex
+	validator admission.CustomValidator
+}
+
+func newValidatorSlot() *validatorSlot {
+	return &validatorSlot{validator: allowingValidator{}}
+}
+
+func (s *validatorSlot) Set(validator admission.CustomValidator) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.validator = validator
+}
+
+func (s *validatorSlot) ValidateCreate(ctx context.Context, object runtime.Object) (admission.Warnings, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.validator.ValidateCreate(ctx, object)
+}
+
+func (s *validatorSlot) ValidateUpdate(ctx context.Context, oldObject, object runtime.Object) (admission.Warnings, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.validator.ValidateUpdate(ctx, oldObject, object)
+}
+
+func (s *validatorSlot) ValidateDelete(ctx context.Context, object runtime.Object) (admission.Warnings, error) {
+	s.lock.RLock()
+	defer s.lock.RUnlock()
+	return s.validator.ValidateDelete(ctx, object)
+}
+
+type allowingValidator struct{}
+
+func (allowingValidator) ValidateCreate(context.Context, runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (allowingValidator) ValidateUpdate(context.Context, runtime.Object, runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+func (allowingValidator) ValidateDelete(context.Context, runtime.Object) (admission.Warnings, error) {
+	return nil, nil
+}
+
+var _ admission.CustomValidator = &validatorSlot{}
+var _ admission.CustomValidator = allowingValidator{}
+var _ rest.WarningHandler = &admissionWarningCollector{}

--- a/deploy/operator/internal/webhook/validation/admission_test.go
+++ b/deploy/operator/internal/webhook/validation/admission_test.go
@@ -30,6 +30,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -81,6 +82,7 @@ type admissionTestEnvironment struct {
 	warnings    *admissionWarningCollector
 	dcdBeta     *validatorSlot
 	dgdBeta     *validatorSlot
+	userID      atomic.Uint64
 }
 
 func startAdmissionTestEnvironment() (*admissionTestEnvironment, error) {
@@ -579,15 +581,47 @@ func (e *admissionTestEnvironment) clientForUser(userInfo *authenticationv1.User
 	if userInfo.UID != "" || len(userInfo.Extra) != 0 {
 		return nil, fmt.Errorf("envtest admission users support username and groups only")
 	}
-	groups := append([]string{}, userInfo.Groups...)
-	groups = append(groups, "system:masters")
-	user, err := e.environment.AddUser(envtest.User{Name: userInfo.Username, Groups: groups}, nil)
+	user, err := e.environment.AddUser(envtest.User{Name: userInfo.Username, Groups: userInfo.Groups}, nil)
 	if err != nil {
+		return nil, err
+	}
+	if err := e.authorizeTestUser(userInfo.Username); err != nil {
 		return nil, err
 	}
 	config := rest.CopyConfig(user.Config())
 	config.WarningHandler = e.warnings
 	return dynamic.NewForConfig(config)
+}
+
+func (e *admissionTestEnvironment) authorizeTestUser(username string) error {
+	// Bind by username so authorization does not add privileged groups to the admission identity.
+	bindingName := fmt.Sprintf("admission-test-cluster-admin-%d", e.userID.Add(1))
+	bindings := e.client.Resource(schema.GroupVersionResource{
+		Group:    "rbac.authorization.k8s.io",
+		Version:  "v1",
+		Resource: "clusterrolebindings",
+	})
+	_, err := bindings.Create(context.Background(), &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "rbac.authorization.k8s.io/v1",
+		"kind":       "ClusterRoleBinding",
+		"metadata": map[string]any{
+			"name": bindingName,
+		},
+		"roleRef": map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "ClusterRole",
+			"name":     "cluster-admin",
+		},
+		"subjects": []any{map[string]any{
+			"apiGroup": "rbac.authorization.k8s.io",
+			"kind":     "User",
+			"name":     username,
+		}},
+	}}, metav1.CreateOptions{})
+	if err != nil {
+		return fmt.Errorf("authorize admission test user %q: %w", username, err)
+	}
+	return nil
 }
 
 type admissionWarningCollector struct {

--- a/deploy/operator/internal/webhook/validation/admission_test.go
+++ b/deploy/operator/internal/webhook/validation/admission_test.go
@@ -387,9 +387,9 @@ func admissionTarget(object map[string]any) (admissionResourceTarget, error) {
 	}
 	var resource string
 	switch kind {
-	case "DynamoComponentDeployment":
+	case admissionDCDKind:
 		resource = "dynamocomponentdeployments"
-	case "DynamoGraphDeployment":
+	case admissionDGDKind:
 		resource = "dynamographdeployments"
 	default:
 		return admissionResourceTarget{}, fmt.Errorf("unsupported admission kind %q", kind)

--- a/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamocomponentdeployment_test.go
@@ -18,7 +18,6 @@
 package validation
 
 import (
-	"fmt"
 	"slices"
 	"testing"
 
@@ -26,10 +25,10 @@ import (
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
-	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	k8sptr "k8s.io/utils/ptr"
 	apixv1alpha1 "sigs.k8s.io/gateway-api-inference-extension/apix/config/v1alpha1"
 )
@@ -40,8 +39,6 @@ const (
 )
 
 func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
-	requestValidators := requestValidatorsFromCRD(t, "nvidia.com_dynamocomponentdeployments.yaml")
-
 	var (
 		oneReplica       = int32(1)
 		validReplicas    = int32(3)
@@ -129,7 +126,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Spec.SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{}
 			}),
-			wantCELErr: "spec.sharedMemory: Invalid value: size is required when disabled is false",
+			wantCELErr: "spec.sharedMemory: Invalid value: \"object\": size is required when disabled is false",
 		},
 
 		// CEL rules generated into the standalone DCD CRD.
@@ -139,7 +136,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Replicas = &oneReplica
 				dcd.Spec.MinAvailable = &validMinAvail
 			}),
-			wantCELErr: "spec: Invalid value: minAvailable must be less than or equal to replicas unless replicas is 0",
+			wantCELErr: "spec: Invalid value: \"object\": minAvailable must be less than or equal to replicas unless replicas is 0",
 		},
 		{
 			name: "v1beta1 replicas below minAvailable are rejected by CEL",
@@ -147,7 +144,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Replicas = &oneReplica
 				dcd.Spec.MinAvailable = &validMinAvail
 			}),
-			wantCELErr: "spec: Invalid value: minAvailable must be less than or equal to replicas unless replicas is 0",
+			wantCELErr: "spec: Invalid value: \"object\": minAvailable must be less than or equal to replicas unless replicas is 0",
 		},
 		{
 			name: "v1alpha1 minAvailable change is rejected by CEL",
@@ -159,7 +156,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Replicas = &validReplicas
 				dcd.Spec.MinAvailable = &validMinAvail
 			}),
-			wantCELErr: "spec: Invalid value: minAvailable is immutable after creation",
+			wantCELErr: "spec: Invalid value: \"object\": minAvailable is immutable after creation",
 		},
 		{
 			name: "v1beta1 minAvailable change is rejected by CEL",
@@ -171,7 +168,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.Replicas = &validReplicas
 				dcd.Spec.MinAvailable = &validMinAvail
 			}),
-			wantCELErr: "spec: Invalid value: minAvailable is immutable after creation",
+			wantCELErr: "spec: Invalid value: \"object\": minAvailable is immutable after creation",
 		},
 		{
 			name: "v1alpha1 inter-pod GMS client containers are rejected by CEL",
@@ -182,7 +179,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					ExtraClientContainers: []string{"metrics"},
 				}
 			}),
-			wantCELErr: "spec.gpuMemoryService: Invalid value: extraClientContainers is only supported with mode=intraPod",
+			wantCELErr: "spec.gpuMemoryService: Invalid value: \"object\": extraClientContainers is only supported with mode=intraPod",
 		},
 		{
 			name: "v1beta1 inter-pod GMS client containers are rejected by CEL",
@@ -194,7 +191,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.gpuMemoryService: Invalid value: extraClientContainers is only supported with mode=IntraPod",
+			wantCELErr: "spec.experimental.gpuMemoryService: Invalid value: \"object\": extraClientContainers is only supported with mode=IntraPod",
 		},
 		{
 			name: "v1alpha1 non-empty GMS extra client pods are rejected by CEL",
@@ -205,7 +202,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					ExtraClientPods: []nvidiacomv1alpha1.GMSClientPodSpec{{Name: "client"}},
 				}
 			}),
-			wantCELErr: "spec.gpuMemoryService: Invalid value: extraClientPods is reserved for inter-pod GMS and is not implemented yet",
+			wantCELErr: "spec.gpuMemoryService: Invalid value: \"object\": extraClientPods is reserved for inter-pod GMS and is not implemented yet",
 		},
 		{
 			name: "v1beta1 non-empty GMS extra client pods are rejected by CEL",
@@ -217,7 +214,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.gpuMemoryService: Invalid value: extraClientPods is reserved for inter-pod GMS and is not implemented yet",
+			wantCELErr: "spec.experimental.gpuMemoryService: Invalid value: \"object\": extraClientPods is reserved for inter-pod GMS and is not implemented yet",
 		},
 		{
 			name: "v1beta1 EPP config on a worker is rejected by CEL",
@@ -226,7 +223,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					ConfigMapRef: &corev1.ConfigMapKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: "epp-config"}},
 				}
 			}),
-			wantCELErr: "spec: Invalid value: eppConfig may only be set when type is epp",
+			wantCELErr: "spec: Invalid value: \"object\": eppConfig may only be set when type is epp",
 		},
 		{
 			name: "v1beta1 checkpoint job with checkpointRef is rejected by CEL",
@@ -239,7 +236,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.checkpoint: Invalid value: checkpoint.job cannot be set when checkpointRef is specified",
+			wantCELErr: "spec.experimental.checkpoint: Invalid value: \"object\": checkpoint.job cannot be set when checkpointRef is specified",
 		},
 
 		// Shared v1alpha1 validation reached through standalone DCD admission.
@@ -372,7 +369,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					Job:           &nvidiacomv1alpha1.ServiceCheckpointJobConfig{},
 				},
 			}),
-			wantCELErr: "spec.checkpoint: Invalid value: checkpoint.job cannot be set when checkpointRef is specified",
+			wantCELErr: "spec.checkpoint: Invalid value: \"object\": checkpoint.job cannot be set when checkpointRef is specified",
 		},
 		{
 			name: "deprecated checkpoint mode with checkpointRef is accepted",
@@ -674,7 +671,12 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 			name: "deprecated dynamo namespace warning shows calculated namespace",
 			deployment: alphaDCDForAdmission(func(dcd *nvidiacomv1alpha1.DynamoComponentDeployment) {
 				dcd.Namespace = "hannahz"
-				dcd.OwnerReferences = []metav1.OwnerReference{{Kind: "DynamoGraphDeployment", Name: "trtllm-disagg"}}
+				dcd.OwnerReferences = []metav1.OwnerReference{{
+					APIVersion: nvidiacomv1alpha1.GroupVersion.String(),
+					Kind:       "DynamoGraphDeployment",
+					Name:       "trtllm-disagg",
+					UID:        types.UID("test-owner"),
+				}}
 				dcd.Spec.DynamoNamespace = k8sptr.To("my-custom-namespace")
 			}),
 			wantWarnings: []string{`spec.dynamoNamespace is deprecated and ignored. Value "my-custom-namespace" will be replaced with "hannahz-trtllm-disagg". Remove this field from your configuration`},
@@ -731,7 +733,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 				dcd.Spec.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
 				dcd.Spec.EPPConfig = &nvidiacomv1beta1.EPPConfig{}
 			}),
-			wantCELErr: "spec.eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+			wantCELErr: "spec.eppConfig: Invalid value: \"object\": exactly one of configMapRef or config must be specified",
 		},
 		{
 			name: "v1alpha1 conflicting EPP config reaches and is rejected by the webhook",
@@ -759,7 +761,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+			wantCELErr: "spec.eppConfig: Invalid value: \"object\": exactly one of configMapRef or config must be specified",
 		},
 		{
 			name: "v1alpha1 EPP config map without a name reaches and is rejected by the webhook",
@@ -800,7 +802,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					Containers: []corev1.Container{{Name: consts.MainContainerName}, {Name: "metrics"}},
 				}}
 			}),
-			wantCELErr: "spec.podTemplate.spec.containers[1]: Invalid value: sidecar containers must specify a non-empty image",
+			wantCELErr: "spec.podTemplate.spec.containers[1]: Invalid value: \"object\": sidecar containers must specify a non-empty image",
 		},
 		{
 			name: "v1alpha1 sidecar without image reaches the webhook",
@@ -818,7 +820,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					InitContainers: []corev1.Container{{Name: "prepare"}},
 				}}
 			}),
-			wantCELErr: "spec.podTemplate.spec.initContainers[0]: Invalid value: init containers must specify a non-empty image",
+			wantCELErr: "spec.podTemplate.spec.initContainers[0]: Invalid value: \"object\": init containers must specify a non-empty image",
 		},
 		{
 			name: "v1alpha1 init container without image reaches the webhook",
@@ -838,7 +840,7 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: consts.MainContainerName}}},
 				}
 			}),
-			wantCELErr: "spec.podTemplate.metadata.annotations: Invalid value: podTemplate backend annotation must be mp or ray, case-insensitively",
+			wantCELErr: "spec.podTemplate.metadata.annotations: Invalid value: \"object\": podTemplate backend annotation must be mp or ray, case-insensitively",
 		},
 		{
 			name: "v1beta1 valid pod template backend annotation reaches the webhook",
@@ -968,95 +970,21 @@ func TestDynamoComponentDeploymentValidator_Validate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			request := admissionUnstructured(t, tt.deployment)
-			var oldRequest map[string]any
-			if tt.oldDeployment != nil {
-				oldRequest = admissionUnstructured(t, tt.oldDeployment)
-			}
-
-			version := admissionSourceVersion(t, tt.deployment)
-			if tt.oldDeployment != nil && admissionSourceVersion(t, tt.oldDeployment) != version {
-				t.Fatalf("old and current source versions differ")
-			}
-			requestValidator, ok := requestValidators[version]
-			if !ok {
-				t.Fatalf("no request validator for source version %q", version)
-			}
-
-			schemaErrs := requestValidator.validateSchema(request, oldRequest)
-			if tt.wantSchemaErr != "" {
-				if tt.wantCELErr != "" || len(tt.wantWebhookErrs) != 0 || len(tt.wantWarnings) != 0 {
-					t.Fatal("schema rejection cannot have downstream expectations")
-				}
-				assertRequestValidationError(t, schemaErrs, tt.wantSchemaErr)
-				return
-			}
-			if len(schemaErrs) != 0 {
-				t.Fatalf("schema errors = %v, want none", schemaErrs)
-			}
-
-			celErrs := requestValidator.celValidator(request, oldRequest)
-			if tt.wantCELErr != "" {
-				if len(tt.wantWebhookErrs) != 0 || len(tt.wantWarnings) != 0 {
-					t.Fatal("CEL rejection cannot have webhook expectations")
-				}
-				assertRequestValidationError(t, celErrs, tt.wantCELErr)
-				return
-			}
-			if len(celErrs) != 0 {
-				t.Fatalf("CEL errors = %v, want none", celErrs)
-			}
-
 			handler := NewDynamoComponentDeploymentHandler()
-			ctx := dgdAdmissionContext(dgdAdmissionOperation(tt.oldDeployment), nvidiacomv1beta1.DynamoComponentDeploymentGVK)
-			var warnings []string
-			var err error
-			if tt.oldDeployment == nil {
-				warnings, err = handler.ValidateCreate(ctx, dcdAdmissionBeta(t, tt.deployment))
-			} else {
-				warnings, err = handler.ValidateUpdate(
-					ctx,
-					dcdAdmissionBeta(t, tt.oldDeployment),
-					dcdAdmissionBeta(t, tt.deployment),
-				)
-			}
-			assertDCDWebhookErrors(t, err, tt.wantWebhookErrs)
+			warnings, err := apiAdmissionTestEnvironment.Admit(
+				t,
+				tt.oldDeployment,
+				tt.deployment,
+				nil,
+				nil,
+				apiAdmissionTestEnvironment.allowDynamoComponentDeployments,
+				func() { apiAdmissionTestEnvironment.useDynamoComponentDeploymentHandler(handler) },
+			)
+			assertAdmissionErrors(t, err, tt.wantSchemaErr, tt.wantCELErr, tt.wantWebhookErrs)
 			if !slices.Equal(warnings, tt.wantWarnings) {
-				t.Fatalf("webhook warnings = %v, want %v", warnings, tt.wantWarnings)
+				t.Fatalf("admission warnings = %v, want %v", warnings, tt.wantWarnings)
 			}
 		})
-	}
-}
-
-func assertDCDWebhookErrors(t *testing.T, err error, want []string) {
-	t.Helper()
-	if len(want) == 0 {
-		if err != nil {
-			t.Fatalf("webhook error = %v, want none", err)
-		}
-		return
-	}
-	if err == nil {
-		t.Fatalf("webhook errors = nil, want %v", want)
-	}
-	statusErr, ok := err.(*k8serrors.StatusError)
-	if !ok || !k8serrors.IsInvalid(err) {
-		t.Fatalf("error = %T %v, want typed Kubernetes invalid error", err, err)
-	}
-	if statusErr.ErrStatus.Details == nil {
-		t.Fatalf("error = %v, want typed field causes", err)
-	}
-
-	causes := statusErr.ErrStatus.Details.Causes
-	got := make([]string, len(causes))
-	for i, cause := range causes {
-		if cause.Field == "" {
-			t.Fatalf("error cause = %#v, want an exact field path", cause)
-		}
-		got[i] = fmt.Sprintf("%s: %s", cause.Field, cause.Message)
-	}
-	if !slices.Equal(got, want) {
-		t.Fatalf("webhook errors = %v, want %v", got, want)
 	}
 }
 
@@ -1112,21 +1040,4 @@ func betaDCDForAdmission(
 		mutate(dcd)
 	}
 	return dcd
-}
-
-func dcdAdmissionBeta(t *testing.T, deployment runtime.Object) *nvidiacomv1beta1.DynamoComponentDeployment {
-	t.Helper()
-	switch deployment := deployment.(type) {
-	case *nvidiacomv1alpha1.DynamoComponentDeployment:
-		beta := &nvidiacomv1beta1.DynamoComponentDeployment{}
-		if err := deployment.ConvertTo(beta); err != nil {
-			t.Fatalf("convert v1alpha1 DCD to v1beta1: %v", err)
-		}
-		return beta
-	case *nvidiacomv1beta1.DynamoComponentDeployment:
-		return deployment.DeepCopy()
-	default:
-		t.Fatalf("unsupported DCD type %T", deployment)
-		return nil
-	}
 }

--- a/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
+++ b/deploy/operator/internal/webhook/validation/dynamographdeployment_test.go
@@ -31,7 +31,6 @@ import (
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
-	admissionv1 "k8s.io/api/admission/v1"
 	authenticationv1 "k8s.io/api/authentication/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +56,6 @@ const (
 const sglangBackendFramework = "sglang"
 
 func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
-	requestValidators := requestValidatorsFromCRD(t, "nvidia.com_dynamographdeployments.yaml")
 	defaultManager := newGroveTopologyTestManager(t, newTestClusterTopology())
 	missingTopologyManager := newGroveTopologyTestManager(t)
 	inferencePoolManager := newInferencePoolTestManager(t)
@@ -120,7 +118,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec: Invalid value: spec.restart must be unset on create; set spec.restart.id after creation to request a restart",
+			wantCELErr: "spec: Invalid value: \"object\": spec.restart must be unset on create; set spec.restart.id after creation to request a restart",
 		},
 		{
 			name: "component topology constraint requires deployment topology",
@@ -154,7 +152,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: exactly one of labelKey or clusterTopologyName is required",
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: \"object\": exactly one of labelKey or clusterTopologyName is required",
 		},
 		{
 			name: "intra-pod failover requires container discovery",
@@ -179,7 +177,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.components[1].experimental.checkpoint: Invalid value: checkpoint.job cannot be set when checkpointRef is specified",
+			wantCELErr: "spec.components[1].experimental.checkpoint: Invalid value: \"object\": checkpoint.job cannot be set when checkpointRef is specified",
 		},
 		{
 			name: "GMS requires GPU resources on the main container",
@@ -212,23 +210,20 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				dgd.Spec.Components[0].ComponentName = dgdAdmissionWorkerName
 				dgd.Spec.Components[1].ComponentName = dgdAdmissionUpperWorkerName
 			}),
-			wantCELErr: "spec.components: Invalid value: component names must be unique case-insensitively",
+			wantCELErr: "spec.components: Invalid value: \"array\": component names must be unique case-insensitively",
 		},
 		{
 			name:       "v1alpha1 converted service names may collide case-insensitively",
 			deployment: alphaDGDForAdmissionWithServiceNames(dgdAdmissionWorkerName, dgdAdmissionUpperWorkerName),
 		},
 		{
-			name: "v1beta1 case-insensitive component names are rejected by CEL on update",
-			oldDeployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
-				dgd.Spec.Components[0].ComponentName = dgdAdmissionWorkerName
-				dgd.Spec.Components[1].ComponentName = dgdAdmissionUpperWorkerName
-			}),
+			name:          "v1beta1 case-insensitive component names are rejected by CEL on update",
+			oldDeployment: betaDGDForAdmission(nil),
 			deployment: dgdAdmissionWithLabel(t, betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				dgd.Spec.Components[0].ComponentName = dgdAdmissionWorkerName
 				dgd.Spec.Components[1].ComponentName = dgdAdmissionUpperWorkerName
 			})),
-			wantCELErr: "spec.components: Invalid value: component names must be unique case-insensitively",
+			wantCELErr: "spec.components: Invalid value: \"array\": component names must be unique case-insensitively",
 		},
 		{
 			name:          "v1alpha1 case-insensitive service names remain updateable",
@@ -263,7 +258,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Containers: []corev1.Container{{Name: consts.MainContainerName}, {Name: "metrics"}},
 				}}
 			}),
-			wantCELErr: "spec.components[1].podTemplate.spec.containers[1]: Invalid value: sidecar containers must specify a non-empty image",
+			wantCELErr: "spec.components[1].podTemplate.spec.containers[1]: Invalid value: \"object\": sidecar containers must specify a non-empty image",
 		},
 		{
 			name: "v1alpha1 converted sidecar without image reaches the webhook",
@@ -290,7 +285,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					InitContainers: []corev1.Container{{Name: "prepare"}},
 				}}
 			}),
-			wantCELErr: "spec.components[1].podTemplate.spec.initContainers[0]: Invalid value: init containers must specify a non-empty image",
+			wantCELErr: "spec.components[1].podTemplate.spec.initContainers[0]: Invalid value: \"object\": init containers must specify a non-empty image",
 		},
 		{
 			name: "v1alpha1 converted init container without image reaches the webhook",
@@ -310,7 +305,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: consts.MainContainerName}}},
 				}
 			}),
-			wantCELErr: "spec.components[1].podTemplate.metadata.annotations: Invalid value: podTemplate backend annotation must be mp or ray, case-insensitively",
+			wantCELErr: "spec.components[1].podTemplate.metadata.annotations: Invalid value: \"object\": podTemplate backend annotation must be mp or ray, case-insensitively",
 		},
 		{
 			name: "v1beta1 valid pod template backend annotation reaches the webhook",
@@ -388,7 +383,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker.Replicas = k8sptr.To(int32(1))
 				worker.MinAvailable = k8sptr.To(int32(2))
 			}),
-			wantCELErr: "spec.components[1]: Invalid value: minAvailable must be less than or equal to replicas unless replicas is 0",
+			wantCELErr: "spec.components[1]: Invalid value: \"object\": minAvailable must be less than or equal to replicas unless replicas is 0",
 		},
 		{
 			name: "v1beta1 valid replicas and minAvailable reach the webhook",
@@ -415,7 +410,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: betaDGDForAdmission(func(dgd *nvidiacomv1beta1.DynamoGraphDeployment) {
 				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(2))
 			}),
-			wantCELErr: "spec.components[1]: Invalid value: minAvailable is immutable after creation",
+			wantCELErr: "spec.components[1]: Invalid value: \"object\": minAvailable is immutable after creation",
 		},
 		{
 			name: "v1beta1 removed minAvailable update is rejected by CEL",
@@ -423,7 +418,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				betaWorkerComponent(dgd).MinAvailable = k8sptr.To(int32(1))
 			}),
 			deployment: betaDGDForAdmission(nil),
-			wantCELErr: "spec.components[1]: Invalid value: minAvailable is immutable after creation",
+			wantCELErr: "spec.components[1]: Invalid value: \"object\": minAvailable is immutable after creation",
 		},
 
 		// Checkpoint rules.
@@ -448,7 +443,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: exactly one of labelKey or clusterTopologyName is required",
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: \"object\": exactly one of labelKey or clusterTopologyName is required",
 		},
 		{
 			name: "v1beta1 label-key KV-transfer policy reaches the webhook",
@@ -472,7 +467,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: preferredWeight is required when enforcement is preferred",
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: \"object\": preferredWeight is required when enforcement is preferred",
 		},
 		{
 			name: "v1beta1 required KV-transfer enforcement with weight is rejected by CEL",
@@ -486,7 +481,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: preferredWeight may only be set when enforcement is preferred",
+			wantCELErr: "spec.experimental.kvTransferPolicy: Invalid value: \"object\": preferredWeight may only be set when enforcement is preferred",
 		},
 		{
 			name: "v1beta1 valid preferred KV-transfer enforcement reaches the webhook",
@@ -617,7 +612,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaInterPodGMS(worker)
 				worker.Experimental.GPUMemoryService.ExtraClientContainers = []string{"metrics"}
 			}),
-			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: extraClientContainers is only supported with mode=IntraPod",
+			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: \"object\": extraClientContainers is only supported with mode=IntraPod",
 		},
 		{
 			name: "v1beta1 non-empty GMS extra client pods are rejected by CEL",
@@ -626,7 +621,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				enableBetaInterPodGMS(worker)
 				worker.Experimental.GPUMemoryService.ExtraClientPods = []nvidiacomv1beta1.GMSClientPodSpec{{Name: "client"}}
 			}),
-			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: extraClientPods is reserved for inter-pod GMS and is not implemented yet",
+			wantCELErr: "spec.components[1].experimental.gpuMemoryService: Invalid value: \"object\": extraClientPods is reserved for inter-pod GMS and is not implemented yet",
 		},
 		{
 			name: "v1beta1 valid GMS configuration reaches the webhook",
@@ -822,11 +817,10 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantSchemaErr: `spec.services.worker.gpuMemoryService.extraClientContainers[0]: Invalid value: "Bad_Name": spec.services.worker.gpuMemoryService.extraClientContainers[0] in body should match '^[a-z0-9]([-a-z0-9]*[a-z0-9])?$'`,
 		},
 		{
-			name: "nil alpha service entry is rejected",
+			name: "nil alpha service entry is pruned before admission",
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				dgd.Spec.Services["ghost"] = nil
 			}),
-			wantSchemaErr: `spec.services.ghost: Invalid value: "null": spec.services.ghost in body must be of type object: "null"`,
 		},
 		{
 			name: "valid preserved alpha-only fields are accepted",
@@ -857,7 +851,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				dgd.Spec.PVCs = []nvidiacomv1alpha1.PVC{{Name: k8sptr.To("cache"), Create: k8sptr.To(true)}}
 			}),
-			wantCELErr: "spec.pvcs[0]: Invalid value: When create is true, size, storageClass, and volumeAccessMode are required",
+			wantCELErr: "spec.pvcs[0]: Invalid value: \"object\": When create is true, size, storageClass, and volumeAccessMode are required",
 		},
 		{
 			name: "alpha compatibility warnings are preserved",
@@ -908,7 +902,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			deployment: alphaDGDForAdmission(func(dgd *nvidiacomv1alpha1.DynamoGraphDeployment) {
 				dgd.Spec.Services["worker"].SharedMemory = &nvidiacomv1alpha1.SharedMemorySpec{}
 			}),
-			wantCELErr: "spec.services[worker].sharedMemory: Invalid value: size is required when disabled is false",
+			wantCELErr: "spec.services[worker].sharedMemory: Invalid value: \"object\": size is required when disabled is false",
 		},
 		{
 			name: "v1alpha1 valid shared memory reaches the webhook",
@@ -935,7 +929,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				worker.ComponentType = nvidiacomv1beta1.ComponentTypeEPP
 				worker.EPPConfig = &nvidiacomv1beta1.EPPConfig{}
 			}),
-			wantCELErr: "spec.components[1].eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+			wantCELErr: "spec.components[1].eppConfig: Invalid value: \"object\": exactly one of configMapRef or config must be specified",
 		},
 		{
 			name: "v1beta1 EPP config with both sources is rejected by CEL",
@@ -950,7 +944,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 					},
 				}
 			}),
-			wantCELErr: "spec.components[1].eppConfig: Invalid value: exactly one of configMapRef or config must be specified",
+			wantCELErr: "spec.components[1].eppConfig: Invalid value: \"object\": exactly one of configMapRef or config must be specified",
 		},
 		{
 			name:    "v1beta1 valid EPP config reaches the webhook",
@@ -1389,7 +1383,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 				LabelKey: "topology.kubernetes.io/zone",
 				Domain:   "zone",
 			}),
-			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy: Invalid value: {"labelKey":"topology.kubernetes.io/zone","domain":"zone"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy`},
+			wantWebhookErrs: []string{`spec.experimental.kvTransferPolicy: Invalid value: {"labelKey":"topology.kubernetes.io/zone","domain":"zone","enforcement":"required"}: is immutable and cannot be added, removed, or changed after creation; delete and recreate the DynamoGraphDeployment to change the KV transfer policy`},
 		},
 		{
 			name: "unchanged kv transfer policy is allowed",
@@ -1482,7 +1476,7 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			wantWebhookErrs: []string{"spec.components[1].replicas: Forbidden: cannot be modified directly when scaling adapter is enabled; scale or update the related DynamoGraphDeploymentScalingAdapter instead"},
 		},
 		{
-			name: "scaling adapter fails closed without user info",
+			name: "scaling adapter fails closed for the default API user",
 			oldDeployment: betaDGDWithWorker(func(worker *nvidiacomv1beta1.DynamoComponentDeploymentSharedSpec) {
 				worker.ScalingAdapter = &nvidiacomv1beta1.ScalingAdapter{}
 				worker.Replicas = k8sptr.To(int32(2))
@@ -1653,66 +1647,26 @@ func TestDynamoGraphDeploymentValidator_Validate(t *testing.T) {
 			for name, value := range tt.environment {
 				t.Setenv(name, value)
 			}
-			current := admissionUnstructured(t, tt.deployment)
-			if tt.mutateRequest != nil {
-				tt.mutateRequest(t, current)
-			}
-			var old map[string]any
-			if tt.oldDeployment != nil {
-				old = admissionUnstructured(t, tt.oldDeployment)
-			}
-
-			version := admissionSourceVersion(t, tt.deployment)
-			requestValidator, ok := requestValidators[version]
-			if !ok {
-				t.Fatalf("no request validator for source version %q", version)
-			}
-			schemaErrs := requestValidator.validateSchema(current, old)
-			if tt.wantSchemaErr != "" {
-				assertRequestValidationError(t, schemaErrs, tt.wantSchemaErr)
-				return
-			}
-			if len(schemaErrs) != 0 {
-				t.Fatalf("schema errors = %v, want none", schemaErrs)
-			}
-
-			celErrs := requestValidator.celValidator(current, old)
-			if tt.wantCELErr != "" {
-				assertRequestValidationError(t, celErrs, tt.wantCELErr)
-				return
-			}
-			if len(celErrs) != 0 {
-				t.Fatalf("CEL errors = %v, want none", celErrs)
-			}
-
-			oldBeta := dgdAdmissionBeta(t, tt.oldDeployment)
-			currentBeta := dgdAdmissionBeta(t, tt.deployment)
 			manager := tt.manager
 			if manager == nil {
 				manager = defaultManager
 			}
 			handler := NewDynamoGraphDeploymentHandler(manager, tt.operator, !tt.groveDisabled)
-			ctx := dgdAdmissionContextWithUserInfo(
-				dgdAdmissionOperation(tt.oldDeployment),
-				nvidiacomv1beta1.DynamoGraphDeploymentGVK,
+			warnings, err := apiAdmissionTestEnvironment.Admit(
+				t,
+				tt.oldDeployment,
+				tt.deployment,
+				tt.mutateRequest,
 				tt.userInfo,
+				apiAdmissionTestEnvironment.allowDynamoGraphDeployments,
+				func() { apiAdmissionTestEnvironment.useDynamoGraphDeploymentHandler(handler) },
 			)
-
-			var (
-				warnings []string
-				err      error
-			)
-			if tt.oldDeployment == nil {
-				warnings, err = handler.ValidateCreate(ctx, currentBeta)
-			} else {
-				warnings, err = handler.ValidateUpdate(ctx, oldBeta, currentBeta)
-			}
-			assertBetaValidationErrors(t, err, tt.wantWebhookErrs)
+			assertAdmissionErrors(t, err, tt.wantSchemaErr, tt.wantCELErr, tt.wantWebhookErrs)
 			if tt.notWantErr != "" && err != nil && strings.Contains(err.Error(), tt.notWantErr) {
-				t.Fatalf("webhook error = %q, must not contain %q", err.Error(), tt.notWantErr)
+				t.Fatalf("admission error = %q, must not contain %q", err.Error(), tt.notWantErr)
 			}
 			if !slices.Equal(warnings, tt.wantWarnings) {
-				t.Fatalf("warnings = %v, want %v", warnings, tt.wantWarnings)
+				t.Fatalf("admission warnings = %v, want %v", warnings, tt.wantWarnings)
 			}
 		})
 	}
@@ -1741,33 +1695,6 @@ func assertFieldPaths(t *testing.T, errs field.ErrorList, want []string) {
 	if strings.Join(got, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("field paths = %v, want %v", got, want)
 	}
-}
-
-func dgdAdmissionBeta(t *testing.T, deployment runtime.Object) *nvidiacomv1beta1.DynamoGraphDeployment {
-	t.Helper()
-	if deployment == nil {
-		return nil
-	}
-	switch deployment := deployment.(type) {
-	case *nvidiacomv1beta1.DynamoGraphDeployment:
-		return deployment.DeepCopy()
-	case *nvidiacomv1alpha1.DynamoGraphDeployment:
-		beta := &nvidiacomv1beta1.DynamoGraphDeployment{}
-		if err := deployment.ConvertTo(beta); err != nil {
-			t.Fatalf("convert v1alpha1 DGD to v1beta1: %v", err)
-		}
-		return beta
-	default:
-		t.Fatalf("unsupported DGD type %T", deployment)
-		return nil
-	}
-}
-
-func dgdAdmissionOperation(oldDeployment runtime.Object) admissionv1.Operation {
-	if oldDeployment == nil {
-		return admissionv1.Create
-	}
-	return admissionv1.Update
 }
 
 func setAlphaCompilationCacheVolumeNameEmpty(t *testing.T, request map[string]any) {
@@ -1918,6 +1845,7 @@ func betaDGDWithStatus(
 	mutateStatus func(*nvidiacomv1beta1.DynamoGraphDeploymentStatus),
 ) *nvidiacomv1beta1.DynamoGraphDeployment {
 	dgd := betaDGDWithSpec(mutateSpec)
+	dgd.Status.State = nvidiacomv1beta1.DGDStateInitializing
 	mutateStatus(&dgd.Status)
 	return dgd
 }
@@ -2112,37 +2040,5 @@ func newTestClusterTopology() *grovev1alpha1.ClusterTopologyBinding {
 				{Domain: grovev1alpha1.TopologyDomainRack, Key: "nvidia.com/rack"},
 			},
 		},
-	}
-}
-
-func assertBetaValidationErrors(t *testing.T, err error, wantErrs []string) {
-	t.Helper()
-	if len(wantErrs) == 0 {
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		return
-	}
-	if err == nil {
-		t.Fatalf("expected errors %v but got nil", wantErrs)
-	}
-	statusErr, ok := err.(*k8serrors.StatusError)
-	if !ok || !k8serrors.IsInvalid(err) {
-		t.Fatalf("error = %T %v, want typed Kubernetes invalid error", err, err)
-	}
-	if statusErr.ErrStatus.Details == nil {
-		t.Fatalf("error = %v, want typed field causes", err)
-	}
-
-	causes := statusErr.ErrStatus.Details.Causes
-	gotErrs := make([]string, len(causes))
-	for i, cause := range causes {
-		if cause.Field == "" {
-			t.Fatalf("error cause = %#v, want an exact field path", cause)
-		}
-		gotErrs[i] = fmt.Sprintf("%s: %s", cause.Field, cause.Message)
-	}
-	if !slices.Equal(gotErrs, wantErrs) {
-		t.Fatalf("webhook errors = %v, want %v", gotErrs, wantErrs)
 	}
 }

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -45,22 +45,31 @@ func admissionUnstructured(t *testing.T, deployment runtime.Object) map[string]a
 	}
 
 	// Several compact fixtures omit TypeMeta, but a real API request requires it.
-	if _, found := request["apiVersion"]; !found {
+	_, hasAPIVersion := request["apiVersion"]
+	_, hasKind := request["kind"]
+	if !hasAPIVersion || !hasKind {
+		var apiVersion, kind string
 		switch deployment.(type) {
 		case *nvidiacomv1alpha1.DynamoGraphDeployment:
-			request["apiVersion"] = nvidiacomv1alpha1.GroupVersion.String()
-			request["kind"] = admissionDGDKind
+			apiVersion = nvidiacomv1alpha1.GroupVersion.String()
+			kind = admissionDGDKind
 		case *nvidiacomv1beta1.DynamoGraphDeployment:
-			request["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
-			request["kind"] = admissionDGDKind
+			apiVersion = nvidiacomv1beta1.GroupVersion.String()
+			kind = admissionDGDKind
 		case *nvidiacomv1alpha1.DynamoComponentDeployment:
-			request["apiVersion"] = nvidiacomv1alpha1.GroupVersion.String()
-			request["kind"] = admissionDCDKind
+			apiVersion = nvidiacomv1alpha1.GroupVersion.String()
+			kind = admissionDCDKind
 		case *nvidiacomv1beta1.DynamoComponentDeployment:
-			request["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
-			request["kind"] = admissionDCDKind
+			apiVersion = nvidiacomv1beta1.GroupVersion.String()
+			kind = admissionDCDKind
 		default:
 			t.Fatalf("unsupported admission object type %T", deployment)
+		}
+		if !hasAPIVersion {
+			request["apiVersion"] = apiVersion
+		}
+		if !hasKind {
+			request["kind"] = kind
 		}
 	}
 	delete(request, "status")

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -32,6 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
+const (
+	admissionDCDKind = "DynamoComponentDeployment"
+	admissionDGDKind = "DynamoGraphDeployment"
+)
+
 func admissionUnstructured(t *testing.T, deployment runtime.Object) map[string]any {
 	t.Helper()
 	request, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deployment)
@@ -44,16 +49,16 @@ func admissionUnstructured(t *testing.T, deployment runtime.Object) map[string]a
 		switch deployment.(type) {
 		case *nvidiacomv1alpha1.DynamoGraphDeployment:
 			request["apiVersion"] = nvidiacomv1alpha1.GroupVersion.String()
-			request["kind"] = "DynamoGraphDeployment"
+			request["kind"] = admissionDGDKind
 		case *nvidiacomv1beta1.DynamoGraphDeployment:
 			request["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
-			request["kind"] = "DynamoGraphDeployment"
+			request["kind"] = admissionDGDKind
 		case *nvidiacomv1alpha1.DynamoComponentDeployment:
 			request["apiVersion"] = nvidiacomv1alpha1.GroupVersion.String()
-			request["kind"] = "DynamoComponentDeployment"
+			request["kind"] = admissionDCDKind
 		case *nvidiacomv1beta1.DynamoComponentDeployment:
 			request["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
-			request["kind"] = "DynamoComponentDeployment"
+			request["kind"] = admissionDCDKind
 		default:
 			t.Fatalf("unsupported admission object type %T", deployment)
 		}

--- a/deploy/operator/internal/webhook/validation/shared_test.go
+++ b/deploy/operator/internal/webhook/validation/shared_test.go
@@ -19,8 +19,6 @@ package validation
 
 import (
 	"context"
-	"path/filepath"
-	goruntime "runtime"
 	"strings"
 	"testing"
 
@@ -28,80 +26,37 @@ import (
 	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
-	crdvalidation "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/validation"
-	apiextensionsvalidation "k8s.io/apiextensions-apiserver/pkg/apiserver/validation"
-	apitest "k8s.io/apiextensions-apiserver/pkg/test"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 )
 
-type crdRequestValidator struct {
-	schemaValidator apiextensionsvalidation.SchemaValidator
-	celValidator    apitest.CELValidateFunc
-}
-
-func requestValidatorsFromCRD(t *testing.T, crdFilename string) map[string]*crdRequestValidator {
-	t.Helper()
-	_, thisFile, _, ok := goruntime.Caller(0)
-	if !ok {
-		t.Fatal("runtime.Caller(0) failed")
-	}
-	crdPath := filepath.Join(filepath.Dir(thisFile), "../../../config/crd/bases", crdFilename)
-	crd := apitest.MustLoadManifest[apiextensionsv1.CustomResourceDefinition](t, crdPath)
-	internalCRD := &apiextensions.CustomResourceDefinition{}
-	if err := apiextensionsv1.Convert_v1_CustomResourceDefinition_To_apiextensions_CustomResourceDefinition(crd, internalCRD, nil); err != nil {
-		t.Fatalf("convert CRD %s: %v", crdFilename, err)
-	}
-
-	internalCRD.Spec.Conversion.WebhookClientConfig.Service.Port = 443
-	for _, version := range internalCRD.Spec.Versions {
-		if version.Storage {
-			internalCRD.Status.StoredVersions = append(internalCRD.Status.StoredVersions, version.Name)
-		}
-	}
-	if errs := crdvalidation.ValidateCustomResourceDefinition(t.Context(), internalCRD); len(errs) != 0 {
-		t.Fatalf("validate CRD %s: %v", crdFilename, errs)
-	}
-
-	celValidators := apitest.VersionValidatorsFromFile(t, crdPath)
-	validators := make(map[string]*crdRequestValidator, len(crd.Spec.Versions))
-	for _, version := range crd.Spec.Versions {
-		var internalSchema apiextensions.JSONSchemaProps
-		if err := apiextensionsv1.Convert_v1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(
-			version.Schema.OpenAPIV3Schema,
-			&internalSchema,
-			nil,
-		); err != nil {
-			t.Fatalf("convert %s schema for %s: %v", crdFilename, version.Name, err)
-		}
-		schemaValidator, _, err := apiextensionsvalidation.NewSchemaValidator(&internalSchema)
-		if err != nil {
-			t.Fatalf("compile %s schema validator for %s: %v", crdFilename, version.Name, err)
-		}
-		validators[version.Name] = &crdRequestValidator{
-			schemaValidator: schemaValidator,
-			celValidator:    celValidators[version.Name],
-		}
-	}
-	return validators
-}
-
-func (v *crdRequestValidator) validateSchema(current, old map[string]any) field.ErrorList {
-	if old == nil {
-		return apiextensionsvalidation.ValidateCustomResource(nil, current, v.schemaValidator)
-	}
-	return apiextensionsvalidation.ValidateCustomResourceUpdate(nil, current, old, v.schemaValidator)
-}
-
 func admissionUnstructured(t *testing.T, deployment runtime.Object) map[string]any {
 	t.Helper()
 	request, err := runtime.DefaultUnstructuredConverter.ToUnstructured(deployment)
 	if err != nil {
 		t.Fatalf("convert %T to unstructured: %v", deployment, err)
+	}
+
+	// Several compact fixtures omit TypeMeta, but a real API request requires it.
+	if _, found := request["apiVersion"]; !found {
+		switch deployment.(type) {
+		case *nvidiacomv1alpha1.DynamoGraphDeployment:
+			request["apiVersion"] = nvidiacomv1alpha1.GroupVersion.String()
+			request["kind"] = "DynamoGraphDeployment"
+		case *nvidiacomv1beta1.DynamoGraphDeployment:
+			request["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
+			request["kind"] = "DynamoGraphDeployment"
+		case *nvidiacomv1alpha1.DynamoComponentDeployment:
+			request["apiVersion"] = nvidiacomv1alpha1.GroupVersion.String()
+			request["kind"] = "DynamoComponentDeployment"
+		case *nvidiacomv1beta1.DynamoComponentDeployment:
+			request["apiVersion"] = nvidiacomv1beta1.GroupVersion.String()
+			request["kind"] = "DynamoComponentDeployment"
+		default:
+			t.Fatalf("unsupported admission object type %T", deployment)
+		}
 	}
 	delete(request, "status")
 	return request
@@ -120,16 +75,6 @@ func admissionSourceVersion(t *testing.T, object runtime.Object) string {
 	default:
 		t.Fatalf("unsupported admission object type %T", object)
 		return ""
-	}
-}
-
-func assertRequestValidationError(t *testing.T, got field.ErrorList, want string) {
-	t.Helper()
-	if len(got) != 1 {
-		t.Fatalf("request errors = %v, want exactly %q", got, want)
-	}
-	if got[0].Error() != want {
-		t.Fatalf("request error = %q, want %q", got[0], want)
 	}
 }
 


### PR DESCRIPTION
## Overview:

Exercise DynamoComponentDeployment and DynamoGraphDeployment validation through the real envtest API server and the Helm-rendered admission registration. This replaces direct validator invocation in the validation matrices and catches routing, conversion, admission identity, warning, and API-server error behavior.

## Details:

- Install the Helm-rendered `ValidatingWebhookConfiguration` in envtest.
- Submit create and update requests with a dynamic Kubernetes client so CRD schema, CEL, conversion, and webhooks run in their real API-server order.
- Preserve request identity while granting test users authorization through separate RBAC bindings.
- Register DynamoComponentDeployment validation on its v1beta1 hub route.
- Make Helm and the chart available to local and containerized operator tests.

## Where should the reviewer start?

- Start with `deploy/operator/internal/webhook/validation/admission_test.go` for the test environment and request path.
- Then review the DCD and DGD matrix changes in the adjacent `*_test.go` files.
- The production routing fix is in `deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml`.

## Related Issues

- Linear: [DYN-3412](https://linear.app/nvidia/issue/DYN-3412)
- [x] Confirmed — no related GitHub issue

## Validation

- `source ../../.venv/bin/activate && make test` from `deploy/operator`
- `source ../../.venv/bin/activate && make lint` from `deploy/operator`
- `bin/helm-v3.17.3 lint ../helm/charts/platform/components/operator --set discoveryBackend=kubernetes` from `deploy/operator`
- built the `tester` Docker target with the operator chart BuildKit context