### PR TITLE
feat(router): add live admission request progress

### DIFF
--- a/lib/kv-router/benches/policy_queue.rs
+++ b/lib/kv-router/benches/policy_queue.rs
@@ -14,7 +14,7 @@ use criterion::{
 use dynamo_kv_router::RouterQueuePolicy;
 use dynamo_kv_router::protocols::WorkerWithDpRank;
 use dynamo_kv_router::scheduling::{
-    PolicyProfile, PolicyQueue, QueueSnapshot, RouterPolicyConfig, WorkerPlacement,
+    PolicyProfile, PolicyQueue, QueueSnapshot, RequestProgress, RouterPolicyConfig, WorkerPlacement,
 };
 
 #[derive(Debug, Clone, Copy)]
@@ -218,6 +218,22 @@ fn bench_drain_shared(c: &mut Criterion) {
     group.finish();
 }
 
+fn bench_request_progress(c: &mut Criterion) {
+    let mut group = c.benchmark_group("request_progress");
+    let (progress, updater) = RequestProgress::new(0);
+    let mut context_tokens = 0usize;
+    group.bench_function("update", |b| {
+        b.iter(|| {
+            context_tokens += 1;
+            updater.update_context_tokens(black_box(context_tokens));
+        });
+    });
+    group.bench_function("read", |b| {
+        b.iter(|| black_box(progress.context_tokens()));
+    });
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
@@ -225,6 +241,6 @@ criterion_group! {
         .warm_up_time(Duration::from_secs(1))
         .measurement_time(Duration::from_secs(3))
         .noise_threshold(0.03);
-    targets = bench_pop_once, bench_drain_fixed_requests, bench_drain_one_per_lane, bench_build_exact_lanes, bench_blocked_fraction, bench_drain_shared
+    targets = bench_pop_once, bench_drain_fixed_requests, bench_drain_one_per_lane, bench_build_exact_lanes, bench_blocked_fraction, bench_drain_shared, bench_request_progress
 }
 criterion_main!(benches);

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -278,7 +278,7 @@ where
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
         let mut cancellation_guard = self
             .queue
-            .cancellation_guard(request.mode.tracked_request_id());
+            .cancellation_guard(request.mode.admission_request_id());
         let track_prefill_tokens = request
             .router_config_override
             .as_ref()
@@ -1494,7 +1494,7 @@ mod tests {
         )
         .unwrap();
         scheduler
-            .schedule_request(request(ScheduleMode::Tracked {
+            .schedule_request(request(ScheduleMode::TrackedWithAdmission {
                 request_id: "req-1".to_owned(),
             }))
             .await
@@ -1555,7 +1555,7 @@ mod tests {
             let scheduler = Arc::clone(&scheduler);
             tokio::spawn(async move {
                 scheduler
-                    .schedule_request(request(ScheduleMode::Tracked {
+                    .schedule_request(request(ScheduleMode::TrackedWithAdmission {
                         request_id: "cancelled-pending".to_owned(),
                     }))
                     .await

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -112,6 +112,7 @@ where
             worker_type,
             monitor_worker_configs,
         )
+        .expect("synthetic policy profile does not require admission strategies")
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -129,7 +130,7 @@ where
         cancellation_token: CancellationToken,
         worker_type: &'static str,
         monitor_worker_configs: bool,
-    ) -> Self {
+    ) -> Result<Self, KvSchedulerError> {
         Self::new_with_policy_profile_and_admission_strategies(
             slots,
             workers_with_configs,
@@ -164,7 +165,21 @@ where
         worker_type: &'static str,
         monitor_worker_configs: bool,
         admission_strategies: PolicyClassAdmissionStrategies,
-    ) -> Self {
+    ) -> Result<Self, KvSchedulerError> {
+        let queue = Arc::new(
+            SchedulerQueue::new_with_policy_profile_and_admission_strategies(
+                Arc::clone(&slots),
+                workers_with_configs.clone(),
+                profile,
+                block_size,
+                selector,
+                prefill_load_estimator,
+                overlap_scores_refresh,
+                overloaded_worker_provider,
+                admission_strategies,
+            )?,
+        );
+
         if monitor_worker_configs {
             let slots_monitor = Arc::clone(&slots);
             let mut monitor_rx = workers_with_configs.clone();
@@ -202,19 +217,6 @@ where
             });
         }
 
-        let queue = Arc::new(
-            SchedulerQueue::new_with_policy_profile_and_admission_strategies(
-                Arc::clone(&slots),
-                workers_with_configs,
-                profile,
-                block_size,
-                selector,
-                prefill_load_estimator,
-                overlap_scores_refresh,
-                overloaded_worker_provider,
-                admission_strategies,
-            ),
-        );
         let (queue_updates, _) = watch::channel(());
         let queue_remote_updates = Arc::clone(&queue);
         let queue_periodic_updates = Arc::clone(&queue);
@@ -260,13 +262,13 @@ where
             }
         });
 
-        Self {
+        Ok(Self {
             slots,
             queue,
             queue_updates,
             track_prefill_tokens_default,
             worker_type,
-        }
+        })
     }
 
     pub async fn schedule_request(
@@ -629,7 +631,7 @@ where
         cancellation_token: CancellationToken,
         worker_type: &'static str,
         monitor_worker_configs: bool,
-    ) -> Self {
+    ) -> Result<Self, KvSchedulerError> {
         Self::new_with_policy_profile(
             slots,
             workers_with_configs,
@@ -1489,7 +1491,8 @@ mod tests {
             "test",
             false,
             strategies,
-        );
+        )
+        .unwrap();
         scheduler
             .schedule_request(request(ScheduleMode::Tracked {
                 request_id: "req-1".to_owned(),
@@ -1545,7 +1548,8 @@ mod tests {
                 "test",
                 false,
                 strategies,
-            ),
+            )
+            .unwrap(),
         );
         let scheduling = {
             let scheduler = Arc::clone(&scheduler);

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -16,10 +16,11 @@ use super::overlap_refresh::{NoopOverlapScoresRefresh, OverlapScoresRefresh};
 use super::policy_config::PolicyProfile;
 use super::prefill_load::PrefillLoadEstimator;
 use super::queue::{ClassQueueStats, SchedulerQueue};
+use super::queue_admission::PolicyClassAdmissionStrategies;
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
-    KvSchedulerError, OverloadedWorkerProvider, PotentialLoad, ScheduleMode, ScheduleRequest,
-    SchedulingRequest, SchedulingResponse, TierOverlapBlocks,
+    KvSchedulerError, OverloadedWorkerProvider, PotentialLoad, RequestOutcome, ScheduleMode,
+    ScheduleRequest, SchedulingRequest, SchedulingResponse, TierOverlapBlocks,
 };
 use crate::protocols::RoutingConstraints;
 use crate::protocols::{LocalBlockHash, WorkerConfigLike, WorkerId, WorkerWithDpRank};
@@ -129,6 +130,41 @@ where
         worker_type: &'static str,
         monitor_worker_configs: bool,
     ) -> Self {
+        Self::new_with_policy_profile_and_admission_strategies(
+            slots,
+            workers_with_configs,
+            profile,
+            block_size,
+            selector,
+            prefill_load_estimator,
+            overlap_scores_refresh,
+            overloaded_worker_provider,
+            recheck_interval,
+            track_prefill_tokens_default,
+            cancellation_token,
+            worker_type,
+            monitor_worker_configs,
+            PolicyClassAdmissionStrategies::new(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_policy_profile_and_admission_strategies(
+        slots: Arc<ActiveSequencesMultiWorker<P>>,
+        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
+        profile: PolicyProfile,
+        block_size: u32,
+        selector: Sel,
+        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        overlap_scores_refresh: Option<Arc<RF>>,
+        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+        recheck_interval: Duration,
+        track_prefill_tokens_default: bool,
+        cancellation_token: CancellationToken,
+        worker_type: &'static str,
+        monitor_worker_configs: bool,
+        admission_strategies: PolicyClassAdmissionStrategies,
+    ) -> Self {
         if monitor_worker_configs {
             let slots_monitor = Arc::clone(&slots);
             let mut monitor_rx = workers_with_configs.clone();
@@ -166,16 +202,19 @@ where
             });
         }
 
-        let queue = Arc::new(SchedulerQueue::new_with_policy_profile(
-            Arc::clone(&slots),
-            workers_with_configs,
-            profile,
-            block_size,
-            selector,
-            prefill_load_estimator,
-            overlap_scores_refresh,
-            overloaded_worker_provider,
-        ));
+        let queue = Arc::new(
+            SchedulerQueue::new_with_policy_profile_and_admission_strategies(
+                Arc::clone(&slots),
+                workers_with_configs,
+                profile,
+                block_size,
+                selector,
+                prefill_load_estimator,
+                overlap_scores_refresh,
+                overloaded_worker_provider,
+                admission_strategies,
+            ),
+        );
         let (queue_updates, _) = watch::channel(());
         let queue_remote_updates = Arc::clone(&queue);
         let queue_periodic_updates = Arc::clone(&queue);
@@ -215,7 +254,7 @@ where
                         break;
                     }
                     _ = recheck_interval.tick() => {
-                        queue_periodic_updates.update().await;
+                        queue_periodic_updates.reconcile().await;
                     }
                 }
             }
@@ -235,6 +274,9 @@ where
         request: ScheduleRequest,
     ) -> Result<SchedulingResponse, KvSchedulerError> {
         let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
+        let mut cancellation_guard = self
+            .queue
+            .cancellation_guard(request.mode.tracked_request_id());
         let track_prefill_tokens = request
             .router_config_override
             .as_ref()
@@ -283,9 +325,13 @@ where
             .enqueue_with_block_hashes(request, block_hashes)
             .await;
 
-        resp_rx
+        let response = resp_rx
             .await
-            .map_err(|_| KvSchedulerError::SubscriberShutdown)?
+            .map_err(|_| KvSchedulerError::SubscriberShutdown)?;
+        if let Some(guard) = cancellation_guard.as_mut() {
+            guard.disarm();
+        }
+        response
     }
 
     #[expect(clippy::too_many_arguments)]
@@ -446,6 +492,7 @@ where
         Ok(())
     }
 
+    /// Legacy slot cleanup. Admission-managed requests should use [`Self::finish`].
     pub async fn free(&self, request_id: &str) -> Result<(), SequenceError> {
         let request_id = request_id.to_string();
         let worker = self.slots.request_worker(&request_id);
@@ -455,6 +502,27 @@ where
             None => self.queue.update().await,
         }
         Ok(())
+    }
+
+    pub async fn mark_dispatched(&self, request_id: &str) {
+        self.queue.dispatched(request_id).await;
+    }
+
+    /// Release request state and report its terminal admission outcome.
+    pub async fn finish(
+        &self,
+        request_id: &str,
+        outcome: RequestOutcome,
+    ) -> Result<(), SequenceError> {
+        let request_id = request_id.to_string();
+        let worker = self.slots.request_worker(&request_id);
+        let result = self.slots.free(&request_id, Instant::now());
+        self.queue.finish(&request_id, outcome).await;
+        match worker {
+            Some(worker) => self.queue.update_worker(worker).await,
+            None => self.queue.update().await,
+        }
+        result
     }
 
     pub fn pending_count(&self) -> usize {
@@ -685,14 +753,18 @@ where
 mod tests {
     use std::collections::HashMap;
     use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
     use std::time::Duration;
 
     use tokio::sync::{mpsc, watch};
 
     use super::*;
     use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData};
-    use crate::scheduling::PrefillLoadEstimator;
     use crate::scheduling::selector::DefaultWorkerSelector;
+    use crate::scheduling::{
+        AdmissionAction, AdmissionDecision, AdmissionEvent, AdmissionRequest,
+        PolicyClassAdmissionStrategy, PrefillLoadEstimator, WorkerPlacement,
+    };
     use crate::sequences::SequenceSubscriber;
     use crate::test_utils::{NoopSequencePublisher, SimpleWorkerConfig};
 
@@ -1349,6 +1421,159 @@ mod tests {
 
         scheduler.free("req-1").await.unwrap();
         assert!(scheduler.get_active_lora_counts().is_empty());
+
+        cancel_token.cancel();
+    }
+
+    struct AbortCountingStrategy(Arc<AtomicUsize>);
+
+    impl PolicyClassAdmissionStrategy for AbortCountingStrategy {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Ready(WorkerPlacement::Any)
+        }
+
+        fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+            if matches!(event, AdmissionEvent::Aborted { .. }) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+            Vec::new()
+        }
+    }
+
+    struct DeferredAbortCountingStrategy(Arc<AtomicUsize>);
+
+    impl PolicyClassAdmissionStrategy for DeferredAbortCountingStrategy {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Defer
+        }
+
+        fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+            if matches!(event, AdmissionEvent::Aborted { .. }) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn finish_aborts_admission_once() {
+        let workers = HashMap::from([(0, SimpleWorkerConfig::default())]);
+        let slots = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            64,
+            HashMap::from([(0, (0, 1))]),
+            false,
+            0,
+            "test",
+        ));
+        let (_cfg_tx, cfg_rx) = watch::channel(workers);
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert(
+            "default".to_owned(),
+            Box::new(AbortCountingStrategy(Arc::clone(&aborted))),
+        );
+        let cancel_token = CancellationToken::new();
+        let scheduler = LocalScheduler::new_with_policy_profile_and_admission_strategies(
+            slots,
+            cfg_rx,
+            PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs),
+            64,
+            DefaultWorkerSelector::new(None, "test"),
+            None,
+            None::<Arc<NoopOverlapScoresRefresh>>,
+            None,
+            Duration::from_secs(60),
+            true,
+            cancel_token.clone(),
+            "test",
+            false,
+            strategies,
+        );
+        scheduler
+            .schedule_request(request(ScheduleMode::Tracked {
+                request_id: "req-1".to_owned(),
+            }))
+            .await
+            .unwrap();
+
+        scheduler
+            .finish("req-1", RequestOutcome::Aborted)
+            .await
+            .unwrap();
+        scheduler
+            .finish("req-1", RequestOutcome::Aborted)
+            .await
+            .unwrap();
+
+        assert_eq!(aborted.load(Ordering::Relaxed), 1);
+        cancel_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn dropping_pending_schedule_aborts_admission_without_reconcile() {
+        let workers = HashMap::from([(0, SimpleWorkerConfig::default())]);
+        let slots = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            64,
+            HashMap::from([(0, (0, 1))]),
+            false,
+            0,
+            "test",
+        ));
+        let (_cfg_tx, cfg_rx) = watch::channel(workers);
+        let aborted = Arc::new(AtomicUsize::new(0));
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert(
+            "default".to_owned(),
+            Box::new(DeferredAbortCountingStrategy(Arc::clone(&aborted))),
+        );
+        let cancel_token = CancellationToken::new();
+        let scheduler = Arc::new(
+            LocalScheduler::new_with_policy_profile_and_admission_strategies(
+                slots,
+                cfg_rx,
+                PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs),
+                64,
+                DefaultWorkerSelector::new(None, "test"),
+                None,
+                None::<Arc<NoopOverlapScoresRefresh>>,
+                None,
+                Duration::from_secs(60),
+                true,
+                cancel_token.clone(),
+                "test",
+                false,
+                strategies,
+            ),
+        );
+        let scheduling = {
+            let scheduler = Arc::clone(&scheduler);
+            tokio::spawn(async move {
+                scheduler
+                    .schedule_request(request(ScheduleMode::Tracked {
+                        request_id: "cancelled-pending".to_owned(),
+                    }))
+                    .await
+            })
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while scheduler.pending_count() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("request did not enter the pending queue");
+        scheduling.abort();
+        let _ = scheduling.await;
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while aborted.load(Ordering::Relaxed) != 1 || scheduler.pending_count() != 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("dropping the selection future did not abort admission");
 
         cancel_token.cancel();
     }

--- a/lib/kv-router/src/scheduling/mod.rs
+++ b/lib/kv-router/src/scheduling/mod.rs
@@ -36,7 +36,8 @@ pub use prefill_load::{
 };
 pub use queue_admission::{
     AdmissionAction, AdmissionDecision, AdmissionEvent, AdmissionId, AdmissionRequest,
-    PolicyClassAdmissionStrategy, QueueAdmissionConfig, WorkerEligibility,
-    WorkerEligibilitySnapshot, WorkerPlacement,
+    PolicyClassAdmissionStrategies, PolicyClassAdmissionStrategy, QueueAdmissionConfig,
+    RequestProgress, RequestProgressUpdater, WorkerEligibility, WorkerEligibilitySnapshot,
+    WorkerPlacement,
 };
 pub use types::*;

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -616,55 +616,65 @@ impl<T> PolicyQueue<T> {
         mut predicate: impl FnMut(&T) -> bool,
     ) -> Vec<PolicyQueueEntry<T>> {
         let mut removed = Vec::new();
-        for class in &mut self.classes {
-            let remove_sequences: FxHashSet<u64> = class
-                .entries()
-                .filter(|entry| predicate(entry.payload()))
-                .map(|entry| entry.enqueue_seq)
-                .collect();
-            if remove_sequences.is_empty() {
-                continue;
-            }
-            let removed_start = removed.len();
+        for class_index in 0..self.classes.len() {
+            removed.extend(self.take_if_in_class(class_index, &mut predicate));
+        }
+        removed
+    }
 
-            let mut retained = BinaryHeap::with_capacity(class.pending.len());
-            for entry in class.pending.drain() {
+    pub(crate) fn take_if_in_class(
+        &mut self,
+        class_index: usize,
+        mut predicate: impl FnMut(&T) -> bool,
+    ) -> Vec<PolicyQueueEntry<T>> {
+        let class = &mut self.classes[class_index];
+        let remove_sequences: FxHashSet<u64> = class
+            .entries()
+            .filter(|entry| predicate(entry.payload()))
+            .map(|entry| entry.enqueue_seq)
+            .collect();
+        if remove_sequences.is_empty() {
+            return Vec::new();
+        }
+
+        let mut removed = Vec::new();
+        let mut retained = BinaryHeap::with_capacity(class.pending.len());
+        for entry in class.pending.drain() {
+            if remove_sequences.contains(&entry.enqueue_seq) {
+                removed.push(entry);
+            } else {
+                retained.push(entry);
+            }
+        }
+        class.pending = retained;
+
+        removed.extend(
+            class
+                .deferred
+                .extract_if(|_, entry| remove_sequences.contains(&entry.enqueue_seq))
+                .map(|(_, entry)| entry),
+        );
+
+        class.ready_by_worker.retain(|_, ready| {
+            let mut retained = BinaryHeap::with_capacity(ready.len());
+            for entry in ready.drain() {
                 if remove_sequences.contains(&entry.enqueue_seq) {
                     removed.push(entry);
                 } else {
                     retained.push(entry);
                 }
             }
-            class.pending = retained;
+            *ready = retained;
+            !ready.is_empty()
+        });
+        class.rebuild_worker_heads();
 
-            let deferred: Vec<PolicyQueueEntry<T>> = class
-                .deferred
-                .extract_if(|_, entry| remove_sequences.contains(&entry.enqueue_seq))
-                .map(|(_, entry)| entry)
-                .collect();
-            removed.extend(deferred);
-
-            class.ready_by_worker.retain(|_, ready| {
-                let mut retained = BinaryHeap::with_capacity(ready.len());
-                for entry in ready.drain() {
-                    if remove_sequences.contains(&entry.enqueue_seq) {
-                        removed.push(entry);
-                    } else {
-                        retained.push(entry);
-                    }
-                }
-                *ready = retained;
-                !ready.is_empty()
-            });
-            class.rebuild_worker_heads();
-
-            for entry in &removed[removed_start..] {
-                subtract_stats(&mut class.stats, entry.snapshot);
-                self.pending_count -= 1;
-            }
-            if class.ready_is_empty() {
-                class.deficit = 0;
-            }
+        for entry in &removed {
+            subtract_stats(&mut class.stats, entry.snapshot);
+            self.pending_count -= 1;
+        }
+        if class.ready_is_empty() {
+            class.deficit = 0;
         }
         removed
     }

--- a/lib/kv-router/src/scheduling/policy_queue.rs
+++ b/lib/kv-router/src/scheduling/policy_queue.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 
 use super::config::RouterQueuePolicy;
 use super::policy_config::{PolicyClassConfig, PolicyProfile};
-use super::queue_admission::WorkerPlacement;
+use super::queue_admission::{AdmissionId, WorkerPlacement};
 use crate::protocols::WorkerWithDpRank;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -190,6 +190,7 @@ impl PartialOrd for WorkerLaneHead {
 struct PolicyClassQueue<T> {
     config: PolicyClassConfig,
     pending: BinaryHeap<PolicyQueueEntry<T>>,
+    deferred: FxHashMap<AdmissionId, PolicyQueueEntry<T>>,
     stats: PolicyQueueStats,
     deficit: usize,
     ready_by_worker: FxHashMap<WorkerWithDpRank, BinaryHeap<PolicyQueueEntry<T>>>,
@@ -198,7 +199,7 @@ struct PolicyClassQueue<T> {
 }
 
 impl<T> PolicyClassQueue<T> {
-    fn is_empty(&self) -> bool {
+    fn ready_is_empty(&self) -> bool {
         self.pending.is_empty() && self.ready_by_worker.is_empty()
     }
 
@@ -206,6 +207,7 @@ impl<T> PolicyClassQueue<T> {
         self.pending
             .iter()
             .chain(self.ready_by_worker.values().flat_map(|ready| ready.iter()))
+            .chain(self.deferred.values())
     }
 
     fn push_ready(&mut self, placement: WorkerPlacement, entry: PolicyQueueEntry<T>) {
@@ -405,6 +407,11 @@ pub struct PolicyQueue<T> {
     candidates: Vec<Option<DispatchCandidate>>,
 }
 
+enum QueueEntryState {
+    Ready(WorkerPlacement),
+    Deferred(AdmissionId),
+}
+
 impl<T> PolicyQueue<T> {
     pub fn new(profile: PolicyProfile) -> Self {
         let class_count = profile.classes().len();
@@ -416,6 +423,7 @@ impl<T> PolicyQueue<T> {
                 .map(|config| PolicyClassQueue {
                     config,
                     pending: BinaryHeap::new(),
+                    deferred: FxHashMap::default(),
                     ready_by_worker: FxHashMap::default(),
                     blocked_workers: FxHashSet::default(),
                     candidate_worker_heads: BTreeSet::new(),
@@ -460,7 +468,7 @@ impl<T> PolicyQueue<T> {
     }
 
     pub fn has_backlog(&self, class_index: usize) -> bool {
-        !self.classes[class_index].is_empty()
+        !self.classes[class_index].ready_is_empty()
     }
 
     pub fn entries(&self) -> impl Iterator<Item = &PolicyQueueEntry<T>> {
@@ -470,26 +478,7 @@ impl<T> PolicyQueue<T> {
     /// Remove queued entries that no longer satisfy `keep`, rebuilding queue
     /// accounting while preserving each retained entry's scheduling key.
     pub fn retain(&mut self, mut keep: impl FnMut(&T) -> bool) {
-        self.pending_count = 0;
-        for class in &mut self.classes {
-            class.pending.retain(|entry| keep(entry.payload()));
-            class.ready_by_worker.retain(|_, ready| {
-                ready.retain(|entry| keep(entry.payload()));
-                !ready.is_empty()
-            });
-            class.rebuild_worker_heads();
-            let mut stats = PolicyQueueStats::default();
-            let mut count = 0;
-            for entry in class.entries() {
-                add_stats(&mut stats, entry.snapshot);
-                count += 1;
-            }
-            class.stats = stats;
-            self.pending_count += count;
-            if class.is_empty() {
-                class.deficit = 0;
-            }
-        }
+        drop(self.take_if(|payload| !keep(payload)));
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -504,6 +493,54 @@ impl<T> PolicyQueue<T> {
         priority_jump: f64,
         strict_priority: u32,
         placement: WorkerPlacement,
+        payload: T,
+    ) -> Result<(), (QueueRejection, T)> {
+        self.enqueue_with_state(
+            class_index,
+            worker_count,
+            snapshot,
+            arrival_offset_secs,
+            priority_jump,
+            strict_priority,
+            QueueEntryState::Ready(placement),
+            payload,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn enqueue_deferred(
+        &mut self,
+        class_index: usize,
+        worker_count: usize,
+        snapshot: QueueSnapshot,
+        arrival_offset_secs: f64,
+        priority_jump: f64,
+        strict_priority: u32,
+        admission_id: AdmissionId,
+        payload: T,
+    ) -> Result<(), (QueueRejection, T)> {
+        self.enqueue_with_state(
+            class_index,
+            worker_count,
+            snapshot,
+            arrival_offset_secs,
+            priority_jump,
+            strict_priority,
+            QueueEntryState::Deferred(admission_id),
+            payload,
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn enqueue_with_state(
+        &mut self,
+        class_index: usize,
+        worker_count: usize,
+        snapshot: QueueSnapshot,
+        arrival_offset_secs: f64,
+        priority_jump: f64,
+        strict_priority: u32,
+        state: QueueEntryState,
         payload: T,
     ) -> Result<(), (QueueRejection, T)> {
         let class = &mut self.classes[class_index];
@@ -523,9 +560,113 @@ impl<T> PolicyQueue<T> {
         );
         self.next_enqueue_seq = self.next_enqueue_seq.wrapping_add(1);
         add_stats(&mut class.stats, snapshot);
-        class.push_ready(placement, entry);
+        match state {
+            QueueEntryState::Ready(placement) => class.push_ready(placement, entry),
+            QueueEntryState::Deferred(admission_id) => {
+                let replaced = class.deferred.insert(admission_id, entry);
+                debug_assert!(replaced.is_none(), "duplicate deferred admission ID");
+            }
+        }
         self.pending_count += 1;
         Ok(())
+    }
+
+    pub(crate) fn make_ready(
+        &mut self,
+        class_index: usize,
+        admission_id: AdmissionId,
+        placement: WorkerPlacement,
+    ) -> bool {
+        let class = &mut self.classes[class_index];
+        let Some(entry) = class.deferred.remove(&admission_id) else {
+            return false;
+        };
+        class.push_ready(placement, entry);
+        true
+    }
+
+    pub(crate) fn deferred_payload_mut(
+        &mut self,
+        class_index: usize,
+        admission_id: AdmissionId,
+    ) -> Option<&mut T> {
+        self.classes[class_index]
+            .deferred
+            .get_mut(&admission_id)
+            .map(PolicyQueueEntry::payload_mut)
+    }
+
+    pub(crate) fn remove_deferred(
+        &mut self,
+        class_index: usize,
+        admission_id: AdmissionId,
+    ) -> Option<PolicyQueueEntry<T>> {
+        let class = &mut self.classes[class_index];
+        let entry = class.deferred.remove(&admission_id)?;
+        subtract_stats(&mut class.stats, entry.snapshot);
+        self.pending_count -= 1;
+        if class.ready_is_empty() {
+            class.deficit = 0;
+        }
+        Some(entry)
+    }
+
+    pub(crate) fn take_if(
+        &mut self,
+        mut predicate: impl FnMut(&T) -> bool,
+    ) -> Vec<PolicyQueueEntry<T>> {
+        let mut removed = Vec::new();
+        for class in &mut self.classes {
+            let remove_sequences: FxHashSet<u64> = class
+                .entries()
+                .filter(|entry| predicate(entry.payload()))
+                .map(|entry| entry.enqueue_seq)
+                .collect();
+            if remove_sequences.is_empty() {
+                continue;
+            }
+            let removed_start = removed.len();
+
+            let mut retained = BinaryHeap::with_capacity(class.pending.len());
+            for entry in class.pending.drain() {
+                if remove_sequences.contains(&entry.enqueue_seq) {
+                    removed.push(entry);
+                } else {
+                    retained.push(entry);
+                }
+            }
+            class.pending = retained;
+
+            let deferred: Vec<PolicyQueueEntry<T>> = class
+                .deferred
+                .extract_if(|_, entry| remove_sequences.contains(&entry.enqueue_seq))
+                .map(|(_, entry)| entry)
+                .collect();
+            removed.extend(deferred);
+
+            class.ready_by_worker.retain(|_, ready| {
+                let mut retained = BinaryHeap::with_capacity(ready.len());
+                for entry in ready.drain() {
+                    if remove_sequences.contains(&entry.enqueue_seq) {
+                        removed.push(entry);
+                    } else {
+                        retained.push(entry);
+                    }
+                }
+                *ready = retained;
+                !ready.is_empty()
+            });
+            class.rebuild_worker_heads();
+
+            for entry in &removed[removed_start..] {
+                subtract_stats(&mut class.stats, entry.snapshot);
+                self.pending_count -= 1;
+            }
+            if class.ready_is_empty() {
+                class.deficit = 0;
+            }
+        }
+        removed
     }
 
     /// Runs one DRR ring pass over dispatchable class heads. If no head has
@@ -551,7 +692,7 @@ impl<T> PolicyQueue<T> {
                 return Some(self.pop_candidate(class_index, candidate));
             }
             self.candidates[class_index] = candidate;
-            if class.is_empty() {
+            if class.ready_is_empty() {
                 class.deficit = 0;
             }
         }
@@ -567,7 +708,7 @@ impl<T> PolicyQueue<T> {
                 class.next_dispatchable(class_index, &mut is_dispatchable)
             };
             let Some(candidate) = candidate else {
-                if class.is_empty() {
+                if class.ready_is_empty() {
                     class.deficit = 0;
                 }
                 continue;
@@ -632,6 +773,7 @@ impl<T> PolicyQueue<T> {
                 .pending
                 .into_iter()
                 .chain(class.ready_by_worker.into_values().flatten())
+                .chain(class.deferred.into_values())
         })
     }
 
@@ -648,7 +790,7 @@ impl<T> PolicyQueue<T> {
             .saturating_sub(entry.snapshot.scheduling_cost_tokens);
         subtract_stats(&mut class.stats, entry.snapshot);
         self.pending_count -= 1;
-        if class.is_empty() {
+        if class.ready_is_empty() {
             class.deficit = 0;
         } else {
             self.carry_class = (class.deficit > 0).then_some(class_index);
@@ -761,6 +903,54 @@ policy_classes:
     quantum: 10
 "#,
         )
+    }
+
+    #[test]
+    fn deferred_entries_count_toward_limits_without_blocking_ready_work() {
+        let mut queue = PolicyQueue::new(admission_profile());
+        let deferred_id = AdmissionId::new(7);
+        queue
+            .enqueue_deferred(
+                0,
+                1,
+                QueueSnapshot::new(20, 5),
+                0.0,
+                0.0,
+                0,
+                deferred_id,
+                "deferred",
+            )
+            .unwrap();
+        assert!(!queue.has_backlog(0));
+        queue
+            .enqueue(
+                0,
+                1,
+                QueueSnapshot::new(10, 0),
+                1.0,
+                0.0,
+                0,
+                WorkerPlacement::Any,
+                "ready",
+            )
+            .unwrap();
+        assert!(queue.has_backlog(0));
+
+        assert_eq!(queue.pending_count(), 2);
+        assert_eq!(queue.class_stats(0).requests, 2);
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "ready"
+        );
+        assert!(queue.pop_next(|_, _, _| true).is_none());
+
+        assert!(queue.make_ready(0, deferred_id, WorkerPlacement::Any));
+        assert_eq!(
+            queue.pop_next(|_, _, _| true).unwrap().into_payload(),
+            "deferred"
+        );
+        assert_eq!(queue.pending_count(), 0);
+        assert_eq!(queue.class_stats(0), PolicyQueueStats::default());
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -688,6 +688,15 @@ impl<
             (class_index, Some(snapshot))
         };
 
+        if let Some(request_id) = request.mode.tracked_request_id()
+            && self.tracked_admissions.contains_key(request_id)
+        {
+            request.respond(Err(KvSchedulerError::BookingFailed(format!(
+                "request {request_id} already has an active admission"
+            ))));
+            return false;
+        }
+
         let mut admission = if request.mode.is_tracked() && self.admission.has_strategy(class_index)
         {
             let allowed_worker_ids = request.allowed_worker_ids.clone();
@@ -877,7 +886,17 @@ impl<
     }
 
     fn handle_cancelled(&mut self, request_id: &str) -> bool {
-        self.handle_finished(request_id, RequestOutcome::Aborted)
+        let rollback_booking = self
+            .tracked_admissions
+            .get(request_id)
+            .is_some_and(|tracked| tracked.worker.is_some() && !tracked.dispatched);
+        if rollback_booking
+            && let Err(error) = self.slots.free(&request_id.to_owned(), Instant::now())
+        {
+            tracing::error!(%request_id, %error, "Failed to roll back cancelled scheduler booking");
+        }
+        let made_ready = self.handle_finished(request_id, RequestOutcome::Aborted);
+        rollback_booking || made_ready
     }
 
     fn handle_finished(&mut self, request_id: &str, outcome: RequestOutcome) -> bool {
@@ -2169,6 +2188,75 @@ policy_classes:
             }
             Vec::new()
         }
+    }
+
+    #[tokio::test]
+    async fn cancellation_after_response_send_rolls_back_booking() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
+            state: Arc::clone(&state),
+        }));
+        let (mut request, response) = make_request("cancelled-after-handoff", 64);
+        request.policy_class = Some("agents".to_owned());
+        let cancellation = queue
+            .cancellation_guard(Some("cancelled-after-handoff"))
+            .unwrap();
+
+        queue.enqueue(request).await;
+        assert_eq!(
+            slots
+                .active_request_counts()
+                .get(&WorkerWithDpRank::new(0, 0))
+                .copied(),
+            Some(1)
+        );
+
+        drop(cancellation);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while state.lock().unwrap().aborted.len() != 1 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancellation did not abort admission");
+
+        slots.assert_completely_drained(decay_now());
+        assert_eq!(state.lock().unwrap().aborted, vec![AdmissionId::new(0)]);
+        drop(response);
+    }
+
+    #[tokio::test]
+    async fn duplicate_request_id_does_not_replace_active_admission() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
+            state: Arc::clone(&state),
+        }));
+        let (mut first, first_response) = make_request("duplicate", 64);
+        first.policy_class = Some("agents".to_owned());
+        queue.enqueue(first).await;
+        first_response.await.unwrap().unwrap();
+
+        let (mut duplicate, duplicate_response) = make_request("duplicate", 64);
+        duplicate.policy_class = Some("agents".to_owned());
+        queue.enqueue(duplicate).await;
+        assert!(matches!(
+            duplicate_response.await.unwrap(),
+            Err(KvSchedulerError::BookingFailed(message))
+                if message == "request duplicate already has an active admission"
+        ));
+        assert_eq!(
+            slots
+                .active_request_counts()
+                .get(&WorkerWithDpRank::new(0, 0))
+                .copied(),
+            Some(1)
+        );
+        assert!(state.lock().unwrap().aborted.is_empty());
+
+        queue.finish("duplicate", RequestOutcome::Aborted).await;
+        queue.update().await;
+        assert_eq!(state.lock().unwrap().aborted, vec![AdmissionId::new(0)]);
+        slots.free(&"duplicate".to_owned(), decay_now()).unwrap();
     }
 
     struct BypassGate {

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -20,9 +20,9 @@ use super::policy_config::{PolicyClassConfig, PolicyProfile};
 use super::policy_queue::{PolicyQueue, QueueSnapshot};
 use super::prefill_load::{PrefillLoadEstimator, effective_prefill_tokens};
 use super::queue_admission::{
-    AdmissionAction, AdmissionDecision, AdmissionTicket, PolicyClassAdmissionController,
-    PolicyClassAdmissionStrategies, RequestProgressUpdater, WorkerEligibility,
-    WorkerEligibilitySnapshot, WorkerPlacement,
+    AdmissionAction, AdmissionDecision, AdmissionTicket, ClassAdmissionAction,
+    PolicyClassAdmissionController, PolicyClassAdmissionStrategies, RequestProgressUpdater,
+    WorkerEligibility, WorkerEligibilitySnapshot, WorkerPlacement,
 };
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
@@ -892,7 +892,12 @@ impl<
 
     fn handle_cancelled(&mut self, request_id: &str) -> bool {
         let Some(tracked) = self.tracked_admissions.get(request_id).copied() else {
-            return false;
+            let request_id = request_id.to_owned();
+            let rollback_booking = self.slots.request_worker(&request_id).is_some();
+            if rollback_booking && let Err(error) = self.slots.free(&request_id, Instant::now()) {
+                tracing::error!(%request_id, %error, "Failed to roll back cancelled scheduler booking");
+            }
+            return rollback_booking;
         };
         let rollback_booking = tracked.worker.is_some() && !tracked.dispatched;
         if rollback_booking
@@ -968,7 +973,7 @@ impl<
 
     fn apply_admission_actions(
         &mut self,
-        actions: impl IntoIterator<Item = super::queue_admission::ClassAdmissionAction>,
+        actions: impl IntoIterator<Item = ClassAdmissionAction>,
     ) -> bool {
         let mut made_ready = false;
         let mut actions: VecDeque<_> = actions.into_iter().collect();
@@ -1037,13 +1042,19 @@ impl<
         for class_index in std::mem::take(&mut self.cancelled_ready_classes) {
             let tracked_admissions = &self.tracked_admissions;
             let cancelled = self.pending.take_if_in_class(class_index, |queued| {
-                queued.admission.is_some()
-                    && queued.request.response_is_closed()
+                let Some(admission) = queued.admission.as_ref() else {
+                    return false;
+                };
+                queued.request.response_is_closed()
                     && queued
                         .request
                         .mode
                         .tracked_request_id()
-                        .is_some_and(|request_id| !tracked_admissions.contains_key(request_id))
+                        .is_some_and(|request_id| {
+                            tracked_admissions
+                                .get(request_id)
+                                .is_none_or(|tracked| tracked.ticket != admission.ticket)
+                        })
             });
             for entry in cancelled {
                 self.subtract_pending_counters(class_index, entry.snapshot());
@@ -1136,12 +1147,13 @@ impl<
             let request = queued.request;
             // A ready cancellation removes lifecycle state before its batched
             // heap cleanup; an intervening capacity update may pop it first.
-            if admission.is_some()
-                && request
-                    .mode
-                    .tracked_request_id()
-                    .is_some_and(|request_id| !self.tracked_admissions.contains_key(request_id))
-            {
+            if admission.as_ref().is_some_and(|admission| {
+                request.mode.tracked_request_id().is_some_and(|request_id| {
+                    self.tracked_admissions
+                        .get(request_id)
+                        .is_none_or(|tracked| tracked.ticket != admission.ticket)
+                })
+            }) {
                 continue;
             }
             tracing::debug!(
@@ -2382,6 +2394,33 @@ policy_classes:
         slots.free(&"unmanaged".to_owned(), decay_now()).unwrap();
     }
 
+    #[tokio::test]
+    async fn cancellation_after_bypassed_handoff_rolls_back_booking() {
+        let events = Arc::new(AtomicUsize::new(0));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(BypassGate {
+            events: Arc::clone(&events),
+        }));
+        let (mut request, response) = make_admission_request("bypassed-handoff", 64);
+        request.policy_class = Some("agents".to_owned());
+        let cancellation = queue.cancellation_guard(Some("bypassed-handoff")).unwrap();
+
+        queue.enqueue(request).await;
+        assert_eq!(
+            slots
+                .active_request_counts()
+                .get(&WorkerWithDpRank::new(0, 0))
+                .copied(),
+            Some(1)
+        );
+
+        drop(cancellation);
+        queue.update().await;
+
+        slots.assert_completely_drained(decay_now());
+        assert_eq!(events.load(Ordering::Relaxed), 0);
+        drop(response);
+    }
+
     #[derive(Default)]
     struct FinishReleaseGate {
         first: Option<AdmissionId>,
@@ -2587,6 +2626,48 @@ policy_classes:
             .collect()
         );
         slots.free(&"blocker".to_owned(), decay_now()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_ready_cleanup_does_not_remove_reused_request_id() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
+            state: Arc::clone(&state),
+        }));
+
+        let (blocker, blocker_response) = make_request("blocker", 64);
+        queue.enqueue(blocker).await;
+        blocker_response.await.unwrap().unwrap();
+
+        let (mut cancelled, cancelled_response) = make_admission_request("reused", 64);
+        cancelled.policy_class = Some("agents".to_owned());
+        let cancellation = queue.cancellation_guard(Some("reused")).unwrap();
+        queue.enqueue(cancelled).await;
+        drop(cancelled_response);
+        drop(cancellation);
+        queue.update().await;
+        assert_eq!(state.lock().unwrap().aborted, vec![AdmissionId::new(0)]);
+
+        let (mut replacement, replacement_response) = make_admission_request("reused", 64);
+        replacement.policy_class = Some("agents".to_owned());
+        queue.enqueue(replacement).await;
+        assert_eq!(queue.pending_count(), 2);
+
+        queue.reconcile().await;
+        assert_eq!(queue.pending_count(), 1);
+        assert_eq!(state.lock().unwrap().aborted, vec![AdmissionId::new(0)]);
+
+        slots.free(&"blocker".to_owned(), decay_now()).unwrap();
+        queue.update().await;
+        let selected = replacement_response.await.unwrap().unwrap();
+        assert!(selected.request_progress.is_some());
+
+        queue
+            .finish("reused", RequestOutcome::Completed { context_tokens: 64 })
+            .await;
+        queue.update().await;
+        assert_eq!(state.lock().unwrap().completed_context_tokens, vec![64]);
+        slots.free(&"reused".to_owned(), decay_now()).unwrap();
     }
 
     #[tokio::test]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1,12 +1,13 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::collections::HashMap;
+use std::collections::{HashMap, VecDeque};
 use std::marker::PhantomData;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
 use std::time::Duration;
 
+use rustc_hash::FxHashSet;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::time::Instant;
 
@@ -18,11 +19,15 @@ use super::overlap_refresh::{
 use super::policy_config::{PolicyClassConfig, PolicyProfile};
 use super::policy_queue::{PolicyQueue, QueueSnapshot};
 use super::prefill_load::{PrefillLoadEstimator, effective_prefill_tokens};
-use super::queue_admission::WorkerPlacement;
+use super::queue_admission::{
+    AdmissionAction, AdmissionDecision, AdmissionTicket, PolicyClassAdmissionController,
+    PolicyClassAdmissionStrategies, RequestProgressUpdater, WorkerEligibility,
+    WorkerEligibilitySnapshot, WorkerPlacement,
+};
 use super::selector::{DefaultWorkerSelector, WorkerSelector};
 use super::types::{
-    KvSchedulerError, OverloadedWorkerProvider, SchedulingContext, SchedulingRequest,
-    SchedulingResponse,
+    KvSchedulerError, OverloadedWorkerProvider, RequestOutcome, SchedulingContext,
+    SchedulingRequest, SchedulingResponse,
 };
 use crate::protocols::{
     LocalBlockHash, PrefillLoadHint, WorkerConfigLike, WorkerId, WorkerWithDpRank,
@@ -52,6 +57,12 @@ struct QueuedRequest {
     request: SchedulingRequest,
     enqueue_at: Instant,
     block_hashes: Option<Vec<LocalBlockHash>>,
+    admission: Option<RequestAdmission>,
+}
+
+struct RequestAdmission {
+    ticket: AdmissionTicket,
+    progress: RequestProgressUpdater,
 }
 
 #[allow(clippy::large_enum_variant)]
@@ -65,6 +76,59 @@ enum AdmissionCommand {
         worker: Option<WorkerWithDpRank>,
         ack_tx: oneshot::Sender<()>,
     },
+    Reconcile {
+        ack_tx: oneshot::Sender<()>,
+    },
+    Dispatched {
+        request_id: String,
+    },
+    Cancelled {
+        request_id: String,
+    },
+    Finished {
+        request_id: String,
+        outcome: RequestOutcome,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+struct TrackedAdmission {
+    ticket: AdmissionTicket,
+    worker: Option<WorkerWithDpRank>,
+    dispatched: bool,
+}
+
+pub(crate) struct SchedulingCancellationGuard {
+    admission_tx: mpsc::Sender<AdmissionCommand>,
+    request_id: Option<String>,
+}
+
+impl SchedulingCancellationGuard {
+    pub(crate) fn disarm(&mut self) {
+        self.request_id = None;
+    }
+}
+
+impl Drop for SchedulingCancellationGuard {
+    fn drop(&mut self) {
+        let Some(request_id) = self.request_id.take() else {
+            return;
+        };
+        let command = AdmissionCommand::Cancelled { request_id };
+        match self.admission_tx.try_send(command) {
+            Ok(()) | Err(mpsc::error::TrySendError::Closed(_)) => {}
+            Err(mpsc::error::TrySendError::Full(command)) => {
+                let Ok(handle) = tokio::runtime::Handle::try_current() else {
+                    tracing::warn!("No tokio runtime for queued admission cancellation");
+                    return;
+                };
+                let admission_tx = self.admission_tx.clone();
+                handle.spawn(async move {
+                    let _ = admission_tx.send(command).await;
+                });
+            }
+        }
+    }
 }
 
 struct SchedulerQueueActor<
@@ -74,6 +138,8 @@ struct SchedulerQueueActor<
     RF: OverlapScoresRefresh,
 > {
     pending: PolicyQueue<QueuedRequest>,
+    admission: PolicyClassAdmissionController,
+    tracked_admissions: HashMap<String, TrackedAdmission>,
     profile: PolicyProfile,
     pending_count: Arc<AtomicUsize>,
     pending_isl_tokens: Arc<AtomicUsize>,
@@ -110,6 +176,7 @@ pub struct SchedulerQueue<
     slots: Arc<ActiveSequencesMultiWorker<P>>,
     workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
     queueing_enabled: bool,
+    admission_enabled: bool,
     supports_overlap_refresh: bool,
     _marker: PhantomData<(Sel, RF)>,
 }
@@ -157,6 +224,31 @@ impl<
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
     ) -> Self {
+        Self::new_with_policy_profile_and_admission_strategies(
+            slots,
+            workers_with_configs,
+            profile,
+            block_size,
+            selector,
+            prefill_load_estimator,
+            overlap_scores_refresh,
+            overloaded_worker_provider,
+            PolicyClassAdmissionStrategies::new(),
+        )
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_policy_profile_and_admission_strategies(
+        slots: Arc<ActiveSequencesMultiWorker<P>>,
+        workers_with_configs: watch::Receiver<HashMap<WorkerId, C>>,
+        profile: PolicyProfile,
+        block_size: u32,
+        selector: Sel,
+        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        overlap_scores_refresh: Option<Arc<RF>>,
+        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+        admission_strategies: PolicyClassAdmissionStrategies,
+    ) -> Self {
         Self::new_with_policy_profile_and_capacity(
             slots,
             workers_with_configs,
@@ -166,6 +258,7 @@ impl<
             prefill_load_estimator,
             overlap_scores_refresh,
             overloaded_worker_provider,
+            admission_strategies,
             ADMISSION_CHANNEL_CAPACITY,
         )
     }
@@ -180,12 +273,15 @@ impl<
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+        admission_strategies: PolicyClassAdmissionStrategies,
         admission_channel_capacity: usize,
     ) -> Self {
+        let admission_enabled = !admission_strategies.is_empty();
         let queueing_enabled = profile
             .classes()
             .iter()
-            .any(PolicyClassConfig::queueing_enabled);
+            .any(PolicyClassConfig::queueing_enabled)
+            || admission_enabled;
         for class in profile.classes() {
             tracing::info!(
                 policy_class = class.name,
@@ -227,6 +323,8 @@ impl<
         let (admission_tx, admission_rx) = mpsc::channel(admission_channel_capacity);
         let actor = SchedulerQueueActor {
             pending: PolicyQueue::new(profile.clone()),
+            admission: PolicyClassAdmissionController::new(&profile, admission_strategies),
+            tracked_admissions: HashMap::new(),
             profile,
             pending_count: Arc::clone(&pending_count),
             pending_isl_tokens: Arc::clone(&pending_isl_tokens),
@@ -250,6 +348,7 @@ impl<
             slots,
             workers_with_configs,
             queueing_enabled,
+            admission_enabled,
             supports_overlap_refresh: overlap_refresh_after.is_some(),
             _marker: PhantomData,
         }
@@ -406,6 +505,62 @@ impl<
         }
     }
 
+    pub(crate) async fn dispatched(&self, request_id: &str) {
+        if !self.admission_enabled {
+            return;
+        }
+        let _ = self
+            .admission_tx
+            .send(AdmissionCommand::Dispatched {
+                request_id: request_id.to_owned(),
+            })
+            .await;
+    }
+
+    pub(crate) fn cancellation_guard(
+        &self,
+        request_id: Option<&str>,
+    ) -> Option<SchedulingCancellationGuard> {
+        if !self.admission_enabled {
+            return None;
+        }
+        let request_id = request_id?.to_owned();
+        Some(SchedulingCancellationGuard {
+            admission_tx: self.admission_tx.clone(),
+            request_id: Some(request_id),
+        })
+    }
+
+    pub(crate) async fn finish(&self, request_id: &str, outcome: RequestOutcome) {
+        if !self.admission_enabled {
+            return;
+        }
+        let _ = self
+            .admission_tx
+            .send(AdmissionCommand::Finished {
+                request_id: request_id.to_owned(),
+                outcome,
+            })
+            .await;
+    }
+
+    pub(crate) async fn reconcile(&self) {
+        if !self.admission_enabled {
+            self.update().await;
+            return;
+        }
+
+        let (ack_tx, ack_rx) = oneshot::channel();
+        if self
+            .admission_tx
+            .send(AdmissionCommand::Reconcile { ack_tx })
+            .await
+            .is_ok()
+        {
+            let _ = ack_rx.await;
+        }
+    }
+
     /// Number of requests currently parked in the pending queue (lock-free).
     pub fn pending_count(&self) -> usize {
         self.pending_count.load(AtomicOrdering::Relaxed)
@@ -455,12 +610,37 @@ impl<
                     block_hashes,
                     ack_tx,
                 } => {
-                    self.handle_enqueue(request, block_hashes);
+                    let made_ready = self.handle_enqueue(request, block_hashes);
                     let _ = ack_tx.send(());
+                    if made_ready {
+                        self.handle_update(None).await;
+                    }
                 }
                 AdmissionCommand::Update { worker, ack_tx } => {
                     self.handle_update(worker).await;
                     let _ = ack_tx.send(());
+                }
+                AdmissionCommand::Reconcile { ack_tx } => {
+                    self.handle_reconcile().await;
+                    let _ = ack_tx.send(());
+                }
+                AdmissionCommand::Dispatched { request_id } => {
+                    if self.handle_dispatched(&request_id) {
+                        self.handle_update(None).await;
+                    }
+                }
+                AdmissionCommand::Cancelled { request_id } => {
+                    if self.handle_cancelled(&request_id) {
+                        self.handle_update(None).await;
+                    }
+                }
+                AdmissionCommand::Finished {
+                    request_id,
+                    outcome,
+                } => {
+                    if self.handle_finished(&request_id, outcome) {
+                        self.handle_update(None).await;
+                    }
                 }
             }
         }
@@ -488,73 +668,170 @@ impl<
 
     fn handle_enqueue(
         &mut self,
-        request: SchedulingRequest,
+        mut request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
-    ) {
-        let eligibility = request.eligibility();
+    ) -> bool {
         let decay_now = Instant::now();
-        // Synthetic and explicit selections avoid cache work. Family
-        // classification reuses one worker generation for snapshot and busy checks.
-        let (class_index, snapshot, should_queue) = if let Some(class_index) = self
+        // Synthetic and explicit selections avoid cache work. Family classification
+        // samples overlap once and reuses it if the request enters queue storage.
+        let (class_index, snapshot) = if let Some(class_index) = self
             .profile
             .direct_class_index(request.policy_class.as_deref())
         {
-            let class = self.profile.class(class_index);
-            let should_queue = self.should_queue(class_index, class, || {
-                self.all_workers_prefill_busy(class, eligibility, decay_now)
-            });
-            (class_index, None, should_queue)
+            (class_index, None)
         } else {
-            let active_tokens = self.slots.active_tokens(decay_now);
             let workers = self.workers_with_configs.borrow();
             let snapshot = Self::snapshot_for_with(&request, &workers);
             let class_index = self
                 .profile
                 .resolve_class_index(request.policy_class.as_deref(), snapshot.uncached_tokens);
-            let class = self.profile.class(class_index);
-            let should_queue = self.should_queue(class_index, class, || {
-                Self::all_workers_prefill_busy_with(&active_tokens, &workers, class, eligibility)
-            });
-            (class_index, Some(snapshot), should_queue)
+            (class_index, Some(snapshot))
         };
+
+        let mut admission = if request.mode.is_tracked() && self.admission.has_strategy(class_index)
+        {
+            let allowed_worker_ids = request.allowed_worker_ids.clone();
+            let pinned_worker = request.pinned_worker;
+            let routing_constraints = request.routing_constraints.clone();
+            let workers = self.workers_with_configs.clone();
+            let overloaded_worker_provider = self.overloaded_worker_provider.clone();
+            let worker_eligibility = WorkerEligibility::new(move || {
+                let workers = workers.borrow();
+                let overloaded_worker_ids = overloaded_worker_provider
+                    .as_ref()
+                    .and_then(|provider| provider());
+                let structural_eligibility = RoutingEligibility::new(
+                    allowed_worker_ids.as_ref(),
+                    None,
+                    pinned_worker,
+                    &routing_constraints,
+                );
+                let mut structural_workers = FxHashSet::default();
+                structural_eligibility.for_each_eligible_worker_rank(&workers, |worker, _| {
+                    structural_workers.insert(worker);
+                });
+                let Some(overloaded_worker_ids) = overloaded_worker_ids.as_ref() else {
+                    return WorkerEligibilitySnapshot::new(structural_workers);
+                };
+                let mut available_workers = structural_workers.clone();
+                available_workers
+                    .retain(|worker| !overloaded_worker_ids.contains(&worker.worker_id));
+                WorkerEligibilitySnapshot::with_availability(structural_workers, available_workers)
+            });
+            self.admission
+                .admit(
+                    class_index,
+                    request.session_id.as_deref(),
+                    request.isl_tokens,
+                    worker_eligibility,
+                )
+                .map(|(ticket, progress, decision)| {
+                    (RequestAdmission { ticket, progress }, decision)
+                })
+        } else {
+            None
+        };
+        let mut deferred = false;
+        if let Some((request_admission, decision)) = admission.as_ref() {
+            match decision {
+                AdmissionDecision::Bypass => admission = None,
+                AdmissionDecision::Ready(placement) => {
+                    if let Err(error) = apply_admission_placement(&mut request, *placement) {
+                        request.respond(Err(error));
+                        return self.abort_admission(request_admission.ticket);
+                    }
+                }
+                AdmissionDecision::Defer => deferred = true,
+            }
+        }
+
+        let class = self.profile.class(class_index);
+        let should_queue = deferred
+            || self.should_queue(class_index, class, || {
+                self.all_workers_prefill_busy(class, request.eligibility(), decay_now)
+            });
         if !should_queue {
-            self.admit_one(request, decay_now);
-            return;
+            return self.admit_one(
+                request,
+                decay_now,
+                admission.map(|(admission, _)| admission),
+            );
         }
 
         let snapshot = snapshot.unwrap_or_else(|| self.snapshot_for(&request));
-        let class = self.profile.class(class_index);
-        tracing::debug!(policy_class = class.name, "queueing request");
+        tracing::debug!(policy_class = class.name, deferred, "queueing request");
         let arrival_offset = self.start_time.elapsed().as_secs_f64();
         let priority_jump = request.priority_jump;
         let strict_priority = request.strict_priority;
         let placement = request
             .pinned_worker
             .map_or(WorkerPlacement::Any, WorkerPlacement::Exact);
+        let deferred_id = deferred
+            .then(|| admission.as_ref().map(|(admission, _)| admission.ticket.id))
+            .flatten();
+        let tracked_admission = admission.as_ref().map(|(admission, _)| {
+            (
+                request
+                    .mode
+                    .tracked_request_id()
+                    .expect("admitted request is tracked")
+                    .to_owned(),
+                admission.ticket,
+            )
+        });
         let queued = QueuedRequest {
             request,
             enqueue_at: decay_now,
             block_hashes,
+            admission: admission.map(|(admission, _)| admission),
         };
         let worker_count = self.workers_with_configs.borrow().len();
-        if let Err((rejection, queued)) = self.pending.enqueue(
-            class_index,
-            worker_count,
-            snapshot,
-            arrival_offset,
-            priority_jump,
-            strict_priority,
-            placement,
-            queued,
-        ) {
+        let enqueue = match deferred_id {
+            Some(admission_id) => self.pending.enqueue_deferred(
+                class_index,
+                worker_count,
+                snapshot,
+                arrival_offset,
+                priority_jump,
+                strict_priority,
+                admission_id,
+                queued,
+            ),
+            None => self.pending.enqueue(
+                class_index,
+                worker_count,
+                snapshot,
+                arrival_offset,
+                priority_jump,
+                strict_priority,
+                placement,
+                queued,
+            ),
+        };
+        if let Err((rejection, queued)) = enqueue {
+            let made_ready = queued
+                .admission
+                .as_ref()
+                .is_some_and(|admission| self.abort_admission(admission.ticket));
             let mut request = queued.request;
             request.respond(Err(KvSchedulerError::QueueRejected(rejection)));
-            return;
+            return made_ready;
+        }
+        if let Some((request_id, ticket)) = tracked_admission {
+            self.tracked_admissions.insert(
+                request_id,
+                TrackedAdmission {
+                    ticket,
+                    worker: None,
+                    dispatched: false,
+                },
+            );
         }
         self.pending_count.fetch_add(1, AtomicOrdering::Relaxed);
         self.pending_isl_tokens
             .fetch_add(snapshot.raw_isl_tokens, AtomicOrdering::Relaxed);
         self.add_class_counters(class_index, snapshot);
+        false
     }
 
     fn should_queue(
@@ -581,6 +858,149 @@ impl<
         // limits, ordering, DRR cost, and counters.
         let context = SchedulingContext::new(request, workers);
         QueueSnapshot::new(request.isl_tokens, context.best_cached_tokens())
+    }
+
+    fn handle_dispatched(&mut self, request_id: &str) -> bool {
+        let Some(tracked) = self.tracked_admissions.get_mut(request_id) else {
+            return false;
+        };
+        if tracked.dispatched {
+            return false;
+        }
+        let Some(worker) = tracked.worker else {
+            tracing::debug!(%request_id, "Ignoring dispatch before queue admission");
+            return false;
+        };
+        tracked.dispatched = true;
+        let actions = self.admission.dispatched(tracked.ticket, worker);
+        self.apply_admission_actions(actions)
+    }
+
+    fn handle_cancelled(&mut self, request_id: &str) -> bool {
+        self.handle_finished(request_id, RequestOutcome::Aborted)
+    }
+
+    fn handle_finished(&mut self, request_id: &str, outcome: RequestOutcome) -> bool {
+        let Some(tracked) = self.tracked_admissions.remove(request_id) else {
+            return false;
+        };
+        if tracked.worker.is_none() {
+            let removed = self
+                .pending
+                .take_if(|queued| queued.request.mode.tracked_request_id() == Some(request_id));
+            debug_assert_eq!(
+                removed.len(),
+                1,
+                "pending admission must have one queue entry"
+            );
+            for entry in removed {
+                self.subtract_pending_counters(entry.class_index(), entry.snapshot());
+            }
+        }
+        match outcome {
+            RequestOutcome::Completed { context_tokens } => {
+                self.complete_admission(tracked.ticket, context_tokens)
+            }
+            RequestOutcome::Aborted => self.abort_admission(tracked.ticket),
+        }
+    }
+
+    fn complete_admission(&mut self, ticket: AdmissionTicket, context_tokens: usize) -> bool {
+        let actions = self.admission.completed(ticket, context_tokens);
+        self.apply_admission_actions(actions)
+    }
+
+    fn abort_admission(&mut self, ticket: AdmissionTicket) -> bool {
+        let actions = self.admission.aborted(ticket);
+        self.apply_admission_actions(actions)
+    }
+
+    fn apply_admission_actions(
+        &mut self,
+        actions: impl IntoIterator<Item = super::queue_admission::ClassAdmissionAction>,
+    ) -> bool {
+        let mut made_ready = false;
+        let mut actions: VecDeque<_> = actions.into_iter().collect();
+        while let Some(class_action) = actions.pop_front() {
+            let AdmissionAction::MakeReady { id, placement } = class_action.action;
+
+            let validation_error = {
+                let Some(queued) = self
+                    .pending
+                    .deferred_payload_mut(class_action.class_index, id)
+                else {
+                    tracing::debug!(
+                        admission_id = id.get(),
+                        "Ignoring unknown make-ready action"
+                    );
+                    continue;
+                };
+                apply_admission_placement(&mut queued.request, placement).err()
+            };
+
+            if let Some(error) = validation_error {
+                let Some(entry) = self.pending.remove_deferred(class_action.class_index, id) else {
+                    continue;
+                };
+                let snapshot = entry.snapshot();
+                self.subtract_pending_counters(class_action.class_index, snapshot);
+                let mut queued = entry.into_payload();
+                if let Some(admission) = queued.admission {
+                    if let Some(request_id) = queued.request.mode.tracked_request_id() {
+                        self.tracked_admissions.remove(request_id);
+                    }
+                    actions.extend(self.admission.aborted(admission.ticket));
+                }
+                queued.request.respond(Err(error));
+                continue;
+            }
+
+            let effective_placement = self
+                .pending
+                .deferred_payload_mut(class_action.class_index, id)
+                .and_then(|queued| queued.request.pinned_worker)
+                .map_or(placement, WorkerPlacement::Exact);
+            if self
+                .pending
+                .make_ready(class_action.class_index, id, effective_placement)
+            {
+                made_ready = true;
+            } else {
+                tracing::debug!(
+                    admission_id = id.get(),
+                    "Ignoring duplicate make-ready action"
+                );
+            }
+        }
+        made_ready
+    }
+
+    fn subtract_pending_counters(&self, class_index: usize, snapshot: QueueSnapshot) {
+        self.pending_count.fetch_sub(1, AtomicOrdering::Relaxed);
+        self.pending_isl_tokens
+            .fetch_sub(snapshot.raw_isl_tokens, AtomicOrdering::Relaxed);
+        self.subtract_class_counters(class_index, snapshot);
+    }
+
+    async fn handle_reconcile(&mut self) {
+        let cancelled = self
+            .pending
+            .take_if(|queued| queued.admission.is_some() && queued.request.response_is_closed());
+        let mut actions = Vec::new();
+        for entry in cancelled {
+            let class_index = entry.class_index();
+            let snapshot = entry.snapshot();
+            self.subtract_pending_counters(class_index, snapshot);
+            if let Some(admission) = entry.payload().admission.as_ref() {
+                if let Some(request_id) = entry.payload().request.mode.tracked_request_id() {
+                    self.tracked_admissions.remove(request_id);
+                }
+                actions.extend(self.admission.aborted(admission.ticket));
+            }
+        }
+        actions.extend(self.admission.reconcile());
+        self.apply_admission_actions(actions);
+        self.handle_update(None).await;
     }
 
     async fn handle_update(&mut self, worker: Option<WorkerWithDpRank>) {
@@ -660,18 +1080,32 @@ impl<
             let admit_now = Instant::now();
             let class_index = popped.class_index();
             let class = self.profile.class(class_index);
-            let request = popped.into_payload().request;
+            let queued = popped.into_payload();
+            let admission = queued.admission;
+            let request = queued.request;
             tracing::debug!(
                 policy_class = class.name,
                 "scheduling request from pending queue"
             );
-            self.admit_one(request, admit_now);
+            self.admit_one(request, admit_now, admission);
         }
     }
 
     /// Run the full scheduling pipeline for a single request:
     /// compute projected load -> select worker -> book tracked state -> respond.
-    fn admit_one(&self, mut request: SchedulingRequest, decay_now: Instant) {
+    fn admit_one(
+        &mut self,
+        mut request: SchedulingRequest,
+        decay_now: Instant,
+        admission: Option<RequestAdmission>,
+    ) -> bool {
+        let admission_key = admission.as_ref().map(|_| {
+            request
+                .mode
+                .tracked_request_id()
+                .expect("admitted request is tracked")
+                .to_owned()
+        });
         request.worker_loads = self
             .slots
             .project_worker_loads(request.token_seq.as_deref(), decay_now);
@@ -701,7 +1135,12 @@ impl<
             Err(e) => {
                 tracing::warn!("scheduling failed: {e}");
                 request.respond(Err(e));
-                return;
+                if let Some(request_id) = admission_key.as_deref() {
+                    self.tracked_admissions.remove(request_id);
+                }
+                return admission
+                    .as_ref()
+                    .is_some_and(|admission| self.abort_admission(admission.ticket));
             }
         };
 
@@ -710,11 +1149,18 @@ impl<
             effective_overlap_blocks: selection.effective_overlap_blocks,
             cached_tokens: selection.cached_tokens,
             selected_worker_tiers,
+            request_progress: admission
+                .as_ref()
+                .map(|admission| admission.progress.clone()),
         };
 
         if !request.mode.is_tracked() {
             request.respond(Ok(response));
-            return;
+            debug_assert!(
+                admission.is_none(),
+                "query-only selection bypasses admission"
+            );
+            return false;
         }
 
         let request_id = request
@@ -738,7 +1184,29 @@ impl<
             worker: selection.worker,
             lora_name: request.lora_name.take(),
         };
-        self.book_and_respond(request, sequence_request, response);
+        let delivered = self.book_and_respond(request, sequence_request, response);
+        if let Some(admission) = admission {
+            if delivered {
+                let request_id = admission_key.expect("admitted request has a lifecycle key");
+                self.tracked_admissions
+                    .entry(request_id)
+                    .and_modify(|tracked| {
+                        debug_assert_eq!(tracked.ticket, admission.ticket);
+                        tracked.worker = Some(selection.worker);
+                    })
+                    .or_insert(TrackedAdmission {
+                        ticket: admission.ticket,
+                        worker: Some(selection.worker),
+                        dispatched: false,
+                    });
+            } else {
+                if let Some(request_id) = admission_key.as_deref() {
+                    self.tracked_admissions.remove(request_id);
+                }
+                return self.abort_admission(admission.ticket);
+            }
+        }
+        false
     }
 
     /// Completes the tracked-admission ownership handoff.
@@ -753,30 +1221,31 @@ impl<
         mut request: SchedulingRequest,
         sequence_request: SequenceRequest,
         response: SchedulingResponse,
-    ) {
+    ) -> bool {
         if request.response_is_closed() {
             tracing::debug!(
                 request_id = %sequence_request.request_id,
                 "Skipping scheduler booking for cancelled request"
             );
-            return;
+            return false;
         }
 
         let request_id = sequence_request.request_id.clone();
         if let Err(error) = self.slots.add_request(sequence_request, Instant::now()) {
             tracing::warn!(%request_id, %error, "Failed to book scheduler state");
             request.respond(Err(KvSchedulerError::BookingFailed(error.to_string())));
-            return;
+            return false;
         }
 
         if request.respond(Ok(response)) {
-            return;
+            return true;
         }
 
         tracing::debug!(%request_id, "Rolling back undelivered scheduler booking");
         if let Err(error) = self.slots.free(&request_id, Instant::now()) {
             tracing::error!(%request_id, %error, "Failed to roll back scheduler booking");
         }
+        false
     }
 
     fn prefill_load_hint_for(
@@ -887,6 +1356,22 @@ impl<
     }
 }
 
+fn apply_admission_placement(
+    request: &mut SchedulingRequest,
+    placement: WorkerPlacement,
+) -> Result<(), KvSchedulerError> {
+    let WorkerPlacement::Exact(worker) = placement else {
+        return Ok(());
+    };
+    if request.pinned_worker.is_some_and(|pinned| pinned != worker) {
+        return Err(KvSchedulerError::BookingFailed(format!(
+            "admission placement {worker:?} conflicts with the request's pinned worker"
+        )));
+    }
+    request.pinned_worker = Some(worker);
+    request.eligibility().validate_pinned_worker_allowed()
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::{HashMap, HashSet};
@@ -904,7 +1389,10 @@ mod tests {
     };
     use crate::scheduling::OverlapSignals;
     use crate::scheduling::types::{KvSchedulerError, ScheduleMode};
-    use crate::scheduling::{RefreshedOverlap, RouterPolicyConfig};
+    use crate::scheduling::{
+        AdmissionEvent, AdmissionId, AdmissionRequest, PolicyClassAdmissionStrategy,
+        RefreshedOverlap, RequestProgress, RouterPolicyConfig,
+    };
     use crate::sequences::{ActiveSequencesMultiWorker, SequencePublisher};
     use crate::test_utils::{NoopSequencePublisher, SimpleWorkerConfig};
     use crate::{DefaultWorkerSelector, WorkerSelector};
@@ -1413,6 +1901,7 @@ mod tests {
             None,
             Some(refresher),
             None,
+            PolicyClassAdmissionStrategies::new(),
             admission_channel_capacity,
         ));
 
@@ -1452,6 +1941,481 @@ mod tests {
             resp_tx: Some(tx),
         };
         (req, rx)
+    }
+
+    #[derive(Default)]
+    struct GateState {
+        deferred: Option<AdmissionId>,
+        session_id: Option<String>,
+        context_tokens: usize,
+        progress: Option<RequestProgress>,
+        dispatched: Vec<WorkerWithDpRank>,
+        completed_context_tokens: Vec<usize>,
+        aborted: Vec<AdmissionId>,
+    }
+
+    struct ReconcileGate {
+        state: Arc<StdMutex<GateState>>,
+    }
+
+    impl PolicyClassAdmissionStrategy for ReconcileGate {
+        fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+            let mut state = self.state.lock().unwrap();
+            state.deferred = Some(request.id());
+            state.session_id = request.session_id().map(str::to_owned);
+            state.context_tokens = request.context_tokens();
+            state.progress = Some(request.progress().clone());
+            AdmissionDecision::Defer
+        }
+
+        fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+            let mut state = self.state.lock().unwrap();
+            match event {
+                AdmissionEvent::Dispatched { worker, .. } => {
+                    state.dispatched.push(worker);
+                    Vec::new()
+                }
+                AdmissionEvent::Completed { id, context_tokens } => {
+                    if state.deferred == Some(id) {
+                        state.deferred = None;
+                    }
+                    state.completed_context_tokens.push(context_tokens);
+                    Vec::new()
+                }
+                AdmissionEvent::Aborted { id } => {
+                    if state.deferred == Some(id) {
+                        state.deferred = None;
+                    }
+                    state.aborted.push(id);
+                    Vec::new()
+                }
+                AdmissionEvent::Reconcile => state
+                    .deferred
+                    .take()
+                    .map(|id| {
+                        vec![AdmissionAction::MakeReady {
+                            id,
+                            placement: WorkerPlacement::Exact(WorkerWithDpRank::new(0, 0)),
+                        }]
+                    })
+                    .unwrap_or_default(),
+            }
+        }
+    }
+
+    fn make_queue_with_admission_strategy(
+        strategy: Box<dyn PolicyClassAdmissionStrategy>,
+    ) -> (
+        Arc<SchedulerQueue<NoopSequencePublisher, SimpleWorkerConfig>>,
+        Arc<ActiveSequencesMultiWorker<NoopSequencePublisher>>,
+    ) {
+        make_queue_with_admission_strategy_and_workers(strategy, 1)
+    }
+
+    fn make_queue_with_admission_strategy_and_workers(
+        strategy: Box<dyn PolicyClassAdmissionStrategy>,
+        worker_count: u64,
+    ) -> (
+        Arc<SchedulerQueue<NoopSequencePublisher, SimpleWorkerConfig>>,
+        Arc<ActiveSequencesMultiWorker<NoopSequencePublisher>>,
+    ) {
+        let profile = policy_profile(
+            r#"
+default_policy_family: standard
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: standard
+    policy_family: standard
+    cache_bucket: all
+    quantum: 1
+  - name: agents
+    queue_admission:
+      type: test
+    prefill_busy_threshold: 0
+    quantum: 1
+"#,
+        );
+        let slots = Arc::new(ActiveSequencesMultiWorker::new(
+            NoopSequencePublisher,
+            16,
+            (0..worker_count).map(|worker| (worker, (0, 1))).collect(),
+            false,
+            0,
+            "test",
+        ));
+        let (_cfg_tx, cfg_rx) = watch::channel(
+            (0..worker_count)
+                .map(|worker| {
+                    (
+                        worker,
+                        SimpleWorkerConfig {
+                            max_num_batched_tokens: Some(1_000),
+                            ..Default::default()
+                        },
+                    )
+                })
+                .collect(),
+        );
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert("agents".to_owned(), strategy);
+        let queue = Arc::new(
+            SchedulerQueue::new_with_policy_profile_and_admission_strategies(
+                Arc::clone(&slots),
+                cfg_rx,
+                profile,
+                16,
+                DefaultWorkerSelector::new(None, "test"),
+                None,
+                None,
+                None,
+                strategies,
+            ),
+        );
+        (queue, slots)
+    }
+
+    #[tokio::test]
+    async fn admission_strategy_defers_releases_and_observes_lifecycle() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReconcileGate {
+            state: Arc::clone(&state),
+        }));
+        let (mut request, response) = make_request("deferred", 64);
+        request.policy_class = Some("agents".to_owned());
+        request.session_id = Some("session-a".to_owned());
+
+        queue.enqueue(request).await;
+        assert_eq!(queue.pending_count(), 1);
+        {
+            let state = state.lock().unwrap();
+            assert_eq!(state.session_id.as_deref(), Some("session-a"));
+            assert_eq!(state.context_tokens, 64);
+            assert!(state.dispatched.is_empty());
+        }
+
+        queue.reconcile().await;
+        let selected = response.await.unwrap().unwrap();
+        assert_eq!(selected.best_worker, WorkerWithDpRank::new(0, 0));
+        let progress = selected.request_progress.unwrap();
+        progress.update_context_tokens(80);
+        assert_eq!(
+            state
+                .lock()
+                .unwrap()
+                .progress
+                .as_ref()
+                .unwrap()
+                .context_tokens(),
+            80
+        );
+        assert_eq!(queue.pending_count(), 0);
+        queue.dispatched("deferred").await;
+        queue.dispatched("deferred").await;
+        queue
+            .finish("deferred", RequestOutcome::Completed { context_tokens: 81 })
+            .await;
+        queue.update().await;
+        {
+            let state = state.lock().unwrap();
+            assert_eq!(state.dispatched, vec![WorkerWithDpRank::new(0, 0)]);
+            assert_eq!(state.completed_context_tokens, vec![81]);
+        }
+
+        slots.free(&"deferred".to_owned(), decay_now()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_deferred_request_receives_one_terminal_event() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, _slots) = make_queue_with_admission_strategy(Box::new(ReconcileGate {
+            state: Arc::clone(&state),
+        }));
+        let (mut request, response) = make_request("cancelled", 64);
+        request.policy_class = Some("agents".to_owned());
+        request.session_id = Some("session-a".to_owned());
+
+        let cancellation = queue.cancellation_guard(Some("cancelled")).unwrap();
+        queue.enqueue(request).await;
+        drop(response);
+        drop(cancellation);
+        queue.update().await;
+
+        assert_eq!(queue.pending_count(), 0);
+        let state = state.lock().unwrap();
+        assert!(state.dispatched.is_empty());
+        assert_eq!(state.aborted, vec![AdmissionId::new(0)]);
+    }
+
+    struct ReadyGate {
+        state: Arc<StdMutex<GateState>>,
+    }
+
+    impl PolicyClassAdmissionStrategy for ReadyGate {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Ready(WorkerPlacement::Any)
+        }
+
+        fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+            let mut state = self.state.lock().unwrap();
+            match event {
+                AdmissionEvent::Dispatched { worker, .. } => state.dispatched.push(worker),
+                AdmissionEvent::Completed { context_tokens, .. } => {
+                    state.completed_context_tokens.push(context_tokens);
+                }
+                AdmissionEvent::Aborted { id } => state.aborted.push(id),
+                AdmissionEvent::Reconcile => {}
+            }
+            Vec::new()
+        }
+    }
+
+    struct BypassGate {
+        events: Arc<AtomicUsize>,
+    }
+
+    impl PolicyClassAdmissionStrategy for BypassGate {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Bypass
+        }
+
+        fn on_event(&mut self, _event: AdmissionEvent) -> Vec<AdmissionAction> {
+            self.events.fetch_add(1, Ordering::Relaxed);
+            Vec::new()
+        }
+    }
+
+    #[tokio::test]
+    async fn bypassed_request_has_no_admission_lifecycle() {
+        let events = Arc::new(AtomicUsize::new(0));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(BypassGate {
+            events: Arc::clone(&events),
+        }));
+        let (mut request, response) = make_request("bypassed", 64);
+        request.policy_class = Some("agents".to_owned());
+        {
+            queue.enqueue(request).await;
+            let selected = response.await.unwrap().unwrap();
+            assert!(selected.request_progress.is_none());
+        }
+
+        queue.dispatched("bypassed").await;
+        queue
+            .finish("bypassed", RequestOutcome::Completed { context_tokens: 64 })
+            .await;
+        queue.update().await;
+        assert_eq!(events.load(Ordering::Relaxed), 0);
+        slots.free(&"bypassed".to_owned(), decay_now()).unwrap();
+
+        let (request, response) = make_request("unmanaged", 64);
+        queue.enqueue(request).await;
+        let selected = response.await.unwrap().unwrap();
+        assert!(selected.request_progress.is_none());
+        slots.free(&"unmanaged".to_owned(), decay_now()).unwrap();
+    }
+
+    #[derive(Default)]
+    struct FinishReleaseGate {
+        first: Option<AdmissionId>,
+        deferred: Option<AdmissionId>,
+    }
+
+    impl PolicyClassAdmissionStrategy for FinishReleaseGate {
+        fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+            if self.first.is_none() {
+                self.first = Some(request.id());
+                AdmissionDecision::Ready(WorkerPlacement::Any)
+            } else {
+                self.deferred = Some(request.id());
+                AdmissionDecision::Defer
+            }
+        }
+
+        fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+            let id = match event {
+                AdmissionEvent::Completed { id, .. } | AdmissionEvent::Aborted { id } => id,
+                _ => return Vec::new(),
+            };
+            if self.first != Some(id) {
+                return Vec::new();
+            }
+            self.deferred
+                .take()
+                .map(|id| {
+                    vec![AdmissionAction::MakeReady {
+                        id,
+                        placement: WorkerPlacement::Any,
+                    }]
+                })
+                .unwrap_or_default()
+        }
+    }
+
+    #[tokio::test]
+    async fn lifecycle_action_drains_without_an_unrelated_update() {
+        let (queue, slots) =
+            make_queue_with_admission_strategy(Box::<FinishReleaseGate>::default());
+        let (mut first, first_response) = make_request("first-admitted", 64);
+        first.policy_class = Some("agents".to_owned());
+        queue.enqueue(first).await;
+        first_response.await.unwrap().unwrap();
+
+        let (mut second, second_response) = make_request("second-deferred", 64);
+        second.policy_class = Some("agents".to_owned());
+        queue.enqueue(second).await;
+        assert_eq!(queue.pending_count(), 1);
+
+        slots
+            .free(&"first-admitted".to_owned(), decay_now())
+            .unwrap();
+        queue
+            .finish(
+                "first-admitted",
+                RequestOutcome::Completed { context_tokens: 64 },
+            )
+            .await;
+        tokio::time::timeout(Duration::from_secs(1), second_response)
+            .await
+            .expect("finish action did not drain the queue")
+            .unwrap()
+            .unwrap();
+        assert_eq!(queue.pending_count(), 0);
+        slots
+            .free(&"second-deferred".to_owned(), decay_now())
+            .unwrap();
+    }
+
+    #[derive(Default)]
+    struct PreservePinGate {
+        deferred: Option<AdmissionId>,
+    }
+
+    impl PolicyClassAdmissionStrategy for PreservePinGate {
+        fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
+            if self.deferred.is_none() {
+                self.deferred = Some(request.id());
+                AdmissionDecision::Defer
+            } else {
+                AdmissionDecision::Ready(WorkerPlacement::Any)
+            }
+        }
+
+        fn on_event(&mut self, event: AdmissionEvent) -> Vec<AdmissionAction> {
+            if !matches!(event, AdmissionEvent::Reconcile) {
+                return Vec::new();
+            }
+            self.deferred
+                .take()
+                .map(|id| {
+                    vec![AdmissionAction::MakeReady {
+                        id,
+                        placement: WorkerPlacement::Any,
+                    }]
+                })
+                .unwrap_or_default()
+        }
+    }
+
+    #[tokio::test]
+    async fn make_ready_any_preserves_existing_exact_worker_lane() {
+        let (queue, slots) =
+            make_queue_with_admission_strategy_and_workers(Box::<PreservePinGate>::default(), 2);
+        for worker_id in 0..2 {
+            let (mut blocker, response) = make_request(&format!("blocker-{worker_id}"), 64);
+            blocker.pinned_worker = Some(WorkerWithDpRank::new(worker_id, 0));
+            queue.enqueue(blocker).await;
+            assert_eq!(
+                response.await.unwrap().unwrap().best_worker,
+                WorkerWithDpRank::new(worker_id, 0)
+            );
+        }
+
+        let (mut pinned, pinned_response) = make_request("pinned-deferred", 64);
+        pinned.policy_class = Some("agents".to_owned());
+        pinned.pinned_worker = Some(WorkerWithDpRank::new(0, 0));
+        queue.enqueue(pinned).await;
+
+        let (mut runnable, runnable_response) = make_request("runnable-shared", 64);
+        runnable.policy_class = Some("agents".to_owned());
+        queue.enqueue(runnable).await;
+        assert_eq!(queue.pending_count(), 2);
+
+        slots.free(&"blocker-1".to_owned(), decay_now()).unwrap();
+        queue.reconcile().await;
+        assert_eq!(
+            tokio::time::timeout(Duration::from_secs(1), runnable_response)
+                .await
+                .expect("pinned lane blocked shared work")
+                .unwrap()
+                .unwrap()
+                .best_worker,
+            WorkerWithDpRank::new(1, 0)
+        );
+
+        slots.free(&"blocker-0".to_owned(), decay_now()).unwrap();
+        queue.update().await;
+        assert_eq!(
+            pinned_response.await.unwrap().unwrap().best_worker,
+            WorkerWithDpRank::new(0, 0)
+        );
+        slots
+            .free(&"runnable-shared".to_owned(), decay_now())
+            .unwrap();
+        slots
+            .free(&"pinned-deferred".to_owned(), decay_now())
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn cancelled_ready_request_is_removed_while_worker_stays_busy() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
+            state: Arc::clone(&state),
+        }));
+
+        let (blocker, blocker_response) = make_request("blocker", 64);
+        queue.enqueue(blocker).await;
+        blocker_response.await.unwrap().unwrap();
+
+        let (mut cancelled, cancelled_response) = make_request("cancelled-ready", 64);
+        cancelled.policy_class = Some("agents".to_owned());
+        let cancellation = queue.cancellation_guard(Some("cancelled-ready")).unwrap();
+        queue.enqueue(cancelled).await;
+        assert_eq!(queue.pending_count(), 1);
+        drop(cancelled_response);
+
+        drop(cancellation);
+        queue.update().await;
+
+        assert_eq!(queue.pending_count(), 0);
+        let state = state.lock().unwrap();
+        assert!(state.dispatched.is_empty());
+        assert_eq!(state.aborted, vec![AdmissionId::new(0)]);
+        slots.free(&"blocker".to_owned(), decay_now()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn backend_abort_finishes_without_dispatching_admission() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReconcileGate {
+            state: Arc::clone(&state),
+        }));
+        let (mut request, response) = make_request("backend-abort", 64);
+        request.policy_class = Some("agents".to_owned());
+
+        queue.enqueue(request).await;
+        queue.reconcile().await;
+        response.await.unwrap().unwrap();
+        queue.finish("backend-abort", RequestOutcome::Aborted).await;
+        queue.update().await;
+
+        let state = state.lock().unwrap();
+        assert!(state.dispatched.is_empty());
+        assert_eq!(state.aborted, vec![AdmissionId::new(0)]);
+        slots
+            .free(&"backend-abort".to_owned(), decay_now())
+            .unwrap();
     }
 
     #[tokio::test(flavor = "multi_thread")]

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -2222,7 +2222,7 @@ policy_classes:
         let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
             state: Arc::clone(&state),
         }));
-        let (mut request, response) = make_request("cancelled-after-handoff", 64);
+        let (mut request, response) = make_admission_request("cancelled-after-handoff", 64);
         request.policy_class = Some("agents".to_owned());
         let cancellation = queue
             .cancellation_guard(Some("cancelled-after-handoff"))
@@ -2257,12 +2257,12 @@ policy_classes:
         let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
             state: Arc::clone(&state),
         }));
-        let (mut first, first_response) = make_request("duplicate", 64);
+        let (mut first, first_response) = make_admission_request("duplicate", 64);
         first.policy_class = Some("agents".to_owned());
         queue.enqueue(first).await;
         first_response.await.unwrap().unwrap();
 
-        let (mut duplicate, duplicate_response) = make_request("duplicate", 64);
+        let (mut duplicate, duplicate_response) = make_admission_request("duplicate", 64);
         duplicate.policy_class = Some("agents".to_owned());
         queue.enqueue(duplicate).await;
         assert!(matches!(

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -690,7 +690,7 @@ impl<
             (class_index, Some(snapshot))
         };
 
-        if let Some(request_id) = request.mode.tracked_request_id()
+        if let Some(request_id) = request.mode.admission_request_id()
             && self.tracked_admissions.contains_key(request_id)
         {
             request.respond(Err(KvSchedulerError::BookingFailed(format!(
@@ -699,7 +699,8 @@ impl<
             return false;
         }
 
-        let mut admission = if request.mode.is_tracked() && self.admission.has_strategy(class_index)
+        let mut admission = if request.mode.admission_request_id().is_some()
+            && self.admission.has_strategy(class_index)
         {
             let allowed_worker_ids = request.allowed_worker_ids.clone();
             let pinned_worker = request.pinned_worker;
@@ -1970,6 +1971,22 @@ mod tests {
         (req, rx)
     }
 
+    fn make_admission_request(
+        request_id: &str,
+        isl_tokens: usize,
+    ) -> (
+        SchedulingRequest,
+        tokio::sync::oneshot::Receiver<
+            Result<SchedulingResponse, crate::scheduling::types::KvSchedulerError>,
+        >,
+    ) {
+        let (mut request, response) = make_request(request_id, isl_tokens);
+        request.mode = ScheduleMode::TrackedWithAdmission {
+            request_id: request_id.to_owned(),
+        };
+        (request, response)
+    }
+
     #[derive(Default)]
     struct GateState {
         deferred: Option<AdmissionId>,
@@ -2110,7 +2127,7 @@ policy_classes:
         let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReconcileGate {
             state: Arc::clone(&state),
         }));
-        let (mut request, response) = make_request("deferred", 64);
+        let (mut request, response) = make_admission_request("deferred", 64);
         request.policy_class = Some("agents".to_owned());
         request.session_id = Some("session-a".to_owned());
 
@@ -2160,7 +2177,7 @@ policy_classes:
         let (queue, _slots) = make_queue_with_admission_strategy(Box::new(ReconcileGate {
             state: Arc::clone(&state),
         }));
-        let (mut request, response) = make_request("cancelled", 64);
+        let (mut request, response) = make_admission_request("cancelled", 64);
         request.policy_class = Some("agents".to_owned());
         request.session_id = Some("session-a".to_owned());
 
@@ -2284,12 +2301,26 @@ policy_classes:
     }
 
     #[tokio::test]
+    async fn legacy_tracked_request_bypasses_admission() {
+        let state = Arc::new(StdMutex::new(GateState::default()));
+        let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate { state }));
+        let (mut request, response) = make_request("legacy", 64);
+        request.policy_class = Some("agents".to_owned());
+
+        queue.enqueue(request).await;
+        let selected = response.await.unwrap().unwrap();
+
+        assert!(selected.request_progress.is_none());
+        slots.free(&"legacy".to_owned(), decay_now()).unwrap();
+    }
+
+    #[tokio::test]
     async fn bypassed_request_has_no_admission_lifecycle() {
         let events = Arc::new(AtomicUsize::new(0));
         let (queue, slots) = make_queue_with_admission_strategy(Box::new(BypassGate {
             events: Arc::clone(&events),
         }));
-        let (mut request, response) = make_request("bypassed", 64);
+        let (mut request, response) = make_admission_request("bypassed", 64);
         request.policy_class = Some("agents".to_owned());
         {
             queue.enqueue(request).await;
@@ -2353,12 +2384,12 @@ policy_classes:
     async fn lifecycle_action_drains_without_an_unrelated_update() {
         let (queue, slots) =
             make_queue_with_admission_strategy(Box::<FinishReleaseGate>::default());
-        let (mut first, first_response) = make_request("first-admitted", 64);
+        let (mut first, first_response) = make_admission_request("first-admitted", 64);
         first.policy_class = Some("agents".to_owned());
         queue.enqueue(first).await;
         first_response.await.unwrap().unwrap();
 
-        let (mut second, second_response) = make_request("second-deferred", 64);
+        let (mut second, second_response) = make_admission_request("second-deferred", 64);
         second.policy_class = Some("agents".to_owned());
         queue.enqueue(second).await;
         assert_eq!(queue.pending_count(), 1);
@@ -2428,12 +2459,12 @@ policy_classes:
             );
         }
 
-        let (mut pinned, pinned_response) = make_request("pinned-deferred", 64);
+        let (mut pinned, pinned_response) = make_admission_request("pinned-deferred", 64);
         pinned.policy_class = Some("agents".to_owned());
         pinned.pinned_worker = Some(WorkerWithDpRank::new(0, 0));
         queue.enqueue(pinned).await;
 
-        let (mut runnable, runnable_response) = make_request("runnable-shared", 64);
+        let (mut runnable, runnable_response) = make_admission_request("runnable-shared", 64);
         runnable.policy_class = Some("agents".to_owned());
         queue.enqueue(runnable).await;
         assert_eq!(queue.pending_count(), 2);
@@ -2475,7 +2506,7 @@ policy_classes:
         queue.enqueue(blocker).await;
         blocker_response.await.unwrap().unwrap();
 
-        let (mut cancelled, cancelled_response) = make_request("cancelled-ready", 64);
+        let (mut cancelled, cancelled_response) = make_admission_request("cancelled-ready", 64);
         cancelled.policy_class = Some("agents".to_owned());
         let cancellation = queue.cancellation_guard(Some("cancelled-ready")).unwrap();
         queue.enqueue(cancelled).await;
@@ -2498,7 +2529,7 @@ policy_classes:
         let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReconcileGate {
             state: Arc::clone(&state),
         }));
-        let (mut request, response) = make_request("backend-abort", 64);
+        let (mut request, response) = make_admission_request("backend-abort", 64);
         request.policy_class = Some("agents".to_owned());
 
         queue.enqueue(request).await;

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -140,6 +140,7 @@ struct SchedulerQueueActor<
     pending: PolicyQueue<QueuedRequest>,
     admission: PolicyClassAdmissionController,
     tracked_admissions: HashMap<String, TrackedAdmission>,
+    cancelled_ready_classes: FxHashSet<usize>,
     profile: PolicyProfile,
     pending_count: Arc<AtomicUsize>,
     pending_isl_tokens: Arc<AtomicUsize>,
@@ -327,6 +328,7 @@ impl<
             pending: PolicyQueue::new(profile.clone()),
             admission,
             tracked_admissions: HashMap::new(),
+            cancelled_ready_classes: FxHashSet::default(),
             profile,
             pending_count: Arc::clone(&pending_count),
             pending_isl_tokens: Arc::clone(&pending_isl_tokens),
@@ -889,17 +891,35 @@ impl<
     }
 
     fn handle_cancelled(&mut self, request_id: &str) -> bool {
-        let rollback_booking = self
-            .tracked_admissions
-            .get(request_id)
-            .is_some_and(|tracked| tracked.worker.is_some() && !tracked.dispatched);
+        let Some(tracked) = self.tracked_admissions.get(request_id).copied() else {
+            return false;
+        };
+        let rollback_booking = tracked.worker.is_some() && !tracked.dispatched;
         if rollback_booking
             && let Err(error) = self.slots.free(&request_id.to_owned(), Instant::now())
         {
             tracing::error!(%request_id, %error, "Failed to roll back cancelled scheduler booking");
         }
-        let made_ready = self.handle_finished(request_id, RequestOutcome::Aborted);
-        rollback_booking || made_ready
+        if tracked.worker.is_some() {
+            let made_ready = self.handle_finished(request_id, RequestOutcome::Aborted);
+            return rollback_booking || made_ready;
+        }
+
+        if let Some(entry) = self
+            .pending
+            .remove_deferred(tracked.ticket.class_index, tracked.ticket.id)
+        {
+            self.tracked_admissions.remove(request_id);
+            self.subtract_pending_counters(entry.class_index(), entry.snapshot());
+            return self.abort_admission(tracked.ticket);
+        }
+
+        // Ready heaps do not have an admission-ID index. Batch cancellations so
+        // one reconcile scans each affected class once instead of once per drop.
+        self.tracked_admissions.remove(request_id);
+        self.cancelled_ready_classes
+            .insert(tracked.ticket.class_index);
+        self.abort_admission(tracked.ticket)
     }
 
     fn handle_finished(&mut self, request_id: &str, outcome: RequestOutcome) -> bool {
@@ -907,16 +927,25 @@ impl<
             return false;
         };
         if tracked.worker.is_none() {
-            let removed = self
+            if let Some(entry) = self
                 .pending
-                .take_if(|queued| queued.request.mode.tracked_request_id() == Some(request_id));
-            debug_assert_eq!(
-                removed.len(),
-                1,
-                "pending admission must have one queue entry"
-            );
-            for entry in removed {
+                .remove_deferred(tracked.ticket.class_index, tracked.ticket.id)
+            {
                 self.subtract_pending_counters(entry.class_index(), entry.snapshot());
+            } else {
+                let removed = self
+                    .pending
+                    .take_if_in_class(tracked.ticket.class_index, |queued| {
+                        queued.request.mode.tracked_request_id() == Some(request_id)
+                    });
+                debug_assert_eq!(
+                    removed.len(),
+                    1,
+                    "pending admission must have one queue entry"
+                );
+                for entry in removed {
+                    self.subtract_pending_counters(entry.class_index(), entry.snapshot());
+                }
             }
         }
         match outcome {
@@ -1005,22 +1034,22 @@ impl<
     }
 
     async fn handle_reconcile(&mut self) {
-        let cancelled = self
-            .pending
-            .take_if(|queued| queued.admission.is_some() && queued.request.response_is_closed());
-        let mut actions = Vec::new();
-        for entry in cancelled {
-            let class_index = entry.class_index();
-            let snapshot = entry.snapshot();
-            self.subtract_pending_counters(class_index, snapshot);
-            if let Some(admission) = entry.payload().admission.as_ref() {
-                if let Some(request_id) = entry.payload().request.mode.tracked_request_id() {
-                    self.tracked_admissions.remove(request_id);
-                }
-                actions.extend(self.admission.aborted(admission.ticket));
+        for class_index in std::mem::take(&mut self.cancelled_ready_classes) {
+            let tracked_admissions = &self.tracked_admissions;
+            let cancelled = self.pending.take_if_in_class(class_index, |queued| {
+                queued.admission.is_some()
+                    && queued.request.response_is_closed()
+                    && queued
+                        .request
+                        .mode
+                        .tracked_request_id()
+                        .is_some_and(|request_id| !tracked_admissions.contains_key(request_id))
+            });
+            for entry in cancelled {
+                self.subtract_pending_counters(class_index, entry.snapshot());
             }
         }
-        actions.extend(self.admission.reconcile());
+        let actions = self.admission.reconcile();
         self.apply_admission_actions(actions);
         self.handle_update(None).await;
     }
@@ -1105,6 +1134,16 @@ impl<
             let queued = popped.into_payload();
             let admission = queued.admission;
             let request = queued.request;
+            // A ready cancellation removes lifecycle state before its batched
+            // heap cleanup; an intervening capacity update may pop it first.
+            if admission.is_some()
+                && request
+                    .mode
+                    .tracked_request_id()
+                    .is_some_and(|request_id| !self.tracked_admissions.contains_key(request_id))
+            {
+                continue;
+            }
             tracing::debug!(
                 policy_class = class.name,
                 "scheduling request from pending queue"
@@ -2496,7 +2535,7 @@ policy_classes:
     }
 
     #[tokio::test]
-    async fn cancelled_ready_request_is_removed_while_worker_stays_busy() {
+    async fn cancelled_ready_requests_are_batched_by_reconcile() {
         let state = Arc::new(StdMutex::new(GateState::default()));
         let (queue, slots) = make_queue_with_admission_strategy(Box::new(ReadyGate {
             state: Arc::clone(&state),
@@ -2506,20 +2545,47 @@ policy_classes:
         queue.enqueue(blocker).await;
         blocker_response.await.unwrap().unwrap();
 
-        let (mut cancelled, cancelled_response) = make_admission_request("cancelled-ready", 64);
-        cancelled.policy_class = Some("agents".to_owned());
-        let cancellation = queue.cancellation_guard(Some("cancelled-ready")).unwrap();
-        queue.enqueue(cancelled).await;
-        assert_eq!(queue.pending_count(), 1);
-        drop(cancelled_response);
-
-        drop(cancellation);
+        for request_id in [
+            "cancelled-ready-0",
+            "cancelled-ready-1",
+            "cancelled-ready-2",
+        ] {
+            let (mut cancelled, cancelled_response) = make_admission_request(request_id, 64);
+            cancelled.policy_class = Some("agents".to_owned());
+            let cancellation = queue.cancellation_guard(Some(request_id)).unwrap();
+            queue.enqueue(cancelled).await;
+            drop(cancelled_response);
+            drop(cancellation);
+        }
+        assert_eq!(queue.pending_count(), 3);
         queue.update().await;
+        assert_eq!(state.lock().unwrap().aborted.len(), 3);
+
+        queue.reconcile().await;
 
         assert_eq!(queue.pending_count(), 0);
+        assert_eq!(queue.pending_isl_tokens(), 0);
+        assert_eq!(
+            queue.class_queue_stats(1),
+            Some(ClassQueueStats {
+                pending_count: 0,
+                pending_isl_tokens: 0,
+                pending_cached_tokens: 0,
+            })
+        );
         let state = state.lock().unwrap();
         assert!(state.dispatched.is_empty());
-        assert_eq!(state.aborted, vec![AdmissionId::new(0)]);
+        assert_eq!(state.aborted.len(), 3);
+        assert_eq!(
+            state.aborted.iter().copied().collect::<HashSet<_>>(),
+            [
+                AdmissionId::new(0),
+                AdmissionId::new(1),
+                AdmissionId::new(2)
+            ]
+            .into_iter()
+            .collect()
+        );
         slots.free(&"blocker".to_owned(), decay_now()).unwrap();
     }
 

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -211,6 +211,7 @@ impl<
             overlap_scores_refresh,
             overloaded_worker_provider,
         )
+        .expect("synthetic policy profile does not require admission strategies")
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -223,7 +224,7 @@ impl<
         prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
-    ) -> Self {
+    ) -> Result<Self, KvSchedulerError> {
         Self::new_with_policy_profile_and_admission_strategies(
             slots,
             workers_with_configs,
@@ -248,7 +249,7 @@ impl<
         overlap_scores_refresh: Option<Arc<RF>>,
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         admission_strategies: PolicyClassAdmissionStrategies,
-    ) -> Self {
+    ) -> Result<Self, KvSchedulerError> {
         Self::new_with_policy_profile_and_capacity(
             slots,
             workers_with_configs,
@@ -275,8 +276,9 @@ impl<
         overloaded_worker_provider: Option<OverloadedWorkerProvider>,
         admission_strategies: PolicyClassAdmissionStrategies,
         admission_channel_capacity: usize,
-    ) -> Self {
+    ) -> Result<Self, KvSchedulerError> {
         let admission_enabled = !admission_strategies.is_empty();
+        let admission = PolicyClassAdmissionController::new(&profile, admission_strategies)?;
         let queueing_enabled = profile
             .classes()
             .iter()
@@ -323,7 +325,7 @@ impl<
         let (admission_tx, admission_rx) = mpsc::channel(admission_channel_capacity);
         let actor = SchedulerQueueActor {
             pending: PolicyQueue::new(profile.clone()),
-            admission: PolicyClassAdmissionController::new(&profile, admission_strategies),
+            admission,
             tracked_admissions: HashMap::new(),
             profile,
             pending_count: Arc::clone(&pending_count),
@@ -340,7 +342,7 @@ impl<
             overloaded_worker_provider,
         };
         tokio::spawn(actor.run(admission_rx));
-        Self {
+        Ok(Self {
             admission_tx,
             pending_count,
             pending_isl_tokens,
@@ -351,7 +353,7 @@ impl<
             admission_enabled,
             supports_overlap_refresh: overlap_refresh_after.is_some(),
             _marker: PhantomData,
-        }
+        })
     }
 }
 
@@ -1702,16 +1704,19 @@ mod tests {
             })
             .collect();
         let (cfg_tx, cfg_rx) = watch::channel(configs);
-        let queue = Arc::new(SchedulerQueue::new_with_policy_profile(
-            Arc::clone(&slots),
-            cfg_rx,
-            profile,
-            block_size,
-            DefaultWorkerSelector::new(None, "test"),
-            None,
-            None,
-            None,
-        ));
+        let queue = Arc::new(
+            SchedulerQueue::new_with_policy_profile(
+                Arc::clone(&slots),
+                cfg_rx,
+                profile,
+                block_size,
+                DefaultWorkerSelector::new(None, "test"),
+                None,
+                None,
+                None,
+            )
+            .unwrap(),
+        );
         (queue, slots, cfg_tx)
     }
 
@@ -1911,18 +1916,21 @@ mod tests {
         }
         let (_cfg_tx, cfg_rx) = watch::channel(configs);
 
-        let queue = Arc::new(SchedulerQueue::new_with_policy_profile_and_capacity(
-            Arc::clone(&slots),
-            cfg_rx,
-            PolicyProfile::synthetic(threshold_frac, crate::config::RouterQueuePolicy::Fcfs),
-            block_size,
-            DefaultWorkerSelector::new(None, "test"),
-            None,
-            Some(refresher),
-            None,
-            PolicyClassAdmissionStrategies::new(),
-            admission_channel_capacity,
-        ));
+        let queue = Arc::new(
+            SchedulerQueue::new_with_policy_profile_and_capacity(
+                Arc::clone(&slots),
+                cfg_rx,
+                PolicyProfile::synthetic(threshold_frac, crate::config::RouterQueuePolicy::Fcfs),
+                block_size,
+                DefaultWorkerSelector::new(None, "test"),
+                None,
+                Some(refresher),
+                None,
+                PolicyClassAdmissionStrategies::new(),
+                admission_channel_capacity,
+            )
+            .unwrap(),
+        );
 
         (queue, slots)
     }
@@ -2090,7 +2098,8 @@ policy_classes:
                 None,
                 None,
                 strategies,
-            ),
+            )
+            .unwrap(),
         );
         (queue, slots)
     }

--- a/lib/kv-router/src/scheduling/queue_admission/controller.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/controller.rs
@@ -9,6 +9,7 @@ use super::{
 };
 use crate::protocols::WorkerWithDpRank;
 use crate::scheduling::policy_config::PolicyProfile;
+use crate::scheduling::types::KvSchedulerError;
 
 pub type PolicyClassAdmissionStrategies = HashMap<String, Box<dyn PolicyClassAdmissionStrategy>>;
 
@@ -29,19 +30,44 @@ pub(crate) struct PolicyClassAdmissionController {
 }
 
 impl PolicyClassAdmissionController {
-    pub fn new(profile: &PolicyProfile, mut strategies: PolicyClassAdmissionStrategies) -> Self {
+    pub fn new(
+        profile: &PolicyProfile,
+        mut strategies: PolicyClassAdmissionStrategies,
+    ) -> Result<Self, KvSchedulerError> {
+        if let Some(class_name) = strategies.iter().find_map(|(class_name, strategy)| {
+            strategy
+                .reconcile_interval()
+                .is_some_and(|interval| interval.is_zero())
+                .then_some(class_name)
+        }) {
+            return Err(KvSchedulerError::InitFailed(format!(
+                "admission strategy for policy class {class_name:?} returned a zero reconcile interval"
+            )));
+        }
+
         let resolved = profile
             .classes()
             .iter()
-            .map(|class| strategies.remove(&class.name))
-            .collect();
+            .map(|class| {
+                let strategy = strategies.remove(&class.name);
+                if let Some(config) = &class.queue_admission
+                    && strategy.is_none()
+                {
+                    return Err(KvSchedulerError::InitFailed(format!(
+                        "policy class {:?} configures admission strategy {:?}, but no implementation was registered",
+                        class.name, config.strategy
+                    )));
+                }
+                Ok(strategy)
+            })
+            .collect::<Result<Vec<_>, _>>()?;
         for class_name in strategies.keys() {
             tracing::warn!(%class_name, "Ignoring admission strategy for unknown policy class");
         }
-        Self {
+        Ok(Self {
             strategies: resolved,
             next_id: 0,
-        }
+        })
     }
 
     pub fn has_strategy(&self, class_index: usize) -> bool {
@@ -137,5 +163,100 @@ impl PolicyClassAdmissionController {
                 action,
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::time::Duration;
+
+    use super::*;
+    use crate::config::RouterQueuePolicy;
+    use crate::scheduling::policy_config::RouterPolicyConfig;
+
+    struct ReadyStrategy;
+
+    impl PolicyClassAdmissionStrategy for ReadyStrategy {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Ready(super::super::WorkerPlacement::Any)
+        }
+    }
+
+    struct ZeroIntervalStrategy;
+
+    impl PolicyClassAdmissionStrategy for ZeroIntervalStrategy {
+        fn admit(&mut self, _request: AdmissionRequest<'_>) -> AdmissionDecision {
+            AdmissionDecision::Bypass
+        }
+
+        fn reconcile_interval(&self) -> Option<Duration> {
+            Some(Duration::ZERO)
+        }
+    }
+
+    fn configured_profile() -> PolicyProfile {
+        RouterPolicyConfig::from_yaml(
+            r#"
+default_policy_family: standard
+uncached_isl_buckets:
+  - min_tokens: 0
+    bucket: all
+policy_classes:
+  - name: standard
+    policy_family: standard
+    cache_bucket: all
+    quantum: 1
+  - name: agents
+    queue_admission:
+      type: test
+    quantum: 1
+"#,
+        )
+        .unwrap()
+        .resolve_profile(None, None, RouterQueuePolicy::Fcfs)
+    }
+
+    #[test]
+    fn rejects_configured_class_without_strategy() {
+        let error = PolicyClassAdmissionController::new(
+            &configured_profile(),
+            PolicyClassAdmissionStrategies::new(),
+        )
+        .err()
+        .unwrap();
+
+        assert!(matches!(error, KvSchedulerError::InitFailed(message) if
+            message.contains("agents") && message.contains("test")));
+    }
+
+    #[test]
+    fn rejects_zero_reconcile_interval() {
+        let profile = PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs);
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert(
+            profile.default_class().name.clone(),
+            Box::new(ZeroIntervalStrategy),
+        );
+
+        let error = PolicyClassAdmissionController::new(&profile, strategies)
+            .err()
+            .unwrap();
+
+        assert!(matches!(error, KvSchedulerError::InitFailed(message) if
+            message.contains("zero reconcile interval")));
+    }
+
+    #[test]
+    fn accepts_programmatic_strategy_without_config() {
+        let profile = PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs);
+        let mut strategies = PolicyClassAdmissionStrategies::new();
+        strategies.insert(
+            profile.default_class().name.clone(),
+            Box::new(ReadyStrategy),
+        );
+
+        let controller = PolicyClassAdmissionController::new(&profile, strategies).unwrap();
+
+        assert!(controller.has_strategy(0));
     }
 }

--- a/lib/kv-router/src/scheduling/queue_admission/controller.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/controller.rs
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use super::{
+    AdmissionAction, AdmissionDecision, AdmissionEvent, AdmissionId, AdmissionRequest,
+    PolicyClassAdmissionStrategy, RequestProgress, RequestProgressUpdater, WorkerEligibility,
+};
+use crate::protocols::WorkerWithDpRank;
+use crate::scheduling::policy_config::PolicyProfile;
+
+pub type PolicyClassAdmissionStrategies = HashMap<String, Box<dyn PolicyClassAdmissionStrategy>>;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AdmissionTicket {
+    pub class_index: usize,
+    pub id: AdmissionId,
+}
+
+pub(crate) struct ClassAdmissionAction {
+    pub class_index: usize,
+    pub action: AdmissionAction,
+}
+
+pub(crate) struct PolicyClassAdmissionController {
+    strategies: Vec<Option<Box<dyn PolicyClassAdmissionStrategy>>>,
+    next_id: u64,
+}
+
+impl PolicyClassAdmissionController {
+    pub fn new(profile: &PolicyProfile, mut strategies: PolicyClassAdmissionStrategies) -> Self {
+        let resolved = profile
+            .classes()
+            .iter()
+            .map(|class| strategies.remove(&class.name))
+            .collect();
+        for class_name in strategies.keys() {
+            tracing::warn!(%class_name, "Ignoring admission strategy for unknown policy class");
+        }
+        Self {
+            strategies: resolved,
+            next_id: 0,
+        }
+    }
+
+    pub fn has_strategy(&self, class_index: usize) -> bool {
+        self.strategies[class_index].is_some()
+    }
+
+    pub fn admit(
+        &mut self,
+        class_index: usize,
+        session_id: Option<&str>,
+        context_tokens: usize,
+        worker_eligibility: WorkerEligibility,
+    ) -> Option<(AdmissionTicket, RequestProgressUpdater, AdmissionDecision)> {
+        let strategy = self.strategies[class_index].as_mut()?;
+        let id = AdmissionId::new(self.next_id);
+        self.next_id = self.next_id.wrapping_add(1);
+        let ticket = AdmissionTicket { class_index, id };
+        let (progress, updater) = RequestProgress::new(context_tokens);
+        let decision = strategy.admit(AdmissionRequest::with_progress(
+            id,
+            session_id,
+            context_tokens,
+            progress,
+            worker_eligibility,
+        ));
+        Some((ticket, updater, decision))
+    }
+
+    pub fn dispatched(
+        &mut self,
+        ticket: AdmissionTicket,
+        worker: WorkerWithDpRank,
+    ) -> Vec<ClassAdmissionAction> {
+        self.event(
+            ticket,
+            AdmissionEvent::Dispatched {
+                id: ticket.id,
+                worker,
+            },
+        )
+    }
+
+    pub fn completed(
+        &mut self,
+        ticket: AdmissionTicket,
+        context_tokens: usize,
+    ) -> Vec<ClassAdmissionAction> {
+        self.event(
+            ticket,
+            AdmissionEvent::Completed {
+                id: ticket.id,
+                context_tokens,
+            },
+        )
+    }
+
+    pub fn aborted(&mut self, ticket: AdmissionTicket) -> Vec<ClassAdmissionAction> {
+        self.event(ticket, AdmissionEvent::Aborted { id: ticket.id })
+    }
+
+    pub fn reconcile(&mut self) -> Vec<ClassAdmissionAction> {
+        let mut actions = Vec::new();
+        for (class_index, strategy) in self.strategies.iter_mut().enumerate() {
+            let Some(strategy) = strategy else {
+                continue;
+            };
+            actions.extend(
+                strategy
+                    .on_event(AdmissionEvent::Reconcile)
+                    .into_iter()
+                    .map(|action| ClassAdmissionAction {
+                        class_index,
+                        action,
+                    }),
+            );
+        }
+        actions
+    }
+
+    fn event(
+        &mut self,
+        ticket: AdmissionTicket,
+        event: AdmissionEvent,
+    ) -> Vec<ClassAdmissionAction> {
+        let Some(strategy) = self.strategies[ticket.class_index].as_mut() else {
+            return Vec::new();
+        };
+        strategy
+            .on_event(event)
+            .into_iter()
+            .map(|action| ClassAdmissionAction {
+                class_index: ticket.class_index,
+                action,
+            })
+            .collect()
+    }
+}

--- a/lib/kv-router/src/scheduling/queue_admission/mod.rs
+++ b/lib/kv-router/src/scheduling/queue_admission/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 
 use rustc_hash::FxHashSet;
@@ -9,6 +10,13 @@ use serde::Deserialize;
 use serde_yaml::Mapping;
 
 use crate::protocols::WorkerWithDpRank;
+
+mod controller;
+
+pub use controller::PolicyClassAdmissionStrategies;
+pub(crate) use controller::{
+    AdmissionTicket, ClassAdmissionAction, PolicyClassAdmissionController,
+};
 
 /// Router-assigned identity for one request's admission lifecycle.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -21,6 +29,50 @@ impl AdmissionId {
 
     pub fn get(self) -> u64 {
         self.0
+    }
+}
+
+/// Lock-free access to the latest logical context observed for one request.
+///
+/// Strategies may retain this reader after [`PolicyClassAdmissionStrategy::admit`]
+/// returns. The request path owns the corresponding updater and publishes
+/// monotonic progress without sending commands through the scheduler actor.
+#[derive(Debug, Clone)]
+pub struct RequestProgress {
+    context_tokens: Arc<AtomicUsize>,
+}
+
+/// Write capability paired with [`RequestProgress`].
+///
+/// Updates are monotonic so concurrent or delayed observations cannot move a
+/// request's logical context backwards.
+#[derive(Debug, Clone)]
+pub struct RequestProgressUpdater {
+    context_tokens: Arc<AtomicUsize>,
+}
+
+impl RequestProgress {
+    pub fn new(initial_context_tokens: usize) -> (Self, RequestProgressUpdater) {
+        let context_tokens = Arc::new(AtomicUsize::new(initial_context_tokens));
+        (
+            Self {
+                context_tokens: Arc::clone(&context_tokens),
+            },
+            RequestProgressUpdater { context_tokens },
+        )
+    }
+
+    #[inline]
+    pub fn context_tokens(&self) -> usize {
+        self.context_tokens.load(Ordering::Relaxed)
+    }
+}
+
+impl RequestProgressUpdater {
+    #[inline]
+    pub fn update_context_tokens(&self, context_tokens: usize) {
+        self.context_tokens
+            .fetch_max(context_tokens, Ordering::Relaxed);
     }
 }
 
@@ -102,6 +154,7 @@ pub struct AdmissionRequest<'a> {
     id: AdmissionId,
     session_id: Option<&'a str>,
     context_tokens: usize,
+    progress: RequestProgress,
     worker_eligibility: WorkerEligibility,
 }
 
@@ -112,10 +165,22 @@ impl<'a> AdmissionRequest<'a> {
         context_tokens: usize,
         worker_eligibility: WorkerEligibility,
     ) -> Self {
+        let (progress, _) = RequestProgress::new(context_tokens);
+        Self::with_progress(id, session_id, context_tokens, progress, worker_eligibility)
+    }
+
+    pub(crate) fn with_progress(
+        id: AdmissionId,
+        session_id: Option<&'a str>,
+        context_tokens: usize,
+        progress: RequestProgress,
+        worker_eligibility: WorkerEligibility,
+    ) -> Self {
         Self {
             id,
             session_id,
             context_tokens,
+            progress,
             worker_eligibility,
         }
     }
@@ -131,6 +196,11 @@ impl<'a> AdmissionRequest<'a> {
     /// Full tokenized request context, not uncached prefill work.
     pub fn context_tokens(&self) -> usize {
         self.context_tokens
+    }
+
+    /// Live logical context for this request.
+    pub fn progress(&self) -> &RequestProgress {
+        &self.progress
     }
 
     pub fn worker_eligibility(&self) -> &WorkerEligibility {
@@ -188,8 +258,9 @@ pub enum AdmissionAction {
 
 /// Policy-class admission behavior.
 ///
-/// The host calls [`Self::admit`] exactly once for each tracked request, using
-/// a unique ID. A bypassed request receives no lifecycle events. A ready
+/// The host calls [`Self::admit`] exactly once for each tracked scheduling
+/// request, using a unique ID. Query-only selection bypasses admission. A
+/// bypassed request receives no lifecycle events. A ready
 /// request may receive one `Dispatched` event and every tracked request
 /// receives exactly one terminal `Completed` or `Aborted` event while the host
 /// remains alive. A deferred request receives no `Dispatched` event until the
@@ -254,6 +325,16 @@ mod tests {
             AdmissionDecision::Ready(WorkerPlacement::Any)
         );
         assert!(strategy.on_event(AdmissionEvent::Reconcile).is_empty());
+    }
+
+    #[test]
+    fn request_progress_is_monotonic() {
+        let (progress, updater) = RequestProgress::new(42);
+
+        updater.update_context_tokens(55);
+        updater.update_context_tokens(50);
+
+        assert_eq!(progress.context_tokens(), 55);
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -87,8 +87,17 @@ pub enum RequestOutcome {
 
 #[derive(Debug, Clone)]
 pub enum ScheduleMode {
-    QueryOnly { request_id: Option<String> },
-    Tracked { request_id: String },
+    QueryOnly {
+        request_id: Option<String>,
+    },
+    /// Tracks worker state; the caller releases it with `free`.
+    Tracked {
+        request_id: String,
+    },
+    /// Tracks worker and admission state; the caller reports dispatch and a terminal outcome.
+    TrackedWithAdmission {
+        request_id: String,
+    },
 }
 
 impl ScheduleMode {
@@ -111,18 +120,32 @@ impl ScheduleMode {
     pub fn request_id(&self) -> Option<&str> {
         match self {
             Self::QueryOnly { request_id } => request_id.as_deref(),
-            Self::Tracked { request_id } => Some(request_id),
+            Self::Tracked { request_id } | Self::TrackedWithAdmission { request_id } => {
+                Some(request_id)
+            }
         }
     }
 
     pub fn is_tracked(&self) -> bool {
-        matches!(self, Self::Tracked { .. })
+        matches!(
+            self,
+            Self::Tracked { .. } | Self::TrackedWithAdmission { .. }
+        )
+    }
+
+    pub(crate) fn admission_request_id(&self) -> Option<&str> {
+        match self {
+            Self::TrackedWithAdmission { request_id } => Some(request_id),
+            Self::QueryOnly { .. } | Self::Tracked { .. } => None,
+        }
     }
 
     pub fn tracked_request_id(&self) -> Option<&str> {
         match self {
             Self::QueryOnly { .. } => None,
-            Self::Tracked { request_id } => Some(request_id),
+            Self::Tracked { request_id } | Self::TrackedWithAdmission { request_id } => {
+                Some(request_id)
+            }
         }
     }
 }

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -18,6 +18,7 @@ use crate::protocols::{
     WorkerWithDpRank,
 };
 use crate::scheduling::policy_queue::QueueRejection;
+use crate::scheduling::queue_admission::RequestProgressUpdater;
 use crate::sequences::WorkerLoadProjection;
 
 pub type OverloadedWorkerProvider =
@@ -75,6 +76,13 @@ pub struct SchedulingResponse {
     pub effective_overlap_blocks: f64,
     pub cached_tokens: usize,
     pub selected_worker_tiers: SelectedWorkerTierSnapshot,
+    pub request_progress: Option<RequestProgressUpdater>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RequestOutcome {
+    Completed { context_tokens: usize },
+    Aborted,
 }
 
 #[derive(Debug, Clone)]

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -450,7 +450,7 @@ impl SelectionCore {
             self.cancel_token.child_token(),
             WORKER_TYPE,
             true,
-        );
+        )?;
         let entry = Arc::new(SelectionEntry {
             key: key.clone(),
             block_size,

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -528,12 +528,101 @@ where
         allowed_worker_ids: Option<HashSet<WorkerId>>,
         routing_constraints: RoutingConstraints,
     ) -> anyhow::Result<FindBestMatchOutcome> {
+        self.find_best_match_details_with_policy_class_inner(
+            context_id,
+            tokens,
+            block_mm_infos,
+            router_config_override,
+            update_states,
+            return_routing_hashes,
+            lora_name,
+            cache_namespace,
+            priority_jump,
+            strict_priority,
+            policy_class,
+            session_id,
+            expected_output_tokens,
+            pinned_worker,
+            allowed_worker_ids,
+            routing_constraints,
+            false,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn find_best_match_details_with_admission(
+        &self,
+        context_id: Option<&str>,
+        tokens: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        router_config_override: Option<&RouterConfigOverride>,
+        update_states: bool,
+        return_routing_hashes: bool,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        policy_class: Option<String>,
+        session_id: Option<String>,
+        expected_output_tokens: Option<u32>,
+        pinned_worker: Option<WorkerWithDpRank>,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+    ) -> anyhow::Result<FindBestMatchOutcome> {
+        self.find_best_match_details_with_policy_class_inner(
+            context_id,
+            tokens,
+            block_mm_infos,
+            router_config_override,
+            update_states,
+            return_routing_hashes,
+            lora_name,
+            cache_namespace,
+            priority_jump,
+            strict_priority,
+            policy_class,
+            session_id,
+            expected_output_tokens,
+            pinned_worker,
+            allowed_worker_ids,
+            routing_constraints,
+            true,
+        )
+        .await
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn find_best_match_details_with_policy_class_inner(
+        &self,
+        context_id: Option<&str>,
+        tokens: &[u32],
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        router_config_override: Option<&RouterConfigOverride>,
+        update_states: bool,
+        return_routing_hashes: bool,
+        lora_name: Option<String>,
+        cache_namespace: Option<String>,
+        priority_jump: f64,
+        strict_priority: u32,
+        policy_class: Option<String>,
+        session_id: Option<String>,
+        expected_output_tokens: Option<u32>,
+        pinned_worker: Option<WorkerWithDpRank>,
+        allowed_worker_ids: Option<HashSet<WorkerId>>,
+        routing_constraints: RoutingConstraints,
+        use_admission: bool,
+    ) -> anyhow::Result<FindBestMatchOutcome> {
         let start = Instant::now();
 
         if update_states && context_id.is_none() {
             anyhow::bail!("context_id must be provided if update_states is true");
         }
-        let mode = if update_states {
+        let mode = if update_states && use_admission {
+            ScheduleMode::TrackedWithAdmission {
+                request_id: context_id.expect("validated above").to_string(),
+            }
+        } else if update_states {
             ScheduleMode::Tracked {
                 request_id: context_id.expect("validated above").to_string(),
             }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -15,9 +15,9 @@ use dynamo_kv_router::{
         WorkerId, WorkerWithDpRank, compute_block_hash_for_seq,
     },
     scheduling::{
-        CacheHitEstimates, OverlapAnalysis, OverloadedWorkerProvider, ScheduleMode,
-        ScheduleRequest, TieredOverlapRefresher, effective_prefill_tokens,
-        overlap::cache_hit_estimates_from_tiered_matches,
+        CacheHitEstimates, OverlapAnalysis, OverloadedWorkerProvider, RequestOutcome,
+        RequestProgressUpdater, ScheduleMode, ScheduleRequest, TieredOverlapRefresher,
+        effective_prefill_tokens, overlap::cache_hit_estimates_from_tiered_matches,
     },
 };
 use dynamo_runtime::{
@@ -76,6 +76,7 @@ pub enum FindBestMatchOutcome {
         effective_overlap_blocks: f64,
         cached_tokens: usize,
         routing_hashes: Option<RoutingDecisionHashes>,
+        request_progress: Option<RequestProgressUpdater>,
     },
     QueueRejected {
         rejection: scheduling::QueueRejection,
@@ -689,6 +690,7 @@ where
             effective_overlap_blocks: response.effective_overlap_blocks,
             cached_tokens: response.cached_tokens,
             routing_hashes,
+            request_progress: response.request_progress,
         })
     }
 
@@ -798,8 +800,22 @@ where
         self.scheduler.mark_prefill_completed(request_id).await
     }
 
+    pub async fn mark_dispatched(&self, request_id: &str) {
+        self.scheduler.mark_dispatched(request_id).await;
+    }
+
+    /// Legacy slot cleanup. Admission-managed requests should use [`Self::finish`].
     pub async fn free(&self, request_id: &str) -> Result<(), SequenceError> {
         self.scheduler.free(request_id).await
+    }
+
+    /// Release request state and report its terminal admission outcome.
+    pub async fn finish(
+        &self,
+        request_id: &str,
+        outcome: RequestOutcome,
+    ) -> Result<(), SequenceError> {
+        self.scheduler.finish(request_id, outcome).await
     }
 
     /// Number of requests currently parked in the scheduler queue.

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -4,6 +4,7 @@
 use std::{sync::Arc, time::Duration};
 
 use dynamo_kv_router::protocols::{TokensWithHashes, WorkerWithDpRank};
+use dynamo_kv_router::scheduling::RequestOutcome;
 use dynamo_runtime::{
     error::{ErrorType, match_error_chain},
     metrics::frontend_perf::{STAGE_ROUTE, StageGuard},
@@ -123,11 +124,16 @@ impl KvPushRouter {
         match selection_result {
             Some(result) => result,
             None => {
-                if !is_query_only && let Err(error) = self.chooser.free(&context_id).await {
+                if !is_query_only
+                    && let Err(error) = self
+                        .chooser
+                        .finish(&context_id, RequestOutcome::Aborted)
+                        .await
+                {
                     tracing::warn!(
                         request_id = %context_id,
                         %error,
-                        "Failed to free scheduler state after cancellation during worker selection"
+                        "Failed to finish scheduler state after cancellation during worker selection"
                     );
                 }
                 Err(cancelled_error(&context_id))

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -20,6 +20,7 @@ use crate::{
     kv_router::{KvRouter, metrics::RouterRequestMetrics},
     preprocessor::PreprocessedRequest,
     protocols::common::{
+        FinishReason,
         llm_backend::LLMEngineOutput,
         timing::{RequestPhase, RoutingData},
     },
@@ -211,6 +212,7 @@ impl KvPushRouter {
             context_id.clone(),
             request,
             selection.scheduler_tracked,
+            selection.request_progress.take(),
         );
 
         let record_result: Result<(), Error> = async {
@@ -340,7 +342,7 @@ impl KvPushRouter {
             }
         };
 
-        guard.mark_dispatched();
+        guard.mark_dispatched().await;
         let stream_context = response_stream.context();
         let context_for_monitoring = stream_context.clone();
         let wrapped_stream = Box::pin(async_stream::stream! {
@@ -350,26 +352,32 @@ impl KvPushRouter {
             let stopped = context_for_monitoring.stopped();
             tokio::pin!(stopped);
 
-            loop {
+            let mut failed = false;
+            let completed = loop {
                 tokio::select! {
                     biased;
 
                     _ = &mut stopped => {
                         tracing::debug!("Request {context_id} cancelled, ending stream");
-                        break;
+                        break false;
                     }
 
                     item = response_stream.next() => {
                         let Some(item) = item else {
-                            break;
+                            break true;
                         };
+                        failed |= response_item_failed(&item);
                         guard.on_item(&item).await;
                         yield item;
                     }
                 }
-            }
+            };
 
-            guard.finish().await;
+            if completed && !failed {
+                guard.finish().await;
+            } else {
+                guard.abort().await;
+            }
         });
         Ok(ResponseStream::new(wrapped_stream, stream_context))
     }
@@ -608,6 +616,18 @@ impl DirectRoutingRouter {
     }
 }
 
+fn response_item_failed(item: &Annotated<LLMEngineOutput>) -> bool {
+    item.error.is_some()
+        || item.event.as_deref() == Some("error")
+        || item
+            .data
+            .as_ref()
+            .and_then(|data| data.finish_reason.as_ref())
+            .is_some_and(|reason| {
+                matches!(reason, FinishReason::Error(_) | FinishReason::Cancelled)
+            })
+}
+
 #[async_trait]
 impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
     for DirectRoutingRouter
@@ -652,6 +672,21 @@ mod tests {
             .output_options(Default::default())
             .build()
             .unwrap()
+    }
+
+    #[test]
+    fn response_item_failed_includes_typed_terminal_failures() {
+        let mut output = LLMEngineOutput::default();
+        assert!(!response_item_failed(&Annotated::from_data(output.clone())));
+
+        output.finish_reason = Some(FinishReason::Error("decode failed".to_string()));
+        assert!(response_item_failed(&Annotated::from_data(output.clone())));
+
+        output.finish_reason = Some(FinishReason::Cancelled);
+        assert!(response_item_failed(&Annotated::from_data(output.clone())));
+
+        output.finish_reason = Some(FinishReason::Length);
+        assert!(!response_item_failed(&Annotated::from_data(output)));
     }
 
     async fn router(session_affinity_ttl: Option<Duration>) -> (KvPushRouter, Runtime) {

--- a/lib/llm/src/kv_router/push_router/request_guard.rs
+++ b/lib/llm/src/kv_router/push_router/request_guard.rs
@@ -3,6 +3,7 @@
 
 use std::sync::Arc;
 
+use dynamo_kv_router::scheduling::{RequestOutcome, RequestProgressUpdater};
 use dynamo_runtime::{
     metrics::frontend_perf::{STAGE_DISPATCH, StageGuard},
     protocols::annotated::Annotated,
@@ -26,23 +27,36 @@ struct RequestCleanup {
     chooser: Arc<KvRouter>,
     context_id: String,
     scheduler_tracked: bool,
+    request_progress: Option<RequestProgressUpdater>,
     freed: bool,
 }
 
 impl RequestCleanup {
-    fn new(chooser: Arc<KvRouter>, context_id: String, scheduler_tracked: bool) -> Self {
+    fn new(
+        chooser: Arc<KvRouter>,
+        context_id: String,
+        scheduler_tracked: bool,
+        request_progress: Option<RequestProgressUpdater>,
+    ) -> Self {
+        debug_assert!(request_progress.is_none() || scheduler_tracked);
         Self {
             chooser,
             context_id,
             scheduler_tracked,
+            request_progress,
             freed: false,
         }
     }
 
-    async fn finish(&mut self) {
-        if self.scheduler_tracked
-            && let Err(error) = self.chooser.free(&self.context_id).await
-        {
+    async fn finish(&mut self, outcome: RequestOutcome) {
+        let result = if !self.scheduler_tracked {
+            Ok(())
+        } else if self.request_progress.is_some() {
+            self.chooser.finish(&self.context_id, outcome).await
+        } else {
+            self.chooser.free(&self.context_id).await
+        };
+        if let Err(error) = result {
             tracing::warn!(
                 request_id = %self.context_id,
                 %error,
@@ -70,8 +84,14 @@ impl Drop for RequestCleanup {
 
         let chooser = self.chooser.clone();
         let context_id = self.context_id.clone();
+        let has_admission_lifecycle = self.request_progress.is_some();
         handle.spawn(async move {
-            if let Err(error) = chooser.free(&context_id).await {
+            let result = if has_admission_lifecycle {
+                chooser.finish(&context_id, RequestOutcome::Aborted).await
+            } else {
+                chooser.free(&context_id).await
+            };
+            if let Err(error) = result {
                 tracing::warn!(
                     request_id = %context_id,
                     %error,
@@ -87,6 +107,7 @@ struct RequestObservability {
     tracker: Option<Arc<RequestTracker>>,
     request_metrics: Arc<RouterRequestMetrics>,
     cumulative_osl: usize,
+    authoritative_context_tokens: Option<usize>,
     metrics_recorded: bool,
     first_token_recorded: bool,
     dispatch_guard: Option<StageGuard>,
@@ -102,6 +123,7 @@ impl RequestObservability {
             tracker,
             request_metrics,
             cumulative_osl: 0,
+            authoritative_context_tokens: None,
             metrics_recorded: false,
             first_token_recorded: false,
             dispatch_guard: None,
@@ -155,6 +177,18 @@ impl RequestObservability {
         self.cumulative_osl
     }
 
+    fn observe_context_tokens(&mut self, context_tokens: usize) {
+        self.authoritative_context_tokens = Some(
+            self.authoritative_context_tokens
+                .map_or(context_tokens, |observed| observed.max(context_tokens)),
+        );
+    }
+
+    fn context_tokens(&self, initial_context_tokens: usize) -> usize {
+        self.authoritative_context_tokens
+            .unwrap_or_else(|| initial_context_tokens.saturating_add(self.cumulative_osl))
+    }
+
     fn observe_output_block_boundary(&self) {
         let Some(tracker) = &self.tracker else {
             return;
@@ -197,11 +231,13 @@ impl RequestObservability {
 
 struct OutputBlockUpdate {
     decay_fraction: Option<f64>,
+    update_scheduler: bool,
 }
 
 /// Tracks when streamed output grows into a new scheduler accounting block.
 struct OutputBlockTracker {
     track_output_blocks: bool,
+    track_request_progress: bool,
     current_total_blocks: usize,
     isl_tokens: usize,
     block_size: usize,
@@ -211,12 +247,14 @@ struct OutputBlockTracker {
 impl OutputBlockTracker {
     fn new(
         track_output_blocks: bool,
+        track_request_progress: bool,
         isl_tokens: usize,
         block_size: usize,
         expected_output_tokens: Option<u32>,
     ) -> Self {
         Self {
             track_output_blocks,
+            track_request_progress,
             current_total_blocks: isl_tokens.div_ceil(block_size),
             isl_tokens,
             block_size,
@@ -225,7 +263,7 @@ impl OutputBlockTracker {
     }
 
     fn observe(&mut self, cumulative_osl: usize) -> Option<OutputBlockUpdate> {
-        if !self.track_output_blocks {
+        if !self.track_output_blocks && !self.track_request_progress {
             return None;
         }
 
@@ -239,7 +277,10 @@ impl OutputBlockTracker {
         let decay_fraction = self
             .expected_output_tokens
             .map(|expected| (1.0 - cumulative_osl as f64 / expected.max(1) as f64).max(0.0));
-        Some(OutputBlockUpdate { decay_fraction })
+        Some(OutputBlockUpdate {
+            decay_fraction,
+            update_scheduler: self.track_output_blocks,
+        })
     }
 }
 
@@ -251,6 +292,7 @@ pub(super) struct RequestGuard {
     cleanup: RequestCleanup,
     observability: RequestObservability,
     output_blocks: OutputBlockTracker,
+    initial_context_tokens: usize,
     prefill_marked: bool,
 }
 
@@ -260,6 +302,7 @@ impl RequestGuard {
         context_id: String,
         request: &PreprocessedRequest,
         scheduler_tracked: bool,
+        request_progress: Option<RequestProgressUpdater>,
     ) -> Self {
         // Snapshot request-scoped inputs now so the guard can outlive the
         // PreprocessedRequest after it is moved into backend dispatch.
@@ -271,18 +314,21 @@ impl RequestGuard {
             .and_then(|routing| routing.expected_output_tokens);
         let track_output_blocks =
             scheduler_tracked && chooser.kv_router_config().router_track_output_blocks;
+        let track_request_progress = request_progress.is_some();
         let request_metrics =
             RouterRequestMetrics::from_component(chooser.client().endpoint.component());
 
         Self {
-            cleanup: RequestCleanup::new(chooser, context_id, scheduler_tracked),
+            cleanup: RequestCleanup::new(chooser, context_id, scheduler_tracked, request_progress),
             observability: RequestObservability::new(request.tracker.clone(), request_metrics),
             output_blocks: OutputBlockTracker::new(
                 track_output_blocks,
+                track_request_progress,
                 isl_tokens,
                 block_size,
                 expected_output_tokens,
             ),
+            initial_context_tokens: isl_tokens,
             prefill_marked: false,
         }
     }
@@ -299,12 +345,27 @@ impl RequestGuard {
         self.observability.record_prefill_start();
     }
 
-    pub(super) fn mark_dispatched(&mut self) {
+    pub(super) async fn mark_dispatched(&mut self) {
+        if self.cleanup.request_progress.is_some() {
+            self.cleanup
+                .chooser
+                .mark_dispatched(&self.cleanup.context_id)
+                .await;
+        }
         self.observability.mark_dispatched();
     }
 
     pub(super) async fn on_item(&mut self, item: &Annotated<LLMEngineOutput>) {
         self.observability.observe_response();
+
+        if let Some(usage) = item
+            .data
+            .as_ref()
+            .and_then(|data| data.completion_usage.as_ref())
+        {
+            self.observability
+                .observe_context_tokens(usage.total_tokens as usize);
+        }
 
         if !self.prefill_marked {
             let has_tokens = item
@@ -331,12 +392,18 @@ impl RequestGuard {
 
         let new_tokens = item.data.as_ref().map_or(0, |data| data.token_ids.len());
         self.observability.observe_tokens(new_tokens);
-        let Some(update) = self
-            .output_blocks
-            .observe(self.observability.cumulative_osl())
-        else {
+        let cumulative_osl = self.observability.cumulative_osl();
+        let Some(update) = self.output_blocks.observe(cumulative_osl) else {
             return;
         };
+
+        if let Some(progress) = &self.cleanup.request_progress {
+            progress
+                .update_context_tokens(self.initial_context_tokens.saturating_add(cumulative_osl));
+        }
+        if !update.update_scheduler {
+            return;
+        }
 
         if let Err(error) = self
             .cleanup
@@ -356,11 +423,19 @@ impl RequestGuard {
     pub(super) async fn finish(&mut self) {
         // Metrics must observe the completed request before cleanup releases its state.
         self.observability.record_metrics();
-        self.cleanup.finish().await;
+        let context_tokens = self
+            .observability
+            .context_tokens(self.initial_context_tokens);
+        if let Some(progress) = &self.cleanup.request_progress {
+            progress.update_context_tokens(context_tokens);
+        }
+        self.cleanup
+            .finish(RequestOutcome::Completed { context_tokens })
+            .await;
     }
 
     pub(super) async fn abort(&mut self) {
-        self.cleanup.finish().await;
+        self.cleanup.finish(RequestOutcome::Aborted).await;
     }
 }
 

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -7,7 +7,7 @@ use dynamo_kv_router::{
     RouterConfigOverride,
     indexer::RoutingDecisionHashes,
     protocols::{BlockExtraInfo, RoutingConstraints, WorkerId, WorkerWithDpRank},
-    scheduling::RoutingEligibility,
+    scheduling::{RequestProgressUpdater, RoutingEligibility},
 };
 use dynamo_runtime::{dynamo_nvtx_range, pipeline::Error};
 
@@ -28,6 +28,7 @@ pub(super) struct WorkerSelection {
     pub(super) cached_tokens: usize,
     pub(super) routing_hashes: Option<RoutingDecisionHashes>,
     pub(super) scheduler_tracked: bool,
+    pub(super) request_progress: Option<RequestProgressUpdater>,
 }
 
 #[derive(Clone, Copy)]
@@ -102,6 +103,7 @@ impl KvPushRouter {
                 effective_overlap_blocks,
                 cached_tokens,
                 routing_hashes,
+                request_progress,
             } => Ok(WorkerSelection {
                 instance_id: worker.worker_id,
                 dp_rank: worker.dp_rank,
@@ -110,6 +112,7 @@ impl KvPushRouter {
                 cached_tokens,
                 routing_hashes,
                 scheduler_tracked: args.scheduler_tracked,
+                request_progress,
             }),
             FindBestMatchOutcome::QueueRejected { rejection } => Err(rejection.into()),
         }

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -76,7 +76,7 @@ impl KvPushRouter {
     async fn select_best_match(&self, args: BestMatchArgs<'_>) -> Result<WorkerSelection, Error> {
         let outcome = self
             .chooser
-            .find_best_match_details_with_policy_class(
+            .find_best_match_details_with_admission(
                 Some(args.context_id),
                 args.routing_parts.token_ids,
                 args.routing_parts.block_mm_infos,

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -153,7 +153,7 @@ where
                 worker_type,
                 watch_worker_configs,
                 admission_strategies,
-            ),
+            )?,
         );
 
         let metrics_scheduler = Arc::clone(&inner);

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -6,8 +6,9 @@ pub use dynamo_kv_router::scheduling::overlap_refresh::{
     NoopOverlapScoresRefresh, OverlapScoresRefresh, RefreshedOverlap,
 };
 pub use dynamo_kv_router::scheduling::{
-    KvSchedulerError, LocalScheduler, OverloadedWorkerProvider, PotentialLoad, ScheduleRequest,
-    SchedulingRequest, SchedulingResponse, TierOverlapBlocks,
+    KvSchedulerError, LocalScheduler, OverloadedWorkerProvider, PolicyClassAdmissionStrategies,
+    PotentialLoad, RequestOutcome, ScheduleRequest, SchedulingRequest, SchedulingResponse,
+    TierOverlapBlocks,
 };
 pub use dynamo_kv_router::selector::DefaultWorkerSelector;
 use dynamo_kv_router::selector::WorkerSelector as WorkerSelectorTrait;
@@ -61,6 +62,36 @@ where
         model_name: Option<&str>,
         worker_type: &'static str,
     ) -> Result<Self, KvSchedulerError> {
+        Self::start_with_admission_strategies(
+            component,
+            block_size,
+            workers_with_configs,
+            selector,
+            kv_router_config,
+            prefill_load_estimator,
+            overlap_scores_refresh,
+            overloaded_worker_provider,
+            model_name,
+            worker_type,
+            PolicyClassAdmissionStrategies::new(),
+        )
+        .await
+    }
+
+    #[expect(clippy::too_many_arguments)]
+    pub async fn start_with_admission_strategies(
+        component: Component,
+        block_size: u32,
+        workers_with_configs: RuntimeConfigWatch,
+        selector: Sel,
+        kv_router_config: &KvRouterConfig,
+        prefill_load_estimator: Option<Arc<dyn PrefillLoadEstimator>>,
+        overlap_scores_refresh: Option<Arc<RF>>,
+        overloaded_worker_provider: Option<OverloadedWorkerProvider>,
+        model_name: Option<&str>,
+        worker_type: &'static str,
+        admission_strategies: PolicyClassAdmissionStrategies,
+    ) -> Result<Self, KvSchedulerError> {
         let initial_workers: HashMap<WorkerId, ModelRuntimeConfig> =
             workers_with_configs.borrow().clone();
 
@@ -83,6 +114,16 @@ where
         let profile = kv_router_config
             .policy_profile(model_name)
             .map_err(|error| KvSchedulerError::InitFailed(error.to_string()))?;
+        let strategy_recheck_interval = admission_strategies
+            .values()
+            .filter_map(|strategy| strategy.reconcile_interval())
+            .min();
+        let queue_recheck_interval = strategy_recheck_interval.map_or_else(
+            || kv_router_config.router_queue_recheck_interval(),
+            |strategy_interval| {
+                strategy_interval.min(kv_router_config.router_queue_recheck_interval())
+            },
+        );
         let metric_model = model_name.unwrap_or("unknown");
         let queue_metrics = profile
             .classes()
@@ -96,21 +137,24 @@ where
             .map(|(index, class)| (class.name.clone(), index))
             .collect();
 
-        let inner = Arc::new(LocalScheduler::new_with_policy_profile(
-            slots,
-            workers_with_configs.clone(),
-            profile,
-            block_size,
-            selector,
-            prefill_load_estimator,
-            overlap_scores_refresh,
-            overloaded_worker_provider,
-            kv_router_config.router_queue_recheck_interval(),
-            kv_router_config.router_track_prefill_tokens,
-            component.drt().child_token(),
-            worker_type,
-            watch_worker_configs,
-        ));
+        let inner = Arc::new(
+            LocalScheduler::new_with_policy_profile_and_admission_strategies(
+                slots,
+                workers_with_configs.clone(),
+                profile,
+                block_size,
+                selector,
+                prefill_load_estimator,
+                overlap_scores_refresh,
+                overloaded_worker_provider,
+                queue_recheck_interval,
+                kv_router_config.router_track_prefill_tokens,
+                component.drt().child_token(),
+                worker_type,
+                watch_worker_configs,
+                admission_strategies,
+            ),
+        );
 
         let metrics_scheduler = Arc::clone(&inner);
         let background_metrics = queue_metrics.clone();
@@ -334,6 +378,20 @@ where
 
     pub async fn free(&self, request_id: &str) -> Result<(), SequenceError> {
         self.inner.free(request_id).await?;
+        self.update_queue_metrics();
+        Ok(())
+    }
+
+    pub async fn mark_dispatched(&self, request_id: &str) {
+        self.inner.mark_dispatched(request_id).await;
+    }
+
+    pub async fn finish(
+        &self,
+        request_id: &str,
+        outcome: RequestOutcome,
+    ) -> Result<(), SequenceError> {
+        self.inner.finish(request_id, outcome).await?;
         self.update_queue_metrics();
         Ok(())
     }

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -170,7 +170,7 @@ impl KvReplayRouter {
             scheduler_cancel.clone(),
             "replay",
             false,
-        ));
+        )?);
         let (event_tx, mut event_rx) = mpsc::unbounded_channel();
         let indexer_clone = indexer.clone();
         let event_task = tokio::spawn(async move {


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Stacked on #11434, this implements the generic policy-class admission host and a typed live request-progress capability. It lets strategies observe in-flight logical context without allocating request IDs or sending best-effort progress commands through the serialized scheduler actor.

CLOSES: DYN-3231

### How This Was Implemented

- Pair a strategy-retained `RequestProgress` reader with a response-stream-owned `RequestProgressUpdater` backed by a monotonic relaxed atomic.
- Carry the updater only for requests that entered a real admission lifecycle; bypassed and admission-disabled requests retain the ordinary scheduling path.
- Let the queue actor own one admission record across pending, selected, dispatched, and terminal states, with idempotent dispatch and terminal notifications.
- Retract deferred or ready queue entries immediately when their scheduling future is dropped, including queue-counter cleanup and one abort event.
- Keep strategy construction explicit through injectable policy-class strategy maps; this PR adds no concrete admission policy.

<details>
<summary>Walkthrough</summary>

#### Mental model

The queue actor creates a reader/writer pair when a strategy admits a tracked request. The strategy retains the reader, while ownership of the writer crosses the scheduling response into the existing response-stream guard.

```mermaid
flowchart LR
  R["Tracked request"] --> Q["Queue actor"]
  Q -->|"read capability"| S["Admission strategy"]
  Q -->|"write capability"| G["RequestGuard"]
  G -->|"atomic block-boundary update"| S
  G -->|"dispatched / completed / aborted"| Q
  Q -->|"lifecycle event"| S
```

#### State and ordering

`AdmissionRequest::context_tokens` remains the immutable initial context. `AdmissionRequest::progress` exposes the latest observed logical context; updater writes use `fetch_max`, so delayed or concurrent observations cannot move the value backward. Relaxed ordering is sufficient because the capability communicates only the numeric latest value and does not publish related memory.

The queue keeps one request-ID-keyed lifecycle record whose worker is absent while pending and present after selection. Dispatch is emitted at most once, terminal completion or abort removes the record, and duplicate or stale notifications are ignored. Strategy actions remain actor-local and reuse the existing policy queue.

#### Request lifecycle

On success, the queue books scheduler state before delivering the response and transfers the updater to `RequestGuard`. The guard publishes cumulative context only when output crosses an accounting-block boundary; normal stream completion publishes the authoritative observed total and emits `Completed`, while cancellation or backend failure emits `Aborted` without committing context.

Before response delivery, a cancellation guard owns the admission lifecycle. Dropping the scheduling future sends a cancellation command, removes deferred or ready queue storage and counters, and emits one abort; after response delivery, the response-stream guard owns cleanup instead.

#### Boundaries and limitations

This contains no ThunderAgent algorithm, client-specific terminal-session behavior, or `dynamo-admission-control` dependency. The capability and queue lifecycle are frontend-local; distributed admission would additionally require globally unique identities, per-session fencing, stale-safe idempotent terminal updates, global capacity accounting, owner-routed wakeups, and frontend-death recovery.

</details>

### Validation

- `cargo test -p dynamo-kv-router --lib --quiet` (639 passed)
- `cargo clippy -p dynamo-kv-router --lib --tests --benches -- -D warnings`
- `cargo check -p dynamo-llm --lib`
- `cargo clippy -p dynamo-llm --lib -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

### Benchmark Results

Release Criterion benchmark on an AMD EPYC 9254. The prior actor-command baseline included request-ID allocation, bounded-channel transport, actor lookup, and strategy dispatch.

| Operation | Time | Comparison |
|---|---:|---:|
| Atomic progress update | 2.525 ns | 87-222x lower than the accepted actor command |
| Atomic progress read | 0.486 ns | N/A |
| Prior accepted actor progress command | 220-560 ns | Baseline |
<!-- codex-pr-description:end -->
