### PR TITLE
build(frontend): update parser and renderer crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2718,9 +2718,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "3.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcc167dc02fd8f01996592adc004e1b192f742f26fa41f7b88799d320c8bbee"
+checksum = "91699e585f751e0ac61db985f794fde10b7983929b41245f34828789297562e1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2740,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.11"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2b9c65028a66f05b2db424d5f472b13662e7c7382c36685b884d6c8e2329"
+checksum = "6a0fa2c447c6cef29cbda22172f2587a5f5ef8eb69af8cae359e277c8b672ec8"
 dependencies = [
  "anyhow",
  "dynamo-parsers",
@@ -2773,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.5"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdad36db205c171171d03036a9cd7641f8824943a528957e26436d5c8ff04a52"
+checksum = "3472f4ee978f581bac985c4f5ebad55a9b1b4ccb025ed3e9df708efa56e83bfa"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ dynamo-runtime = { path = "lib/runtime", version = "1.3.0" }
 dynamo-llm = { path = "lib/llm", version = "1.3.0" }
 dynamo-rl = { path = "lib/rl", version = "1.3.0" }
 dynamo-tokenizers = { version = "=1.5.0" }
-dynamo-renderer = { version = "=1.3.5" }
+dynamo-renderer = { version = "=1.3.8" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.3.0" }
 dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.3.0" }
@@ -53,11 +53,11 @@ dynamo-memory = { path = "lib/memory", version = "1.3.0" }
 dynamo-mocker = { path = "lib/mocker", version = "1.3.0" }
 dynamo-kv-router = { path = "lib/kv-router", version = "1.3.0", features = ["metrics", "runtime-protocols"] }
 dynamo-protocols = { version = "=2.0.1" }
-dynamo-parsers = { version = "3.1.0" }
+dynamo-parsers = { version = "4.1.1" }
 # Published on crates.io. To see all available versions:
 #   web:          https://crates.io/crates/dynamo-parsers-v2/versions
 #   sparse index: curl https://index.crates.io/dy/na/dynamo-parsers-v2   (one JSON line per release; read the "vers" field)
-dynamo-parsers-v2 = { version = "0.1.11" }
+dynamo-parsers-v2 = { version = "0.1.17" }
 dynamo-backend-common = { path = "lib/backend-common", version = "1.3.0" }
 fastokens = { version = "0.2.0" }
 

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1709,9 +1709,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "3.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcc167dc02fd8f01996592adc004e1b192f742f26fa41f7b88799d320c8bbee"
+checksum = "91699e585f751e0ac61db985f794fde10b7983929b41245f34828789297562e1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -1731,9 +1731,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.11"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2b9c65028a66f05b2db424d5f472b13662e7c7382c36685b884d6c8e2329"
+checksum = "6a0fa2c447c6cef29cbda22172f2587a5f5ef8eb69af8cae359e277c8b672ec8"
 dependencies = [
  "anyhow",
  "dynamo-parsers",
@@ -1764,9 +1764,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.5"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdad36db205c171171d03036a9cd7641f8824943a528957e26436d5c8ff04a52"
+checksum = "3472f4ee978f581bac985c4f5ebad55a9b1b4ccb025ed3e9df708efa56e83bfa"
 dependencies = [
  "anyhow",
  "chrono",

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2322,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers"
-version = "3.1.0"
+version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcc167dc02fd8f01996592adc004e1b192f742f26fa41f7b88799d320c8bbee"
+checksum = "91699e585f751e0ac61db985f794fde10b7983929b41245f34828789297562e1"
 dependencies = [
  "aho-corasick",
  "anyhow",
@@ -2344,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-parsers-v2"
-version = "0.1.11"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf3d2b9c65028a66f05b2db424d5f472b13662e7c7382c36685b884d6c8e2329"
+checksum = "6a0fa2c447c6cef29cbda22172f2587a5f5ef8eb69af8cae359e277c8b672ec8"
 dependencies = [
  "anyhow",
  "dynamo-parsers",
@@ -2415,9 +2415,9 @@ dependencies = [
 
 [[package]]
 name = "dynamo-renderer"
-version = "1.3.5"
+version = "1.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdad36db205c171171d03036a9cd7641f8824943a528957e26436d5c8ff04a52"
+checksum = "3472f4ee978f581bac985c4f5ebad55a9b1b4ccb025ed3e9df708efa56e83bfa"
 dependencies = [
  "anyhow",
  "chrono",

--- a/lib/bindings/python/Cargo.toml
+++ b/lib/bindings/python/Cargo.toml
@@ -49,7 +49,7 @@ mm-routing = ["dynamo-llm/mm-routing"]
 aiconfigurator-core = { git = "https://github.com/ai-dynamo/aiconfigurator.git", rev = "ffbab15797d3a3f14c382e937c0ab0c1c5cbc530", package = "aiconfigurator-core", optional = true }
 dynamo-runtime = { path = "../../runtime" }
 dynamo-mocker = { path = "../../mocker" }
-dynamo-parsers = { version = "3.0.0" }
+dynamo-parsers = { version = "4.1.1" }
 dynamo-backend-common = { path = "../../backend-common" }
 
 anyhow = { version = "1" }


### PR DESCRIPTION
## Summary

- update `dynamo-parsers` from 3.1.0 to 4.1.1
- update `dynamo-parsers-v2` from 0.1.11 to 0.1.17
- update `dynamo-renderer` from 1.3.5 to 1.3.8
- refresh the root, Python binding, and KVBM lockfiles without unrelated dependency churn
- consume the v1 tool-call jail terminal-emission fix published from ai-dynamo/frontend-crates#101

## Validation

- `cargo check -p dynamo-llm --locked`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --locked`
- `cargo test -p dynamo-llm --lib --locked` — 1,611 passed, 5 ignored, 0 failed
- commit-time pre-commit hooks

## Tracking

- [DIS-2374](https://linear.app/nvidia/issue/DIS-2374/fix-duplicate-terminal-finish-reason-in-v1-tool-call-jail)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated underlying rendering and parsing components to newer versions.
  * Improved compatibility and reliability for Python bindings through updated parser support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->