### PR TITLE
docs(kubernetes): document DGD scale-to-zero limitation

### DIFF
--- a/docs/kubernetes/autoscaling.md
+++ b/docs/kubernetes/autoscaling.md
@@ -7,6 +7,19 @@ subtitle: Scales DGD services with the DynamoGraphDeploymentScalingAdapter using
 
 This guide explains how to configure autoscaling for DynamoGraphDeployment (DGD) services using the `sglang-agg` example from `examples/backends/sglang/deploy/agg.yaml`.
 
+## Scale-to-Zero Limitation
+
+> [!WARNING]
+> Scale-to-zero is currently not fully supported for DGD worker components. The
+> `DynamoGraphDeploymentScalingAdapter` (DGDSA) and operator accept a replica count of `0`, but when
+> every worker for a model scales to zero, the frontend removes the model from `/v1/models` because
+> no live `ModelDeploymentCard` remains. Requests for the model return HTTP 404 and do not provide
+> a model-specific demand signal that Kubernetes Event-driven Autoscaling (KEDA) or Planner can use
+> to scale the workers up again. For request-driven autoscaling, keep at least one replica for each
+> required worker component by setting `minReplicas: 1` for the Kubernetes Horizontal Pod
+> Autoscaler (HPA) or `minReplicaCount: 1` for KEDA. Scaling back up from zero requires a manual
+> action or another external signal that does not depend on frontend model discovery.
+
 ## Example DGD
 
 All examples in this guide use the following DGD:
@@ -399,13 +412,12 @@ KEDA (Kubernetes Event-driven Autoscaling) extends Kubernetes with event-driven 
 - No Prometheus Adapter configuration needed
 - PromQL queries are defined in the ScaledObject itself (declarative, per-deployment)
 - Easy to update - just `kubectl apply` the ScaledObject
-- Can scale to zero when idle
 - Supports multiple triggers per object
 
 **When to use KEDA:**
 - You want simpler configuration (no Prometheus Adapter to manage)
 - You need event-driven scaling (e.g., queue depth, Kafka, etc.)
-- You want to scale to zero when idle
+- You want event-driven scaling while retaining at least one replica for each required worker component
 
 ### Installing KEDA
 
@@ -678,9 +690,9 @@ spec:
 
 ### 4. Set Sensible Min/Max Replicas
 
-Always configure minimum and maximum replicas in your HPA/KEDA to prevent:
-- Scaling to zero (unless intentional)
-- Unbounded scaling that exhausts cluster resources
+Always configure minimum and maximum replicas in your HPA/KEDA. For request-driven autoscaling, set
+the minimum to `1` or higher for each required worker component because scale-to-zero is not fully
+supported. Set a maximum to prevent unbounded scaling that exhausts cluster resources.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

Document that scale-to-zero is currently not fully supported for DynamoGraphDeployment worker components.

Although the DynamoGraphDeploymentScalingAdapter and operator accept a replica count of zero, scaling every worker for a model to zero removes its live ModelDeploymentCards. The frontend then removes the model from `/v1/models`, returns HTTP 404 for requests, and does not emit the model-specific demand signal needed for request-driven scale-up.

This change:

- Adds a prominent scale-to-zero limitation to the autoscaling guide.
- Recommends retaining at least one replica for each required worker component.
- Explains that recovery from zero requires manual scaling or an independent external signal.
- Removes the contradictory claim that the documented KEDA flow supports scaling workers to zero.
- Updates the autoscaling best practices accordingly.

Related to #10753.