### PR TITLE
ci: restore PR reminder write permission

### DIFF
--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -23,6 +23,7 @@ jobs:
     environment: external_collaborator
     permissions:
       issues: write
+      pull-requests: write
     runs-on: ubuntu-latest
     steps:
       - name: Check for trusted contributor


### PR DESCRIPTION
## Summary

- restore `pull-requests: write` for the PR reminder workflow
- allow the workflow to comment on and label external pull requests without receiving `403 Resource not accessible by integration`
- restore the permission removed in #11093, after which external-contributor reminder runs began failing

## Validation

- parsed `.github/workflows/pr_full_ci_reminder.yaml` successfully as YAML
- ran `git diff --check`
- verified commit `70657ffb133` has a valid SSH signature from `SHA256:8ylJai9wNRQRLU7zrwWuHpO0x2osQ3fjaXI0FTgXWwM`
<!-- devin-review-badge-begin -->

Closes OPS-7626

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11538" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated pull request workflow permissions to support writing pull request notifications and status updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->