### PR TITLE
perf(runtime): avoid copying MessagePack event payloads

### DIFF
--- a/lib/runtime/src/transports/event_plane/codec.rs
+++ b/lib/runtime/src/transports/event_plane/codec.rs
@@ -3,9 +3,9 @@
 
 //! Event plane codec for serializing/deserializing envelopes and payloads.
 
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use bytes::Bytes;
-use serde::{Serialize, de::DeserializeOwned};
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
 
 use super::EventEnvelope;
 
@@ -54,6 +54,13 @@ impl Codec {
         }
     }
 
+    /// Decode only the envelope identity without allocating its topic or payload.
+    pub(crate) fn decode_envelope_identity(&self, bytes: &Bytes) -> Result<(u64, u64)> {
+        match self {
+            Codec::Msgpack(c) => c.decode_envelope_identity(bytes),
+        }
+    }
+
     /// Encode a typed payload to bytes (for embedding in envelope)
     pub fn encode_payload<T: Serialize>(&self, payload: &T) -> Result<Bytes> {
         match self {
@@ -79,13 +86,14 @@ impl Codec {
 #[derive(Debug, Clone, Copy, Default)]
 pub struct MsgpackCodec;
 
-#[derive(Serialize)]
+#[derive(Deserialize, Serialize)]
 struct BorrowedEventEnvelope<'a> {
     publisher_id: u64,
     sequence: u64,
     published_at: u64,
+    #[serde(borrow)]
     topic: &'a str,
-    #[serde(serialize_with = "serialize_bytes")]
+    #[serde(borrow, serialize_with = "serialize_bytes")]
     payload: &'a [u8],
 }
 
@@ -120,7 +128,32 @@ impl MsgpackCodec {
     }
 
     pub fn decode_envelope(&self, bytes: &Bytes) -> Result<EventEnvelope> {
-        Ok(rmp_serde::from_slice(bytes)?)
+        let envelope: BorrowedEventEnvelope<'_> = rmp_serde::from_slice(bytes)?;
+        let payload_start = (envelope.payload.as_ptr() as usize)
+            .checked_sub(bytes.as_ptr() as usize)
+            .ok_or_else(|| {
+                anyhow!("MessagePack envelope payload is not borrowed from its frame")
+            })?;
+        let payload_end = payload_start
+            .checked_add(envelope.payload.len())
+            .ok_or_else(|| anyhow!("MessagePack envelope payload range overflowed"))?;
+
+        if payload_end > bytes.len() {
+            bail!("MessagePack envelope payload exceeds its frame");
+        }
+
+        Ok(EventEnvelope {
+            publisher_id: envelope.publisher_id,
+            sequence: envelope.sequence,
+            published_at: envelope.published_at,
+            topic: envelope.topic.to_owned(),
+            payload: bytes.slice(payload_start..payload_end),
+        })
+    }
+
+    pub(crate) fn decode_envelope_identity(&self, bytes: &Bytes) -> Result<(u64, u64)> {
+        let envelope: BorrowedEventEnvelope<'_> = rmp_serde::from_slice(bytes)?;
+        Ok((envelope.publisher_id, envelope.sequence))
     }
 
     pub fn encode_payload<T: Serialize>(&self, payload: &T) -> Result<Bytes> {
@@ -166,6 +199,15 @@ mod tests {
         assert_eq!(decoded.published_at, envelope.published_at);
         assert_eq!(decoded.topic, envelope.topic);
         assert_eq!(decoded.payload, envelope.payload);
+
+        let frame_start = encoded.as_ptr() as usize;
+        let frame_end = frame_start + encoded.len();
+        let payload_start = decoded.payload.as_ptr() as usize;
+        let payload_end = payload_start + decoded.payload.len();
+        assert!(
+            (frame_start..=frame_end).contains(&payload_start) && payload_end <= frame_end,
+            "decoded payload must share the encoded frame's backing storage"
+        );
     }
 
     #[test]
@@ -187,13 +229,38 @@ mod tests {
             .unwrap();
         assert_eq!(borrowed, owned);
 
-        let decoded: EventEnvelope = rmp_serde::from_slice(&borrowed).unwrap();
+        let decoded = codec.decode_envelope(&borrowed).unwrap();
 
         assert_eq!(decoded.publisher_id, 12345);
         assert_eq!(decoded.sequence, 42);
         assert_eq!(decoded.published_at, 1700000000000);
         assert_eq!(decoded.topic, "test-topic");
         assert_eq!(decoded.payload.as_ref(), payload);
+    }
+
+    #[test]
+    fn test_msgpack_codec_envelope_identity_decode() {
+        let codec = MsgpackCodec;
+        let encoded = codec
+            .encode_envelope_parts(12345, 42, 1700000000000, "test-topic", b"payload")
+            .unwrap();
+
+        assert_eq!(
+            codec.decode_envelope_identity(&encoded).unwrap(),
+            (12345, 42)
+        );
+    }
+
+    #[test]
+    fn test_msgpack_codec_rejects_malformed_envelope() {
+        let codec = MsgpackCodec;
+
+        assert!(codec.decode_envelope(&Bytes::from_static(&[0xc1])).is_err());
+        assert!(
+            codec
+                .decode_envelope_identity(&Bytes::from_static(&[0xc1]))
+                .is_err()
+        );
     }
 
     #[test]

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -243,16 +243,14 @@ impl Stream for DeduplicatingStream {
             match Pin::new(&mut self.inner).poll_next(cx) {
                 Poll::Ready(Some(Ok(bytes))) => {
                     // Decode envelope to extract publisher_id and sequence
-                    match self.codec.decode_envelope(&bytes) {
-                        Ok(envelope) => {
-                            let key = (envelope.publisher_id, envelope.sequence);
-
+                    match self.codec.decode_envelope_identity(&bytes) {
+                        Ok(key) => {
                             // Check if we've seen this event before
                             if self.seen_events.contains(&key) {
                                 // Duplicate - skip and continue loop
                                 tracing::debug!(
-                                    publisher_id = envelope.publisher_id,
-                                    sequence = envelope.sequence,
+                                    publisher_id = key.0,
+                                    sequence = key.1,
                                     "Filtered duplicate event from multi-broker setup"
                                 );
                                 continue;

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -170,13 +170,13 @@ impl ZmqPubTransport {
 impl EventTransportTx for ZmqPubTransport {
     async fn publish(&self, _subject: &str, envelope_bytes: Bytes) -> Result<()> {
         let codec = MsgpackCodec;
-        let envelope = codec.decode_envelope(&envelope_bytes)?;
+        let (publisher_id, sequence) = codec.decode_envelope_identity(&envelope_bytes)?;
 
         let frame = Frame::new(envelope_bytes);
         let frames = vec![
             self.topic.as_bytes().to_vec(),
-            envelope.publisher_id.to_be_bytes().to_vec(),
-            envelope.sequence.to_be_bytes().to_vec(),
+            publisher_id.to_be_bytes().to_vec(),
+            sequence.to_be_bytes().to_vec(),
             frame.encode().to_vec(),
         ];
 


### PR DESCRIPTION
## Summary

- Decode MessagePack event-envelope payloads as slices of their received `Bytes` frame, avoiding the receive-side `Vec<u8>` copy.
- Use an allocation-free identity decoder in deduplication and ZMQ publisher framing.
- Preserve the public event-envelope API, typed-event behavior, and wire format.

## Performance

A local AgentX/Weka c256 frontend profile on the equivalent envelope-decoding change reduced `Codec::decode_envelope` inclusive samples from 5.07% to 0.16% (-96.8%) and eliminated the envelope payload `VecVisitor` subtree (4.70% to 0.00%). Overall serialization fell from 14.55% to 9.48%.

The comparison used a retained control rather than a fresh interleaved A/B, and the mocker/client partition was CPU-saturated. Treat its CPU/request change (11.818 ms to 11.679 ms) as diagnostic, not a capacity claim.

## Validation

- `cargo fmt --all --check`
- `cargo test -p dynamo-runtime msgpack_codec --lib`
- `cargo clippy -p dynamo-runtime --lib -- -D warnings`
- Local AgentX/Weka on-CPU profile: block size 1, frontend CPUs 0-1, eight SGLang FIFO mockers plus AIPerf on CPUs 2-23, 40-second DWARF capture at 99 Hz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved event processing by extracting publisher and sequence metadata without fully decoding message topics and payloads.
  * Reduced unnecessary memory allocation during event decoding.
  * Decoded payloads can now reference the original encoded message data.

* **Reliability**
  * Added validation to reject malformed or out-of-bounds encoded envelopes.
  * Improved handling of duplicate event detection and message publishing metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->