### PR TITLE
test: fix flaky test_nixl_connector_object_roundtrip

### DIFF
--- a/components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py
@@ -3,6 +3,7 @@
 
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 import torch
@@ -128,7 +129,9 @@ def test_nixl_connector_object_roundtrip(fake_nixl):
             "outputs": [{"token_ids": [1, 2], "text": "hi", "finish_reason": "stop"}],
             "multimodal_output": {"sr": 16000},
         }
-        ok, size, metadata = connector.put("1", "router", "req-obj", payload)
+        ok, size, metadata = connector.put(
+            "1", "router", f"req-obj-{uuid4().hex}", payload
+        )
 
         assert ok is True
         assert metadata is not None

--- a/components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py
+++ b/components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py
@@ -129,16 +129,15 @@ def test_nixl_connector_object_roundtrip(fake_nixl):
             "outputs": [{"token_ids": [1, 2], "text": "hi", "finish_reason": "stop"}],
             "multimodal_output": {"sr": 16000},
         }
-        ok, size, metadata = connector.put(
-            "1", "router", f"req-obj-{uuid4().hex}", payload
-        )
+        request_id = f"req-obj-{uuid4().hex}"
+        ok, size, metadata = connector.put("1", "router", request_id, payload)
 
         assert ok is True
         assert metadata is not None
         assert size > 0
         assert metadata["kind"] == "serialized_obj"
 
-        out = connector.get("1", "router", "req-obj", metadata=metadata)
+        out = connector.get("1", "router", request_id, metadata=metadata)
         assert out is not None
         received, _ = out
         assert received == payload


### PR DESCRIPTION
<!-- dd-meta {"pullId":"a5385d59-5633-44d9-8ea4-fe82fc7bd748","source":"chat","resourceId":"a1e10e48-4dc1-4237-8a1a-055e1ca84223","workflowId":"ae233c08-ff31-4612-a2f3-68bd99e873f2","codeChangeId":"ae233c08-ff31-4612-a2f3-68bd99e873f2","sourceType":"test-optimization"} -->
## Overview:

Fixing `test_nixl_connector_object_roundtrip`

This test was flaky due to order-dependent request key reuse in the object roundtrip path. The test previously used a fixed request key (`req-obj`) for `put`, which can collide with existing pending state when execution order changes and lead to intermittent `put` failures (`ok=False`).

## Details:

- Imported `uuid4` in the omni NIXL connector test module.
- Updated `test_nixl_connector_object_roundtrip` to use a unique request id for `connector.put(...)` (`f"req-obj-{uuid4().hex}"`).
- Kept assertions and overall test intent unchanged (object payload roundtrip and equality validation).

## Where should the reviewer start?

- components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py

## Testing (Validation)

- `ruff check --fix components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py`
- `isort components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py`
- `ruff format components/src/dynamo/vllm/tests/omni/test_omni_nixl_connector.py`
- Attempted to run the target test 4 times, but execution is blocked in this sandbox:
  - pytest startup fails due to missing `pydantic`
  - direct runtime attempts fail due to missing `torch`

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

---

PR by Bits - [View session in Datadog](https://us3.datadoghq.com/code/a1e10e48-4dc1-4237-8a1a-055e1ca84223)

Comment @datadog to request changes
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11544" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated connector round-trip testing to use unique request identifiers, improving test isolation and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->