### PR TITLE
ci: await PR reminder comment creation

### DIFF
--- a/.github/workflows/pr_full_ci_reminder.yaml
+++ b/.github/workflows/pr_full_ci_reminder.yaml
@@ -56,7 +56,7 @@ jobs:
           script: |
             const { REPOSITORY, CONTRIBUTOR } = process.env
 
-            github.rest.issues.createComment({
+            await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,


### PR DESCRIPTION
## Summary

- await the PR reminder comment API request so failures propagate to the workflow step
- address https://github.com/ai-dynamo/dynamo/pull/11538#discussion_r3560757489 after #11538 merged before the review fix could be pushed

## Validation

- parsed `.github/workflows/pr_full_ci_reminder.yaml` successfully as YAML
- ran `git diff --check`
- created the commit with an explicit SSH signature and DCO signoff
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11545" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the reliability of automated pull request reminders by ensuring comments are posted completely before processing continues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->