### PR TITLE
test(lora): skip MinIO-backed LoRA tests when Docker is unavailable

### DIFF
--- a/tests/serve/lora_utils.py
+++ b/tests/serve/lora_utils.py
@@ -136,8 +136,11 @@ class MinioService:
         """
         Connect to MinIO service, starting a container if necessary.
 
+        Skips the test (pytest.skip) when neither a running MinIO nor a Docker daemon
+        is available on the runner.
+
         Raises:
-            RuntimeError: If MinIO cannot be started or connected to.
+            RuntimeError: If MinIO container startup itself fails.
         """
         self._logger.info("Connecting to MinIO...")
 
@@ -147,11 +150,15 @@ class MinioService:
             self._owns_container = False
             return
 
-        # Try to start Docker container
+        # Neither a pre-started MinIO nor a Docker daemon is available on this runner
+        # (e.g. Slurm/enroot CI executors have no Docker), so LoRA tests needing
+        # S3-compatible storage cannot run here. Skip rather than error, so the suite
+        # passes on Docker-less runners -- consistent with this module's contract of
+        # "pre-started MinIO in CI / auto-start Docker locally".
         if not self._is_docker_available():
-            raise RuntimeError(
-                "MinIO is not available and Docker is not accessible.\n"
-                "Start MinIO manually:\n"
+            pytest.skip(
+                "MinIO not available and Docker not accessible on this runner; "
+                "skipping LoRA tests that require S3-compatible storage. To run locally:\n"
                 "  docker run -d -p 9000:9000 -p 9001:9001 "
                 "-e MINIO_ROOT_USER=minioadmin -e MINIO_ROOT_PASSWORD=minioadmin "
                 f"--name {self.CONTAINER_NAME} "


### PR DESCRIPTION
#### Overview:

Forward-port of a general test-robustness fix that currently lives only on the internal `rubin-devel` branch: the `minio_lora_service` fixture raised `RuntimeError` — a hard job failure — when neither a pre-started MinIO nor a Docker daemon was available, instead of skipping. On Docker-less CI runners this turns an environment gap into a red job.

#### Details:

`tests/serve/lora_utils.py`'s `MinioService.start()` now calls `pytest.skip(...)` when `_is_docker_available()` is `False` (no already-running MinIO **and** no Docker daemon) — consistent with the module's "pre-started MinIO in CI / auto-start Docker locally" contract. Where Docker **is** available it behaves exactly as before (starts the container; still raises if the container itself genuinely fails to start), so this is a no-op on normal runners.

Why it matters: on executors without Docker (Slurm/enroot, and the Rubin bring-up images that run pytest inside a container) `test_lora_aggregated_router` errored at setup and failed the whole job. This fix already exists on `rubin-devel`; forward-porting to `main` so it benefits all Docker-less CI — and reaches the Rubin images, which clone `main` for their test code.

#### Where should the reviewer start?

`tests/serve/lora_utils.py` — the `start()` method: the added `if not self._is_docker_available(): pytest.skip(...)` branch (conditional, so it only skips when there's genuinely no MinIO/Docker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11546" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LoRA tests now skip gracefully when MinIO is unavailable and Docker cannot be used, instead of failing the test suite.
  * Updated startup error documentation to accurately describe MinIO container startup failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->