### PR TITLE
feat(router): add provider-keyed tracking hashes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2436,6 +2436,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum 0.8.4",
+ "blake3",
  "chrono",
  "criterion",
  "crossbeam-queue",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2471,6 +2471,7 @@ dependencies = [
  "tracing-appender",
  "uuid",
  "xxhash-rust",
+ "zeroize",
  "zmq",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,6 +167,7 @@ validator = { version = "0.20.0", features = ["derive"] }
 uuid = { version = "1.18.1", features = ["v4", "serde"] }
 url = { version = "2.5", features = ["serde"] }
 xxhash-rust = { version = "0.8", features = ["xxh3", "const_xxh3"] }
+zeroize = { version = "1" }
 
 # ext-proc / Envoy gRPC
 prost = { version = "0.13.5" }

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -38,6 +38,9 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "router_track_output_blocks",
     "router_assume_kv_reuse",
     "router_track_prefill_tokens",
+    "router_tracking_hash",
+    "router_tracking_key_file",
+    "router_tracking_key_id",
     "router_prefill_load_model",
     "router_ttl_secs",
     "router_queue_threshold",
@@ -117,6 +120,9 @@ class KvRouterConfigBase(ConfigBase):
     router_track_output_blocks: bool
     router_assume_kv_reuse: bool
     router_track_prefill_tokens: bool
+    router_tracking_hash: str = "public-xxh3-v1"
+    router_tracking_key_file: Optional[str] = None
+    router_tracking_key_id: Optional[str] = None
     router_prefill_load_model: str
     router_ttl_secs: float
     router_queue_threshold: Optional[float]
@@ -321,6 +327,28 @@ class KvRouterArgGroup(ArgGroup):
                 "Use --no-router-track-prefill-tokens to ignore prompt tokens in router "
                 "prefill-token load, queue pressure, and active_prefill_tokens metrics."
             ),
+        )
+        add_argument(
+            g,
+            flag_name="--router-tracking-hash",
+            env_var="DYN_ROUTER_TRACKING_HASH",
+            default="public-xxh3-v1",
+            choices=["public-xxh3-v1", "keyed-xxh3-v1"],
+            help="KV Router: Hash function for router-derived active-sequence identities.",
+        )
+        add_argument(
+            g,
+            flag_name="--router-tracking-key-file",
+            env_var="DYN_ROUTER_TRACKING_KEY_FILE",
+            default=None,
+            help="KV Router: File containing the 32-byte provider tracking key.",
+        )
+        add_argument(
+            g,
+            flag_name="--router-tracking-key-id",
+            env_var="DYN_ROUTER_TRACKING_KEY_ID",
+            default=None,
+            help="KV Router: Provider-managed tracking-key epoch identifier.",
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -274,6 +274,46 @@ def test_load_aware_preserves_prefill_load_scale() -> None:
     assert kwargs["prefill_load_scale"] == 2.5
 
 
+def test_tracking_hash_cli_flows_to_binding_kwargs(tmp_path: Path) -> None:
+    key_file = tmp_path / "tracking-key"
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    args = parser.parse_args(
+        [
+            "--router-tracking-hash",
+            "keyed-xxh3-v1",
+            "--router-tracking-key-file",
+            str(key_file),
+            "--router-tracking-key-id",
+            "2026-01",
+        ]
+    )
+    kwargs = KvRouterConfigBase.from_cli_args(args).kv_router_kwargs()
+
+    assert kwargs["router_tracking_hash"] == "keyed-xxh3-v1"
+    assert kwargs["router_tracking_key_file"] == str(key_file)
+    assert kwargs["router_tracking_key_id"] == "2026-01"
+
+
+def test_tracking_hash_environment_flows_to_binding_kwargs(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    key_file = tmp_path / "tracking-key"
+    monkeypatch.setenv("DYN_ROUTER_TRACKING_HASH", "keyed-xxh3-v1")
+    monkeypatch.setenv("DYN_ROUTER_TRACKING_KEY_FILE", str(key_file))
+    monkeypatch.setenv("DYN_ROUTER_TRACKING_KEY_ID", "2026-01")
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    args = parser.parse_args([])
+    kwargs = KvRouterConfigBase.from_cli_args(args).kv_router_kwargs()
+
+    assert kwargs["router_tracking_hash"] == "keyed-xxh3-v1"
+    assert kwargs["router_tracking_key_file"] == str(key_file)
+    assert kwargs["router_tracking_key_id"] == "2026-01"
+
+
 def test_load_aware_preserves_cache_hit_weights() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -13,7 +13,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use anyhow::Result;
-use dynamo_kv_router::config::{RouterConfigOverride, kv_router_config_from_dynamo_env};
+use dynamo_kv_router::config::{RouterConfigOverride, try_kv_router_config_from_dynamo_env};
 use dynamo_kv_router::protocols::{RoutingConstraints, WorkerWithDpRank};
 use dynamo_llm::discovery::{ModelManager, WORKER_TYPE_DECODE};
 use dynamo_llm::kv_router::prefill_router::PrefillQueryOutcome;
@@ -121,7 +121,8 @@ impl Router {
 
         // TODO(epp-rolling-namespace): Rebind both routers when the active
         // generation-suffixed worker namespace changes during a rolling update.
-        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        let mut kv_router_config =
+            try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
         // TODO(epp-multi-replica): Provide authoritative admission across EPP
         // replicas; replica-sync alone does not close the selection-to-booking race.
         kv_router_config.skip_initial_worker_wait = true;

--- a/docs/components/frontend/configuration.md
+++ b/docs/components/frontend/configuration.md
@@ -74,6 +74,9 @@ explains when to adjust these settings.
 | `--router-track-active-blocks` / `--no-router-track-active-blocks` | `DYN_ROUTER_TRACK_ACTIVE_BLOCKS` | `true` | Track blocks used by in-progress requests for load balancing |
 | `--router-track-output-blocks` / `--no-router-track-output-blocks` | `DYN_ROUTER_TRACK_OUTPUT_BLOCKS` | `false` | Track output blocks with fractional decay during generation |
 | `--router-assume-kv-reuse` / `--no-router-assume-kv-reuse` | `DYN_ROUTER_ASSUME_KV_REUSE` | `true` | Assume KV cache reuse when tracking active blocks |
+| `--router-tracking-hash` | `DYN_ROUTER_TRACKING_HASH` | `public-xxh3-v1` | Tracking-identity algorithm: `public-xxh3-v1` or experimental `keyed-xxh3-v1` |
+| `--router-tracking-key-file` | `DYN_ROUTER_TRACKING_KEY_FILE` | — | File containing exactly 32 raw key bytes. Required by `keyed-xxh3-v1` |
+| `--router-tracking-key-id` | `DYN_ROUTER_TRACKING_KEY_ID` | — | Nonempty provider-managed key epoch. Required by `keyed-xxh3-v1` |
 | `--router-track-prefill-tokens` / `--no-router-track-prefill-tokens` | `DYN_ROUTER_TRACK_PREFILL_TOKENS` | `true` | Include prompt-side prefill tokens in active-load accounting |
 | `--router-prefill-load-model` | `DYN_ROUTER_PREFILL_LOAD_MODEL` | `none` | Prompt-side load model: `none` for static load or `aic` for oldest-prefill decay using an AIC prediction |
 | `--router-queue-threshold` | `DYN_ROUTER_QUEUE_THRESHOLD` | unset | Queue threshold fraction of prefill capacity. Setting a numeric value enables queueing; priority hints only affect requests waiting in this queue |

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -222,6 +222,41 @@ For Kubernetes deployment examples, see [Kubernetes Topology-Aware KV Transfer](
 - `--no-router-track-prefill-tokens`: Disables prompt-side prefill token accounting in the router's active load model. Use this for decode-only routing paths where prompt processing already happened elsewhere.
 - `--router-replica-sync`: Disabled by default. Enables best-effort Runtime event-plane synchronization of KV active-sequence state. Session-affinity synchronization is independent and starts when `--router-session-affinity-ttl-secs` is set.
 
+### Tracking Hash Identities
+
+**Experimental.** Set `--router-tracking-hash keyed-xxh3-v1` to make
+router-derived active-sequence identities depend on a provider key. The default
+`public-xxh3-v1` mode preserves the existing public XXH3 identities.
+
+Keyed mode requires `--router-tracking-key-file` to name a file containing
+exactly 32 raw bytes and `--router-tracking-key-id` to contain a nonempty key
+epoch. The corresponding environment variables are
+`DYN_ROUTER_TRACKING_HASH`, `DYN_ROUTER_TRACKING_KEY_FILE`, and
+`DYN_ROUTER_TRACKING_KEY_ID`. Invalid or unreadable key configuration stops
+startup instead of falling back to public hashing.
+
+The router derives independent block and chain XXH3 seeds from one keyed BLAKE3
+digest for each request scope. The scope includes the algorithm version, key ID,
+model, routing group, block size, normalized `cache_salt`, LoRA adapter, and
+Eagle mode. Multimodal identity remains part of the canonical bytes for each
+block. Seeded XXH3 is not a pseudorandom function or message authentication
+code, so keep tracking hashes and the APIs that accept them on a trusted
+internal plane.
+
+Public block hashes continue to drive primary-indexer lookups. Keyed sequence
+hashes drive active tracking, reservations, prompt membership, and projected
+load. Engine hashes, universal positional lineage hashes, KV events, and
+standalone indexer APIs do not change. `--no-router-assume-kv-reuse` continues
+to use random tracking identities while retaining public indexer hashes.
+
+Selection requests and standalone slot-tracker calls that supply precomputed
+sequence hashes remain trusted inputs. Dynamo does not attach or negotiate an
+algorithm or key epoch in HTTP requests, selection payloads, tracker lifecycle
+events, or replica messages. Initialize every producer with the same algorithm,
+key, and key ID. To rotate the key, change the key and key ID together, restart
+all producers, and flush or recreate derived tracker state before resuming
+traffic. Mixed epochs are not detected.
+
 ## KV Indexer / Approx KV Indexer
 
 - `--router-ttl-secs`: Time-to-live in seconds for blocks in the router's local cache predictions. Defaults to 120.0 seconds when `--no-router-kv-events` is used.

--- a/docs/components/router/standalone-selection.md
+++ b/docs/components/router/standalone-selection.md
@@ -47,8 +47,10 @@ indexer recovery, replica synchronization, and shutdown. It exposes the same
 worker, selection, bookkeeping, inspection, peer-membership, and recovery
 operations as the standalone HTTP service.
 
-`SelectionCore::new_local` creates an intentionally unsynchronized core for
-tests and local-only use. Production integrations should use
+`SelectionCore::try_new_local` creates an intentionally unsynchronized core for
+tests and local-only use while reporting invalid tracking-hash configuration.
+`SelectionCore::new_local` remains available for compatibility and panics on
+invalid configuration. Production integrations should use
 `SelectionServiceBuilder` so startup recovery, readiness, and background-task
 lifecycle remain consistent with the standalone service.
 
@@ -69,6 +71,9 @@ APIs. Those bindings should wrap `SelectionService` rather than construct
 | `--selection-cache-ttl-secs` | `120` | Seconds an unclaimed pending selection lives before eviction. |
 | `--selection-cache-max-entries` | `4096` | Maximum resident pending selections, evicting oldest first. |
 | `--selection-cache-max-bytes` | `268435456` | Approximate byte budget across resident pending selections. |
+| `--router-tracking-hash` | environment/default | Override the tracking algorithm with `public-xxh3-v1` or experimental `keyed-xxh3-v1`. |
+| `--router-tracking-key-file` | environment/none | Override the path to the 32-byte provider key file. |
+| `--router-tracking-key-id` | environment/none | Override the provider-managed key epoch. |
 
 Router scheduling behavior continues to use the standard Dynamo router
 environment configuration.
@@ -176,6 +181,13 @@ snapshot.
 
 The previous public fields `cached_tokens` and `effective_overlap_blocks` have
 been removed. Their values remain internal scheduler inputs.
+
+When a request supplies `token_ids`, the selector derives tracking hashes with
+its configured tracking-hash context while retaining public hashes for indexer
+lookups. Requests that instead supply `block_hashes`, `sequence_hashes`, and
+`isl_tokens` remain trusted precomputed inputs. The service does not reject,
+rewrite, or label those identities in keyed mode. Configure every precomputed
+hash producer with the same algorithm, key, and key ID as the selector.
 
 ## Ray Select-Then-Reserve Flow
 
@@ -322,6 +334,10 @@ replica-sync peers. They do not alter the HTTP indexer-recovery peers.
   resynchronization for replica lifecycle events.
 - Unknown worker, model, routing-group, DP-rank, and block-size events are dropped.
   Register the same worker catalog on every selector before routing traffic.
+- Replica messages carry opaque tracking hashes and do not negotiate the
+  tracking algorithm or key epoch. Configure all hash producers consistently.
+  For key rotation, stop traffic, change the key and key ID together, restart
+  all producers, and recreate derived tracker state before resuming traffic.
 - The v1 replica envelope uses `routing_group` and is incompatible with binaries that
   send `tenant_id`. Drain active reservations and lifecycle traffic, upgrade all connected
   selectors together, re-register worker catalogs, and then resume traffic. Active advisory

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 
 use dynamo_kv_router::{
-    config::{RouterConfigOverride, kv_router_config_from_dynamo_env},
+    config::{RouterConfigOverride, try_kv_router_config_from_dynamo_env},
     protocols::*,
 };
 use dynamo_llm::kv_router::publisher::KvEventPublisher;
@@ -755,7 +755,13 @@ pub unsafe extern "C" fn create_routers(
             );
         }
 
-        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        let mut kv_router_config = match try_kv_router_config_from_dynamo_env() {
+            Ok(config) => config,
+            Err(error) => {
+                tracing::error!(%error, "Invalid KV router environment configuration");
+                return Err(QueryRouterResult::ErrInitFailed);
+            }
+        };
         kv_router_config.skip_initial_worker_wait = true;
 
         // Build endpoint using the actual namespace discovered from workers,

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "anyhow",
  "arc-swap",
  "async-trait",
+ "blake3",
  "crossbeam-queue",
  "dashmap",
  "derive_builder",
@@ -1567,6 +1568,7 @@ dependencies = [
  "tracing",
  "uuid",
  "xxhash-rust",
+ "zeroize",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2170,6 +2170,7 @@ dependencies = [
  "tracing-appender",
  "uuid",
  "xxhash-rust",
+ "zeroize",
  "zmq",
 ]
 

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2140,6 +2140,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
+ "blake3",
  "chrono",
  "crossbeam-queue",
  "dashmap",

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -13,11 +13,11 @@ use pyo3::{
 };
 use pyo3_async_runtimes::TaskLocals;
 
+use dynamo_kv_router::TrackingHashAlgorithm as RsTrackingHashAlgorithm;
 use dynamo_kv_router::config::{
     KvRouterConfig as RsKvRouterConfig, RouterPrefillLoadModel as RsRouterPrefillLoadModel,
     apply_deprecated_overlap_score_weight_override,
 };
-use dynamo_kv_router::TrackingHashAlgorithm as RsTrackingHashAlgorithm;
 use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -17,6 +17,7 @@ use dynamo_kv_router::config::{
     KvRouterConfig as RsKvRouterConfig, RouterPrefillLoadModel as RsRouterPrefillLoadModel,
     apply_deprecated_overlap_score_weight_override,
 };
+use dynamo_kv_router::TrackingHashAlgorithm as RsTrackingHashAlgorithm;
 use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
@@ -237,7 +238,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None, router_tracking_hash="public-xxh3-v1", router_tracking_key_file=None, router_tracking_key_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -264,6 +265,9 @@ impl KvRouterConfig {
         overlap_score_credit_decay: f64,
         mut prefill_load_scale: f64,
         router_policy_config: Option<String>,
+        router_tracking_hash: &str,
+        router_tracking_key_file: Option<PathBuf>,
+        router_tracking_key_id: Option<String>,
     ) -> PyResult<Self> {
         if let Some(value) = overlap_score_weight {
             apply_deprecated_overlap_score_weight(
@@ -286,6 +290,11 @@ impl KvRouterConfig {
             router_track_output_blocks,
             router_assume_kv_reuse,
             router_track_prefill_tokens,
+            router_tracking_hash: router_tracking_hash
+                .parse::<RsTrackingHashAlgorithm>()
+                .map_err(PyValueError::new_err)?,
+            router_tracking_key_file,
+            router_tracking_key_id,
             router_prefill_load_model: router_prefill_load_model
                 .parse::<RsRouterPrefillLoadModel>()
                 .map_err(PyValueError::new_err)?,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -20,10 +20,10 @@ use crate::Endpoint;
 ))]
 use clap::Parser;
 #[cfg(feature = "select-service")]
-use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
-use dynamo_kv_router::config::{KvRouterConfig, RouterConfigOverride};
-#[cfg(feature = "select-service")]
 use dynamo_kv_router::TrackingHashAlgorithm;
+#[cfg(feature = "select-service")]
+use dynamo_kv_router::config::try_kv_router_config_from_dynamo_env;
+use dynamo_kv_router::config::{KvRouterConfig, RouterConfigOverride};
 use dynamo_kv_router::protocols::compute_block_hash_for_seq;
 use dynamo_kv_router::protocols::*;
 #[cfg(feature = "kv-indexer")]
@@ -397,7 +397,8 @@ where
         init_standalone_logging();
 
         let rt = tokio::runtime::Runtime::new()?;
-        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        let mut kv_router_config =
+            try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
         if let Some(algorithm) = cli.router_tracking_hash {
             kv_router_config.router_tracking_hash = algorithm;
         }
@@ -521,7 +522,9 @@ impl SelectionService {
                 "replica_sync_peers requires replica_sync_port",
             ));
         }
-        let mut builder = SelectionServiceBuilder::new(kv_router_config_from_dynamo_env())
+        let kv_router_config =
+            try_kv_router_config_from_dynamo_env().map_err(PyValueError::new_err)?;
+        let mut builder = SelectionServiceBuilder::new(kv_router_config)
             .indexer_threads(indexer_threads)
             .indexer_peers(indexer_peers.unwrap_or_default())
             .selection_cache(selection_cache.unwrap_or_default().inner);

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -407,11 +407,9 @@ mod select_service_cli_tests {
         let default = SelectServiceCli::try_parse_from(["dynamo.select_service"]).unwrap();
         assert_eq!(default.router_assume_kv_reuse_override(), None);
 
-        let enabled = SelectServiceCli::try_parse_from([
-            "dynamo.select_service",
-            "--router-assume-kv-reuse",
-        ])
-        .unwrap();
+        let enabled =
+            SelectServiceCli::try_parse_from(["dynamo.select_service", "--router-assume-kv-reuse"])
+                .unwrap();
         assert_eq!(enabled.router_assume_kv_reuse_override(), Some(true));
 
         let disabled = SelectServiceCli::try_parse_from([

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -22,6 +22,8 @@ use clap::Parser;
 #[cfg(feature = "select-service")]
 use dynamo_kv_router::config::kv_router_config_from_dynamo_env;
 use dynamo_kv_router::config::{KvRouterConfig, RouterConfigOverride};
+#[cfg(feature = "select-service")]
+use dynamo_kv_router::TrackingHashAlgorithm;
 use dynamo_kv_router::protocols::compute_block_hash_for_seq;
 use dynamo_kv_router::protocols::*;
 #[cfg(feature = "kv-indexer")]
@@ -305,6 +307,18 @@ struct SelectServiceCli {
     /// Approximate byte budget across resident pending selections
     #[arg(long)]
     selection_cache_max_bytes: Option<usize>,
+
+    /// Hash function for router-derived active-sequence identities
+    #[arg(long)]
+    router_tracking_hash: Option<TrackingHashAlgorithm>,
+
+    /// File containing the 32-byte provider tracking key
+    #[arg(long)]
+    router_tracking_key_file: Option<std::path::PathBuf>,
+
+    /// Provider-managed tracking-key epoch identifier
+    #[arg(long)]
+    router_tracking_key_id: Option<String>,
 }
 
 #[cfg(all(test, feature = "select-service"))]
@@ -383,13 +397,23 @@ where
         init_standalone_logging();
 
         let rt = tokio::runtime::Runtime::new()?;
+        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        if let Some(algorithm) = cli.router_tracking_hash {
+            kv_router_config.router_tracking_hash = algorithm;
+        }
+        if let Some(key_file) = cli.router_tracking_key_file {
+            kv_router_config.router_tracking_key_file = Some(key_file);
+        }
+        if let Some(key_id) = cli.router_tracking_key_id {
+            kv_router_config.router_tracking_key_id = Some(key_id);
+        }
         rt.block_on(selection::run_server(SelectionServiceConfig {
             port: cli.port,
             threads: cli.threads,
             indexer_peers: cli.indexer_peers,
             replica_sync_port: cli.replica_sync_port,
             replica_sync_peers: cli.replica_sync_peers,
-            kv_router_config: kv_router_config_from_dynamo_env(),
+            kv_router_config,
             selection_cache: selection_cache_config_from_overrides(
                 cli.selection_cache_ttl_secs,
                 cli.selection_cache_max_entries,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -308,6 +308,14 @@ struct SelectServiceCli {
     #[arg(long)]
     selection_cache_max_bytes: Option<usize>,
 
+    /// Assume KV cache reuse when deriving active-sequence identities
+    #[arg(long, conflicts_with = "no_router_assume_kv_reuse")]
+    router_assume_kv_reuse: bool,
+
+    /// Generate random active-sequence identities instead of assuming KV reuse
+    #[arg(long, conflicts_with = "router_assume_kv_reuse")]
+    no_router_assume_kv_reuse: bool,
+
     /// Hash function for router-derived active-sequence identities
     #[arg(long)]
     router_tracking_hash: Option<TrackingHashAlgorithm>,
@@ -319,6 +327,19 @@ struct SelectServiceCli {
     /// Provider-managed tracking-key epoch identifier
     #[arg(long)]
     router_tracking_key_id: Option<String>,
+}
+
+#[cfg(feature = "select-service")]
+impl SelectServiceCli {
+    fn router_assume_kv_reuse_override(&self) -> Option<bool> {
+        if self.router_assume_kv_reuse {
+            Some(true)
+        } else if self.no_router_assume_kv_reuse {
+            Some(false)
+        } else {
+            None
+        }
+    }
 }
 
 #[cfg(all(test, feature = "select-service"))]
@@ -380,6 +401,34 @@ mod select_service_cli_tests {
         assert_eq!(config.max_entries, 100);
         assert_eq!(config.max_bytes, 1_048_576);
     }
+
+    #[test]
+    fn parses_router_assume_kv_reuse_overrides() {
+        let default = SelectServiceCli::try_parse_from(["dynamo.select_service"]).unwrap();
+        assert_eq!(default.router_assume_kv_reuse_override(), None);
+
+        let enabled = SelectServiceCli::try_parse_from([
+            "dynamo.select_service",
+            "--router-assume-kv-reuse",
+        ])
+        .unwrap();
+        assert_eq!(enabled.router_assume_kv_reuse_override(), Some(true));
+
+        let disabled = SelectServiceCli::try_parse_from([
+            "dynamo.select_service",
+            "--no-router-assume-kv-reuse",
+        ])
+        .unwrap();
+        assert_eq!(disabled.router_assume_kv_reuse_override(), Some(false));
+
+        let conflict = SelectServiceCli::try_parse_from([
+            "dynamo.select_service",
+            "--router-assume-kv-reuse",
+            "--no-router-assume-kv-reuse",
+        ])
+        .unwrap_err();
+        assert_eq!(conflict.kind(), clap::error::ErrorKind::ArgumentConflict);
+    }
 }
 
 pub fn run_select_service_cli<I, T>(args: I) -> anyhow::Result<()>
@@ -399,6 +448,9 @@ where
         let rt = tokio::runtime::Runtime::new()?;
         let mut kv_router_config =
             try_kv_router_config_from_dynamo_env().map_err(anyhow::Error::msg)?;
+        if let Some(assume_kv_reuse) = cli.router_assume_kv_reuse_override() {
+            kv_router_config.router_assume_kv_reuse = assume_kv_reuse;
+        }
         if let Some(algorithm) = cli.router_tracking_hash {
             kv_router_config.router_tracking_hash = algorithm;
         }

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1870,6 +1870,9 @@ class KvRouterConfig:
         overlap_score_credit_decay: float = 0.0,
         prefill_load_scale: float = 1.0,
         router_policy_config: Optional[str] = None,
+        router_tracking_hash: Literal["public-xxh3-v1", "keyed-xxh3-v1"] = "public-xxh3-v1",
+        router_tracking_key_file: Optional[str | os.PathLike[str]] = None,
+        router_tracking_key_id: Optional[str] = None,
     ) -> None:
         """
         Create a KV router configuration.
@@ -1891,6 +1894,12 @@ class KvRouterConfig:
             router_assume_kv_reuse: Assume KV cache reuse when tracking active blocks (default: True).
                 When True, computes actual block hashes. When False, generates random hashes.
             router_track_prefill_tokens: Include prompt-side prefill tokens in active load accounting (default: True).
+            router_tracking_hash: Tracking identity algorithm, "public-xxh3-v1" or
+                "keyed-xxh3-v1" (default: "public-xxh3-v1").
+            router_tracking_key_file: File containing exactly 32 raw provider-key bytes.
+                Required only for keyed tracking mode.
+            router_tracking_key_id: Provider-managed key epoch mixed into keyed scope
+                derivation. Required only for keyed tracking mode.
             router_prefill_load_model: Prompt-side prefill load model (default: "none").
                 "none" keeps static prompt load accounting.
                 "aic" decays the oldest active prefill request using AIC-predicted duration.

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -33,6 +33,7 @@ dynamo-truthy = { workspace = true }
 anyhow = { workspace = true }
 arc-swap = "1.9.1"
 async-trait = { workspace = true }
+blake3 = { workspace = true }
 dashmap = { workspace = true }
 indexmap = { workspace = true }
 ordered-float = { workspace = true }
@@ -85,4 +86,8 @@ tower = { version = "0.5", features = ["util"] }
 
 [[bench]]
 name = "policy_queue"
+harness = false
+
+[[bench]]
+name = "tracking_hash"
 harness = false

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -51,6 +51,7 @@ tracing = { workspace = true }
 zmq = { version = "0.10", optional = true }
 uuid = { workspace = true }
 xxhash-rust = { workspace = true }
+zeroize = { workspace = true }
 
 # dependencies
 crossbeam-queue = "0.3"

--- a/lib/kv-router/benches/tracking_hash.rs
+++ b/lib/kv-router/benches/tracking_hash.rs
@@ -6,7 +6,9 @@ use std::io::Write;
 use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
 use dynamo_kv_router::config::KvRouterConfig;
 use dynamo_kv_router::protocols::{BlockHashOptions, compute_block_hash_for_seq};
-use dynamo_kv_router::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
+use dynamo_kv_router::{
+    RoutingPartitionRef, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+};
 use tempfile::NamedTempFile;
 
 const BENCHMARK_KEY: [u8; 32] = [0x5a; 32];
@@ -21,7 +23,11 @@ fn benchmark_blake3_sequence_hashes(
 ) -> Vec<u64> {
     let mut scope_hasher = blake3::Hasher::new_keyed(provider_key);
     scope_hasher.update(BLAKE3_SCOPE_DOMAIN);
-    for value in ["benchmark", scope.model_name, scope.routing_group] {
+    for value in [
+        "benchmark",
+        scope.partition.model_name,
+        scope.partition.routing_group,
+    ] {
         scope_hasher.update(&(value.len() as u64).to_le_bytes());
         scope_hasher.update(value.as_bytes());
     }
@@ -81,8 +87,7 @@ fn tracking_hash(c: &mut Criterion) {
     .unwrap();
     let block_size = 16;
     let scope = TrackingHashScope {
-        model_name: "benchmark-model",
-        routing_group: "default",
+        partition: RoutingPartitionRef::new("benchmark-model", "default"),
         block_size,
     };
 

--- a/lib/kv-router/benches/tracking_hash.rs
+++ b/lib/kv-router/benches/tracking_hash.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::io::Write;
+
+use criterion::{BenchmarkId, Criterion, Throughput, black_box, criterion_group, criterion_main};
+use dynamo_kv_router::config::KvRouterConfig;
+use dynamo_kv_router::protocols::{BlockHashOptions, compute_block_hash_for_seq};
+use dynamo_kv_router::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
+use tempfile::NamedTempFile;
+
+fn tracking_hash(c: &mut Criterion) {
+    let mut key_file = NamedTempFile::new().unwrap();
+    key_file.write_all(&[0x5a; 32]).unwrap();
+    let public_context = TrackingHashContext::from_config(&KvRouterConfig::default()).unwrap();
+    let keyed_context = TrackingHashContext::from_config(&KvRouterConfig {
+        router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+        router_tracking_key_file: Some(key_file.path().to_path_buf()),
+        router_tracking_key_id: Some("benchmark".to_string()),
+        ..Default::default()
+    })
+    .unwrap();
+    let block_size = 16;
+    let scope = TrackingHashScope {
+        model_name: "benchmark-model",
+        routing_group: "default",
+        block_size,
+    };
+
+    let mut group = c.benchmark_group("tracking_hash");
+    for blocks in [1_u32, 32, 128] {
+        let tokens = (0..blocks * block_size).collect::<Vec<_>>();
+        let options = BlockHashOptions::default();
+        let public_blocks = compute_block_hash_for_seq(&tokens, block_size, options);
+        group.throughput(Throughput::Elements(u64::from(blocks)));
+        group.bench_with_input(BenchmarkId::new("public", blocks), &blocks, |b, _| {
+            b.iter(|| {
+                black_box(public_context.compute_sequence_hashes(
+                    scope,
+                    black_box(&tokens),
+                    options,
+                    Some(&public_blocks),
+                ))
+            })
+        });
+        group.bench_with_input(BenchmarkId::new("keyed", blocks), &blocks, |b, _| {
+            b.iter(|| {
+                black_box(keyed_context.compute_sequence_hashes(
+                    scope,
+                    black_box(&tokens),
+                    options,
+                    Some(&public_blocks),
+                ))
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, tracking_hash);
+criterion_main!(benches);

--- a/lib/kv-router/benches/tracking_hash.rs
+++ b/lib/kv-router/benches/tracking_hash.rs
@@ -9,9 +9,68 @@ use dynamo_kv_router::protocols::{BlockHashOptions, compute_block_hash_for_seq};
 use dynamo_kv_router::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 use tempfile::NamedTempFile;
 
+const BENCHMARK_KEY: [u8; 32] = [0x5a; 32];
+const BLAKE3_SCOPE_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/benchmark-blake3-scope\0";
+const BLAKE3_BLOCK_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/benchmark-blake3-block\0";
+const BLAKE3_CHAIN_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/benchmark-blake3-chain\0";
+
+fn benchmark_blake3_sequence_hashes(
+    provider_key: &[u8; 32],
+    scope: TrackingHashScope<'_>,
+    tokens: &[u32],
+) -> Vec<u64> {
+    let mut scope_hasher = blake3::Hasher::new_keyed(provider_key);
+    scope_hasher.update(BLAKE3_SCOPE_DOMAIN);
+    for value in ["benchmark", scope.model_name, scope.routing_group] {
+        scope_hasher.update(&(value.len() as u64).to_le_bytes());
+        scope_hasher.update(value.as_bytes());
+    }
+    scope_hasher.update(&scope.block_size.to_le_bytes());
+    let scope_key = *scope_hasher.finalize().as_bytes();
+
+    let block_size = scope.block_size as usize;
+    if block_size == 0 {
+        return Vec::new();
+    }
+    let mut sequence_hashes: Vec<u64> = Vec::with_capacity(tokens.len() / block_size);
+    for chunk in tokens.chunks_exact(block_size) {
+        let mut block_hasher = blake3::Hasher::new_keyed(&scope_key);
+        block_hasher.update(BLAKE3_BLOCK_DOMAIN);
+        #[cfg(target_endian = "little")]
+        {
+            // SAFETY: u32 is plain-old-data and its little-endian memory
+            // representation matches the canonical token encoding.
+            let chunk_bytes = unsafe {
+                std::slice::from_raw_parts(
+                    chunk.as_ptr().cast::<u8>(),
+                    std::mem::size_of_val(chunk),
+                )
+            };
+            block_hasher.update(chunk_bytes);
+        }
+        #[cfg(not(target_endian = "little"))]
+        for token in chunk {
+            block_hasher.update(&token.to_le_bytes());
+        }
+        let block_hash =
+            u64::from_le_bytes(block_hasher.finalize().as_bytes()[..8].try_into().unwrap());
+        let sequence_hash = if let Some(parent) = sequence_hashes.last().copied() {
+            let mut chain_hasher = blake3::Hasher::new_keyed(&scope_key);
+            chain_hasher.update(BLAKE3_CHAIN_DOMAIN);
+            chain_hasher.update(&parent.to_le_bytes());
+            chain_hasher.update(&block_hash.to_le_bytes());
+            u64::from_le_bytes(chain_hasher.finalize().as_bytes()[..8].try_into().unwrap())
+        } else {
+            block_hash
+        };
+        sequence_hashes.push(sequence_hash);
+    }
+    sequence_hashes
+}
+
 fn tracking_hash(c: &mut Criterion) {
     let mut key_file = NamedTempFile::new().unwrap();
-    key_file.write_all(&[0x5a; 32]).unwrap();
+    key_file.write_all(&BENCHMARK_KEY).unwrap();
     let public_context = TrackingHashContext::from_config(&KvRouterConfig::default()).unwrap();
     let keyed_context = TrackingHashContext::from_config(&KvRouterConfig {
         router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
@@ -35,24 +94,39 @@ fn tracking_hash(c: &mut Criterion) {
         group.throughput(Throughput::Elements(u64::from(blocks)));
         group.bench_with_input(BenchmarkId::new("public", blocks), &blocks, |b, _| {
             b.iter(|| {
-                black_box(public_context.compute_sequence_hashes(
+                black_box(public_context.compute_sequence_hashes_for_tracking(
                     scope,
                     black_box(&tokens),
                     options,
+                    true,
                     Some(&public_blocks),
                 ))
             })
         });
-        group.bench_with_input(BenchmarkId::new("keyed", blocks), &blocks, |b, _| {
+        group.bench_with_input(BenchmarkId::new("keyed-xxh3", blocks), &blocks, |b, _| {
             b.iter(|| {
-                black_box(keyed_context.compute_sequence_hashes(
+                black_box(keyed_context.compute_sequence_hashes_for_tracking(
                     scope,
                     black_box(&tokens),
                     options,
+                    true,
                     Some(&public_blocks),
                 ))
             })
         });
+        group.bench_with_input(
+            BenchmarkId::new("keyed-blake3-reference", blocks),
+            &blocks,
+            |b, _| {
+                b.iter(|| {
+                    black_box(benchmark_blake3_sequence_hashes(
+                        &BENCHMARK_KEY,
+                        scope,
+                        black_box(&tokens),
+                    ))
+                })
+            },
+        );
     }
     group.finish();
 }

--- a/lib/kv-router/benches/tracking_hash.rs
+++ b/lib/kv-router/benches/tracking_hash.rs
@@ -92,7 +92,7 @@ fn tracking_hash(c: &mut Criterion) {
     };
 
     let mut group = c.benchmark_group("tracking_hash");
-    for blocks in [1_u32, 32, 128] {
+    for blocks in [1_u32, 32, 128, 62_500] {
         let tokens = (0..blocks * block_size).collect::<Vec<_>>();
         let options = BlockHashOptions::default();
         let public_blocks = compute_block_hash_for_seq(&tokens, block_size, options);

--- a/lib/kv-router/src/identity.rs
+++ b/lib/kv-router/src/identity.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-//! Compact identities for logical KV indexers and DC-local producer pools.
+//! Shared identities for routing partitions, logical KV indexers, and DC-local producer pools.
 //!
-//! Identity material is resolved on control paths. Mutation and query paths carry only these
-//! fixed-size values or physical lane indices.
+//! Hashed indexer identity material is resolved on control paths. Mutation and query paths carry
+//! only those fixed-size values or physical lane indices.
 
 use std::collections::BTreeMap;
 use std::fmt;
@@ -17,10 +17,90 @@ pub const MAX_EXPLICIT_IDENTITY_ENTRIES: usize = 32;
 pub const MAX_EXPLICIT_IDENTITY_KEY_BYTES: usize = 128;
 pub const MAX_EXPLICIT_IDENTITY_VALUE_BYTES: usize = 1024;
 
+/// Routing group used when a request does not specify one.
+pub const DEFAULT_ROUTING_GROUP: &str = "default";
+
 const CACHE_SEMANTICS_DEFAULT_V1: &[u8] = b"dynamo/indexer-cache-semantics/default/v1";
 const CACHE_SEMANTICS_EXPLICIT_V1: &[u8] = b"dynamo/indexer-cache-semantics/explicit/v1";
 const ROUTING_SCOPE_DEFAULT_V1: &[u8] = b"dynamo/indexer-routing-scope/default/v1";
 const ROUTING_SCOPE_EXPLICIT_V1: &[u8] = b"dynamo/indexer-routing-scope/explicit/v1";
+
+#[cfg(any(
+    feature = "standalone-indexer",
+    feature = "standalone-selection",
+    feature = "standalone-slot-tracker"
+))]
+pub(crate) fn default_routing_group() -> String {
+    DEFAULT_ROUTING_GROUP.to_string()
+}
+
+/// Logical routing partition shared by selection, indexing, and active-sequence tracking.
+#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoutingPartitionId {
+    pub model_name: String,
+    pub routing_group: String,
+}
+
+impl RoutingPartitionId {
+    pub fn new(model_name: impl Into<String>, routing_group: impl Into<String>) -> Self {
+        Self {
+            model_name: model_name.into(),
+            routing_group: routing_group.into(),
+        }
+    }
+
+    pub fn as_ref(&self) -> RoutingPartitionRef<'_> {
+        RoutingPartitionRef::new(&self.model_name, &self.routing_group)
+    }
+}
+
+impl fmt::Display for RoutingPartitionId {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.as_ref().fmt(formatter)
+    }
+}
+
+/// Borrowed view of a [`RoutingPartitionId`].
+#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+pub struct RoutingPartitionRef<'a> {
+    pub model_name: &'a str,
+    pub routing_group: &'a str,
+}
+
+impl<'a> RoutingPartitionRef<'a> {
+    pub const fn new(model_name: &'a str, routing_group: &'a str) -> Self {
+        Self {
+            model_name,
+            routing_group,
+        }
+    }
+
+    pub fn into_owned(self) -> RoutingPartitionId {
+        RoutingPartitionId::new(self.model_name, self.routing_group)
+    }
+}
+
+impl fmt::Display for RoutingPartitionRef<'_> {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "model={} routing_group={}",
+            self.model_name, self.routing_group
+        )
+    }
+}
+
+impl<'a> From<&'a RoutingPartitionId> for RoutingPartitionRef<'a> {
+    fn from(partition: &'a RoutingPartitionId) -> Self {
+        partition.as_ref()
+    }
+}
+
+impl From<RoutingPartitionRef<'_>> for RoutingPartitionId {
+    fn from(partition: RoutingPartitionRef<'_>) -> Self {
+        partition.into_owned()
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -390,7 +470,28 @@ fn write_digest(formatter: &mut fmt::Formatter<'_>, digest: &[u8; 16]) -> fmt::R
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+
+    #[test]
+    fn routing_partition_identity_matches_registry_key_semantics() {
+        let partition = RoutingPartitionId::new("model-a", "group-a");
+        let equivalent = RoutingPartitionId::new("model-a", "group-a");
+        let other_group = RoutingPartitionId::new("model-a", "group-b");
+        let other_model = RoutingPartitionId::new("model-b", "group-a");
+        let mut registry_keys = HashSet::new();
+
+        assert!(registry_keys.insert(partition.clone()));
+        assert!(!registry_keys.insert(equivalent));
+        assert!(registry_keys.insert(other_group));
+        assert!(registry_keys.insert(other_model));
+        assert_eq!(registry_keys.len(), 3);
+
+        let borrowed = partition.as_ref();
+        assert_eq!(borrowed, RoutingPartitionRef::new("model-a", "group-a"));
+        assert_eq!(borrowed.into_owned(), partition);
+    }
 
     #[test]
     fn explicit_identity_map_rejects_duplicate_json_keys() {

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -69,4 +69,6 @@ pub use scheduling::PrefillLoadEstimator;
 pub use scheduling::policy::{FcfsPolicy, RouterSchedulingPolicy, SchedulingPolicy, WsptPolicy};
 pub use scheduling::{KvSchedulerError, PotentialLoad, SchedulingRequest, SchedulingResponse};
 pub use selector::{DefaultWorkerSelector, WorkerSelector};
-pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
+pub use tracking_hash::{
+    DEFAULT_TRACKING_ROUTING_GROUP, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+};

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -18,6 +18,7 @@ pub mod recovery;
 pub mod scheduling;
 pub mod sequences;
 pub mod services;
+pub mod tracking_hash;
 pub mod zmq_wire;
 
 // Backward-compat re-exports: old top-level module paths still work
@@ -68,3 +69,4 @@ pub use scheduling::PrefillLoadEstimator;
 pub use scheduling::policy::{FcfsPolicy, RouterSchedulingPolicy, SchedulingPolicy, WsptPolicy};
 pub use scheduling::{KvSchedulerError, PotentialLoad, SchedulingRequest, SchedulingResponse};
 pub use selector::{DefaultWorkerSelector, WorkerSelector};
+pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -50,7 +50,7 @@ pub use config::{
     ConditionalDisaggPolicyKind, KvRouterConfig, RouterConfigOverride, RouterPrefillLoadModel,
     RouterQueuePolicy, SharedCacheType,
 };
-pub use identity::DcId;
+pub use identity::{DEFAULT_ROUTING_GROUP, DcId, RoutingPartitionId, RoutingPartitionRef};
 #[allow(deprecated)]
 pub use indexer::{
     AnchorAwareBranchShardedIndexer, AnchorRef, AnchorTask, BranchShardedIndexer,
@@ -69,6 +69,4 @@ pub use scheduling::PrefillLoadEstimator;
 pub use scheduling::policy::{FcfsPolicy, RouterSchedulingPolicy, SchedulingPolicy, WsptPolicy};
 pub use scheduling::{KvSchedulerError, PotentialLoad, SchedulingRequest, SchedulingResponse};
 pub use selector::{DefaultWorkerSelector, WorkerSelector};
-pub use tracking_hash::{
-    DEFAULT_TRACKING_ROUTING_GROUP, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
-};
+pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -119,15 +119,32 @@ pub(crate) fn compute_block_hash_for_seq_with_seed(
     options: BlockHashOptions<'_>,
     seed: u64,
 ) -> Vec<LocalBlockHash> {
+    let estimated_blocks = complete_block_count(
+        tokens.len(),
+        kv_block_size,
+        options.is_eagle.unwrap_or(false),
+    );
+    let mut hashes = Vec::with_capacity(estimated_blocks);
+    for_each_block_hash_for_seq_with_seed(tokens, kv_block_size, options, seed, |hash| {
+        hashes.push(hash);
+    });
+    hashes
+}
+
+fn for_each_block_hash_for_seq_with_seed(
+    tokens: &[u32],
+    kv_block_size: u32,
+    options: BlockHashOptions<'_>,
+    seed: u64,
+    mut visit: impl FnMut(LocalBlockHash),
+) {
     if kv_block_size == 0 {
-        return Vec::new();
+        return;
     }
 
     let is_eagle_flag = options.is_eagle.unwrap_or(false);
     let stride = kv_block_size as usize;
     let window_size = if is_eagle_flag { stride + 1 } else { stride };
-    let estimated_blocks = complete_block_count(tokens.len(), kv_block_size, is_eagle_flag);
-    let mut hashes = Vec::with_capacity(estimated_blocks);
     let mut bytes = Vec::with_capacity(window_size * std::mem::size_of::<u32>());
     let mut mm_hashes = Vec::new();
     let mut block_idx = 0;
@@ -151,16 +168,14 @@ pub(crate) fn compute_block_hash_for_seq_with_seed(
                 bytes.extend_from_slice(&mm_hash.to_le_bytes());
             }
 
-            hashes.push(LocalBlockHash(xxh3::xxh3_64_with_seed(&bytes, seed)));
+            visit(LocalBlockHash(xxh3::xxh3_64_with_seed(&bytes, seed)));
         } else {
-            hashes.push(hash_block_no_mm(chunk, seed, &mut bytes));
+            visit(hash_block_no_mm(chunk, seed, &mut bytes));
         }
 
         start += stride;
         block_idx += 1;
     }
-
-    hashes
 }
 
 /// Compute the next rolling sequence hash from a parent sequence hash and the
@@ -183,17 +198,49 @@ pub fn compute_seq_hash_for_block(block_hashes: &[LocalBlockHash]) -> Vec<Sequen
     compute_seq_hash_for_block_with(block_hashes, compute_next_seq_hash)
 }
 
-/// Compute rolling sequence hashes with an explicit XXH3 chain seed.
-pub(crate) fn compute_seq_hash_for_block_with_seed(
-    block_hashes: &[LocalBlockHash],
-    seed: u64,
+/// Compute rolling sequence hashes directly from canonical token blocks with
+/// separate XXH3 block and chain seeds, without materializing block hashes.
+pub(crate) fn compute_seq_hash_for_tokens_with_seeds(
+    tokens: &[u32],
+    kv_block_size: u32,
+    options: BlockHashOptions<'_>,
+    block_seed: u64,
+    chain_seed: u64,
 ) -> Vec<SequenceHash> {
-    compute_seq_hash_for_block_with(block_hashes, |parent, block| {
-        let mut bytes = [0_u8; 16];
-        bytes[..8].copy_from_slice(&parent.to_le_bytes());
-        bytes[8..].copy_from_slice(&block.0.to_le_bytes());
-        xxh3::xxh3_64_with_seed(&bytes, seed)
-    })
+    let estimated_blocks = complete_block_count(
+        tokens.len(),
+        kv_block_size,
+        options.is_eagle.unwrap_or(false),
+    );
+    let mut sequence_hashes = Vec::with_capacity(estimated_blocks);
+    for_each_block_hash_for_seq_with_seed(
+        tokens,
+        kv_block_size,
+        options,
+        block_seed,
+        |block_hash| {
+            let sequence_hash = sequence_hashes
+                .last()
+                .copied()
+                .map_or(block_hash.0, |parent| {
+                    compute_next_seq_hash_with_seed(parent, block_hash, chain_seed)
+                });
+            sequence_hashes.push(sequence_hash);
+        },
+    );
+    sequence_hashes
+}
+
+#[inline]
+fn compute_next_seq_hash_with_seed(
+    parent: SequenceHash,
+    block: LocalBlockHash,
+    seed: u64,
+) -> SequenceHash {
+    let mut bytes = [0_u8; 16];
+    bytes[..8].copy_from_slice(&parent.to_le_bytes());
+    bytes[8..].copy_from_slice(&block.0.to_le_bytes());
+    xxh3::xxh3_64_with_seed(&bytes, seed)
 }
 
 fn compute_seq_hash_for_block_with(

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -91,11 +91,21 @@ pub fn compute_block_hash_for_seq(
     kv_block_size: u32,
     options: BlockHashOptions<'_>,
 ) -> Vec<LocalBlockHash> {
+    compute_block_hash_for_seq_with_seed(tokens, kv_block_size, options, block_hash_seed(options))
+}
+
+/// Compute local block hashes with an explicit XXH3 seed while preserving the
+/// canonical token, multimodal, and Eagle encodings used by the public hash path.
+pub(crate) fn compute_block_hash_for_seq_with_seed(
+    tokens: &[u32],
+    kv_block_size: u32,
+    options: BlockHashOptions<'_>,
+    seed: u64,
+) -> Vec<LocalBlockHash> {
     if kv_block_size == 0 {
         return Vec::new();
     }
 
-    let seed = block_hash_seed(options);
     let is_eagle_flag = options.is_eagle.unwrap_or(false);
     let stride = kv_block_size as usize;
     let window_size = if is_eagle_flag { stride + 1 } else { stride };
@@ -157,6 +167,26 @@ pub fn compute_next_seq_hash(
 /// - The first block's sequence hash equals its block hash
 /// - Subsequent blocks' sequence hash = hash([parent_sequence_hash, current_block_hash], seed)
 pub fn compute_seq_hash_for_block(block_hashes: &[LocalBlockHash]) -> Vec<SequenceHash> {
+    compute_seq_hash_for_block_with(block_hashes, compute_next_seq_hash)
+}
+
+/// Compute rolling sequence hashes with an explicit XXH3 chain seed.
+pub(crate) fn compute_seq_hash_for_block_with_seed(
+    block_hashes: &[LocalBlockHash],
+    seed: u64,
+) -> Vec<SequenceHash> {
+    compute_seq_hash_for_block_with(block_hashes, |parent, block| {
+        let mut bytes = [0_u8; 16];
+        bytes[..8].copy_from_slice(&parent.to_le_bytes());
+        bytes[8..].copy_from_slice(&block.0.to_le_bytes());
+        xxh3::xxh3_64_with_seed(&bytes, seed)
+    })
+}
+
+fn compute_seq_hash_for_block_with(
+    block_hashes: &[LocalBlockHash],
+    next_hash: impl Fn(SequenceHash, LocalBlockHash) -> SequenceHash,
+) -> Vec<SequenceHash> {
     if block_hashes.is_empty() {
         return Vec::new();
     }
@@ -166,7 +196,7 @@ pub fn compute_seq_hash_for_block(block_hashes: &[LocalBlockHash]) -> Vec<Sequen
 
     for i in 1..block_hashes.len() {
         let parent_seq_hash = sequence_hashes[i - 1];
-        sequence_hashes.push(compute_next_seq_hash(parent_seq_hash, block_hashes[i]));
+        sequence_hashes.push(next_hash(parent_seq_hash, block_hashes[i]));
     }
 
     sequence_hashes

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -94,6 +94,23 @@ pub fn compute_block_hash_for_seq(
     compute_block_hash_for_seq_with_seed(tokens, kv_block_size, options, block_hash_seed(options))
 }
 
+/// Count complete canonical blocks for normal and Eagle token windows.
+pub(crate) fn complete_block_count(
+    token_count: usize,
+    kv_block_size: u32,
+    is_eagle: bool,
+) -> usize {
+    let stride = kv_block_size as usize;
+    if stride == 0 {
+        return 0;
+    }
+    if is_eagle {
+        token_count.saturating_sub(1) / stride
+    } else {
+        token_count / stride
+    }
+}
+
 /// Compute local block hashes with an explicit XXH3 seed while preserving the
 /// canonical token, multimodal, and Eagle encodings used by the public hash path.
 pub(crate) fn compute_block_hash_for_seq_with_seed(
@@ -109,11 +126,7 @@ pub(crate) fn compute_block_hash_for_seq_with_seed(
     let is_eagle_flag = options.is_eagle.unwrap_or(false);
     let stride = kv_block_size as usize;
     let window_size = if is_eagle_flag { stride + 1 } else { stride };
-    let estimated_blocks = if is_eagle_flag {
-        tokens.len().saturating_sub(1) / stride
-    } else {
-        tokens.len() / stride
-    };
+    let estimated_blocks = complete_block_count(tokens.len(), kv_block_size, is_eagle_flag);
     let mut hashes = Vec::with_capacity(estimated_blocks);
     let mut bytes = Vec::with_capacity(window_size * std::mem::size_of::<u32>());
     let mut mm_hashes = Vec::new();

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -15,7 +15,9 @@ use crate::protocols::{
     BlockHashOptions, LocalBlockHash, complete_block_count, compute_block_hash_for_seq,
     compute_seq_hash_for_block,
 };
-use crate::tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
+use crate::tracking_hash::{
+    TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope, validate_tracking_hash_options,
+};
 
 const fn default_track_prefill_tokens() -> bool {
     true
@@ -627,15 +629,12 @@ pub struct KvRouterConfig {
     pub router_track_prefill_tokens: bool,
 
     /// Hash algorithm used for router-derived active-sequence identities.
-    #[serde(default)]
     pub router_tracking_hash: TrackingHashAlgorithm,
 
     /// File containing the 32-byte provider key used by keyed tracking mode.
-    #[serde(default)]
     pub router_tracking_key_file: Option<PathBuf>,
 
     /// Provider-managed epoch identifier mixed into keyed tracking scope derivation.
-    #[serde(default)]
     pub router_tracking_key_id: Option<String>,
 
     /// Optional model for estimating effective prompt-side prefill load over time.
@@ -845,29 +844,11 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
 }
 
 fn validate_kv_router_config(config: &KvRouterConfig) -> Result<(), String> {
-    match config.router_tracking_hash {
-        TrackingHashAlgorithm::PublicXxh3V1 => {
-            if config.router_tracking_key_file.is_some() || config.router_tracking_key_id.is_some()
-            {
-                return Err(
-                    "router tracking key options require router_tracking_hash=keyed-xxh3-v1"
-                        .to_string(),
-                );
-            }
-        }
-        TrackingHashAlgorithm::KeyedXxh3V1 => {
-            if config.router_tracking_key_file.is_none() {
-                return Err("keyed-xxh3-v1 requires router_tracking_key_file".to_string());
-            }
-            let valid_key_id = config
-                .router_tracking_key_id
-                .as_deref()
-                .is_some_and(|value| !value.is_empty() && value.trim() == value);
-            if !valid_key_id {
-                return Err("keyed-xxh3-v1 requires a nonempty router_tracking_key_id".to_string());
-            }
-        }
-    }
+    validate_tracking_hash_options(
+        config.router_tracking_hash,
+        config.router_tracking_key_file.is_some(),
+        config.router_tracking_key_id.as_deref(),
+    )?;
     if config.router_track_output_blocks && !config.router_track_active_blocks {
         return Err(
             "router_track_output_blocks requires router_track_active_blocks=true".to_string(),

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -1156,13 +1156,13 @@ fn random_sequence_hashes(num_blocks: usize) -> Vec<u64> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::identity::RoutingPartitionRef;
     use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo, compute_seq_hash_for_block};
     use std::collections::HashMap;
 
     fn test_tracking_scope(block_size: u32) -> TrackingHashScope<'static> {
         TrackingHashScope {
-            model_name: "model",
-            routing_group: "default",
+            partition: RoutingPartitionRef::new("model", "default"),
             block_size,
         }
     }

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -11,7 +11,10 @@ use std::time::Duration;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::protocols::{BlockHashOptions, LocalBlockHash};
+use crate::protocols::{
+    BlockHashOptions, LocalBlockHash, complete_block_count, compute_block_hash_for_seq,
+    compute_seq_hash_for_block,
+};
 use crate::tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 
 const fn default_track_prefill_tokens() -> bool {
@@ -94,8 +97,24 @@ pub fn apply_deprecated_overlap_score_weight_override(
 }
 
 /// Build a [`KvRouterConfig`] from defaults and standard Dynamo environment variables.
+///
+/// # Panics
+///
+/// Panics when `DYN_ROUTER_TRACKING_HASH` is not a supported algorithm. Startup
+/// paths should use [`try_kv_router_config_from_dynamo_env`] to report the error.
 pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
-    let config = kv_router_config_from_lookup(|key| env::var(key).ok());
+    try_kv_router_config_from_dynamo_env()
+        .unwrap_or_else(|error| panic!("invalid Dynamo router environment configuration: {error}"))
+}
+
+/// Build a [`KvRouterConfig`] from standard Dynamo environment variables.
+pub fn try_kv_router_config_from_dynamo_env() -> Result<KvRouterConfig, String> {
+    let config = kv_router_config_from_lookup(|key| env::var(key).ok())?;
+    log_env_config(&config);
+    Ok(config)
+}
+
+fn log_env_config(config: &KvRouterConfig) {
     tracing::info!(
         overlap_score_credit = config.overlap_score_credit,
         overlap_score_credit_decay = config.overlap_score_credit_decay,
@@ -119,10 +138,11 @@ pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
         router_predicted_ttl_secs = ?config.router_predicted_ttl_secs,
         "KvRouterConfig initialized (DYN_* env overrides applied)"
     );
-    config
 }
 
-fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvRouterConfig {
+fn kv_router_config_from_lookup(
+    get_env: impl Fn(&str) -> Option<String>,
+) -> Result<KvRouterConfig, String> {
     fn parse_f64(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<f64> {
         get_env(key).and_then(|value| value.parse().ok())
     }
@@ -180,7 +200,7 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
         config.router_track_prefill_tokens = value;
     }
     if let Some(value) = get_env("DYN_ROUTER_TRACKING_HASH") {
-        config.router_tracking_hash = value.parse().unwrap_or(TrackingHashAlgorithm::Invalid);
+        config.router_tracking_hash = value.parse()?;
     }
     if let Some(value) = get_env("DYN_ROUTER_TRACKING_KEY_FILE") {
         config.router_tracking_key_file = Some(value.into());
@@ -227,7 +247,7 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
         config.router_predicted_ttl_secs = Some(value);
     }
 
-    config
+    Ok(config)
 }
 
 fn apply_deprecated_overlap_score_weight_override_option(
@@ -844,15 +864,8 @@ fn validate_kv_router_config(config: &KvRouterConfig) -> Result<(), String> {
                 .as_deref()
                 .is_some_and(|value| !value.is_empty() && value.trim() == value);
             if !valid_key_id {
-                return Err(
-                    "keyed-xxh3-v1 requires a nonempty router_tracking_key_id".to_string(),
-                );
+                return Err("keyed-xxh3-v1 requires a nonempty router_tracking_key_id".to_string());
             }
-        }
-        TrackingHashAlgorithm::Invalid => {
-            return Err(
-                "router_tracking_hash must be public-xxh3-v1 or keyed-xxh3-v1".to_string(),
-            );
         }
     }
     if config.router_track_output_blocks && !config.router_track_active_blocks {
@@ -1067,7 +1080,54 @@ impl KvRouterConfig {
     /// - `None` if `router_track_active_blocks` is false
     /// - Random hashes if `router_track_active_blocks` is true but `router_assume_kv_reuse` is false
     /// - Actual sequence hashes if both are true
+    /// # Panics
+    ///
+    /// Panics in keyed mode because the legacy interface has no initialized
+    /// [`TrackingHashContext`]. Keyed callers must use
+    /// [`Self::compute_seq_hashes_for_tracking_with_context`].
     pub fn compute_seq_hashes_for_tracking(
+        &self,
+        tokens: &[u32],
+        block_size: u32,
+        config_override: Option<&RouterConfigOverride>,
+        hash_options: BlockHashOptions<'_>,
+        precomputed_block_hashes: Option<&[LocalBlockHash]>,
+    ) -> Option<Vec<u64>> {
+        assert_eq!(
+            self.router_tracking_hash,
+            TrackingHashAlgorithm::PublicXxh3V1,
+            "compute_seq_hashes_for_tracking cannot be used with keyed tracking; initialize a TrackingHashContext and call compute_seq_hashes_for_tracking_with_context"
+        );
+
+        if !self.router_track_active_blocks {
+            return None;
+        }
+
+        let num_blocks = complete_block_count(
+            tokens.len(),
+            block_size,
+            hash_options.is_eagle.unwrap_or(false),
+        );
+        if num_blocks == 0 {
+            return Some(Vec::new());
+        }
+
+        if self.assume_kv_reuse(config_override) {
+            let block_hashes = match precomputed_block_hashes {
+                Some(block_hashes) => block_hashes,
+                None => {
+                    let computed = compute_block_hash_for_seq(tokens, block_size, hash_options);
+                    return Some(compute_seq_hash_for_block(&computed));
+                }
+            };
+            Some(compute_seq_hash_for_block(block_hashes))
+        } else {
+            Some(random_sequence_hashes(num_blocks))
+        }
+    }
+
+    /// Compute sequence hashes with a router-initialized tracking-hash context.
+    pub fn compute_seq_hashes_for_tracking_with_context(
         &self,
         tracking_hash: &TrackingHashContext,
         scope: TrackingHashScope<'_>,
@@ -1076,27 +1136,23 @@ impl KvRouterConfig {
         hash_options: BlockHashOptions<'_>,
         precomputed_block_hashes: Option<&[LocalBlockHash]>,
     ) -> Option<Vec<u64>> {
+        assert_eq!(
+            tracking_hash.algorithm(),
+            self.router_tracking_hash,
+            "tracking hash context must match KvRouterConfig"
+        );
         if !self.router_track_active_blocks {
             return None;
         }
 
-        let num_blocks = tokens.len() / scope.block_size as usize;
-        if num_blocks == 0 {
-            return Some(Vec::new());
-        }
-
         let assume_kv_reuse = self.assume_kv_reuse(config_override);
-
-        if assume_kv_reuse {
-            Some(tracking_hash.compute_sequence_hashes(
-                scope,
-                tokens,
-                hash_options,
-                precomputed_block_hashes,
-            ))
-        } else {
-            Some((0..num_blocks).map(|_| fastrand::u64(..)).collect())
-        }
+        Some(tracking_hash.compute_sequence_hashes_for_tracking(
+            scope,
+            tokens,
+            hash_options,
+            assume_kv_reuse,
+            precomputed_block_hashes,
+        ))
     }
 
     /// Check if KV event subscription should be started.
@@ -1112,15 +1168,15 @@ impl KvRouterConfig {
     }
 }
 
+fn random_sequence_hashes(num_blocks: usize) -> Vec<u64> {
+    (0..num_blocks).map(|_| fastrand::u64(..)).collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo, compute_seq_hash_for_block};
     use std::collections::HashMap;
-
-    fn public_tracking_context(config: &KvRouterConfig) -> TrackingHashContext {
-        TrackingHashContext::from_config(config).unwrap()
-    }
 
     fn test_tracking_scope(block_size: u32) -> TrackingHashScope<'static> {
         TrackingHashScope {
@@ -1131,6 +1187,10 @@ mod tests {
     }
 
     fn config_from_values(values: &[(&str, &str)]) -> KvRouterConfig {
+        try_config_from_values(values).unwrap()
+    }
+
+    fn try_config_from_values(values: &[(&str, &str)]) -> Result<KvRouterConfig, String> {
         let values: HashMap<&str, &str> = values.iter().copied().collect();
         kv_router_config_from_lookup(|key| values.get(key).map(|value| (*value).to_string()))
     }
@@ -1223,18 +1283,15 @@ mod tests {
             assert!(invalid_credit.validate_config().is_err());
         }
 
-        let invalid_hash = config_from_values(&[("DYN_ROUTER_TRACKING_HASH", "mystery")]);
-        assert_eq!(
-            invalid_hash.router_tracking_hash,
-            TrackingHashAlgorithm::Invalid
-        );
-        assert!(invalid_hash.validate_config().is_err());
+        let error = try_config_from_values(&[("DYN_ROUTER_TRACKING_HASH", "mystery")]).unwrap_err();
+        assert!(error.contains("public-xxh3-v1 or keyed-xxh3-v1"));
+
+        assert!(serde_json::to_string(&config_from_values(&[])).is_ok());
     }
 
     #[test]
     fn compute_seq_hashes_for_tracking_uses_mm_hashes() {
         let cfg = KvRouterConfig::default();
-        let tracking_hash = public_tracking_context(&cfg);
         let tokens = vec![1, 2, 3, 4];
         let mm_infos = vec![
             Some(BlockExtraInfo {
@@ -1247,20 +1304,12 @@ mod tests {
         ];
 
         let without_mm = cfg
-            .compute_seq_hashes_for_tracking(
-                &tracking_hash,
-                test_tracking_scope(2),
-                &tokens,
-                None,
-                BlockHashOptions::default(),
-                None,
-            )
+            .compute_seq_hashes_for_tracking(&tokens, 2, None, BlockHashOptions::default(), None)
             .unwrap();
         let with_mm = cfg
             .compute_seq_hashes_for_tracking(
-                &tracking_hash,
-                test_tracking_scope(2),
                 &tokens,
+                2,
                 None,
                 BlockHashOptions {
                     block_mm_infos: Some(&mm_infos),
@@ -1276,20 +1325,60 @@ mod tests {
     #[test]
     fn compute_seq_hashes_for_tracking_uses_precomputed_block_hashes() {
         let config = KvRouterConfig::default();
-        let tracking_hash = public_tracking_context(&config);
         let tokens: Vec<u32> = (0..8).collect();
         let precomputed = vec![LocalBlockHash(11), LocalBlockHash(29)];
 
         let seq_hashes = config.compute_seq_hashes_for_tracking(
-            &tracking_hash,
-            test_tracking_scope(4),
             &tokens,
+            4,
             None,
             BlockHashOptions::default(),
             Some(&precomputed),
         );
 
         assert_eq!(seq_hashes, Some(compute_seq_hash_for_block(&precomputed)));
+    }
+
+    #[test]
+    fn context_aware_tracking_matches_public_legacy_api() {
+        let config = KvRouterConfig::default();
+        let context = TrackingHashContext::from_config(&config).unwrap();
+        let tokens: Vec<u32> = (0..8).collect();
+
+        let legacy = config.compute_seq_hashes_for_tracking(
+            &tokens,
+            4,
+            None,
+            BlockHashOptions::default(),
+            None,
+        );
+        let context_aware = config.compute_seq_hashes_for_tracking_with_context(
+            &context,
+            test_tracking_scope(4),
+            &tokens,
+            None,
+            BlockHashOptions::default(),
+            None,
+        );
+
+        assert_eq!(legacy, context_aware);
+    }
+
+    #[test]
+    #[should_panic(expected = "cannot be used with keyed tracking")]
+    fn legacy_tracking_api_does_not_fall_back_in_keyed_mode() {
+        let config = KvRouterConfig {
+            router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+            ..Default::default()
+        };
+
+        let _ = config.compute_seq_hashes_for_tracking(
+            &[1, 2, 3, 4],
+            4,
+            None,
+            BlockHashOptions::default(),
+            None,
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -3,6 +3,7 @@
 
 use std::env::{self, VarError};
 use std::fmt;
+use std::path::PathBuf;
 use std::str::FromStr;
 use std::sync::OnceLock;
 use std::time::Duration;
@@ -10,9 +11,8 @@ use std::time::Duration;
 use derive_builder::Builder;
 use serde::{Deserialize, Serialize};
 
-use crate::protocols::{
-    BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq, compute_seq_hash_for_block,
-};
+use crate::protocols::{BlockHashOptions, LocalBlockHash};
+use crate::tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};
 
 const fn default_track_prefill_tokens() -> bool {
     true
@@ -106,6 +106,8 @@ pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
         router_track_active_blocks = config.router_track_active_blocks,
         router_track_output_blocks = config.router_track_output_blocks,
         router_track_prefill_tokens = config.router_track_prefill_tokens,
+        router_tracking_hash = %config.router_tracking_hash,
+        router_tracking_key_id = ?config.router_tracking_key_id,
         router_queue_threshold = ?config.router_queue_threshold,
         router_policy_config = ?config.router_policy_config,
         conditional_disagg_enabled = config.conditional_disagg_enabled,
@@ -176,6 +178,15 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_PREFILL_TOKENS") {
         config.router_track_prefill_tokens = value;
+    }
+    if let Some(value) = get_env("DYN_ROUTER_TRACKING_HASH") {
+        config.router_tracking_hash = value.parse().unwrap_or(TrackingHashAlgorithm::Invalid);
+    }
+    if let Some(value) = get_env("DYN_ROUTER_TRACKING_KEY_FILE") {
+        config.router_tracking_key_file = Some(value.into());
+    }
+    if let Some(value) = get_env("DYN_ROUTER_TRACKING_KEY_ID") {
+        config.router_tracking_key_id = Some(value);
     }
     if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_QUEUE_THRESHOLD") {
         config.router_queue_threshold = Some(value);
@@ -475,6 +486,9 @@ struct KvRouterConfigSerde {
     router_track_output_blocks: bool,
     router_assume_kv_reuse: bool,
     router_track_prefill_tokens: bool,
+    router_tracking_hash: TrackingHashAlgorithm,
+    router_tracking_key_file: Option<PathBuf>,
+    router_tracking_key_id: Option<String>,
     router_prefill_load_model: RouterPrefillLoadModel,
     router_ttl_secs: f64,
     router_queue_threshold: Option<f64>,
@@ -515,6 +529,9 @@ impl Default for KvRouterConfigSerde {
             router_track_output_blocks: config.router_track_output_blocks,
             router_assume_kv_reuse: config.router_assume_kv_reuse,
             router_track_prefill_tokens: config.router_track_prefill_tokens,
+            router_tracking_hash: config.router_tracking_hash,
+            router_tracking_key_file: config.router_tracking_key_file,
+            router_tracking_key_id: config.router_tracking_key_id,
             router_prefill_load_model: config.router_prefill_load_model,
             router_ttl_secs: config.router_ttl_secs,
             router_queue_threshold: config.router_queue_threshold,
@@ -588,6 +605,18 @@ pub struct KvRouterConfig {
     /// and potential prefill-token load calculations.
     #[serde(default = "default_track_prefill_tokens")]
     pub router_track_prefill_tokens: bool,
+
+    /// Hash algorithm used for router-derived active-sequence identities.
+    #[serde(default)]
+    pub router_tracking_hash: TrackingHashAlgorithm,
+
+    /// File containing the 32-byte provider key used by keyed tracking mode.
+    #[serde(default)]
+    pub router_tracking_key_file: Option<PathBuf>,
+
+    /// Provider-managed epoch identifier mixed into keyed tracking scope derivation.
+    #[serde(default)]
+    pub router_tracking_key_id: Option<String>,
 
     /// Optional model for estimating effective prompt-side prefill load over time.
     pub router_prefill_load_model: RouterPrefillLoadModel,
@@ -707,6 +736,9 @@ impl Default for KvRouterConfig {
             router_track_output_blocks: false,
             router_assume_kv_reuse: true,
             router_track_prefill_tokens: default_track_prefill_tokens(),
+            router_tracking_hash: TrackingHashAlgorithm::default(),
+            router_tracking_key_file: None,
+            router_tracking_key_id: None,
             router_prefill_load_model: RouterPrefillLoadModel::default(),
             router_ttl_secs: 120.0,
             router_queue_threshold: None,
@@ -760,6 +792,9 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             router_track_output_blocks: compat.router_track_output_blocks,
             router_assume_kv_reuse: compat.router_assume_kv_reuse,
             router_track_prefill_tokens: compat.router_track_prefill_tokens,
+            router_tracking_hash: compat.router_tracking_hash,
+            router_tracking_key_file: compat.router_tracking_key_file,
+            router_tracking_key_id: compat.router_tracking_key_id,
             router_prefill_load_model: compat.router_prefill_load_model,
             router_ttl_secs: compat.router_ttl_secs,
             router_queue_threshold: compat.router_queue_threshold,
@@ -790,6 +825,36 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
 }
 
 fn validate_kv_router_config(config: &KvRouterConfig) -> Result<(), String> {
+    match config.router_tracking_hash {
+        TrackingHashAlgorithm::PublicXxh3V1 => {
+            if config.router_tracking_key_file.is_some() || config.router_tracking_key_id.is_some()
+            {
+                return Err(
+                    "router tracking key options require router_tracking_hash=keyed-xxh3-v1"
+                        .to_string(),
+                );
+            }
+        }
+        TrackingHashAlgorithm::KeyedXxh3V1 => {
+            if config.router_tracking_key_file.is_none() {
+                return Err("keyed-xxh3-v1 requires router_tracking_key_file".to_string());
+            }
+            let valid_key_id = config
+                .router_tracking_key_id
+                .as_deref()
+                .is_some_and(|value| !value.is_empty() && value.trim() == value);
+            if !valid_key_id {
+                return Err(
+                    "keyed-xxh3-v1 requires a nonempty router_tracking_key_id".to_string(),
+                );
+            }
+        }
+        TrackingHashAlgorithm::Invalid => {
+            return Err(
+                "router_tracking_hash must be public-xxh3-v1 or keyed-xxh3-v1".to_string(),
+            );
+        }
+    }
     if config.router_track_output_blocks && !config.router_track_active_blocks {
         return Err(
             "router_track_output_blocks requires router_track_active_blocks=true".to_string(),
@@ -1004,8 +1069,9 @@ impl KvRouterConfig {
     /// - Actual sequence hashes if both are true
     pub fn compute_seq_hashes_for_tracking(
         &self,
+        tracking_hash: &TrackingHashContext,
+        scope: TrackingHashScope<'_>,
         tokens: &[u32],
-        block_size: u32,
         config_override: Option<&RouterConfigOverride>,
         hash_options: BlockHashOptions<'_>,
         precomputed_block_hashes: Option<&[LocalBlockHash]>,
@@ -1014,7 +1080,7 @@ impl KvRouterConfig {
             return None;
         }
 
-        let num_blocks = tokens.len() / block_size as usize;
+        let num_blocks = tokens.len() / scope.block_size as usize;
         if num_blocks == 0 {
             return Some(Vec::new());
         }
@@ -1022,14 +1088,12 @@ impl KvRouterConfig {
         let assume_kv_reuse = self.assume_kv_reuse(config_override);
 
         if assume_kv_reuse {
-            let block_hashes = match precomputed_block_hashes {
-                Some(block_hashes) => block_hashes,
-                None => {
-                    let computed = compute_block_hash_for_seq(tokens, block_size, hash_options);
-                    return Some(compute_seq_hash_for_block(&computed));
-                }
-            };
-            Some(compute_seq_hash_for_block(block_hashes))
+            Some(tracking_hash.compute_sequence_hashes(
+                scope,
+                tokens,
+                hash_options,
+                precomputed_block_hashes,
+            ))
         } else {
             Some((0..num_blocks).map(|_| fastrand::u64(..)).collect())
         }
@@ -1051,8 +1115,20 @@ impl KvRouterConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo};
+    use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo, compute_seq_hash_for_block};
     use std::collections::HashMap;
+
+    fn public_tracking_context(config: &KvRouterConfig) -> TrackingHashContext {
+        TrackingHashContext::from_config(config).unwrap()
+    }
+
+    fn test_tracking_scope(block_size: u32) -> TrackingHashScope<'static> {
+        TrackingHashScope {
+            model_name: "model",
+            routing_group: "default",
+            block_size,
+        }
+    }
 
     fn config_from_values(values: &[(&str, &str)]) -> KvRouterConfig {
         let values: HashMap<&str, &str> = values.iter().copied().collect();
@@ -1071,6 +1147,12 @@ mod tests {
             ("DYN_ROUTER_TRACK_ACTIVE_BLOCKS", "0"),
             ("DYN_ROUTER_TRACK_OUTPUT_BLOCKS", "on"),
             ("DYN_ROUTER_TRACK_PREFILL_TOKENS", "false"),
+            ("DYN_ROUTER_TRACKING_HASH", "keyed-xxh3-v1"),
+            (
+                "DYN_ROUTER_TRACKING_KEY_FILE",
+                "/run/secrets/dynamo/tracking-key",
+            ),
+            ("DYN_ROUTER_TRACKING_KEY_ID", "2026-01"),
             ("DYN_ROUTER_QUEUE_THRESHOLD", "4.5"),
         ]);
 
@@ -1083,6 +1165,15 @@ mod tests {
         assert!(!config.router_track_active_blocks);
         assert!(config.router_track_output_blocks);
         assert!(!config.router_track_prefill_tokens);
+        assert_eq!(
+            config.router_tracking_hash,
+            TrackingHashAlgorithm::KeyedXxh3V1
+        );
+        assert_eq!(
+            config.router_tracking_key_file,
+            Some(PathBuf::from("/run/secrets/dynamo/tracking-key"))
+        );
+        assert_eq!(config.router_tracking_key_id.as_deref(), Some("2026-01"));
         assert_eq!(config.router_queue_threshold, Some(4.5));
 
         let predicted = config_from_values(&[("DYN_ROUTER_PREDICTED_TTL_SECS", "60")]);
@@ -1131,11 +1222,19 @@ mod tests {
                 config_from_values(&[("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", value)]);
             assert!(invalid_credit.validate_config().is_err());
         }
+
+        let invalid_hash = config_from_values(&[("DYN_ROUTER_TRACKING_HASH", "mystery")]);
+        assert_eq!(
+            invalid_hash.router_tracking_hash,
+            TrackingHashAlgorithm::Invalid
+        );
+        assert!(invalid_hash.validate_config().is_err());
     }
 
     #[test]
     fn compute_seq_hashes_for_tracking_uses_mm_hashes() {
         let cfg = KvRouterConfig::default();
+        let tracking_hash = public_tracking_context(&cfg);
         let tokens = vec![1, 2, 3, 4];
         let mm_infos = vec![
             Some(BlockExtraInfo {
@@ -1148,12 +1247,20 @@ mod tests {
         ];
 
         let without_mm = cfg
-            .compute_seq_hashes_for_tracking(&tokens, 2, None, BlockHashOptions::default(), None)
+            .compute_seq_hashes_for_tracking(
+                &tracking_hash,
+                test_tracking_scope(2),
+                &tokens,
+                None,
+                BlockHashOptions::default(),
+                None,
+            )
             .unwrap();
         let with_mm = cfg
             .compute_seq_hashes_for_tracking(
+                &tracking_hash,
+                test_tracking_scope(2),
                 &tokens,
-                2,
                 None,
                 BlockHashOptions {
                     block_mm_infos: Some(&mm_infos),
@@ -1169,12 +1276,14 @@ mod tests {
     #[test]
     fn compute_seq_hashes_for_tracking_uses_precomputed_block_hashes() {
         let config = KvRouterConfig::default();
+        let tracking_hash = public_tracking_context(&config);
         let tokens: Vec<u32> = (0..8).collect();
         let precomputed = vec![LocalBlockHash(11), LocalBlockHash(29)];
 
         let seq_hashes = config.compute_seq_hashes_for_tracking(
+            &tracking_hash,
+            test_tracking_scope(4),
             &tokens,
-            4,
             None,
             BlockHashOptions::default(),
             Some(&precomputed),

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -126,6 +126,7 @@ fn log_env_config(config: &KvRouterConfig) {
         router_replica_sync = config.router_replica_sync,
         router_track_active_blocks = config.router_track_active_blocks,
         router_track_output_blocks = config.router_track_output_blocks,
+        router_assume_kv_reuse = config.router_assume_kv_reuse,
         router_track_prefill_tokens = config.router_track_prefill_tokens,
         router_tracking_hash = %config.router_tracking_hash,
         router_tracking_key_id = ?config.router_tracking_key_id,
@@ -197,6 +198,9 @@ fn kv_router_config_from_lookup(
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
         config.router_track_output_blocks = value;
+    }
+    if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_ASSUME_KV_REUSE") {
+        config.router_assume_kv_reuse = value;
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_PREFILL_TOKENS") {
         config.router_track_prefill_tokens = value;
@@ -1187,6 +1191,7 @@ mod tests {
             ("DYN_ROUTER_REPLICA_SYNC", "yes"),
             ("DYN_ROUTER_TRACK_ACTIVE_BLOCKS", "0"),
             ("DYN_ROUTER_TRACK_OUTPUT_BLOCKS", "on"),
+            ("DYN_ROUTER_ASSUME_KV_REUSE", "false"),
             ("DYN_ROUTER_TRACK_PREFILL_TOKENS", "false"),
             ("DYN_ROUTER_TRACKING_HASH", "keyed-xxh3-v1"),
             (
@@ -1205,6 +1210,7 @@ mod tests {
         assert!(config.router_replica_sync);
         assert!(!config.router_track_active_blocks);
         assert!(config.router_track_output_blocks);
+        assert!(!config.router_assume_kv_reuse);
         assert!(!config.router_track_prefill_tokens);
         assert_eq!(
             config.router_tracking_hash,

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -12,6 +12,7 @@ use tokio::sync::{Mutex, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::{RoutingPartitionId, RoutingPartitionRef};
 use crate::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
 use crate::sequences::{SequencePublishQueueError, SequencePublisher, SequenceSubscriber};
 use crate::services::common::zmq::{create_bound_pub_socket, create_sub_socket, validate_endpoint};
@@ -26,6 +27,20 @@ pub(crate) struct ScopedReplicaEvent {
     pub routing_group: String,
     pub block_size: u32,
     pub event: ActiveSequenceEvent,
+}
+
+impl ScopedReplicaEvent {
+    pub(crate) fn partition_ref(&self) -> RoutingPartitionRef<'_> {
+        RoutingPartitionRef::new(&self.model_name, &self.routing_group)
+    }
+
+    pub(crate) fn into_parts(self) -> (RoutingPartitionId, u32, ActiveSequenceEvent) {
+        (
+            RoutingPartitionId::new(self.model_name, self.routing_group),
+            self.block_size,
+            self.event,
+        )
+    }
 }
 
 pub(crate) type ReplicaEventSender = mpsc::Sender<ScopedReplicaEvent>;
@@ -109,8 +124,7 @@ pub(crate) struct ScopedSequencePublisher {
 
 #[derive(Clone)]
 struct ScopedReplicaPublisher {
-    model_name: Arc<str>,
-    routing_group: Arc<str>,
+    partition: Arc<RoutingPartitionId>,
     block_size: u32,
     tx: ReplicaEventSender,
     cancel_token: CancellationToken,
@@ -122,16 +136,14 @@ impl ScopedSequencePublisher {
     }
 
     pub(crate) fn enabled(
-        model_name: Arc<str>,
-        routing_group: Arc<str>,
+        partition: Arc<RoutingPartitionId>,
         block_size: u32,
         tx: ReplicaEventSender,
         cancel_token: CancellationToken,
     ) -> Self {
         Self {
             replica: Some(ScopedReplicaPublisher {
-                model_name,
-                routing_group,
+                partition,
                 block_size,
                 tx,
                 cancel_token,
@@ -146,8 +158,8 @@ impl SequencePublisher for ScopedSequencePublisher {
             return Ok(());
         };
         let envelope = ScopedReplicaEvent {
-            model_name: replica.model_name.to_string(),
-            routing_group: replica.routing_group.to_string(),
+            model_name: replica.partition.model_name.clone(),
+            routing_group: replica.partition.routing_group.clone(),
             block_size: replica.block_size,
             event,
         };
@@ -250,8 +262,7 @@ pub(crate) fn setup_replica_sync(
 
 pub(crate) fn setup_scoped_replica_sync(
     config: Option<&ReplicaSyncConfig>,
-    model_name: &str,
-    routing_group: &str,
+    partition: &RoutingPartitionId,
     block_size: u32,
 ) -> ScopedReplicaSync {
     let Some(config) = config else {
@@ -266,8 +277,7 @@ pub(crate) fn setup_scoped_replica_sync(
     let (replica_tx, replica_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
     ScopedReplicaSync {
         publisher: ScopedSequencePublisher::enabled(
-            Arc::from(model_name),
-            Arc::from(routing_group),
+            Arc::new(partition.clone()),
             block_size,
             config.outbound_tx.clone(),
             config.cancel_token.clone(),
@@ -300,10 +310,13 @@ pub(crate) fn start_replica_publisher(
             };
 
             let request_id = event.event.request_id.clone();
+            let partition = event.partition_ref();
             let payload = match rmp_serde::to_vec_named(&event) {
                 Ok(payload) => payload,
                 Err(error) => {
                     tracing::error!(
+                        model_name = %partition.model_name,
+                        routing_group = %partition.routing_group,
                         request_id = %request_id,
                         "Failed to encode active-sequence replica event: {error}"
                     );
@@ -315,6 +328,8 @@ pub(crate) fn start_replica_publisher(
                 .await
             {
                 tracing::error!(
+                    model_name = %partition.model_name,
+                    routing_group = %partition.routing_group,
                     request_id = %request_id,
                     "Failed to publish active-sequence replica event: {error}"
                 );
@@ -541,7 +556,7 @@ mod tests {
     use super::*;
     use crate::protocols::{ActiveSequenceEventData, WorkerWithDpRank};
     #[cfg(feature = "standalone-slot-tracker")]
-    use crate::services::slot_tracker::registry::{SlotTrackerRegistry, TrackerKey};
+    use crate::services::slot_tracker::registry::SlotTrackerRegistry;
 
     fn event() -> ScopedReplicaEvent {
         ScopedReplicaEvent {
@@ -584,12 +599,39 @@ mod tests {
     fn replica_event_wire_schema_uses_routing_group() {
         let payload = rmp_serde::to_vec_named(&event()).unwrap();
         let value: serde_json::Value = rmp_serde::from_slice(&payload).unwrap();
+        let fields = value.as_object().unwrap();
 
+        assert_eq!(fields.len(), 4);
+        assert!(fields.contains_key("model_name"));
         assert_eq!(value["routing_group"], "group");
+        assert!(fields.contains_key("block_size"));
+        assert!(fields.contains_key("event"));
+        assert!(value.get("partition").is_none());
         assert!(value.get("tenant_id").is_none());
 
         let decoded: ScopedReplicaEvent = rmp_serde::from_slice(&payload).unwrap();
-        assert_eq!(decoded.routing_group, "group");
+        assert_eq!(
+            decoded.partition_ref(),
+            RoutingPartitionRef::new("model", "group")
+        );
+    }
+
+    #[test]
+    fn previous_flat_replica_event_wire_schema_is_accepted() {
+        let previous = serde_json::json!({
+            "model_name": "model",
+            "routing_group": "group",
+            "block_size": 16,
+            "event": event().event,
+        });
+        let payload = rmp_serde::to_vec_named(&previous).unwrap();
+
+        let decoded: ScopedReplicaEvent = rmp_serde::from_slice(&payload).unwrap();
+        assert_eq!(
+            decoded.partition_ref(),
+            RoutingPartitionRef::new("model", "group")
+        );
+        assert_eq!(decoded.block_size, 16);
     }
 
     #[test]
@@ -610,8 +652,7 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(1);
         let cancel_token = CancellationToken::new();
         let publisher = ScopedSequencePublisher::enabled(
-            Arc::from("model"),
-            Arc::from("group"),
+            Arc::new(RoutingPartitionId::new("model", "group")),
             16,
             tx,
             cancel_token.clone(),
@@ -720,7 +761,7 @@ mod tests {
                 dispatch_registry_b.dispatch_replica_event(event)
             })
             .unwrap();
-        let key = TrackerKey::new("model".to_string(), Some("group".to_string()));
+        let key = RoutingPartitionId::new("model", "group");
         registry_a.register(key.clone(), 1, 16, 0, 1).unwrap();
         registry_b.register(key.clone(), 1, 16, 0, 1).unwrap();
         let worker = WorkerWithDpRank::new(1, 0);

--- a/lib/kv-router/src/services/indexer/mod.rs
+++ b/lib/kv-router/src/services/indexer/mod.rs
@@ -9,7 +9,8 @@
 //! a ZMQ listener that ingests its KV events into a per-(model, routing group)
 //! [`backend::Indexer`].
 //!
-//! `IndexerKey { model_name, routing_group }` remains this service's sole registry authority.
+//! [`RoutingPartitionId`](crate::identity::RoutingPartitionId) remains this service's sole registry
+//! authority for `(model_name, routing_group)`.
 //! Resolving it to `IndexerDomainId` is intentionally deferred until registration can carry
 //! authoritative explicit identity material; hashing local defaults here would create a second
 //! authority without enabling safe cross-service identity.

--- a/lib/kv-router/src/services/indexer/recovery.rs
+++ b/lib/kv-router/src/services/indexer/recovery.rs
@@ -6,9 +6,10 @@ use std::collections::HashMap;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::RouterEvent;
 
-use super::registry::{IndexerKey, WorkerRegistry};
+use super::registry::WorkerRegistry;
 
 #[derive(Deserialize)]
 struct DumpEntry {
@@ -65,10 +66,7 @@ async fn try_recover_from_peer(
             .split_once(':')
             .ok_or_else(|| anyhow::anyhow!("invalid dump key format: {map_key}"))?;
 
-        let key = IndexerKey {
-            model_name: model_name.to_string(),
-            routing_group: routing_group.to_string(),
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         let indexer = registry.get_or_create_indexer(key, entry.block_size);
 

--- a/lib/kv-router/src/services/indexer/registry.rs
+++ b/lib/kv-router/src/services/indexer/registry.rs
@@ -14,17 +14,12 @@ use serde::Serialize;
 use tokio::sync::watch;
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::RoutingPartitionId;
 use crate::indexer::KvIndexerMetrics;
 use crate::protocols::WorkerId;
 
 use super::backend::{Indexer, create_indexer_with_metrics};
 use super::listener::spawn_zmq_listener;
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct IndexerKey {
-    pub model_name: String,
-    pub routing_group: String,
-}
 
 pub struct IndexerEntry {
     pub indexer: Indexer,
@@ -309,13 +304,13 @@ impl ListenerRecord {
 }
 
 pub struct WorkerEntry {
-    key: IndexerKey,
+    key: RoutingPartitionId,
     listeners: HashMap<u32, Arc<ListenerRecord>>,
 }
 
 pub struct WorkerRegistry {
     workers: DashMap<WorkerId, WorkerEntry>,
-    indexers: DashMap<IndexerKey, IndexerEntry>,
+    indexers: DashMap<RoutingPartitionId, IndexerEntry>,
     peers: DashMap<String, ()>,
     watermarks: DashMap<(WorkerId, u32), Arc<AtomicU64>>,
     num_threads: usize,
@@ -418,10 +413,7 @@ impl WorkerRegistry {
         block_size: u32,
         replay_endpoint: Option<String>,
     ) -> Result<()> {
-        let key = IndexerKey {
-            model_name,
-            routing_group,
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
@@ -504,10 +496,7 @@ impl WorkerRegistry {
         model_name: &str,
         routing_group: &str,
     ) -> Result<()> {
-        let key = IndexerKey {
-            model_name: model_name.to_string(),
-            routing_group: routing_group.to_string(),
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         if let Some(entry) = self.workers.get(&instance_id) {
             if entry.key != key {
@@ -546,10 +535,7 @@ impl WorkerRegistry {
         model_name: &str,
         routing_group: &str,
     ) -> Result<()> {
-        let key = IndexerKey {
-            model_name: model_name.to_string(),
-            routing_group: routing_group.to_string(),
-        };
+        let key = RoutingPartitionId::new(model_name, routing_group);
 
         let (record, remove_worker) = {
             let mut entry = self
@@ -741,11 +727,14 @@ impl WorkerRegistry {
             .collect()
     }
 
-    pub fn get_indexer(&self, key: &IndexerKey) -> Option<Ref<'_, IndexerKey, IndexerEntry>> {
+    pub fn get_indexer(
+        &self,
+        key: &RoutingPartitionId,
+    ) -> Option<Ref<'_, RoutingPartitionId, IndexerEntry>> {
         self.indexers.get(key)
     }
 
-    pub fn get_or_create_indexer(&self, key: IndexerKey, block_size: u32) -> Indexer {
+    pub fn get_or_create_indexer(&self, key: RoutingPartitionId, block_size: u32) -> Indexer {
         let entry = self.indexers.entry(key.clone()).or_insert_with(|| {
             tracing::info!(
                 model_name = %key.model_name,
@@ -774,7 +763,7 @@ impl WorkerRegistry {
         entry.indexer.clone()
     }
 
-    pub fn all_indexers_with_block_size(&self) -> Vec<(IndexerKey, Indexer, u32)> {
+    pub fn all_indexers_with_block_size(&self) -> Vec<(RoutingPartitionId, Indexer, u32)> {
         self.indexers
             .iter()
             .map(|entry| {
@@ -818,7 +807,7 @@ impl WorkerRegistry {
         );
     }
 
-    fn maybe_remove_indexer(&self, key: &IndexerKey) {
+    fn maybe_remove_indexer(&self, key: &RoutingPartitionId) {
         if self.workers.iter().any(|entry| entry.value().key == *key) {
             return;
         }
@@ -1123,10 +1112,7 @@ mod tests {
         // trivially without exercising the filter.
         let registry = test_registry();
 
-        let key = IndexerKey {
-            model_name: "llama3".to_string(),
-            routing_group: "acme".to_string(),
-        };
+        let key = RoutingPartitionId::new("llama3", "acme");
 
         // Inject the empty-listener WorkerEntry directly.
         registry.workers.insert(

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -14,6 +14,7 @@ use prometheus::Encoder;
 use serde::{Deserialize, Serialize};
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::{RoutingPartitionId, default_routing_group};
 #[cfg(feature = "metrics")]
 use crate::indexer::KvIndexerMetrics;
 use crate::indexer::TieredMatchDetails;
@@ -21,7 +22,7 @@ use crate::protocols::{BlockHashOptions, LocalBlockHash, WorkerId, compute_block
 use crate::services::overlap::{MooncakeOverlapSummary, build_mooncake_overlap_summaries};
 
 use super::backend::Indexer;
-use super::registry::{IndexerKey, ListenerControlError, WorkerRegistry};
+use super::registry::{ListenerControlError, WorkerRegistry};
 
 /// We need to fit one million tokens as JSON text, this should do it.
 const QUERY_REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
@@ -77,10 +78,6 @@ impl AppState {
             access_log_sink: None,
         })
     }
-}
-
-fn default_routing_group() -> String {
-    "default".to_string()
 }
 
 #[derive(Deserialize)]
@@ -316,10 +313,7 @@ async fn run_tiered_query(
 
 async fn query(State(state): State<Arc<AppState>>, Json(req): Json<QueryRequest>) -> Response {
     let model = req.model_name.clone();
-    let key = IndexerKey {
-        model_name: req.model_name,
-        routing_group: req.routing_group,
-    };
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     let Some(ie) = state.registry.get_indexer(&key) else {
         let mut resp = (
             StatusCode::NOT_FOUND,
@@ -370,10 +364,7 @@ async fn query_by_hash(
         return resp;
     }
 
-    let key = IndexerKey {
-        model_name: req.model_name,
-        routing_group: req.routing_group,
-    };
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     let Some(ie) = state.registry.get_indexer(&key) else {
         let mut resp = (
             StatusCode::NOT_FOUND,

--- a/lib/kv-router/src/services/selection/catalog.rs
+++ b/lib/kv-router/src/services/selection/catalog.rs
@@ -5,12 +5,12 @@ use std::collections::HashMap;
 
 use parking_lot::RwLock;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::{WorkerId, WorkerWithDpRank};
 
 use super::error::SelectionError;
 use super::types::{
-    SelectionKey, SelectionWorkerConfig, WorkerCatalogRecord, WorkerLifecycle, WorkerPatchRequest,
-    WorkerRequest,
+    SelectionWorkerConfig, WorkerCatalogRecord, WorkerLifecycle, WorkerPatchRequest, WorkerRequest,
 };
 
 #[derive(Debug, Default)]
@@ -91,7 +91,7 @@ impl WorkerCatalog {
         records
     }
 
-    pub(super) fn has_schedulable_for_key(&self, key: &SelectionKey) -> bool {
+    pub(super) fn has_schedulable_for_key(&self, key: &RoutingPartitionId) -> bool {
         self.workers.read().values().any(|record| {
             record.lifecycle == WorkerLifecycle::Schedulable
                 && record.model_name == key.model_name
@@ -101,7 +101,7 @@ impl WorkerCatalog {
 
     pub(super) fn scheduler_configs_for_key(
         &self,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> HashMap<WorkerId, SelectionWorkerConfig> {
         self.workers
             .read()
@@ -130,7 +130,7 @@ impl WorkerCatalog {
     pub(super) fn schedulable_endpoint(
         &self,
         worker_id: WorkerId,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> Option<String> {
         let workers = self.workers.read();
         let record = workers.get(&worker_id)?;
@@ -146,7 +146,7 @@ impl WorkerCatalog {
     pub(super) fn schedulable_worker_endpoint(
         &self,
         worker: WorkerWithDpRank,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> Option<String> {
         let workers = self.workers.read();
         let record = workers.get(&worker.worker_id)?;

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -10,6 +10,7 @@ use parking_lot::RwLock;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::RoutingPartitionId;
 use crate::indexer::TieredMatchDetails;
 use crate::protocols::{
     ActiveSequenceEvent, LocalBlockHash, PrefillLoadHint, RoutingConstraints, WorkerId,
@@ -41,8 +42,8 @@ use super::pending::{PendingSelection, SelectionCache, SelectionCacheConfig};
 use super::types::{
     ModelLoadResponse, OverlapScoresRequest, OverlapScoresResponse, PotentialLoadsRequest,
     ReadyResponse, ReservationRequest, ReservationResponse, SelectAndReserveRequest, SelectRequest,
-    SelectResponse, SelectionKey, SelectionWorkerConfig, WORKER_TYPE, WorkerCatalogRecord,
-    WorkerLifecycle, WorkerPatchRequest, WorkerRequest,
+    SelectResponse, SelectionWorkerConfig, WORKER_TYPE, WorkerCatalogRecord, WorkerLifecycle,
+    WorkerPatchRequest, WorkerRequest,
 };
 
 type SelectionScheduler = LocalScheduler<
@@ -53,7 +54,7 @@ type SelectionScheduler = LocalScheduler<
 >;
 
 struct SelectionEntry {
-    key: SelectionKey,
+    key: RoutingPartitionId,
     block_size: u32,
     is_eagle: bool,
     indexer: Indexer,
@@ -70,7 +71,7 @@ struct PreparedSelectionInputs {
 }
 
 struct SelectionOperation {
-    key: SelectionKey,
+    key: RoutingPartitionId,
     selection_id: Option<String>,
     prompt: PromptRequest,
     router_config_override: Option<RouterConfigOverride>,
@@ -87,7 +88,7 @@ struct SelectionOperation {
 /// Resolved inputs for booking a reservation, shared by the cached and explicit
 /// `create_reservation` paths.
 struct ReservationBooking {
-    key: SelectionKey,
+    key: RoutingPartitionId,
     selection_id: String,
     worker: WorkerWithDpRank,
     sequence_hashes: Vec<SequenceHash>,
@@ -110,7 +111,7 @@ pub struct SelectionServiceConfig {
 
 pub struct SelectionCore {
     catalog: WorkerCatalog,
-    entries: RwLock<HashMap<SelectionKey, Arc<SelectionEntry>>>,
+    entries: RwLock<HashMap<RoutingPartitionId, Arc<SelectionEntry>>>,
     indexer_registry: Arc<WorkerRegistry>,
     kv_router_config: crate::config::KvRouterConfig,
     cancel_token: CancellationToken,
@@ -249,24 +250,24 @@ impl SelectionCore {
     }
 
     pub(crate) fn dispatch_replica_event(&self, envelope: ScopedReplicaEvent) {
+        let (key, block_size, event) = envelope.into_parts();
         if self
             .replica_config
             .as_ref()
-            .is_some_and(|config| config.is_self_event(&envelope.event))
+            .is_some_and(|config| config.is_self_event(&event))
         {
             return;
         }
 
-        let key = SelectionKey::new(envelope.model_name, envelope.routing_group);
         let Some(entry) = self.entries.read().get(&key).cloned() else {
             tracing::trace!(%key, "Dropping replica event for unknown selector entry");
             return;
         };
-        if entry.block_size != envelope.block_size {
+        if entry.block_size != block_size {
             tracing::debug!(
                 %key,
                 expected_block_size = entry.block_size,
-                received_block_size = envelope.block_size,
+                received_block_size = block_size,
                 "Dropping selector replica event with mismatched block size"
             );
             return;
@@ -274,7 +275,7 @@ impl SelectionCore {
         let Some(replica_tx) = &entry.replica_tx else {
             return;
         };
-        match replica_tx.try_send(envelope.event) {
+        match replica_tx.try_send(event) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(event)) => {
                 tracing::trace!(
@@ -407,7 +408,7 @@ impl SelectionCore {
     fn mark_incomplete_after_reconcile_error(
         &self,
         worker_id: WorkerId,
-        key: SelectionKey,
+        key: RoutingPartitionId,
         error: SelectionError,
     ) -> Result<WorkerCatalogRecord, SelectionError> {
         let updated = self
@@ -466,12 +467,8 @@ impl SelectionCore {
         }
 
         let (workers_tx, workers_rx) = watch::channel(HashMap::new());
-        let scoped_replica_sync = setup_scoped_replica_sync(
-            self.replica_config.as_ref(),
-            &key.model_name,
-            &key.routing_group,
-            block_size,
-        );
+        let scoped_replica_sync =
+            setup_scoped_replica_sync(self.replica_config.as_ref(), &key, block_size);
         let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
             scoped_replica_sync.publisher,
             block_size as usize,
@@ -489,7 +486,7 @@ impl SelectionCore {
 
         let indexer = self
             .indexer_registry
-            .get_or_create_indexer(key.indexer_key(), block_size);
+            .get_or_create_indexer(key.clone(), block_size);
         let overlap_refresh = Arc::new(TieredOverlapRefresher::new(
             indexer.clone(),
             self.kv_router_config.clone(),
@@ -587,7 +584,7 @@ impl SelectionCore {
             return;
         }
 
-        let key = record.key().indexer_key();
+        let key = record.key();
         let indexer = self
             .indexer_registry
             .get_indexer(&key)
@@ -597,7 +594,7 @@ impl SelectionCore {
         }
     }
 
-    fn publish_scheduler_config(&self, key: &SelectionKey) -> Result<(), SelectionError> {
+    fn publish_scheduler_config(&self, key: &RoutingPartitionId) -> Result<(), SelectionError> {
         let Some(entry) = self.entries.read().get(key).cloned() else {
             return Ok(());
         };
@@ -607,7 +604,7 @@ impl SelectionCore {
         })
     }
 
-    fn ready_entry(&self, key: &SelectionKey) -> Result<Arc<SelectionEntry>, SelectionError> {
+    fn ready_entry(&self, key: &RoutingPartitionId) -> Result<Arc<SelectionEntry>, SelectionError> {
         if self.catalog.schedulable_count() == 0 {
             return Err(SelectionError::NotReady(
                 "no schedulable workers are available".to_string(),
@@ -638,7 +635,7 @@ impl SelectionCore {
     ) -> Result<SelectResponse, SelectionError> {
         self.schedule_selection(
             SelectionOperation {
-                key: SelectionKey::new(req.model_name, req.routing_group),
+                key: RoutingPartitionId::new(req.model_name, req.routing_group),
                 selection_id: req.selection_id,
                 prompt: req.prompt,
                 router_config_override: req.router_config_override,
@@ -673,7 +670,7 @@ impl SelectionCore {
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         self.schedule_selection(
             SelectionOperation {
-                key: SelectionKey::new(req.model_name, req.routing_group),
+                key: RoutingPartitionId::new(req.model_name, req.routing_group),
                 selection_id: Some(selection_id),
                 prompt: req.prompt,
                 router_config_override: req.router_config_override,
@@ -830,7 +827,7 @@ impl SelectionCore {
     ) -> Result<ReservationResponse, SelectionError> {
         self.ensure_running()?;
 
-        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
+        let key = RoutingPartitionId::new(req.model_name.clone(), req.routing_group.clone());
 
         // Explicit form: book on the given worker under selection_id, discarding
         // any cached selection for the id so a later replay can't book stale state.
@@ -914,7 +911,7 @@ impl SelectionCore {
     fn schedulable_endpoint(
         &self,
         worker_id: WorkerId,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
     ) -> Result<String, SelectionError> {
         self.catalog
             .schedulable_endpoint(worker_id, key)
@@ -928,7 +925,7 @@ impl SelectionCore {
     /// Book a reservation from a self-contained request (explicit worker_id and prompt).
     async fn reserve_explicit(
         &self,
-        key: SelectionKey,
+        key: RoutingPartitionId,
         worker_id: WorkerId,
         req: ReservationRequest,
     ) -> Result<ReservationResponse, SelectionError> {
@@ -1112,7 +1109,7 @@ impl SelectionCore {
         &self,
         req: PotentialLoadsRequest,
     ) -> Result<Vec<PotentialLoad>, SelectionError> {
-        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
+        let key = RoutingPartitionId::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let prepared = self
             .prepare_selection_inputs(
@@ -1139,7 +1136,7 @@ impl SelectionCore {
         &self,
         req: OverlapScoresRequest,
     ) -> Result<OverlapScoresResponse, SelectionError> {
-        let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
+        let key = RoutingPartitionId::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
         let block_hashes = req
             .prompt
@@ -1198,7 +1195,7 @@ impl SelectionCore {
         })
     }
 
-    fn schedulable_worker_ranks(&self, key: &SelectionKey) -> Vec<WorkerWithDpRank> {
+    fn schedulable_worker_ranks(&self, key: &RoutingPartitionId) -> Vec<WorkerWithDpRank> {
         let configs = self.catalog.scheduler_configs_for_key(key);
         let mut workers = Vec::new();
         for (worker_id, config) in configs {
@@ -1214,8 +1211,7 @@ impl SelectionCore {
 
 fn tracking_scope(entry: &SelectionEntry) -> TrackingHashScope<'_> {
     TrackingHashScope {
-        model_name: &entry.key.model_name,
-        routing_group: &entry.key.routing_group,
+        partition: entry.key.as_ref(),
         block_size: entry.block_size,
     }
 }
@@ -1561,7 +1557,7 @@ mod tests {
             request.max_num_batched_tokens = Some(8);
             core.upsert_worker(request).await.expect("worker upsert");
         }
-        let key = SelectionKey::new("model".to_string(), "default".to_string());
+        let key = RoutingPartitionId::new("model", "default");
         let entry = core.entries.read().get(&key).cloned().expect("entry");
         entry
             .indexer

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -124,16 +124,27 @@ pub struct SelectionCore {
 impl SelectionCore {
     /// Create an intentionally local selector without replica synchronization
     /// or startup recovery.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the tracking-hash configuration is invalid. Use
+    /// [`Self::try_new_local`] when configuration errors must be reported.
     pub fn new_local(
         kv_router_config: crate::config::KvRouterConfig,
         indexer_threads: usize,
         cancel_token: CancellationToken,
         cache_config: SelectionCacheConfig,
     ) -> Self {
-        Self::try_new_local(kv_router_config, indexer_threads, cancel_token, cache_config)
-            .expect("selection tracking hash configuration must be valid")
+        Self::try_new_local(
+            kv_router_config,
+            indexer_threads,
+            cancel_token,
+            cache_config,
+        )
+        .expect("selection tracking hash configuration must be valid")
     }
 
+    /// Create a local selector and report invalid tracking configuration.
     pub fn try_new_local(
         kv_router_config: crate::config::KvRouterConfig,
         indexer_threads: usize,

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -32,10 +32,11 @@ use crate::services::indexer::backend::Indexer;
 use crate::services::indexer::recovery;
 use crate::services::indexer::registry::WorkerRegistry;
 use crate::services::overlap::MooncakeOverlapSummary;
+use crate::tracking_hash::{TrackingHashContext, TrackingHashScope};
 
 use super::catalog::WorkerCatalog;
 use super::error::SelectionError;
-use super::input::PromptRequest;
+use super::input::{PromptRequest, TrackingHashInput};
 use super::pending::{PendingSelection, SelectionCache, SelectionCacheConfig};
 use super::types::{
     ModelLoadResponse, OverlapScoresRequest, OverlapScoresResponse, PotentialLoadsRequest,
@@ -117,6 +118,7 @@ pub struct SelectionCore {
     /// Booking inputs captured by `select`, keyed by `selection_id`, so a later
     /// `create_reservation` can replay them without re-sending the prompt.
     selection_cache: SelectionCache,
+    tracking_hash: Arc<TrackingHashContext>,
 }
 
 impl SelectionCore {
@@ -128,14 +130,29 @@ impl SelectionCore {
         cancel_token: CancellationToken,
         cache_config: SelectionCacheConfig,
     ) -> Self {
-        Self::new_inner(
+        Self::try_new_local(kv_router_config, indexer_threads, cancel_token, cache_config)
+            .expect("selection tracking hash configuration must be valid")
+    }
+
+    pub fn try_new_local(
+        kv_router_config: crate::config::KvRouterConfig,
+        indexer_threads: usize,
+        cancel_token: CancellationToken,
+        cache_config: SelectionCacheConfig,
+    ) -> anyhow::Result<Self> {
+        kv_router_config
+            .validate_config()
+            .map_err(anyhow::Error::msg)?;
+        let tracking_hash = Arc::new(TrackingHashContext::from_config(&kv_router_config)?);
+        Ok(Self::new_inner(
             kv_router_config,
             indexer_threads,
             cancel_token,
             None,
             true,
             cache_config,
-        )
+            tracking_hash,
+        ))
     }
 
     pub(super) fn new_managed(
@@ -144,6 +161,7 @@ impl SelectionCore {
         cancel_token: CancellationToken,
         replica_config: Option<ReplicaSyncConfig>,
         cache_config: SelectionCacheConfig,
+        tracking_hash: Arc<TrackingHashContext>,
     ) -> Self {
         Self::new_inner(
             kv_router_config,
@@ -152,6 +170,7 @@ impl SelectionCore {
             replica_config,
             false,
             cache_config,
+            tracking_hash,
         )
     }
 
@@ -162,6 +181,7 @@ impl SelectionCore {
         replica_config: Option<ReplicaSyncConfig>,
         signal_indexer_ready: bool,
         cache_config: SelectionCacheConfig,
+        tracking_hash: Arc<TrackingHashContext>,
     ) -> Self {
         let cancel_token = cancel_token.child_token();
         let indexer_registry = Arc::new(WorkerRegistry::new_with_cancel_token(
@@ -179,6 +199,7 @@ impl SelectionCore {
             cancel_token,
             replica_config,
             selection_cache: SelectionCache::new(&cache_config),
+            tracking_hash,
         }
     }
 
@@ -686,7 +707,14 @@ impl SelectionCore {
             sequence_hashes,
             isl_tokens,
             overlap,
-        } = self.prepare_selection_inputs(&entry, &prompt).await?;
+        } = self
+            .prepare_selection_inputs(
+                &entry,
+                &prompt,
+                self.kv_router_config
+                    .assume_kv_reuse(router_config_override.as_ref()),
+            )
+            .await?;
         let mode = if book {
             ScheduleMode::Tracked {
                 request_id: selection_id.clone().ok_or_else(|| {
@@ -894,9 +922,16 @@ impl SelectionCore {
         req: ReservationRequest,
     ) -> Result<ReservationResponse, SelectionError> {
         let entry = self.ready_entry(&key)?;
-        let normalized = req
-            .prompt
-            .normalize_for_reservation(entry.block_size, entry.is_eagle)?;
+        let normalized = req.prompt.normalize_for_reservation(
+            entry.is_eagle,
+            TrackingHashInput {
+                context: &self.tracking_hash,
+                scope: tracking_scope(&entry),
+                assume_kv_reuse: self
+                    .kv_router_config
+                    .assume_kv_reuse(req.router_config_override.as_ref()),
+            },
+        )?;
         let prefill_load_hint = req
             .effective_prefill_tokens
             .map(|tokens| {
@@ -1068,7 +1103,14 @@ impl SelectionCore {
     ) -> Result<Vec<PotentialLoad>, SelectionError> {
         let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
-        let prepared = self.prepare_selection_inputs(&entry, &req.prompt).await?;
+        let prepared = self
+            .prepare_selection_inputs(
+                &entry,
+                &req.prompt,
+                self.kv_router_config
+                    .assume_kv_reuse(req.router_config_override.as_ref()),
+            )
+            .await?;
         let track_prefill_tokens = req
             .router_config_override
             .as_ref()
@@ -1088,13 +1130,13 @@ impl SelectionCore {
     ) -> Result<OverlapScoresResponse, SelectionError> {
         let key = SelectionKey::new(req.model_name.clone(), req.routing_group.clone());
         let entry = self.ready_entry(&key)?;
-        let normalized = req
+        let block_hashes = req
             .prompt
-            .normalize_for_selection(entry.block_size, entry.is_eagle)?;
-        let num_blocks = normalized.block_hashes.len();
+            .block_hashes_for_indexer(entry.block_size, entry.is_eagle)?;
+        let num_blocks = block_hashes.len();
         let tiered = entry
             .indexer
-            .find_tiered_matches(normalized.block_hashes)
+            .find_tiered_matches(block_hashes)
             .await
             .map_err(|error| SelectionError::Internal(error.to_string()))?;
         let schedulable_workers = self.schedulable_worker_ranks(&key);
@@ -1115,8 +1157,16 @@ impl SelectionCore {
         &self,
         entry: &SelectionEntry,
         prompt: &PromptRequest,
+        assume_kv_reuse: bool,
     ) -> Result<PreparedSelectionInputs, SelectionError> {
-        let normalized = prompt.normalize_for_selection(entry.block_size, entry.is_eagle)?;
+        let normalized = prompt.normalize_for_selection(
+            entry.is_eagle,
+            TrackingHashInput {
+                context: &self.tracking_hash,
+                scope: tracking_scope(entry),
+                assume_kv_reuse,
+            },
+        )?;
         let tiered = if normalized.block_hashes.is_empty() {
             TieredMatchDetails::default()
         } else {
@@ -1148,6 +1198,14 @@ impl SelectionCore {
             }
         }
         workers
+    }
+}
+
+fn tracking_scope(entry: &SelectionEntry) -> TrackingHashScope<'_> {
+    TrackingHashScope {
+        model_name: &entry.key.model_name,
+        routing_group: &entry.key.routing_group,
+        block_size: entry.block_size,
     }
 }
 

--- a/lib/kv-router/src/services/selection/input.rs
+++ b/lib/kv-router/src/services/selection/input.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_tokens::SequenceHash;
-use rand::Rng;
 use serde::Deserialize;
 
 use crate::protocols::{
@@ -56,7 +55,7 @@ impl PromptRequest {
         tracking: TrackingHashInput<'_>,
     ) -> Result<NormalizedPrompt, SelectionError> {
         if let Some((token_ids, block_mm_infos)) = self.routing_tokens_and_mm_infos() {
-            return Ok(normalize_tokens(
+            return Ok(normalize_tokens_for_selection(
                 token_ids,
                 self.lora_name.as_deref(),
                 self.cache_namespace.as_deref(),
@@ -84,18 +83,14 @@ impl PromptRequest {
         tracking: TrackingHashInput<'_>,
     ) -> Result<NormalizedReservation, SelectionError> {
         if let Some((token_ids, block_mm_infos)) = self.routing_tokens_and_mm_infos() {
-            let normalized = normalize_tokens(
+            return Ok(normalize_tokens_for_reservation(
                 token_ids,
                 self.lora_name.as_deref(),
                 self.cache_namespace.as_deref(),
                 block_mm_infos,
                 self.is_eagle.unwrap_or(default_is_eagle),
                 tracking,
-            );
-            return Ok(NormalizedReservation {
-                sequence_hashes: normalized.sequence_hashes,
-                isl_tokens: normalized.isl_tokens,
-            });
+            ));
         }
 
         let sequence_hashes = self.sequence_hashes.as_ref().ok_or_else(|| {
@@ -158,7 +153,7 @@ impl PromptRequest {
     }
 }
 
-fn normalize_tokens(
+fn normalize_tokens_for_selection(
     token_ids: &[u32],
     lora_name: Option<&str>,
     cache_namespace: Option<&str>,
@@ -166,36 +161,50 @@ fn normalize_tokens(
     is_eagle: bool,
     tracking: TrackingHashInput<'_>,
 ) -> NormalizedPrompt {
-    let block_hashes = compute_block_hash_for_seq(
-        token_ids,
-        tracking.scope.block_size,
-        BlockHashOptions {
-            block_mm_infos,
-            lora_name,
-            cache_namespace,
-            is_eagle: Some(is_eagle),
-        },
-    );
-    let sequence_hashes = if tracking.assume_kv_reuse {
-        tracking.context.compute_sequence_hashes(
-            tracking.scope,
-            token_ids,
-            BlockHashOptions {
-                block_mm_infos,
-                lora_name,
-                cache_namespace,
-                is_eagle: Some(is_eagle),
-            },
-            Some(&block_hashes),
-        )
-    } else {
-        let mut rng = rand::rng();
-        (0..block_hashes.len())
-            .map(|_| rng.random::<SequenceHash>())
-            .collect()
+    let hash_options = BlockHashOptions {
+        block_mm_infos,
+        lora_name,
+        cache_namespace,
+        is_eagle: Some(is_eagle),
     };
+    let block_hashes =
+        compute_block_hash_for_seq(token_ids, tracking.scope.block_size, hash_options);
+    let sequence_hashes = tracking.context.compute_sequence_hashes_for_tracking(
+        tracking.scope,
+        token_ids,
+        hash_options,
+        tracking.assume_kv_reuse,
+        Some(&block_hashes),
+    );
     NormalizedPrompt {
         block_hashes,
+        sequence_hashes,
+        isl_tokens: token_ids.len(),
+    }
+}
+
+fn normalize_tokens_for_reservation(
+    token_ids: &[u32],
+    lora_name: Option<&str>,
+    cache_namespace: Option<&str>,
+    block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+    is_eagle: bool,
+    tracking: TrackingHashInput<'_>,
+) -> NormalizedReservation {
+    let hash_options = BlockHashOptions {
+        block_mm_infos,
+        lora_name,
+        cache_namespace,
+        is_eagle: Some(is_eagle),
+    };
+    let sequence_hashes = tracking.context.compute_sequence_hashes_for_tracking(
+        tracking.scope,
+        token_ids,
+        hash_options,
+        tracking.assume_kv_reuse,
+        None,
+    );
+    NormalizedReservation {
         sequence_hashes,
         isl_tokens: token_ids.len(),
     }

--- a/lib/kv-router/src/services/selection/input.rs
+++ b/lib/kv-router/src/services/selection/input.rs
@@ -2,16 +2,23 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use dynamo_tokens::SequenceHash;
+use rand::Rng;
 use serde::Deserialize;
 
 use crate::protocols::{
     BlockExtraInfo, BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq,
-    compute_seq_hash_for_block,
 };
+use crate::tracking_hash::{TrackingHashContext, TrackingHashScope};
 
 use super::error::SelectionError;
 
 type RoutingTokensAndMmInfos<'a> = (&'a [u32], Option<&'a [Option<BlockExtraInfo>]>);
+
+pub(super) struct TrackingHashInput<'a> {
+    pub(super) context: &'a TrackingHashContext,
+    pub(super) scope: TrackingHashScope<'a>,
+    pub(super) assume_kv_reuse: bool,
+}
 
 #[derive(Debug, Clone, Deserialize)]
 pub struct MmRoutingInfoRequest {
@@ -45,17 +52,17 @@ pub struct PromptRequest {
 impl PromptRequest {
     pub(super) fn normalize_for_selection(
         &self,
-        block_size: u32,
         default_is_eagle: bool,
+        tracking: TrackingHashInput<'_>,
     ) -> Result<NormalizedPrompt, SelectionError> {
         if let Some((token_ids, block_mm_infos)) = self.routing_tokens_and_mm_infos() {
             return Ok(normalize_tokens(
                 token_ids,
-                block_size,
                 self.lora_name.as_deref(),
                 self.cache_namespace.as_deref(),
                 block_mm_infos,
                 self.is_eagle.unwrap_or(default_is_eagle),
+                tracking,
             ));
         }
 
@@ -73,17 +80,17 @@ impl PromptRequest {
 
     pub(super) fn normalize_for_reservation(
         &self,
-        block_size: u32,
         default_is_eagle: bool,
+        tracking: TrackingHashInput<'_>,
     ) -> Result<NormalizedReservation, SelectionError> {
         if let Some((token_ids, block_mm_infos)) = self.routing_tokens_and_mm_infos() {
             let normalized = normalize_tokens(
                 token_ids,
-                block_size,
                 self.lora_name.as_deref(),
                 self.cache_namespace.as_deref(),
                 block_mm_infos,
                 self.is_eagle.unwrap_or(default_is_eagle),
+                tracking,
             );
             return Ok(NormalizedReservation {
                 sequence_hashes: normalized.sequence_hashes,
@@ -105,6 +112,36 @@ impl PromptRequest {
         })
     }
 
+    pub(super) fn block_hashes_for_indexer(
+        &self,
+        block_size: u32,
+        default_is_eagle: bool,
+    ) -> Result<Vec<LocalBlockHash>, SelectionError> {
+        if let Some((token_ids, block_mm_infos)) = self.routing_tokens_and_mm_infos() {
+            return Ok(compute_block_hash_for_seq(
+                token_ids,
+                block_size,
+                BlockHashOptions {
+                    block_mm_infos,
+                    lora_name: self.lora_name.as_deref(),
+                    cache_namespace: self.cache_namespace.as_deref(),
+                    is_eagle: Some(self.is_eagle.unwrap_or(default_is_eagle)),
+                },
+            ));
+        }
+
+        let block_hashes = self.block_hashes.as_ref().ok_or_else(|| {
+            SelectionError::BadRequest("block_hashes is required without token_ids".to_string())
+        })?;
+        let sequence_hashes = self.sequence_hashes.as_ref().ok_or_else(|| {
+            SelectionError::BadRequest("sequence_hashes is required without token_ids".to_string())
+        })?;
+        let isl_tokens = self.isl_tokens.ok_or_else(|| {
+            SelectionError::BadRequest("isl_tokens is required without token_ids".to_string())
+        })?;
+        Ok(normalize_hashes(block_hashes, sequence_hashes, isl_tokens)?.block_hashes)
+    }
+
     fn routing_tokens_and_mm_infos(&self) -> Option<RoutingTokensAndMmInfos<'_>> {
         if let Some(mm_routing_info) = &self.mm_routing_info
             && !mm_routing_info.routing_token_ids.is_empty()
@@ -123,15 +160,15 @@ impl PromptRequest {
 
 fn normalize_tokens(
     token_ids: &[u32],
-    block_size: u32,
     lora_name: Option<&str>,
     cache_namespace: Option<&str>,
     block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
     is_eagle: bool,
+    tracking: TrackingHashInput<'_>,
 ) -> NormalizedPrompt {
     let block_hashes = compute_block_hash_for_seq(
         token_ids,
-        block_size,
+        tracking.scope.block_size,
         BlockHashOptions {
             block_mm_infos,
             lora_name,
@@ -139,7 +176,24 @@ fn normalize_tokens(
             is_eagle: Some(is_eagle),
         },
     );
-    let sequence_hashes = compute_seq_hash_for_block(&block_hashes);
+    let sequence_hashes = if tracking.assume_kv_reuse {
+        tracking.context.compute_sequence_hashes(
+            tracking.scope,
+            token_ids,
+            BlockHashOptions {
+                block_mm_infos,
+                lora_name,
+                cache_namespace,
+                is_eagle: Some(is_eagle),
+            },
+            Some(&block_hashes),
+        )
+    } else {
+        let mut rng = rand::rng();
+        (0..block_hashes.len())
+            .map(|_| rng.random::<SequenceHash>())
+            .collect()
+    };
     NormalizedPrompt {
         block_hashes,
         sequence_hashes,

--- a/lib/kv-router/src/services/selection/mod.rs
+++ b/lib/kv-router/src/services/selection/mod.rs
@@ -28,7 +28,7 @@ pub use service::{SelectionService, SelectionServiceBuilder};
 pub use types::{
     ModelLoadResponse, OutputBlockRequest, OverlapScoresRequest, OverlapScoresResponse,
     PotentialLoadsRequest, ReadyResponse, ReservationRequest, ReservationResponse,
-    SelectAndReserveRequest, SelectRequest, SelectResponse, SelectionKey, SelectionWorkerConfig,
+    SelectAndReserveRequest, SelectRequest, SelectResponse, SelectionWorkerConfig,
     SharedCacheOverlapScore, WorkerCatalogRecord, WorkerLifecycle, WorkerOverlapScore,
     WorkerPatchRequest, WorkerRequest,
 };

--- a/lib/kv-router/src/services/selection/pending.rs
+++ b/lib/kv-router/src/services/selection/pending.rs
@@ -12,9 +12,8 @@ use std::time::{Duration, Instant};
 use dynamo_tokens::SequenceHash;
 use parking_lot::Mutex;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::WorkerWithDpRank;
-
-use super::types::SelectionKey;
 
 /// How long a pending selection lives before it is evicted.
 const SELECTION_CACHE_TTL: Duration = Duration::from_secs(120);
@@ -49,7 +48,7 @@ impl Default for SelectionCacheConfig {
 
 /// Booking inputs captured by `select`, replayed by a later `create_reservation`.
 pub(super) struct PendingSelection {
-    pub key: SelectionKey,
+    pub key: RoutingPartitionId,
     pub worker: WorkerWithDpRank,
     pub sequence_hashes: Vec<SequenceHash>,
     pub isl_tokens: usize,
@@ -66,8 +65,8 @@ struct Entry {
     bytes: usize,
 }
 
-/// Scoped by `(SelectionKey, selection_id)`; `SelectionKey` is (model, routing_group).
-type CacheKey = (SelectionKey, String);
+/// Scoped by `(RoutingPartitionId, selection_id)`.
+type CacheKey = (RoutingPartitionId, String);
 
 /// Approximate resident bytes: sequence hashes plus id and scope strings.
 fn entry_bytes(key: &CacheKey, selection: &PendingSelection) -> usize {
@@ -87,7 +86,7 @@ struct State {
     total_bytes: usize,
 }
 
-/// Maps `(SelectionKey, selection_id)` -> the booking inputs computed during `select`.
+/// Maps `(RoutingPartitionId, selection_id)` to the booking inputs computed during `select`.
 pub(super) struct SelectionCache {
     ttl: Duration,
     max_entries: usize,
@@ -183,7 +182,7 @@ impl SelectionCache {
     /// once the booking lands.
     pub(super) fn peek(
         &self,
-        key: &SelectionKey,
+        key: &RoutingPartitionId,
         selection_id: &str,
         now: Instant,
     ) -> Option<(Arc<PendingSelection>, u64)> {
@@ -198,7 +197,7 @@ impl SelectionCache {
 
     /// Consume the entry after a booking lands, only if its `generation` still
     /// matches the peek; a newer `select` for the id survives.
-    pub(super) fn remove(&self, key: &SelectionKey, selection_id: &str, generation: u64) {
+    pub(super) fn remove(&self, key: &RoutingPartitionId, selection_id: &str, generation: u64) {
         let cache_key = (key.clone(), selection_id.to_string());
         let mut state = self.state.lock();
         if state
@@ -211,7 +210,7 @@ impl SelectionCache {
     }
 
     /// Drop any cached selection for the id (an explicit booking supersedes it).
-    pub(super) fn discard(&self, key: &SelectionKey, selection_id: &str) {
+    pub(super) fn discard(&self, key: &RoutingPartitionId, selection_id: &str) {
         let cache_key = (key.clone(), selection_id.to_string());
         let mut state = self.state.lock();
         self.remove_locked(&mut state, &cache_key);
@@ -254,8 +253,8 @@ mod tests {
         cache_with(CAP, usize::MAX)
     }
 
-    fn key() -> SelectionKey {
-        SelectionKey::new("model", "default")
+    fn key() -> RoutingPartitionId {
+        RoutingPartitionId::new("model", "default")
     }
 
     fn pending(worker_id: u64) -> PendingSelection {

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -11,6 +11,7 @@ use crate::scheduling::PotentialLoad;
 use crate::services::common::replica_sync::{
     PeerManager, ReplicaPeerError, ReplicaSyncRuntime, setup_replica_sync,
 };
+use crate::tracking_hash::TrackingHashContext;
 
 use super::core::{SelectionCore, SelectionServiceConfig};
 use super::error::SelectionError;
@@ -64,6 +65,10 @@ impl SelectionServiceBuilder {
     }
 
     pub async fn build(self) -> anyhow::Result<SelectionService> {
+        self.kv_router_config
+            .validate_config()
+            .map_err(anyhow::Error::msg)?;
+        let tracking_hash = Arc::new(TrackingHashContext::from_config(&self.kv_router_config)?);
         let cancel_token = CancellationToken::new();
         let mut startup_guard = StartupGuard::new(cancel_token.clone());
         let replica_runtime = setup_replica_sync(
@@ -78,6 +83,7 @@ impl SelectionServiceBuilder {
             cancel_token.clone(),
             replica_config,
             self.selection_cache,
+            tracking_hash,
         ));
 
         if !self.indexer_peers.is_empty() {

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -76,6 +76,13 @@ impl SelectionServiceBuilder {
             &self.replica_sync_peers,
             cancel_token.child_token(),
         )?;
+        if replica_runtime.is_some() {
+            tracing::info!(
+                router_tracking_hash = %tracking_hash.algorithm(),
+                router_tracking_key_id = ?tracking_hash.key_id(),
+                "Selection replica synchronization initialized"
+            );
+        }
         let replica_config = replica_runtime.as_ref().map(ReplicaSyncRuntime::config);
         let core = Arc::new(SelectionCore::new_managed(
             self.kv_router_config,

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -14,6 +14,7 @@ use tower::ServiceExt;
 use super::input::{MmRoutingInfoRequest, PromptRequest, TrackingHashInput};
 use super::server::create_router;
 use super::*;
+use crate::identity::RoutingPartitionRef;
 use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
 use crate::protocols::{
     BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, OverlapScores, StorageTier,
@@ -46,8 +47,7 @@ fn normalize_prompt(request: &PromptRequest) -> super::input::NormalizedPrompt {
             TrackingHashInput {
                 context: &context,
                 scope: TrackingHashScope {
-                    model_name: "model",
-                    routing_group: "default",
+                    partition: RoutingPartitionRef::new("model", "default"),
                     block_size: 4,
                 },
                 assume_kv_reuse: true,
@@ -214,8 +214,7 @@ fn keyed_prompt_tracking_leaves_indexer_hashes_public() {
             TrackingHashInput {
                 context: &context,
                 scope: TrackingHashScope {
-                    model_name: "model",
-                    routing_group: "default",
+                    partition: RoutingPartitionRef::new("model", "default"),
                     block_size: 4,
                 },
                 assume_kv_reuse: true,
@@ -253,8 +252,7 @@ fn disabled_kv_reuse_keeps_public_indexer_hashes_and_randomizes_tracking() {
                 TrackingHashInput {
                     context: &context,
                     scope: TrackingHashScope {
-                        model_name: "model",
-                        routing_group: "default",
+                        partition: RoutingPartitionRef::new("model", "default"),
                         block_size: 4,
                     },
                     assume_kv_reuse: false,
@@ -290,8 +288,7 @@ fn keyed_reservation_hashes_directly_from_tokens() {
     }))
     .unwrap();
     let scope = TrackingHashScope {
-        model_name: "model",
-        routing_group: "default",
+        partition: RoutingPartitionRef::new("model", "default"),
         block_size: 4,
     };
 
@@ -346,8 +343,7 @@ fn randomized_reservation_uses_canonical_complete_block_count() {
                 TrackingHashInput {
                     context: &context,
                     scope: TrackingHashScope {
-                        model_name: "model",
-                        routing_group: "default",
+                        partition: RoutingPartitionRef::new("model", "default"),
                         block_size: 4,
                     },
                     assume_kv_reuse: false,

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -5,12 +5,13 @@ use axum::Router;
 use axum::body::{Body, to_bytes};
 use axum::http::{Request, StatusCode, header};
 use axum::response::Response;
+use std::io::Write;
 use std::net::TcpListener as StdTcpListener;
 use std::sync::Arc;
 use std::time::Duration;
 use tower::ServiceExt;
 
-use super::input::{MmRoutingInfoRequest, PromptRequest};
+use super::input::{MmRoutingInfoRequest, PromptRequest, TrackingHashInput};
 use super::server::create_router;
 use super::*;
 use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
@@ -20,6 +21,8 @@ use crate::protocols::{
 };
 use crate::scheduling::config::RouterConfigOverride;
 use crate::scheduling::overlap::build_overlap_scores_response;
+use crate::{TrackingHashContext, TrackingHashScope};
+use tempfile::NamedTempFile;
 
 fn test_config() -> crate::config::KvRouterConfig {
     crate::config::KvRouterConfig {
@@ -32,6 +35,25 @@ fn test_config() -> crate::config::KvRouterConfig {
 fn app() -> Router {
     let service = Arc::new(SelectionService::new_local_for_test(test_config(), 1));
     create_router(Arc::new(AppState { service }))
+}
+
+fn normalize_prompt(request: &PromptRequest) -> super::input::NormalizedPrompt {
+    let config = test_config();
+    let context = TrackingHashContext::from_config(&config).unwrap();
+    request
+        .normalize_for_selection(
+            false,
+            TrackingHashInput {
+                context: &context,
+                scope: TrackingHashScope {
+                    model_name: "model",
+                    routing_group: "default",
+                    block_size: 4,
+                },
+                assume_kv_reuse: true,
+            },
+        )
+        .expect("normalize prompt")
 }
 
 async fn response_json(response: Response) -> serde_json::Value {
@@ -131,9 +153,7 @@ fn prompt_normalization_uses_mm_routing_info_and_eagle_hashing() {
         is_eagle: Some(true),
     };
 
-    let normalized = request
-        .normalize_for_selection(4, false)
-        .expect("normalize prompt");
+    let normalized = normalize_prompt(&request);
     let expected_block_hashes = compute_block_hash_for_seq(
         &[10, 11, 12, 13, 14, 15, 16, 17],
         4,
@@ -164,15 +184,93 @@ fn prompt_request_cache_salt_changes_normalized_hashes() {
     }))
     .expect("deserialize unsalted prompt");
 
-    let salted = salted
-        .normalize_for_selection(4, false)
-        .expect("normalize salted prompt");
-    let unsalted = unsalted
-        .normalize_for_selection(4, false)
-        .expect("normalize unsalted prompt");
+    let salted = normalize_prompt(&salted);
+    let unsalted = normalize_prompt(&unsalted);
 
     assert_ne!(salted.block_hashes, unsalted.block_hashes);
     assert_ne!(salted.sequence_hashes, unsalted.sequence_hashes);
+}
+
+#[test]
+fn keyed_prompt_tracking_leaves_indexer_hashes_public() {
+    let mut key_file = NamedTempFile::new().unwrap();
+    key_file.write_all(&[0x35; 32]).unwrap();
+    let config = crate::config::KvRouterConfig {
+        router_tracking_hash: crate::TrackingHashAlgorithm::KeyedXxh3V1,
+        router_tracking_key_file: Some(key_file.path().to_path_buf()),
+        router_tracking_key_id: Some("2026-01".to_string()),
+        ..test_config()
+    };
+    let context = TrackingHashContext::from_config(&config).unwrap();
+    let request: PromptRequest = serde_json::from_value(serde_json::json!({
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+        "cache_salt": "tenant-a"
+    }))
+    .unwrap();
+
+    let normalized = request
+        .normalize_for_selection(
+            false,
+            TrackingHashInput {
+                context: &context,
+                scope: TrackingHashScope {
+                    model_name: "model",
+                    routing_group: "default",
+                    block_size: 4,
+                },
+                assume_kv_reuse: true,
+            },
+        )
+        .unwrap();
+    let public_blocks = compute_block_hash_for_seq(
+        &[1, 2, 3, 4, 5, 6, 7, 8],
+        4,
+        BlockHashOptions {
+            cache_namespace: Some("tenant-a"),
+            ..Default::default()
+        },
+    );
+
+    assert_eq!(normalized.block_hashes, public_blocks);
+    assert_ne!(
+        normalized.sequence_hashes,
+        compute_seq_hash_for_block(&public_blocks)
+    );
+}
+
+#[test]
+fn disabled_kv_reuse_keeps_public_indexer_hashes_and_randomizes_tracking() {
+    let config = test_config();
+    let context = TrackingHashContext::from_config(&config).unwrap();
+    let request: PromptRequest = serde_json::from_value(serde_json::json!({
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8]
+    }))
+    .unwrap();
+    let normalize = || {
+        request
+            .normalize_for_selection(
+                false,
+                TrackingHashInput {
+                    context: &context,
+                    scope: TrackingHashScope {
+                        model_name: "model",
+                        routing_group: "default",
+                        block_size: 4,
+                    },
+                    assume_kv_reuse: false,
+                },
+            )
+            .unwrap()
+    };
+
+    let first = normalize();
+    let second = normalize();
+    let public_blocks =
+        compute_block_hash_for_seq(&[1, 2, 3, 4, 5, 6, 7, 8], 4, BlockHashOptions::default());
+
+    assert_eq!(first.block_hashes, public_blocks);
+    assert_eq!(second.block_hashes, public_blocks);
+    assert_ne!(first.sequence_hashes, second.sequence_hashes);
 }
 
 #[test]

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -318,6 +318,61 @@ fn keyed_reservation_hashes_directly_from_tokens() {
 }
 
 #[test]
+fn keyed_hash_only_inputs_remain_trusted_for_selection_and_reservation() {
+    let mut key_file = NamedTempFile::new().unwrap();
+    key_file.write_all(&[0x59; 32]).unwrap();
+    let config = crate::config::KvRouterConfig {
+        router_tracking_hash: crate::TrackingHashAlgorithm::KeyedXxh3V1,
+        router_tracking_key_file: Some(key_file.path().to_path_buf()),
+        router_tracking_key_id: Some("2026-01".to_string()),
+        ..test_config()
+    };
+    let context = TrackingHashContext::from_config(&config).unwrap();
+    let request: PromptRequest = serde_json::from_value(serde_json::json!({
+        "block_hashes": [11, 29],
+        "sequence_hashes": [-1, 7],
+        "isl_tokens": 8
+    }))
+    .unwrap();
+    let scope = TrackingHashScope {
+        partition: RoutingPartitionRef::new("model", "default"),
+        block_size: 4,
+    };
+
+    let selection = request
+        .normalize_for_selection(
+            false,
+            TrackingHashInput {
+                context: &context,
+                scope,
+                assume_kv_reuse: true,
+            },
+        )
+        .unwrap();
+    let reservation = request
+        .normalize_for_reservation(
+            false,
+            TrackingHashInput {
+                context: &context,
+                scope,
+                assume_kv_reuse: true,
+            },
+        )
+        .unwrap();
+
+    assert_eq!(
+        selection.block_hashes,
+        vec![
+            crate::protocols::LocalBlockHash(11),
+            crate::protocols::LocalBlockHash(29)
+        ]
+    );
+    assert_eq!(selection.sequence_hashes, vec![u64::MAX, 7]);
+    assert_eq!(reservation.sequence_hashes, vec![u64::MAX, 7]);
+    assert_eq!(reservation.isl_tokens, 8);
+}
+
+#[test]
 fn randomized_reservation_uses_canonical_complete_block_count() {
     let config = test_config();
     let context = TrackingHashContext::from_config(&config).unwrap();

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -274,6 +274,92 @@ fn disabled_kv_reuse_keeps_public_indexer_hashes_and_randomizes_tracking() {
 }
 
 #[test]
+fn keyed_reservation_hashes_directly_from_tokens() {
+    let mut key_file = NamedTempFile::new().unwrap();
+    key_file.write_all(&[0x47; 32]).unwrap();
+    let config = crate::config::KvRouterConfig {
+        router_tracking_hash: crate::TrackingHashAlgorithm::KeyedXxh3V1,
+        router_tracking_key_file: Some(key_file.path().to_path_buf()),
+        router_tracking_key_id: Some("2026-01".to_string()),
+        ..test_config()
+    };
+    let context = TrackingHashContext::from_config(&config).unwrap();
+    let request: PromptRequest = serde_json::from_value(serde_json::json!({
+        "token_ids": [1, 2, 3, 4, 5, 6, 7, 8],
+        "cache_salt": "tenant-a"
+    }))
+    .unwrap();
+    let scope = TrackingHashScope {
+        model_name: "model",
+        routing_group: "default",
+        block_size: 4,
+    };
+
+    let normalized = request
+        .normalize_for_reservation(
+            false,
+            TrackingHashInput {
+                context: &context,
+                scope,
+                assume_kv_reuse: true,
+            },
+        )
+        .unwrap();
+    let expected = context.compute_sequence_hashes_for_tracking(
+        scope,
+        &[1, 2, 3, 4, 5, 6, 7, 8],
+        BlockHashOptions {
+            cache_namespace: Some("tenant-a"),
+            ..Default::default()
+        },
+        true,
+        None,
+    );
+
+    assert_eq!(normalized.sequence_hashes, expected);
+    assert_eq!(normalized.isl_tokens, 8);
+}
+
+#[test]
+fn randomized_reservation_uses_canonical_complete_block_count() {
+    let config = test_config();
+    let context = TrackingHashContext::from_config(&config).unwrap();
+    let cases = [
+        (Vec::new(), false, 0),
+        (vec![1, 2, 3], false, 0),
+        (vec![1, 2, 3, 4], false, 1),
+        (vec![1, 2, 3, 4], true, 0),
+        (vec![1, 2, 3, 4, 5], true, 1),
+        (vec![1, 2, 3, 4, 5, 6, 7, 8], true, 1),
+        (vec![1, 2, 3, 4, 5, 6, 7, 8, 9], true, 2),
+    ];
+
+    for (token_ids, is_eagle, expected_blocks) in cases {
+        let request: PromptRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": token_ids,
+            "is_eagle": is_eagle
+        }))
+        .unwrap();
+        let normalized = request
+            .normalize_for_reservation(
+                false,
+                TrackingHashInput {
+                    context: &context,
+                    scope: TrackingHashScope {
+                        model_name: "model",
+                        routing_group: "default",
+                        block_size: 4,
+                    },
+                    assume_kv_reuse: false,
+                },
+            )
+            .unwrap();
+
+        assert_eq!(normalized.sequence_hashes.len(), expected_blocks);
+    }
+}
+
+#[test]
 fn overlap_scores_response_honors_override_and_includes_python_shape_fields() {
     let worker = WorkerWithDpRank::new(1, 0);
     let idle_worker = WorkerWithDpRank::new(2, 0);

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -14,11 +14,11 @@ use crate::scheduling::config::RouterConfigOverride;
 pub use crate::scheduling::{OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore};
 use crate::services::indexer::registry::IndexerKey;
 use crate::services::overlap::MooncakeOverlapSummary;
+use crate::tracking_hash::DEFAULT_TRACKING_ROUTING_GROUP;
 
 use super::input::PromptRequest;
 
 const DEFAULT_MODEL_NAME: &str = "default";
-const DEFAULT_ROUTING_GROUP: &str = "default";
 pub(super) const WORKER_TYPE: &str = "select";
 pub(super) const REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
@@ -27,7 +27,7 @@ fn default_model_name() -> String {
 }
 
 fn default_routing_group() -> String {
-    DEFAULT_ROUTING_GROUP.to_string()
+    DEFAULT_TRACKING_ROUTING_GROUP.to_string()
 }
 
 #[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -2,19 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
+use crate::identity::{RoutingPartitionId, default_routing_group};
 use crate::protocols::{
     DpRank, KvTransferEnforcement, RoutingConstraints, WorkerConfigLike, WorkerId, WorkerWithDpRank,
 };
 use crate::scheduling::PotentialLoad;
 use crate::scheduling::config::RouterConfigOverride;
 pub use crate::scheduling::{OverlapScoresResponse, SharedCacheOverlapScore, WorkerOverlapScore};
-use crate::services::indexer::registry::IndexerKey;
 use crate::services::overlap::MooncakeOverlapSummary;
-use crate::tracking_hash::DEFAULT_TRACKING_ROUTING_GROUP;
 
 use super::input::PromptRequest;
 
@@ -24,42 +22,6 @@ pub(super) const REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 
 fn default_model_name() -> String {
     DEFAULT_MODEL_NAME.to_string()
-}
-
-fn default_routing_group() -> String {
-    DEFAULT_TRACKING_ROUTING_GROUP.to_string()
-}
-
-#[derive(Debug, Clone, Hash, PartialEq, Eq, Serialize)]
-pub struct SelectionKey {
-    pub model_name: String,
-    pub routing_group: String,
-}
-
-impl SelectionKey {
-    pub(super) fn new(model_name: impl Into<String>, routing_group: impl Into<String>) -> Self {
-        Self {
-            model_name: model_name.into(),
-            routing_group: routing_group.into(),
-        }
-    }
-
-    pub(super) fn indexer_key(&self) -> IndexerKey {
-        IndexerKey {
-            model_name: self.model_name.clone(),
-            routing_group: self.routing_group.clone(),
-        }
-    }
-}
-
-impl fmt::Display for SelectionKey {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "model={} routing_group={}",
-            self.model_name, self.routing_group
-        )
-    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
@@ -187,8 +149,8 @@ impl WorkerCatalogRecord {
         }
     }
 
-    pub(super) fn key(&self) -> SelectionKey {
-        SelectionKey::new(self.model_name.clone(), self.routing_group.clone())
+    pub(super) fn key(&self) -> RoutingPartitionId {
+        RoutingPartitionId::new(self.model_name.clone(), self.routing_group.clone())
     }
 
     pub(super) fn dp_start(&self) -> u32 {

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -12,6 +12,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+use crate::identity::RoutingPartitionId;
 use crate::protocols::{PrefillLoadHint, WorkerId, WorkerWithDpRank};
 use crate::scheduling::PotentialLoad;
 use crate::sequences::topology::{WorkerDpRange, WorkerTopologyError};
@@ -23,25 +24,6 @@ use crate::sequences::{
 use crate::services::common::replica_sync::{
     ReplicaSyncConfig, ScopedReplicaEvent, ScopedSequencePublisher, setup_scoped_replica_sync,
 };
-
-fn default_routing_group() -> String {
-    "default".to_string()
-}
-
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-pub struct TrackerKey {
-    pub model_name: String,
-    pub routing_group: String,
-}
-
-impl TrackerKey {
-    pub fn new(model_name: String, routing_group: Option<String>) -> Self {
-        Self {
-            model_name,
-            routing_group: routing_group.unwrap_or_else(default_routing_group),
-        }
-    }
-}
 
 #[derive(Debug, Clone, Serialize, PartialEq, Eq)]
 pub struct WorkerInfo {
@@ -117,18 +99,13 @@ struct TrackerEntry {
 
 impl TrackerEntry {
     fn new(
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         block_size: u32,
         root_cancel_token: &CancellationToken,
         replica_config: Option<&ReplicaSyncConfig>,
     ) -> Arc<Self> {
         let cancel_token = root_cancel_token.child_token();
-        let scoped_replica_sync = setup_scoped_replica_sync(
-            replica_config,
-            &key.model_name,
-            &key.routing_group,
-            block_size,
-        );
+        let scoped_replica_sync = setup_scoped_replica_sync(replica_config, key, block_size);
         let tracker = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
             scoped_replica_sync.publisher,
             block_size as usize,
@@ -154,7 +131,7 @@ impl TrackerEntry {
 }
 
 pub struct SlotTrackerRegistry {
-    trackers: DashMap<TrackerKey, Arc<TrackerEntry>>,
+    trackers: DashMap<RoutingPartitionId, Arc<TrackerEntry>>,
     root_cancel_token: CancellationToken,
     replica_config: Option<ReplicaSyncConfig>,
 }
@@ -181,7 +158,7 @@ impl SlotTrackerRegistry {
 
     pub fn register(
         &self,
-        key: TrackerKey,
+        key: RoutingPartitionId,
         worker_id: WorkerId,
         block_size: u32,
         dp_start: u32,
@@ -227,7 +204,11 @@ impl SlotTrackerRegistry {
         }
     }
 
-    pub fn unregister(&self, key: &TrackerKey, worker_id: WorkerId) -> Result<(), RegistryError> {
+    pub fn unregister(
+        &self,
+        key: &RoutingPartitionId,
+        worker_id: WorkerId,
+    ) -> Result<(), RegistryError> {
         loop {
             let Some(entry) = self
                 .trackers
@@ -296,7 +277,7 @@ impl SlotTrackerRegistry {
 
     pub fn add_request(
         &self,
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         request_id: String,
         worker: WorkerWithDpRank,
         sequence_hashes: Vec<SequenceHash>,
@@ -324,7 +305,7 @@ impl SlotTrackerRegistry {
 
     pub fn mark_prefill_completed(
         &self,
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         request_id: &str,
     ) -> Result<(), ServiceError> {
         let entry = self.entry(key)?;
@@ -334,7 +315,7 @@ impl SlotTrackerRegistry {
         Ok(())
     }
 
-    pub fn free(&self, key: &TrackerKey, request_id: &str) -> Result<(), ServiceError> {
+    pub fn free(&self, key: &RoutingPartitionId, request_id: &str) -> Result<(), ServiceError> {
         let entry = self.entry(key)?;
         entry
             .tracker
@@ -383,7 +364,7 @@ impl SlotTrackerRegistry {
 
     pub fn potential_loads(
         &self,
-        key: &TrackerKey,
+        key: &RoutingPartitionId,
         sequence_hashes: &[SequenceHash],
         new_isl_tokens: usize,
     ) -> Result<Vec<PotentialLoad>, RegistryError> {
@@ -407,15 +388,15 @@ impl SlotTrackerRegistry {
     }
 
     pub(crate) fn dispatch_replica_event(&self, envelope: ScopedReplicaEvent) {
+        let (key, block_size, event) = envelope.into_parts();
         if self
             .replica_config
             .as_ref()
-            .is_some_and(|config| config.is_self_event(&envelope.event))
+            .is_some_and(|config| config.is_self_event(&event))
         {
             return;
         }
 
-        let key = TrackerKey::new(envelope.model_name, Some(envelope.routing_group));
         let Some(entry) = self
             .trackers
             .get(&key)
@@ -428,12 +409,12 @@ impl SlotTrackerRegistry {
             );
             return;
         };
-        if entry.block_size != envelope.block_size {
+        if entry.block_size != block_size {
             tracing::debug!(
                 model_name = %key.model_name,
                 routing_group = %key.routing_group,
                 expected_block_size = entry.block_size,
-                received_block_size = envelope.block_size,
+                received_block_size = block_size,
                 "Dropping replica event with mismatched block size"
             );
             return;
@@ -441,7 +422,7 @@ impl SlotTrackerRegistry {
         let Some(replica_tx) = &entry.replica_tx else {
             return;
         };
-        match replica_tx.try_send(envelope.event) {
+        match replica_tx.try_send(event) {
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Full(event)) => {
                 tracing::trace!(
@@ -461,7 +442,7 @@ impl SlotTrackerRegistry {
         }
     }
 
-    fn entry(&self, key: &TrackerKey) -> Result<Arc<TrackerEntry>, RegistryError> {
+    fn entry(&self, key: &RoutingPartitionId) -> Result<Arc<TrackerEntry>, RegistryError> {
         self.trackers
             .get(key)
             .map(|entry| Arc::clone(entry.value()))
@@ -471,7 +452,7 @@ impl SlotTrackerRegistry {
             })
     }
 
-    fn is_attached(&self, key: &TrackerKey, entry: &Arc<TrackerEntry>) -> bool {
+    fn is_attached(&self, key: &RoutingPartitionId, entry: &Arc<TrackerEntry>) -> bool {
         self.trackers
             .get(key)
             .is_some_and(|current| Arc::ptr_eq(current.value(), entry))
@@ -494,7 +475,7 @@ fn validate_block_size(block_size: u32) -> Result<(), RegistryError> {
     Ok(())
 }
 
-fn topology_error(key: &TrackerKey, error: WorkerTopologyError) -> RegistryError {
+fn topology_error(key: &RoutingPartitionId, error: WorkerTopologyError) -> RegistryError {
     match error {
         WorkerTopologyError::InvalidDpSize { .. } => RegistryError::InvalidDpSize,
         WorkerTopologyError::InvalidDpRange {
@@ -514,7 +495,7 @@ fn topology_error(key: &TrackerKey, error: WorkerTopologyError) -> RegistryError
 }
 
 fn matches_filters(
-    key: &TrackerKey,
+    key: &RoutingPartitionId,
     model_name: Option<&str>,
     routing_group: Option<&str>,
 ) -> bool {
@@ -531,8 +512,8 @@ mod tests {
         SlotTrackerRegistry::new(CancellationToken::new())
     }
 
-    fn key(routing_group: &str) -> TrackerKey {
-        TrackerKey::new("model".to_string(), Some(routing_group.to_string()))
+    fn key(routing_group: &str) -> RoutingPartitionId {
+        RoutingPartitionId::new("model", routing_group)
     }
 
     fn replica_event(

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -14,19 +14,16 @@ use dynamo_tokens::SequenceHash;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
+use crate::identity::{RoutingPartitionId, default_routing_group};
 use crate::protocols::WorkerWithDpRank;
 use crate::sequences::SequenceError;
 use crate::services::common::replica_sync::PeerManager;
 use crate::services::common::replica_sync_http;
 
-use super::registry::{RegistryError, ServiceError, SlotTrackerRegistry, TrackerKey};
+use super::registry::{RegistryError, ServiceError, SlotTrackerRegistry};
 
 pub struct AppState {
     pub registry: Arc<SlotTrackerRegistry>,
-}
-
-fn default_routing_group() -> String {
-    "default".to_string()
 }
 
 #[derive(Deserialize)]
@@ -123,7 +120,7 @@ async fn register(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.register(
         key,
         req.worker_id,
@@ -144,7 +141,7 @@ async fn unregister(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.unregister(&key, req.worker_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => registry_error(error),
@@ -170,7 +167,7 @@ async fn add(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
 
     // Lifecycle delivery is intentionally arrival-ordered. Consumers should
     // normally await /add before sending /prefill_complete or /free.
@@ -194,7 +191,7 @@ async fn prefill_complete(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.mark_prefill_completed(&key, &req.request_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => service_error(error),
@@ -209,7 +206,7 @@ async fn free(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state.registry.free(&key, &req.request_id) {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => service_error(error),
@@ -235,7 +232,7 @@ async fn potential_loads(
         Ok(payload) => payload,
         Err(error) => return json_rejection(error),
     };
-    let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let key = RoutingPartitionId::new(req.model_name, req.routing_group);
     match state
         .registry
         .potential_loads(&key, &req.sequence_hashes, req.new_isl_tokens)

--- a/lib/kv-router/src/tracking_hash.rs
+++ b/lib/kv-router/src/tracking_hash.rs
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
 
 use crate::config::KvRouterConfig;
+use crate::identity::RoutingPartitionRef;
 use crate::protocols::{
     BlockHashOptions, LocalBlockHash, complete_block_count, compute_block_hash_for_seq,
     compute_block_hash_for_seq_with_seed, compute_seq_hash_for_block,
@@ -21,9 +22,6 @@ use crate::protocols::{
 
 const KEY_SIZE: usize = 32;
 const KEYED_XXH3_V1_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/keyed-xxh3-v1\0";
-
-/// Default routing group used when a router request does not specify one.
-pub const DEFAULT_TRACKING_ROUTING_GROUP: &str = "default";
 
 /// Hash algorithm used only for router-derived active-sequence tracking state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -84,8 +82,7 @@ pub(crate) fn validate_tracking_hash_options(
 /// same derived tracking identities.
 #[derive(Clone, Copy, Debug)]
 pub struct TrackingHashScope<'a> {
-    pub model_name: &'a str,
-    pub routing_group: &'a str,
+    pub partition: RoutingPartitionRef<'a>,
     pub block_size: u32,
 }
 
@@ -240,8 +237,8 @@ impl TrackingHashContext {
         let mut hasher = blake3::Hasher::new_keyed(key);
         hasher.update(KEYED_XXH3_V1_DOMAIN);
         frame_string(&mut hasher, 1, self.key_id.as_deref().unwrap_or_default());
-        frame_string(&mut hasher, 2, scope.model_name);
-        frame_string(&mut hasher, 3, scope.routing_group);
+        frame_string(&mut hasher, 2, scope.partition.model_name);
+        frame_string(&mut hasher, 3, scope.partition.routing_group);
         frame_fixed(&mut hasher, 4, &scope.block_size.to_le_bytes());
         frame_optional_string(&mut hasher, 5, normalize_optional(options.cache_namespace));
         frame_optional_string(&mut hasher, 6, normalize_optional(options.lora_name));
@@ -305,8 +302,7 @@ mod tests {
 
     fn scope<'a>(model_name: &'a str, routing_group: &'a str) -> TrackingHashScope<'a> {
         TrackingHashScope {
-            model_name,
-            routing_group,
+            partition: RoutingPartitionRef::new(model_name, routing_group),
             block_size: 4,
         }
     }
@@ -395,8 +391,7 @@ mod tests {
             base,
             first.compute_sequence_hashes(
                 TrackingHashScope {
-                    model_name: "model-a",
-                    routing_group: "group-a",
+                    partition: RoutingPartitionRef::new("model-a", "group-a"),
                     block_size: 3,
                 },
                 &tokens,

--- a/lib/kv-router/src/tracking_hash.rs
+++ b/lib/kv-router/src/tracking_hash.rs
@@ -7,7 +7,7 @@ use std::fmt;
 use std::fs;
 use std::str::FromStr;
 
-use anyhow::{Context, Result, anyhow, bail};
+use anyhow::{Context, Result, bail};
 use dynamo_tokens::SequenceHash;
 use serde::{Deserialize, Serialize};
 use zeroize::Zeroizing;
@@ -59,6 +59,27 @@ impl FromStr for TrackingHashAlgorithm {
     }
 }
 
+pub(crate) fn validate_tracking_hash_options(
+    algorithm: TrackingHashAlgorithm,
+    has_key_file: bool,
+    key_id: Option<&str>,
+) -> std::result::Result<(), String> {
+    match algorithm {
+        TrackingHashAlgorithm::PublicXxh3V1 if has_key_file || key_id.is_some() => Err(
+            "router tracking key options require router_tracking_hash=keyed-xxh3-v1".to_string(),
+        ),
+        TrackingHashAlgorithm::KeyedXxh3V1 if !has_key_file => {
+            Err("keyed-xxh3-v1 requires router_tracking_key_file".to_string())
+        }
+        TrackingHashAlgorithm::KeyedXxh3V1
+            if !key_id.is_some_and(|value| !value.is_empty() && value.trim() == value) =>
+        {
+            Err("keyed-xxh3-v1 requires a nonempty router_tracking_key_id".to_string())
+        }
+        _ => Ok(()),
+    }
+}
+
 /// Stable, trusted scope shared by router instances that should produce the
 /// same derived tracking identities.
 #[derive(Clone, Copy, Debug)]
@@ -93,31 +114,28 @@ impl fmt::Debug for TrackingHashContext {
 impl TrackingHashContext {
     /// Load and validate the runtime context from router configuration.
     pub fn from_config(config: &KvRouterConfig) -> Result<Self> {
+        validate_tracking_hash_options(
+            config.router_tracking_hash,
+            config.router_tracking_key_file.is_some(),
+            config.router_tracking_key_id.as_deref(),
+        )
+        .map_err(anyhow::Error::msg)?;
+
         match config.router_tracking_hash {
-            TrackingHashAlgorithm::PublicXxh3V1 => {
-                if config.router_tracking_key_file.is_some()
-                    || config.router_tracking_key_id.is_some()
-                {
-                    bail!("router tracking key options require router_tracking_hash=keyed-xxh3-v1");
-                }
-                Ok(Self {
-                    algorithm: TrackingHashAlgorithm::PublicXxh3V1,
-                    key_id: None,
-                    provider_key: None,
-                })
-            }
+            TrackingHashAlgorithm::PublicXxh3V1 => Ok(Self {
+                algorithm: TrackingHashAlgorithm::PublicXxh3V1,
+                key_id: None,
+                provider_key: None,
+            }),
             TrackingHashAlgorithm::KeyedXxh3V1 => {
                 let key_id = config
                     .router_tracking_key_id
                     .as_deref()
-                    .filter(|value| !value.is_empty() && value.trim() == *value)
-                    .ok_or_else(|| {
-                        anyhow!("keyed-xxh3-v1 requires a nonempty router_tracking_key_id")
-                    })?;
+                    .expect("validated keyed tracking config must have a key ID");
                 let key_path = config
                     .router_tracking_key_file
                     .as_ref()
-                    .ok_or_else(|| anyhow!("keyed-xxh3-v1 requires router_tracking_key_file"))?;
+                    .expect("validated keyed tracking config must have a key file");
                 let key_bytes = Zeroizing::new(
                     fs::read(key_path).context("failed to read router tracking key file")?,
                 );
@@ -553,19 +571,42 @@ mod tests {
 
     #[test]
     fn config_validation_enforces_mode_specific_options() {
+        let assert_rejected_by_both = |config: &KvRouterConfig, expected: &str| {
+            assert_eq!(config.validate_config().unwrap_err(), expected);
+            assert_eq!(
+                TrackingHashContext::from_config(config)
+                    .unwrap_err()
+                    .to_string(),
+                expected
+            );
+        };
+
         let public_with_key = KvRouterConfig {
             router_tracking_key_file: Some("key".into()),
             ..Default::default()
         };
-        assert!(public_with_key.validate_config().is_err());
+        assert_rejected_by_both(
+            &public_with_key,
+            "router tracking key options require router_tracking_hash=keyed-xxh3-v1",
+        );
 
         let keyed_without_options = KvRouterConfig {
             router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
             ..Default::default()
         };
-        assert!(keyed_without_options.validate_config().is_err());
+        assert_rejected_by_both(
+            &keyed_without_options,
+            "keyed-xxh3-v1 requires router_tracking_key_file",
+        );
+
+        let (_key_file, keyed_with_whitespace_id) = keyed_config(" 2026-01", &[1; KEY_SIZE]);
+        assert_rejected_by_both(
+            &keyed_with_whitespace_id,
+            "keyed-xxh3-v1 requires a nonempty router_tracking_key_id",
+        );
 
         let (_key_file, keyed) = keyed_config("2026-01", &[1; KEY_SIZE]);
         assert!(keyed.validate_config().is_ok());
+        assert!(TrackingHashContext::from_config(&keyed).is_ok());
     }
 }

--- a/lib/kv-router/src/tracking_hash.rs
+++ b/lib/kv-router/src/tracking_hash.rs
@@ -10,16 +10,20 @@ use std::str::FromStr;
 use anyhow::{Context, Result, anyhow, bail};
 use dynamo_tokens::SequenceHash;
 use serde::{Deserialize, Serialize};
+use zeroize::Zeroizing;
 
 use crate::config::KvRouterConfig;
 use crate::protocols::{
-    BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq,
+    BlockHashOptions, LocalBlockHash, complete_block_count, compute_block_hash_for_seq,
     compute_block_hash_for_seq_with_seed, compute_seq_hash_for_block,
     compute_seq_hash_for_block_with_seed,
 };
 
 const KEY_SIZE: usize = 32;
 const KEYED_XXH3_V1_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/keyed-xxh3-v1\0";
+
+/// Default routing group used when a router request does not specify one.
+pub const DEFAULT_TRACKING_ROUTING_GROUP: &str = "default";
 
 /// Hash algorithm used only for router-derived active-sequence tracking state.
 #[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
@@ -30,9 +34,6 @@ pub enum TrackingHashAlgorithm {
     PublicXxh3V1,
     /// Provider-keyed scope derivation with XXH3 block and chain hashing.
     KeyedXxh3V1,
-    /// Invalid value captured from an environment variable so startup validation can fail.
-    #[serde(skip)]
-    Invalid,
 }
 
 impl fmt::Display for TrackingHashAlgorithm {
@@ -40,7 +41,6 @@ impl fmt::Display for TrackingHashAlgorithm {
         formatter.write_str(match self {
             Self::PublicXxh3V1 => "public-xxh3-v1",
             Self::KeyedXxh3V1 => "keyed-xxh3-v1",
-            Self::Invalid => "invalid",
         })
     }
 }
@@ -73,7 +73,7 @@ pub struct TrackingHashScope<'a> {
 pub struct TrackingHashContext {
     algorithm: TrackingHashAlgorithm,
     key_id: Option<Box<str>>,
-    provider_key: Option<[u8; KEY_SIZE]>,
+    provider_key: Option<Zeroizing<[u8; KEY_SIZE]>>,
 }
 
 impl fmt::Debug for TrackingHashContext {
@@ -118,26 +118,22 @@ impl TrackingHashContext {
                     .router_tracking_key_file
                     .as_ref()
                     .ok_or_else(|| anyhow!("keyed-xxh3-v1 requires router_tracking_key_file"))?;
-                let key_bytes = fs::read(key_path).with_context(|| {
-                    format!(
-                        "failed to read router tracking key file {}",
-                        key_path.display()
-                    )
-                })?;
+                let key_bytes = Zeroizing::new(
+                    fs::read(key_path).context("failed to read router tracking key file")?,
+                );
                 let actual_size = key_bytes.len();
-                let provider_key: [u8; KEY_SIZE] = key_bytes.try_into().map_err(|_| {
-                    anyhow!(
+                if actual_size != KEY_SIZE {
+                    bail!(
                         "router tracking key file must contain exactly {KEY_SIZE} raw bytes; found {actual_size}"
-                    )
-                })?;
+                    );
+                }
+                let mut provider_key = Zeroizing::new([0_u8; KEY_SIZE]);
+                provider_key.copy_from_slice(&key_bytes);
                 Ok(Self {
                     algorithm: TrackingHashAlgorithm::KeyedXxh3V1,
                     key_id: Some(key_id.into()),
                     provider_key: Some(provider_key),
                 })
-            }
-            TrackingHashAlgorithm::Invalid => {
-                bail!("router_tracking_hash is invalid")
             }
         }
     }
@@ -146,10 +142,15 @@ impl TrackingHashContext {
         self.algorithm
     }
 
+    /// Return the provider-managed key epoch without exposing secret material.
+    pub fn key_id(&self) -> Option<&str> {
+        self.key_id.as_deref()
+    }
+
     /// Compute sequence identities for active tracking. Public mode may reuse
     /// already-computed public block hashes; keyed mode must hash canonical
     /// block bytes under its derived block seed.
-    pub fn compute_sequence_hashes(
+    pub(crate) fn compute_sequence_hashes(
         &self,
         scope: TrackingHashScope<'_>,
         tokens: &[u32],
@@ -178,9 +179,34 @@ impl TrackingHashContext {
                 );
                 compute_seq_hash_for_block_with_seed(&block_hashes, chain_seed)
             }
-            TrackingHashAlgorithm::Invalid => {
-                unreachable!("invalid tracking hash algorithms cannot construct a context")
-            }
+        }
+    }
+
+    /// Compute active-tracking identities using the configured reuse policy.
+    ///
+    /// Callers that start from raw tokens should use this method rather than
+    /// choosing between keyed/public and random identities themselves.
+    pub fn compute_sequence_hashes_for_tracking(
+        &self,
+        scope: TrackingHashScope<'_>,
+        tokens: &[u32],
+        options: BlockHashOptions<'_>,
+        assume_kv_reuse: bool,
+        precomputed_public_block_hashes: Option<&[LocalBlockHash]>,
+    ) -> Vec<SequenceHash> {
+        let num_blocks = complete_block_count(
+            tokens.len(),
+            scope.block_size,
+            options.is_eagle.unwrap_or(false),
+        );
+        if num_blocks == 0 {
+            return Vec::new();
+        }
+
+        if assume_kv_reuse {
+            self.compute_sequence_hashes(scope, tokens, options, precomputed_public_block_hashes)
+        } else {
+            (0..num_blocks).map(|_| fastrand::u64(..)).collect()
         }
     }
 
@@ -242,6 +268,7 @@ mod tests {
     use std::io::Write;
 
     use tempfile::NamedTempFile;
+    use zeroize::Zeroize;
 
     use super::*;
     use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo};
@@ -482,7 +509,11 @@ mod tests {
             router_tracking_key_id: Some("2026-01".to_string()),
             ..Default::default()
         };
-        assert!(TrackingHashContext::from_config(&missing_config).is_err());
+        let missing_error = TrackingHashContext::from_config(&missing_config)
+            .unwrap_err()
+            .to_string();
+        assert!(missing_error.contains("failed to read router tracking key file"));
+        assert!(!missing_error.contains("/definitely/missing/tracking-key"));
 
         let unreadable_dir = tempfile::tempdir().unwrap();
         let unreadable_config = KvRouterConfig {
@@ -491,12 +522,11 @@ mod tests {
             router_tracking_key_id: Some("2026-01".to_string()),
             ..Default::default()
         };
-        assert!(
-            TrackingHashContext::from_config(&unreadable_config)
-                .unwrap_err()
-                .to_string()
-                .contains("failed to read router tracking key file")
-        );
+        let unreadable_error = TrackingHashContext::from_config(&unreadable_config)
+            .unwrap_err()
+            .to_string();
+        assert!(unreadable_error.contains("failed to read router tracking key file"));
+        assert!(!unreadable_error.contains(&unreadable_dir.path().display().to_string()));
 
         let (_key_file, valid_config) = keyed_config("2026-01", &[0xab; KEY_SIZE]);
         let debug = format!(
@@ -505,6 +535,20 @@ mod tests {
         );
         assert!(debug.contains("[REDACTED]"));
         assert!(!debug.contains("171"));
+    }
+
+    #[test]
+    fn retained_key_is_zeroizable_and_only_epoch_is_exposed() {
+        let (_key_file, config) = keyed_config("2026-01", &[0xab; KEY_SIZE]);
+        let mut context = TrackingHashContext::from_config(&config).unwrap();
+
+        assert_eq!(context.key_id(), Some("2026-01"));
+        let provider_key = context.provider_key.as_mut().unwrap();
+        provider_key.zeroize();
+        assert_eq!(provider_key.as_ref(), &[0_u8; KEY_SIZE]);
+
+        let public = TrackingHashContext::from_config(&KvRouterConfig::default()).unwrap();
+        assert_eq!(public.key_id(), None);
     }
 
     #[test]

--- a/lib/kv-router/src/tracking_hash.rs
+++ b/lib/kv-router/src/tracking_hash.rs
@@ -16,8 +16,7 @@ use crate::config::KvRouterConfig;
 use crate::identity::RoutingPartitionRef;
 use crate::protocols::{
     BlockHashOptions, LocalBlockHash, complete_block_count, compute_block_hash_for_seq,
-    compute_block_hash_for_seq_with_seed, compute_seq_hash_for_block,
-    compute_seq_hash_for_block_with_seed,
+    compute_seq_hash_for_block, compute_seq_hash_for_tokens_with_seeds,
 };
 
 const KEY_SIZE: usize = 32;
@@ -80,6 +79,10 @@ pub(crate) fn validate_tracking_hash_options(
 
 /// Stable, trusted scope shared by router instances that should produce the
 /// same derived tracking identities.
+///
+/// TODO(#11971): Evaluate deriving the static tracking-domain identity from
+/// `IndexerDomainId`. `PoolId` and `DcId` represent placement and must remain
+/// excluded from tracking identity.
 #[derive(Clone, Copy, Debug)]
 pub struct TrackingHashScope<'a> {
     pub partition: RoutingPartitionRef<'a>,
@@ -186,13 +189,13 @@ impl TrackingHashContext {
             }
             TrackingHashAlgorithm::KeyedXxh3V1 => {
                 let (block_seed, chain_seed) = self.derive_seeds(scope, options);
-                let block_hashes = compute_block_hash_for_seq_with_seed(
+                compute_seq_hash_for_tokens_with_seeds(
                     tokens,
                     scope.block_size,
                     options,
                     block_seed,
-                );
-                compute_seq_hash_for_block_with_seed(&block_hashes, chain_seed)
+                    chain_seed,
+                )
             }
         }
     }

--- a/lib/kv-router/src/tracking_hash.rs
+++ b/lib/kv-router/src/tracking_hash.rs
@@ -1,0 +1,527 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Router-owned hashing for derived active-sequence tracking state.
+
+use std::fmt;
+use std::fs;
+use std::str::FromStr;
+
+use anyhow::{Context, Result, anyhow, bail};
+use dynamo_tokens::SequenceHash;
+use serde::{Deserialize, Serialize};
+
+use crate::config::KvRouterConfig;
+use crate::protocols::{
+    BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq,
+    compute_block_hash_for_seq_with_seed, compute_seq_hash_for_block,
+    compute_seq_hash_for_block_with_seed,
+};
+
+const KEY_SIZE: usize = 32;
+const KEYED_XXH3_V1_DOMAIN: &[u8] = b"dynamo.router.tracking-hash/keyed-xxh3-v1\0";
+
+/// Hash algorithm used only for router-derived active-sequence tracking state.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum TrackingHashAlgorithm {
+    /// Existing public XXH3 block and sequence hash construction.
+    #[default]
+    PublicXxh3V1,
+    /// Provider-keyed scope derivation with XXH3 block and chain hashing.
+    KeyedXxh3V1,
+    /// Invalid value captured from an environment variable so startup validation can fail.
+    #[serde(skip)]
+    Invalid,
+}
+
+impl fmt::Display for TrackingHashAlgorithm {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::PublicXxh3V1 => "public-xxh3-v1",
+            Self::KeyedXxh3V1 => "keyed-xxh3-v1",
+            Self::Invalid => "invalid",
+        })
+    }
+}
+
+impl FromStr for TrackingHashAlgorithm {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "public-xxh3-v1" => Ok(Self::PublicXxh3V1),
+            "keyed-xxh3-v1" => Ok(Self::KeyedXxh3V1),
+            _ => Err(format!(
+                "router_tracking_hash must be public-xxh3-v1 or keyed-xxh3-v1, got {value:?}"
+            )),
+        }
+    }
+}
+
+/// Stable, trusted scope shared by router instances that should produce the
+/// same derived tracking identities.
+#[derive(Clone, Copy, Debug)]
+pub struct TrackingHashScope<'a> {
+    pub model_name: &'a str,
+    pub routing_group: &'a str,
+    pub block_size: u32,
+}
+
+/// Runtime tracking-hash state. Secret bytes are intentionally excluded from
+/// serialization and debug output.
+pub struct TrackingHashContext {
+    algorithm: TrackingHashAlgorithm,
+    key_id: Option<Box<str>>,
+    provider_key: Option<[u8; KEY_SIZE]>,
+}
+
+impl fmt::Debug for TrackingHashContext {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("TrackingHashContext")
+            .field("algorithm", &self.algorithm)
+            .field("key_id", &self.key_id)
+            .field(
+                "provider_key",
+                &self.provider_key.as_ref().map(|_| "[REDACTED]"),
+            )
+            .finish()
+    }
+}
+
+impl TrackingHashContext {
+    /// Load and validate the runtime context from router configuration.
+    pub fn from_config(config: &KvRouterConfig) -> Result<Self> {
+        match config.router_tracking_hash {
+            TrackingHashAlgorithm::PublicXxh3V1 => {
+                if config.router_tracking_key_file.is_some()
+                    || config.router_tracking_key_id.is_some()
+                {
+                    bail!("router tracking key options require router_tracking_hash=keyed-xxh3-v1");
+                }
+                Ok(Self {
+                    algorithm: TrackingHashAlgorithm::PublicXxh3V1,
+                    key_id: None,
+                    provider_key: None,
+                })
+            }
+            TrackingHashAlgorithm::KeyedXxh3V1 => {
+                let key_id = config
+                    .router_tracking_key_id
+                    .as_deref()
+                    .filter(|value| !value.is_empty() && value.trim() == *value)
+                    .ok_or_else(|| {
+                        anyhow!("keyed-xxh3-v1 requires a nonempty router_tracking_key_id")
+                    })?;
+                let key_path = config
+                    .router_tracking_key_file
+                    .as_ref()
+                    .ok_or_else(|| anyhow!("keyed-xxh3-v1 requires router_tracking_key_file"))?;
+                let key_bytes = fs::read(key_path).with_context(|| {
+                    format!(
+                        "failed to read router tracking key file {}",
+                        key_path.display()
+                    )
+                })?;
+                let actual_size = key_bytes.len();
+                let provider_key: [u8; KEY_SIZE] = key_bytes.try_into().map_err(|_| {
+                    anyhow!(
+                        "router tracking key file must contain exactly {KEY_SIZE} raw bytes; found {actual_size}"
+                    )
+                })?;
+                Ok(Self {
+                    algorithm: TrackingHashAlgorithm::KeyedXxh3V1,
+                    key_id: Some(key_id.into()),
+                    provider_key: Some(provider_key),
+                })
+            }
+            TrackingHashAlgorithm::Invalid => {
+                bail!("router_tracking_hash is invalid")
+            }
+        }
+    }
+
+    pub fn algorithm(&self) -> TrackingHashAlgorithm {
+        self.algorithm
+    }
+
+    /// Compute sequence identities for active tracking. Public mode may reuse
+    /// already-computed public block hashes; keyed mode must hash canonical
+    /// block bytes under its derived block seed.
+    pub fn compute_sequence_hashes(
+        &self,
+        scope: TrackingHashScope<'_>,
+        tokens: &[u32],
+        options: BlockHashOptions<'_>,
+        precomputed_public_block_hashes: Option<&[LocalBlockHash]>,
+    ) -> Vec<SequenceHash> {
+        match self.algorithm {
+            TrackingHashAlgorithm::PublicXxh3V1 => {
+                if let Some(block_hashes) = precomputed_public_block_hashes {
+                    compute_seq_hash_for_block(block_hashes)
+                } else {
+                    compute_seq_hash_for_block(&compute_block_hash_for_seq(
+                        tokens,
+                        scope.block_size,
+                        options,
+                    ))
+                }
+            }
+            TrackingHashAlgorithm::KeyedXxh3V1 => {
+                let (block_seed, chain_seed) = self.derive_seeds(scope, options);
+                let block_hashes = compute_block_hash_for_seq_with_seed(
+                    tokens,
+                    scope.block_size,
+                    options,
+                    block_seed,
+                );
+                compute_seq_hash_for_block_with_seed(&block_hashes, chain_seed)
+            }
+            TrackingHashAlgorithm::Invalid => {
+                unreachable!("invalid tracking hash algorithms cannot construct a context")
+            }
+        }
+    }
+
+    fn derive_seeds(
+        &self,
+        scope: TrackingHashScope<'_>,
+        options: BlockHashOptions<'_>,
+    ) -> (u64, u64) {
+        let key = self
+            .provider_key
+            .as_ref()
+            .expect("keyed tracking hash context must contain a provider key");
+        let mut hasher = blake3::Hasher::new_keyed(key);
+        hasher.update(KEYED_XXH3_V1_DOMAIN);
+        frame_string(&mut hasher, 1, self.key_id.as_deref().unwrap_or_default());
+        frame_string(&mut hasher, 2, scope.model_name);
+        frame_string(&mut hasher, 3, scope.routing_group);
+        frame_fixed(&mut hasher, 4, &scope.block_size.to_le_bytes());
+        frame_optional_string(&mut hasher, 5, normalize_optional(options.cache_namespace));
+        frame_optional_string(&mut hasher, 6, normalize_optional(options.lora_name));
+        frame_fixed(
+            &mut hasher,
+            7,
+            &[u8::from(options.is_eagle.unwrap_or(false))],
+        );
+
+        let digest = hasher.finalize();
+        let bytes = digest.as_bytes();
+        let block_seed = u64::from_le_bytes(bytes[..8].try_into().unwrap());
+        let chain_seed = u64::from_le_bytes(bytes[8..16].try_into().unwrap());
+        (block_seed, chain_seed)
+    }
+}
+
+fn normalize_optional(value: Option<&str>) -> Option<&str> {
+    value.filter(|value| !value.is_empty())
+}
+
+fn frame_string(hasher: &mut blake3::Hasher, tag: u8, value: &str) {
+    frame_fixed(hasher, tag, value.as_bytes());
+}
+
+fn frame_optional_string(hasher: &mut blake3::Hasher, tag: u8, value: Option<&str>) {
+    hasher.update(&[tag, u8::from(value.is_some())]);
+    if let Some(value) = value {
+        hasher.update(&(value.len() as u64).to_le_bytes());
+        hasher.update(value.as_bytes());
+    }
+}
+
+fn frame_fixed(hasher: &mut blake3::Hasher, tag: u8, value: &[u8]) {
+    hasher.update(&[tag]);
+    hasher.update(&(value.len() as u64).to_le_bytes());
+    hasher.update(value);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use tempfile::NamedTempFile;
+
+    use super::*;
+    use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo};
+
+    fn keyed_config(key_id: &str, key_bytes: &[u8]) -> (NamedTempFile, KvRouterConfig) {
+        let mut key_file = NamedTempFile::new().unwrap();
+        key_file.write_all(key_bytes).unwrap();
+        let config = KvRouterConfig {
+            router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+            router_tracking_key_file: Some(key_file.path().to_path_buf()),
+            router_tracking_key_id: Some(key_id.to_string()),
+            ..Default::default()
+        };
+        (key_file, config)
+    }
+
+    fn scope<'a>(model_name: &'a str, routing_group: &'a str) -> TrackingHashScope<'a> {
+        TrackingHashScope {
+            model_name,
+            routing_group,
+            block_size: 4,
+        }
+    }
+
+    #[test]
+    fn public_mode_is_bit_compatible() {
+        let context = TrackingHashContext::from_config(&KvRouterConfig::default()).unwrap();
+        let tokens: Vec<u32> = (0..8).collect();
+        let options = BlockHashOptions {
+            cache_namespace: Some("tenant-a"),
+            lora_name: Some("adapter-a"),
+            ..Default::default()
+        };
+        let public_blocks = compute_block_hash_for_seq(&tokens, 4, options);
+
+        assert_eq!(
+            context.compute_sequence_hashes(
+                scope("model", "default"),
+                &tokens,
+                options,
+                Some(&public_blocks),
+            ),
+            compute_seq_hash_for_block(&public_blocks)
+        );
+    }
+
+    #[test]
+    fn keyed_hash_vector_pins_scope_and_chain_framing() {
+        let (_key_file, config) = keyed_config("2026-01", &[0x5a; KEY_SIZE]);
+        let context = TrackingHashContext::from_config(&config).unwrap();
+        let tokens: Vec<u32> = (0..12).collect();
+
+        let hashes = context.compute_sequence_hashes(
+            scope("model-a", "tenant-a"),
+            &tokens,
+            BlockHashOptions {
+                cache_namespace: Some("cache-a"),
+                lora_name: Some("adapter-a"),
+                ..Default::default()
+            },
+            None,
+        );
+
+        assert_eq!(
+            hashes,
+            vec![
+                4_363_769_719_052_127_296,
+                14_998_523_962_162_619_427,
+                13_920_914_207_884_994_756,
+            ]
+        );
+    }
+
+    #[test]
+    fn keyed_contexts_are_stable_and_scope_sensitive() {
+        let (_key_file, config) = keyed_config("2026-01", &[0x23; KEY_SIZE]);
+        let first = TrackingHashContext::from_config(&config).unwrap();
+        let second = TrackingHashContext::from_config(&config).unwrap();
+        let (_next_key_file, next_config) = keyed_config("2026-02", &[0x23; KEY_SIZE]);
+        let next_epoch = TrackingHashContext::from_config(&next_config).unwrap();
+        let tokens: Vec<u32> = (0..12).collect();
+        let base_options = BlockHashOptions::default();
+        let base =
+            first.compute_sequence_hashes(scope("model-a", "group-a"), &tokens, base_options, None);
+
+        assert_eq!(
+            base,
+            second.compute_sequence_hashes(
+                scope("model-a", "group-a"),
+                &tokens,
+                base_options,
+                None,
+            )
+        );
+        assert_ne!(
+            base,
+            first
+                .compute_sequence_hashes(scope("model-b", "group-a"), &tokens, base_options, None,)
+        );
+        assert_ne!(
+            base,
+            first
+                .compute_sequence_hashes(scope("model-a", "group-b"), &tokens, base_options, None,)
+        );
+        assert_ne!(
+            base,
+            first.compute_sequence_hashes(
+                TrackingHashScope {
+                    model_name: "model-a",
+                    routing_group: "group-a",
+                    block_size: 3,
+                },
+                &tokens,
+                base_options,
+                None,
+            )
+        );
+        assert_ne!(
+            base,
+            next_epoch.compute_sequence_hashes(
+                scope("model-a", "group-a"),
+                &tokens,
+                base_options,
+                None,
+            )
+        );
+        assert_ne!(
+            base,
+            first.compute_sequence_hashes(
+                scope("model-a", "group-a"),
+                &tokens,
+                BlockHashOptions {
+                    cache_namespace: Some("cache-a"),
+                    ..Default::default()
+                },
+                None,
+            )
+        );
+        assert_ne!(
+            base,
+            first.compute_sequence_hashes(
+                scope("model-a", "group-a"),
+                &tokens,
+                BlockHashOptions {
+                    lora_name: Some("adapter-a"),
+                    ..Default::default()
+                },
+                None,
+            )
+        );
+        assert_ne!(
+            base,
+            first.compute_sequence_hashes(
+                scope("model-a", "group-a"),
+                &tokens,
+                BlockHashOptions {
+                    is_eagle: Some(true),
+                    ..Default::default()
+                },
+                None,
+            )
+        );
+    }
+
+    #[test]
+    fn keyed_vectors_pin_multimodal_eagle_and_partial_block_rules() {
+        let (_key_file, config) = keyed_config("2026-01", &[0x41; KEY_SIZE]);
+        let context = TrackingHashContext::from_config(&config).unwrap();
+        let tokens: Vec<u32> = (0..10).collect();
+        let mm_infos = vec![
+            Some(BlockExtraInfo {
+                mm_objects: vec![BlockMmObjectInfo {
+                    mm_hash: 42,
+                    offsets: vec![(0, 2)],
+                }],
+            }),
+            None,
+        ];
+
+        let without_mm = context.compute_sequence_hashes(
+            scope("model", "default"),
+            &tokens,
+            BlockHashOptions::default(),
+            None,
+        );
+        let with_mm = context.compute_sequence_hashes(
+            scope("model", "default"),
+            &tokens,
+            BlockHashOptions {
+                block_mm_infos: Some(&mm_infos),
+                ..Default::default()
+            },
+            None,
+        );
+        let with_eagle = context.compute_sequence_hashes(
+            scope("model", "default"),
+            &tokens,
+            BlockHashOptions {
+                is_eagle: Some(true),
+                ..Default::default()
+            },
+            None,
+        );
+
+        assert_eq!(without_mm.len(), 2);
+        assert_eq!(
+            with_mm,
+            vec![13_077_030_603_177_067_515, 12_131_634_976_806_651_614]
+        );
+        assert_eq!(
+            with_eagle,
+            vec![18_351_479_723_295_049_348, 8_577_555_336_206_814_019]
+        );
+        assert_ne!(without_mm, with_mm);
+    }
+
+    #[test]
+    fn key_loading_rejects_missing_and_malformed_files_without_exposing_bytes() {
+        let (_short_file, short_config) = keyed_config("2026-01", &[7; KEY_SIZE - 1]);
+        assert!(
+            TrackingHashContext::from_config(&short_config)
+                .unwrap_err()
+                .to_string()
+                .contains("exactly 32 raw bytes")
+        );
+
+        let (_long_file, long_config) = keyed_config("2026-01", &[8; KEY_SIZE + 1]);
+        assert!(
+            TrackingHashContext::from_config(&long_config)
+                .unwrap_err()
+                .to_string()
+                .contains("exactly 32 raw bytes")
+        );
+
+        let missing_config = KvRouterConfig {
+            router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+            router_tracking_key_file: Some("/definitely/missing/tracking-key".into()),
+            router_tracking_key_id: Some("2026-01".to_string()),
+            ..Default::default()
+        };
+        assert!(TrackingHashContext::from_config(&missing_config).is_err());
+
+        let unreadable_dir = tempfile::tempdir().unwrap();
+        let unreadable_config = KvRouterConfig {
+            router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+            router_tracking_key_file: Some(unreadable_dir.path().to_path_buf()),
+            router_tracking_key_id: Some("2026-01".to_string()),
+            ..Default::default()
+        };
+        assert!(
+            TrackingHashContext::from_config(&unreadable_config)
+                .unwrap_err()
+                .to_string()
+                .contains("failed to read router tracking key file")
+        );
+
+        let (_key_file, valid_config) = keyed_config("2026-01", &[0xab; KEY_SIZE]);
+        let debug = format!(
+            "{:?}",
+            TrackingHashContext::from_config(&valid_config).unwrap()
+        );
+        assert!(debug.contains("[REDACTED]"));
+        assert!(!debug.contains("171"));
+    }
+
+    #[test]
+    fn config_validation_enforces_mode_specific_options() {
+        let public_with_key = KvRouterConfig {
+            router_tracking_key_file: Some("key".into()),
+            ..Default::default()
+        };
+        assert!(public_with_key.validate_config().is_err());
+
+        let keyed_without_options = KvRouterConfig {
+            router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+            ..Default::default()
+        };
+        assert!(keyed_without_options.validate_config().is_err());
+
+        let (_key_file, keyed) = keyed_config("2026-01", &[1; KEY_SIZE]);
+        assert!(keyed.validate_config().is_ok());
+    }
+}

--- a/lib/kv-router/tests/standalone_indexer_http.rs
+++ b/lib/kv-router/tests/standalone_indexer_http.rs
@@ -15,12 +15,13 @@
 use std::sync::Arc;
 use std::time::Duration;
 
+use dynamo_kv_router::RoutingPartitionId;
 use dynamo_kv_router::protocols::{
     BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
     KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, compute_block_hash_for_seq,
     compute_seq_hash_for_block,
 };
-use dynamo_kv_router::services::indexer::registry::{IndexerKey, WorkerRegistry};
+use dynamo_kv_router::services::indexer::registry::WorkerRegistry;
 use dynamo_kv_router::services::indexer::server::{AppState, create_router};
 use dynamo_kv_router::zmq_wire::{BlockHashValue, RawKvEvent};
 use serde_json::json;
@@ -127,22 +128,14 @@ async fn add_group_events(
     block_size: u32,
     events: Vec<RouterEvent>,
 ) {
-    let indexer = registry.get_or_create_indexer(
-        IndexerKey {
-            model_name: model.to_string(),
-            routing_group: routing_group.to_string(),
-        },
-        block_size,
-    );
+    let indexer =
+        registry.get_or_create_indexer(RoutingPartitionId::new(model, routing_group), block_size);
     for event in events {
         indexer.apply_event_routed(event).await;
     }
     // Force the in-flight events through KvIndexer's mpsc channel before the
     // first query lands; otherwise the test races the indexer worker.
-    if let Some(entry) = registry.get_indexer(&IndexerKey {
-        model_name: model.to_string(),
-        routing_group: routing_group.to_string(),
-    }) {
+    if let Some(entry) = registry.get_indexer(&RoutingPartitionId::new(model, routing_group)) {
         let dump = entry.indexer.dump_events().await.expect("dump events");
         // dump_events provides the FIFO barrier we need; we don't care about
         // its contents here.
@@ -492,10 +485,7 @@ async fn duplicate_store_warning_is_exported() {
     let state = Arc::new(AppState::new(4).expect("create app state"));
     state.registry.signal_ready();
 
-    let key = IndexerKey {
-        model_name: MODEL.to_string(),
-        routing_group: ROUTING_GROUP.to_string(),
-    };
+    let key = RoutingPartitionId::new(MODEL, ROUTING_GROUP);
     let indexer = state
         .registry
         .get_or_create_indexer(key.clone(), BLOCK_SIZE);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -5,7 +5,8 @@ use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use dynamo_kv_router::{
-    KvSchedulerError, PrefillLoadEstimator, SharedKvCache, TrackingHashContext, TrackingHashScope,
+    DEFAULT_TRACKING_ROUTING_GROUP, KvSchedulerError, PrefillLoadEstimator, SharedKvCache,
+    TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
     indexer::{KvRouterError, RoutingDecisionHashes},
     protocols::KV_EVENT_SUBJECT,
@@ -223,6 +224,21 @@ where
     lora_filter: Option<Arc<crate::lora::LoraFilter>>,
 }
 
+fn resolve_tracking_model_name(
+    algorithm: TrackingHashAlgorithm,
+    model_name: Option<&str>,
+) -> Result<String> {
+    if algorithm == TrackingHashAlgorithm::KeyedXxh3V1 {
+        return model_name
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+            .ok_or_else(|| {
+                anyhow::anyhow!("model_name is required for keyed router tracking hashes")
+            });
+    }
+    Ok(model_name.unwrap_or_default().to_owned())
+}
+
 impl<Sel> KvRouter<Sel>
 where
     Sel: dynamo_kv_router::selector::WorkerSelector<ModelRuntimeConfig> + Send + Sync + 'static,
@@ -246,7 +262,8 @@ where
         let kv_router_config = kv_router_config.unwrap_or_default();
         kv_router_config.validate().map_err(anyhow::Error::msg)?;
         let tracking_hash = TrackingHashContext::from_config(&kv_router_config)?;
-        let tracking_model_name = model_name.clone().unwrap_or_default();
+        let tracking_model_name =
+            resolve_tracking_model_name(tracking_hash.algorithm(), model_name.as_deref())?;
         let component = endpoint.component();
         // Router-owned tasks derive from this token so a rebuild cannot cancel the runtime.
         let cancellation_token = component.drt().child_token();
@@ -398,7 +415,7 @@ where
     fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
         TrackingHashScope {
             model_name: &self.tracking_model_name,
-            routing_group: "default",
+            routing_group: DEFAULT_TRACKING_ROUTING_GROUP,
             block_size: self.block_size,
         }
     }
@@ -635,14 +652,15 @@ where
         let hash_elapsed = start.elapsed();
         // Compute seq_hashes only if scheduler needs it for active blocks tracking
         let maybe_seq_hashes = tracing::info_span!("kv_router.compute_seq_hashes").in_scope(|| {
-            self.kv_router_config.compute_seq_hashes_for_tracking(
-                &self.tracking_hash,
-                self.tracking_hash_scope(),
-                tokens,
-                router_config_override,
-                hash_options,
-                Some(&block_hashes),
-            )
+            self.kv_router_config
+                .compute_seq_hashes_for_tracking_with_context(
+                    &self.tracking_hash,
+                    self.tracking_hash_scope(),
+                    tokens,
+                    router_config_override,
+                    hash_options,
+                    Some(&block_hashes),
+                )
         });
         let seq_hash_elapsed = start.elapsed();
 
@@ -852,14 +870,16 @@ where
             is_eagle: Some(self.is_eagle),
         };
 
-        let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
-            &self.tracking_hash,
-            self.tracking_hash_scope(),
-            tokens,
-            router_config_override,
-            hash_options,
-            None,
-        );
+        let maybe_seq_hashes = self
+            .kv_router_config
+            .compute_seq_hashes_for_tracking_with_context(
+                &self.tracking_hash,
+                self.tracking_hash_scope(),
+                tokens,
+                router_config_override,
+                hash_options,
+                None,
+            );
         let track_prefill_tokens = self
             .kv_router_config
             .track_prefill_tokens(router_config_override);
@@ -1053,14 +1073,16 @@ where
         };
         let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, hash_options);
 
-        let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
-            &self.tracking_hash,
-            self.tracking_hash_scope(),
-            tokens,
-            router_config_override,
-            hash_options,
-            Some(&block_hashes),
-        );
+        let maybe_seq_hashes = self
+            .kv_router_config
+            .compute_seq_hashes_for_tracking_with_context(
+                &self.tracking_hash,
+                self.tracking_hash_scope(),
+                tokens,
+                router_config_override,
+                hash_options,
+                Some(&block_hashes),
+            );
         let track_prefill_tokens = self
             .kv_router_config
             .track_prefill_tokens(router_config_override);
@@ -1298,6 +1320,29 @@ mod tests {
 
     use crate::kv_router::scheduler::KvSchedulerError;
     use crate::local_model::runtime_config::ModelRuntimeConfig;
+
+    #[test]
+    fn keyed_tracking_requires_nonempty_model_name() {
+        assert!(resolve_tracking_model_name(TrackingHashAlgorithm::KeyedXxh3V1, None).is_err());
+        assert!(resolve_tracking_model_name(TrackingHashAlgorithm::KeyedXxh3V1, Some("")).is_err());
+        assert_eq!(
+            resolve_tracking_model_name(TrackingHashAlgorithm::KeyedXxh3V1, Some("model-a"))
+                .unwrap(),
+            "model-a"
+        );
+    }
+
+    #[test]
+    fn public_tracking_preserves_optional_model_name() {
+        assert_eq!(
+            resolve_tracking_model_name(TrackingHashAlgorithm::PublicXxh3V1, None).unwrap(),
+            ""
+        );
+        assert_eq!(
+            resolve_tracking_model_name(TrackingHashAlgorithm::PublicXxh3V1, Some("")).unwrap(),
+            ""
+        );
+    }
 
     #[test]
     fn weighted_cache_hit_estimates_include_lower_tiers() {

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -5,7 +5,7 @@ use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use dynamo_kv_router::{
-    KvSchedulerError, PrefillLoadEstimator, SharedKvCache,
+    KvSchedulerError, PrefillLoadEstimator, SharedKvCache, TrackingHashContext, TrackingHashScope,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
     indexer::{KvRouterError, RoutingDecisionHashes},
     protocols::KV_EVENT_SUBJECT,
@@ -211,6 +211,8 @@ where
     client: Client,
     is_eagle: bool,
     kv_event_subscription: Option<indexer::KvEventSubscriptionHandle>,
+    tracking_hash: TrackingHashContext,
+    tracking_model_name: String,
     _served_indexer_handle: Option<ServedIndexerHandle>,
     /// Optional external shared KV cache pool. When present, `find_best_match`
     /// queries it in parallel with the indexer and factors shared hits into scoring.
@@ -243,6 +245,8 @@ where
     ) -> Result<Self> {
         let kv_router_config = kv_router_config.unwrap_or_default();
         kv_router_config.validate().map_err(anyhow::Error::msg)?;
+        let tracking_hash = TrackingHashContext::from_config(&kv_router_config)?;
+        let tracking_model_name = model_name.clone().unwrap_or_default();
         let component = endpoint.component();
         // Router-owned tasks derive from this token so a rebuild cannot cancel the runtime.
         let cancellation_token = component.drt().child_token();
@@ -358,6 +362,8 @@ where
             client,
             is_eagle,
             kv_event_subscription,
+            tracking_hash,
+            tracking_model_name,
             _served_indexer_handle: served_indexer_handle,
             shared_cache,
             lora_filter,
@@ -387,6 +393,14 @@ where
 
     pub fn is_eagle(&self) -> bool {
         self.is_eagle
+    }
+
+    fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
+        TrackingHashScope {
+            model_name: &self.tracking_model_name,
+            routing_group: "default",
+            block_size: self.block_size,
+        }
     }
 
     fn cache_hit_estimates_from_tiered_matches(
@@ -622,8 +636,9 @@ where
         // Compute seq_hashes only if scheduler needs it for active blocks tracking
         let maybe_seq_hashes = tracing::info_span!("kv_router.compute_seq_hashes").in_scope(|| {
             self.kv_router_config.compute_seq_hashes_for_tracking(
+                &self.tracking_hash,
+                self.tracking_hash_scope(),
                 tokens,
-                self.block_size,
                 router_config_override,
                 hash_options,
                 Some(&block_hashes),
@@ -838,8 +853,9 @@ where
         };
 
         let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
+            &self.tracking_hash,
+            self.tracking_hash_scope(),
             tokens,
-            self.block_size,
             router_config_override,
             hash_options,
             None,
@@ -1038,8 +1054,9 @@ where
         let block_hashes = compute_block_hash_for_seq(tokens, self.block_size, hash_options);
 
         let maybe_seq_hashes = self.kv_router_config.compute_seq_hashes_for_tracking(
+            &self.tracking_hash,
+            self.tracking_hash_scope(),
             tokens,
-            self.block_size,
             router_config_override,
             hash_options,
             Some(&block_hashes),

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -5,8 +5,8 @@ use std::{collections::HashSet, sync::Arc, time::Instant};
 
 use anyhow::Result;
 use dynamo_kv_router::{
-    DEFAULT_TRACKING_ROUTING_GROUP, KvSchedulerError, PrefillLoadEstimator, SharedKvCache,
-    TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+    DEFAULT_ROUTING_GROUP, KvSchedulerError, PrefillLoadEstimator, RoutingPartitionRef,
+    SharedKvCache, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
     config::{KvRouterConfig, RouterConfigOverride, min_initial_workers_from_env},
     indexer::{KvRouterError, RoutingDecisionHashes},
     protocols::KV_EVENT_SUBJECT,
@@ -414,8 +414,7 @@ where
 
     fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
         TrackingHashScope {
-            model_name: &self.tracking_model_name,
-            routing_group: DEFAULT_TRACKING_ROUTING_GROUP,
+            partition: RoutingPartitionRef::new(&self.tracking_model_name, DEFAULT_ROUTING_GROUP),
             block_size: self.block_size,
         }
     }

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -23,8 +23,8 @@ use dynamo_kv_router::scheduling::{
 use dynamo_kv_router::sequences::topology::WorkerDpRange;
 use dynamo_kv_router::{
     ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, SchedulingRequest,
-    SequenceRequest, TrackingHashContext, TrackingHashScope, WorkerLoadProjection, WorkerSelector,
-    scheduling::TierOverlapBlocks,
+    SequenceRequest, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
+    WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
 };
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
@@ -646,7 +646,9 @@ impl OfflineReplayRouter {
                     .find_matches_for_hashes(replay_hashes.local_block_hashes);
                 let token_seq = if !self.config.router_track_active_blocks {
                     None
-                } else if self.config.router_assume_kv_reuse {
+                } else if self.config.router_assume_kv_reuse
+                    && self.tracking_hash.algorithm() == TrackingHashAlgorithm::PublicXxh3V1
+                {
                     Some(replay_hashes.sequence_hashes)
                 } else {
                     self.config.compute_seq_hashes_for_tracking_with_context(
@@ -857,16 +859,19 @@ impl OfflineReplayRouter {
 
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
     use std::sync::Arc;
     use std::time::Duration;
 
-    use dynamo_kv_router::PrefillLoadEstimator;
     use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel, RouterQueuePolicy};
     use dynamo_kv_router::protocols::{
-        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerId,
+        BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData,
+        KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier,
+        WorkerId,
     };
+    use dynamo_kv_router::{PrefillLoadEstimator, TrackingHashAlgorithm};
     use rustc_hash::FxHashMap;
+    use tempfile::NamedTempFile;
     use uuid::Uuid;
 
     use super::{OfflineReplayRouter, ReplayRequestHashes, SyncReplayIndexer, WorkerAdmission};
@@ -996,6 +1001,36 @@ mod tests {
         let scheduling_request = pending.scheduling_request(64, FxHashMap::default());
 
         assert_eq!(scheduling_request.session_id.as_deref(), Some("session-a"));
+    }
+
+    #[test]
+    fn keyed_replay_hashes_derive_tracking_identities_from_tokens() {
+        let mut key_file = NamedTempFile::new().unwrap();
+        key_file.write_all(&[0x39; 32]).unwrap();
+        let config = KvRouterConfig {
+            router_tracking_hash: TrackingHashAlgorithm::KeyedXxh3V1,
+            router_tracking_key_file: Some(key_file.path().to_path_buf()),
+            router_tracking_key_id: Some("2026-01".to_string()),
+            ..Default::default()
+        };
+        let router = OfflineReplayRouter::new(&replay_args(), Some(config), None, 1).unwrap();
+        let request = request(1, 7);
+        let replay_hashes = ReplayRequestHashes::from_tokens(&request.tokens, router.block_size);
+        let expected = router.config.compute_seq_hashes_for_tracking_with_context(
+            &router.tracking_hash,
+            router.tracking_hash_scope(),
+            &request.tokens,
+            None,
+            BlockHashOptions::default(),
+            None,
+        );
+
+        let pending = router
+            .build_pending_request(&request, Some(replay_hashes.clone()), None)
+            .unwrap();
+
+        assert_eq!(pending.token_seq, expected);
+        assert_ne!(pending.token_seq, Some(replay_hashes.sequence_hashes));
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -649,7 +649,7 @@ impl OfflineReplayRouter {
                 } else if self.config.router_assume_kv_reuse {
                     Some(replay_hashes.sequence_hashes)
                 } else {
-                    self.config.compute_seq_hashes_for_tracking(
+                    self.config.compute_seq_hashes_for_tracking_with_context(
                         &self.tracking_hash,
                         self.tracking_hash_scope(),
                         &request.tokens,
@@ -662,7 +662,7 @@ impl OfflineReplayRouter {
             }
             None => {
                 let overlaps = self.indexer.find_matches_for_request(&request.tokens, None);
-                let token_seq = self.config.compute_seq_hashes_for_tracking(
+                let token_seq = self.config.compute_seq_hashes_for_tracking_with_context(
                     &self.tracking_hash,
                     self.tracking_hash_scope(),
                     &request.tokens,

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -22,9 +22,9 @@ use dynamo_kv_router::scheduling::{
 };
 use dynamo_kv_router::sequences::topology::WorkerDpRange;
 use dynamo_kv_router::{
-    ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, SchedulingRequest,
-    SequenceRequest, TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope,
-    WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
+    ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, RoutingPartitionRef,
+    SchedulingRequest, SequenceRequest, TrackingHashAlgorithm, TrackingHashContext,
+    TrackingHashScope, WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
 };
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
@@ -695,8 +695,7 @@ impl OfflineReplayRouter {
 
     fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
         TrackingHashScope {
-            model_name: "replay",
-            routing_group: "default",
+            partition: RoutingPartitionRef::new("replay", "default"),
             block_size: self.block_size,
         }
     }

--- a/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
+++ b/lib/mocker/src/replay/offline/extensions/kv_router/mod.rs
@@ -23,7 +23,8 @@ use dynamo_kv_router::scheduling::{
 use dynamo_kv_router::sequences::topology::WorkerDpRange;
 use dynamo_kv_router::{
     ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, SchedulingRequest,
-    SequenceRequest, WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
+    SequenceRequest, TrackingHashContext, TrackingHashScope, WorkerLoadProjection, WorkerSelector,
+    scheduling::TierOverlapBlocks,
 };
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
@@ -232,6 +233,7 @@ pub(crate) struct OfflineReplayRouter {
     indexer: SyncReplayIndexer,
     prefill_load_estimator: Option<ReplayPrefillLoadEstimator>,
     decay_time_epoch: Instant,
+    tracking_hash: TrackingHashContext,
 }
 
 pub(in crate::replay) struct KvRouterPlacement {
@@ -364,6 +366,7 @@ impl OfflineReplayRouter {
         num_workers: usize,
     ) -> Result<Self> {
         let config = replay_router_config(args, router_config);
+        let tracking_hash = TrackingHashContext::from_config(&config)?;
         let worker_config_template = replay_worker_config(args);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
         let slots = replay_slots(args, &workers_with_configs);
@@ -388,6 +391,7 @@ impl OfflineReplayRouter {
             // synthetic `Instant`s. All subsequent decay/accounting uses virtual replay
             // time derived from this epoch, not wall-clock progression.
             decay_time_epoch: Instant::now(),
+            tracking_hash,
         })
     }
 
@@ -646,8 +650,9 @@ impl OfflineReplayRouter {
                     Some(replay_hashes.sequence_hashes)
                 } else {
                     self.config.compute_seq_hashes_for_tracking(
+                        &self.tracking_hash,
+                        self.tracking_hash_scope(),
                         &request.tokens,
-                        self.block_size,
                         None,
                         BlockHashOptions::default(),
                         None,
@@ -658,8 +663,9 @@ impl OfflineReplayRouter {
             None => {
                 let overlaps = self.indexer.find_matches_for_request(&request.tokens, None);
                 let token_seq = self.config.compute_seq_hashes_for_tracking(
+                    &self.tracking_hash,
+                    self.tracking_hash_scope(),
                     &request.tokens,
-                    self.block_size,
                     None,
                     BlockHashOptions::default(),
                     None,
@@ -683,6 +689,14 @@ impl OfflineReplayRouter {
             policy_class: request.policy_class.clone(),
             session_id,
         })
+    }
+
+    fn tracking_hash_scope(&self) -> TrackingHashScope<'_> {
+        TrackingHashScope {
+            model_name: "replay",
+            routing_group: "default",
+            block_size: self.block_size,
+        }
     }
 
     fn admit_request(

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -6,7 +6,6 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result, anyhow};
-use dynamo_kv_router::ConcurrentRadixTree;
 use dynamo_kv_router::config::KvRouterConfig;
 use dynamo_kv_router::indexer::{
     KvIndexer, KvIndexerInterface, KvIndexerMetrics, ThreadPoolIndexer,
@@ -15,6 +14,7 @@ use dynamo_kv_router::protocols::{
     BlockHashOptions, OverlapScores, RouterEvent, RoutingConstraints, StorageTier, WorkerId,
 };
 use dynamo_kv_router::scheduling::TierOverlapBlocks;
+use dynamo_kv_router::{ConcurrentRadixTree, TrackingHashContext, TrackingHashScope};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -135,6 +135,7 @@ pub(crate) struct KvReplayRouter {
     event_tx: Mutex<Option<mpsc::UnboundedSender<RouterEvent>>>,
     event_task: Mutex<Option<tokio::task::JoinHandle<()>>>,
     indexer: ReplayIndexer,
+    tracking_hash: TrackingHashContext,
 }
 
 impl KvReplayRouter {
@@ -145,6 +146,7 @@ impl KvReplayRouter {
         num_workers: usize,
     ) -> Result<Self> {
         let config = replay_router_config(args, router_config);
+        let tracking_hash = TrackingHashContext::from_config(&config)?;
         let indexer =
             create_replay_indexer(args.block_size as u32, config.router_event_threads as usize);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
@@ -189,6 +191,7 @@ impl KvReplayRouter {
             event_tx: Mutex::new(Some(event_tx)),
             event_task: Mutex::new(Some(event_task)),
             indexer,
+            tracking_hash,
         })
     }
 
@@ -230,8 +233,13 @@ impl KvReplayRouter {
             })
             .collect();
         let token_seq = self.config.compute_seq_hashes_for_tracking(
+            &self.tracking_hash,
+            TrackingHashScope {
+                model_name: "replay",
+                routing_group: "default",
+                block_size: self.block_size,
+            },
             &request.tokens,
-            self.block_size,
             None,
             BlockHashOptions::default(),
             None,

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -14,7 +14,9 @@ use dynamo_kv_router::protocols::{
     BlockHashOptions, OverlapScores, RouterEvent, RoutingConstraints, StorageTier, WorkerId,
 };
 use dynamo_kv_router::scheduling::TierOverlapBlocks;
-use dynamo_kv_router::{ConcurrentRadixTree, TrackingHashContext, TrackingHashScope};
+use dynamo_kv_router::{
+    ConcurrentRadixTree, RoutingPartitionRef, TrackingHashContext, TrackingHashScope,
+};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
@@ -235,8 +237,7 @@ impl KvReplayRouter {
         let token_seq = self.config.compute_seq_hashes_for_tracking_with_context(
             &self.tracking_hash,
             TrackingHashScope {
-                model_name: "replay",
-                routing_group: "default",
+                partition: RoutingPartitionRef::new("replay", "default"),
                 block_size: self.block_size,
             },
             &request.tokens,

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -232,7 +232,7 @@ impl KvReplayRouter {
                 )
             })
             .collect();
-        let token_seq = self.config.compute_seq_hashes_for_tracking(
+        let token_seq = self.config.compute_seq_hashes_for_tracking_with_context(
             &self.tracking_hash,
             TrackingHashScope {
                 model_name: "replay",


### PR DESCRIPTION
## Summary

- add opt-in `keyed-xxh3-v1` identities for router-derived active tracking, backed by a zeroized 32-byte provider key and provider-managed key ID
- preserve public primary-indexer hashes, the legacy public Rust hashing API, precomputed-hash inputs, replica envelopes, slot-tracker APIs, KV events, standalone indexer APIs, and all existing wire formats
- make environment parsing fallible for startup callers, reject invalid keyed configuration before router initialization, and retain the non-fallible configuration helper as a compatibility wrapper with a clear panic
- require a nonempty model identity for keyed embedded routers, share the default routing-group constant across embedded and selection paths, and log only the algorithm and key ID when replica synchronization initializes
- avoid calculating discarded public block hashes for reservations and use one canonical normal/Eagle complete-block counter across deterministic and random tracking paths
- centralize raw-token tracking identity policy behind one public context method used by embedded, replay, lifecycle, and standalone-selection paths; keep the lower-level reusable-hash operation crate-private
- document the flags, environment variables, trusted-plane boundary, rotation procedure, and XXH3's non-PRF limitation

### Selection behavior change

Token-bearing standalone selection requests now honor `router_assume_kv_reuse=false` by using random tracking identities, matching the embedded router. Public block hashes still drive indexer lookups, so this changes active-load tracking behavior without changing indexer identity.

### Trust and rotation boundary

Precomputed sequence hashes remain trusted opaque inputs. Producers are responsible for using the deployment's configured tracking hash function and maintaining lineage uniqueness. Replica synchronization also transports opaque hashes: it logs the local algorithm and key ID at initialization but does not negotiate or carry epoch metadata.

Keyed tracking therefore assumes a trusted internal plane and identically configured hash producers. Seeded XXH3 is not a PRF or MAC. Rotation is a coordinated hard cut: change the key and key ID together, restart all producers, and flush or recreate derived tracker state. This PR does not add authentication, mixed-epoch detection, negotiation, dual reads, or live reload.

## Benchmarks

Criterion, 100 samples per arm:

| Complete blocks | Public XXH3 | Keyed XXH3 | Benchmark-only keyed BLAKE3 | Keyed XXH3 overhead |
| --- | ---: | ---: | ---: | ---: |
| 32 | 108.90 ns | 360.99 ns | 6.392 us | +252.09 ns (+231%) |
| 128 | 470.50 ns | 968.71 ns | 25.499 us | +498.21 ns (+106%) |

The keyed-XXH3 regression is sustained above 5%. It comes from the required keyed scope derivation plus a second canonical per-block hashing pass; public primary-indexer block hashes cannot be reused as keyed tracking hashes. Keyed XXH3 remains about 17.7x faster than the keyed-BLAKE3 block-and-chain comparison at 32 blocks and 26.3x faster at 128 blocks. The BLAKE3 arm is benchmark-only and is not exposed as a production algorithm.

## Validation

- rebased onto `origin/main` at `ee1d3b35f9`; `git range-diff` verified both PR commits were preserved after the final replay
- audited main's live-admission progress, active-request expiry, replica session-affinity, and DC CKF relay changes; live-admission reuses the centralized active-tracking identities, while CKF/KV-event identities intentionally remain public
- `cargo fmt --all -- --check`
- `git diff --check refs/remotes/origin/main..HEAD`
- `cargo test -p dynamo-kv-router --features standalone-selection,standalone-slot-tracker --lib` (913 passed, 2 ignored)
- `cargo test -p dynamo-llm --lib` (1,729 passed, 5 ignored)
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --features select-service,slot-tracker`
- `cargo check -p dynamo-kv-router --features standalone-selection,standalone-slot-tracker --benches`

## Follow-up

[DEP 11971](https://github.com/ai-dynamo/dynamo/issues/11971) is the existing draft architecture gate for this work. It records the precomputed-trust, replica-negotiation, threat-model, and `IndexerDomainId`/tracking-domain relationship concerns that require architectural review; this PR does not modify the DEP.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable router tracking hashes, including public and keyed modes.
  * Added support for provider-managed tracking keys and key identifiers through CLI, environment variables, and Python APIs.
  * Keyed tracking preserves public indexer hashes while providing scoped sequence identities.

* **Bug Fixes**
  * Invalid router tracking configuration now prevents startup with clear initialization errors.

* **Documentation**
  * Documented configuration, validation requirements, hash behavior, and key rotation procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
