### PR TITLE
feat(sglang): add cache-salt-aware routing

### DIFF
--- a/components/src/dynamo/sglang/llm_engine.py
+++ b/components/src/dynamo/sglang/llm_engine.py
@@ -78,6 +78,7 @@ from dynamo.sglang.capacity import (
 from dynamo.sglang.logits_processing import activate_logits_processors
 from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import format_zmq_endpoint
+from dynamo.sglang.request_utils import cache_salt_kwargs
 
 if TYPE_CHECKING:
     from dynamo._core.backend import EngineMetrics  # type: ignore[import-not-found]
@@ -1029,6 +1030,8 @@ class SglangLLMEngine(LLMEngine):
         request_input = self._input_param_manager.get_input_param(
             dict(request), use_tokenizer=self._use_sglang_tokenizer
         )
-        return {
+        input_param = {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
         }
+        input_param.update(cache_salt_kwargs(self.engine, request))
+        return input_param

--- a/components/src/dynamo/sglang/request_handlers/handler_base.py
+++ b/components/src/dynamo/sglang/request_handlers/handler_base.py
@@ -47,6 +47,7 @@ from dynamo.sglang._compat import start_profile_compat
 from dynamo.sglang.args import Config
 from dynamo.sglang.pause import SGLangEnginePauseController
 from dynamo.sglang.publisher import DynamoSglangPublisher
+from dynamo.sglang.request_utils import cache_salt_kwargs
 
 logger = logging.getLogger(__name__)
 
@@ -1013,9 +1014,11 @@ class BaseWorkerHandler(LoraMixin, RLMixin, BaseGenerativeHandler[RequestT, Resp
             request, use_tokenizer=self.use_sglang_tokenizer
         )
 
-        return {
+        input_param = {
             "prompt" if isinstance(request_input, str) else "input_ids": request_input
         }
+        input_param.update(cache_salt_kwargs(self.engine, request))
+        return input_param
 
     @staticmethod
     def _get_guided_decoding_params(

--- a/components/src/dynamo/sglang/request_utils.py
+++ b/components/src/dynamo/sglang/request_utils.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+from dynamo.sglang._compat import filter_supported_async_generate_kwargs
+
+
+def request_cache_salt(request: Mapping[str, Any]) -> Optional[str]:
+    """Return the first non-empty cache salt in routing-authoritative order."""
+    extra_args = request.get("extra_args")
+    sources = (
+        request.get("routing"),
+        request.get("nvext"),
+        extra_args.get("nvext") if isinstance(extra_args, Mapping) else None,
+    )
+    for source in sources:
+        if not isinstance(source, Mapping):
+            continue
+        cache_salt = source.get("cache_salt")
+        if cache_salt is None or cache_salt == "":
+            continue
+        if not isinstance(cache_salt, str):
+            raise ValueError("cache_salt must be a string")
+        return cache_salt
+    return None
+
+
+def cache_salt_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[str, str]:
+    """Build the required SGLang Engine kwarg for a cache-salted request."""
+    cache_salt = request_cache_salt(request)
+    if cache_salt is None:
+        return {}
+
+    kwargs = filter_supported_async_generate_kwargs(engine, {"cache_salt": cache_salt})
+    if "cache_salt" not in kwargs:
+        raise ValueError(
+            "cache_salt requires an SGLang version whose "
+            "Engine.async_generate accepts cache_salt"
+        )
+    return kwargs

--- a/components/src/dynamo/sglang/request_utils.py
+++ b/components/src/dynamo/sglang/request_utils.py
@@ -36,7 +36,7 @@ def cache_salt_kwargs(engine: Any, request: Mapping[str, Any]) -> dict[str, str]
     kwargs = filter_supported_async_generate_kwargs(engine, {"cache_salt": cache_salt})
     if "cache_salt" not in kwargs:
         raise ValueError(
-            "cache_salt requires an SGLang version whose "
-            "Engine.async_generate accepts cache_salt"
+            "cache_salt requires Engine.async_generate to accept cache_salt "
+            "and expose an inspectable signature"
         )
     return kwargs

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -39,7 +39,9 @@ from dynamo.sglang.health_check import (
     SglangDisaggHealthCheckPayload,
     SglangPrefillHealthCheckPayload,
 )
+from dynamo.sglang.request_handlers.handler_base import BaseWorkerHandler
 from dynamo.sglang.request_handlers.llm.decode_handler import DecodeWorkerHandler
+from dynamo.sglang.request_utils import cache_salt_kwargs, request_cache_salt
 from dynamo.sglang.tests.conftest import make_cli_args_fixture
 
 try:
@@ -66,6 +68,88 @@ pytestmark = [
 # Create SGLang-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_sglang_cli = make_cli_args_fixture("dynamo.sglang")
+
+
+def test_request_cache_salt_precedence_and_empty_fallback():
+    assert (
+        request_cache_salt(
+            {
+                "routing": {"cache_salt": "tenant-routing"},
+                "nvext": {"cache_salt": "tenant-top"},
+                "extra_args": {"nvext": {"cache_salt": "tenant-extra"}},
+            }
+        )
+        == "tenant-routing"
+    )
+    assert (
+        request_cache_salt(
+            {
+                "routing": {"cache_salt": ""},
+                "nvext": {"cache_salt": "tenant-top"},
+                "extra_args": {"nvext": {"cache_salt": "tenant-extra"}},
+            }
+        )
+        == "tenant-top"
+    )
+    assert (
+        request_cache_salt(
+            {
+                "routing": {"cache_salt": ""},
+                "nvext": {"cache_salt": ""},
+                "extra_args": {"nvext": {"cache_salt": "tenant-extra"}},
+            }
+        )
+        == "tenant-extra"
+    )
+    assert request_cache_salt({}) is None
+
+
+def test_cache_salt_kwargs_require_supported_engine():
+    class NewEngine:
+        async def async_generate(self, cache_salt=None):
+            pass
+
+    class OldEngine:
+        async def async_generate(self, input_ids=None):
+            pass
+
+    request = {"routing": {"cache_salt": "tenant-a"}}
+    assert cache_salt_kwargs(NewEngine(), request) == {"cache_salt": "tenant-a"}
+    with pytest.raises(ValueError, match="Engine.async_generate accepts cache_salt"):
+        cache_salt_kwargs(OldEngine(), request)
+    assert cache_salt_kwargs(OldEngine(), {}) == {}
+
+
+def test_cache_salt_forwarded_by_worker_and_unified_input_paths():
+    class NewEngine:
+        async def async_generate(self, cache_salt=None):
+            pass
+
+    class InputParamManager:
+        def get_input_param(self, request, use_tokenizer):
+            assert use_tokenizer is False
+            return request["token_ids"]
+
+    request = {
+        "token_ids": [1, 2, 3],
+        "routing": {"cache_salt": "tenant-a"},
+    }
+    worker = SimpleNamespace(
+        input_param_manager=InputParamManager(),
+        use_sglang_tokenizer=False,
+        engine=NewEngine(),
+    )
+    unified = SimpleNamespace(
+        _input_param_manager=InputParamManager(),
+        _use_sglang_tokenizer=False,
+        engine=NewEngine(),
+    )
+
+    expected = {"input_ids": [1, 2, 3], "cache_salt": "tenant-a"}
+    assert BaseWorkerHandler._get_input_param(worker, request) == expected
+    assert sglang_llm_engine.SglangLLMEngine._get_input_param(unified, request) == (
+        expected
+    )
 
 
 def _make_sglang_config(**overrides):

--- a/components/src/dynamo/sglang/tests/test_sglang_unit.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_unit.py
@@ -104,6 +104,19 @@ def test_request_cache_salt_precedence_and_empty_fallback():
     assert request_cache_salt({}) is None
 
 
+@pytest.mark.parametrize(
+    "request",
+    [
+        {"routing": {"cache_salt": 1}},
+        {"nvext": {"cache_salt": 1}},
+        {"extra_args": {"nvext": {"cache_salt": 1}}},
+    ],
+)
+def test_request_cache_salt_rejects_non_string_values(request):
+    with pytest.raises(ValueError, match="cache_salt must be a string"):
+        request_cache_salt(request)
+
+
 def test_cache_salt_kwargs_require_supported_engine():
     class NewEngine:
         async def async_generate(self, cache_salt=None):
@@ -113,10 +126,15 @@ def test_cache_salt_kwargs_require_supported_engine():
         async def async_generate(self, input_ids=None):
             pass
 
+    class UninspectableEngine:
+        async_generate = sys.getsizeof
+
     request = {"routing": {"cache_salt": "tenant-a"}}
     assert cache_salt_kwargs(NewEngine(), request) == {"cache_salt": "tenant-a"}
-    with pytest.raises(ValueError, match="Engine.async_generate accepts cache_salt"):
+    with pytest.raises(ValueError, match="expose an inspectable signature"):
         cache_salt_kwargs(OldEngine(), request)
+    with pytest.raises(ValueError, match="expose an inspectable signature"):
+        cache_salt_kwargs(UninspectableEngine(), request)
     assert cache_salt_kwargs(OldEngine(), {}) == {}
 
 

--- a/lib/kv-router/src/zmq_wire/deserialize.rs
+++ b/lib/kv-router/src/zmq_wire/deserialize.rs
@@ -10,7 +10,10 @@ use serde::de::{self, IgnoredAny, MapAccess, SeqAccess, Visitor};
 use crate::protocols::BlockExtraInfo;
 
 use super::extra_keys::{extra_keys_to_block_mm_infos, extra_keys_to_cache_namespace};
-use super::filter::{BlockStoredTrailingField, KvCacheEventMetadata, KvCacheEventTrailingField};
+use super::filter::{
+    BlockStoredPositionSeven, BlockStoredTrailingField, KvCacheEventMetadata,
+    KvCacheEventTrailingField,
+};
 use super::types::{BlockHashValue, ExtraKeyItem, KvTokenIds, RawKvEvent};
 
 /// Our producers use msgspec with `tag=True` and `array_like=True`, which
@@ -182,7 +185,15 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 // Position 5 was lora_id in older formats; consume and discard for compat.
                 let _lora_id: Option<u64> = seq.next_element()?.unwrap_or(None);
                 let medium: Option<String> = seq.next_element()?.unwrap_or(None);
-                let lora_name: Option<String> = seq.next_element()?.unwrap_or(None);
+                let position_seven: Option<BlockStoredPositionSeven> =
+                    seq.next_element()?.unwrap_or(None);
+                let (lora_name, explicit_cache_namespace) = match position_seven {
+                    Some(BlockStoredPositionSeven::LoraName(lora_name)) => (Some(lora_name), None),
+                    Some(BlockStoredPositionSeven::Metadata(metadata)) => {
+                        (None, metadata.cache_salt)
+                    }
+                    None => (None, None),
+                };
                 let extra_keys: Option<Vec<Option<Vec<ExtraKeyItem>>>> =
                     seq.next_element()?.unwrap_or(None);
                 let mut block_mm_infos: Option<Vec<Option<BlockExtraInfo>>> = None;
@@ -204,8 +215,9 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
 
                 while seq.next_element::<IgnoredAny>()?.is_some() {}
 
-                let cache_namespace =
-                    extra_keys_to_cache_namespace(extra_keys.as_deref(), lora_name.as_deref());
+                let cache_namespace = explicit_cache_namespace.or_else(|| {
+                    extra_keys_to_cache_namespace(extra_keys.as_deref(), lora_name.as_deref())
+                });
                 let block_mm_infos =
                     block_mm_infos.or_else(|| extra_keys_to_block_mm_infos(extra_keys));
                 let (raw_token_ids, is_eagle) = normalize_token_ids(token_ids);

--- a/lib/kv-router/src/zmq_wire/filter.rs
+++ b/lib/kv-router/src/zmq_wire/filter.rs
@@ -8,6 +8,18 @@ use serde::Serialize;
 use crate::protocols::BlockExtraInfo;
 
 #[derive(Debug, Deserialize)]
+pub(super) struct BlockStoredMetadata {
+    pub(super) cache_salt: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub(super) enum BlockStoredPositionSeven {
+    LoraName(String),
+    Metadata(BlockStoredMetadata),
+}
+
+#[derive(Debug, Deserialize)]
 #[serde(untagged)]
 pub(super) enum KvCacheEventTrailingField {
     GroupIdx(u32),

--- a/lib/kv-router/src/zmq_wire/filter.rs
+++ b/lib/kv-router/src/zmq_wire/filter.rs
@@ -16,6 +16,8 @@ pub(super) struct BlockStoredMetadata {
 #[serde(untagged)]
 pub(super) enum BlockStoredPositionSeven {
     LoraName(String),
+    // SGLang emits this metadata only in its array-like positional wire form.
+    // Named/map events use the existing top-level `cache_salt` field instead.
     Metadata(BlockStoredMetadata),
 }
 

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -52,6 +52,94 @@ fn test_deserialize_bigram_block_stored_sequence() {
 }
 
 #[derive(Serialize)]
+struct SglangBlockStoredMetadataFixture {
+    cache_salt: &'static str,
+}
+
+#[test]
+fn test_deserialize_sglang_cache_salt_metadata_at_position_seven() {
+    let raw_event = (
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![10u32, 11],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        Some(SglangBlockStoredMetadataFixture {
+            cache_salt: "tenant-a",
+        }),
+    );
+    let encoded = to_vec(&raw_event).unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    let RawKvEvent::BlockStored {
+        cache_namespace,
+        lora_name,
+        ..
+    } = event
+    else {
+        panic!("expected BlockStored");
+    };
+    assert_eq!(cache_namespace.as_deref(), Some("tenant-a"));
+    assert_eq!(lora_name, None);
+}
+
+#[test]
+fn test_sglang_metadata_takes_precedence_over_extra_keys_fallback() {
+    let raw_event = (
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![10u32, 11],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        Some(SglangBlockStoredMetadataFixture {
+            cache_salt: "tenant-a",
+        }),
+        Some(vec![Some(vec!["dynamo-cache-salt:tenant-b"])]),
+    );
+    let encoded = to_vec(&raw_event).unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    let RawKvEvent::BlockStored {
+        cache_namespace, ..
+    } = event
+    else {
+        panic!("expected BlockStored");
+    };
+    assert_eq!(cache_namespace.as_deref(), Some("tenant-a"));
+}
+
+#[test]
+fn test_deserialize_vllm_lora_name_at_position_seven() {
+    let raw_event = (
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![10u32, 11],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        Some("adapter-a"),
+    );
+    let encoded = to_vec(&raw_event).unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    let RawKvEvent::BlockStored {
+        cache_namespace,
+        lora_name,
+        ..
+    } = event
+    else {
+        panic!("expected BlockStored");
+    };
+    assert_eq!(cache_namespace, None);
+    assert_eq!(lora_name.as_deref(), Some("adapter-a"));
+}
+
+#[derive(Serialize)]
 struct MapBlockStoredFixture {
     #[serde(rename = "type")]
     event_type: &'static str,

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -56,6 +56,11 @@ struct SglangBlockStoredMetadataFixture {
     cache_salt: &'static str,
 }
 
+#[derive(Serialize)]
+struct SglangBlockStoredOptionalMetadataFixture {
+    cache_salt: Option<&'static str>,
+}
+
 #[test]
 fn test_deserialize_sglang_cache_salt_metadata_at_position_seven() {
     let raw_event = (
@@ -110,6 +115,55 @@ fn test_sglang_metadata_takes_precedence_over_extra_keys_fallback() {
         panic!("expected BlockStored");
     };
     assert_eq!(cache_namespace.as_deref(), Some("tenant-a"));
+}
+
+#[test]
+fn test_sglang_metadata_without_cache_salt_uses_extra_keys_fallback() {
+    let raw_event = (
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![10u32, 11],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        Some(std::collections::BTreeMap::<String, String>::new()),
+        Some(vec![Some(vec!["dynamo-cache-salt:tenant-b"])]),
+    );
+    let encoded = to_vec(&raw_event).unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    let RawKvEvent::BlockStored {
+        cache_namespace, ..
+    } = event
+    else {
+        panic!("expected BlockStored");
+    };
+    assert_eq!(cache_namespace.as_deref(), Some("tenant-b"));
+}
+
+#[test]
+fn test_sglang_null_cache_salt_metadata_remains_unsalted() {
+    let raw_event = (
+        "BlockStored",
+        vec![BlockHashValue::Unsigned(11)],
+        Option::<BlockHashValue>::None,
+        vec![10u32, 11],
+        2usize,
+        Option::<u64>::None,
+        Option::<String>::None,
+        Some(SglangBlockStoredOptionalMetadataFixture { cache_salt: None }),
+    );
+    let encoded = to_vec(&raw_event).unwrap();
+    let event: RawKvEvent = from_slice(&encoded).unwrap();
+
+    let RawKvEvent::BlockStored {
+        cache_namespace, ..
+    } = event
+    else {
+        panic!("expected BlockStored");
+    };
+    assert_eq!(cache_namespace, None);
 }
 
 #[test]

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -14,6 +14,7 @@ import pytest
 from tests.router.e2e_harness import (
     ManagedEngineProcessMixin,
     run_basic_router_test,
+    run_cache_salt_isolation_test,
     run_disagg_router_decisions_test,
     run_indexers_sync_test,
     run_router_decisions_test,
@@ -279,6 +280,33 @@ def test_sglang_kv_router_basic(
         request_plane=request_plane,
         block_size=PAGE_SIZE,
         model_name=MODEL_NAME,
+    )
+
+
+@pytest.mark.e2e
+@pytest.mark.model(MODEL_NAME)
+@pytest.mark.pre_merge
+@pytest.mark.gpu_1
+@pytest.mark.profiled_vram_gib(12.0)
+@pytest.mark.requested_sglang_kv_tokens(2048)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.timeout(300)
+def test_sglang_cache_salt_isolation(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_models,
+    set_ucx_tls_no_mm,
+    request_plane,
+):
+    run_cache_salt_isolation_test(
+        engine_process_cls=SGLangProcess,
+        engine_args_name="sglang_args",
+        engine_args=SGLANG_ARGS,
+        request=request,
+        request_plane=request_plane,
+        model_name=MODEL_NAME,
+        block_size=PAGE_SIZE,
+        component_name="backend",
     )
 
 


### PR DESCRIPTION
## Summary

- Forward the first non-empty cache salt from `routing.cache_salt`, top-level `nvext.cache_salt`, or `extra_args.nvext.cache_salt` to SGLang's base-model generation paths.
- Preserve unsalted compatibility with older/custom SGLang builds and return a clear error when a salted request reaches an `Engine.async_generate` implementation without `cache_salt` support.
- Decode SGLang's typed metadata map in positional `BlockStored` slot 7 while preserving vLLM's string `lora_name` and `extra_keys` fallback behavior.
- Add SGLang to the existing two-worker cache-salt isolation E2E harness.

This draft depends on [sgl-project/sglang#30827](https://github.com/sgl-project/sglang/pull/30827). Before merge, the SGLang Python/runtime-image pins and lockfile must be updated to the first released build containing that change, and the GPU E2E test must be rerun against that image.

## Validation

- `cargo test -p dynamo-kv-router zmq_wire::tests` (26 passed)
- `cargo fmt --all --check`
- Black 23.1.0, isort 5.12.0, and Ruff 0.5.2 checks on all changed Python files
- Python bytecode compilation for all changed SGLang component and router E2E modules
- GPU E2E not run locally; pending the released SGLang runtime image described above

## Where should the reviewer start?

- `components/src/dynamo/sglang/request_utils.py` for request extraction and capability handling
- `lib/kv-router/src/zmq_wire/deserialize.rs` for positional event decoding and namespace precedence
- `tests/router/test_router_e2e_with_sglang.py` for the isolation harness integration

## Related Issues

- [x] Confirmed — no related issue
