### PR TITLE
fix(vllm): propagate embedding prompt truncation (#11099) [cherry-pick → release/1.3.0]

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3886,7 +3886,8 @@ class EmbeddingWorkerHandler:
         ``"base64"``); when ``"base64"`` is requested, each per-input vector is
         serialized as a base64-encoded string of little-endian ``f32`` bytes
         per the OpenAI spec, so the byte count matches the (possibly reduced)
-        dimensionality.
+        dimensionality. Optional ``truncate_prompt_tokens`` is forwarded to
+        vLLM's tokenizer path for raw-text inputs.
         """
         model_name = request.get("model") or self.config.served_model_name or ""
         input_field = request.get("input")
@@ -3917,6 +3918,25 @@ class EmbeddingWorkerHandler:
                 f"Invalid 'encoding_format' value {encoding_format!r}; "
                 "expected 'float' or 'base64'"
             )
+
+        truncate_prompt_tokens = request.get("truncate_prompt_tokens")
+        tokenization_kwargs: dict[str, Any] | None = None
+        if truncate_prompt_tokens is not None:
+            if not isinstance(truncate_prompt_tokens, int) or isinstance(
+                truncate_prompt_tokens, bool
+            ):
+                raise TypeError(
+                    "Invalid 'truncate_prompt_tokens' type "
+                    f"{type(truncate_prompt_tokens).__name__}; expected int"
+                )
+            if truncate_prompt_tokens < -1:
+                raise ValueError(
+                    "truncate_prompt_tokens must be >= -1, "
+                    f"got {truncate_prompt_tokens}"
+                )
+            tokenization_kwargs = {
+                "truncate_prompt_tokens": truncate_prompt_tokens,
+            }
 
         # Request the pooled sentence embedding. With no task, vLLM's
         # encode() resolves to per-token output (the full ``n_tokens x
@@ -3958,11 +3978,15 @@ class EmbeddingWorkerHandler:
             )
             final_output = None
             async with self._abort_monitor(context, request_id):
-                async for out in self.engine_client.encode(
-                    prompt=encode_arg,
-                    pooling_params=pooling_params,
-                    request_id=request_id,
-                ):
+                encode_kwargs: dict[str, Any] = {
+                    "prompt": encode_arg,
+                    "pooling_params": pooling_params,
+                    "request_id": request_id,
+                }
+                if tokenization_kwargs is not None and isinstance(encode_arg, str):
+                    encode_kwargs["tokenization_kwargs"] = tokenization_kwargs
+
+                async for out in self.engine_client.encode(**encode_kwargs):
                     final_output = out
             if final_output is None:
                 raise RuntimeError(

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -1488,6 +1488,106 @@ class TestEmbeddingWorkerHandlerCancellation:
 
     @pytest.mark.asyncio
     @pytest.mark.timeout(5)
+    async def test_raw_text_truncation_forwarded_to_vllm(self):
+        """Raw text inputs forward ``truncate_prompt_tokens`` to vLLM's
+        tokenizer path, including the ``-1`` sentinel vLLM accepts.
+        """
+        handler = self._make_embedding_handler()
+        context = self._make_context()
+        captured: list[dict] = []
+
+        async def fake_encode(
+            prompt, pooling_params, request_id, *, tokenization_kwargs=None
+        ):
+            captured.append(
+                {"prompt": prompt, "tokenization_kwargs": tokenization_kwargs}
+            )
+            output = MagicMock()
+            output.outputs.data = torch.tensor([0.1, 0.2, 0.3])
+            output.prompt_token_ids = [1, 2, 3]
+            yield output
+
+        handler.engine_client.encode = fake_encode
+
+        for truncate_prompt_tokens in (2048, -1):
+            request = {
+                "input": "hello",
+                "model": "test-model",
+                "truncate_prompt_tokens": truncate_prompt_tokens,
+            }
+            _ = [r async for r in handler.generate(request, context)]
+
+        assert captured == [
+            {
+                "prompt": "hello",
+                "tokenization_kwargs": {"truncate_prompt_tokens": 2048},
+            },
+            {
+                "prompt": "hello",
+                "tokenization_kwargs": {"truncate_prompt_tokens": -1},
+            },
+        ]
+
+    @pytest.mark.parametrize(
+        ("truncate_prompt_tokens", "error_type", "match"),
+        [
+            ("2048", TypeError, "Invalid 'truncate_prompt_tokens' type"),
+            (True, TypeError, "Invalid 'truncate_prompt_tokens' type"),
+            (-2, ValueError, "truncate_prompt_tokens must be >= -1"),
+        ],
+    )
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_truncate_prompt_tokens_rejects_invalid_values(
+        self, truncate_prompt_tokens, error_type, match
+    ):
+        """Invalid truncation values fail before the request reaches vLLM."""
+        handler = self._make_embedding_handler()
+        context = self._make_context()
+
+        request = {
+            "input": "hello",
+            "model": "test-model",
+            "truncate_prompt_tokens": truncate_prompt_tokens,
+        }
+        with pytest.raises(error_type, match=match):
+            async for _ in handler.generate(request, context):
+                pass
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
+    async def test_truncation_uses_default_encode_shape_when_not_tokenizing(self):
+        """Pretokenized inputs stay on the default encode path because callers
+        already control token-id truncation before reaching vLLM.
+        """
+        handler = self._make_embedding_handler()
+        context = self._make_context()
+        prompts = []
+
+        async def fake_encode(prompt, pooling_params, request_id):
+            prompts.append(prompt)
+            output = MagicMock()
+            output.outputs.data = torch.tensor([0.1, 0.2, 0.3])
+            output.prompt_token_ids = [1, 2, 3]
+            yield output
+
+        handler.engine_client.encode = fake_encode
+
+        request = {"input": "hello", "model": "test-model"}
+        _ = [r async for r in handler.generate(request, context)]
+
+        request = {
+            "input": [1, 2, 3],
+            "model": "test-model",
+            "truncate_prompt_tokens": 2,
+        }
+        _ = [r async for r in handler.generate(request, context)]
+
+        assert prompts[0] == "hello"
+        assert prompts[1]["prompt_token_ids"] == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    @pytest.mark.timeout(5)
     async def test_oversized_dimensions_raises(self):
         """When vLLM silently clamps an oversized ``dimensions`` request (a
         model enabled via ``--hf-overrides '{"is_matryoshka": true}'`` with no

--- a/lib/llm/src/protocols/openai/embeddings.rs
+++ b/lib/llm/src/protocols/openai/embeddings.rs
@@ -17,6 +17,11 @@ pub struct NvCreateEmbeddingRequest {
     #[schema(value_type = Object)]
     pub inner: dynamo_protocols::types::CreateEmbeddingRequest,
 
+    /// vLLM tokenizer option for raw-text embedding requests. vLLM accepts
+    /// -1 as the sentinel for truncating to the model's maximum length.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub truncate_prompt_tokens: Option<i64>,
+
     #[serde(skip_serializing_if = "Option::is_none")]
     pub nvext: Option<NvExt>,
 }
@@ -82,5 +87,42 @@ impl AnnotationsProvider for NvCreateEmbeddingRequest {
             .and_then(|nvext| nvext.annotations.as_ref())
             .map(|annotations| annotations.contains(&annotation.to_string()))
             .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::NvCreateEmbeddingRequest;
+    use serde_json::json;
+
+    #[test]
+    fn truncate_prompt_tokens_round_trips() {
+        for truncate_prompt_tokens in [2048, -1] {
+            let request: NvCreateEmbeddingRequest = serde_json::from_value(json!({
+                "model": "test-model",
+                "input": "hello",
+                "truncate_prompt_tokens": truncate_prompt_tokens
+            }))
+            .unwrap();
+
+            assert_eq!(request.truncate_prompt_tokens, Some(truncate_prompt_tokens));
+
+            let value = serde_json::to_value(request).unwrap();
+            assert_eq!(value["truncate_prompt_tokens"], truncate_prompt_tokens);
+        }
+    }
+
+    #[test]
+    fn omitted_truncate_prompt_tokens_is_not_serialized() {
+        let request: NvCreateEmbeddingRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+
+        assert_eq!(request.truncate_prompt_tokens, None);
+
+        let value = serde_json::to_value(request).unwrap();
+        assert!(value.get("truncate_prompt_tokens").is_none());
     }
 }


### PR DESCRIPTION
#### Overview:

Cherry-pick of #11099 into `release/1.3.0`. **Stacked on top of the #10248 cherry-pick** (base branch: `tzulingk/cherrypick-10248-embedding-pooling`) — merge that PR first, then this one's base will collapse to `release/1.3.0`.

#### Details:

Backports `fix(vllm): propagate embedding prompt truncation` (#11099). Adds `truncate_prompt_tokens` support to the vLLM embedding path:

- New `truncate_prompt_tokens: Option<i64>` field on `NvCreateEmbeddingRequest` (Rust protocol), serialized only when set; `-1` sentinel accepted.
- The Python worker validates `truncate_prompt_tokens` and forwards it to vLLM's tokenizer path via `tokenization_kwargs` for raw-text inputs only. Pretokenized inputs stay on the default encode path (callers already control token-id truncation).

Depends on #10248: this PR's forwarding builds on the `task="embed"` encode path introduced there, so it is stacked on that cherry-pick. Cleanly cherry-picked (no conflicts) from merge commit `e1ca5a710c`.

#### Where should the reviewer start?

- `lib/llm/src/protocols/openai/embeddings.rs` — new `truncate_prompt_tokens` field + serde round-trip tests.
- `components/src/dynamo/vllm/handlers.py` — `truncate_prompt_tokens` validation + conditional `tokenization_kwargs` forwarding in `EmbeddingWorkerHandler.generate`.
- `components/src/dynamo/vllm/tests/test_vllm_worker_handler.py` — `test_raw_text_truncation_forwarded_to_vllm`, `test_truncate_prompt_tokens_rejects_invalid_values`, `test_truncation_uses_default_encode_shape_when_not_tokenizing`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11556" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->