### PR TITLE
feat(kvbm): support 4096-token logical blocks

### DIFF
--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader/slot.rs
@@ -429,7 +429,7 @@ impl VllmConnectorSlot {
     ) -> Self {
         assert!(!tokens.is_empty(), "tokens must be non-empty");
         let block_size = block_manager.block_size();
-        debug_assert!(block_size.is_power_of_two() && block_size <= 1024);
+        debug_assert!(block_size.is_power_of_two() && block_size <= 4096);
         let sequence = TokenBlockSequence::new(tokens, block_size as u32, Some(salt_hash));
 
         Self {

--- a/lib/kvbm-logical/src/lib.rs
+++ b/lib/kvbm-logical/src/lib.rs
@@ -48,6 +48,9 @@ pub use sequence::{
 pub type BlockId = usize;
 pub type SequenceHash = dynamo_tokens::PositionalLineageHash;
 
+/// Largest logical KV-cache block supported by the block manager, in tokens.
+pub const MAX_LOGICAL_BLOCK_SIZE_TOKENS: usize = 4096;
+
 /// Stable, process-unique identifier for a `BlockManager`'s underlying
 /// `BlockStore`.
 ///

--- a/lib/kvbm-logical/src/manager/builder.rs
+++ b/lib/kvbm-logical/src/manager/builder.rs
@@ -10,6 +10,7 @@ use crate::metrics::{BlockPoolMetrics, MetricsAggregator, short_type_name};
 use crate::tinylfu::TinyLFUTracker;
 
 use crate::{
+    MAX_LOGICAL_BLOCK_SIZE_TOKENS,
     blocks::BlockMetadata,
     pools::{
         BlockDuplicationPolicy, BlockStore, InactiveIndex,
@@ -120,7 +121,8 @@ pub struct BlockManagerConfigBuilder<T: BlockMetadata> {
     /// Number of blocks in the pool
     block_count: Option<usize>,
 
-    /// Size of each block in tokens (must be power of 2, 1-1024)
+    /// Size of each block in tokens (must be a power of 2 no larger than
+    /// [`MAX_LOGICAL_BLOCK_SIZE_TOKENS`])
     /// Default: 16
     block_size: Option<usize>,
 
@@ -177,15 +179,16 @@ impl<T: BlockMetadata> BlockManagerConfigBuilder<T> {
     /// Set the block size (number of tokens per block).
     ///
     /// # Requirements
-    /// - Must be >= 1 and <= 1024
+    /// - Must be between 1 and [`MAX_LOGICAL_BLOCK_SIZE_TOKENS`] (inclusive)
     /// - Must be a power of 2
     ///
     /// # Panics
     /// Panics if the block size doesn't meet requirements.
     pub fn block_size(mut self, size: usize) -> Self {
         assert!(
-            (1..=1024).contains(&size),
-            "block_size must be between 1 and 1024, got {}",
+            (1..=MAX_LOGICAL_BLOCK_SIZE_TOKENS).contains(&size),
+            "block_size must be between 1 and {}, got {}",
+            MAX_LOGICAL_BLOCK_SIZE_TOKENS,
             size
         );
         assert!(
@@ -331,10 +334,12 @@ impl<T: BlockMetadata> BlockManagerConfigBuilder<T> {
 
         // Validate block_size
         let block_size = self.block_size.unwrap_or(16);
-        if !block_size.is_power_of_two() || !(1..=1024).contains(&block_size) {
+        if !block_size.is_power_of_two()
+            || !(1..=MAX_LOGICAL_BLOCK_SIZE_TOKENS).contains(&block_size)
+        {
             return Err(format!(
-                "Invalid block_size {}: must be a power of 2 between 1 and 1024",
-                block_size
+                "Invalid block_size {}: must be a power of 2 between 1 and {}",
+                block_size, MAX_LOGICAL_BLOCK_SIZE_TOKENS
             ));
         }
 

--- a/lib/kvbm-logical/src/manager/tests.rs
+++ b/lib/kvbm-logical/src/manager/tests.rs
@@ -742,6 +742,8 @@ mod block_size_tests {
     #[case(256)]
     #[case(512)]
     #[case(1024)]
+    #[case(2048)]
+    #[case(4096)]
     fn test_builder_block_size_power_of_two(#[case] size: usize) {
         let registry = BlockRegistry::new();
         let result = BlockManager::<TestBlockData>::builder()
@@ -761,15 +763,15 @@ mod block_size_tests {
     }
 
     #[test]
-    #[should_panic(expected = "block_size must be between 1 and 1024")]
+    #[should_panic(expected = "block_size must be between 1 and 4096")]
     fn test_builder_block_size_too_large() {
         BlockManager::<TestBlockData>::builder()
             .block_count(10)
-            .block_size(2048); // Too large
+            .block_size(8192); // Too large
     }
 
     #[test]
-    #[should_panic(expected = "block_size must be between 1 and 1024")]
+    #[should_panic(expected = "block_size must be between 1 and 4096")]
     fn test_builder_block_size_zero() {
         BlockManager::<TestBlockData>::builder()
             .block_count(10)

--- a/lib/kvbm-logical/src/pools/block_proptest.rs
+++ b/lib/kvbm-logical/src/pools/block_proptest.rs
@@ -103,7 +103,9 @@ pub(crate) mod tests {
         /// complete-able guard.
         #[test]
         fn prop_valid_block_sizes_work(
-            block_size in prop::sample::select(&[1usize, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]),
+            block_size in prop::sample::select(&[
+                1usize, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096,
+            ]),
         ) {
             prop_assert!(validate_test_block_size(block_size));
 

--- a/lib/kvbm-logical/src/testing/config.rs
+++ b/lib/kvbm-logical/src/testing/config.rs
@@ -6,6 +6,8 @@
 //! This module provides constants and utilities for consistent testing across
 //! all v2 block manager components.
 
+use crate::MAX_LOGICAL_BLOCK_SIZE_TOKENS;
+
 /// Default block size for testing (4 tokens)
 ///
 /// Most tests use 4-token sequences like [100, 101, 102, 103].
@@ -18,9 +20,9 @@ pub const DEFAULT_TEST_BLOCK_COUNT: usize = 10;
 
 /// Common test block sizes for parameterized testing
 ///
-/// These cover the full range of valid block sizes from 1 to 1024,
+/// These cover the full range of valid block sizes from 1 to 4096,
 /// all being powers of 2 as required by the validation.
-pub const TEST_BLOCK_SIZES: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024];
+pub const TEST_BLOCK_SIZES: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
 
 /// Small set of block sizes for focused testing
 pub const COMMON_TEST_BLOCK_SIZES: &[usize] = &[1, 4, 16, 64];
@@ -41,7 +43,7 @@ pub mod constants {
     pub const LARGE: usize = 64;
 
     /// Maximum block size
-    pub const MAX: usize = 1024;
+    pub const MAX: usize = crate::MAX_LOGICAL_BLOCK_SIZE_TOKENS;
 }
 
 /// Validate that a block size is suitable for testing
@@ -50,9 +52,10 @@ pub mod constants {
 /// * `size` - The block size to validate
 ///
 /// # Returns
-/// `true` if the size is a power of 2 between 1 and 1024 (inclusive)
+/// `true` if the size is a power of 2 between 1 and
+/// [`MAX_LOGICAL_BLOCK_SIZE_TOKENS`] (inclusive)
 pub fn validate_test_block_size(size: usize) -> bool {
-    size.is_power_of_two() && (1..=1024).contains(&size)
+    size.is_power_of_two() && (1..=MAX_LOGICAL_BLOCK_SIZE_TOKENS).contains(&size)
 }
 
 /// Generate a sequence of tokens for testing with the given block size
@@ -109,13 +112,13 @@ mod tests {
         assert!(validate_test_block_size(1));
         assert!(validate_test_block_size(4));
         assert!(validate_test_block_size(16));
-        assert!(validate_test_block_size(1024));
+        assert!(validate_test_block_size(4096));
 
         // Invalid sizes
         assert!(!validate_test_block_size(0));
         assert!(!validate_test_block_size(3)); // Not power of 2
         assert!(!validate_test_block_size(5)); // Not power of 2
-        assert!(!validate_test_block_size(2048)); // Too large
+        assert!(!validate_test_block_size(8192)); // Too large
     }
 
     #[test]

--- a/lib/kvbm-logical/src/testing/config.rs
+++ b/lib/kvbm-logical/src/testing/config.rs
@@ -20,9 +20,24 @@ pub const DEFAULT_TEST_BLOCK_COUNT: usize = 10;
 
 /// Common test block sizes for parameterized testing
 ///
-/// These cover the full range of valid block sizes from 1 to 4096,
+/// These cover the full range of valid block sizes from 1 to
+/// [`MAX_LOGICAL_BLOCK_SIZE_TOKENS`],
 /// all being powers of 2 as required by the validation.
-pub const TEST_BLOCK_SIZES: &[usize] = &[1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096];
+pub const TEST_BLOCK_SIZES: &[usize] = &[
+    1,
+    2,
+    4,
+    8,
+    16,
+    32,
+    64,
+    128,
+    256,
+    512,
+    1024,
+    2048,
+    MAX_LOGICAL_BLOCK_SIZE_TOKENS,
+];
 
 /// Small set of block sizes for focused testing
 pub const COMMON_TEST_BLOCK_SIZES: &[usize] = &[1, 4, 16, 64];

--- a/lib/kvbm-logical/src/testing/sequences.rs
+++ b/lib/kvbm-logical/src/testing/sequences.rs
@@ -34,8 +34,9 @@ impl BlockSequenceBuilder {
         use super::config::validate_test_block_size;
         assert!(
             validate_test_block_size(size),
-            "Invalid block size: {}. Must be power of 2 between 1 and 1024",
-            size
+            "Invalid block size: {}. Must be power of 2 between 1 and {}",
+            size,
+            crate::MAX_LOGICAL_BLOCK_SIZE_TOKENS
         );
         self.block_size = size;
         self

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -60,6 +60,25 @@ fn make_args() -> MockEngineArgs {
         .unwrap()
 }
 
+#[test]
+fn supports_4096_token_kv_cache_blocks() {
+    let args = MockEngineArgs::builder()
+        .block_size(4096)
+        .num_gpu_blocks(3488)
+        .max_num_batched_tokens(Some(4096))
+        .max_num_seqs(Some(1))
+        .enable_chunked_prefill(true)
+        .enable_prefix_caching(true)
+        .speedup_ratio(0.0)
+        .build()
+        .unwrap();
+
+    let core = VllmCore::new(args);
+
+    assert_eq!(core.kv_manager.block_size(), 4096);
+    assert_eq!(core.kv_manager.max_capacity(), 3488);
+}
+
 fn router_args() -> MockEngineArgs {
     MockEngineArgs::builder()
         .block_size(4)


### PR DESCRIPTION
## Summary

- raise the logical KV-cache block-size ceiling from 1,024 to 4,096 tokens
- centralize the supported maximum in `MAX_LOGICAL_BLOCK_SIZE_TOKENS`
- extend builder, property, and mocker scheduler coverage through 4,096 tokens while rejecting 8,192

This lets mocker replay represent coarse logical cache pages directly instead of being constrained by the previous 1,024-token validation limit.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p kvbm-logical --lib` (506 passed)
- `cargo test -p dynamo-mocker supports_4096_token_kv_cache_blocks -- --nocapture` (1 passed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum supported KV-cache block size to 4096 tokens.
  * Added support for configuring and using 2048- and 4096-token blocks.

* **Bug Fixes**
  * Updated block-size validation and error messages to reflect the expanded limit.

* **Tests**
  * Added coverage confirming 4096-token blocks work correctly and report expected capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->