### PR TITLE
fix(mocker): model MTP prefix block recomputation

### DIFF
--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1415,6 +1415,7 @@ impl VllmCore {
                                 self.args.num_gpu_blocks,
                                 self.args.block_size,
                                 &self.kv_manager,
+                                self.args.aic_nextn.is_some(),
                             )
                         }
                     }
@@ -1725,9 +1726,13 @@ impl VllmCore {
             prefill_cost
                 .map(|cost| cost.cached_tokens)
                 .unwrap_or_else(|| {
-                    self.kv_manager
-                        .get_prefill_cost(&request.sequence)
-                        .cached_tokens
+                    policy::apply_mtp_prefix_recompute(
+                        self.args.scheduling_policy(),
+                        self.args.block_size,
+                        self.args.aic_nextn.is_some(),
+                        self.kv_manager.get_prefill_cost(&request.sequence),
+                    )
+                    .cached_tokens
                 })
         } else {
             0

--- a/lib/mocker/src/scheduler/vllm/core.rs
+++ b/lib/mocker/src/scheduler/vllm/core.rs
@@ -1196,7 +1196,7 @@ impl VllmCore {
         &mut self,
         uuid: Uuid,
         now_ms: f64,
-        prefill_cost: &PrefillCost,
+        g1_cached_tokens: usize,
     ) -> SwapInAdmissionAttempt {
         use crate::kv_manager::kvbm_backend::BatchSwapInOutcome;
         if !self.kv_manager.has_offload_engine() {
@@ -1210,13 +1210,16 @@ impl VllmCore {
         if !matches!(request.status, RequestStatus::Waiting) {
             return SwapInAdmissionAttempt::NoHit;
         }
+        // Lower-tier lookup starts after the physical G1 prefix. MTP may
+        // recompute the final matched block, but that changes compute
+        // accounting rather than which blocks are resident in G1.
         let block_size = request.sequence.block_size();
-        let skip_blocks = prefill_cost.cached_tokens / block_size;
+        let skip_blocks = g1_cached_tokens / block_size;
         let plhs = request.sequence.positional_lineage_hashes();
         tracing::trace!(
             %uuid,
             now_ms,
-            cached_tokens = prefill_cost.cached_tokens,
+            cached_tokens = g1_cached_tokens,
             skip_blocks,
             plhs_len = plhs.len(),
             "kvbm-offload: swap-in admission probe"
@@ -1403,26 +1406,32 @@ impl VllmCore {
                                 cached_tokens: request.sequence.num_input_tokens(),
                                 active_cached_tokens: request.sequence.num_input_tokens(),
                             },
+                            g1_cached_tokens: request.sequence.num_input_tokens(),
                         },
                         AdmissionStage::PendingDestinationHead => break,
                         AdmissionStage::FreshKv => {
                             let is_fresh = request.status == RequestStatus::Waiting;
                             policy::decide_waiting_admission(
-                                scheduling_policy,
+                                policy::WaitingAdmissionConfig {
+                                    policy: scheduling_policy,
+                                    num_gpu_blocks: self.args.num_gpu_blocks,
+                                    block_size: self.args.block_size,
+                                    mtp_enabled: self.args.aic_nextn.is_some(),
+                                },
                                 &request.sequence,
                                 is_fresh,
                                 running_seqs,
-                                self.args.num_gpu_blocks,
-                                self.args.block_size,
                                 &self.kv_manager,
-                                self.args.aic_nextn.is_some(),
                             )
                         }
                     }
                 }
             };
-            let prefill_cost = match decision {
-                AdmissionDecision::Admit { prefill_cost } => prefill_cost,
+            let (prefill_cost, _g1_cached_tokens) = match decision {
+                AdmissionDecision::Admit {
+                    prefill_cost,
+                    g1_cached_tokens,
+                } => (prefill_cost, g1_cached_tokens),
                 AdmissionDecision::Wait => {
                     break;
                 }
@@ -1445,7 +1454,7 @@ impl VllmCore {
                 }
             };
             #[cfg(feature = "kvbm-offload")]
-            match self.try_park_for_swap_in(uuid, now_ms, &prefill_cost) {
+            match self.try_park_for_swap_in(uuid, now_ms, _g1_cached_tokens) {
                 SwapInAdmissionAttempt::Parked => continue,
                 SwapInAdmissionAttempt::BlockedOnG1Offload => break,
                 SwapInAdmissionAttempt::NoHit => {}

--- a/lib/mocker/src/scheduler/vllm/policy.rs
+++ b/lib/mocker/src/scheduler/vllm/policy.rs
@@ -42,6 +42,31 @@ pub(super) fn generation_complete(sequence: &ActiveSequence, max_model_len: Opti
     remaining_generation_tokens(sequence, max_model_len) == 0
 }
 
+/// Apply vLLM's EAGLE/MTP prefix-cache rule.
+///
+/// The drafter needs hidden states from the final matched block, so vLLM
+/// removes one block from every non-empty prefix-cache hit and recomputes it
+/// during prefill. Keep that backend-specific accounting here rather than in
+/// the shared scheduler core.
+pub(super) fn apply_mtp_prefix_recompute(
+    policy: SchedulingPolicy,
+    block_size: usize,
+    mtp_enabled: bool,
+    mut prefill_cost: PrefillCost,
+) -> PrefillCost {
+    if policy != SchedulingPolicy::Vllm || !mtp_enabled || prefill_cost.cached_tokens < block_size {
+        return prefill_cost;
+    }
+
+    prefill_cost.cached_tokens -= block_size;
+    prefill_cost.new_tokens += block_size;
+    prefill_cost.new_blocks += 1;
+    prefill_cost.active_cached_tokens = prefill_cost
+        .active_cached_tokens
+        .min(prefill_cost.cached_tokens);
+    prefill_cost
+}
+
 /// Decide whether the FIFO head can enter the shared scheduler core.
 ///
 /// vLLM reserves only the current known sequence. TRT-LLM
@@ -55,6 +80,7 @@ pub(super) fn decide_waiting_admission<'a>(
     num_gpu_blocks: usize,
     block_size: usize,
     kv_manager: &KvManager,
+    mtp_enabled: bool,
 ) -> AdmissionDecision {
     if is_fresh {
         match policy {
@@ -73,7 +99,12 @@ pub(super) fn decide_waiting_admission<'a>(
         }
     }
 
-    let prefill_cost = kv_manager.get_prefill_cost(sequence);
+    let prefill_cost = apply_mtp_prefix_recompute(
+        policy,
+        block_size,
+        mtp_enabled,
+        kv_manager.get_prefill_cost(sequence),
+    );
     let available = match policy {
         SchedulingPolicy::Vllm => num_gpu_blocks.saturating_sub(kv_manager.num_active_blocks()),
         SchedulingPolicy::TrtllmGuaranteedNoEvict => {

--- a/lib/mocker/src/scheduler/vllm/policy.rs
+++ b/lib/mocker/src/scheduler/vllm/policy.rs
@@ -9,9 +9,20 @@ use crate::kv_manager::KvManager;
 
 #[derive(Debug)]
 pub(super) enum AdmissionDecision {
-    Admit { prefill_cost: PrefillCost },
+    Admit {
+        prefill_cost: PrefillCost,
+        g1_cached_tokens: usize,
+    },
     Wait,
     Reject,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct WaitingAdmissionConfig {
+    pub(super) policy: SchedulingPolicy,
+    pub(super) num_gpu_blocks: usize,
+    pub(super) block_size: usize,
+    pub(super) mtp_enabled: bool,
 }
 
 pub(super) fn should_reject_for_model_len(
@@ -73,15 +84,19 @@ pub(super) fn apply_mtp_prefix_recompute(
 /// `GUARANTEED_NO_EVICT` reserves the request through its maximum completion
 /// and accounts for the completion reservations of running requests.
 pub(super) fn decide_waiting_admission<'a>(
-    policy: SchedulingPolicy,
+    config: WaitingAdmissionConfig,
     sequence: &ActiveSequence,
     is_fresh: bool,
     running: impl Iterator<Item = &'a ActiveSequence>,
-    num_gpu_blocks: usize,
-    block_size: usize,
     kv_manager: &KvManager,
-    mtp_enabled: bool,
 ) -> AdmissionDecision {
+    let WaitingAdmissionConfig {
+        policy,
+        num_gpu_blocks,
+        block_size,
+        mtp_enabled,
+    } = config;
+
     if is_fresh {
         match policy {
             SchedulingPolicy::Vllm => {
@@ -99,12 +114,10 @@ pub(super) fn decide_waiting_admission<'a>(
         }
     }
 
-    let prefill_cost = apply_mtp_prefix_recompute(
-        policy,
-        block_size,
-        mtp_enabled,
-        kv_manager.get_prefill_cost(sequence),
-    );
+    let raw_prefill_cost = kv_manager.get_prefill_cost(sequence);
+    let g1_cached_tokens = raw_prefill_cost.cached_tokens;
+    let prefill_cost =
+        apply_mtp_prefix_recompute(policy, block_size, mtp_enabled, raw_prefill_cost);
     let available = match policy {
         SchedulingPolicy::Vllm => num_gpu_blocks.saturating_sub(kv_manager.num_active_blocks()),
         SchedulingPolicy::TrtllmGuaranteedNoEvict => {
@@ -123,7 +136,10 @@ pub(super) fn decide_waiting_admission<'a>(
     if needed > available {
         AdmissionDecision::Wait
     } else {
-        AdmissionDecision::Admit { prefill_cost }
+        AdmissionDecision::Admit {
+            prefill_cost,
+            g1_cached_tokens,
+        }
     }
 }
 

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -9,14 +9,17 @@
 use uuid::Uuid;
 
 use crate::common::protocols::{
-    DirectRequest, EngineType, KvEventPublishers, MockEngineArgs, SchedulingPolicy,
+    DirectRequest, EngineType, KvEventPublishers, MockEngineArgs, PrefillCost, SchedulingPolicy,
 };
 use crate::common::sequence::ActiveSequence;
 use crate::kv_manager::KvManager;
 use crate::kv_manager::kvbm_backend::G1Acquire;
 use crate::scheduler::vllm::{RequestStatus, VllmCore};
 
-use super::{AdmissionDecision, decide_waiting_admission, should_reject_for_model_len};
+use super::{
+    AdmissionDecision, WaitingAdmissionConfig, apply_mtp_prefix_recompute,
+    decide_waiting_admission, should_reject_for_model_len,
+};
 
 mod vllm {
     use super::*;
@@ -26,19 +29,62 @@ mod vllm {
     }
 
     #[test]
+    fn mtp_recomputes_exactly_one_cached_prefix_block() {
+        let adjusted = apply_mtp_prefix_recompute(
+            SchedulingPolicy::Vllm,
+            4,
+            true,
+            PrefillCost {
+                new_blocks: 1,
+                new_tokens: 4,
+                cached_tokens: 8,
+                active_cached_tokens: 8,
+            },
+        );
+
+        assert_eq!(adjusted.cached_tokens, 4);
+        assert_eq!(adjusted.active_cached_tokens, 4);
+        assert_eq!(adjusted.new_tokens, 8);
+        assert_eq!(adjusted.new_blocks, 2);
+    }
+
+    #[test]
+    fn mtp_recompute_does_not_change_trtllm_accounting() {
+        let original = PrefillCost {
+            new_blocks: 1,
+            new_tokens: 4,
+            cached_tokens: 8,
+            active_cached_tokens: 8,
+        };
+        let adjusted = apply_mtp_prefix_recompute(
+            SchedulingPolicy::TrtllmGuaranteedNoEvict,
+            4,
+            true,
+            original.clone(),
+        );
+
+        assert_eq!(adjusted.new_blocks, original.new_blocks);
+        assert_eq!(adjusted.new_tokens, original.new_tokens);
+        assert_eq!(adjusted.cached_tokens, original.cached_tokens);
+        assert_eq!(adjusted.active_cached_tokens, original.active_cached_tokens);
+    }
+
+    #[test]
     fn admits_when_current_sequence_fits_without_reserving_future_output() {
         let manager = kv_manager(4);
         let sequence = ActiveSequence::new((0..8).collect(), 32, Some(4), false, false);
 
         let decision = decide_waiting_admission(
-            SchedulingPolicy::Vllm,
+            WaitingAdmissionConfig {
+                policy: SchedulingPolicy::Vllm,
+                num_gpu_blocks: 4,
+                block_size: 4,
+                mtp_enabled: false,
+            },
             &sequence,
             true,
             std::iter::empty(),
-            4,
-            4,
             &manager,
-            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Admit { .. }));
@@ -53,14 +99,16 @@ mod vllm {
         let sequence = ActiveSequence::new((0..8).collect(), 32, Some(4), false, false);
 
         let decision = decide_waiting_admission(
-            SchedulingPolicy::Vllm,
+            WaitingAdmissionConfig {
+                policy: SchedulingPolicy::Vllm,
+                num_gpu_blocks: 4,
+                block_size: 4,
+                mtp_enabled: false,
+            },
             &sequence,
             true,
             std::iter::empty(),
-            4,
-            4,
             &manager,
-            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Wait));
@@ -72,14 +120,16 @@ mod vllm {
         let sequence = ActiveSequence::new((0..20).collect(), 1, Some(4), false, false);
 
         let decision = decide_waiting_admission(
-            SchedulingPolicy::Vllm,
+            WaitingAdmissionConfig {
+                policy: SchedulingPolicy::Vllm,
+                num_gpu_blocks: 4,
+                block_size: 4,
+                mtp_enabled: false,
+            },
             &sequence,
             true,
             std::iter::empty(),
-            4,
-            4,
             &manager,
-            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Reject));
@@ -240,17 +290,43 @@ mod vllm {
         let sequence = ActiveSequence::new((0..12).collect(), 1, Some(4), true, false);
 
         let decision = decide_waiting_admission(
-            SchedulingPolicy::Vllm,
+            WaitingAdmissionConfig {
+                policy: SchedulingPolicy::Vllm,
+                num_gpu_blocks: 3,
+                block_size: 4,
+                mtp_enabled: false,
+            },
             &sequence,
             true,
             std::iter::empty(),
-            3,
-            4,
             &manager,
-            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Admit { .. }));
+    }
+
+    #[test]
+    fn mtp_recompute_requires_one_additional_available_block() {
+        let mut manager = kv_manager(3);
+        let mut holder = ActiveSequence::new((0..8).collect(), 1, Some(4), true, false);
+        let signal = holder.take_creation_signal().unwrap();
+        assert!(matches!(manager.process(&signal), G1Acquire::Ready(2)));
+        let sequence = ActiveSequence::new((0..12).collect(), 1, Some(4), true, false);
+
+        let decision = decide_waiting_admission(
+            WaitingAdmissionConfig {
+                policy: SchedulingPolicy::Vllm,
+                num_gpu_blocks: 3,
+                block_size: 4,
+                mtp_enabled: true,
+            },
+            &sequence,
+            true,
+            std::iter::empty(),
+            &manager,
+        );
+
+        assert!(matches!(decision, AdmissionDecision::Wait));
     }
 
     #[test]
@@ -268,14 +344,16 @@ mod vllm {
         let sequence = ActiveSequence::new((0..12).collect(), 1, Some(4), true, false);
 
         let decision = decide_waiting_admission(
-            SchedulingPolicy::Vllm,
+            WaitingAdmissionConfig {
+                policy: SchedulingPolicy::Vllm,
+                num_gpu_blocks: 3,
+                block_size: 4,
+                mtp_enabled: false,
+            },
             &sequence,
             true,
             std::iter::empty(),
-            3,
-            4,
             &manager,
-            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Wait));

--- a/lib/mocker/src/scheduler/vllm/policy/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/policy/tests.rs
@@ -38,6 +38,7 @@ mod vllm {
             4,
             4,
             &manager,
+            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Admit { .. }));
@@ -59,6 +60,7 @@ mod vllm {
             4,
             4,
             &manager,
+            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Wait));
@@ -77,6 +79,7 @@ mod vllm {
             4,
             4,
             &manager,
+            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Reject));
@@ -244,6 +247,7 @@ mod vllm {
             3,
             4,
             &manager,
+            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Admit { .. }));
@@ -271,6 +275,7 @@ mod vllm {
             3,
             4,
             &manager,
+            false,
         );
 
         assert!(matches!(decision, AdmissionDecision::Wait));

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -3192,6 +3192,8 @@ mod offload {
             .enable_chunked_prefill(true)
             .enable_prefix_caching(true)
             .speedup_ratio(0.0)
+            .aic_nextn(Some(1))
+            .aic_nextn_accept_rates(Some("1".to_string()))
             .build()
             .unwrap();
         let mut core = VllmCore::new(args);

--- a/lib/mocker/src/scheduler/vllm/tests.rs
+++ b/lib/mocker/src/scheduler/vllm/tests.rs
@@ -1396,6 +1396,58 @@ mod core_behavior {
     }
 
     #[test]
+    fn test_mtp_recomputes_last_prefix_cache_block() {
+        fn second_request_admission_reuse(mtp_enabled: bool) -> (usize, u64, u64) {
+            let mut builder = MockEngineArgs::builder()
+                .block_size(4)
+                .num_gpu_blocks(16)
+                .max_num_batched_tokens(Some(16))
+                .max_num_seqs(Some(1))
+                .enable_prefix_caching(true)
+                .speedup_ratio(0.0);
+            if mtp_enabled {
+                builder = builder
+                    .aic_nextn(Some(1))
+                    .aic_nextn_accept_rates(Some("1".to_string()));
+            }
+            let mut core = VllmCore::new(builder.build().unwrap());
+            let mut collector = crate::replay::TraceCollector::default();
+
+            core.receive(DirectRequest {
+                tokens: (0..8).collect(),
+                max_output_tokens: 1,
+                output_token_ids: None,
+                uuid: Some(Uuid::from_u128(1)),
+                dp_rank: 0,
+                arrival_timestamp_ms: None,
+                ..Default::default()
+            });
+            core.execute_pass(&mut collector, 0.0);
+            assert!(core.is_empty());
+
+            core.receive(DirectRequest {
+                tokens: (0..12).collect(),
+                max_output_tokens: 1,
+                output_token_ids: None,
+                uuid: Some(Uuid::from_u128(2)),
+                dp_rank: 0,
+                arrival_timestamp_ms: None,
+                ..Default::default()
+            });
+            let pass = core.execute_pass(&mut collector, 1.0);
+            let fpm = pass.fpm.expect("forward-pass metrics should be present");
+            (
+                pass.admissions[0].reused_input_tokens,
+                fpm.sum_prefill_tokens,
+                fpm.sum_prefill_kv_tokens,
+            )
+        }
+
+        assert_eq!(second_request_admission_reuse(false), (8, 4, 8));
+        assert_eq!(second_request_admission_reuse(true), (4, 8, 4));
+    }
+
+    #[test]
     fn test_mtp_releases_unused_block_reservations() {
         let args = MockEngineArgs::builder()
             .block_size(2)


### PR DESCRIPTION
vLLM removes the last matched prefix block because the speculative drafter needs its hidden states. Without this adjustment, mocker overstates prefix reuse and understates prefill work for MTP requests.

## Summary

- model vLLM EAGLE/MTP prefix-cache behavior by recomputing the final matched cache block
- apply the adjusted prefill cost consistently during waiting admission and reuse reporting
- keep the rule scoped to the vLLM scheduling policy when MTP is enabled
- add a regression test showing a one-block shift from cached KV tokens to prefill tokens

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker` (497 passed, 1 ignored)

## Reference

- https://github.com/vllm-project/vllm/issues/38182
- https://github.com/vllm-project/vllm/issues/44858

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved vLLM admission and prefix-cache handling when MTP is enabled.
  * Corrected cached-token and prefill-cost calculations for requests using cached prefixes.
  * Improved scheduling decisions for requests waiting for admission.

* **Tests**
  * Added coverage verifying prefix-cache behavior with and without MTP enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->