### PR TITLE
refactor(selection): use `selection_id` as the single reservation id

### DIFF
--- a/docs/components/router/standalone-selection.md
+++ b/docs/components/router/standalone-selection.md
@@ -123,12 +123,11 @@ Select a worker without booking active load:
 ### `POST /select_and_reserve`
 
 Select and atomically book load in the receiving selector process. Supply a
-globally unique `reservation_id`, or allow the service to generate one:
+globally unique `selection_id`, or allow the service to generate one:
 
 ```json
 {
   "selection_id": "select-123",
-  "reservation_id": "request-123",
   "model_name": "model",
   "routing_group": "default",
   "block_hashes": [11, 12, 13, 14, 15, 16, 17, 18],
@@ -142,7 +141,6 @@ Both endpoints return the same selection shape:
 ```json
 {
   "selection_id": "select-123",
-  "reservation_id": "request-123",
   "model_name": "model",
   "routing_group": "default",
   "worker_id": 1,
@@ -160,7 +158,7 @@ Both endpoints return the same selection shape:
 }
 ```
 
-`selection_id` and `reservation_id` are omitted when absent. All `overlap`
+`selection_id` is omitted when absent. All `overlap`
 values are matched token counts. `gpu`, `cpu`, and `disk` use the cumulative
 Mooncake tier semantics documented in the standalone indexer's
 [per-instance tier breakdown](standalone-indexer.md#per-instance-tier-breakdown).
@@ -182,9 +180,9 @@ Ray can keep model invocation separate from selector admission:
 
 1. Call `POST /select`.
 2. Send the request to the returned `endpoint` and `dp_rank`.
-3. Call `POST /reservations` with a globally unique reservation ID, selected
-   worker identity, the same prompt representation, and the returned
-   `effective_prefill_tokens`.
+3. Call `POST /reservations` with a `selection_id` (globally unique; reuse the
+   one from `/select`), the selected worker identity, the same prompt
+   representation, and the returned `effective_prefill_tokens`.
 4. Report prefill completion and request completion through the lifecycle API.
 
 ```http
@@ -192,7 +190,7 @@ POST /reservations
 Content-Type: application/json
 
 {
-  "reservation_id": "request-123",
+  "selection_id": "request-123",
   "model_name": "model",
   "routing_group": "default",
   "worker_id": 1,
@@ -211,9 +209,9 @@ reservation API does not accept or derive accounting from overlap fields.
 ## Reservation Lifecycle
 
 ```http
-POST /reservations/{reservation_id}/prefill_complete
-POST /reservations/{reservation_id}/output_block
-DELETE /reservations/{reservation_id}
+POST /reservations/{selection_id}/prefill_complete
+POST /reservations/{selection_id}/output_block
+DELETE /reservations/{selection_id}
 ```
 
 `prefill_complete` clears active prefill load. `output_block` updates only the

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -572,11 +572,11 @@ impl SelectionService {
     fn prefill_complete<'p>(
         &self,
         py: Python<'p>,
-        reservation_id: String,
+        selection_id: String,
     ) -> PyResult<Bound<'p, PyAny>> {
         let core = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            core.prefill_complete(&reservation_id)
+            core.prefill_complete(&selection_id)
                 .await
                 .map_err(selection_to_pyerr)?;
             Ok(())
@@ -584,14 +584,10 @@ impl SelectionService {
     }
 
     /// Record one decode output block for a reservation, advancing its decode load.
-    #[pyo3(signature = (reservation_id, *, decay_fraction = None))]
-    fn add_output_block(
-        &self,
-        reservation_id: String,
-        decay_fraction: Option<f64>,
-    ) -> PyResult<()> {
+    #[pyo3(signature = (selection_id, *, decay_fraction = None))]
+    fn add_output_block(&self, selection_id: String, decay_fraction: Option<f64>) -> PyResult<()> {
         self.inner
-            .add_output_block(&reservation_id, decay_fraction)
+            .add_output_block(&selection_id, decay_fraction)
             .map_err(selection_to_pyerr)
     }
 
@@ -599,11 +595,11 @@ impl SelectionService {
     fn free_reservation<'p>(
         &self,
         py: Python<'p>,
-        reservation_id: String,
+        selection_id: String,
     ) -> PyResult<Bound<'p, PyAny>> {
         let core = self.inner.clone();
         pyo3_async_runtimes::tokio::future_into_py(py, async move {
-            core.free_reservation(&reservation_id)
+            core.free_reservation(&selection_id)
                 .await
                 .map_err(selection_to_pyerr)?;
             Ok(())

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -711,17 +711,17 @@ class SelectionService:
         """Book a request's load against a chosen worker."""
         ...
 
-    async def prefill_complete(self, reservation_id: str) -> None:
+    async def prefill_complete(self, selection_id: str) -> None:
         """Mark a reservation's prefill complete; its load shifts prefill -> decode."""
         ...
 
     def add_output_block(
-        self, reservation_id: str, *, decay_fraction: Optional[float] = None
+        self, selection_id: str, *, decay_fraction: Optional[float] = None
     ) -> None:
         """Record one decode output block for a reservation, advancing its decode load."""
         ...
 
-    async def free_reservation(self, reservation_id: str) -> None:
+    async def free_reservation(self, selection_id: str) -> None:
         """Free a finished reservation, releasing its tracked load."""
         ...
 

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -68,7 +68,6 @@ struct PreparedSelectionInputs {
 struct SelectionOperation {
     key: SelectionKey,
     selection_id: Option<String>,
-    reservation_id: Option<String>,
     prompt: PromptRequest,
     router_config_override: Option<RouterConfigOverride>,
     expected_output_tokens: Option<u32>,
@@ -575,7 +574,6 @@ impl SelectionCore {
             SelectionOperation {
                 key: SelectionKey::new(req.model_name, req.routing_group),
                 selection_id: req.selection_id,
-                reservation_id: None,
                 prompt: req.prompt,
                 router_config_override: req.router_config_override,
                 expected_output_tokens: req.expected_output_tokens,
@@ -604,14 +602,13 @@ impl SelectionCore {
         req: SelectAndReserveRequest,
         policy_class: Option<String>,
     ) -> Result<SelectResponse, SelectionError> {
-        let reservation_id = req
-            .reservation_id
+        let selection_id = req
+            .selection_id
             .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
         self.schedule_selection(
             SelectionOperation {
                 key: SelectionKey::new(req.model_name, req.routing_group),
-                selection_id: req.selection_id,
-                reservation_id: Some(reservation_id),
+                selection_id: Some(selection_id),
                 prompt: req.prompt,
                 router_config_override: req.router_config_override,
                 expected_output_tokens: req.expected_output_tokens,
@@ -636,7 +633,6 @@ impl SelectionCore {
         let SelectionOperation {
             key,
             selection_id,
-            reservation_id,
             prompt,
             router_config_override,
             expected_output_tokens,
@@ -659,9 +655,9 @@ impl SelectionCore {
         } = self.prepare_selection_inputs(&entry, &prompt).await?;
         let mode = if book {
             ScheduleMode::Tracked {
-                request_id: reservation_id.clone().ok_or_else(|| {
+                request_id: selection_id.clone().ok_or_else(|| {
                     SelectionError::Internal(
-                        "booked selection did not include a reservation ID".to_string(),
+                        "booked selection did not include a selection ID".to_string(),
                     )
                 })?,
             }
@@ -711,7 +707,6 @@ impl SelectionCore {
 
         Ok(SelectResponse {
             selection_id,
-            reservation_id,
             model_name: key.model_name,
             routing_group: key.routing_group,
             worker_id: response.best_worker.worker_id,
@@ -760,7 +755,7 @@ impl SelectionCore {
         entry
             .scheduler
             .add_request(SequenceRequest {
-                request_id: req.reservation_id.clone(),
+                request_id: req.selection_id.clone(),
                 token_sequence: Some(normalized.sequence_hashes),
                 track_prefill_tokens,
                 expected_output_tokens: req.expected_output_tokens,
@@ -771,7 +766,7 @@ impl SelectionCore {
             .await?;
 
         Ok(ReservationResponse {
-            reservation_id: req.reservation_id,
+            selection_id: req.selection_id,
             model_name: key.model_name,
             routing_group: key.routing_group,
             worker_id: worker.worker_id,
@@ -780,37 +775,37 @@ impl SelectionCore {
         })
     }
 
-    pub async fn prefill_complete(&self, reservation_id: &str) -> Result<(), SelectionError> {
+    pub async fn prefill_complete(&self, selection_id: &str) -> Result<(), SelectionError> {
         let entries = { self.entries.read().values().cloned().collect::<Vec<_>>() };
         for entry in entries {
-            match entry.scheduler.mark_prefill_completed(reservation_id).await {
+            match entry.scheduler.mark_prefill_completed(selection_id).await {
                 Ok(()) => return Ok(()),
                 Err(SequenceError::RequestNotFound { .. }) => continue,
                 Err(error) => return Err(error.into()),
             }
         }
         Err(SelectionError::NotFound(format!(
-            "reservation {reservation_id} not found"
+            "reservation {selection_id} not found"
         )))
     }
 
-    pub async fn free_reservation(&self, reservation_id: &str) -> Result<(), SelectionError> {
+    pub async fn free_reservation(&self, selection_id: &str) -> Result<(), SelectionError> {
         let entries = { self.entries.read().values().cloned().collect::<Vec<_>>() };
         for entry in entries {
-            match entry.scheduler.free(reservation_id).await {
+            match entry.scheduler.free(selection_id).await {
                 Ok(()) => return Ok(()),
                 Err(SequenceError::RequestNotFound { .. }) => continue,
                 Err(error) => return Err(error.into()),
             }
         }
         Err(SelectionError::NotFound(format!(
-            "reservation {reservation_id} not found"
+            "reservation {selection_id} not found"
         )))
     }
 
     pub fn add_output_block(
         &self,
-        reservation_id: &str,
+        selection_id: &str,
         decay_fraction: Option<f64>,
     ) -> Result<(), SelectionError> {
         if let Some(frac) = decay_fraction
@@ -825,7 +820,7 @@ impl SelectionCore {
         for entry in entries {
             match entry
                 .scheduler
-                .add_output_block(reservation_id, decay_fraction)
+                .add_output_block(selection_id, decay_fraction)
             {
                 Ok(()) => return Ok(()),
                 Err(SequenceError::RequestNotFound { .. }) => continue,
@@ -833,7 +828,7 @@ impl SelectionCore {
             }
         }
         Err(SelectionError::NotFound(format!(
-            "reservation {reservation_id} not found"
+            "reservation {selection_id} not found"
         )))
     }
 
@@ -1039,12 +1034,11 @@ mod tests {
         }
     }
 
-    fn reserve_request(reservation_id: &str) -> SelectAndReserveRequest {
+    fn reserve_request(selection_id: &str) -> SelectAndReserveRequest {
         SelectAndReserveRequest {
             model_name: "model".to_string(),
             routing_group: "default".to_string(),
-            selection_id: None,
-            reservation_id: Some(reservation_id.to_string()),
+            selection_id: Some(selection_id.to_string()),
             prompt: prompt(),
             router_config_override: None,
             expected_output_tokens: None,
@@ -1202,7 +1196,7 @@ mod tests {
             .create_reservation(ReservationRequest {
                 model_name: "model".to_string(),
                 routing_group: "default".to_string(),
-                reservation_id: "res-after-shutdown".to_string(),
+                selection_id: "res-after-shutdown".to_string(),
                 worker_id: 1,
                 dp_rank: None,
                 prompt: prompt(),
@@ -1283,7 +1277,7 @@ mod tests {
             core.create_reservation(ReservationRequest {
                 model_name: "model".to_string(),
                 routing_group: "default".to_string(),
-                reservation_id: format!("occupy-{worker_id}"),
+                selection_id: format!("occupy-{worker_id}"),
                 worker_id,
                 dp_rank: Some(0),
                 prompt: PromptRequest {
@@ -1312,7 +1306,6 @@ mod tests {
                     model_name: "model".to_string(),
                     routing_group: "default".to_string(),
                     selection_id: Some("refresh-selection".to_string()),
-                    reservation_id: Some("refreshed-request".to_string()),
                     prompt: PromptRequest {
                         token_ids: None,
                         mm_routing_info: None,

--- a/lib/kv-router/src/services/selection/server.rs
+++ b/lib/kv-router/src/services/selection/server.rs
@@ -142,9 +142,9 @@ async fn create_reservation(
 
 async fn prefill_complete(
     State(state): State<Arc<AppState>>,
-    Path(reservation_id): Path<String>,
+    Path(selection_id): Path<String>,
 ) -> Response {
-    match state.service.prefill_complete(&reservation_id).await {
+    match state.service.prefill_complete(&selection_id).await {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => error.into_response(),
     }
@@ -152,9 +152,9 @@ async fn prefill_complete(
 
 async fn delete_reservation(
     State(state): State<Arc<AppState>>,
-    Path(reservation_id): Path<String>,
+    Path(selection_id): Path<String>,
 ) -> Response {
-    match state.service.free_reservation(&reservation_id).await {
+    match state.service.free_reservation(&selection_id).await {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => error.into_response(),
     }
@@ -162,7 +162,7 @@ async fn delete_reservation(
 
 async fn add_output_block(
     State(state): State<Arc<AppState>>,
-    Path(reservation_id): Path<String>,
+    Path(selection_id): Path<String>,
     payload: Result<Json<OutputBlockRequest>, JsonRejection>,
 ) -> Response {
     let Json(req) = match payload {
@@ -171,7 +171,7 @@ async fn add_output_block(
     };
     match state
         .service
-        .add_output_block(&reservation_id, req.decay_fraction)
+        .add_output_block(&selection_id, req.decay_fraction)
     {
         Ok(()) => json_ok(StatusCode::OK),
         Err(error) => error.into_response(),
@@ -313,14 +313,14 @@ pub(crate) fn create_router(state: Arc<AppState>) -> Router {
         .route("/select_and_reserve", post(select_and_reserve))
         .route("/reservations", post(create_reservation))
         .route(
-            "/reservations/{reservation_id}/prefill_complete",
+            "/reservations/{selection_id}/prefill_complete",
             post(prefill_complete),
         )
         .route(
-            "/reservations/{reservation_id}/output_block",
+            "/reservations/{selection_id}/output_block",
             post(add_output_block),
         )
-        .route("/reservations/{reservation_id}", delete(delete_reservation))
+        .route("/reservations/{selection_id}", delete(delete_reservation))
         .route("/workers", post(create_worker).get(list_workers))
         .route(
             "/workers/{worker_id}",

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -241,20 +241,20 @@ impl SelectionService {
         self.core.create_reservation(req).await
     }
 
-    pub async fn prefill_complete(&self, reservation_id: &str) -> Result<(), SelectionError> {
-        self.core.prefill_complete(reservation_id).await
+    pub async fn prefill_complete(&self, selection_id: &str) -> Result<(), SelectionError> {
+        self.core.prefill_complete(selection_id).await
     }
 
     pub fn add_output_block(
         &self,
-        reservation_id: &str,
+        selection_id: &str,
         decay_fraction: Option<f64>,
     ) -> Result<(), SelectionError> {
-        self.core.add_output_block(reservation_id, decay_fraction)
+        self.core.add_output_block(selection_id, decay_fraction)
     }
 
-    pub async fn free_reservation(&self, reservation_id: &str) -> Result<(), SelectionError> {
-        self.core.free_reservation(reservation_id).await
+    pub async fn free_reservation(&self, selection_id: &str) -> Result<(), SelectionError> {
+        self.core.free_reservation(selection_id).await
     }
 
     pub fn ready(&self) -> ReadyResponse {

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -367,12 +367,12 @@ async fn select_and_reserve_books_and_duplicate_reservation_conflicts() {
     let response = post(
         app.clone(),
         "/select_and_reserve",
-        r#"{"model_name":"model","token_ids":[1,2,3,4],"reservation_id":"res-a"}"#,
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"res-a"}"#,
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);
     let body = response_json(response).await;
-    assert_eq!(body["reservation_id"], "res-a");
+    assert_eq!(body["selection_id"], "res-a");
     assert_eq!(body["effective_prefill_tokens"], 4);
 
     let loads_response = app
@@ -391,7 +391,7 @@ async fn select_and_reserve_books_and_duplicate_reservation_conflicts() {
     let duplicate = post(
         app.clone(),
         "/select_and_reserve",
-        r#"{"model_name":"model","token_ids":[1,2,3,4],"reservation_id":"res-a"}"#,
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"res-a"}"#,
     )
     .await;
     assert_eq!(duplicate.status(), StatusCode::CONFLICT);
@@ -450,7 +450,7 @@ policy_classes:
     let reserved = post_with_policy_class(
         app.clone(),
         "/select_and_reserve",
-        r#"{"model_name":"model","token_ids":[1,2,3,4],"reservation_id":"latency-active"}"#,
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"latency-active"}"#,
         Some("latency"),
     )
     .await;
@@ -491,7 +491,7 @@ async fn output_block_endpoint_updates_reserved_load() {
     let response = post(
         app.clone(),
         "/select_and_reserve",
-        r#"{"model_name":"model","token_ids":[1,2,3,4],"reservation_id":"res-output"}"#,
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"res-output"}"#,
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);
@@ -562,7 +562,7 @@ async fn explicit_reservation_books_after_select() {
 
     let reservation = serde_json::json!({
         "model_name": "model",
-        "reservation_id": "res-b",
+        "selection_id": "res-b",
         "worker_id": selected["worker_id"],
         "dp_rank": selected["dp_rank"],
         "sequence_hashes": [1],
@@ -598,7 +598,7 @@ async fn explicit_reservation_rejects_effective_prefill_above_isl() {
     );
     let reservation = serde_json::json!({
         "model_name": "model",
-        "reservation_id": "res-too-large",
+        "selection_id": "res-too-large",
         "worker_id": 1,
         "sequence_hashes": [1],
         "isl_tokens": 4,
@@ -634,7 +634,7 @@ async fn explicit_reservation_rejects_unschedulable_worker() {
 
     let reservation = serde_json::json!({
         "model_name": "model",
-        "reservation_id": "res-unschedulable",
+        "selection_id": "res-unschedulable",
         "worker_id": 1,
         "sequence_hashes": [1],
         "isl_tokens": 4
@@ -689,7 +689,7 @@ async fn selector_replica_sync_propagates_request_lifecycle() {
     let response = post(
         app_a.clone(),
         "/select_and_reserve",
-        r#"{"model_name":"model","token_ids":[1,2,3,4],"reservation_id":"replicated"}"#,
+        r#"{"model_name":"model","token_ids":[1,2,3,4],"selection_id":"replicated"}"#,
     )
     .await;
     assert_eq!(response.status(), StatusCode::OK);

--- a/lib/kv-router/src/services/selection/types.rs
+++ b/lib/kv-router/src/services/selection/types.rs
@@ -435,8 +435,6 @@ pub struct SelectAndReserveRequest {
     pub routing_group: String,
     #[serde(default)]
     pub selection_id: Option<String>,
-    #[serde(default)]
-    pub reservation_id: Option<String>,
     #[serde(flatten)]
     pub prompt: PromptRequest,
     #[serde(default)]
@@ -463,7 +461,7 @@ pub struct ReservationRequest {
     pub model_name: String,
     #[serde(default = "default_routing_group")]
     pub routing_group: String,
-    pub reservation_id: String,
+    pub selection_id: String,
     pub worker_id: WorkerId,
     #[serde(default)]
     pub dp_rank: Option<DpRank>,
@@ -511,8 +509,6 @@ pub struct OverlapScoresRequest {
 pub struct SelectResponse {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub selection_id: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub reservation_id: Option<String>,
     pub model_name: String,
     pub routing_group: String,
     pub worker_id: WorkerId,
@@ -525,7 +521,7 @@ pub struct SelectResponse {
 
 #[derive(Debug, Serialize)]
 pub struct ReservationResponse {
-    pub reservation_id: String,
+    pub selection_id: String,
     pub model_name: String,
     pub routing_group: String,
     pub worker_id: WorkerId,


### PR DESCRIPTION
## Overview:

Retire `reservation_id` from the selection service, and `selection_id` becomes the single booking id.

Groundwork for #11416 (token-cache), which builds on the single-id contract.

## Details:

- `POST /reservations` books under `selection_id` (was `reservation_id`); `worker_id` is still required.
- `POST /select_and_reserve` takes one id, `selection_id`, generated when omitted (returned in the response); the separate `reservation_id` is gone.
- `SelectResponse` / `ReservationResponse` and the lifecycle endpoints key on `selection_id`.
- Behavior-preserving rename: existing tests updated to the new field, no new tests added.

## API changes

### HTTP

- Booking: `POST /reservations`:
```diff
-{ "reservation_id": "req-123", "worker_id": 1, "sequence_hashes": [..], "isl_tokens": 512 }
+{ "selection_id": "req-123",  "worker_id": 1, "sequence_hashes": [..], "isl_tokens": 512 }
```

- Select + book: `POST /select_and_reserve`:
```diff
-{ "selection_id": "sel-123", "reservation_id": "req-123", .. }
+{ "selection_id": "sel-123", .. }        # generated if omitted
```

- Responses (`/select`, `/select_and_reserve`, `/reservations`): the `reservation_id` field is removed; the booked id is reported as `selection_id`.

- Lifecycle:
```diff
-POST   /reservations/{reservation_id}/prefill_complete
-POST   /reservations/{reservation_id}/output_block
-DELETE /reservations/{reservation_id}
+POST   /reservations/{selection_id}/prefill_complete
+POST   /reservations/{selection_id}/output_block
+DELETE /reservations/{selection_id}
```

### Python (`SelectionService`)
```diff
-await svc.prefill_complete(reservation_id)
-svc.add_output_block(reservation_id, decay_fraction=..)
-await svc.free_reservation(reservation_id)
+await svc.prefill_complete(selection_id)
+svc.add_output_block(selection_id, decay_fraction=..)
+await svc.free_reservation(selection_id)
```
- `create_reservation(request)` / `select_and_reserve(request)` take dicts, so their keys follow the HTTP schema above (`reservation_id` → `selection_id`).

## Where should the reviewer start?

1. `lib/kv-router/src/services/selection/types.rs`: request/response field changes.
2. `lib/kv-router/src/services/selection/core/mod.rs`: `create_reservation` and `select_and_reserve` (single id; UUID generated when absent).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11561" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Replaced `reservation_id` with `selection_id` across selection and reservation workflows.
  * Updated select-and-reserve responses and reservation requests to use `selection_id`.
  * Updated reservation lifecycle endpoints for prefill completion, output blocks, and deletion.
  * Selection IDs are now generated when needed and reused throughout the reservation lifecycle.
* **Documentation**
  * Updated API guidance and examples to reflect the new identifier naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->