### PR TITLE
fix(preprocessor): isolate reasoning parser state per choice in interleaved n>1 streams

### DIFF
--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -284,14 +284,23 @@ where
     attach_metrics_annotation(response, &metrics);
 }
 
-// Reasoning State for reasoning parsing transformation step
+// Reasoning State for reasoning parsing transformation step.
+//
+// The reasoning parser and the guided-JSON bypass decision are kept per
+// `choice.index` so that with `n > 1` one choice's bare-JSON bypass cannot
+// suppress another choice's reasoning split. This mirrors the per-choice state
+// already used by the tool-call jail and the leading-`<think>` strip stage.
+struct ChoiceReasoningState {
+    parser: Box<dyn ReasoningParser>,
+    guided_json_bypass_decision: Option<bool>,
+}
+
 struct ReasoningState {
     stream: Pin<Box<dyn Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send>>,
-    reasoning_parser: Option<Box<dyn ReasoningParser>>,
+    parser_name: String,
+    prompt_injected_reasoning: bool,
     bypass_bare_guided_json: bool,
-    // TODO: Track this per choice.index for n > 1. The current bypass
-    // decision and parser state are shared across all streamed choices.
-    guided_json_bypass_decision: Option<bool>,
+    choices: HashMap<u32, ChoiceReasoningState>,
 }
 
 /// Per-image routing payload accumulated by `gather_multi_modal_data` and
@@ -3539,81 +3548,100 @@ impl OpenAIPreprocessor {
     where
         S: Stream<Item = Annotated<NvCreateChatCompletionStreamResponse>> + Send + 'static,
     {
-        // Initialize reasoning parser from parser_name
-        let mut reasoning_parser = Box::new(ReasoningParserType::get_reasoning_parser_from_name(
-            parser_name.as_ref(),
-        )) as Box<dyn ReasoningParser>;
-
-        if prompt_injected_reasoning {
-            reasoning_parser.set_in_reasoning(true);
-        }
-
+        // Parsers and bypass decisions are created lazily per `choice.index`
+        // inside the unfold loop, so `n > 1` choices never share state.
         let state = ReasoningState {
             stream: Box::pin(stream),
-            reasoning_parser: Some(reasoning_parser),
+            parser_name,
+            prompt_injected_reasoning,
             bypass_bare_guided_json,
-            guided_json_bypass_decision: None,
+            choices: HashMap::new(),
         };
 
         stream::unfold(state, |mut state| async move {
             if let Some(response) = state.stream.next().await {
-                let guided_json_bypass_decision = if state.bypass_bare_guided_json {
-                    match state.guided_json_bypass_decision {
-                        Some(decision) => Some(decision),
-                        None => {
-                            // Decide once from the first non-whitespace content.
-                            let decision = response.data.as_ref().and_then(|data| {
-                                data.inner.choices.iter().find_map(|choice| {
-                                    if let Some(ChatCompletionMessageContent::Text(text)) =
-                                        choice.delta.content.as_ref()
-                                    {
-                                        let text = text.trim_start();
-                                        if text.is_empty() {
-                                            return None;
-                                        }
-                                        return Some(matches!(text.as_bytes()[0], b'[' | b'{'));
-                                    }
-                                    None
-                                })
-                            });
-                            if let Some(decision) = decision {
-                                state.guided_json_bypass_decision = Some(decision);
-                            }
-                            decision
-                        }
-                    }
-                } else {
-                    Some(false)
-                };
+                // Split disjoint field borrows so the per-choice map and the
+                // parser-factory inputs can be used together inside map_data.
+                // Scoped in a block so the borrows end before `state` moves.
+                let processed_response = {
+                    let ReasoningState {
+                        parser_name,
+                        prompt_injected_reasoning,
+                        bypass_bare_guided_json,
+                        choices,
+                        ..
+                    } = &mut state;
+                    let parser_name = &*parser_name;
+                    let prompt_injected_reasoning = *prompt_injected_reasoning;
+                    let bypass_bare_guided_json = *bypass_bare_guided_json;
 
-                // Process the response through reasoning parser if available
-                let processed_response = if guided_json_bypass_decision != Some(false) {
-                    // Keep bare JSON and leading whitespace available to the tool jail.
-                    response
-                } else if let Some(ref mut parser) = state.reasoning_parser {
                     response.map_data(|mut data| {
-                        // Process all choices, not just the first one
                         for choice in data.inner.choices.iter_mut() {
-                            // Reasoning parsing only applies to text content
-                            if let Some(ChatCompletionMessageContent::Text(text)) =
-                                choice.delta.content.as_ref()
-                            {
-                                let parser_result =
-                                    parser.parse_reasoning_streaming_incremental(text, &[]);
+                            let choice_state = choices.entry(choice.index).or_insert_with(|| {
+                                let mut parser =
+                                    Box::new(ReasoningParserType::get_reasoning_parser_from_name(
+                                        parser_name,
+                                    ))
+                                        as Box<dyn ReasoningParser>;
+                                if prompt_injected_reasoning {
+                                    parser.set_in_reasoning(true);
+                                }
+                                ChoiceReasoningState {
+                                    parser,
+                                    guided_json_bypass_decision: None,
+                                }
+                            });
 
-                                // Update this specific choice with parsed content
+                            // Decide once per choice, from ITS OWN first
+                            // non-whitespace content, whether the backend
+                            // emitted bare guided JSON (`[`/`{`) that must reach
+                            // the tool jail unparsed.
+                            let bypass_decision = if bypass_bare_guided_json {
+                                match choice_state.guided_json_bypass_decision {
+                                    Some(decision) => Some(decision),
+                                    None => {
+                                        let decision = match choice.delta.content.as_ref() {
+                                            Some(ChatCompletionMessageContent::Text(text)) => {
+                                                let text = text.trim_start();
+                                                if text.is_empty() {
+                                                    None
+                                                } else {
+                                                    Some(matches!(text.as_bytes()[0], b'[' | b'{'))
+                                                }
+                                            }
+                                            _ => None,
+                                        };
+                                        if let Some(decision) = decision {
+                                            choice_state.guided_json_bypass_decision =
+                                                Some(decision);
+                                        }
+                                        decision
+                                    }
+                                }
+                            } else {
+                                Some(false)
+                            };
+
+                            // Only a choice decided NOT to bypass is parsed. A
+                            // bare-JSON or still-undecided (whitespace-only)
+                            // choice keeps its content untouched for the jail.
+                            // Reasoning parsing only applies to text content;
+                            // multimodal content passes through unchanged.
+                            if bypass_decision == Some(false)
+                                && let Some(ChatCompletionMessageContent::Text(text)) =
+                                    choice.delta.content.as_ref()
+                            {
+                                let parser_result = choice_state
+                                    .parser
+                                    .parse_reasoning_streaming_incremental(text, &[]);
                                 choice.delta.content = parser_result
                                     .get_some_normal_text()
                                     .map(ChatCompletionMessageContent::Text);
                                 choice.delta.reasoning_content = parser_result.get_some_reasoning();
                             }
-                            // For multimodal content, pass through unchanged
                         }
                         Ok(data)
                     })
-                } else {
-                    // No reasoning parser configured, pass through unchanged
-                    response
                 };
 
                 Some((processed_response, state))

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -456,6 +456,46 @@ fn mock_final_chunk() -> NvCreateChatCompletionStreamResponse {
     }
 }
 
+/// Terminal `finish_reason=Stop` chunk carrying one finish per listed choice
+/// index — the multi-choice analog of `mock_final_chunk`, so an `n > 1` stream
+/// flushes every choice's jail state.
+fn mock_multi_choice_final_chunk(indices: &[u32]) -> NvCreateChatCompletionStreamResponse {
+    use dynamo_protocols::types::{
+        ChatChoiceStream, ChatCompletionStreamResponseDelta, CreateChatCompletionStreamResponse,
+    };
+    #[allow(deprecated)]
+    let choices = indices
+        .iter()
+        .map(|index| ChatChoiceStream {
+            index: *index,
+            delta: ChatCompletionStreamResponseDelta {
+                role: None,
+                content: None,
+                tool_calls: None,
+                function_call: None,
+                refusal: None,
+                reasoning_content: None,
+            },
+            finish_reason: Some(FinishReason::Stop),
+            logprobs: None,
+        })
+        .collect();
+    NvCreateChatCompletionStreamResponse {
+        inner: CreateChatCompletionStreamResponse {
+            id: "test-id".to_string(),
+            choices,
+            created: 0,
+            model: "test-model".to_string(),
+            system_fingerprint: None,
+            object: "chat.completion.chunk".to_string(),
+            usage: None,
+            service_tier: None,
+        },
+        nvext: None,
+        llm_metrics: None,
+    }
+}
+
 /// Regression for DeepSeek V4 tool-continuation turns.
 ///
 /// The V4 formatter seeds `<think>` into the prompt after a merged tool result,
@@ -1494,6 +1534,43 @@ async fn drain_stream(
     }
 }
 
+/// One choice's accumulated stream output, keyed by `choice.index` in
+/// `demux_by_choice`. Tool calls stay keyed by tool index so fragments merge.
+#[derive(Default)]
+struct PerChoice {
+    reasoning: String,
+    content: String,
+    tool_calls: BTreeMap<u32, MergedToolCall>,
+}
+
+/// Demux collected output chunks by `choice.index`, merging each choice's
+/// reasoning/content/tool-call deltas in arrival order.
+fn demux_by_choice(
+    output_chunks: &[Annotated<NvCreateChatCompletionStreamResponse>],
+) -> BTreeMap<u32, PerChoice> {
+    let mut by_choice: BTreeMap<u32, PerChoice> = BTreeMap::new();
+    for output in output_chunks {
+        let Some(data) = output.data.as_ref() else {
+            continue;
+        };
+        for choice in &data.inner.choices {
+            let entry = by_choice.entry(choice.index).or_default();
+            if let Some(r) = &choice.delta.reasoning_content {
+                entry.reasoning.push_str(r);
+            }
+            if let Some(c) = &choice.delta.content {
+                entry.content.push_str(get_text(c));
+            }
+            if let Some(tcs) = &choice.delta.tool_calls {
+                for tc in tcs {
+                    entry.tool_calls.entry(tc.index).or_default().merge_from(tc);
+                }
+            }
+        }
+    }
+    by_choice
+}
+
 /// Assert the standard "tool call extracted, nothing leaks" success shape
 /// shared by every matrix row that expects a successful extraction.
 fn assert_clean_tool_call(
@@ -1618,6 +1695,569 @@ async fn tool_choice_matrix_force_reasoning_named_bare_json() {
         );
         assert_clean_tool_call(&case, &content, &tool_calls, "San Francisco");
     }
+}
+
+/// Regression (GH-11997): with `n > 1`, each choice must decide bare-JSON vs.
+/// reasoning-first INDEPENDENTLY. Choice 0 streams bare guided JSON (bypass →
+/// tool call), choice 1 streams `reasoning</think>{json}` in the SAME chunks.
+/// The pre-fix stream made ONE global bypass decision from whichever choice
+/// emitted content first (choice 0's `[`) and applied it to every choice, so
+/// choice 1's reasoning + `</think>` leaked into `content` and its
+/// `reasoning_content` was lost. Per-choice state keeps the two isolated, and
+/// the different locations (SF vs. Boston) confirm no cross-contamination.
+#[tokio::test]
+async fn postprocessor_parsing_stream_multi_choice_isolates_guided_bypass_decision() {
+    let preprocessor = build_preprocessor(Some("deepseek_r1"), Some("nemotron_nano"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+
+    // choice 0: bare guided JSON. choice 1: reasoning, then `</think>`, then JSON.
+    let json0 = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let json1 = r#"[{"name":"get_weather","parameters":{"location":"Boston"}}]"#;
+
+    let input_chunks = vec![
+        // First content chunk: choice 0 leads with `[` (decides bypass), choice 1
+        // leads with reasoning text (must decide NOT to bypass).
+        mock_multi_choice_content_chunk(&[(0, "["), (1, "Let me check.")]),
+        mock_multi_choice_content_chunk(&[(0, &json0[1..]), (1, "</think>")]),
+        mock_multi_choice_content_chunk(&[(1, json1)]),
+        mock_multi_choice_final_chunk(&[0, 1]),
+    ];
+    let input_stream = stream::iter(input_chunks.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, &request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    let by_choice = demux_by_choice(&output_chunks);
+
+    let c0 = by_choice.get(&0).expect("choice 0 produced output");
+    assert!(
+        c0.reasoning.is_empty(),
+        "choice 0 (bare JSON) must not produce reasoning_content, got: {:?}",
+        c0.reasoning
+    );
+    let c0_calls: Vec<MergedToolCall> = c0.tool_calls.values().cloned().collect();
+    assert_clean_tool_call(
+        "choice 0 bare JSON",
+        &c0.content,
+        &c0_calls,
+        "San Francisco",
+    );
+
+    let c1 = by_choice.get(&1).expect("choice 1 produced output");
+    assert_eq!(
+        c1.reasoning, "Let me check.",
+        "choice 1 reasoning must be separated, not bypassed by choice 0's decision"
+    );
+    let c1_calls: Vec<MergedToolCall> = c1.tool_calls.values().cloned().collect();
+    assert_clean_tool_call("choice 1 reasoning-first", &c1.content, &c1_calls, "Boston");
+}
+
+// ---------------------------------------------------------------------------
+// GH-11997 step 3: n>1 synthetic-interleave lane (per-choice state isolation).
+//
+// Invariant: `demux(parse(interleave(A@0, B@1, ...)))[i] == parse(shape_i)`.
+// Each choice's demuxed output must equal what that same single-choice shape
+// produces on its own (n=1). No n>1 fixture is authored — the golden is each
+// shape's own solo run, computed at test time. Single-choice fixtures are
+// mathematically blind to this bug class: with one choice, per-response and
+// per-choice state are identical, so only interleaving two divergent shapes in
+// one stream reveals a stage that keyed state per response instead of per
+// `choice.index`.
+//
+// Sibling lanes over the frontend-crates v1 jail and v2 stream corpus live in
+// ai-dynamo/frontend-crates (`parsers/v1/tests/jail_interleave.rs`,
+// `conformance/tests/parity_toolcalling_stream_interleave.rs`); the schedule
+// core below is the dynamo-side copy of that lane's origin module.
+mod interleave {
+    //! Deterministic multi-choice interleave schedules. No RNG: every failure
+    //! reproduces byte-exactly. A "shape" is one choice's ordered delta texts.
+    //! `interleave` merges k shapes into one ordered list of chunks, each chunk
+    //! a `(choice.index, delta)` list, ready for `mock_multi_choice_content_chunk`.
+
+    #[derive(Clone, Copy, Debug)]
+    pub enum Schedule {
+        /// One delta from each choice per round, in index order: 0,1,0,1,...
+        RoundRobin,
+        /// Choice `i` starts `i * offset` rounds late (choice 0 streams alone
+        /// first), then the rest interleave by global round.
+        FirstByteOffset(usize),
+        /// Split choice 0's delta in half around the other choices' deltas of
+        /// the same round — stresses a marker split across a choice boundary.
+        BoundarySplit,
+    }
+
+    /// Every schedule the lane exercises — shared by the lossless roundtrip
+    /// test and the isolation assertion so the two cannot drift apart.
+    pub const ALL_SCHEDULES: [Schedule; 4] = [
+        Schedule::RoundRobin,
+        Schedule::FirstByteOffset(1),
+        Schedule::FirstByteOffset(2),
+        Schedule::BoundarySplit,
+    ];
+
+    /// Split `s` near the middle on a UTF-8 char boundary. Returns `("", s)`
+    /// when the string is too short to split (single char / empty).
+    fn split_mid(s: &str) -> (&str, &str) {
+        if s.len() < 2 {
+            return ("", s);
+        }
+        let mut mid = s.len() / 2;
+        while mid < s.len() && !s.is_char_boundary(mid) {
+            mid += 1;
+        }
+        if mid == s.len() {
+            return ("", s);
+        }
+        s.split_at(mid)
+    }
+
+    pub fn interleave(shapes: &[Vec<&str>], schedule: Schedule) -> Vec<Vec<(u32, String)>> {
+        let max_len = shapes.iter().map(|s| s.len()).max().unwrap_or(0);
+        let mut chunks: Vec<Vec<(u32, String)>> = Vec::new();
+        match schedule {
+            // RoundRobin is FirstByteOffset(0): every choice starts at round 0.
+            Schedule::RoundRobin | Schedule::FirstByteOffset(_) => {
+                let offset = match schedule {
+                    Schedule::FirstByteOffset(o) => o,
+                    _ => 0,
+                };
+                // Emit (round, index, delta) events, then order by (round, index)
+                // so each choice's stream starts `index * offset` rounds late.
+                let mut events: Vec<(usize, u32, String)> = Vec::new();
+                for (i, shape) in shapes.iter().enumerate() {
+                    for (j, delta) in shape.iter().enumerate() {
+                        events.push((i * offset + j, i as u32, (*delta).to_string()));
+                    }
+                }
+                events.sort_by_key(|(round, idx, _)| (*round, *idx));
+                chunks = events
+                    .into_iter()
+                    .map(|(_, idx, d)| vec![(idx, d)])
+                    .collect();
+            }
+            Schedule::BoundarySplit => {
+                for t in 0..max_len {
+                    // Choice 0's delta halves bracket the other choices' deltas
+                    // of the same round (no halves when choice 0 is exhausted).
+                    let halves = shapes.first().and_then(|s| s.get(t)).map(|d| split_mid(d));
+                    if let Some((h1, _)) = halves
+                        && !h1.is_empty()
+                    {
+                        chunks.push(vec![(0, h1.to_string())]);
+                    }
+                    for (i, shape) in shapes.iter().enumerate().skip(1) {
+                        if let Some(delta) = shape.get(t) {
+                            chunks.push(vec![(i as u32, (*delta).to_string())]);
+                        }
+                    }
+                    if let Some((_, h2)) = halves {
+                        chunks.push(vec![(0, h2.to_string())]);
+                    }
+                }
+            }
+        }
+        chunks
+    }
+
+    /// Rewrite the generator's positional `0..k` indices onto arbitrary
+    /// `indices`, so a lane can present non-contiguous and unsorted
+    /// `choice.index` values. State keyed by vector position, or code assuming
+    /// sorted contiguous indices, survives the plain lanes but not this one.
+    pub fn remap(chunks: &[Vec<(u32, String)>], indices: &[u32]) -> Vec<Vec<(u32, String)>> {
+        chunks
+            .iter()
+            .map(|chunk| {
+                chunk
+                    .iter()
+                    .map(|(i, d)| (indices[*i as usize], d.clone()))
+                    .collect()
+            })
+            .collect()
+    }
+
+    /// Merge each run of adjacent chunks carrying disjoint indices into one
+    /// chunk, so a single response carries several choices' deltas — the packed
+    /// shape real engines emit. Per-choice delta order is preserved because a
+    /// chunk is never merged with one that repeats an index it already holds.
+    pub fn pack(chunks: &[Vec<(u32, String)>]) -> Vec<Vec<(u32, String)>> {
+        let mut out: Vec<Vec<(u32, String)>> = Vec::new();
+        for chunk in chunks {
+            let disjoint = out
+                .last()
+                .is_some_and(|last| chunk.iter().all(|(i, _)| last.iter().all(|(j, _)| j != i)));
+            if disjoint {
+                out.last_mut()
+                    .expect("checked non-empty")
+                    .extend(chunk.iter().cloned());
+            } else {
+                out.push(chunk.clone());
+            }
+        }
+        out
+    }
+
+    /// De-interleave: concatenate every delta per `choice.index` in arrival
+    /// order. The lossless invariant is on concatenated content per choice.
+    pub fn deinterleave(chunks: &[Vec<(u32, String)>]) -> std::collections::BTreeMap<u32, String> {
+        let mut map: std::collections::BTreeMap<u32, String> = std::collections::BTreeMap::new();
+        for chunk in chunks {
+            for (idx, delta) in chunk {
+                map.entry(*idx).or_default().push_str(delta);
+            }
+        }
+        map
+    }
+}
+
+/// Every schedule must be lossless: de-interleaving its output by
+/// `choice.index` recovers each shape's concatenated content byte-exactly.
+#[test]
+fn interleave_schedules_are_lossless() {
+    use interleave::{ALL_SCHEDULES, deinterleave, interleave, pack, remap};
+    let shapes = vec![
+        vec!["Let me ch", "eck.", "</think>", "answer0"],
+        vec!["Short", " reasoning</think>", "answer1"],
+        vec!["one-shot choice2"],
+    ];
+    let expected: BTreeMap<u32, String> = shapes
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (i as u32, s.concat()))
+        .collect();
+    for schedule in ALL_SCHEDULES {
+        let recovered = deinterleave(&interleave(&shapes, schedule));
+        assert_eq!(
+            recovered, expected,
+            "schedule {schedule:?} lost or reordered per-choice content"
+        );
+    }
+
+    // remap + pack must be lossless too. A `pack` that swallowed a delta would
+    // otherwise weaken the isolation lanes built on top of it.
+    let indices = [u32::MAX, 7, 2];
+    let expected_mapped: BTreeMap<u32, String> = shapes
+        .iter()
+        .enumerate()
+        .map(|(i, s)| (indices[i], s.concat()))
+        .collect();
+    for schedule in ALL_SCHEDULES {
+        let chunks = pack(&remap(&interleave(&shapes, schedule), &indices));
+        assert_eq!(
+            deinterleave(&chunks),
+            expected_mapped,
+            "schedule {schedule:?} lost content under remap+pack"
+        );
+        assert!(
+            chunks.iter().any(|c| c.len() > 1),
+            "schedule {schedule:?}: pack produced no multi-choice chunk, so the \
+             packed lane would not differ from the unpacked one"
+        );
+    }
+}
+
+/// Comparable projection of one choice's demuxed output: reasoning, content,
+/// and assembled tool calls (name + arguments per tool index). This lane
+/// intentionally does not assert finish reasons.
+#[derive(Default, PartialEq, Eq, Debug)]
+struct ChoiceOutput {
+    reasoning: String,
+    content: String,
+    tool_calls: Vec<(Option<String>, String)>,
+}
+
+/// Drive `postprocessor_parsing_stream` over pre-built content chunks (one
+/// `(index, delta)` list per chunk) plus a terminal finish for every index,
+/// then demux the output by `choice.index` into a `ChoiceOutput` per choice.
+async fn run_interleaved(
+    preprocessor: &Arc<OpenAIPreprocessor>,
+    request: &NvCreateChatCompletionRequest,
+    chunks: &[Vec<(u32, String)>],
+) -> BTreeMap<u32, ChoiceOutput> {
+    let mut indices: Vec<u32> = chunks
+        .iter()
+        .flat_map(|c| c.iter().map(|(i, _)| *i))
+        .collect();
+    indices.sort_unstable();
+    indices.dedup();
+
+    let mut input: Vec<NvCreateChatCompletionStreamResponse> = chunks
+        .iter()
+        .map(|chunk| {
+            let refs: Vec<(u32, &str)> = chunk.iter().map(|(i, s)| (*i, s.as_str())).collect();
+            mock_multi_choice_content_chunk(&refs)
+        })
+        .collect();
+    input.push(mock_multi_choice_final_chunk(&indices));
+
+    let input_stream = stream::iter(input.into_iter().map(Annotated::from_data));
+    let output_stream = preprocessor
+        .postprocessor_parsing_stream(input_stream, request, false, false)
+        .expect("postprocessor_parsing_stream should build");
+    let output_chunks: Vec<Annotated<NvCreateChatCompletionStreamResponse>> =
+        output_stream.collect().await;
+
+    demux_by_choice(&output_chunks)
+        .into_iter()
+        .map(|(idx, acc)| {
+            (
+                idx,
+                ChoiceOutput {
+                    reasoning: acc.reasoning,
+                    content: acc.content,
+                    tool_calls: acc
+                        .tool_calls
+                        .into_values()
+                        .map(|tc| (tc.name, tc.arguments))
+                        .collect(),
+                },
+            )
+        })
+        .collect()
+}
+
+/// Run one shape solo (single choice at index 0) and return its `ChoiceOutput`.
+async fn solo_output(
+    preprocessor: &Arc<OpenAIPreprocessor>,
+    request: &NvCreateChatCompletionRequest,
+    shape: &[&str],
+) -> ChoiceOutput {
+    let chunks = interleave::interleave(&[shape.to_vec()], interleave::Schedule::RoundRobin);
+    let mut out = run_interleaved(preprocessor, request, &chunks).await;
+    out.remove(&0).unwrap_or_default()
+}
+
+/// Core invariant assertion: for `shapes` interleaved under `schedule`, each
+/// choice's demuxed output equals that shape's solo (n=1) output.
+async fn assert_interleave_isolated(
+    label: &str,
+    preprocessor: &Arc<OpenAIPreprocessor>,
+    request: &NvCreateChatCompletionRequest,
+    shapes: &[Vec<&str>],
+) {
+    let indices: Vec<u32> = (0..shapes.len() as u32).collect();
+    assert_interleave_isolated_mapped(label, preprocessor, request, shapes, &indices, false).await;
+}
+
+/// Same invariant with an explicit `choice.index` per shape and optional
+/// chunk packing. `assert_interleave_isolated` is the contiguous, one-choice-
+/// per-chunk case; both route through here so the two cannot drift apart.
+async fn assert_interleave_isolated_mapped(
+    label: &str,
+    preprocessor: &Arc<OpenAIPreprocessor>,
+    request: &NvCreateChatCompletionRequest,
+    shapes: &[Vec<&str>],
+    indices: &[u32],
+    pack_chunks: bool,
+) {
+    let mut goldens: Vec<ChoiceOutput> = Vec::new();
+    for shape in shapes {
+        goldens.push(solo_output(preprocessor, request, shape).await);
+    }
+    // Sanity: the shapes must actually diverge, or the lane proves nothing.
+    if shapes.len() >= 2 {
+        assert!(
+            goldens.iter().any(|g| *g != goldens[0]),
+            "{label}: shapes do not diverge; interleave lane would prove nothing"
+        );
+    }
+    for schedule in interleave::ALL_SCHEDULES {
+        let mut chunks = interleave::remap(&interleave::interleave(shapes, schedule), indices);
+        if pack_chunks {
+            chunks = interleave::pack(&chunks);
+        }
+        let demuxed = run_interleaved(preprocessor, request, &chunks).await;
+        for (i, golden) in goldens.iter().enumerate() {
+            let idx = indices[i];
+            let got = demuxed.get(&idx).unwrap_or_else(|| {
+                panic!("{label} [{schedule:?}]: choice index {idx} produced no output")
+            });
+            assert_eq!(
+                got, golden,
+                "{label} [{schedule:?}]: choice index {idx} demuxed output != its solo (n=1) output \
+                 — cross-choice state leak"
+            );
+        }
+    }
+}
+
+/// Guided-JSON bypass + tool-jail stage: a choice that leads with bare guided
+/// JSON must not freeze the bypass decision for a reasoning-first choice.
+/// Generalizes `..._isolates_guided_bypass_decision` across schedules/pairs.
+#[tokio::test]
+async fn postprocessor_parsing_stream_interleave_isolates_tool_bypass_stage() {
+    let preprocessor = build_preprocessor(Some("deepseek_r1"), Some("nemotron_nano"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+
+    let json_sf = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let json_boston = r#"[{"name":"get_weather","parameters":{"location":"Boston"}}]"#;
+    let json_paris = r#"[{"name":"get_weather","parameters":{"location":"Paris"}}]"#;
+    let json_denver = r#"[{"name":"get_weather","parameters":{"location":"Denver"}}]"#;
+
+    let bare_json = vec!["[", &json_sf[1..]];
+    let reasoning_first = vec!["Let me check.", "</think>", json_boston];
+    let reasoning_first2 = vec!["Thinking hard.", "</think>", json_paris];
+    // reasoning text and the `</think>` close marker split across deltas.
+    let tag_split = vec!["Let me ch", "eck.", "</th", "ink>", json_denver];
+    // Whitespace-only leading deltas leave this choice's bypass decision on the
+    // undecided (`None`) arm until its first non-whitespace delta. The pre-fix
+    // code read the decision from whichever choice spoke first anywhere in the
+    // chunk, so an undecided choice was exactly where a foreign verdict landed.
+    let ws_then_bare_json = vec!["  ", "[", &json_paris[1..]];
+    let ws_then_reasoning = vec![" ", "\t", "Let me check.", "</think>", json_denver];
+
+    // k=2 pairs: the known killer, two reasoning choices, and a split-marker pair.
+    assert_interleave_isolated(
+        "bare-JSON x reasoning-first",
+        &preprocessor,
+        &request,
+        &[bare_json.clone(), reasoning_first.clone()],
+    )
+    .await;
+    assert_interleave_isolated(
+        "reasoning x reasoning (distinct)",
+        &preprocessor,
+        &request,
+        &[reasoning_first.clone(), reasoning_first2.clone()],
+    )
+    .await;
+    assert_interleave_isolated(
+        "bare-JSON x split-marker reasoning",
+        &preprocessor,
+        &request,
+        &[bare_json.clone(), tag_split.clone()],
+    )
+    .await;
+    // Whitespace-lead shapes exercise the undecided (`None`) bypass arm, which
+    // the schedules above never reach because every shape's first delta already
+    // decides.
+    assert_interleave_isolated(
+        "whitespace-lead bare-JSON x reasoning-first",
+        &preprocessor,
+        &request,
+        &[ws_then_bare_json.clone(), reasoning_first2.clone()],
+    )
+    .await;
+    assert_interleave_isolated(
+        "whitespace-lead reasoning x whitespace-lead bare-JSON",
+        &preprocessor,
+        &request,
+        &[ws_then_reasoning, ws_then_bare_json],
+    )
+    .await;
+    // k=3: prove the per-choice state map generalizes past two choices.
+    assert_interleave_isolated(
+        "k=3 bare-JSON x reasoning x reasoning",
+        &preprocessor,
+        &request,
+        &[bare_json, reasoning_first, reasoning_first2],
+    )
+    .await;
+}
+
+/// Non-contiguous, unsorted `choice.index` values packed several-per-chunk.
+/// Every other lane emits contiguous `0..k`, one choice per chunk, so state
+/// keyed by vector position — or code assuming sorted, contiguous, one-per-
+/// chunk indices — passes those and fails only here.
+#[tokio::test]
+async fn postprocessor_parsing_stream_interleave_isolates_noncontiguous_packed_indices() {
+    let preprocessor = build_preprocessor(Some("deepseek_r1"), Some("nemotron_nano"));
+    let request = streaming_tool_request(ChatCompletionToolChoiceOption::Required);
+
+    let json_sf = r#"[{"name":"get_weather","parameters":{"location":"San Francisco"}}]"#;
+    let json_boston = r#"[{"name":"get_weather","parameters":{"location":"Boston"}}]"#;
+
+    let ws_lead = vec!["  ", "Delayed.", "</think>", json_boston];
+    let bare_json = vec!["[", &json_sf[1..]];
+    let reasoning_first = vec!["Let me check.", "</think>", json_boston];
+
+    // `u32::MAX` exercises the key's full range; running both descending and
+    // ascending proves nothing depends on the indices' relative order.
+    for indices in [vec![u32::MAX, 7, 2], vec![2, 7, u32::MAX]] {
+        assert_interleave_isolated_mapped(
+            &format!("non-contiguous {indices:?}, packed chunks"),
+            &preprocessor,
+            &request,
+            &[ws_lead.clone(), bare_json.clone(), reasoning_first.clone()],
+            &indices,
+            true,
+        )
+        .await;
+    }
+}
+
+/// Pure reasoning-split / `<think>`-strip stage (no tools): each choice's
+/// `reasoning_content` vs `content` split must be decided per `choice.index`.
+#[tokio::test]
+async fn postprocessor_parsing_stream_interleave_isolates_reasoning_split_stage() {
+    let preprocessor = build_preprocessor(Some("deepseek_r1"), None);
+    let request: NvCreateChatCompletionRequest = serde_json::from_value(serde_json::json!({
+        "model": "test-model",
+        "messages": [{"role": "user", "content": "Explain your answer."}],
+        "stream": true,
+        "temperature": 0.0
+    }))
+    .unwrap();
+
+    // deepseek_r1 is force-reasoning: output starts inside reasoning, `</think>`
+    // closes it. Divergent shapes stress per-choice reasoning state.
+    let reason_then_answer_a = vec!["I should compute.", "</think>", "The result is 42."];
+    let reason_then_answer_b = vec!["A different path.", "</think>", "The result is 7."];
+    let reason_only = vec!["Still thinking, never closes."];
+    // `</think>` split across deltas stresses per-choice strip buffering.
+    let tag_split = vec!["Split rea", "soning.", "</th", "ink>", "Final answer."];
+    // Whitespace-only lead: nothing for the parser to act on until delta 2.
+    let ws_then_reason = vec!["  ", "Delayed start.", "</think>", "Answer C."];
+    // Malformed: a second `</think>` after reasoning already closed. It must be
+    // treated as ordinary content, and only for the choice that emitted it.
+    let double_close = vec!["Reason.", "</think>", "Answer.", "</think>", " tail."];
+
+    assert_interleave_isolated(
+        "reason+answer A x B",
+        &preprocessor,
+        &request,
+        &[reason_then_answer_a.clone(), reason_then_answer_b.clone()],
+    )
+    .await;
+    assert_interleave_isolated(
+        "reason+answer x reason-only",
+        &preprocessor,
+        &request,
+        &[reason_then_answer_a.clone(), reason_only.clone()],
+    )
+    .await;
+    assert_interleave_isolated(
+        "reason+answer x split-marker",
+        &preprocessor,
+        &request,
+        &[reason_then_answer_a.clone(), tag_split],
+    )
+    .await;
+    // Whitespace-lead and malformed-marker shapes: the reasoning state machine
+    // must stay per-choice on the paths the schedules above do not enumerate.
+    assert_interleave_isolated(
+        "whitespace-lead reasoning x reason+answer",
+        &preprocessor,
+        &request,
+        &[ws_then_reason, reason_then_answer_b.clone()],
+    )
+    .await;
+    assert_interleave_isolated(
+        "double-close marker x reason+answer",
+        &preprocessor,
+        &request,
+        &[double_close, reason_then_answer_a.clone()],
+    )
+    .await;
+    // k=3 across the reasoning stage.
+    assert_interleave_isolated(
+        "k=3 reasoning split",
+        &preprocessor,
+        &request,
+        &[reason_then_answer_a, reason_then_answer_b, reason_only],
+    )
+    .await;
 }
 
 /// Per-request thinking disablement must retain the old required-tool behavior


### PR DESCRIPTION
#### Overview:

With `n>1` (multiple completions in one request), all choices stream back **interleaved in ONE SSE stream** — the engine generates them concurrently, and each chunk's deltas are tagged with a `choice.index`:

```
data: {"choices":[{"index":0,"delta":{"content":"Short."}}]}
data: {"choices":[{"index":1,"delta":{"content":"Still thinking..."}}]}
data: {"choices":[{"index":0,"delta":{"content":"</think>"}}]}
data: {"choices":[{"index":1,"delta":{"content":"more thoughts</think>"}}]}
...
```

The streaming reasoning stage is a state machine consuming these deltas in arrival order — but it kept **one** shared reasoning parser and one response-global "bare-JSON vs reasoning-first" bypass decision for the whole stream. So one choice's `</think>` (or bypass decision) mutated the state the other choice's next delta was parsed with: the choices cross-contaminate, and the corruption depends on which choice's delta happens to arrive first (nondeterministic in production). This PR keys the reasoning parser and the bypass decision per `choice.index` so each choice gets its own state machine and the interleaving becomes harmless. At `n=1` there is nothing to interleave, which is why every existing single-choice test was blind to this.

#### Examples (interleaved input → before/after output):

Both cases below are **measured** from the test harness: "before" is the pre-fix code (per-choice state re-keyed to one shared entry), "after" is this PR.

**Case 1 — shared bypass decision (tools).** `n=2`, `tool_choice=required`, deepseek_r1 reasoning + nemotron_nano tool parser. Choice 0 streams bare guided JSON; choice 1 reasons first, then emits its tool JSON. Interleaved input:

```
data: {"choices":[{"index":0,"delta":{"content":"["}}]}
data: {"choices":[{"index":1,"delta":{"content":"Let me check."}}]}
data: {"choices":[{"index":0,"delta":{"content":"{\"name\":\"get_weather\",\"parameters\":{\"location\":\"San Francisco\"}}]"}}]}
data: {"choices":[{"index":1,"delta":{"content":"</think>"}}]}
data: {"choices":[{"index":1,"delta":{"content":"[{\"name\":\"get_weather\",\"parameters\":{\"location\":\"Boston\"}}]"}}]}
```

```
before:  choice 0  content=""  reasoning_content=""                tool_call = get_weather({"location":"San Francisco"})
         choice 1  content=""  reasoning_content=""                tool_call = get_weather({"location":"Boston"})
                   ↑ "Let me check.</think>" is LOST — choice 0's leading "[" latched the stream-wide bare-JSON bypass ON, so choice 1's reasoning was never split out
after:   choice 0  content=""  reasoning_content=""                tool_call = get_weather({"location":"San Francisco"})
         choice 1  content=""  reasoning_content="Let me check."   tool_call = get_weather({"location":"Boston"})
```

(Depending on parser family and arrival timing, the mislabeled text can instead leak into `content` — that is the gemma-4 variant in the History section.)

**Case 2 — shared reasoning state machine (no tools).** `n=2`, force-reasoning parser (deepseek_r1), plain chat. Choice 0 finishes its reasoning first; the split inside choice 1's reasoning is just a chunk boundary — where it falls relative to the other choice's `</think>` is timing luck. Interleaved input:

```
data: {"choices":[{"index":0,"delta":{"content":"Short."}}]}
data: {"choices":[{"index":1,"delta":{"content":"Still thinking..."}}]}
data: {"choices":[{"index":0,"delta":{"content":"</think>"}}]}
data: {"choices":[{"index":1,"delta":{"content":"more thoughts</think>"}}]}
data: {"choices":[{"index":0,"delta":{"content":"Answer A"}}]}
data: {"choices":[{"index":1,"delta":{"content":"Answer B"}}]}
```

```
before:  choice 0  content="Answer A"               reasoning_content="Short."
         choice 1  content="more thoughtsAnswer B"  reasoning_content="Still thinking..."
                   ↑ choice 0's </think> flipped the ONE shared parser out of reasoning mode, so choice 1's later reasoning was mislabeled as content
after:   choice 0  content="Answer A"               reasoning_content="Short."
         choice 1  content="Answer B"               reasoning_content="Still thinking...more thoughts"
```

#### History (how this was found):

- 2026-07-02: `dynamo-review-agent[bot]` flagged during review of #11205 that `guided_json_bypass_decision` is latched once for the whole stream, so `n>1` guided-tool streams with mixed bare-JSON / reasoning-first choices apply whichever choice speaks first to all of them ([review comment](https://github.com/ai-dynamo/dynamo/pull/11205#discussion_r3517154473)).
- 2026-07-05: Indrajit (@indrajit96) reproduced the corruption on **unmodified `main`** — gemma-4-E2B-it, `--reasoning-parser gemma4 --dyn-reasoning-parser gemma4`, `tool_choice: "required"`, `enable_thinking: true`: clean at `n=1`, corrupted at `n=2` — establishing the bug predates #11205 ([repro](https://github.com/ai-dynamo/dynamo/pull/11205#discussion_r3525866926)).
- 2026-07-08: #11205 merged with a `TODO: Track this per choice.index for n > 1` marking the known gap.
- 2026-07-10: DIS-2381 filed with the stage audit (3 of the 4 stateful stream stages — `<think>` strip, tool-call jail, `tool_parser_v2` — already key state per `choice.index`; this stage was the one outlier); this PR opened as steps 1–2 of that plan.

#### Details:

- Replace the shared `Box<dyn ReasoningParser>` + global `guided_json_bypass_decision` with a `HashMap<u32, ChoiceReasoningState>`, created lazily per `choice.index` — mirrors the per-choice state the tool-call jail and the leading-`<think>` strip stage already use.
- `n=1` behavior is byte-identical (one map entry equals the old global), so no fixture/golden churn.
- Bug predates #11205 (reproduced on `main` with gemma-4 `n=2`); #11205's review surfaced it. Follow-up (DIS-2381): a synthetic-interleave test lane over existing single-choice stream fixtures to guard all parser families generically.

#### Tracking:

- Closes #11997 (public bug report for this defect).
- Internal Linear ticket: DIS-2381 -- holds the four-stage audit and the synthetic-interleave test plan. Deliberately not referenced from #11997's body, which is world-visible (see `.ai/linear-ticket-refs.md`).

#### Related PRs:

- https://github.com/ai-dynamo/frontend-crates/pull/135 — sibling DIS-2381 test lanes over the v1 jail and v2 stream corpus (same interleave/demux invariant, parser layer).
- #11205 — where the shared-state gap was flagged and reproduced; merged with the `TODO: Track this per choice.index for n > 1` that this PR closes.

#### Verification:

Rebased onto current main (was 270 behind; squashed to one commit). Main's 8 commits touching `preprocessor.rs` since the old merge-base do not touch `parse_reasoning_content_from_stream_inner`, `ReasoningState`, `guided_json_bypass_decision`, or `StripChoiceState` -- the rebase was conflict-free and the diff stays at 2 files.

- `cargo test -p dynamo-llm --test postprocessor_parsing_stream` -> **52 passed, 0 failed** (exit 0).
- `cargo clippy -p dynamo-llm --tests` -> exit 0 (only the build script's CUDA FATBIN notices).
- `cargo fmt --all --check` -> exit 0.
- The test file is **+640 / -0**: no pre-existing test is modified or deleted, so the ~47 untouched tests with literal `assert_eq!` expectations are what carry the `n=1` byte-identical claim.

**Mutation check.** Collapsing the per-choice keying (`choices.entry(choice.index)` -> `choices.entry(0)`) with *only* the newly added whitespace/malformed assertions left in place fails both lanes, naming those shapes:

```
whitespace-lead reasoning x reason+answer [FirstByteOffset(2)]: choice 1 demuxed output != its solo (n=1) output - cross-choice state leak
whitespace-lead bare-JSON x reasoning-first [RoundRobin]: choice 0 demuxed output != its solo (n=1) output - cross-choice state leak
```

Separately, the whole added lane was run unchanged against the pre-fix merge-base build and fails there, so the tests are red before the fix and green after.

**Index/order coverage.** The interleave generator emitted contiguous `0..k` indices, one choice per chunk, so no lane exercised packed chunks or non-contiguous/unsorted `choice.index`. Added `remap` + `pack` transforms over the existing schedules (not a second generator) and a lane running indices `[u32::MAX, 7, 2]` and `[2, 7, u32::MAX]` with several choices packed per chunk. Mutating the stage to read only the first choice of each chunk (`.iter_mut().take(1)`) shows the split cleanly:

| Lane | packed-blind mutation |
|---|---|
| `interleave_isolates_tool_bypass_stage` | passes (blind) |
| `interleave_isolates_reasoning_split_stage` | passes (blind) |
| `interleave_isolates_noncontiguous_packed_indices` | **fails** |

The `remap`/`pack` helpers are themselves covered by the lossless roundtrip test, which also asserts packing actually produced a multi-choice chunk.

#### Known limitation (pre-existing, not addressed here):

`parse_reasoning_content_from_stream_inner` drops its per-choice parser states at EOF without calling `ReasoningParser::finish_reasoning_stream()`, so a close marker split across the final delta boundary is lost (choice emits `alpha` then `</th`, EOF -> `reasoning_content` is `alpha`). That trait method has no caller anywhere in `lib/` on this branch or on `main`, and this PR adds no EOF branch, so the behavior is unchanged at both `n=1` and `n>1`. Fixing it would change `n=1` output and invalidate the no-fixture-churn property above, so it is tracked separately.

#### Not addressed here: #12676 (same class, different stage):

@indrajit96 filed #12676 off this review: with `n>1`, streaming tool dispatch dedups by `tool_call.id` alone, so if two choices emit the same ID the second choice's `tool_call_dispatch` event is suppressed. Same root class as this PR -- request-scoped state applied across choices -- but a different stage, and **this PR does not fix it**.

| | This PR | #12676 |
|---|---|---|
| Stage | Reasoning split (preprocessor) | Streaming tool dispatch (HTTP service) |
| File | `lib/llm/src/preprocessor.rs` | `lib/llm/src/http/service/openai.rs` |
| Shared state | one `ReasoningParser` + one response-global bypass flag | request-global `HashSet<String>` (`dispatched_ids`, :1886) |
| Symptom | `reasoning_content` lost, or reasoning leaks into `content` | second choice's dispatch event silently suppressed |
| Fix | `HashMap<u32, ChoiceReasoningState>` keyed by `choice.index` | `HashSet<(u32, String)>` |
| Why tests missed it | every fixture was single-choice | the `n>1` test uses distinct IDs `call_a` / `call_b` (:5926) |

Verified disjoint, not assumed: this PR's diff touches `http/service/openai.rs` **0** times and mentions `dispatched_ids` **0** times, and that signature is byte-identical on this branch and on `main`. Merging this leaves #12676 reproducing as reported.

Both share the same blind spot worth noting for reviewers: every existing test was effectively single-key, so shared state passed all of them.

#### Where should the reviewer start?

`lib/llm/src/preprocessor.rs` (the `ReasoningState` / `parse_reasoning_content_from_stream_inner` change), then `lib/llm/tests/postprocessor_parsing_stream.rs`.

/coderabbit profile chill





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streamed responses with multiple choices so reasoning and guided JSON are processed independently.
  * Prevented content from one choice from affecting reasoning, tool calls, or JSON handling in another.
  * Preserved correct separation of reasoning text and tool-call output when responses are interleaved.

* **Tests**
  * Added coverage for multi-choice streaming, interleaved responses, guided JSON, and reasoning-content separation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

