### PR TITLE
fix(gms): preserve runtime tensor aliases

### DIFF
--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -14,10 +14,17 @@ from __future__ import annotations
 import copyreg
 import logging
 import weakref
+from dataclasses import dataclass
 from typing import TYPE_CHECKING, Iterator, Tuple
 
 import torch
-from gpu_memory_service.client.torch.tensor import GMSTensorSpec, TensorMetadata
+from gpu_memory_service.client.torch.tensor import (
+    GMSTensorSpec,
+    TensorMetadata,
+    _storage_from_pointer,
+    _tensor_from_storage,
+    _validate_layout,
+)
 
 if TYPE_CHECKING:
     from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
@@ -136,13 +143,15 @@ def _resolve_module_attr(
     parts = qualified_name.split(".")
     mod = root
     for p in parts[:-1]:
-        if hasattr(mod, p):
-            mod = getattr(mod, p)
-        elif hasattr(mod, "__getitem__"):
-            try:
-                mod = mod[int(p)] if p.isdigit() else mod[p]
-            except Exception:
+        if isinstance(mod, torch.nn.Module) and p in mod._modules:
+            mod = mod._modules[p]
+        elif isinstance(mod, torch.nn.Module) and p in mod.__dict__:
+            value = mod.__dict__[p]
+            if not isinstance(value, (list, tuple)):
                 raise AttributeError(f"Cannot resolve {p!r} in {qualified_name!r}")
+            mod = value
+        elif isinstance(mod, (list, tuple)) and p.isdigit():
+            mod = mod[int(p)]
         else:
             raise AttributeError(f"Cannot resolve {p!r} in {qualified_name!r}")
     return mod, parts[-1]
@@ -257,9 +266,7 @@ def _validate_parameter_swap(
     _make_parameter_replacement(parameter, probe, name=name)
 
 
-def _tensor_source(
-    spec: GMSTensorSpec,
-) -> tuple[str, int, tuple[int, ...], tuple[int, ...], torch.dtype,]:
+def _tensor_source(spec: GMSTensorSpec):
     return (
         spec.allocation_id,
         spec.offset_bytes,
@@ -311,6 +318,263 @@ def _validate_observed_storage(
     observed[storage_ptr] = (name, tensor)
 
 
+@dataclass
+class _TensorDescriptor:
+    name: str
+    tensor: torch.Tensor
+    meta: TensorMetadata
+    buffer_persistent: bool
+    object_group_id: int
+
+
+@dataclass
+class _StorageComponent:
+    storage_group_id: int
+    storage_nbytes: int
+    members: list[_TensorDescriptor]
+    allocation_id: str | None = None
+    storage_base_offset: int | None = None
+
+
+def _storage_impl_identity(tensor: torch.Tensor) -> int:
+    """Return the private identity used only to compare StorageImpl topology."""
+    return int(tensor.untyped_storage()._cdata)
+
+
+def _validate_tensor_contract(
+    tensor: torch.Tensor,
+    *,
+    name: str,
+    is_parameter: bool,
+) -> None:
+    if tensor.is_conj() or tensor.is_neg():
+        raise RuntimeError(
+            f"GMS does not support lazy conjugate/negative tensor {name!r}"
+        )
+    element_size = tensor.element_size()
+    if tensor.untyped_storage().data_ptr() % element_size:
+        raise RuntimeError(f"GMS tensor storage is unaligned at {name!r}")
+    _validate_layout(
+        tuple(tensor.shape),
+        tuple(tensor.stride()),
+        tensor.dtype,
+        int(tensor.storage_offset()),
+        int(tensor.untyped_storage().nbytes()),
+    )
+    if not is_parameter:
+        _validate_plain_nonparameter(tensor, name=name)
+        if tensor.requires_grad or tensor.grad_fn is not None:
+            raise RuntimeError(
+                f"GMS inference storage does not support autograd tensor {name!r}"
+            )
+    elif not tensor.is_leaf or tensor.grad_fn is not None:
+        raise RuntimeError(f"GMS only supports leaf Parameters at {name!r}")
+
+
+def _discover_storage_components(
+    model: torch.nn.Module,
+) -> list[_StorageComponent]:
+    entries = list(_iter_module_tensors(model))
+    # PyTorch exposes no public StorageImpl identity. Keep this private value
+    # isolated to grouping wrappers that must share one reconstructed storage.
+    components_by_storage: dict[int, _StorageComponent] = {}
+    object_groups: dict[int, int] = {}
+
+    for name, tensor, tensor_type in entries:
+        mod, attr = _resolve_module_attr(model, name)
+        if _resolve_existing_tensor(model, name, mod, attr, tensor_type) is not tensor:
+            continue
+        _validate_tensor_contract(
+            tensor,
+            name=name,
+            is_parameter=isinstance(tensor, torch.nn.Parameter),
+        )
+        object_group_id = object_groups.setdefault(id(tensor), len(object_groups))
+
+        storage = tensor.untyped_storage()
+        storage_id = _storage_impl_identity(tensor)
+        component = components_by_storage.get(storage_id)
+        if component is None:
+            component = _StorageComponent(
+                storage_group_id=len(components_by_storage),
+                storage_nbytes=int(storage.nbytes()),
+                members=[],
+            )
+            components_by_storage[storage_id] = component
+        component.members.append(
+            _TensorDescriptor(
+                name=name,
+                tensor=tensor,
+                meta=TensorMetadata.from_tensor(tensor, tensor_type),
+                buffer_persistent=(
+                    tensor_type == "buffer"
+                    and attr not in mod._non_persistent_buffers_set
+                ),
+                object_group_id=object_group_id,
+            )
+        )
+    return list(components_by_storage.values())
+
+
+def _locate_components(
+    components: list[_StorageComponent],
+    mappings: dict[int, object],
+    *,
+    require_parameters: bool,
+) -> list[_StorageComponent]:
+    located: list[_StorageComponent] = []
+    for component in components:
+        storage_ptr = int(component.members[0].tensor.untyped_storage().data_ptr())
+        for va, mapping in mappings.items():
+            end = storage_ptr + component.storage_nbytes
+            mapping_end = va + mapping.aligned_size
+            if max(va, storage_ptr) < min(mapping_end, end) and not (
+                va <= storage_ptr and end <= mapping_end
+            ):
+                raise RuntimeError(
+                    f"Storage component {component.storage_group_id} exceeds "
+                    f"GMS allocation {mapping.allocation_id!r}"
+                )
+            if va <= storage_ptr and end <= mapping_end:
+                component.allocation_id = str(mapping.allocation_id)
+                component.storage_base_offset = storage_ptr - va
+                located.append(component)
+                break
+        else:
+            if require_parameters and any(
+                isinstance(member.tensor, torch.nn.Parameter)
+                for member in component.members
+            ):
+                raise RuntimeError(
+                    f"Tensor {component.members[0].name!r} not found in any "
+                    "GMS allocation"
+                )
+            logger.debug(
+                "[GMS] Skipping storage component for %r outside GMS allocations",
+                component.members[0].name,
+            )
+    _validate_component_intervals(located)
+    return located
+
+
+def _validate_component_intervals(components: list[_StorageComponent]) -> None:
+    grouped: dict[str, list[tuple[int, int, int]]] = {}
+    for component in components:
+        start = int(component.storage_base_offset)
+        grouped.setdefault(str(component.allocation_id), []).append(
+            (start, start + component.storage_nbytes, component.storage_group_id)
+        )
+    for allocation_id, intervals in grouped.items():
+        ordered = sorted(intervals)
+        for previous, current in zip(ordered, ordered[1:], strict=False):
+            if previous[1] > current[0]:
+                raise RuntimeError(
+                    "Distinct StorageImpl byte ranges overlap in allocation "
+                    f"{allocation_id!r}: storage groups "
+                    f"{previous[2]} and {current[2]}"
+                )
+
+
+def _unique_members(
+    components: list[_StorageComponent],
+) -> list[_TensorDescriptor]:
+    return list(
+        {
+            member.object_group_id: member
+            for component in components
+            for member in component.members
+        }.values()
+    )
+
+
+def _swap_order(members: list[_TensorDescriptor]) -> list[_TensorDescriptor]:
+    tensors = {id(member.tensor) for member in members}
+
+    def depth(member: _TensorDescriptor) -> int:
+        result = 0
+        base = member.tensor._base
+        while base is not None and id(base) in tensors:
+            result += 1
+            base = base._base
+        return result
+
+    return sorted(members, key=depth, reverse=True)
+
+
+def _has_parameter_accumulator_owner(
+    tensor: torch.Tensor,
+    expected_use_count: int,
+) -> bool:
+    """Disambiguate one AccumulateGrad owner from an unknown TensorImpl owner."""
+    if not (
+        isinstance(tensor, torch.nn.Parameter)
+        and tensor.requires_grad
+        and tensor.is_leaf
+        and tensor._use_count() == expected_use_count + 1
+    ):
+        return False
+    gradient_edge = torch.autograd.graph.get_gradient_edge(tensor)
+    return (
+        gradient_edge.node is not None and tensor._use_count() == expected_use_count + 1
+    )
+
+
+def _validate_swap_ownership(members: list[_TensorDescriptor]) -> None:
+    tensors = {id(member.tensor): member.tensor for member in members}
+    child_counts: dict[int, int] = {}
+    for member in members:
+        base = member.tensor._base
+        if base is not None and tensors.get(id(base)) is base:
+            child_counts[id(base)] = child_counts.get(id(base), 0) + 1
+
+    # TensorImpl use counts are private, but public swap_tensors enforces them.
+    # Comparing here lets the complete operation fail before any mutation.
+    for member in members:
+        tensor = member.tensor
+        if weakref.getweakrefs(tensor):
+            raise RuntimeError(
+                f"Cannot preserve Python identity for GMS tensor {member.name!r}: "
+                "torch.utils.swap_tensors does not support weak references"
+            )
+        expected = 1 + child_counts.get(id(tensor), 0)
+        use_count = tensor._use_count()
+        parameter_accumulator = _has_parameter_accumulator_owner(tensor, expected)
+        if use_count != expected and not parameter_accumulator:
+            raise RuntimeError(
+                f"Cannot safely swap GMS tensor {member.name!r}: TensorImpl use "
+                f"count is {use_count}, expected {expected} from discovered tensors"
+            )
+
+
+def _replacement_for(
+    member: _TensorDescriptor,
+    storage: torch.UntypedStorage,
+) -> torch.Tensor:
+    tensor = _tensor_from_storage(
+        storage,
+        list(member.meta.shape),
+        list(member.meta.stride),
+        member.meta.dtype,
+        int(member.tensor.storage_offset())
+        if member.meta.storage is None
+        else int(member.meta.storage["storage_offset"]),
+    )
+    if isinstance(member.tensor, torch.nn.Parameter):
+        return _make_parameter_replacement(member.tensor, tensor, name=member.name)
+    return tensor
+
+
+def _apply_replacements(
+    members: list[_TensorDescriptor],
+    replacements: dict[int, torch.Tensor],
+) -> None:
+    """Swap child-first; failures are terminal and the caller discards the model."""
+    for member in _swap_order(members):
+        replacement = replacements.pop(member.object_group_id)
+        _swap_tensor_contents(member.tensor, replacement, name=member.name)
+        del replacement
+
+
 # =============================================================================
 # Public API - Registration and Materialization
 # =============================================================================
@@ -329,33 +593,283 @@ def register_module_tensors(
     Returns:
         Allocation IDs referenced by registered tensors.
     """
+    components = _locate_components(
+        _discover_storage_components(model),
+        gms_client_memory_manager.mappings,
+        require_parameters=True,
+    )
+    _validate_swap_ownership(_unique_members(components))
     referenced_allocation_ids: set[str] = set()
-    for name, tensor, tensor_type in _iter_module_tensors(model):
-        ptr = int(tensor.data_ptr())
-
-        # Find allocation containing this tensor
-        for va, mapping in gms_client_memory_manager.mappings.items():
-            if va <= ptr < va + mapping.aligned_size:
-                offset = ptr - va
-                meta = TensorMetadata.from_tensor(tensor, tensor_type)
-                gms_client_memory_manager.metadata_put(
-                    key=name,
-                    allocation_id=mapping.allocation_id,
-                    offset_bytes=offset,
-                    value=meta.to_bytes(),
-                )
-                referenced_allocation_ids.add(mapping.allocation_id)
-                break
-        else:
-            # No mapping matched - tensor pointer not in any GMS allocation
-            if tensor_type == "parameter":
-                # Parameters are model weights - must be in GMS allocations
-                raise RuntimeError(f"Tensor {name!r} not found in any GMS allocation")
-            # Buffers and tensor_attrs may be dynamically allocated (e.g., KV cache)
-            logger.debug(
-                "[GMS] Skipping %s %r - not in GMS allocations", tensor_type, name
+    for component in components:
+        assert component.allocation_id is not None
+        assert component.storage_base_offset is not None
+        referenced_allocation_ids.add(component.allocation_id)
+        for member in component.members:
+            element_size = torch.empty((), dtype=member.meta.dtype).element_size()
+            offset_bytes = (
+                component.storage_base_offset
+                + member.tensor.storage_offset() * element_size
             )
+            meta = TensorMetadata.from_tensor(
+                member.tensor,
+                member.meta.tensor_type,
+                storage={
+                    "schema_version": 1,
+                    "storage_group_id": component.storage_group_id,
+                    "object_group_id": member.object_group_id,
+                    "storage_base_offset": component.storage_base_offset,
+                    "storage_nbytes": component.storage_nbytes,
+                    "storage_offset": int(member.tensor.storage_offset()),
+                    "buffer_persistent": member.buffer_persistent,
+                },
+            )
+            if not gms_client_memory_manager.metadata_put(
+                key=member.name,
+                allocation_id=component.allocation_id,
+                offset_bytes=offset_bytes,
+                value=meta.to_bytes(),
+            ):
+                raise RuntimeError(f"Failed to register GMS tensor {member.name!r}")
     return referenced_allocation_ids
+
+
+def _resolve_slot(
+    model: torch.nn.Module,
+    name: str,
+    meta: TensorMetadata,
+) -> torch.Tensor:
+    mod, attr = _resolve_module_attr(model, name)
+    if meta.tensor_type == "parameter":
+        if not isinstance(mod, torch.nn.Module) or attr not in mod._parameters:
+            raise RuntimeError(
+                f"GMS tensor {name!r} is a Parameter but the reader slot is not"
+            )
+        tensor = mod._parameters[attr]
+        if not isinstance(tensor, torch.nn.Parameter):
+            raise RuntimeError(f"Reader Parameter slot {name!r} is empty or invalid")
+    elif meta.tensor_type == "buffer":
+        if not isinstance(mod, torch.nn.Module) or attr not in mod._buffers:
+            raise RuntimeError(
+                f"GMS tensor {name!r} is a buffer but the reader slot is not"
+            )
+        tensor = mod._buffers[attr]
+        if not torch.is_tensor(tensor):
+            raise RuntimeError(f"Reader buffer slot {name!r} is empty or invalid")
+        persistent = attr not in mod._non_persistent_buffers_set
+        if meta.storage is not None and persistent != meta.storage["buffer_persistent"]:
+            raise RuntimeError(f"Reader buffer persistence differs at {name!r}")
+    else:
+        tensor = _resolve_existing_tensor(model, name, mod, attr, meta.tensor_type)
+        if tensor is None:
+            raise RuntimeError(
+                f"GMS tensor attribute {name!r} requires a preexisting direct "
+                "Tensor object"
+            )
+        if isinstance(mod, torch.nn.Module) and (
+            attr in mod._parameters or attr in mod._buffers
+        ):
+            raise RuntimeError(f"Reader tensor attribute slot differs at {name!r}")
+    return tensor
+
+
+def _components_from_specs(
+    specs: dict[str, GMSTensorSpec],
+    model: torch.nn.Module,
+) -> list[_StorageComponent]:
+    if any(not spec.meta.is_storage_component for spec in specs.values()):
+        raise RuntimeError("Cannot mix legacy and storage-component GMS metadata")
+    components: dict[tuple[str, int], _StorageComponent] = {}
+    objects: dict[int, torch.Tensor] = {}
+    reader_objects: dict[int, int] = {}
+    object_sources: dict[int, tuple[str, int]] = {}
+    object_layouts: dict[int, tuple[object, ...]] = {}
+    component_storages: dict[tuple[str, int], int] = {}
+    storage_components: dict[int, tuple[str, int]] = {}
+
+    for name, spec in specs.items():
+        meta = spec.meta
+        tensor = _resolve_slot(model, name, meta)
+        if tuple(tensor.shape) != meta.shape or tensor.dtype != meta.dtype:
+            raise RuntimeError(
+                f"Shape/dtype mismatch for {name}: "
+                f"existing={tuple(tensor.shape)}/{tensor.dtype}, "
+                f"gms={meta.shape}/{meta.dtype}"
+            )
+        _validate_tensor_contract(
+            tensor,
+            name=name,
+            is_parameter=isinstance(tensor, torch.nn.Parameter),
+        )
+
+        assert meta.storage is not None
+        if meta.tensor_type != "buffer" and meta.storage["buffer_persistent"]:
+            raise RuntimeError(f"Invalid buffer persistence at GMS tensor {name!r}")
+        storage_group_id = int(meta.storage["storage_group_id"])
+        object_group_id = int(meta.storage["object_group_id"])
+        storage_base_offset = int(meta.storage["storage_base_offset"])
+        storage_offset = int(meta.storage["storage_offset"])
+        storage_nbytes = int(meta.storage["storage_nbytes"])
+        element_size = torch.empty((), dtype=meta.dtype).element_size()
+        expected_offset = storage_base_offset + storage_offset * element_size
+        if expected_offset % element_size:
+            raise RuntimeError(f"Unaligned GMS tensor metadata at {name!r}")
+        if spec.offset_bytes != expected_offset:
+            raise RuntimeError(
+                f"GMS legacy offset disagrees with tensor layout at {name!r}"
+            )
+        try:
+            _validate_layout(
+                meta.shape,
+                meta.stride,
+                meta.dtype,
+                storage_offset,
+                storage_nbytes,
+            )
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Invalid GMS tensor metadata at {name!r}: {exc}"
+            ) from exc
+
+        previous_object = objects.setdefault(object_group_id, tensor)
+        previous_reader = reader_objects.setdefault(id(tensor), object_group_id)
+        layout = (meta.shape, meta.stride, meta.dtype, storage_offset)
+        previous_layout = object_layouts.setdefault(object_group_id, layout)
+        if previous_object is not tensor:
+            raise RuntimeError(
+                f"Reader exact-alias topology differs for GMS tensor {name!r}"
+            )
+        if previous_reader != object_group_id or previous_layout != layout:
+            raise RuntimeError(
+                f"Reader tensor aliases incompatible GMS entries at {name!r}"
+            )
+
+        component_key = (spec.allocation_id, storage_group_id)
+        previous_source = object_sources.setdefault(object_group_id, component_key)
+        if previous_source != component_key:
+            raise RuntimeError(
+                f"Reader tensor aliases incompatible GMS entries at {name!r}"
+            )
+        storage_identity = _storage_impl_identity(tensor)
+        previous_storage = component_storages.setdefault(
+            component_key, storage_identity
+        )
+        previous_component = storage_components.setdefault(
+            storage_identity, component_key
+        )
+        if previous_storage != storage_identity or previous_component != component_key:
+            raise RuntimeError(
+                f"Reader StorageImpl topology differs at GMS tensor {name!r}"
+            )
+        component = components.get(component_key)
+        if component is None:
+            component = _StorageComponent(
+                storage_group_id=storage_group_id,
+                storage_nbytes=storage_nbytes,
+                members=[],
+                allocation_id=spec.allocation_id,
+                storage_base_offset=storage_base_offset,
+            )
+            components[component_key] = component
+        elif (
+            component.storage_nbytes != storage_nbytes
+            or component.storage_base_offset != storage_base_offset
+        ):
+            raise RuntimeError(f"Inconsistent GMS storage component at tensor {name!r}")
+        component.members.append(
+            _TensorDescriptor(
+                name=name,
+                tensor=tensor,
+                meta=meta,
+                buffer_persistent=bool(meta.storage["buffer_persistent"]),
+                object_group_id=object_group_id,
+            )
+        )
+    result = list(components.values())
+    _validate_component_intervals(result)
+    return result
+
+
+def _mapped_allocations(
+    manager: "GMSClientMemoryManager",
+    components: list[_StorageComponent],
+) -> tuple[dict[str, int], list[int]]:
+    existing = {
+        str(mapping.allocation_id): int(va) for va, mapping in manager.mappings.items()
+    }
+    allocation_ids = {component.allocation_id for component in components}
+    mapped: dict[str, int] = {}
+    imported: list[int] = []
+    try:
+        for allocation_id in allocation_ids:
+            assert allocation_id is not None
+            if allocation_id in existing:
+                va = existing[allocation_id]
+            else:
+                va = manager.create_mapping(allocation_id=allocation_id)
+                imported.append(va)
+            mapped[allocation_id] = va
+            allocation_nbytes = int(manager.mappings[va].aligned_size)
+            for component in components:
+                if component.allocation_id != allocation_id:
+                    continue
+                assert component.storage_base_offset is not None
+                if (
+                    component.storage_base_offset < 0
+                    or component.storage_base_offset + component.storage_nbytes
+                    > allocation_nbytes
+                ):
+                    raise RuntimeError(
+                        f"GMS storage component {component.storage_group_id} "
+                        f"exceeds allocation {allocation_id!r}"
+                    )
+    except BaseException:
+        for va in reversed(imported):
+            manager.free_va(va)
+        raise
+    return mapped, imported
+
+
+def _materialize_component_specs(
+    manager: "GMSClientMemoryManager",
+    specs: dict[str, GMSTensorSpec],
+    model: torch.nn.Module,
+    device_index: int,
+) -> None:
+    components = _components_from_specs(specs, model)
+    members = _unique_members(components)
+    _validate_swap_ownership(members)
+    mapped, imported = _mapped_allocations(manager, components)
+    replacements: dict[int, torch.Tensor] = {}
+    try:
+        for component in components:
+            assert component.allocation_id is not None
+            assert component.storage_base_offset is not None
+            source_storage = _storage_from_pointer(
+                mapped[component.allocation_id] + component.storage_base_offset,
+                component.storage_nbytes,
+                device_index,
+            )
+            if any(
+                isinstance(member.tensor, torch.nn.Parameter)
+                for member in component.members
+            ):
+                target_storage = source_storage
+            else:
+                target_storage = (
+                    torch.empty(0, dtype=torch.uint8, device=source_storage.device)
+                    .set_(source_storage, 0, (source_storage.nbytes(),), (1,))
+                    .clone()
+                    .untyped_storage()
+                )
+            for member in _unique_members([component]):
+                replacements[member.object_group_id] = _replacement_for(
+                    member, target_storage
+                )
+        _apply_replacements(members, replacements)
+    except BaseException:
+        for va in reversed(imported):
+            manager.free_va(va)
+        raise
 
 
 def materialize_module_from_gms(
@@ -366,132 +880,79 @@ def materialize_module_from_gms(
 ) -> None:
     """Materialize model tensors from GMS.
 
+    A failure after tensor mutation begins is terminal; discard the model.
+
     Args:
         gms_client_memory_manager: GMS client memory manager in read mode.
         model: Model to populate with tensors.
         device_index: CUDA device index.
     """
     specs = GMSTensorSpec.load_all(gms_client_memory_manager)
-    parameters = _registered_parameters(model)
-    aliases: dict[
-        int,
-        tuple[
-            torch.Tensor,
-            tuple[
-                str,
-                int,
-                tuple[int, ...],
-                tuple[int, ...],
-                torch.dtype,
-            ],
-        ],
-    ] = {}
-    resolved: list[
-        tuple[
-            str,
-            GMSTensorSpec,
-            object,
-            str,
-            torch.Tensor | None,
-            torch.nn.Parameter | None,
-        ]
-    ] = []
-    observed_storage: dict[int, tuple[str, torch.Tensor]] = {}
-    validated_parameters: set[int] = set()
-    target_device = torch.device("cuda", device_index)
+    if any(spec.meta.is_storage_component for spec in specs.values()):
+        _materialize_component_specs(
+            gms_client_memory_manager, specs, model, device_index
+        )
+        return
 
-    # Resolve and validate every observed target before materializing or
-    # mutating any model tensor. Exact aliases are supported; aliases hidden
-    # inside arbitrary helper objects are intentionally not discoverable.
+    parameters = _registered_parameters(model)
+    aliases = {}
+    resolved = []
+    observed_storage = {}
+    validated_parameters = set()
+    target_device = torch.device("cuda", device_index)
     for name, spec in specs.items():
         mod, attr = _resolve_module_attr(model, name)
         tensor_type = spec.meta.tensor_type
-        existing = _resolve_existing_tensor(model, name, mod, attr, tensor_type)
-        parameter = parameters.get(id(existing)) if existing is not None else None
-
-        if existing is not None:
-            if existing.shape != spec.meta.shape or existing.dtype != spec.meta.dtype:
+        existing = _resolve_slot(model, name, spec.meta)
+        parameter = parameters.get(id(existing))
+        if existing.shape != spec.meta.shape or existing.dtype != spec.meta.dtype:
+            raise RuntimeError(
+                f"Shape/dtype mismatch for {name}: "
+                f"existing={tuple(existing.shape)}/{existing.dtype}, "
+                f"gms={spec.meta.shape}/{spec.meta.dtype}"
+            )
+        source = _tensor_source(spec)
+        previous = aliases.get(id(existing))
+        if previous is not None and previous[0] is existing:
+            if previous[1] != source:
                 raise RuntimeError(
-                    f"Shape/dtype mismatch for {name}: "
-                    f"existing={tuple(existing.shape)}/{existing.dtype}, "
-                    f"gms={spec.meta.shape}/{spec.meta.dtype}"
+                    f"Reader tensor aliases incompatible GMS entries at {name!r}"
                 )
-            source = _tensor_source(spec)
-            previous = aliases.get(id(existing))
-            if previous is not None and previous[0] is existing:
-                if previous[1] != source:
-                    raise RuntimeError(
-                        f"Reader tensor aliases incompatible GMS entries at {name!r}"
-                    )
-            else:
-                aliases[id(existing)] = (existing, source)
-                is_nonparameter = parameter is None
-                if is_nonparameter:
-                    _validate_plain_nonparameter(existing, name=name)
-                _validate_observed_storage(
-                    observed_storage,
-                    name=name,
-                    tensor=existing,
-                )
-            if (
-                parameter is not None
-                and id(parameter) not in validated_parameters
-                and (parameter.is_meta or parameter.device != target_device)
-            ):
-                _validate_parameter_swap(parameter, name=name)
-                validated_parameters.add(id(parameter))
-        resolved.append((name, spec, mod, attr, existing, parameter))
+        else:
+            aliases[id(existing)] = (existing, source)
+            if parameter is None:
+                _validate_plain_nonparameter(existing, name=name)
+            _validate_observed_storage(observed_storage, name=name, tensor=existing)
+        if (
+            parameter is not None
+            and id(parameter) not in validated_parameters
+            and (parameter.is_meta or parameter.device != target_device)
+        ):
+            _validate_parameter_swap(parameter, name=name)
+            validated_parameters.add(id(parameter))
+        resolved.append((name, spec, existing, parameter))
 
-    materialized: set[int] = set()
-    for name, spec, mod, attr, existing, parameter in resolved:
-        if existing is not None and id(existing) in materialized:
+    materialized = set()
+    for name, spec, existing, parameter in resolved:
+        if id(existing) in materialized:
             continue
         tensor_type = spec.meta.tensor_type
-
-        # Tensor attrs and buffers need private writable storage. Swap the
-        # TensorImpl so every exact Python alias of an existing tensor survives.
         if tensor_type in ("tensor_attr", "buffer") and parameter is None:
-            if existing is not None:
-                tensor = spec.materialize(gms_client_memory_manager, device_index)
-                private = tensor.detach().clone()
-                _swap_tensor_contents(existing, private, name=name)
-                materialized.add(id(existing))
-            else:
-                tensor = spec.materialize(gms_client_memory_manager, device_index)
-                private = tensor.detach().clone()
-                if tensor_type == "buffer" and attr in mod._buffers:
-                    mod._buffers[attr] = private
-                elif attr.isdigit() or isinstance(
-                    getattr(type(mod), attr, None), property
-                ):
-                    raise RuntimeError(
-                        f"Cannot materialize GMS tensor {name!r} without "
-                        "an existing Tensor object"
-                    )
-                else:
-                    setattr(mod, attr, private)
+            tensor = spec.materialize(gms_client_memory_manager, device_index)
+            private = tensor.detach().clone()
+            _swap_tensor_contents(existing, private, name=name)
+            materialized.add(id(existing))
             continue
 
         tensor = spec.materialize(gms_client_memory_manager, device_index)
-
-        # A registered Parameter always stays on the dedicated parameter path,
-        # even when this metadata entry names an ordinary instance alias.
         if parameter is not None:
             if parameter.is_meta or parameter.device != tensor.device:
-                replacement = _make_parameter_replacement(
-                    parameter,
-                    tensor,
-                    name=name,
-                )
+                replacement = _make_parameter_replacement(parameter, tensor, name=name)
                 _swap_tensor_contents(parameter, replacement, name=name)
             else:
                 parameter.data = tensor
             materialized.add(id(parameter))
             continue
-
-        # Fallback: set as attribute
-        setattr(mod, attr, tensor)
-
     # Check for meta tensors and warn
     meta_tensors = [n for n, p in model.named_parameters() if p.is_meta]
     meta_tensors += [n for n, b in model.named_buffers() if b.is_meta]
@@ -525,104 +986,69 @@ def rebind_nonparameter_tensors(
     Must run before CUDA graph capture: the clones live at new addresses.
 
     Discoverable exact aliases keep their original Python Tensor object.
-    Discovery is limited to registered fields and direct module instance
-    attributes (including tensor lists/tuples); aliases hidden in arbitrary
-    helper objects are not inspected. Observed distinct tensor objects that
-    share storage (for example, views) are unsupported.
+    Distinct discovered tensors sharing one StorageImpl are rebuilt together
+    over one private storage copy. Discovery remains limited to registered
+    fields and direct module instance attributes (including tensor lists/tuples).
 
     Returns the number of bytes rebound, i.e. how much memory is duplicated
     between the read-only GMS copies and the private clones.
 
-    Displaced GMS TensorImpls remain owned by a private model holder for the
-    model's lifetime. If ``retain_gms_tensors`` is provided, each displaced
-    owner is also appended for compatibility with deferred publication.
+    One detached storage owner per copied component retains the original GMS
+    allocation. If ``retain_gms_tensors`` is provided, each owner is also
+    appended for compatibility with deferred publication.
+
+    A failure after tensor mutation begins is terminal; discard the model.
     """
-    mappings = gms_client_memory_manager.mappings
-    rebound_bytes = 0
-    module_tensors = list(_iter_module_tensors(model))
-    parameters = {
-        id(tensor): tensor
-        for _, tensor, tensor_type in module_tensors
-        if tensor_type == "parameter"
-    }
-    seen: dict[int, torch.Tensor] = {}
-    candidates: list[tuple[str, torch.Tensor]] = []
-    storage_owners: dict[int, tuple[str, torch.Tensor]] = {}
-    for name, tensor, tensor_type in module_tensors:
-        mod, attr = _resolve_module_attr(model, name)
-        if _resolve_existing_tensor(model, name, mod, attr, tensor_type) is not tensor:
-            continue
-        if seen.get(id(tensor)) is tensor:
-            continue
-        seen[id(tensor)] = tensor
-        ptr = int(tensor.data_ptr())
+    components = _locate_components(
+        _discover_storage_components(model),
+        gms_client_memory_manager.mappings,
+        require_parameters=False,
+    )
+    candidates = [
+        component
+        for component in components
         if not any(
-            va <= ptr < va + mapping.aligned_size for va, mapping in mappings.items()
-        ):
-            continue
-
-        is_candidate = not (
-            tensor_type == "parameter" or parameters.get(id(tensor)) is tensor
+            isinstance(member.tensor, torch.nn.Parameter)
+            for member in component.members
         )
-        if tensor._base is not None:
-            raise RuntimeError(f"GMS cannot rebind tensor view {name!r}")
-        if is_candidate:
-            _validate_plain_nonparameter(tensor, name=name)
-
-        storage_ptr = int(tensor.untyped_storage().data_ptr())
-        if storage_ptr == 0:
-            if is_candidate:
-                candidates.append((name, tensor))
-            continue
-        previous = storage_owners.get(storage_ptr)
-        if previous is not None and previous[1] is not tensor:
-            raise RuntimeError(
-                "GMS cannot rebind distinct tensors that share storage: "
-                f"{previous[0]!r} and {name!r}"
-            )
-        storage_owners[storage_ptr] = (name, tensor)
-        if is_candidate:
-            candidates.append((name, tensor))
-
-    # Drop discovery references before swap_tensors checks TensorImpl use counts.
-    module_tensors.clear()
-    tensor = None
-    mod = None
-    prepared = [(name, tensor, tensor.detach().clone()) for name, tensor in candidates]
-    if not prepared:
+    ]
+    if not candidates:
         return 0
+    members = _unique_members(candidates)
+    _validate_swap_ownership(members)
+    replacements: dict[int, torch.Tensor] = {}
+    source_owners: list[torch.Tensor] = []
+    for component in candidates:
+        source_storage = component.members[0].tensor.untyped_storage()
+        source_owner = torch.empty(
+            0, dtype=torch.uint8, device=source_storage.device
+        ).set_(
+            source_storage,
+            0,
+            (component.storage_nbytes,),
+            (1,),
+        )
+        target_storage = source_owner.clone().untyped_storage()
+        source_owners.append(source_owner)
+        for member in _unique_members([component]):
+            replacements[member.object_group_id] = _replacement_for(
+                member, target_storage
+            )
+
     owners = _get_or_create_rebound_tensor_owners(model)
     owner_count = len(owners.tensors)
     retained_count = len(retain_gms_tensors) if retain_gms_tensors is not None else 0
-    completed: list[tuple[str, torch.Tensor, torch.Tensor]] = []
     try:
-        for name, tensor, private in prepared:
-            _swap_tensor_contents(tensor, private, name=name)
-            completed.append((name, tensor, private))
-    except BaseException as swap_error:
-        rollback_error: BaseException | None = None
-        for name, tensor, private in reversed(completed):
-            try:
-                _swap_tensor_contents(tensor, private, name=name)
-            except BaseException as exc:
-                rollback_error = rollback_error or exc
+        _apply_replacements(members, replacements)
+    except BaseException:
         del owners.tensors[owner_count:]
         if retain_gms_tensors is not None:
             del retain_gms_tensors[retained_count:]
         if owner_count == 0 and not owners.tensors:
             model.__dict__.pop(_REBOUND_TENSOR_OWNERS_ATTR, None)
-        if rollback_error is not None:
-            raise RuntimeError(
-                "GMS tensor rebind failed and rollback was incomplete"
-            ) from rollback_error
-        raise swap_error
+        raise
 
-    displaced = [private for _, _, private in completed]
-    owners.tensors.extend(displaced)
+    owners.tensors.extend(source_owners)
     if retain_gms_tensors is not None:
-        retain_gms_tensors.extend(displaced)
-    rebound_bytes = sum(
-        tensor.numel() * tensor.element_size() for _, tensor, _ in completed
-    )
-
-    return rebound_bytes
+        retain_gms_tensors.extend(source_owners)
+    return sum(component.storage_nbytes for component in candidates)

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -56,8 +56,6 @@ class _DiscoveredTensor:
 class _DiscoveredStorage:
     storage: torch.UntypedStorage
     objects: list[_DiscoveredTensor]
-    allocation_id: str | None = None
-    storage_base_offset: int | None = None
 
     @property
     def has_parameter(self) -> bool:
@@ -150,11 +148,14 @@ def _iter_module_tensor_bindings(
     """Yield each supported tensor and its direct module binding."""
     for module_path, module in model.named_modules(remove_duplicate=False):
         _get_displaced_source_tensors(module)
+        prefix = f"{module_path}." if module_path else ""
         for name, parameter in module.named_parameters(
             recurse=False, remove_duplicate=False
         ):
-            path = f"{module_path}.{name}" if module_path else name
-            yield parameter, ModuleTensorBinding(path, ModuleTensorKind.PARAMETER)
+            yield (
+                parameter,
+                ModuleTensorBinding(f"{prefix}{name}", ModuleTensorKind.PARAMETER),
+            )
 
         for name, buffer in module.named_buffers(recurse=False, remove_duplicate=False):
             kind = (
@@ -162,8 +163,7 @@ def _iter_module_tensor_bindings(
                 if name in module._non_persistent_buffers_set
                 else ModuleTensorKind.PERSISTENT_BUFFER
             )
-            path = f"{module_path}.{name}" if module_path else name
-            yield buffer, ModuleTensorBinding(path, kind)
+            yield buffer, ModuleTensorBinding(f"{prefix}{name}", kind)
 
         registered = (
             set(module._parameters) | set(module._buffers) | set(module._modules)
@@ -176,20 +176,19 @@ def _iter_module_tensor_bindings(
             ):
                 continue
             if torch.is_tensor(value):
-                path = f"{module_path}.{name}" if module_path else name
-                yield value, ModuleTensorBinding(path, ModuleTensorKind.ATTRIBUTE)
+                yield (
+                    value,
+                    ModuleTensorBinding(f"{prefix}{name}", ModuleTensorKind.ATTRIBUTE),
+                )
             elif type(value) in (list, tuple):
                 for index, element in enumerate(value):
                     if torch.is_tensor(element):
-                        name_with_index = f"{name}.{index}"
-                        path = (
-                            f"{module_path}.{name_with_index}"
-                            if module_path
-                            else name_with_index
-                        )
                         yield (
                             element,
-                            ModuleTensorBinding(path, ModuleTensorKind.ATTRIBUTE),
+                            ModuleTensorBinding(
+                                f"{prefix}{name}.{index}",
+                                ModuleTensorKind.ATTRIBUTE,
+                            ),
                         )
 
 
@@ -275,28 +274,34 @@ def _match_storages_to_gms_mappings(
     mappings: dict[int, object],
     *,
     require_parameters: bool,
-) -> list[_DiscoveredStorage]:
+) -> list[tuple[_DiscoveredStorage, str, int]]:
     """Match complete StorageImpl envelopes to their containing GMS mappings."""
-    located: list[_DiscoveredStorage] = []
+    located: list[tuple[_DiscoveredStorage, str, int]] = []
     for ordinal, discovered_storage in enumerate(storages):
         storage_ptr = int(discovered_storage.storage.data_ptr())
         storage_nbytes = int(discovered_storage.storage.nbytes())
         storage_end = storage_ptr + storage_nbytes
-        containing: list[tuple[int, object]] = []
+        containing: tuple[int, object] | None = None
         for va, mapping in mappings.items():
-            mapping_end = int(va) + int(mapping.aligned_size)
-            overlaps = max(int(va), storage_ptr) < min(mapping_end, storage_end)
-            if overlaps and not (int(va) <= storage_ptr and storage_end <= mapping_end):
+            mapping_start = int(va)
+            mapping_end = mapping_start + int(mapping.aligned_size)
+            contains = mapping_start <= storage_ptr and storage_end <= mapping_end
+            if (
+                max(mapping_start, storage_ptr) < min(mapping_end, storage_end)
+                and not contains
+            ):
                 raise RuntimeError(
                     f"Storage {ordinal} exceeds GMS allocation "
                     f"{mapping.allocation_id!r}"
                 )
-            if int(va) <= storage_ptr and storage_end <= mapping_end:
-                containing.append((int(va), mapping))
+            if contains:
+                if containing is not None:
+                    raise RuntimeError(
+                        f"Storage {ordinal} belongs to multiple GMS allocations"
+                    )
+                containing = (mapping_start, mapping)
 
-        if len(containing) > 1:
-            raise RuntimeError(f"Storage {ordinal} belongs to multiple GMS allocations")
-        if not containing:
+        if containing is None:
             if require_parameters and discovered_storage.has_parameter:
                 raise RuntimeError(
                     f"Parameter {discovered_storage.objects[0].bindings[0].path!r} "
@@ -308,17 +313,14 @@ def _match_storages_to_gms_mappings(
             )
             continue
 
-        va, mapping = containing[0]
-        discovered_storage.allocation_id = str(mapping.allocation_id)
-        discovered_storage.storage_base_offset = storage_ptr - va
-        located.append(discovered_storage)
+        va, mapping = containing
+        located.append(
+            (discovered_storage, str(mapping.allocation_id), storage_ptr - va)
+        )
 
     intervals: dict[str, list[tuple[int, int]]] = {}
-    for discovered_storage in located:
-        start = discovered_storage.storage_base_offset
-        if start is None or discovered_storage.allocation_id is None:
-            raise RuntimeError("Located GMS storage is missing its allocation envelope")
-        intervals.setdefault(discovered_storage.allocation_id, []).append(
+    for discovered_storage, allocation_id, start in located:
+        intervals.setdefault(allocation_id, []).append(
             (start, start + discovered_storage.storage.nbytes())
         )
     for allocation_id, allocation_intervals in intervals.items():
@@ -430,29 +432,21 @@ def register_module_tensors(
     )
     entries: list[tuple[str, str, int, bytes]] = []
     referenced_allocation_ids: set[str] = set()
-    for ordinal, discovered_storage in enumerate(storages):
-        if (
-            discovered_storage.allocation_id is None
-            or discovered_storage.storage_base_offset is None
-        ):
-            raise RuntimeError("Located GMS storage is missing its allocation envelope")
+    for ordinal, (
+        discovered_storage,
+        allocation_id,
+        storage_base_offset,
+    ) in enumerate(storages):
         key = f"{STORAGE_MANIFEST_PREFIX}{ordinal}"
         manifest = _build_storage_manifest(discovered_storage)
         _validate_storage_manifest(
             manifest,
             key=key,
-            storage_base_offset=discovered_storage.storage_base_offset,
+            storage_base_offset=storage_base_offset,
         )
         encoded = msgspec.msgpack.encode(manifest)
-        entries.append(
-            (
-                key,
-                discovered_storage.allocation_id,
-                discovered_storage.storage_base_offset,
-                encoded,
-            )
-        )
-        referenced_allocation_ids.add(discovered_storage.allocation_id)
+        entries.append((key, allocation_id, storage_base_offset, encoded))
+        referenced_allocation_ids.add(allocation_id)
 
     for key, allocation_id, storage_base_offset, encoded in entries:
         if not gms_client_memory_manager.metadata_put(
@@ -544,16 +538,14 @@ def _resolve_submodule_path(
     return module
 
 
-def _has_data_descriptor(module: torch.nn.Module, attr: str) -> bool:
-    descriptor = next(
+_MISSING = object()
+
+
+def _static_module_attribute(module: torch.nn.Module, attr: str) -> object:
+    return next(
         (cls.__dict__[attr] for cls in type(module).__mro__ if attr in cls.__dict__),
-        None,
+        _MISSING,
     )
-    return hasattr(descriptor, "__set__")
-
-
-def _class_defines_attribute(module: torch.nn.Module, attr: str) -> bool:
-    return any(attr in cls.__dict__ for cls in type(module).__mro__)
 
 
 def _resolve_tensor_destination(
@@ -572,7 +564,7 @@ def _resolve_tensor_destination(
             attr in module._buffers
             or attr in module._modules
             or attr in module.__dict__
-            or _class_defines_attribute(module, attr)
+            or _static_module_attribute(module, attr) is not _MISSING
         ):
             raise RuntimeError(
                 f"GMS parameter destination {binding.path!r} collides with "
@@ -595,7 +587,7 @@ def _resolve_tensor_destination(
             attr in module._parameters
             or attr in module._modules
             or attr in module.__dict__
-            or _class_defines_attribute(module, attr)
+            or _static_module_attribute(module, attr) is not _MISSING
         ):
             raise RuntimeError(
                 f"GMS buffer destination {binding.path!r} collides with "
@@ -632,41 +624,13 @@ def _resolve_tensor_destination(
         raise RuntimeError(
             f"GMS attribute destination {binding.path!r} is not a direct tensor"
         )
-    if attr not in module.__dict__ and _has_data_descriptor(module, attr):
+    if attr not in module.__dict__ and hasattr(
+        _static_module_attribute(module, attr), "__set__"
+    ):
         raise RuntimeError(
             f"GMS attribute destination {binding.path!r} is not representable"
         )
     return _ResolvedTensorDestination(binding, module, attr, existing)
-
-
-def _find_parameter_template(
-    destinations: tuple[_ResolvedTensorDestination, ...],
-) -> torch.nn.Parameter | None:
-    return next(
-        (
-            destination.existing
-            for destination in destinations
-            if destination.binding.kind is ModuleTensorKind.PARAMETER
-            and isinstance(destination.existing, torch.nn.Parameter)
-        ),
-        None,
-    )
-
-
-def _parameter_slot_names(parameter_type: type[torch.nn.Parameter]) -> tuple[str, ...]:
-    names: list[str] = []
-    for cls in parameter_type.__mro__:
-        declared = cls.__dict__.get("__slots__", ())
-        if isinstance(declared, str):
-            declared = (declared,)
-        for name in declared:
-            if name in ("__dict__", "__weakref__"):
-                continue
-            if name.startswith("__") and not name.endswith("__"):
-                name = f"_{cls.__name__.lstrip('_')}{name}"
-            if name not in names:
-                names.append(name)
-    return tuple(names)
 
 
 def _make_parameter_from_template(
@@ -681,7 +645,7 @@ def _make_parameter_from_template(
     try:
         parameter = torch.Tensor._make_subclass(type(template), tensor, requires_grad)
         parameter.__dict__ = template.__dict__.copy()
-        for name in _parameter_slot_names(type(template)):
+        for name in dict.fromkeys(copyreg._slotnames(type(template))):
             if hasattr(template, name):
                 setattr(parameter, name, getattr(template, name))
     except Exception as exc:
@@ -690,19 +654,6 @@ def _make_parameter_from_template(
             f"{type(template).__name__}: {exc}"
         ) from exc
     return parameter
-
-
-def _clone_storage_with_source_owner(
-    storage: torch.UntypedStorage,
-) -> tuple[torch.UntypedStorage, torch.Tensor]:
-    """Clone a storage while retaining a tensor that owns the displaced source."""
-    source_owner = torch.empty(0, dtype=torch.uint8, device=storage.device).set_(
-        storage,
-        0,
-        (storage.nbytes(),),
-        (1,),
-    )
-    return source_owner.clone().untyped_storage(), source_owner
 
 
 def _free_imported_mappings(
@@ -814,7 +765,7 @@ def materialize_module_from_gms(
                 target_storage = source_storage
             else:
                 clone_started = True
-                target_storage, _ = _clone_storage_with_source_owner(source_storage)
+                target_storage = source_storage.clone()
 
             for tensor_object, object_destinations in manifest_destinations:
                 dtype = _dtype_from_name(tensor_object.dtype)
@@ -831,8 +782,17 @@ def materialize_module_from_gms(
                     if destination.binding.kind is ModuleTensorKind.PARAMETER
                 )
                 if parameter_destinations:
+                    template = next(
+                        (
+                            destination.existing
+                            for destination in object_destinations
+                            if destination.binding.kind is ModuleTensorKind.PARAMETER
+                            and isinstance(destination.existing, torch.nn.Parameter)
+                        ),
+                        None,
+                    )
                     tensor = _make_parameter_from_template(
-                        _find_parameter_template(object_destinations),
+                        template,
                         tensor,
                         path=parameter_destinations[0].binding.path,
                         requires_grad=tensor_object.requires_grad,
@@ -860,20 +820,6 @@ def materialize_module_from_gms(
         )
 
 
-def _swap_tensor_contents(
-    existing: torch.Tensor,
-    replacement: torch.Tensor,
-    *,
-    path: str,
-) -> None:
-    if not hasattr(torch.utils, "swap_tensors"):
-        raise RuntimeError("GMS publisher rebinding requires torch.utils.swap_tensors")
-    try:
-        torch.utils.swap_tensors(existing, replacement)
-    except RuntimeError as exc:
-        raise RuntimeError(f"Cannot rebind GMS tensor {path!r}: {exc}") from exc
-
-
 def _swap_discovered_tensors(
     objects: list[_DiscoveredTensor],
     replacements: dict[int, torch.Tensor],
@@ -898,25 +844,6 @@ def _swap_discovered_tensors(
         return depth
 
     ordered = sorted(objects, key=base_depth, reverse=True)
-    for tensor_object in ordered:
-        existing = tensor_object.tensor
-        replacement = replacements[id(existing)]
-        path = tensor_object.bindings[0].path
-        for tensor, name in ((existing, "t1"), (replacement, "t2")):
-            if weakref.getweakrefs(tensor):
-                raise RuntimeError(
-                    f"Cannot rebind GMS tensor {path!r}: "
-                    f"{name} has weakref associated with it"
-                )
-
-        existing_slots = set(copyreg._slotnames(existing.__class__))
-        replacement_slots = set(copyreg._slotnames(replacement.__class__))
-        if existing_slots != replacement_slots:
-            raise RuntimeError(
-                f"Cannot rebind GMS tensor {path!r}: "
-                "replacement has different Python slots"
-            )
-
     accumulate_grad_checks: list[tuple[torch.Tensor, int, str]] = []
     for tensor_object in ordered:
         existing = tensor_object.tensor
@@ -926,6 +853,11 @@ def _swap_discovered_tensors(
             (existing, "t1", group_base_uses.get(id(existing), 0)),
             (replacement, "t2", 0),
         ):
+            if weakref.getweakrefs(tensor):
+                raise RuntimeError(
+                    f"Cannot rebind GMS tensor {path!r}: "
+                    f"{name} has weakref associated with it"
+                )
             use_count = tensor._use_count() - released_uses
             ownership_error = (
                 f"Cannot rebind GMS tensor {path!r}: expected use_count of "
@@ -937,6 +869,14 @@ def _swap_discovered_tensors(
                     raise RuntimeError(ownership_error)
                 accumulate_grad_checks.append((tensor, released_uses, ownership_error))
 
+        existing_slots = set(copyreg._slotnames(existing.__class__))
+        replacement_slots = set(copyreg._slotnames(replacement.__class__))
+        if existing_slots != replacement_slots:
+            raise RuntimeError(
+                f"Cannot rebind GMS tensor {path!r}: "
+                "replacement has different Python slots"
+            )
+
     for tensor, released_uses, ownership_error in accumulate_grad_checks:
         torch.autograd.graph.get_gradient_edge(tensor)
         if tensor._use_count() - released_uses != 2:
@@ -944,11 +884,11 @@ def _swap_discovered_tensors(
 
     for tensor_object in ordered:
         replacement = replacements.pop(id(tensor_object.tensor))
-        _swap_tensor_contents(
-            tensor_object.tensor,
-            replacement,
-            path=tensor_object.bindings[0].path,
-        )
+        path = tensor_object.bindings[0].path
+        try:
+            torch.utils.swap_tensors(tensor_object.tensor, replacement)
+        except RuntimeError as exc:
+            raise RuntimeError(f"Cannot rebind GMS tensor {path!r}: {exc}") from exc
         del replacement
 
 
@@ -965,7 +905,7 @@ def rebind_nonparameter_tensors(
     )
     candidates = [
         discovered_storage
-        for discovered_storage in storages
+        for discovered_storage, _, _ in storages
         if not discovered_storage.has_parameter
     ]
     if not candidates:
@@ -975,9 +915,16 @@ def rebind_nonparameter_tensors(
     source_owners: list[torch.Tensor] = []
     objects: list[_DiscoveredTensor] = []
     for discovered_storage in candidates:
-        target_storage, source_owner = _clone_storage_with_source_owner(
-            discovered_storage.storage
+        source_storage = discovered_storage.storage
+        source_owner = torch.empty(
+            0, dtype=torch.uint8, device=source_storage.device
+        ).set_(
+            source_storage,
+            0,
+            (source_storage.nbytes(),),
+            (1,),
         )
+        target_storage = source_storage.clone()
         source_owners.append(source_owner)
         for tensor_object in discovered_storage.objects:
             tensor = tensor_object.tensor

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -11,7 +11,9 @@ This module provides module-level tensor operations:
 
 from __future__ import annotations
 
+import copyreg
 import logging
+import weakref
 from typing import TYPE_CHECKING, Iterator, Tuple
 
 import torch
@@ -21,6 +23,42 @@ if TYPE_CHECKING:
     from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
 
 logger = logging.getLogger(__name__)
+
+_REBOUND_TENSOR_OWNERS_ATTR = "_gms_rebound_tensor_owners"
+
+
+class _ReboundTensorOwners:
+    """Model-scoped owners for GMS storage displaced by tensor swaps."""
+
+    def __init__(self) -> None:
+        self.tensors: list[torch.Tensor] = []
+
+
+def _get_or_create_rebound_tensor_owners(
+    model: torch.nn.Module,
+) -> _ReboundTensorOwners:
+    owners = model.__dict__.get(_REBOUND_TENSOR_OWNERS_ATTR)
+    if isinstance(owners, _ReboundTensorOwners):
+        return owners
+    namespace_collision = any(
+        _REBOUND_TENSOR_OWNERS_ATTR in model.__dict__[namespace]
+        for namespace in ("_parameters", "_buffers", "_modules")
+    )
+    class_collision = any(
+        _REBOUND_TENSOR_OWNERS_ATTR in cls.__dict__ for cls in type(model).__mro__
+    )
+    if (
+        _REBOUND_TENSOR_OWNERS_ATTR in model.__dict__
+        or namespace_collision
+        or class_collision
+    ):
+        raise RuntimeError(
+            f"Reserved GMS attribute {_REBOUND_TENSOR_OWNERS_ATTR!r} "
+            "collides with an existing model attribute"
+        )
+    owners = _ReboundTensorOwners()
+    model.__dict__[_REBOUND_TENSOR_OWNERS_ATTR] = owners
+    return owners
 
 
 # =============================================================================
@@ -58,18 +96,16 @@ def _iter_module_tensors(
             qualified = f"{prefix}{name}" if prefix else name
             yield (qualified, buf, "buffer")
 
-    # Other tensor attributes (not params/buffers/submodules)
+    # Other tensor attributes explicitly stored on the module instance.
+    # Do not inspect class descriptors: properties may return derived tensor
+    # aliases that are not writable materialization targets.
     skip = (
         set(module._parameters.keys())
         | set(module._buffers.keys())
         | set(module._modules.keys())
     )
-    for attr_name in dir(module):
+    for attr_name, attr_val in module.__dict__.items():
         if attr_name in skip or attr_name.startswith("__"):
-            continue
-        try:
-            attr_val = getattr(module, attr_name, None)
-        except Exception:
             continue
 
         if torch.is_tensor(attr_val) and attr_val.is_cuda:
@@ -110,6 +146,169 @@ def _resolve_module_attr(
         else:
             raise AttributeError(f"Cannot resolve {p!r} in {qualified_name!r}")
     return mod, parts[-1]
+
+
+def _resolve_existing_tensor(
+    model: torch.nn.Module,
+    name: str,
+    mod: object,
+    attr: str,
+    tensor_type: str,
+) -> torch.Tensor | None:
+    """Return the Tensor object at a supported direct module location."""
+    if attr.isdigit() and isinstance(mod, (list, tuple)):
+        owner, container_attr = _resolve_module_attr(model, name.rsplit(".", 1)[0])
+        if isinstance(getattr(type(owner), container_attr, None), property):
+            return None
+        value = mod[int(attr)]
+        return value if torch.is_tensor(value) else None
+
+    if tensor_type == "buffer" and attr in mod._buffers:
+        value = mod._buffers[attr]
+        return value if torch.is_tensor(value) else None
+
+    if isinstance(getattr(type(mod), attr, None), property):
+        return None
+    value = getattr(mod, attr, None)
+    return value if torch.is_tensor(value) else None
+
+
+def _swap_tensor_contents(
+    existing: torch.Tensor,
+    replacement: torch.Tensor,
+    *,
+    name: str,
+) -> None:
+    """Swap TensorImpls while preserving ``existing`` Python identity."""
+    if torch.torch_version.TorchVersion(torch.__version__) < (2, 4) or not hasattr(
+        torch.utils, "swap_tensors"
+    ):
+        raise RuntimeError(
+            "GMS identity-preserving tensor materialization requires "
+            "torch.utils.swap_tensors with TensorImpl use-count safety "
+            "(PyTorch 2.4+)"
+        )
+    try:
+        torch.utils.swap_tensors(existing, replacement)
+    except RuntimeError as exc:
+        raise RuntimeError(
+            f"Cannot preserve Python identity for GMS tensor {name!r}: "
+            f"torch.utils.swap_tensors failed: {exc}"
+        ) from exc
+
+
+def _copy_parameter_state(
+    parameter: torch.nn.Parameter,
+    replacement: torch.nn.Parameter,
+    *,
+    name: str,
+) -> None:
+    """Give an exact-class replacement the original Parameter's Python state."""
+    try:
+        replacement.__dict__ = parameter.__dict__
+        for slot in copyreg._slotnames(type(parameter)) or ():
+            if hasattr(parameter, slot):
+                setattr(replacement, slot, getattr(parameter, slot))
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot preserve Python state for GMS parameter {name!r} "
+            f"of type {type(parameter).__name__}: {exc}"
+        ) from exc
+
+
+def _make_parameter_replacement(
+    parameter: torch.nn.Parameter,
+    tensor: torch.Tensor,
+    *,
+    name: str,
+) -> torch.nn.Parameter:
+    """Wrap ``tensor`` without invoking a heterogeneous Parameter constructor."""
+    try:
+        replacement = torch.Tensor._make_subclass(
+            type(parameter), tensor, parameter.requires_grad
+        )
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot materialize GMS parameter {name!r} as "
+            f"{type(parameter).__name__}: {exc}"
+        ) from exc
+    _copy_parameter_state(parameter, replacement, name=name)
+    return replacement
+
+
+def _validate_parameter_swap(
+    parameter: torch.nn.Parameter,
+    *,
+    name: str,
+) -> None:
+    """Fail before reader mutation if an exact-class Parameter cannot be swapped."""
+    if weakref.getweakrefs(parameter):
+        raise RuntimeError(
+            f"Cannot preserve Python identity for GMS parameter {name!r}: "
+            "torch.utils.swap_tensors does not support weak references"
+        )
+    use_count = parameter._use_count()
+    if use_count > 1:
+        raise RuntimeError(
+            f"Cannot preserve Python identity for GMS parameter {name!r}: "
+            f"TensorImpl use count is {use_count}, expected 1"
+        )
+    probe = torch.empty(0, dtype=parameter.dtype, device="meta")
+    _make_parameter_replacement(parameter, probe, name=name)
+
+
+def _tensor_source(
+    spec: GMSTensorSpec,
+) -> tuple[str, int, tuple[int, ...], tuple[int, ...], torch.dtype,]:
+    return (
+        spec.allocation_id,
+        spec.offset_bytes,
+        spec.meta.shape,
+        spec.meta.stride,
+        spec.meta.dtype,
+    )
+
+
+def _registered_parameters(
+    model: torch.nn.Module,
+) -> dict[int, torch.nn.Parameter]:
+    """Index every registered Parameter by exact Python identity."""
+    return {
+        id(parameter): parameter
+        for module in model.modules()
+        for parameter in module._parameters.values()
+        if parameter is not None
+    }
+
+
+def _validate_plain_nonparameter(tensor: torch.Tensor, *, name: str) -> None:
+    if type(tensor) is not torch.Tensor:
+        raise RuntimeError(
+            f"GMS does not support non-parameter Tensor subclass at {name!r}: "
+            f"{type(tensor).__name__}"
+        )
+
+
+def _validate_observed_storage(
+    observed: dict[int, tuple[str, torch.Tensor]],
+    *,
+    name: str,
+    tensor: torch.Tensor,
+) -> None:
+    """Reject observed views or distinct objects sharing storage."""
+    if tensor._base is not None:
+        raise RuntimeError(f"GMS cannot materialize tensor view {name!r}")
+
+    storage_ptr = int(tensor.untyped_storage().data_ptr())
+    if storage_ptr == 0:
+        return
+    previous = observed.get(storage_ptr)
+    if previous is not None and previous[1] is not tensor:
+        raise RuntimeError(
+            "GMS cannot materialize distinct tensors that share storage: "
+            f"{previous[0]!r} and {name!r}"
+        )
+    observed[storage_ptr] = (name, tensor)
 
 
 # =============================================================================
@@ -173,41 +372,122 @@ def materialize_module_from_gms(
         device_index: CUDA device index.
     """
     specs = GMSTensorSpec.load_all(gms_client_memory_manager)
+    parameters = _registered_parameters(model)
+    aliases: dict[
+        int,
+        tuple[
+            torch.Tensor,
+            tuple[
+                str,
+                int,
+                tuple[int, ...],
+                tuple[int, ...],
+                torch.dtype,
+            ],
+        ],
+    ] = {}
+    resolved: list[
+        tuple[
+            str,
+            GMSTensorSpec,
+            object,
+            str,
+            torch.Tensor | None,
+            torch.nn.Parameter | None,
+        ]
+    ] = []
+    observed_storage: dict[int, tuple[str, torch.Tensor]] = {}
+    validated_parameters: set[int] = set()
+    target_device = torch.device("cuda", device_index)
 
+    # Resolve and validate every observed target before materializing or
+    # mutating any model tensor. Exact aliases are supported; aliases hidden
+    # inside arbitrary helper objects are intentionally not discoverable.
     for name, spec in specs.items():
-        tensor = spec.materialize(gms_client_memory_manager, device_index)
         mod, attr = _resolve_module_attr(model, name)
         tensor_type = spec.meta.tensor_type
+        existing = _resolve_existing_tensor(model, name, mod, attr, tensor_type)
+        parameter = parameters.get(id(existing)) if existing is not None else None
 
-        # Tensor attrs and buffers: clone since they may be mutated
-        if tensor_type in ("tensor_attr", "buffer"):
-            if (
-                tensor_type == "buffer"
-                and hasattr(mod, "_buffers")
-                and attr in mod._buffers
-            ):
-                mod._buffers[attr] = tensor.detach().clone()
-            else:
-                setattr(mod, attr, tensor.detach().clone())
-            continue
-
-        # Parameters: in-place update or replace meta tensors
-        if hasattr(mod, "_parameters") and attr in mod._parameters:
-            param = mod._parameters[attr]
-            if param is not None:
-                if param.shape != tensor.shape or param.dtype != tensor.dtype:
+        if existing is not None:
+            if existing.shape != spec.meta.shape or existing.dtype != spec.meta.dtype:
+                raise RuntimeError(
+                    f"Shape/dtype mismatch for {name}: "
+                    f"existing={tuple(existing.shape)}/{existing.dtype}, "
+                    f"gms={spec.meta.shape}/{spec.meta.dtype}"
+                )
+            source = _tensor_source(spec)
+            previous = aliases.get(id(existing))
+            if previous is not None and previous[0] is existing:
+                if previous[1] != source:
                     raise RuntimeError(
-                        f"Shape/dtype mismatch for {name}: "
-                        f"param={tuple(param.shape)}/{param.dtype}, "
-                        f"gms={tuple(tensor.shape)}/{tensor.dtype}"
+                        f"Reader tensor aliases incompatible GMS entries at {name!r}"
                     )
-                if param.is_meta or param.device != tensor.device:
-                    mod._parameters[attr] = torch.nn.Parameter(
-                        tensor, requires_grad=param.requires_grad
+            else:
+                aliases[id(existing)] = (existing, source)
+                is_nonparameter = parameter is None
+                if is_nonparameter:
+                    _validate_plain_nonparameter(existing, name=name)
+                _validate_observed_storage(
+                    observed_storage,
+                    name=name,
+                    tensor=existing,
+                )
+            if (
+                parameter is not None
+                and id(parameter) not in validated_parameters
+                and (parameter.is_meta or parameter.device != target_device)
+            ):
+                _validate_parameter_swap(parameter, name=name)
+                validated_parameters.add(id(parameter))
+        resolved.append((name, spec, mod, attr, existing, parameter))
+
+    materialized: set[int] = set()
+    for name, spec, mod, attr, existing, parameter in resolved:
+        if existing is not None and id(existing) in materialized:
+            continue
+        tensor_type = spec.meta.tensor_type
+
+        # Tensor attrs and buffers need private writable storage. Swap the
+        # TensorImpl so every exact Python alias of an existing tensor survives.
+        if tensor_type in ("tensor_attr", "buffer") and parameter is None:
+            if existing is not None:
+                tensor = spec.materialize(gms_client_memory_manager, device_index)
+                private = tensor.detach().clone()
+                _swap_tensor_contents(existing, private, name=name)
+                materialized.add(id(existing))
+            else:
+                tensor = spec.materialize(gms_client_memory_manager, device_index)
+                private = tensor.detach().clone()
+                if tensor_type == "buffer" and attr in mod._buffers:
+                    mod._buffers[attr] = private
+                elif attr.isdigit() or isinstance(
+                    getattr(type(mod), attr, None), property
+                ):
+                    raise RuntimeError(
+                        f"Cannot materialize GMS tensor {name!r} without "
+                        "an existing Tensor object"
                     )
                 else:
-                    param.data = tensor
-                continue
+                    setattr(mod, attr, private)
+            continue
+
+        tensor = spec.materialize(gms_client_memory_manager, device_index)
+
+        # A registered Parameter always stays on the dedicated parameter path,
+        # even when this metadata entry names an ordinary instance alias.
+        if parameter is not None:
+            if parameter.is_meta or parameter.device != tensor.device:
+                replacement = _make_parameter_replacement(
+                    parameter,
+                    tensor,
+                    name=name,
+                )
+                _swap_tensor_contents(parameter, replacement, name=name)
+            else:
+                parameter.data = tensor
+            materialized.add(id(parameter))
+            continue
 
         # Fallback: set as attribute
         setattr(mod, attr, tensor)
@@ -244,61 +524,105 @@ def rebind_nonparameter_tensors(
 
     Must run before CUDA graph capture: the clones live at new addresses.
 
+    Discoverable exact aliases keep their original Python Tensor object.
+    Discovery is limited to registered fields and direct module instance
+    attributes (including tensor lists/tuples); aliases hidden in arbitrary
+    helper objects are not inspected. Observed distinct tensor objects that
+    share storage (for example, views) are unsupported.
+
     Returns the number of bytes rebound, i.e. how much memory is duplicated
     between the read-only GMS copies and the private clones.
 
-    If ``retain_gms_tensors`` is provided, the original GMS-backed tensors
-    are appended to it. A deferred writer that rebinds before commit must
-    keep those references alive so the underlying GMS pool allocations are
-    not freed before the layout is published.
+    Displaced GMS TensorImpls remain owned by a private model holder for the
+    model's lifetime. If ``retain_gms_tensors`` is provided, each displaced
+    owner is also appended for compatibility with deferred publication.
     """
     mappings = gms_client_memory_manager.mappings
     rebound_bytes = 0
-    for name, tensor, tensor_type in list(_iter_module_tensors(model)):
-        if tensor_type == "parameter":
+    module_tensors = list(_iter_module_tensors(model))
+    parameters = {
+        id(tensor): tensor
+        for _, tensor, tensor_type in module_tensors
+        if tensor_type == "parameter"
+    }
+    seen: dict[int, torch.Tensor] = {}
+    candidates: list[tuple[str, torch.Tensor]] = []
+    storage_owners: dict[int, tuple[str, torch.Tensor]] = {}
+    for name, tensor, tensor_type in module_tensors:
+        mod, attr = _resolve_module_attr(model, name)
+        if _resolve_existing_tensor(model, name, mod, attr, tensor_type) is not tensor:
             continue
+        if seen.get(id(tensor)) is tensor:
+            continue
+        seen[id(tensor)] = tensor
         ptr = int(tensor.data_ptr())
         if not any(
             va <= ptr < va + mapping.aligned_size for va, mapping in mappings.items()
         ):
-            # Allocated outside the GMS pool; already private.
             continue
 
-        mod, attr = _resolve_module_attr(model, name)
-        if (
-            tensor_type == "buffer"
-            and hasattr(mod, "_buffers")
-            and attr in mod._buffers
-        ):
-            mod._buffers[attr] = tensor.detach().clone()
-        elif attr.isdigit() and not isinstance(mod, torch.nn.Module):
-            # Element of a tensor list/tuple attribute.
-            if isinstance(mod, list):
-                mod[int(attr)] = tensor.detach().clone()
-            elif isinstance(mod, tuple):
-                # Tuples are immutable: rebuild the tuple on its owner.
-                container_name, _ = name.rsplit(".", 1)
-                owner, container_attr = _resolve_module_attr(model, container_name)
-                if isinstance(getattr(type(owner), container_attr, None), property):
-                    # Read-only derived attribute; the underlying tensors
-                    # are iterated (and rebound) separately.
-                    logger.debug("[GMS] Skipping property attribute %r", name)
-                    continue
-                elements = list(mod)
-                elements[int(attr)] = tensor.detach().clone()
-                setattr(owner, container_attr, tuple(elements))
-            else:
-                logger.debug("[GMS] Cannot rebind container element %r", name)
-                continue
-        else:
-            if isinstance(getattr(type(mod), attr, None), property):
-                # Read-only derived attribute; the underlying tensor is
-                # iterated (and rebound) separately.
-                logger.debug("[GMS] Skipping property attribute %r", name)
-                continue
-            setattr(mod, attr, tensor.detach().clone())
+        is_candidate = not (
+            tensor_type == "parameter" or parameters.get(id(tensor)) is tensor
+        )
+        if tensor._base is not None:
+            raise RuntimeError(f"GMS cannot rebind tensor view {name!r}")
+        if is_candidate:
+            _validate_plain_nonparameter(tensor, name=name)
+
+        storage_ptr = int(tensor.untyped_storage().data_ptr())
+        if storage_ptr == 0:
+            if is_candidate:
+                candidates.append((name, tensor))
+            continue
+        previous = storage_owners.get(storage_ptr)
+        if previous is not None and previous[1] is not tensor:
+            raise RuntimeError(
+                "GMS cannot rebind distinct tensors that share storage: "
+                f"{previous[0]!r} and {name!r}"
+            )
+        storage_owners[storage_ptr] = (name, tensor)
+        if is_candidate:
+            candidates.append((name, tensor))
+
+    # Drop discovery references before swap_tensors checks TensorImpl use counts.
+    module_tensors.clear()
+    tensor = None
+    mod = None
+    prepared = [(name, tensor, tensor.detach().clone()) for name, tensor in candidates]
+    if not prepared:
+        return 0
+    owners = _get_or_create_rebound_tensor_owners(model)
+    owner_count = len(owners.tensors)
+    retained_count = len(retain_gms_tensors) if retain_gms_tensors is not None else 0
+    completed: list[tuple[str, torch.Tensor, torch.Tensor]] = []
+    try:
+        for name, tensor, private in prepared:
+            _swap_tensor_contents(tensor, private, name=name)
+            completed.append((name, tensor, private))
+    except BaseException as swap_error:
+        rollback_error: BaseException | None = None
+        for name, tensor, private in reversed(completed):
+            try:
+                _swap_tensor_contents(tensor, private, name=name)
+            except BaseException as exc:
+                rollback_error = rollback_error or exc
+        del owners.tensors[owner_count:]
         if retain_gms_tensors is not None:
-            retain_gms_tensors.append(tensor)
-        rebound_bytes += tensor.numel() * tensor.element_size()
+            del retain_gms_tensors[retained_count:]
+        if owner_count == 0 and not owners.tensors:
+            model.__dict__.pop(_REBOUND_TENSOR_OWNERS_ATTR, None)
+        if rollback_error is not None:
+            raise RuntimeError(
+                "GMS tensor rebind failed and rollback was incomplete"
+            ) from rollback_error
+        raise swap_error
+
+    displaced = [private for _, _, private in completed]
+    owners.tensors.extend(displaced)
+    if retain_gms_tensors is not None:
+        retain_gms_tensors.extend(displaced)
+    rebound_bytes = sum(
+        tensor.numel() * tensor.element_size() for _, tensor, _ in completed
+    )
 
     return rebound_bytes

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -4,13 +4,13 @@
 """Publish and materialize PyTorch module storage through GMS.
 
 Write:
-  module -> discover storages -> match GMS mappings -> build manifests -> metadata
+  module -> discover -> match/select -> validate -> build manifests -> metadata
 Read:
   metadata -> validate/resolve -> GMS map -> parameter-containing storage
                               `-> clone ---> all other storage
 Writer rebind:
-  discover/match -> skip parameter-containing storage
-                 `-> clone/swap non-parameter-only storage -> retain source owners
+  discover -> match/select -> validate -> clone/swap non-parameter-only storage
+                                      `-> retain source owners
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ import copyreg
 import logging
 import weakref
 from dataclasses import dataclass
+from itertools import pairwise
 from typing import TYPE_CHECKING, Iterator
 
 import msgspec
@@ -205,6 +206,22 @@ def _discover_module_storages(model: torch.nn.Module) -> list[_DiscoveredStorage
 
     storages: dict[int, _DiscoveredStorage] = {}
     for tensor_object in objects.values():
+        storage = tensor_object.tensor.untyped_storage()
+        storage_id = int(storage._cdata)
+        discovered_storage = storages.get(storage_id)
+        if discovered_storage is None:
+            discovered_storage = _DiscoveredStorage(storage, [])
+            storages[storage_id] = discovered_storage
+        discovered_storage.objects.append(tensor_object)
+    return list(storages.values())
+
+
+def _validate_discovered_storage(
+    discovered_storage: _DiscoveredStorage,
+) -> None:
+    """Validate that a discovered StorageImpl is representable by GMS."""
+    storage = discovered_storage.storage
+    for tensor_object in discovered_storage.objects:
         tensor = tensor_object.tensor
         has_parameter_binding = any(
             binding.kind is ModuleTensorKind.PARAMETER
@@ -242,7 +259,6 @@ def _discover_module_storages(model: torch.nn.Module) -> list[_DiscoveredStorage
                 f"{tensor_object.bindings[0].path!r}"
             )
 
-        storage = tensor.untyped_storage()
         if storage.nbytes() == 0:
             raise RuntimeError(
                 "GMS module manifests do not support zero-byte StorageImpls: "
@@ -260,13 +276,6 @@ def _discover_module_storages(model: torch.nn.Module) -> list[_DiscoveredStorage
             int(tensor.storage_offset()),
             int(storage.nbytes()),
         )
-        storage_id = int(storage._cdata)
-        discovered_storage = storages.get(storage_id)
-        if discovered_storage is None:
-            discovered_storage = _DiscoveredStorage(storage, [])
-            storages[storage_id] = discovered_storage
-        discovered_storage.objects.append(tensor_object)
-    return list(storages.values())
 
 
 def _match_storages_to_gms_mappings(
@@ -325,7 +334,7 @@ def _match_storages_to_gms_mappings(
         )
     for allocation_id, allocation_intervals in intervals.items():
         ordered = sorted(allocation_intervals)
-        for previous, current in zip(ordered, ordered[1:], strict=False):
+        for previous, current in pairwise(ordered):
             if previous[1] > current[0]:
                 raise RuntimeError(
                     "Distinct StorageImpl byte ranges overlap in allocation "
@@ -430,6 +439,9 @@ def register_module_tensors(
         gms_client_memory_manager.mappings,
         require_parameters=True,
     )
+    for discovered_storage, _, _ in storages:
+        _validate_discovered_storage(discovered_storage)
+
     entries: list[tuple[str, str, int, bytes]] = []
     referenced_allocation_ids: set[str] = set()
     for ordinal, (
@@ -517,7 +529,7 @@ def _load_storage_manifests(
                 paths.add(binding.path)
     for allocation_id, allocation_intervals in intervals.items():
         ordered = sorted(allocation_intervals)
-        for previous, current in zip(ordered, ordered[1:], strict=False):
+        for previous, current in pairwise(ordered):
             if previous[1] > current[0]:
                 raise RuntimeError(
                     "GMS storage manifests overlap in allocation "
@@ -637,22 +649,15 @@ def _make_parameter_from_template(
     template: torch.nn.Parameter | None,
     tensor: torch.Tensor,
     *,
-    path: str,
     requires_grad: bool,
 ) -> torch.nn.Parameter:
     if template is None:
         return torch.nn.Parameter(tensor, requires_grad=requires_grad)
-    try:
-        parameter = torch.Tensor._make_subclass(type(template), tensor, requires_grad)
-        parameter.__dict__ = template.__dict__.copy()
-        for name in dict.fromkeys(copyreg._slotnames(type(template))):
-            if hasattr(template, name):
-                setattr(parameter, name, getattr(template, name))
-    except Exception as exc:
-        raise RuntimeError(
-            f"Cannot materialize GMS parameter {path!r} as "
-            f"{type(template).__name__}: {exc}"
-        ) from exc
+    parameter = torch.Tensor._make_subclass(type(template), tensor, requires_grad)
+    parameter.__dict__ = template.__dict__.copy()
+    for name in dict.fromkeys(copyreg._slotnames(type(template))):
+        if hasattr(template, name):
+            setattr(parameter, name, getattr(template, name))
     return parameter
 
 
@@ -776,12 +781,10 @@ def materialize_module_from_gms(
                     dtype,
                     tensor_object.storage_offset_bytes // dtype.itemsize,
                 )
-                parameter_destinations = tuple(
-                    destination
+                if any(
+                    destination.binding.kind is ModuleTensorKind.PARAMETER
                     for destination in object_destinations
-                    if destination.binding.kind is ModuleTensorKind.PARAMETER
-                )
-                if parameter_destinations:
+                ):
                     template = next(
                         (
                             destination.existing
@@ -794,7 +797,6 @@ def materialize_module_from_gms(
                     tensor = _make_parameter_from_template(
                         template,
                         tensor,
-                        path=parameter_destinations[0].binding.path,
                         requires_grad=tensor_object.requires_grad,
                     )
                 materialized.append((tensor, object_destinations))
@@ -908,6 +910,9 @@ def rebind_nonparameter_tensors(
         for discovered_storage, _, _ in storages
         if not discovered_storage.has_parameter
     ]
+    for discovered_storage in candidates:
+        _validate_discovered_storage(discovered_storage)
+
     if not candidates:
         return 0
 

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -1,13 +1,7 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Module tensor operations for GPU Memory Service.
-
-This module provides module-level tensor operations:
-- Module tensor iteration
-- Tensor registration (write path)
-- Tensor materialization (read path)
-"""
+"""Publish and materialize PyTorch module storage through GMS."""
 
 from __future__ import annotations
 
@@ -15,12 +9,16 @@ import copyreg
 import logging
 import weakref
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Iterator, Tuple
+from typing import TYPE_CHECKING, Iterator
 
+import msgspec
 import torch
 from gpu_memory_service.client.torch.tensor import (
-    GMSTensorSpec,
-    TensorMetadata,
+    STORAGE_MANIFEST_PREFIX,
+    Slot,
+    StorageManifest,
+    TensorObject,
+    _dtype_from_name,
     _storage_from_pointer,
     _tensor_from_storage,
     _validate_layout,
@@ -35,841 +33,618 @@ _REBOUND_TENSOR_OWNERS_ATTR = "_gms_rebound_tensor_owners"
 
 
 class _ReboundTensorOwners:
-    """Model-scoped owners for GMS storage displaced by tensor swaps."""
-
     def __init__(self) -> None:
         self.tensors: list[torch.Tensor] = []
 
 
-def _get_or_create_rebound_tensor_owners(
-    model: torch.nn.Module,
-) -> _ReboundTensorOwners:
-    owners = model.__dict__.get(_REBOUND_TENSOR_OWNERS_ATTR)
-    if isinstance(owners, _ReboundTensorOwners):
-        return owners
-    namespace_collision = any(
-        _REBOUND_TENSOR_OWNERS_ATTR in model.__dict__[namespace]
-        for namespace in ("_parameters", "_buffers", "_modules")
-    )
-    class_collision = any(
-        _REBOUND_TENSOR_OWNERS_ATTR in cls.__dict__ for cls in type(model).__mro__
-    )
-    if (
-        _REBOUND_TENSOR_OWNERS_ATTR in model.__dict__
-        or namespace_collision
-        or class_collision
-    ):
-        raise RuntimeError(
-            f"Reserved GMS attribute {_REBOUND_TENSOR_OWNERS_ATTR!r} "
-            "collides with an existing model attribute"
-        )
-    owners = _ReboundTensorOwners()
-    model.__dict__[_REBOUND_TENSOR_OWNERS_ATTR] = owners
-    return owners
-
-
-# =============================================================================
-# Module Tensor Iteration
-# =============================================================================
-
-
-def _iter_module_tensors(
-    module: torch.nn.Module,
-    prefix: str = "",
-) -> Iterator[Tuple[str, torch.Tensor, str]]:
-    """Iterate over all CUDA tensors in a module tree.
-
-    Yields (qualified_name, tensor, tensor_type) for:
-    - Parameters (tensor_type="parameter")
-    - Buffers (tensor_type="buffer")
-    - Other tensor attributes like _k_scale (tensor_type="tensor_attr")
-
-    Args:
-        module: The nn.Module to iterate.
-        prefix: Prefix for qualified names (used in recursion).
-
-    Yields:
-        (name, tensor, tensor_type) tuples for each CUDA tensor.
-    """
-    # Parameters
-    for name, param in module._parameters.items():
-        if param is not None and param.is_cuda:
-            qualified = f"{prefix}{name}" if prefix else name
-            yield (qualified, param, "parameter")
-
-    # Buffers
-    for name, buf in module._buffers.items():
-        if buf is not None and buf.is_cuda:
-            qualified = f"{prefix}{name}" if prefix else name
-            yield (qualified, buf, "buffer")
-
-    # Other tensor attributes explicitly stored on the module instance.
-    # Do not inspect class descriptors: properties may return derived tensor
-    # aliases that are not writable materialization targets.
-    skip = (
-        set(module._parameters.keys())
-        | set(module._buffers.keys())
-        | set(module._modules.keys())
-    )
-    for attr_name, attr_val in module.__dict__.items():
-        if attr_name in skip or attr_name.startswith("__"):
-            continue
-
-        if torch.is_tensor(attr_val) and attr_val.is_cuda:
-            qualified = f"{prefix}{attr_name}" if prefix else attr_name
-            yield (qualified, attr_val, "tensor_attr")
-        elif isinstance(attr_val, (list, tuple)) and attr_val:
-            if all(torch.is_tensor(x) and x.is_cuda for x in attr_val):
-                for i, x in enumerate(attr_val):
-                    qualified = (
-                        f"{prefix}{attr_name}.{i}" if prefix else f"{attr_name}.{i}"
-                    )
-                    yield (qualified, x, "tensor_attr")
-
-    # Recurse into submodules
-    for name, submodule in module._modules.items():
-        if submodule is not None:
-            subprefix = f"{prefix}{name}." if prefix else f"{name}."
-            yield from _iter_module_tensors(submodule, subprefix)
-
-
-def _resolve_module_attr(
-    root: torch.nn.Module, qualified_name: str
-) -> Tuple[torch.nn.Module, str]:
-    """Resolve a dotted name to (parent_module, leaf_attr).
-
-    Handles ModuleList/Sequential (numeric indices) and ModuleDict (key access).
-    """
-    parts = qualified_name.split(".")
-    mod = root
-    for p in parts[:-1]:
-        if isinstance(mod, torch.nn.Module) and p in mod._modules:
-            mod = mod._modules[p]
-        elif isinstance(mod, torch.nn.Module) and p in mod.__dict__:
-            value = mod.__dict__[p]
-            if not isinstance(value, (list, tuple)):
-                raise AttributeError(f"Cannot resolve {p!r} in {qualified_name!r}")
-            mod = value
-        elif isinstance(mod, (list, tuple)) and p.isdigit():
-            mod = mod[int(p)]
-        else:
-            raise AttributeError(f"Cannot resolve {p!r} in {qualified_name!r}")
-    return mod, parts[-1]
-
-
-def _resolve_existing_tensor(
-    model: torch.nn.Module,
-    name: str,
-    mod: object,
-    attr: str,
-    tensor_type: str,
-) -> torch.Tensor | None:
-    """Return the Tensor object at a supported direct module location."""
-    if attr.isdigit() and isinstance(mod, (list, tuple)):
-        owner, container_attr = _resolve_module_attr(model, name.rsplit(".", 1)[0])
-        if isinstance(getattr(type(owner), container_attr, None), property):
-            return None
-        value = mod[int(attr)]
-        return value if torch.is_tensor(value) else None
-
-    if tensor_type == "buffer" and attr in mod._buffers:
-        value = mod._buffers[attr]
-        return value if torch.is_tensor(value) else None
-
-    if isinstance(getattr(type(mod), attr, None), property):
-        return None
-    value = getattr(mod, attr, None)
-    return value if torch.is_tensor(value) else None
-
-
-def _swap_tensor_contents(
-    existing: torch.Tensor,
-    replacement: torch.Tensor,
-    *,
-    name: str,
-) -> None:
-    """Swap TensorImpls while preserving ``existing`` Python identity."""
-    if torch.torch_version.TorchVersion(torch.__version__) < (2, 4) or not hasattr(
-        torch.utils, "swap_tensors"
-    ):
-        raise RuntimeError(
-            "GMS identity-preserving tensor materialization requires "
-            "torch.utils.swap_tensors with TensorImpl use-count safety "
-            "(PyTorch 2.4+)"
-        )
-    try:
-        torch.utils.swap_tensors(existing, replacement)
-    except RuntimeError as exc:
-        raise RuntimeError(
-            f"Cannot preserve Python identity for GMS tensor {name!r}: "
-            f"torch.utils.swap_tensors failed: {exc}"
-        ) from exc
-
-
-def _copy_parameter_state(
-    parameter: torch.nn.Parameter,
-    replacement: torch.nn.Parameter,
-    *,
-    name: str,
-) -> None:
-    """Give an exact-class replacement the original Parameter's Python state."""
-    try:
-        replacement.__dict__ = parameter.__dict__
-        for slot in copyreg._slotnames(type(parameter)) or ():
-            if hasattr(parameter, slot):
-                setattr(replacement, slot, getattr(parameter, slot))
-    except Exception as exc:
-        raise RuntimeError(
-            f"Cannot preserve Python state for GMS parameter {name!r} "
-            f"of type {type(parameter).__name__}: {exc}"
-        ) from exc
-
-
-def _make_parameter_replacement(
-    parameter: torch.nn.Parameter,
-    tensor: torch.Tensor,
-    *,
-    name: str,
-) -> torch.nn.Parameter:
-    """Wrap ``tensor`` without invoking a heterogeneous Parameter constructor."""
-    try:
-        replacement = torch.Tensor._make_subclass(
-            type(parameter), tensor, parameter.requires_grad
-        )
-    except Exception as exc:
-        raise RuntimeError(
-            f"Cannot materialize GMS parameter {name!r} as "
-            f"{type(parameter).__name__}: {exc}"
-        ) from exc
-    _copy_parameter_state(parameter, replacement, name=name)
-    return replacement
-
-
-def _validate_parameter_swap(
-    parameter: torch.nn.Parameter,
-    *,
-    name: str,
-) -> None:
-    """Fail before reader mutation if an exact-class Parameter cannot be swapped."""
-    if weakref.getweakrefs(parameter):
-        raise RuntimeError(
-            f"Cannot preserve Python identity for GMS parameter {name!r}: "
-            "torch.utils.swap_tensors does not support weak references"
-        )
-    use_count = parameter._use_count()
-    if use_count > 1:
-        raise RuntimeError(
-            f"Cannot preserve Python identity for GMS parameter {name!r}: "
-            f"TensorImpl use count is {use_count}, expected 1"
-        )
-    probe = torch.empty(0, dtype=parameter.dtype, device="meta")
-    _make_parameter_replacement(parameter, probe, name=name)
-
-
-def _tensor_source(spec: GMSTensorSpec):
-    return (
-        spec.allocation_id,
-        spec.offset_bytes,
-        spec.meta.shape,
-        spec.meta.stride,
-        spec.meta.dtype,
-    )
-
-
-def _registered_parameters(
-    model: torch.nn.Module,
-) -> dict[int, torch.nn.Parameter]:
-    """Index every registered Parameter by exact Python identity."""
-    return {
-        id(parameter): parameter
-        for module in model.modules()
-        for parameter in module._parameters.values()
-        if parameter is not None
-    }
-
-
-def _validate_plain_nonparameter(tensor: torch.Tensor, *, name: str) -> None:
-    if type(tensor) is not torch.Tensor:
-        raise RuntimeError(
-            f"GMS does not support non-parameter Tensor subclass at {name!r}: "
-            f"{type(tensor).__name__}"
-        )
-
-
-def _validate_observed_storage(
-    observed: dict[int, tuple[str, torch.Tensor]],
-    *,
-    name: str,
-    tensor: torch.Tensor,
-) -> None:
-    """Reject observed views or distinct objects sharing storage."""
-    if tensor._base is not None:
-        raise RuntimeError(f"GMS cannot materialize tensor view {name!r}")
-
-    storage_ptr = int(tensor.untyped_storage().data_ptr())
-    if storage_ptr == 0:
-        return
-    previous = observed.get(storage_ptr)
-    if previous is not None and previous[1] is not tensor:
-        raise RuntimeError(
-            "GMS cannot materialize distinct tensors that share storage: "
-            f"{previous[0]!r} and {name!r}"
-        )
-    observed[storage_ptr] = (name, tensor)
-
-
 @dataclass
-class _TensorDescriptor:
-    name: str
+class _DiscoveredObject:
     tensor: torch.Tensor
-    meta: TensorMetadata
-    buffer_persistent: bool
-    object_group_id: int
+    slots: list[Slot]
 
 
 @dataclass
-class _StorageComponent:
-    storage_group_id: int
-    storage_nbytes: int
-    members: list[_TensorDescriptor]
+class _DiscoveredStorage:
+    storage: torch.UntypedStorage
+    objects: list[_DiscoveredObject]
     allocation_id: str | None = None
     storage_base_offset: int | None = None
 
-
-def _storage_impl_identity(tensor: torch.Tensor) -> int:
-    """Return the private identity used only to compare StorageImpl topology."""
-    return int(tensor.untyped_storage()._cdata)
-
-
-def _validate_tensor_contract(
-    tensor: torch.Tensor,
-    *,
-    name: str,
-    is_parameter: bool,
-) -> None:
-    if tensor.is_conj() or tensor.is_neg():
-        raise RuntimeError(
-            f"GMS does not support lazy conjugate/negative tensor {name!r}"
+    @property
+    def has_parameter(self) -> bool:
+        return any(
+            slot.kind == "parameter"
+            for tensor_object in self.objects
+            for slot in tensor_object.slots
         )
-    element_size = tensor.element_size()
-    if tensor.untyped_storage().data_ptr() % element_size:
-        raise RuntimeError(f"GMS tensor storage is unaligned at {name!r}")
-    _validate_layout(
-        tuple(tensor.shape),
-        tuple(tensor.stride()),
-        tensor.dtype,
-        int(tensor.storage_offset()),
-        int(tensor.untyped_storage().nbytes()),
-    )
-    if not is_parameter:
-        _validate_plain_nonparameter(tensor, name=name)
-        if tensor.requires_grad or tensor.grad_fn is not None:
-            raise RuntimeError(
-                f"GMS inference storage does not support autograd tensor {name!r}"
-            )
-    elif not tensor.is_leaf or tensor.grad_fn is not None:
-        raise RuntimeError(f"GMS only supports leaf Parameters at {name!r}")
 
 
-def _discover_storage_components(
+@dataclass(frozen=True)
+class _StoredManifest:
+    allocation_id: str
+    storage_base_offset: int
+    manifest: StorageManifest
+
+
+@dataclass(frozen=True)
+class _SlotTarget:
+    slot: Slot
+    module: torch.nn.Module
+    attr: str
+    existing: torch.Tensor | None
+    index: int | None = None
+
+    @property
+    def destination(self) -> tuple[int, str, int | None]:
+        if self.index is not None:
+            container = self.module.__dict__[self.attr]
+            if isinstance(container, list):
+                return id(container), "", self.index
+            return id(self.module.__dict__), self.attr, self.index
+        return id(self.module), self.attr, None
+
+    def install(self, tensor: torch.Tensor) -> None:
+        if self.slot.kind == "parameter":
+            self.module._parameters[self.attr] = tensor
+        elif self.slot.kind in ("persistent_buffer", "nonpersistent_buffer"):
+            self.module._buffers[self.attr] = tensor
+            if self.slot.kind == "persistent_buffer":
+                self.module._non_persistent_buffers_set.discard(self.attr)
+            else:
+                self.module._non_persistent_buffers_set.add(self.attr)
+        elif self.index is None:
+            self.module.__dict__[self.attr] = tensor
+        else:
+            container = self.module.__dict__[self.attr]
+            if isinstance(container, list):
+                container[self.index] = tensor
+            else:
+                values = list(container)
+                values[self.index] = tensor
+                self.module.__dict__[self.attr] = tuple(values)
+
+
+@dataclass(frozen=True)
+class _MaterializedObject:
+    tensor: torch.Tensor
+    targets: tuple[_SlotTarget, ...]
+
+
+def _iter_module_slots(
     model: torch.nn.Module,
-) -> list[_StorageComponent]:
-    entries = list(_iter_module_tensors(model))
-    # PyTorch exposes no public StorageImpl identity. Keep this private value
-    # isolated to grouping wrappers that must share one reconstructed storage.
-    components_by_storage: dict[int, _StorageComponent] = {}
-    object_groups: dict[int, int] = {}
+) -> Iterator[tuple[torch.Tensor, Slot]]:
+    for module_path, module in model.named_modules(remove_duplicate=False):
+        for name, parameter in module.named_parameters(
+            recurse=False, remove_duplicate=False
+        ):
+            path = f"{module_path}.{name}" if module_path else name
+            yield parameter, Slot(path, "parameter")
 
-    for name, tensor, tensor_type in entries:
-        mod, attr = _resolve_module_attr(model, name)
-        if _resolve_existing_tensor(model, name, mod, attr, tensor_type) is not tensor:
-            continue
-        _validate_tensor_contract(
-            tensor,
-            name=name,
-            is_parameter=isinstance(tensor, torch.nn.Parameter),
+        for name, buffer in module.named_buffers(recurse=False, remove_duplicate=False):
+            kind = (
+                "nonpersistent_buffer"
+                if name in module._non_persistent_buffers_set
+                else "persistent_buffer"
+            )
+            path = f"{module_path}.{name}" if module_path else name
+            yield buffer, Slot(path, kind)
+
+        registered = (
+            set(module._parameters) | set(module._buffers) | set(module._modules)
         )
-        object_group_id = object_groups.setdefault(id(tensor), len(object_groups))
+        for name, value in module.__dict__.items():
+            if name in registered or name.startswith("__"):
+                continue
+            if torch.is_tensor(value):
+                path = f"{module_path}.{name}" if module_path else name
+                yield value, Slot(path, "attribute")
+            elif type(value) in (list, tuple):
+                for index, element in enumerate(value):
+                    if torch.is_tensor(element):
+                        name_with_index = f"{name}.{index}"
+                        path = (
+                            f"{module_path}.{name_with_index}"
+                            if module_path
+                            else name_with_index
+                        )
+                        yield element, Slot(path, "attribute")
+
+
+def _discover_module_storage(model: torch.nn.Module) -> list[_DiscoveredStorage]:
+    objects: dict[int, _DiscoveredObject] = {}
+    for tensor, slot in _iter_module_slots(model):
+        tensor_object = objects.get(id(tensor))
+        if tensor_object is None:
+            tensor_object = _DiscoveredObject(tensor, [])
+            objects[id(tensor)] = tensor_object
+        if slot not in tensor_object.slots:
+            tensor_object.slots.append(slot)
+
+    storages: dict[int, _DiscoveredStorage] = {}
+    for tensor_object in objects.values():
+        tensor = tensor_object.tensor
+        has_parameter_slot = any(
+            slot.kind == "parameter" for slot in tensor_object.slots
+        )
+        if isinstance(tensor, torch.nn.Parameter) and not has_parameter_slot:
+            raise RuntimeError(
+                f"Unregistered Parameter at {tensor_object.slots[0].path!r} "
+                "has no parameter slot"
+            )
+        if has_parameter_slot and not isinstance(tensor, torch.nn.Parameter):
+            raise RuntimeError(
+                f"GMS parameter slot {tensor_object.slots[0].path!r} "
+                "does not contain a Parameter"
+            )
+        if not has_parameter_slot and type(tensor) is not torch.Tensor:
+            raise RuntimeError(
+                "GMS does not support non-parameter Tensor subclass at "
+                f"{tensor_object.slots[0].path!r}: {type(tensor).__name__}"
+            )
+        if tensor.is_conj() or tensor.is_neg():
+            raise RuntimeError(
+                "GMS does not support lazy conjugate/negative tensor "
+                f"{tensor_object.slots[0].path!r}"
+            )
+        if has_parameter_slot:
+            if not tensor.is_leaf or tensor.grad_fn is not None:
+                raise RuntimeError(
+                    f"GMS only supports leaf Parameters at "
+                    f"{tensor_object.slots[0].path!r}"
+                )
+        elif tensor.requires_grad or tensor.grad_fn is not None:
+            raise RuntimeError(
+                "GMS inference storage does not support autograd tensor "
+                f"{tensor_object.slots[0].path!r}"
+            )
 
         storage = tensor.untyped_storage()
-        storage_id = _storage_impl_identity(tensor)
-        component = components_by_storage.get(storage_id)
-        if component is None:
-            component = _StorageComponent(
-                storage_group_id=len(components_by_storage),
-                storage_nbytes=int(storage.nbytes()),
-                members=[],
+        if storage.nbytes() == 0:
+            raise RuntimeError(
+                "GMS module manifests do not support zero-byte StorageImpls: "
+                f"{tensor_object.slots[0].path!r}"
             )
-            components_by_storage[storage_id] = component
-        component.members.append(
-            _TensorDescriptor(
-                name=name,
-                tensor=tensor,
-                meta=TensorMetadata.from_tensor(tensor, tensor_type),
-                buffer_persistent=(
-                    tensor_type == "buffer"
-                    and attr not in mod._non_persistent_buffers_set
-                ),
-                object_group_id=object_group_id,
+        storage_offset_bytes = int(tensor.storage_offset()) * tensor.dtype.itemsize
+        if (storage.data_ptr() + storage_offset_bytes) % tensor.dtype.itemsize:
+            raise RuntimeError(
+                f"GMS tensor data is unaligned at {tensor_object.slots[0].path!r}"
             )
+        _validate_layout(
+            tuple(tensor.shape),
+            tuple(tensor.stride()),
+            tensor.dtype,
+            int(tensor.storage_offset()),
+            int(storage.nbytes()),
         )
-    return list(components_by_storage.values())
+        storage_id = int(storage._cdata)
+        discovered_storage = storages.get(storage_id)
+        if discovered_storage is None:
+            discovered_storage = _DiscoveredStorage(storage, [])
+            storages[storage_id] = discovered_storage
+        discovered_storage.objects.append(tensor_object)
+    return list(storages.values())
 
 
-def _locate_components(
-    components: list[_StorageComponent],
+def _locate_storage(
+    storages: list[_DiscoveredStorage],
     mappings: dict[int, object],
     *,
     require_parameters: bool,
-) -> list[_StorageComponent]:
-    located: list[_StorageComponent] = []
-    for component in components:
-        storage_ptr = int(component.members[0].tensor.untyped_storage().data_ptr())
+) -> list[_DiscoveredStorage]:
+    located: list[_DiscoveredStorage] = []
+    for ordinal, discovered_storage in enumerate(storages):
+        storage_ptr = int(discovered_storage.storage.data_ptr())
+        storage_nbytes = int(discovered_storage.storage.nbytes())
+        storage_end = storage_ptr + storage_nbytes
+        containing: list[tuple[int, object]] = []
         for va, mapping in mappings.items():
-            end = storage_ptr + component.storage_nbytes
-            mapping_end = va + mapping.aligned_size
-            if max(va, storage_ptr) < min(mapping_end, end) and not (
-                va <= storage_ptr and end <= mapping_end
-            ):
+            mapping_end = int(va) + int(mapping.aligned_size)
+            overlaps = max(int(va), storage_ptr) < min(mapping_end, storage_end)
+            if overlaps and not (int(va) <= storage_ptr and storage_end <= mapping_end):
                 raise RuntimeError(
-                    f"Storage component {component.storage_group_id} exceeds "
-                    f"GMS allocation {mapping.allocation_id!r}"
+                    f"Storage {ordinal} exceeds GMS allocation "
+                    f"{mapping.allocation_id!r}"
                 )
-            if va <= storage_ptr and end <= mapping_end:
-                component.allocation_id = str(mapping.allocation_id)
-                component.storage_base_offset = storage_ptr - va
-                located.append(component)
-                break
-        else:
-            if require_parameters and any(
-                isinstance(member.tensor, torch.nn.Parameter)
-                for member in component.members
-            ):
+            if int(va) <= storage_ptr and storage_end <= mapping_end:
+                containing.append((int(va), mapping))
+
+        if len(containing) > 1:
+            raise RuntimeError(f"Storage {ordinal} belongs to multiple GMS allocations")
+        if not containing:
+            if require_parameters and discovered_storage.has_parameter:
                 raise RuntimeError(
-                    f"Tensor {component.members[0].name!r} not found in any "
-                    "GMS allocation"
+                    f"Parameter {discovered_storage.objects[0].slots[0].path!r} "
+                    "is not contained in a GMS allocation"
                 )
             logger.debug(
-                "[GMS] Skipping storage component for %r outside GMS allocations",
-                component.members[0].name,
+                "[GMS] Skipping storage for %r outside GMS allocations",
+                discovered_storage.objects[0].slots[0].path,
             )
-    _validate_component_intervals(located)
-    return located
+            continue
 
+        va, mapping = containing[0]
+        discovered_storage.allocation_id = str(mapping.allocation_id)
+        discovered_storage.storage_base_offset = storage_ptr - va
+        located.append(discovered_storage)
 
-def _validate_component_intervals(components: list[_StorageComponent]) -> None:
-    grouped: dict[str, list[tuple[int, int, int]]] = {}
-    for component in components:
-        start = int(component.storage_base_offset)
-        grouped.setdefault(str(component.allocation_id), []).append(
-            (start, start + component.storage_nbytes, component.storage_group_id)
+    intervals: dict[str, list[tuple[int, int]]] = {}
+    for discovered_storage in located:
+        start = discovered_storage.storage_base_offset
+        if start is None or discovered_storage.allocation_id is None:
+            raise RuntimeError("Located GMS storage is missing its allocation envelope")
+        intervals.setdefault(discovered_storage.allocation_id, []).append(
+            (start, start + discovered_storage.storage.nbytes())
         )
-    for allocation_id, intervals in grouped.items():
-        ordered = sorted(intervals)
+    for allocation_id, allocation_intervals in intervals.items():
+        ordered = sorted(allocation_intervals)
         for previous, current in zip(ordered, ordered[1:], strict=False):
             if previous[1] > current[0]:
                 raise RuntimeError(
                     "Distinct StorageImpl byte ranges overlap in allocation "
-                    f"{allocation_id!r}: storage groups "
-                    f"{previous[2]} and {current[2]}"
+                    f"{allocation_id!r}: {previous} and {current}"
                 )
+    return located
 
 
-def _unique_members(
-    components: list[_StorageComponent],
-) -> list[_TensorDescriptor]:
-    return list(
-        {
-            member.object_group_id: member
-            for component in components
-            for member in component.members
-        }.values()
-    )
-
-
-def _swap_order(members: list[_TensorDescriptor]) -> list[_TensorDescriptor]:
-    tensors = {id(member.tensor) for member in members}
-
-    def depth(member: _TensorDescriptor) -> int:
-        result = 0
-        base = member.tensor._base
-        while base is not None and id(base) in tensors:
-            result += 1
-            base = base._base
-        return result
-
-    return sorted(members, key=depth, reverse=True)
-
-
-def _has_parameter_accumulator_owner(
-    tensor: torch.Tensor,
-    expected_use_count: int,
-) -> bool:
-    """Disambiguate one AccumulateGrad owner from an unknown TensorImpl owner."""
-    if not (
-        isinstance(tensor, torch.nn.Parameter)
-        and tensor.requires_grad
-        and tensor.is_leaf
-        and tensor._use_count() == expected_use_count + 1
-    ):
-        return False
-    gradient_edge = torch.autograd.graph.get_gradient_edge(tensor)
-    return (
-        gradient_edge.node is not None and tensor._use_count() == expected_use_count + 1
-    )
-
-
-def _validate_swap_ownership(members: list[_TensorDescriptor]) -> None:
-    tensors = {id(member.tensor): member.tensor for member in members}
-    child_counts: dict[int, int] = {}
-    for member in members:
-        base = member.tensor._base
-        if base is not None and tensors.get(id(base)) is base:
-            child_counts[id(base)] = child_counts.get(id(base), 0) + 1
-
-    # TensorImpl use counts are private, but public swap_tensors enforces them.
-    # Comparing here lets the complete operation fail before any mutation.
-    for member in members:
-        tensor = member.tensor
-        if weakref.getweakrefs(tensor):
-            raise RuntimeError(
-                f"Cannot preserve Python identity for GMS tensor {member.name!r}: "
-                "torch.utils.swap_tensors does not support weak references"
+def _manifest_for_storage(discovered_storage: _DiscoveredStorage) -> StorageManifest:
+    return StorageManifest(
+        nbytes=int(discovered_storage.storage.nbytes()),
+        objects=tuple(
+            TensorObject(
+                dtype=str(tensor_object.tensor.dtype).removeprefix("torch."),
+                shape=tuple(tensor_object.tensor.shape),
+                stride=tuple(tensor_object.tensor.stride()),
+                storage_offset_bytes=(
+                    int(tensor_object.tensor.storage_offset())
+                    * tensor_object.tensor.dtype.itemsize
+                ),
+                requires_grad=bool(tensor_object.tensor.requires_grad),
+                slots=tuple(tensor_object.slots),
             )
-        expected = 1 + child_counts.get(id(tensor), 0)
-        use_count = tensor._use_count()
-        parameter_accumulator = _has_parameter_accumulator_owner(tensor, expected)
-        if use_count != expected and not parameter_accumulator:
-            raise RuntimeError(
-                f"Cannot safely swap GMS tensor {member.name!r}: TensorImpl use "
-                f"count is {use_count}, expected {expected} from discovered tensors"
-            )
-
-
-def _replacement_for(
-    member: _TensorDescriptor,
-    storage: torch.UntypedStorage,
-) -> torch.Tensor:
-    tensor = _tensor_from_storage(
-        storage,
-        list(member.meta.shape),
-        list(member.meta.stride),
-        member.meta.dtype,
-        int(member.tensor.storage_offset())
-        if member.meta.storage is None
-        else int(member.meta.storage["storage_offset"]),
+            for tensor_object in discovered_storage.objects
+        ),
     )
-    if isinstance(member.tensor, torch.nn.Parameter):
-        return _make_parameter_replacement(member.tensor, tensor, name=member.name)
-    return tensor
 
 
-def _apply_replacements(
-    members: list[_TensorDescriptor],
-    replacements: dict[int, torch.Tensor],
+def _validate_manifest(
+    manifest: StorageManifest,
+    *,
+    key: str,
+    storage_base_offset: int | None = None,
 ) -> None:
-    """Swap child-first; failures are terminal and the caller discards the model."""
-    for member in _swap_order(members):
-        replacement = replacements.pop(member.object_group_id)
-        _swap_tensor_contents(member.tensor, replacement, name=member.name)
-        del replacement
-
-
-# =============================================================================
-# Public API - Registration and Materialization
-# =============================================================================
+    if manifest.nbytes <= 0:
+        raise RuntimeError(f"GMS storage manifest {key!r} has nonpositive size")
+    if not manifest.objects:
+        raise RuntimeError(f"GMS storage manifest {key!r} has no tensor objects")
+    if storage_base_offset is not None and storage_base_offset < 0:
+        raise RuntimeError(f"GMS storage manifest {key!r} has negative base offset")
+    paths: set[str] = set()
+    for tensor_object in manifest.objects:
+        try:
+            dtype = _dtype_from_name(tensor_object.dtype)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Invalid dtype in GMS storage manifest {key!r}: {exc}"
+            ) from exc
+        if tensor_object.storage_offset_bytes % dtype.itemsize:
+            raise RuntimeError(
+                f"Unaligned tensor byte offset in GMS storage manifest {key!r}"
+            )
+        if storage_base_offset is not None and storage_base_offset % dtype.itemsize:
+            raise RuntimeError(
+                f"Unaligned storage envelope in GMS storage manifest {key!r}"
+            )
+        try:
+            _validate_layout(
+                tensor_object.shape,
+                tensor_object.stride,
+                dtype,
+                tensor_object.storage_offset_bytes // dtype.itemsize,
+                manifest.nbytes,
+            )
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Invalid tensor layout in GMS storage manifest {key!r}: {exc}"
+            ) from exc
+        if not tensor_object.slots:
+            raise RuntimeError(
+                f"Tensor object in GMS storage manifest {key!r} has no slots"
+            )
+        has_parameter = any(slot.kind == "parameter" for slot in tensor_object.slots)
+        if tensor_object.requires_grad and not has_parameter:
+            raise RuntimeError(
+                f"Non-parameter tensor object in GMS storage manifest {key!r} "
+                "requires gradients"
+            )
+        for slot in tensor_object.slots:
+            if not slot.path or slot.path in paths:
+                raise RuntimeError(
+                    f"Duplicate or empty slot path in GMS storage manifest {key!r}: "
+                    f"{slot.path!r}"
+                )
+            paths.add(slot.path)
 
 
 def register_module_tensors(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
 ) -> set[str]:
-    """Register all model tensors into the GMS metadata store.
-
-    Args:
-        gms_client_memory_manager: GMS client memory manager in write mode.
-        model: PyTorch model to register.
-
-    Returns:
-        Allocation IDs referenced by registered tensors.
-    """
-    components = _locate_components(
-        _discover_storage_components(model),
+    """Publish one typed storage manifest for each GMS-backed StorageImpl."""
+    storages = _locate_storage(
+        _discover_module_storage(model),
         gms_client_memory_manager.mappings,
         require_parameters=True,
     )
-    _validate_swap_ownership(_unique_members(components))
+    entries: list[tuple[str, str, int, bytes]] = []
     referenced_allocation_ids: set[str] = set()
-    for component in components:
-        assert component.allocation_id is not None
-        assert component.storage_base_offset is not None
-        referenced_allocation_ids.add(component.allocation_id)
-        for member in component.members:
-            element_size = torch.empty((), dtype=member.meta.dtype).element_size()
-            offset_bytes = (
-                component.storage_base_offset
-                + member.tensor.storage_offset() * element_size
+    for ordinal, discovered_storage in enumerate(storages):
+        if (
+            discovered_storage.allocation_id is None
+            or discovered_storage.storage_base_offset is None
+        ):
+            raise RuntimeError("Located GMS storage is missing its allocation envelope")
+        key = f"{STORAGE_MANIFEST_PREFIX}{ordinal}"
+        manifest = _manifest_for_storage(discovered_storage)
+        _validate_manifest(
+            manifest,
+            key=key,
+            storage_base_offset=discovered_storage.storage_base_offset,
+        )
+        encoded = msgspec.msgpack.encode(manifest)
+        entries.append(
+            (
+                key,
+                discovered_storage.allocation_id,
+                discovered_storage.storage_base_offset,
+                encoded,
             )
-            meta = TensorMetadata.from_tensor(
-                member.tensor,
-                member.meta.tensor_type,
-                storage={
-                    "schema_version": 1,
-                    "storage_group_id": component.storage_group_id,
-                    "object_group_id": member.object_group_id,
-                    "storage_base_offset": component.storage_base_offset,
-                    "storage_nbytes": component.storage_nbytes,
-                    "storage_offset": int(member.tensor.storage_offset()),
-                    "buffer_persistent": member.buffer_persistent,
-                },
-            )
-            if not gms_client_memory_manager.metadata_put(
-                key=member.name,
-                allocation_id=component.allocation_id,
-                offset_bytes=offset_bytes,
-                value=meta.to_bytes(),
-            ):
-                raise RuntimeError(f"Failed to register GMS tensor {member.name!r}")
+        )
+        referenced_allocation_ids.add(discovered_storage.allocation_id)
+
+    for key, allocation_id, storage_base_offset, encoded in entries:
+        if not gms_client_memory_manager.metadata_put(
+            key=key,
+            allocation_id=allocation_id,
+            offset_bytes=storage_base_offset,
+            value=encoded,
+        ):
+            raise RuntimeError(f"Failed to publish GMS storage manifest {key!r}")
     return referenced_allocation_ids
 
 
-def _resolve_slot(
-    model: torch.nn.Module,
-    name: str,
-    meta: TensorMetadata,
-) -> torch.Tensor:
-    mod, attr = _resolve_module_attr(model, name)
-    if meta.tensor_type == "parameter":
-        if not isinstance(mod, torch.nn.Module) or attr not in mod._parameters:
+def _load_storage_manifests(
+    manager: "GMSClientMemoryManager",
+) -> list[_StoredManifest]:
+    loaded: list[tuple[int, _StoredManifest]] = []
+    for key in manager.metadata_list(STORAGE_MANIFEST_PREFIX):
+        suffix = key.removeprefix(STORAGE_MANIFEST_PREFIX)
+        if not suffix.isascii() or not suffix.isdecimal() or str(int(suffix)) != suffix:
+            raise RuntimeError(f"Invalid GMS storage manifest key {key!r}")
+        got = manager.metadata_get(key)
+        if got is None:
+            raise RuntimeError(f"GMS storage manifest disappeared: {key!r}")
+        allocation_id, storage_base_offset, value = got
+        if type(storage_base_offset) is not int:
             raise RuntimeError(
-                f"GMS tensor {name!r} is a Parameter but the reader slot is not"
-            )
-        tensor = mod._parameters[attr]
-        if not isinstance(tensor, torch.nn.Parameter):
-            raise RuntimeError(f"Reader Parameter slot {name!r} is empty or invalid")
-    elif meta.tensor_type == "buffer":
-        if not isinstance(mod, torch.nn.Module) or attr not in mod._buffers:
-            raise RuntimeError(
-                f"GMS tensor {name!r} is a buffer but the reader slot is not"
-            )
-        tensor = mod._buffers[attr]
-        if not torch.is_tensor(tensor):
-            raise RuntimeError(f"Reader buffer slot {name!r} is empty or invalid")
-        persistent = attr not in mod._non_persistent_buffers_set
-        if meta.storage is not None and persistent != meta.storage["buffer_persistent"]:
-            raise RuntimeError(f"Reader buffer persistence differs at {name!r}")
-    else:
-        tensor = _resolve_existing_tensor(model, name, mod, attr, meta.tensor_type)
-        if tensor is None:
-            raise RuntimeError(
-                f"GMS tensor attribute {name!r} requires a preexisting direct "
-                "Tensor object"
-            )
-        if isinstance(mod, torch.nn.Module) and (
-            attr in mod._parameters or attr in mod._buffers
-        ):
-            raise RuntimeError(f"Reader tensor attribute slot differs at {name!r}")
-    return tensor
-
-
-def _components_from_specs(
-    specs: dict[str, GMSTensorSpec],
-    model: torch.nn.Module,
-) -> list[_StorageComponent]:
-    if any(not spec.meta.is_storage_component for spec in specs.values()):
-        raise RuntimeError("Cannot mix legacy and storage-component GMS metadata")
-    components: dict[tuple[str, int], _StorageComponent] = {}
-    objects: dict[int, torch.Tensor] = {}
-    reader_objects: dict[int, int] = {}
-    object_sources: dict[int, tuple[str, int]] = {}
-    object_layouts: dict[int, tuple[object, ...]] = {}
-    component_storages: dict[tuple[str, int], int] = {}
-    storage_components: dict[int, tuple[str, int]] = {}
-
-    for name, spec in specs.items():
-        meta = spec.meta
-        tensor = _resolve_slot(model, name, meta)
-        if tuple(tensor.shape) != meta.shape or tensor.dtype != meta.dtype:
-            raise RuntimeError(
-                f"Shape/dtype mismatch for {name}: "
-                f"existing={tuple(tensor.shape)}/{tensor.dtype}, "
-                f"gms={meta.shape}/{meta.dtype}"
-            )
-        _validate_tensor_contract(
-            tensor,
-            name=name,
-            is_parameter=isinstance(tensor, torch.nn.Parameter),
-        )
-
-        assert meta.storage is not None
-        if meta.tensor_type != "buffer" and meta.storage["buffer_persistent"]:
-            raise RuntimeError(f"Invalid buffer persistence at GMS tensor {name!r}")
-        storage_group_id = int(meta.storage["storage_group_id"])
-        object_group_id = int(meta.storage["object_group_id"])
-        storage_base_offset = int(meta.storage["storage_base_offset"])
-        storage_offset = int(meta.storage["storage_offset"])
-        storage_nbytes = int(meta.storage["storage_nbytes"])
-        element_size = torch.empty((), dtype=meta.dtype).element_size()
-        expected_offset = storage_base_offset + storage_offset * element_size
-        if expected_offset % element_size:
-            raise RuntimeError(f"Unaligned GMS tensor metadata at {name!r}")
-        if spec.offset_bytes != expected_offset:
-            raise RuntimeError(
-                f"GMS legacy offset disagrees with tensor layout at {name!r}"
+                f"GMS storage manifest {key!r} has a non-integer base offset"
             )
         try:
-            _validate_layout(
-                meta.shape,
-                meta.stride,
-                meta.dtype,
-                storage_offset,
-                storage_nbytes,
-            )
-        except ValueError as exc:
-            raise RuntimeError(
-                f"Invalid GMS tensor metadata at {name!r}: {exc}"
-            ) from exc
-
-        previous_object = objects.setdefault(object_group_id, tensor)
-        previous_reader = reader_objects.setdefault(id(tensor), object_group_id)
-        layout = (meta.shape, meta.stride, meta.dtype, storage_offset)
-        previous_layout = object_layouts.setdefault(object_group_id, layout)
-        if previous_object is not tensor:
-            raise RuntimeError(
-                f"Reader exact-alias topology differs for GMS tensor {name!r}"
-            )
-        if previous_reader != object_group_id or previous_layout != layout:
-            raise RuntimeError(
-                f"Reader tensor aliases incompatible GMS entries at {name!r}"
-            )
-
-        component_key = (spec.allocation_id, storage_group_id)
-        previous_source = object_sources.setdefault(object_group_id, component_key)
-        if previous_source != component_key:
-            raise RuntimeError(
-                f"Reader tensor aliases incompatible GMS entries at {name!r}"
-            )
-        storage_identity = _storage_impl_identity(tensor)
-        previous_storage = component_storages.setdefault(
-            component_key, storage_identity
+            manifest = msgspec.msgpack.decode(value, type=StorageManifest)
+        except msgspec.DecodeError as exc:
+            raise RuntimeError(f"Invalid GMS storage manifest {key!r}: {exc}") from exc
+        _validate_manifest(
+            manifest,
+            key=key,
+            storage_base_offset=storage_base_offset,
         )
-        previous_component = storage_components.setdefault(
-            storage_identity, component_key
-        )
-        if previous_storage != storage_identity or previous_component != component_key:
-            raise RuntimeError(
-                f"Reader StorageImpl topology differs at GMS tensor {name!r}"
-            )
-        component = components.get(component_key)
-        if component is None:
-            component = _StorageComponent(
-                storage_group_id=storage_group_id,
-                storage_nbytes=storage_nbytes,
-                members=[],
-                allocation_id=spec.allocation_id,
-                storage_base_offset=storage_base_offset,
-            )
-            components[component_key] = component
-        elif (
-            component.storage_nbytes != storage_nbytes
-            or component.storage_base_offset != storage_base_offset
-        ):
-            raise RuntimeError(f"Inconsistent GMS storage component at tensor {name!r}")
-        component.members.append(
-            _TensorDescriptor(
-                name=name,
-                tensor=tensor,
-                meta=meta,
-                buffer_persistent=bool(meta.storage["buffer_persistent"]),
-                object_group_id=object_group_id,
+        loaded.append(
+            (
+                int(suffix),
+                _StoredManifest(
+                    str(allocation_id),
+                    storage_base_offset,
+                    manifest,
+                ),
             )
         )
-    result = list(components.values())
-    _validate_component_intervals(result)
-    return result
+    loaded.sort(key=lambda item: item[0])
+    if not loaded:
+        raise RuntimeError("No GMS module storage manifests found")
+    if [ordinal for ordinal, _ in loaded] != list(range(len(loaded))):
+        raise RuntimeError("GMS storage manifest ordinals must be contiguous")
+
+    intervals: dict[str, list[tuple[int, int]]] = {}
+    paths: set[str] = set()
+    for _, stored in loaded:
+        start = stored.storage_base_offset
+        intervals.setdefault(stored.allocation_id, []).append(
+            (start, start + stored.manifest.nbytes)
+        )
+        for tensor_object in stored.manifest.objects:
+            for slot in tensor_object.slots:
+                if slot.path in paths:
+                    raise RuntimeError(f"Duplicate GMS destination slot {slot.path!r}")
+                paths.add(slot.path)
+    for allocation_id, allocation_intervals in intervals.items():
+        ordered = sorted(allocation_intervals)
+        for previous, current in zip(ordered, ordered[1:], strict=False):
+            if previous[1] > current[0]:
+                raise RuntimeError(
+                    "GMS storage manifests overlap in allocation "
+                    f"{allocation_id!r}: {previous} and {current}"
+                )
+    return [stored for _, stored in loaded]
 
 
-def _mapped_allocations(
-    manager: "GMSClientMemoryManager",
-    components: list[_StorageComponent],
-) -> tuple[dict[str, int], list[int]]:
-    existing = {
-        str(mapping.allocation_id): int(va) for va, mapping in manager.mappings.items()
-    }
-    allocation_ids = {component.allocation_id for component in components}
-    mapped: dict[str, int] = {}
-    imported: list[int] = []
-    try:
-        for allocation_id in allocation_ids:
-            assert allocation_id is not None
-            if allocation_id in existing:
-                va = existing[allocation_id]
-            else:
-                va = manager.create_mapping(allocation_id=allocation_id)
-                imported.append(va)
-            mapped[allocation_id] = va
-            allocation_nbytes = int(manager.mappings[va].aligned_size)
-            for component in components:
-                if component.allocation_id != allocation_id:
-                    continue
-                assert component.storage_base_offset is not None
-                if (
-                    component.storage_base_offset < 0
-                    or component.storage_base_offset + component.storage_nbytes
-                    > allocation_nbytes
-                ):
-                    raise RuntimeError(
-                        f"GMS storage component {component.storage_group_id} "
-                        f"exceeds allocation {allocation_id!r}"
-                    )
-    except BaseException:
-        for va in reversed(imported):
-            manager.free_va(va)
-        raise
-    return mapped, imported
+def _resolve_module(model: torch.nn.Module, path: list[str]) -> torch.nn.Module:
+    module = model
+    for name in path:
+        if name not in module._modules or module._modules[name] is None:
+            raise RuntimeError(f"Unsupported GMS destination module path {name!r}")
+        module = module._modules[name]
+    return module
 
 
-def _materialize_component_specs(
-    manager: "GMSClientMemoryManager",
-    specs: dict[str, GMSTensorSpec],
+def _has_data_descriptor(module: torch.nn.Module, attr: str) -> bool:
+    descriptor = next(
+        (cls.__dict__[attr] for cls in type(module).__mro__ if attr in cls.__dict__),
+        None,
+    )
+    return hasattr(descriptor, "__set__")
+
+
+def _class_defines_attribute(module: torch.nn.Module, attr: str) -> bool:
+    return any(attr in cls.__dict__ for cls in type(module).__mro__)
+
+
+def _resolve_slot_target(
     model: torch.nn.Module,
-    device_index: int,
-) -> None:
-    components = _components_from_specs(specs, model)
-    members = _unique_members(components)
-    _validate_swap_ownership(members)
-    mapped, imported = _mapped_allocations(manager, components)
-    replacements: dict[int, torch.Tensor] = {}
-    try:
-        for component in components:
-            assert component.allocation_id is not None
-            assert component.storage_base_offset is not None
-            source_storage = _storage_from_pointer(
-                mapped[component.allocation_id] + component.storage_base_offset,
-                component.storage_nbytes,
-                device_index,
+    slot: Slot,
+) -> _SlotTarget:
+    parts = slot.path.split(".")
+    if any(not part for part in parts):
+        raise RuntimeError(f"Invalid GMS destination slot path {slot.path!r}")
+
+    if slot.kind == "parameter":
+        module = _resolve_module(model, parts[:-1])
+        attr = parts[-1]
+        if (
+            attr in module._buffers
+            or attr in module._modules
+            or attr in module.__dict__
+            or _class_defines_attribute(module, attr)
+        ):
+            raise RuntimeError(
+                f"GMS parameter destination {slot.path!r} collides with "
+                "another module slot"
             )
-            if any(
-                isinstance(member.tensor, torch.nn.Parameter)
-                for member in component.members
-            ):
-                target_storage = source_storage
-            else:
-                target_storage = (
-                    torch.empty(0, dtype=torch.uint8, device=source_storage.device)
-                    .set_(source_storage, 0, (source_storage.nbytes(),), (1,))
-                    .clone()
-                    .untyped_storage()
-                )
-            for member in _unique_members([component]):
-                replacements[member.object_group_id] = _replacement_for(
-                    member, target_storage
-                )
-        _apply_replacements(members, replacements)
-    except BaseException:
-        for va in reversed(imported):
+        existing = module._parameters.get(attr)
+        if existing is not None and not isinstance(existing, torch.nn.Parameter):
+            raise RuntimeError(
+                f"GMS parameter destination {slot.path!r} is not a Parameter"
+            )
+        return _SlotTarget(slot, module, attr, existing)
+
+    if slot.kind in ("persistent_buffer", "nonpersistent_buffer"):
+        module = _resolve_module(model, parts[:-1])
+        attr = parts[-1]
+        if (
+            attr in module._parameters
+            or attr in module._modules
+            or attr in module.__dict__
+            or _class_defines_attribute(module, attr)
+        ):
+            raise RuntimeError(
+                f"GMS buffer destination {slot.path!r} collides with "
+                "another module slot"
+            )
+        existing = module._buffers.get(attr)
+        if existing is not None and not torch.is_tensor(existing):
+            raise RuntimeError(f"GMS buffer destination {slot.path!r} is not a Tensor")
+        return _SlotTarget(slot, module, attr, existing)
+
+    if len(parts) >= 2 and parts[-1].isdecimal():
+        module = _resolve_module(model, parts[:-2])
+        attr = parts[-2]
+        container = module.__dict__.get(attr)
+        index = int(parts[-1])
+        if type(container) not in (list, tuple) or index >= len(container):
+            raise RuntimeError(f"GMS sequence destination {slot.path!r} is unsupported")
+        existing = container[index] if torch.is_tensor(container[index]) else None
+        return _SlotTarget(slot, module, attr, existing, index)
+
+    module = _resolve_module(model, parts[:-1])
+    attr = parts[-1]
+    if attr in module._parameters or attr in module._buffers or attr in module._modules:
+        raise RuntimeError(
+            f"GMS attribute destination {slot.path!r} collides with another module slot"
+        )
+    existing = module.__dict__.get(attr)
+    if attr in module.__dict__ and not torch.is_tensor(existing):
+        raise RuntimeError(
+            f"GMS attribute destination {slot.path!r} is not a direct tensor"
+        )
+    if attr not in module.__dict__ and _has_data_descriptor(module, attr):
+        raise RuntimeError(
+            f"GMS attribute destination {slot.path!r} is not representable"
+        )
+    return _SlotTarget(slot, module, attr, existing)
+
+
+def _parameter_template(
+    targets: tuple[_SlotTarget, ...],
+) -> torch.nn.Parameter | None:
+    return next(
+        (
+            target.existing
+            for target in targets
+            if target.slot.kind == "parameter"
+            and isinstance(target.existing, torch.nn.Parameter)
+        ),
+        None,
+    )
+
+
+def _parameter_slot_names(parameter_type: type[torch.nn.Parameter]) -> tuple[str, ...]:
+    names: list[str] = []
+    for cls in parameter_type.__mro__:
+        declared = cls.__dict__.get("__slots__", ())
+        if isinstance(declared, str):
+            declared = (declared,)
+        for name in declared:
+            if name in ("__dict__", "__weakref__"):
+                continue
+            if name.startswith("__") and not name.endswith("__"):
+                name = f"_{cls.__name__.lstrip('_')}{name}"
+            if name not in names:
+                names.append(name)
+    return tuple(names)
+
+
+def _make_parameter(
+    template: torch.nn.Parameter | None,
+    tensor: torch.Tensor,
+    *,
+    path: str,
+    requires_grad: bool,
+) -> torch.nn.Parameter:
+    if template is None:
+        return torch.nn.Parameter(tensor, requires_grad=requires_grad)
+    try:
+        parameter = torch.Tensor._make_subclass(type(template), tensor, requires_grad)
+        parameter.__dict__ = template.__dict__.copy()
+        for name in _parameter_slot_names(type(template)):
+            if hasattr(template, name):
+                setattr(parameter, name, getattr(template, name))
+    except Exception as exc:
+        raise RuntimeError(
+            f"Cannot materialize GMS parameter {path!r} as "
+            f"{type(template).__name__}: {exc}"
+        ) from exc
+    return parameter
+
+
+def _clone_storage(
+    storage: torch.UntypedStorage,
+) -> tuple[torch.UntypedStorage, torch.Tensor]:
+    source_owner = torch.empty(0, dtype=torch.uint8, device=storage.device).set_(
+        storage,
+        0,
+        (storage.nbytes(),),
+        (1,),
+    )
+    return source_owner.clone().untyped_storage(), source_owner
+
+
+def _free_imported_mappings(
+    manager: "GMSClientMemoryManager",
+    imported: list[int],
+) -> None:
+    for va in reversed(imported):
+        try:
             manager.free_va(va)
-        raise
+        except BaseException:
+            logger.exception("[GMS] Failed to release imported mapping at %#x", va)
 
 
 def materialize_module_from_gms(
@@ -878,177 +653,285 @@ def materialize_module_from_gms(
     *,
     device_index: int,
 ) -> None:
-    """Materialize model tensors from GMS.
-
-    A failure after tensor mutation begins is terminal; discard the model.
-
-    Args:
-        gms_client_memory_manager: GMS client memory manager in read mode.
-        model: Model to populate with tensors.
-        device_index: CUDA device index.
-    """
-    specs = GMSTensorSpec.load_all(gms_client_memory_manager)
-    if any(spec.meta.is_storage_component for spec in specs.values()):
-        _materialize_component_specs(
-            gms_client_memory_manager, specs, model, device_index
+    """Replace supported module slots with objects reconstructed from GMS."""
+    if int(gms_client_memory_manager.device) != device_index:
+        raise RuntimeError(
+            "GMS manager device does not match materialization device: "
+            f"{gms_client_memory_manager.device} vs {device_index}"
         )
-        return
+    stored_manifests = _load_storage_manifests(gms_client_memory_manager)
+    targets: list[list[tuple[TensorObject, tuple[_SlotTarget, ...]]]] = []
+    destinations: dict[tuple[int, str, int | None], tuple[int, int]] = {}
+    for manifest_index, stored in enumerate(stored_manifests):
+        manifest_targets: list[tuple[TensorObject, tuple[_SlotTarget, ...]]] = []
+        for object_index, tensor_object in enumerate(stored.manifest.objects):
+            object_id = (manifest_index, object_index)
+            unique_targets: dict[tuple[int, str, int | None], _SlotTarget] = {}
+            for slot in tensor_object.slots:
+                target = _resolve_slot_target(model, slot)
+                previous_target = unique_targets.get(target.destination)
+                if previous_target is not None:
+                    if previous_target.slot.kind != target.slot.kind:
+                        raise RuntimeError(
+                            "GMS source slots resolve to incompatible destination "
+                            f"{slot.path!r}"
+                        )
+                    continue
+                previous_object = destinations.setdefault(target.destination, object_id)
+                if previous_object != object_id:
+                    raise RuntimeError(
+                        "Distinct GMS tensor objects resolve to the same destination "
+                        f"{slot.path!r}"
+                    )
+                unique_targets[target.destination] = target
+            object_targets = tuple(unique_targets.values())
+            manifest_targets.append((tensor_object, object_targets))
+        targets.append(manifest_targets)
 
-    parameters = _registered_parameters(model)
-    aliases = {}
-    resolved = []
-    observed_storage = {}
-    validated_parameters = set()
-    target_device = torch.device("cuda", device_index)
-    for name, spec in specs.items():
-        mod, attr = _resolve_module_attr(model, name)
-        tensor_type = spec.meta.tensor_type
-        existing = _resolve_slot(model, name, spec.meta)
-        parameter = parameters.get(id(existing))
-        if existing.shape != spec.meta.shape or existing.dtype != spec.meta.dtype:
-            raise RuntimeError(
-                f"Shape/dtype mismatch for {name}: "
-                f"existing={tuple(existing.shape)}/{existing.dtype}, "
-                f"gms={spec.meta.shape}/{spec.meta.dtype}"
-            )
-        source = _tensor_source(spec)
-        previous = aliases.get(id(existing))
-        if previous is not None and previous[0] is existing:
-            if previous[1] != source:
+    allocation_ids = list(
+        dict.fromkeys(stored.allocation_id for stored in stored_manifests)
+    )
+    existing_vas = set(gms_client_memory_manager.mappings)
+    mapped: dict[str, int] = {}
+    imported: list[int] = []
+    clone_started = False
+    installation_started = False
+    try:
+        for allocation_id in allocation_ids:
+            va = gms_client_memory_manager.create_mapping(allocation_id=allocation_id)
+            mapped[allocation_id] = va
+            if va not in existing_vas:
+                imported.append(va)
+            mapping = gms_client_memory_manager.mappings.get(va)
+            if mapping is None or str(mapping.allocation_id) != allocation_id:
                 raise RuntimeError(
-                    f"Reader tensor aliases incompatible GMS entries at {name!r}"
+                    f"GMS mapping for allocation {allocation_id!r} is inconsistent"
                 )
-        else:
-            aliases[id(existing)] = (existing, source)
-            if parameter is None:
-                _validate_plain_nonparameter(existing, name=name)
-            _validate_observed_storage(observed_storage, name=name, tensor=existing)
-        if (
-            parameter is not None
-            and id(parameter) not in validated_parameters
-            and (parameter.is_meta or parameter.device != target_device)
-        ):
-            _validate_parameter_swap(parameter, name=name)
-            validated_parameters.add(id(parameter))
-        resolved.append((name, spec, existing, parameter))
 
-    materialized = set()
-    for name, spec, existing, parameter in resolved:
-        if id(existing) in materialized:
-            continue
-        tensor_type = spec.meta.tensor_type
-        if tensor_type in ("tensor_attr", "buffer") and parameter is None:
-            tensor = spec.materialize(gms_client_memory_manager, device_index)
-            private = tensor.detach().clone()
-            _swap_tensor_contents(existing, private, name=name)
-            materialized.add(id(existing))
-            continue
-
-        tensor = spec.materialize(gms_client_memory_manager, device_index)
-        if parameter is not None:
-            if parameter.is_meta or parameter.device != tensor.device:
-                replacement = _make_parameter_replacement(parameter, tensor, name=name)
-                _swap_tensor_contents(parameter, replacement, name=name)
+        materialized: list[_MaterializedObject] = []
+        for stored, manifest_targets in zip(stored_manifests, targets, strict=True):
+            mapping = gms_client_memory_manager.mappings[mapped[stored.allocation_id]]
+            if (
+                stored.storage_base_offset < 0
+                or stored.storage_base_offset + stored.manifest.nbytes
+                > int(mapping.aligned_size)
+            ):
+                raise RuntimeError(
+                    f"GMS storage manifest exceeds allocation {stored.allocation_id!r}"
+                )
+            source_storage = _storage_from_pointer(
+                mapped[stored.allocation_id] + stored.storage_base_offset,
+                stored.manifest.nbytes,
+                device_index,
+            )
+            has_parameter = any(
+                slot.kind == "parameter"
+                for tensor_object in stored.manifest.objects
+                for slot in tensor_object.slots
+            )
+            if has_parameter:
+                target_storage = source_storage
             else:
-                parameter.data = tensor
-            materialized.add(id(parameter))
-            continue
-    # Check for meta tensors and warn
-    meta_tensors = [n for n, p in model.named_parameters() if p.is_meta]
-    meta_tensors += [n for n, b in model.named_buffers() if b.is_meta]
+                clone_started = True
+                target_storage, _ = _clone_storage(source_storage)
+
+            for tensor_object, object_targets in manifest_targets:
+                dtype = _dtype_from_name(tensor_object.dtype)
+                tensor = _tensor_from_storage(
+                    target_storage,
+                    list(tensor_object.shape),
+                    list(tensor_object.stride),
+                    dtype,
+                    tensor_object.storage_offset_bytes // dtype.itemsize,
+                )
+                parameter_targets = tuple(
+                    target
+                    for target in object_targets
+                    if target.slot.kind == "parameter"
+                )
+                if parameter_targets:
+                    tensor = _make_parameter(
+                        _parameter_template(object_targets),
+                        tensor,
+                        path=parameter_targets[0].slot.path,
+                        requires_grad=tensor_object.requires_grad,
+                    )
+                materialized.append(_MaterializedObject(tensor, object_targets))
+
+        installation_started = True
+        for tensor_object in materialized:
+            for target in tensor_object.targets:
+                target.install(tensor_object.tensor)
+    except BaseException:
+        if not installation_started:
+            if clone_started and imported:
+                torch.cuda.synchronize(device_index)
+            _free_imported_mappings(gms_client_memory_manager, imported)
+        raise
+
+    meta_tensors = [name for name, value in model.named_parameters() if value.is_meta]
+    meta_tensors += [name for name, value in model.named_buffers() if value.is_meta]
     if meta_tensors:
         logger.warning(
-            "[GMS] %d meta tensors not in metadata: %s",
+            "[GMS] %d meta tensors not in storage manifests: %s",
             len(meta_tensors),
             meta_tensors[:10],
         )
 
 
+def _swap_tensor_contents(
+    existing: torch.Tensor,
+    replacement: torch.Tensor,
+    *,
+    path: str,
+) -> None:
+    if not hasattr(torch.utils, "swap_tensors"):
+        raise RuntimeError("GMS publisher rebinding requires torch.utils.swap_tensors")
+    try:
+        torch.utils.swap_tensors(existing, replacement)
+    except RuntimeError as exc:
+        raise RuntimeError(f"Cannot rebind GMS tensor {path!r}: {exc}") from exc
+
+
+def _swap_discovered_objects(
+    objects: list[_DiscoveredObject],
+    replacements: dict[int, torch.Tensor],
+) -> None:
+    if not hasattr(torch.utils, "swap_tensors"):
+        raise RuntimeError("GMS publisher rebinding requires torch.utils.swap_tensors")
+
+    object_ids = {id(tensor_object.tensor) for tensor_object in objects}
+    group_base_uses: dict[int, int] = {}
+    for tensor_object in objects:
+        base = tensor_object.tensor._base
+        if base is not None and id(base) in object_ids:
+            group_base_uses[id(base)] = group_base_uses.get(id(base), 0) + 1
+
+    def base_depth(tensor_object: _DiscoveredObject) -> int:
+        depth = 0
+        base = tensor_object.tensor._base
+        while base is not None and id(base) in object_ids:
+            depth += 1
+            base = base._base
+        return depth
+
+    ordered = sorted(objects, key=base_depth, reverse=True)
+    for tensor_object in ordered:
+        existing = tensor_object.tensor
+        replacement = replacements[id(existing)]
+        path = tensor_object.slots[0].path
+        for tensor, name in ((existing, "t1"), (replacement, "t2")):
+            if weakref.getweakrefs(tensor):
+                raise RuntimeError(
+                    f"Cannot rebind GMS tensor {path!r}: "
+                    f"{name} has weakref associated with it"
+                )
+
+        existing_slots = set(copyreg._slotnames(existing.__class__))
+        replacement_slots = set(copyreg._slotnames(replacement.__class__))
+        if existing_slots != replacement_slots:
+            raise RuntimeError(
+                f"Cannot rebind GMS tensor {path!r}: "
+                "replacement has different Python slots"
+            )
+
+    accumulate_grad_checks: list[tuple[torch.Tensor, int, str]] = []
+    for tensor_object in ordered:
+        existing = tensor_object.tensor
+        replacement = replacements[id(existing)]
+        path = tensor_object.slots[0].path
+        for tensor, name, released_uses in (
+            (existing, "t1", group_base_uses.get(id(existing), 0)),
+            (replacement, "t2", 0),
+        ):
+            use_count = tensor._use_count() - released_uses
+            ownership_error = (
+                f"Cannot rebind GMS tensor {path!r}: expected use_count of "
+                f"{name} to be 1 or 2 with an AccumulateGrad node but got "
+                f"{use_count}"
+            )
+            if use_count > 1:
+                if use_count != 2 or not tensor.is_leaf:
+                    raise RuntimeError(ownership_error)
+                accumulate_grad_checks.append((tensor, released_uses, ownership_error))
+
+    for tensor, released_uses, ownership_error in accumulate_grad_checks:
+        torch.autograd.graph.get_gradient_edge(tensor)
+        if tensor._use_count() - released_uses != 2:
+            raise RuntimeError(ownership_error)
+
+    for tensor_object in ordered:
+        replacement = replacements.pop(id(tensor_object.tensor))
+        _swap_tensor_contents(
+            tensor_object.tensor,
+            replacement,
+            path=tensor_object.slots[0].path,
+        )
+        del replacement
+
+
 def rebind_nonparameter_tensors(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
-    *,
-    retain_gms_tensors: list[torch.Tensor] | None = None,
 ) -> int:
-    """Re-bind GMS-resident non-parameter tensors to private clones.
-
-    The publisher builds the whole model inside the GMS memory pool, so
-    buffers and tensor attributes (fp8 KV scales, quantization ranges, ...)
-    land in the same committed allocations as the weights, which are
-    remapped read-only after publish. Unlike parameters, these tensors can
-    be written after load (for example ``init_fp8_kv_scales`` on wake),
-    which faults on the read-only mapping. Cloning them into ordinary CUDA
-    memory gives the publisher the same binding semantics importers get
-    from ``materialize_module_from_gms``: parameters stay on the shared
-    read-only mapping, everything else is private and writable. The GMS
-    copies stay registered so importers can still materialize from them.
-
-    Must run before CUDA graph capture: the clones live at new addresses.
-
-    Discoverable exact aliases keep their original Python Tensor object.
-    Distinct discovered tensors sharing one StorageImpl are rebuilt together
-    over one private storage copy. Discovery remains limited to registered
-    fields and direct module instance attributes (including tensor lists/tuples).
-
-    Returns the number of bytes rebound, i.e. how much memory is duplicated
-    between the read-only GMS copies and the private clones.
-
-    One detached storage owner per copied component retains the original GMS
-    allocation. If ``retain_gms_tensors`` is provided, each owner is also
-    appended for compatibility with deferred publication.
-
-    A failure after tensor mutation begins is terminal; discard the model.
-    """
-    components = _locate_components(
-        _discover_storage_components(model),
+    """Clone each non-parameter-only GMS storage once into writable CUDA memory."""
+    storages = _locate_storage(
+        _discover_module_storage(model),
         gms_client_memory_manager.mappings,
         require_parameters=False,
     )
     candidates = [
-        component
-        for component in components
-        if not any(
-            isinstance(member.tensor, torch.nn.Parameter)
-            for member in component.members
-        )
+        discovered_storage
+        for discovered_storage in storages
+        if not discovered_storage.has_parameter
     ]
     if not candidates:
         return 0
-    members = _unique_members(candidates)
-    _validate_swap_ownership(members)
+
+    if _REBOUND_TENSOR_OWNERS_ATTR not in model.__dict__:
+        namespace_collision = any(
+            _REBOUND_TENSOR_OWNERS_ATTR in namespace
+            for namespace in (
+                model._parameters,
+                model._buffers,
+                model._modules,
+            )
+        )
+        class_collision = any(
+            _REBOUND_TENSOR_OWNERS_ATTR in cls.__dict__ for cls in type(model).__mro__
+        )
+        if namespace_collision or class_collision:
+            raise RuntimeError(
+                f"Reserved GMS attribute {_REBOUND_TENSOR_OWNERS_ATTR!r} "
+                "collides with an existing model attribute"
+            )
+        owners = _ReboundTensorOwners()
+        model.__dict__[_REBOUND_TENSOR_OWNERS_ATTR] = owners
+    else:
+        owners = model.__dict__[_REBOUND_TENSOR_OWNERS_ATTR]
+    if not isinstance(owners, _ReboundTensorOwners):
+        raise RuntimeError(
+            f"Reserved GMS attribute {_REBOUND_TENSOR_OWNERS_ATTR!r} "
+            "collides with an existing model attribute"
+        )
+
     replacements: dict[int, torch.Tensor] = {}
     source_owners: list[torch.Tensor] = []
-    for component in candidates:
-        source_storage = component.members[0].tensor.untyped_storage()
-        source_owner = torch.empty(
-            0, dtype=torch.uint8, device=source_storage.device
-        ).set_(
-            source_storage,
-            0,
-            (component.storage_nbytes,),
-            (1,),
-        )
-        target_storage = source_owner.clone().untyped_storage()
+    objects: list[_DiscoveredObject] = []
+    for discovered_storage in candidates:
+        target_storage, source_owner = _clone_storage(discovered_storage.storage)
         source_owners.append(source_owner)
-        for member in _unique_members([component]):
-            replacements[member.object_group_id] = _replacement_for(
-                member, target_storage
+        for tensor_object in discovered_storage.objects:
+            tensor = tensor_object.tensor
+            replacements[id(tensor)] = _tensor_from_storage(
+                target_storage,
+                list(tensor.shape),
+                list(tensor.stride()),
+                tensor.dtype,
+                int(tensor.storage_offset()),
             )
+            objects.append(tensor_object)
 
-    owners = _get_or_create_rebound_tensor_owners(model)
-    owner_count = len(owners.tensors)
-    retained_count = len(retain_gms_tensors) if retain_gms_tensors is not None else 0
-    try:
-        _apply_replacements(members, replacements)
-    except BaseException:
-        del owners.tensors[owner_count:]
-        if retain_gms_tensors is not None:
-            del retain_gms_tensors[retained_count:]
-        if owner_count == 0 and not owners.tensors:
-            model.__dict__.pop(_REBOUND_TENSOR_OWNERS_ATTR, None)
-        raise
-
+    _swap_discovered_objects(objects, replacements)
     owners.tensors.extend(source_owners)
-    if retain_gms_tensors is not None:
-        retain_gms_tensors.extend(source_owners)
-    return sum(component.storage_nbytes for component in candidates)
+    return sum(discovered_storage.storage.nbytes() for discovered_storage in candidates)

--- a/lib/gpu_memory_service/client/torch/module.py
+++ b/lib/gpu_memory_service/client/torch/module.py
@@ -1,7 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Publish and materialize PyTorch module storage through GMS."""
+"""Publish and materialize PyTorch module storage through GMS.
+
+Write:
+  module -> discover storages -> match GMS mappings -> build manifests -> metadata
+Read:
+  metadata -> validate/resolve -> GMS map -> parameter-containing storage
+                              `-> clone ---> all other storage
+Writer rebind:
+  discover/match -> skip parameter-containing storage
+                 `-> clone/swap non-parameter-only storage -> retain source owners
+"""
 
 from __future__ import annotations
 
@@ -15,7 +25,8 @@ import msgspec
 import torch
 from gpu_memory_service.client.torch.tensor import (
     STORAGE_MANIFEST_PREFIX,
-    Slot,
+    ModuleTensorBinding,
+    ModuleTensorKind,
     StorageManifest,
     TensorObject,
     _dtype_from_name,
@@ -29,33 +40,31 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_REBOUND_TENSOR_OWNERS_ATTR = "_gms_rebound_tensor_owners"
-
-
-class _ReboundTensorOwners:
-    def __init__(self) -> None:
-        self.tensors: list[torch.Tensor] = []
+_DISPLACED_SOURCE_TENSORS_ATTR = "_gms_displaced_source_tensors"
+_DISPLACED_SOURCE_TENSORS_SENTINEL = object()
 
 
 @dataclass
-class _DiscoveredObject:
+class _DiscoveredTensor:
+    """One Python tensor object plus every module binding that aliases it."""
+
     tensor: torch.Tensor
-    slots: list[Slot]
+    bindings: list[ModuleTensorBinding]
 
 
 @dataclass
 class _DiscoveredStorage:
     storage: torch.UntypedStorage
-    objects: list[_DiscoveredObject]
+    objects: list[_DiscoveredTensor]
     allocation_id: str | None = None
     storage_base_offset: int | None = None
 
     @property
     def has_parameter(self) -> bool:
         return any(
-            slot.kind == "parameter"
+            binding.kind is ModuleTensorKind.PARAMETER
             for tensor_object in self.objects
-            for slot in tensor_object.slots
+            for binding in tensor_object.bindings
         )
 
 
@@ -67,8 +76,8 @@ class _StoredManifest:
 
 
 @dataclass(frozen=True)
-class _SlotTarget:
-    slot: Slot
+class _ResolvedTensorDestination:
+    binding: ModuleTensorBinding
     module: torch.nn.Module
     attr: str
     existing: torch.Tensor | None
@@ -84,11 +93,14 @@ class _SlotTarget:
         return id(self.module), self.attr, None
 
     def install(self, tensor: torch.Tensor) -> None:
-        if self.slot.kind == "parameter":
+        if self.binding.kind is ModuleTensorKind.PARAMETER:
             self.module._parameters[self.attr] = tensor
-        elif self.slot.kind in ("persistent_buffer", "nonpersistent_buffer"):
+        elif (
+            self.binding.kind is ModuleTensorKind.PERSISTENT_BUFFER
+            or self.binding.kind is ModuleTensorKind.NONPERSISTENT_BUFFER
+        ):
             self.module._buffers[self.attr] = tensor
-            if self.slot.kind == "persistent_buffer":
+            if self.binding.kind is ModuleTensorKind.PERSISTENT_BUFFER:
                 self.module._non_persistent_buffers_set.discard(self.attr)
             else:
                 self.module._non_persistent_buffers_set.add(self.attr)
@@ -104,40 +116,68 @@ class _SlotTarget:
                 self.module.__dict__[self.attr] = tuple(values)
 
 
-@dataclass(frozen=True)
-class _MaterializedObject:
-    tensor: torch.Tensor
-    targets: tuple[_SlotTarget, ...]
+def _get_displaced_source_tensors(
+    module: torch.nn.Module,
+) -> list[torch.Tensor] | None:
+    namespace_collision = any(
+        _DISPLACED_SOURCE_TENSORS_ATTR in namespace
+        for namespace in (module._parameters, module._buffers, module._modules)
+    )
+    class_collision = any(
+        _DISPLACED_SOURCE_TENSORS_ATTR in cls.__dict__ for cls in type(module).__mro__
+    )
+    if not namespace_collision and not class_collision:
+        if _DISPLACED_SOURCE_TENSORS_ATTR not in module.__dict__:
+            return None
+        owner_state = module.__dict__[_DISPLACED_SOURCE_TENSORS_ATTR]
+        if (
+            type(owner_state) is tuple
+            and len(owner_state) == 2
+            and owner_state[0] is _DISPLACED_SOURCE_TENSORS_SENTINEL
+            and type(owner_state[1]) is list
+            and all(torch.is_tensor(tensor) for tensor in owner_state[1])
+        ):
+            return owner_state[1]
+    raise RuntimeError(
+        f"Reserved GMS attribute {_DISPLACED_SOURCE_TENSORS_ATTR!r} "
+        "collides with an existing model attribute"
+    )
 
 
-def _iter_module_slots(
+def _iter_module_tensor_bindings(
     model: torch.nn.Module,
-) -> Iterator[tuple[torch.Tensor, Slot]]:
+) -> Iterator[tuple[torch.Tensor, ModuleTensorBinding]]:
+    """Yield each supported tensor and its direct module binding."""
     for module_path, module in model.named_modules(remove_duplicate=False):
+        _get_displaced_source_tensors(module)
         for name, parameter in module.named_parameters(
             recurse=False, remove_duplicate=False
         ):
             path = f"{module_path}.{name}" if module_path else name
-            yield parameter, Slot(path, "parameter")
+            yield parameter, ModuleTensorBinding(path, ModuleTensorKind.PARAMETER)
 
         for name, buffer in module.named_buffers(recurse=False, remove_duplicate=False):
             kind = (
-                "nonpersistent_buffer"
+                ModuleTensorKind.NONPERSISTENT_BUFFER
                 if name in module._non_persistent_buffers_set
-                else "persistent_buffer"
+                else ModuleTensorKind.PERSISTENT_BUFFER
             )
             path = f"{module_path}.{name}" if module_path else name
-            yield buffer, Slot(path, kind)
+            yield buffer, ModuleTensorBinding(path, kind)
 
         registered = (
             set(module._parameters) | set(module._buffers) | set(module._modules)
         )
         for name, value in module.__dict__.items():
-            if name in registered or name.startswith("__"):
+            if (
+                name in registered
+                or name == _DISPLACED_SOURCE_TENSORS_ATTR
+                or name.startswith("__")
+            ):
                 continue
             if torch.is_tensor(value):
                 path = f"{module_path}.{name}" if module_path else name
-                yield value, Slot(path, "attribute")
+                yield value, ModuleTensorBinding(path, ModuleTensorKind.ATTRIBUTE)
             elif type(value) in (list, tuple):
                 for index, element in enumerate(value):
                     if torch.is_tensor(element):
@@ -147,67 +187,72 @@ def _iter_module_slots(
                             if module_path
                             else name_with_index
                         )
-                        yield element, Slot(path, "attribute")
+                        yield (
+                            element,
+                            ModuleTensorBinding(path, ModuleTensorKind.ATTRIBUTE),
+                        )
 
 
-def _discover_module_storage(model: torch.nn.Module) -> list[_DiscoveredStorage]:
-    objects: dict[int, _DiscoveredObject] = {}
-    for tensor, slot in _iter_module_slots(model):
+def _discover_module_storages(model: torch.nn.Module) -> list[_DiscoveredStorage]:
+    """Group supported module tensors by Python identity and StorageImpl."""
+    objects: dict[int, _DiscoveredTensor] = {}
+    for tensor, binding in _iter_module_tensor_bindings(model):
         tensor_object = objects.get(id(tensor))
         if tensor_object is None:
-            tensor_object = _DiscoveredObject(tensor, [])
+            tensor_object = _DiscoveredTensor(tensor, [])
             objects[id(tensor)] = tensor_object
-        if slot not in tensor_object.slots:
-            tensor_object.slots.append(slot)
+        if binding not in tensor_object.bindings:
+            tensor_object.bindings.append(binding)
 
     storages: dict[int, _DiscoveredStorage] = {}
     for tensor_object in objects.values():
         tensor = tensor_object.tensor
-        has_parameter_slot = any(
-            slot.kind == "parameter" for slot in tensor_object.slots
+        has_parameter_binding = any(
+            binding.kind is ModuleTensorKind.PARAMETER
+            for binding in tensor_object.bindings
         )
-        if isinstance(tensor, torch.nn.Parameter) and not has_parameter_slot:
+        if isinstance(tensor, torch.nn.Parameter) and not has_parameter_binding:
             raise RuntimeError(
-                f"Unregistered Parameter at {tensor_object.slots[0].path!r} "
-                "has no parameter slot"
+                f"Unregistered Parameter at {tensor_object.bindings[0].path!r} "
+                "has no parameter binding"
             )
-        if has_parameter_slot and not isinstance(tensor, torch.nn.Parameter):
+        if has_parameter_binding and not isinstance(tensor, torch.nn.Parameter):
             raise RuntimeError(
-                f"GMS parameter slot {tensor_object.slots[0].path!r} "
+                f"GMS parameter binding {tensor_object.bindings[0].path!r} "
                 "does not contain a Parameter"
             )
-        if not has_parameter_slot and type(tensor) is not torch.Tensor:
+        if not has_parameter_binding and type(tensor) is not torch.Tensor:
             raise RuntimeError(
                 "GMS does not support non-parameter Tensor subclass at "
-                f"{tensor_object.slots[0].path!r}: {type(tensor).__name__}"
+                f"{tensor_object.bindings[0].path!r}: {type(tensor).__name__}"
             )
         if tensor.is_conj() or tensor.is_neg():
             raise RuntimeError(
                 "GMS does not support lazy conjugate/negative tensor "
-                f"{tensor_object.slots[0].path!r}"
+                f"{tensor_object.bindings[0].path!r}"
             )
-        if has_parameter_slot:
+        if has_parameter_binding:
             if not tensor.is_leaf or tensor.grad_fn is not None:
                 raise RuntimeError(
                     f"GMS only supports leaf Parameters at "
-                    f"{tensor_object.slots[0].path!r}"
+                    f"{tensor_object.bindings[0].path!r}"
                 )
         elif tensor.requires_grad or tensor.grad_fn is not None:
             raise RuntimeError(
                 "GMS inference storage does not support autograd tensor "
-                f"{tensor_object.slots[0].path!r}"
+                f"{tensor_object.bindings[0].path!r}"
             )
 
         storage = tensor.untyped_storage()
         if storage.nbytes() == 0:
             raise RuntimeError(
                 "GMS module manifests do not support zero-byte StorageImpls: "
-                f"{tensor_object.slots[0].path!r}"
+                f"{tensor_object.bindings[0].path!r}"
             )
         storage_offset_bytes = int(tensor.storage_offset()) * tensor.dtype.itemsize
         if (storage.data_ptr() + storage_offset_bytes) % tensor.dtype.itemsize:
             raise RuntimeError(
-                f"GMS tensor data is unaligned at {tensor_object.slots[0].path!r}"
+                f"GMS tensor data is unaligned at {tensor_object.bindings[0].path!r}"
             )
         _validate_layout(
             tuple(tensor.shape),
@@ -225,12 +270,13 @@ def _discover_module_storage(model: torch.nn.Module) -> list[_DiscoveredStorage]
     return list(storages.values())
 
 
-def _locate_storage(
+def _match_storages_to_gms_mappings(
     storages: list[_DiscoveredStorage],
     mappings: dict[int, object],
     *,
     require_parameters: bool,
 ) -> list[_DiscoveredStorage]:
+    """Match complete StorageImpl envelopes to their containing GMS mappings."""
     located: list[_DiscoveredStorage] = []
     for ordinal, discovered_storage in enumerate(storages):
         storage_ptr = int(discovered_storage.storage.data_ptr())
@@ -253,12 +299,12 @@ def _locate_storage(
         if not containing:
             if require_parameters and discovered_storage.has_parameter:
                 raise RuntimeError(
-                    f"Parameter {discovered_storage.objects[0].slots[0].path!r} "
+                    f"Parameter {discovered_storage.objects[0].bindings[0].path!r} "
                     "is not contained in a GMS allocation"
                 )
             logger.debug(
                 "[GMS] Skipping storage for %r outside GMS allocations",
-                discovered_storage.objects[0].slots[0].path,
+                discovered_storage.objects[0].bindings[0].path,
             )
             continue
 
@@ -286,7 +332,10 @@ def _locate_storage(
     return located
 
 
-def _manifest_for_storage(discovered_storage: _DiscoveredStorage) -> StorageManifest:
+def _build_storage_manifest(
+    discovered_storage: _DiscoveredStorage,
+) -> StorageManifest:
+    """Build one manifest for a discovered StorageImpl and all of its tensors."""
     return StorageManifest(
         nbytes=int(discovered_storage.storage.nbytes()),
         objects=tuple(
@@ -299,19 +348,20 @@ def _manifest_for_storage(discovered_storage: _DiscoveredStorage) -> StorageMani
                     * tensor_object.tensor.dtype.itemsize
                 ),
                 requires_grad=bool(tensor_object.tensor.requires_grad),
-                slots=tuple(tensor_object.slots),
+                bindings=tuple(tensor_object.bindings),
             )
             for tensor_object in discovered_storage.objects
         ),
     )
 
 
-def _validate_manifest(
+def _validate_storage_manifest(
     manifest: StorageManifest,
     *,
     key: str,
     storage_base_offset: int | None = None,
 ) -> None:
+    """Validate manifest layouts, bindings, and optional allocation envelope."""
     if manifest.nbytes <= 0:
         raise RuntimeError(f"GMS storage manifest {key!r} has nonpositive size")
     if not manifest.objects:
@@ -346,23 +396,26 @@ def _validate_manifest(
             raise RuntimeError(
                 f"Invalid tensor layout in GMS storage manifest {key!r}: {exc}"
             ) from exc
-        if not tensor_object.slots:
+        if not tensor_object.bindings:
             raise RuntimeError(
-                f"Tensor object in GMS storage manifest {key!r} has no slots"
+                f"Tensor object in GMS storage manifest {key!r} has no bindings"
             )
-        has_parameter = any(slot.kind == "parameter" for slot in tensor_object.slots)
+        has_parameter = any(
+            binding.kind is ModuleTensorKind.PARAMETER
+            for binding in tensor_object.bindings
+        )
         if tensor_object.requires_grad and not has_parameter:
             raise RuntimeError(
                 f"Non-parameter tensor object in GMS storage manifest {key!r} "
                 "requires gradients"
             )
-        for slot in tensor_object.slots:
-            if not slot.path or slot.path in paths:
+        for binding in tensor_object.bindings:
+            if not binding.path or binding.path in paths:
                 raise RuntimeError(
-                    f"Duplicate or empty slot path in GMS storage manifest {key!r}: "
-                    f"{slot.path!r}"
+                    f"Duplicate or empty binding path in GMS storage manifest {key!r}: "
+                    f"{binding.path!r}"
                 )
-            paths.add(slot.path)
+            paths.add(binding.path)
 
 
 def register_module_tensors(
@@ -370,8 +423,8 @@ def register_module_tensors(
     model: torch.nn.Module,
 ) -> set[str]:
     """Publish one typed storage manifest for each GMS-backed StorageImpl."""
-    storages = _locate_storage(
-        _discover_module_storage(model),
+    storages = _match_storages_to_gms_mappings(
+        _discover_module_storages(model),
         gms_client_memory_manager.mappings,
         require_parameters=True,
     )
@@ -384,8 +437,8 @@ def register_module_tensors(
         ):
             raise RuntimeError("Located GMS storage is missing its allocation envelope")
         key = f"{STORAGE_MANIFEST_PREFIX}{ordinal}"
-        manifest = _manifest_for_storage(discovered_storage)
-        _validate_manifest(
+        manifest = _build_storage_manifest(discovered_storage)
+        _validate_storage_manifest(
             manifest,
             key=key,
             storage_base_offset=discovered_storage.storage_base_offset,
@@ -415,6 +468,7 @@ def register_module_tensors(
 def _load_storage_manifests(
     manager: "GMSClientMemoryManager",
 ) -> list[_StoredManifest]:
+    """Decode, validate, and order every published storage manifest."""
     loaded: list[tuple[int, _StoredManifest]] = []
     for key in manager.metadata_list(STORAGE_MANIFEST_PREFIX):
         suffix = key.removeprefix(STORAGE_MANIFEST_PREFIX)
@@ -432,7 +486,7 @@ def _load_storage_manifests(
             manifest = msgspec.msgpack.decode(value, type=StorageManifest)
         except msgspec.DecodeError as exc:
             raise RuntimeError(f"Invalid GMS storage manifest {key!r}: {exc}") from exc
-        _validate_manifest(
+        _validate_storage_manifest(
             manifest,
             key=key,
             storage_base_offset=storage_base_offset,
@@ -461,10 +515,12 @@ def _load_storage_manifests(
             (start, start + stored.manifest.nbytes)
         )
         for tensor_object in stored.manifest.objects:
-            for slot in tensor_object.slots:
-                if slot.path in paths:
-                    raise RuntimeError(f"Duplicate GMS destination slot {slot.path!r}")
-                paths.add(slot.path)
+            for binding in tensor_object.bindings:
+                if binding.path in paths:
+                    raise RuntimeError(
+                        f"Duplicate GMS destination binding {binding.path!r}"
+                    )
+                paths.add(binding.path)
     for allocation_id, allocation_intervals in intervals.items():
         ordered = sorted(allocation_intervals)
         for previous, current in zip(ordered, ordered[1:], strict=False):
@@ -476,7 +532,10 @@ def _load_storage_manifests(
     return [stored for _, stored in loaded]
 
 
-def _resolve_module(model: torch.nn.Module, path: list[str]) -> torch.nn.Module:
+def _resolve_submodule_path(
+    model: torch.nn.Module,
+    path: list[str],
+) -> torch.nn.Module:
     module = model
     for name in path:
         if name not in module._modules or module._modules[name] is None:
@@ -497,16 +556,17 @@ def _class_defines_attribute(module: torch.nn.Module, attr: str) -> bool:
     return any(attr in cls.__dict__ for cls in type(module).__mro__)
 
 
-def _resolve_slot_target(
+def _resolve_tensor_destination(
     model: torch.nn.Module,
-    slot: Slot,
-) -> _SlotTarget:
-    parts = slot.path.split(".")
+    binding: ModuleTensorBinding,
+) -> _ResolvedTensorDestination:
+    """Resolve one source binding to a validated reader-model destination."""
+    parts = binding.path.split(".")
     if any(not part for part in parts):
-        raise RuntimeError(f"Invalid GMS destination slot path {slot.path!r}")
+        raise RuntimeError(f"Invalid GMS destination binding path {binding.path!r}")
 
-    if slot.kind == "parameter":
-        module = _resolve_module(model, parts[:-1])
+    if binding.kind is ModuleTensorKind.PARAMETER:
+        module = _resolve_submodule_path(model, parts[:-1])
         attr = parts[-1]
         if (
             attr in module._buffers
@@ -515,18 +575,21 @@ def _resolve_slot_target(
             or _class_defines_attribute(module, attr)
         ):
             raise RuntimeError(
-                f"GMS parameter destination {slot.path!r} collides with "
-                "another module slot"
+                f"GMS parameter destination {binding.path!r} collides with "
+                "another module binding"
             )
         existing = module._parameters.get(attr)
         if existing is not None and not isinstance(existing, torch.nn.Parameter):
             raise RuntimeError(
-                f"GMS parameter destination {slot.path!r} is not a Parameter"
+                f"GMS parameter destination {binding.path!r} is not a Parameter"
             )
-        return _SlotTarget(slot, module, attr, existing)
+        return _ResolvedTensorDestination(binding, module, attr, existing)
 
-    if slot.kind in ("persistent_buffer", "nonpersistent_buffer"):
-        module = _resolve_module(model, parts[:-1])
+    if (
+        binding.kind is ModuleTensorKind.PERSISTENT_BUFFER
+        or binding.kind is ModuleTensorKind.NONPERSISTENT_BUFFER
+    ):
+        module = _resolve_submodule_path(model, parts[:-1])
         attr = parts[-1]
         if (
             attr in module._parameters
@@ -535,51 +598,56 @@ def _resolve_slot_target(
             or _class_defines_attribute(module, attr)
         ):
             raise RuntimeError(
-                f"GMS buffer destination {slot.path!r} collides with "
-                "another module slot"
+                f"GMS buffer destination {binding.path!r} collides with "
+                "another module binding"
             )
         existing = module._buffers.get(attr)
         if existing is not None and not torch.is_tensor(existing):
-            raise RuntimeError(f"GMS buffer destination {slot.path!r} is not a Tensor")
-        return _SlotTarget(slot, module, attr, existing)
+            raise RuntimeError(
+                f"GMS buffer destination {binding.path!r} is not a Tensor"
+            )
+        return _ResolvedTensorDestination(binding, module, attr, existing)
 
     if len(parts) >= 2 and parts[-1].isdecimal():
-        module = _resolve_module(model, parts[:-2])
+        module = _resolve_submodule_path(model, parts[:-2])
         attr = parts[-2]
         container = module.__dict__.get(attr)
         index = int(parts[-1])
         if type(container) not in (list, tuple) or index >= len(container):
-            raise RuntimeError(f"GMS sequence destination {slot.path!r} is unsupported")
+            raise RuntimeError(
+                f"GMS sequence destination {binding.path!r} is unsupported"
+            )
         existing = container[index] if torch.is_tensor(container[index]) else None
-        return _SlotTarget(slot, module, attr, existing, index)
+        return _ResolvedTensorDestination(binding, module, attr, existing, index)
 
-    module = _resolve_module(model, parts[:-1])
+    module = _resolve_submodule_path(model, parts[:-1])
     attr = parts[-1]
     if attr in module._parameters or attr in module._buffers or attr in module._modules:
         raise RuntimeError(
-            f"GMS attribute destination {slot.path!r} collides with another module slot"
+            f"GMS attribute destination {binding.path!r} collides with "
+            "another module binding"
         )
     existing = module.__dict__.get(attr)
     if attr in module.__dict__ and not torch.is_tensor(existing):
         raise RuntimeError(
-            f"GMS attribute destination {slot.path!r} is not a direct tensor"
+            f"GMS attribute destination {binding.path!r} is not a direct tensor"
         )
     if attr not in module.__dict__ and _has_data_descriptor(module, attr):
         raise RuntimeError(
-            f"GMS attribute destination {slot.path!r} is not representable"
+            f"GMS attribute destination {binding.path!r} is not representable"
         )
-    return _SlotTarget(slot, module, attr, existing)
+    return _ResolvedTensorDestination(binding, module, attr, existing)
 
 
-def _parameter_template(
-    targets: tuple[_SlotTarget, ...],
+def _find_parameter_template(
+    destinations: tuple[_ResolvedTensorDestination, ...],
 ) -> torch.nn.Parameter | None:
     return next(
         (
-            target.existing
-            for target in targets
-            if target.slot.kind == "parameter"
-            and isinstance(target.existing, torch.nn.Parameter)
+            destination.existing
+            for destination in destinations
+            if destination.binding.kind is ModuleTensorKind.PARAMETER
+            and isinstance(destination.existing, torch.nn.Parameter)
         ),
         None,
     )
@@ -601,7 +669,7 @@ def _parameter_slot_names(parameter_type: type[torch.nn.Parameter]) -> tuple[str
     return tuple(names)
 
 
-def _make_parameter(
+def _make_parameter_from_template(
     template: torch.nn.Parameter | None,
     tensor: torch.Tensor,
     *,
@@ -624,9 +692,10 @@ def _make_parameter(
     return parameter
 
 
-def _clone_storage(
+def _clone_storage_with_source_owner(
     storage: torch.UntypedStorage,
 ) -> tuple[torch.UntypedStorage, torch.Tensor]:
+    """Clone a storage while retaining a tensor that owns the displaced source."""
     source_owner = torch.empty(0, dtype=torch.uint8, device=storage.device).set_(
         storage,
         0,
@@ -653,40 +722,48 @@ def materialize_module_from_gms(
     *,
     device_index: int,
 ) -> None:
-    """Replace supported module slots with objects reconstructed from GMS."""
+    """Map parameter-containing storages read-only and clone all other storages."""
     if int(gms_client_memory_manager.device) != device_index:
         raise RuntimeError(
             "GMS manager device does not match materialization device: "
             f"{gms_client_memory_manager.device} vs {device_index}"
         )
     stored_manifests = _load_storage_manifests(gms_client_memory_manager)
-    targets: list[list[tuple[TensorObject, tuple[_SlotTarget, ...]]]] = []
+    resolved: list[
+        list[tuple[TensorObject, tuple[_ResolvedTensorDestination, ...]]]
+    ] = []
     destinations: dict[tuple[int, str, int | None], tuple[int, int]] = {}
     for manifest_index, stored in enumerate(stored_manifests):
-        manifest_targets: list[tuple[TensorObject, tuple[_SlotTarget, ...]]] = []
+        manifest_destinations: list[
+            tuple[TensorObject, tuple[_ResolvedTensorDestination, ...]]
+        ] = []
         for object_index, tensor_object in enumerate(stored.manifest.objects):
             object_id = (manifest_index, object_index)
-            unique_targets: dict[tuple[int, str, int | None], _SlotTarget] = {}
-            for slot in tensor_object.slots:
-                target = _resolve_slot_target(model, slot)
-                previous_target = unique_targets.get(target.destination)
-                if previous_target is not None:
-                    if previous_target.slot.kind != target.slot.kind:
+            unique_destinations: dict[
+                tuple[int, str, int | None], _ResolvedTensorDestination
+            ] = {}
+            for binding in tensor_object.bindings:
+                destination = _resolve_tensor_destination(model, binding)
+                previous_destination = unique_destinations.get(destination.destination)
+                if previous_destination is not None:
+                    if previous_destination.binding.kind is not binding.kind:
                         raise RuntimeError(
-                            "GMS source slots resolve to incompatible destination "
-                            f"{slot.path!r}"
+                            "GMS source bindings resolve to incompatible destination "
+                            f"{binding.path!r}"
                         )
                     continue
-                previous_object = destinations.setdefault(target.destination, object_id)
+                previous_object = destinations.setdefault(
+                    destination.destination, object_id
+                )
                 if previous_object != object_id:
                     raise RuntimeError(
                         "Distinct GMS tensor objects resolve to the same destination "
-                        f"{slot.path!r}"
+                        f"{binding.path!r}"
                     )
-                unique_targets[target.destination] = target
-            object_targets = tuple(unique_targets.values())
-            manifest_targets.append((tensor_object, object_targets))
-        targets.append(manifest_targets)
+                unique_destinations[destination.destination] = destination
+            object_destinations = tuple(unique_destinations.values())
+            manifest_destinations.append((tensor_object, object_destinations))
+        resolved.append(manifest_destinations)
 
     allocation_ids = list(
         dict.fromkeys(stored.allocation_id for stored in stored_manifests)
@@ -708,8 +785,12 @@ def materialize_module_from_gms(
                     f"GMS mapping for allocation {allocation_id!r} is inconsistent"
                 )
 
-        materialized: list[_MaterializedObject] = []
-        for stored, manifest_targets in zip(stored_manifests, targets, strict=True):
+        materialized: list[
+            tuple[torch.Tensor, tuple[_ResolvedTensorDestination, ...]]
+        ] = []
+        for stored, manifest_destinations in zip(
+            stored_manifests, resolved, strict=True
+        ):
             mapping = gms_client_memory_manager.mappings[mapped[stored.allocation_id]]
             if (
                 stored.storage_base_offset < 0
@@ -725,17 +806,17 @@ def materialize_module_from_gms(
                 device_index,
             )
             has_parameter = any(
-                slot.kind == "parameter"
+                binding.kind is ModuleTensorKind.PARAMETER
                 for tensor_object in stored.manifest.objects
-                for slot in tensor_object.slots
+                for binding in tensor_object.bindings
             )
             if has_parameter:
                 target_storage = source_storage
             else:
                 clone_started = True
-                target_storage, _ = _clone_storage(source_storage)
+                target_storage, _ = _clone_storage_with_source_owner(source_storage)
 
-            for tensor_object, object_targets in manifest_targets:
+            for tensor_object, object_destinations in manifest_destinations:
                 dtype = _dtype_from_name(tensor_object.dtype)
                 tensor = _tensor_from_storage(
                     target_storage,
@@ -744,24 +825,24 @@ def materialize_module_from_gms(
                     dtype,
                     tensor_object.storage_offset_bytes // dtype.itemsize,
                 )
-                parameter_targets = tuple(
-                    target
-                    for target in object_targets
-                    if target.slot.kind == "parameter"
+                parameter_destinations = tuple(
+                    destination
+                    for destination in object_destinations
+                    if destination.binding.kind is ModuleTensorKind.PARAMETER
                 )
-                if parameter_targets:
-                    tensor = _make_parameter(
-                        _parameter_template(object_targets),
+                if parameter_destinations:
+                    tensor = _make_parameter_from_template(
+                        _find_parameter_template(object_destinations),
                         tensor,
-                        path=parameter_targets[0].slot.path,
+                        path=parameter_destinations[0].binding.path,
                         requires_grad=tensor_object.requires_grad,
                     )
-                materialized.append(_MaterializedObject(tensor, object_targets))
+                materialized.append((tensor, object_destinations))
 
         installation_started = True
-        for tensor_object in materialized:
-            for target in tensor_object.targets:
-                target.install(tensor_object.tensor)
+        for tensor, object_destinations in materialized:
+            for destination in object_destinations:
+                destination.install(tensor)
     except BaseException:
         if not installation_started:
             if clone_started and imported:
@@ -793,10 +874,11 @@ def _swap_tensor_contents(
         raise RuntimeError(f"Cannot rebind GMS tensor {path!r}: {exc}") from exc
 
 
-def _swap_discovered_objects(
-    objects: list[_DiscoveredObject],
+def _swap_discovered_tensors(
+    objects: list[_DiscoveredTensor],
     replacements: dict[int, torch.Tensor],
 ) -> None:
+    """Preflight and swap a group of identity-preserving tensor replacements."""
     if not hasattr(torch.utils, "swap_tensors"):
         raise RuntimeError("GMS publisher rebinding requires torch.utils.swap_tensors")
 
@@ -807,7 +889,7 @@ def _swap_discovered_objects(
         if base is not None and id(base) in object_ids:
             group_base_uses[id(base)] = group_base_uses.get(id(base), 0) + 1
 
-    def base_depth(tensor_object: _DiscoveredObject) -> int:
+    def base_depth(tensor_object: _DiscoveredTensor) -> int:
         depth = 0
         base = tensor_object.tensor._base
         while base is not None and id(base) in object_ids:
@@ -819,7 +901,7 @@ def _swap_discovered_objects(
     for tensor_object in ordered:
         existing = tensor_object.tensor
         replacement = replacements[id(existing)]
-        path = tensor_object.slots[0].path
+        path = tensor_object.bindings[0].path
         for tensor, name in ((existing, "t1"), (replacement, "t2")):
             if weakref.getweakrefs(tensor):
                 raise RuntimeError(
@@ -839,7 +921,7 @@ def _swap_discovered_objects(
     for tensor_object in ordered:
         existing = tensor_object.tensor
         replacement = replacements[id(existing)]
-        path = tensor_object.slots[0].path
+        path = tensor_object.bindings[0].path
         for tensor, name, released_uses in (
             (existing, "t1", group_base_uses.get(id(existing), 0)),
             (replacement, "t2", 0),
@@ -865,7 +947,7 @@ def _swap_discovered_objects(
         _swap_tensor_contents(
             tensor_object.tensor,
             replacement,
-            path=tensor_object.slots[0].path,
+            path=tensor_object.bindings[0].path,
         )
         del replacement
 
@@ -874,9 +956,10 @@ def rebind_nonparameter_tensors(
     gms_client_memory_manager: "GMSClientMemoryManager",
     model: torch.nn.Module,
 ) -> int:
-    """Clone each non-parameter-only GMS storage once into writable CUDA memory."""
-    storages = _locate_storage(
-        _discover_module_storage(model),
+    """Clone each non-parameter-only GMS storage once."""
+    displaced_source_tensors = _get_displaced_source_tensors(model)
+    storages = _match_storages_to_gms_mappings(
+        _discover_module_storages(model),
         gms_client_memory_manager.mappings,
         require_parameters=False,
     )
@@ -888,38 +971,13 @@ def rebind_nonparameter_tensors(
     if not candidates:
         return 0
 
-    if _REBOUND_TENSOR_OWNERS_ATTR not in model.__dict__:
-        namespace_collision = any(
-            _REBOUND_TENSOR_OWNERS_ATTR in namespace
-            for namespace in (
-                model._parameters,
-                model._buffers,
-                model._modules,
-            )
-        )
-        class_collision = any(
-            _REBOUND_TENSOR_OWNERS_ATTR in cls.__dict__ for cls in type(model).__mro__
-        )
-        if namespace_collision or class_collision:
-            raise RuntimeError(
-                f"Reserved GMS attribute {_REBOUND_TENSOR_OWNERS_ATTR!r} "
-                "collides with an existing model attribute"
-            )
-        owners = _ReboundTensorOwners()
-        model.__dict__[_REBOUND_TENSOR_OWNERS_ATTR] = owners
-    else:
-        owners = model.__dict__[_REBOUND_TENSOR_OWNERS_ATTR]
-    if not isinstance(owners, _ReboundTensorOwners):
-        raise RuntimeError(
-            f"Reserved GMS attribute {_REBOUND_TENSOR_OWNERS_ATTR!r} "
-            "collides with an existing model attribute"
-        )
-
     replacements: dict[int, torch.Tensor] = {}
     source_owners: list[torch.Tensor] = []
-    objects: list[_DiscoveredObject] = []
+    objects: list[_DiscoveredTensor] = []
     for discovered_storage in candidates:
-        target_storage, source_owner = _clone_storage(discovered_storage.storage)
+        target_storage, source_owner = _clone_storage_with_source_owner(
+            discovered_storage.storage
+        )
         source_owners.append(source_owner)
         for tensor_object in discovered_storage.objects:
             tensor = tensor_object.tensor
@@ -932,6 +990,12 @@ def rebind_nonparameter_tensors(
             )
             objects.append(tensor_object)
 
-    _swap_discovered_objects(objects, replacements)
-    owners.tensors.extend(source_owners)
+    _swap_discovered_tensors(objects, replacements)
+    if displaced_source_tensors is None:
+        model.__dict__[_DISPLACED_SOURCE_TENSORS_ATTR] = (
+            _DISPLACED_SOURCE_TENSORS_SENTINEL,
+            source_owners,
+        )
+    else:
+        displaced_source_tensors.extend(source_owners)
     return sum(discovered_storage.storage.nbytes() for discovered_storage in candidates)

--- a/lib/gpu_memory_service/client/torch/tensor.py
+++ b/lib/gpu_memory_service/client/torch/tensor.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import List, Tuple
 
 import msgspec
 import torch
@@ -28,16 +27,16 @@ class ModuleTensorBinding(msgspec.Struct, frozen=True, forbid_unknown_fields=Tru
 
 class TensorObject(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     dtype: str
-    shape: Tuple[int, ...]
-    stride: Tuple[int, ...]
+    shape: tuple[int, ...]
+    stride: tuple[int, ...]
     storage_offset_bytes: int
     requires_grad: bool
-    bindings: Tuple[ModuleTensorBinding, ...]
+    bindings: tuple[ModuleTensorBinding, ...]
 
 
 class StorageManifest(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     nbytes: int
-    objects: Tuple[TensorObject, ...]
+    objects: tuple[TensorObject, ...]
 
 
 def _dtype_from_name(name: str) -> torch.dtype:
@@ -64,8 +63,8 @@ def _storage_from_pointer(
 
 def _tensor_from_storage(
     storage: torch.UntypedStorage,
-    shape: List[int],
-    stride: List[int],
+    shape: list[int],
+    stride: list[int],
     dtype: torch.dtype,
     storage_offset: int = 0,
 ) -> torch.Tensor:
@@ -81,8 +80,8 @@ def _tensor_from_storage(
 
 def _tensor_from_pointer(
     data_ptr: int,
-    shape: List[int],
-    stride: List[int],
+    shape: list[int],
+    stride: list[int],
     dtype: torch.dtype,
     device_index: int,
 ) -> torch.Tensor:
@@ -93,8 +92,8 @@ def _tensor_from_pointer(
 
 
 def _layout_end_bytes(
-    shape: List[int] | Tuple[int, ...],
-    stride: List[int] | Tuple[int, ...],
+    shape: list[int] | tuple[int, ...],
+    stride: list[int] | tuple[int, ...],
     dtype: torch.dtype,
     storage_offset: int,
 ) -> int:
@@ -118,8 +117,8 @@ def _layout_end_bytes(
 
 
 def _validate_layout(
-    shape: List[int] | Tuple[int, ...],
-    stride: List[int] | Tuple[int, ...],
+    shape: list[int] | tuple[int, ...],
+    stride: list[int] | tuple[int, ...],
     dtype: torch.dtype,
     storage_offset: int,
     storage_nbytes: int,

--- a/lib/gpu_memory_service/client/torch/tensor.py
+++ b/lib/gpu_memory_service/client/torch/tensor.py
@@ -14,6 +14,8 @@ STORAGE_MANIFEST_PREFIX = "torch.module.storage/"
 
 
 class ModuleTensorKind(str, Enum):
+    """Classify how a tensor is bound to a module."""
+
     PARAMETER = "parameter"
     PERSISTENT_BUFFER = "persistent_buffer"
     NONPERSISTENT_BUFFER = "nonpersistent_buffer"
@@ -21,11 +23,15 @@ class ModuleTensorKind(str, Enum):
 
 
 class ModuleTensorBinding(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+    """Name one module binding for a tensor object."""
+
     path: str
     kind: ModuleTensorKind
 
 
 class TensorObject(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+    """Describe one tensor identity within a storage manifest."""
+
     dtype: str
     shape: tuple[int, ...]
     stride: tuple[int, ...]
@@ -35,6 +41,8 @@ class TensorObject(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
 
 
 class StorageManifest(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+    """Describe one shared StorageImpl and its tensor objects."""
+
     nbytes: int
     objects: tuple[TensorObject, ...]
 

--- a/lib/gpu_memory_service/client/torch/tensor.py
+++ b/lib/gpu_memory_service/client/torch/tensor.py
@@ -1,29 +1,49 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tensor utilities for GPU Memory Service.
-
-This module provides low-level tensor functionality:
-- Tensor creation from CUDA pointers
-- Tensor metadata serialization/deserialization
-- GMS tensor spec for metadata store entries
-"""
+"""Tensor storage utilities and the GMS module storage manifest."""
 
 from __future__ import annotations
 
-import json
-from dataclasses import dataclass
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import List, Literal, Tuple
 
+import msgspec
 import torch
 
-if TYPE_CHECKING:
-    from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+STORAGE_MANIFEST_PREFIX = "torch.module.storage/"
+
+SlotKind = Literal[
+    "parameter",
+    "persistent_buffer",
+    "nonpersistent_buffer",
+    "attribute",
+]
 
 
-# =============================================================================
-# Tensor Creation from CUDA Pointer
-# =============================================================================
+class Slot(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+    path: str
+    kind: SlotKind
+
+
+class TensorObject(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+    dtype: str
+    shape: Tuple[int, ...]
+    stride: Tuple[int, ...]
+    storage_offset_bytes: int
+    requires_grad: bool
+    slots: Tuple[Slot, ...]
+
+
+class StorageManifest(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+    nbytes: int
+    objects: Tuple[TensorObject, ...]
+
+
+def _dtype_from_name(name: str) -> torch.dtype:
+    dtype = getattr(torch, name, None)
+    if not isinstance(dtype, torch.dtype) or str(dtype) != f"torch.{name}":
+        raise ValueError(f"Unknown or noncanonical dtype: {name!r}")
+    return dtype
 
 
 def _storage_from_pointer(
@@ -65,68 +85,10 @@ def _tensor_from_pointer(
     dtype: torch.dtype,
     device_index: int,
 ) -> torch.Tensor:
-    """Create a torch.Tensor from a raw CUDA pointer without copying data.
-
-    Uses PyTorch's internal APIs to create a tensor that aliases existing
-    GPU memory. The tensor does NOT own the memory - the caller must ensure
-    the memory remains valid for the tensor's lifetime.
-
-    Args:
-        data_ptr: CUDA device pointer (virtual address) to the tensor data.
-        shape: Tensor dimensions.
-        stride: Tensor strides (in elements, not bytes).
-        dtype: Tensor data type.
-        device_index: CUDA device index where the memory resides.
-
-    Returns:
-        A tensor aliasing the specified GPU memory.
-    """
+    """Create a non-owning CUDA tensor from a raw pointer."""
     storage_size_bytes = _layout_end_bytes(shape, stride, dtype, 0)
     storage = _storage_from_pointer(data_ptr, storage_size_bytes, device_index)
     return _tensor_from_storage(storage, shape, stride, dtype)
-
-
-# =============================================================================
-# Tensor Metadata - serialization format for metadata store
-# =============================================================================
-
-
-def _parse_dtype(dtype_str: str) -> torch.dtype:
-    """Parse dtype string (e.g., 'torch.float16') to torch.dtype."""
-    s = str(dtype_str)
-    if s.startswith("torch."):
-        s = s.split(".", 1)[1]
-    dt = getattr(torch, s, None)
-    if not isinstance(dt, torch.dtype):
-        raise ValueError(f"Unknown dtype: {dtype_str!r}")
-    return dt
-
-
-_TENSOR_TYPES = frozenset(("parameter", "buffer", "tensor_attr"))
-_STORAGE_FIELDS = frozenset(
-    (
-        "schema_version",
-        "storage_group_id",
-        "object_group_id",
-        "storage_base_offset",
-        "storage_nbytes",
-        "storage_offset",
-        "buffer_persistent",
-    )
-)
-_BASE_FIELDS = frozenset(("shape", "dtype", "stride", "tensor_type"))
-
-
-def _strict_int(value: object, field: str, *, minimum: int = 0) -> int:
-    if type(value) is not int or value < minimum:
-        raise ValueError(f"{field} must be an integer >= {minimum}")
-    return value
-
-
-def _strict_int_list(value: object, field: str) -> Tuple[int, ...]:
-    if not isinstance(value, list):
-        raise ValueError(f"{field} must be a list")
-    return tuple(_strict_int(item, field) for item in value)
 
 
 def _layout_end_bytes(
@@ -146,13 +108,12 @@ def _layout_end_bytes(
         raise ValueError("Tensor stride must contain nonnegative integers")
     if type(storage_offset) is not int or storage_offset < 0:
         raise ValueError("Tensor storage offset must be a nonnegative integer")
-    element_size = torch.empty((), dtype=dtype).element_size()
     if any(dim == 0 for dim in shape):
-        return storage_offset * element_size
+        return storage_offset * dtype.itemsize
     last_element = storage_offset + sum(
         step * (dim - 1) for dim, step in zip(shape, stride, strict=True)
     )
-    return (last_element + 1) * element_size
+    return (last_element + 1) * dtype.itemsize
 
 
 def _validate_layout(
@@ -166,180 +127,3 @@ def _validate_layout(
         raise ValueError("Storage size must be a nonnegative integer")
     if _layout_end_bytes(shape, stride, dtype, storage_offset) > storage_nbytes:
         raise ValueError("Tensor layout exceeds its storage bounds")
-
-
-@dataclass(frozen=True)
-class TensorMetadata:
-    """Metadata for a tensor stored in the GMS metadata store."""
-
-    shape: Tuple[int, ...]
-    dtype: torch.dtype
-    stride: Tuple[int, ...]
-    tensor_type: str = "parameter"  # "parameter", "buffer", or "tensor_attr"
-    storage: dict[str, object] | None = None
-
-    @classmethod
-    def from_tensor(
-        cls,
-        tensor: torch.Tensor,
-        tensor_type: str = "parameter",
-        *,
-        storage: dict[str, object] | None = None,
-    ) -> "TensorMetadata":
-        """Create TensorMetadata from an existing tensor."""
-        return cls(
-            shape=tuple(tensor.shape),
-            dtype=tensor.dtype,
-            stride=tuple(int(s) for s in tensor.stride()),
-            tensor_type=tensor_type,
-            storage=storage,
-        )
-
-    @classmethod
-    def from_bytes(cls, value: bytes) -> "TensorMetadata":
-        """Parse metadata from JSON bytes."""
-        obj = json.loads(value.decode("utf-8"))
-        if not isinstance(obj, dict):
-            raise ValueError("Tensor metadata must be a JSON object")
-        is_storage_component = "storage" in obj
-        if is_storage_component and set(obj) != _BASE_FIELDS | {"storage"}:
-            raise ValueError("Storage-component metadata has unknown or missing fields")
-        shape = _strict_int_list(obj["shape"], "shape")
-        dtype = _parse_dtype(obj["dtype"])
-
-        if is_storage_component:
-            stride = _strict_int_list(obj["stride"], "stride")
-        elif "stride" in obj and obj["stride"] is not None:
-            stride = _strict_int_list(obj["stride"], "stride")
-        else:
-            # Legacy format: compute contiguous stride
-            stride = []
-            acc = 1
-            for d in reversed(shape):
-                stride.append(acc)
-                acc *= d
-            stride = tuple(reversed(stride)) if stride else ()
-
-        if len(shape) != len(stride):
-            raise ValueError("Tensor shape and stride lengths differ")
-        tensor_type = obj.get("tensor_type", "parameter")
-        if tensor_type not in _TENSOR_TYPES:
-            raise ValueError(f"Unknown tensor type: {tensor_type!r}")
-
-        if "storage" not in obj:
-            return cls(
-                shape=shape,
-                dtype=dtype,
-                stride=stride,
-                tensor_type=tensor_type,
-            )
-        storage = obj["storage"]
-        if not isinstance(storage, dict) or set(storage) != _STORAGE_FIELDS:
-            raise ValueError("Storage-component metadata fields must be exact")
-        if _strict_int(storage["schema_version"], "schema_version") != 1:
-            raise ValueError("Unsupported storage-component schema version")
-        if type(storage["buffer_persistent"]) is not bool:
-            raise ValueError("buffer_persistent must be a boolean")
-        normalized = {
-            field: _strict_int(storage[field], field)
-            for field in _STORAGE_FIELDS
-            if field not in ("schema_version", "buffer_persistent")
-        }
-        normalized["schema_version"] = 1
-        normalized["buffer_persistent"] = storage["buffer_persistent"]
-        return cls(shape, dtype, stride, tensor_type, normalized)
-
-    def to_bytes(self) -> bytes:
-        """Serialize to JSON bytes for metadata store."""
-        obj = {
-            "shape": list(self.shape),
-            "dtype": str(self.dtype),
-            "stride": list(self.stride),
-            "tensor_type": self.tensor_type,
-        }
-        if self.storage is not None:
-            obj["storage"] = self.storage
-        return json.dumps(obj, sort_keys=True).encode("utf-8")
-
-    @property
-    def is_storage_component(self) -> bool:
-        return self.storage is not None
-
-
-# =============================================================================
-# GMS Tensor Spec - metadata entry from store
-# =============================================================================
-
-
-@dataclass(frozen=True)
-class GMSTensorSpec:
-    """A tensor entry from the GMS metadata store."""
-
-    key: str
-    name: str
-    allocation_id: str
-    offset_bytes: int
-    meta: TensorMetadata
-
-    @classmethod
-    def load_all(
-        cls, gms_client_memory_manager: "GMSClientMemoryManager"
-    ) -> Dict[str, "GMSTensorSpec"]:
-        """Load all metadata entries.
-
-        Returns:
-            Mapping of tensor name -> GMSTensorSpec.
-        """
-        specs: Dict[str, GMSTensorSpec] = {}
-
-        for key in gms_client_memory_manager.metadata_list():
-            got = gms_client_memory_manager.metadata_get(key)
-            if got is None:
-                raise RuntimeError(f"Metadata key disappeared: {key}")
-
-            allocation_id, offset_bytes, value = got
-
-            if key in specs:
-                raise RuntimeError(f"Duplicate tensor name: {key}")
-
-            specs[key] = cls(
-                key=key,
-                name=key,
-                allocation_id=str(allocation_id),
-                offset_bytes=int(offset_bytes),
-                meta=TensorMetadata.from_bytes(value),
-            )
-
-        return specs
-
-    def materialize(
-        self,
-        gms_client_memory_manager: "GMSClientMemoryManager",
-        device_index: int,
-    ) -> torch.Tensor:
-        """Create a tensor aliasing mapped CUDA memory."""
-        base_va = gms_client_memory_manager.create_mapping(
-            allocation_id=self.allocation_id
-        )
-        mapping = gms_client_memory_manager.mappings[base_va]
-        allocation_nbytes = int(mapping.aligned_size)
-        tensor_nbytes = _layout_end_bytes(
-            self.meta.shape,
-            self.meta.stride,
-            self.meta.dtype,
-            0,
-        )
-        if (
-            self.offset_bytes < 0
-            or self.offset_bytes + tensor_nbytes > allocation_nbytes
-        ):
-            raise ValueError(f"Tensor {self.name!r} exceeds allocation bounds")
-        ptr = int(base_va) + int(self.offset_bytes)
-
-        return _tensor_from_pointer(
-            ptr,
-            list(self.meta.shape),
-            list(self.meta.stride),
-            self.meta.dtype,
-            device_index,
-        )

--- a/lib/gpu_memory_service/client/torch/tensor.py
+++ b/lib/gpu_memory_service/client/torch/tensor.py
@@ -5,24 +5,25 @@
 
 from __future__ import annotations
 
-from typing import List, Literal, Tuple
+from enum import Enum
+from typing import List, Tuple
 
 import msgspec
 import torch
 
 STORAGE_MANIFEST_PREFIX = "torch.module.storage/"
 
-SlotKind = Literal[
-    "parameter",
-    "persistent_buffer",
-    "nonpersistent_buffer",
-    "attribute",
-]
+
+class ModuleTensorKind(str, Enum):
+    PARAMETER = "parameter"
+    PERSISTENT_BUFFER = "persistent_buffer"
+    NONPERSISTENT_BUFFER = "nonpersistent_buffer"
+    ATTRIBUTE = "attribute"
 
 
-class Slot(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
+class ModuleTensorBinding(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     path: str
-    kind: SlotKind
+    kind: ModuleTensorKind
 
 
 class TensorObject(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
@@ -31,7 +32,7 @@ class TensorObject(msgspec.Struct, frozen=True, forbid_unknown_fields=True):
     stride: Tuple[int, ...]
     storage_offset_bytes: int
     requires_grad: bool
-    slots: Tuple[Slot, ...]
+    bindings: Tuple[ModuleTensorBinding, ...]
 
 
 class StorageManifest(msgspec.Struct, frozen=True, forbid_unknown_fields=True):

--- a/lib/gpu_memory_service/client/torch/tensor.py
+++ b/lib/gpu_memory_service/client/torch/tensor.py
@@ -26,6 +26,38 @@ if TYPE_CHECKING:
 # =============================================================================
 
 
+def _storage_from_pointer(
+    data_ptr: int,
+    size_bytes: int,
+    device_index: int,
+) -> torch.UntypedStorage:
+    """Create non-owning CUDA storage for an existing mapped byte range."""
+    if data_ptr < 0 or size_bytes < 0:
+        raise ValueError("Storage pointer and size must be nonnegative")
+    return torch._C._construct_storage_from_data_pointer(
+        data_ptr,
+        torch.device("cuda", device_index),
+        size_bytes,
+    )
+
+
+def _tensor_from_storage(
+    storage: torch.UntypedStorage,
+    shape: List[int],
+    stride: List[int],
+    dtype: torch.dtype,
+    storage_offset: int = 0,
+) -> torch.Tensor:
+    """Create an independent TensorImpl wrapper over ``storage``."""
+    _validate_layout(shape, stride, dtype, storage_offset, storage.nbytes())
+    return torch.empty(0, dtype=dtype, device=storage.device).set_(
+        storage,
+        storage_offset,
+        shape,
+        stride,
+    )
+
+
 def _tensor_from_pointer(
     data_ptr: int,
     shape: List[int],
@@ -49,42 +81,9 @@ def _tensor_from_pointer(
     Returns:
         A tensor aliasing the specified GPU memory.
     """
-    device = torch.device("cuda", device_index)
-
-    # Calculate storage size in bytes based on stride (handles non-contiguous tensors)
-    # For non-contiguous tensors, the memory footprint is larger than numel * element_size
-    element_size = torch.tensor([], dtype=dtype).element_size()
-
-    if shape and stride:
-        if len(shape) != len(stride):
-            raise ValueError(
-                f"Shape and stride length mismatch: {len(shape)} vs {len(stride)}"
-            )
-        # Maximum offset = sum of stride[i] * (shape[i] - 1) for all dimensions
-        max_offset = sum(
-            s * (d - 1) for s, d in zip(stride, shape, strict=True) if d > 0
-        )
-        required_elements = max_offset + 1
-    else:
-        # Scalar tensor or empty tensor
-        required_elements = 1
-
-    storage_size_bytes = required_elements * element_size
-
-    # Create storage from raw pointer (does not take ownership)
-    storage = torch._C._construct_storage_from_data_pointer(
-        data_ptr, device, storage_size_bytes
-    )
-
-    # Create tensor from storage with metadata
-    metadata = {
-        "size": torch.Size(shape),
-        "stride": stride,
-        "storage_offset": 0,
-        "dtype": dtype,
-    }
-
-    return torch._C._construct_CUDA_Tensor_From_Storage_And_Metadata(metadata, storage)
+    storage_size_bytes = _layout_end_bytes(shape, stride, dtype, 0)
+    storage = _storage_from_pointer(data_ptr, storage_size_bytes, device_index)
+    return _tensor_from_storage(storage, shape, stride, dtype)
 
 
 # =============================================================================
@@ -103,6 +102,72 @@ def _parse_dtype(dtype_str: str) -> torch.dtype:
     return dt
 
 
+_TENSOR_TYPES = frozenset(("parameter", "buffer", "tensor_attr"))
+_STORAGE_FIELDS = frozenset(
+    (
+        "schema_version",
+        "storage_group_id",
+        "object_group_id",
+        "storage_base_offset",
+        "storage_nbytes",
+        "storage_offset",
+        "buffer_persistent",
+    )
+)
+_BASE_FIELDS = frozenset(("shape", "dtype", "stride", "tensor_type"))
+
+
+def _strict_int(value: object, field: str, *, minimum: int = 0) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{field} must be an integer >= {minimum}")
+    return value
+
+
+def _strict_int_list(value: object, field: str) -> Tuple[int, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"{field} must be a list")
+    return tuple(_strict_int(item, field) for item in value)
+
+
+def _layout_end_bytes(
+    shape: List[int] | Tuple[int, ...],
+    stride: List[int] | Tuple[int, ...],
+    dtype: torch.dtype,
+    storage_offset: int,
+) -> int:
+    """Return the exclusive byte end needed by a nonnegative strided layout."""
+    if len(shape) != len(stride):
+        raise ValueError(
+            f"Shape and stride length mismatch: {len(shape)} vs {len(stride)}"
+        )
+    if any(type(dim) is not int or dim < 0 for dim in shape):
+        raise ValueError("Tensor shape must contain nonnegative integers")
+    if any(type(step) is not int or step < 0 for step in stride):
+        raise ValueError("Tensor stride must contain nonnegative integers")
+    if type(storage_offset) is not int or storage_offset < 0:
+        raise ValueError("Tensor storage offset must be a nonnegative integer")
+    element_size = torch.empty((), dtype=dtype).element_size()
+    if any(dim == 0 for dim in shape):
+        return storage_offset * element_size
+    last_element = storage_offset + sum(
+        step * (dim - 1) for dim, step in zip(shape, stride, strict=True)
+    )
+    return (last_element + 1) * element_size
+
+
+def _validate_layout(
+    shape: List[int] | Tuple[int, ...],
+    stride: List[int] | Tuple[int, ...],
+    dtype: torch.dtype,
+    storage_offset: int,
+    storage_nbytes: int,
+) -> None:
+    if type(storage_nbytes) is not int or storage_nbytes < 0:
+        raise ValueError("Storage size must be a nonnegative integer")
+    if _layout_end_bytes(shape, stride, dtype, storage_offset) > storage_nbytes:
+        raise ValueError("Tensor layout exceeds its storage bounds")
+
+
 @dataclass(frozen=True)
 class TensorMetadata:
     """Metadata for a tensor stored in the GMS metadata store."""
@@ -111,10 +176,15 @@ class TensorMetadata:
     dtype: torch.dtype
     stride: Tuple[int, ...]
     tensor_type: str = "parameter"  # "parameter", "buffer", or "tensor_attr"
+    storage: dict[str, object] | None = None
 
     @classmethod
     def from_tensor(
-        cls, tensor: torch.Tensor, tensor_type: str = "parameter"
+        cls,
+        tensor: torch.Tensor,
+        tensor_type: str = "parameter",
+        *,
+        storage: dict[str, object] | None = None,
     ) -> "TensorMetadata":
         """Create TensorMetadata from an existing tensor."""
         return cls(
@@ -122,17 +192,25 @@ class TensorMetadata:
             dtype=tensor.dtype,
             stride=tuple(int(s) for s in tensor.stride()),
             tensor_type=tensor_type,
+            storage=storage,
         )
 
     @classmethod
     def from_bytes(cls, value: bytes) -> "TensorMetadata":
         """Parse metadata from JSON bytes."""
         obj = json.loads(value.decode("utf-8"))
-        shape = tuple(int(x) for x in obj["shape"])
+        if not isinstance(obj, dict):
+            raise ValueError("Tensor metadata must be a JSON object")
+        is_storage_component = "storage" in obj
+        if is_storage_component and set(obj) != _BASE_FIELDS | {"storage"}:
+            raise ValueError("Storage-component metadata has unknown or missing fields")
+        shape = _strict_int_list(obj["shape"], "shape")
         dtype = _parse_dtype(obj["dtype"])
 
-        if "stride" in obj and obj["stride"] is not None:
-            stride = tuple(int(x) for x in obj["stride"])
+        if is_storage_component:
+            stride = _strict_int_list(obj["stride"], "stride")
+        elif "stride" in obj and obj["stride"] is not None:
+            stride = _strict_int_list(obj["stride"], "stride")
         else:
             # Legacy format: compute contiguous stride
             stride = []
@@ -142,24 +220,50 @@ class TensorMetadata:
                 acc *= d
             stride = tuple(reversed(stride)) if stride else ()
 
-        return cls(
-            shape=shape,
-            dtype=dtype,
-            stride=stride,
-            tensor_type=obj.get("tensor_type", "parameter"),
-        )
+        if len(shape) != len(stride):
+            raise ValueError("Tensor shape and stride lengths differ")
+        tensor_type = obj.get("tensor_type", "parameter")
+        if tensor_type not in _TENSOR_TYPES:
+            raise ValueError(f"Unknown tensor type: {tensor_type!r}")
+
+        if "storage" not in obj:
+            return cls(
+                shape=shape,
+                dtype=dtype,
+                stride=stride,
+                tensor_type=tensor_type,
+            )
+        storage = obj["storage"]
+        if not isinstance(storage, dict) or set(storage) != _STORAGE_FIELDS:
+            raise ValueError("Storage-component metadata fields must be exact")
+        if _strict_int(storage["schema_version"], "schema_version") != 1:
+            raise ValueError("Unsupported storage-component schema version")
+        if type(storage["buffer_persistent"]) is not bool:
+            raise ValueError("buffer_persistent must be a boolean")
+        normalized = {
+            field: _strict_int(storage[field], field)
+            for field in _STORAGE_FIELDS
+            if field not in ("schema_version", "buffer_persistent")
+        }
+        normalized["schema_version"] = 1
+        normalized["buffer_persistent"] = storage["buffer_persistent"]
+        return cls(shape, dtype, stride, tensor_type, normalized)
 
     def to_bytes(self) -> bytes:
         """Serialize to JSON bytes for metadata store."""
-        return json.dumps(
-            {
-                "shape": list(self.shape),
-                "dtype": str(self.dtype),
-                "stride": list(self.stride),
-                "tensor_type": self.tensor_type,
-            },
-            sort_keys=True,
-        ).encode("utf-8")
+        obj = {
+            "shape": list(self.shape),
+            "dtype": str(self.dtype),
+            "stride": list(self.stride),
+            "tensor_type": self.tensor_type,
+        }
+        if self.storage is not None:
+            obj["storage"] = self.storage
+        return json.dumps(obj, sort_keys=True).encode("utf-8")
+
+    @property
+    def is_storage_component(self) -> bool:
+        return self.storage is not None
 
 
 # =============================================================================
@@ -217,6 +321,19 @@ class GMSTensorSpec:
         base_va = gms_client_memory_manager.create_mapping(
             allocation_id=self.allocation_id
         )
+        mapping = gms_client_memory_manager.mappings[base_va]
+        allocation_nbytes = int(mapping.aligned_size)
+        tensor_nbytes = _layout_end_bytes(
+            self.meta.shape,
+            self.meta.stride,
+            self.meta.dtype,
+            0,
+        )
+        if (
+            self.offset_bytes < 0
+            or self.offset_bytes + tensor_nbytes > allocation_nbytes
+        ):
+            raise ValueError(f"Tensor {self.name!r} exceeds allocation bounds")
         ptr = int(base_va) + int(self.offset_bytes)
 
         return _tensor_from_pointer(

--- a/lib/gpu_memory_service/integrations/common/utils.py
+++ b/lib/gpu_memory_service/integrations/common/utils.py
@@ -140,16 +140,15 @@ def finalize_gms_write(
     allocator: "GMSClientMemoryManager",
     model: torch.nn.Module,
 ) -> GMSCommittedMemoryStats:
-    """Finalize GMS write mode: register tensors, commit, reconnect in read mode.
+    """Finalize GMS write mode and reconnect in read mode.
 
-    Flow: register tensors -> sync -> unmap + commit -> connect(RO) -> remap
-    -> rebind non-parameter tensors to private clones
+    Flow: register tensors -> rebind non-parameter tensors to private clones
+    -> sync -> unmap + commit -> connect(RO) -> remap
 
     The rebind mirrors the importer binding semantics from
-    ``materialize_module_from_gms``: after publish, the read-only GMS
-    mapping backs parameters only, while buffers and tensor attributes that
-    may be written later (fp8 KV scale re-initialization on wake,
-    quantization range updates) live in ordinary CUDA memory.
+    ``materialize_module_from_gms``. It runs before publication so a terminal
+    tensor swap failure cannot commit an unusable layout. Any failure releases
+    the writer best-effort without replacing the original exception.
 
     Args:
         allocator: The GMS client memory manager in write mode.
@@ -158,9 +157,16 @@ def finalize_gms_write(
     Returns:
         Committed/pruned byte stats.
     """
-    stats = prepare_gms_write(allocator, model)
-    publish_gms_write(allocator)
-    rebound_bytes = rebind_nonparameter_tensors(allocator, model)
+    try:
+        stats = prepare_gms_write(allocator, model)
+        rebound_bytes = rebind_nonparameter_tensors(allocator, model)
+        publish_gms_write(allocator)
+    except BaseException:
+        try:
+            allocator.close(best_effort=True)
+        except BaseException:
+            logger.exception("[GMS] Failed to release failed write finalization")
+        raise
 
     logger.info(
         "[GMS] Committed %.2f GiB, switched to read mode with %d mappings "

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -23,10 +23,10 @@ from gpu_memory_service.client.torch.allocator import (
     gms_use_mem_pool,
 )
 from gpu_memory_service.client.torch.module import (
-    _discover_module_storage,
-    _locate_storage,
-    _make_parameter,
-    _swap_discovered_objects,
+    _discover_module_storages,
+    _make_parameter_from_template,
+    _match_storages_to_gms_mappings,
+    _swap_discovered_tensors,
     materialize_module_from_gms,
 )
 from gpu_memory_service.client.torch.tensor import (
@@ -262,10 +262,10 @@ def _move_untracked_params(
         if target_device.index is None
         else int(target_device.index)
     )
-    discovered_storages = _discover_module_storage(model)
+    discovered_storages = _discover_module_storages(model)
     located_storage_ids = {
         id(discovered_storage)
-        for discovered_storage in _locate_storage(
+        for discovered_storage in _match_storages_to_gms_mappings(
             discovered_storages,
             gms_client.mappings,
             require_parameters=False,
@@ -305,14 +305,14 @@ def _move_untracked_params(
                     int(tensor.storage_offset()),
                 )
                 if isinstance(tensor, torch.nn.Parameter):
-                    replacement = _make_parameter(
+                    replacement = _make_parameter_from_template(
                         tensor,
                         replacement,
-                        path=tensor_object.slots[0].path,
+                        path=tensor_object.bindings[0].path,
                         requires_grad=bool(tensor.requires_grad),
                     )
                 replacements[id(tensor)] = replacement
                 del replacement
                 objects.append(tensor_object)
 
-        _swap_discovered_objects(objects, replacements)
+        _swap_discovered_tensors(objects, replacements)

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -22,7 +22,17 @@ from gpu_memory_service.client.torch.allocator import (
     get_or_create_gms_client_memory_manager,
     gms_use_mem_pool,
 )
-from gpu_memory_service.client.torch.module import materialize_module_from_gms
+from gpu_memory_service.client.torch.module import (
+    _discover_module_storage,
+    _locate_storage,
+    _make_parameter,
+    _swap_discovered_objects,
+    materialize_module_from_gms,
+)
+from gpu_memory_service.client.torch.tensor import (
+    _storage_from_pointer,
+    _tensor_from_storage,
+)
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.utils import get_socket_path
 from gpu_memory_service.integrations.common.utils import finalize_gms_write
@@ -157,15 +167,26 @@ def _load_rw(
     global _last_imported_weights_bytes
 
     target_device = torch.device("cuda", device_index)
+    finalization_started = False
+    try:
+        with gms_use_mem_pool("weights", target_device):
+            model, moe_load_balancer = original_load(
+                self, checkpoint_dir, checkpoint_loader
+            )
+            _move_untracked_params(model, gms_client, target_device)
+            torch.cuda.empty_cache()
 
-    with gms_use_mem_pool("weights", target_device):
-        model, moe_load_balancer = original_load(
-            self, checkpoint_dir, checkpoint_loader
-        )
-        _move_untracked_params(model, gms_client, target_device)
-        torch.cuda.empty_cache()
-
-    _last_imported_weights_bytes = finalize_gms_write(gms_client, model).committed_bytes
+        finalization_started = True
+        _last_imported_weights_bytes = finalize_gms_write(
+            gms_client, model
+        ).committed_bytes
+    except BaseException:
+        if not finalization_started:
+            try:
+                gms_client.close(best_effort=True)
+            except BaseException:
+                logger.exception("[GMS] Failed to release failed TRT-LLM write")
+        raise
 
     logger.info(
         "[GMS] TRT-LLM RW: published %.2f GiB",
@@ -226,14 +247,6 @@ def _load_ro(self, checkpoint_dir, checkpoint_loader, gms_client, device_index):
     return model, moe_load_balancer
 
 
-def _ptr_in_gms(gms_client: "GMSClientMemoryManager", ptr: int) -> bool:
-    """Return True if the given CUDA VA is within any active GMS mapping."""
-    for va, mapping in gms_client.mappings.items():
-        if va <= ptr < va + mapping.aligned_size:
-            return True
-    return False
-
-
 def _move_untracked_params(
     model: torch.nn.Module,
     gms_client: "GMSClientMemoryManager",
@@ -244,53 +257,62 @@ def _move_untracked_params(
     TRT-LLM may allocate some parameters outside the pluggable-allocator scope.
     This ensures all weight tensors end up tracked by GMS before we commit.
     """
-    from gpu_memory_service.client.torch.module import _iter_module_tensors
-    from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
-
     device_index = (
         torch.cuda.current_device()
         if target_device.index is None
         else int(target_device.index)
     )
-    seen: set[int] = set()
+    discovered_storages = _discover_module_storage(model)
+    located_storage_ids = {
+        id(discovered_storage)
+        for discovered_storage in _locate_storage(
+            discovered_storages,
+            gms_client.mappings,
+            require_parameters=False,
+        )
+    }
+    storages = [
+        discovered_storage
+        for discovered_storage in discovered_storages
+        if discovered_storage.has_parameter
+        and discovered_storage.storage.device.type == "cuda"
+        and id(discovered_storage) not in located_storage_ids
+    ]
+    replacements: dict[int, torch.Tensor] = {}
+    objects = []
+    source_owners: list[torch.Tensor] = []
 
     with torch.no_grad():
-        for _name, tensor, tensor_type in _iter_module_tensors(model):
-            if tensor_type != "parameter" or tensor is None or not tensor.is_cuda:
-                continue
-            storage_ptr = tensor.storage().data_ptr()
-            if storage_ptr in seen:
-                continue
-            seen.add(storage_ptr)
-
-            if _ptr_in_gms(gms_client, int(tensor.data_ptr())):
-                continue
-
-            # Allocate a new mapping and copy the tensor into it
-            nbytes = _storage_nbytes(tensor)
+        for discovered_storage in storages:
+            storage = discovered_storage.storage
+            nbytes = int(storage.nbytes())
             base_va = gms_client.create_mapping(size=nbytes, tag="weights")
-            replacement = _tensor_from_pointer(
-                int(base_va),
-                list(tensor.shape),
-                list(tensor.stride()),
-                tensor.dtype,
-                device_index,
+            target_storage = _storage_from_pointer(base_va, nbytes, device_index)
+            source_owner = _tensor_from_storage(storage, [nbytes], [1], torch.uint8)
+            target_owner = _tensor_from_storage(
+                target_storage, [nbytes], [1], torch.uint8
             )
-            replacement.copy_(tensor)
-            tensor.data = replacement
+            target_owner.copy_(source_owner)
+            source_owners.append(source_owner)
 
+            for tensor_object in discovered_storage.objects:
+                tensor = tensor_object.tensor
+                replacement = _tensor_from_storage(
+                    target_storage,
+                    list(tensor.shape),
+                    list(tensor.stride()),
+                    tensor.dtype,
+                    int(tensor.storage_offset()),
+                )
+                if isinstance(tensor, torch.nn.Parameter):
+                    replacement = _make_parameter(
+                        tensor,
+                        replacement,
+                        path=tensor_object.slots[0].path,
+                        requires_grad=bool(tensor.requires_grad),
+                    )
+                replacements[id(tensor)] = replacement
+                del replacement
+                objects.append(tensor_object)
 
-def _storage_nbytes(tensor: torch.Tensor) -> int:
-    if tensor.numel() == 0:
-        return 0
-    element_size = int(tensor.element_size())
-    shape = list(tensor.shape)
-    stride = list(tensor.stride())
-    if not shape:
-        return element_size
-    max_offset = sum(
-        abs(int(s)) * (int(d) - 1)
-        for s, d in zip(stride, shape, strict=True)
-        if int(d) > 1
-    )
-    return int((max_offset + 1) * element_size)
+        _swap_discovered_objects(objects, replacements)

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -27,6 +27,7 @@ from gpu_memory_service.client.torch.module import (
     _make_parameter_from_template,
     _match_storages_to_gms_mappings,
     _swap_discovered_tensors,
+    _validate_discovered_storage,
     materialize_module_from_gms,
 )
 from gpu_memory_service.client.torch.tensor import (
@@ -278,6 +279,9 @@ def _move_untracked_params(
         and discovered_storage.storage.device.type == "cuda"
         and id(discovered_storage) not in located_storage_ids
     ]
+    for discovered_storage in storages:
+        _validate_discovered_storage(discovered_storage)
+
     replacements: dict[int, torch.Tensor] = {}
     objects = []
 
@@ -302,7 +306,6 @@ def _move_untracked_params(
                     replacement = _make_parameter_from_template(
                         tensor,
                         replacement,
-                        path=tensor_object.bindings[0].path,
                         requires_grad=bool(tensor.requires_grad),
                     )
                 replacements[id(tensor)] = replacement

--- a/lib/gpu_memory_service/integrations/trtllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/trtllm/model_loader.py
@@ -265,7 +265,7 @@ def _move_untracked_params(
     discovered_storages = _discover_module_storages(model)
     located_storage_ids = {
         id(discovered_storage)
-        for discovered_storage in _match_storages_to_gms_mappings(
+        for discovered_storage, _, _ in _match_storages_to_gms_mappings(
             discovered_storages,
             gms_client.mappings,
             require_parameters=False,
@@ -280,7 +280,6 @@ def _move_untracked_params(
     ]
     replacements: dict[int, torch.Tensor] = {}
     objects = []
-    source_owners: list[torch.Tensor] = []
 
     with torch.no_grad():
         for discovered_storage in storages:
@@ -288,12 +287,7 @@ def _move_untracked_params(
             nbytes = int(storage.nbytes())
             base_va = gms_client.create_mapping(size=nbytes, tag="weights")
             target_storage = _storage_from_pointer(base_va, nbytes, device_index)
-            source_owner = _tensor_from_storage(storage, [nbytes], [1], torch.uint8)
-            target_owner = _tensor_from_storage(
-                target_storage, [nbytes], [1], torch.uint8
-            )
-            target_owner.copy_(source_owner)
-            source_owners.append(source_owner)
+            target_storage.copy_(storage)
 
             for tensor_object in discovered_storage.objects:
                 tensor = tensor_object.tensor

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -58,10 +58,7 @@ _last_imported_weights_bytes: int = 0
 _last_model_memory_usage_offset_bytes: int = 0
 
 # First writer's GMS client awaiting publication after vLLM memory profiling.
-# The retained tensors keep rebound-away GMS pool allocations alive until
-# commit; see rebind_nonparameter_tensors.
 _pending_gms_client: "GMSClientMemoryManager | None" = None
-_pending_retained_gms_tensors: list[torch.Tensor] = []
 
 
 def get_imported_weights_bytes() -> int:
@@ -83,25 +80,22 @@ def _store_pending_gms_write(
     gms_client: "GMSClientMemoryManager",
     stats: GMSCommittedMemoryStats,
     rebound_bytes: int,
-    retained_gms_tensors: list[torch.Tensor],
 ) -> None:
     global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
-    global _pending_gms_client, _pending_retained_gms_tensors
+    global _pending_gms_client
 
     if _pending_gms_client is not None:
         raise RuntimeError("A GMS write is already awaiting publication")
     _pending_gms_client = gms_client
-    _pending_retained_gms_tensors = retained_gms_tensors
     _last_imported_weights_bytes = stats.committed_bytes
     _last_model_memory_usage_offset_bytes = stats.pruned_bytes + rebound_bytes
 
 
 def _take_pending_gms_write() -> "GMSClientMemoryManager | None":
-    global _pending_gms_client, _pending_retained_gms_tensors
+    global _pending_gms_client
 
     gms_client = _pending_gms_client
     _pending_gms_client = None
-    _pending_retained_gms_tensors = []
     return gms_client
 
 
@@ -136,9 +130,7 @@ def publish_pending_gms_write() -> bool:
 def abort_pending_gms_write() -> bool:
     """Abort and clear the pending vLLM first-writer state, if any.
 
-    Releases the RPC lease best-effort without CUDA cleanup: an abort may
-    run with CUDA in an error state where a normal close synchronizes and
-    calls os._exit.
+    Releases the writer best-effort because CUDA may already be in an error state.
     """
     gms_client = _take_pending_gms_write()
     if gms_client is None:
@@ -255,6 +247,7 @@ def _load_read_mode(
 
     When MX is active, registers materialized tensors with NIXL so this
     node is discoverable as a P2P source (e.g. for shadow engine failover).
+    Meta-model setup remains responsible for hidden non-tensor backend state.
     """
     global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
@@ -276,7 +269,10 @@ def _load_read_mode(
         )
         return model.eval()
     except Exception:
-        gms_client.close()
+        try:
+            gms_client.close()
+        except Exception:
+            logger.exception("[GMS] Failed to close read-mode client")
         raise
 
 
@@ -356,13 +352,9 @@ def _load_write_mode_impl(
 
     stats = prepare_gms_write(gms_client, model)
     # The private clones must exist before vLLM profiles memory so the
-    # profiled peak covers them. The retained GMS originals stay alive until
-    # commit, for readers to materialize from.
-    retained_gms_tensors: list[torch.Tensor] = []
-    rebound_bytes = rebind_nonparameter_tensors(
-        gms_client, model, retain_gms_tensors=retained_gms_tensors
-    )
-    _store_pending_gms_write(gms_client, stats, rebound_bytes, retained_gms_tensors)
+    # profiled peak covers them.
+    rebound_bytes = rebind_nonparameter_tensors(gms_client, model)
+    _store_pending_gms_write(gms_client, stats, rebound_bytes)
 
     logger.info(
         "[GMS] Write mode: prepared %.2f GiB for publication after profiling "
@@ -388,9 +380,6 @@ def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
         with meta_device:
             model = initialize_model(vllm_config=vllm_config, model_config=model_config)
 
-    try:
-        process_weights_after_loading(model, model_config, meta_device)
-    except Exception as e:
-        logger.debug("[GMS] Post-processing on meta tensors: %s", e)
+    process_weights_after_loading(model, model_config, meta_device)
 
     return model

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -287,6 +287,33 @@ def _load_write_mode(
     default_loader,
     target_device: torch.device,
 ) -> torch.nn.Module:
+    """Load a writer model, releasing its lease on every failed preparation."""
+    try:
+        return _load_write_mode_impl(
+            gms_client,
+            vllm_config,
+            model_config,
+            default_loader,
+            target_device,
+        )
+    except BaseException:
+        try:
+            if _pending_gms_client is gms_client:
+                abort_pending_gms_write()
+            else:
+                gms_client.close(best_effort=True)
+        except BaseException:
+            logger.exception("[GMS] Failed to release failed write-mode load")
+        raise
+
+
+def _load_write_mode_impl(
+    gms_client: "GMSClientMemoryManager",
+    vllm_config,
+    model_config,
+    default_loader,
+    target_device: torch.device,
+) -> torch.nn.Module:
     """Load model from disk and prepare weights for GMS publication (RW mode).
 
     Initializes model using GMS memory pool, loads weights from disk,

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import gc
 import sys
 import weakref
 from contextlib import nullcontext
@@ -30,7 +31,11 @@ from gpu_memory_service.client.torch.module import (
     rebind_nonparameter_tensors,
     register_module_tensors,
 )
-from gpu_memory_service.client.torch.tensor import STORAGE_MANIFEST_PREFIX, Slot
+from gpu_memory_service.client.torch.tensor import (
+    STORAGE_MANIFEST_PREFIX,
+    ModuleTensorBinding,
+    ModuleTensorKind,
+)
 from gpu_memory_service.integrations.common import utils as common_utils
 from gpu_memory_service.integrations.trtllm import model_loader as trtllm_model_loader
 from gpu_memory_service.integrations.vllm import model_loader
@@ -177,7 +182,23 @@ def _writer_for_tensor(tensor: torch.Tensor):
     return store, _Manager(store, allocations, mapped=True)
 
 
-def test_manifest_groups_exact_alias_slots_and_shared_storage_objects():
+def test_module_tensor_binding_round_trip_uses_lowercase_kind():
+    binding = ModuleTensorBinding(
+        "value",
+        ModuleTensorKind.NONPERSISTENT_BUFFER,
+    )
+    encoded = msgspec.msgpack.encode(binding)
+
+    assert msgspec.msgpack.decode(encoded) == {
+        "path": "value",
+        "kind": "nonpersistent_buffer",
+    }
+    decoded = msgspec.msgpack.decode(encoded, type=ModuleTensorBinding)
+    assert decoded == binding
+    assert decoded.kind is ModuleTensorKind.NONPERSISTENT_BUFFER
+
+
+def test_manifest_groups_exact_alias_bindings_and_shared_storage_objects():
     backing = torch.arange(8, dtype=torch.float32)
     first = backing[1:7:2]
     second = torch.empty(0).set_(
@@ -208,13 +229,15 @@ def test_manifest_groups_exact_alias_slots_and_shared_storage_objects():
         "stride": [2],
         "storage_offset_bytes": 4,
         "requires_grad": False,
-        "slots": [
+        "bindings": [
             {"path": "first", "kind": "attribute"},
             {"path": "first_alias", "kind": "attribute"},
         ],
     }
     assert manifest["objects"][1]["storage_offset_bytes"] == 8
-    assert manifest["objects"][1]["slots"] == [{"path": "second", "kind": "attribute"}]
+    assert manifest["objects"][1]["bindings"] == [
+        {"path": "second", "kind": "attribute"}
+    ]
     assert "allocation_id" not in payload.decode("latin1")
 
 
@@ -434,7 +457,7 @@ def test_parameter_subclass_state_comes_from_canonical_reader_template(
     torch.testing.assert_close(parameter, source)
 
 
-def test_reader_creates_writer_final_slots_absent_from_initial_model(
+def test_reader_creates_writer_final_bindings_absent_from_initial_model(
     cpu_storage_pointer,
 ):
     source = torch.nn.Parameter(
@@ -644,12 +667,14 @@ def test_reader_validates_storage_envelope_alignment_before_mapping():
     "mutate",
     [
         lambda manifest: manifest.update({"unknown": True}),
-        lambda manifest: manifest["objects"][0]["slots"][0].update({"kind": "invalid"}),
-        lambda manifest: manifest["objects"][0]["slots"].append(
-            manifest["objects"][0]["slots"][0].copy()
+        lambda manifest: manifest["objects"][0]["bindings"][0].update(
+            {"kind": "invalid"}
+        ),
+        lambda manifest: manifest["objects"][0]["bindings"].append(
+            manifest["objects"][0]["bindings"][0].copy()
         ),
     ],
-    ids=("unknown-field", "invalid-literal", "duplicate-slot"),
+    ids=("unknown-field", "invalid-enum", "duplicate-binding"),
 )
 def test_reader_rejects_compact_malformed_manifest_cases(mutate):
     tensor = torch.arange(4, dtype=torch.float32)
@@ -707,7 +732,7 @@ def test_reader_rejects_noncontiguous_ordinals_and_overlapping_manifests():
     store.entries[key] = store.entries.pop(f"{STORAGE_MANIFEST_PREFIX}1")
     allocation_id, _, payload = store.entries[key]
     second = msgspec.msgpack.decode(payload)
-    second["objects"][0]["slots"][0]["path"] = "other"
+    second["objects"][0]["bindings"][0]["path"] = "other"
     store.entries[f"{STORAGE_MANIFEST_PREFIX}1"] = (
         allocation_id,
         4,
@@ -803,7 +828,9 @@ def test_discovery_does_not_invoke_properties_or_walk_helper_graphs():
     manifest = msgspec.msgpack.decode(next(iter(store.entries.values()))[2])
 
     assert model.property_reads == 0
-    assert manifest["objects"][0]["slots"] == [{"path": "direct", "kind": "attribute"}]
+    assert manifest["objects"][0]["bindings"] == [
+        {"path": "direct", "kind": "attribute"}
+    ]
 
 
 def test_unregistered_parameter_and_zero_byte_storage_are_rejected():
@@ -839,11 +866,35 @@ def test_publisher_rebind_clones_storage_once_and_retains_one_source_owner():
     assert model.view is view
     assert model.backing.untyped_storage()._cdata != old_storage
     assert model.backing.untyped_storage()._cdata == model.view.untyped_storage()._cdata
-    owners = model.__dict__["_gms_rebound_tensor_owners"].tensors
+    sentinel, owners = model.__dict__["_gms_displaced_source_tensors"]
+    assert sentinel is torch_module._DISPLACED_SOURCE_TENSORS_SENTINEL
     assert len(owners) == 1
     assert owners[0].untyped_storage()._cdata == old_storage
+    owner_ref = weakref.ref(owners[0])
+    del owners
+    gc.collect()
+    retained_owner = owner_ref()
+    assert retained_owner is not None
+    assert retained_owner.untyped_storage()._cdata == old_storage
     model.view.add_(10)
     torch.testing.assert_close(model.backing[1::2], model.view)
+
+
+def test_second_rebind_preserves_displaced_source_owner_state():
+    tensor = torch.arange(4, dtype=torch.float32)
+    model = torch.nn.Module()
+    model.runtime = tensor
+    _, manager = _writer_for_tensor(tensor)
+
+    rebind_nonparameter_tensors(manager, model)
+    owner_state = model.__dict__["_gms_displaced_source_tensors"]
+    owners = owner_state[1]
+    owner = owners[0]
+
+    assert rebind_nonparameter_tensors(manager, model) == 0
+    assert model.__dict__["_gms_displaced_source_tensors"] is owner_state
+    assert len(owners) == 1
+    assert owners[0] is owner
 
 
 def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
@@ -852,8 +903,14 @@ def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
     with torch.no_grad():
         view = parameter[1::2]
     objects = [
-        torch_module._DiscoveredObject(parameter, [Slot("weight", "parameter")]),
-        torch_module._DiscoveredObject(view, [Slot("view", "attribute")]),
+        torch_module._DiscoveredTensor(
+            parameter,
+            [ModuleTensorBinding("weight", ModuleTensorKind.PARAMETER)],
+        ),
+        torch_module._DiscoveredTensor(
+            view,
+            [ModuleTensorBinding("view", ModuleTensorKind.ATTRIBUTE)],
+        ),
     ]
     target_storage = parameter.detach().clone().untyped_storage()
     replacements = {}
@@ -867,7 +924,7 @@ def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
             int(tensor.storage_offset()),
         )
         if isinstance(tensor, torch.nn.Parameter):
-            replacement = torch_module._make_parameter(
+            replacement = torch_module._make_parameter_from_template(
                 tensor,
                 replacement,
                 path="weight",
@@ -876,7 +933,7 @@ def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
         replacements[id(tensor)] = replacement
         del replacement
 
-    torch_module._swap_discovered_objects(objects, replacements)
+    torch_module._swap_discovered_tensors(objects, replacements)
 
     assert replacements == {}
     assert parameter.untyped_storage()._cdata == view.untyped_storage()._cdata
@@ -888,8 +945,14 @@ def test_swap_preflight_failure_does_not_mutate_earlier_objects():
     first = torch.arange(4, dtype=torch.float32)
     second = torch.arange(4, dtype=torch.float32) + 10
     objects = [
-        torch_module._DiscoveredObject(first, [Slot("first", "attribute")]),
-        torch_module._DiscoveredObject(second, [Slot("second", "attribute")]),
+        torch_module._DiscoveredTensor(
+            first,
+            [ModuleTensorBinding("first", ModuleTensorKind.ATTRIBUTE)],
+        ),
+        torch_module._DiscoveredTensor(
+            second,
+            [ModuleTensorBinding("second", ModuleTensorKind.ATTRIBUTE)],
+        ),
     ]
     replacements = {
         id(first): torch.full_like(first, 20),
@@ -900,7 +963,7 @@ def test_swap_preflight_failure_does_not_mutate_earlier_objects():
     second_ref = weakref.ref(second)
 
     with pytest.raises(RuntimeError, match="second.*weakref"):
-        torch_module._swap_discovered_objects(objects, replacements)
+        torch_module._swap_discovered_tensors(objects, replacements)
 
     assert second_ref() is second
     assert first.untyped_storage()._cdata == first_storage
@@ -909,11 +972,23 @@ def test_swap_preflight_failure_does_not_mutate_earlier_objects():
     torch.testing.assert_close(second, torch.arange(4, dtype=torch.float32) + 10)
 
 
-def test_rebound_tensor_owner_rejects_existing_none():
+def test_displaced_source_collision_is_rejected_without_rebind_candidate():
+    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+    model = torch.nn.Module()
+    model.weight = parameter
+    model.__dict__["_gms_displaced_source_tensors"] = [torch.ones(1)]
+    _, manager = _writer_for_tensor(parameter)
+
+    with pytest.raises(RuntimeError, match="Reserved GMS attribute"):
+        rebind_nonparameter_tensors(manager, model)
+
+
+def test_displaced_source_collision_is_rejected_on_submodule():
     tensor = torch.arange(4, dtype=torch.float32)
     model = torch.nn.Module()
-    model.runtime = tensor
-    model.__dict__["_gms_rebound_tensor_owners"] = None
+    model.child = torch.nn.Module()
+    model.child.runtime = tensor
+    model.child.__dict__["_gms_displaced_source_tensors"] = None
     _, manager = _writer_for_tensor(tensor)
 
     with pytest.raises(RuntimeError, match="Reserved GMS attribute"):

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -808,7 +808,7 @@ def test_discovery_does_not_invoke_properties_or_walk_helper_graphs():
     ]
 
 
-def test_unregistered_parameter_and_zero_byte_storage_are_rejected():
+def test_selected_invalid_storage_is_rejected_before_publication_or_rebind():
     parameter = torch.nn.Parameter(torch.ones(1))
     model = torch.nn.Module()
     model.__dict__["hidden"] = parameter
@@ -816,12 +816,62 @@ def test_unregistered_parameter_and_zero_byte_storage_are_rejected():
     with pytest.raises(RuntimeError, match="Unregistered Parameter"):
         register_module_tensors(writer, model)
 
+    valid = torch.arange(4, dtype=torch.float32)
     empty = torch.empty(0)
     model = torch.nn.Module()
+    model.valid = valid
     model.empty = empty
-    _, writer = _writer_for_tensor(empty)
+    store = _MetadataStore()
+    writer = _Manager(
+        store,
+        {
+            "valid": (
+                valid.untyped_storage().data_ptr(),
+                valid.untyped_storage().nbytes(),
+            ),
+            "empty": (empty.untyped_storage().data_ptr(), 0),
+        },
+        mapped=True,
+    )
+    old_storage = valid.untyped_storage()._cdata
     with pytest.raises(RuntimeError, match="zero-byte"):
         register_module_tensors(writer, model)
+    assert store.entries == {}
+    with pytest.raises(RuntimeError, match="zero-byte"):
+        rebind_nonparameter_tensors(writer, model)
+    assert valid.untyped_storage()._cdata == old_storage
+
+
+def test_unmapped_unsupported_nonparameters_are_ignored():
+    valid = torch.arange(4, dtype=torch.float32)
+    empty = torch.empty(0)
+    autograd = torch.ones(1, requires_grad=True)
+    model = torch.nn.Module()
+    model.valid = valid
+    model.register_buffer("empty", empty)
+    model.autograd = autograd
+    store, writer = _writer_for_tensor(valid)
+    empty_storage = empty.untyped_storage()._cdata
+    autograd_storage = autograd.untyped_storage()._cdata
+
+    assert register_module_tensors(writer, model) == {"allocation"}
+    manifest = msgspec.msgpack.decode(next(iter(store.entries.values()))[2])
+    assert [binding["path"] for binding in manifest["objects"][0]["bindings"]] == [
+        "valid"
+    ]
+
+    model.register_parameter("cpu_weight", torch.nn.Parameter(torch.ones(1)))
+    with pytest.raises(RuntimeError, match=r"Parameter 'cpu_weight'.*not contained"):
+        register_module_tensors(writer, model)
+    model.cpu_weight = None
+
+    old_valid_storage = valid.untyped_storage()._cdata
+    assert (
+        rebind_nonparameter_tensors(writer, model) == valid.untyped_storage().nbytes()
+    )
+    assert valid.untyped_storage()._cdata != old_valid_storage
+    assert empty.untyped_storage()._cdata == empty_storage
+    assert autograd.untyped_storage()._cdata == autograd_storage
 
 
 def test_publisher_rebind_clones_once_retains_source_and_is_idempotent():
@@ -888,7 +938,6 @@ def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
             replacement = torch_module._make_parameter_from_template(
                 tensor,
                 replacement,
-                path="weight",
                 requires_grad=True,
             )
         replacements[id(tensor)] = replacement
@@ -923,7 +972,7 @@ def test_swap_preflight_failure_does_not_mutate_earlier_objects():
     second_storage = second.untyped_storage()._cdata
     second_ref = weakref.ref(second)
 
-    with pytest.raises(RuntimeError, match="second.*weakref"):
+    with pytest.raises(RuntimeError, match=r"second.*weakref"):
         torch_module._swap_discovered_tensors(objects, replacements)
 
     assert second_ref() is second

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -1,13 +1,14 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Unit tests for deferred GMS write publication in the vLLM integration."""
+"""Focused tests for GMS storage-manifest publication and materialization."""
 
 from __future__ import annotations
 
-import json
+import sys
 import weakref
-from types import SimpleNamespace
+from contextlib import nullcontext
+from types import ModuleType, SimpleNamespace
 
 import pytest
 from _deps import HAS_GMS, HAS_TORCH
@@ -21,16 +22,17 @@ if not HAS_GMS:
 if not HAS_TORCH:
     pytest.skip("torch is required", allow_module_level=True)
 
+import msgspec
 import torch
 from gpu_memory_service.client.torch import module as torch_module
 from gpu_memory_service.client.torch.module import (
-    _iter_module_tensors,
     materialize_module_from_gms,
     rebind_nonparameter_tensors,
     register_module_tensors,
 )
-from gpu_memory_service.client.torch.tensor import GMSTensorSpec, TensorMetadata
+from gpu_memory_service.client.torch.tensor import STORAGE_MANIFEST_PREFIX, Slot
 from gpu_memory_service.integrations.common import utils as common_utils
+from gpu_memory_service.integrations.trtllm import model_loader as trtllm_model_loader
 from gpu_memory_service.integrations.vllm import model_loader
 
 pytestmark = [
@@ -41,10 +43,64 @@ pytestmark = [
 ]
 
 
+class _MetadataStore:
+    def __init__(self) -> None:
+        self.entries: dict[str, tuple[str, int, bytes]] = {}
+
+
+class _Manager:
+    def __init__(
+        self,
+        store: _MetadataStore,
+        allocations: dict[str, tuple[int, int]],
+        *,
+        mapped: bool,
+    ) -> None:
+        self.device = 0
+        self.store = store
+        self.allocations = allocations
+        self.mappings = {}
+        self.mapping_calls: list[str] = []
+        self.freed: list[int] = []
+        if mapped:
+            for allocation_id, (va, nbytes) in allocations.items():
+                self.mappings[va] = SimpleNamespace(
+                    allocation_id=allocation_id,
+                    aligned_size=nbytes,
+                )
+
+    def metadata_put(self, *, key, allocation_id, offset_bytes, value):
+        self.store.entries[key] = (allocation_id, offset_bytes, value)
+        return True
+
+    def metadata_list(self, prefix=""):
+        return sorted(key for key in self.store.entries if key.startswith(prefix))
+
+    def metadata_get(self, key):
+        return self.store.entries.get(key)
+
+    def create_mapping(self, *, allocation_id):
+        self.mapping_calls.append(allocation_id)
+        for va, mapping in self.mappings.items():
+            if mapping.allocation_id == allocation_id:
+                return va
+        va, nbytes = self.allocations[allocation_id]
+        self.mappings[va] = SimpleNamespace(
+            allocation_id=allocation_id,
+            aligned_size=nbytes,
+        )
+        return va
+
+    def free_va(self, va):
+        self.freed.append(va)
+        del self.mappings[va]
+
+
 class _FakeAllocator:
     def __init__(self, events: list[str], *, fail_commit: bool = False):
         self.events = events
         self.fail_commit = fail_commit
+        self.fail_close = False
         self.total_bytes = 100
         self.mappings = {
             1: SimpleNamespace(allocation_id="weight", aligned_size=60),
@@ -64,11 +120,24 @@ class _FakeAllocator:
 
     def close(self, *, best_effort=False):
         self.events.append("close_best_effort" if best_effort else "close")
+        if self.fail_close:
+            raise RuntimeError("close failed")
+
+
+@pytest.fixture
+def cpu_storage_pointer(monkeypatch):
+    def storage_from_pointer(data_ptr, size_bytes, _device_index):
+        return torch._C._construct_storage_from_data_pointer(
+            data_ptr,
+            torch.device("cpu"),
+            size_bytes,
+        )
+
+    monkeypatch.setattr(torch_module, "_storage_from_pointer", storage_from_pointer)
 
 
 @pytest.fixture
 def gms_write(monkeypatch):
-    """A prepared (registered + pruned, uncommitted) fake GMS write."""
     events = []
     allocator = _FakeAllocator(events)
 
@@ -87,7 +156,7 @@ def gms_write(monkeypatch):
     monkeypatch.setattr(
         common_utils,
         "rebind_nonparameter_tensors",
-        lambda _allocator, _model, **_kwargs: events.append("rebind") or 12,
+        lambda _allocator, _model: events.append("rebind") or 12,
     )
 
     stats = common_utils.prepare_gms_write(allocator, object())
@@ -97,374 +166,201 @@ def gms_write(monkeypatch):
 @pytest.fixture(autouse=True)
 def clear_pending_write(monkeypatch):
     monkeypatch.setattr(model_loader, "_pending_gms_client", None)
-    monkeypatch.setattr(model_loader, "_pending_retained_gms_tensors", [])
     monkeypatch.setattr(model_loader, "_last_imported_weights_bytes", 0)
     monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
 
 
-def test_prepare_registers_prunes_and_defers_commit(gms_write):
-    """Prepare must not commit; accounting covers pruned and rebound bytes."""
-    allocator, stats, events = gms_write
-
-    assert events == ["register", "prune"]
-    assert stats.committed_bytes == 60
-    assert stats.pruned_bytes == 40
-    assert stats.pruned_count == 1
-
-    model_loader._store_pending_gms_write(allocator, stats, 12, [])
-
-    assert model_loader.get_imported_weights_bytes() == 60
-    assert model_loader.get_model_memory_usage_offset_bytes() == 52
-
-
-def test_pending_write_publish_clears_pending(gms_write):
-    allocator, stats, events = gms_write
-    model_loader._store_pending_gms_write(allocator, stats, 12, [])
-    assert model_loader.has_pending_gms_write()
-
-    assert model_loader.publish_pending_gms_write()
-
-    assert events == ["register", "prune", "commit", "connect", "remap"]
-    assert not model_loader.has_pending_gms_write()
-    assert not model_loader.publish_pending_gms_write()
-
-
-def test_pending_write_abort_releases_writer_without_cuda_cleanup(gms_write):
-    allocator, stats, events = gms_write
-    retained = [object()]
-    model_loader._store_pending_gms_write(allocator, stats, 12, retained)
-
-    assert model_loader.abort_pending_gms_write()
-
-    assert events == ["register", "prune", "close_best_effort"]
-    assert "close" not in events
-    assert model_loader._pending_retained_gms_tensors == []
-    assert not model_loader.has_pending_gms_write()
-    assert not model_loader.abort_pending_gms_write()
-
-
-def test_publication_failure_releases_writer_and_preserves_error(gms_write):
-    allocator, stats, events = gms_write
-    allocator.fail_commit = True
-    model_loader._store_pending_gms_write(allocator, stats, 12, [])
-
-    with pytest.raises(RuntimeError, match="commit failed"):
-        model_loader.publish_pending_gms_write()
-
-    assert events == ["register", "prune", "commit", "close_best_effort"]
-    assert not model_loader.has_pending_gms_write()
-
-
-def test_eager_finalize_preserves_publish_then_rebind_order(gms_write):
-    """SGLang/TRT-LLM keep the eager register->commit->reconnect->rebind flow."""
-    allocator, _, events = gms_write
-    events.clear()
-    allocator.total_bytes = 100
-    allocator.mappings[2] = SimpleNamespace(allocation_id="scratch", aligned_size=40)
-
-    stats = common_utils.finalize_gms_write(allocator, object())
-
-    assert stats.committed_bytes == 60
-    assert stats.pruned_bytes == 40
-    assert events == [
-        "register",
-        "prune",
-        "commit",
-        "connect",
-        "remap",
-        "rebind",
-    ]
-
-
-def _manager_for(tensor):
+def _writer_for_tensor(tensor: torch.Tensor):
+    store = _MetadataStore()
     storage = tensor.untyped_storage()
-    return SimpleNamespace(
-        mappings={
-            storage.data_ptr(): SimpleNamespace(
-                allocation_id="allocation",
-                aligned_size=storage.nbytes(),
-            )
-        }
+    allocations = {"allocation": (storage.data_ptr(), storage.nbytes())}
+    return store, _Manager(store, allocations, mapped=True)
+
+
+def test_manifest_groups_exact_alias_slots_and_shared_storage_objects():
+    backing = torch.arange(8, dtype=torch.float32)
+    first = backing[1:7:2]
+    second = torch.empty(0).set_(
+        backing.untyped_storage(),
+        2,
+        (3,),
+        (1,),
     )
+    model = torch.nn.Module()
+    model.first = first
+    model.first_alias = first
+    model.second = second
+    store, writer = _writer_for_tensor(backing)
+
+    assert register_module_tensors(writer, model) == {"allocation"}
+    assert list(store.entries) == [f"{STORAGE_MANIFEST_PREFIX}0"]
+
+    allocation_id, storage_base_offset, payload = next(iter(store.entries.values()))
+    manifest = msgspec.msgpack.decode(payload)
+    assert allocation_id == "allocation"
+    assert storage_base_offset == 0
+    assert set(manifest) == {"nbytes", "objects"}
+    assert manifest["nbytes"] == backing.untyped_storage().nbytes()
+    assert len(manifest["objects"]) == 2
+    assert manifest["objects"][0] == {
+        "dtype": "float32",
+        "shape": [3],
+        "stride": [2],
+        "storage_offset_bytes": 4,
+        "requires_grad": False,
+        "slots": [
+            {"path": "first", "kind": "attribute"},
+            {"path": "first_alias", "kind": "attribute"},
+        ],
+    }
+    assert manifest["objects"][1]["storage_offset_bytes"] == 8
+    assert manifest["objects"][1]["slots"] == [{"path": "second", "kind": "attribute"}]
+    assert "allocation_id" not in payload.decode("latin1")
 
 
-def _set_module_tensors(monkeypatch, *entries):
-    monkeypatch.setattr(
-        torch_module, "_iter_module_tensors", lambda _model: iter(entries)
+def test_reader_replaces_split_and_shared_placeholder_topology(cpu_storage_pointer):
+    backing = torch.arange(8, dtype=torch.float32)
+    exact = backing[::2]
+    distinct = torch.empty(0).set_(
+        backing.untyped_storage(),
+        1,
+        (4,),
+        (2,),
     )
+    writer_model = torch.nn.Module()
+    writer_model.exact_a = exact
+    writer_model.exact_b = exact
+    writer_model.distinct_a = backing
+    writer_model.distinct_b = distinct
+    store, writer = _writer_for_tensor(backing)
+    register_module_tensors(writer, writer_model)
+
+    shared_placeholder = torch.zeros(1)
+    reader_model = torch.nn.Module()
+    reader_model.exact_a = torch.zeros(2)
+    reader_model.exact_b = torch.ones(3, dtype=torch.float64)
+    reader_model.distinct_a = shared_placeholder
+    reader_model.distinct_b = shared_placeholder
+    names = ("exact_a", "exact_b", "distinct_a", "distinct_b")
+    old_placeholders = tuple(reader_model.__dict__[name] for name in names)
+    reader = _Manager(store, writer.allocations, mapped=False)
+
+    materialize_module_from_gms(reader, reader_model, device_index=0)
+
+    assert reader.mapping_calls == ["allocation"]
+    assert reader_model.exact_a is reader_model.exact_b
+    assert reader_model.distinct_a is not reader_model.distinct_b
+    assert all(
+        reader_model.__dict__[name] is not old
+        for name, old in zip(names, old_placeholders, strict=True)
+    )
+    storage_ids = {
+        reader_model.__dict__[name].untyped_storage()._cdata for name in names
+    }
+    assert len(storage_ids) == 1
+    assert backing.untyped_storage()._cdata not in storage_ids
+    torch.testing.assert_close(reader_model.exact_a, backing[::2])
+    torch.testing.assert_close(reader_model.distinct_b, backing[1::2])
+    reader_model.exact_a[1] = 99
+    assert reader_model.distinct_a[2].item() == 99
 
 
-def _spec(
-    tensor,
-    tensor_type,
-    *,
-    allocation_id="allocation",
-    offset_bytes=0,
+def test_mixed_dtype_byte_offsets_and_one_mapping_per_allocation(
+    cpu_storage_pointer,
 ):
-    return SimpleNamespace(
-        allocation_id=allocation_id,
-        offset_bytes=offset_bytes,
-        meta=TensorMetadata.from_tensor(tensor, tensor_type),
-        materialize=lambda _manager, _device: tensor.detach().clone(),
+    allocation = torch.tensor(
+        [0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0],
+        dtype=torch.uint8,
     )
-
-
-def _set_specs(monkeypatch, specs):
-    monkeypatch.setattr(
-        torch_module.GMSTensorSpec,
-        "load_all",
-        classmethod(lambda _cls, _manager: specs),
+    first_storage = torch._C._construct_storage_from_data_pointer(
+        allocation.data_ptr() + 4,
+        torch.device("cpu"),
+        8,
     )
-
-
-def _component_spec(
-    name,
-    tensor,
-    tensor_type,
-    *,
-    storage_group_id,
-    object_group_id,
-    storage_base_offset,
-    storage_nbytes,
-    buffer_persistent=False,
-    allocation_id="allocation",
-):
-    meta = TensorMetadata.from_tensor(
-        tensor,
-        tensor_type,
-        storage={
-            "schema_version": 1,
-            "storage_group_id": storage_group_id,
-            "object_group_id": object_group_id,
-            "storage_base_offset": storage_base_offset,
-            "storage_nbytes": storage_nbytes,
-            "storage_offset": tensor.storage_offset(),
-            "buffer_persistent": buffer_persistent,
-        },
+    second_storage = torch._C._construct_storage_from_data_pointer(
+        allocation.data_ptr() + 12,
+        torch.device("cpu"),
+        4,
     )
-    element_size = tensor.element_size()
-    return GMSTensorSpec(
-        key=name,
-        name=name,
-        allocation_id=allocation_id,
-        offset_bytes=storage_base_offset + tensor.storage_offset() * element_size,
-        meta=meta,
-    )
+    octets = torch.empty(0, dtype=torch.uint8).set_(first_storage, 0, (8,), (1,))
+    words = torch.empty(0, dtype=torch.int32).set_(first_storage, 0, (2,), (1,))
+    tail = torch.empty(0, dtype=torch.int32).set_(second_storage, 0, (1,), (1,))
+    writer_model = torch.nn.Module()
+    writer_model.octets = octets
+    writer_model.words = words
+    writer_model.tail = tail
+    store = _MetadataStore()
+    allocations = {
+        "allocation": (allocation.data_ptr(), allocation.untyped_storage().nbytes())
+    }
+    writer = _Manager(store, allocations, mapped=True)
 
-
-def test_tensor_iteration_ignores_read_only_buffer_alias_property():
-    class RoutedExpertsLike(torch.nn.Module):
-        def __init__(self):
-            super().__init__()
-            self.property_reads = 0
-            self.register_buffer(
-                "_expert_map",
-                torch.empty(4, device="meta", dtype=torch.int32),
-                persistent=False,
-            )
-
-        @property
-        def expert_map(self):
-            self.property_reads += 1
-            return self._expert_map
-
-    model = RoutedExpertsLike()
-
-    assert list(_iter_module_tensors(model)) == []
-    assert model.property_reads == 0
-    assert "_expert_map" in model._non_persistent_buffers_set
-
-
-def test_rebind_does_not_swap_parameter_alias(monkeypatch):
-    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
-    model = torch.nn.Module()
-    model.register_parameter("weight", parameter)
-    model.__dict__["parameter_alias"] = parameter
-    _set_module_tensors(
-        monkeypatch,
-        ("weight", parameter, "parameter"),
-        ("parameter_alias", parameter, "tensor_attr"),
-    )
-    parameter_ptr = parameter.data_ptr()
-    retained = []
-
-    assert (
-        rebind_nonparameter_tensors(
-            _manager_for(parameter), model, retain_gms_tensors=retained
-        )
-        == 0
-    )
-    assert model.weight is model.parameter_alias is parameter
-    assert parameter.data_ptr() == parameter_ptr
-    assert retained == []
-
-
-def test_rebound_tensor_owner_is_collision_safe(monkeypatch):
-    model = torch.nn.Module()
-    model.__dict__["_gms_rebound_tensor_owners"] = None
-    tensor = torch.zeros(4)
-    model.runtime = tensor
-    _set_module_tensors(monkeypatch, ("runtime", tensor, "tensor_attr"))
-
-    with pytest.raises(RuntimeError, match="Reserved GMS attribute"):
-        rebind_nonparameter_tensors(_manager_for(tensor), model)
-
-
-def test_rebind_fails_closed_when_swap_rejects_weakref(monkeypatch):
-    source = torch.arange(4)
-    source_ref = weakref.ref(source)
-    model = torch.nn.Module()
-    model.runtime = source
-    _set_module_tensors(monkeypatch, ("runtime", source, "tensor_attr"))
-    source_ptr = source.data_ptr()
-
-    with pytest.raises(RuntimeError, match="does not support weak references"):
-        rebind_nonparameter_tensors(_manager_for(source), model)
-
-    assert source_ref() is source
-    assert source.data_ptr() == source_ptr
-
-
-def test_rebind_supports_discovered_view_with_undiscovered_base(monkeypatch):
-    base = torch.arange(8)
-    view = base[::2]
-    model = torch.nn.Module()
-    model.view = view
-    _set_module_tensors(monkeypatch, ("view", view, "tensor_attr"))
-
-    assert rebind_nonparameter_tensors(_manager_for(base), model) == base.nbytes
-    torch.testing.assert_close(model.view, torch.tensor([0, 2, 4, 6]))
-
-
-def test_rebind_skips_ephemeral_property_view(monkeypatch):
-    class Model(torch.nn.Module):
-        @property
-        def derived(self):
-            return self.runtime[:]
-
-    model = Model()
-    model.runtime = torch.arange(4)
-    runtime_ptr = model.runtime.data_ptr()
-
-    def iter_tensors(_model):
-        yield ("derived", model.derived, "tensor_attr")
-        yield ("runtime", model.runtime, "tensor_attr")
-
-    monkeypatch.setattr(torch_module, "_iter_module_tensors", iter_tensors)
-
-    assert (
-        rebind_nonparameter_tensors(_manager_for(model.runtime), model)
-        == model.runtime.numel() * model.runtime.element_size()
-    )
-    assert model.runtime.data_ptr() != runtime_ptr
-
-
-@pytest.mark.parametrize("alias_first", [False, True])
-def test_reader_parameter_alias_keeps_parameter_identity(monkeypatch, alias_first):
-    parameter = torch.nn.Parameter(torch.zeros(4))
-    model = torch.nn.Module()
-    model.register_parameter("weight", parameter)
-    model.__dict__["weight_alias"] = parameter
-    expected = torch.arange(4, dtype=torch.float32)
-    entries = [
-        ("weight", _spec(expected, "parameter")),
-        ("weight_alias", _spec(expected, "tensor_attr")),
+    assert register_module_tensors(writer, writer_model) == {"allocation"}
+    assert list(store.entries) == [
+        f"{STORAGE_MANIFEST_PREFIX}0",
+        f"{STORAGE_MANIFEST_PREFIX}1",
     ]
-    if alias_first:
-        entries.reverse()
-    _set_specs(monkeypatch, dict(entries))
+    assert [entry[1] for entry in store.entries.values()] == [4, 12]
 
-    materialize_module_from_gms(object(), model, device_index=0)
+    reader_model = torch.nn.Module()
+    reader_model.octets = torch.empty(0)
+    reader_model.words = torch.empty(0)
+    reader_model.tail = torch.empty(0)
+    reader = _Manager(store, allocations, mapped=True)
+    materialize_module_from_gms(reader, reader_model, device_index=0)
 
-    assert model.weight is model.weight_alias is parameter
-    assert type(parameter) is torch.nn.Parameter
-    assert model._parameters["weight"] is parameter
-    torch.testing.assert_close(parameter, expected)
+    assert reader.mapping_calls == ["allocation"]
+    assert reader_model.octets.dtype == torch.uint8
+    assert reader_model.words.dtype == torch.int32
+    assert (
+        reader_model.octets.untyped_storage()._cdata
+        == reader_model.words.untyped_storage()._cdata
+        != reader_model.tail.untyped_storage()._cdata
+    )
+    assert reader_model.octets.untyped_storage()._cdata != first_storage._cdata
+    assert reader_model.tail.untyped_storage()._cdata != second_storage._cdata
+    torch.testing.assert_close(
+        reader_model.words,
+        torch.tensor([1, 2], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        reader_model.tail,
+        torch.tensor([3], dtype=torch.int32),
+    )
+    reader_model.words[0] = 257
+    torch.testing.assert_close(
+        reader_model.octets,
+        torch.tensor([1, 1, 0, 0, 2, 0, 0, 0], dtype=torch.uint8),
+    )
 
 
-@pytest.mark.parametrize("alias_first", [False, True])
-def test_reader_parameter_alias_conflict_fails_before_mutation(
-    monkeypatch, alias_first
+def test_nonpersistent_buffer_direct_list_and_tuple_bind_same_source_object(
+    cpu_storage_pointer,
 ):
-    parameter = torch.nn.Parameter(torch.zeros(4))
-    model = torch.nn.Module()
-    model.register_parameter("weight", parameter)
-    model.__dict__["weight_alias"] = parameter
-    entries = [
-        ("weight", _spec(torch.ones(4), "parameter")),
-        (
-            "weight_alias",
-            _spec(torch.ones(4), "tensor_attr", offset_bytes=16),
-        ),
-    ]
-    if alias_first:
-        entries.reverse()
-    _set_specs(monkeypatch, dict(entries))
+    tensor = torch.arange(4, dtype=torch.float32)
+    writer_model = torch.nn.Module()
+    writer_model.register_buffer("runtime", tensor, persistent=False)
+    writer_model.direct = tensor
+    writer_model.values = [tensor]
+    writer_model.fixed = (tensor,)
+    store, writer = _writer_for_tensor(tensor)
+    register_module_tensors(writer, writer_model)
 
-    with pytest.raises(RuntimeError, match="aliases incompatible GMS entries"):
-        materialize_module_from_gms(object(), model, device_index=0)
+    reader_model = torch.nn.Module()
+    reader_model.register_buffer("runtime", torch.zeros(1))
+    reader_model.direct = torch.zeros(2)
+    reader_model.values = [torch.zeros(3)]
+    old_tuple = (torch.zeros(5),)
+    reader_model.fixed = old_tuple
+    reader = _Manager(store, writer.allocations, mapped=False)
+    materialize_module_from_gms(reader, reader_model, device_index=0)
 
-    assert model.weight is model.weight_alias is parameter
-    assert type(parameter) is torch.nn.Parameter
-    assert model._parameters["weight"] is parameter
-    torch.testing.assert_close(parameter, torch.zeros(4))
-
-
-def test_reader_preserves_nonpersistent_buffer(monkeypatch):
-    model = torch.nn.Module()
-    buffer = torch.zeros(4)
-    model.register_buffer("expert_mask", buffer, persistent=False)
-    _set_specs(monkeypatch, {"expert_mask": _spec(torch.ones(4), "buffer")})
-
-    materialize_module_from_gms(object(), model, device_index=0)
-
-    assert model.expert_mask is buffer
-    assert model._buffers["expert_mask"] is buffer
-    assert "expert_mask" in model._non_persistent_buffers_set
-    assert "expert_mask" not in model.state_dict()
-    torch.testing.assert_close(buffer, torch.ones(4))
-
-
-def test_legacy_reader_rejects_discovered_view_placeholders(monkeypatch):
-    model = torch.nn.Module()
-    model.first = torch.zeros(4)
-    model.view = model.first[:]
-    _set_specs(
-        monkeypatch,
-        {
-            "first": _spec(torch.ones(4), "tensor_attr"),
-            "view": _spec(torch.ones(4), "tensor_attr"),
-        },
-    )
-
-    with pytest.raises(RuntimeError, match="cannot materialize tensor view"):
-        materialize_module_from_gms(object(), model, device_index=0)
-
-    torch.testing.assert_close(model.first, torch.zeros(4))
-
-
-def test_legacy_reader_rejects_distinct_shared_storage_placeholders(monkeypatch):
-    model = torch.nn.Module()
-    model.first = torch.zeros(4)
-    model.second = torch.empty(0)
-    model.second.set_(model.first.untyped_storage(), 0, (4,), (1,))
-    assert model.second._base is None
-    _set_specs(
-        monkeypatch,
-        {
-            "first": _spec(torch.ones(4), "tensor_attr"),
-            "second": _spec(torch.ones(4), "tensor_attr"),
-        },
-    )
-
-    with pytest.raises(RuntimeError, match="distinct tensors that share storage"):
-        materialize_module_from_gms(object(), model, device_index=0)
-
-    torch.testing.assert_close(model.first, torch.zeros(4))
-
-
-class _TensorSubclass(torch.Tensor):
-    pass
+    assert reader_model.runtime is reader_model.direct
+    assert reader_model.runtime is reader_model.values[0]
+    assert reader_model.runtime is reader_model.fixed[0]
+    assert reader_model.fixed is not old_tuple
+    assert "runtime" in reader_model._non_persistent_buffers_set
+    assert "runtime" not in reader_model.state_dict()
 
 
 class _LoaderParameter(torch.nn.Parameter):
@@ -476,7 +372,6 @@ class _LoaderParameter(torch.nn.Parameter):
         *,
         weight_loader,
         tp_rank,
-        tp_size,
         requires_grad,
     ):
         return super().__new__(cls, data, requires_grad=requires_grad)
@@ -487,602 +382,835 @@ class _LoaderParameter(torch.nn.Parameter):
         *,
         weight_loader,
         tp_rank,
-        tp_size,
         requires_grad,
     ):
-        self._weight_loader = weight_loader
+        self.weight_loader = weight_loader
         self.tp_rank = tp_rank
-        self.tp_size = tp_size
-        self.slot_state = {"requires_constructor_arguments": True}
+        self.slot_state = {"loader_state": True}
 
 
-@pytest.mark.parametrize("alias_first", [False, True])
-def test_reader_materializes_parameter_subclass_without_losing_state(
-    monkeypatch, alias_first
+def test_parameter_subclass_state_comes_from_canonical_reader_template(
+    cpu_storage_pointer,
 ):
+    source = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+    writer_model = torch.nn.Module()
+    writer_model.register_parameter("left", source)
+    writer_model.register_parameter("right", source)
+    store, writer = _writer_for_tensor(source)
+    register_module_tensors(writer, writer_model)
+
     def weight_loader(tensor):
         return tensor
 
-    parameter = _LoaderParameter(
-        torch.zeros(4, device="meta"),
-        weight_loader=weight_loader,
-        tp_rank=2,
-        tp_size=8,
-        requires_grad=True,
-    )
-    parameter_state = parameter.__dict__
-    slot_state = parameter.slot_state
-    model = torch.nn.Module()
-    model.register_parameter("weight", parameter)
-    model.__dict__["weight_alias"] = parameter
-    expected = torch.arange(4, dtype=torch.float32)
-    entries = [
-        ("weight", _spec(expected, "parameter")),
-        ("weight_alias", _spec(expected, "tensor_attr")),
-    ]
-    if alias_first:
-        entries.reverse()
-    _set_specs(monkeypatch, dict(entries))
+    slot_state = {"loader_state": True}
 
-    materialize_module_from_gms(object(), model, device_index=0)
+    def template():
+        parameter = _LoaderParameter(
+            torch.empty(2, device="meta"),
+            weight_loader=weight_loader,
+            tp_rank=3,
+            requires_grad=True,
+        )
+        parameter.slot_state = slot_state
+        return parameter
 
-    assert model.weight is model.weight_alias is parameter
-    assert model._parameters["weight"] is parameter
+    reader_model = torch.nn.Module()
+    left = template()
+    right = torch.nn.Parameter(torch.empty(2, device="meta"), requires_grad=False)
+    right.uncomparable_state = torch.ones(2)
+    reader_model.register_parameter("left", left)
+    reader_model.register_parameter("right", right)
+    reader = _Manager(store, writer.allocations, mapped=False)
+    materialize_module_from_gms(reader, reader_model, device_index=0)
+
+    parameter = reader_model.left
+    assert parameter is reader_model.right
+    assert parameter is not left and parameter is not right
     assert type(parameter) is _LoaderParameter
-    assert parameter.__dict__ is parameter_state
-    assert parameter._weight_loader is weight_loader
-    assert parameter.tp_rank == 2
-    assert parameter.tp_size == 8
+    assert parameter.weight_loader is weight_loader
+    assert parameter.tp_rank == 3
     assert parameter.slot_state is slot_state
     assert parameter.requires_grad
-    assert not parameter.is_meta
-    torch.testing.assert_close(parameter, expected)
+    torch.testing.assert_close(parameter, source)
 
 
-def test_reader_rejects_weak_parameter_before_mutation(monkeypatch):
-    parameter = _LoaderParameter(
-        torch.zeros(4, device="meta"),
-        weight_loader=lambda tensor: tensor,
-        tp_rank=0,
-        tp_size=1,
+def test_reader_creates_writer_final_slots_absent_from_initial_model(
+    cpu_storage_pointer,
+):
+    source = torch.nn.Parameter(
+        torch.arange(4, dtype=torch.float32),
         requires_grad=False,
     )
-    parameter_ref = weakref.ref(parameter)
-    model = torch.nn.Module()
-    model.runtime = torch.zeros(4)
-    model.register_parameter("weight", parameter)
-    _set_specs(
-        monkeypatch,
-        {
-            "runtime": _spec(torch.ones(4), "tensor_attr"),
-            "weight": _spec(torch.ones(4), "parameter"),
-        },
-    )
+    runtime = torch.arange(3, dtype=torch.float32)
+    writer_model = torch.nn.Module()
+    writer_model.register_parameter("weight_scale", source)
+    writer_model.register_buffer("runtime_scale", runtime, persistent=False)
+    writer_model.final_scale = runtime
+    store = _MetadataStore()
+    allocations = {
+        "parameter": (
+            source.untyped_storage().data_ptr(),
+            source.untyped_storage().nbytes(),
+        ),
+        "runtime": (
+            runtime.untyped_storage().data_ptr(),
+            runtime.untyped_storage().nbytes(),
+        ),
+    }
+    writer = _Manager(store, allocations, mapped=True)
+    register_module_tensors(writer, writer_model)
 
-    with pytest.raises(RuntimeError, match="does not support weak references"):
-        materialize_module_from_gms(object(), model, device_index=0)
+    reader_model = torch.nn.Module()
+    reader_model.register_parameter("unrelated", torch.nn.Parameter(torch.empty(1)))
+    reader = _Manager(store, writer.allocations, mapped=False)
+    materialize_module_from_gms(reader, reader_model, device_index=0)
 
-    assert parameter_ref() is parameter
-    assert model._parameters["weight"] is parameter
-    assert type(parameter) is _LoaderParameter
-    assert parameter.is_meta
-    torch.testing.assert_close(model.runtime, torch.zeros(4))
-
-
-def test_nonparameter_component_copies_storage_once(monkeypatch):
-    base = torch.arange(8, dtype=torch.float32)
-    view = base[2::2]
-    model = torch.nn.Module()
-    model.base = base
-    model.view = view
-    manager = _manager_for(base)
-    old_storage = base.untyped_storage()._cdata
-    _set_module_tensors(
-        monkeypatch,
-        ("base", base, "tensor_attr"),
-        ("view", view, "tensor_attr"),
-    )
-
-    rebound = rebind_nonparameter_tensors(manager, model)
-
-    assert rebound == base.untyped_storage().nbytes()
-    assert model.base.untyped_storage()._cdata != old_storage
-    assert model.base.untyped_storage()._cdata == model.view.untyped_storage()._cdata
-    model.view.add_(10)
-    torch.testing.assert_close(model.base[2::2], model.view)
+    assert type(reader_model.weight_scale) is torch.nn.Parameter
+    assert not reader_model.weight_scale.requires_grad
+    assert reader_model.runtime_scale is reader_model.final_scale
+    assert "runtime_scale" in reader_model._non_persistent_buffers_set
+    torch.testing.assert_close(reader_model.weight_scale, source)
+    torch.testing.assert_close(reader_model.runtime_scale, runtime)
 
 
-def test_mixed_dtype_component_reconstructs_shared_storage(monkeypatch):
-    source_octets = torch.tensor([1, 0, 0, 0, 2, 0, 0, 0], dtype=torch.uint8)
-    source_storage = source_octets.untyped_storage()
-    source_words = torch.empty(0, dtype=torch.int32).set_(source_storage, 0, (2,), (1,))
-    writer = torch.nn.Module()
-    writer.octets = source_octets
-    writer.words = source_words
-    _set_module_tensors(
-        monkeypatch,
-        ("octets", source_octets, "tensor_attr"),
-        ("words", source_words, "tensor_attr"),
-    )
+def test_reader_rejects_distinct_sources_for_tied_submodule_destination():
+    first = torch.arange(2, dtype=torch.float32)
+    second = torch.arange(2, dtype=torch.float32) + 10
+    writer_model = torch.nn.Module()
+    writer_model.a = torch.nn.Module()
+    writer_model.b = torch.nn.Module()
+    writer_model.a.value = first
+    writer_model.b.value = second
+    store = _MetadataStore()
+    allocations = {
+        "first": (
+            first.untyped_storage().data_ptr(),
+            first.untyped_storage().nbytes(),
+        ),
+        "second": (
+            second.untyped_storage().data_ptr(),
+            second.untyped_storage().nbytes(),
+        ),
+    }
+    writer = _Manager(store, allocations, mapped=True)
+    register_module_tensors(writer, writer_model)
 
-    specs = {}
+    shared = torch.nn.Module()
+    shared.value = torch.zeros(1)
+    reader_model = torch.nn.Module()
+    reader_model.a = shared
+    reader_model.b = shared
+    reader = _Manager(store, allocations, mapped=False)
 
-    def metadata_put(*, key, allocation_id, offset_bytes, value):
-        specs[key] = GMSTensorSpec(
-            key=key,
-            name=key,
-            allocation_id=allocation_id,
-            offset_bytes=offset_bytes,
-            meta=TensorMetadata.from_bytes(value),
-        )
-        return True
+    with pytest.raises(RuntimeError, match="same destination"):
+        materialize_module_from_gms(reader, reader_model, device_index=0)
 
-    manager = _manager_for(source_octets)
-    manager.metadata_put = metadata_put
-    assert register_module_tensors(manager, writer) == {"allocation"}
-
-    reader_octets = torch.zeros(8, dtype=torch.uint8)
-    reader_storage = reader_octets.untyped_storage()
-    reader_words = torch.empty(0, dtype=torch.int32).set_(reader_storage, 0, (2,), (1,))
-    reader = torch.nn.Module()
-    reader.octets = reader_octets
-    reader.words = reader_words
-    _set_specs(monkeypatch, specs)
-    monkeypatch.setattr(
-        torch_module,
-        "_storage_from_pointer",
-        lambda _ptr, _size, _device: source_storage,
-    )
-
-    materialize_module_from_gms(manager, reader, device_index=0)
-
-    assert reader.octets is reader_octets and reader.words is reader_words
-    assert (
-        reader.octets.untyped_storage()._cdata == reader.words.untyped_storage()._cdata
-    )
-    torch.testing.assert_close(reader.octets, source_octets)
-    torch.testing.assert_close(reader.words, torch.tensor([1, 2], dtype=torch.int32))
-    reader.words[0] = 257
-    torch.testing.assert_close(
-        reader.octets, torch.tensor([1, 1, 0, 0, 2, 0, 0, 0], dtype=torch.uint8)
-    )
+    assert reader.mapping_calls == []
+    torch.testing.assert_close(shared.value, torch.zeros(1))
 
 
-def test_writer_rejects_distinct_overlapping_storage_ranges(monkeypatch):
+def test_reader_deduplicates_same_source_for_tied_submodule_destination(
+    cpu_storage_pointer,
+):
+    source = torch.arange(2, dtype=torch.float32)
+    writer_shared = torch.nn.Module()
+    writer_shared.value = source
+    writer_model = torch.nn.Module()
+    writer_model.a = writer_shared
+    writer_model.b = writer_shared
+    store, writer = _writer_for_tensor(source)
+    register_module_tensors(writer, writer_model)
+
+    reader_shared = torch.nn.Module()
+    reader_shared.value = torch.zeros(1)
+    reader_model = torch.nn.Module()
+    reader_model.a = reader_shared
+    reader_model.b = reader_shared
+    reader = _Manager(store, writer.allocations, mapped=False)
+
+    materialize_module_from_gms(reader, reader_model, device_index=0)
+
+    assert reader_model.a.value is reader_model.b.value
+    torch.testing.assert_close(reader_model.a.value, source)
+
+
+def test_writer_rejects_out_of_bounds_and_overlapping_storages():
     allocation = torch.arange(16, dtype=torch.uint8)
-    ptr = allocation.data_ptr()
     first_storage = torch._C._construct_storage_from_data_pointer(
-        ptr, torch.device("cpu"), 12
+        allocation.data_ptr(),
+        torch.device("cpu"),
+        12,
     )
     second_storage = torch._C._construct_storage_from_data_pointer(
-        ptr + 4, torch.device("cpu"), 12
+        allocation.data_ptr() + 4,
+        torch.device("cpu"),
+        12,
     )
     first = torch.empty(0, dtype=torch.uint8).set_(first_storage, 0, (12,), (1,))
     second = torch.empty(0, dtype=torch.uint8).set_(second_storage, 0, (12,), (1,))
     model = torch.nn.Module()
     model.first = first
     model.second = second
-    manager = SimpleNamespace(
-        mappings={
-            ptr: SimpleNamespace(
-                allocation_id="allocation",
-                aligned_size=allocation.untyped_storage().nbytes(),
-            )
-        },
-        metadata_put=lambda **_kwargs: pytest.fail("metadata was mutated"),
-    )
-    _set_module_tensors(
-        monkeypatch,
-        ("first", first, "tensor_attr"),
-        ("second", second, "tensor_attr"),
+    store = _MetadataStore()
+    manager = _Manager(
+        store,
+        {"allocation": (allocation.data_ptr(), allocation.untyped_storage().nbytes())},
+        mapped=True,
     )
 
     with pytest.raises(RuntimeError, match="byte ranges overlap"):
         register_module_tensors(manager, model)
+    assert store.entries == {}
 
-
-def test_writer_accepts_ordinary_trainable_leaf_parameter(monkeypatch):
-    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
-    model = torch.nn.Module()
-    model.register_parameter("weight", parameter)
-    _set_module_tensors(monkeypatch, ("weight", parameter, "parameter"))
-    published = []
-    manager = _manager_for(parameter)
-    manager.metadata_put = lambda **kwargs: published.append(kwargs) or True
-
-    assert register_module_tensors(manager, model) == {"allocation"}
-    assert [entry["key"] for entry in published] == ["weight"]
-
-
-def test_hidden_no_grad_view_fails_public_preflights(monkeypatch):
-    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
-    with torch.no_grad():
-        hidden_view = parameter[:]
-    model = torch.nn.Module()
-    model.register_parameter("weight", parameter)
-    _set_module_tensors(monkeypatch, ("weight", parameter, "parameter"))
-    manager = _manager_for(parameter)
-    manager.metadata_put = lambda **_kwargs: pytest.fail("metadata was mutated")
-
-    with pytest.raises(RuntimeError, match="TensorImpl use count"):
+    manager.mappings[allocation.data_ptr()].aligned_size = 8
+    model.second = None
+    with pytest.raises(RuntimeError, match="exceeds GMS allocation"):
         register_module_tensors(manager, model)
-
-    runtime = torch.zeros(4)
-    model.runtime = runtime
-    _set_specs(
-        monkeypatch,
-        {
-            "runtime": _component_spec(
-                "runtime",
-                runtime,
-                "tensor_attr",
-                storage_group_id=0,
-                object_group_id=0,
-                storage_base_offset=0,
-                storage_nbytes=runtime.untyped_storage().nbytes(),
-            ),
-            "weight": _component_spec(
-                "weight",
-                parameter,
-                "parameter",
-                storage_group_id=1,
-                object_group_id=1,
-                storage_base_offset=runtime.untyped_storage().nbytes(),
-                storage_nbytes=parameter.untyped_storage().nbytes(),
-            ),
-        },
-    )
-    reader_manager = SimpleNamespace(
-        mappings={},
-        create_mapping=lambda **_kwargs: pytest.fail("reader mapping was created"),
-    )
-
-    with pytest.raises(RuntimeError, match="TensorImpl use count"):
-        materialize_module_from_gms(reader_manager, model, device_index=0)
-
-    assert hidden_view.shape == parameter.shape
-    torch.testing.assert_close(runtime, torch.zeros(4))
-    torch.testing.assert_close(parameter, torch.arange(4, dtype=torch.float32))
+    assert store.entries == {}
 
 
-@pytest.mark.parametrize("trainable_view", [False, True])
-def test_writer_rejects_unsupported_view_ownership(monkeypatch, trainable_view):
-    base = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
-    model = torch.nn.Module()
-    if trainable_view:
-        model.register_parameter("weight", base)
-        model.view = base[::2]
-        entries = [("weight", base, "parameter"), ("view", model.view, "tensor_attr")]
-    else:
-        model.runtime = base.data
-        model.helper = SimpleNamespace(view=model.runtime[::2])
-        entries = [("runtime", model.runtime, "tensor_attr")]
-    _set_module_tensors(monkeypatch, *entries)
-    manager = _manager_for(base)
-    manager.metadata_put = lambda **_kwargs: pytest.fail("metadata was mutated")
-
-    with pytest.raises(RuntimeError, match="autograd tensor|TensorImpl use count"):
-        register_module_tensors(manager, model)
-
-
-def test_reader_rejects_overlapping_wire_components_before_mapping(monkeypatch):
-    model = torch.nn.Module()
-    model.first = torch.zeros(2)
-    model.second = torch.zeros(2)
-    specs = {
-        "first": _component_spec(
-            "first",
-            model.first,
-            "tensor_attr",
-            storage_group_id=0,
-            object_group_id=0,
-            storage_base_offset=0,
-            storage_nbytes=8,
+def test_reader_bounds_failure_releases_only_new_mapping(
+    cpu_storage_pointer,
+    monkeypatch,
+):
+    existing = torch.arange(4, dtype=torch.float32)
+    imported = torch.arange(4, dtype=torch.float32) + 10
+    writer_model = torch.nn.Module()
+    writer_model.existing = existing
+    writer_model.imported = imported
+    store = _MetadataStore()
+    allocations = {
+        "existing": (
+            existing.untyped_storage().data_ptr(),
+            existing.untyped_storage().nbytes(),
         ),
-        "second": _component_spec(
-            "second",
-            model.second,
-            "tensor_attr",
-            storage_group_id=1,
-            object_group_id=1,
-            storage_base_offset=4,
-            storage_nbytes=8,
+        "imported": (
+            imported.untyped_storage().data_ptr(),
+            imported.untyped_storage().nbytes(),
         ),
     }
-    _set_specs(monkeypatch, specs)
-    manager = SimpleNamespace(create_mapping=lambda **_kwargs: pytest.fail("mapped"))
+    writer = _Manager(store, allocations, mapped=True)
+    register_module_tensors(writer, writer_model)
+    bad_key = next(
+        key
+        for key, (allocation_id, _, _) in store.entries.items()
+        if allocation_id == "imported"
+    )
+    allocation_id, _, payload = store.entries[bad_key]
+    store.entries[bad_key] = (
+        allocation_id,
+        imported.untyped_storage().nbytes(),
+        payload,
+    )
+    reader_model = torch.nn.Module()
+    reader_model.existing = torch.zeros(1)
+    reader_model.imported = torch.zeros(1)
+    reader = _Manager(store, allocations, mapped=False)
+    existing_va, existing_nbytes = allocations["existing"]
+    existing_mapping = SimpleNamespace(
+        allocation_id="existing",
+        aligned_size=existing_nbytes,
+    )
+    reader.mappings[existing_va] = existing_mapping
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda _device: None)
 
-    with pytest.raises(RuntimeError, match="byte ranges overlap"):
-        materialize_module_from_gms(manager, model, device_index=0)
+    with pytest.raises(RuntimeError, match="exceeds allocation"):
+        materialize_module_from_gms(reader, reader_model, device_index=0)
 
-    torch.testing.assert_close(model.first, torch.zeros(2))
+    assert reader.freed == [imported.untyped_storage().data_ptr()]
+    assert reader.mappings == {existing_va: existing_mapping}
+
+
+def test_reader_validates_storage_envelope_alignment_before_mapping():
+    tensor = torch.arange(4, dtype=torch.float32)
+    writer_model = torch.nn.Module()
+    writer_model.runtime = tensor
+    store, writer = _writer_for_tensor(tensor)
+    register_module_tensors(writer, writer_model)
+    key = f"{STORAGE_MANIFEST_PREFIX}0"
+    allocation_id, _, payload = store.entries[key]
+    store.entries[key] = (allocation_id, 2, payload)
+    reader_model = torch.nn.Module()
+    reader_model.runtime = torch.zeros(1)
+    reader = _Manager(store, writer.allocations, mapped=False)
+
+    with pytest.raises(RuntimeError, match="Unaligned storage envelope"):
+        materialize_module_from_gms(reader, reader_model, device_index=0)
+
+    assert reader.mapping_calls == []
 
 
 @pytest.mark.parametrize(
-    "wire_shared",
-    [True, False],
-    ids=("wire-shared-reader-split", "wire-split-reader-shared"),
+    "mutate",
+    [
+        lambda manifest: manifest.update({"unknown": True}),
+        lambda manifest: manifest["objects"][0]["slots"][0].update({"kind": "invalid"}),
+        lambda manifest: manifest["objects"][0]["slots"].append(
+            manifest["objects"][0]["slots"][0].copy()
+        ),
+    ],
+    ids=("unknown-field", "invalid-literal", "duplicate-slot"),
 )
-def test_reader_rejects_storage_impl_topology_before_mapping(monkeypatch, wire_shared):
-    first = torch.zeros(2)
-    if wire_shared:
-        second = torch.ones(2)
-        wire_topology = ((0, 0), (0, 0))
-    else:
-        second = torch.empty(0).set_(first.untyped_storage(), 0, (2,), (1,))
-        wire_topology = ((0, 0), (1, first.untyped_storage().nbytes()))
-    model = torch.nn.Module()
-    model.first = first
-    model.second = second
-    identities = (first, second)
-    specs = {
-        name: _component_spec(
-            name,
-            tensor,
-            "tensor_attr",
-            storage_group_id=storage_group_id,
-            object_group_id=object_group_id,
-            storage_base_offset=storage_base_offset,
-            storage_nbytes=tensor.numel() * tensor.element_size(),
-        )
-        for object_group_id, (
-            name,
-            tensor,
-            (storage_group_id, storage_base_offset),
-        ) in enumerate(
-            zip(
-                ("first", "second"),
-                identities,
-                wire_topology,
-                strict=True,
-            )
-        )
-    }
-    _set_specs(monkeypatch, specs)
-    manager = SimpleNamespace(
-        mappings={},
-        create_mapping=lambda **_kwargs: pytest.fail("reader mapping was created"),
-    )
-
-    with pytest.raises(RuntimeError, match="StorageImpl topology differs"):
-        materialize_module_from_gms(manager, model, device_index=0)
-
-    assert model.first is first
-    assert model.second is second
-    torch.testing.assert_close(first, torch.zeros(2))
-    torch.testing.assert_close(second, torch.ones(2) if wire_shared else torch.zeros(2))
-
-
-def test_component_schema_is_strict_and_keeps_legacy_offset():
+def test_reader_rejects_compact_malformed_manifest_cases(mutate):
     tensor = torch.arange(4, dtype=torch.float32)
-    meta = TensorMetadata.from_tensor(
-        tensor,
-        "tensor_attr",
-        storage={
-            "schema_version": 1,
-            "storage_group_id": 3,
-            "object_group_id": 4,
-            "storage_base_offset": 16,
-            "storage_nbytes": 32,
-            "storage_offset": 0,
-            "buffer_persistent": False,
-        },
+    writer_model = torch.nn.Module()
+    writer_model.runtime = tensor
+    store, writer = _writer_for_tensor(tensor)
+    register_module_tensors(writer, writer_model)
+    key = f"{STORAGE_MANIFEST_PREFIX}0"
+    allocation_id, offset, payload = store.entries[key]
+    manifest = msgspec.msgpack.decode(payload)
+    mutate(manifest)
+    store.entries[key] = (
+        allocation_id,
+        offset,
+        msgspec.msgpack.encode(manifest),
     )
-    encoded = json.loads(meta.to_bytes())
-    assert encoded["storage"]["schema_version"] == 1
-    assert encoded["storage"]["storage_base_offset"] == 16
-    assert encoded["storage"]["storage_offset"] == 0
+    reader = _Manager(store, writer.allocations, mapped=False)
 
-    null_stride = encoded.copy()
-    null_stride["stride"] = None
-    with pytest.raises(ValueError, match="stride must be a list"):
-        TensorMetadata.from_bytes(json.dumps(null_stride).encode())
+    with pytest.raises(RuntimeError, match="GMS storage manifest"):
+        materialize_module_from_gms(reader, torch.nn.Module(), device_index=0)
 
-    del encoded["storage"]["storage_nbytes"]
-    with pytest.raises(ValueError, match="fields must be exact"):
-        TensorMetadata.from_bytes(json.dumps(encoded).encode())
-
-    for legacy_stride in ("", ',"stride":null'):
-        legacy = TensorMetadata.from_bytes(
-            (
-                '{"shape":[4],"dtype":"torch.float32",'
-                f'"tensor_type":"parameter"{legacy_stride}}}'
-            ).encode()
-        )
-        assert not legacy.is_storage_component
-        assert legacy.stride == (1,)
-
-    with pytest.raises(ValueError, match="Unknown tensor type"):
-        TensorMetadata.from_bytes(
-            b'{"shape":[4],"dtype":"torch.float32","tensor_type":"unknown"}'
-        )
+    assert reader.mapping_calls == []
 
 
-def test_reader_rejects_nontensor_slot_before_mapping(monkeypatch):
-    tensor = torch.zeros(4)
-    bad = torch.nn.Module()
-    bad.sentinel = "not a tensor"
-    _set_specs(
-        monkeypatch,
-        {
-            "sentinel": _component_spec(
-                "sentinel",
-                tensor,
-                "tensor_attr",
-                storage_group_id=0,
-                object_group_id=0,
-                storage_base_offset=0,
-                storage_nbytes=tensor.untyped_storage().nbytes(),
-            )
-        },
+def test_reader_rejects_malformed_msgpack():
+    store = _MetadataStore()
+    store.entries[f"{STORAGE_MANIFEST_PREFIX}0"] = (
+        "allocation",
+        0,
+        b"\xc1",
     )
-    with pytest.raises(RuntimeError, match="preexisting direct Tensor"):
-        materialize_module_from_gms(object(), bad, device_index=0)
+    reader = _Manager(store, {}, mapped=False)
 
-    _set_specs(monkeypatch, {"sentinel": _spec(tensor, "tensor_attr")})
-    with pytest.raises(RuntimeError, match="preexisting direct Tensor"):
-        materialize_module_from_gms(object(), bad, device_index=0)
+    with pytest.raises(RuntimeError, match="Invalid GMS storage manifest"):
+        materialize_module_from_gms(reader, torch.nn.Module(), device_index=0)
+
+    assert reader.mapping_calls == []
 
 
-def test_component_allocation_bounds_failure_cleans_only_new_mapping(monkeypatch):
+def test_reader_rejects_noncontiguous_ordinals_and_overlapping_manifests():
+    tensor = torch.arange(4, dtype=torch.float32)
+    writer_model = torch.nn.Module()
+    writer_model.runtime = tensor
+    store, writer = _writer_for_tensor(tensor)
+    register_module_tensors(writer, writer_model)
+    key = f"{STORAGE_MANIFEST_PREFIX}0"
+    entry = store.entries.pop(key)
+    store.entries[f"{STORAGE_MANIFEST_PREFIX}1"] = entry
+    reader = _Manager(store, writer.allocations, mapped=False)
+
+    with pytest.raises(RuntimeError, match="ordinals must be contiguous"):
+        materialize_module_from_gms(reader, torch.nn.Module(), device_index=0)
+    assert reader.mapping_calls == []
+
+    store.entries[key] = store.entries.pop(f"{STORAGE_MANIFEST_PREFIX}1")
+    allocation_id, _, payload = store.entries[key]
+    second = msgspec.msgpack.decode(payload)
+    second["objects"][0]["slots"][0]["path"] = "other"
+    store.entries[f"{STORAGE_MANIFEST_PREFIX}1"] = (
+        allocation_id,
+        4,
+        msgspec.msgpack.encode(second),
+    )
+
+    with pytest.raises(RuntimeError, match="manifests overlap"):
+        materialize_module_from_gms(reader, torch.nn.Module(), device_index=0)
+    assert reader.mapping_calls == []
+
+
+def test_reader_keeps_mapping_when_clone_cleanup_cannot_synchronize(
+    cpu_storage_pointer,
+    monkeypatch,
+):
+    tensor = torch.arange(4, dtype=torch.float32)
+    writer_model = torch.nn.Module()
+    writer_model.runtime = tensor
+    store, writer = _writer_for_tensor(tensor)
+    register_module_tensors(writer, writer_model)
+    reader_model = torch.nn.Module()
+    reader_model.runtime = torch.zeros(1)
+    reader = _Manager(store, writer.allocations, mapped=False)
+    events: list[str] = []
+    real_free = reader.free_va
+
+    def fail_tensor(*_args, **_kwargs):
+        raise RuntimeError("materialization failed")
+
+    def fail_sync(_device):
+        events.append("synchronize")
+        raise RuntimeError("synchronize failed")
+
+    def free(va):
+        events.append("free")
+        real_free(va)
+
+    monkeypatch.setattr(torch_module, "_tensor_from_storage", fail_tensor)
+    monkeypatch.setattr(torch.cuda, "synchronize", fail_sync)
+    reader.free_va = free
+
+    with pytest.raises(RuntimeError, match="synchronize failed"):
+        materialize_module_from_gms(reader, reader_model, device_index=0)
+
+    assert events == ["synchronize"]
+    assert reader.freed == []
+    assert list(reader.mappings) == [tensor.untyped_storage().data_ptr()]
+
+
+def test_reader_ignores_metadata_outside_storage_prefix(
+    cpu_storage_pointer,
+):
+    tensor = torch.arange(4, dtype=torch.float32)
+    writer_model = torch.nn.Module()
+    writer_model.runtime = tensor
+    store, writer = _writer_for_tensor(tensor)
+    register_module_tensors(writer, writer_model)
+    store.entries["runtime"] = ("missing", 0, b"unrelated")
+    reader_model = torch.nn.Module()
+    reader_model.runtime = torch.zeros(1)
+    reader = _Manager(store, writer.allocations, mapped=False)
+
+    materialize_module_from_gms(reader, reader_model, device_index=0)
+
+    torch.testing.assert_close(reader_model.runtime, tensor)
+
+
+def test_reader_rejects_metadata_without_storage_manifests():
+    store = _MetadataStore()
+    store.entries["runtime"] = ("allocation", 0, b"unsupported")
+    manager = _Manager(store, {}, mapped=False)
+
+    with pytest.raises(RuntimeError, match="No GMS module storage manifests"):
+        materialize_module_from_gms(manager, torch.nn.Module(), device_index=0)
+
+
+def test_discovery_does_not_invoke_properties_or_walk_helper_graphs():
+    class Model(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.property_reads = 0
+            self.direct = torch.arange(4)
+            self.helper = SimpleNamespace(hidden=torch.arange(4))
+
+        @property
+        def derived(self):
+            self.property_reads += 1
+            return self.direct
+
+    model = Model()
+    store, writer = _writer_for_tensor(model.direct)
+    register_module_tensors(writer, model)
+    manifest = msgspec.msgpack.decode(next(iter(store.entries.values()))[2])
+
+    assert model.property_reads == 0
+    assert manifest["objects"][0]["slots"] == [{"path": "direct", "kind": "attribute"}]
+
+
+def test_unregistered_parameter_and_zero_byte_storage_are_rejected():
+    parameter = torch.nn.Parameter(torch.ones(1))
     model = torch.nn.Module()
-    model.existing = torch.zeros(2)
-    model.imported = torch.ones(2)
-    identities = (model.existing, model.imported)
-    _set_specs(
-        monkeypatch,
-        {
-            "existing": _component_spec(
-                "existing",
-                model.existing,
-                "tensor_attr",
-                storage_group_id=0,
-                object_group_id=0,
-                storage_base_offset=0,
-                storage_nbytes=model.existing.untyped_storage().nbytes(),
-                allocation_id="existing",
-            ),
-            "imported": _component_spec(
-                "imported",
-                model.imported,
-                "tensor_attr",
-                storage_group_id=1,
-                object_group_id=1,
-                storage_base_offset=4,
-                storage_nbytes=model.imported.untyped_storage().nbytes(),
-                allocation_id="imported",
-            ),
-        },
-    )
-    existing_mapping = SimpleNamespace(allocation_id="existing", aligned_size=8)
-    manager = SimpleNamespace(mappings={100: existing_mapping})
-    freed = []
+    model.__dict__["hidden"] = parameter
+    _, writer = _writer_for_tensor(parameter)
+    with pytest.raises(RuntimeError, match="Unregistered Parameter"):
+        register_module_tensors(writer, model)
 
-    def create_mapping(*, allocation_id):
-        assert allocation_id == "imported"
-        manager.mappings[200] = SimpleNamespace(
-            allocation_id=allocation_id, aligned_size=8
+    empty = torch.empty(0)
+    model = torch.nn.Module()
+    model.empty = empty
+    _, writer = _writer_for_tensor(empty)
+    with pytest.raises(RuntimeError, match="zero-byte"):
+        register_module_tensors(writer, model)
+
+
+def test_publisher_rebind_clones_storage_once_and_retains_one_source_owner():
+    backing = torch.arange(8, dtype=torch.float32)
+    view = backing[1::2]
+    assert view._base is backing
+    model = torch.nn.Module()
+    model.backing = backing
+    model.backing_alias = backing
+    model.view = view
+    _, manager = _writer_for_tensor(backing)
+    old_storage = backing.untyped_storage()._cdata
+    rebound = rebind_nonparameter_tensors(manager, model)
+
+    assert rebound == backing.untyped_storage().nbytes()
+    assert model.backing is backing is model.backing_alias
+    assert model.view is view
+    assert model.backing.untyped_storage()._cdata != old_storage
+    assert model.backing.untyped_storage()._cdata == model.view.untyped_storage()._cdata
+    owners = model.__dict__["_gms_rebound_tensor_owners"].tensors
+    assert len(owners) == 1
+    assert owners[0].untyped_storage()._cdata == old_storage
+    model.view.add_(10)
+    torch.testing.assert_close(model.backing[1::2], model.view)
+
+
+def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
+    parameter = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
+    torch.autograd.graph.get_gradient_edge(parameter)
+    with torch.no_grad():
+        view = parameter[1::2]
+    objects = [
+        torch_module._DiscoveredObject(parameter, [Slot("weight", "parameter")]),
+        torch_module._DiscoveredObject(view, [Slot("view", "attribute")]),
+    ]
+    target_storage = parameter.detach().clone().untyped_storage()
+    replacements = {}
+    for tensor_object in objects:
+        tensor = tensor_object.tensor
+        replacement = torch_module._tensor_from_storage(
+            target_storage,
+            list(tensor.shape),
+            list(tensor.stride()),
+            tensor.dtype,
+            int(tensor.storage_offset()),
         )
-        return 200
+        if isinstance(tensor, torch.nn.Parameter):
+            replacement = torch_module._make_parameter(
+                tensor,
+                replacement,
+                path="weight",
+                requires_grad=True,
+            )
+        replacements[id(tensor)] = replacement
+        del replacement
 
-    def free_va(va):
-        freed.append(va)
-        del manager.mappings[va]
+    torch_module._swap_discovered_objects(objects, replacements)
 
-    manager.create_mapping = create_mapping
-    manager.free_va = free_va
-
-    with pytest.raises(RuntimeError, match="exceeds allocation"):
-        materialize_module_from_gms(manager, model, device_index=0)
-
-    assert model.existing is identities[0]
-    assert model.imported is identities[1]
-    torch.testing.assert_close(model.existing, torch.zeros(2))
-    torch.testing.assert_close(model.imported, torch.ones(2))
-    assert manager.mappings == {100: existing_mapping}
-    assert freed == [200]
+    assert replacements == {}
+    assert parameter.untyped_storage()._cdata == view.untyped_storage()._cdata
+    torch.testing.assert_close(parameter, torch.arange(8, dtype=torch.float32))
+    torch.testing.assert_close(view, torch.tensor([1, 3, 5, 7], dtype=torch.float32))
 
 
-@pytest.mark.parametrize("reader", [False, True])
-def test_nonparameter_tensor_subclass_is_rejected(monkeypatch, reader):
-    tensor = torch.Tensor._make_subclass(_TensorSubclass, torch.zeros(4))
+def test_swap_preflight_failure_does_not_mutate_earlier_objects():
+    first = torch.arange(4, dtype=torch.float32)
+    second = torch.arange(4, dtype=torch.float32) + 10
+    objects = [
+        torch_module._DiscoveredObject(first, [Slot("first", "attribute")]),
+        torch_module._DiscoveredObject(second, [Slot("second", "attribute")]),
+    ]
+    replacements = {
+        id(first): torch.full_like(first, 20),
+        id(second): torch.full_like(second, 30),
+    }
+    first_storage = first.untyped_storage()._cdata
+    second_storage = second.untyped_storage()._cdata
+    second_ref = weakref.ref(second)
+
+    with pytest.raises(RuntimeError, match="second.*weakref"):
+        torch_module._swap_discovered_objects(objects, replacements)
+
+    assert second_ref() is second
+    assert first.untyped_storage()._cdata == first_storage
+    assert second.untyped_storage()._cdata == second_storage
+    torch.testing.assert_close(first, torch.arange(4, dtype=torch.float32))
+    torch.testing.assert_close(second, torch.arange(4, dtype=torch.float32) + 10)
+
+
+def test_rebound_tensor_owner_rejects_existing_none():
+    tensor = torch.arange(4, dtype=torch.float32)
     model = torch.nn.Module()
     model.runtime = tensor
+    model.__dict__["_gms_rebound_tensor_owners"] = None
+    _, manager = _writer_for_tensor(tensor)
 
-    if reader:
-        _set_specs(monkeypatch, {"runtime": _spec(torch.ones(4), "tensor_attr")})
-
-        def call():
-            materialize_module_from_gms(object(), model, device_index=0)
-
-    else:
-        _set_module_tensors(monkeypatch, ("runtime", tensor, "tensor_attr"))
-
-        def call():
-            rebind_nonparameter_tensors(_manager_for(tensor), model)
-
-    with pytest.raises(RuntimeError, match="non-parameter Tensor subclass"):
-        call()
-
-    assert model.runtime is tensor
-    torch.testing.assert_close(tensor, torch.zeros(4))
+    with pytest.raises(RuntimeError, match="Reserved GMS attribute"):
+        rebind_nonparameter_tensors(manager, model)
 
 
-def test_rebind_failure_is_terminal(monkeypatch):
-    model = torch.nn.Module()
-    model.first = torch.arange(4, dtype=torch.float32)
-    model.second = torch.arange(4, dtype=torch.float32) + 10
-    retained = []
-    manager = SimpleNamespace(
-        mappings={
-            model.first.data_ptr(): SimpleNamespace(
-                allocation_id="first",
-                aligned_size=model.first.untyped_storage().nbytes(),
-            ),
-            model.second.data_ptr(): SimpleNamespace(
-                allocation_id="second",
-                aligned_size=model.second.untyped_storage().nbytes(),
-            ),
-        }
+def test_prepare_and_publish_accounting(gms_write):
+    allocator, stats, events = gms_write
+    assert events == ["register", "prune"]
+    assert stats.committed_bytes == 60
+    assert stats.pruned_bytes == 40
+    assert stats.pruned_count == 1
+
+    model_loader._store_pending_gms_write(allocator, stats, 12)
+    assert model_loader.get_imported_weights_bytes() == 60
+    assert model_loader.get_model_memory_usage_offset_bytes() == 52
+    assert model_loader.publish_pending_gms_write()
+    assert events == ["register", "prune", "commit", "connect", "remap"]
+
+
+def test_eager_finalize_rebinds_before_publication(gms_write):
+    allocator, _, events = gms_write
+    events.clear()
+    allocator.total_bytes = 100
+    allocator.mappings[2] = SimpleNamespace(
+        allocation_id="scratch",
+        aligned_size=40,
     )
-    _set_module_tensors(
-        monkeypatch,
-        ("first", model.first, "tensor_attr"),
-        ("second", model.second, "tensor_attr"),
+
+    stats = common_utils.finalize_gms_write(allocator, object())
+
+    assert stats.committed_bytes == 60
+    assert events == [
+        "register",
+        "prune",
+        "rebind",
+        "commit",
+        "connect",
+        "remap",
+    ]
+
+
+def test_eager_finalize_releases_after_partial_rebind_without_publishing(
+    gms_write, monkeypatch
+):
+    allocator, _, events = gms_write
+    events.clear()
+    allocator.fail_close = True
+    allocator.total_bytes = 100
+    allocator.mappings[2] = SimpleNamespace(
+        allocation_id="scratch",
+        aligned_size=40,
     )
-    real_swap = torch_module._swap_tensor_contents
-    calls = 0
 
-    def fail_second(existing, replacement, *, name):
-        nonlocal calls
-        calls += 1
-        if calls == 2:
-            raise RuntimeError("injected second swap failure")
-        real_swap(existing, replacement, name=name)
+    model = SimpleNamespace(partially_rebound=False)
 
-    monkeypatch.setattr(torch_module, "_swap_tensor_contents", fail_second)
+    def fail_rebind(_allocator, rebound_model):
+        events.append("rebind")
+        rebound_model.partially_rebound = True
+        raise RuntimeError("rebind failed")
 
-    with pytest.raises(RuntimeError, match="injected second swap failure"):
-        rebind_nonparameter_tensors(manager, model, retain_gms_tensors=retained)
+    monkeypatch.setattr(common_utils, "rebind_nonparameter_tensors", fail_rebind)
 
-    assert retained == []
-    assert "_gms_rebound_tensor_owners" not in model.__dict__
+    with pytest.raises(RuntimeError, match="rebind failed"):
+        common_utils.finalize_gms_write(allocator, model)
+
+    assert model.partially_rebound
+    assert events == ["register", "prune", "rebind", "close_best_effort"]
 
 
-def test_failed_vllm_write_load_releases_lease(monkeypatch):
-    client = SimpleNamespace(
-        close=lambda *, best_effort: events.append(("close", best_effort))
+def test_eager_finalize_commit_failure_releases_and_preserves_error(gms_write):
+    allocator, _, events = gms_write
+    events.clear()
+    allocator.fail_commit = True
+    allocator.fail_close = True
+    allocator.total_bytes = 100
+    allocator.mappings[2] = SimpleNamespace(
+        allocation_id="scratch",
+        aligned_size=40,
     )
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        common_utils.finalize_gms_write(allocator, object())
+
+    assert events == [
+        "register",
+        "prune",
+        "rebind",
+        "commit",
+        "close_best_effort",
+    ]
+
+
+@pytest.mark.parametrize("failure_stage", ("load", "move", "empty_cache"))
+def test_trt_rw_pre_finalization_failure_closes_once_and_preserves_error(
+    monkeypatch, failure_stage
+):
     events = []
+
+    def fail_at(stage):
+        events.append(stage)
+        if stage == failure_stage:
+            raise RuntimeError(f"{stage} failed")
+
+    def close(*, best_effort):
+        assert best_effort
+        events.append("close")
+        raise RuntimeError("close failed")
+
+    def original_load(*_args):
+        fail_at("load")
+        return object(), object()
+
+    monkeypatch.setattr(
+        trtllm_model_loader,
+        "gms_use_mem_pool",
+        lambda *_args: nullcontext(),
+    )
+    monkeypatch.setattr(
+        trtllm_model_loader,
+        "_move_untracked_params",
+        lambda *_args: fail_at("move"),
+    )
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: fail_at("empty_cache"))
+    client = SimpleNamespace(close=close)
+
+    with pytest.raises(RuntimeError, match=f"{failure_stage} failed"):
+        trtllm_model_loader._load_rw(
+            object(),
+            None,
+            None,
+            client,
+            0,
+            original_load,
+        )
+
+    assert events.count("close") == 1
+    assert events[-1] == "close"
+
+
+def test_trt_rw_finalization_failure_is_not_closed_twice(monkeypatch):
+    events = []
+
+    def close(*, best_effort):
+        assert best_effort
+        events.append("close")
+        raise RuntimeError("close failed")
+
+    client = SimpleNamespace(close=close)
+
+    def fail_finalize(finalize_client, _model):
+        events.append("finalize")
+        try:
+            finalize_client.close(best_effort=True)
+        except RuntimeError:
+            pass
+        raise RuntimeError("finalize failed")
+
+    monkeypatch.setattr(
+        trtllm_model_loader,
+        "gms_use_mem_pool",
+        lambda *_args: nullcontext(),
+    )
+    monkeypatch.setattr(trtllm_model_loader, "_move_untracked_params", lambda *_: None)
+    monkeypatch.setattr(torch.cuda, "empty_cache", lambda: None)
+    monkeypatch.setattr(trtllm_model_loader, "finalize_gms_write", fail_finalize)
+
+    with pytest.raises(RuntimeError, match="finalize failed"):
+        trtllm_model_loader._load_rw(
+            object(),
+            None,
+            None,
+            client,
+            0,
+            lambda *_args: (object(), object()),
+        )
+
+    assert events == ["finalize", "close"]
+
+
+def test_publication_failure_uses_best_effort_close_and_preserves_error(gms_write):
+    allocator, stats, events = gms_write
+    allocator.fail_commit = True
+    model_loader._store_pending_gms_write(allocator, stats, 12)
+
+    with pytest.raises(RuntimeError, match="commit failed"):
+        model_loader.publish_pending_gms_write()
+
+    assert events == ["register", "prune", "commit", "close_best_effort"]
+    assert not model_loader.has_pending_gms_write()
+
+
+def test_abort_pending_write_uses_best_effort_close(gms_write):
+    allocator, stats, events = gms_write
+    model_loader._store_pending_gms_write(allocator, stats, 12)
+
+    assert model_loader.abort_pending_gms_write()
+    assert events == ["register", "prune", "close_best_effort"]
+    assert not model_loader.has_pending_gms_write()
+
+
+def test_write_load_failure_uses_best_effort_close_and_preserves_error(monkeypatch):
+    events = []
+    client = SimpleNamespace(
+        close=lambda *, best_effort: events.append(
+            "close_best_effort" if best_effort else "close"
+        )
+    )
     monkeypatch.setattr(
         model_loader,
         "_load_write_mode_impl",
-        lambda *_args: (_ for _ in ()).throw(RuntimeError("rebind failed")),
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("load failed")),
     )
 
-    with pytest.raises(RuntimeError, match="rebind failed"):
+    with pytest.raises(RuntimeError, match="load failed"):
         model_loader._load_write_mode(client, None, None, None, torch.device("cpu"))
 
-    assert events == [("close", True)]
+    assert events == ["close_best_effort"]
     assert not model_loader.has_pending_gms_write()
 
 
-def test_failed_vllm_write_load_clears_pending_state(monkeypatch):
+def test_read_mode_runs_meta_post_load_once_before_materialization(monkeypatch):
     events = []
-    client = SimpleNamespace(
-        close=lambda *, best_effort: events.append(("close", best_effort))
+    model = SimpleNamespace(eval=lambda: model)
+    manager = SimpleNamespace(close=lambda: events.append("close"), total_bytes=16)
+    loader_utils = ModuleType("vllm.model_executor.model_loader.utils")
+    loader_utils.initialize_model = lambda **_kwargs: (
+        events.append("initialize") or model
+    )
+    loader_utils.process_weights_after_loading = lambda *_args: events.append(
+        "post-load"
+    )
+    torch_utils = ModuleType("vllm.utils.torch_utils")
+    torch_utils.set_default_torch_dtype = lambda _dtype: nullcontext()
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader.utils",
+        loader_utils,
+    )
+    monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils)
+    monkeypatch.setattr(
+        model_loader,
+        "setup_meta_tensor_workaround",
+        lambda: events.append("setup"),
+    )
+    monkeypatch.setattr(
+        model_loader,
+        "materialize_module_from_gms",
+        lambda *_args, **_kwargs: events.append("materialize"),
+    )
+    monkeypatch.setattr(model_loader, "get_mx_load_context", lambda *_args: None)
+
+    model_config = SimpleNamespace(dtype=torch.float32)
+    assert model_loader._load_read_mode(manager, object(), model_config, 0) is model
+    assert events == ["setup", "initialize", "post-load", "materialize"]
+
+
+def test_meta_post_load_failure_prevents_materialization(monkeypatch):
+    events = []
+
+    def fail_close():
+        events.append("close")
+        raise RuntimeError("close failed")
+
+    manager = SimpleNamespace(close=fail_close)
+    model = SimpleNamespace(eval=lambda: model)
+    loader_utils = ModuleType("vllm.model_executor.model_loader.utils")
+    loader_utils.initialize_model = lambda **_kwargs: (
+        events.append("initialize") or model
     )
 
-    def fail_after_pending(*_args):
-        model_loader._pending_gms_client = client
-        model_loader._pending_retained_gms_tensors = [object()]
-        raise RuntimeError("model eval failed")
+    def fail_post_load(*_args):
+        events.append("post-load")
+        raise RuntimeError("post-load failed")
 
-    monkeypatch.setattr(model_loader, "_load_write_mode_impl", fail_after_pending)
+    loader_utils.process_weights_after_loading = fail_post_load
+    torch_utils = ModuleType("vllm.utils.torch_utils")
+    torch_utils.set_default_torch_dtype = lambda _dtype: nullcontext()
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader.utils",
+        loader_utils,
+    )
+    monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils)
+    monkeypatch.setattr(model_loader, "setup_meta_tensor_workaround", lambda: None)
+    monkeypatch.setattr(
+        model_loader,
+        "materialize_module_from_gms",
+        lambda *_args, **_kwargs: events.append("materialize"),
+    )
 
-    with pytest.raises(RuntimeError, match="model eval failed"):
-        model_loader._load_write_mode(client, None, None, None, torch.device("cpu"))
+    with pytest.raises(RuntimeError, match="post-load failed"):
+        model_loader._load_read_mode(
+            manager,
+            object(),
+            SimpleNamespace(dtype=torch.float32),
+            0,
+        )
 
-    assert events == [("close", True)]
-    assert model_loader._pending_retained_gms_tensors == []
-    assert not model_loader.has_pending_gms_write()
+    assert events == ["initialize", "post-load", "close"]

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -35,6 +35,7 @@ from gpu_memory_service.client.torch.tensor import (
     STORAGE_MANIFEST_PREFIX,
     ModuleTensorBinding,
     ModuleTensorKind,
+    StorageManifest,
 )
 from gpu_memory_service.integrations.common import utils as common_utils
 from gpu_memory_service.integrations.trtllm import model_loader as trtllm_model_loader
@@ -142,7 +143,7 @@ def cpu_storage_pointer(monkeypatch):
 
 
 @pytest.fixture
-def gms_write(monkeypatch):
+def gms_allocator(monkeypatch):
     events = []
     allocator = _FakeAllocator(events)
 
@@ -163,7 +164,12 @@ def gms_write(monkeypatch):
         "rebind_nonparameter_tensors",
         lambda _allocator, _model: events.append("rebind") or 12,
     )
+    return allocator, events
 
+
+@pytest.fixture
+def gms_write(gms_allocator):
+    allocator, events = gms_allocator
     stats = common_utils.prepare_gms_write(allocator, object())
     return allocator, stats, events
 
@@ -175,27 +181,40 @@ def clear_pending_write(monkeypatch):
     monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
 
 
+@pytest.fixture
+def fake_vllm_read(monkeypatch):
+    events = []
+    model = SimpleNamespace(eval=lambda: model)
+    loader_utils = ModuleType("vllm.model_executor.model_loader.utils")
+    loader_utils.initialize_model = lambda **_kwargs: (
+        events.append("initialize") or model
+    )
+    loader_utils.process_weights_after_loading = lambda *_args: events.append(
+        "post-load"
+    )
+    torch_utils = ModuleType("vllm.utils.torch_utils")
+    torch_utils.set_default_torch_dtype = lambda _dtype: nullcontext()
+    monkeypatch.setitem(
+        sys.modules,
+        "vllm.model_executor.model_loader.utils",
+        loader_utils,
+    )
+    monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils)
+    monkeypatch.setattr(model_loader, "setup_meta_tensor_workaround", lambda: None)
+    monkeypatch.setattr(
+        model_loader,
+        "materialize_module_from_gms",
+        lambda *_args, **_kwargs: events.append("materialize"),
+    )
+    monkeypatch.setattr(model_loader, "get_mx_load_context", lambda *_args: None)
+    return loader_utils, model, events
+
+
 def _writer_for_tensor(tensor: torch.Tensor):
     store = _MetadataStore()
     storage = tensor.untyped_storage()
     allocations = {"allocation": (storage.data_ptr(), storage.nbytes())}
     return store, _Manager(store, allocations, mapped=True)
-
-
-def test_module_tensor_binding_round_trip_uses_lowercase_kind():
-    binding = ModuleTensorBinding(
-        "value",
-        ModuleTensorKind.NONPERSISTENT_BUFFER,
-    )
-    encoded = msgspec.msgpack.encode(binding)
-
-    assert msgspec.msgpack.decode(encoded) == {
-        "path": "value",
-        "kind": "nonpersistent_buffer",
-    }
-    decoded = msgspec.msgpack.decode(encoded, type=ModuleTensorBinding)
-    assert decoded == binding
-    assert decoded.kind is ModuleTensorKind.NONPERSISTENT_BUFFER
 
 
 def test_manifest_groups_exact_alias_bindings_and_shared_storage_objects():
@@ -223,25 +242,25 @@ def test_manifest_groups_exact_alias_bindings_and_shared_storage_objects():
     assert set(manifest) == {"nbytes", "objects"}
     assert manifest["nbytes"] == backing.untyped_storage().nbytes()
     assert len(manifest["objects"]) == 2
-    assert manifest["objects"][0] == {
-        "dtype": "float32",
-        "shape": [3],
-        "stride": [2],
-        "storage_offset_bytes": 4,
-        "requires_grad": False,
-        "bindings": [
-            {"path": "first", "kind": "attribute"},
-            {"path": "first_alias", "kind": "attribute"},
-        ],
-    }
+    first_object = manifest["objects"][0]
+    assert first_object["dtype"] == "float32"
+    assert first_object["shape"] == [3]
+    assert first_object["stride"] == [2]
+    assert first_object["storage_offset_bytes"] == 4
+    assert not first_object["requires_grad"]
+    assert first_object["bindings"] == [
+        {"path": "first", "kind": "attribute"},
+        {"path": "first_alias", "kind": "attribute"},
+    ]
     assert manifest["objects"][1]["storage_offset_bytes"] == 8
     assert manifest["objects"][1]["bindings"] == [
         {"path": "second", "kind": "attribute"}
     ]
-    assert "allocation_id" not in payload.decode("latin1")
+    typed = msgspec.msgpack.decode(payload, type=StorageManifest)
+    assert typed.objects[0].bindings[0].kind is ModuleTensorKind.ATTRIBUTE
 
 
-def test_reader_replaces_split_and_shared_placeholder_topology(cpu_storage_pointer):
+def test_reader_uses_source_topology_and_binding_forms(cpu_storage_pointer):
     backing = torch.arange(8, dtype=torch.float32)
     exact = backing[::2]
     distinct = torch.empty(0).set_(
@@ -255,8 +274,23 @@ def test_reader_replaces_split_and_shared_placeholder_topology(cpu_storage_point
     writer_model.exact_b = exact
     writer_model.distinct_a = backing
     writer_model.distinct_b = distinct
+    writer_model.register_buffer("runtime", exact, persistent=False)
+    writer_model.direct = exact
+    writer_model.values = [exact]
+    writer_model.fixed = (exact,)
     store, writer = _writer_for_tensor(backing)
     register_module_tensors(writer, writer_model)
+    manifest = msgspec.msgpack.decode(next(iter(store.entries.values()))[2])
+    runtime_binding = next(
+        binding
+        for tensor_object in manifest["objects"]
+        for binding in tensor_object["bindings"]
+        if binding["path"] == "runtime"
+    )
+    assert runtime_binding == {
+        "path": "runtime",
+        "kind": "nonpersistent_buffer",
+    }
 
     shared_placeholder = torch.zeros(1)
     reader_model = torch.nn.Module()
@@ -264,24 +298,36 @@ def test_reader_replaces_split_and_shared_placeholder_topology(cpu_storage_point
     reader_model.exact_b = torch.ones(3, dtype=torch.float64)
     reader_model.distinct_a = shared_placeholder
     reader_model.distinct_b = shared_placeholder
-    names = ("exact_a", "exact_b", "distinct_a", "distinct_b")
-    old_placeholders = tuple(reader_model.__dict__[name] for name in names)
+    reader_model.register_buffer("runtime", torch.zeros(1))
+    reader_model.direct = torch.zeros(2)
+    reader_model.values = [torch.zeros(3)]
+    old_tuple = (torch.zeros(5),)
+    reader_model.fixed = old_tuple
     reader = _Manager(store, writer.allocations, mapped=False)
 
     materialize_module_from_gms(reader, reader_model, device_index=0)
 
     assert reader.mapping_calls == ["allocation"]
-    assert reader_model.exact_a is reader_model.exact_b
-    assert reader_model.distinct_a is not reader_model.distinct_b
-    assert all(
-        reader_model.__dict__[name] is not old
-        for name, old in zip(names, old_placeholders, strict=True)
+    exact_aliases = (
+        reader_model.exact_a,
+        reader_model.exact_b,
+        reader_model.runtime,
+        reader_model.direct,
+        reader_model.values[0],
+        reader_model.fixed[0],
     )
-    storage_ids = {
-        reader_model.__dict__[name].untyped_storage()._cdata for name in names
-    }
+    assert all(alias is reader_model.exact_a for alias in exact_aliases)
+    assert reader_model.distinct_a is not reader_model.distinct_b
+    storage_ids = {tensor.untyped_storage()._cdata for tensor in exact_aliases}
+    storage_ids.update(
+        tensor.untyped_storage()._cdata
+        for tensor in (reader_model.distinct_a, reader_model.distinct_b)
+    )
     assert len(storage_ids) == 1
     assert backing.untyped_storage()._cdata not in storage_ids
+    assert reader_model.fixed is not old_tuple
+    assert "runtime" in reader_model._non_persistent_buffers_set
+    assert "runtime" not in reader_model.state_dict()
     torch.testing.assert_close(reader_model.exact_a, backing[::2])
     torch.testing.assert_close(reader_model.distinct_b, backing[1::2])
     reader_model.exact_a[1] = 99
@@ -355,35 +401,6 @@ def test_mixed_dtype_byte_offsets_and_one_mapping_per_allocation(
         reader_model.octets,
         torch.tensor([1, 1, 0, 0, 2, 0, 0, 0], dtype=torch.uint8),
     )
-
-
-def test_nonpersistent_buffer_direct_list_and_tuple_bind_same_source_object(
-    cpu_storage_pointer,
-):
-    tensor = torch.arange(4, dtype=torch.float32)
-    writer_model = torch.nn.Module()
-    writer_model.register_buffer("runtime", tensor, persistent=False)
-    writer_model.direct = tensor
-    writer_model.values = [tensor]
-    writer_model.fixed = (tensor,)
-    store, writer = _writer_for_tensor(tensor)
-    register_module_tensors(writer, writer_model)
-
-    reader_model = torch.nn.Module()
-    reader_model.register_buffer("runtime", torch.zeros(1))
-    reader_model.direct = torch.zeros(2)
-    reader_model.values = [torch.zeros(3)]
-    old_tuple = (torch.zeros(5),)
-    reader_model.fixed = old_tuple
-    reader = _Manager(store, writer.allocations, mapped=False)
-    materialize_module_from_gms(reader, reader_model, device_index=0)
-
-    assert reader_model.runtime is reader_model.direct
-    assert reader_model.runtime is reader_model.values[0]
-    assert reader_model.runtime is reader_model.fixed[0]
-    assert reader_model.fixed is not old_tuple
-    assert "runtime" in reader_model._non_persistent_buffers_set
-    assert "runtime" not in reader_model.state_dict()
 
 
 class _LoaderParameter(torch.nn.Parameter):
@@ -496,9 +513,12 @@ def test_reader_creates_writer_final_bindings_absent_from_initial_model(
     torch.testing.assert_close(reader_model.runtime_scale, runtime)
 
 
-def test_reader_rejects_distinct_sources_for_tied_submodule_destination():
+@pytest.mark.parametrize("distinct_sources", (False, True))
+def test_reader_resolves_tied_submodule_destinations(
+    cpu_storage_pointer, distinct_sources
+):
     first = torch.arange(2, dtype=torch.float32)
-    second = torch.arange(2, dtype=torch.float32) + 10
+    second = first + 10 if distinct_sources else first
     writer_model = torch.nn.Module()
     writer_model.a = torch.nn.Module()
     writer_model.b = torch.nn.Module()
@@ -506,14 +526,8 @@ def test_reader_rejects_distinct_sources_for_tied_submodule_destination():
     writer_model.b.value = second
     store = _MetadataStore()
     allocations = {
-        "first": (
-            first.untyped_storage().data_ptr(),
-            first.untyped_storage().nbytes(),
-        ),
-        "second": (
-            second.untyped_storage().data_ptr(),
-            second.untyped_storage().nbytes(),
-        ),
+        name: (tensor.untyped_storage().data_ptr(), tensor.untyped_storage().nbytes())
+        for name, tensor in (("first", first), ("second", second))
     }
     writer = _Manager(store, allocations, mapped=True)
     register_module_tensors(writer, writer_model)
@@ -525,36 +539,15 @@ def test_reader_rejects_distinct_sources_for_tied_submodule_destination():
     reader_model.b = shared
     reader = _Manager(store, allocations, mapped=False)
 
-    with pytest.raises(RuntimeError, match="same destination"):
+    if distinct_sources:
+        with pytest.raises(RuntimeError, match="same destination"):
+            materialize_module_from_gms(reader, reader_model, device_index=0)
+        assert reader.mapping_calls == []
+        torch.testing.assert_close(shared.value, torch.zeros(1))
+    else:
         materialize_module_from_gms(reader, reader_model, device_index=0)
-
-    assert reader.mapping_calls == []
-    torch.testing.assert_close(shared.value, torch.zeros(1))
-
-
-def test_reader_deduplicates_same_source_for_tied_submodule_destination(
-    cpu_storage_pointer,
-):
-    source = torch.arange(2, dtype=torch.float32)
-    writer_shared = torch.nn.Module()
-    writer_shared.value = source
-    writer_model = torch.nn.Module()
-    writer_model.a = writer_shared
-    writer_model.b = writer_shared
-    store, writer = _writer_for_tensor(source)
-    register_module_tensors(writer, writer_model)
-
-    reader_shared = torch.nn.Module()
-    reader_shared.value = torch.zeros(1)
-    reader_model = torch.nn.Module()
-    reader_model.a = reader_shared
-    reader_model.b = reader_shared
-    reader = _Manager(store, writer.allocations, mapped=False)
-
-    materialize_module_from_gms(reader, reader_model, device_index=0)
-
-    assert reader_model.a.value is reader_model.b.value
-    torch.testing.assert_close(reader_model.a.value, source)
+        assert reader_model.a.value is reader_model.b.value
+        torch.testing.assert_close(reader_model.a.value, first)
 
 
 def test_writer_rejects_out_of_bounds_and_overlapping_storages():
@@ -782,24 +775,6 @@ def test_reader_keeps_mapping_when_clone_cleanup_cannot_synchronize(
     assert list(reader.mappings) == [tensor.untyped_storage().data_ptr()]
 
 
-def test_reader_ignores_metadata_outside_storage_prefix(
-    cpu_storage_pointer,
-):
-    tensor = torch.arange(4, dtype=torch.float32)
-    writer_model = torch.nn.Module()
-    writer_model.runtime = tensor
-    store, writer = _writer_for_tensor(tensor)
-    register_module_tensors(writer, writer_model)
-    store.entries["runtime"] = ("missing", 0, b"unrelated")
-    reader_model = torch.nn.Module()
-    reader_model.runtime = torch.zeros(1)
-    reader = _Manager(store, writer.allocations, mapped=False)
-
-    materialize_module_from_gms(reader, reader_model, device_index=0)
-
-    torch.testing.assert_close(reader_model.runtime, tensor)
-
-
 def test_reader_rejects_metadata_without_storage_manifests():
     store = _MetadataStore()
     store.entries["runtime"] = ("allocation", 0, b"unsupported")
@@ -849,7 +824,7 @@ def test_unregistered_parameter_and_zero_byte_storage_are_rejected():
         register_module_tensors(writer, model)
 
 
-def test_publisher_rebind_clones_storage_once_and_retains_one_source_owner():
+def test_publisher_rebind_clones_once_retains_source_and_is_idempotent():
     backing = torch.arange(8, dtype=torch.float32)
     view = backing[1::2]
     assert view._base is backing
@@ -866,10 +841,13 @@ def test_publisher_rebind_clones_storage_once_and_retains_one_source_owner():
     assert model.view is view
     assert model.backing.untyped_storage()._cdata != old_storage
     assert model.backing.untyped_storage()._cdata == model.view.untyped_storage()._cdata
-    sentinel, owners = model.__dict__["_gms_displaced_source_tensors"]
-    assert sentinel is torch_module._DISPLACED_SOURCE_TENSORS_SENTINEL
+    owners = torch_module._get_displaced_source_tensors(model)
+    assert owners is not None
     assert len(owners) == 1
     assert owners[0].untyped_storage()._cdata == old_storage
+    assert rebind_nonparameter_tensors(manager, model) == 0
+    assert torch_module._get_displaced_source_tensors(model) is owners
+    assert len(owners) == 1
     owner_ref = weakref.ref(owners[0])
     del owners
     gc.collect()
@@ -878,23 +856,6 @@ def test_publisher_rebind_clones_storage_once_and_retains_one_source_owner():
     assert retained_owner.untyped_storage()._cdata == old_storage
     model.view.add_(10)
     torch.testing.assert_close(model.backing[1::2], model.view)
-
-
-def test_second_rebind_preserves_displaced_source_owner_state():
-    tensor = torch.arange(4, dtype=torch.float32)
-    model = torch.nn.Module()
-    model.runtime = tensor
-    _, manager = _writer_for_tensor(tensor)
-
-    rebind_nonparameter_tensors(manager, model)
-    owner_state = model.__dict__["_gms_displaced_source_tensors"]
-    owners = owner_state[1]
-    owner = owners[0]
-
-    assert rebind_nonparameter_tensors(manager, model) == 0
-    assert model.__dict__["_gms_displaced_source_tensors"] is owner_state
-    assert len(owners) == 1
-    assert owners[0] is owner
 
 
 def test_swap_accepts_exclusively_owned_replacements_for_parameter_and_view():
@@ -972,23 +933,17 @@ def test_swap_preflight_failure_does_not_mutate_earlier_objects():
     torch.testing.assert_close(second, torch.arange(4, dtype=torch.float32) + 10)
 
 
-def test_displaced_source_collision_is_rejected_without_rebind_candidate():
-    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
-    model = torch.nn.Module()
-    model.weight = parameter
-    model.__dict__["_gms_displaced_source_tensors"] = [torch.ones(1)]
-    _, manager = _writer_for_tensor(parameter)
-
-    with pytest.raises(RuntimeError, match="Reserved GMS attribute"):
-        rebind_nonparameter_tensors(manager, model)
-
-
-def test_displaced_source_collision_is_rejected_on_submodule():
+@pytest.mark.parametrize("on_submodule", (False, True), ids=("root", "submodule"))
+def test_displaced_source_collision_is_rejected(on_submodule):
     tensor = torch.arange(4, dtype=torch.float32)
     model = torch.nn.Module()
-    model.child = torch.nn.Module()
-    model.child.runtime = tensor
-    model.child.__dict__["_gms_displaced_source_tensors"] = None
+    target = torch.nn.Module() if on_submodule else model
+    if on_submodule:
+        model.child = target
+        target.runtime = tensor
+    else:
+        model.weight = torch.nn.Parameter(tensor)
+    target.__dict__["_gms_displaced_source_tensors"] = None
     _, manager = _writer_for_tensor(tensor)
 
     with pytest.raises(RuntimeError, match="Reserved GMS attribute"):
@@ -1009,14 +964,8 @@ def test_prepare_and_publish_accounting(gms_write):
     assert events == ["register", "prune", "commit", "connect", "remap"]
 
 
-def test_eager_finalize_rebinds_before_publication(gms_write):
-    allocator, _, events = gms_write
-    events.clear()
-    allocator.total_bytes = 100
-    allocator.mappings[2] = SimpleNamespace(
-        allocation_id="scratch",
-        aligned_size=40,
-    )
+def test_eager_finalize_rebinds_before_publication(gms_allocator):
+    allocator, events = gms_allocator
 
     stats = common_utils.finalize_gms_write(allocator, object())
 
@@ -1032,16 +981,10 @@ def test_eager_finalize_rebinds_before_publication(gms_write):
 
 
 def test_eager_finalize_releases_after_partial_rebind_without_publishing(
-    gms_write, monkeypatch
+    gms_allocator, monkeypatch
 ):
-    allocator, _, events = gms_write
-    events.clear()
+    allocator, events = gms_allocator
     allocator.fail_close = True
-    allocator.total_bytes = 100
-    allocator.mappings[2] = SimpleNamespace(
-        allocation_id="scratch",
-        aligned_size=40,
-    )
 
     model = SimpleNamespace(partially_rebound=False)
 
@@ -1059,16 +1002,10 @@ def test_eager_finalize_releases_after_partial_rebind_without_publishing(
     assert events == ["register", "prune", "rebind", "close_best_effort"]
 
 
-def test_eager_finalize_commit_failure_releases_and_preserves_error(gms_write):
-    allocator, _, events = gms_write
-    events.clear()
+def test_eager_finalize_commit_failure_releases_and_preserves_error(gms_allocator):
+    allocator, events = gms_allocator
     allocator.fail_commit = True
     allocator.fail_close = True
-    allocator.total_bytes = 100
-    allocator.mappings[2] = SimpleNamespace(
-        allocation_id="scratch",
-        aligned_size=40,
-    )
 
     with pytest.raises(RuntimeError, match="commit failed"):
         common_utils.finalize_gms_write(allocator, object())
@@ -1210,75 +1147,38 @@ def test_write_load_failure_uses_best_effort_close_and_preserves_error(monkeypat
     assert not model_loader.has_pending_gms_write()
 
 
-def test_read_mode_runs_meta_post_load_once_before_materialization(monkeypatch):
-    events = []
-    model = SimpleNamespace(eval=lambda: model)
+def test_read_mode_runs_meta_post_load_once_before_materialization(
+    monkeypatch, fake_vllm_read
+):
+    _, model, events = fake_vllm_read
     manager = SimpleNamespace(close=lambda: events.append("close"), total_bytes=16)
-    loader_utils = ModuleType("vllm.model_executor.model_loader.utils")
-    loader_utils.initialize_model = lambda **_kwargs: (
-        events.append("initialize") or model
-    )
-    loader_utils.process_weights_after_loading = lambda *_args: events.append(
-        "post-load"
-    )
-    torch_utils = ModuleType("vllm.utils.torch_utils")
-    torch_utils.set_default_torch_dtype = lambda _dtype: nullcontext()
-    monkeypatch.setitem(
-        sys.modules,
-        "vllm.model_executor.model_loader.utils",
-        loader_utils,
-    )
-    monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils)
     monkeypatch.setattr(
         model_loader,
         "setup_meta_tensor_workaround",
         lambda: events.append("setup"),
     )
-    monkeypatch.setattr(
-        model_loader,
-        "materialize_module_from_gms",
-        lambda *_args, **_kwargs: events.append("materialize"),
-    )
-    monkeypatch.setattr(model_loader, "get_mx_load_context", lambda *_args: None)
 
     model_config = SimpleNamespace(dtype=torch.float32)
     assert model_loader._load_read_mode(manager, object(), model_config, 0) is model
     assert events == ["setup", "initialize", "post-load", "materialize"]
 
 
-def test_meta_post_load_failure_prevents_materialization(monkeypatch):
-    events = []
+def test_meta_post_load_failure_prevents_materialization(
+    fake_vllm_read,
+):
+    loader_utils, _, events = fake_vllm_read
 
     def fail_close():
         events.append("close")
         raise RuntimeError("close failed")
 
     manager = SimpleNamespace(close=fail_close)
-    model = SimpleNamespace(eval=lambda: model)
-    loader_utils = ModuleType("vllm.model_executor.model_loader.utils")
-    loader_utils.initialize_model = lambda **_kwargs: (
-        events.append("initialize") or model
-    )
 
     def fail_post_load(*_args):
         events.append("post-load")
         raise RuntimeError("post-load failed")
 
     loader_utils.process_weights_after_loading = fail_post_load
-    torch_utils = ModuleType("vllm.utils.torch_utils")
-    torch_utils.set_default_torch_dtype = lambda _dtype: nullcontext()
-    monkeypatch.setitem(
-        sys.modules,
-        "vllm.model_executor.model_loader.utils",
-        loader_utils,
-    )
-    monkeypatch.setitem(sys.modules, "vllm.utils.torch_utils", torch_utils)
-    monkeypatch.setattr(model_loader, "setup_meta_tensor_workaround", lambda: None)
-    monkeypatch.setattr(
-        model_loader,
-        "materialize_module_from_gms",
-        lambda *_args, **_kwargs: events.append("materialize"),
-    )
 
     with pytest.raises(RuntimeError, match="post-load failed"):
         model_loader._load_read_mode(

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import json
 import weakref
 from types import SimpleNamespace
 
@@ -26,8 +27,9 @@ from gpu_memory_service.client.torch.module import (
     _iter_module_tensors,
     materialize_module_from_gms,
     rebind_nonparameter_tensors,
+    register_module_tensors,
 )
-from gpu_memory_service.client.torch.tensor import TensorMetadata
+from gpu_memory_service.client.torch.tensor import GMSTensorSpec, TensorMetadata
 from gpu_memory_service.integrations.common import utils as common_utils
 from gpu_memory_service.integrations.vllm import model_loader
 
@@ -177,7 +179,12 @@ def test_eager_finalize_preserves_publish_then_rebind_order(gms_write):
 def _manager_for(tensor):
     storage = tensor.untyped_storage()
     return SimpleNamespace(
-        mappings={storage.data_ptr(): SimpleNamespace(aligned_size=storage.nbytes())}
+        mappings={
+            storage.data_ptr(): SimpleNamespace(
+                allocation_id="allocation",
+                aligned_size=storage.nbytes(),
+            )
+        }
     )
 
 
@@ -207,6 +214,41 @@ def _set_specs(monkeypatch, specs):
         torch_module.GMSTensorSpec,
         "load_all",
         classmethod(lambda _cls, _manager: specs),
+    )
+
+
+def _component_spec(
+    name,
+    tensor,
+    tensor_type,
+    *,
+    storage_group_id,
+    object_group_id,
+    storage_base_offset,
+    storage_nbytes,
+    buffer_persistent=False,
+    allocation_id="allocation",
+):
+    meta = TensorMetadata.from_tensor(
+        tensor,
+        tensor_type,
+        storage={
+            "schema_version": 1,
+            "storage_group_id": storage_group_id,
+            "object_group_id": object_group_id,
+            "storage_base_offset": storage_base_offset,
+            "storage_nbytes": storage_nbytes,
+            "storage_offset": tensor.storage_offset(),
+            "buffer_persistent": buffer_persistent,
+        },
+    )
+    element_size = tensor.element_size()
+    return GMSTensorSpec(
+        key=name,
+        name=name,
+        allocation_id=allocation_id,
+        offset_bytes=storage_base_offset + tensor.storage_offset() * element_size,
+        meta=meta,
     )
 
 
@@ -276,22 +318,22 @@ def test_rebind_fails_closed_when_swap_rejects_weakref(monkeypatch):
     _set_module_tensors(monkeypatch, ("runtime", source, "tensor_attr"))
     source_ptr = source.data_ptr()
 
-    with pytest.raises(RuntimeError, match="swap_tensors failed:.*weakref"):
+    with pytest.raises(RuntimeError, match="does not support weak references"):
         rebind_nonparameter_tensors(_manager_for(source), model)
 
     assert source_ref() is source
     assert source.data_ptr() == source_ptr
 
 
-def test_rebind_rejects_distinct_views(monkeypatch):
+def test_rebind_supports_discovered_view_with_undiscovered_base(monkeypatch):
     base = torch.arange(8)
     view = base[::2]
     model = torch.nn.Module()
     model.view = view
     _set_module_tensors(monkeypatch, ("view", view, "tensor_attr"))
 
-    with pytest.raises(RuntimeError, match="cannot rebind tensor view"):
-        rebind_nonparameter_tensors(_manager_for(base), model)
+    assert rebind_nonparameter_tensors(_manager_for(base), model) == base.nbytes
+    torch.testing.assert_close(model.view, torch.tensor([0, 2, 4, 6]))
 
 
 def test_rebind_skips_ephemeral_property_view(monkeypatch):
@@ -383,7 +425,7 @@ def test_reader_preserves_nonpersistent_buffer(monkeypatch):
     torch.testing.assert_close(buffer, torch.ones(4))
 
 
-def test_reader_rejects_observed_view_before_mutation(monkeypatch):
+def test_legacy_reader_rejects_discovered_view_placeholders(monkeypatch):
     model = torch.nn.Module()
     model.first = torch.zeros(4)
     model.view = model.first[:]
@@ -401,7 +443,7 @@ def test_reader_rejects_observed_view_before_mutation(monkeypatch):
     torch.testing.assert_close(model.first, torch.zeros(4))
 
 
-def test_reader_rejects_observed_shared_storage_before_mutation(monkeypatch):
+def test_legacy_reader_rejects_distinct_shared_storage_placeholders(monkeypatch):
     model = torch.nn.Module()
     model.first = torch.zeros(4)
     model.second = torch.empty(0)
@@ -527,6 +569,420 @@ def test_reader_rejects_weak_parameter_before_mutation(monkeypatch):
     torch.testing.assert_close(model.runtime, torch.zeros(4))
 
 
+def test_nonparameter_component_copies_storage_once(monkeypatch):
+    base = torch.arange(8, dtype=torch.float32)
+    view = base[2::2]
+    model = torch.nn.Module()
+    model.base = base
+    model.view = view
+    manager = _manager_for(base)
+    old_storage = base.untyped_storage()._cdata
+    _set_module_tensors(
+        monkeypatch,
+        ("base", base, "tensor_attr"),
+        ("view", view, "tensor_attr"),
+    )
+
+    rebound = rebind_nonparameter_tensors(manager, model)
+
+    assert rebound == base.untyped_storage().nbytes()
+    assert model.base.untyped_storage()._cdata != old_storage
+    assert model.base.untyped_storage()._cdata == model.view.untyped_storage()._cdata
+    model.view.add_(10)
+    torch.testing.assert_close(model.base[2::2], model.view)
+
+
+def test_mixed_dtype_component_reconstructs_shared_storage(monkeypatch):
+    source_octets = torch.tensor([1, 0, 0, 0, 2, 0, 0, 0], dtype=torch.uint8)
+    source_storage = source_octets.untyped_storage()
+    source_words = torch.empty(0, dtype=torch.int32).set_(source_storage, 0, (2,), (1,))
+    writer = torch.nn.Module()
+    writer.octets = source_octets
+    writer.words = source_words
+    _set_module_tensors(
+        monkeypatch,
+        ("octets", source_octets, "tensor_attr"),
+        ("words", source_words, "tensor_attr"),
+    )
+
+    specs = {}
+
+    def metadata_put(*, key, allocation_id, offset_bytes, value):
+        specs[key] = GMSTensorSpec(
+            key=key,
+            name=key,
+            allocation_id=allocation_id,
+            offset_bytes=offset_bytes,
+            meta=TensorMetadata.from_bytes(value),
+        )
+        return True
+
+    manager = _manager_for(source_octets)
+    manager.metadata_put = metadata_put
+    assert register_module_tensors(manager, writer) == {"allocation"}
+
+    reader_octets = torch.zeros(8, dtype=torch.uint8)
+    reader_storage = reader_octets.untyped_storage()
+    reader_words = torch.empty(0, dtype=torch.int32).set_(reader_storage, 0, (2,), (1,))
+    reader = torch.nn.Module()
+    reader.octets = reader_octets
+    reader.words = reader_words
+    _set_specs(monkeypatch, specs)
+    monkeypatch.setattr(
+        torch_module,
+        "_storage_from_pointer",
+        lambda _ptr, _size, _device: source_storage,
+    )
+
+    materialize_module_from_gms(manager, reader, device_index=0)
+
+    assert reader.octets is reader_octets and reader.words is reader_words
+    assert (
+        reader.octets.untyped_storage()._cdata == reader.words.untyped_storage()._cdata
+    )
+    torch.testing.assert_close(reader.octets, source_octets)
+    torch.testing.assert_close(reader.words, torch.tensor([1, 2], dtype=torch.int32))
+    reader.words[0] = 257
+    torch.testing.assert_close(
+        reader.octets, torch.tensor([1, 1, 0, 0, 2, 0, 0, 0], dtype=torch.uint8)
+    )
+
+
+def test_writer_rejects_distinct_overlapping_storage_ranges(monkeypatch):
+    allocation = torch.arange(16, dtype=torch.uint8)
+    ptr = allocation.data_ptr()
+    first_storage = torch._C._construct_storage_from_data_pointer(
+        ptr, torch.device("cpu"), 12
+    )
+    second_storage = torch._C._construct_storage_from_data_pointer(
+        ptr + 4, torch.device("cpu"), 12
+    )
+    first = torch.empty(0, dtype=torch.uint8).set_(first_storage, 0, (12,), (1,))
+    second = torch.empty(0, dtype=torch.uint8).set_(second_storage, 0, (12,), (1,))
+    model = torch.nn.Module()
+    model.first = first
+    model.second = second
+    manager = SimpleNamespace(
+        mappings={
+            ptr: SimpleNamespace(
+                allocation_id="allocation",
+                aligned_size=allocation.untyped_storage().nbytes(),
+            )
+        },
+        metadata_put=lambda **_kwargs: pytest.fail("metadata was mutated"),
+    )
+    _set_module_tensors(
+        monkeypatch,
+        ("first", first, "tensor_attr"),
+        ("second", second, "tensor_attr"),
+    )
+
+    with pytest.raises(RuntimeError, match="byte ranges overlap"):
+        register_module_tensors(manager, model)
+
+
+def test_writer_accepts_ordinary_trainable_leaf_parameter(monkeypatch):
+    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+    model = torch.nn.Module()
+    model.register_parameter("weight", parameter)
+    _set_module_tensors(monkeypatch, ("weight", parameter, "parameter"))
+    published = []
+    manager = _manager_for(parameter)
+    manager.metadata_put = lambda **kwargs: published.append(kwargs) or True
+
+    assert register_module_tensors(manager, model) == {"allocation"}
+    assert [entry["key"] for entry in published] == ["weight"]
+
+
+def test_hidden_no_grad_view_fails_public_preflights(monkeypatch):
+    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+    with torch.no_grad():
+        hidden_view = parameter[:]
+    model = torch.nn.Module()
+    model.register_parameter("weight", parameter)
+    _set_module_tensors(monkeypatch, ("weight", parameter, "parameter"))
+    manager = _manager_for(parameter)
+    manager.metadata_put = lambda **_kwargs: pytest.fail("metadata was mutated")
+
+    with pytest.raises(RuntimeError, match="TensorImpl use count"):
+        register_module_tensors(manager, model)
+
+    runtime = torch.zeros(4)
+    model.runtime = runtime
+    _set_specs(
+        monkeypatch,
+        {
+            "runtime": _component_spec(
+                "runtime",
+                runtime,
+                "tensor_attr",
+                storage_group_id=0,
+                object_group_id=0,
+                storage_base_offset=0,
+                storage_nbytes=runtime.untyped_storage().nbytes(),
+            ),
+            "weight": _component_spec(
+                "weight",
+                parameter,
+                "parameter",
+                storage_group_id=1,
+                object_group_id=1,
+                storage_base_offset=runtime.untyped_storage().nbytes(),
+                storage_nbytes=parameter.untyped_storage().nbytes(),
+            ),
+        },
+    )
+    reader_manager = SimpleNamespace(
+        mappings={},
+        create_mapping=lambda **_kwargs: pytest.fail("reader mapping was created"),
+    )
+
+    with pytest.raises(RuntimeError, match="TensorImpl use count"):
+        materialize_module_from_gms(reader_manager, model, device_index=0)
+
+    assert hidden_view.shape == parameter.shape
+    torch.testing.assert_close(runtime, torch.zeros(4))
+    torch.testing.assert_close(parameter, torch.arange(4, dtype=torch.float32))
+
+
+@pytest.mark.parametrize("trainable_view", [False, True])
+def test_writer_rejects_unsupported_view_ownership(monkeypatch, trainable_view):
+    base = torch.nn.Parameter(torch.arange(8, dtype=torch.float32))
+    model = torch.nn.Module()
+    if trainable_view:
+        model.register_parameter("weight", base)
+        model.view = base[::2]
+        entries = [("weight", base, "parameter"), ("view", model.view, "tensor_attr")]
+    else:
+        model.runtime = base.data
+        model.helper = SimpleNamespace(view=model.runtime[::2])
+        entries = [("runtime", model.runtime, "tensor_attr")]
+    _set_module_tensors(monkeypatch, *entries)
+    manager = _manager_for(base)
+    manager.metadata_put = lambda **_kwargs: pytest.fail("metadata was mutated")
+
+    with pytest.raises(RuntimeError, match="autograd tensor|TensorImpl use count"):
+        register_module_tensors(manager, model)
+
+
+def test_reader_rejects_overlapping_wire_components_before_mapping(monkeypatch):
+    model = torch.nn.Module()
+    model.first = torch.zeros(2)
+    model.second = torch.zeros(2)
+    specs = {
+        "first": _component_spec(
+            "first",
+            model.first,
+            "tensor_attr",
+            storage_group_id=0,
+            object_group_id=0,
+            storage_base_offset=0,
+            storage_nbytes=8,
+        ),
+        "second": _component_spec(
+            "second",
+            model.second,
+            "tensor_attr",
+            storage_group_id=1,
+            object_group_id=1,
+            storage_base_offset=4,
+            storage_nbytes=8,
+        ),
+    }
+    _set_specs(monkeypatch, specs)
+    manager = SimpleNamespace(create_mapping=lambda **_kwargs: pytest.fail("mapped"))
+
+    with pytest.raises(RuntimeError, match="byte ranges overlap"):
+        materialize_module_from_gms(manager, model, device_index=0)
+
+    torch.testing.assert_close(model.first, torch.zeros(2))
+
+
+@pytest.mark.parametrize(
+    "wire_shared",
+    [True, False],
+    ids=("wire-shared-reader-split", "wire-split-reader-shared"),
+)
+def test_reader_rejects_storage_impl_topology_before_mapping(monkeypatch, wire_shared):
+    first = torch.zeros(2)
+    if wire_shared:
+        second = torch.ones(2)
+        wire_topology = ((0, 0), (0, 0))
+    else:
+        second = torch.empty(0).set_(first.untyped_storage(), 0, (2,), (1,))
+        wire_topology = ((0, 0), (1, first.untyped_storage().nbytes()))
+    model = torch.nn.Module()
+    model.first = first
+    model.second = second
+    identities = (first, second)
+    specs = {
+        name: _component_spec(
+            name,
+            tensor,
+            "tensor_attr",
+            storage_group_id=storage_group_id,
+            object_group_id=object_group_id,
+            storage_base_offset=storage_base_offset,
+            storage_nbytes=tensor.numel() * tensor.element_size(),
+        )
+        for object_group_id, (
+            name,
+            tensor,
+            (storage_group_id, storage_base_offset),
+        ) in enumerate(
+            zip(
+                ("first", "second"),
+                identities,
+                wire_topology,
+                strict=True,
+            )
+        )
+    }
+    _set_specs(monkeypatch, specs)
+    manager = SimpleNamespace(
+        mappings={},
+        create_mapping=lambda **_kwargs: pytest.fail("reader mapping was created"),
+    )
+
+    with pytest.raises(RuntimeError, match="StorageImpl topology differs"):
+        materialize_module_from_gms(manager, model, device_index=0)
+
+    assert model.first is first
+    assert model.second is second
+    torch.testing.assert_close(first, torch.zeros(2))
+    torch.testing.assert_close(second, torch.ones(2) if wire_shared else torch.zeros(2))
+
+
+def test_component_schema_is_strict_and_keeps_legacy_offset():
+    tensor = torch.arange(4, dtype=torch.float32)
+    meta = TensorMetadata.from_tensor(
+        tensor,
+        "tensor_attr",
+        storage={
+            "schema_version": 1,
+            "storage_group_id": 3,
+            "object_group_id": 4,
+            "storage_base_offset": 16,
+            "storage_nbytes": 32,
+            "storage_offset": 0,
+            "buffer_persistent": False,
+        },
+    )
+    encoded = json.loads(meta.to_bytes())
+    assert encoded["storage"]["schema_version"] == 1
+    assert encoded["storage"]["storage_base_offset"] == 16
+    assert encoded["storage"]["storage_offset"] == 0
+
+    null_stride = encoded.copy()
+    null_stride["stride"] = None
+    with pytest.raises(ValueError, match="stride must be a list"):
+        TensorMetadata.from_bytes(json.dumps(null_stride).encode())
+
+    del encoded["storage"]["storage_nbytes"]
+    with pytest.raises(ValueError, match="fields must be exact"):
+        TensorMetadata.from_bytes(json.dumps(encoded).encode())
+
+    for legacy_stride in ("", ',"stride":null'):
+        legacy = TensorMetadata.from_bytes(
+            (
+                '{"shape":[4],"dtype":"torch.float32",'
+                f'"tensor_type":"parameter"{legacy_stride}}}'
+            ).encode()
+        )
+        assert not legacy.is_storage_component
+        assert legacy.stride == (1,)
+
+    with pytest.raises(ValueError, match="Unknown tensor type"):
+        TensorMetadata.from_bytes(
+            b'{"shape":[4],"dtype":"torch.float32","tensor_type":"unknown"}'
+        )
+
+
+def test_reader_rejects_nontensor_slot_before_mapping(monkeypatch):
+    tensor = torch.zeros(4)
+    bad = torch.nn.Module()
+    bad.sentinel = "not a tensor"
+    _set_specs(
+        monkeypatch,
+        {
+            "sentinel": _component_spec(
+                "sentinel",
+                tensor,
+                "tensor_attr",
+                storage_group_id=0,
+                object_group_id=0,
+                storage_base_offset=0,
+                storage_nbytes=tensor.untyped_storage().nbytes(),
+            )
+        },
+    )
+    with pytest.raises(RuntimeError, match="preexisting direct Tensor"):
+        materialize_module_from_gms(object(), bad, device_index=0)
+
+    _set_specs(monkeypatch, {"sentinel": _spec(tensor, "tensor_attr")})
+    with pytest.raises(RuntimeError, match="preexisting direct Tensor"):
+        materialize_module_from_gms(object(), bad, device_index=0)
+
+
+def test_component_allocation_bounds_failure_cleans_only_new_mapping(monkeypatch):
+    model = torch.nn.Module()
+    model.existing = torch.zeros(2)
+    model.imported = torch.ones(2)
+    identities = (model.existing, model.imported)
+    _set_specs(
+        monkeypatch,
+        {
+            "existing": _component_spec(
+                "existing",
+                model.existing,
+                "tensor_attr",
+                storage_group_id=0,
+                object_group_id=0,
+                storage_base_offset=0,
+                storage_nbytes=model.existing.untyped_storage().nbytes(),
+                allocation_id="existing",
+            ),
+            "imported": _component_spec(
+                "imported",
+                model.imported,
+                "tensor_attr",
+                storage_group_id=1,
+                object_group_id=1,
+                storage_base_offset=4,
+                storage_nbytes=model.imported.untyped_storage().nbytes(),
+                allocation_id="imported",
+            ),
+        },
+    )
+    existing_mapping = SimpleNamespace(allocation_id="existing", aligned_size=8)
+    manager = SimpleNamespace(mappings={100: existing_mapping})
+    freed = []
+
+    def create_mapping(*, allocation_id):
+        assert allocation_id == "imported"
+        manager.mappings[200] = SimpleNamespace(
+            allocation_id=allocation_id, aligned_size=8
+        )
+        return 200
+
+    def free_va(va):
+        freed.append(va)
+        del manager.mappings[va]
+
+    manager.create_mapping = create_mapping
+    manager.free_va = free_va
+
+    with pytest.raises(RuntimeError, match="exceeds allocation"):
+        materialize_module_from_gms(manager, model, device_index=0)
+
+    assert model.existing is identities[0]
+    assert model.imported is identities[1]
+    torch.testing.assert_close(model.existing, torch.zeros(2))
+    torch.testing.assert_close(model.imported, torch.ones(2))
+    assert manager.mappings == {100: existing_mapping}
+    assert freed == [200]
+
+
 @pytest.mark.parametrize("reader", [False, True])
 def test_nonparameter_tensor_subclass_is_rejected(monkeypatch, reader):
     tensor = torch.Tensor._make_subclass(_TensorSubclass, torch.zeros(4))
@@ -552,20 +1008,20 @@ def test_nonparameter_tensor_subclass_is_rejected(monkeypatch, reader):
     torch.testing.assert_close(tensor, torch.zeros(4))
 
 
-def test_rebind_rolls_back_multi_candidate_failure_and_retries(monkeypatch):
+def test_rebind_failure_is_terminal(monkeypatch):
     model = torch.nn.Module()
     model.first = torch.arange(4, dtype=torch.float32)
     model.second = torch.arange(4, dtype=torch.float32) + 10
-    first_ptr = model.first.data_ptr()
-    second_ptr = model.second.data_ptr()
     retained = []
     manager = SimpleNamespace(
         mappings={
-            first_ptr: SimpleNamespace(
-                aligned_size=model.first.untyped_storage().nbytes()
+            model.first.data_ptr(): SimpleNamespace(
+                allocation_id="first",
+                aligned_size=model.first.untyped_storage().nbytes(),
             ),
-            second_ptr: SimpleNamespace(
-                aligned_size=model.second.untyped_storage().nbytes()
+            model.second.data_ptr(): SimpleNamespace(
+                allocation_id="second",
+                aligned_size=model.second.untyped_storage().nbytes(),
             ),
         }
     )
@@ -589,19 +1045,8 @@ def test_rebind_rolls_back_multi_candidate_failure_and_retries(monkeypatch):
     with pytest.raises(RuntimeError, match="injected second swap failure"):
         rebind_nonparameter_tensors(manager, model, retain_gms_tensors=retained)
 
-    assert model.first.data_ptr() == first_ptr
-    assert model.second.data_ptr() == second_ptr
     assert retained == []
     assert "_gms_rebound_tensor_owners" not in model.__dict__
-
-    monkeypatch.setattr(torch_module, "_swap_tensor_contents", real_swap)
-    assert (
-        rebind_nonparameter_tensors(manager, model, retain_gms_tensors=retained)
-        == 2 * model.first.numel() * model.first.element_size()
-    )
-    assert model.first.data_ptr() != first_ptr
-    assert model.second.data_ptr() != second_ptr
-    assert len(retained) == 2
 
 
 def test_failed_vllm_write_load_releases_lease(monkeypatch):

--- a/lib/gpu_memory_service/tests/test_gms_write_publication.py
+++ b/lib/gpu_memory_service/tests/test_gms_write_publication.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import weakref
 from types import SimpleNamespace
 
 import pytest
@@ -19,6 +20,14 @@ if not HAS_GMS:
 if not HAS_TORCH:
     pytest.skip("torch is required", allow_module_level=True)
 
+import torch
+from gpu_memory_service.client.torch import module as torch_module
+from gpu_memory_service.client.torch.module import (
+    _iter_module_tensors,
+    materialize_module_from_gms,
+    rebind_nonparameter_tensors,
+)
+from gpu_memory_service.client.torch.tensor import TensorMetadata
 from gpu_memory_service.integrations.common import utils as common_utils
 from gpu_memory_service.integrations.vllm import model_loader
 
@@ -163,3 +172,472 @@ def test_eager_finalize_preserves_publish_then_rebind_order(gms_write):
         "remap",
         "rebind",
     ]
+
+
+def _manager_for(tensor):
+    storage = tensor.untyped_storage()
+    return SimpleNamespace(
+        mappings={storage.data_ptr(): SimpleNamespace(aligned_size=storage.nbytes())}
+    )
+
+
+def _set_module_tensors(monkeypatch, *entries):
+    monkeypatch.setattr(
+        torch_module, "_iter_module_tensors", lambda _model: iter(entries)
+    )
+
+
+def _spec(
+    tensor,
+    tensor_type,
+    *,
+    allocation_id="allocation",
+    offset_bytes=0,
+):
+    return SimpleNamespace(
+        allocation_id=allocation_id,
+        offset_bytes=offset_bytes,
+        meta=TensorMetadata.from_tensor(tensor, tensor_type),
+        materialize=lambda _manager, _device: tensor.detach().clone(),
+    )
+
+
+def _set_specs(monkeypatch, specs):
+    monkeypatch.setattr(
+        torch_module.GMSTensorSpec,
+        "load_all",
+        classmethod(lambda _cls, _manager: specs),
+    )
+
+
+def test_tensor_iteration_ignores_read_only_buffer_alias_property():
+    class RoutedExpertsLike(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.property_reads = 0
+            self.register_buffer(
+                "_expert_map",
+                torch.empty(4, device="meta", dtype=torch.int32),
+                persistent=False,
+            )
+
+        @property
+        def expert_map(self):
+            self.property_reads += 1
+            return self._expert_map
+
+    model = RoutedExpertsLike()
+
+    assert list(_iter_module_tensors(model)) == []
+    assert model.property_reads == 0
+    assert "_expert_map" in model._non_persistent_buffers_set
+
+
+def test_rebind_does_not_swap_parameter_alias(monkeypatch):
+    parameter = torch.nn.Parameter(torch.arange(4, dtype=torch.float32))
+    model = torch.nn.Module()
+    model.register_parameter("weight", parameter)
+    model.__dict__["parameter_alias"] = parameter
+    _set_module_tensors(
+        monkeypatch,
+        ("weight", parameter, "parameter"),
+        ("parameter_alias", parameter, "tensor_attr"),
+    )
+    parameter_ptr = parameter.data_ptr()
+    retained = []
+
+    assert (
+        rebind_nonparameter_tensors(
+            _manager_for(parameter), model, retain_gms_tensors=retained
+        )
+        == 0
+    )
+    assert model.weight is model.parameter_alias is parameter
+    assert parameter.data_ptr() == parameter_ptr
+    assert retained == []
+
+
+def test_rebound_tensor_owner_is_collision_safe(monkeypatch):
+    model = torch.nn.Module()
+    model.__dict__["_gms_rebound_tensor_owners"] = None
+    tensor = torch.zeros(4)
+    model.runtime = tensor
+    _set_module_tensors(monkeypatch, ("runtime", tensor, "tensor_attr"))
+
+    with pytest.raises(RuntimeError, match="Reserved GMS attribute"):
+        rebind_nonparameter_tensors(_manager_for(tensor), model)
+
+
+def test_rebind_fails_closed_when_swap_rejects_weakref(monkeypatch):
+    source = torch.arange(4)
+    source_ref = weakref.ref(source)
+    model = torch.nn.Module()
+    model.runtime = source
+    _set_module_tensors(monkeypatch, ("runtime", source, "tensor_attr"))
+    source_ptr = source.data_ptr()
+
+    with pytest.raises(RuntimeError, match="swap_tensors failed:.*weakref"):
+        rebind_nonparameter_tensors(_manager_for(source), model)
+
+    assert source_ref() is source
+    assert source.data_ptr() == source_ptr
+
+
+def test_rebind_rejects_distinct_views(monkeypatch):
+    base = torch.arange(8)
+    view = base[::2]
+    model = torch.nn.Module()
+    model.view = view
+    _set_module_tensors(monkeypatch, ("view", view, "tensor_attr"))
+
+    with pytest.raises(RuntimeError, match="cannot rebind tensor view"):
+        rebind_nonparameter_tensors(_manager_for(base), model)
+
+
+def test_rebind_skips_ephemeral_property_view(monkeypatch):
+    class Model(torch.nn.Module):
+        @property
+        def derived(self):
+            return self.runtime[:]
+
+    model = Model()
+    model.runtime = torch.arange(4)
+    runtime_ptr = model.runtime.data_ptr()
+
+    def iter_tensors(_model):
+        yield ("derived", model.derived, "tensor_attr")
+        yield ("runtime", model.runtime, "tensor_attr")
+
+    monkeypatch.setattr(torch_module, "_iter_module_tensors", iter_tensors)
+
+    assert (
+        rebind_nonparameter_tensors(_manager_for(model.runtime), model)
+        == model.runtime.numel() * model.runtime.element_size()
+    )
+    assert model.runtime.data_ptr() != runtime_ptr
+
+
+@pytest.mark.parametrize("alias_first", [False, True])
+def test_reader_parameter_alias_keeps_parameter_identity(monkeypatch, alias_first):
+    parameter = torch.nn.Parameter(torch.zeros(4))
+    model = torch.nn.Module()
+    model.register_parameter("weight", parameter)
+    model.__dict__["weight_alias"] = parameter
+    expected = torch.arange(4, dtype=torch.float32)
+    entries = [
+        ("weight", _spec(expected, "parameter")),
+        ("weight_alias", _spec(expected, "tensor_attr")),
+    ]
+    if alias_first:
+        entries.reverse()
+    _set_specs(monkeypatch, dict(entries))
+
+    materialize_module_from_gms(object(), model, device_index=0)
+
+    assert model.weight is model.weight_alias is parameter
+    assert type(parameter) is torch.nn.Parameter
+    assert model._parameters["weight"] is parameter
+    torch.testing.assert_close(parameter, expected)
+
+
+@pytest.mark.parametrize("alias_first", [False, True])
+def test_reader_parameter_alias_conflict_fails_before_mutation(
+    monkeypatch, alias_first
+):
+    parameter = torch.nn.Parameter(torch.zeros(4))
+    model = torch.nn.Module()
+    model.register_parameter("weight", parameter)
+    model.__dict__["weight_alias"] = parameter
+    entries = [
+        ("weight", _spec(torch.ones(4), "parameter")),
+        (
+            "weight_alias",
+            _spec(torch.ones(4), "tensor_attr", offset_bytes=16),
+        ),
+    ]
+    if alias_first:
+        entries.reverse()
+    _set_specs(monkeypatch, dict(entries))
+
+    with pytest.raises(RuntimeError, match="aliases incompatible GMS entries"):
+        materialize_module_from_gms(object(), model, device_index=0)
+
+    assert model.weight is model.weight_alias is parameter
+    assert type(parameter) is torch.nn.Parameter
+    assert model._parameters["weight"] is parameter
+    torch.testing.assert_close(parameter, torch.zeros(4))
+
+
+def test_reader_preserves_nonpersistent_buffer(monkeypatch):
+    model = torch.nn.Module()
+    buffer = torch.zeros(4)
+    model.register_buffer("expert_mask", buffer, persistent=False)
+    _set_specs(monkeypatch, {"expert_mask": _spec(torch.ones(4), "buffer")})
+
+    materialize_module_from_gms(object(), model, device_index=0)
+
+    assert model.expert_mask is buffer
+    assert model._buffers["expert_mask"] is buffer
+    assert "expert_mask" in model._non_persistent_buffers_set
+    assert "expert_mask" not in model.state_dict()
+    torch.testing.assert_close(buffer, torch.ones(4))
+
+
+def test_reader_rejects_observed_view_before_mutation(monkeypatch):
+    model = torch.nn.Module()
+    model.first = torch.zeros(4)
+    model.view = model.first[:]
+    _set_specs(
+        monkeypatch,
+        {
+            "first": _spec(torch.ones(4), "tensor_attr"),
+            "view": _spec(torch.ones(4), "tensor_attr"),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="cannot materialize tensor view"):
+        materialize_module_from_gms(object(), model, device_index=0)
+
+    torch.testing.assert_close(model.first, torch.zeros(4))
+
+
+def test_reader_rejects_observed_shared_storage_before_mutation(monkeypatch):
+    model = torch.nn.Module()
+    model.first = torch.zeros(4)
+    model.second = torch.empty(0)
+    model.second.set_(model.first.untyped_storage(), 0, (4,), (1,))
+    assert model.second._base is None
+    _set_specs(
+        monkeypatch,
+        {
+            "first": _spec(torch.ones(4), "tensor_attr"),
+            "second": _spec(torch.ones(4), "tensor_attr"),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="distinct tensors that share storage"):
+        materialize_module_from_gms(object(), model, device_index=0)
+
+    torch.testing.assert_close(model.first, torch.zeros(4))
+
+
+class _TensorSubclass(torch.Tensor):
+    pass
+
+
+class _LoaderParameter(torch.nn.Parameter):
+    __slots__ = ("slot_state",)
+
+    def __new__(
+        cls,
+        data,
+        *,
+        weight_loader,
+        tp_rank,
+        tp_size,
+        requires_grad,
+    ):
+        return super().__new__(cls, data, requires_grad=requires_grad)
+
+    def __init__(
+        self,
+        data,
+        *,
+        weight_loader,
+        tp_rank,
+        tp_size,
+        requires_grad,
+    ):
+        self._weight_loader = weight_loader
+        self.tp_rank = tp_rank
+        self.tp_size = tp_size
+        self.slot_state = {"requires_constructor_arguments": True}
+
+
+@pytest.mark.parametrize("alias_first", [False, True])
+def test_reader_materializes_parameter_subclass_without_losing_state(
+    monkeypatch, alias_first
+):
+    def weight_loader(tensor):
+        return tensor
+
+    parameter = _LoaderParameter(
+        torch.zeros(4, device="meta"),
+        weight_loader=weight_loader,
+        tp_rank=2,
+        tp_size=8,
+        requires_grad=True,
+    )
+    parameter_state = parameter.__dict__
+    slot_state = parameter.slot_state
+    model = torch.nn.Module()
+    model.register_parameter("weight", parameter)
+    model.__dict__["weight_alias"] = parameter
+    expected = torch.arange(4, dtype=torch.float32)
+    entries = [
+        ("weight", _spec(expected, "parameter")),
+        ("weight_alias", _spec(expected, "tensor_attr")),
+    ]
+    if alias_first:
+        entries.reverse()
+    _set_specs(monkeypatch, dict(entries))
+
+    materialize_module_from_gms(object(), model, device_index=0)
+
+    assert model.weight is model.weight_alias is parameter
+    assert model._parameters["weight"] is parameter
+    assert type(parameter) is _LoaderParameter
+    assert parameter.__dict__ is parameter_state
+    assert parameter._weight_loader is weight_loader
+    assert parameter.tp_rank == 2
+    assert parameter.tp_size == 8
+    assert parameter.slot_state is slot_state
+    assert parameter.requires_grad
+    assert not parameter.is_meta
+    torch.testing.assert_close(parameter, expected)
+
+
+def test_reader_rejects_weak_parameter_before_mutation(monkeypatch):
+    parameter = _LoaderParameter(
+        torch.zeros(4, device="meta"),
+        weight_loader=lambda tensor: tensor,
+        tp_rank=0,
+        tp_size=1,
+        requires_grad=False,
+    )
+    parameter_ref = weakref.ref(parameter)
+    model = torch.nn.Module()
+    model.runtime = torch.zeros(4)
+    model.register_parameter("weight", parameter)
+    _set_specs(
+        monkeypatch,
+        {
+            "runtime": _spec(torch.ones(4), "tensor_attr"),
+            "weight": _spec(torch.ones(4), "parameter"),
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="does not support weak references"):
+        materialize_module_from_gms(object(), model, device_index=0)
+
+    assert parameter_ref() is parameter
+    assert model._parameters["weight"] is parameter
+    assert type(parameter) is _LoaderParameter
+    assert parameter.is_meta
+    torch.testing.assert_close(model.runtime, torch.zeros(4))
+
+
+@pytest.mark.parametrize("reader", [False, True])
+def test_nonparameter_tensor_subclass_is_rejected(monkeypatch, reader):
+    tensor = torch.Tensor._make_subclass(_TensorSubclass, torch.zeros(4))
+    model = torch.nn.Module()
+    model.runtime = tensor
+
+    if reader:
+        _set_specs(monkeypatch, {"runtime": _spec(torch.ones(4), "tensor_attr")})
+
+        def call():
+            materialize_module_from_gms(object(), model, device_index=0)
+
+    else:
+        _set_module_tensors(monkeypatch, ("runtime", tensor, "tensor_attr"))
+
+        def call():
+            rebind_nonparameter_tensors(_manager_for(tensor), model)
+
+    with pytest.raises(RuntimeError, match="non-parameter Tensor subclass"):
+        call()
+
+    assert model.runtime is tensor
+    torch.testing.assert_close(tensor, torch.zeros(4))
+
+
+def test_rebind_rolls_back_multi_candidate_failure_and_retries(monkeypatch):
+    model = torch.nn.Module()
+    model.first = torch.arange(4, dtype=torch.float32)
+    model.second = torch.arange(4, dtype=torch.float32) + 10
+    first_ptr = model.first.data_ptr()
+    second_ptr = model.second.data_ptr()
+    retained = []
+    manager = SimpleNamespace(
+        mappings={
+            first_ptr: SimpleNamespace(
+                aligned_size=model.first.untyped_storage().nbytes()
+            ),
+            second_ptr: SimpleNamespace(
+                aligned_size=model.second.untyped_storage().nbytes()
+            ),
+        }
+    )
+    _set_module_tensors(
+        monkeypatch,
+        ("first", model.first, "tensor_attr"),
+        ("second", model.second, "tensor_attr"),
+    )
+    real_swap = torch_module._swap_tensor_contents
+    calls = 0
+
+    def fail_second(existing, replacement, *, name):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise RuntimeError("injected second swap failure")
+        real_swap(existing, replacement, name=name)
+
+    monkeypatch.setattr(torch_module, "_swap_tensor_contents", fail_second)
+
+    with pytest.raises(RuntimeError, match="injected second swap failure"):
+        rebind_nonparameter_tensors(manager, model, retain_gms_tensors=retained)
+
+    assert model.first.data_ptr() == first_ptr
+    assert model.second.data_ptr() == second_ptr
+    assert retained == []
+    assert "_gms_rebound_tensor_owners" not in model.__dict__
+
+    monkeypatch.setattr(torch_module, "_swap_tensor_contents", real_swap)
+    assert (
+        rebind_nonparameter_tensors(manager, model, retain_gms_tensors=retained)
+        == 2 * model.first.numel() * model.first.element_size()
+    )
+    assert model.first.data_ptr() != first_ptr
+    assert model.second.data_ptr() != second_ptr
+    assert len(retained) == 2
+
+
+def test_failed_vllm_write_load_releases_lease(monkeypatch):
+    client = SimpleNamespace(
+        close=lambda *, best_effort: events.append(("close", best_effort))
+    )
+    events = []
+    monkeypatch.setattr(
+        model_loader,
+        "_load_write_mode_impl",
+        lambda *_args: (_ for _ in ()).throw(RuntimeError("rebind failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="rebind failed"):
+        model_loader._load_write_mode(client, None, None, None, torch.device("cpu"))
+
+    assert events == [("close", True)]
+    assert not model_loader.has_pending_gms_write()
+
+
+def test_failed_vllm_write_load_clears_pending_state(monkeypatch):
+    events = []
+    client = SimpleNamespace(
+        close=lambda *, best_effort: events.append(("close", best_effort))
+    )
+
+    def fail_after_pending(*_args):
+        model_loader._pending_gms_client = client
+        model_loader._pending_retained_gms_tensors = [object()]
+        raise RuntimeError("model eval failed")
+
+    monkeypatch.setattr(model_loader, "_load_write_mode_impl", fail_after_pending)
+
+    with pytest.raises(RuntimeError, match="model eval failed"):
+        model_loader._load_write_mode(client, None, None, None, torch.device("cpu"))
+
+    assert events == [("close", True)]
+    assert model_loader._pending_retained_gms_tensors == []
+    assert not model_loader.has_pending_gms_write()

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -55,6 +55,7 @@ from gpu_memory_service.client.torch.tensor import (
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import _reset_vmm_singleton
 from gpu_memory_service.integrations.common.utils import prepare_gms_write
+from gpu_memory_service.integrations.trtllm import model_loader as trtllm_model_loader
 from gpu_memory_service.integrations.vllm import model_loader
 from gpu_memory_service.server.rpc import GMSRPCServer
 
@@ -118,6 +119,76 @@ class _AliasedRuntimeTensor(torch.nn.Module):
             self.indexer.indexer_op.expert_map,
             self.helper.expert_map,
         )
+
+
+def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
+    backing = torch.arange(16, device="cuda", dtype=torch.float32)
+    left = torch.nn.Parameter(backing[2:14:2], requires_grad=True)
+    sibling = torch.nn.Parameter(backing[3:12:2], requires_grad=False)
+    view = backing[1:15:3]
+    model = torch.nn.Module()
+    model.register_parameter("left", left)
+    model.register_parameter("left_alias", left)
+    model.register_parameter("sibling", sibling)
+    model.backing = backing
+    model.view = view
+    model.view_alias = view
+    expected = {
+        name: tensor.detach().clone()
+        for name, tensor in (
+            ("left", left),
+            ("sibling", sibling),
+            ("backing", backing),
+            ("view", view),
+        )
+    }
+    objects = {
+        name: tensor
+        for name, tensor in (
+            ("left", left),
+            ("sibling", sibling),
+            ("backing", backing),
+            ("view", view),
+        )
+    }
+    old_storage = backing.untyped_storage()._cdata
+    storage_nbytes = backing.untyped_storage().nbytes()
+    offsets = {name: tensor.storage_offset() for name, tensor in objects.items()}
+    strides = {name: tensor.stride() for name, tensor in objects.items()}
+
+    manager = GMSClientMemoryManager(running_gms, device=0)
+    manager.connect(RequestedLockType.RW)
+    tensor: torch.Tensor | None = None
+    try:
+        trtllm_model_loader._move_untracked_params(
+            model,
+            manager,
+            torch.device("cuda", 0),
+        )
+
+        assert len(manager.mappings) == 1
+        assert next(iter(manager.mappings.values())).size == storage_nbytes
+        assert model.left is model.left_alias is left
+        assert model.sibling is sibling
+        assert model.backing is backing
+        assert model.view is model.view_alias is view
+        assert model.left.requires_grad
+        assert not model.sibling.requires_grad
+        storage_ids = {tensor.untyped_storage()._cdata for tensor in objects.values()}
+        assert len(storage_ids) == 1
+        assert old_storage not in storage_ids
+        for name, tensor in objects.items():
+            assert tensor.storage_offset() == offsets[name]
+            assert tensor.stride() == strides[name]
+            torch.testing.assert_close(tensor, expected[name])
+        model.backing[3] = 123
+        assert model.sibling[0].item() == 123
+    finally:
+        del model, left, sibling, backing, view
+        tensor = None
+        objects.clear()
+        expected.clear()
+        manager.close()
 
 
 @pytest.fixture
@@ -368,20 +439,20 @@ def test_finalize_gms_write_rebinds_nonparameter_tensors(running_gms):
         writer.close()
 
 
-@pytest.mark.timeout(60)
-def test_deferred_gms_write_preserves_runtime_tensor_aliases(running_gms, monkeypatch):
+@pytest.mark.timeout(120)
+def test_deferred_gms_write_reconstructs_runtime_tensor_aliases(
+    running_gms, monkeypatch
+):
     socket_path = running_gms
     monkeypatch.setattr(
         "gpu_memory_service.common.utils.get_socket_path",
         lambda _device, _tag: socket_path,
     )
     monkeypatch.setattr(model_loader, "_pending_gms_client", None)
-    monkeypatch.setattr(model_loader, "_pending_retained_gms_tensors", [])
     monkeypatch.setattr(model_loader, "_last_imported_weights_bytes", 0)
     monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
     model: _AliasedRuntimeTensor | None = None
     original: torch.Tensor | None = None
-    retained_gms_tensors: list[torch.Tensor] = []
     writer = get_or_create_gms_client_memory_manager(
         socket_path,
         device=0,
@@ -400,42 +471,23 @@ def test_deferred_gms_write_preserves_runtime_tensor_aliases(running_gms, monkey
         model.unrelated = unrelated_helper
 
         stats = prepare_gms_write(writer, model)
-        rebound_bytes = rebind_nonparameter_tensors(
-            writer,
-            model,
-            retain_gms_tensors=retained_gms_tensors,
-        )
+        rebound_bytes = rebind_nonparameter_tensors(writer, model)
         assert rebound_bytes == original.numel() * original.element_size()
         holder = model.__dict__["_gms_rebound_tensor_owners"]
         assert all(alias is original for alias in model.aliases())
         assert original.data_ptr() != gms_ptr
-        assert len(retained_gms_tensors) == len(holder.tensors) == 1
-        assert retained_gms_tensors[0] is holder.tensors[0] is not original
-        assert retained_gms_tensors[0].data_ptr() == gms_ptr
+        assert len(holder.tensors) == 1
+        assert holder.tensors[0] is not original
+        assert holder.tensors[0].data_ptr() == gms_ptr
         assert model.unrelated is unrelated_helper
         assert model.unrelated.tensor is unrelated
         assert list(model.state_dict()) == []
         del holder
 
-        repeated_retained: list[torch.Tensor] = []
-        assert (
-            rebind_nonparameter_tensors(
-                writer,
-                model,
-                retain_gms_tensors=repeated_retained,
-            )
-            == 0
-        )
-        assert repeated_retained == []
+        assert rebind_nonparameter_tensors(writer, model) == 0
 
-        model_loader._store_pending_gms_write(
-            writer,
-            stats,
-            rebound_bytes,
-            retained_gms_tensors,
-        )
+        model_loader._store_pending_gms_write(writer, stats, rebound_bytes)
         assert model_loader.publish_pending_gms_write()
-        retained_gms_tensors.clear()
 
         writer.unmap_all_vas()
         writer.abort()
@@ -454,17 +506,22 @@ def test_deferred_gms_write_preserves_runtime_tensor_aliases(running_gms, monkey
 
         materialize_module_from_gms(writer, reader, device_index=0)
 
-        assert all(alias is reader_original for alias in reader.aliases())
+        reconstructed = reader.indexer._expert_map
+        assert reconstructed is reader.indexer.duplicate_buffer_alias
+        assert reconstructed is reader.indexer.tensor_list[0]
+        assert reconstructed is reader.indexer.tensor_tuple[0]
+        assert reconstructed is reader.indexer.indexer_op.expert_map
+        assert reconstructed is not reader_original
         assert reader.helper is reader_helper
-        assert reader_original.is_cuda
-        assert reader_original.data_ptr() != gms_ptr
-        _assert_exact_tensor_equal(original_values, reader_original)
+        assert reader.helper.expert_map is reader_original
+        assert reconstructed.is_cuda
+        assert reconstructed.data_ptr() != gms_ptr
+        _assert_exact_tensor_equal(original_values, reconstructed)
     finally:
         primary_failure = sys.exc_info()[0] is not None
         if model is not None:
             del model
         original = None
-        retained_gms_tensors.clear()
         cleanup_error: BaseException | None = None
         try:
             gc.collect()
@@ -481,10 +538,6 @@ def test_deferred_gms_write_preserves_runtime_tensor_aliases(running_gms, monkey
                 writer.close()
             except BaseException as exc:
                 cleanup_error = cleanup_error or exc
-                try:
-                    writer.close(best_effort=True)
-                except BaseException:
-                    pass
         if cleanup_error is not None and not primary_failure:
             raise cleanup_error
 
@@ -597,7 +650,8 @@ def test_shared_interior_storages_survive_import_and_remap(running_gms):
         assert mapping_calls == [(allocation_id, 0)]
         assert info_calls == [allocation_id]
         assert all(
-            getattr(reader_model, name) is tensor for name, tensor in identities.items()
+            getattr(reader_model, name) is not tensor
+            for name, tensor in identities.items()
         )
         assert reader_model.data_weight is not reader_model.data_alias
         assert (

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -87,15 +87,18 @@ class _AliasedRuntimeTensor(torch.nn.Module):
         self.direct = tensor
 
 
+@pytest.mark.timeout(120)
 def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
     backing = torch.arange(16, device="cuda", dtype=torch.float32)
     left = torch.nn.Parameter(backing[2:14:2], requires_grad=True)
     sibling = torch.nn.Parameter(backing[3:12:2], requires_grad=False)
     view = backing[1:15:3]
+    empty = torch.empty(0, device="cuda")
     model = torch.nn.Module()
     model.register_parameter("left", left)
     model.register_parameter("left_alias", left)
     model.register_parameter("sibling", sibling)
+    model.register_buffer("empty", empty)
     model.backing = backing
     model.view = view
     model.view_alias = view
@@ -119,6 +122,7 @@ def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
         assert next(iter(manager.mappings.values())).size == storage_nbytes
         assert model.left is model.left_alias is left
         assert model.sibling is sibling
+        assert model.empty is empty
         assert model.backing is backing
         assert model.view is model.view_alias is view
         assert model.left.requires_grad
@@ -135,7 +139,7 @@ def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
         assert model.sibling[0].item() == 123
     finally:
         del tensor, expected_tensor
-        del model, left, sibling, backing, view, objects, expected
+        del model, left, sibling, backing, view, empty, objects, expected
         manager.close()
 
 
@@ -468,34 +472,39 @@ def test_live_gms_tensor_survives_unmap_and_remap(running_gms):
     reader.close()
 
 
+@pytest.mark.timeout(120)
 def test_shared_interior_storages_survive_import_and_remap(running_gms):
-    writer = GMSClientMemoryManager(running_gms, device=0)
-    writer.connect(RequestedLockType.RW)
-    allocation_va = writer.create_mapping(size=4096, tag="weights")
-    allocation_id = writer.mappings[allocation_va].allocation_id
+    with GMSClientMemoryManager(running_gms, device=0) as writer:
+        writer.connect(RequestedLockType.RW)
+        data_storage = view_storage = None
+        data_tensor = view_tensor = None
+        writer_model = None
+        try:
+            allocation_va = writer.create_mapping(size=4096, tag="weights")
+            allocation_id = writer.mappings[allocation_va].allocation_id
 
-    data_storage = _storage_from_pointer(allocation_va + 128, 32, 0)
-    view_storage = _storage_from_pointer(allocation_va + 256, 48, 0)
-    data_tensor = _tensor_from_storage(data_storage, [8], [1], torch.float32)
-    view_tensor = _tensor_from_storage(view_storage, [12], [1], torch.float32)
-    data_tensor.copy_(torch.arange(8, device="cuda", dtype=torch.float32))
-    view_tensor.copy_(torch.arange(12, device="cuda", dtype=torch.float32) + 20)
+            data_storage = _storage_from_pointer(allocation_va + 128, 32, 0)
+            view_storage = _storage_from_pointer(allocation_va + 256, 48, 0)
+            data_tensor = _tensor_from_storage(data_storage, [8], [1], torch.float32)
+            view_tensor = _tensor_from_storage(view_storage, [12], [1], torch.float32)
+            data_tensor.copy_(torch.arange(8, device="cuda", dtype=torch.float32))
+            view_tensor.copy_(torch.arange(12, device="cuda", dtype=torch.float32) + 20)
 
-    writer_model = torch.nn.Module()
-    writer_model.register_parameter(
-        "data_weight", torch.nn.Parameter(data_tensor, requires_grad=True)
-    )
-    writer_model.data_exact = writer_model.data_weight
-    writer_model.data_view = writer_model.data_weight.data
-    writer_model.register_parameter(
-        "view_weight", torch.nn.Parameter(view_tensor, requires_grad=False)
-    )
-    writer_model.strided = writer_model.view_weight[2:10:2]
-    writer_model.transposed = writer_model.view_weight.reshape(3, 4).T
-    register_module_tensors(writer, writer_model)
-    assert writer.commit()
-    del writer_model, data_tensor, view_tensor, data_storage, view_storage
-    writer.close()
+            writer_model = torch.nn.Module()
+            writer_model.register_parameter(
+                "data_weight", torch.nn.Parameter(data_tensor, requires_grad=True)
+            )
+            writer_model.data_exact = writer_model.data_weight
+            writer_model.data_view = writer_model.data_weight.data
+            writer_model.register_parameter(
+                "view_weight", torch.nn.Parameter(view_tensor, requires_grad=False)
+            )
+            writer_model.strided = writer_model.view_weight[2:10:2]
+            writer_model.transposed = writer_model.view_weight.reshape(3, 4).T
+            register_module_tensors(writer, writer_model)
+            assert writer.commit()
+        finally:
+            del writer_model, data_tensor, view_tensor, data_storage, view_storage
 
     reader_model = torch.nn.Module()
     reader_model.register_parameter(

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -10,12 +10,9 @@ materialization from committed GMS-backed weights.
 from __future__ import annotations
 
 import asyncio
-import gc
 import os
-import sys
 import threading
 import time
-from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -37,11 +34,6 @@ if not HAS_CUDA:
 
 import torch
 from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
-from gpu_memory_service.client.torch.allocator import (
-    get_gms_client_memory_manager,
-    get_or_create_gms_client_memory_manager,
-    gms_use_mem_pool,
-)
 from gpu_memory_service.client.torch.module import (
     materialize_module_from_gms,
     rebind_nonparameter_tensors,
@@ -88,37 +80,11 @@ class _TinyModule(torch.nn.Module):
         return torch.relu(y)
 
 
-class _RoutedExpertsLike(torch.nn.Module):
-    def __init__(self, tensor: torch.Tensor) -> None:
-        super().__init__()
-        self.register_buffer("_expert_map", tensor, persistent=False)
-
-    @property
-    def expert_map(self) -> torch.Tensor:
-        return self._expert_map
-
-
 class _AliasedRuntimeTensor(torch.nn.Module):
     def __init__(self, tensor: torch.Tensor) -> None:
         super().__init__()
-        self.indexer = _RoutedExpertsLike(tensor)
-        self.indexer.__dict__["duplicate_buffer_alias"] = tensor
-        self.indexer.tensor_list = [tensor]
-        self.indexer.tensor_tuple = (tensor,)
-        self.indexer.indexer_op = torch.nn.Module()
-        self.indexer.indexer_op.expert_map = tensor
-        self.helper = SimpleNamespace(expert_map=tensor)
-
-    def aliases(self) -> tuple[torch.Tensor, ...]:
-        return (
-            self.indexer._expert_map,
-            self.indexer.expert_map,
-            self.indexer.duplicate_buffer_alias,
-            self.indexer.tensor_list[0],
-            self.indexer.tensor_tuple[0],
-            self.indexer.indexer_op.expert_map,
-            self.helper.expert_map,
-        )
+        self.register_buffer("runtime", tensor, persistent=False)
+        self.direct = tensor
 
 
 def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
@@ -133,32 +99,15 @@ def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
     model.backing = backing
     model.view = view
     model.view_alias = view
-    expected = {
-        name: tensor.detach().clone()
-        for name, tensor in (
-            ("left", left),
-            ("sibling", sibling),
-            ("backing", backing),
-            ("view", view),
-        )
-    }
-    objects = {
-        name: tensor
-        for name, tensor in (
-            ("left", left),
-            ("sibling", sibling),
-            ("backing", backing),
-            ("view", view),
-        )
-    }
+    objects = (left, sibling, backing, view)
+    expected = tuple(tensor.detach().clone() for tensor in objects)
+    layouts = tuple((tensor.storage_offset(), tensor.stride()) for tensor in objects)
     old_storage = backing.untyped_storage()._cdata
     storage_nbytes = backing.untyped_storage().nbytes()
-    offsets = {name: tensor.storage_offset() for name, tensor in objects.items()}
-    strides = {name: tensor.stride() for name, tensor in objects.items()}
 
     manager = GMSClientMemoryManager(running_gms, device=0)
     manager.connect(RequestedLockType.RW)
-    tensor: torch.Tensor | None = None
+    tensor = expected_tensor = None
     try:
         trtllm_model_loader._move_untracked_params(
             model,
@@ -174,20 +123,19 @@ def test_trtllm_moves_complete_shared_parameter_storage_once(running_gms):
         assert model.view is model.view_alias is view
         assert model.left.requires_grad
         assert not model.sibling.requires_grad
-        storage_ids = {tensor.untyped_storage()._cdata for tensor in objects.values()}
+        storage_ids = {tensor.untyped_storage()._cdata for tensor in objects}
         assert len(storage_ids) == 1
         assert old_storage not in storage_ids
-        for name, tensor in objects.items():
-            assert tensor.storage_offset() == offsets[name]
-            assert tensor.stride() == strides[name]
-            torch.testing.assert_close(tensor, expected[name])
+        for tensor, expected_tensor, layout in zip(
+            objects, expected, layouts, strict=True
+        ):
+            assert (tensor.storage_offset(), tensor.stride()) == layout
+            torch.testing.assert_close(tensor, expected_tensor)
         model.backing[3] = 123
         assert model.sibling[0].item() == 123
     finally:
-        del model, left, sibling, backing, view
-        tensor = None
-        objects.clear()
-        expected.clear()
+        del tensor, expected_tensor
+        del model, left, sibling, backing, view, objects, expected
         manager.close()
 
 
@@ -443,103 +391,46 @@ def test_finalize_gms_write_rebinds_nonparameter_tensors(running_gms):
 def test_deferred_gms_write_reconstructs_runtime_tensor_aliases(
     running_gms, monkeypatch
 ):
-    socket_path = running_gms
-    monkeypatch.setattr(
-        "gpu_memory_service.common.utils.get_socket_path",
-        lambda _device, _tag: socket_path,
-    )
     monkeypatch.setattr(model_loader, "_pending_gms_client", None)
     monkeypatch.setattr(model_loader, "_last_imported_weights_bytes", 0)
     monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
+    writer = GMSClientMemoryManager(running_gms, device=0)
+    writer.connect(RequestedLockType.RW)
     model: _AliasedRuntimeTensor | None = None
     original: torch.Tensor | None = None
-    writer = get_or_create_gms_client_memory_manager(
-        socket_path,
-        device=0,
-        mode=RequestedLockType.RW,
-        tag="weights",
-    )
 
     try:
         original_values = torch.arange(8, device="cuda", dtype=torch.int32)
-        with gms_use_mem_pool("weights", device=0):
-            original = original_values.clone()
-        gms_ptr = original.data_ptr()
-        unrelated = torch.full((8,), -1, device="cuda", dtype=torch.int32)
-        unrelated_helper = SimpleNamespace(tensor=unrelated)
+        _, original = _make_gms_tensor(writer, original_values, tag="weights")
         model = _AliasedRuntimeTensor(original)
-        model.unrelated = unrelated_helper
 
         stats = prepare_gms_write(writer, model)
         rebound_bytes = rebind_nonparameter_tensors(writer, model)
         assert rebound_bytes == original.numel() * original.element_size()
-        _, displaced_sources = model.__dict__["_gms_displaced_source_tensors"]
-        assert all(alias is original for alias in model.aliases())
-        assert original.data_ptr() != gms_ptr
-        assert len(displaced_sources) == 1
-        assert displaced_sources[0] is not original
-        assert displaced_sources[0].data_ptr() == gms_ptr
-        assert model.unrelated is unrelated_helper
-        assert model.unrelated.tensor is unrelated
-        assert list(model.state_dict()) == []
-        del displaced_sources
-
-        assert rebind_nonparameter_tensors(writer, model) == 0
-
         model_loader._store_pending_gms_write(writer, stats, rebound_bytes)
         assert model_loader.publish_pending_gms_write()
-
-        writer.unmap_all_vas()
-        writer.abort()
-        gc.collect()
-        torch.cuda.empty_cache()
-        writer.connect(RequestedLockType.RO)
-        writer.remap_all_vas()
-
-        model.indexer.tensor_list[0].fill_(17)
-        for alias in model.aliases():
-            _assert_exact_tensor_equal(torch.full_like(original, 17), alias)
-
-        reader_original = torch.empty_like(original, device="meta")
-        reader = _AliasedRuntimeTensor(reader_original)
-        reader_helper = reader.helper
-
-        materialize_module_from_gms(writer, reader, device_index=0)
-
-        reconstructed = reader.indexer._expert_map
-        assert reconstructed is reader.indexer.duplicate_buffer_alias
-        assert reconstructed is reader.indexer.tensor_list[0]
-        assert reconstructed is reader.indexer.tensor_tuple[0]
-        assert reconstructed is reader.indexer.indexer_op.expert_map
-        assert reconstructed is not reader_original
-        assert reader.helper is reader_helper
-        assert reader.helper.expert_map is reader_original
-        assert reconstructed.is_cuda
-        assert reconstructed.data_ptr() != gms_ptr
-        _assert_exact_tensor_equal(original_values, reconstructed)
+        assert model.runtime is model.direct
+        model.runtime.fill_(17)
+        _assert_exact_tensor_equal(torch.full_like(original, 17), model.direct)
     finally:
-        primary_failure = sys.exc_info()[0] is not None
-        if model is not None:
-            del model
-        original = None
-        cleanup_error: BaseException | None = None
-        try:
-            gc.collect()
-            torch.cuda.empty_cache()
-        except BaseException as exc:
-            cleanup_error = exc
         if model_loader.has_pending_gms_write():
-            try:
-                model_loader.abort_pending_gms_write()
-            except BaseException as exc:
-                cleanup_error = cleanup_error or exc
-        if get_gms_client_memory_manager("weights") is writer:
-            try:
-                writer.close()
-            except BaseException as exc:
-                cleanup_error = cleanup_error or exc
-        if cleanup_error is not None and not primary_failure:
-            raise cleanup_error
+            model_loader.abort_pending_gms_write()
+        model = None
+        original = None
+        writer.close()
+
+    with GMSClientMemoryManager(running_gms, device=0) as manager:
+        manager.connect(RequestedLockType.RO)
+        placeholder = torch.empty_like(original_values, device="meta")
+        reader = _AliasedRuntimeTensor(placeholder)
+        materialize_module_from_gms(manager, reader, device_index=0)
+
+        reconstructed = reader.runtime
+        assert reconstructed is reader.direct
+        assert reconstructed is not placeholder
+        assert "runtime" in reader._non_persistent_buffers_set
+        assert "runtime" not in reader.state_dict()
+        _assert_exact_tensor_equal(original_values, reconstructed)
 
 
 def test_live_gms_tensor_survives_unmap_and_remap(running_gms):
@@ -594,7 +485,8 @@ def test_shared_interior_storages_survive_import_and_remap(running_gms):
     writer_model.register_parameter(
         "data_weight", torch.nn.Parameter(data_tensor, requires_grad=True)
     )
-    writer_model.data_alias = writer_model.data_weight.data
+    writer_model.data_exact = writer_model.data_weight
+    writer_model.data_view = writer_model.data_weight.data
     writer_model.register_parameter(
         "view_weight", torch.nn.Parameter(view_tensor, requires_grad=False)
     )
@@ -610,53 +502,25 @@ def test_shared_interior_storages_survive_import_and_remap(running_gms):
         "data_weight",
         torch.nn.Parameter(torch.zeros(8, device="cuda"), requires_grad=True),
     )
-    reader_model.data_alias = reader_model.data_weight.data
+    reader_model.data_exact = reader_model.data_weight
+    reader_model.data_view = reader_model.data_weight.data
     reader_model.register_parameter(
         "view_weight",
         torch.nn.Parameter(torch.zeros(12, device="cuda"), requires_grad=False),
     )
     reader_model.strided = reader_model.view_weight[2:10:2]
     reader_model.transposed = reader_model.view_weight.reshape(3, 4).T
-    identities = {
-        name: getattr(reader_model, name)
-        for name in (
-            "data_weight",
-            "data_alias",
-            "view_weight",
-            "strided",
-            "transposed",
-        )
-    }
 
     with GMSClientMemoryManager(running_gms, device=0) as reader:
         reader.connect(RequestedLockType.RO)
-        real_create_mapping = reader.create_mapping
-        real_get_handle_info = reader.get_handle_info
-        mapping_calls = []
-        info_calls = []
-
-        def create_mapping(*, allocation_id=None, size=0, tag="default"):
-            mapping_calls.append((allocation_id, size))
-            return real_create_mapping(allocation_id, size, tag)
-
-        def get_handle_info(requested_allocation_id):
-            info_calls.append(requested_allocation_id)
-            return real_get_handle_info(requested_allocation_id)
-
-        reader.create_mapping = create_mapping
-        reader.get_handle_info = get_handle_info
         materialize_module_from_gms(reader, reader_model, device_index=0)
-
-        assert mapping_calls == [(allocation_id, 0)]
-        assert info_calls == [allocation_id]
-        assert all(
-            getattr(reader_model, name) is not tensor
-            for name, tensor in identities.items()
-        )
-        assert reader_model.data_weight is not reader_model.data_alias
+        assert len(reader.mappings) == 1
+        assert next(iter(reader.mappings.values())).allocation_id == allocation_id
+        assert reader_model.data_weight is reader_model.data_exact
+        assert reader_model.data_weight is not reader_model.data_view
         assert (
             reader_model.data_weight.untyped_storage()._cdata
-            == reader_model.data_alias.untyped_storage()._cdata
+            == reader_model.data_view.untyped_storage()._cdata
         )
         assert (
             reader_model.view_weight.untyped_storage()._cdata
@@ -673,7 +537,7 @@ def test_shared_interior_storages_survive_import_and_remap(running_gms):
         reader.connect(RequestedLockType.RO)
         reader.remap_all_vas()
         torch.testing.assert_close(
-            reader_model.data_alias,
+            reader_model.data_view,
             torch.arange(8, device="cuda", dtype=torch.float32),
         )
         torch.testing.assert_close(

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -473,16 +473,16 @@ def test_deferred_gms_write_reconstructs_runtime_tensor_aliases(
         stats = prepare_gms_write(writer, model)
         rebound_bytes = rebind_nonparameter_tensors(writer, model)
         assert rebound_bytes == original.numel() * original.element_size()
-        holder = model.__dict__["_gms_rebound_tensor_owners"]
+        _, displaced_sources = model.__dict__["_gms_displaced_source_tensors"]
         assert all(alias is original for alias in model.aliases())
         assert original.data_ptr() != gms_ptr
-        assert len(holder.tensors) == 1
-        assert holder.tensors[0] is not original
-        assert holder.tensors[0].data_ptr() == gms_ptr
+        assert len(displaced_sources) == 1
+        assert displaced_sources[0] is not original
+        assert displaced_sources[0].data_ptr() == gms_ptr
         assert model.unrelated is unrelated_helper
         assert model.unrelated.tensor is unrelated
         assert list(model.state_dict()) == []
-        del holder
+        del displaced_sources
 
         assert rebind_nonparameter_tensors(writer, model) == 0
 

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -10,9 +10,12 @@ materialization from committed GMS-backed weights.
 from __future__ import annotations
 
 import asyncio
+import gc
 import os
+import sys
 import threading
 import time
+from types import SimpleNamespace
 from typing import cast
 
 import pytest
@@ -34,13 +37,21 @@ if not HAS_CUDA:
 
 import torch
 from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
+from gpu_memory_service.client.torch.allocator import (
+    get_gms_client_memory_manager,
+    get_or_create_gms_client_memory_manager,
+    gms_use_mem_pool,
+)
 from gpu_memory_service.client.torch.module import (
     materialize_module_from_gms,
+    rebind_nonparameter_tensors,
     register_module_tensors,
 )
 from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import _reset_vmm_singleton
+from gpu_memory_service.integrations.common.utils import prepare_gms_write
+from gpu_memory_service.integrations.vllm import model_loader
 from gpu_memory_service.server.rpc import GMSRPCServer
 
 pytestmark = [
@@ -70,6 +81,39 @@ class _TinyModule(torch.nn.Module):
         y = y + self.scale
         y = y * self.extra
         return torch.relu(y)
+
+
+class _RoutedExpertsLike(torch.nn.Module):
+    def __init__(self, tensor: torch.Tensor) -> None:
+        super().__init__()
+        self.register_buffer("_expert_map", tensor, persistent=False)
+
+    @property
+    def expert_map(self) -> torch.Tensor:
+        return self._expert_map
+
+
+class _AliasedRuntimeTensor(torch.nn.Module):
+    def __init__(self, tensor: torch.Tensor) -> None:
+        super().__init__()
+        self.indexer = _RoutedExpertsLike(tensor)
+        self.indexer.__dict__["duplicate_buffer_alias"] = tensor
+        self.indexer.tensor_list = [tensor]
+        self.indexer.tensor_tuple = (tensor,)
+        self.indexer.indexer_op = torch.nn.Module()
+        self.indexer.indexer_op.expert_map = tensor
+        self.helper = SimpleNamespace(expert_map=tensor)
+
+    def aliases(self) -> tuple[torch.Tensor, ...]:
+        return (
+            self.indexer._expert_map,
+            self.indexer.expert_map,
+            self.indexer.duplicate_buffer_alias,
+            self.indexer.tensor_list[0],
+            self.indexer.tensor_tuple[0],
+            self.indexer.indexer_op.expert_map,
+            self.helper.expert_map,
+        )
 
 
 @pytest.fixture
@@ -318,6 +362,127 @@ def test_finalize_gms_write_rebinds_nonparameter_tensors(running_gms):
     finally:
         del gms_model
         writer.close()
+
+
+@pytest.mark.timeout(60)
+def test_deferred_gms_write_preserves_runtime_tensor_aliases(running_gms, monkeypatch):
+    socket_path = running_gms
+    monkeypatch.setattr(
+        "gpu_memory_service.common.utils.get_socket_path",
+        lambda _device, _tag: socket_path,
+    )
+    monkeypatch.setattr(model_loader, "_pending_gms_client", None)
+    monkeypatch.setattr(model_loader, "_pending_retained_gms_tensors", [])
+    monkeypatch.setattr(model_loader, "_last_imported_weights_bytes", 0)
+    monkeypatch.setattr(model_loader, "_last_model_memory_usage_offset_bytes", 0)
+    model: _AliasedRuntimeTensor | None = None
+    original: torch.Tensor | None = None
+    retained_gms_tensors: list[torch.Tensor] = []
+    writer = get_or_create_gms_client_memory_manager(
+        socket_path,
+        device=0,
+        mode=RequestedLockType.RW,
+        tag="weights",
+    )
+
+    try:
+        original_values = torch.arange(8, device="cuda", dtype=torch.int32)
+        with gms_use_mem_pool("weights", device=0):
+            original = original_values.clone()
+        gms_ptr = original.data_ptr()
+        unrelated = torch.full((8,), -1, device="cuda", dtype=torch.int32)
+        unrelated_helper = SimpleNamespace(tensor=unrelated)
+        model = _AliasedRuntimeTensor(original)
+        model.unrelated = unrelated_helper
+
+        stats = prepare_gms_write(writer, model)
+        rebound_bytes = rebind_nonparameter_tensors(
+            writer,
+            model,
+            retain_gms_tensors=retained_gms_tensors,
+        )
+        assert rebound_bytes == original.numel() * original.element_size()
+        holder = model.__dict__["_gms_rebound_tensor_owners"]
+        assert all(alias is original for alias in model.aliases())
+        assert original.data_ptr() != gms_ptr
+        assert len(retained_gms_tensors) == len(holder.tensors) == 1
+        assert retained_gms_tensors[0] is holder.tensors[0] is not original
+        assert retained_gms_tensors[0].data_ptr() == gms_ptr
+        assert model.unrelated is unrelated_helper
+        assert model.unrelated.tensor is unrelated
+        assert list(model.state_dict()) == []
+        del holder
+
+        repeated_retained: list[torch.Tensor] = []
+        assert (
+            rebind_nonparameter_tensors(
+                writer,
+                model,
+                retain_gms_tensors=repeated_retained,
+            )
+            == 0
+        )
+        assert repeated_retained == []
+
+        model_loader._store_pending_gms_write(
+            writer,
+            stats,
+            rebound_bytes,
+            retained_gms_tensors,
+        )
+        assert model_loader.publish_pending_gms_write()
+        retained_gms_tensors.clear()
+
+        writer.unmap_all_vas()
+        writer.abort()
+        gc.collect()
+        torch.cuda.empty_cache()
+        writer.connect(RequestedLockType.RO)
+        writer.remap_all_vas()
+
+        model.indexer.tensor_list[0].fill_(17)
+        for alias in model.aliases():
+            _assert_exact_tensor_equal(torch.full_like(original, 17), alias)
+
+        reader_original = torch.empty_like(original, device="meta")
+        reader = _AliasedRuntimeTensor(reader_original)
+        reader_helper = reader.helper
+
+        materialize_module_from_gms(writer, reader, device_index=0)
+
+        assert all(alias is reader_original for alias in reader.aliases())
+        assert reader.helper is reader_helper
+        assert reader_original.is_cuda
+        assert reader_original.data_ptr() != gms_ptr
+        _assert_exact_tensor_equal(original_values, reader_original)
+    finally:
+        primary_failure = sys.exc_info()[0] is not None
+        if model is not None:
+            del model
+        original = None
+        retained_gms_tensors.clear()
+        cleanup_error: BaseException | None = None
+        try:
+            gc.collect()
+            torch.cuda.empty_cache()
+        except BaseException as exc:
+            cleanup_error = exc
+        if model_loader.has_pending_gms_write():
+            try:
+                model_loader.abort_pending_gms_write()
+            except BaseException as exc:
+                cleanup_error = cleanup_error or exc
+        if get_gms_client_memory_manager("weights") is writer:
+            try:
+                writer.close()
+            except BaseException as exc:
+                cleanup_error = cleanup_error or exc
+                try:
+                    writer.close(best_effort=True)
+                except BaseException:
+                    pass
+        if cleanup_error is not None and not primary_failure:
+            raise cleanup_error
 
 
 def test_live_gms_tensor_survives_unmap_and_remap(running_gms):

--- a/lib/gpu_memory_service/tests/test_torch_integration.py
+++ b/lib/gpu_memory_service/tests/test_torch_integration.py
@@ -47,7 +47,11 @@ from gpu_memory_service.client.torch.module import (
     rebind_nonparameter_tensors,
     register_module_tensors,
 )
-from gpu_memory_service.client.torch.tensor import _tensor_from_pointer
+from gpu_memory_service.client.torch.tensor import (
+    _storage_from_pointer,
+    _tensor_from_pointer,
+    _tensor_from_storage,
+)
 from gpu_memory_service.common.locks import RequestedLockType
 from gpu_memory_service.common.vmm import _reset_vmm_singleton
 from gpu_memory_service.integrations.common.utils import prepare_gms_write
@@ -518,6 +522,115 @@ def test_live_gms_tensor_survives_unmap_and_remap(running_gms):
     _assert_exact_tensor_equal(expected, torch.relu((gms_tensor + 7.0).square()))
 
     reader.close()
+
+
+def test_shared_interior_storages_survive_import_and_remap(running_gms):
+    writer = GMSClientMemoryManager(running_gms, device=0)
+    writer.connect(RequestedLockType.RW)
+    allocation_va = writer.create_mapping(size=4096, tag="weights")
+    allocation_id = writer.mappings[allocation_va].allocation_id
+
+    data_storage = _storage_from_pointer(allocation_va + 128, 32, 0)
+    view_storage = _storage_from_pointer(allocation_va + 256, 48, 0)
+    data_tensor = _tensor_from_storage(data_storage, [8], [1], torch.float32)
+    view_tensor = _tensor_from_storage(view_storage, [12], [1], torch.float32)
+    data_tensor.copy_(torch.arange(8, device="cuda", dtype=torch.float32))
+    view_tensor.copy_(torch.arange(12, device="cuda", dtype=torch.float32) + 20)
+
+    writer_model = torch.nn.Module()
+    writer_model.register_parameter(
+        "data_weight", torch.nn.Parameter(data_tensor, requires_grad=True)
+    )
+    writer_model.data_alias = writer_model.data_weight.data
+    writer_model.register_parameter(
+        "view_weight", torch.nn.Parameter(view_tensor, requires_grad=False)
+    )
+    writer_model.strided = writer_model.view_weight[2:10:2]
+    writer_model.transposed = writer_model.view_weight.reshape(3, 4).T
+    register_module_tensors(writer, writer_model)
+    assert writer.commit()
+    del writer_model, data_tensor, view_tensor, data_storage, view_storage
+    writer.close()
+
+    reader_model = torch.nn.Module()
+    reader_model.register_parameter(
+        "data_weight",
+        torch.nn.Parameter(torch.zeros(8, device="cuda"), requires_grad=True),
+    )
+    reader_model.data_alias = reader_model.data_weight.data
+    reader_model.register_parameter(
+        "view_weight",
+        torch.nn.Parameter(torch.zeros(12, device="cuda"), requires_grad=False),
+    )
+    reader_model.strided = reader_model.view_weight[2:10:2]
+    reader_model.transposed = reader_model.view_weight.reshape(3, 4).T
+    identities = {
+        name: getattr(reader_model, name)
+        for name in (
+            "data_weight",
+            "data_alias",
+            "view_weight",
+            "strided",
+            "transposed",
+        )
+    }
+
+    with GMSClientMemoryManager(running_gms, device=0) as reader:
+        reader.connect(RequestedLockType.RO)
+        real_create_mapping = reader.create_mapping
+        real_get_handle_info = reader.get_handle_info
+        mapping_calls = []
+        info_calls = []
+
+        def create_mapping(*, allocation_id=None, size=0, tag="default"):
+            mapping_calls.append((allocation_id, size))
+            return real_create_mapping(allocation_id, size, tag)
+
+        def get_handle_info(requested_allocation_id):
+            info_calls.append(requested_allocation_id)
+            return real_get_handle_info(requested_allocation_id)
+
+        reader.create_mapping = create_mapping
+        reader.get_handle_info = get_handle_info
+        materialize_module_from_gms(reader, reader_model, device_index=0)
+
+        assert mapping_calls == [(allocation_id, 0)]
+        assert info_calls == [allocation_id]
+        assert all(
+            getattr(reader_model, name) is tensor for name, tensor in identities.items()
+        )
+        assert reader_model.data_weight is not reader_model.data_alias
+        assert (
+            reader_model.data_weight.untyped_storage()._cdata
+            == reader_model.data_alias.untyped_storage()._cdata
+        )
+        assert (
+            reader_model.view_weight.untyped_storage()._cdata
+            == reader_model.strided.untyped_storage()._cdata
+            == reader_model.transposed.untyped_storage()._cdata
+        )
+        reader_va = next(iter(reader.mappings))
+        assert reader_model.data_weight.data_ptr() == reader_va + 128
+        assert reader_model.strided.storage_offset() == 2
+        assert reader_model.transposed.stride() == (1, 4)
+
+        reader.unmap_all_vas()
+        reader.abort()
+        reader.connect(RequestedLockType.RO)
+        reader.remap_all_vas()
+        torch.testing.assert_close(
+            reader_model.data_alias,
+            torch.arange(8, device="cuda", dtype=torch.float32),
+        )
+        torch.testing.assert_close(
+            reader_model.strided,
+            torch.tensor([22, 24, 26, 28], device="cuda", dtype=torch.float32),
+        )
+        torch.testing.assert_close(
+            reader_model.transposed,
+            (torch.arange(12, device="cuda", dtype=torch.float32) + 20).reshape(3, 4).T,
+        )
+        del reader_model
 
 
 def test_materialized_module_from_gms_matches_plain_module_forward(running_gms):


### PR DESCRIPTION
## Summary

This revision intentionally replaces the existing GMS Torch metadata format. There are no production users that require schema compatibility, so the reader no longer carries a legacy decoder, schema versions, synthetic storage/object group IDs, or generic helpers such as `strict_int` and `strict_int_list`.

The new contract is storage-first:

- write one typed MessagePack `StorageManifest` per PyTorch `StorageImpl`
- describe each distinct tensor object's dtype, shape, stride, byte offset, `requires_grad`, and module bindings inside that storage manifest
- represent exact aliases as multiple bindings on one tensor object
- represent distinct views or tensors sharing storage as sibling tensor objects in one manifest
- use `ModuleTensorKind`, a string-backed enum, instead of literal strings or string matching
- keep the GMS allocation ID and storage base offset only in the outer metadata envelope
- treat the writer's tensor/storage graph as authoritative when constructing a fresh reader; reader placeholder identity and placeholder storage topology are not part of the contract

This is a deliberately breaking metadata change. Old GMS Torch metadata must be regenerated by loading the model through the write path again.

The implementation was also simplified in response to review:

- removed the one-field displaced-owner wrapper and retained owners in collision-safe sentinel-backed model state
- removed the one-use materialized-object record in favor of a local typed tuple
- renamed `Slot` to `ModuleTensorBinding`, `_DiscoveredObject` to `_DiscoveredTensor`, and the reader target to `_ResolvedTensorDestination`
- renamed the private pipeline stages and added concise stage docstrings plus a top-level write/read/rebind flow diagram
- separated policy-free discovery from GMS allocation selection and validation, so unrelated unsupported non-parameter tensors are ignored while every selected storage is validated before side effects
- kept `_DiscoveredTensor` and `_ResolvedTensorDestination` as named records because they represent real identity and installation boundaries rather than generic containers
- kept the storage lifecycle together in `module.py`; splitting it would add private coupling among discovery, publication, materialization, rebinding, and TensorRT-LLM relocation, while `tensor.py` already separates the schema and raw-storage operations
- use PyTorch `UntypedStorage.clone()` / `copy_()` directly for complete storage envelopes instead of temporary byte-tensor copy wrappers
- make storage-to-GMS matching return allocation-envelope data rather than mutating discovery records with optional state
- remove custom slot enumeration and one-use cloning/template/swap helpers where stdlib or direct local control flow is clearer
- consolidate overlapping tests around behavioral boundaries: 46 test functions became 41 while retaining malformed input, topology, rollback, atomicity, publication, backend, and real CUDA cases

Even after adding focused review regressions, the cleanup series removes a net 222 lines.

## Before and after

The examples below show the decoded structures. The new manifest is MessagePack on the wire.

### Before: one metadata value per tensor slot

```json
{
  "shape": [4, 8],
  "dtype": "torch.float16",
  "stride": [8, 1],
  "tensor_type": "tensor_attr",
  "storage": {
    "schema_version": 1,
    "storage_group_id": 3,
    "object_group_id": 7,
    "storage_base_offset": 4096,
    "storage_nbytes": 1024,
    "storage_offset": 16,
    "buffer_persistent": false
  }
}
```

Every slot repeated tensor and storage fields. The reader reconstructed aliases and shared storage by joining integer group IDs while preserving the legacy per-tensor `offset_bytes` meaning.

### After: one manifest per storage

Outer GMS metadata envelope:

```json
{
  "key": "torch.module.storage/0",
  "allocation_id": "<gms-allocation-id>",
  "offset_bytes": 4096,
  "value": "<MessagePack StorageManifest>"
}
```

Conceptually decoded manifest:

```json
{
  "nbytes": 1024,
  "objects": [
    {
      "dtype": "float16",
      "shape": [4, 8],
      "stride": [8, 1],
      "storage_offset_bytes": 32,
      "requires_grad": false,
      "bindings": [
        {"path": "runtime_cache", "kind": "attribute"},
        {"path": "runtime_cache_alias", "kind": "attribute"}
      ]
    },
    {
      "dtype": "float16",
      "shape": [2, 8],
      "stride": [16, 1],
      "storage_offset_bytes": 32,
      "requires_grad": false,
      "bindings": [
        {"path": "runtime_view", "kind": "nonpersistent_buffer"}
      ]
    }
  ]
}
```

There are no embedded allocation IDs and no join IDs. The structure directly expresses the source storage graph. `kind` remains a lowercase string on the wire, but typed decoding produces a `ModuleTensorKind` enum and rejects unknown values.

## Lifecycle and ownership

The writer discovers complete `StorageImpl` groups without applying GMS policy, selects the groups owned by GMS, validates the complete selected set, publishes their manifests, and rebinds mutable non-parameter-only storage before commit. Parameter-containing storage remains one shared read-only mapping so parameter aliases and views retain their original storage topology. Tensor swaps are preflighted before mutation. TensorRT-LLM relocation copies each complete untracked storage once and reconstructs all of its tensor objects with their original layouts.

The fresh reader imports each allocation once, reconstructs each storage once, then installs the source bindings. Missing parameter, buffer, and direct-attribute bindings may be created; conflicting destinations fail closed. vLLM performs required post-load processing once on the meta model and propagates failure rather than returning a partially initialized reader.

Failure paths release writer leases best-effort. Imported CUDA mappings are freed only after synchronization proves that asynchronous copies are no longer using them.

## What this PR handles

| Flow | Role of this PR |
| --- | --- |
| First disk/checkpoint load into GMS | Publishes the storage manifests after backend loading and post-processing. |
| New process cold start or restart from existing GMS state | Creates a fresh model shell and materializes the published tensor/storage graph. |
| Initial shadow-engine attachment that uses the GMS read path | Uses the same fresh-reader materialization path. |
| Shadow-engine sleep/wake or failover after tensors are already materialized | Does not rerun the manifest reader. The existing GMS VA unmap/remap lifecycle preserves the already-created tensor objects. |
| GMS allocation snapshot to disk and restore | The snapshot layer copies allocations and metadata. Because allocation identity lives only in the outer envelope, restore can remap that identity without decoding or rewriting the opaque manifest. This PR does not add snapshot orchestration itself. |
| CRIU/process snapshot restore | Does not rebuild the Python module from these manifests; the process object graph is restored and GMS remaps its preserved virtual addresses. |

Backend state hidden outside normal `nn.Module` tensor bindings is still owned by the backend's meta-model/post-load lifecycle. This PR does not attempt to serialize arbitrary Python or backend runtime state.

## Guards retained

The remaining checks protect concrete correctness boundaries for storage selected by a GMS operation: typed MessagePack fields and enum values, canonical dtypes, storage bounds and alignment, non-overlapping allocation ranges, unique destination bindings, reserved internal-state collisions, supported tensor/Parameter ownership for `torch.utils.swap_tensors`, and safe CUDA cleanup. Compatibility-only and placeholder-topology guards were removed.

## Validation

The branch was rebased onto current `main`; the GMS VMMDevice abstraction and its singleton-reset integration coverage were retained during conflict resolution.

Passed locally:

```bash
files=$(git diff HEAD^ --name-only -- '*.py')
ruff format --check $files
ruff check $files
python3 -m compileall -q $files
git diff HEAD^ --check
```

Independent production, test-coverage, final-code, and validation reviews approved the refactor. The consolidated suite retains the distinct schema, malformed payload, alias/shared-storage, source-authoritative installation, rollback, swap atomicity, publication ordering, backend cleanup, and real CUDA integration behaviors.

In the previous full CI run:

- all 31 selected tests in the GMS GPU shard passed, including the new shared-storage, alias, remap, materialization, and TensorRT-LLM relocation coverage
- the expanded GMS publication tests passed in the sequential runtime shard
- vLLM, SGLang, and TensorRT-LLM runtime test pipelines passed
- the nine reported failures reduced to seven jobs affected by unrelated, non-hermetic AIConfigurator API/bincode dependency skew and two downstream aggregate gates
- three additional stale replay failures were already fixed on `main` and are included by this rebase

A new CI run is required for HEAD `87f501b354`.

Runtime and GPU tests were not run in the local checkout because it has no `.venv` and the available Python environment lacks `pytest`, `torch`, and `msgspec`. Full backend and snapshot E2E validation remains pending.

AI assistance was used to investigate, implement, review, and validate this change. The submitting human must review and understand every changed line before marking it ready for review.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added reliable saving and restoration of shared, aliased, and non-persistent tensors.
  - Preserved tensor layouts, offsets, data types, gradients, parameter subclasses, and tied weights during model migration.
  - Added support for reconstructing runtime tensor aliases after deferred writes.

- **Bug Fixes**
  - Improved cleanup and recovery when publishing, importing, or materializing tensors fails.
  - Prevented incomplete mappings and stale pending writes after errors.
  - Improved handling of shared storage during import and remapping.

- **Tests**
  - Expanded coverage for storage manifests, aliasing, validation, failure handling, and publication ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
