### PR TITLE
fix(llm): support JSON5 non-finite values in MM-routing config.json

### DIFF
--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -265,9 +265,10 @@ pub fn resolve_routing_tokens(model_id: &str, model_dir: &Path) -> RoutingTokens
     }
 }
 
-/// Read + parse a JSON file under `model_dir`. Warns on read or parse
-/// failure (missing files are silent — many models legitimately lack
-/// `tokenizer_config.json`). Returns `None` on any error.
+/// Read and parse a model metadata file under `model_dir`.
+/// `config.json` accepts JSON5 syntax; `tokenizer_config.json` remains strict JSON.
+/// Warns on read or parse failure (missing files are silent — many models
+/// legitimately lack `tokenizer_config.json`). Returns `None` on any error.
 fn read_json(model_dir: &Path, filename: &str) -> Option<serde_json::Value> {
     let path = model_dir.join(filename);
     let raw = match std::fs::read_to_string(&path) {
@@ -283,7 +284,12 @@ fn read_json(model_dir: &Path, filename: &str) -> Option<serde_json::Value> {
             return None;
         }
     };
-    match serde_json::from_str(&raw) {
+    let res = if filename == "config.json" {
+        json_five::from_str(&raw).map_err(|e| e.to_string())
+    } else {
+        serde_json::from_str(&raw).map_err(|e| e.to_string())
+    };
+    match res {
         Ok(v) => Some(v),
         Err(e) => {
             tracing::warn!(
@@ -404,5 +410,45 @@ mod tests {
              the supported-families list in docs.",
             missing
         );
+    }
+
+    #[test]
+    fn test_resolve_routing_tokens_with_infinity_config() {
+        let dir = tempfile::tempdir().unwrap();
+        let config_content = r#"{
+            "model_type": "qwen2_5_vl",
+            "image_token_id": 151655,
+            "vision_token_id": 151655,
+            "time_step_limit": [0.0, Infinity]
+        }"#;
+        std::fs::write(dir.path().join("config.json"), config_content).unwrap();
+
+        let tokenizer_content = r#"{
+            "version": "1.0",
+            "truncation": null,
+            "padding": null,
+            "added_tokens": [
+                {
+                    "id": 151655,
+                    "content": "<|image_pad|>",
+                    "single_word": false,
+                    "lstrip": false,
+                    "rstrip": false,
+                    "normalized": false,
+                    "special": true
+                }
+            ],
+            "model": {
+                "type": "BPE",
+                "vocab": {
+                    "<|image_pad|>": 151655
+                },
+                "merges": []
+            }
+        }"#;
+        std::fs::write(dir.path().join("tokenizer.json"), tokenizer_content).unwrap();
+
+        let tokens = resolve_routing_tokens("Qwen/Qwen2.5-VL-7B-Instruct", dir.path());
+        assert_eq!(tokens.image_token_id, Some(151655));
     }
 }


### PR DESCRIPTION
## Overview:

fix(llm): support JSON5 non-finite values in MM-routing `config.json`

## Details:

  During MM-routing initialization, `resolve_routing_tokens` reads a model's  `config.json` to resolve image placeholder tokens.

  This path previously used `serde_json::from_str`, which rejects JSON5  non-finite literals such as `Infinity`. 

If an otherwise valid supported VLM  configuration contains an unrelated field such as:

example: https://github.com/ai-dynamo/dynamo/blob/main/lib/llm/tests/data/sample-models/NVIDIA-Nemotron-Nano-12B-v2-Base/config.json

```
  "time_step_limit": [
    0.0,
    Infinity
  ],
```

the entire config.json parse fails. Image placeholder resolution then returns  None, disabling MM-aware KV routing and falling back to text-prefix routing.

  Parse only config.json with json_five. Keep  tokenizer_config.json on strict serde_json parsing.

Adds coverage for a Qwen2.5-VL routing configuration containing Infinity,  verifying that image token resolution still succeeds.


## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11567" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model configuration loading to support non-standard numeric values such as `Infinity`.
  * Fixed routing token resolution for models whose configuration includes infinite time-step limits.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->