### PR TITLE
perf(kv-router): streamline block release cleanup

### DIFF
--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -67,6 +67,10 @@ impl BlockTracker {
     ///
     /// # Collision scope
     ///
+    /// Collision handling is outside the active-sequence tracker's scope: it
+    /// assumes distinct live lineages have distinct [`SequenceHash`] values and
+    /// does not detect, prevent, or recover from true hash collisions.
+    ///
     /// `SequenceHash` is a probabilistic 64-bit identifier, so collisions are
     /// possible but very unlikely. A collision matters here only when both
     /// blocks are live in the same `WorkerWithDpRank` tracker: each worker and

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -174,22 +174,14 @@ impl BlockTracker {
         let mut current = tail;
 
         while let Some(node_id) = current {
-            let shared = {
-                let node = self
-                    .nodes
-                    .get_mut(node_id)
-                    .expect("request chain references a missing block node");
-                let incoming = node.incoming.get();
-                if incoming > 1 {
-                    node.incoming = NonZeroU32::new(incoming - 1)
-                        .expect("shared block ownership count cannot become zero");
-                    true
-                } else {
-                    false
-                }
-            };
-
-            if shared {
+            let node = self
+                .nodes
+                .get_mut(node_id)
+                .expect("request chain references a missing block node");
+            let incoming = node.incoming.get();
+            if incoming > 1 {
+                node.incoming = NonZeroU32::new(incoming - 1)
+                    .expect("shared block ownership count cannot become zero");
                 retained = Some(node_id);
                 break;
             }
@@ -740,6 +732,19 @@ mod tests {
         tracker.unique_blocks.insert(2, node_id);
         let _ = tracker.contains_block(&2);
         drop(chain);
+    }
+
+    #[cfg(debug_assertions)]
+    #[test]
+    #[should_panic(expected = "block hash index references a different live node")]
+    fn release_rejects_hash_index_alias() {
+        let mut tracker = BlockTracker::default();
+        let (first, _) = tracker.acquire_prompt(&[1]);
+        let (_second, _) = tracker.acquire_prompt(&[2]);
+        let aliased_node_id = tracker.node_id_for(2);
+
+        tracker.unique_blocks.insert(1, aliased_node_id);
+        let _ = tracker.release(first);
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -6,7 +6,6 @@ use rustc_hash::FxHashMap;
 #[cfg(debug_assertions)]
 use rustc_hash::FxHashSet;
 use slotmap::{SlotMap, new_key_type};
-use std::collections::hash_map::Entry;
 use std::num::NonZeroU32;
 
 new_key_type! {
@@ -175,45 +174,45 @@ impl BlockTracker {
         let mut current = tail;
 
         while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("request chain references a missing block node");
-            let incoming = node.incoming.get();
-
-            if incoming > 1 {
-                self.nodes
+            let shared = {
+                let node = self
+                    .nodes
                     .get_mut(node_id)
-                    .expect("request chain references a missing block node")
-                    .incoming = NonZeroU32::new(incoming - 1)
-                    .expect("shared block ownership count cannot become zero");
+                    .expect("request chain references a missing block node");
+                let incoming = node.incoming.get();
+                if incoming > 1 {
+                    node.incoming = NonZeroU32::new(incoming - 1)
+                        .expect("shared block ownership count cannot become zero");
+                    true
+                } else {
+                    false
+                }
+            };
+
+            if shared {
                 retained = Some(node_id);
                 break;
             }
 
             let node = self
                 .nodes
-                .get(node_id)
-                .expect("request chain references a missing block node");
+                .remove(node_id)
+                .expect("validated block node disappeared before removal");
             let hash = node.hash;
             let depth = node.depth;
             let parent = node.parent;
 
-            match self.unique_blocks.entry(hash) {
-                Entry::Occupied(entry) => {
-                    assert_eq!(
-                        *entry.get(),
-                        node_id,
-                        "block hash index references a different live node"
-                    );
-                    entry.remove();
-                }
-                Entry::Vacant(_) => panic!("live block node is missing from the hash index"),
+            let indexed_node_id = self
+                .unique_blocks
+                .remove(&hash)
+                .expect("live block node is missing from the hash index");
+            debug_assert_eq!(
+                indexed_node_id, node_id,
+                "block hash index references a different live node"
+            );
+            if !self.fractional_blocks.is_empty() {
+                self.fractional_blocks.remove(&hash);
             }
-            self.fractional_blocks.remove(&hash);
-            self.nodes
-                .remove(node_id)
-                .expect("validated block node disappeared before removal");
 
             if depth <= prompt_depth {
                 removed_prompt_rev.push(hash);


### PR DESCRIPTION
## Overview

Reduce redundant work in the default `BlockTracker::release` path. Active-prompt cleanup walks millions of blocks in capacity-stress workloads, so repeated arena accesses and unnecessary fractional-map probes directly affect free-service latency and drain throughput.

## Summary

- inspect each block node once with mutable access before deciding whether to decrement shared ownership or remove an exclusive node
- remove exclusive arena nodes once and destructure their fields for the remaining cleanup
- retain the single-lookup hash-index removal while making its redundant hash-to-node identity check debug-only
- skip fractional-map removal when fractional accounting is inactive

There are no public API changes or intended behavior changes.

## Details

The shared path now performs one mutable arena lookup instead of a read followed by a mutable lookup. The exclusive path removes the validated arena node directly instead of reading it again before removal. The old `Entry`-based hash-index removal was already a single hash lookup; changing it to `remove` is a simplification, while the hot-path difference is that the redundant identity assertion is debug-only. Release builds already trust `SequenceHash` uniqueness during insertion, where collision checks are also debug-only. A debug-mode regression test now pins the identity assertion and its diagnostic message.

The change preserves release ordering, shared-prefix ownership, output-chain compatibility, fractional accounting when enabled, and iterative deep-chain cleanup.

## Where should the reviewer start?

`BlockTracker::release` and `release_rejects_hash_index_alias` in `lib/kv-router/src/sequences/block_tracker.rs`.

## Related Issues

**This PR is NOT linked to an issue:**

- [x] Confirmed — no related issue

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-kv-router --lib` (742 passed, 2 ignored)
- one baseline arm followed by one candidate arm of `active_sequences_bench`, using CPUs 0-1, jemalloc, block size 2, trace-length factor 512, eight workers, eight operation lanes, 1,048,576 GPU blocks, a 1 ms offered schedule, and seed 42

The baseline binary was built from commit `28649cabdb1b75889928fae73cf15a336f9c453f`. The candidate binary was built from that exact source with this release-path patch applied; the measured patch was subsequently committed as `4139d7641fbdcba7204df5b9c886733146e286e5`. Follow-up commit `82ca3a9064aac358c9c496e14e67f2b0f5264d9c` applies the reviewer's semantically equivalent direct-borrow form and adds the debug-only test, so the benchmark was not rerun.

| Metric | Baseline | Candidate | Change |
| --- | ---: | ---: | ---: |
| Logical block visits/s | 221.2M | 288.4M | +30.4% |
| Logical operations/s | 21,942 | 28,616 | +30.4% |
| Free service p50 | 47.1 us | 43.3 us | -8.0% |
| Free service p99 | 1,327.4 us | 1,090.3 us | -17.9% |
| Free service p999 | 4,332.8 us | 3,272.5 us | -24.5% |
| Drain time | 135.7 ms | 103.8 ms | -23.5% |

Both arms completed exactly 1,000 adds, prefill completions, and frees; 10,079,232 release block visits; and 30,237,696 total logical block visits. Exact IDs, per-worker FIFO ordering, generator validity, and empty final state all passed with no failure reasons. Both arms reported the expected `kept_up=false` result under the 1 ms capacity-stress schedule. This single-run comparison is directional.