### PR TITLE
fix(frontend): reject over-budget max tokens

### DIFF
--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3512,6 +3512,7 @@ mod tests {
 
     use super::*;
     use crate::discovery::ModelManagerError;
+    use crate::protocols::common::StopConditionsProvider;
     use crate::protocols::common::extensions::NvExt;
     use crate::protocols::openai::chat_completions::NvCreateChatCompletionRequest;
     use crate::protocols::openai::common_ext::CommonExt;
@@ -3683,6 +3684,19 @@ mod tests {
             },
             nvext: None,
         }
+    }
+
+    #[test]
+    fn test_responses_max_output_tokens_reaches_chat_budget_field() {
+        let mut response_request = make_base_request();
+        response_request.inner.max_output_tokens = Some(256);
+
+        let unified_request: UnifiedRequest = response_request.try_into().unwrap();
+        let chat_request = unified_request.into_inner();
+        let stop_conditions = chat_request.extract_stop_conditions().unwrap();
+
+        assert_eq!(chat_request.inner.max_completion_tokens, Some(256));
+        assert_eq!(stop_conditions.max_tokens, Some(256));
     }
 
     #[test]

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -318,6 +318,38 @@ impl OpenAIPreprocessor {
         Some(context_length.saturating_sub(prompt_len as u32))
     }
 
+    fn validate_explicit_max_tokens_budget(
+        prompt_len: usize,
+        max_tokens: Option<u32>,
+        context_length: u32,
+    ) -> Result<()> {
+        let Some(max_tokens) = max_tokens else {
+            return Ok(());
+        };
+        if context_length == 0 {
+            return Ok(());
+        }
+
+        let max_len = context_length as usize;
+        let completion_len = max_tokens as usize;
+        let requested_tokens = prompt_len.saturating_add(completion_len);
+        if requested_tokens > max_len {
+            return Err(DynamoError::builder()
+                .error_type(ErrorType::InvalidArgument)
+                .message(format!(
+                    "This model's maximum context length is {} tokens. \
+                     However, you requested {} tokens \
+                     ({} in the messages, {} in the completion). \
+                     Please reduce the length of the messages or completion.",
+                    max_len, requested_tokens, prompt_len, completion_len,
+                ))
+                .build()
+                .into());
+        }
+
+        Ok(())
+    }
+
     /// Prompt length for sizing the omitted-`max_tokens` cap. Prefers the
     /// MM-expanded length; a 0 (serde-default / absent) counts as missing. With
     /// images but no expanded length, defers to the backend (`None`); text-only
@@ -943,6 +975,13 @@ impl OpenAIPreprocessor {
             has_images,
             preprocessed.token_ids.len(),
         );
+        if let Some(prompt_len) = effective_prompt_len {
+            Self::validate_explicit_max_tokens_budget(
+                prompt_len,
+                preprocessed.stop_conditions.max_tokens,
+                self.context_length,
+            )?;
+        }
         if preprocessed.stop_conditions.max_tokens.is_none()
             && let Some(prompt_len) = effective_prompt_len
             && let Some(max_tokens) =
@@ -3540,6 +3579,13 @@ impl
             .await?;
 
         let mut common_request = builder.build()?;
+        if common_request.prompt_embeds.is_none() {
+            Self::validate_explicit_max_tokens_budget(
+                common_request.token_ids.len(),
+                common_request.stop_conditions.max_tokens,
+                self.context_length,
+            )?;
+        }
         attach_agent_context_from_context(&mut common_request, &context);
 
         let trace_state = crate::request_trace::build_request_end_trace_state(
@@ -4489,6 +4535,27 @@ mod tests {
                 PreprocessRequestOptions::default()
             ),
             None
+        );
+    }
+
+    #[test]
+    fn test_validate_explicit_max_tokens_budget() {
+        OpenAIPreprocessor::validate_explicit_max_tokens_budget(10, Some(90), 100).unwrap();
+        OpenAIPreprocessor::validate_explicit_max_tokens_budget(10, None, 100).unwrap();
+        OpenAIPreprocessor::validate_explicit_max_tokens_budget(10, Some(256), 0).unwrap();
+
+        let err =
+            OpenAIPreprocessor::validate_explicit_max_tokens_budget(10, Some(91), 100).unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("This model's maximum context length is 100 tokens."),
+            "{message}"
+        );
+        assert!(
+            message.contains(
+                "However, you requested 101 tokens (10 in the messages, 91 in the completion)."
+            ),
+            "{message}"
         );
     }
 


### PR DESCRIPTION
## Overview:

Reject requests during frontend preprocessing when an explicit output-token budget plus prompt tokens exceeds the model context length. This aligns Dynamo request validation with backend behavior such as vLLM returning a client error for over-budget requests.

## Summary

- Add frontend validation for explicit `max_tokens` / `max_completion_tokens` budgets after prompt tokenization.
- Preserve existing omitted-token behavior by only rejecting explicitly requested budgets.
- Cover the Responses API handoff so `max_output_tokens` reaches the same chat budget field before preprocessing.

## Details:

The budget check runs after Dynamo has an effective prompt token count. Text-only requests use the tokenized prompt length. Multimodal requests use the expanded multimodal prompt length when routing metadata provides one, and defer to backend validation when Dynamo only has unexpanded image placeholder tokens.

The completion path performs the same validation after tokenization and skips prompt-embedding requests, where token length is not represented by `token_ids`.

## Where should the reviewer start?

- `lib/llm/src/preprocessor.rs`: `validate_explicit_max_tokens_budget` and its call sites in chat-like and completion preprocessing.
- `lib/llm/src/http/service/openai.rs`: Responses API conversion test for `max_output_tokens`.

## Validation

- `cargo fmt --check`
- `git diff --check upstream/main...HEAD`
- `cargo test -p dynamo-llm test_validate_explicit_max_tokens_budget --lib` could not run to completion locally on macOS because `dynamo-llm` fails to compile before tests on Linux-gated imports: `dynamo_memory::numa`, `nix::fcntl::fallocate`, and `OFlag::O_DIRECT`.
- `cargo test -p dynamo-llm test_responses_max_output_tokens_reaches_chat_budget_field --lib` hit the same local macOS compile gate before tests.

## Related Issues

**This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11570" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured maximum output token settings are consistently applied across Responses API requests.
  * Added validation to prevent requested prompt and completion tokens from exceeding the model’s context limit.
  * Requests that exceed the available context now return a clear error describing the configured limit and token usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->