### PR TITLE
perf(vllm): avoid token deltas for unary requests

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2947,7 +2947,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             self.default_sampling_params,
             self.model_max_len,
             enable_rl=self.config.enable_rl,
-            disaggregation_mode=self.config.disaggregation_mode,
+            disaggregation_mode=mode,
         )
 
         if kv_params is not None:
@@ -3276,7 +3276,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             self.default_sampling_params,
             self.model_max_len,
             enable_rl=self.config.enable_rl,
-            disaggregation_mode=self.config.disaggregation_mode,
+            disaggregation_mode=DisaggregationMode.PREFILL,
         )
 
         # One protocol instance per request; carries per-request state

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -97,6 +97,7 @@ logger = logging.getLogger(__name__)
 
 _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
+_FINAL_REQUEST_OUTPUT_KIND = RequestOutputKind.FINAL_ONLY
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -719,6 +720,7 @@ def build_sampling_params(
     default_sampling_params: Dict[str, Any],
     model_max_len: int | None = None,
     enable_rl: bool = False,
+    disaggregation_mode: DisaggregationMode | None = None,
 ) -> SamplingParams:
     """
     Build SamplingParams from a PreprocessedRequest (internal protocol format).
@@ -730,6 +732,9 @@ def build_sampling_params(
             ``generation_config.json`` (vLLM ``ModelConfig.get_diff_sampling_param``).
             Used for non-RL/chat clients that want the model's recommended
             sampling defaults applied transparently.
+        disaggregation_mode: Worker topology. FINAL_ONLY is safe only for an
+            aggregated worker; decode workers need an early output to release
+            their deferred-abort guard after KV transfer.
 
     Returns:
         SamplingParams configured from the request
@@ -844,11 +849,26 @@ def build_sampling_params(
         configured_default = default_sampling_params.get("max_tokens", dynamic_default)
         sampling_params.max_tokens = min(configured_default, dynamic_default)
 
-    # Dynamo's internal token path consumes disjoint token deltas. This mirrors
-    # the SGLang integration and lets vLLM's stream_interval gate reduce backend
-    # bridge pressure before chunks cross into Dynamo.
+    # The frontend always consumes a stream internally, even when it folds the
+    # external response. For a known non-streaming client, let vLLM return one
+    # final token batch and avoid constructing a Python RequestOutput per decode
+    # step. Textual and visible-token stops remain on DELTA because Dynamo, not
+    # vLLM, enforces those conditions incrementally. A missing signal means an
+    # older frontend or an unknown/disaggregated worker, so retain the legacy
+    # DELTA behavior during rolling updates and for deferred-abort safety.
+    stop_conditions = request.get("stop_conditions", {}) or {}
+    client_streaming = output_options.get("client_streaming")
+    needs_incremental_stops = bool(stop_conditions.get("stop")) or bool(
+        stop_conditions.get("stop_token_ids_visible")
+    )
     sampling_params.detokenize = False
-    sampling_params.output_kind = _DELTA_REQUEST_OUTPUT_KIND
+    sampling_params.output_kind = (
+        _FINAL_REQUEST_OUTPUT_KIND
+        if disaggregation_mode == DisaggregationMode.AGGREGATED
+        and client_streaming is False
+        and not needs_incremental_stops
+        else _DELTA_REQUEST_OUTPUT_KIND
+    )
 
     return sampling_params
 
@@ -2719,7 +2739,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     if raw_routed_experts is not None:
                         raw_routed_experts_by_output[output_idx] = raw_routed_experts
 
-                    # vLLM DELTA outputs already align token_ids/logprobs to this chunk.
+                    # vLLM DELTA and FINAL_ONLY outputs align token_ids/logprobs
+                    # to the returned chunk.
                     tokenizer = getattr(self.engine_client, "tokenizer", None)
                     log_probs, top_logprobs = self._extract_logprobs(
                         output, 0, tokenizer=tokenizer
@@ -2926,6 +2947,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             self.default_sampling_params,
             self.model_max_len,
             enable_rl=self.config.enable_rl,
+            disaggregation_mode=self.config.disaggregation_mode,
         )
 
         if kv_params is not None:
@@ -3254,6 +3276,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             self.default_sampling_params,
             self.model_max_len,
             enable_rl=self.config.enable_rl,
+            disaggregation_mode=self.config.disaggregation_mode,
         )
 
         # One protocol instance per request; carries per-request state

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -434,6 +434,7 @@ class VllmLLMEngine(LLMEngine):
             self._default_sampling_params,
             self._model_max_len,
             enable_rl=self.enable_rl,
+            disaggregation_mode=self.disaggregation_mode,
         )
 
         # vLLM's KV transfer is internal to NixlConnector
@@ -558,7 +559,8 @@ class VllmLLMEngine(LLMEngine):
                     "token_ids": token_ids,
                 }
 
-                # `build_sampling_params` forces DELTA output → offset 0.
+                # DELTA and FINAL_ONLY outputs both align token_ids/logprobs
+                # to the returned chunk, so extraction starts at offset 0.
                 # `fallback_to_first_on_missing=True` matches legacy
                 # vLLM handler: always emit when vLLM returned a dict.
                 (

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -315,7 +315,7 @@ async def test_generate_tokens_accepts_final_only_multi_choice_output():
         "prompt_tokens": 2,
         "completion_tokens": 3,
         "total_tokens": 5,
-        "prompt_tokens_details": None,
+        "prompt_tokens_details": {"cached_tokens": 0},
     }
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -93,24 +93,89 @@ async def _collect_handler_chunks(responses):
     return chunks, handler
 
 
-def test_build_sampling_params_forces_delta_token_mode():
+def _build_sampling_params(
+    output_options=None,
+    stop_conditions=None,
+    disaggregation_mode=DisaggregationMode.AGGREGATED,
+):
     request = {
         "token_ids": [1, 2, 3],
         "sampling_options": {"output_kind": RequestOutputKind.CUMULATIVE},
-        "stop_conditions": {},
-        "output_options": {},
+        "stop_conditions": stop_conditions or {},
+        "output_options": output_options or {},
     }
 
-    sampling_params = build_sampling_params(
+    return build_sampling_params(
         request,
         default_sampling_params={
             "detokenize": True,
             "output_kind": RequestOutputKind.CUMULATIVE,
         },
+        disaggregation_mode=disaggregation_mode,
     )
+
+
+@pytest.mark.parametrize("client_streaming", [True, None])
+def test_build_sampling_params_uses_delta_for_streaming_or_legacy_frontend(
+    client_streaming,
+):
+    output_options = (
+        {} if client_streaming is None else {"client_streaming": client_streaming}
+    )
+    sampling_params = _build_sampling_params(output_options=output_options)
 
     assert sampling_params.detokenize is False
     assert sampling_params.output_kind == RequestOutputKind.DELTA
+
+
+def test_build_sampling_params_uses_final_only_for_nonstreaming_client():
+    sampling_params = _build_sampling_params(output_options={"client_streaming": False})
+
+    assert sampling_params.detokenize is False
+    assert sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
+
+
+@pytest.mark.parametrize(
+    "disaggregation_mode",
+    [None, DisaggregationMode.PREFILL, DisaggregationMode.DECODE],
+)
+def test_build_sampling_params_keeps_delta_outside_aggregated_mode(
+    disaggregation_mode,
+):
+    sampling_params = _build_sampling_params(
+        output_options={"client_streaming": False},
+        disaggregation_mode=disaggregation_mode,
+    )
+
+    assert sampling_params.output_kind == RequestOutputKind.DELTA
+
+
+@pytest.mark.parametrize(
+    "stop_conditions",
+    [
+        {"stop": ["stop here"]},
+        {"stop_token_ids_visible": [42]},
+    ],
+)
+def test_build_sampling_params_keeps_delta_for_frontend_enforced_stops(
+    stop_conditions,
+):
+    sampling_params = _build_sampling_params(
+        output_options={"client_streaming": False},
+        stop_conditions=stop_conditions,
+    )
+
+    assert sampling_params.output_kind == RequestOutputKind.DELTA
+
+
+def test_build_sampling_params_allows_final_only_for_hidden_stop_tokens():
+    sampling_params = _build_sampling_params(
+        output_options={"client_streaming": False},
+        stop_conditions={"stop_token_ids_hidden": [42]},
+    )
+
+    assert sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
+    assert 42 in sampling_params.stop_token_ids
 
 
 @pytest.mark.asyncio
@@ -217,6 +282,44 @@ async def test_generate_tokens_reads_delta_aligned_logprobs_from_zero_offset():
 
 
 @pytest.mark.asyncio
+async def test_generate_tokens_accepts_final_only_multi_choice_output():
+    first_logprobs = [
+        {7: SimpleNamespace(logprob=-0.7, rank=1, decoded_token="a")},
+        {8: SimpleNamespace(logprob=-0.8, rank=1, decoded_token="b")},
+    ]
+    responses = [
+        _request_output(
+            [
+                _output(
+                    [7, 8],
+                    index=0,
+                    finish_reason="length",
+                    logprobs=first_logprobs,
+                ),
+                _output([9], index=1, finish_reason="stop"),
+            ],
+            prompt_token_ids=[10, 11],
+        )
+    ]
+
+    chunks, _ = await _collect_handler_chunks(responses)
+
+    assert [(chunk["index"], chunk["token_ids"]) for chunk in chunks] == [
+        (0, [7, 8]),
+        (1, [9]),
+    ]
+    assert chunks[0]["log_probs"] == [-0.7, -0.8]
+    assert chunks[0]["finish_reason"] == "length"
+    assert chunks[1]["finish_reason"] == "stop"
+    assert chunks[-1]["completion_usage"] == {
+        "prompt_tokens": 2,
+        "completion_tokens": 3,
+        "total_tokens": 5,
+        "prompt_tokens_details": None,
+    }
+
+
+@pytest.mark.asyncio
 async def test_generate_tokens_keeps_multichunk_delta_logprobs_aligned():
     first_logprobs = [
         {7: SimpleNamespace(logprob=-0.7, rank=1, decoded_token="a")},
@@ -250,7 +353,7 @@ async def test_generate_tokens_keeps_multichunk_delta_logprobs_aligned():
         (1, {"cached_tokens": 1}),
     ],
 )
-async def test_unified_llm_engine_passes_delta_chunks_and_counts_usage(
+async def test_unified_llm_engine_accepts_final_only_output_and_counts_usage(
     num_cached_tokens,
     expected_prompt_tokens_details,
 ):
@@ -288,14 +391,14 @@ async def test_unified_llm_engine_passes_delta_chunks_and_counts_usage(
                 "token_ids": [10, 11],
                 "sampling_options": {},
                 "stop_conditions": {},
-                "output_options": {},
+                "output_options": {"client_streaming": False},
             },
             _FakeContext(),
         )
     ]
 
     sampling_params = engine.engine_client.calls[0][0][1]
-    assert sampling_params.output_kind == RequestOutputKind.DELTA
+    assert sampling_params.output_kind == RequestOutputKind.FINAL_ONLY
     assert [chunk["token_ids"] for chunk in chunks] == [[1], [2, 3]]
     assert chunks[-1]["completion_usage"] == {
         "prompt_tokens": 2,

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -399,12 +399,18 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
     from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
     from dynamo.vllm import llm_engine
 
-    captured: dict[str, bool] = {}
+    captured: dict[str, object] = {}
 
     def fake_build_sampling_params(
-        request, default_sampling_params, model_max_len=None, *, enable_rl=False
+        request,
+        default_sampling_params,
+        model_max_len=None,
+        *,
+        enable_rl=False,
+        disaggregation_mode=None,
     ):
         captured["enable_rl"] = enable_rl
+        captured["disaggregation_mode"] = disaggregation_mode
         return SimpleNamespace(extra_args=None)
 
     async def empty_generation():
@@ -439,6 +445,7 @@ def test_unified_generate_passes_enable_rl_to_sampling_params(monkeypatch):
     asyncio.run(run_generate())
 
     assert captured["enable_rl"] is True
+    assert captured["disaggregation_mode"] == CommonDisaggregationMode.AGGREGATED
 
 
 @pytest.mark.asyncio

--- a/lib/llm/src/grpc/service/openai.rs
+++ b/lib/llm/src/grpc/service/openai.rs
@@ -10,6 +10,7 @@ use futures::{Stream, StreamExt, stream};
 use std::sync::Arc;
 
 use crate::http::service::metadata::extract_metadata_from_grpc;
+use crate::preprocessor::CLIENT_STREAMING_CONTEXT_KEY;
 use crate::protocols::openai::ParsingOptions;
 use crate::protocols::openai::completions::{
     NvCreateCompletionRequest, NvCreateCompletionResponse,
@@ -65,7 +66,8 @@ pub async fn completion_response_stream(
     };
     let metadata = extract_metadata_from_grpc(metadata)
         .map_err(|err| Status::invalid_argument(err.to_string()))?;
-    let request = Context::with_id_and_metadata(request, request_id.clone(), metadata);
+    let mut request = Context::with_id_and_metadata(request, request_id.clone(), metadata);
+    request.insert(CLIENT_STREAMING_CONTEXT_KEY, streaming);
     let context = request.context();
 
     // create the connection handles

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -37,6 +37,7 @@ use super::{
     },
     service_v2,
 };
+use crate::preprocessor::CLIENT_STREAMING_CONTEXT_KEY;
 use crate::protocols::anthropic::stream_converter::AnthropicStreamConverter;
 use crate::protocols::anthropic::types::{
     AnthropicCountTokensRequest, AnthropicCountTokensResponse, AnthropicCreateMessageRequest,
@@ -337,7 +338,8 @@ async fn anthropic_messages(
             .or_insert(serde_json::Value::Bool(false));
     }
 
-    let request = context.map(|_req| chat_request);
+    let mut request = context.map(|_req| chat_request);
+    request.insert(CLIENT_STREAMING_CONTEXT_KEY, streaming);
 
     // Gate the experimental v2 batch finalize on the request's tool_choice, mirroring the
     // streaming gate (required/named + structural-tag stay on the v1 finalize path).

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -46,7 +46,7 @@ use super::{
     service_v2,
 };
 use crate::engines::ValidateRequest;
-use crate::preprocessor::PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY;
+use crate::preprocessor::{CLIENT_STREAMING_CONTEXT_KEY, PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY};
 use crate::protocols::common::extensions::{
     AGENT_CONTEXT_CONTEXT_KEY, AgentContext, SESSION_AFFINITY_CONTEXT_KEY, SessionAffinityId,
     agent_context_from_headers, apply_header_routing_overrides, session_affinity_from_headers,
@@ -2315,6 +2315,7 @@ async fn responses(
         });
 
     let mut request = context.map(|mut _req| chat_request);
+    request.insert(CLIENT_STREAMING_CONTEXT_KEY, streaming);
     if response_params.max_output_tokens.is_none() {
         request.insert(PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY, true);
     }

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -247,6 +247,14 @@ static DIM_FETCH_HTTP_CLIENT: std::sync::LazyLock<reqwest::Client> =
 
 pub(crate) const PRESERVE_OMITTED_MAX_TOKENS_CONTEXT_KEY: &str =
     "dynamo.llm.preserve_omitted_max_tokens";
+pub(crate) const CLIENT_STREAMING_CONTEXT_KEY: &str = "dynamo.llm.client_streaming";
+
+fn client_streaming_from_context(context: &PipelineContext<()>, fallback: bool) -> bool {
+    context
+        .get::<bool>(CLIENT_STREAMING_CONTEXT_KEY)
+        .map(|streaming| *streaming)
+        .unwrap_or(fallback)
+}
 
 fn attach_agent_context_from_context(
     request: &mut PreprocessedRequest,
@@ -3211,6 +3219,7 @@ impl
         // Preserve original inbound streaming flag before any internal overrides
         let request_id = context.id().to_string();
         let original_stream_flag = request.inner.stream.unwrap_or(false);
+        let client_streaming = client_streaming_from_context(&context, original_stream_flag);
 
         // Build request payload handle (None if request trace is disabled / not eligible).
         // The handle snapshots the pristine request and its arrival time here;
@@ -3254,6 +3263,7 @@ impl
         let (mut common_request, annotations, prompt_injected_reasoning) = self
             .preprocess_request_with_options(&request, tracker.as_deref(), preprocess_options)
             .await?;
+        common_request.output_options.client_streaming = Some(client_streaming);
         attach_agent_context_from_context(&mut common_request, &context);
 
         let uses_tool_call_structural_tag = self.apply_tool_choice_guided_decoding(
@@ -3402,6 +3412,7 @@ impl
 
         // Preserve original streaming flag
         let original_stream_flag = request.inner.stream.unwrap_or(false);
+        let client_streaming = client_streaming_from_context(&context, original_stream_flag);
 
         // For non-streaming requests (stream=false), enable usage by default
         // This ensures compliance with OpenAI API spec where non-streaming responses
@@ -3442,6 +3453,7 @@ impl
             .await?;
 
         let mut common_request = builder.build()?;
+        common_request.output_options.client_streaming = Some(client_streaming);
         attach_agent_context_from_context(&mut common_request, &context);
 
         let trace_state = crate::request_trace::build_request_end_trace_state(
@@ -3623,6 +3635,16 @@ mod tests {
     use super::*;
     use crate::protocols::common::preprocessor::MultimodalData;
     use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
+
+    #[test]
+    fn test_client_streaming_context_overrides_internal_stream_flag() {
+        let mut context = PipelineContext::new(());
+        assert!(client_streaming_from_context(&context, true));
+        assert!(!client_streaming_from_context(&context, false));
+
+        context.insert(CLIENT_STREAMING_CONTEXT_KEY, false);
+        assert!(!client_streaming_from_context(&context, true));
+    }
 
     fn url_entry(u: &str) -> MultimodalData {
         MultimodalData::Url(url::Url::parse(u).unwrap())

--- a/lib/llm/src/protocols/common.rs
+++ b/lib/llm/src/protocols/common.rs
@@ -535,6 +535,14 @@ impl SamplingOptions {
 /// Collection of options that control what information the inference engine returns in the response.
 #[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct OutputOptions {
+    /// Whether the original client request asked for a streaming response.
+    ///
+    /// Dynamo may stream internally even when the external response is folded
+    /// into one object. Backends can use this signal to avoid constructing
+    /// incremental output for non-streaming clients. `None` preserves the
+    /// legacy behavior for mixed-version frontend/worker deployments.
+    pub client_streaming: Option<bool>,
+
     /// Number of log probabilities to return per output token.
     /// Note that the implementation follows the OpenAI API: The return
     /// result includes the log probabilities on the `logprobs` most likely
@@ -722,6 +730,23 @@ impl From<CompletionContext> for PromptType {
 mod tests {
 
     use super::*;
+
+    #[test]
+    fn test_output_options_client_streaming_is_backward_compatible() {
+        let legacy: OutputOptions = serde_json::from_value(serde_json::json!({
+            "logprobs": 2
+        }))
+        .unwrap();
+        assert_eq!(legacy.client_streaming, None);
+
+        for client_streaming in [true, false] {
+            let options: OutputOptions = serde_json::from_value(serde_json::json!({
+                "client_streaming": client_streaming
+            }))
+            .unwrap();
+            assert_eq!(options.client_streaming, Some(client_streaming));
+        }
+    }
 
     #[test]
     fn test_completion_context_new() {

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -225,6 +225,7 @@ impl<T: OpenAIOutputOptionsProvider> OutputOptionsProvider for T {
         let return_tokens_as_token_ids = self.get_return_tokens_as_token_ids();
 
         Ok(common::OutputOptions {
+            client_streaming: None,
             logprobs,
             prompt_logprobs,
             skip_special_tokens,


### PR DESCRIPTION
## Why

Dynamo consumes an internal stream even when an external OpenAI request uses `stream:false`. The vLLM worker therefore constructs and transports an output for every decode step before the frontend folds those deltas into one response. Preserving client-streaming intent lets safe aggregate unary requests use vLLM `FINAL_ONLY`, while conservative fallbacks retain delta output for stop handling, streaming, mixed versions, and disaggregated workers.

## Effect

H100 image workload, three replications, 1,000 requests per cell, OSL 70:

| Offered rate | FINAL_ONLY | Dynamo native | Direct vLLM |
|---:|---:|---:|---:|
| 16 req/s | 15.570 req/s | 15.568 req/s | 15.569 req/s |
| 24 req/s | 18.163 req/s | 20.126 req/s | 18.441 req/s |
| 32 req/s | 19.981 req/s | 19.368 req/s | 19.873 req/s |

The optimization removes intermediate output work, but this image workload remains dominated by other stages.

## What Change

- Propagate optional client-streaming intent through frontend preprocessing.
- Select `FINAL_ONLY` only for safe aggregate unary requests.
- Retain `DELTA` for streaming, stops, legacy, prefill, and decode paths.

## Test Plan

- 71 CI checks pass, including Rust, Python, GPU, and deployment suites.
- H100: 45 AIPerf cells, 45,000 measured requests, zero errors.
