### PR TITLE
fix(planner): resolve aggregate workers by component type

### DIFF
--- a/components/src/dynamo/planner/monitoring/dgd_services.py
+++ b/components/src/dynamo/planner/monitoring/dgd_services.py
@@ -210,6 +210,15 @@ def get_component_from_type_or_name(
         component_names = [name for name, _ in matching_components]
         raise DuplicateSubComponentError(component_type.value, component_names)
 
+    if not matching_components and component_type == SubComponentType.DECODE:
+        generic_workers = [
+            (name, component)
+            for name, component in components.items()
+            if get_component_type(component) == V1BETA1_GENERIC_WORKER_COMPONENT_TYPE
+        ]
+        if len(generic_workers) == 1:
+            matching_components = generic_workers
+
     if not matching_components and component_name in components:
         component = components[component_name]
         if not _can_use_explicit_component_name(component, component_type):

--- a/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
+++ b/components/src/dynamo/planner/tests/unit/test_kubernetes_connector.py
@@ -378,6 +378,55 @@ def test_get_service_name_from_v1beta_worker_type_by_name(kubernetes_connector):
     assert service.number_replicas() == 2
 
 
+def test_get_service_name_from_unique_v1beta_worker_type_for_decode(
+    kubernetes_connector,
+):
+    deployment = _deployment(_component("arbitrary-name", "worker", replicas=2))
+
+    service = get_component_from_type_or_name(deployment, SubComponentType.DECODE)
+
+    assert service.name == "arbitrary-name"
+    assert service.number_replicas() == 2
+
+
+def test_get_service_name_from_multiple_v1beta_workers_by_name(
+    kubernetes_connector,
+):
+    deployment = _deployment(
+        _component("prefill-name", "worker"),
+        _component("decode-name", "worker"),
+    )
+
+    with pytest.raises(SubComponentNotFoundError):
+        get_component_from_type_or_name(deployment, SubComponentType.DECODE)
+
+    service = get_component_from_type_or_name(
+        deployment, SubComponentType.DECODE, "decode-name"
+    )
+    assert service.name == "decode-name"
+
+
+@pytest.mark.asyncio
+async def test_validate_deployment_agg_worker_by_type(
+    kubernetes_connector, mock_kube_api
+):
+    mock_kube_api.get_graph_deployment.return_value = _deployment(
+        _component("Frontend", "frontend", replicas=1),
+        _component(
+            "arbitrary-name",
+            "worker",
+            replicas=2,
+            args=["--model", "Qwen/Qwen3-8B"],
+        ),
+    )
+
+    await kubernetes_connector.validate_deployment(
+        decode_component_name="stale-default-name",
+        require_prefill=False,
+        require_decode=True,
+    )
+
+
 def test_get_service_name_from_sub_component_type_not_found(kubernetes_connector):
     deployment = _deployment(_component("test-component-decode", "decode", replicas=3))
     with pytest.raises(SubComponentNotFoundError) as exc_info:


### PR DESCRIPTION
## Summary

- Resolve aggregate planner workers by their DGD component type instead of backend-specific names.
- Treat the sole generic `type: worker` component as the planner's decode component, regardless of its name.
- Keep the existing explicit-name fallback when multiple generic workers make type-only selection ambiguous.

This fixes #11491 and lets #9848 rename vLLM workers without carrying planner-side aliases for every historical name.

## Validation

- Current-main A/B through `KubernetesConnector.validate_deployment`: an aggregate DGD with an arbitrary worker name fails before this change and passes after it.
- `test_kubernetes_connector.py`: 75 passed.
- Ruff check and format check passed for both changed files.

Live-cluster startup and scaling were not run because they require a real aggregate deployment.
