### PR TITLE
feat(codeowners): contributor tooling -- who_owns --people, dynamo-codeowners skill, docs playbook

### DIFF
--- a/.agents/skills/dynamo-codeowners/SKILL.md
+++ b/.agents/skills/dynamo-codeowners/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: dynamo-codeowners
+description: Work with Dynamo's generated CODEOWNERS - find out who reviews a change, fix a failing codeowners CI check, change review routing, or grant an external contributor area-scoped ownership. Use when the codeowners check fails on a PR, a new directory is unclaimed, someone asks who reviews a path or PR, review routing needs to change, or a contributor should be added as a code owner.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - codeowners
+    - review-routing
+    - dev-workflow
+---
+
+# Skill: CODEOWNERS Operations
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+The root `CODEOWNERS` is a build artifact generated from
+`.github/codeowners/areas.yaml` (one entry per subsystem area mapping path
+globs to a GitHub team). Never hand-edit `CODEOWNERS` - CI regenerates it and
+fails on any drift. Every change goes through `areas.yaml` (or
+`external_contributors.yaml`) followed by regeneration.
+
+Pick the flow that matches the situation.
+
+## Flow 1: Who reviews this change?
+
+```bash
+# owners of your working tree's changed files (union, as GitHub will request)
+python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed
+
+# owners of specific paths
+python .github/codeowners/who_owns.py --codeowners CODEOWNERS <path> [<path> ...]
+```
+
+Add `--people` to expand each team to its member logins. This works only for
+NVIDIA org members with an authenticated `gh` - GitHub does not show team
+membership to non-members. Without it (or when the lookup fails), the team
+handles are the answer; the actual reviewers appear on the PR once it opens.
+
+## Flow 2: The `codeowners` CI check failed
+
+This is the coverage gate doing its job: the PR adds at least one file that no
+area claims. Nothing ships unowned.
+
+1. Read the failing job log. The gate prints the exact uncovered files:
+   `catch-all-only sample (add an area or classify rule to cover these): [...]`.
+2. Decide which area owns the new path. Match it to the subsystem whose code it
+   extends (the PR that introduced `examples/custom_encoder/` was a multimodal
+   feature, so the claim went under the `multimodal` area).
+3. Add ONE line to `.github/codeowners/areas.yaml` under that area's
+   `path_globs` (directory claims end with `/`). If the path will recur under
+   many parents, a `classify.keyword_rules` entry (substring -> area) covers
+   future instances too.
+4. Regenerate and verify:
+   ```bash
+   python .github/codeowners/build_codeowners.py \
+       --areas .github/codeowners/areas.yaml --repo . --strict
+   python .github/codeowners/emit_codeowners.py \
+       --areas .github/codeowners/areas.yaml --repo . --out CODEOWNERS
+   ```
+   The strict run must report 100% coverage.
+5. Commit `areas.yaml` and `CODEOWNERS` together (same commit), signed
+   (`git commit -s`).
+
+## Flow 3: Change review routing
+
+Edit `.github/codeowners/areas.yaml` - move a glob between areas, add a
+`shared:` entry (multi-team co-ownership; any one team's approval satisfies
+the gate), or adjust `classify` rules. Then regenerate exactly as in Flow 2
+step 4 and commit both files. Routing changes are owned by the process team,
+which is auto-requested on the PR.
+
+## Flow 4: Grant an external contributor area-scoped ownership
+
+Individuals who have earned ownership of an area are attached to the area's
+label - never to a copy of its globs - in
+`.github/codeowners/external_contributors.yaml`:
+
+```yaml
+contributors:
+  - name: Jane Doe
+    github: janedoe          # -> @janedoe appended to the area's lines
+    level: maintainer        # contributor | trusted_contributor | maintainer | core_maintainer
+    affiliation: Example Org
+    areas: [router]          # area labels from areas.yaml
+```
+
+Regeneration (Flow 2 step 4) appends the handle as a co-owner on every line
+the area's team owns and rebuilds `CONTRIBUTORS.md`. Commit all three files
+(`external_contributors.yaml`, `CODEOWNERS`, `CONTRIBUTORS.md`) together.
+`level` is standing metadata shown in `CONTRIBUTORS.md`; routing is granted by
+`areas`.
+
+## Reference
+
+- Schema, the last-match-wins model, and the change process:
+  `.github/codeowners/README.md`
+- The gate and drift check run in `.github/workflows/codeowners.yml` on every
+  PR; both must pass before merge.

--- a/.agents/skills/repo-codeowners/SKILL.md
+++ b/.agents/skills/repo-codeowners/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: dynamo-codeowners
+name: repo-codeowners
 description: Work with Dynamo's generated CODEOWNERS - find out who reviews a change, fix a failing codeowners CI check, change review routing, or grant an external contributor area-scoped ownership. Use when the codeowners check fails on a PR, a new directory is unclaimed, someone asks who reviews a path or PR, review routing needs to change, or a contributor should be added as a code owner.
 license: Apache-2.0
 metadata:
@@ -40,6 +40,9 @@ Add `--people` to expand each team to its member logins. This works only for
 NVIDIA org members with an authenticated `gh` - GitHub does not show team
 membership to non-members. Without it (or when the lookup fails), the team
 handles are the answer; the actual reviewers appear on the PR once it opens.
+For an open PR, the `codeowners-reviewers` workflow also posts this table
+(with member names when the org-read secret is configured) to its run summary
+in the Actions tab, visible to external contributors.
 
 ## Flow 2: The `codeowners` CI check failed
 

--- a/.github/codeowners/README.md
+++ b/.github/codeowners/README.md
@@ -22,6 +22,11 @@ team membership to members of the org, so this works for org members with an
 authenticated `gh`; everyone else sees the team handles (the actual reviewers
 appear on the PR once it opens).
 
+External contributors: every PR also gets a "Who reviews this PR" table in
+the `codeowners-reviewers` workflow's run summary (Actions tab), expanded to
+member names when the repo's org-read token is configured -- no org
+membership or local tooling needed.
+
 A line with more than one team is co-ownership: under "any one approves," any one
 of them satisfies the gate, so co-ownership adds review *visibility* without
 adding required approvals.

--- a/.github/codeowners/README.md
+++ b/.github/codeowners/README.md
@@ -17,6 +17,11 @@ python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed --base m
 python .github/codeowners/who_owns.py --codeowners CODEOWNERS lib/llm/foo.rs deploy/operator/bar.go
 ```
 
+Add `--people` to expand each team to its member logins. GitHub only shows
+team membership to members of the org, so this works for org members with an
+authenticated `gh`; everyone else sees the team handles (the actual reviewers
+appear on the PR once it opens).
+
 A line with more than one team is co-ownership: under "any one approves," any one
 of them satisfies the gate, so co-ownership adds review *visibility* without
 adding required approvals.

--- a/.github/codeowners/test_codeowners.py
+++ b/.github/codeowners/test_codeowners.py
@@ -401,6 +401,53 @@ class TestComputeResolution:
 
 
 # ------------------------------------------------------------------
+# who_owns.team_members() -- roster expansion (--people)
+# ------------------------------------------------------------------
+
+import subprocess  # noqa: E402
+
+import who_owns  # noqa: E402
+
+
+class TestTeamMembers:
+    def test_expands_team_via_fetcher(self) -> None:
+        cache: dict = {}
+        fetched = []
+
+        def fake(org: str, slug: str) -> list[str]:
+            fetched.append((org, slug))
+            return ["zoe", "amy"]
+
+        members = who_owns.team_members("@acme/router", fetch=fake, cache=cache)
+        assert members == ["amy", "zoe"]  # sorted
+        assert fetched == [("acme", "router")]
+        # second lookup served from cache, fetcher not called again
+        assert who_owns.team_members("@acme/router", fetch=fake, cache=cache) == [
+            "amy",
+            "zoe",
+        ]
+        assert fetched == [("acme", "router")]
+
+    def test_fetch_failure_returns_none_and_caches_negative(self) -> None:
+        cache: dict = {}
+        calls = []
+
+        def boom(org: str, slug: str) -> list[str]:
+            calls.append(slug)
+            raise subprocess.CalledProcessError(1, "gh")
+
+        assert who_owns.team_members("@acme/router", fetch=boom, cache=cache) is None
+        assert who_owns.team_members("@acme/router", fetch=boom, cache=cache) is None
+        assert calls == ["router"]  # failure cached; no retry storm
+
+    def test_individual_handle_passes_through(self) -> None:
+        def never(org: str, slug: str) -> list[str]:
+            raise AssertionError("fetcher must not be called for @handles")
+
+        assert who_owns.team_members("@octocat", fetch=never, cache={}) is None
+
+
+# ------------------------------------------------------------------
 # TypedDict / dataclass surface
 # ------------------------------------------------------------------
 

--- a/.github/codeowners/test_codeowners.py
+++ b/.github/codeowners/test_codeowners.py
@@ -447,6 +447,31 @@ class TestTeamMembers:
         assert who_owns.team_members("@octocat", fetch=never, cache={}) is None
 
 
+class TestChangedFiles:
+    def test_includes_untracked_files(self, tmp_path) -> None:
+        # Brand-new (unstaged) files are the ones the coverage gate cares
+        # about most; `git diff` alone never lists them.
+        repo = tmp_path / "r"
+        repo.mkdir()
+
+        def git(*args: str) -> None:
+            subprocess.check_output(
+                ["git", "-C", str(repo), *args], stderr=subprocess.DEVNULL
+            )
+
+        git("init", "-q")
+        git("config", "user.email", "t@example.com")
+        git("config", "user.name", "t")
+        (repo / "tracked.txt").write_text("x")
+        git("add", "tracked.txt")
+        git("commit", "-q", "-m", "init")
+        (repo / "tracked.txt").write_text("y")  # modified, unstaged
+        (repo / "brand_new.txt").write_text("z")  # untracked
+
+        files = who_owns.changed_files(str(repo), "HEAD")
+        assert files == ["brand_new.txt", "tracked.txt"]
+
+
 # ------------------------------------------------------------------
 # TypedDict / dataclass surface
 # ------------------------------------------------------------------

--- a/.github/codeowners/who_owns.py
+++ b/.github/codeowners/who_owns.py
@@ -11,6 +11,10 @@ has to read 300 rules to find a reviewer.
   # the teams that will be auto-requested on your PR (union over changed files)
   python who_owns.py --codeowners CODEOWNERS --changed --base main
 
+  # same, expanding each team to its member logins (org members only --
+  # GitHub does not show team membership to non-members)
+  python who_owns.py --codeowners CODEOWNERS --changed --people
+
 Owners listed on a single line are co-owners (any one's approval satisfies
 the gate). Advisory teams are auto-requested too, but never block the merge.
 
@@ -59,6 +63,79 @@ def advisory_for(
         if pat and match(pat, filepath):
             teams.update(r.get("request_review_from", []))
     return teams
+
+
+_TEAM_CACHE: dict[str, list[str] | None] = {}
+_PEOPLE_WARNED = False
+
+
+def _gh_fetch(org: str, slug: str) -> list[str]:
+    """Fetch a team's member logins via the ``gh`` CLI."""
+    out = subprocess.check_output(
+        [
+            "gh",
+            "api",
+            f"orgs/{org}/teams/{slug}/members",
+            "--paginate",
+            "--jq",
+            ".[].login",
+        ],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    )
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def team_members(team, fetch=_gh_fetch, cache=None):
+    """Member logins for an ``@org/slug`` team, or ``None`` when unavailable.
+
+    GitHub only shows team membership to members of the org, so this works
+    for org members with an authenticated ``gh`` and cannot work for external
+    contributors -- callers degrade to the team handle. Individual ``@handle``
+    owners (no slash) return ``None`` and pass through unchanged. Results,
+    including failures, are cached per run.
+    """
+    if cache is None:
+        cache = _TEAM_CACHE
+    if team in cache:
+        return cache[team]
+    members = None
+    if team.startswith("@") and "/" in team:
+        org, slug = team[1:].split("/", 1)
+        try:
+            members = sorted(fetch(org, slug))
+        except (OSError, subprocess.CalledProcessError):
+            members = None
+    cache[team] = members
+    return members
+
+
+def _warn_people_unavailable() -> None:
+    global _PEOPLE_WARNED
+    if not _PEOPLE_WARNED:
+        print(
+            "note: team membership is only visible to org members "
+            "(authenticated gh required); showing teams only",
+            file=sys.stderr,
+        )
+        _PEOPLE_WARNED = True
+
+
+def _with_people(owner: str) -> str:
+    """Render an owner as ``@org/team (member, member, ...)`` when possible."""
+    members = team_members(owner)
+    if members is None:
+        if owner.startswith("@") and "/" in owner:
+            _warn_people_unavailable()
+        return owner
+    return f"{owner} ({', '.join(members) if members else 'no members'})"
+
+
+def _team_url(team: str) -> str | None:
+    if team.startswith("@") and "/" in team:
+        org, slug = team[1:].split("/", 1)
+        return f"https://github.com/orgs/{org}/teams/{slug}"
+    return None
 
 
 def changed_files(repo: str, base: str) -> list[str]:
@@ -116,6 +193,12 @@ def main() -> int:
     ap.add_argument(
         "--base", default="main", help="base ref for --changed (default: main)"
     )
+    ap.add_argument(
+        "--people",
+        action="store_true",
+        help="expand teams to member logins (org members with an "
+        "authenticated gh only; membership is not publicly visible)",
+    )
     ap.add_argument("--repo", default=".", help="repo root for --changed (default: .)")
     ap.add_argument(
         "paths", nargs="*", help="paths to resolve (when not using --changed)"
@@ -136,6 +219,9 @@ def main() -> int:
         if not files:
             ap.error("pass one or more paths, or use --changed")
 
+    # Per-path expansion only for explicit paths (small N); --changed PRs can
+    # touch many files, so people are shown once in the union summary instead.
+    expand_paths = args.people and not args.changed
     union_owners: set[str] = set()
     union_advisory: set[str] = set()
     for f in files:
@@ -144,7 +230,7 @@ def main() -> int:
         union_owners.update(owners)
         union_advisory.update(adv)
         owners_str = (
-            " ".join(owners)
+            " ".join(_with_people(o) if expand_paths else o for o in owners)
             if owners
             else "(no owner -- falls through; CI coverage gate should block this)"
         )
@@ -158,7 +244,9 @@ def main() -> int:
         print("\n" + "=" * 60)
         print(f"Teams auto-requested on this PR ({len(union_owners)}):")
         for t in sorted(union_owners):
-            print(f"  {t}")
+            print(f"  {_with_people(t) if args.people else t}")
+            if args.people and (url := _team_url(t)):
+                print(f"      {url}")
         if union_advisory:
             print(f"Advisory (non-blocking), {len(union_advisory)}:")
             for t in sorted(union_advisory):

--- a/.github/codeowners/who_owns.py
+++ b/.github/codeowners/who_owns.py
@@ -141,12 +141,17 @@ def _team_url(team: str) -> str | None:
 def changed_files(repo: str, base: str) -> list[str]:
     """Files changed vs ``base`` (merge-base diff), falling back to plain diff.
 
-    Returns ``[]`` only when a diff actually succeeded and was empty. If every
-    fallback fails (not a git checkout, unknown base), the last git error is
-    surfaced instead of masquerading as "no changed files".
+    Untracked (not yet staged) files are included too -- brand-new paths are
+    exactly the ones the coverage gate cares about, and ``git diff`` alone
+    never shows them.
+
+    Returns ``[]`` only when the lookups actually succeeded and were empty.
+    If everything fails (not a git checkout, unknown base), the last git
+    error is surfaced instead of masquerading as "no changed files".
     """
     last_err: subprocess.CalledProcessError | None = None
     any_ok = False
+    changed: list[str] = []
     for args in ([f"{base}...HEAD"], [base], []):
         try:
             out = subprocess.check_output(
@@ -158,15 +163,26 @@ def changed_files(repo: str, base: str) -> list[str]:
             last_err = err
             continue
         any_ok = True
-        files = [p for p in out.splitlines() if p.strip()]
-        if files:
-            return files
+        changed = [p for p in out.splitlines() if p.strip()]
+        if changed:
+            break
+    untracked: list[str] = []
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", repo, "ls-files", "--others", "--exclude-standard"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        untracked = [p for p in out.splitlines() if p.strip()]
+        any_ok = True
+    except (OSError, subprocess.CalledProcessError):
+        pass
     if not any_ok and last_err is not None:
         raise SystemExit(
             f"git diff failed in {repo!r} (not a checkout, or base "
             f"{base!r} unavailable): {last_err}"
         )
-    return []
+    return sorted(set(changed) | set(untracked))
 
 
 def main() -> int:

--- a/.github/workflows/codeowners-reviewers.yml
+++ b/.github/workflows/codeowners-reviewers.yml
@@ -1,0 +1,57 @@
+name: codeowners-reviewers
+
+# Posts "who reviews this PR" (owning teams, expanded to member logins when an
+# org-read token is available) into the run's job summary. On a public repo the
+# summary is visible to everyone -- including external contributors, who cannot
+# see team membership on GitHub itself -- and it ages out with run retention
+# instead of living in the PR conversation or git history.
+#
+# SECURITY: this runs on pull_request_target so the org-read secret is
+# available for fork PRs. It must therefore NEVER check out or execute code
+# from the PR head: it checks out the BASE ref only and reads the PR's file
+# list via the API. Do not add a head-ref checkout to this workflow.
+
+on:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  reviewers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4 # base ref only (see SECURITY note above)
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install pyyaml
+      - name: Post owners to the job summary
+        env:
+          # ORG_READ_TOKEN: fine-grained token with org members:read, set as a
+          # repo secret. Optional -- without it the default token is used,
+          # member lookups fail closed, and the summary shows team handles.
+          GH_TOKEN: ${{ secrets.ORG_READ_TOKEN != '' && secrets.ORG_READ_TOKEN || github.token }}
+          PR: ${{ github.event.pull_request.number }}
+        run: |
+          files=$(gh api "repos/${{ github.repository }}/pulls/${PR}/files" --paginate --jq '.[].filename')
+          total=$(printf '%s\n' "$files" | grep -c . || true)
+          shown=$(printf '%s\n' "$files" | head -200)
+          {
+            echo "## Who reviews this PR"
+            echo
+            echo "Owning teams are auto-requested on the PR; any one owner per matched rule approves."
+            echo "Member expansion needs org-visible team data -- when unavailable, team handles are shown."
+            echo
+            echo '```'
+            printf '%s\n' "$shown" | xargs -d '\n' python .github/codeowners/who_owns.py \
+              --codeowners CODEOWNERS --people
+            echo '```'
+            if [ "$total" -gt 200 ]; then
+              echo
+              echo "_Showing the first 200 of ${total} changed files._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,11 +35,11 @@ to it — edit only the canonical copy. Reach for the right group first:
 - `dep-status` — check DEP status and list DEPs by lifecycle state or area
 - `dep-update` — advance DEP lifecycle: triage, PIC assignment, review, approval
 - `dynamo-clone-hotpath-audit` — audit Rust hot-path `.clone()` calls
-- `dynamo-codeowners` — who reviews a change, fixing a failing `codeowners` check, changing review routing
 - `dynamo-docs` — Fern docs-site content per the style guide
 - `dynamo-frontend-benchmark` — benchmark/profile the frontend against mock workers
 - `graham-code-review` — strict Rust/systems review in Graham King's style
 - `pr-monitor` — CI health check, failure root-cause, and skip analysis
+- `repo-codeowners` — who reviews a change, fixing a failing `codeowners` check, changing review routing
 
 **For deploying and operating Dynamo:**
 
@@ -141,7 +141,7 @@ cargo fmt --all && cargo clippy --workspace
   If the `codeowners` check fails after adding a new directory, claim it with
   one line under the owning area in `areas.yaml`, regenerate, and commit both
   files together. External contributors earn area-scoped co-ownership via
-  `.github/codeowners/external_contributors.yaml`. The `dynamo-codeowners`
+  `.github/codeowners/external_contributors.yaml`. The `repo-codeowners`
   skill automates all of this.
 - Full CI on a PR runs only after a maintainer comments `/ok to test <sha>` with the short
   SHA of the latest commit; copy-pr-bot then creates the `pull-request/N` branch that

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@ to it — edit only the canonical copy. Reach for the right group first:
 - `dep-status` — check DEP status and list DEPs by lifecycle state or area
 - `dep-update` — advance DEP lifecycle: triage, PIC assignment, review, approval
 - `dynamo-clone-hotpath-audit` — audit Rust hot-path `.clone()` calls
+- `dynamo-codeowners` — who reviews a change, fixing a failing `codeowners` check, changing review routing
 - `dynamo-docs` — Fern docs-site content per the style guide
 - `dynamo-frontend-benchmark` — benchmark/profile the frontend against mock workers
 - `graham-code-review` — strict Rust/systems review in Graham King's style
@@ -135,7 +136,13 @@ cargo fmt --all && cargo clippy --workspace
 - Do not hand-edit the root `CODEOWNERS` — it is generated. To change review
   routing, edit `.github/codeowners/areas.yaml` and regenerate; CI gates 100%
   coverage and `CODEOWNERS`↔`areas.yaml` drift. See
-  `.github/codeowners/README.md` (use `who_owns.py` to check who reviews a path).
+  `.github/codeowners/README.md` (use `who_owns.py --changed` to check who
+  reviews your PR; `--people` expands teams to members for org members).
+  If the `codeowners` check fails after adding a new directory, claim it with
+  one line under the owning area in `areas.yaml`, regenerate, and commit both
+  files together. External contributors earn area-scoped co-ownership via
+  `.github/codeowners/external_contributors.yaml`. The `dynamo-codeowners`
+  skill automates all of this.
 - Full CI on a PR runs only after a maintainer comments `/ok to test <sha>` with the short
   SHA of the latest commit; copy-pr-bot then creates the `pull-request/N` branch that
   triggers it. Fix failures before requesting human review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Or view the source: [`docs/contribution-guide.md`](docs/contribution-guide.md)
 
 - [Good first issues](https://github.com/ai-dynamo/dynamo/labels/good-first-issue)
 - [Help wanted](https://github.com/ai-dynamo/dynamo/labels/help-wanted)
+- [Code ownership](.github/codeowners/README.md) -- who reviews my PR, fixing the `codeowners` check, earning area ownership
 - [Open a bug report](https://github.com/ai-dynamo/dynamo/issues/new?template=bug_report.yml)
 - [Propose a feature](https://github.com/ai-dynamo/dynamo/issues/new?template=feature_request.yml)
 - [Design Proposals](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22)

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -226,7 +226,7 @@ The contribution process depends on the size and scope of your change. Even when
 
 5. **Trigger CI Tests** — For external contributors, a maintainer must comment `/ok to test COMMIT-ID` to run the full CI suite, where `COMMIT-ID` is the short SHA of your latest commit. Fix any failing tests before requesting human review.
 
-6. **Request Review** — Add the person who approved your issue as a reviewer. Check [CODEOWNERS](https://github.com/ai-dynamo/dynamo/blob/main/CODEOWNERS) for required approvers based on files modified.
+6. **Request Review** — Add the person who approved your issue as a reviewer. The teams that own the areas your PR touches are auto-requested when the PR opens; preview them with `python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed`. If the `codeowners` check fails because your PR adds a directory no area claims, add a one-line claim under the owning area in [`.github/codeowners/areas.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/.github/codeowners/areas.yaml), regenerate, and commit both files (see the [CODEOWNERS README](https://github.com/ai-dynamo/dynamo/blob/main/.github/codeowners/README.md)). Contributors who sustain ownership of an area can be added as area-scoped code owners via [`external_contributors.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/.github/codeowners/external_contributors.yaml) and appear in [CONTRIBUTORS.md](https://github.com/ai-dynamo/dynamo/blob/main/CONTRIBUTORS.md).
 
 > [!IMPORTANT]
 > **AI-Generated Code:** While we encourage using AI tools, you must fully understand every change in your PR. Inability to explain submitted code will result in rejection.


### PR DESCRIPTION
## Summary

Follow-up to #10715. Contributors now hit two new realities: reviews auto-route by area, and the `codeowners` gate fails any PR that adds an unclaimed directory. This PR ships the contributor-facing tooling for both:

- **`who_owns.py --people`** expands owning teams to member logins via `gh` and prints each team's URL in the `--changed` union summary. GitHub only shows team membership to org members, so the flag is an org-member convenience: for everyone else it degrades to team handles with an explanatory note, and the actual reviewers appear on the PR once it opens. The fetcher and cache are injectable and unit-tested (expansion, cached negative lookups, individual-handle pass-through).
- **New `dynamo-codeowners` skill** (`.agents/skills/dynamo-codeowners/`): the playbook for the four situations contributors hit -- who reviews my change; the `codeowners` check failed (read the gate's uncovered-files sample, one-line `areas.yaml` claim, regenerate, commit both files); changing review routing; granting an external contributor area-scoped ownership via `external_contributors.yaml`. Model-invocable so coding agents auto-trigger it on gate failures.
- **Docs**: AGENTS.md gains the gate-failure playbook and skill pointer; CONTRIBUTING.md links the code-ownership README; docs/contribution-guide.md replaces the stale "check the CODEOWNERS file for required approvers" step with the auto-request flow, the gate-failure fix, and the external-contributor path.

No changes to the generated `CODEOWNERS`, the emit pipeline, or routing semantics.

### Second commit

- **`codeowners-reviewers` workflow**: posts "who reviews this PR" into its run summary on every PR -- visible to external contributors (GitHub hides team membership from non-members), expanded to member logins when the optional `ORG_READ_TOKEN` repo secret is set, team handles otherwise. Runs on `pull_request_target` with base-ref checkout only; PR code is never executed (SECURITY note in the workflow). Note: as a `pull_request_target` workflow it takes effect for PRs only after this merges to main.
- **`who_owns.py --changed` now includes untracked files** (found by dogfooding on this PR: the not-yet-committed skill file was invisible to `--changed`). Git-fixture unit test added.
- **Skill renamed to `repo-codeowners`** -- `dynamo-codeowners` read like one of the `dynamo-*-codeowners` team handles.

## Validation

- `.github/codeowners/test_codeowners.py`: 67 passed (3 new tests for `team_members`).
- `build_codeowners.py --strict`: 4521/4521 files explicitly owned (100%).
- `emit_codeowners.py` run twice: byte-identical, no drift against the committed `CODEOWNERS`.
- `scripts/validate_skills.py`: 14 skills OK (new skill indexed in AGENTS.md).
- Live smoke: `who_owns.py --changed --people` on this branch expands docs/ops/process teams with member logins and URLs; with broken auth it prints the one-line note and falls back to team handles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional `--people` mode to show team members when membership visibility is available.
  - Added graceful handling and caching when team membership cannot be retrieved.

- **Documentation**
  - Added guidance for code ownership, reviewer routing, ownership checks, and resolving coverage failures.
  - Documented the new `--people` option and updated contribution resources with code ownership links.

- **Tests**
  - Added coverage for team expansion, lookup failures, caching, and individual owner handles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
