### PR TITLE
feat(codeowners): who_owns --people expands teams to members; --changed sees untracked files

### DIFF
--- a/.github/codeowners/README.md
+++ b/.github/codeowners/README.md
@@ -17,6 +17,11 @@ python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed --base m
 python .github/codeowners/who_owns.py --codeowners CODEOWNERS lib/llm/foo.rs deploy/operator/bar.go
 ```
 
+Add `--people` to expand each team to its member logins. GitHub only shows
+team membership to members of the org, so this works for org members with an
+authenticated `gh`; everyone else sees the team handles (the actual reviewers
+appear on the PR once it opens).
+
 A line with more than one team is co-ownership: under "any one approves," any one
 of them satisfies the gate, so co-ownership adds review *visibility* without
 adding required approvals.

--- a/.github/codeowners/test_codeowners.py
+++ b/.github/codeowners/test_codeowners.py
@@ -939,6 +939,52 @@ class TestChangedFiles:
         files = who_owns.changed_files(str(repo), "HEAD")
         assert files == ["brand_new.txt", "tracked.txt"]
 
+    def test_bad_base_with_untracked_raises(self, monkeypatch) -> None:
+        # When ALL git-diff fallbacks fail AND ls-files succeeds, the diff
+        # failure must still be surfaced (not silently masked by ls-files
+        # succeeding). Tested via monkeypatch because the no-arg diff fallback
+        # always succeeds in a valid repo, making the scenario unreachable
+        # with a real git setup.
+        def fake_check_output(cmd, **kwargs):
+            if "diff" in cmd:
+                raise subprocess.CalledProcessError(128, cmd)
+            if "ls-files" in cmd:
+                return "untracked.txt\n"
+            raise subprocess.CalledProcessError(128, cmd)
+
+        monkeypatch.setattr(subprocess, "check_output", fake_check_output)
+
+        with pytest.raises(SystemExit):
+            who_owns.changed_files("/fake/repo", "nonexistent-base-ref")
+
+    def test_untracked_in_subdir_is_repo_root_relative(self, tmp_path) -> None:
+        # git ls-files without --full-name returns paths relative to cwd
+        # when run from a subdirectory. --full-name ensures repo-root-relative
+        # output so CODEOWNERS matching is always correct.
+        repo = tmp_path / "r"
+        repo.mkdir()
+
+        def git(*args: str) -> None:
+            subprocess.check_output(
+                ["git", "-C", str(repo), *args], stderr=subprocess.DEVNULL
+            )
+
+        git("init", "-q")
+        git("config", "user.email", "t@example.com")
+        git("config", "user.name", "t")
+        (repo / "seed.txt").write_text("x")
+        git("add", "seed.txt")
+        git("commit", "-q", "-m", "init")
+        subdir = repo / "subdir"
+        subdir.mkdir()
+        (subdir / "new.txt").write_text("z")  # untracked in a subdirectory
+
+        # Pass repo=subdir to simulate running from a subdirectory; the
+        # returned path must be repo-root-relative (subdir/new.txt), not
+        # the bare filename (new.txt).
+        files = who_owns.changed_files(str(subdir), "HEAD")
+        assert "subdir/new.txt" in files
+
 
 # ------------------------------------------------------------------
 # TypedDict / dataclass surface

--- a/.github/codeowners/test_codeowners.py
+++ b/.github/codeowners/test_codeowners.py
@@ -30,6 +30,7 @@ from build_codeowners import (  # noqa: E402
     is_policy_change,
     split_coverage,
 )
+import who_owns  # noqa: E402
 from codeowners_match import (  # noqa: E402
     Area,
     ResolvedModel,
@@ -594,9 +595,9 @@ class TestEmissionIsTreeIndependent:
         import inspect
 
         sig = inspect.signature(_render_codeowners)
-        assert (
-            "tree" not in sig.parameters
-        ), "emit tree parameter reintroduced -- see TestEmissionIsTreeIndependent"
+        assert "tree" not in sig.parameters, (
+            "emit tree parameter reintroduced -- see TestEmissionIsTreeIndependent"
+        )
         sig_base = inspect.signature(compute_resolution)
         # tree is still accepted (backward-compat) but must default to None
         # so callers that omit it get pure behavior for free.
@@ -869,6 +870,74 @@ class TestPolicyChangeFallback:
         result = _run_build(repo, areas, "--changed-only", "--base", base)
         assert result.returncode == 1
         assert "owned/b.txt" in result.stdout
+
+
+# ------------------------------------------------------------------
+# who_owns.team_members() -- roster expansion (--people)
+# ------------------------------------------------------------------
+
+
+class TestTeamMembers:
+    def test_expands_team_via_fetcher(self) -> None:
+        cache: dict = {}
+        fetched = []
+
+        def fake(org: str, slug: str) -> list[str]:
+            fetched.append((org, slug))
+            return ["zoe", "amy"]
+
+        members = who_owns.team_members("@acme/router", fetch=fake, cache=cache)
+        assert members == ["amy", "zoe"]  # sorted
+        assert fetched == [("acme", "router")]
+        # second lookup served from cache, fetcher not called again
+        assert who_owns.team_members("@acme/router", fetch=fake, cache=cache) == [
+            "amy",
+            "zoe",
+        ]
+        assert fetched == [("acme", "router")]
+
+    def test_fetch_failure_returns_none_and_caches_negative(self) -> None:
+        cache: dict = {}
+        calls = []
+
+        def boom(org: str, slug: str) -> list[str]:
+            calls.append(slug)
+            raise subprocess.CalledProcessError(1, "gh")
+
+        assert who_owns.team_members("@acme/router", fetch=boom, cache=cache) is None
+        assert who_owns.team_members("@acme/router", fetch=boom, cache=cache) is None
+        assert calls == ["router"]  # failure cached; no retry storm
+
+    def test_individual_handle_passes_through(self) -> None:
+        def never(org: str, slug: str) -> list[str]:
+            raise AssertionError("fetcher must not be called for @handles")
+
+        assert who_owns.team_members("@octocat", fetch=never, cache={}) is None
+
+
+class TestChangedFiles:
+    def test_includes_untracked_files(self, tmp_path) -> None:
+        # Brand-new (unstaged) files are the ones the coverage gate cares
+        # about most; `git diff` alone never lists them.
+        repo = tmp_path / "r"
+        repo.mkdir()
+
+        def git(*args: str) -> None:
+            subprocess.check_output(
+                ["git", "-C", str(repo), *args], stderr=subprocess.DEVNULL
+            )
+
+        git("init", "-q")
+        git("config", "user.email", "t@example.com")
+        git("config", "user.name", "t")
+        (repo / "tracked.txt").write_text("x")
+        git("add", "tracked.txt")
+        git("commit", "-q", "-m", "init")
+        (repo / "tracked.txt").write_text("y")  # modified, unstaged
+        (repo / "brand_new.txt").write_text("z")  # untracked
+
+        files = who_owns.changed_files(str(repo), "HEAD")
+        assert files == ["brand_new.txt", "tracked.txt"]
 
 
 # ------------------------------------------------------------------

--- a/.github/codeowners/test_codeowners.py
+++ b/.github/codeowners/test_codeowners.py
@@ -25,12 +25,12 @@ import pytest
 # Allow `import codeowners_match` when pytest runs from the repo root.
 sys.path.insert(0, str(Path(__file__).parent))
 
+import who_owns  # noqa: E402
 from build_codeowners import (  # noqa: E402
     CoverageGate,
     is_policy_change,
     split_coverage,
 )
-import who_owns  # noqa: E402
 from codeowners_match import (  # noqa: E402
     Area,
     ResolvedModel,

--- a/.github/codeowners/test_codeowners.py
+++ b/.github/codeowners/test_codeowners.py
@@ -595,9 +595,8 @@ class TestEmissionIsTreeIndependent:
         import inspect
 
         sig = inspect.signature(_render_codeowners)
-        assert "tree" not in sig.parameters, (
-            "emit tree parameter reintroduced -- see TestEmissionIsTreeIndependent"
-        )
+        msg = "emit tree parameter reintroduced -- see TestEmissionIsTreeIndependent"
+        assert "tree" not in sig.parameters, msg
         sig_base = inspect.signature(compute_resolution)
         # tree is still accepted (backward-compat) but must default to None
         # so callers that omit it get pure behavior for free.

--- a/.github/codeowners/who_owns.py
+++ b/.github/codeowners/who_owns.py
@@ -82,6 +82,7 @@ def _gh_fetch(org: str, slug: str) -> list[str]:
         ],
         text=True,
         stderr=subprocess.DEVNULL,
+        timeout=30,
     )
     return [line for line in out.splitlines() if line.strip()]
 
@@ -110,7 +111,7 @@ def team_members(team, fetch=_gh_fetch, cache=None):
     if parsed := _parse_team(team):
         try:
             members = sorted(fetch(*parsed))
-        except (OSError, subprocess.CalledProcessError):
+        except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
             members = None
     cache[team] = members
     return members
@@ -155,7 +156,7 @@ def changed_files(repo: str, base: str) -> list[str]:
     error is surfaced instead of masquerading as "no changed files".
     """
     last_err: subprocess.CalledProcessError | None = None
-    any_ok = False
+    diff_ok = False
     changed: list[str] = []
     for args in ([f"{base}...HEAD"], [base], []):
         try:
@@ -167,22 +168,29 @@ def changed_files(repo: str, base: str) -> list[str]:
         except subprocess.CalledProcessError as err:
             last_err = err
             continue
-        any_ok = True
+        diff_ok = True
         changed = [p for p in out.splitlines() if p.strip()]
         if changed:
             break
     untracked: list[str] = []
     try:
         out = subprocess.check_output(
-            ["git", "-C", repo, "ls-files", "--others", "--exclude-standard"],
+            [
+                "git",
+                "-C",
+                repo,
+                "ls-files",
+                "--others",
+                "--exclude-standard",
+                "--full-name",
+            ],
             text=True,
             stderr=subprocess.DEVNULL,
         )
         untracked = [p for p in out.splitlines() if p.strip()]
-        any_ok = True
     except (OSError, subprocess.CalledProcessError):
         pass
-    if not any_ok and last_err is not None:
+    if not diff_ok and last_err is not None:
         raise SystemExit(
             f"git diff failed in {repo!r} (not a checkout, or base "
             f"{base!r} unavailable): {last_err}"

--- a/.github/codeowners/who_owns.py
+++ b/.github/codeowners/who_owns.py
@@ -11,6 +11,10 @@ has to read 300 rules to find a reviewer.
   # the teams that will be auto-requested on your PR (union over changed files)
   python who_owns.py --codeowners CODEOWNERS --changed --base main
 
+  # same, expanding each team to its member logins (org members only --
+  # GitHub does not show team membership to non-members)
+  python who_owns.py --codeowners CODEOWNERS --changed --people
+
 Owners listed on a single line are co-owners (any one's approval satisfies
 the gate). Advisory teams are auto-requested too, but never block the merge.
 
@@ -61,15 +65,98 @@ def advisory_for(
     return teams
 
 
+_TEAM_CACHE: dict[str, list[str] | None] = {}
+_PEOPLE_WARNED = False
+
+
+def _gh_fetch(org: str, slug: str) -> list[str]:
+    """Fetch a team's member logins via the ``gh`` CLI."""
+    out = subprocess.check_output(
+        [
+            "gh",
+            "api",
+            f"orgs/{org}/teams/{slug}/members",
+            "--paginate",
+            "--jq",
+            ".[].login",
+        ],
+        text=True,
+        stderr=subprocess.DEVNULL,
+    )
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def _parse_team(owner: str):
+    """``@org/slug`` -> ``(org, slug)``; ``None`` for individual ``@handle``s."""
+    if owner.startswith("@") and "/" in owner:
+        return tuple(owner[1:].split("/", 1))
+    return None
+
+
+def team_members(team, fetch=_gh_fetch, cache=None):
+    """Member logins for an ``@org/slug`` team, or ``None`` when unavailable.
+
+    GitHub only shows team membership to members of the org, so this works
+    for org members with an authenticated ``gh`` and cannot work for external
+    contributors -- callers degrade to the team handle. Individual ``@handle``
+    owners (no slash) return ``None`` and pass through unchanged. Results,
+    including failures, are cached per run.
+    """
+    if cache is None:
+        cache = _TEAM_CACHE
+    if team in cache:
+        return cache[team]
+    members = None
+    if parsed := _parse_team(team):
+        try:
+            members = sorted(fetch(*parsed))
+        except (OSError, subprocess.CalledProcessError):
+            members = None
+    cache[team] = members
+    return members
+
+
+def _warn_people_unavailable() -> None:
+    global _PEOPLE_WARNED
+    if not _PEOPLE_WARNED:
+        print(
+            "note: team membership is only visible to org members "
+            "(authenticated gh required); showing teams only",
+            file=sys.stderr,
+        )
+        _PEOPLE_WARNED = True
+
+
+def _with_people(owner: str) -> str:
+    """Render an owner as ``@org/team (member, member, ...)`` when possible."""
+    members = team_members(owner)
+    if members is None:
+        if _parse_team(owner):
+            _warn_people_unavailable()
+        return owner
+    return f"{owner} ({', '.join(members) if members else 'no members'})"
+
+
+def _team_url(team: str) -> str | None:
+    if parsed := _parse_team(team):
+        return "https://github.com/orgs/{}/teams/{}".format(*parsed)
+    return None
+
+
 def changed_files(repo: str, base: str) -> list[str]:
     """Files changed vs ``base`` (merge-base diff), falling back to plain diff.
 
-    Returns ``[]`` only when a diff actually succeeded and was empty. If every
-    fallback fails (not a git checkout, unknown base), the last git error is
-    surfaced instead of masquerading as "no changed files".
+    Untracked (not yet staged) files are included too -- brand-new paths are
+    exactly the ones the coverage gate cares about, and ``git diff`` alone
+    never shows them.
+
+    Returns ``[]`` only when the lookups actually succeeded and were empty.
+    If everything fails (not a git checkout, unknown base), the last git
+    error is surfaced instead of masquerading as "no changed files".
     """
     last_err: subprocess.CalledProcessError | None = None
     any_ok = False
+    changed: list[str] = []
     for args in ([f"{base}...HEAD"], [base], []):
         try:
             out = subprocess.check_output(
@@ -81,15 +168,26 @@ def changed_files(repo: str, base: str) -> list[str]:
             last_err = err
             continue
         any_ok = True
-        files = [p for p in out.splitlines() if p.strip()]
-        if files:
-            return files
+        changed = [p for p in out.splitlines() if p.strip()]
+        if changed:
+            break
+    untracked: list[str] = []
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", repo, "ls-files", "--others", "--exclude-standard"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        untracked = [p for p in out.splitlines() if p.strip()]
+        any_ok = True
+    except (OSError, subprocess.CalledProcessError):
+        pass
     if not any_ok and last_err is not None:
         raise SystemExit(
             f"git diff failed in {repo!r} (not a checkout, or base "
             f"{base!r} unavailable): {last_err}"
         )
-    return []
+    return sorted(set(changed) | set(untracked))
 
 
 def main() -> int:
@@ -116,6 +214,12 @@ def main() -> int:
     ap.add_argument(
         "--base", default="main", help="base ref for --changed (default: main)"
     )
+    ap.add_argument(
+        "--people",
+        action="store_true",
+        help="expand teams to member logins (org members with an "
+        "authenticated gh only; membership is not publicly visible)",
+    )
     ap.add_argument("--repo", default=".", help="repo root for --changed (default: .)")
     ap.add_argument(
         "paths", nargs="*", help="paths to resolve (when not using --changed)"
@@ -136,6 +240,9 @@ def main() -> int:
         if not files:
             ap.error("pass one or more paths, or use --changed")
 
+    # Per-path expansion only for explicit paths (small N); --changed PRs can
+    # touch many files, so people are shown once in the union summary instead.
+    expand_paths = args.people and not args.changed
     union_owners: set[str] = set()
     union_advisory: set[str] = set()
     for f in files:
@@ -144,7 +251,7 @@ def main() -> int:
         union_owners.update(owners)
         union_advisory.update(adv)
         owners_str = (
-            " ".join(owners)
+            " ".join(_with_people(o) if expand_paths else o for o in owners)
             if owners
             else "(no owner -- falls through; CI coverage gate should block this)"
         )
@@ -158,7 +265,9 @@ def main() -> int:
         print("\n" + "=" * 60)
         print(f"Teams auto-requested on this PR ({len(union_owners)}):")
         for t in sorted(union_owners):
-            print(f"  {t}")
+            print(f"  {_with_people(t) if args.people else t}")
+            if args.people and (url := _team_url(t)):
+                print(f"      {url}")
         if union_advisory:
             print(f"Advisory (non-blocking), {len(union_advisory)}:")
             for t in sorted(union_advisory):


### PR DESCRIPTION
## Summary

Splits the tooling half out of #11579 (closed in favor of this stack).

- `who_owns.py --people` expands owning teams to member logins via `gh`, with each team's URL in the `--changed` union summary. GitHub only shows team membership to org members, so the flag degrades to team handles with an explanatory note for everyone else. Fetcher and cache are injectable and unit-tested (expansion, cached negative lookups, individual-handle pass-through).
- `--changed` now includes untracked files (`git ls-files --others --exclude-standard`): brand-new paths are exactly what the coverage gate cares about, and `git diff` never lists them. Found by dogfooding: a not-yet-committed file was invisible to `--changed`, so a co-ownership review request came as a surprise. Git-fixture unit test added.
- The coverage report now lists globs matching no files (11 exist in today's taxonomy) -- deletions never fail a gate, so dead claims otherwise accumulate silently in `areas.yaml`. Informational only, never blocking.
- README documents `--people` and its org-member scope.

**Stack order:** first of three. #11581 (reviewer-summary workflow) is coupled to this PR -- it invokes `who_owns.py --people` from CI, so it merges second; #11582 (skill + docs) documents both and merges last.

## Validation

- `.github/codeowners/test_codeowners.py`: 68 passed (4 new).
- Live smoke: `--people` expands teams with authenticated gh; with broken auth prints the one-line note and falls back to team handles; untracked probe file appears in `--changed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional `--people` option to expand CODEOWNERS teams into member logins.
  * Added GitHub team links and clearer team-member formatting where membership data is available.
  * Included untracked files and unstaged changes when determining affected files.

* **Documentation**
  * Documented the new `--people` option and its authentication behavior.

* **Bug Fixes**
  * Improved handling of unavailable team membership data and change detection results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

