### PR TITLE
docs(codeowners): repo-codeowners skill + contributor playbook

### DIFF
--- a/.agents/skills/repo-codeowners/SKILL.md
+++ b/.agents/skills/repo-codeowners/SKILL.md
@@ -69,6 +69,13 @@ area claims. Nothing ships unowned.
 5. Commit `areas.yaml` and `CODEOWNERS` together (same commit), signed
    (`git commit -s`).
 
+Removals fail differently: deleting a directory never fails coverage (it
+counts files, and a claim matching nothing is not an error), but regeneration
+drops the directory's rule, so the **drift check** fails until the
+regenerated `CODEOWNERS` is committed with the deletion. Run step 4 and
+commit both files. While there, prune the now-dead glob from `areas.yaml`;
+the `build_codeowners.py` report lists globs that no longer match any file.
+
 ## Flow 3: Change review routing
 
 Edit `.github/codeowners/areas.yaml` - move a glob between areas, add a

--- a/.agents/skills/repo-codeowners/SKILL.md
+++ b/.agents/skills/repo-codeowners/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: repo-codeowners
+description: Work with Dynamo's generated CODEOWNERS - find out who reviews a change, fix a failing codeowners CI check, change review routing, or grant an external contributor area-scoped ownership. Use when the codeowners check fails on a PR, a new directory is unclaimed, someone asks who reviews a path or PR, review routing needs to change, or a contributor should be added as a code owner.
+license: Apache-2.0
+metadata:
+  author: NVIDIA
+  tags:
+    - dynamo
+    - codeowners
+    - review-routing
+    - dev-workflow
+---
+
+# Skill: CODEOWNERS Operations
+
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: CC-BY-4.0
+-->
+
+The root `CODEOWNERS` is a build artifact generated from
+`.github/codeowners/areas.yaml` (one entry per subsystem area mapping path
+globs to a GitHub team). Never hand-edit `CODEOWNERS` - CI regenerates it and
+fails on any drift. Every change goes through `areas.yaml` (or
+`external_contributors.yaml`) followed by regeneration.
+
+Pick the flow that matches the situation.
+
+## Flow 1: Who reviews this change?
+
+```bash
+# owners of your working tree's changed files (union, as GitHub will request)
+python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed
+
+# owners of specific paths
+python .github/codeowners/who_owns.py --codeowners CODEOWNERS <path> [<path> ...]
+```
+
+Add `--people` to expand each team to its member logins. This works only for
+NVIDIA org members with an authenticated `gh` - GitHub does not show team
+membership to non-members. Without it (or when the lookup fails), the team
+handles are the answer; the actual reviewers appear on the PR once it opens.
+For an open PR, the `codeowners-reviewers` workflow also posts this table
+(with member names when the org-read secret is configured) to its run summary
+in the Actions tab, visible to external contributors.
+
+## Flow 2: The `codeowners` CI check failed
+
+This is the coverage gate doing its job: the PR adds at least one file that no
+area claims. Nothing ships unowned.
+
+1. Read the failing job log. The gate prints the exact uncovered files:
+   `catch-all-only sample (add an area or classify rule to cover these): [...]`.
+2. Decide which area owns the new path. Match it to the subsystem whose code it
+   extends (the PR that introduced `examples/custom_encoder/` was a multimodal
+   feature, so the claim went under the `multimodal` area).
+3. Add ONE line to `.github/codeowners/areas.yaml` under that area's
+   `path_globs` (directory claims end with `/`). If the path will recur under
+   many parents, a `classify.keyword_rules` entry (substring -> area) covers
+   future instances too.
+4. Regenerate and verify:
+   ```bash
+   python .github/codeowners/build_codeowners.py \
+       --areas .github/codeowners/areas.yaml --repo . --strict
+   python .github/codeowners/emit_codeowners.py \
+       --areas .github/codeowners/areas.yaml --repo . --out CODEOWNERS
+   ```
+   The strict run must report 100% coverage.
+5. Commit `areas.yaml` and `CODEOWNERS` together (same commit), signed
+   (`git commit -s`).
+
+## Flow 3: Change review routing
+
+Edit `.github/codeowners/areas.yaml` - move a glob between areas, add a
+`shared:` entry (multi-team co-ownership; any one team's approval satisfies
+the gate), or adjust `classify` rules. Then regenerate exactly as in Flow 2
+step 4 and commit both files. Routing changes are owned by the process team,
+which is auto-requested on the PR.
+
+## Flow 4: Grant an external contributor area-scoped ownership
+
+Individuals who have earned ownership of an area are attached to the area's
+label - never to a copy of its globs - in
+`.github/codeowners/external_contributors.yaml`:
+
+```yaml
+contributors:
+  - name: Jane Doe
+    github: janedoe          # -> @janedoe appended to the area's lines
+    level: maintainer        # contributor | trusted_contributor | maintainer | core_maintainer
+    affiliation: Example Org
+    areas: [router]          # area labels from areas.yaml
+```
+
+Regeneration (Flow 2 step 4) appends the handle as a co-owner on every line
+the area's team owns and rebuilds `CONTRIBUTORS.md`. Commit all three files
+(`external_contributors.yaml`, `CODEOWNERS`, `CONTRIBUTORS.md`) together.
+`level` is standing metadata shown in `CONTRIBUTORS.md`; routing is granted by
+`areas`.
+
+## Reference
+
+- Schema, the last-match-wins model, and the change process:
+  `.github/codeowners/README.md`
+- The gate and drift check run in `.github/workflows/codeowners.yml` on every
+  PR; both must pass before merge.

--- a/.agents/skills/repo-codeowners/SKILL.md
+++ b/.agents/skills/repo-codeowners/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: repo-codeowners
-description: Work with Dynamo's generated CODEOWNERS - find out who reviews a change, fix a failing codeowners CI check, change review routing, or grant an external contributor area-scoped ownership. Use when the codeowners check fails on a PR, a new directory is unclaimed, someone asks who reviews a path or PR, review routing needs to change, or a contributor should be added as a code owner.
+description: Works with Dynamo's generated CODEOWNERS - finds out who reviews a change, fixes a failing codeowners CI check, changes review routing, or grants an external contributor area-scoped ownership. Use when the codeowners check fails on a PR, a new directory is unclaimed, someone asks who reviews a path or PR, review routing needs to change, or a contributor should be added as a code owner.
 license: Apache-2.0
 metadata:
   author: NVIDIA
@@ -74,8 +74,9 @@ area claims. Nothing ships unowned.
 Edit `.github/codeowners/areas.yaml` - move a glob between areas, add a
 `shared:` entry (multi-team co-ownership; any one team's approval satisfies
 the gate), or adjust `classify` rules. Then regenerate exactly as in Flow 2
-step 4 and commit both files. Routing changes are owned by the process team,
-which is auto-requested on the PR.
+step 4 and commit both files. A routing PR auto-requests the ops team (which
+owns `.github/codeowners/`) and the process team (which owns the generated
+root `CODEOWNERS`); either review covers its half.
 
 ## Flow 4: Grant an external contributor area-scoped ownership
 

--- a/.agents/skills/repo-codeowners/SKILL.md
+++ b/.agents/skills/repo-codeowners/SKILL.md
@@ -47,23 +47,26 @@ in the Actions tab, visible to external contributors.
 ## Flow 2: The `codeowners` CI check failed
 
 This is the coverage gate doing its job: the PR adds at least one file that no
-area claims. Nothing ships unowned.
+area claims. Nothing ships unowned. On pull requests the gate is diff-aware:
+only files YOUR PR adds or changes block it; unowned paths inherited from the
+base branch are a non-fatal warning. (A PR that edits ownership policy itself
+is judged against the full tree, since a policy edit can orphan any path.)
 
 1. Read the failing job log. The gate prints the exact uncovered files:
-   `catch-all-only sample (add an area or classify rule to cover these): [...]`.
+   `catch-all-only sample (add an explicit glob to cover these): [...]`.
 2. Decide which area owns the new path. Match it to the subsystem whose code it
    extends (the PR that introduced `examples/custom_encoder/` was a multimodal
    feature, so the claim went under the `multimodal` area).
 3. Add ONE line to `.github/codeowners/areas.yaml` under that area's
-   `path_globs` (directory claims end with `/`). If the path will recur under
-   many parents, a `classify.keyword_rules` entry (substring -> area) covers
-   future instances too.
+   `path_globs` (directory claims end with `/`). There is no keyword-based
+   auto-classification - every claim is an explicit glob (or a `shared:`
+   entry for multi-team paths).
 4. Regenerate and verify:
    ```bash
    python .github/codeowners/build_codeowners.py \
        --areas .github/codeowners/areas.yaml --repo . --strict
    python .github/codeowners/emit_codeowners.py \
-       --areas .github/codeowners/areas.yaml --repo . --out CODEOWNERS
+       --areas .github/codeowners/areas.yaml --out CODEOWNERS
    ```
    The strict run must report 100% coverage.
 5. Commit `areas.yaml` and `CODEOWNERS` together (same commit), signed
@@ -79,11 +82,28 @@ the `build_codeowners.py` report lists globs that no longer match any file.
 ## Flow 3: Change review routing
 
 Edit `.github/codeowners/areas.yaml` - move a glob between areas, add a
-`shared:` entry (multi-team co-ownership; any one team's approval satisfies
-the gate), or adjust `classify` rules. Then regenerate exactly as in Flow 2
-step 4 and commit both files. A routing PR auto-requests the ops team (which
-owns `.github/codeowners/`) and the process team (which owns the generated
-root `CODEOWNERS`); either review covers its half.
+`shared:` entry (multi-team co-ownership), or adjust `classify.filetype_rules`.
+Then regenerate exactly as in Flow 2 step 4 and commit both files. A routing
+PR auto-requests the ops team (which owns `.github/codeowners/`) and the
+process team (which owns the generated root `CODEOWNERS`); either review
+covers its half.
+
+Semantics worth knowing before you file one:
+
+- **Any one owner approves.** GitHub combines all owners on a CODEOWNERS line
+  with OR: for a co-owned file, one approval from any listed team satisfies
+  the branch protection. Co-ownership adds review visibility, not extra
+  required approvals.
+- **The PR UI can mislead.** When a reviewer belongs to more than one owning
+  team, GitHub's reviewers panel may drop a codeowner entry that is actually
+  satisfied (or pending). Branch protection still enforces correctly - trust
+  the merge gate, not the panel.
+- **Last match wins.** A more specific rule later in the generated file
+  replaces earlier owners for its paths - so a nested override can
+  intentionally narrow a parent's co-ownership. Paths whose joint ownership
+  must never be dropped are declared under `required_owners:` in
+  `areas.yaml`; the CI gate fails any policy change that removes a declared
+  owner from a matching path.
 
 ## Flow 4: Grant an external contributor area-scoped ownership
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,8 +136,9 @@ cargo fmt --all && cargo clippy --workspace
 - Do not hand-edit the root `CODEOWNERS` — it is generated. To change review
   routing, edit `.github/codeowners/areas.yaml` and regenerate; CI gates 100%
   coverage and `CODEOWNERS`↔`areas.yaml` drift. See
-  `.github/codeowners/README.md` (use `who_owns.py --changed` to check who
-  reviews your PR; `--people` expands teams to members for org members).
+  `.github/codeowners/README.md`. To check who reviews your PR:
+  `python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed`
+  (`--people` expands teams to members for org members).
   If the `codeowners` check fails after adding a new directory, claim it with
   one line under the owning area in `areas.yaml`, regenerate, and commit both
   files together. External contributors earn area-scoped co-ownership via

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ to it — edit only the canonical copy. Reach for the right group first:
 - `dynamo-frontend-benchmark` — benchmark/profile the frontend against mock workers
 - `graham-code-review` — strict Rust/systems review in Graham King's style
 - `pr-monitor` — CI health check, failure root-cause, and skip analysis
+- `repo-codeowners` — who reviews a change, fixing a failing `codeowners` check, changing review routing
 
 **For deploying and operating Dynamo:**
 
@@ -135,7 +136,13 @@ cargo fmt --all && cargo clippy --workspace
 - Do not hand-edit the root `CODEOWNERS` — it is generated. To change review
   routing, edit `.github/codeowners/areas.yaml` and regenerate; CI gates 100%
   coverage and `CODEOWNERS`↔`areas.yaml` drift. See
-  `.github/codeowners/README.md` (use `who_owns.py` to check who reviews a path).
+  `.github/codeowners/README.md` (use `who_owns.py --changed` to check who
+  reviews your PR; `--people` expands teams to members for org members).
+  If the `codeowners` check fails after adding a new directory, claim it with
+  one line under the owning area in `areas.yaml`, regenerate, and commit both
+  files together. External contributors earn area-scoped co-ownership via
+  `.github/codeowners/external_contributors.yaml`. The `repo-codeowners`
+  skill automates all of this.
 - Full CI on a PR runs only after a maintainer comments `/ok to test <sha>` with the short
   SHA of the latest commit; copy-pr-bot then creates the `pull-request/N` branch that
   triggers it. Fix failures before requesting human review.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,7 @@ Or view the source: [`docs/contribution-guide.md`](docs/contribution-guide.md)
 
 - [Good first issues](https://github.com/ai-dynamo/dynamo/labels/good-first-issue)
 - [Help wanted](https://github.com/ai-dynamo/dynamo/labels/help-wanted)
+- [Code ownership](.github/codeowners/README.md) -- who reviews my PR, fixing the `codeowners` check, earning area ownership
 - [Open a bug report](https://github.com/ai-dynamo/dynamo/issues/new?template=bug_report.yml)
 - [Propose a feature](https://github.com/ai-dynamo/dynamo/issues/new?template=feature_request.yml)
 - [Design Proposals](https://github.com/ai-dynamo/dynamo/issues?q=is%3Aissue+label%3A%22dep%3Adraft%22%2C%22dep%3Aproposed%22%2C%22dep%3Aapproved%22%2C%22dep%3Aimplementing%22%2C%22dep%3Acompleted%22%2C%22dep%3Adeferred%22%2C%22dep%3Asuperseeded%22)

--- a/docs/contribution-guide.md
+++ b/docs/contribution-guide.md
@@ -226,7 +226,7 @@ The contribution process depends on the size and scope of your change. Even when
 
 5. **Trigger CI Tests** — For external contributors, a maintainer must comment `/ok to test COMMIT-ID` to run the full CI suite, where `COMMIT-ID` is the short SHA of your latest commit. Fix any failing tests before requesting human review.
 
-6. **Request Review** — Add the person who approved your issue as a reviewer. Check [CODEOWNERS](https://github.com/ai-dynamo/dynamo/blob/main/CODEOWNERS) for required approvers based on files modified.
+6. **Request Review** — Add the person who approved your issue as a reviewer. The teams that own the areas your PR touches are auto-requested when the PR opens; preview them with `python .github/codeowners/who_owns.py --codeowners CODEOWNERS --changed`. If the `codeowners` check fails because your PR adds a directory no area claims, add a one-line claim under the owning area in [`.github/codeowners/areas.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/.github/codeowners/areas.yaml), regenerate, and commit both files (see the [CODEOWNERS README](https://github.com/ai-dynamo/dynamo/blob/main/.github/codeowners/README.md)). Contributors who sustain ownership of an area can be added as area-scoped code owners via [`external_contributors.yaml`](https://github.com/ai-dynamo/dynamo/blob/main/.github/codeowners/external_contributors.yaml) and appear in [CONTRIBUTORS.md](https://github.com/ai-dynamo/dynamo/blob/main/CONTRIBUTORS.md).
 
 > [!IMPORTANT]
 > **AI-Generated Code:** While we encourage using AI tools, you must fully understand every change in your PR. Inability to explain submitted code will result in rejection.


### PR DESCRIPTION
## Overview

Contributor-facing playbook for the generated CODEOWNERS system that shipped in #10715: a `repo-codeowners` agent skill plus updates to AGENTS.md, CONTRIBUTING.md, and the contribution guide.

## Details

- New `.agents/skills/repo-codeowners` skill: the playbook for the four situations contributors hit -- who reviews my change; the `codeowners` check failed (one-line `areas.yaml` claim + regenerate); changing review routing (auto-requests ops + process); granting external contributors area-scoped ownership via `external_contributors.yaml`. Model-invocable so coding agents auto-trigger it on gate failures; indexed in AGENTS.md.
- AGENTS.md, CONTRIBUTING.md, and docs/contribution-guide.md describe the auto-request flow and gate-failure fix; the stale "check the CODEOWNERS file for required approvers" step is gone.

**Stack order:** this PR references `who_owns.py --people` (#11580), the `codeowners-reviewers` workflow (#11581), and the `required_owners` declaration (#11869). Merge #11580, #11581, and #11869 first; this PR merges last so every documented command, workflow, and `areas.yaml` section exists on main when it lands.

## Where should the reviewer start?

`.agents/skills/repo-codeowners/SKILL.md` -- the four flows are the substance; the other three files are one-paragraph pointers to it.

## Related Issues

Follow-up to #10715. Companion PRs: #11580 (who_owns --people), #11581 (reviewer-summary workflow). No standalone issue -- tracked by the CODEOWNERS rollout.

## Validation

- `scripts/validate_skills.py`: 14 skills OK (new skill indexed in AGENTS.md).
- Docs changes route to the docs team via the codeowners gate (dogfood).
- Rebased onto current main; commands re-verified against the tree (`emit_codeowners.py` no longer takes `--repo`, `classify.keyword_rules` removed, diff-aware PR coverage gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

