### PR TITLE
ci: Split Dynamo CI port ranges by workload

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from tests.utils.collection_env_guard import (
     format_collection_env_changes,
     snapshot_collection_env,
 )
-from tests.utils.constants import TEST_MODELS, DefaultPort
+from tests.utils.constants import DynamoPortRange, TEST_MODELS, DefaultPort
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (
     ServicePorts,
@@ -1322,15 +1322,15 @@ def dynamo_dynamic_ports(num_system_ports) -> Generator[ServicePorts, None, None
     # rather than leaking them until stale cleanup and exhausting the xdist pool.
     all_ports: list[int] = []
     try:
-        frontend_port = allocate_port(DefaultPort.FRONTEND.value)
+        frontend_port = allocate_port(DynamoPortRange.SERVE.value)
         all_ports.append(frontend_port)
-        system_port_list = allocate_ports(num_system_ports, DefaultPort.SYSTEM1.value)
+        system_port_list = allocate_ports(num_system_ports, DynamoPortRange.SERVE.value)
         all_ports.extend(system_port_list)
-        kv_event_port = allocate_port(DefaultPort.SYSTEM1.value)
+        kv_event_port = allocate_port(DynamoPortRange.SERVE.value)
         all_ports.append(kv_event_port)
         # One NIXL side-channel port per worker (avoids xdist collisions on shared hosts).
         nixl_side_channel_ports = allocate_ports(
-            num_system_ports, DefaultPort.SYSTEM1.value
+            num_system_ports, DynamoPortRange.NIXL.value
         )
         all_ports.extend(nixl_side_channel_ports)
         yield ServicePorts(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ from tests.utils.collection_env_guard import (
     format_collection_env_changes,
     snapshot_collection_env,
 )
-from tests.utils.constants import DynamoPortRange, TEST_MODELS, DefaultPort
+from tests.utils.constants import TEST_MODELS, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (
     ServicePorts,
@@ -1322,7 +1322,7 @@ def dynamo_dynamic_ports(num_system_ports) -> Generator[ServicePorts, None, None
     # rather than leaking them until stale cleanup and exhausting the xdist pool.
     all_ports: list[int] = []
     try:
-        frontend_port = allocate_port(DynamoPortRange.SERVE.value)
+        frontend_port = allocate_port(DynamoPortRange.FRONTEND.value)
         all_ports.append(frontend_port)
         system_port_list = allocate_ports(num_system_ports, DynamoPortRange.SERVE.value)
         all_ports.extend(system_port_list)

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -23,7 +23,7 @@ from tests.fault_tolerance.cancellation.utils import (
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
@@ -122,7 +122,7 @@ class DynamoWorkerProcess(ManagedProcess):
         # Forward-pass metrics: SGLang publishes FPM over a per-worker ipc://
         # path, so the env var only enables the feature (the value is never
         # bound). Allocate one per worker for cleanup symmetry with system_port.
-        self.fpm_port = allocate_port(20380)
+        self.fpm_port = allocate_port(DynamoPortRange.FPM.value)
         env["DYN_FORWARDPASS_METRIC_PORT"] = str(self.fpm_port)
 
         # Set GPU assignment for disaggregated mode (like disagg.sh)
@@ -221,7 +221,7 @@ def test_request_cancellation_sglang_aggregated(
     logger.info("Sanity check if latest test is getting executed")
 
     # Allocate ports to avoid conflicts with parallel tests
-    system_port = allocate_port(9100)
+    system_port = allocate_port(DynamoPortRange.SERVE.value)
 
     # Step 1: Start the frontend (allocates its own port)
     with DynamoFrontendProcess(request) as frontend:
@@ -333,8 +333,8 @@ def test_request_cancellation_sglang_decode_cancel(
     """
 
     # Allocate ports to avoid conflicts with parallel tests
-    decode_system_port = allocate_port(9100)
-    prefill_system_port = allocate_port(9200)
+    decode_system_port = allocate_port(DynamoPortRange.SERVE.value)
+    prefill_system_port = allocate_port(DynamoPortRange.SERVE.value)
 
     # Step 1: Start the frontend (allocates its own port)
     with DynamoFrontendProcess(request) as frontend:

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -123,6 +123,7 @@ class DynamoWorkerProcess(ManagedProcess):
         # path, so the env var only enables the feature (the value is never
         # bound). Allocate one per worker for cleanup symmetry with system_port.
         self.fpm_port = allocate_port(DynamoPortRange.FPM.value)
+        request.addfinalizer(lambda port=self.fpm_port: deallocate_port(port))
         env["DYN_FORWARDPASS_METRIC_PORT"] = str(self.fpm_port)
 
         # Set GPU assignment for disaggregated mode (like disagg.sh)
@@ -222,6 +223,7 @@ def test_request_cancellation_sglang_aggregated(
 
     # Allocate ports to avoid conflicts with parallel tests
     system_port = allocate_port(DynamoPortRange.SERVE.value)
+    request.addfinalizer(lambda port=system_port: deallocate_port(port))
 
     # Step 1: Start the frontend (allocates its own port)
     with DynamoFrontendProcess(request) as frontend:
@@ -334,7 +336,9 @@ def test_request_cancellation_sglang_decode_cancel(
 
     # Allocate ports to avoid conflicts with parallel tests
     decode_system_port = allocate_port(DynamoPortRange.SERVE.value)
+    request.addfinalizer(lambda port=decode_system_port: deallocate_port(port))
     prefill_system_port = allocate_port(DynamoPortRange.SERVE.value)
+    request.addfinalizer(lambda port=prefill_system_port: deallocate_port(port))
 
     # Step 1: Start the frontend (allocates its own port)
     with DynamoFrontendProcess(request) as frontend:

--- a/tests/fault_tolerance/cancellation/test_sglang.py
+++ b/tests/fault_tolerance/cancellation/test_sglang.py
@@ -23,7 +23,7 @@ from tests.fault_tolerance.cancellation.utils import (
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -25,7 +25,7 @@ from tests.fault_tolerance.cancellation.utils import (
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -62,6 +62,7 @@ class DynamoWorkerProcess(ManagedProcess):
         """
         # Allocate system port for this worker
         system_port = allocate_port(DynamoPortRange.SERVE.value)
+        request.addfinalizer(lambda port=system_port: deallocate_port(port))
         self.system_port = system_port
         self.frontend_port = frontend_port
 

--- a/tests/fault_tolerance/cancellation/test_trtllm.py
+++ b/tests/fault_tolerance/cancellation/test_trtllm.py
@@ -25,7 +25,7 @@ from tests.fault_tolerance.cancellation.utils import (
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
@@ -61,7 +61,7 @@ class DynamoWorkerProcess(ManagedProcess):
             mode: One of "prefill_and_decode", "prefill", "decode"
         """
         # Allocate system port for this worker
-        system_port = allocate_port(9100)
+        system_port = allocate_port(DynamoPortRange.SERVE.value)
         self.system_port = system_port
         self.frontend_port = frontend_port
 

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -25,7 +25,7 @@ from tests.fault_tolerance.cancellation.utils import (
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.device import (
     build_nixl_kv_transfer_config_json,
     get_default_vllm_block_size,
@@ -56,7 +56,7 @@ class DynamoWorkerProcess(ManagedProcess):
         timeout_s: int = 300,
     ):
         # Allocate system port for this worker
-        system_port = allocate_port(9100)
+        system_port = allocate_port(DynamoPortRange.SERVE.value)
         self.system_port = system_port
         self.frontend_port = frontend_port
 

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -57,6 +57,7 @@ class DynamoWorkerProcess(ManagedProcess):
     ):
         # Allocate system port for this worker
         system_port = allocate_port(DynamoPortRange.SERVE.value)
+        request.addfinalizer(lambda port=system_port: deallocate_port(port))
         self.system_port = system_port
         self.frontend_port = frontend_port
 

--- a/tests/fault_tolerance/cancellation/test_vllm.py
+++ b/tests/fault_tolerance/cancellation/test_vllm.py
@@ -25,7 +25,7 @@ from tests.fault_tolerance.cancellation.utils import (
     verify_frontend_cancellation_metrics,
     verify_runtime_cancellation_metrics,
 )
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.device import (
     build_nixl_kv_transfer_config_json,
     get_default_vllm_block_size,

--- a/tests/fault_tolerance/etcd_ha/utils.py
+++ b/tests/fault_tolerance/etcd_ha/utils.py
@@ -155,6 +155,7 @@ class EtcdCluster:
         # Reserve contiguous ports for the full cluster to avoid collisions with
         # other tests that may also run local etcd instances.
         reserved_ports = allocate_contiguous_ports(1, num_replicas * 2, base_port)
+        request.addfinalizer(lambda ports=reserved_ports: deallocate_ports(ports))
         self._reserved_ports = reserved_ports
         self.base_port = reserved_ports[0]
         self.replicas: List[Optional[EtcdReplicaServer]] = []

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -15,7 +15,7 @@ import shutil
 
 import pytest
 
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
@@ -95,7 +95,7 @@ class DynamoWorkerProcess(ManagedProcess):
         disagg_mode: str | None = None,
     ):
         self.worker_id = worker_id
-        self.system_port = allocate_port(9100)
+        self.system_port = allocate_port(DynamoPortRange.SERVE.value)
         self.bootstrap_port: int | None = None
         self.prefill_port: int | None = None
         self.disagg_mode = disagg_mode

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -124,7 +124,7 @@ class DynamoWorkerProcess(ManagedProcess):
             command.append("--skip-tokenizer-init")
         else:
             # Disaggregated
-            self.bootstrap_port = allocate_port(12340)
+            self.bootstrap_port = allocate_port(DynamoPortRange.BOOTSTRAP.value)
             request.addfinalizer(lambda port=self.bootstrap_port: deallocate_port(port))
             command.extend(
                 [
@@ -139,7 +139,7 @@ class DynamoWorkerProcess(ManagedProcess):
                 ]
             )
             if disagg_mode == "prefill":
-                self.prefill_port = allocate_port(20000)
+                self.prefill_port = allocate_port(DynamoPortRange.PREFILL.value)
                 request.addfinalizer(
                     lambda port=self.prefill_port: deallocate_port(port)
                 )

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -15,7 +15,7 @@ import shutil
 
 import pytest
 
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port

--- a/tests/fault_tolerance/migration/test_sglang.py
+++ b/tests/fault_tolerance/migration/test_sglang.py
@@ -96,6 +96,7 @@ class DynamoWorkerProcess(ManagedProcess):
     ):
         self.worker_id = worker_id
         self.system_port = allocate_port(DynamoPortRange.SERVE.value)
+        request.addfinalizer(lambda port=self.system_port: deallocate_port(port))
         self.bootstrap_port: int | None = None
         self.prefill_port: int | None = None
         self.disagg_mode = disagg_mode
@@ -124,6 +125,7 @@ class DynamoWorkerProcess(ManagedProcess):
         else:
             # Disaggregated
             self.bootstrap_port = allocate_port(12340)
+            request.addfinalizer(lambda port=self.bootstrap_port: deallocate_port(port))
             command.extend(
                 [
                     "--disaggregation-mode",
@@ -138,6 +140,9 @@ class DynamoWorkerProcess(ManagedProcess):
             )
             if disagg_mode == "prefill":
                 self.prefill_port = allocate_port(20000)
+                request.addfinalizer(
+                    lambda port=self.prefill_port: deallocate_port(port)
+                )
                 command.extend(["--port", str(self.prefill_port)])
 
         # Set environment variables

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -15,7 +15,7 @@ import shutil
 
 import pytest
 
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
@@ -91,7 +91,7 @@ class DynamoWorkerProcess(ManagedProcess):
         mode: str = "prefill_and_decode",
     ):
         self.worker_id = worker_id
-        self.system_port = allocate_port(9100)
+        self.system_port = allocate_port(DynamoPortRange.SERVE.value)
         self.mode = mode
 
         command = [

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -92,6 +92,7 @@ class DynamoWorkerProcess(ManagedProcess):
     ):
         self.worker_id = worker_id
         self.system_port = allocate_port(DynamoPortRange.SERVE.value)
+        request.addfinalizer(lambda port=self.system_port: deallocate_port(port))
         self.mode = mode
 
         command = [

--- a/tests/fault_tolerance/migration/test_trtllm.py
+++ b/tests/fault_tolerance/migration/test_trtllm.py
@@ -15,7 +15,7 @@ import shutil
 
 import pytest
 
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -16,7 +16,7 @@ import shutil
 
 import pytest
 
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port
@@ -92,7 +92,7 @@ class DynamoWorkerProcess(ManagedProcess):
         is_prefill: bool | None = None,
     ):
         self.worker_id = worker_id
-        self.system_port = allocate_port(9100)
+        self.system_port = allocate_port(DynamoPortRange.SERVE.value)
 
         command = [
             "python3",

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -93,6 +93,7 @@ class DynamoWorkerProcess(ManagedProcess):
     ):
         self.worker_id = worker_id
         self.system_port = allocate_port(DynamoPortRange.SERVE.value)
+        request.addfinalizer(lambda port=self.system_port: deallocate_port(port))
 
         command = [
             "python3",

--- a/tests/fault_tolerance/migration/test_vllm.py
+++ b/tests/fault_tolerance/migration/test_vllm.py
@@ -16,7 +16,7 @@ import shutil
 
 import pytest
 
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.payloads import check_models_api
 from tests.utils.port_utils import allocate_port, deallocate_port

--- a/tests/frontend/test_request_tracing_logs.py
+++ b/tests/frontend/test_request_tracing_logs.py
@@ -25,7 +25,7 @@ import pytest
 import requests
 
 from tests.frontend.conftest import MockerWorkerProcess, wait_for_http_completions_ready
-from tests.utils.constants import QWEN
+from tests.utils.constants import QWEN, DynamoPortRange
 from tests.utils.managed_process import DynamoFrontendProcess
 from tests.utils.port_utils import allocate_port, deallocate_port
 
@@ -247,7 +247,7 @@ def tracing_services_disagg(
 ):
     """Disaggregated frontend + prefill/decode mocker workers with JSONL logging."""
     ports = dynamo_dynamic_ports
-    decode_system_port = allocate_port(8200)
+    decode_system_port = allocate_port(DynamoPortRange.SERVE.value)
     try:
         with DynamoFrontendProcess(
             request,
@@ -599,7 +599,7 @@ def tracing_services_disagg_slow(
 ):
     """Disaggregated frontend + slow prefill/decode workers for crash testing."""
     ports = dynamo_dynamic_ports
-    decode_system_port = allocate_port(8200)
+    decode_system_port = allocate_port(DynamoPortRange.SERVE.value)
     try:
         with DynamoFrontendProcess(
             request,

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -33,7 +33,7 @@ TEST_PROMPT = (
 
 
 def allocate_frontend_ports(request, count: int) -> list[int]:
-    ports = allocate_ports(count, DynamoPortRange.ROUTER.value)
+    ports = allocate_ports(count, DynamoPortRange.FRONTEND.value)
     request.addfinalizer(lambda: deallocate_ports(ports))
     return ports
 

--- a/tests/router/e2e_harness.py
+++ b/tests/router/e2e_harness.py
@@ -14,7 +14,7 @@ from tests.router.common import (
     _test_router_indexers_sync,
 )
 from tests.router.helper import generate_random_suffix, managed_runtime
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DynamoPortRange
 from tests.utils.port_utils import allocate_ports, deallocate_ports
 from tests.utils.test_output import resolve_test_output_path
 
@@ -33,7 +33,7 @@ TEST_PROMPT = (
 
 
 def allocate_frontend_ports(request, count: int) -> list[int]:
-    ports = allocate_ports(count, DefaultPort.FRONTEND.value)
+    ports = allocate_ports(count, DynamoPortRange.ROUTER.value)
     request.addfinalizer(lambda: deallocate_ports(ports))
     return ports
 

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -19,7 +19,7 @@ from tests.router.e2e_harness import (
     run_router_decisions_test,
 )
 from tests.router.helper import generate_random_suffix
-from tests.utils.constants import DynamoPortRange, DefaultPort
+from tests.utils.constants import DynamoPortRange
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -114,7 +114,7 @@ class SGLangProcess(ManagedEngineProcessMixin):
         # socket (path derived from the worker's connection_id), so unlike vLLM
         # it never binds this port -- the env var only flips the feature on. One
         # shared value across workers is therefore sufficient (no collision).
-        self._fpm_port = allocate_port(DynamoPortRange.ROUTER.value)
+        self._fpm_port = allocate_port(DynamoPortRange.FPM.value)
         request.addfinalizer(
             lambda: deallocate_ports(
                 self._system_ports + self._kv_event_ports + [self._fpm_port]

--- a/tests/router/test_router_e2e_with_sglang.py
+++ b/tests/router/test_router_e2e_with_sglang.py
@@ -19,7 +19,7 @@ from tests.router.e2e_harness import (
     run_router_decisions_test,
 )
 from tests.router.helper import generate_random_suffix
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DynamoPortRange, DefaultPort
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (
@@ -105,16 +105,16 @@ class SGLangProcess(ManagedEngineProcessMixin):
 
         # Dynamically allocate unique system and KV event ports to avoid
         # conflicts in parallel test runs.
-        self._system_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        self._system_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
         kv_event_rank_span = data_parallel_size or 1
         self._kv_event_ports = allocate_contiguous_ports(
-            num_workers, kv_event_rank_span, DefaultPort.SYSTEM1.value
+            num_workers, kv_event_rank_span, DynamoPortRange.ROUTER.value
         )
         # Forward-pass metrics: SGLang publishes FPM over a per-worker ipc://
         # socket (path derived from the worker's connection_id), so unlike vLLM
         # it never binds this port -- the env var only flips the feature on. One
         # shared value across workers is therefore sufficient (no collision).
-        self._fpm_port = allocate_port(DefaultPort.SYSTEM1.value)
+        self._fpm_port = allocate_port(DynamoPortRange.ROUTER.value)
         request.addfinalizer(
             lambda: deallocate_ports(
                 self._system_ports + self._kv_event_ports + [self._fpm_port]

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -19,7 +19,7 @@ from tests.router.e2e_harness import (
     run_router_decisions_test,
 )
 from tests.router.helper import generate_random_suffix
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DynamoPortRange, DefaultPort
 from tests.utils.gpu_args import build_trtllm_override_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import allocate_ports, deallocate_ports
@@ -118,7 +118,7 @@ class TRTLLMProcess(ManagedEngineProcessMixin):
 
         # Dynamically allocate unique system ports (one per worker) to avoid
         # conflicts when tests run in parallel via pytest-xdist.
-        self._system_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        self._system_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
         request.addfinalizer(lambda: deallocate_ports(self._system_ports))
 
         if trtllm_args is None:

--- a/tests/router/test_router_e2e_with_trtllm.py
+++ b/tests/router/test_router_e2e_with_trtllm.py
@@ -19,7 +19,7 @@ from tests.router.e2e_harness import (
     run_router_decisions_test,
 )
 from tests.router.helper import generate_random_suffix
-from tests.utils.constants import DynamoPortRange, DefaultPort
+from tests.utils.constants import DynamoPortRange
 from tests.utils.gpu_args import build_trtllm_override_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import allocate_ports, deallocate_ports

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -171,7 +171,9 @@ class VLLMProcess(ManagedEngineProcessMixin):
             else []
         )
         self._indexer_ports = (
-            allocate_ports(2, DynamoPortRange.ROUTER.value) if standalone_indexer else []
+            allocate_ports(2, DynamoPortRange.ROUTER.value)
+            if standalone_indexer
+            else []
         )
         if standalone_indexer:
             self._standalone_indexer_port = self._indexer_ports[0]

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -140,11 +140,17 @@ class VLLMProcess(ManagedEngineProcessMixin):
         self._indexer_process: Optional[ManagedProcess] = None
         self._indexer_b_process: Optional[ManagedProcess] = None
 
+        allocated_ports: list[int] = []
+        request.addfinalizer(lambda: deallocate_ports(allocated_ports))
+
         # Dynamically allocate unique system, KV event, and NIXL side-channel
         # ports (one of each per worker) to avoid conflicts in parallel test runs.
         self._system_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        allocated_ports.extend(self._system_ports)
         self._kv_event_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
-        self._nixl_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        allocated_ports.extend(self._kv_event_ports)
+        self._nixl_ports = allocate_ports(num_workers, DynamoPortRange.NIXL.value)
+        allocated_ports.extend(self._nixl_ports)
         # Per-worker forward-pass-metrics (FPM) base ports. Setting
         # DYN_FORWARDPASS_METRIC_PORT makes dynamo.vllm auto-inject
         # InstrumentedScheduler, whose ZMQ PUB binds ``base_port + dp_rank`` in
@@ -163,31 +169,24 @@ class VLLMProcess(ManagedEngineProcessMixin):
         # uses num_workers=1.) External/hybrid LB, where dp_start > 0, isn't used.
         self._fpm_block = max(1, data_parallel_size or 1)
         self._fpm_ports = allocate_contiguous_ports(
-            num_workers, self._fpm_block, DynamoPortRange.ROUTER.value
+            num_workers, self._fpm_block, DynamoPortRange.FPM.value
         )
+        allocated_ports.extend(self._fpm_ports)
         self._replay_ports = (
             allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
             if standalone_indexer and zmq_replay
             else []
         )
+        allocated_ports.extend(self._replay_ports)
         self._indexer_ports = (
             allocate_ports(2, DynamoPortRange.ROUTER.value)
             if standalone_indexer
             else []
         )
+        allocated_ports.extend(self._indexer_ports)
         if standalone_indexer:
             self._standalone_indexer_port = self._indexer_ports[0]
             self._standalone_indexer_b_port = self._indexer_ports[1]
-        request.addfinalizer(
-            lambda: deallocate_ports(
-                self._system_ports
-                + self._kv_event_ports
-                + self._nixl_ports
-                + self._fpm_ports
-                + self._replay_ports
-                + self._indexer_ports
-            )
-        )
 
         if vllm_args is None:
             vllm_args = {}

--- a/tests/router/test_router_e2e_with_vllm.py
+++ b/tests/router/test_router_e2e_with_vllm.py
@@ -28,7 +28,7 @@ from tests.router.helper import (
     get_kv_indexer_test_env,
     wait_for_indexer_workers_active,
 )
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DynamoPortRange
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import (
@@ -142,9 +142,9 @@ class VLLMProcess(ManagedEngineProcessMixin):
 
         # Dynamically allocate unique system, KV event, and NIXL side-channel
         # ports (one of each per worker) to avoid conflicts in parallel test runs.
-        self._system_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
-        self._kv_event_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
-        self._nixl_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        self._system_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        self._kv_event_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        self._nixl_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
         # Per-worker forward-pass-metrics (FPM) base ports. Setting
         # DYN_FORWARDPASS_METRIC_PORT makes dynamo.vllm auto-inject
         # InstrumentedScheduler, whose ZMQ PUB binds ``base_port + dp_rank`` in
@@ -163,15 +163,15 @@ class VLLMProcess(ManagedEngineProcessMixin):
         # uses num_workers=1.) External/hybrid LB, where dp_start > 0, isn't used.
         self._fpm_block = max(1, data_parallel_size or 1)
         self._fpm_ports = allocate_contiguous_ports(
-            num_workers, self._fpm_block, DefaultPort.SYSTEM1.value
+            num_workers, self._fpm_block, DynamoPortRange.ROUTER.value
         )
         self._replay_ports = (
-            allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+            allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
             if standalone_indexer and zmq_replay
             else []
         )
         self._indexer_ports = (
-            allocate_ports(2, DefaultPort.SYSTEM1.value) if standalone_indexer else []
+            allocate_ports(2, DynamoPortRange.ROUTER.value) if standalone_indexer else []
         )
         if standalone_indexer:
             self._standalone_indexer_port = self._indexer_ports[0]

--- a/tests/router/test_router_e2e_with_vllm_xpu.py
+++ b/tests/router/test_router_e2e_with_vllm_xpu.py
@@ -28,7 +28,7 @@ from tests.router.e2e_harness import (
     run_router_decisions_test,
 )
 from tests.router.helper import generate_random_suffix
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DynamoPortRange
 from tests.utils.device import get_default_vllm_block_size
 from tests.utils.managed_process import ManagedProcess
 from tests.utils.port_utils import allocate_ports, deallocate_ports
@@ -107,10 +107,10 @@ class XPUVLLMProcess(ManagedEngineProcessMixin):
         self._request = request
         self._request_plane = request_plane
 
-        self._system_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
-        self._kv_event_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
-        self._nixl_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
-        self._fpm_ports = allocate_ports(num_workers, DefaultPort.SYSTEM1.value)
+        self._system_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        self._kv_event_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        self._nixl_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        self._fpm_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
         request.addfinalizer(
             lambda: deallocate_ports(
                 self._system_ports

--- a/tests/router/test_router_e2e_with_vllm_xpu.py
+++ b/tests/router/test_router_e2e_with_vllm_xpu.py
@@ -107,18 +107,20 @@ class XPUVLLMProcess(ManagedEngineProcessMixin):
         self._request = request
         self._request_plane = request_plane
 
+        allocated_ports: list[int] = []
+        request.addfinalizer(lambda: deallocate_ports(allocated_ports))
+
         self._system_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
+        allocated_ports.extend(self._system_ports)
+
         self._kv_event_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
-        self._nixl_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
-        self._fpm_ports = allocate_ports(num_workers, DynamoPortRange.ROUTER.value)
-        request.addfinalizer(
-            lambda: deallocate_ports(
-                self._system_ports
-                + self._kv_event_ports
-                + self._nixl_ports
-                + self._fpm_ports
-            )
-        )
+        allocated_ports.extend(self._kv_event_ports)
+
+        self._nixl_ports = allocate_ports(num_workers, DynamoPortRange.NIXL.value)
+        allocated_ports.extend(self._nixl_ports)
+
+        self._fpm_ports = allocate_ports(num_workers, DynamoPortRange.FPM.value)
+        allocated_ports.extend(self._fpm_ports)
 
         if vllm_args is None:
             vllm_args = {}

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -19,7 +19,7 @@ import pytest
 from dynamo.common.utils.paths import WORKSPACE_DIR
 from tests.conftest import ServicePorts
 from tests.utils.client import send_request
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DefaultPort, DynamoPortRange
 from tests.utils.engine_process import (
     EngineConfig,
     EngineLogError,
@@ -302,7 +302,7 @@ def _prepare_deployment(
     # Disagg scripts need a unique bootstrap port so parallel runs don't collide.
     disagg_bootstrap_port: int | None = None
     if config.script_name and "disagg" in config.script_name:
-        disagg_bootstrap_port = allocate_port(12000)
+        disagg_bootstrap_port = allocate_port(DynamoPortRange.BOOTSTRAP.value)
         merged_env["DYN_DISAGG_BOOTSTRAP_PORT"] = str(disagg_bootstrap_port)
 
     return _PreparedDeployment(

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -32,6 +32,21 @@ class DefaultPort(IntEnum):
     SYSTEM2 = 8082
 
 
+class DynamoPortRange(IntEnum):
+    """Disjoint port bases for Dynamo CI allocations.
+
+    These bases are intentionally spaced far enough apart to leave headroom
+    for the allocator's 500-port random start offset plus sequential retries,
+    so concurrent host-network test containers can allocate independently
+    without colliding across serve, router, NIXL, and FPM workloads.
+    """
+
+    SERVE = 24000
+    NIXL = 25500
+    ROUTER = 27000
+    FPM = 28500
+
+
 # Env-driven defaults for specific test groups
 # Allows overriding via environment variables
 ROUTER_MODEL_NAME = os.environ.get("ROUTER_MODEL_NAME", QWEN)

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -38,9 +38,10 @@ class DynamoPortRange(IntEnum):
     These bases are intentionally spaced far enough apart to leave headroom
     for the allocator's 500-port random start offset plus sequential retries,
     so concurrent host-network test containers can allocate independently
-    without colliding across serve, router, NIXL, and FPM workloads.
+    without colliding across frontend, serve, router, NIXL, and FPM workloads.
     """
 
+    FRONTEND = 22500
     SERVE = 24000
     NIXL = 25500
     ROUTER = 27000

--- a/tests/utils/constants.py
+++ b/tests/utils/constants.py
@@ -38,12 +38,15 @@ class DynamoPortRange(IntEnum):
     These bases are intentionally spaced far enough apart to leave headroom
     for the allocator's 500-port random start offset plus sequential retries,
     so concurrent host-network test containers can allocate independently
-    without colliding across frontend, serve, router, NIXL, and FPM workloads.
+    without colliding across frontend, serve, bootstrap, prefill, router,
+    NIXL, and FPM workloads.
     """
 
     FRONTEND = 22500
     SERVE = 24000
-    NIXL = 25500
+    BOOTSTRAP = 24600
+    PREFILL = 25200
+    NIXL = 25800
     ROUTER = 27000
     FPM = 28500
 

--- a/tests/utils/managed_process.py
+++ b/tests/utils/managed_process.py
@@ -15,7 +15,7 @@ from typing import Any, List, Optional
 import psutil
 import requests
 
-from tests.utils.constants import DefaultPort
+from tests.utils.constants import DefaultPort, DynamoPortRange
 from tests.utils.port_utils import allocate_port, deallocate_port
 from tests.utils.test_output import resolve_test_output_path
 
@@ -930,7 +930,7 @@ class DynamoFrontendProcess(ManagedProcess):
         if frontend_port == 0:
             # Treat `0` as "allocate a random free port" for xdist-safe tests.
             # We allocate within the i16-safe range required by the Rust side.
-            frontend_port = allocate_port(DefaultPort.FRONTEND.value)
+            frontend_port = allocate_port(DynamoPortRange.FRONTEND.value)
             self._allocated_http_port = frontend_port
 
         # If frontend_port is unset, dynamo.frontend defaults to DefaultPort.FRONTEND.

--- a/tests/utils/port_utils.py
+++ b/tests/utils/port_utils.py
@@ -26,6 +26,7 @@ _PORT_REGISTRY_FILE = Path(tempfile.gettempdir()) / "pytest_port_allocations.jso
 # TODO: Get Rust backend to use u16 instead of i16 so we can use full 1024-65535 range
 _PORT_MIN = 1024
 _PORT_MAX = 32767
+_START_PORT_RANDOM_OFFSET_MAX = 500
 
 
 @dataclass(frozen=True)
@@ -98,7 +99,7 @@ def allocate_ports(count: int, start_port: int) -> list[int]:
 
     Port range is limited to i16 (1024-32767) due to Rust backend expecting i16.
 
-    Searches from a random offset (start_port + random(100)) and walks up incrementally.
+    Searches from a random offset (start_port + random(500)) and walks up incrementally.
     Wraps around to _PORT_MIN (1024) when exceeding _PORT_MAX. Retries up to 100 times.
 
     Args:
@@ -148,8 +149,8 @@ def allocate_ports(count: int, start_port: int) -> list[int]:
             allocated_ports = set(int(p) for p in registry.keys())
             ports: list[int] = []
 
-            # Start searching from desired port + random offset
-            current_port = start_port + random.randint(0, 100)
+            # Start searching from desired port + random offset.
+            current_port = start_port + random.randint(0, _START_PORT_RANDOM_OFFSET_MAX)
             if current_port > _PORT_MAX:
                 current_port = _PORT_MIN + (current_port - _PORT_MAX - 1)
 
@@ -260,7 +261,7 @@ def allocate_contiguous_ports(
             allocated_ports = set(int(p) for p in registry.keys())
             ports: list[int] = []
 
-            current_port = start_port + random.randint(0, 100)
+            current_port = start_port + random.randint(0, _START_PORT_RANDOM_OFFSET_MAX)
             if current_port + block_size - 1 > _PORT_MAX:
                 current_port = _PORT_MIN
 

--- a/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
+++ b/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
@@ -68,7 +68,7 @@ from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
-from tests.utils.port_utils import allocate_port, deallocate_port
+from tests.utils.port_utils import allocate_port, deallocate_port, deallocate_ports
 
 logger = logging.getLogger(__name__)
 
@@ -197,9 +197,12 @@ class _DynamoBenchmarkWorker(ManagedProcess):
         self.bench_mode = bench_mode
         self.is_prefill = is_prefill
         self.frontend_port = frontend_port
+        allocated_ports: list[int] = []
+        request.addfinalizer(lambda ports=allocated_ports: deallocate_ports(ports))
 
         # Allocate a per-worker system port like the cancellation test does.
         self.system_port = allocate_port(DynamoPortRange.SERVE.value)
+        allocated_ports.append(self.system_port)
         # Allocate a per-worker forward-pass-metrics ZMQ publisher port.
         # ``InstrumentedScheduler`` (auto-injected by --benchmark-mode) binds
         # ``tcp://*:DYN_FORWARDPASS_METRIC_PORT + dp_rank`` for the FPM
@@ -209,6 +212,7 @@ class _DynamoBenchmarkWorker(ManagedProcess):
         # cancellation test never hits this because it doesn't run with
         # --benchmark-mode and so doesn't auto-inject InstrumentedScheduler.
         self.fpm_port = allocate_port(DynamoPortRange.FPM.value)
+        allocated_ports.append(self.fpm_port)
 
         env = os.environ.copy()
         if "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" not in env:

--- a/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
+++ b/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
@@ -64,7 +64,7 @@ from pathlib import Path
 import pytest
 
 from tests.utils.client import send_request
-from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME, DynamoPortRange
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api

--- a/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
+++ b/tests/vllm_self_benchmark/test_self_benchmark_gpu.py
@@ -64,7 +64,7 @@ from pathlib import Path
 import pytest
 
 from tests.utils.client import send_request
-from tests.utils.constants import FAULT_TOLERANCE_MODEL_NAME
+from tests.utils.constants import DynamoPortRange, FAULT_TOLERANCE_MODEL_NAME
 from tests.utils.gpu_args import build_gpu_mem_args
 from tests.utils.managed_process import DynamoFrontendProcess, ManagedProcess
 from tests.utils.payloads import check_health_generate, check_models_api
@@ -199,7 +199,7 @@ class _DynamoBenchmarkWorker(ManagedProcess):
         self.frontend_port = frontend_port
 
         # Allocate a per-worker system port like the cancellation test does.
-        self.system_port = allocate_port(9100)
+        self.system_port = allocate_port(DynamoPortRange.SERVE.value)
         # Allocate a per-worker forward-pass-metrics ZMQ publisher port.
         # ``InstrumentedScheduler`` (auto-injected by --benchmark-mode) binds
         # ``tcp://*:DYN_FORWARDPASS_METRIC_PORT + dp_rank`` for the FPM
@@ -208,7 +208,7 @@ class _DynamoBenchmarkWorker(ManagedProcess):
         # The operator sets this per-engine via DynamoFPMBasePort; the
         # cancellation test never hits this because it doesn't run with
         # --benchmark-mode and so doesn't auto-inject InstrumentedScheduler.
-        self.fpm_port = allocate_port(20380)
+        self.fpm_port = allocate_port(DynamoPortRange.FPM.value)
 
         env = os.environ.copy()
         if "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES" not in env:


### PR DESCRIPTION
## Overview:

Split the dynamic frontend port off from the serve/system pool so host-network CI can isolate frontend, worker/system, KV event, router, NIXL, and FPM allocations more cleanly.

## Details:

- Introduced a dedicated `DynamoPortRange.FRONTEND` base for the dynamic serve frontend.
- Kept serve worker/system ports and KV event ports on the serve range.
- Kept router, NIXL, and FPM on their own disjoint bases.
- Increased the allocator random start offset to 500 and widened the gaps between ranges to leave headroom for sequential scans.

## Where should the reviewer start?

- `tests/utils/constants.py` for the updated port base layout.
- `tests/conftest.py` for the serve fixture allocation changes.
- `tests/utils/port_utils.py` for the allocator offset change.

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11587" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved test reliability by allocating service, router, metrics, and side-channel ports dynamically from dedicated, non-overlapping ranges.
  * Reduced port collisions during concurrent test execution and containerized runs.
  * Expanded port allocation probing to better handle busy ports.

* **Tests**
  * Updated fault-tolerance, migration, router, and benchmarking scenarios to use the shared port allocation strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->