### PR TITLE
feat(metrics): add KV-cache hit-rate speed-of-light estimator

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -226,6 +226,7 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<llm::fpm::FpmEventRelay>()?;
     m.add_class::<llm::fpm::FpmDirectPublisher>()?;
     m.add_class::<llm::fpm::FpmEventSubscriber>()?;
+    m.add_class::<llm::kv_cache_sol::KvCacheSolEstimator>()?;
     m.add_class::<llm::lora::LoRADownloader>()?;
     m.add_class::<http::HttpService>()?;
     m.add_class::<http::HttpAsyncEngine>()?;

--- a/lib/bindings/python/rust/llm.rs
+++ b/lib/bindings/python/rust/llm.rs
@@ -29,6 +29,7 @@ pub mod engine_perf;
 pub mod entrypoint;
 pub mod fpm;
 pub mod kv;
+pub mod kv_cache_sol;
 pub mod local_model;
 pub mod lora;
 pub mod model_card;

--- a/lib/bindings/python/rust/llm/kv_cache_sol.rs
+++ b/lib/bindings/python/rust/llm/kv_cache_sol.rs
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use pyo3::prelude::*;
+
+use super::*;
+
+#[pyclass]
+pub(crate) struct KvCacheSolEstimator {
+    inner: llm_rs::kv_cache_sol::KvCacheSolEstimator,
+}
+
+#[pymethods]
+impl KvCacheSolEstimator {
+    #[new]
+    #[pyo3(signature = (endpoint, horizon_secs=3600, max_cache_blocks=5_000_000, max_pending_requests=100_000))]
+    fn new(
+        endpoint: Endpoint,
+        horizon_secs: u64,
+        max_cache_blocks: usize,
+        max_pending_requests: usize,
+    ) -> PyResult<Self> {
+        if horizon_secs == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "horizon_secs must be greater than zero",
+            ));
+        }
+        if max_cache_blocks == 0 || max_pending_requests == 0 {
+            return Err(pyo3::exceptions::PyValueError::new_err(
+                "max_cache_blocks and max_pending_requests must be greater than zero",
+            ));
+        }
+        let component = endpoint.inner.component().clone();
+        let runtime = component.drt().runtime().secondary();
+        let inner = runtime
+            .block_on(llm_rs::kv_cache_sol::KvCacheSolEstimator::start(
+                component,
+                Duration::from_secs(horizon_secs),
+                max_cache_blocks,
+                max_pending_requests,
+            ))
+            .map_err(to_pyerr)?;
+        Ok(Self { inner })
+    }
+
+    fn shutdown(&self) {
+        self.inner.shutdown();
+    }
+}

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1137,6 +1137,20 @@ class KvEventPublisher:
         ...
 
 
+class KvCacheSolEstimator:
+    """CPU-only subscriber that estimates the workload KV-cache hit-rate upper bound."""
+
+    def __init__(
+        self,
+        endpoint: Endpoint,
+        horizon_secs: int = 3600,
+        max_cache_blocks: int = 5_000_000,
+        max_pending_requests: int = 100_000,
+    ) -> None: ...
+
+    def shutdown(self) -> None: ...
+
+
 class FpmEventRelay:
     """
     Relay that bridges ForwardPassMetrics from a local raw ZMQ PUB socket

--- a/lib/bindings/python/src/dynamo/kv_cache_sol/__init__.py
+++ b/lib/bindings/python/src/dynamo/kv_cache_sol/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU-only KV-cache speed-of-light estimator component."""

--- a/lib/bindings/python/src/dynamo/kv_cache_sol/__main__.py
+++ b/lib/bindings/python/src/dynamo/kv_cache_sol/__main__.py
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from dynamo.kv_cache_sol.main import main
+
+if __name__ == "__main__":
+    main()

--- a/lib/bindings/python/src/dynamo/kv_cache_sol/main.py
+++ b/lib/bindings/python/src/dynamo/kv_cache_sol/main.py
@@ -1,0 +1,59 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import asyncio
+import logging
+import os
+
+import uvloop
+
+from dynamo.llm import KvCacheSolEstimator
+from dynamo.runtime import DistributedRuntime, dynamo_worker
+from dynamo.runtime.logging import configure_dynamo_logging
+
+configure_dynamo_logging()
+logger = logging.getLogger(__name__)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="CPU-only workload KV-cache speed-of-light estimator"
+    )
+    parser.add_argument(
+        "--namespace", default=os.environ.get("DYN_NAMESPACE", "dynamo")
+    )
+    parser.add_argument("--component", default="kv-cache-sol")
+    parser.add_argument("--horizon-secs", type=int, default=3600)
+    parser.add_argument("--max-cache-blocks", type=int, default=5_000_000)
+    parser.add_argument("--max-pending-requests", type=int, default=100_000)
+    return parser.parse_args()
+
+
+@dynamo_worker()
+async def worker(runtime: DistributedRuntime) -> None:
+    args = parse_args()
+    endpoint = runtime.endpoint(f"{args.namespace}.{args.component}.metrics")
+    estimator = KvCacheSolEstimator(
+        endpoint,
+        horizon_secs=args.horizon_secs,
+        max_cache_blocks=args.max_cache_blocks,
+        max_pending_requests=args.max_pending_requests,
+    )
+    logger.info(
+        "KV-cache speed-of-light estimator started: namespace=%s horizon=%ss",
+        args.namespace,
+        args.horizon_secs,
+    )
+    if not os.environ.get("DYN_SYSTEM_PORT"):
+        logger.warning(
+            "DYN_SYSTEM_PORT is not set; set it to expose estimator Prometheus metrics"
+        )
+    try:
+        await asyncio.Event().wait()
+    finally:
+        estimator.shutdown()
+
+
+def main() -> None:
+    uvloop.run(worker())

--- a/lib/bindings/python/src/dynamo/llm/__init__.py
+++ b/lib/bindings/python/src/dynamo/llm/__init__.py
@@ -16,6 +16,7 @@ from dynamo._core import FpmEventSubscriber as FpmEventSubscriber
 from dynamo._core import HttpAsyncEngine as HttpAsyncEngine
 from dynamo._core import HttpService as HttpService
 from dynamo._core import KserveGrpcService as KserveGrpcService
+from dynamo._core import KvCacheSolEstimator as KvCacheSolEstimator
 from dynamo._core import KvEventPublisher as KvEventPublisher
 from dynamo._core import KvRouter as KvRouter
 from dynamo._core import KvRouterConfig as KvRouterConfig

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -1626,6 +1626,7 @@ impl ModelWatcher {
                         encoder_chooser.clone(),
                         uses_multimodal_cache_routing(card),
                         router_config.session_affinity_ttl_secs,
+                        card.runtime_config.enable_eagle,
                     )
                     .await
                     .context("build_preprocessed_routing")?,

--- a/lib/llm/src/entrypoint/input/common.rs
+++ b/lib/llm/src/entrypoint/input/common.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::pin::Pin;
+use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 
 use dynamo_renderer::PromptFormatter;
@@ -12,6 +13,7 @@ use crate::{
     engines::StreamingEngineAdapter,
     entrypoint::EngineConfig,
     http::service::metrics::Metrics,
+    kv_cache_sol::KvCacheSolTap,
     kv_router::indexer::try_build_cache_indexer,
     kv_router::{
         EncoderRouter, KvPushRouter, KvRouter, PrefillRouter, metrics::RouterRequestMetrics,
@@ -39,14 +41,13 @@ use crate::{
 use dynamo_kv_router::config::min_initial_workers_from_env;
 use dynamo_runtime::{
     DistributedRuntime,
-    component::Client,
+    component::{Client, Component},
     engine::{AsyncEngineStream, Data},
     pipeline::{
         Context, ManyOut, MultimodalCacheKeyExtractor, Operator, PushRouter, RouterMode,
         SegmentSource, ServiceBackend, ServiceEngine, ServiceFrontend, SingleIn, Source,
     },
 };
-use std::sync::Arc;
 
 fn multimodal_cache_key_from_url(url: &str) -> String {
     blake3::hash(url.as_bytes()).to_hex().to_string()
@@ -82,6 +83,10 @@ pub struct PreprocessedRouting {
         ServiceEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>>,
     prefill_router: Arc<PrefillRouter>,
     encoder_router: Arc<EncoderRouter>,
+    component: Component,
+    is_eagle: bool,
+    router_mode: RouterMode,
+    kv_cache_sol_tap: Arc<OnceLock<Option<Arc<KvCacheSolTap>>>>,
 }
 
 pub struct PreparedEngine {
@@ -243,6 +248,7 @@ pub async fn build_preprocessed_routing(
     encoder_chooser: Option<Arc<EncoderRouter>>,
     enable_multimodal_cache_indexer: bool,
     session_affinity_ttl_secs: Option<u64>,
+    is_eagle: bool,
 ) -> anyhow::Result<PreprocessedRouting> {
     // Fail fast on an unsupported LoRA + router-mode combination BEFORE waiting for the initial
     // worker set, so a misconfiguration surfaces immediately at startup rather than after the
@@ -308,6 +314,10 @@ pub async fn build_preprocessed_routing(
         backend_engine,
         prefill_router,
         encoder_router,
+        component: client.endpoint.component().clone(),
+        is_eagle,
+        router_mode,
+        kv_cache_sol_tap: Arc::new(OnceLock::new()),
     })
 }
 
@@ -459,6 +469,23 @@ where
 }
 
 impl PreprocessedRouting {
+    fn kv_cache_sol_tap(
+        &self,
+        card: &ModelDeploymentCard,
+    ) -> anyhow::Result<Option<Arc<KvCacheSolTap>>> {
+        if let Some(tap) = self.kv_cache_sol_tap.get() {
+            return Ok(tap.clone());
+        }
+        let tap = KvCacheSolTap::from_env(
+            self.component.clone(),
+            card.kv_cache_block_size,
+            self.is_eagle,
+            self.router_mode.is_kv_routing(),
+        )?;
+        let _ = self.kv_cache_sol_tap.set(tap.clone());
+        Ok(self.kv_cache_sol_tap.get().cloned().unwrap_or(tap))
+    }
+
     /// The normal way to build an inference pipeline. Connect this directly to HTTP layer.
     pub fn build_pipeline<Req, Resp>(
         &self,
@@ -487,10 +514,25 @@ impl PreprocessedRouting {
         let prefill_op = self.prefill_router.into_operator();
         let encoder_op = self.encoder_router.into_operator();
         let backend = ServiceBackend::from_engine(self.backend_engine.clone());
+        let preprocessor_forward = preprocessor_op.forward_edge();
+        let preprocessor_backward = preprocessor_op.backward_edge();
+        let migration_forward = migration.forward_edge();
+        let migration_backward = migration.backward_edge();
 
-        let engine = frontend
-            .link(preprocessor_op.forward_edge())?
-            .link(migration.forward_edge())?
+        frontend.link(preprocessor_forward.clone())?;
+        if let Some(tap) = self.kv_cache_sol_tap(card)? {
+            let tap = tap.into_operator_for::<BackendOutput>();
+            preprocessor_forward
+                .link(tap.forward_edge())?
+                .link(migration_forward.clone())?;
+            migration_backward
+                .link(tap.backward_edge())?
+                .link(preprocessor_backward.clone())?;
+        } else {
+            preprocessor_forward.link(migration_forward.clone())?;
+            migration_backward.link(preprocessor_backward.clone())?;
+        }
+        migration_forward
             .link(token_backend.forward_edge())?
             .link(encoder_op.forward_edge())?
             .link(prefill_op.forward_edge())?
@@ -498,11 +540,10 @@ impl PreprocessedRouting {
             .link(prefill_op.backward_edge())?
             .link(encoder_op.backward_edge())?
             .link(token_backend.backward_edge())?
-            .link(migration.backward_edge())?
-            .link(preprocessor_op.backward_edge())?
-            .link(frontend)?;
+            .link(migration_backward)?;
+        preprocessor_backward.link(frontend.clone())?;
 
-        Ok(engine)
+        Ok(frontend)
     }
 
     /// Bring your own pre/post processor. Used when frontend has `--dyn-chat-processor
@@ -525,18 +566,30 @@ impl PreprocessedRouting {
         let prefill_op = self.prefill_router.into_operator();
         let encoder_op = self.encoder_router.into_operator();
         let backend = ServiceBackend::from_engine(self.backend_engine.clone());
+        let migration_forward = migration.forward_edge();
+        let migration_backward = migration.backward_edge();
 
-        let engine = frontend
-            .link(migration.forward_edge())?
+        if let Some(tap) = self.kv_cache_sol_tap(card)? {
+            let tap = tap.into_operator_for::<LLMEngineOutput>();
+            frontend
+                .link(tap.forward_edge())?
+                .link(migration_forward.clone())?;
+            migration_backward
+                .link(tap.backward_edge())?
+                .link(frontend.clone())?;
+        } else {
+            frontend.link(migration_forward.clone())?;
+            migration_backward.link(frontend.clone())?;
+        }
+        migration_forward
             .link(encoder_op.forward_edge())?
             .link(prefill_op.forward_edge())?
             .link(backend)?
             .link(prefill_op.backward_edge())?
             .link(encoder_op.backward_edge())?
-            .link(migration.backward_edge())?
-            .link(frontend)?;
+            .link(migration_backward)?;
 
-        Ok(engine)
+        Ok(frontend)
     }
 }
 

--- a/lib/llm/src/kv_cache_sol.rs
+++ b/lib/llm/src/kv_cache_sol.rs
@@ -1,0 +1,703 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Out-of-band estimator for the workload-specific KV-cache speed-of-light hit rate.
+
+use std::collections::{BTreeMap, HashMap};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use anyhow::{Context as _, Result};
+use dynamo_kv_router::protocols::{
+    BlockExtraInfo, BlockHashOptions, compute_block_hash_for_seq, compute_next_seq_hash,
+    compute_seq_hash_for_block,
+};
+use dynamo_runtime::component::Component;
+use dynamo_runtime::metrics::MetricsHierarchy;
+use dynamo_runtime::pipeline::{
+    AsyncEngineContextProvider, ManyOut, Operator, PipelineOperator, ResponseStream,
+    ServerStreamingEngine, SingleIn, async_trait,
+};
+use dynamo_runtime::protocols::annotated::Annotated;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use dynamo_runtime::transports::event_plane::EventPublisher;
+use futures::StreamExt;
+use prometheus::{IntCounterVec, IntGauge};
+use serde::{Deserialize, Serialize};
+use tokio::sync::mpsc;
+
+use crate::protocols::TokenIdType;
+use crate::protocols::common::llm_backend::{BackendOutput, LLMEngineOutput, PreprocessedRequest};
+use crate::protocols::common::timing::RequestTracker;
+use dynamo_runtime::engine::Data;
+
+const KV_CACHE_SOL_TOPIC: &str = "kv-cache-sol-v1";
+const DEFAULT_QUEUE_CAPACITY: usize = 256;
+const MAX_PRODUCER_INFLIGHT_REQUESTS: usize = 100_000;
+
+fn now_ms() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| duration.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+fn env_enabled(name: &str) -> bool {
+    std::env::var(name).ok().is_some_and(|value| {
+        matches!(
+            value.to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+struct KvCacheSolDomain {
+    pub model: String,
+    pub model_config: String,
+    pub block_size: u32,
+    pub is_eagle: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum KvCacheSolEventKind {
+    RequestStart {
+        prompt_sequence_hashes: Vec<u64>,
+        prompt_tokens: u64,
+    },
+    RequestEnd {
+        continuation_sequence_hashes: BTreeMap<u32, Vec<u64>>,
+        observed_cached_tokens: Option<u64>,
+    },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+struct KvCacheSolEvent {
+    pub producer_sequence: u64,
+    pub occurred_at_ms: u64,
+    pub request_id: String,
+    pub domain: KvCacheSolDomain,
+    pub kind: KvCacheSolEventKind,
+}
+
+struct ProducerMetrics {
+    events_total: IntCounterVec,
+    events_dropped_total: IntCounterVec,
+    skipped_requests_total: IntCounterVec,
+    queue_depth: IntGauge,
+    degraded: IntGauge,
+}
+
+impl ProducerMetrics {
+    fn new(component: &Component) -> Result<Self> {
+        let metrics = component.metrics();
+        Ok(Self {
+            events_total: metrics.create_intcountervec(
+                "kv_cache_sol_events_total",
+                "KV-cache speed-of-light events published by type",
+                &["event_type"],
+                &[],
+            )?,
+            events_dropped_total: metrics.create_intcountervec(
+                "kv_cache_sol_events_dropped_total",
+                "KV-cache speed-of-light events dropped before publication",
+                &["reason"],
+                &[],
+            )?,
+            skipped_requests_total: metrics.create_intcountervec(
+                "kv_cache_sol_skipped_requests_total",
+                "Requests excluded from KV-cache speed-of-light estimation",
+                &["reason"],
+                &[],
+            )?,
+            queue_depth: metrics.create_intgauge(
+                "kv_cache_sol_queue_depth",
+                "Events waiting in the local KV-cache speed-of-light publisher queue",
+                &[],
+            )?,
+            degraded: metrics.create_intgauge(
+                "kv_cache_sol_producer_degraded",
+                "Whether this producer has lost or rejected a KV-cache speed-of-light event",
+                &[],
+            )?,
+        })
+    }
+
+    fn record_drop(&self, reason: &str) {
+        self.events_dropped_total.with_label_values(&[reason]).inc();
+        self.degraded.set(1);
+    }
+}
+
+#[derive(Clone)]
+struct KvCacheSolProducer {
+    tx: mpsc::Sender<RawEvent>,
+    missing_sequences: Arc<AtomicU64>,
+    metrics: Arc<ProducerMetrics>,
+    block_size: u32,
+    is_eagle: bool,
+    router_computes_hashes: bool,
+}
+
+enum PromptHashInput {
+    Router {
+        tracker: Arc<RequestTracker>,
+        prompt_tokens: usize,
+        tail_token_ids: Vec<TokenIdType>,
+    },
+    Tokens {
+        token_ids: Vec<TokenIdType>,
+        block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
+    },
+}
+
+struct RawStart {
+    occurred_at_ms: u64,
+    request_id: String,
+    domain: KvCacheSolDomain,
+    prompt: PromptHashInput,
+    next_block_mm_info: Option<BlockExtraInfo>,
+    lora_name: Option<String>,
+    cache_namespace: Option<String>,
+}
+
+struct RawEnd {
+    occurred_at_ms: u64,
+    request_id: String,
+    output_tokens: BTreeMap<u32, Vec<TokenIdType>>,
+    observed_cached_tokens: Option<usize>,
+}
+
+enum RawEvent {
+    Start(RawStart),
+    End(RawEnd),
+}
+
+impl KvCacheSolProducer {
+    pub fn from_env(
+        component: Component,
+        block_size: u32,
+        is_eagle: bool,
+        router_computes_hashes: bool,
+    ) -> Result<Option<Self>> {
+        if !env_enabled("DYN_KV_CACHE_SOL_ENABLED") {
+            return Ok(None);
+        }
+        if block_size == 0 {
+            anyhow::bail!("DYN_KV_CACHE_SOL_ENABLED requires a non-zero KV cache block size");
+        }
+        let queue_capacity = std::env::var("DYN_KV_CACHE_SOL_QUEUE_CAPACITY")
+            .ok()
+            .map(|value| value.parse::<usize>())
+            .transpose()
+            .context("invalid DYN_KV_CACHE_SOL_QUEUE_CAPACITY")?
+            .unwrap_or(DEFAULT_QUEUE_CAPACITY);
+        if queue_capacity == 0 {
+            anyhow::bail!("DYN_KV_CACHE_SOL_QUEUE_CAPACITY must be greater than zero");
+        }
+
+        let metrics = Arc::new(ProducerMetrics::new(&component)?);
+        let (tx, rx) = mpsc::channel(queue_capacity);
+        let missing_sequences = Arc::new(AtomicU64::new(0));
+        let producer = Self {
+            tx,
+            missing_sequences: missing_sequences.clone(),
+            metrics: metrics.clone(),
+            block_size,
+            is_eagle,
+            router_computes_hashes,
+        };
+        let runtime = component.drt().runtime().secondary();
+        runtime.spawn(publisher_worker(component, rx, metrics, missing_sequences));
+        Ok(Some(producer))
+    }
+
+    fn try_send(&self, event: RawEvent) {
+        match self.tx.try_send(event) {
+            Ok(()) => self
+                .metrics
+                .queue_depth
+                .set(self.tx.max_capacity().saturating_sub(self.tx.capacity()) as i64),
+            Err(mpsc::error::TrySendError::Full(_)) => {
+                self.missing_sequences.fetch_add(1, Ordering::Relaxed);
+                self.metrics.record_drop("queue_full");
+            }
+            Err(mpsc::error::TrySendError::Closed(_)) => {
+                self.missing_sequences.fetch_add(1, Ordering::Relaxed);
+                self.metrics.queue_depth.set(0);
+                self.metrics.record_drop("worker_closed");
+            }
+        }
+    }
+
+    fn prepare_start(
+        &self,
+        request_id: String,
+        request: &mut PreprocessedRequest,
+    ) -> Option<(RawStart, Arc<RequestTracker>)> {
+        if request.is_probe {
+            self.metrics
+                .skipped_requests_total
+                .with_label_values(&["health_probe"])
+                .inc();
+            return None;
+        }
+        if request.prompt_embeds.is_some() {
+            self.metrics
+                .skipped_requests_total
+                .with_label_values(&["prompt_embeds"])
+                .inc();
+            return None;
+        }
+        let Some(model_config) = request.mdc_sum.clone() else {
+            self.metrics
+                .skipped_requests_total
+                .with_label_values(&["missing_model_config"])
+                .inc();
+            return None;
+        };
+
+        let tracker = request
+            .tracker
+            .get_or_insert_with(|| Arc::new(RequestTracker::new()))
+            .clone();
+        tracker.enable_kv_cache_sol_tracking();
+        let (tokens, block_mm_infos) = request.block_mm_routing_info();
+        let completed_blocks =
+            tokens.len().saturating_sub(usize::from(self.is_eagle)) / self.block_size as usize;
+        let next_block_mm_info = block_mm_infos
+            .and_then(|infos| infos.get(completed_blocks))
+            .cloned()
+            .flatten();
+        let prompt = if self.router_computes_hashes {
+            let retained = self.block_size as usize + usize::from(self.is_eagle);
+            PromptHashInput::Router {
+                tracker: tracker.clone(),
+                prompt_tokens: tokens.len(),
+                tail_token_ids: tokens[tokens.len().saturating_sub(retained)..].to_vec(),
+            }
+        } else {
+            PromptHashInput::Tokens {
+                token_ids: tokens.to_vec(),
+                block_mm_infos: block_mm_infos.map(ToOwned::to_owned),
+            }
+        };
+        let routing = request.routing.as_ref();
+        let domain = KvCacheSolDomain {
+            model: request.model.clone(),
+            model_config,
+            block_size: self.block_size,
+            is_eagle: self.is_eagle,
+        };
+        Some((
+            RawStart {
+                occurred_at_ms: now_ms(),
+                request_id,
+                domain,
+                prompt,
+                next_block_mm_info,
+                lora_name: routing.and_then(|hints| hints.lora_name.clone()),
+                cache_namespace: routing.and_then(|hints| hints.cache_namespace.clone()),
+            },
+            tracker,
+        ))
+    }
+
+    fn start(&self, start: RawStart) {
+        self.try_send(RawEvent::Start(start));
+    }
+
+    fn end(
+        &self,
+        request_id: String,
+        output_tokens: BTreeMap<u32, Vec<TokenIdType>>,
+        observed_cached_tokens: Option<usize>,
+    ) {
+        self.try_send(RawEvent::End(RawEnd {
+            occurred_at_ms: now_ms(),
+            request_id,
+            output_tokens,
+            observed_cached_tokens,
+        }));
+    }
+}
+
+#[derive(Clone)]
+struct HashContinuation {
+    block_size: u32,
+    is_eagle: bool,
+    tail: Vec<TokenIdType>,
+    parent_sequence_hash: Option<u64>,
+    next_block_mm_info: Option<BlockExtraInfo>,
+    lora_name: Option<String>,
+    cache_namespace: Option<String>,
+}
+
+impl HashContinuation {
+    fn new(start: &RawStart, sequence_hashes: &[u64], tail: Vec<TokenIdType>) -> Self {
+        Self {
+            block_size: start.domain.block_size,
+            is_eagle: start.domain.is_eagle,
+            tail,
+            parent_sequence_hash: sequence_hashes.last().copied(),
+            next_block_mm_info: start.next_block_mm_info.clone(),
+            lora_name: start.lora_name.clone(),
+            cache_namespace: start.cache_namespace.clone(),
+        }
+    }
+
+    fn append(&mut self, tokens: &[TokenIdType]) -> Vec<u64> {
+        self.tail.extend_from_slice(tokens);
+        let stride = self.block_size as usize;
+        let window = stride + usize::from(self.is_eagle);
+        let mut hashes = Vec::new();
+        let mut consumed = 0;
+        while self.tail.len().saturating_sub(consumed) >= window {
+            let mm_infos = self.next_block_mm_info.take().map(|info| vec![Some(info)]);
+            let local = compute_block_hash_for_seq(
+                &self.tail[consumed..consumed + window],
+                self.block_size,
+                BlockHashOptions {
+                    block_mm_infos: mm_infos.as_deref(),
+                    lora_name: self.lora_name.as_deref(),
+                    cache_namespace: self.cache_namespace.as_deref(),
+                    is_eagle: Some(self.is_eagle),
+                },
+            )[0];
+            let sequence = self
+                .parent_sequence_hash
+                .map_or(local.0, |parent| compute_next_seq_hash(parent, local));
+            hashes.push(sequence);
+            self.parent_sequence_hash = Some(sequence);
+            consumed += stride;
+        }
+        if consumed > 0 {
+            self.tail.drain(..consumed);
+        }
+        hashes
+    }
+}
+
+struct RequestHashState {
+    domain: KvCacheSolDomain,
+    continuation: HashContinuation,
+}
+
+async fn publisher_worker(
+    component: Component,
+    mut rx: mpsc::Receiver<RawEvent>,
+    metrics: Arc<ProducerMetrics>,
+    missing_sequences: Arc<AtomicU64>,
+) {
+    let publisher =
+        match EventPublisher::for_namespace(component.namespace(), KV_CACHE_SOL_TOPIC).await {
+            Ok(publisher) => publisher,
+            Err(error) => {
+                metrics.queue_depth.set(0);
+                metrics.record_drop("publisher_init");
+                tracing::error!(%error, "failed to initialize KV-cache speed-of-light publisher");
+                return;
+            }
+        };
+    let mut requests: HashMap<String, RequestHashState> = HashMap::new();
+    let mut next_sequence = 0_u64;
+    while let Some(raw) = rx.recv().await {
+        metrics.queue_depth.set(rx.len() as i64);
+        let sequence = reserve_publisher_sequence(&mut next_sequence, &missing_sequences);
+        let event = match raw {
+            RawEvent::Start(start) => {
+                if requests.len() >= MAX_PRODUCER_INFLIGHT_REQUESTS {
+                    metrics.record_drop("inflight_capacity");
+                    continue;
+                }
+                if requests.contains_key(&start.request_id) {
+                    metrics.record_drop("duplicate_request_id");
+                    continue;
+                }
+                let (sequence_hashes, prompt_tokens, tail) = match &start.prompt {
+                    PromptHashInput::Router {
+                        tracker,
+                        prompt_tokens,
+                        tail_token_ids,
+                    } => {
+                        let Some(hashes) = tracker.kv_cache_sol_prompt_hashes() else {
+                            metrics.record_drop("missing_router_hashes");
+                            continue;
+                        };
+                        let tail_start =
+                            hashes.sequence_hashes.len() * start.domain.block_size as usize;
+                        if tail_start > *prompt_tokens {
+                            metrics.record_drop("invalid_router_hashes");
+                            continue;
+                        }
+                        let tail_len = prompt_tokens - tail_start;
+                        if tail_len > tail_token_ids.len() {
+                            metrics.record_drop("invalid_router_hashes");
+                            continue;
+                        }
+                        (
+                            hashes.sequence_hashes.clone(),
+                            *prompt_tokens,
+                            tail_token_ids[tail_token_ids.len() - tail_len..].to_vec(),
+                        )
+                    }
+                    PromptHashInput::Tokens {
+                        token_ids,
+                        block_mm_infos,
+                    } => {
+                        let local = compute_block_hash_for_seq(
+                            token_ids,
+                            start.domain.block_size,
+                            BlockHashOptions {
+                                block_mm_infos: block_mm_infos.as_deref(),
+                                lora_name: start.lora_name.as_deref(),
+                                cache_namespace: start.cache_namespace.as_deref(),
+                                is_eagle: Some(start.domain.is_eagle),
+                            },
+                        );
+                        let sequence_hashes = compute_seq_hash_for_block(&local);
+                        let tail_start = sequence_hashes.len() * start.domain.block_size as usize;
+                        (
+                            sequence_hashes,
+                            token_ids.len(),
+                            token_ids[tail_start.min(token_ids.len())..].to_vec(),
+                        )
+                    }
+                };
+                let continuation = HashContinuation::new(&start, &sequence_hashes, tail);
+                requests.insert(
+                    start.request_id.clone(),
+                    RequestHashState {
+                        domain: start.domain.clone(),
+                        continuation,
+                    },
+                );
+                KvCacheSolEvent {
+                    producer_sequence: sequence,
+                    occurred_at_ms: start.occurred_at_ms,
+                    request_id: start.request_id,
+                    domain: start.domain,
+                    kind: KvCacheSolEventKind::RequestStart {
+                        prompt_sequence_hashes: sequence_hashes,
+                        prompt_tokens: prompt_tokens as u64,
+                    },
+                }
+            }
+            RawEvent::End(end) => {
+                let Some(state) = requests.remove(&end.request_id) else {
+                    metrics.record_drop("orphan_end");
+                    continue;
+                };
+                let mut continuation_sequence_hashes = BTreeMap::new();
+                for (choice, tokens) in end.output_tokens {
+                    let mut continuation = state.continuation.clone();
+                    continuation_sequence_hashes.insert(choice, continuation.append(&tokens));
+                }
+                KvCacheSolEvent {
+                    producer_sequence: sequence,
+                    occurred_at_ms: end.occurred_at_ms,
+                    request_id: end.request_id,
+                    domain: state.domain,
+                    kind: KvCacheSolEventKind::RequestEnd {
+                        continuation_sequence_hashes,
+                        observed_cached_tokens: end
+                            .observed_cached_tokens
+                            .map(|value| value as u64),
+                    },
+                }
+            }
+        };
+        let event_type = match event.kind {
+            KvCacheSolEventKind::RequestStart { .. } => "request_start",
+            KvCacheSolEventKind::RequestEnd { .. } => "request_end",
+        };
+        match publisher.publish(&event).await {
+            Ok(()) => metrics.events_total.with_label_values(&[event_type]).inc(),
+            Err(error) => {
+                metrics.record_drop("publish_error");
+                tracing::warn!(%error, "failed to publish KV-cache speed-of-light event");
+            }
+        }
+    }
+}
+
+fn reserve_publisher_sequence(next_sequence: &mut u64, missing_sequences: &AtomicU64) -> u64 {
+    *next_sequence = next_sequence.saturating_add(missing_sequences.swap(0, Ordering::AcqRel));
+    let sequence = *next_sequence;
+    *next_sequence = next_sequence.saturating_add(1);
+    sequence
+}
+
+pub(crate) struct KvCacheSolTap {
+    producer: KvCacheSolProducer,
+}
+
+impl KvCacheSolTap {
+    pub(crate) fn from_env(
+        component: Component,
+        block_size: u32,
+        is_eagle: bool,
+        router_computes_hashes: bool,
+    ) -> Result<Option<Arc<Self>>> {
+        Ok(
+            KvCacheSolProducer::from_env(component, block_size, is_eagle, router_computes_hashes)?
+                .map(|producer| Arc::new(Self { producer })),
+        )
+    }
+
+    #[allow(clippy::type_complexity)]
+    pub(crate) fn into_operator_for<Resp>(
+        self: &Arc<Self>,
+    ) -> Arc<
+        PipelineOperator<
+            SingleIn<PreprocessedRequest>,
+            ManyOut<Annotated<Resp>>,
+            SingleIn<PreprocessedRequest>,
+            ManyOut<Annotated<Resp>>,
+        >,
+    >
+    where
+        Resp: SolResponse,
+    {
+        Operator::into_operator(self)
+    }
+}
+
+pub(crate) trait SolResponse: Data {
+    fn sol_token_ids(&self) -> &[TokenIdType];
+    fn sol_choice_index(&self) -> u32;
+    fn sol_observed_cached_tokens(&self) -> Option<usize>;
+}
+
+macro_rules! impl_sol_response {
+    ($response:ty) => {
+        impl SolResponse for $response {
+            fn sol_token_ids(&self) -> &[TokenIdType] {
+                &self.token_ids
+            }
+
+            fn sol_choice_index(&self) -> u32 {
+                self.index.unwrap_or(0)
+            }
+
+            fn sol_observed_cached_tokens(&self) -> Option<usize> {
+                self.completion_usage
+                    .as_ref()
+                    .and_then(|usage| usage.prompt_tokens_details.as_ref())
+                    .and_then(|details| details.cached_tokens)
+                    .map(|value| value as usize)
+            }
+        }
+    };
+}
+
+impl_sol_response!(LLMEngineOutput);
+impl_sol_response!(BackendOutput);
+
+struct ResponseEndGuard {
+    producer: KvCacheSolProducer,
+    request_id: Option<String>,
+    output_tokens: BTreeMap<u32, Vec<TokenIdType>>,
+    observed_cached_tokens: Option<usize>,
+}
+
+impl ResponseEndGuard {
+    fn finish(&mut self) {
+        let Some(request_id) = self.request_id.take() else {
+            return;
+        };
+        self.producer.end(
+            request_id,
+            std::mem::take(&mut self.output_tokens),
+            self.observed_cached_tokens,
+        );
+    }
+}
+
+impl Drop for ResponseEndGuard {
+    fn drop(&mut self) {
+        self.finish();
+    }
+}
+
+#[async_trait]
+impl<Resp>
+    Operator<
+        SingleIn<PreprocessedRequest>,
+        ManyOut<Annotated<Resp>>,
+        SingleIn<PreprocessedRequest>,
+        ManyOut<Annotated<Resp>>,
+    > for KvCacheSolTap
+where
+    Resp: SolResponse,
+{
+    async fn generate(
+        &self,
+        request: SingleIn<PreprocessedRequest>,
+        next: ServerStreamingEngine<PreprocessedRequest, Annotated<Resp>>,
+    ) -> Result<ManyOut<Annotated<Resp>>> {
+        let producer = &self.producer;
+        let (mut request, context) = request.into_parts();
+        let request_id = context.id().to_string();
+        let pending_start = producer.prepare_start(request_id.clone(), &mut request);
+        let input = context.map(|_| request);
+        let mut downstream = match next.generate(input).await {
+            Ok(stream) => stream,
+            Err(error) => {
+                if let Some((start, tracker)) = pending_start {
+                    producer.start(start);
+                    producer.end(
+                        request_id,
+                        BTreeMap::new(),
+                        tracker.worker_observed_cached_tokens(),
+                    );
+                }
+                return Err(error);
+            }
+        };
+        let Some((start, tracker)) = pending_start else {
+            return Ok(downstream);
+        };
+        producer.start(start);
+
+        let stream_context = downstream.context();
+        let producer = producer.clone();
+        let end_guard = ResponseEndGuard {
+            producer,
+            request_id: Some(request_id),
+            output_tokens: BTreeMap::new(),
+            observed_cached_tokens: tracker.worker_observed_cached_tokens(),
+        };
+        let wrapped = async_stream::stream! {
+            let mut end_guard = end_guard;
+            while let Some(item) = downstream.next().await {
+                if let Some(output) = item.data.as_ref() {
+                    end_guard
+                        .output_tokens
+                        .entry(output.sol_choice_index())
+                        .or_default()
+                        .extend_from_slice(output.sol_token_ids());
+                    if end_guard.observed_cached_tokens.is_none() {
+                        end_guard.observed_cached_tokens = output.sol_observed_cached_tokens();
+                        if let Some(value) = end_guard.observed_cached_tokens {
+                            tracker.record_worker_observed_cached_tokens(value);
+                        }
+                    }
+                }
+                yield item;
+            }
+            end_guard.finish();
+        };
+        Ok(ResponseStream::new(Box::pin(wrapped), stream_context))
+    }
+}
+
+mod estimator;
+pub use estimator::KvCacheSolEstimator;
+
+#[cfg(test)]
+use estimator::{DomainCache, EstimatorMetrics, KvCacheSolCore, SolObservation, run_estimator};
+#[cfg(test)]
+mod tests;

--- a/lib/llm/src/kv_cache_sol/estimator.rs
+++ b/lib/llm/src/kv_cache_sol/estimator.rs
@@ -1,0 +1,490 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::{BTreeSet, HashMap};
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Result;
+use dynamo_runtime::component::Component;
+use dynamo_runtime::metrics::MetricsHierarchy;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use dynamo_runtime::transports::event_plane::EventSubscriber;
+use prometheus::{IntCounterVec, IntGauge};
+use tokio_util::sync::CancellationToken;
+
+use super::{KV_CACHE_SOL_TOPIC, KvCacheSolDomain, KvCacheSolEvent, KvCacheSolEventKind, now_ms};
+
+#[derive(Default)]
+pub(super) struct DomainCache {
+    pub(super) expirations: HashMap<u64, u64>,
+    // Keep exactly one ordered expiry entry per retained hash. A binary heap
+    // leaves one stale entry behind on every refresh, so a hot prefix can grow
+    // memory independently of max_cache_blocks even though `expirations`
+    // remains bounded.
+    pub(super) expiry_queue: BTreeSet<(u64, u64)>,
+}
+
+impl DomainCache {
+    pub(super) fn prune(&mut self, watermark_ms: u64) {
+        while let Some((expires_at, hash)) = self.expiry_queue.first().copied() {
+            if expires_at > watermark_ms {
+                break;
+            }
+            self.expiry_queue.remove(&(expires_at, hash));
+            self.expirations.remove(&hash);
+        }
+    }
+
+    pub(super) fn insert(&mut self, hash: u64, expires_at: u64) -> bool {
+        match self.expirations.get_mut(&hash) {
+            Some(current_expiry) => {
+                // Events from different producers can have slightly skewed
+                // timestamps. Never shorten an already-known retention window.
+                if expires_at > *current_expiry {
+                    self.expiry_queue.remove(&(*current_expiry, hash));
+                    *current_expiry = expires_at;
+                    self.expiry_queue.insert((expires_at, hash));
+                }
+                false
+            }
+            None => {
+                self.expirations.insert(hash, expires_at);
+                self.expiry_queue.insert((expires_at, hash));
+                true
+            }
+        }
+    }
+}
+
+struct PendingRequest {
+    domain: KvCacheSolDomain,
+    prompt_tokens: u64,
+    hit_tokens: u64,
+    expires_at_ms: u64,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(super) enum SolObservation {
+    Start {
+        domain: KvCacheSolDomain,
+        prompt_tokens: u64,
+        hit_tokens: u64,
+    },
+    End {
+        domain: KvCacheSolDomain,
+        prompt_tokens: Option<u64>,
+        comparable_hit_tokens: Option<u64>,
+        observed_cached_tokens: Option<u64>,
+    },
+}
+
+pub(super) struct KvCacheSolCore {
+    horizon_ms: u64,
+    max_cache_blocks: usize,
+    max_pending_requests: usize,
+    watermark_ms: u64,
+    pub(super) caches: HashMap<KvCacheSolDomain, DomainCache>,
+    pending: HashMap<(u64, String), PendingRequest>,
+    cache_blocks: usize,
+    degraded_until_ms: u64,
+}
+
+impl KvCacheSolCore {
+    pub(super) fn new(
+        horizon: Duration,
+        max_cache_blocks: usize,
+        max_pending_requests: usize,
+    ) -> Self {
+        Self {
+            horizon_ms: horizon.as_millis() as u64,
+            max_cache_blocks,
+            max_pending_requests,
+            watermark_ms: 0,
+            caches: HashMap::new(),
+            pending: HashMap::new(),
+            cache_blocks: 0,
+            degraded_until_ms: 0,
+        }
+    }
+
+    pub(super) fn advance_to(&mut self, occurred_at_ms: u64) {
+        self.watermark_ms = self.watermark_ms.max(occurred_at_ms);
+        let mut expired_blocks = 0;
+        self.caches.retain(|_, cache| {
+            let before = cache.expirations.len();
+            cache.prune(self.watermark_ms);
+            expired_blocks += before.saturating_sub(cache.expirations.len());
+            !cache.expirations.is_empty()
+        });
+        self.cache_blocks = self.cache_blocks.saturating_sub(expired_blocks);
+        self.pending
+            .retain(|_, pending| pending.expires_at_ms > self.watermark_ms);
+    }
+
+    pub(super) fn apply(&mut self, publisher_id: u64, event: KvCacheSolEvent) -> SolObservation {
+        self.advance_to(event.occurred_at_ms);
+        let cache = self.caches.entry(event.domain.clone()).or_default();
+        let expires_at = event.occurred_at_ms.saturating_add(self.horizon_ms);
+
+        match event.kind {
+            KvCacheSolEventKind::RequestStart {
+                prompt_sequence_hashes,
+                prompt_tokens,
+            } => {
+                let hit_blocks = prompt_sequence_hashes
+                    .iter()
+                    .take_while(|hash| cache.expirations.contains_key(hash))
+                    .count() as u64;
+                let hit_tokens = (hit_blocks * event.domain.block_size as u64).min(prompt_tokens);
+                if expires_at > self.watermark_ms {
+                    for hash in prompt_sequence_hashes {
+                        if !cache.expirations.contains_key(&hash)
+                            && self.cache_blocks >= self.max_cache_blocks
+                        {
+                            self.degraded_until_ms = self.degraded_until_ms.max(expires_at);
+                            break;
+                        }
+                        if cache.insert(hash, expires_at) {
+                            self.cache_blocks += 1;
+                        }
+                    }
+                }
+                if expires_at > self.watermark_ms {
+                    if self.pending.len() >= self.max_pending_requests {
+                        self.degraded_until_ms = self.degraded_until_ms.max(expires_at);
+                    } else {
+                        self.pending.insert(
+                            (publisher_id, event.request_id),
+                            PendingRequest {
+                                domain: event.domain.clone(),
+                                prompt_tokens,
+                                hit_tokens,
+                                expires_at_ms: expires_at,
+                            },
+                        );
+                    }
+                }
+                SolObservation::Start {
+                    domain: event.domain,
+                    prompt_tokens,
+                    hit_tokens,
+                }
+            }
+            KvCacheSolEventKind::RequestEnd {
+                continuation_sequence_hashes,
+                observed_cached_tokens,
+                ..
+            } => {
+                if expires_at > self.watermark_ms {
+                    for hash in continuation_sequence_hashes.into_values().flatten() {
+                        if !cache.expirations.contains_key(&hash)
+                            && self.cache_blocks >= self.max_cache_blocks
+                        {
+                            self.degraded_until_ms = self.degraded_until_ms.max(expires_at);
+                            break;
+                        }
+                        if cache.insert(hash, expires_at) {
+                            self.cache_blocks += 1;
+                        }
+                    }
+                }
+                let pending = self.pending.remove(&(publisher_id, event.request_id));
+                if pending.is_none() && expires_at > self.watermark_ms {
+                    self.degraded_until_ms = self.degraded_until_ms.max(expires_at);
+                }
+                SolObservation::End {
+                    domain: pending
+                        .as_ref()
+                        .map(|pending| pending.domain.clone())
+                        .unwrap_or(event.domain),
+                    prompt_tokens: pending.as_ref().map(|pending| pending.prompt_tokens),
+                    comparable_hit_tokens: pending.as_ref().map(|pending| pending.hit_tokens),
+                    observed_cached_tokens,
+                }
+            }
+        }
+    }
+
+    pub(super) fn cache_blocks(&self) -> usize {
+        self.cache_blocks
+    }
+
+    pub(super) fn pending_requests(&self) -> usize {
+        self.pending.len()
+    }
+
+    pub(super) fn degraded(&self) -> bool {
+        self.watermark_ms < self.degraded_until_ms
+    }
+
+    fn mark_degraded_at(&mut self, occurred_at_ms: u64) {
+        self.watermark_ms = self.watermark_ms.max(occurred_at_ms);
+        self.degraded_until_ms = self
+            .degraded_until_ms
+            .max(occurred_at_ms.saturating_add(self.horizon_ms));
+    }
+
+    fn horizon_ms(&self) -> u64 {
+        self.horizon_ms
+    }
+}
+
+pub(super) struct EstimatorMetrics {
+    pub(super) requests_total: IntCounterVec,
+    pub(super) prompt_tokens_total: IntCounterVec,
+    hit_tokens_total: IntCounterVec,
+    observed_prompt_tokens_total: IntCounterVec,
+    observed_cached_tokens_total: IntCounterVec,
+    comparable_hit_tokens_total: IntCounterVec,
+    pub(super) events_total: IntCounterVec,
+    events_dropped_total: IntCounterVec,
+    cache_blocks: IntGauge,
+    pub(super) pending_requests: IntGauge,
+    lag_seconds: prometheus::Gauge,
+    horizon_seconds: IntGauge,
+    pub(super) degraded: IntGauge,
+}
+
+impl EstimatorMetrics {
+    pub(super) fn new(component: &Component, horizon: Duration) -> Result<Self> {
+        let metrics = component.metrics();
+        let labels = &["model", "model_config"];
+        let result = Self {
+            requests_total: metrics.create_intcountervec(
+                "kv_cache_sol_requests_total",
+                "Requests evaluated by the KV-cache speed-of-light estimator",
+                labels,
+                &[],
+            )?,
+            prompt_tokens_total: metrics.create_intcountervec(
+                "kv_cache_sol_prompt_tokens_total",
+                "Prompt tokens evaluated by the KV-cache speed-of-light estimator",
+                labels,
+                &[],
+            )?,
+            hit_tokens_total: metrics.create_intcountervec(
+                "kv_cache_sol_hit_tokens_total",
+                "Theoretical prompt cache-hit tokens",
+                labels,
+                &[],
+            )?,
+            observed_prompt_tokens_total: metrics.create_intcountervec(
+                "kv_cache_sol_observed_prompt_tokens_total",
+                "Prompt tokens with backend-observed cache metadata",
+                labels,
+                &[],
+            )?,
+            observed_cached_tokens_total: metrics.create_intcountervec(
+                "kv_cache_sol_observed_cached_tokens_total",
+                "Backend-observed cached prompt tokens",
+                labels,
+                &[],
+            )?,
+            comparable_hit_tokens_total: metrics.create_intcountervec(
+                "kv_cache_sol_comparable_hit_tokens_total",
+                "Theoretical hit tokens for requests with backend observations",
+                labels,
+                &[],
+            )?,
+            events_total: metrics.create_intcountervec(
+                "kv_cache_sol_events_total",
+                "KV-cache speed-of-light events consumed by type",
+                &["event_type"],
+                &[],
+            )?,
+            events_dropped_total: metrics.create_intcountervec(
+                "kv_cache_sol_events_dropped_total",
+                "Detected missing or invalid KV-cache speed-of-light events",
+                &["reason"],
+                &[],
+            )?,
+            cache_blocks: metrics.create_intgauge(
+                "kv_cache_sol_cache_blocks",
+                "Sequence hashes retained by the KV-cache speed-of-light estimator",
+                &[],
+            )?,
+            pending_requests: metrics.create_intgauge(
+                "kv_cache_sol_pending_requests",
+                "Requests waiting for a matching end event",
+                &[],
+            )?,
+            lag_seconds: metrics.create_gauge(
+                "kv_cache_sol_lag_seconds",
+                "Event occurrence-to-consumption lag in seconds",
+                &[],
+            )?,
+            horizon_seconds: metrics.create_intgauge(
+                "kv_cache_sol_horizon_seconds",
+                "Configured theoretical cache retention horizon",
+                &[],
+            )?,
+            degraded: metrics.create_intgauge(
+                "kv_cache_sol_degraded",
+                "Whether event loss, lateness, or capacity limits invalidate the estimate",
+                &[],
+            )?,
+        };
+        result.horizon_seconds.set(horizon.as_secs() as i64);
+        Ok(result)
+    }
+}
+
+pub struct KvCacheSolEstimator {
+    cancel: CancellationToken,
+}
+
+impl KvCacheSolEstimator {
+    pub async fn start(
+        component: Component,
+        horizon: Duration,
+        max_cache_blocks: usize,
+        max_pending_requests: usize,
+    ) -> Result<Self> {
+        let subscriber = EventSubscriber::for_namespace(component.namespace(), KV_CACHE_SOL_TOPIC)
+            .await?
+            .typed::<KvCacheSolEvent>();
+        let metrics = Arc::new(EstimatorMetrics::new(&component, horizon)?);
+        let cancel = component.drt().child_token();
+        let task_cancel = cancel.clone();
+        let runtime = component.drt().runtime().secondary();
+        runtime.spawn(run_estimator(
+            subscriber,
+            KvCacheSolCore::new(horizon, max_cache_blocks, max_pending_requests),
+            metrics,
+            task_cancel,
+        ));
+        Ok(Self { cancel })
+    }
+
+    pub fn shutdown(&self) {
+        self.cancel.cancel();
+    }
+}
+
+impl Drop for KvCacheSolEstimator {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
+pub(super) async fn run_estimator(
+    mut subscriber: dynamo_runtime::transports::event_plane::TypedEventSubscriber<KvCacheSolEvent>,
+    mut core: KvCacheSolCore,
+    metrics: Arc<EstimatorMetrics>,
+    cancel: CancellationToken,
+) {
+    let mut last_sequence: HashMap<u64, (u64, u64)> = HashMap::new();
+    let mut maintenance = tokio::time::interval(Duration::from_secs(1));
+    maintenance.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    loop {
+        let next = tokio::select! {
+            _ = cancel.cancelled() => break,
+            _ = maintenance.tick() => {
+                let watermark_ms = now_ms();
+                core.advance_to(watermark_ms);
+                last_sequence.retain(|_, (_, last_seen_ms)| {
+                    last_seen_ms.saturating_add(core.horizon_ms()) > watermark_ms
+                });
+                metrics.cache_blocks.set(core.cache_blocks() as i64);
+                metrics.pending_requests.set(core.pending_requests() as i64);
+                metrics.degraded.set(i64::from(core.degraded()));
+                continue;
+            }
+            next = subscriber.next() => next,
+        };
+        let Some(result) = next else { break };
+        let (envelope, event) = match result {
+            Ok(value) => value,
+            Err(error) => {
+                metrics
+                    .events_dropped_total
+                    .with_label_values(&["decode_error"])
+                    .inc();
+                core.mark_degraded_at(now_ms());
+                metrics.degraded.set(i64::from(core.degraded()));
+                tracing::warn!(%error, "invalid KV-cache speed-of-light event");
+                continue;
+            }
+        };
+        if event.domain.block_size == 0 {
+            metrics
+                .events_dropped_total
+                .with_label_values(&["invalid_domain"])
+                .inc();
+            core.mark_degraded_at(event.occurred_at_ms);
+            metrics.degraded.set(i64::from(core.degraded()));
+            continue;
+        }
+        last_sequence.retain(|_, (_, last_seen_ms)| {
+            last_seen_ms.saturating_add(core.horizon_ms()) > event.occurred_at_ms
+        });
+        let sequence_gap = match last_sequence.insert(
+            envelope.publisher_id,
+            (event.producer_sequence, event.occurred_at_ms),
+        ) {
+            Some((previous, _)) => event.producer_sequence != previous.saturating_add(1),
+            None => event.producer_sequence != 0,
+        };
+        if sequence_gap {
+            metrics
+                .events_dropped_total
+                .with_label_values(&["sequence_gap"])
+                .inc();
+            core.mark_degraded_at(event.occurred_at_ms);
+        }
+        metrics
+            .lag_seconds
+            .set(now_ms().saturating_sub(event.occurred_at_ms) as f64 / 1000.0);
+        let event_type = match event.kind {
+            KvCacheSolEventKind::RequestStart { .. } => "request_start",
+            KvCacheSolEventKind::RequestEnd { .. } => "request_end",
+        };
+        metrics.events_total.with_label_values(&[event_type]).inc();
+        match core.apply(envelope.publisher_id, event) {
+            SolObservation::Start {
+                domain,
+                prompt_tokens,
+                hit_tokens,
+            } => {
+                let labels = &[domain.model.as_str(), domain.model_config.as_str()];
+                metrics.requests_total.with_label_values(labels).inc();
+                metrics
+                    .prompt_tokens_total
+                    .with_label_values(labels)
+                    .inc_by(prompt_tokens);
+                metrics
+                    .hit_tokens_total
+                    .with_label_values(labels)
+                    .inc_by(hit_tokens);
+            }
+            SolObservation::End {
+                domain,
+                prompt_tokens,
+                comparable_hit_tokens,
+                observed_cached_tokens,
+            } => {
+                if let (Some(prompt), Some(hit), Some(observed)) =
+                    (prompt_tokens, comparable_hit_tokens, observed_cached_tokens)
+                {
+                    let labels = &[domain.model.as_str(), domain.model_config.as_str()];
+                    metrics
+                        .observed_prompt_tokens_total
+                        .with_label_values(labels)
+                        .inc_by(prompt);
+                    metrics
+                        .comparable_hit_tokens_total
+                        .with_label_values(labels)
+                        .inc_by(hit);
+                    metrics
+                        .observed_cached_tokens_total
+                        .with_label_values(labels)
+                        .inc_by(observed.min(prompt));
+                }
+            }
+        }
+        metrics.cache_blocks.set(core.cache_blocks() as i64);
+        metrics.pending_requests.set(core.pending_requests() as i64);
+        metrics.degraded.set(i64::from(core.degraded()));
+    }
+}

--- a/lib/llm/src/kv_cache_sol/tests.rs
+++ b/lib/llm/src/kv_cache_sol/tests.rs
@@ -1,0 +1,543 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::time::Duration;
+
+use super::*;
+use dynamo_runtime::distributed::DistributedConfig;
+use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber};
+use dynamo_runtime::{DistributedRuntime, Runtime};
+use tokio::time::timeout;
+use tokio_util::sync::CancellationToken;
+
+fn domain(eagle: bool) -> KvCacheSolDomain {
+    KvCacheSolDomain {
+        model: "model".to_string(),
+        model_config: "config".to_string(),
+        block_size: 4,
+        is_eagle: eagle,
+    }
+}
+
+fn start_event(id: &str, time: u64, hashes: Vec<u64>, tokens: u64) -> KvCacheSolEvent {
+    KvCacheSolEvent {
+        producer_sequence: 0,
+        occurred_at_ms: time,
+        request_id: id.to_string(),
+        domain: domain(false),
+        kind: KvCacheSolEventKind::RequestStart {
+            prompt_sequence_hashes: hashes,
+            prompt_tokens: tokens,
+        },
+    }
+}
+
+fn start_event_in_domain(
+    id: &str,
+    time: u64,
+    hashes: Vec<u64>,
+    tokens: u64,
+    model_config: &str,
+) -> KvCacheSolEvent {
+    let mut event = start_event(id, time, hashes, tokens);
+    event.domain.model_config = model_config.to_string();
+    event
+}
+
+fn end_event(id: &str, time: u64, sequence: u64) -> KvCacheSolEvent {
+    KvCacheSolEvent {
+        producer_sequence: sequence,
+        occurred_at_ms: time,
+        request_id: id.to_string(),
+        domain: domain(false),
+        kind: KvCacheSolEventKind::RequestEnd {
+            continuation_sequence_hashes: BTreeMap::new(),
+            observed_cached_tokens: Some(0),
+        },
+    }
+}
+
+#[test]
+fn longest_prefix_hits_and_horizon_expiry() {
+    let mut core = KvCacheSolCore::new(Duration::from_millis(100), 100, 100);
+    let first = core.apply(1, start_event("a", 10, vec![11, 12], 8));
+    assert!(matches!(first, SolObservation::Start { hit_tokens: 0, .. }));
+    let second = core.apply(1, start_event("b", 20, vec![11, 12, 13], 12));
+    assert!(matches!(
+        second,
+        SolObservation::Start { hit_tokens: 8, .. }
+    ));
+    let expired = core.apply(1, start_event("c", 121, vec![11, 12], 8));
+    assert!(matches!(
+        expired,
+        SolObservation::Start { hit_tokens: 0, .. }
+    ));
+}
+
+#[test]
+fn hot_prefix_refresh_keeps_expiry_index_bounded() {
+    let mut cache = DomainCache::default();
+    assert!(cache.insert(11, 100));
+    for expires_at in 101..=100_000 {
+        assert!(!cache.insert(11, expires_at));
+    }
+
+    assert_eq!(cache.expirations.len(), 1);
+    assert_eq!(cache.expiry_queue.len(), 1);
+    cache.prune(100_000);
+    assert!(cache.expirations.is_empty());
+    assert!(cache.expiry_queue.is_empty());
+}
+
+#[test]
+fn refresh_with_an_older_timestamp_never_shortens_expiry() {
+    let mut cache = DomainCache::default();
+    assert!(cache.insert(11, 200));
+    assert!(!cache.insert(11, 100));
+    cache.prune(150);
+
+    assert_eq!(cache.expirations.get(&11), Some(&200));
+    assert_eq!(cache.expiry_queue.len(), 1);
+}
+
+#[test]
+fn expired_inactive_domain_releases_global_capacity() {
+    let mut core = KvCacheSolCore::new(Duration::from_millis(100), 1, 100);
+    core.apply(1, start_event_in_domain("a", 10, vec![11], 4, "config-a"));
+    assert_eq!(core.cache_blocks(), 1);
+
+    let observation = core.apply(1, start_event_in_domain("b", 111, vec![22], 4, "config-b"));
+    assert!(matches!(
+        observation,
+        SolObservation::Start { hit_tokens: 0, .. }
+    ));
+    assert_eq!(core.cache_blocks(), 1);
+    assert!(!core.degraded());
+    assert!(
+        core.caches
+            .keys()
+            .all(|domain| domain.model_config != "config-a")
+    );
+}
+
+#[test]
+fn cache_block_capacity_is_a_hard_bound_under_domain_churn() {
+    let mut core = KvCacheSolCore::new(Duration::from_millis(10), 8, 10_000);
+    for index in 0..10_000_u64 {
+        core.apply(
+            1,
+            start_event_in_domain(
+                &format!("request-{index}"),
+                index,
+                vec![index],
+                4,
+                &format!("config-{}", index % 16),
+            ),
+        );
+        assert!(core.cache_blocks() <= 8);
+    }
+    assert!(core.caches.len() <= 16);
+}
+
+#[test]
+fn identical_request_ids_from_different_publishers_do_not_collide() {
+    let mut core = KvCacheSolCore::new(Duration::from_secs(1), 100, 100);
+    core.apply(1, start_event("shared-id", 10, vec![11], 4));
+    core.apply(2, start_event("shared-id", 11, vec![22], 4));
+    assert_eq!(core.pending_requests(), 2);
+
+    core.apply(1, end_event("shared-id", 20, 1));
+    core.apply(2, end_event("shared-id", 21, 1));
+    assert_eq!(core.pending_requests(), 0);
+    assert!(!core.degraded());
+}
+
+#[test]
+fn pending_request_capacity_is_a_hard_bound() {
+    let mut core = KvCacheSolCore::new(Duration::from_secs(1), 100, 2);
+    core.apply(1, start_event("a", 10, vec![11], 4));
+    core.apply(1, start_event("b", 11, vec![12], 4));
+    core.apply(1, start_event("c", 12, vec![13], 4));
+
+    assert_eq!(core.pending_requests(), 2);
+    assert!(core.degraded());
+}
+
+#[test]
+fn degraded_and_pending_state_expire_after_the_horizon() {
+    let mut core = KvCacheSolCore::new(Duration::from_millis(100), 0, 100);
+    core.apply(1, start_event("a", 10, vec![11], 4));
+
+    assert!(core.degraded());
+    assert_eq!(core.pending_requests(), 1);
+
+    core.advance_to(110);
+    assert!(!core.degraded());
+    assert_eq!(core.pending_requests(), 0);
+}
+
+#[tokio::test]
+async fn queue_overflow_and_worker_close_are_sticky_producer_failures() -> Result<()> {
+    let runtime = Runtime::from_current()?;
+    let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+    let namespace = drt.namespace(format!("kv-sol-queue-{}", uuid::Uuid::new_v4()))?;
+    let component = namespace.component("producer")?;
+    let metrics = Arc::new(ProducerMetrics::new(&component)?);
+    let (tx, rx) = mpsc::channel(1);
+    let producer = KvCacheSolProducer {
+        tx,
+        missing_sequences: Arc::new(AtomicU64::new(0)),
+        metrics: metrics.clone(),
+        block_size: 4,
+        is_eagle: false,
+        router_computes_hashes: false,
+    };
+
+    producer.try_send(RawEvent::End(RawEnd {
+        occurred_at_ms: 1,
+        request_id: "first".to_string(),
+        output_tokens: BTreeMap::new(),
+        observed_cached_tokens: None,
+    }));
+    producer.try_send(RawEvent::End(RawEnd {
+        occurred_at_ms: 2,
+        request_id: "overflow".to_string(),
+        output_tokens: BTreeMap::new(),
+        observed_cached_tokens: None,
+    }));
+
+    assert_eq!(metrics.queue_depth.get(), 1);
+    assert_eq!(metrics.degraded.get(), 1);
+    assert_eq!(
+        metrics
+            .events_dropped_total
+            .with_label_values(&["queue_full"])
+            .get(),
+        1
+    );
+    assert_eq!(producer.missing_sequences.load(Ordering::Relaxed), 1);
+
+    drop(rx);
+    producer.try_send(RawEvent::End(RawEnd {
+        occurred_at_ms: 3,
+        request_id: "closed".to_string(),
+        output_tokens: BTreeMap::new(),
+        observed_cached_tokens: None,
+    }));
+    assert_eq!(metrics.queue_depth.get(), 0);
+    assert_eq!(
+        metrics
+            .events_dropped_total
+            .with_label_values(&["worker_closed"])
+            .get(),
+        1
+    );
+    assert_eq!(producer.missing_sequences.load(Ordering::Relaxed), 2);
+
+    drt.shutdown();
+    Ok(())
+}
+
+#[tokio::test]
+async fn dropping_an_unpolled_stream_publishes_request_end() -> Result<()> {
+    let runtime = Runtime::from_current()?;
+    let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+    let namespace = drt.namespace(format!("kv-sol-drop-{}", uuid::Uuid::new_v4()))?;
+    let component = namespace.component("producer")?;
+    let metrics = Arc::new(ProducerMetrics::new(&component)?);
+    let (tx, mut rx) = mpsc::channel(1);
+    let producer = KvCacheSolProducer {
+        tx,
+        missing_sequences: Arc::new(AtomicU64::new(0)),
+        metrics,
+        block_size: 4,
+        is_eagle: false,
+        router_computes_hashes: false,
+    };
+    let guard = ResponseEndGuard {
+        producer,
+        request_id: Some("unpolled".to_string()),
+        output_tokens: BTreeMap::new(),
+        observed_cached_tokens: None,
+    };
+    let stream = async_stream::stream! {
+        let _guard = guard;
+        if false {
+            yield ();
+        }
+    };
+
+    drop(stream);
+    assert!(matches!(rx.try_recv(), Ok(RawEvent::End(_))));
+    drt.shutdown();
+    Ok(())
+}
+
+#[tokio::test]
+async fn process_local_event_plane_round_trip_drains_cleanly() -> Result<()> {
+    let runtime = Runtime::from_current()?;
+    let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local()).await?;
+    let namespace = drt.namespace(format!("kv-sol-wire-{}", uuid::Uuid::new_v4()))?;
+    let component = namespace.component("estimator")?;
+    let subscriber = EventSubscriber::for_namespace(&namespace, KV_CACHE_SOL_TOPIC)
+        .await?
+        .typed::<KvCacheSolEvent>();
+    let publisher = EventPublisher::for_namespace(&namespace, KV_CACHE_SOL_TOPIC).await?;
+    let metrics = Arc::new(EstimatorMetrics::new(&component, Duration::from_secs(60))?);
+    let cancel = CancellationToken::new();
+    let task = tokio::spawn(run_estimator(
+        subscriber,
+        KvCacheSolCore::new(Duration::from_secs(60), 100, 100),
+        metrics.clone(),
+        cancel.clone(),
+    ));
+
+    // Avoid the PUB/SUB slow-joiner window before sending the first event.
+    tokio::time::sleep(Duration::from_millis(150)).await;
+    publisher
+        .publish(&start_event("wire", now_ms(), vec![11], 4))
+        .await?;
+    publisher.publish(&end_event("wire", now_ms(), 1)).await?;
+
+    timeout(Duration::from_secs(5), async {
+        loop {
+            if metrics
+                .events_total
+                .with_label_values(&["request_end"])
+                .get()
+                == 1
+            {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await?;
+
+    let labels = &["model", "config"];
+    assert_eq!(
+        metrics
+            .events_total
+            .with_label_values(&["request_start"])
+            .get(),
+        1
+    );
+    assert_eq!(metrics.requests_total.with_label_values(labels).get(), 1);
+    assert_eq!(
+        metrics.prompt_tokens_total.with_label_values(labels).get(),
+        4
+    );
+    assert_eq!(metrics.pending_requests.get(), 0);
+    assert_eq!(metrics.degraded.get(), 0);
+
+    cancel.cancel();
+    task.await?;
+    drt.shutdown();
+    Ok(())
+}
+
+#[test]
+fn continuation_completes_partial_standard_block() {
+    let tokens = vec![1, 2, 3, 4, 5, 6];
+    let start = RawStart {
+        occurred_at_ms: 0,
+        request_id: "r".to_string(),
+        domain: domain(false),
+        prompt: PromptHashInput::Tokens {
+            token_ids: tokens.clone(),
+            block_mm_infos: None,
+        },
+        next_block_mm_info: None,
+        lora_name: None,
+        cache_namespace: None,
+    };
+    let local = compute_block_hash_for_seq(&tokens, 4, BlockHashOptions::default());
+    let seq = compute_seq_hash_for_block(&local);
+    let mut continuation = HashContinuation::new(&start, &seq, tokens[4..].to_vec());
+    let next = continuation.append(&[7, 8, 9, 10, 11, 12]);
+    let all = compute_block_hash_for_seq(
+        &[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        4,
+        BlockHashOptions::default(),
+    );
+    assert_eq!(next, compute_seq_hash_for_block(&all)[1..]);
+}
+
+#[test]
+fn continuation_matches_eagle_hashing() {
+    let tokens = vec![1, 2, 3, 4, 5, 6];
+    let mut start = RawStart {
+        occurred_at_ms: 0,
+        request_id: "r".to_string(),
+        domain: domain(true),
+        prompt: PromptHashInput::Tokens {
+            token_ids: tokens.clone(),
+            block_mm_infos: None,
+        },
+        next_block_mm_info: None,
+        lora_name: None,
+        cache_namespace: None,
+    };
+    start.domain.is_eagle = true;
+    let options = BlockHashOptions {
+        is_eagle: Some(true),
+        ..Default::default()
+    };
+    let local = compute_block_hash_for_seq(&tokens, 4, options);
+    let seq = compute_seq_hash_for_block(&local);
+    let mut continuation = HashContinuation::new(&start, &seq, tokens[4..].to_vec());
+    let next = continuation.append(&[7, 8, 9, 10, 11, 12]);
+    let all = compute_block_hash_for_seq(&[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12], 4, options);
+    assert_eq!(next, compute_seq_hash_for_block(&all)[1..]);
+}
+
+#[test]
+fn long_continuation_matches_single_pass_hashing() {
+    let prompt = vec![1, 2, 3, 4, 5, 6];
+    let generated: Vec<_> = (0..16_384).map(|token| token as TokenIdType).collect();
+    let start = RawStart {
+        occurred_at_ms: 0,
+        request_id: "long".to_string(),
+        domain: domain(false),
+        prompt: PromptHashInput::Tokens {
+            token_ids: prompt.clone(),
+            block_mm_infos: None,
+        },
+        next_block_mm_info: None,
+        lora_name: None,
+        cache_namespace: None,
+    };
+    let prompt_hashes = compute_seq_hash_for_block(&compute_block_hash_for_seq(
+        &prompt,
+        4,
+        BlockHashOptions::default(),
+    ));
+    let mut continuation = HashContinuation::new(&start, &prompt_hashes, prompt[4..].to_vec());
+    let actual = continuation.append(&generated);
+
+    let mut all = prompt;
+    all.extend_from_slice(&generated);
+    let expected = compute_seq_hash_for_block(&compute_block_hash_for_seq(
+        &all,
+        4,
+        BlockHashOptions::default(),
+    ));
+    assert_eq!(actual, expected[1..]);
+}
+
+#[test]
+fn continuation_preserves_lora_namespace_and_multimodal_hashing() {
+    let mm = BlockExtraInfo {
+        mm_objects: vec![dynamo_kv_router::protocols::BlockMmObjectInfo {
+            mm_hash: 42,
+            offsets: vec![(0, 2)],
+        }],
+    };
+    let tokens = vec![1, 2, 3, 4, 5, 6];
+    let prompt_mm_infos = vec![None, Some(mm.clone())];
+    let start = RawStart {
+        occurred_at_ms: 0,
+        request_id: "r".to_string(),
+        domain: domain(false),
+        prompt: PromptHashInput::Tokens {
+            token_ids: tokens.clone(),
+            block_mm_infos: Some(prompt_mm_infos.clone()),
+        },
+        next_block_mm_info: Some(mm.clone()),
+        lora_name: Some("adapter".to_string()),
+        cache_namespace: Some("tenant".to_string()),
+    };
+    let options = BlockHashOptions {
+        block_mm_infos: Some(&prompt_mm_infos),
+        lora_name: start.lora_name.as_deref(),
+        cache_namespace: start.cache_namespace.as_deref(),
+        is_eagle: Some(false),
+    };
+    let initial = compute_block_hash_for_seq(&tokens, 4, options);
+    let initial_seq = compute_seq_hash_for_block(&initial);
+    let mut continuation = HashContinuation::new(&start, &initial_seq, tokens[4..].to_vec());
+    let next = continuation.append(&[7, 8]);
+    let full_tokens = [1, 2, 3, 4, 5, 6, 7, 8];
+    let full_mm = [None, Some(mm)];
+    let expected = compute_seq_hash_for_block(&compute_block_hash_for_seq(
+        &full_tokens,
+        4,
+        BlockHashOptions {
+            block_mm_infos: Some(&full_mm),
+            lora_name: Some("adapter"),
+            cache_namespace: Some("tenant"),
+            is_eagle: Some(false),
+        },
+    ));
+    assert_eq!(next, expected[1..]);
+}
+
+#[test]
+fn response_continuation_becomes_a_future_prompt_hit() {
+    let tokens = vec![1, 2, 3, 4, 5, 6];
+    let local = compute_block_hash_for_seq(&tokens, 4, BlockHashOptions::default());
+    let prompt_hashes = compute_seq_hash_for_block(&local);
+    let start = RawStart {
+        occurred_at_ms: 10,
+        request_id: "a".to_string(),
+        domain: domain(false),
+        prompt: PromptHashInput::Tokens {
+            token_ids: tokens.clone(),
+            block_mm_infos: None,
+        },
+        next_block_mm_info: None,
+        lora_name: None,
+        cache_namespace: None,
+    };
+    let mut continuation = HashContinuation::new(&start, &prompt_hashes, tokens[4..].to_vec());
+    let response_hashes = continuation.append(&[7, 8]);
+
+    let mut core = KvCacheSolCore::new(Duration::from_secs(1), 100, 100);
+    core.apply(1, start_event("a", 10, prompt_hashes.clone(), 6));
+    core.apply(
+        1,
+        KvCacheSolEvent {
+            producer_sequence: 1,
+            occurred_at_ms: 20,
+            request_id: "a".to_string(),
+            domain: domain(false),
+            kind: KvCacheSolEventKind::RequestEnd {
+                continuation_sequence_hashes: BTreeMap::from([(0, response_hashes.clone())]),
+                observed_cached_tokens: Some(0),
+            },
+        },
+    );
+    let next = core.apply(
+        1,
+        start_event("b", 30, vec![prompt_hashes[0], response_hashes[0]], 8),
+    );
+    assert!(matches!(next, SolObservation::Start { hit_tokens: 8, .. }));
+}
+
+#[test]
+fn publisher_sequence_follows_worker_order_and_preserves_real_gaps() {
+    let missing = AtomicU64::new(0);
+    let mut next = 0;
+    assert_eq!(reserve_publisher_sequence(&mut next, &missing), 0);
+    assert_eq!(reserve_publisher_sequence(&mut next, &missing), 1);
+
+    missing.fetch_add(3, Ordering::Relaxed);
+    assert_eq!(reserve_publisher_sequence(&mut next, &missing), 5);
+    assert_eq!(reserve_publisher_sequence(&mut next, &missing), 6);
+}
+
+#[test]
+fn event_wire_payload_contains_no_raw_tokens() {
+    let start_json = serde_json::to_string(&start_event("a", 10, vec![11, 12], 8)).unwrap();
+    assert!(!start_json.contains("token_ids"));
+    assert!(start_json.contains("prompt_sequence_hashes"));
+
+    let mut end = end_event("a", 20, 1);
+    end.kind = KvCacheSolEventKind::RequestEnd {
+        continuation_sequence_hashes: BTreeMap::from([(0, vec![101, 102])]),
+        observed_cached_tokens: Some(4),
+    };
+    let end_json = serde_json::to_string(&end).unwrap();
+    assert!(!end_json.contains("token_ids"));
+    assert!(end_json.contains("continuation_sequence_hashes"));
+}

--- a/lib/llm/src/kv_router/prefill_router/admission.rs
+++ b/lib/llm/src/kv_router/prefill_router/admission.rs
@@ -94,6 +94,14 @@ impl PrefillRouter {
             }
         }
 
+        if let Some(cached_tokens) = prompt_tokens_details
+            .as_ref()
+            .and_then(|details| details.cached_tokens)
+            && let Some(tracker) = tracker.as_ref()
+        {
+            tracker.record_worker_observed_cached_tokens(cached_tokens as usize);
+        }
+
         let Some(output) = &first_output.data else {
             return Err(PrefillError::NoDisaggregatedParams(
                 "Prefill router output has no data field".to_string(),

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -214,6 +214,13 @@ impl KvPushRouter {
         );
 
         let record_result: Result<(), Error> = async {
+            if let Some(hashes) = selection.routing_hashes.as_ref()
+                && let Some(tracker) = request.tracker.as_ref()
+                && tracker.kv_cache_sol_tracking_enabled()
+            {
+                tracker.record_kv_cache_sol_prompt_hashes(hashes.clone());
+            }
+
             if !is_query_only && self.chooser.indexer().records_routing_decisions() {
                 let worker = WorkerWithDpRank::new(selection.instance_id, selection.dp_rank);
                 let record_result = if let Some(hashes) = selection.routing_hashes.take() {

--- a/lib/llm/src/kv_router/push_router/selection.rs
+++ b/lib/llm/src/kv_router/push_router/selection.rs
@@ -137,8 +137,12 @@ impl KvPushRouter {
             .unwrap_or(0);
         let expected_output_tokens = routing.and_then(|routing| routing.expected_output_tokens);
         let allowed_worker_ids = routing.and_then(|routing| routing.allowed_worker_ids.clone());
-        let return_routing_hashes =
-            !is_query_only && self.chooser.indexer().records_routing_decisions();
+        let return_routing_hashes = !is_query_only
+            && (self.chooser.indexer().records_routing_decisions()
+                || request
+                    .tracker
+                    .as_ref()
+                    .is_some_and(|tracker| tracker.kv_cache_sol_tracking_enabled()));
         let routing_constraints = routing
             .and_then(|routing| routing.routing_constraints.clone())
             .unwrap_or_default();

--- a/lib/llm/src/lib.rs
+++ b/lib/llm/src/lib.rs
@@ -19,6 +19,7 @@ pub mod grpc;
 pub mod http;
 pub mod hub;
 // pub mod key_value_store;
+pub mod kv_cache_sol;
 pub mod kv_router;
 pub mod local_model;
 pub mod lora;

--- a/lib/llm/src/protocols/common/timing.rs
+++ b/lib/llm/src/protocols/common/timing.rs
@@ -16,10 +16,18 @@ use serde::{Deserialize, Serialize};
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 use utoipa::ToSchema;
 
+use dynamo_kv_router::indexer::RoutingDecisionHashes;
+
 use crate::http::service::metrics::{
     WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE, WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE,
     WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE,
 };
+
+#[derive(Debug, Default)]
+struct KvCacheSolTracking {
+    prompt_hashes: OnceLock<RoutingDecisionHashes>,
+    worker_observed_cached_tokens: OnceLock<usize>,
+}
 use crate::protocols::common::extensions::WorkerIdInfo;
 
 /// Worker type constants for Prometheus metric labels.
@@ -116,6 +124,10 @@ pub struct RequestTracker {
 
     /// Number of cached tokens derived from the effective cache hit - set once via OnceLock
     cached_tokens: OnceLock<usize>,
+
+    /// Optional speed-of-light state. Keeping the feature behind one lazy cell avoids
+    /// spreading its state across every request tracker when the feature is disabled.
+    kv_cache_sol_tracking: OnceLock<KvCacheSolTracking>,
 
     /// Output sequence length in tokens - updated atomically as tokens stream back
     osl_tokens: AtomicU64,
@@ -222,6 +234,7 @@ impl RequestTracker {
             isl_blocks: OnceLock::new(),
             isl_tokens: OnceLock::new(),
             cached_tokens: OnceLock::new(),
+            kv_cache_sol_tracking: OnceLock::new(),
             osl_tokens: AtomicU64::new(0),
             prefill_worker_id: OnceLock::new(),
             prefill_dp_rank: OnceLock::new(),
@@ -281,6 +294,44 @@ impl RequestTracker {
 
     pub fn cached_tokens(&self) -> Option<usize> {
         self.cached_tokens.get().copied()
+    }
+
+    /// Record a cache hit count reported by the inference backend.
+    pub(crate) fn record_worker_observed_cached_tokens(&self, cached_tokens: usize) -> bool {
+        self.kv_cache_sol_tracking.get().is_some_and(|tracking| {
+            tracking
+                .worker_observed_cached_tokens
+                .set(cached_tokens)
+                .is_ok()
+        })
+    }
+
+    pub(crate) fn worker_observed_cached_tokens(&self) -> Option<usize> {
+        self.kv_cache_sol_tracking
+            .get()
+            .and_then(|tracking| tracking.worker_observed_cached_tokens.get())
+            .copied()
+    }
+
+    pub(crate) fn enable_kv_cache_sol_tracking(&self) {
+        self.kv_cache_sol_tracking
+            .get_or_init(KvCacheSolTracking::default);
+    }
+
+    pub(crate) fn kv_cache_sol_tracking_enabled(&self) -> bool {
+        self.kv_cache_sol_tracking.get().is_some()
+    }
+
+    pub(crate) fn record_kv_cache_sol_prompt_hashes(&self, hashes: RoutingDecisionHashes) -> bool {
+        self.kv_cache_sol_tracking
+            .get()
+            .is_some_and(|tracking| tracking.prompt_hashes.set(hashes).is_ok())
+    }
+
+    pub(crate) fn kv_cache_sol_prompt_hashes(&self) -> Option<&RoutingDecisionHashes> {
+        self.kv_cache_sol_tracking
+            .get()
+            .and_then(|tracking| tracking.prompt_hashes.get())
     }
 
     /// Record current output sequence length in tokens. Updated at each output block boundary.
@@ -747,8 +798,11 @@ mod tests {
         let tracker = RequestTracker::new();
 
         tracker.record_isl(512, Some(256));
+        tracker.enable_kv_cache_sol_tracking();
+        tracker.record_worker_observed_cached_tokens(192);
         assert_eq!(tracker.isl_tokens(), Some(512));
         assert_eq!(tracker.cached_tokens(), Some(256));
+        assert_eq!(tracker.worker_observed_cached_tokens(), Some(192));
 
         tracker.record_osl(100);
         assert_eq!(tracker.osl_tokens(), 100);


### PR DESCRIPTION
## Summary

- add an opt-in, CPU-only tap that observes preprocessed requests and streamed responses without blocking the inference path
- reuse KV-router sequence hashes when available; otherwise hash prompts in a bounded background worker
- preserve block multimodal metadata, LoRA/cache namespace identity, block size, and Eagle hashing semantics
- publish only request metadata and compact sequence hashes over the event plane—never prompts or token IDs
- add a standalone `python -m dynamo.kv_cache_sol` estimator that exposes workload speed-of-light and backend-comparison Prometheus metrics
- bound producer queues, in-flight state, retained hashes, and pending requests, with explicit drop/degraded metrics

## Motivation

DYN-3468 needs a workload-specific upper bound for KV-cache hit rate: whether each request prefix could have been present if all reusable prefixes from the configured retention horizon were retained. The estimator is deliberately independent of backend cache capacity and eviction policy, and runs out of band so it can be enabled on production-shaped workloads with minimal request-path overhead.

The auxiliary comparison against backend-reported cached tokens currently uses Dynamo's nominal routing block granularity. vLLM DCP/PCP aligns reusable hits to a larger physical cache-block multiple; backend-aware normalization is tracked separately in DYN-3478.

## Validation

- `cargo test -p dynamo-llm kv_cache_sol --lib` — 18 passed, including process-local event-plane round trip, bounded-state, drop detection, privacy, Eagle, LoRA, multimodal, and continuation tests
- `cargo test -p dynamo-llm test_record_isl_osl --lib`
- `cargo clippy -p dynamo-llm --lib -- -D warnings`
- `cargo clippy --manifest-path lib/bindings/python/Cargo.toml --lib -- -D warnings`
- `cargo check --manifest-path lib/bindings/python/Cargo.toml --lib`
- Python compile, isort, black, flake8, ruff, codespell, whitespace, and merge-conflict hooks
- B300/Kimi K2.6 AgentX C64 deployment: 3,330 matched start/end events, final pending and queue depth 0, no drops or degraded state, and no measurable throughput/latency regression
- B300 C8 diagnostic confirmed the remaining comparison delta is DCP4/PCP cache-hit alignment rather than event backlog or cross-session overlap

Linear: [DYN-3468](https://linear.app/nvidia/issue/DYN-3468/estimate-the-speed-of-light-upper-bound-for-kv-cache-hit-rate)