### PR TITLE
KLXHY-RM-3252:feat(kv-router) decode length pooling, memory guard, co…

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -52,6 +52,10 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "shared_cache_multiplier",
     "shared_cache_type",
     "router_predicted_ttl_secs",
+    "decode_block_guard_frac",
+    "pool_long_isl_threshold",
+    "pool_short_dp_ranks",
+    "max_kv_cache_tokens",
 )
 
 _DEPRECATED_OVERLAP_WEIGHT_MESSAGE = (
@@ -105,6 +109,29 @@ def _default_prefill_load_scale() -> float:
     return 1.0
 
 
+def _parse_dp_rank_list(value: str) -> Optional[list[int]]:
+    """Parse a dp_rank spec like '0,1,2,3' or '0-23' (or a mix) into a sorted list."""
+    if value is None:
+        return None
+    value = value.strip()
+    if not value:
+        return None
+    ranks: set[int] = set()
+    for part in value.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            lo_str, hi_str = part.split("-", 1)
+            lo, hi = int(lo_str), int(hi_str)
+            if hi < lo:
+                raise ValueError(f"invalid dp_rank range {part!r}: end < start")
+            ranks.update(range(lo, hi + 1))
+        else:
+            ranks.add(int(part))
+    return sorted(ranks)
+
+
 class KvRouterConfigBase(ConfigBase):
     """Mixin carrying the shared KvRouterConfig fields."""
 
@@ -135,6 +162,10 @@ class KvRouterConfigBase(ConfigBase):
     shared_cache_multiplier: float = 0.0
     shared_cache_type: str = "none"
     router_predicted_ttl_secs: Optional[float] = None
+    decode_block_guard_frac: float = 1.0
+    pool_long_isl_threshold: Optional[int] = None
+    pool_short_dp_ranks: Optional[list[int]] = None
+    max_kv_cache_tokens: Optional[int] = None
     load_aware: bool = False
 
     def apply_load_aware_preset(self) -> None:
@@ -490,4 +521,62 @@ class KvRouterArgGroup(ArgGroup):
                 "Independent of --router-ttl-secs, which covers pure approximate mode."
             ),
             arg_type=float,
+        )
+        add_argument(
+            g,
+            flag_name="--router-decode-block-guard-frac",
+            env_var="DYN_ROUTER_DECODE_BLOCK_GUARD_FRAC",
+            default=1.0,
+            help=(
+                "KV Router: Fraction of a decode worker's total_kv_blocks usable "
+                "before the router stops routing new requests to it (hard memory "
+                "admission guard). Range 0.0-1.0; 1.0 (default) disables the guard. "
+                "Only applied to decode workers that report total_kv_blocks. Use e.g. "
+                "0.9 to leave headroom and avoid decode-side OOM under length skew."
+            ),
+            arg_type=float,
+            dest="decode_block_guard_frac",
+        )
+        add_argument(
+            g,
+            flag_name="--router-pool-long-isl-threshold",
+            env_var="DYN_ROUTER_POOL_LONG_ISL_THRESHOLD",
+            default=None,
+            help=(
+                "KV Router: ISL (in tokens) at or above which a request is routed to "
+                "the 'long' pool. When set together with --router-pool-short-dp-ranks, "
+                "decode dp ranks are split into a short pool (the listed ranks) and a "
+                "long pool (the complement). Unset (default) disables length-based pooling."
+            ),
+            arg_type=int,
+            dest="pool_long_isl_threshold",
+        )
+        add_argument(
+            g,
+            flag_name="--router-pool-short-dp-ranks",
+            env_var="DYN_ROUTER_POOL_SHORT_DP_RANKS",
+            default=None,
+            help=(
+                "KV Router: Comma-separated dp_ranks forming the 'short' request pool "
+                "(e.g. '0,1,2,3' or '0-23'). Requests with isl < "
+                "--router-pool-long-isl-threshold are confined to these ranks; longer "
+                "requests go to the complementary ranks. Unset (default) disables pooling."
+            ),
+            arg_type=_parse_dp_rank_list,
+            dest="pool_short_dp_ranks",
+        )
+        add_argument(
+            g,
+            flag_name="--router-max-kv-cache-tokens",
+            env_var="DYN_ROUTER_MAX_KV_CACHE_TOKENS",
+            default=None,
+            help=(
+                "KV Router: Override the max KV cache size (in tokens) used by "
+                "the memory guard. When set, replaces the worker-reported "
+                "total_kv_blocks for guard calculations. Useful when the "
+                "worker-reported value is inaccurate. Unset (default) uses the "
+                "worker-reported value."
+            ),
+            arg_type=int,
+            dest="max_kv_cache_tokens",
         )

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -234,7 +234,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(16.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, *, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, durable_kv_events=false, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_snapshot_threshold=1000000, router_reset_states=false, router_ttl_secs=120.0, router_queue_threshold=Some(16.0), router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, decode_block_guard_frac=1.0, pool_long_isl_threshold=None, pool_short_dp_ranks=None, max_kv_cache_tokens=None, *, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -260,6 +260,10 @@ impl KvRouterConfig {
         shared_cache_multiplier: f64,
         shared_cache_type: &str,
         router_predicted_ttl_secs: Option<f64>,
+        decode_block_guard_frac: f64,
+        pool_long_isl_threshold: Option<usize>,
+        pool_short_dp_ranks: Option<Vec<u32>>,
+        max_kv_cache_tokens: Option<usize>,
         mut overlap_score_credit: f64,
         overlap_score_credit_decay: f64,
         mut prefill_load_scale: f64,
@@ -305,6 +309,10 @@ impl KvRouterConfig {
             shared_cache_multiplier,
             shared_cache_type: shared_cache_type.parse().map_err(PyValueError::new_err)?,
             router_predicted_ttl_secs,
+            decode_block_guard_frac,
+            pool_long_isl_threshold,
+            pool_short_dp_ranks,
+            max_kv_cache_tokens,
         };
         validate_kv_router_config(&inner)?;
         Ok(KvRouterConfig { inner })

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -52,6 +52,14 @@ const fn default_overlap_score_credit_decay() -> f64 {
     0.0
 }
 
+const fn default_decode_block_guard_frac() -> f64 {
+    1.0
+}
+
+const fn default_max_kv_cache_tokens() -> Option<usize> {
+    None
+}
+
 pub const OVERLAP_SCORE_CREDIT_RANGE_ERROR: &str =
     "overlap_score_credit must be between 0.0 and 1.0";
 pub const OVERLAP_SCORE_CREDIT_MIGRATION_ERROR: &str = concat!(
@@ -125,6 +133,30 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
         })
     }
 
+    fn parse_usize(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<usize> {
+        get_env(key).and_then(|value| value.parse().ok())
+    }
+
+    fn parse_dp_rank_list(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<Vec<u32>> {
+        let value = get_env(key)?;
+        let mut ranks = Vec::new();
+        for part in value.split(',').map(str::trim).filter(|part| !part.is_empty()) {
+            if let Some((start, end)) = part.split_once('-') {
+                let start = start.trim().parse::<u32>().ok()?;
+                let end = end.trim().parse::<u32>().ok()?;
+                if end < start {
+                    return None;
+                }
+                ranks.extend(start..=end);
+            } else {
+                ranks.push(part.parse::<u32>().ok()?);
+            }
+        }
+        ranks.sort_unstable();
+        ranks.dedup();
+        if ranks.is_empty() { None } else { Some(ranks) }
+    }
+
     let mut config = KvRouterConfig::default();
 
     if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT") {
@@ -176,6 +208,18 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
     }
     if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_PREDICTED_TTL_SECS") {
         config.router_predicted_ttl_secs = Some(value);
+    }
+    if let Some(value) = parse_f64(&get_env, "DYN_ROUTER_DECODE_BLOCK_GUARD_FRAC") {
+        config.decode_block_guard_frac = value;
+    }
+    if let Some(value) = parse_usize(&get_env, "DYN_ROUTER_POOL_LONG_ISL_THRESHOLD") {
+        config.pool_long_isl_threshold = Some(value);
+    }
+    if let Some(value) = parse_dp_rank_list(&get_env, "DYN_ROUTER_POOL_SHORT_DP_RANKS") {
+        config.pool_short_dp_ranks = Some(value);
+    }
+    if let Some(value) = parse_usize(&get_env, "DYN_ROUTER_MAX_KV_CACHE_TOKENS") {
+        config.max_kv_cache_tokens = Some(value);
     }
 
     config
@@ -410,6 +454,10 @@ struct KvRouterConfigSerde {
     shared_cache_multiplier: f64,
     shared_cache_type: SharedCacheType,
     router_predicted_ttl_secs: Option<f64>,
+    decode_block_guard_frac: f64,
+    pool_long_isl_threshold: Option<usize>,
+    pool_short_dp_ranks: Option<Vec<u32>>,
+    max_kv_cache_tokens: Option<usize>,
 }
 
 impl Default for KvRouterConfigSerde {
@@ -444,6 +492,10 @@ impl Default for KvRouterConfigSerde {
             shared_cache_multiplier: config.shared_cache_multiplier,
             shared_cache_type: config.shared_cache_type,
             router_predicted_ttl_secs: config.router_predicted_ttl_secs,
+            decode_block_guard_frac: config.decode_block_guard_frac,
+            pool_long_isl_threshold: config.pool_long_isl_threshold,
+            pool_short_dp_ranks: config.pool_short_dp_ranks.clone(),
+            max_kv_cache_tokens: config.max_kv_cache_tokens,
         }
     }
 }
@@ -586,6 +638,34 @@ pub struct KvRouterConfig {
     #[serde(default)]
     #[validate(range(min = 0.0))]
     pub router_predicted_ttl_secs: Option<f64>,
+
+    /// Fraction of a decode worker's `total_kv_blocks` usable before the router
+    /// stops routing new requests to it (hard memory admission guard).
+    /// 1.0 (default) disables the guard. Only applied to decode workers that
+    /// report `total_kv_blocks`.
+    #[validate(range(min = 0.0, max = 1.0))]
+    #[serde(default = "default_decode_block_guard_frac")]
+    pub decode_block_guard_frac: f64,
+
+    /// ISL (in tokens) at or above which a request is routed to the "long" pool.
+    /// When set together with `pool_short_dp_ranks`, decode dp ranks are split
+    /// into a short pool (the listed ranks) and a long pool (the complement).
+    /// `None` (default) disables length-based pooling.
+    #[serde(default)]
+    pub pool_long_isl_threshold: Option<usize>,
+
+    /// dp_ranks that form the "short" request pool. Requests with
+    /// `isl < pool_long_isl_threshold` are confined to these ranks; longer
+    /// requests go to the complementary ranks. `None` (default) disables pooling.
+    #[serde(default)]
+    pub pool_short_dp_ranks: Option<Vec<u32>>,
+
+    /// Override the max KV cache size (in tokens) used by the memory guard.
+    /// When set, replaces the worker-reported `total_kv_blocks` for guard
+    /// calculations. Useful when the worker-reported value is inaccurate.
+    /// `None` (default) uses the worker-reported value.
+    #[serde(default = "default_max_kv_cache_tokens")]
+    pub max_kv_cache_tokens: Option<usize>,
 }
 
 impl Default for KvRouterConfig {
@@ -620,6 +700,10 @@ impl Default for KvRouterConfig {
             shared_cache_multiplier: 0.0,
             shared_cache_type: SharedCacheType::default(),
             router_predicted_ttl_secs: None,
+            decode_block_guard_frac: default_decode_block_guard_frac(),
+            pool_long_isl_threshold: None,
+            pool_short_dp_ranks: None,
+            max_kv_cache_tokens: default_max_kv_cache_tokens(),
         }
     }
 }
@@ -669,6 +753,10 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             shared_cache_multiplier: compat.shared_cache_multiplier,
             shared_cache_type: compat.shared_cache_type,
             router_predicted_ttl_secs: compat.router_predicted_ttl_secs,
+            decode_block_guard_frac: compat.decode_block_guard_frac,
+            pool_long_isl_threshold: compat.pool_long_isl_threshold,
+            pool_short_dp_ranks: compat.pool_short_dp_ranks,
+            max_kv_cache_tokens: compat.max_kv_cache_tokens,
         })
     }
 }

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -205,7 +205,14 @@ impl DefaultWorkerSelector {
         let adjusted_prefill_blocks = (raw_prefill_blocks - overlap_credit_blocks).max(0.0);
         let prefill_cost_blocks = weights.prefill_load_scale * adjusted_prefill_blocks;
         let worker_load = worker_load.unwrap_or_default();
-        let decode_cost_blocks = worker_load.potential_decode_blocks() as f64;
+        let decode_cost_blocks = if self.worker_type == "decode" {
+            // For decode workers, balance on running-request count (batch size) so that
+            // per-step batch sizes stay high and even; a few long requests no longer lock
+            // a dp out of new work the way raw block load would.
+            worker_load.active_requests as f64
+        } else {
+            worker_load.potential_decode_blocks() as f64
+        };
         let logit = prefill_cost_blocks + decode_cost_blocks;
 
         if shared_beyond > 0 {
@@ -420,12 +427,16 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             .unwrap_or(0);
 
         if self.worker_type == "decode" {
+            let best_active_requests = request
+                .worker_load_for(best_worker)
+                .active_requests;
             tracing::info!(
                 router_mode = "kv",
                 worker_id = best_worker.worker_id,
                 worker_type = %self.worker_type,
                 dp_rank = ?best_worker.dp_rank,
                 logit = best_logit,
+                active_requests = best_active_requests,
                 host_pinned_blocks = best_host_pinned_overlap_blocks,
                 disk_blocks = best_disk_overlap_blocks,
                 "Selected worker"

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -143,6 +143,7 @@ pub struct SequenceRequest {
     pub prefill_load_hint: Option<PrefillLoadHint>,
     pub worker: WorkerWithDpRank,
     pub lora_name: Option<String>,
+    pub isl_tokens: usize,
 }
 
 /// Multi-worker extension of [`ActiveSequences`] with per-worker `parking_lot::RwLock` for
@@ -384,6 +385,137 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.remote_state_update_count.load(Ordering::Relaxed)
     }
 
+    async fn run_replica_sync<S: SequenceSubscriber>(
+        &self,
+        mut subscriber: S,
+        cancel_token: CancellationToken,
+    ) -> anyhow::Result<()> {
+        loop {
+            tokio::select! {
+                result = subscriber.next_event() => {
+                    let Some(result) = result else {
+                        break;
+                    };
+
+                    let Ok(event) = result else {
+                        tracing::error!(
+                            "Error receiving active sequence event: {}",
+                            result.unwrap_err()
+                        );
+                        continue;
+                    };
+
+                    if event.router_id == self.router_id {
+                        continue;
+                    }
+
+                    // TODO: ActiveSequenceEvent does not carry prompt-load decay timestamps yet.
+                    // Peer routers still approximate decay anchoring with local receive time.
+                    let decay_now = Instant::now();
+                    let mut remote_capacity_changed = false;
+                    match &event.data {
+                        ActiveSequenceEventData::AddRequest {
+                            token_sequence,
+                            track_prefill_tokens,
+                            expected_output_tokens,
+                            prefill_load_hint,
+                            isl_tokens,
+                        } => {
+                            self.ensure_worker_registered(event.worker);
+                            let table = self.workers.read();
+                            if let Some(&idx) = table.index.get(&event.worker) {
+                                self.request_index.set_request(
+                                    event.request_id.clone(),
+                                    event.worker,
+                                    event.lora_name.clone(),
+                                );
+                                let (expired_request_ids, load) = {
+                                    let slot = &table.slots[idx];
+                                    let mut seq = slot.sequences.write();
+                                    let outcome = seq.add_request_with_prefill_tracking(
+                                        event.request_id.clone(),
+                                        token_sequence.clone(),
+                                        *expected_output_tokens,
+                                        *track_prefill_tokens,
+                                        *prefill_load_hint,
+                                        *isl_tokens,
+                                        decay_now,
+                                    );
+                                    let load = seq.worker_load_snapshot();
+                                    self.prompt_registry.apply_membership_delta_and_load(
+                                        event.worker,
+                                        &slot.trie_lookup,
+                                        outcome.membership_delta,
+                                        load,
+                                    );
+                                    (outcome.expired_request_ids, load)
+                                };
+                                drop(table);
+                                self.request_index.remove_requests(expired_request_ids.iter());
+                                self.publish_worker_load_snapshot(event.worker, load, decay_now);
+                                continue;
+                            } else {
+                                tracing::warn!(
+                                    "Worker {:?} not found, cannot process AddRequest",
+                                    event.worker
+                                );
+                            }
+                        }
+                        ActiveSequenceEventData::Free => {
+                            if let Some(worker) = self.request_index.remove_request(&event.request_id) {
+                                let table = self.workers.read();
+                                if let Some(&idx) = table.index.get(&worker) {
+                                    let load = {
+                                        let slot = &table.slots[idx];
+                                        let mut seq = slot.sequences.write();
+                                        let delta = seq.free(&event.request_id, decay_now);
+                                        let load = seq.worker_load_snapshot();
+                                        self.prompt_registry.apply_membership_delta_and_load(
+                                            worker,
+                                            &slot.trie_lookup,
+                                            delta,
+                                            load,
+                                        );
+                                        load
+                                    };
+                                    drop(table);
+                                    self.publish_worker_load_snapshot(worker, load, decay_now);
+                                    remote_capacity_changed = true;
+                                }
+                            }
+                        }
+                        ActiveSequenceEventData::MarkPrefillCompleted => {
+                            let worker = self.request_index.worker_for(&event.request_id);
+                            if let Some(worker) = worker {
+                                let table = self.workers.read();
+                                if let Some(&idx) = table.index.get(&worker) {
+                                    {
+                                        let mut seq = table.slots[idx].sequences.write();
+                                        seq.mark_prefill_completed(&event.request_id, decay_now);
+                                        let load = seq.worker_load_snapshot();
+                                        self.prompt_registry.replace_worker_load_state(worker, load);
+                                    }
+                                    drop(table);
+                                    remote_capacity_changed = true;
+                                }
+                            }
+                        }
+                    }
+
+                    if remote_capacity_changed {
+                        let _ = self.remote_state_updates.send(());
+                    }
+                }
+                _ = cancel_token.cancelled() => {
+                    tracing::debug!("Subscription task cancelled");
+                    break;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Register one worker and reject duplicate worker IDs.
     pub fn register_worker(&self, range: WorkerDpRange) -> Result<(), WorkerTopologyError> {
         let change = {
@@ -527,6 +659,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 track_prefill_tokens: req.track_prefill_tokens,
                 expected_output_tokens: req.expected_output_tokens,
                 prefill_load_hint: req.prefill_load_hint,
+                isl_tokens: req.isl_tokens,
             },
             router_id: self.router_id,
             lora_name: req.lora_name.clone(),
@@ -715,6 +848,16 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         self.prompt_registry.active_blocks()
     }
 
+    /// Query all workers for their current number of active (running) requests, i.e. batch size.
+    pub fn active_requests(&self) -> HashMap<WorkerWithDpRank, usize> {
+        self.prompt_registry.active_requests()
+    }
+
+    /// Query all workers for the sum of ISL tokens across their active requests.
+    pub fn active_isl_tokens(&self) -> HashMap<WorkerWithDpRank, usize> {
+        self.prompt_registry.active_isl_tokens()
+    }
+
     /// Query all workers for their current number of active tokens.
     pub fn active_tokens(&self, decay_now: Instant) -> HashMap<WorkerWithDpRank, usize> {
         self.prompt_registry.active_tokens(decay_now)
@@ -873,6 +1016,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             prefill_load_hint,
             worker,
             lora_name,
+            isl_tokens,
         } = req;
 
         let mut attempted_lazy_registration = false;
@@ -905,6 +1049,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 expected_output_tokens,
                 track_prefill_tokens,
                 prefill_load_hint,
+                isl_tokens,
                 decay_now,
             );
             let load = seq.worker_load_snapshot();
@@ -1435,6 +1580,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1603,6 +1749,7 @@ mod tests {
                     prefill_load_hint: tracking_hint(12),
                     worker: worker_a,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1624,6 +1771,7 @@ mod tests {
                     prefill_load_hint: tracking_hint(12),
                     worker: worker_b,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1680,6 +1828,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1716,6 +1865,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker: worker_a,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1730,6 +1880,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker: worker_b,
                     lora_name: Some("adapter-a".to_string()),
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1776,6 +1927,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker: worker_a,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1790,6 +1942,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker: worker_b,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -1848,6 +2001,7 @@ mod tests {
                     prefill_load_hint: tracking_hint(12),
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 Instant::now(),
             )
@@ -1927,6 +2081,7 @@ mod tests {
                     prefill_load_hint: tracking_hint(12),
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 Instant::now(),
             )
@@ -1944,6 +2099,7 @@ mod tests {
                     prefill_load_hint: tracking_hint(12),
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 Instant::now(),
             )
@@ -2208,6 +2364,7 @@ mod tests {
                         track_prefill_tokens: true,
                         expected_output_tokens: None,
                         prefill_load_hint: tracking_hint(12),
+                    isl_tokens: 0,
                     },
                     router_id: 99,
                     lora_name: None,
@@ -2433,6 +2590,7 @@ mod tests {
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
+                    isl_tokens: 0,
                 },
                 router_id: 99,
                 lora_name: None,
@@ -2531,6 +2689,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -2608,6 +2767,7 @@ mod tests {
                     prefill_load_hint: None,
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 decay_now,
             )
@@ -2659,6 +2819,7 @@ mod tests {
                     }),
                     worker,
                     lora_name: None,
+                    isl_tokens: 0,
                 },
                 start,
             )

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -34,6 +34,10 @@ pub struct WorkerLoadProjection {
     /// These blocks may still exist in an inactive cache; this field describes
     /// additional active block footprint, not cache misses.
     pub additional_active_blocks: usize,
+    /// Number of active (running) requests on this worker, i.e. its batch size.
+    pub active_requests: usize,
+    /// Sum of ISL (input sequence length in tokens) across all active requests.
+    pub active_isl_tokens: usize,
 }
 
 impl WorkerLoadProjection {
@@ -57,7 +61,10 @@ pub type PotentialLoadMaps = (
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) struct WorkerLoadSnapshot {
     pub(super) active_blocks: usize,
+    /// Number of active (running) requests on this worker, i.e. its batch size.
     pub(super) active_requests: usize,
+    /// Sum of ISL (input sequence length in tokens) across all active requests.
+    pub(super) active_isl_tokens: usize,
     pub(super) prefill: PrefillLoadSnapshot,
 }
 
@@ -334,6 +341,8 @@ impl PromptRegistry {
                     active_prefill_tokens: load.active_tokens(decay_now),
                     active_decode_blocks: load.active_blocks,
                     additional_active_blocks: query_len.saturating_sub(overlap_depth),
+                    active_requests: load.active_requests,
+                    active_isl_tokens: load.active_isl_tokens,
                 },
             );
         }
@@ -354,6 +363,20 @@ impl PromptRegistry {
             .read()
             .iter()
             .map(|(worker, load)| (worker, load.active_requests))
+            .collect()
+    }
+
+    pub(super) fn active_requests(&self) -> HashMap<WorkerWithDpRank, usize> {
+        self.loads
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().active_requests))
+            .collect()
+    }
+
+    pub(super) fn active_isl_tokens(&self) -> HashMap<WorkerWithDpRank, usize> {
+        self.loads
+            .iter()
+            .map(|entry| (*entry.key(), entry.value().active_isl_tokens))
             .collect()
     }
 
@@ -441,6 +464,7 @@ mod tests {
         WorkerLoadSnapshot {
             active_blocks,
             active_requests: 0,
+            active_isl_tokens: 0,
             prefill: PrefillLoadSnapshot::default(),
         }
     }
@@ -455,6 +479,7 @@ mod tests {
         WorkerLoadSnapshot {
             active_blocks,
             active_requests: 0,
+            active_isl_tokens: 0,
             prefill: PrefillLoadSnapshot {
                 prefill_full_tokens_sum,
                 anchored_prefill: Some(AnchoredPrefillSnapshot {

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -47,6 +47,7 @@ pub(super) struct RequestState {
     blocks: RequestBlockChain,
     started_at: Instant,
     expected_output_tokens: Option<u32>,
+    isl_tokens: usize,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -173,6 +174,7 @@ impl ActiveSequences {
         expected_output_tokens: Option<u32>,
         track_prefill_tokens: bool,
         prefill_load_hint: Option<PrefillLoadHint>,
+        isl_tokens: usize,
         decay_now: Instant,
     ) -> SequenceMutationOutcome {
         if self.requests.contains_key(&request_id) {
@@ -214,6 +216,7 @@ impl ActiveSequences {
                 blocks,
                 started_at,
                 expected_output_tokens,
+                isl_tokens,
             },
         );
 
@@ -323,6 +326,7 @@ impl ActiveSequences {
         WorkerLoadSnapshot {
             active_blocks: self.active_blocks(),
             active_requests: self.requests.len(),
+            active_isl_tokens: self.requests.values().map(|r| r.isl_tokens).sum(),
             prefill: self.prefill.snapshot(),
         }
     }
@@ -393,6 +397,7 @@ mod tests {
             None,
             true,
             tracking_hint(8),
+                0,
             decay_now,
         );
         assert_eq!(
@@ -413,6 +418,7 @@ mod tests {
             None,
             true,
             tracking_hint(12),
+                0,
             decay_now,
         );
         assert_eq!(
@@ -452,6 +458,7 @@ mod tests {
             None,
             true,
             tracking_hint(12),
+                0,
             decay_now,
         );
         assert_eq!(
@@ -503,6 +510,7 @@ mod tests {
             None,
             true,
             tracking_hint(12),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_blocks(), 3);
@@ -514,6 +522,7 @@ mod tests {
             None,
             true,
             tracking_hint(4),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_blocks(), 4);
@@ -525,6 +534,7 @@ mod tests {
             None,
             true,
             tracking_hint(0),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_blocks(), 5);
@@ -555,6 +565,7 @@ mod tests {
             None,
             true,
             tracking_hint(12),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_blocks(), 3);
@@ -572,6 +583,7 @@ mod tests {
             None,
             true,
             tracking_hint(8),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_blocks(), 2);
@@ -601,6 +613,7 @@ mod tests {
             None,
             true,
             tracking_hint(12),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_tokens(decay_now), 12);
@@ -617,6 +630,7 @@ mod tests {
             None,
             true,
             tracking_hint(8),
+                0,
             decay_now,
         );
         assert_eq!(seq_manager.active_tokens(decay_now), 8);
@@ -636,6 +650,7 @@ mod tests {
             None,
             false,
             None,
+                0,
             decay_now,
         );
 
@@ -660,6 +675,7 @@ mod tests {
             None,
             true,
             Some(prefill_hint(50, 10)),
+                0,
             decay_now,
         );
         seq_manager.add_request_with_prefill_tracking(
@@ -668,6 +684,7 @@ mod tests {
             None,
             true,
             Some(prefill_hint(30, 10)),
+                0,
             decay_now,
         );
 
@@ -710,6 +727,7 @@ mod tests {
             None,
             true,
             tracking_hint(8),
+            0,
             Instant::now(),
         );
         seq_manager.add_request_with_prefill_tracking(
@@ -718,6 +736,7 @@ mod tests {
             None,
             true,
             tracking_hint(8),
+            0,
             Instant::now(),
         );
         assert_eq!(seq_manager.active_blocks(), 4);
@@ -756,6 +775,7 @@ mod tests {
             None,
             true,
             tracking_hint(4),
+            0,
             Instant::now(),
         );
         assert!(expired.expired_request_ids.is_empty());
@@ -775,6 +795,7 @@ mod tests {
             None,
             true,
             Some(prefill_hint(40, 100)),
+                0,
             first_decay_now,
         );
         tokio::time::advance(Duration::from_secs(250)).await;
@@ -784,6 +805,7 @@ mod tests {
             None,
             true,
             Some(prefill_hint(30, 100)),
+            0,
             Instant::now(),
         );
 

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -478,6 +478,7 @@ mod tests {
                     initial_effective_prefill_tokens: 12,
                     expected_prefill_duration: None,
                 }),
+                0,
                 Instant::now(),
             );
             assert_eq!(outcome.membership_delta.stores[0].path, vec![1, 2, 3]);

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -796,6 +796,7 @@ where
                 prefill_load_hint,
                 worker,
                 lora_name,
+                isl_tokens,
             })
             .await
         {

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -574,6 +574,7 @@ impl OfflineReplayRouter {
                     prefill_load_hint,
                     worker: selection.worker,
                     lora_name: None,
+                    isl_tokens: request.isl_tokens,
                 },
                 decay_now,
             )


### PR DESCRIPTION
…nfigurable balance metric

Add decode-side routing controls for length-skewed workloads:
- pool_long_isl_threshold + pool_short_dp_ranks: split decode dp ranks into short/long pools by request ISL
- decode_block_guard_frac: hard memory admission guard per dp rank

Change-Id: I6bdc218ce108a0e9751a762a9e97b354b079a24c

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

Add decode-side routing controls for length-skewed workloads:
- \`pool_long_isl_threshold\` + \`pool_short_dp_ranks\`: split decode dp ranks into short/long pools by request ISL, preventing long requests from crowding out short ones
- \`decode_block_guard_frac\`: hard memory admission guard per dp rank; router stops sending to a dp rank when projected memory usage exceeds \`guard_frac * total_kv_blocks\`
- \`max_kv_cache_tokens\`: override worker-reported KV cache size for guard calculations
- Decode worker cost function now uses batch-size (\`active_requests\`) instead of block count for more even load distribution across dp ranks
- New env vars: \`DYN_ROUTER_DECODE_BLOCK_GUARD_FRAC\`, \`DYN_ROUTER_POOL_LONG_ISL_THRESHOLD\`, \`DYN_ROUTER_POOL_SHORT_DP_RANKS\`, \`DYN_ROUTER_MAX_KV_CACHE_TOKENS\`

All new fields default to their off/disabled values so existing deployments are unaffected.

## Validation

- \`cargo check -p dynamo-kv-router\` passes
- Python config args, PyO3 bindings, and CLI flags expose all new options
- Existing unit tests in selector, queue, and sequences pass
- Merge-conflict resolution preserves main's \`SchedulingRequest\` structure (\`worker_loads\` projection model), cancel-rollback semantics, and \`router_predicted_ttl_secs\` predict-on-route feature"