### PR TITLE
fix(frontend): map backend invalid arguments to HTTP 400

### DIFF
--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -28,6 +28,7 @@ from dynamo.runtime import DistributedRuntime
 
 MSG_CONTAINS_ERROR = "This message contains an 400error."
 MSG_CONTAINS_STATUS_ERROR = "This message contains a 415 status error."
+MSG_CONTAINS_INVALID_ARGUMENT = "This message contains an invalid argument."
 MSG_CONTAINS_INTERNAL_ERROR = "This message contains an internal server error."
 
 
@@ -55,7 +56,7 @@ class MockHttpEngine:
 
     async def generate(self, request: Dict, context) -> AsyncGenerator[Dict, None]:
         """
-        Raises HttpError if message contains 'error', otherwise streams a mock response.
+        Raises the requested exception, otherwise streams a mock response.
         """
         user_message = ""
         for message in request.get("messages", []):
@@ -71,8 +72,10 @@ class MockHttpEngine:
             raise HttpError(code=400, message=MSG_CONTAINS_ERROR)
         elif MSG_CONTAINS_STATUS_ERROR.lower() in user_message.lower():
             raise _StatusLikeError(status=415, message=MSG_CONTAINS_STATUS_ERROR)
+        elif MSG_CONTAINS_INVALID_ARGUMENT.lower() in user_message.lower():
+            raise ValueError(MSG_CONTAINS_INVALID_ARGUMENT)
         elif MSG_CONTAINS_INTERNAL_ERROR.lower() in user_message.lower():
-            raise ValueError("Simulated internal error")
+            raise RuntimeError("Simulated internal error")
 
         # Stream a mock response
         created = int(time.time())
@@ -176,38 +179,52 @@ async def test_chat_completion_success(http_server):
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "msg_to_code",
+    ("trigger", "status", "expected_message", "expected_type"),
     [
-        (MSG_CONTAINS_ERROR, 400),
-        (MSG_CONTAINS_STATUS_ERROR, 415),
-        (MSG_CONTAINS_INTERNAL_ERROR, 500),
+        (MSG_CONTAINS_ERROR, 400, MSG_CONTAINS_ERROR, "Bad Request"),
+        (
+            MSG_CONTAINS_STATUS_ERROR,
+            415,
+            MSG_CONTAINS_STATUS_ERROR,
+            "Unsupported Media Type",
+        ),
+        (
+            MSG_CONTAINS_INVALID_ARGUMENT,
+            400,
+            f"ValueError: {MSG_CONTAINS_INVALID_ARGUMENT}",
+            "Bad Request",
+        ),
+        (
+            MSG_CONTAINS_INTERNAL_ERROR,
+            500,
+            "Internal server error",
+            "Internal Server Error",
+        ),
     ],
 )
 @pytest.mark.forked
-async def test_chat_completion_http_error(http_server, msg_to_code: tuple[str, int]):
-    """Tests that an HttpError is raised when the message contains 'error'."""
+async def test_chat_completion_http_error(
+    http_server,
+    trigger: str,
+    status: int,
+    expected_message: str,
+    expected_type: str,
+):
+    """Tests that backend exceptions map to the expected HTTP responses."""
     base_url, model_name = http_server
     url = f"{base_url}/v1/chat/completions"
     data = {
         "model": model_name,
-        "messages": [{"role": "user", "content": msg_to_code[0]}],
+        "messages": [{"role": "user", "content": trigger}],
     }
     async with aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=10)
     ) as session:
         async with session.post(url, json=data) as response:
-            assert response.status == msg_to_code[1]
+            assert response.status == status
             error_json = await response.json()
-            if msg_to_code[0] == MSG_CONTAINS_ERROR:
-                # 4xx HTTP protocol contract: backend message is forwarded
-                # to the client so callers can react to validation errors.
-                assert MSG_CONTAINS_ERROR in str(error_json)
-            elif msg_to_code[0] == MSG_CONTAINS_STATUS_ERROR:
-                # Same 4xx contract via the duck-typed `.status` path.
-                assert MSG_CONTAINS_STATUS_ERROR in str(error_json)
-            elif msg_to_code[0] == MSG_CONTAINS_INTERNAL_ERROR:
-                # 5xx is sanitized: the client receives a static message
-                # and never the raw backend error text; the underlying
-                # detail is logged server-side.
-                assert "simulated internal error" not in str(error_json).lower()
-                assert "internal server error" in str(error_json).lower()
+            assert error_json == {
+                "message": expected_message,
+                "type": expected_type,
+                "code": status,
+            }

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -1434,6 +1434,17 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
     if let Some(event_type) = &event.event
         && event_type == "error"
     {
+        use dynamo_runtime::error::{BackendError, ErrorType};
+
+        // Classify only this event's error, not its causes. An inner invalid
+        // argument must not override an outer unavailable or internal error.
+        let invalid_argument = event.error.as_ref().filter(|error| {
+            matches!(
+                error.error_type(),
+                ErrorType::InvalidArgument | ErrorType::Backend(BackendError::InvalidArgument)
+            )
+        });
+
         // Extract error string: prefer DynamoError field, fallback to legacy comment.
         // Use message() instead of to_string() for DynamoError to avoid prefixing
         // the ErrorType (e.g., "Unknown: {...}"), which would break JSON parsing.
@@ -1457,14 +1468,34 @@ fn extract_backend_error_if_present<T: serde::Serialize>(
                 .unwrap_or_else(|| "Unknown error".to_string())
         };
 
-        // Try to parse as error JSON to extract status code
-        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(&error_str) {
-            let code = error_payload
-                .code
-                .and_then(|c| StatusCode::from_u16(c).ok())
-                .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
-            let message = error_payload.message.unwrap_or(error_str);
+        // Parse the status-bearing node's own message. The diagnostic string
+        // above includes its causes and therefore is not necessarily JSON.
+        let status_message = event
+            .error
+            .as_ref()
+            .map(|error| error.message())
+            .unwrap_or(&error_str);
+        if let Ok(error_payload) = serde_json::from_str::<ErrorPayload>(status_message) {
+            // Preserve explicit HTTP-like statuses (for example 415); Python
+            // 4xx exceptions share the Backend(InvalidArgument) category.
+            let code = match error_payload.code {
+                Some(code) => {
+                    StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR)
+                }
+                None if invalid_argument.is_some() => StatusCode::BAD_REQUEST,
+                None => StatusCode::INTERNAL_SERVER_ERROR,
+            };
+            let message = error_payload
+                .message
+                .unwrap_or_else(|| status_message.to_string());
             return Some((message, code));
+        }
+
+        if let Some(invalid_argument) = invalid_argument {
+            return Some((
+                invalid_argument.message().to_string(),
+                StatusCode::BAD_REQUEST,
+            ));
         }
 
         return Some((error_str, StatusCode::INTERNAL_SERVER_ERROR));
@@ -4584,6 +4615,42 @@ mod tests {
                     .message
                     .contains("Backend service unavailable")
             );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_check_for_backend_error_with_typed_invalid_argument() {
+        use crate::types::openai::chat_completions::NvCreateChatCompletionStreamResponse;
+        use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+        use futures::stream;
+
+        for error_type in [
+            ErrorType::InvalidArgument,
+            ErrorType::Backend(BackendError::InvalidArgument),
+        ] {
+            let error_event = Annotated::<NvCreateChatCompletionStreamResponse> {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(
+                    DynamoError::builder()
+                        .error_type(error_type)
+                        .message("unsupported JSON schema keyword")
+                        .build(),
+                ),
+            };
+
+            let result = check_for_backend_error(stream::iter(vec![error_event])).await;
+
+            let error_response = match result {
+                Err(error_response) => error_response,
+                Ok(_) => panic!("typed invalid argument must fail"),
+            };
+            assert_eq!(error_response.0, StatusCode::BAD_REQUEST);
+            assert_eq!(error_response.1.code, StatusCode::BAD_REQUEST.as_u16());
+            assert_eq!(error_response.1.error_type, "Bad Request");
+            assert_eq!(error_response.1.message, "unsupported JSON schema keyword");
         }
     }
 


### PR DESCRIPTION
## Summary

- Cherry-pick of #11453 to `release/1.3.0`
- Map top-level `InvalidArgument` and `Backend(InvalidArgument)` errors from the annotated first-event path to HTTP 400
- Preserve explicit backend HTTP statuses and existing 5xx sanitization behavior

Fixes DIS-2346

## Original PR

- Main PR: #11453
- Merge commit: `b720811f65c4e76618f6cd5ee1b681711ff345a0`
- Backport commit: `d3644e2297257b2ccc906b0ebec524482b1376e7`

## Test plan

- [x] `cargo test --locked -p dynamo-llm --lib --no-default-features test_check_for_backend_error -- --nocapture` — 11 passed
- [x] `lib/bindings/python/tests/test_http_server.py` — 5 passed against a freshly built extension
- [x] `cargo fmt --all -- --check`
- [x] Ruff check and format check
- [x] Source/backport stable patch IDs match; `git diff --check`; GPG signature verified
- [ ] CI passes