### PR TITLE
fix(vllm): update Qwen3-TTS prompt estimator

### DIFF
--- a/components/src/dynamo/vllm/omni/audio_handler.py
+++ b/components/src/dynamo/vllm/omni/audio_handler.py
@@ -380,8 +380,8 @@ class AudioGenerationHandler:
         Falls back to 2048 if the model-specific estimator is unavailable.
         """
         try:
-            from vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker import (
-                Qwen3TTSTalkerForConditionalGeneration,
+            from vllm_omni.model_executor.models.qwen3_tts.prompt_embeds_builder import (
+                Qwen3TTSPromptEmbedsBuilder,
             )
 
             if not hasattr(self, "_tts_tokenizer") or self._tts_tokenizer is None:
@@ -397,7 +397,7 @@ class AudioGenerationHandler:
             talker_config = getattr(hf_config, "talker_config", None)
             task_type = (tts_params.get("task_type") or ["CustomVoice"])[0]
 
-            return Qwen3TTSTalkerForConditionalGeneration.estimate_prompt_len_from_additional_information(
+            return Qwen3TTSPromptEmbedsBuilder.estimate_prompt_len_from_additional_information(
                 additional_information=tts_params,
                 task_type=task_type,
                 tokenize_prompt=lambda t: self._tts_tokenizer(t, padding=False)[

--- a/components/src/dynamo/vllm/omni/audio_handler.py
+++ b/components/src/dynamo/vllm/omni/audio_handler.py
@@ -11,7 +11,15 @@ import base64
 import logging
 from typing import Any, Dict
 
+from transformers import AutoTokenizer
 from vllm_omni.inputs.data import OmniTextPrompt
+
+try:
+    from vllm_omni.model_executor.models.qwen3_tts.prompt_embeds_builder import (
+        Qwen3TTSPromptEmbedsBuilder,
+    )
+except ImportError:
+    Qwen3TTSPromptEmbedsBuilder = None  # type: ignore[assignment, misc]
 
 from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
 from dynamo.common.utils.output_modalities import RequestType
@@ -379,25 +387,25 @@ class AudioGenerationHandler:
 
         Falls back to 2048 if the model-specific estimator is unavailable.
         """
-        try:
-            from vllm_omni.model_executor.models.qwen3_tts.prompt_embeds_builder import (
-                Qwen3TTSPromptEmbedsBuilder,
+        if Qwen3TTSPromptEmbedsBuilder is None:
+            logger.warning(
+                "Qwen3-TTS prompt estimator is unavailable, using fallback 2048"
+            )
+            return 2048
+
+        if not hasattr(self, "_tts_tokenizer") or self._tts_tokenizer is None:
+            self._tts_tokenizer = AutoTokenizer.from_pretrained(
+                self.config.model,
+                trust_remote_code=self.config.engine_args.trust_remote_code,
+                padding_side="left",
             )
 
-            if not hasattr(self, "_tts_tokenizer") or self._tts_tokenizer is None:
-                from transformers import AutoTokenizer
+        hf_config = self.engine_client.model_config.hf_config
+        talker_config = getattr(hf_config, "talker_config", None)
+        task_type = (tts_params.get("task_type") or ["CustomVoice"])[0]
 
-                self._tts_tokenizer = AutoTokenizer.from_pretrained(
-                    self.config.model,
-                    trust_remote_code=self.config.engine_args.trust_remote_code,
-                    padding_side="left",
-                )
-
-            hf_config = self.engine_client.model_config.hf_config
-            talker_config = getattr(hf_config, "talker_config", None)
-            task_type = (tts_params.get("task_type") or ["CustomVoice"])[0]
-
-            return Qwen3TTSPromptEmbedsBuilder.estimate_prompt_len_from_additional_information(
+        return (
+            Qwen3TTSPromptEmbedsBuilder.estimate_prompt_len_from_additional_information(
                 additional_information=tts_params,
                 task_type=task_type,
                 tokenize_prompt=lambda t: self._tts_tokenizer(t, padding=False)[
@@ -414,8 +422,4 @@ class AudioGenerationHandler:
                     else None
                 ),
             )
-        except Exception as e:
-            logger.warning(
-                "Failed to estimate TTS prompt length, using fallback 2048: %s", e
-            )
-            return 2048
+        )

--- a/components/src/dynamo/vllm/tests/omni/test_audio_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_audio_handler.py
@@ -3,6 +3,8 @@
 
 """Unit tests for AudioGenerationHandler."""
 
+import sys
+from types import ModuleType, SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -156,6 +158,31 @@ class TestIsTtsModel:
         handler = _make_audio_handler()
         handler.engine_client.stage_list = None
         assert handler._is_tts_model() is False
+
+
+def test_tts_prompt_len_uses_prompt_embeds_builder(monkeypatch):
+    module_name = "vllm_omni.model_executor.models.qwen3_tts.prompt_embeds_builder"
+    estimator = MagicMock(return_value=37)
+    module = ModuleType(module_name)
+    module.Qwen3TTSPromptEmbedsBuilder = SimpleNamespace(
+        estimate_prompt_len_from_additional_information=estimator
+    )
+    monkeypatch.setitem(sys.modules, module_name, module)
+
+    legacy_module_name = "vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker"
+    monkeypatch.setitem(sys.modules, legacy_module_name, ModuleType(legacy_module_name))
+
+    handler = _make_audio_handler()
+    handler._tts_tokenizer = lambda _text, padding: {"input_ids": [1, 2]}
+    handler.engine_client.model_config.hf_config = SimpleNamespace(
+        talker_config=SimpleNamespace(
+            codec_language_id={"english": 1},
+            spk_is_dialect={"vivian": "english"},
+        )
+    )
+
+    assert handler._estimate_tts_prompt_len({"task_type": ["CustomVoice"]}) == 37
+    estimator.assert_called_once()
 
 
 class TestEngineInputsFromAudio:

--- a/components/src/dynamo/vllm/tests/omni/test_audio_handler.py
+++ b/components/src/dynamo/vllm/tests/omni/test_audio_handler.py
@@ -3,8 +3,7 @@
 
 """Unit tests for AudioGenerationHandler."""
 
-import sys
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -12,6 +11,7 @@ import pytest
 try:
     from dynamo.common.protocols.audio_protocol import NvCreateAudioSpeechRequest
     from dynamo.common.utils.output_modalities import RequestType
+    from dynamo.vllm.omni import audio_handler as audio_handler_module
     from dynamo.vllm.omni.audio_handler import AudioGenerationHandler
 except ImportError:
     pytest.skip("vLLM omni dependencies not available", allow_module_level=True)
@@ -161,28 +161,55 @@ class TestIsTtsModel:
 
 
 def test_tts_prompt_len_uses_prompt_embeds_builder(monkeypatch):
-    module_name = "vllm_omni.model_executor.models.qwen3_tts.prompt_embeds_builder"
     estimator = MagicMock(return_value=37)
-    module = ModuleType(module_name)
-    module.Qwen3TTSPromptEmbedsBuilder = SimpleNamespace(
-        estimate_prompt_len_from_additional_information=estimator
+    monkeypatch.setattr(
+        audio_handler_module,
+        "Qwen3TTSPromptEmbedsBuilder",
+        SimpleNamespace(estimate_prompt_len_from_additional_information=estimator),
     )
-    monkeypatch.setitem(sys.modules, module_name, module)
-
-    legacy_module_name = "vllm_omni.model_executor.models.qwen3_tts.qwen3_tts_talker"
-    monkeypatch.setitem(sys.modules, legacy_module_name, ModuleType(legacy_module_name))
 
     handler = _make_audio_handler()
-    handler._tts_tokenizer = lambda _text, padding: {"input_ids": [1, 2]}
+    tokenizer = MagicMock(return_value={"input_ids": [1, 2]})
+    handler._tts_tokenizer = tokenizer
+    codec_language_id = {"english": 1}
+    spk_is_dialect = {"vivian": "english"}
     handler.engine_client.model_config.hf_config = SimpleNamespace(
         talker_config=SimpleNamespace(
-            codec_language_id={"english": 1},
-            spk_is_dialect={"vivian": "english"},
+            codec_language_id=codec_language_id,
+            spk_is_dialect=spk_is_dialect,
         )
     )
+    tts_params = {"task_type": ["CustomVoice"], "input": "hello"}
 
-    assert handler._estimate_tts_prompt_len({"task_type": ["CustomVoice"]}) == 37
-    estimator.assert_called_once()
+    assert handler._estimate_tts_prompt_len(tts_params) == 37
+
+    kwargs = estimator.call_args.kwargs
+    assert kwargs["additional_information"] is tts_params
+    assert kwargs["task_type"] == "CustomVoice"
+    assert kwargs["codec_language_id"] is codec_language_id
+    assert kwargs["spk_is_dialect"] is spk_is_dialect
+    assert kwargs["tokenize_prompt"]("hello") == [1, 2]
+    tokenizer.assert_called_once_with("hello", padding=False)
+
+
+def test_tts_prompt_len_falls_back_when_builder_is_unavailable(monkeypatch):
+    monkeypatch.setattr(audio_handler_module, "Qwen3TTSPromptEmbedsBuilder", None)
+
+    assert _make_audio_handler()._estimate_tts_prompt_len({}) == 2048
+
+
+def test_tts_prompt_len_propagates_estimator_errors(monkeypatch):
+    estimator = MagicMock(side_effect=RuntimeError("estimator failed"))
+    monkeypatch.setattr(
+        audio_handler_module,
+        "Qwen3TTSPromptEmbedsBuilder",
+        SimpleNamespace(estimate_prompt_len_from_additional_information=estimator),
+    )
+    handler = _make_audio_handler()
+    handler._tts_tokenizer = MagicMock(return_value={"input_ids": [1, 2]})
+
+    with pytest.raises(RuntimeError, match="estimator failed"):
+        handler._estimate_tts_prompt_len({})
 
 
 class TestEngineInputsFromAudio:


### PR DESCRIPTION
## Overview:

Qwen3-TTS prompt-length estimation imports the estimator from the talker model. Current vLLM-Omni exposes it on `Qwen3TTSPromptEmbedsBuilder`, so the stale import falls back to the generic 2048-token estimate.

## Details:

- Call the prompt-length estimator through `Qwen3TTSPromptEmbedsBuilder`.
- Add a focused regression test that exposes the current builder API while omitting the legacy talker estimator.

This keeps Dynamo aligned with the current vLLM-Omni API. Accurate prompt length matters because Qwen3-TTS uses placeholder tokens for model-side prompt embeddings; the generic fallback can produce invalid or poor-quality audio.

## Where should the reviewer start?

`components/src/dynamo/vllm/omni/audio_handler.py` contains the estimator API update. The regression test is in `components/src/dynamo/vllm/tests/omni/test_audio_handler.py`.

## Testing

- Verified the regression test fails before the fix with `assert 2048 == 37` and passes after it.
- Full audio-handler unit file: `19 passed`.
- Dynamo pre-commit hooks passed for both changed files.
- Sent a real Qwen3-TTS request through Dynamo using the fixed source and no local estimator patch: HTTP 200, valid non-silent 24 kHz mono WAV, and local Whisper reproduced the requested sentence exactly.

## Related Issues

**This PR is linked to an issue:**

- Relates to [DYN-3479](https://linear.app/nvidia/issue/DYN-3479/voice-make-the-local-stt-reference-agent-work-on-unmodified)