### PR TITLE
feat(compliance): backport OSRB CSV diffs to 1.3.0

### DIFF
--- a/.github/actions/changed-files/action.yml
+++ b/.github/actions/changed-files/action.yml
@@ -52,6 +52,12 @@ outputs:
   docs:
     description: 'Whether docs files changed'
     value: ${{ steps.filter.outputs.docs_any_modified }}
+  base_ref:
+    description: 'PR target branch (baseRefName) for push-to-pull-request/N events; empty otherwise. Used for OSRB compliance-diff baseline selection.'
+    value: ${{ steps.merge-base.outputs.base_ref }}
+  merge_base_sha:
+    description: 'True PR merge-base SHA for push-to-pull-request/N events; empty otherwise. Used as the stable OSRB diff baseline starting point.'
+    value: ${{ steps.merge-base.outputs.base_sha }}
 
 runs:
   using: "composite"
@@ -87,8 +93,12 @@ runs:
           # Fetch the merge-base commit so tj-actions can `git diff` against it.
           git fetch --no-tags --depth=1 origin "$BASE_SHA"
           echo "base_sha=$BASE_SHA" >> "$GITHUB_OUTPUT"
+          # Expose the PR's target branch for the OSRB compliance-diff baseline
+          # selection (main vs release/*). See resolve_diff_base.py.
+          echo "base_ref=$BASE" >> "$GITHUB_OUTPUT"
         else
           echo "base_sha=" >> "$GITHUB_OUTPUT"
+          echo "base_ref=" >> "$GITHUB_OUTPUT"
         fi
 
     - name: Check for changes

--- a/.github/actions/compliance-extract/action.yml
+++ b/.github/actions/compliance-extract/action.yml
@@ -57,6 +57,35 @@ inputs:
     description: 'SCCACHE region (= aws_default_region the build passed). See sccache_bucket.'
     required: false
     default: ''
+  diff_base_sha:
+    description: |
+      Commit SHA of the baseline build to diff this build's OSRB CSV against
+      (resolved by container/compliance/resolve_diff_base.py in the caller).
+      Empty means "no baseline" — the diff step then writes a baseline_unavailable
+      marker instead of a real diff. resolve_diff_base.py also supplies the exact
+      artifact id used to fetch the prior build's CSV.
+    required: false
+    default: ''
+  diff_base_label:
+    description: 'Human label for the diff baseline (from resolve_diff_base.py); shown in the baseline_unavailable marker row when the baseline can''t be fetched.'
+    required: false
+    default: ''
+  diff_base_artifact_id:
+    description: 'Exact GitHub Actions artifact id resolved by resolve_diff_base.py.'
+    required: false
+    default: ''
+  diff_base_run_id:
+    description: 'Workflow run id that generated the baseline artifact; used for the link in BASELINE.md.'
+    required: false
+    default: ''
+  gh_token:
+    description: |
+      Token with `actions: read` used to download the baseline compliance
+      artifact from its (different) workflow run. Pass
+      secrets.GITHUB_TOKEN. When empty, the diff step skips the fetch and emits a
+      baseline_unavailable marker.
+    required: false
+    default: ''
 
 runs:
   using: 'composite'
@@ -144,6 +173,133 @@ runs:
         fi
         echo "Named OSRB files for ${IMG} @ ${SHA8}:"
         find /tmp/compliance -name 'osrb-*' -print
+
+    # Download the baseline build's compliance artifact so we can diff against
+    # it. The resolver supplies the exact artifact id and generating run id, so
+    # this step downloads directly without searching the artifact list again.
+    # Any miss (expired retention, never built, no token) leaves
+    # /tmp/compliance-base empty — the diff step then writes a
+    # baseline_unavailable marker rather than failing the build.
+    - name: Fetch baseline compliance artifact
+      id: fetch-baseline
+      if: ${{ inputs.diff_base_artifact_id != '' && inputs.gh_token != '' }}
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.gh_token }}
+        REPO: ${{ github.repository }}
+        ARTIFACT_ID: ${{ inputs.diff_base_artifact_id }}
+        BASE_RUN_ID: ${{ inputs.diff_base_run_id }}
+      run: |
+        set -euo pipefail
+        ARCHIVE="${RUNNER_TEMP}/compliance-baseline-${ARTIFACT_ID}.zip"
+        mkdir -p /tmp/compliance-base
+        if [ -n "${BASE_RUN_ID}" ]; then
+          echo "baseline_run_id=${BASE_RUN_ID}" >> "$GITHUB_OUTPUT"
+        fi
+        if gh api -X GET "/repos/${REPO}/actions/artifacts/${ARTIFACT_ID}/zip" \
+          > "${ARCHIVE}" && unzip -q "${ARCHIVE}" -d /tmp/compliance-base; then
+          echo "Downloaded baseline artifact ${ARTIFACT_ID}."
+          echo "baseline_available=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "Baseline download failed; diff will mark it unavailable."
+          echo "baseline_available=false" >> "$GITHUB_OUTPUT"
+        fi
+
+    # Emit osrb-<image>-<arch>-<sha8>.diff.csv next to each full CSV, comparing
+    # this build against the baseline, plus a self-describing baseline/ folder
+    # (metadata + a copy of the baseline CSV) so the archive documents exactly
+    # what the diff was taken against. Always runs so a diff file (real or a
+    # baseline_unavailable marker) always ships. The base CSV, if present, lives
+    # under /tmp/compliance-base/linux_<arch>/ with a different sha8 (matched by
+    # glob per arch).
+    - name: Compute OSRB diff
+      if: always()
+      shell: bash
+      env:
+        REPO: ${{ github.repository }}
+        BASE_SHA: ${{ inputs.diff_base_sha }}
+        BASE_LABEL: ${{ inputs.diff_base_label }}
+        BASE_RUN_ID: ${{ steps.fetch-baseline.outputs.baseline_run_id }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+
+        # Write baseline/ (metadata + baseline CSV copy) into an arch dir.
+        # $1 = arch dir, $2 = baseline CSV path ('' when unavailable).
+        write_baseline_folder() {
+          local dir="$1/baseline" base_csv="$2"
+          mkdir -p "${dir}"
+          {
+            echo "# OSRB diff baseline"
+            echo
+            echo "The \`*.diff.csv\` next to this folder compares this build's OSRB"
+            echo "dependency CSV against the baseline described below."
+            echo
+            echo "## How the baseline is chosen (by build context)"
+            echo "- PR targeting \`main\` -> PR merge-base (or nearest earlier commit with an artifact)"
+            echo "- Post-merge on \`main\` -> the previous commit on \`main\`"
+            echo "- PR / post-merge on \`release/*\` -> highest release tag \`vX.Y.Z\` strictly older than the current version (semver first, later publish date breaks same-version ties)"
+            echo "- Nightly -> the previous successful scheduled nightly run (manual runs excluded)"
+            echo
+            echo "## This build's baseline"
+            echo "- Label: ${BASE_LABEL:-(none)}"
+            if [ -n "${BASE_SHA}" ]; then
+              echo "- Baseline commit SHA: \`${BASE_SHA}\`"
+              echo "- Commit: https://github.com/${REPO}/commit/${BASE_SHA}"
+            else
+              echo "- Baseline commit SHA: (none — no baseline was available)"
+            fi
+            if [ -n "${BASE_RUN_ID:-}" ] && [ "${BASE_RUN_ID}" != "null" ]; then
+              echo "- Generating workflow run: https://github.com/${REPO}/actions/runs/${BASE_RUN_ID}"
+            fi
+            if [ -n "${base_csv}" ]; then
+              echo "- Baseline CSV (copied into this folder): \`$(basename "${base_csv}")\`"
+            else
+              echo "- Baseline CSV: unavailable (expired artifact, first build of the line, or no prior run)"
+            fi
+          } > "${dir}/BASELINE.md"
+          if [ -n "${base_csv}" ]; then cp "${base_csv}" "${dir}/"; fi
+          echo "Wrote baseline folder: ${dir}"
+        }
+
+        diff_one() {  # $1 = current CSV, $2 = arch dir name (e.g. linux_amd64)
+          local cur="$1" arch_dir="$2"
+          local out="${cur%.csv}.diff.csv"
+          local base_csv="" base_arg=()
+          # Pick the baseline's full CSV, skipping its own *.diff.csv sibling
+          # (baseline artifacts now ship a diff too, and osrb-*.csv would match it).
+          for cand in /tmp/compliance-base/"${arch_dir}"/osrb-*.csv; do
+            [ -f "${cand}" ] || continue
+            case "${cand}" in *.diff.csv) continue;; esac
+            base_csv="${cand}"
+            base_arg=(--base "${base_csv}")
+            break
+          done
+          python3 container/compliance/diff_osrb_csv.py \
+            --current "${cur}" \
+            "${base_arg[@]}" \
+            --baseline-label "${BASE_LABEL}" \
+            --output "${out}"
+          echo "Wrote diff: ${out}"
+          write_baseline_folder "$(dirname "${cur}")" "${base_csv}"
+        }
+        found=0
+        for d in /tmp/compliance/linux_*; do
+          [ -d "$d" ] || continue
+          for cur in "$d"/osrb-*.csv; do
+            [ -f "$cur" ] || continue
+            case "$cur" in *.diff.csv) continue;; esac
+            found=1
+            diff_one "$cur" "$(basename "$d")"
+          done
+        done
+        if [ "${found}" -eq 0 ]; then  # single-platform: files directly under dest
+          for cur in /tmp/compliance/osrb-*.csv; do
+            [ -f "$cur" ] || continue
+            case "$cur" in *.diff.csv) continue;; esac
+            diff_one "$cur" "."
+          done
+        fi
 
     # /sources/ — reproducible tarball of source archives for everything we
     # ship on top of the FROM base. Bigger than legal/sboms (typically

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -26,6 +26,11 @@ on:
 
 permissions:
   contents: read
+  # Lets the build jobs' compliance-extract query the Actions API for the
+  # previous successful cron-triggered nightly run (manual runs are excluded)
+  # and download its baseline compliance artifact to diff the OSRB CSV against.
+  # A reusable workflow's token can't exceed the caller's.
+  actions: read
 
 
 env:
@@ -258,6 +263,10 @@ jobs:
       # context includes deploy/inference-gateway/ext-proc (a cargo vendor
       # workspace member).
       archive_sources: false
+      # OSRB CSV diff baseline: nightly context -> diff against the previous
+      # successful scheduled nightly run's compliance artifacts; manual runs
+      # are excluded (see resolve_diff_base.py).
+      diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit
@@ -275,6 +284,10 @@ jobs:
       inline_compliance: true
       build_timeout_minutes: 120
       archive_sources: false
+      # OSRB CSV diff baseline: nightly context -> diff against the previous
+      # successful scheduled nightly run's compliance artifacts; manual runs
+      # are excluded (see resolve_diff_base.py).
+      diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit
@@ -292,6 +305,10 @@ jobs:
       inline_compliance: true
       build_timeout_minutes: 120
       archive_sources: false
+      # OSRB CSV diff baseline: nightly context -> diff against the previous
+      # successful scheduled nightly run's compliance artifacts; manual runs
+      # are excluded (see resolve_diff_base.py).
+      diff_event_context: nightly
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -18,6 +18,10 @@ on:
 
 permissions:
   contents: read
+  # Lets the build jobs' compliance-extract download a PRIOR run's baseline
+  # compliance artifact (cross-run) to diff the OSRB CSV against. A reusable
+  # workflow's token can't exceed the caller's, so this must be granted here.
+  actions: read
 
 jobs:
   # ============================================================================
@@ -197,6 +201,10 @@ jobs:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
       build_timeout_minutes: 120
+      # OSRB CSV diff baseline: post-merge context. main -> previous commit;
+      # release/* -> prior release tag (see resolve_diff_base.py).
+      diff_event_context: push
+      diff_current_branch: ${{ github.ref_name }}
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-runtime-{0}', github.sha) || '' }}
@@ -235,6 +243,10 @@ jobs:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
       build_timeout_minutes: 120
+      # OSRB CSV diff baseline: post-merge context. main -> previous commit;
+      # release/* -> prior release tag (see resolve_diff_base.py).
+      diff_event_context: push
+      diff_current_branch: ${{ github.ref_name }}
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-vllm-efa' || '' }}
         ${{ github.ref_name == 'main' && format('main-vllm-efa-{0}', github.sha) || '' }}
@@ -254,6 +266,10 @@ jobs:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
       build_timeout_minutes: 120
+      # OSRB CSV diff baseline: post-merge context. main -> previous commit;
+      # release/* -> prior release tag (see resolve_diff_base.py).
+      diff_event_context: push
+      diff_current_branch: ${{ github.ref_name }}
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-runtime-{0}', github.sha) || '' }}
@@ -292,6 +308,10 @@ jobs:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
       build_timeout_minutes: 120
+      # OSRB CSV diff baseline: post-merge context. main -> previous commit;
+      # release/* -> prior release tag (see resolve_diff_base.py).
+      diff_event_context: push
+      diff_current_branch: ${{ github.ref_name }}
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-sglang-efa' || '' }}
         ${{ github.ref_name == 'main' && format('main-sglang-efa-{0}', github.sha) || '' }}
@@ -311,6 +331,10 @@ jobs:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
       build_timeout_minutes: 120
+      # OSRB CSV diff baseline: post-merge context. main -> previous commit;
+      # release/* -> prior release tag (see resolve_diff_base.py).
+      diff_event_context: push
+      diff_current_branch: ${{ github.ref_name }}
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-trtllm-runtime' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-runtime-{0}', github.sha) || '' }}
@@ -349,6 +373,10 @@ jobs:
       builder_name: b-${{ github.run_id }}-${{ github.run_attempt }}
       inline_compliance: true
       build_timeout_minutes: 120
+      # OSRB CSV diff baseline: post-merge context. main -> previous commit;
+      # release/* -> prior release tag (see resolve_diff_base.py).
+      diff_event_context: push
+      diff_current_branch: ${{ github.ref_name }}
       extra_tags: |
         ${{ github.ref_name == 'main' && 'main-trtllm-efa' || '' }}
         ${{ github.ref_name == 'main' && format('main-trtllm-efa-{0}', github.sha) || '' }}

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -36,6 +36,8 @@ jobs:
       benchmarks: ${{ steps.changes.outputs.benchmarks }}
       sample: ${{ steps.changes.outputs.sample }}
       efa: ${{ steps.changes.outputs.efa }}
+      base_ref: ${{ steps.changes.outputs.base_ref }}
+      merge_base_sha: ${{ steps.changes.outputs.merge_base_sha }}
       builder_name: ${{ steps.export-builder-name.outputs.builder_name }}
     steps:
       - name: Checkout code
@@ -296,6 +298,18 @@ jobs:
       inline_compliance: true
       artifact_retention_days: '7'
       build_timeout_minutes: 60
+      # OSRB CSV diff baseline: the target branch selects the rule, while the
+      # merge-base pins PR->main diffs to the PR's fork point.
+      diff_event_context: pr
+      diff_current_branch: ${{ github.ref_name }}
+      diff_base_branch: ${{ needs.changed-files.outputs.base_ref }}
+      diff_merge_base_sha: ${{ needs.changed-files.outputs.merge_base_sha }}
+    # actions: read lets the build download a prior run's baseline compliance
+    # artifact to diff against (a reusable workflow's token can't exceed the
+    # caller's). Missing -> the diff soft-degrades, build stays green.
+    permissions:
+      contents: read
+      actions: read
     secrets: inherit
 
   vllm-dev-build:
@@ -334,6 +348,18 @@ jobs:
       inline_compliance: true
       artifact_retention_days: '7'
       build_timeout_minutes: 60
+      # OSRB CSV diff baseline: the target branch selects the rule, while the
+      # merge-base pins PR->main diffs to the PR's fork point.
+      diff_event_context: pr
+      diff_current_branch: ${{ github.ref_name }}
+      diff_base_branch: ${{ needs.changed-files.outputs.base_ref }}
+      diff_merge_base_sha: ${{ needs.changed-files.outputs.merge_base_sha }}
+    # actions: read lets the build download a prior run's baseline compliance
+    # artifact to diff against (a reusable workflow's token can't exceed the
+    # caller's). Missing -> the diff soft-degrades, build stays green.
+    permissions:
+      contents: read
+      actions: read
     secrets: inherit
 
   sglang-dev-build:
@@ -365,6 +391,18 @@ jobs:
       inline_compliance: true
       artifact_retention_days: '7'
       build_timeout_minutes: 60
+      # OSRB CSV diff baseline: the target branch selects the rule, while the
+      # merge-base pins PR->main diffs to the PR's fork point.
+      diff_event_context: pr
+      diff_current_branch: ${{ github.ref_name }}
+      diff_base_branch: ${{ needs.changed-files.outputs.base_ref }}
+      diff_merge_base_sha: ${{ needs.changed-files.outputs.merge_base_sha }}
+    # actions: read lets the build download a prior run's baseline compliance
+    # artifact to diff against (a reusable workflow's token can't exceed the
+    # caller's). Missing -> the diff soft-degrades, build stays green.
+    permissions:
+      contents: read
+      actions: read
     secrets: inherit
 
   trtllm-dev-build:
@@ -397,6 +435,18 @@ jobs:
       inline_compliance: true
       artifact_retention_days: '7'
       build_timeout_minutes: 60
+      # OSRB CSV diff baseline: the target branch selects the rule, while the
+      # merge-base pins PR->main diffs to the PR's fork point.
+      diff_event_context: pr
+      diff_current_branch: ${{ github.ref_name }}
+      diff_base_branch: ${{ needs.changed-files.outputs.base_ref }}
+      diff_merge_base_sha: ${{ needs.changed-files.outputs.merge_base_sha }}
+    # actions: read lets the build download a prior run's baseline compliance
+    # artifact to diff against (a reusable workflow's token can't exceed the
+    # caller's). Missing -> the diff soft-degrades, build stays green.
+    permissions:
+      contents: read
+      actions: read
     secrets: inherit
 
   sglang-efa-build:
@@ -414,6 +464,18 @@ jobs:
       inline_compliance: true
       artifact_retention_days: '7'
       build_timeout_minutes: 60
+      # OSRB CSV diff baseline: the target branch selects the rule, while the
+      # merge-base pins PR->main diffs to the PR's fork point.
+      diff_event_context: pr
+      diff_current_branch: ${{ github.ref_name }}
+      diff_base_branch: ${{ needs.changed-files.outputs.base_ref }}
+      diff_merge_base_sha: ${{ needs.changed-files.outputs.merge_base_sha }}
+    # actions: read lets the build download a prior run's baseline compliance
+    # artifact to diff against (a reusable workflow's token can't exceed the
+    # caller's). Missing -> the diff soft-degrades, build stays green.
+    permissions:
+      contents: read
+      actions: read
     secrets: inherit
 
   trtllm-efa-build:
@@ -431,6 +493,18 @@ jobs:
       inline_compliance: true
       artifact_retention_days: '7'
       build_timeout_minutes: 60
+      # OSRB CSV diff baseline: the target branch selects the rule, while the
+      # merge-base pins PR->main diffs to the PR's fork point.
+      diff_event_context: pr
+      diff_current_branch: ${{ github.ref_name }}
+      diff_base_branch: ${{ needs.changed-files.outputs.base_ref }}
+      diff_merge_base_sha: ${{ needs.changed-files.outputs.merge_base_sha }}
+    # actions: read lets the build download a prior run's baseline compliance
+    # artifact to diff against (a reusable workflow's token can't exceed the
+    # caller's). Missing -> the diff soft-degrades, build stays green.
+    permissions:
+      contents: read
+      actions: read
     secrets: inherit
 
   planner-build:

--- a/.github/workflows/shared-build-image.yml
+++ b/.github/workflows/shared-build-image.yml
@@ -144,6 +144,29 @@ on:
         required: false
         type: string
         default: '30'
+      diff_event_context:
+        description: |
+          Where this build runs, for OSRB CSV diff-baseline selection: 'pr' for a
+          PR build (pass diff_base_branch and diff_merge_base_sha), 'push' for a
+          post-merge build. Empty disables diffing.
+        required: false
+        type: string
+        default: ''
+      diff_current_branch:
+        description: 'github.ref_name of this build (pull-request/N, main, release/X.Y.Z). Used for diff-baseline selection.'
+        required: false
+        type: string
+        default: ''
+      diff_base_branch:
+        description: 'For PR builds, the PR''s target branch (e.g. main or release/1.3.0). Empty for pushes.'
+        required: false
+        type: string
+        default: ''
+      diff_merge_base_sha:
+        description: 'For PR builds targeting main, the true merge-base SHA. Pins the diff baseline to the PR fork point.'
+        required: false
+        type: string
+        default: ''
     secrets:
       AWS_DEFAULT_REGION:
         required: true
@@ -182,6 +205,14 @@ jobs:
     # cuda_version empty -- name: cpu, linux/amd64
     name: Build multi-arch ${{ matrix.cuda_version == '' && 'cpu' || format('cuda{0}', matrix.cuda_version) }}
     timeout-minutes: ${{ inputs.build_timeout_minutes }}
+    # contents: read for checkout; actions: read lets the compliance-extract
+    # action download a PRIOR run's baseline compliance artifact (cross-run) to
+    # diff this build's OSRB CSV against. Callers must also grant actions: read
+    # (a reusable workflow's token can't exceed the caller's) — pr.yaml and
+    # post-merge-ci.yml do. When it's not granted the diff soft-degrades.
+    permissions:
+      contents: read
+      actions: read
     outputs:
       target_tag_plain: ${{ steps.calculate-target-tag.outputs.target_tag_plain }}
       test_tag_plain: ${{ steps.calculate-target-tag.outputs.test_tag_plain }}
@@ -449,10 +480,69 @@ jobs:
       # would do. Also runs in the legacy compliance_only sibling-job mode (no
       # caller sets that today; see the input note). Skipped for dev / local-dev
       # targets (those don't ship and don't go through OSRB).
+      # Resolve which prior build's OSRB CSV to diff this one against. The rules
+      # depend on where we run (PR merge-base vs post-merge main vs release branch);
+      # see container/compliance/resolve_diff_base.py. Reads the current version
+      # from pyproject.toml for the release-branch case, and deepens history by
+      # one so HEAD~1 is reachable for the main post-merge case (checkout is
+      # shallow). Best-effort: any failure leaves base_sha empty and the diff
+      # step writes a baseline_unavailable marker (never fails the build).
+      - name: Resolve diff baseline
+        id: resolve-diff-base
+        if: ${{ (inputs.compliance_only || inputs.inline_compliance) && inputs.target != 'dev' && inputs.target != 'local-dev' && inputs.diff_event_context != '' }}
+        shell: bash
+        # All workflow-context values are passed via env (never interpolated into
+        # the script body) so attacker-controllable strings like branch names
+        # can't inject shell — see zizmor "template-injection".
+        env:
+          # Used by the nightly context to query the Actions API for the previous
+          # run (needs actions: read; the caller must grant it). Harmless otherwise.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DIFF_EVENT_CONTEXT: ${{ inputs.diff_event_context }}
+          DIFF_CURRENT_BRANCH: ${{ inputs.diff_current_branch }}
+          DIFF_BASE_BRANCH: ${{ inputs.diff_base_branch }}
+          DIFF_MERGE_BASE_SHA: ${{ inputs.diff_merge_base_sha }}
+          DIFF_CURRENT_SHA: ${{ inputs.source_ref != '' && inputs.source_ref || github.sha }}
+          DIFF_REPO: ${{ github.repository }}
+          DIFF_RUN_ID: ${{ github.run_id }}
+          # Container artifact prefix: lets the main-baseline walk look up
+          # compliance-<sha>-<prefix> availability per commit.
+          DIFF_ARTIFACT_PREFIX: ${{ steps.calculate-target-tag.outputs.target_tag_plain }}
+        run: |
+          # The build checkout is shallow with no tags. Make the refs each
+          # baseline rule needs reachable (all best-effort; a miss just yields an
+          # empty base_sha and a baseline_unavailable diff). Depth 30 gives the
+          # first-parent baseline walks enough history to find an artifact:
+          git fetch --deepen=30 --quiet || true                                     # HEAD~N (main post-merge walk)
+          git fetch --tags --quiet || true                                          # vX.Y.Z tags (release branch)
+          if [ "${DIFF_BASE_BRANCH}" = "main" ] \
+            && [ -n "${DIFF_MERGE_BASE_SHA}" ]; then
+            git fetch --no-tags --depth=30 origin "${DIFF_MERGE_BASE_SHA}" --quiet || true # stable PR fork-point walk
+          fi
+          CURRENT_VERSION=$(grep -m1 -E '^version[[:space:]]*=' pyproject.toml | sed -E 's/.*"([^"]+)".*/\1/' || true)
+          python3 container/compliance/resolve_diff_base.py \
+            --event-context "${DIFF_EVENT_CONTEXT}" \
+            --current-branch "${DIFF_CURRENT_BRANCH}" \
+            --base-branch "${DIFF_BASE_BRANCH}" \
+            --merge-base-sha "${DIFF_MERGE_BASE_SHA}" \
+            --current-sha "${DIFF_CURRENT_SHA}" \
+            --current-version "${CURRENT_VERSION}" \
+            --artifact-prefix "${DIFF_ARTIFACT_PREFIX}" \
+            --repo "${DIFF_REPO}" \
+            --current-run-id "${DIFF_RUN_ID}" \
+            >> "$GITHUB_OUTPUT"
+
       - name: Compliance extract
         if: ${{ (inputs.compliance_only || inputs.inline_compliance) && inputs.target != 'dev' && inputs.target != 'local-dev' }}
         uses: ./.github/actions/compliance-extract
         with:
+          # Diff baseline resolved above (empty when diffing is disabled or no
+          # baseline applies); gh_token lets the action fetch it cross-run.
+          diff_base_sha: ${{ steps.resolve-diff-base.outputs.base_sha }}
+          diff_base_label: ${{ steps.resolve-diff-base.outputs.base_label }}
+          diff_base_artifact_id: ${{ steps.resolve-diff-base.outputs.base_artifact_id }}
+          diff_base_run_id: ${{ steps.resolve-diff-base.outputs.base_run_id }}
+          gh_token: ${{ secrets.GITHUB_TOKEN }}
           framework: ${{ inputs.framework }}
           target: ${{ inputs.target }}
           platform: ${{ inputs.platform }}

--- a/container/compliance/README.md
+++ b/container/compliance/README.md
@@ -20,6 +20,8 @@ own filesystem; CI extracts `/legal` and `/sboms` from that stage with a warm ca
 | `overrides.py`, `license_overrides.yaml` | Authoritative `(ecosystem, name) → SPDX` overrides consulted before automatic detection. |
 | `native_packages.yaml` | From-source / binary components attributed via a hand-curated overlay (optional `license_text_path`). |
 | `verify_sbom_diff.py` | Cross-checks generated NOTICES against the base SBOM corpus; fails on drift. |
+| `resolve_diff_base.py` | Picks the baseline commit to diff a build's OSRB CSV against (PR→main / post-merge→main / release branch→prior release tag). |
+| `diff_osrb_csv.py` | Diffs two OSRB CSVs into a change-typed `*.diff.csv` (additions, version bumps, license changes, removals). |
 
 ## How it works
 
@@ -67,6 +69,47 @@ switched a base image and the corpus must be re-captured.
 
 Artifacts appear in the workflow run as `compliance-<prefix>-<suffix>-legal` /
 `-sboms` / `-sources`.
+
+### Per-build OSRB diff
+
+Alongside each `osrb-<image>-<arch>-<sha8>.csv`, the compliance-extract action
+writes `osrb-<image>-<arch>-<sha8>.diff.csv` comparing this build's dependency
+set against a context-dependent baseline. The diff notes four change kinds —
+additions, version bumps, license changes, removals — ordered by change bucket
+(additions → version+license changes → version bumps → license-only changes →
+removals), then by ecosystem (`rust, python, go, dpkg, native`), then name.
+
+The baseline (resolved by `resolve_diff_base.py`) depends on where the build runs:
+
+- **PR targeting `main`** → the PR's true merge-base (fork point), walking backward
+  on first-parent history only when that commit lacks this container's
+  `compliance-<sha>-<container>` artifact. Advancing `main` alone does not move
+  this starting point; it moves when the PR is rebased or updated with `main`.
+- **Post-merge on `main`** → the same walk, starting from the previous commit on `main`.
+- **PR targeting / post-merge on `release/*`** → the release tag `vX.Y.Z` that is
+  the highest one strictly older than the current version (semver order first —
+  `1.3.0` beats `1.2.5` for a `1.3.1` build regardless of publish date). Among
+  tags sharing an `X.Y.Z` base (e.g. `v1.2.3-nemo-3` vs `v1.2.3-minimax`), the
+  one published later wins.
+- **Nightly** → the previous successful scheduled run of the nightly workflow
+  (found via the Actions API); manual runs are excluded and the selected run's
+  commit names the baseline artifact.
+
+The baseline CSV is fetched by downloading the baseline commit's
+`compliance-<baseSHA>-<container>` artifact (needs `actions: read`). Baselines
+live only as Actions artifacts, so an expired/absent one is not fatal: the diff
+then contains a single `baseline_unavailable` row and the build stays green.
+
+Each arch also gets a self-describing `baseline/` folder next to the diff so the
+archive records exactly what was compared against:
+
+```text
+linux_<arch>/
+  osrb-<container>-<arch>-<sha8>.diff.csv
+  baseline/
+    BASELINE.md                              # selection rules + baseline SHA, commit link, generating-run link, label
+    osrb-<container>-<arch>-<baseSHA8>.csv   # a copy of the baseline CSV (absent when the baseline was unavailable)
+```
 
 ## License detection
 

--- a/container/compliance/diff_osrb_csv.py
+++ b/container/compliance/diff_osrb_csv.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Diff two new-format OSRB dependency CSVs into a change-typed diff CSV.
+
+The OSRB CSV is the cross-ecosystem ``osrb-deps.csv`` written by
+``compliance.generators.common.write_merged_csv`` — columns::
+
+    ecosystem,name,version,spdx,source_url,notes
+
+This tool compares a *current* CSV against a *base* CSV and emits a diff CSV
+that notes exactly four kinds of change: additions, version bumps, license
+changes, and removals (a single dependency may be both a version bump and a
+license change). It never fails on a missing base: when ``--base`` is omitted or
+empty, it writes a single ``baseline_unavailable`` row carrying ``--baseline-label``
+so a diff file always ships alongside the full CSV.
+
+Usage:
+    diff_osrb_csv.py --current cur.csv --base base.csv --output out.diff.csv
+    diff_osrb_csv.py --current cur.csv --output out.diff.csv \\
+        --baseline-label "release baseline v1.2.1 (artifact expired)"
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+# Diff CSV column order. Kept stable so downstream OSRB tooling can rely on it.
+DIFF_FIELDNAMES = [
+    "change",
+    "ecosystem",
+    "name",
+    "old_version",
+    "new_version",
+    "old_spdx",
+    "new_spdx",
+    "source_url",
+    "notes",
+]
+
+# ``change`` values, listed in the primary sort order requested by OSRB:
+# additions first, then version bumps that also change license, then plain
+# version bumps, then license-only changes, then removals.
+ADDED = "added"
+VERSION_AND_LICENSE_CHANGED = "version_and_license_changed"
+VERSION_CHANGED = "version_changed"
+LICENSE_CHANGED = "license_changed"
+REMOVED = "removed"
+BASELINE_UNAVAILABLE = "baseline_unavailable"
+
+CHANGE_ORDER = {
+    ADDED: 0,
+    VERSION_AND_LICENSE_CHANGED: 1,
+    VERSION_CHANGED: 2,
+    LICENSE_CHANGED: 3,
+    REMOVED: 4,
+    BASELINE_UNAVAILABLE: 5,
+}
+
+# Secondary sort: ecosystem "type" in this fixed order, then name alphabetically.
+ECOSYSTEM_ORDER = {"rust": 0, "python": 1, "go": 2, "dpkg": 3, "native": 4}
+
+
+def read_osrb_csv(path: Path) -> list[dict[str, str]]:
+    """Read an OSRB deps CSV into a list of row dicts (empty list if absent)."""
+    if not path or not Path(path).is_file():
+        return []
+    with Path(path).open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        rows = []
+        for row in reader:
+            rows.append(
+                {
+                    "ecosystem": (row.get("ecosystem") or "").strip(),
+                    "name": (row.get("name") or "").strip(),
+                    "version": (row.get("version") or "").strip(),
+                    "spdx": (row.get("spdx") or "").strip(),
+                    "source_url": (row.get("source_url") or "").strip(),
+                    "notes": (row.get("notes") or "").strip(),
+                }
+            )
+        return rows
+
+
+def _by_name(
+    rows: list[dict[str, str]],
+) -> dict[tuple[str, str], dict[str, dict[str, str]]]:
+    """Group rows by (ecosystem, name) -> {version: row}.
+
+    Keying by name (not version) lets a version bump surface as a change rather
+    than an add+remove pair. Packages shipped at multiple versions keep every
+    version under the same key so nothing is silently dropped.
+    """
+    grouped: dict[tuple[str, str], dict[str, dict[str, str]]] = {}
+    for row in rows:
+        key = (row["ecosystem"], row["name"])
+        grouped.setdefault(key, {})[row["version"]] = row
+    return grouped
+
+
+def _added_row(row: dict[str, str]) -> dict[str, str]:
+    return {
+        "change": ADDED,
+        "ecosystem": row["ecosystem"],
+        "name": row["name"],
+        "old_version": "",
+        "new_version": row["version"],
+        "old_spdx": "",
+        "new_spdx": row["spdx"],
+        "source_url": row["source_url"],
+        "notes": row["notes"],
+    }
+
+
+def _removed_row(row: dict[str, str]) -> dict[str, str]:
+    return {
+        "change": REMOVED,
+        "ecosystem": row["ecosystem"],
+        "name": row["name"],
+        "old_version": row["version"],
+        "new_version": "",
+        "old_spdx": row["spdx"],
+        "new_spdx": "",
+        "source_url": row["source_url"],
+        "notes": row["notes"],
+    }
+
+
+def _changed_row(base: dict[str, str], cur: dict[str, str]) -> dict[str, str]:
+    """A row present in both sides with a differing version and/or license."""
+    version_changed = base["version"] != cur["version"]
+    license_changed = base["spdx"] != cur["spdx"]
+    if version_changed and license_changed:
+        change = VERSION_AND_LICENSE_CHANGED
+    elif version_changed:
+        change = VERSION_CHANGED
+    else:
+        change = LICENSE_CHANGED
+    return {
+        "change": change,
+        "ecosystem": cur["ecosystem"],
+        "name": cur["name"],
+        "old_version": base["version"],
+        "new_version": cur["version"],
+        "old_spdx": base["spdx"],
+        "new_spdx": cur["spdx"],
+        # Prefer the current metadata; fall back to the base's.
+        "source_url": cur["source_url"] or base["source_url"],
+        "notes": cur["notes"] or base["notes"],
+    }
+
+
+def compute_diff(
+    current_rows: list[dict[str, str]],
+    base_rows: list[dict[str, str]],
+) -> list[dict[str, str]]:
+    """Compute the change rows between a base and a current OSRB CSV."""
+    cur = _by_name(current_rows)
+    base = _by_name(base_rows)
+    out: list[dict[str, str]] = []
+
+    for key in cur.keys() | base.keys():
+        cur_vers = cur.get(key, {})
+        base_vers = base.get(key, {})
+        if cur_vers and not base_vers:  # name is brand new
+            out.extend(_added_row(r) for r in cur_vers.values())
+        elif base_vers and not cur_vers:  # name dropped entirely
+            out.extend(_removed_row(r) for r in base_vers.values())
+        elif set(cur_vers) == set(base_vers):
+            # Same version set: only a license move can be a change here.
+            for v in cur_vers:
+                if cur_vers[v]["spdx"] != base_vers[v]["spdx"]:
+                    out.append(_changed_row(base_vers[v], cur_vers[v]))
+        elif len(cur_vers) == 1 and len(base_vers) == 1:
+            # Clean single-version bump (the common case).
+            out.append(
+                _changed_row(
+                    next(iter(base_vers.values())),
+                    next(iter(cur_vers.values())),
+                )
+            )
+        else:
+            # Multi-version mismatch: degrade to per-version add/remove, plus
+            # license changes for versions shared across both sides.
+            for v in set(cur_vers) - set(base_vers):
+                out.append(_added_row(cur_vers[v]))
+            for v in set(base_vers) - set(cur_vers):
+                out.append(_removed_row(base_vers[v]))
+            for v in set(cur_vers) & set(base_vers):
+                if cur_vers[v]["spdx"] != base_vers[v]["spdx"]:
+                    out.append(_changed_row(base_vers[v], cur_vers[v]))
+
+    return sort_diff_rows(out)
+
+
+def sort_diff_rows(rows: list[dict[str, str]]) -> list[dict[str, str]]:
+    """Sort by change bucket, then ecosystem type, then name (case-insensitive)."""
+    return sorted(
+        rows,
+        key=lambda r: (
+            CHANGE_ORDER.get(r["change"], len(CHANGE_ORDER)),
+            ECOSYSTEM_ORDER.get(r["ecosystem"], len(ECOSYSTEM_ORDER)),
+            r["name"].lower(),
+            r["new_version"] or r["old_version"],
+        ),
+    )
+
+
+def baseline_unavailable_rows(label: str) -> list[dict[str, str]]:
+    """A single marker row emitted when no base CSV is available to diff against."""
+    return [
+        {
+            "change": BASELINE_UNAVAILABLE,
+            "ecosystem": "",
+            "name": label or "baseline unavailable",
+            "old_version": "",
+            "new_version": "",
+            "old_spdx": "",
+            "new_spdx": "",
+            "source_url": "",
+            "notes": "no baseline CSV was available to diff against",
+        }
+    ]
+
+
+def write_diff_csv(rows: list[dict[str, str]], output_path: Path) -> None:
+    """Write the diff rows to output_path (stable byte-order)."""
+    Path(output_path).parent.mkdir(parents=True, exist_ok=True)
+    with Path(output_path).open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=DIFF_FIELDNAMES, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Diff two new-format OSRB dependency CSVs into a change-typed diff CSV",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--current", required=True, help="Path to the current commit's OSRB CSV"
+    )
+    parser.add_argument(
+        "--base",
+        default="",
+        help="Path to the baseline OSRB CSV (omit/empty for the baseline_unavailable marker)",
+    )
+    parser.add_argument(
+        "--output", "-o", required=True, help="Path to write the diff CSV"
+    )
+    parser.add_argument(
+        "--baseline-label",
+        default="",
+        help="Human label for the baseline (used in the baseline_unavailable marker row)",
+    )
+    args = parser.parse_args()
+
+    current_path = Path(args.current)
+    if not current_path.is_file():
+        print(f"ERROR: --current does not exist: {current_path}", file=sys.stderr)
+        sys.exit(1)
+
+    output_path = Path(args.output)
+    base_path = Path(args.base) if args.base else None
+
+    if base_path is None or not base_path.is_file():
+        reason = "no --base given" if base_path is None else f"missing: {base_path}"
+        print(f"Baseline unavailable ({reason}); writing marker diff.", file=sys.stderr)
+        write_diff_csv(baseline_unavailable_rows(args.baseline_label), output_path)
+        return
+
+    rows = compute_diff(read_osrb_csv(current_path), read_osrb_csv(base_path))
+    write_diff_csv(rows, output_path)
+    print(f"Wrote {len(rows)} diff rows to {output_path}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()

--- a/container/compliance/resolve_diff_base.py
+++ b/container/compliance/resolve_diff_base.py
@@ -1,0 +1,475 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve the baseline commit to diff a build's OSRB CSV against.
+
+The baseline depends on where the build runs:
+
+1. PR targeting ``main``            -> the PR's merge-base, walking backward
+                                       only when that commit lacks the artifact.
+2. Post-merge push to ``main``      -> the previous commit on ``main`` (HEAD~1).
+3. PR targeting / push to a ``release/*`` branch
+                                    -> the release tag ``vX.Y.Z`` that is the
+                                       highest one strictly older than the
+                                       current version. Semver order first
+                                       (``1.3.0`` beats ``1.2.5`` for a ``1.3.1``
+                                       build, regardless of publish date); when
+                                       several tags share the same ``X.Y.Z`` base
+                                       (e.g. ``v1.2.3-nemo-3`` vs ``v1.2.3-minimax``)
+                                       the one published later wins.
+4. Nightly build                    -> the previous successful scheduled run of
+                                       the same workflow, found via the Actions
+                                       API; manual ``workflow_dispatch`` runs are
+                                       excluded and the selected run's
+                                       ``head_sha`` names the baseline artifact.
+
+Prints four ``key=value`` lines to stdout (suitable for ``>> "$GITHUB_OUTPUT"``)::
+
+    base_sha=<40-hex-sha or empty>
+    base_label=<human description of the baseline>
+    base_artifact_id=<GitHub Actions artifact id or empty>
+    base_run_id=<generating workflow run id or empty>
+
+An empty ``base_sha`` is not an error: it means there is no baseline to diff
+against (first release of a line, unrecognized context, or a commit that could
+not be resolved). Callers degrade gracefully.
+
+Usage:
+    resolve_diff_base.py --event-context {pr|push} --current-branch <ref_name> \\
+        --base-branch <baseRefName|''> --merge-base-sha <sha|''> \\
+        --current-sha <sha> \\
+        --current-version <X.Y.Z|''> --repo <owner/repo>
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+
+# Matches a leading X.Y.Z in a tag/version, tolerant of any suffix
+# (-rc6, -nemo-3, -minimax, .dev1, ...). We deliberately do NOT rely on PEP 440
+# parsing because release tags like ``v1.2.3-nemo-3`` are not PEP 440 valid.
+_RELEASE_RE = re.compile(r"^v?(\d+)\.(\d+)\.(\d+)")
+
+
+def parse_release_tuple(text: str) -> tuple[int, int, int] | None:
+    """Extract the (major, minor, patch) tuple from a tag/version, or None."""
+    if not text:
+        return None
+    m = _RELEASE_RE.match(text.strip())
+    if not m:
+        return None
+    return (int(m.group(1)), int(m.group(2)), int(m.group(3)))
+
+
+def pick_prior_release_tag(
+    current_version: str,
+    tag_dates: list[tuple[str, int]],
+) -> str | None:
+    """Pick the release tag to diff a release build against.
+
+    ``tag_dates`` is a list of ``(tag_name, unix_publish_date)``. Returns the
+    chosen tag name, or None when no suitable prior tag exists.
+
+    Selection: among tags whose ``X.Y.Z`` base is strictly less than the current
+    version's base, take the highest base (semver). If several tags share that
+    highest base, take the one published latest.
+    """
+    cur = parse_release_tuple(current_version)
+    if cur is None:
+        return None
+
+    candidates: list[tuple[tuple[int, int, int], int, str]] = []
+    for tag, date in tag_dates:
+        base = parse_release_tuple(tag)
+        if base is None:  # unparseable tag -> skip, never crash
+            continue
+        if base < cur:  # strictly older by semver base
+            candidates.append((base, date, tag))
+    if not candidates:
+        return None
+
+    # Highest base wins (semver first); within the same base, latest publish
+    # date wins (chronological tie-break).
+    best = max(candidates, key=lambda c: (c[0], c[1]))
+    return best[2]
+
+
+def is_release_branch(ref: str) -> bool:
+    """True for a release branch ref such as ``release/1.3.0``."""
+    return bool(ref) and ref.startswith("release/")
+
+
+def _git(*args: str) -> str | None:
+    """Run a read-only git command; return stripped stdout or None on failure."""
+    try:
+        out = subprocess.run(
+            ["git", *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"git {' '.join(args)} failed: {exc}", file=sys.stderr)
+        return None
+    sha = out.stdout.strip()
+    return sha or None
+
+
+def _tag_dates() -> list[tuple[str, int]]:
+    """List (tag, unix_date) for every ``v*`` tag. Empty on failure."""
+    out = _git(
+        "for-each-ref",
+        "--format=%(refname:short)%09%(creatordate:unix)",
+        "refs/tags/v*",
+    )
+    if not out:
+        return []
+    pairs: list[tuple[str, int]] = []
+    for line in out.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        tag, date = parts[0].strip(), parts[1].strip()
+        try:
+            pairs.append((tag, int(date)))
+        except ValueError:
+            continue
+    return pairs
+
+
+def _gh(*args: str) -> str | None:
+    """Run a `gh api` call; return stripped stdout or None on failure.
+
+    Reads GH_TOKEN from the environment (set by the CI resolve step).
+    """
+    try:
+        out = subprocess.run(
+            ["gh", "api", *args],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as exc:
+        print(f"gh api {' '.join(args)} failed: {exc}", file=sys.stderr)
+        return None
+    return out.stdout.strip() or None
+
+
+def pick_previous_run_sha(current_run_id: int, runs: list[dict]) -> str | None:
+    """Return the head SHA of the most recent successful scheduled prior run.
+
+    ``runs`` is a list of ``{"id", "head_sha", "event", "conclusion"}``
+    dicts. Run ids increase over time, so "before this run" is
+    ``id < current_run_id`` and "most recent" is the max such id. Requiring
+    ``event == "schedule"`` keeps successful manual nightlies from becoming the
+    baseline for the next cron-triggered run.
+    """
+    prev = [
+        r
+        for r in runs
+        if isinstance(r.get("id"), int)
+        and r["id"] < current_run_id
+        and r.get("event") == "schedule"
+        and r.get("conclusion") == "success"
+    ]
+    if not prev:
+        return None
+    best = max(prev, key=lambda r: r["id"])
+    return best.get("head_sha") or None
+
+
+def _fetch_workflow_runs(repo: str, current_run_id: int) -> list[dict]:
+    """List recent runs of the current run's workflow. Empty on any failure."""
+    workflow_id = _gh(
+        f"/repos/{repo}/actions/runs/{current_run_id}", "--jq", ".workflow_id"
+    )
+    if not workflow_id:
+        return []
+    # per_page goes in the query string (not `-f`) so `gh api` stays a GET; a
+    # `-f` field would flip it to POST and the runs list would never resolve.
+    raw = _gh(
+        f"/repos/{repo}/actions/workflows/{workflow_id}/runs"
+        "?event=schedule&status=success&per_page=50",
+        "--jq",
+        "[.workflow_runs[] | {id, head_sha, event, conclusion}]",
+    )
+    if not raw:
+        return []
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+
+
+def _short(sha: str) -> str:
+    return sha[:8] if sha else ""
+
+
+def find_artifact(
+    repo: str, sha: str, prefix: str
+) -> tuple[tuple[str, str] | None, bool]:
+    """Return ((artifact_id, run_id), api_error) for a compliance artifact."""
+    if not (repo and sha and prefix):
+        return None, False
+    out = _gh(
+        f"/repos/{repo}/actions/artifacts?name=compliance-{sha}-{prefix}",
+        "--jq",
+        "[.artifacts[] | select(.expired == false)] "
+        "| sort_by(.created_at) | last "
+        '| if . == null then "absent" '
+        r'else "\(.id)\t\(.workflow_run.id)" end',
+    )
+    if out is None:
+        return None, True
+    if out == "absent":
+        return None, False
+    ids = out.split("\t", 1)
+    if len(ids) != 2 or not all(value.isdigit() for value in ids):
+        return None, True
+    return (ids[0], ids[1]), False
+
+
+def _first_parent_shas(ref: str, limit: int) -> list[str]:
+    """First-parent commit SHAs reachable from ref (newest first), capped at limit."""
+    out = _git("rev-list", "--first-parent", "-n", str(limit), ref)
+    return out.splitlines() if out else []
+
+
+def pick_commit_with_artifact(
+    shas, find_fn
+) -> tuple[str | None, tuple[str, str] | None, bool]:
+    """Return (first matching sha, artifact ids, saw_error).
+
+    saw_error is True if any lookup reported an API failure, letting the
+    caller fall back instead of mistaking a flaky API for "no baseline".
+    """
+    saw_error = False
+    for sha in shas:
+        artifact, api_error = find_fn(sha)
+        saw_error = saw_error or api_error
+        if artifact:
+            return sha, artifact, saw_error
+    return None, None, saw_error
+
+
+def _resolve_main_baseline(
+    start_ref: str,
+    repo: str,
+    artifact_prefix: str,
+    label: str = "main",
+    limit: int = 25,
+) -> tuple[str, str, str, str]:
+    """Baseline for the main cases: the most recent commit on main's first-parent
+    history (from ``start_ref`` backward) that actually has a
+    ``compliance-<sha>-<prefix>`` artifact.
+
+    Post-merge builds every framework, but each container's artifact lands at a
+    different time (and a leg can fail), so the tip of main frequently lacks a
+    given container's artifact when a PR builds. Walking back finds the newest
+    commit that does have it, per container.
+    """
+    tip = _git("rev-parse", start_ref)
+    if not tip:
+        return (
+            "",
+            f"{label} baseline ({start_ref} unresolved; shallow clone?)",
+            "",
+            "",
+        )
+    # Without a prefix (or token) we can't check availability -> use the tip,
+    # preserving the original behavior.
+    if not artifact_prefix:
+        return tip, f"{label} {_short(tip)}", "", ""
+    shas = _first_parent_shas(start_ref, limit)
+    chosen, artifact, saw_error = pick_commit_with_artifact(
+        shas, lambda s: find_artifact(repo, s, artifact_prefix)
+    )
+    if chosen and artifact:
+        artifact_id, run_id = artifact
+        if chosen == tip:
+            return chosen, f"{label} {_short(chosen)}", artifact_id, run_id
+        return (
+            chosen,
+            f"{label} {_short(chosen)} (nearest with {artifact_prefix} artifact)",
+            artifact_id,
+            run_id,
+        )
+    if saw_error:
+        # Preserve the candidate SHA for diagnostics. Without an artifact id,
+        # the download soft-degrades to a baseline_unavailable diff.
+        return (
+            tip,
+            f"{label} {_short(tip)} (artifact availability unchecked)",
+            "",
+            "",
+        )
+    return (
+        "",
+        f"no {label} commit with a {artifact_prefix} artifact in last {limit}",
+        "",
+        "",
+    )
+
+
+def _with_artifact(
+    sha: str, label: str, repo: str, artifact_prefix: str
+) -> tuple[str, str, str, str]:
+    """Attach the exact artifact and run ids to a resolved baseline."""
+    if not (sha and artifact_prefix):
+        return sha, label, "", ""
+    artifact, _ = find_artifact(repo, sha, artifact_prefix)
+    if not artifact:
+        return sha, label, "", ""
+    artifact_id, run_id = artifact
+    return sha, label, artifact_id, run_id
+
+
+def resolve(
+    event_context: str,
+    current_branch: str,
+    base_branch: str,
+    current_version: str,
+    repo: str = "",
+    current_run_id: str = "",
+    artifact_prefix: str = "",
+    merge_base_sha: str = "",
+) -> tuple[str, str, str, str]:
+    """Return (base_sha, base_label, artifact_id, run_id)."""
+    # Rule 4: nightly build -> previous successful scheduled run of the same
+    # workflow. Manual workflow_dispatch runs are deliberately excluded.
+    if event_context == "nightly":
+        try:
+            rid = int(current_run_id)
+        except (TypeError, ValueError):
+            return "", "nightly baseline (no current run id)", "", ""
+        sha = pick_previous_run_sha(rid, _fetch_workflow_runs(repo, rid))
+        if sha:
+            return _with_artifact(
+                sha,
+                f"previous scheduled nightly {_short(sha)}",
+                repo,
+                artifact_prefix,
+            )
+        return "", "no previous successful scheduled nightly run found", "", ""
+
+    # Rule 1: PR targeting main -> the PR's stable fork point, walking backward
+    # only if that commit lacks this container's artifact.
+    if event_context == "pr" and base_branch == "main":
+        if not merge_base_sha:
+            return "", "PR merge-base unavailable", "", ""
+        return _resolve_main_baseline(
+            merge_base_sha, repo, artifact_prefix, label="PR merge-base"
+        )
+
+    # Rule 2: post-merge push to main -> walk back from the previous main commit
+    # (HEAD is the just-merged commit, still building, so start at HEAD~1).
+    if event_context == "push" and current_branch == "main":
+        return _resolve_main_baseline("HEAD~1", repo, artifact_prefix)
+
+    # Rule 3: PR targeting / push to a release branch -> prior release tag.
+    release_ref = base_branch if is_release_branch(base_branch) else current_branch
+    if is_release_branch(release_ref):
+        if not parse_release_tuple(current_version):
+            return (
+                "",
+                f"release baseline (no parseable current version '{current_version}')",
+                "",
+                "",
+            )
+        tag = pick_prior_release_tag(current_version, _tag_dates())
+        if tag is None:
+            return (
+                "",
+                f"no prior release tag older than {current_version} (first of its line)",
+                "",
+                "",
+            )
+        sha = _git("rev-list", "-n", "1", tag)
+        if sha:
+            return _with_artifact(
+                sha,
+                f"release baseline {tag} ({_short(sha)})",
+                repo,
+                artifact_prefix,
+            )
+        return "", f"release baseline {tag} (could not resolve tag commit)", "", ""
+
+    # Fallback: unrecognized context -> no baseline.
+    return "", "no baseline (unrecognized build context)", "", ""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Resolve the baseline commit to diff a build's OSRB CSV against",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--event-context", required=True, choices=["pr", "push", "nightly"]
+    )
+    parser.add_argument(
+        "--current-branch",
+        default="",
+        help="github.ref_name (main, release/X.Y.Z, ...)",
+    )
+    parser.add_argument(
+        "--base-branch",
+        default="",
+        help="For PRs, the PR's target branch (gh pr view --json baseRefName); empty for pushes",
+    )
+    parser.add_argument(
+        "--merge-base-sha",
+        default="",
+        help="For PRs targeting main, the true merge-base SHA used as the stable baseline starting point",
+    )
+    parser.add_argument("--current-sha", default="", help="github.sha (informational)")
+    parser.add_argument(
+        "--current-version",
+        default="",
+        help="Current X.Y.Z version (from pyproject.toml); required for release baselines",
+    )
+    parser.add_argument(
+        "--repo", default="", help="owner/repo (required for the nightly context)"
+    )
+    parser.add_argument(
+        "--current-run-id",
+        default="",
+        help="github.run_id of this build; used by the nightly context to find the previous run",
+    )
+    parser.add_argument(
+        "--artifact-prefix",
+        default="",
+        help="Container artifact prefix (target_tag_plain, e.g. vllm-runtime); for the "
+        "main cases, the resolver walks main's history for a commit that has a "
+        "compliance-<sha>-<prefix> artifact. Requires --repo and GH_TOKEN.",
+    )
+    args = parser.parse_args()
+
+    base_sha, base_label, base_artifact_id, base_run_id = resolve(
+        args.event_context,
+        args.current_branch,
+        args.base_branch,
+        args.current_version,
+        args.repo,
+        args.current_run_id,
+        args.artifact_prefix,
+        args.merge_base_sha,
+    )
+
+    print(
+        f"Resolved diff baseline: {base_label} (sha={base_sha or 'none'})",
+        file=sys.stderr,
+    )
+    # stdout carries ONLY the GITHUB_OUTPUT key=value lines.
+    print(f"base_sha={base_sha}")
+    print(f"base_label={base_label}")
+    print(f"base_artifact_id={base_artifact_id}")
+    print(f"base_run_id={base_run_id}")
+
+
+if __name__ == "__main__":
+    main()

--- a/container/compliance/tests/test_diff_osrb_csv.py
+++ b/container/compliance/tests/test_diff_osrb_csv.py
@@ -1,0 +1,162 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the OSRB CSV diff.
+
+Run from the repo root with the compliance package on the path:
+
+    PYTHONPATH=container python -m pytest container/compliance/tests/test_diff_osrb_csv.py
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from compliance.diff_osrb_csv import (
+    ADDED,
+    BASELINE_UNAVAILABLE,
+    LICENSE_CHANGED,
+    REMOVED,
+    VERSION_AND_LICENSE_CHANGED,
+    VERSION_CHANGED,
+    baseline_unavailable_rows,
+    compute_diff,
+    read_osrb_csv,
+    write_diff_csv,
+)
+from compliance.generators.common import Component, write_merged_csv
+
+# CPU-only unit tests; markers are required by .ai/pytest-guidelines.md
+# (lifecycle / test-type / hardware categories).
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+
+def _write_csv(path: Path, components: list[Component]) -> Path:
+    return write_merged_csv(components, {}, path)
+
+
+def _c(eco: str, name: str, version: str, spdx: str = "MIT") -> Component:
+    return Component(ecosystem=eco, name=name, version=version, spdx=spdx)
+
+
+def _rows(
+    components: list[Component], tmp_path: Path, fname: str
+) -> list[dict[str, str]]:
+    return read_osrb_csv(_write_csv(tmp_path / fname, components))
+
+
+class TestChangeClassification:
+    def test_added(self, tmp_path):
+        cur = _rows([_c("python", "brand-new", "1.0.0")], tmp_path, "cur.csv")
+        base = _rows([], tmp_path, "base.csv")
+        diff = compute_diff(cur, base)
+        assert [r["change"] for r in diff] == [ADDED]
+        assert diff[0]["new_version"] == "1.0.0"
+        assert diff[0]["old_version"] == ""
+
+    def test_removed(self, tmp_path):
+        cur = _rows([], tmp_path, "cur.csv")
+        base = _rows([_c("python", "gone", "2.0.0")], tmp_path, "base.csv")
+        diff = compute_diff(cur, base)
+        assert [r["change"] for r in diff] == [REMOVED]
+        assert diff[0]["old_version"] == "2.0.0"
+        assert diff[0]["new_version"] == ""
+
+    def test_version_changed(self, tmp_path):
+        cur = _rows([_c("rust", "serde", "1.1.0", "MIT")], tmp_path, "cur.csv")
+        base = _rows([_c("rust", "serde", "1.0.0", "MIT")], tmp_path, "base.csv")
+        diff = compute_diff(cur, base)
+        assert [r["change"] for r in diff] == [VERSION_CHANGED]
+        assert (diff[0]["old_version"], diff[0]["new_version"]) == ("1.0.0", "1.1.0")
+
+    def test_license_changed_only(self, tmp_path):
+        cur = _rows([_c("rust", "serde", "1.0.0", "Apache-2.0")], tmp_path, "cur.csv")
+        base = _rows([_c("rust", "serde", "1.0.0", "MIT")], tmp_path, "base.csv")
+        diff = compute_diff(cur, base)
+        assert [r["change"] for r in diff] == [LICENSE_CHANGED]
+        assert (diff[0]["old_spdx"], diff[0]["new_spdx"]) == ("MIT", "Apache-2.0")
+
+    def test_version_and_license_changed(self, tmp_path):
+        cur = _rows([_c("rust", "serde", "1.1.0", "Apache-2.0")], tmp_path, "cur.csv")
+        base = _rows([_c("rust", "serde", "1.0.0", "MIT")], tmp_path, "base.csv")
+        diff = compute_diff(cur, base)
+        assert [r["change"] for r in diff] == [VERSION_AND_LICENSE_CHANGED]
+
+    def test_identical_is_empty(self, tmp_path):
+        comps = [_c("python", "requests", "2.0.0")]
+        assert (
+            compute_diff(
+                _rows(comps, tmp_path, "c.csv"), _rows(comps, tmp_path, "b.csv")
+            )
+            == []
+        )
+
+
+class TestOrdering:
+    def test_bucket_then_ecosystem_then_name(self, tmp_path):
+        cur = _rows(
+            [
+                _c("python", "z-added", "1.0.0"),
+                _c("rust", "a-added", "1.0.0"),
+                _c("python", "verbump", "2.0.0", "MIT"),
+                _c("rust", "verbump2", "2.0.0", "Apache-2.0"),  # version+license
+                _c("go", "liconly", "1.0.0", "BSD-3-Clause"),  # license only
+            ],
+            tmp_path,
+            "cur.csv",
+        )
+        base = _rows(
+            [
+                _c("python", "verbump", "1.0.0", "MIT"),
+                _c("rust", "verbump2", "1.0.0", "MIT"),  # version+license changed
+                _c("go", "liconly", "1.0.0", "MIT"),  # license only changed
+                _c("dpkg", "removed-pkg", "3.0.0"),
+            ],
+            tmp_path,
+            "base.csv",
+        )
+        diff = compute_diff(cur, base)
+        got = [(r["change"], r["ecosystem"], r["name"]) for r in diff]
+        assert got == [
+            # additions: rust before python (ecosystem order), then name
+            (ADDED, "rust", "a-added"),
+            (ADDED, "python", "z-added"),
+            # version+license change bucket
+            (VERSION_AND_LICENSE_CHANGED, "rust", "verbump2"),
+            # version-only change bucket
+            (VERSION_CHANGED, "python", "verbump"),
+            # license-only change bucket
+            (LICENSE_CHANGED, "go", "liconly"),
+            # removals
+            (REMOVED, "dpkg", "removed-pkg"),
+        ]
+
+
+class TestMultiVersion:
+    def test_multi_version_mismatch_degrades_to_add_remove(self, tmp_path):
+        cur = _rows(
+            [_c("python", "pkg", "1.0.0"), _c("python", "pkg", "2.0.0")],
+            tmp_path,
+            "cur.csv",
+        )
+        base = _rows([_c("python", "pkg", "1.0.0")], tmp_path, "base.csv")
+        diff = compute_diff(cur, base)
+        # 1.0.0 unchanged (present both sides), 2.0.0 is a new version -> added
+        assert [(r["change"], r["new_version"]) for r in diff] == [(ADDED, "2.0.0")]
+
+
+class TestBaselineUnavailable:
+    def test_marker_rows(self):
+        rows = baseline_unavailable_rows("release baseline v1.2.1 (expired)")
+        assert len(rows) == 1
+        assert rows[0]["change"] == BASELINE_UNAVAILABLE
+        assert rows[0]["name"] == "release baseline v1.2.1 (expired)"
+
+    def test_write_and_reread(self, tmp_path):
+        out = tmp_path / "x.diff.csv"
+        write_diff_csv(baseline_unavailable_rows("lbl"), out)
+        text = out.read_text()
+        assert text.startswith(
+            "change,ecosystem,name,old_version,new_version,old_spdx,new_spdx,source_url,notes\n"
+        )
+        assert BASELINE_UNAVAILABLE in text

--- a/container/compliance/tests/test_resolve_diff_base.py
+++ b/container/compliance/tests/test_resolve_diff_base.py
@@ -1,0 +1,294 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the CI diff-baseline resolver.
+
+Run from the repo root with the compliance package on the path:
+
+    PYTHONPATH=container python -m pytest container/compliance/tests/test_resolve_diff_base.py
+"""
+
+from __future__ import annotations
+
+import pytest
+from compliance import resolve_diff_base
+from compliance.resolve_diff_base import (
+    find_artifact,
+    is_release_branch,
+    parse_release_tuple,
+    pick_commit_with_artifact,
+    pick_previous_run_sha,
+    pick_prior_release_tag,
+    resolve,
+)
+
+# CPU-only unit tests; markers are required by .ai/pytest-guidelines.md
+# (lifecycle / test-type / hardware categories).
+pytestmark = [pytest.mark.pre_merge, pytest.mark.unit, pytest.mark.gpu_0]
+
+
+def _run(
+    run_id: int,
+    head_sha: str,
+    conclusion: str | None = "success",
+    event: str = "schedule",
+) -> dict:
+    return {
+        "id": run_id,
+        "head_sha": head_sha,
+        "event": event,
+        "conclusion": conclusion,
+    }
+
+
+class TestParseReleaseTuple:
+    def test_plain_and_prefixed(self):
+        assert parse_release_tuple("1.3.1") == (1, 3, 1)
+        assert parse_release_tuple("v1.3.1") == (1, 3, 1)
+
+    def test_suffixed(self):
+        assert parse_release_tuple("v1.2.3-nemo-3") == (1, 2, 3)
+        assert parse_release_tuple("v0.0.0-rc6") == (0, 0, 0)
+
+    def test_unparseable(self):
+        assert parse_release_tuple("") is None
+        assert parse_release_tuple("vfoo") is None
+        assert parse_release_tuple("runtime-1.0.0") is None
+
+
+class TestPickPriorReleaseTag:
+    def test_semver_beats_chronology(self):
+        # 1.3.0 was published EARLIER than 1.2.5, but for a 1.3.1 build the
+        # highest semver strictly older wins -> 1.3.0.
+        tags = [("v1.3.0", 100), ("v1.2.5", 200)]
+        assert pick_prior_release_tag("1.3.1", tags) == "v1.3.0"
+
+    def test_same_base_tie_broken_by_later_publish(self):
+        # Both share base 1.2.3; current is 1.2.4; pick the later-published tag.
+        tags = [("v1.2.3-nemo-3", 100), ("v1.2.3-minimax", 200)]
+        assert pick_prior_release_tag("1.2.4", tags) == "v1.2.3-minimax"
+
+    def test_same_base_tie_order_independent(self):
+        tags = [("v1.2.3-minimax", 200), ("v1.2.3-nemo-3", 100)]
+        assert pick_prior_release_tag("1.2.4", tags) == "v1.2.3-minimax"
+
+    def test_no_older_tag_returns_none(self):
+        tags = [("v1.3.1", 100), ("v1.4.0", 200)]
+        assert pick_prior_release_tag("1.3.1", tags) is None
+
+    def test_empty_returns_none(self):
+        assert pick_prior_release_tag("1.3.1", []) is None
+
+    def test_unparseable_tags_skipped(self):
+        tags = [("vfoo", 100), ("garbage", 150), ("v1.2.0", 200)]
+        assert pick_prior_release_tag("1.3.0", tags) == "v1.2.0"
+
+    def test_unparseable_current_version(self):
+        assert pick_prior_release_tag("not-a-version", [("v1.0.0", 1)]) is None
+
+    def test_equal_base_excluded(self):
+        # A tag at the SAME base as current is the current release, not a prior.
+        tags = [("v1.3.0", 50), ("v1.2.9", 40)]
+        assert pick_prior_release_tag("1.3.0", tags) == "v1.2.9"
+
+
+class TestPickPreviousRunSha:
+    def test_most_recent_prior_success(self):
+        runs = [
+            _run(100, "cur", conclusion=None),  # current, in progress
+            _run(90, "sha90"),
+            _run(80, "sha80"),
+        ]
+        assert pick_previous_run_sha(100, runs) == "sha90"
+
+    def test_skips_failed_runs(self):
+        runs = [_run(90, "sha90", conclusion="failure"), _run(80, "sha80")]
+        assert pick_previous_run_sha(100, runs) == "sha80"
+
+    def test_skips_successful_manual_runs(self):
+        runs = [
+            _run(95, "manual", event="workflow_dispatch"),
+            _run(90, "scheduled"),
+        ]
+        assert pick_previous_run_sha(100, runs) == "scheduled"
+
+    def test_ignores_runs_at_or_after_current(self):
+        runs = [_run(100, "cur"), _run(110, "future")]
+        assert pick_previous_run_sha(100, runs) is None
+
+    def test_empty(self):
+        assert pick_previous_run_sha(100, []) is None
+
+
+class TestFetchWorkflowRuns:
+    def test_requests_only_successful_scheduled_runs(self, monkeypatch):
+        responses = iter(
+            [
+                "1234",
+                '[{"id": 90, "head_sha": "scheduled", '
+                '"event": "schedule", "conclusion": "success"}]',
+            ]
+        )
+        calls = []
+
+        def fake_gh(*args):
+            calls.append(args)
+            return next(responses)
+
+        monkeypatch.setattr(resolve_diff_base, "_gh", fake_gh)
+
+        assert resolve_diff_base._fetch_workflow_runs("ai-dynamo/dynamo", 100) == [
+            {
+                "id": 90,
+                "head_sha": "scheduled",
+                "event": "schedule",
+                "conclusion": "success",
+            }
+        ]
+        assert calls[1][0].endswith("?event=schedule&status=success&per_page=50")
+        assert calls[1][2] == ("[.workflow_runs[] | {id, head_sha, event, conclusion}]")
+
+
+class TestPickCommitWithArtifact:
+    def test_returns_first_with_artifact(self):
+        # tip (sha_a) has none; walk back to sha_b which does.
+        have = {"sha_b"}
+        chosen, artifact, saw_error = pick_commit_with_artifact(
+            ["sha_a", "sha_b", "sha_c"],
+            lambda s: (("artifact", "run"), False) if s in have else (None, False),
+        )
+        assert chosen == "sha_b"
+        assert artifact == ("artifact", "run")
+        assert saw_error is False
+
+    def test_tip_has_artifact(self):
+        chosen, artifact, saw_error = pick_commit_with_artifact(
+            ["sha_a", "sha_b"], lambda s: (("artifact", "run"), False)
+        )
+        assert chosen == "sha_a"
+        assert artifact == ("artifact", "run")
+        assert saw_error is False
+
+    def test_none_found(self):
+        chosen, artifact, saw_error = pick_commit_with_artifact(
+            ["sha_a", "sha_b"], lambda s: (None, False)
+        )
+        assert chosen is None
+        assert artifact is None
+        assert saw_error is False
+
+    def test_api_error_then_hit(self):
+        results = {
+            "sha_a": (None, True),
+            "sha_b": (("artifact", "run"), False),
+        }
+        chosen, artifact, saw_error = pick_commit_with_artifact(
+            ["sha_a", "sha_b"], lambda s: results[s]
+        )
+        assert chosen == "sha_b"
+        assert artifact == ("artifact", "run")
+        assert saw_error is True
+
+    def test_all_api_error(self):
+        chosen, artifact, saw_error = pick_commit_with_artifact(
+            ["sha_a", "sha_b"], lambda s: (None, True)
+        )
+        assert chosen is None
+        assert artifact is None
+        assert saw_error is True
+
+    def test_empty(self):
+        assert pick_commit_with_artifact([], lambda s: (None, False)) == (
+            None,
+            None,
+            False,
+        )
+
+
+class TestFindArtifact:
+    def test_returns_exact_artifact_and_run_ids(self, monkeypatch):
+        monkeypatch.setattr(resolve_diff_base, "_gh", lambda *args: "123\t456")
+        assert find_artifact("ai-dynamo/dynamo", "sha", "vllm-runtime") == (
+            ("123", "456"),
+            False,
+        )
+
+    def test_distinguishes_absent_from_api_error(self, monkeypatch):
+        monkeypatch.setattr(resolve_diff_base, "_gh", lambda *args: "absent")
+        assert find_artifact("repo", "sha", "prefix") == (None, False)
+        monkeypatch.setattr(resolve_diff_base, "_gh", lambda *args: None)
+        assert find_artifact("repo", "sha", "prefix") == (None, True)
+
+
+class TestIsReleaseBranch:
+    def test_matches(self):
+        assert is_release_branch("release/1.3.0")
+        assert is_release_branch("release/1.3.0-cosmos3-dev.1")
+
+    def test_non_matches(self):
+        assert not is_release_branch("main")
+        assert not is_release_branch("pull-request/42")
+        assert not is_release_branch("")
+
+
+class TestResolveDispatch:
+    """Rule dispatch without touching git: assert which branch of resolve() fires
+    by inspecting the label. Rules 1/2/3 hit git; the fallback and the
+    unparseable-version paths do not."""
+
+    def test_fallback_no_baseline(self):
+        sha, label, artifact_id, run_id = resolve("push", "some-feature-branch", "", "")
+        assert sha == ""
+        assert "unrecognized" in label
+        assert artifact_id == run_id == ""
+
+    def test_release_push_without_version(self):
+        # Release context but no parseable version -> no git rev-list, empty sha.
+        sha, label, _, _ = resolve("push", "release/1.3.0", "", "")
+        assert sha == ""
+        assert "no parseable current version" in label
+
+    def test_pr_to_release_without_version(self):
+        sha, label, _, _ = resolve("pr", "pull-request/7", "release/1.3.0", "")
+        assert sha == ""
+        assert "no parseable current version" in label
+
+    def test_nightly_without_run_id(self):
+        # No run id -> no API call, empty sha, descriptive label.
+        sha, label, _, _ = resolve("nightly", "main", "", "", repo="ai-dynamo/dynamo")
+        assert sha == ""
+        assert "no current run id" in label
+
+    def test_pr_to_main_requires_merge_base(self):
+        sha, label, _, _ = resolve("pr", "pull-request/7", "main", "")
+        assert sha == ""
+        assert label == "PR merge-base unavailable"
+
+    def test_pr_to_main_starts_from_merge_base(self, monkeypatch):
+        calls = []
+
+        def fake_resolve(start_ref, repo, prefix, label="main", limit=25):
+            calls.append((start_ref, repo, prefix, label, limit))
+            return "base", label, "artifact", "run"
+
+        monkeypatch.setattr(resolve_diff_base, "_resolve_main_baseline", fake_resolve)
+
+        result = resolve(
+            "pr",
+            "pull-request/7",
+            "main",
+            "",
+            repo="ai-dynamo/dynamo",
+            artifact_prefix="vllm-runtime",
+            merge_base_sha="fork-point",
+        )
+
+        assert result == ("base", "PR merge-base", "artifact", "run")
+        assert calls == [
+            (
+                "fork-point",
+                "ai-dynamo/dynamo",
+                "vllm-runtime",
+                "PR merge-base",
+                25,
+            )
+        ]


### PR DESCRIPTION
## Summary

- Backports #11240 to `release/1.3.0` by cherry-picking main commit `c6e26c5cee594bf57bd47152c8b23a7c9f8580bc`.
- Adds OSRB CSV diff generation and baseline resolution to compliance artifacts.

Closes OPS-7283

## Validation

- `uv run --no-project --with pytest pytest -q -c /dev/null container/compliance/tests/test_diff_osrb_csv.py container/compliance/tests/test_resolve_diff_base.py` (43 passed)
- `uvx pre-commit run --from-ref github/release/1.3.0 --to-ref HEAD`
- `git verify-commit HEAD` with SSH ED25519 fingerprint `SHA256:8ylJai9wNRQRLU7zrwWuHpO0x2osQ3fjaXI0FTgXWwM`