### PR TITLE
fix: cover root CLAUDE.md in codeowners and match main/pr triggers

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -360,6 +360,7 @@ areas:
   - ATTRIBUTIONS-Rust.md
   - ATTRIBUTIONS-container-frontend.md
   - ATTRIBUTIONS.md
+  - CLAUDE.md
   - CODEOWNERS
   - CODE_OF_CONDUCT.md
   - CONTRIBUTING.md

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -11,8 +11,7 @@ on:
   push:
     branches: [main]
     paths:
-      - ".github/codeowners/**"
-      - "CODEOWNERS"
+      - "**"
 
 # This workflow runs scripts sourced from the PR diff; keep the token
 # read-only and out of the persisted git config (zizmor: artipacked,

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -134,6 +134,7 @@
 /skills                                                                                       @ai-dynamo/dynamo-process-codeowners
 /LICENSE                                                                                      @ai-dynamo/dynamo-process-codeowners
 /AGENTS.md                                                                                    @ai-dynamo/dynamo-process-codeowners
+/CLAUDE.md                                                                                    @ai-dynamo/dynamo-process-codeowners
 /CODEOWNERS                                                                                   @ai-dynamo/dynamo-process-codeowners
 /SECURITY.md                                                                                  @ai-dynamo/dynamo-process-codeowners
 /.claude/skills                                                                               @ai-dynamo/dynamo-process-codeowners


### PR DESCRIPTION
Root CLAUDE.md fell through to the codeowners catch-all, failing the strict coverage gate. Add it to the process area alongside AGENTS.md and regenerate CODEOWNERS.

The push:main trigger was path-filtered to codeowners sources only, so a top-level file added elsewhere never re-validated on main. Broaden to all paths, mirroring the pull_request trigger.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11603" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code ownership coverage for `CLAUDE.md`.
  * Expanded ownership validation to run for pull requests affecting any files.
  * Ensured process-related documentation changes receive the appropriate review coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->