### PR TITLE
fix(responses): preserve raw reasoning output

### DIFF
--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -9,9 +9,9 @@ use dynamo_protocols::types::responses::{
     AssistantRole, FunctionCallOutput, FunctionToolCall, IncludeEnum, InputContent, InputItem,
     InputOutputMessageContent, InputParam, InputRole, InputTokenDetails, Instructions, Item,
     MessageItem, OutputItem, OutputMessage, OutputMessageContent, OutputStatus, OutputTextContent,
-    OutputTokenDetails, PromptCacheRetention, Reasoning, ReasoningItem, Response,
-    ResponseTextParam, ResponseUsage, Role as ResponseRole, ServiceTier, Status, SummaryPart,
-    SummaryTextContent, TextResponseFormatConfiguration, Tool, ToolChoiceOptions, ToolChoiceParam,
+    OutputTokenDetails, PromptCacheRetention, Reasoning, ReasoningItem, ReasoningTextContent,
+    Response, ResponseTextParam, ResponseUsage, Role as ResponseRole, ServiceTier, Status,
+    SummaryPart, TextResponseFormatConfiguration, Tool, ToolChoiceOptions, ToolChoiceParam,
     Truncation,
 };
 use dynamo_protocols::types::{
@@ -125,6 +125,32 @@ pub(crate) fn patch_response_for_spec(
         serde_json::json!(frequency_penalty),
     );
     obj.insert("store".into(), serde_json::json!(store));
+
+    if let Some(serde_json::Value::Array(output)) = obj.get_mut("output") {
+        tag_reasoning_content_parts(output);
+    }
+}
+
+/// async-openai 0.34 serializes `ReasoningItem.content` parts without the
+/// `type` discriminator required by the Responses API wire format.
+pub(crate) fn tag_reasoning_content_parts(items: &mut [serde_json::Value]) {
+    for item in items {
+        let Some(item) = item.as_object_mut() else {
+            continue;
+        };
+        if item.get("type").and_then(|value| value.as_str()) != Some("reasoning") {
+            continue;
+        }
+        let Some(serde_json::Value::Array(content)) = item.get_mut("content") else {
+            continue;
+        };
+        for part in content {
+            if let Some(part) = part.as_object_mut() {
+                part.entry("type")
+                    .or_insert_with(|| serde_json::Value::String("reasoning_text".into()));
+            }
+        }
+    }
 }
 
 impl Serialize for NvResponse {
@@ -350,7 +376,8 @@ fn convert_upstream_input_content_to_text(
 #[derive(Default)]
 struct PendingAssistant {
     content: Option<String>,
-    reasoning_content: Option<String>,
+    reasoning_segments: Vec<String>,
+    pending_reasoning: String,
     tool_calls: Vec<ChatCompletionMessageToolCall>,
     touched: bool,
 }
@@ -367,29 +394,33 @@ impl PendingAssistant {
         }
     }
 
-    /// Route prior-turn reasoning summary text into the pending assistant's
-    /// `reasoning_content`. Codex and the Agents SDK round-trip `Item::Reasoning`
-    /// mid-turn so the model can see its own chain-of-thought as input context.
     fn push_reasoning(&mut self, text: &str) {
         self.touched = true;
-        if text.is_empty() {
-            return;
-        }
-        match self.reasoning_content.as_mut() {
-            Some(existing) => existing.push_str(text),
-            None => self.reasoning_content = Some(text.to_string()),
-        }
+        self.pending_reasoning.push_str(text);
     }
 
     fn push_tool_call(&mut self, call: ChatCompletionMessageToolCall) {
         self.touched = true;
+        self.reasoning_segments
+            .push(std::mem::take(&mut self.pending_reasoning));
         self.tool_calls.push(call);
     }
 
-    fn flush_into(self, out: &mut Vec<ChatCompletionRequestMessage>) {
+    fn flush_into(mut self, out: &mut Vec<ChatCompletionRequestMessage>) {
         if !self.touched {
             return;
         }
+        self.reasoning_segments.push(self.pending_reasoning);
+
+        let reasoning_content = if !self.tool_calls.is_empty()
+            && self.reasoning_segments.iter().any(|text| !text.is_empty())
+        {
+            Some(ReasoningContent::Segments(self.reasoning_segments))
+        } else {
+            let text = self.reasoning_segments.concat();
+            (!text.is_empty()).then_some(ReasoningContent::Text(text))
+        };
+
         // Content rules:
         //   - real text pushed → emit Some(Text(text))
         //   - pure tool-call turn (no text, has tool_calls) → emit None, matching
@@ -412,7 +443,7 @@ impl PendingAssistant {
         out.push(ChatCompletionRequestMessage::Assistant(
             ChatCompletionRequestAssistantMessage {
                 content,
-                reasoning_content: self.reasoning_content.map(ReasoningContent::Text),
+                reasoning_content,
                 refusal: None,
                 name: None,
                 audio: None,
@@ -511,12 +542,23 @@ fn convert_input_items_to_messages(
                     ));
                 }
                 Item::Reasoning(r) => {
-                    let text = r
-                        .summary
-                        .iter()
-                        .map(|SummaryPart::SummaryText(t)| t.text.as_str())
-                        .collect::<Vec<_>>()
-                        .join("");
+                    let content = r
+                        .content
+                        .as_ref()
+                        .map(|parts| {
+                            parts
+                                .iter()
+                                .map(|part| part.text.as_str())
+                                .collect::<String>()
+                        })
+                        .filter(|text| !text.is_empty());
+                    let summary = || {
+                        r.summary
+                            .iter()
+                            .map(|SummaryPart::SummaryText(part)| part.text.as_str())
+                            .collect::<String>()
+                    };
+                    let text = content.unwrap_or_else(summary);
                     pending.push_reasoning(&text);
                 }
                 other => {
@@ -993,6 +1035,22 @@ pub fn chat_completion_to_response(
     let mut output = Vec::new();
 
     if let Some(choice) = choice {
+        // Raw model reasoning is reasoning text, not a generated summary. Keep
+        // it before any tool calls so output order matches the decoded turn.
+        if let Some(reasoning_text) = choice.message.reasoning_content
+            && !reasoning_text.is_empty()
+        {
+            output.push(OutputItem::Reasoning(ReasoningItem {
+                id: format!("rs_{}", Uuid::new_v4().simple()),
+                summary: vec![],
+                content: Some(vec![ReasoningTextContent {
+                    text: reasoning_text,
+                }]),
+                encrypted_content: None,
+                status: Some(OutputStatus::Completed),
+            }));
+        }
+
         // Handle structured tool calls
         if let Some(tool_calls) = choice.message.tool_calls {
             for tc in &tool_calls {
@@ -1005,21 +1063,6 @@ pub fn chat_completion_to_response(
                     status: Some(OutputStatus::Completed),
                 }));
             }
-        }
-
-        // Map reasoning_content to a Reasoning output item
-        if let Some(reasoning_text) = choice.message.reasoning_content
-            && !reasoning_text.is_empty()
-        {
-            output.push(OutputItem::Reasoning(ReasoningItem {
-                id: format!("rs_{}", Uuid::new_v4().simple()),
-                summary: vec![SummaryPart::SummaryText(SummaryTextContent {
-                    text: reasoning_text,
-                })],
-                content: None,
-                encrypted_content: None,
-                status: Some(OutputStatus::Completed),
-            }));
         }
 
         // Handle text content -- also parse <tool_call> blocks from models
@@ -1956,47 +1999,92 @@ mod tests {
     }
 
     #[test]
-    fn test_reasoning_item_routed_into_reasoning_content() {
-        // Regression: Codex / Agents SDK round-trip Item::Reasoning mid-turn.
-        // The converter must route the reasoning summary into the coalesced
-        // assistant message's `reasoning_content`, not silently drop it.
+    fn test_reasoning_item_replay_prefers_content_with_summary_fallback() {
         use dynamo_protocols::types::responses::{
-            InputReasoningItem, SummaryPart, SummaryTextContent,
+            InputReasoningItem, ReasoningTextContent, SummaryPart, SummaryTextContent,
         };
 
+        let cases = [
+            (
+                InputReasoningItem {
+                    id: Some("rs_summary".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: "summary reasoning".into(),
+                    })],
+                    content: None,
+                    encrypted_content: None,
+                    status: None,
+                },
+                "summary reasoning",
+            ),
+            (
+                InputReasoningItem {
+                    id: Some("rs_content".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: "fallback summary".into(),
+                    })],
+                    content: Some(vec![ReasoningTextContent {
+                        text: "raw reasoning".into(),
+                    }]),
+                    encrypted_content: None,
+                    status: None,
+                },
+                "raw reasoning",
+            ),
+        ];
+
+        for (reasoning, expected) in cases {
+            let req = NvCreateResponse {
+                inner: CreateResponse {
+                    input: InputParam::Items(vec![InputItem::Item(Item::Reasoning(reasoning))]),
+                    model: Some("test-model".into()),
+                    ..Default::default()
+                },
+                nvext: None,
+            };
+
+            let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+            assert!(matches!(
+                &chat_req.inner.messages[0],
+                ChatCompletionRequestMessage::Assistant(message)
+                    if matches!(
+                        message.reasoning_content.as_ref(),
+                        Some(ReasoningContent::Text(text)) if text == expected
+                    )
+            ));
+        }
+    }
+
+    #[test]
+    fn test_interleaved_reasoning_and_tool_calls_preserve_segments() {
+        use dynamo_protocols::types::responses::{InputReasoningItem, ReasoningTextContent};
+
+        let reasoning = |id: &str, text: &str| {
+            InputItem::Item(Item::Reasoning(InputReasoningItem {
+                id: Some(id.into()),
+                summary: vec![],
+                content: Some(vec![ReasoningTextContent { text: text.into() }]),
+                encrypted_content: None,
+                status: None,
+            }))
+        };
+        let tool_call = |call_id: &str, name: &str| {
+            InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                arguments: "{}".into(),
+                call_id: call_id.into(),
+                namespace: None,
+                name: name.into(),
+                id: None,
+                status: None,
+            }))
+        };
         let req = NvCreateResponse {
             inner: CreateResponse {
                 input: InputParam::Items(vec![
-                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
-                        content: vec![InputContent::InputText(InputTextContent {
-                            text: "solve".into(),
-                        })],
-                        role: InputRole::User,
-                        status: None,
-                    }))),
-                    InputItem::Item(Item::Reasoning(InputReasoningItem {
-                        id: Some("rs_1".into()),
-                        summary: vec![SummaryPart::SummaryText(SummaryTextContent {
-                            text: "thinking step 1".into(),
-                        })],
-                        content: None,
-                        encrypted_content: None,
-                        status: None,
-                    })),
-                    InputItem::Item(Item::FunctionCall(FunctionToolCall {
-                        arguments: "{}".into(),
-                        call_id: "c".into(),
-                        namespace: None,
-                        name: "f".into(),
-                        id: None,
-                        status: None,
-                    })),
-                    InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
-                        call_id: "c".into(),
-                        output: FunctionCallOutput::Text("ok".into()),
-                        id: None,
-                        status: None,
-                    })),
+                    reasoning("rs_1", "first thought"),
+                    tool_call("call_1", "first_tool"),
+                    reasoning("rs_2", "second thought"),
+                    tool_call("call_2", "second_tool"),
                 ]),
                 model: Some("test-model".into()),
                 ..Default::default()
@@ -2005,22 +2093,18 @@ mod tests {
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
-        let messages = &chat_req.inner.messages;
-        assert_eq!(messages.len(), 3);
-        match &messages[1] {
-            ChatCompletionRequestMessage::Assistant(a) => {
-                match a
-                    .reasoning_content
-                    .as_ref()
-                    .expect("reasoning must be preserved")
-                {
-                    ReasoningContent::Text(t) => assert_eq!(t, "thinking step 1"),
-                    _ => panic!("expected Text reasoning content"),
-                }
-                assert!(a.tool_calls.is_some());
-            }
-            _ => panic!("expected assistant message with reasoning + tool_calls"),
-        }
+        let ChatCompletionRequestMessage::Assistant(message) = &chat_req.inner.messages[0] else {
+            panic!("expected assistant message");
+        };
+        assert_eq!(
+            message.reasoning_content,
+            Some(ReasoningContent::Segments(vec![
+                "first thought".into(),
+                "second thought".into(),
+                String::new(),
+            ]))
+        );
+        assert_eq!(message.tool_calls.as_ref().unwrap().len(), 2);
     }
 
     #[test]
@@ -2472,7 +2556,7 @@ mod tests {
                         role: dynamo_protocols::types::Role::Assistant,
                         function_call: None,
                         audio: None,
-                        reasoning_content: None,
+                        reasoning_content: Some("Need the weather tool".into()),
                     },
                     finish_reason: None,
                     logprobs: None,
@@ -2489,8 +2573,16 @@ mod tests {
 
         let wrapped =
             chat_completion_to_response(chat_resp, &ResponseParams::default(), None).unwrap();
-        assert_eq!(wrapped.inner.output.len(), 1);
-        match &wrapped.inner.output[0] {
+        assert_eq!(wrapped.inner.output.len(), 2);
+        let OutputItem::Reasoning(reasoning) = &wrapped.inner.output[0] else {
+            panic!("Expected Reasoning output before the tool call");
+        };
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(
+            reasoning.content.as_ref().unwrap()[0].text,
+            "Need the weather tool"
+        );
+        match &wrapped.inner.output[1] {
             OutputItem::FunctionCall(fc) => {
                 assert_eq!(fc.call_id, "call_abc");
                 assert_eq!(fc.name, "get_weather");
@@ -3004,7 +3096,8 @@ thinking
     /// emitted as `null` when None.
     #[test]
     fn test_response_wire_format_shape() {
-        let chat_resp = make_chat_resp_with_text("hello");
+        let mut chat_resp = make_chat_resp_with_text("hello");
+        chat_resp.inner.choices[0].message.reasoning_content = Some("raw reasoning".into());
         let params = ResponseParams::default();
         let resp = chat_completion_to_response(chat_resp, &params, None).unwrap();
         let json = serde_json::to_value(&resp).unwrap();
@@ -3023,6 +3116,13 @@ thinking
         assert!(json["output"].is_array());
         assert!(json["output"][0].get("id").is_some());
         assert!(json["output"][0].get("status").is_some());
+        assert_eq!(json["output"][0]["type"], "reasoning");
+        assert_eq!(json["output"][0]["summary"], serde_json::json!([]));
+        assert_eq!(
+            json["output"][0]["content"][0],
+            serde_json::json!({"type": "reasoning_text", "text": "raw reasoning"})
+        );
+        assert_eq!(json["output"][1]["type"], "message");
 
         // Nullable-required fields must be present as null (not missing).
         for key in [

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -1157,8 +1157,7 @@ pub fn chat_completion_to_response(
         output_limit_reached =
             choice.finish_reason == Some(dynamo_protocols::types::FinishReason::Length);
 
-        // Raw model reasoning is reasoning text, not a generated summary. Keep
-        // it before any tool calls so output order matches the decoded turn.
+        // Reasoning precedes tool calls so output order matches the decoded turn.
         if let Some(reasoning_text) = choice.message.reasoning_content
             && !reasoning_text.is_empty()
             && params.reasoning_summary_requested()

--- a/lib/llm/src/protocols/openai/responses/mod.rs
+++ b/lib/llm/src/protocols/openai/responses/mod.rs
@@ -10,9 +10,10 @@ use dynamo_protocols::types::responses::{
     InputContent, InputItem, InputOutputMessageContent, InputParam, InputRole, InputTokenDetails,
     Instructions, Item, MessageItem, NamespaceToolParamTool, OutputItem, OutputMessage,
     OutputMessageContent, OutputStatus, OutputTextContent, OutputTokenDetails,
-    PromptCacheRetention, Reasoning, ReasoningItem, Response, ResponseTextParam, ResponseUsage,
-    Role as ResponseRole, ServiceTier, Status, SummaryPart, SummaryTextContent,
-    TextResponseFormatConfiguration, Tool, ToolChoiceOptions, ToolChoiceParam, Truncation,
+    PromptCacheRetention, Reasoning, ReasoningItem, ReasoningItemContent, ReasoningTextContent,
+    Response, ResponseTextParam, ResponseUsage, Role as ResponseRole, ServiceTier, Status,
+    SummaryPart, TextResponseFormatConfiguration, Tool, ToolChoiceOptions, ToolChoiceParam,
+    Truncation,
 };
 use dynamo_protocols::types::{
     ChatCompletionMessageToolCall, ChatCompletionNamedToolChoice,
@@ -404,7 +405,8 @@ fn convert_upstream_input_content_to_text(
 #[derive(Default)]
 struct PendingAssistant {
     content: Option<String>,
-    reasoning_content: Option<String>,
+    reasoning_segments: Vec<String>,
+    pending_reasoning: String,
     tool_calls: Vec<ChatCompletionMessageToolCall>,
     touched: bool,
 }
@@ -421,29 +423,33 @@ impl PendingAssistant {
         }
     }
 
-    /// Route prior-turn reasoning summary text into the pending assistant's
-    /// `reasoning_content`. Codex and the Agents SDK round-trip `Item::Reasoning`
-    /// mid-turn so the model can see its own chain-of-thought as input context.
     fn push_reasoning(&mut self, text: &str) {
         self.touched = true;
-        if text.is_empty() {
-            return;
-        }
-        match self.reasoning_content.as_mut() {
-            Some(existing) => existing.push_str(text),
-            None => self.reasoning_content = Some(text.to_string()),
-        }
+        self.pending_reasoning.push_str(text);
     }
 
     fn push_tool_call(&mut self, call: ChatCompletionMessageToolCall) {
         self.touched = true;
+        self.reasoning_segments
+            .push(std::mem::take(&mut self.pending_reasoning));
         self.tool_calls.push(call);
     }
 
-    fn flush_into(self, out: &mut Vec<ChatCompletionRequestMessage>) {
+    fn flush_into(mut self, out: &mut Vec<ChatCompletionRequestMessage>) {
         if !self.touched {
             return;
         }
+        self.reasoning_segments.push(self.pending_reasoning);
+
+        let reasoning_content = if !self.tool_calls.is_empty()
+            && self.reasoning_segments.iter().any(|text| !text.is_empty())
+        {
+            Some(ReasoningContent::Segments(self.reasoning_segments))
+        } else {
+            let text = self.reasoning_segments.concat();
+            (!text.is_empty()).then_some(ReasoningContent::Text(text))
+        };
+
         // Content rules:
         //   - real text pushed → emit Some(Text(text))
         //   - pure tool-call turn (no text, has tool_calls) → emit None, matching
@@ -466,7 +472,7 @@ impl PendingAssistant {
         out.push(ChatCompletionRequestMessage::Assistant(
             ChatCompletionRequestAssistantMessage {
                 content,
-                reasoning_content: self.reasoning_content.map(ReasoningContent::Text),
+                reasoning_content,
                 refusal: None,
                 name: None,
                 audio: None,
@@ -565,12 +571,23 @@ fn convert_input_items_to_messages(
                     ));
                 }
                 Item::Reasoning(r) => {
-                    let text = r
-                        .summary
-                        .iter()
-                        .map(|SummaryPart::SummaryText(t)| t.text.as_str())
-                        .collect::<Vec<_>>()
-                        .join("");
+                    let content = r
+                        .content
+                        .as_ref()
+                        .map(|parts| {
+                            parts
+                                .iter()
+                                .map(|part| part.text.as_str())
+                                .collect::<String>()
+                        })
+                        .filter(|text| !text.is_empty());
+                    let summary = || {
+                        r.summary
+                            .iter()
+                            .map(|SummaryPart::SummaryText(part)| part.text.as_str())
+                            .collect::<String>()
+                    };
+                    let text = content.unwrap_or_else(summary);
                     pending.push_reasoning(&text);
                 }
                 other => {
@@ -1140,16 +1157,20 @@ pub fn chat_completion_to_response(
         output_limit_reached =
             choice.finish_reason == Some(dynamo_protocols::types::FinishReason::Length);
 
+        // Raw model reasoning is reasoning text, not a generated summary. Keep
+        // it before any tool calls so output order matches the decoded turn.
         if let Some(reasoning_text) = choice.message.reasoning_content
             && !reasoning_text.is_empty()
             && params.reasoning_summary_requested()
         {
             output.push(OutputItem::Reasoning(ReasoningItem {
                 id: Some(format!("rs_{}", Uuid::new_v4().simple())),
-                summary: vec![SummaryPart::SummaryText(SummaryTextContent {
-                    text: reasoning_text,
-                })],
-                content: None,
+                summary: vec![],
+                content: Some(vec![ReasoningItemContent::ReasoningText(
+                    ReasoningTextContent {
+                        text: reasoning_text,
+                    },
+                )]),
                 encrypted_content: None,
                 status: Some(OutputStatus::Completed),
             }));
@@ -1168,7 +1189,6 @@ pub fn chat_completion_to_response(
                 }));
             }
         }
-
         // Handle text content -- also parse <tool_call> blocks from models
         // that emit tool calls as text (e.g. Qwen3)
         let content_text = match choice.message.content {
@@ -1363,6 +1383,27 @@ mod tests {
             }),
             chat_template_args: None,
         }
+    }
+
+    fn requested_reasoning_params() -> ResponseParams {
+        use dynamo_protocols::types::responses::ReasoningSummary;
+
+        ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn reasoning_text(item: &ReasoningItem) -> &str {
+        let Some(ReasoningItemContent::ReasoningText(content)) =
+            item.content.as_ref().and_then(|content| content.first())
+        else {
+            panic!("expected reasoning text content");
+        };
+        &content.text
     }
 
     #[test]
@@ -2166,47 +2207,93 @@ mod tests {
     }
 
     #[test]
-    fn test_reasoning_item_routed_into_reasoning_content() {
-        // Regression: Codex / Agents SDK round-trip Item::Reasoning mid-turn.
-        // The converter must route the reasoning summary into the coalesced
-        // assistant message's `reasoning_content`, not silently drop it.
+    fn test_reasoning_item_replay_prefers_content_with_summary_fallback() {
         use dynamo_protocols::types::responses::{
-            InputReasoningItem, SummaryPart, SummaryTextContent,
+            InputReasoningItem, ReasoningTextContent, SummaryPart, SummaryTextContent,
         };
 
+        let cases = [
+            (
+                InputReasoningItem {
+                    id: Some("rs_summary".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: "summary reasoning".into(),
+                    })],
+                    content: None,
+                    encrypted_content: None,
+                    status: None,
+                },
+                "summary reasoning",
+            ),
+            (
+                InputReasoningItem {
+                    id: Some("rs_content".into()),
+                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
+                        text: "fallback summary".into(),
+                    })],
+                    content: Some(vec![ReasoningTextContent {
+                        text: "raw reasoning".into(),
+                    }]),
+                    encrypted_content: None,
+                    status: None,
+                },
+                "raw reasoning",
+            ),
+        ];
+
+        for (reasoning, expected) in cases {
+            let req = NvCreateResponse {
+                inner: CreateResponse {
+                    input: InputParam::Items(vec![InputItem::Item(Item::Reasoning(reasoning))]),
+                    model: Some("test-model".into()),
+                    ..Default::default()
+                },
+                nvext: None,
+                chat_template_args: None,
+            };
+
+            let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
+            assert!(matches!(
+                &chat_req.inner.messages[0],
+                ChatCompletionRequestMessage::Assistant(message)
+                    if matches!(
+                        message.reasoning_content.as_ref(),
+                        Some(ReasoningContent::Text(text)) if text == expected
+                    )
+            ));
+        }
+    }
+
+    #[test]
+    fn test_interleaved_reasoning_and_tool_calls_preserve_segments() {
+        use dynamo_protocols::types::responses::{InputReasoningItem, ReasoningTextContent};
+
+        let reasoning = |id: &str, text: &str| {
+            InputItem::Item(Item::Reasoning(InputReasoningItem {
+                id: Some(id.into()),
+                summary: vec![],
+                content: Some(vec![ReasoningTextContent { text: text.into() }]),
+                encrypted_content: None,
+                status: None,
+            }))
+        };
+        let tool_call = |call_id: &str, name: &str| {
+            InputItem::Item(Item::FunctionCall(FunctionToolCall {
+                arguments: "{}".into(),
+                call_id: call_id.into(),
+                namespace: None,
+                name: name.into(),
+                id: None,
+                status: None,
+            }))
+        };
         let req = NvCreateResponse {
             inner: CreateResponse {
                 input: InputParam::Items(vec![
-                    InputItem::Item(Item::Message(MessageItem::Input(InputMessage {
-                        content: vec![InputContent::InputText(InputTextContent {
-                            text: "solve".into(),
-                        })],
-                        role: InputRole::User,
-                        status: None,
-                    }))),
-                    InputItem::Item(Item::Reasoning(InputReasoningItem {
-                        id: Some("rs_1".into()),
-                        summary: vec![SummaryPart::SummaryText(SummaryTextContent {
-                            text: "thinking step 1".into(),
-                        })],
-                        content: None,
-                        encrypted_content: None,
-                        status: None,
-                    })),
-                    InputItem::Item(Item::FunctionCall(FunctionToolCall {
-                        arguments: "{}".into(),
-                        call_id: "c".into(),
-                        namespace: None,
-                        name: "f".into(),
-                        id: None,
-                        status: None,
-                    })),
-                    InputItem::Item(Item::FunctionCallOutput(FunctionCallOutputItemParam {
-                        call_id: "c".into(),
-                        output: FunctionCallOutput::Text("ok".into()),
-                        id: None,
-                        status: None,
-                    })),
+                    reasoning("rs_1", "first thought"),
+                    tool_call("call_1", "first_tool"),
+                    reasoning("rs_2", "second thought"),
+                    tool_call("call_2", "second_tool"),
                 ]),
                 model: Some("test-model".into()),
                 ..Default::default()
@@ -2216,22 +2303,18 @@ mod tests {
         };
 
         let chat_req: NvCreateChatCompletionRequest = req.try_into().unwrap();
-        let messages = &chat_req.inner.messages;
-        assert_eq!(messages.len(), 3);
-        match &messages[1] {
-            ChatCompletionRequestMessage::Assistant(a) => {
-                match a
-                    .reasoning_content
-                    .as_ref()
-                    .expect("reasoning must be preserved")
-                {
-                    ReasoningContent::Text(t) => assert_eq!(t, "thinking step 1"),
-                    _ => panic!("expected Text reasoning content"),
-                }
-                assert!(a.tool_calls.is_some());
-            }
-            _ => panic!("expected assistant message with reasoning + tool_calls"),
-        }
+        let ChatCompletionRequestMessage::Assistant(message) = &chat_req.inner.messages[0] else {
+            panic!("expected assistant message");
+        };
+        assert_eq!(
+            message.reasoning_content,
+            Some(ReasoningContent::Segments(vec![
+                "first thought".into(),
+                "second thought".into(),
+                String::new(),
+            ]))
+        );
+        assert_eq!(message.tool_calls.as_ref().unwrap().len(), 2);
     }
 
     #[test]
@@ -2804,7 +2887,7 @@ mod tests {
                         role: dynamo_protocols::types::Role::Assistant,
                         function_call: None,
                         audio: None,
-                        reasoning_content: None,
+                        reasoning_content: Some("Need the weather tool".into()),
                     },
                     finish_reason: None,
                     logprobs: None,
@@ -2820,9 +2903,14 @@ mod tests {
         };
 
         let wrapped =
-            chat_completion_to_response(chat_resp, &ResponseParams::default(), None).unwrap();
-        assert_eq!(wrapped.inner.output.len(), 1);
-        match &wrapped.inner.output[0] {
+            chat_completion_to_response(chat_resp, &requested_reasoning_params(), None).unwrap();
+        assert_eq!(wrapped.inner.output.len(), 2);
+        let OutputItem::Reasoning(reasoning) = &wrapped.inner.output[0] else {
+            panic!("Expected Reasoning output before the tool call");
+        };
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning_text(reasoning), "Need the weather tool");
+        match &wrapped.inner.output[1] {
             OutputItem::FunctionCall(fc) => {
                 assert_eq!(fc.call_id, "call_abc");
                 assert_eq!(fc.name, "get_weather");
@@ -3363,9 +3451,7 @@ thinking
     }
 
     #[test]
-    fn test_reasoning_summary_requires_explicit_request() {
-        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
-
+    fn test_reasoning_text_requires_explicit_request() {
         let unrequested = chat_completion_to_response(
             make_chat_resp_with_reasoning("private reasoning"),
             &ResponseParams::default(),
@@ -3380,13 +3466,7 @@ thinking
                 .all(|item| !matches!(item, OutputItem::Reasoning(_)))
         );
 
-        let params = ResponseParams {
-            reasoning: Some(Reasoning {
-                effort: None,
-                summary: Some(ReasoningSummary::Auto),
-            }),
-            ..Default::default()
-        };
+        let params = requested_reasoning_params();
         let requested =
             chat_completion_to_response(make_chat_resp_with_reasoning("summary"), &params, None)
                 .unwrap();
@@ -3398,13 +3478,9 @@ thinking
                 OutputItem::Reasoning(reasoning) => Some(reasoning),
                 _ => None,
             })
-            .expect("requested reasoning summary output");
-        assert_eq!(
-            reasoning.summary,
-            vec![SummaryPart::SummaryText(SummaryTextContent {
-                text: "summary".into(),
-            })]
-        );
+            .expect("requested reasoning output");
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning_text(reasoning), "summary");
     }
 
     #[test]
@@ -3666,8 +3742,9 @@ thinking
     /// emitted as `null` when None.
     #[test]
     fn test_response_wire_format_shape() {
-        let chat_resp = make_chat_resp_with_text("hello");
-        let params = ResponseParams::default();
+        let mut chat_resp = make_chat_resp_with_text("hello");
+        chat_resp.inner.choices[0].message.reasoning_content = Some("raw reasoning".into());
+        let params = requested_reasoning_params();
         let resp = chat_completion_to_response(chat_resp, &params, None).unwrap();
         let json = serde_json::to_value(&resp).unwrap();
 
@@ -3685,6 +3762,13 @@ thinking
         assert!(json["output"].is_array());
         assert!(json["output"][0].get("id").is_some());
         assert!(json["output"][0].get("status").is_some());
+        assert_eq!(json["output"][0]["type"], "reasoning");
+        assert_eq!(json["output"][0]["summary"], serde_json::json!([]));
+        assert_eq!(
+            json["output"][0]["content"][0],
+            serde_json::json!({"type": "reasoning_text", "text": "raw reasoning"})
+        );
+        assert_eq!(json["output"][1]["type"], "message");
 
         // Nullable-required fields must be present as null (not missing).
         for key in [
@@ -3697,7 +3781,6 @@ thinking
             "instructions",
             "previous_response_id",
             "prompt_cache_key",
-            "reasoning",
         ] {
             assert_eq!(
                 json.get(key),

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -16,16 +16,18 @@ use axum::response::sse::Event;
 use dynamo_protocols::types::responses::{
     AssistantRole, FunctionToolCall, InputTokenDetails, Instructions, OutputContent, OutputItem,
     OutputMessage, OutputMessageContent, OutputStatus, OutputTextContent, OutputTokenDetails,
-    Response, ResponseCompletedEvent, ResponseContentPartAddedEvent, ResponseContentPartDoneEvent,
-    ResponseCreatedEvent, ResponseFailedEvent, ResponseFunctionCallArgumentsDeltaEvent,
+    ReasoningItem, ReasoningTextContent, Response, ResponseCompletedEvent,
+    ResponseContentPartAddedEvent, ResponseContentPartDoneEvent, ResponseCreatedEvent,
+    ResponseFailedEvent, ResponseFunctionCallArgumentsDeltaEvent,
     ResponseFunctionCallArgumentsDoneEvent, ResponseInProgressEvent, ResponseOutputItemAddedEvent,
-    ResponseOutputItemDoneEvent, ResponseStreamEvent, ResponseTextDeltaEvent,
-    ResponseTextDoneEvent, ResponseTextParam, ResponseUsage, ServiceTier, Status,
-    TextResponseFormatConfiguration, ToolChoiceOptions, ToolChoiceParam, Truncation,
+    ResponseOutputItemDoneEvent, ResponseReasoningTextDeltaEvent, ResponseReasoningTextDoneEvent,
+    ResponseStreamEvent, ResponseTextDeltaEvent, ResponseTextDoneEvent, ResponseTextParam,
+    ResponseUsage, ServiceTier, Status, TextResponseFormatConfiguration, ToolChoiceOptions,
+    ToolChoiceParam, Truncation,
 };
 use serde::{
     Serialize,
-    ser::{SerializeMap, Serializer},
+    ser::{SerializeMap, SerializeSeq, Serializer},
 };
 use uuid::Uuid;
 
@@ -49,12 +51,37 @@ pub struct ResponseStreamConverter {
     message_started: bool,
     message_output_index: u32,
     accumulated_text: String,
+    // Ordered reasoning spans. A new item is opened if reasoning resumes after
+    // text or a tool call, preserving interleaved model output.
+    reasoning_items: Vec<ReasoningState>,
+    active_reasoning_index: Option<usize>,
     // Function call tracking
     function_call_items: Vec<FunctionCallState>,
     // Output index counter
     next_output_index: u32,
     // Usage stats from the backend's final chunk
     usage: Option<ResponseUsage>,
+}
+
+struct ReasoningState {
+    item_id: String,
+    accumulated_text: String,
+    output_index: u32,
+    done: bool,
+}
+
+impl ReasoningState {
+    fn completed_item(&self) -> ReasoningItem {
+        ReasoningItem {
+            id: self.item_id.clone(),
+            summary: vec![],
+            content: Some(vec![ReasoningTextContent {
+                text: self.accumulated_text.clone(),
+            }]),
+            encrypted_content: None,
+            status: Some(OutputStatus::Completed),
+        }
+    }
 }
 
 struct FunctionCallState {
@@ -92,6 +119,8 @@ impl ResponseStreamConverter {
             message_started: false,
             message_output_index: 0,
             accumulated_text: String::new(),
+            reasoning_items: Vec::new(),
+            active_reasoning_index: None,
             function_call_items: Vec::new(),
             next_output_index: 0,
             usage: None,
@@ -108,6 +137,118 @@ impl ResponseStreamConverter {
         let seq = self.sequence_number;
         self.sequence_number += 1;
         seq
+    }
+
+    fn append_reasoning_delta(
+        &mut self,
+        reasoning: &str,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        if self.active_reasoning_index.is_none() {
+            let output_index = self.next_output_index;
+            self.next_output_index += 1;
+            let item_id = format!("rs_{}", Uuid::new_v4().simple());
+            self.reasoning_items.push(ReasoningState {
+                item_id: item_id.clone(),
+                accumulated_text: String::new(),
+                output_index,
+                done: false,
+            });
+            self.active_reasoning_index = Some(self.reasoning_items.len() - 1);
+
+            let item_added =
+                ResponseStreamEvent::ResponseOutputItemAdded(ResponseOutputItemAddedEvent {
+                    sequence_number: self.next_seq(),
+                    output_index,
+                    item: OutputItem::Reasoning(ReasoningItem {
+                        id: item_id.clone(),
+                        summary: vec![],
+                        content: Some(vec![]),
+                        encrypted_content: None,
+                        status: Some(OutputStatus::InProgress),
+                    }),
+                });
+            events.push(self.make_sse_event(&item_added));
+
+            let part_added =
+                ResponseStreamEvent::ResponseContentPartAdded(ResponseContentPartAddedEvent {
+                    sequence_number: self.next_seq(),
+                    item_id,
+                    output_index,
+                    content_index: 0,
+                    part: OutputContent::ReasoningText(ReasoningTextContent {
+                        text: String::new(),
+                    }),
+                });
+            events.push(self.make_sse_event(&part_added));
+        }
+
+        let state_index = self
+            .active_reasoning_index
+            .expect("reasoning state must be active after opening it");
+        let (item_id, output_index) = {
+            let state = &mut self.reasoning_items[state_index];
+            state.accumulated_text.push_str(reasoning);
+            (state.item_id.clone(), state.output_index)
+        };
+        let delta =
+            ResponseStreamEvent::ResponseReasoningTextDelta(ResponseReasoningTextDeltaEvent {
+                sequence_number: self.next_seq(),
+                item_id,
+                output_index,
+                content_index: 0,
+                delta: reasoning.to_string(),
+            });
+        events.push(self.make_sse_event(&delta));
+    }
+
+    fn append_active_reasoning_done_events(
+        &mut self,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        let Some(state_index) = self.active_reasoning_index.take() else {
+            return;
+        };
+        let (item_id, output_index, text, item) = {
+            let state = &mut self.reasoning_items[state_index];
+            if state.done {
+                return;
+            }
+            state.done = true;
+            (
+                state.item_id.clone(),
+                state.output_index,
+                state.accumulated_text.clone(),
+                state.completed_item(),
+            )
+        };
+
+        let text_done =
+            ResponseStreamEvent::ResponseReasoningTextDone(ResponseReasoningTextDoneEvent {
+                sequence_number: self.next_seq(),
+                item_id: item_id.clone(),
+                output_index,
+                content_index: 0,
+                text: text.clone(),
+            });
+        events.push(self.make_sse_event(&text_done));
+
+        let part_done =
+            ResponseStreamEvent::ResponseContentPartDone(ResponseContentPartDoneEvent {
+                sequence_number: self.next_seq(),
+                item_id: item_id.clone(),
+                output_index,
+                content_index: 0,
+                part: OutputContent::ReasoningText(ReasoningTextContent { text }),
+            });
+        events.push(self.make_sse_event(&part_done));
+
+        let item_done = ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
+            sequence_number: self.next_seq(),
+            output_index,
+            item: OutputItem::Reasoning(item),
+        });
+        events.push(self.make_sse_event(&item_done));
     }
 
     fn make_response(&self, status: Status, output: Vec<OutputItem>) -> Response {
@@ -239,6 +380,12 @@ impl ResponseStreamConverter {
         for choice in &chunk.inner.choices {
             let delta = &choice.delta;
 
+            if let Some(reasoning) = &delta.reasoning_content
+                && !reasoning.is_empty()
+            {
+                self.append_reasoning_delta(reasoning, events);
+            }
+
             // Handle text content deltas — extract text from the enum
             let content_text = match &delta.content {
                 Some(ChatCompletionMessageContent::Text(text)) => Some(text.as_str()),
@@ -251,6 +398,8 @@ impl ResponseStreamConverter {
             if let Some(content) = content_text
                 && !content.is_empty()
             {
+                self.append_active_reasoning_done_events(events);
+
                 // Emit output_item.added + content_part.added on first text
                 if !self.message_started {
                     self.message_started = true;
@@ -305,6 +454,9 @@ impl ResponseStreamConverter {
 
             // Handle tool call deltas
             if let Some(tool_calls) = &delta.tool_calls {
+                if !tool_calls.is_empty() {
+                    self.append_active_reasoning_done_events(events);
+                }
                 for tc in tool_calls {
                     let tc_index = tc.index as usize;
 
@@ -490,6 +642,12 @@ impl ResponseStreamConverter {
 
     fn completed_output(&self) -> Vec<OutputItem> {
         let mut output = Vec::new();
+        for reasoning in &self.reasoning_items {
+            output.push((
+                reasoning.output_index,
+                OutputItem::Reasoning(reasoning.completed_item()),
+            ));
+        }
         if self.message_started {
             output.push((
                 self.message_output_index,
@@ -534,6 +692,8 @@ impl ResponseStreamConverter {
 
     /// Append remaining output completion events and `response.completed` at stream end.
     pub fn append_end_events(&mut self, events: &mut Vec<Result<Event, anyhow::Error>>) {
+        self.append_active_reasoning_done_events(events);
+
         // Close text message if it was started
         if self.message_started {
             let text_done = ResponseStreamEvent::ResponseOutputTextDone(ResponseTextDoneEvent {
@@ -677,6 +837,22 @@ impl ResponseStreamConverter {
                     spec,
                 ))
             }
+            ResponseStreamEvent::ResponseOutputItemAdded(event) => {
+                serde_json::to_string(&OutputItemEventForSpec {
+                    event_type: "response.output_item.added",
+                    sequence_number: event.sequence_number,
+                    output_index: event.output_index,
+                    item: &event.item,
+                })
+            }
+            ResponseStreamEvent::ResponseOutputItemDone(event) => {
+                serde_json::to_string(&OutputItemEventForSpec {
+                    event_type: "response.output_item.done",
+                    sequence_number: event.sequence_number,
+                    output_index: event.output_index,
+                    item: &event.item,
+                })
+            }
             _ => serde_json::to_string(event),
         }
     }
@@ -733,6 +909,88 @@ struct ResponseForSpec<'a> {
     spec: ResponseSpecFields,
 }
 
+struct OutputItemEventForSpec<'a> {
+    event_type: &'static str,
+    sequence_number: u64,
+    output_index: u32,
+    item: &'a OutputItem,
+}
+
+impl Serialize for OutputItemEventForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(4))?;
+        map.serialize_entry("type", self.event_type)?;
+        map.serialize_entry("sequence_number", &self.sequence_number)?;
+        map.serialize_entry("output_index", &self.output_index)?;
+        map.serialize_entry("item", &OutputItemForSpec(self.item))?;
+        map.end()
+    }
+}
+
+struct OutputItemsForSpec<'a>(&'a [OutputItem]);
+
+impl Serialize for OutputItemsForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for item in self.0 {
+            sequence.serialize_element(&OutputItemForSpec(item))?;
+        }
+        sequence.end()
+    }
+}
+
+struct OutputItemForSpec<'a>(&'a OutputItem);
+
+impl Serialize for OutputItemForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        match self.0 {
+            OutputItem::Reasoning(item) => ReasoningItemForSpec(item).serialize(serializer),
+            item => item.serialize(serializer),
+        }
+    }
+}
+
+struct ReasoningItemForSpec<'a>(&'a ReasoningItem);
+
+impl Serialize for ReasoningItemForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let item = self.0;
+        let mut map = serializer.serialize_map(None)?;
+        map.serialize_entry("type", "reasoning")?;
+        map.serialize_entry("id", &item.id)?;
+        map.serialize_entry("summary", &item.summary)?;
+        if let Some(content) = &item.content {
+            map.serialize_entry("content", &ReasoningContentForSpec(content))?;
+        }
+        serialize_optional_entry(&mut map, "encrypted_content", &item.encrypted_content)?;
+        serialize_optional_entry(&mut map, "status", &item.status)?;
+        map.end()
+    }
+}
+
+struct ReasoningContentForSpec<'a>(&'a [ReasoningTextContent]);
+
+impl Serialize for ReasoningContentForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut sequence = serializer.serialize_seq(Some(self.0.len()))?;
+        for part in self.0 {
+            sequence.serialize_element(&ReasoningTextContentForSpec(part))?;
+        }
+        sequence.end()
+    }
+}
+
+struct ReasoningTextContentForSpec<'a>(&'a ReasoningTextContent);
+
+impl Serialize for ReasoningTextContentForSpec<'_> {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut map = serializer.serialize_map(Some(2))?;
+        map.serialize_entry("type", "reasoning_text")?;
+        map.serialize_entry("text", &self.0.text)?;
+        map.end()
+    }
+}
+
 // Mirrors async-openai's `Response` serialization while writing Dynamo's
 // OpenResponses spec fields directly, avoiding a per-stream-event Value tree.
 impl Serialize for ResponseForSpec<'_> {
@@ -754,7 +1012,7 @@ impl Serialize for ResponseForSpec<'_> {
         serialize_optional_entry(&mut map, "metadata", &response.metadata)?;
         map.serialize_entry("model", &response.model)?;
         map.serialize_entry("object", &response.object)?;
-        map.serialize_entry("output", &response.output)?;
+        map.serialize_entry("output", &OutputItemsForSpec(&response.output))?;
         serialize_optional_entry(
             &mut map,
             "parallel_tool_calls",
@@ -1023,6 +1281,13 @@ mod tests {
         }
     }
 
+    fn reasoning_chunk(text: &str) -> NvCreateChatCompletionStreamResponse {
+        let mut chunk = text_chunk("");
+        chunk.inner.choices[0].delta.content = None;
+        chunk.inner.choices[0].delta.reasoning_content = Some(text.into());
+        chunk
+    }
+
     /// Extract the SSE event type from a Result<Event, _>.
     fn event_type(event: &Result<Event, anyhow::Error>) -> String {
         let debug = format!("{:?}", event.as_ref().unwrap());
@@ -1055,6 +1320,11 @@ mod tests {
                 params.frequency_penalty.unwrap_or(0.0),
                 params.store.unwrap_or(false),
             );
+        }
+        if let serde_json::Value::Object(ref mut obj) = value
+            && let Some(item) = obj.get_mut("item")
+        {
+            super::super::tag_reasoning_content_parts(std::slice::from_mut(item));
         }
         value
     }
@@ -1431,6 +1701,129 @@ mod tests {
     }
 
     #[test]
+    fn test_reasoning_stream_lifecycle_and_eof_completion() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let start_events = conv.emit_start_events();
+
+        assert_eq!(
+            event_types(&conv.process_chunk(&reasoning_chunk("Let me"))),
+            vec![
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
+            ]
+        );
+        assert_eq!(
+            event_types(&conv.process_chunk(&reasoning_chunk(" think"))),
+            vec!["response.reasoning_text.delta".to_string()]
+        );
+
+        let end_events = conv.emit_end_events();
+        assert_eq!(
+            event_types(&end_events),
+            vec![
+                "response.reasoning_text.done".to_string(),
+                "response.content_part.done".to_string(),
+                "response.output_item.done".to_string(),
+                "response.completed".to_string(),
+            ]
+        );
+        assert_eq!(
+            conv.sequence_number as usize,
+            start_events.len() + 3 + 1 + end_events.len()
+        );
+
+        let output = conv.completed_output();
+        let OutputItem::Reasoning(reasoning) = &output[0] else {
+            panic!("expected reasoning output");
+        };
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning.content.as_ref().unwrap()[0].text, "Let me think");
+    }
+
+    #[test]
+    fn test_empty_reasoning_delta_is_ignored() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        assert!(conv.process_chunk(&reasoning_chunk("")).is_empty());
+        assert!(conv.reasoning_items.is_empty());
+    }
+
+    #[test]
+    fn test_reasoning_closes_before_text_and_tool_output() {
+        let transitions = [
+            (text_chunk("Answer."), false),
+            (
+                tool_call_chunk(0, Some("call-1"), Some("lookup"), Some("{}")),
+                true,
+            ),
+        ];
+
+        for (transition, is_tool) in transitions {
+            let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+            let _ = conv.process_chunk(&reasoning_chunk("Thinking."));
+
+            let transition_types = event_types(&conv.process_chunk(&transition));
+            assert_eq!(
+                &transition_types[..3],
+                [
+                    "response.reasoning_text.done",
+                    "response.content_part.done",
+                    "response.output_item.done",
+                ]
+            );
+            assert!(
+                !event_types(&conv.emit_end_events())
+                    .iter()
+                    .any(|event| event == "response.reasoning_text.done")
+            );
+
+            let output = conv.completed_output();
+            assert_eq!(output.len(), 2);
+            assert!(matches!(output[0], OutputItem::Reasoning(_)));
+            assert_eq!(matches!(output[1], OutputItem::FunctionCall(_)), is_tool);
+        }
+    }
+
+    #[test]
+    fn test_interleaved_reasoning_opens_ordered_items() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
+        let _ = conv.process_chunk(&reasoning_chunk("first thought"));
+        let _ = conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("lookup"),
+            Some("{}"),
+        ));
+
+        let resumed_types = event_types(&conv.process_chunk(&reasoning_chunk("second thought")));
+        assert_eq!(
+            resumed_types,
+            vec![
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
+            ]
+        );
+        let _ = conv.emit_end_events();
+
+        let output = conv.completed_output();
+        assert_eq!(output.len(), 3);
+        assert!(matches!(output[0], OutputItem::Reasoning(_)));
+        assert!(matches!(output[1], OutputItem::FunctionCall(_)));
+        assert!(matches!(output[2], OutputItem::Reasoning(_)));
+        let reasoning_texts: Vec<_> = output
+            .iter()
+            .filter_map(|item| match item {
+                OutputItem::Reasoning(reasoning) => {
+                    Some(reasoning.content.as_ref().unwrap()[0].text.as_str())
+                }
+                _ => None,
+            })
+            .collect();
+        assert_eq!(reasoning_texts, vec!["first thought", "second thought"]);
+    }
+
+    #[test]
     fn test_completed_output_keeps_tool_before_later_text() {
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
         let _ = conv.emit_start_events();
@@ -1555,12 +1948,40 @@ mod tests {
                 arguments: "{\"q\":\"x\"}".to_string(),
             },
         );
+        let reasoning_item = OutputItem::Reasoning(ReasoningItem {
+            id: "rs_1".into(),
+            summary: vec![],
+            content: Some(vec![ReasoningTextContent {
+                text: "raw reasoning".into(),
+            }]),
+            encrypted_content: None,
+            status: Some(OutputStatus::Completed),
+        });
+        let reasoning_added =
+            ResponseStreamEvent::ResponseOutputItemAdded(ResponseOutputItemAddedEvent {
+                sequence_number: conv.next_seq(),
+                output_index: 2,
+                item: reasoning_item.clone(),
+            });
+        let reasoning_done =
+            ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
+                sequence_number: conv.next_seq(),
+                output_index: 2,
+                item: reasoning_item.clone(),
+            });
         let completed_event = ResponseStreamEvent::ResponseCompleted(ResponseCompletedEvent {
             sequence_number: conv.next_seq(),
-            response: conv.make_response(Status::Completed, vec![]),
+            response: conv.make_response(Status::Completed, vec![reasoning_item]),
         });
 
-        for event in [&response_event, &text_event, &tool_event, &completed_event] {
+        for event in [
+            &response_event,
+            &text_event,
+            &tool_event,
+            &reasoning_added,
+            &reasoning_done,
+            &completed_event,
+        ] {
             assert_eq!(
                 optimized_event_json(&conv, event),
                 legacy_event_json(event, &params)
@@ -1572,5 +1993,15 @@ mod tests {
         assert_eq!(response_json["response"]["frequency_penalty"], 0.5);
         assert_eq!(response_json["response"]["store"], true);
         assert!(response_json["response"]["max_tool_calls"].is_null());
+
+        for event in [&reasoning_added, &reasoning_done] {
+            let json = optimized_event_json(&conv, event);
+            assert_eq!(json["item"]["content"][0]["type"], "reasoning_text");
+        }
+        let completed_json = optimized_event_json(&conv, &completed_event);
+        assert_eq!(
+            completed_json["response"]["output"][0]["content"][0]["type"],
+            "reasoning_text"
+        );
     }
 }

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -53,8 +53,8 @@ pub struct ResponseStreamConverter {
     message_output_index: u32,
     message_output_status: Option<OutputStatus>,
     accumulated_text: String,
-    // Ordered reasoning spans. A new item is opened if reasoning resumes after
-    // text or a tool call, preserving interleaved model output.
+    // Ordered reasoning spans; a new item opens when reasoning resumes after
+    // a tool call.
     reasoning_items: Vec<ReasoningState>,
     active_reasoning_index: Option<usize>,
     // Function call tracking
@@ -153,48 +153,56 @@ impl ResponseStreamConverter {
         reasoning: &str,
         events: &mut Vec<Result<Event, anyhow::Error>>,
     ) {
-        if self.active_reasoning_index.is_none() {
-            let output_index = self.next_output_index;
-            self.next_output_index += 1;
-            let item_id = format!("rs_{}", Uuid::new_v4().simple());
-            self.reasoning_items.push(ReasoningState {
-                item_id: item_id.clone(),
-                accumulated_text: String::new(),
-                output_index,
-                output_status: None,
-            });
-            self.active_reasoning_index = Some(self.reasoning_items.len() - 1);
+        let state_index = match self.active_reasoning_index {
+            Some(state_index) => state_index,
+            None => {
+                // Close pending tool calls first: live event order must match
+                // the final output order.
+                let output_status = self.output_status();
+                self.append_pending_function_call_done_events(events, output_status);
 
-            let item_added =
-                ResponseStreamEvent::ResponseOutputItemAdded(ResponseOutputItemAddedEvent {
-                    sequence_number: self.next_seq(),
+                let output_index = self.next_output_index;
+                self.next_output_index += 1;
+                let item_id = format!("rs_{}", Uuid::new_v4().simple());
+                self.reasoning_items.push(ReasoningState {
+                    item_id: item_id.clone(),
+                    accumulated_text: String::new(),
                     output_index,
-                    item: OutputItem::Reasoning(ReasoningItem {
-                        id: Some(item_id.clone()),
-                        summary: vec![],
-                        content: Some(vec![]),
-                        encrypted_content: None,
-                        status: Some(OutputStatus::InProgress),
-                    }),
+                    output_status: None,
                 });
-            events.push(self.make_sse_event(&item_added));
+                let state_index = self.reasoning_items.len() - 1;
+                self.active_reasoning_index = Some(state_index);
 
-            let part_added =
-                ResponseStreamEvent::ResponseContentPartAdded(ResponseContentPartAddedEvent {
-                    sequence_number: self.next_seq(),
-                    item_id,
-                    output_index,
-                    content_index: 0,
-                    part: OutputContent::ReasoningText(ReasoningTextContent {
-                        text: String::new(),
-                    }),
-                });
-            events.push(self.make_sse_event(&part_added));
-        }
+                let item_added =
+                    ResponseStreamEvent::ResponseOutputItemAdded(ResponseOutputItemAddedEvent {
+                        sequence_number: self.next_seq(),
+                        output_index,
+                        item: OutputItem::Reasoning(ReasoningItem {
+                            id: Some(item_id.clone()),
+                            summary: vec![],
+                            content: Some(vec![]),
+                            encrypted_content: None,
+                            status: Some(OutputStatus::InProgress),
+                        }),
+                    });
+                events.push(self.make_sse_event(&item_added));
 
-        let state_index = self
-            .active_reasoning_index
-            .expect("reasoning state must be active after opening it");
+                let part_added =
+                    ResponseStreamEvent::ResponseContentPartAdded(ResponseContentPartAddedEvent {
+                        sequence_number: self.next_seq(),
+                        item_id,
+                        output_index,
+                        content_index: 0,
+                        part: OutputContent::ReasoningText(ReasoningTextContent {
+                            text: String::new(),
+                        }),
+                    });
+                events.push(self.make_sse_event(&part_added));
+
+                state_index
+            }
+        };
+
         let (item_id, output_index) = {
             let state = &mut self.reasoning_items[state_index];
             state.accumulated_text.push_str(reasoning);
@@ -2309,6 +2317,8 @@ mod tests {
         assert_eq!(
             resumed_types,
             vec![
+                "response.function_call_arguments.done".to_string(),
+                "response.output_item.done".to_string(),
                 "response.output_item.added".to_string(),
                 "response.content_part.added".to_string(),
                 "response.reasoning_text.delta".to_string(),
@@ -2329,6 +2339,53 @@ mod tests {
             })
             .collect();
         assert_eq!(reasoning_texts, vec!["first thought", "second thought"]);
+    }
+
+    /// Resumed reasoning closes the pending tool call before opening the next item.
+    #[test]
+    fn test_resumed_reasoning_completes_pending_tool_call_first() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), reasoning_params());
+
+        let _ = conv.process_chunk(&reasoning_chunk("first thought"));
+        let _ = conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("lookup"),
+            Some("{}"),
+        ));
+
+        let resumed_types = event_types(&conv.process_chunk(&reasoning_chunk("second thought")));
+        assert_eq!(
+            resumed_types,
+            vec![
+                "response.function_call_arguments.done".to_string(),
+                "response.output_item.done".to_string(),
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
+            ]
+        );
+
+        // No tool-call done events repeat at stream end.
+        let end_types = event_types(&conv.emit_end_events());
+        assert_eq!(
+            end_types,
+            vec![
+                "response.reasoning_text.done".to_string(),
+                "response.content_part.done".to_string(),
+                "response.output_item.done".to_string(),
+                "response.completed".to_string(),
+            ]
+        );
+
+        let output = conv.completed_output();
+        assert_eq!(output.len(), 3);
+        assert!(matches!(output[0], OutputItem::Reasoning(_)));
+        let OutputItem::FunctionCall(call) = &output[1] else {
+            panic!("expected function call output");
+        };
+        assert_eq!(call.status, Some(OutputStatus::Completed));
+        assert!(matches!(output[2], OutputItem::Reasoning(_)));
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -16,16 +16,15 @@ use axum::response::sse::Event;
 use dynamo_protocols::types::responses::{
     AssistantRole, ErrorObject, FunctionToolCall, IncompleteDetails, InputTokenDetails,
     Instructions, OutputContent, OutputItem, OutputMessage, OutputMessageContent, OutputStatus,
-    OutputTextContent, OutputTokenDetails, ReasoningItem, Response, ResponseCompletedEvent,
-    ResponseContentPartAddedEvent, ResponseContentPartDoneEvent, ResponseCreatedEvent,
-    ResponseFailedEvent, ResponseFunctionCallArgumentsDeltaEvent,
-    ResponseFunctionCallArgumentsDoneEvent, ResponseInProgressEvent, ResponseIncompleteEvent,
-    ResponseOutputItemAddedEvent, ResponseOutputItemDoneEvent,
-    ResponseReasoningSummaryPartAddedEvent, ResponseReasoningSummaryPartDoneEvent,
-    ResponseReasoningSummaryTextDeltaEvent, ResponseReasoningSummaryTextDoneEvent,
+    OutputTextContent, OutputTokenDetails, ReasoningItem, ReasoningItemContent,
+    ReasoningTextContent, Response, ResponseCompletedEvent, ResponseContentPartAddedEvent,
+    ResponseContentPartDoneEvent, ResponseCreatedEvent, ResponseFailedEvent,
+    ResponseFunctionCallArgumentsDeltaEvent, ResponseFunctionCallArgumentsDoneEvent,
+    ResponseInProgressEvent, ResponseIncompleteEvent, ResponseOutputItemAddedEvent,
+    ResponseOutputItemDoneEvent, ResponseReasoningTextDeltaEvent, ResponseReasoningTextDoneEvent,
     ResponseStreamEvent, ResponseTextDeltaEvent, ResponseTextDoneEvent, ResponseTextParam,
-    ResponseUsage, ServiceTier, Status, SummaryPart, SummaryTextContent,
-    TextResponseFormatConfiguration, ToolChoiceOptions, ToolChoiceParam, Truncation,
+    ResponseUsage, ServiceTier, Status, TextResponseFormatConfiguration, ToolChoiceOptions,
+    ToolChoiceParam, Truncation,
 };
 use serde::{
     Serialize,
@@ -54,13 +53,10 @@ pub struct ResponseStreamConverter {
     message_output_index: u32,
     message_output_status: Option<OutputStatus>,
     accumulated_text: String,
-    // Reasoning summary tracking
-    reasoning_item_id: String,
-    reasoning_started: bool,
-    reasoning_done: bool,
-    reasoning_output_index: u32,
-    reasoning_output_status: Option<OutputStatus>,
-    accumulated_reasoning: String,
+    // Ordered reasoning spans. A new item is opened if reasoning resumes after
+    // text or a tool call, preserving interleaved model output.
+    reasoning_items: Vec<ReasoningState>,
+    active_reasoning_index: Option<usize>,
     // Function call tracking
     function_call_items: Vec<FunctionCallState>,
     // Output index counter
@@ -69,6 +65,29 @@ pub struct ResponseStreamConverter {
     usage: Option<ResponseUsage>,
     // The backend exhausted the output budget.
     output_limit_reached: bool,
+}
+
+struct ReasoningState {
+    item_id: String,
+    accumulated_text: String,
+    output_index: u32,
+    output_status: Option<OutputStatus>,
+}
+
+impl ReasoningState {
+    fn completed_item(&self, output_status: OutputStatus) -> ReasoningItem {
+        ReasoningItem {
+            id: Some(self.item_id.clone()),
+            summary: vec![],
+            content: Some(vec![ReasoningItemContent::ReasoningText(
+                ReasoningTextContent {
+                    text: self.accumulated_text.clone(),
+                },
+            )]),
+            encrypted_content: None,
+            status: Some(self.output_status.unwrap_or(output_status)),
+        }
+    }
 }
 
 struct FunctionCallState {
@@ -108,12 +127,8 @@ impl ResponseStreamConverter {
             message_output_index: 0,
             message_output_status: None,
             accumulated_text: String::new(),
-            reasoning_item_id: format!("rs_{}", Uuid::new_v4().simple()),
-            reasoning_started: false,
-            reasoning_done: false,
-            reasoning_output_index: 0,
-            reasoning_output_status: None,
-            accumulated_reasoning: String::new(),
+            reasoning_items: Vec::new(),
+            active_reasoning_index: None,
             function_call_items: Vec::new(),
             next_output_index: 0,
             usage: None,
@@ -131,6 +146,119 @@ impl ResponseStreamConverter {
         let seq = self.sequence_number;
         self.sequence_number += 1;
         seq
+    }
+
+    fn append_reasoning_delta(
+        &mut self,
+        reasoning: &str,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+    ) {
+        if self.active_reasoning_index.is_none() {
+            let output_index = self.next_output_index;
+            self.next_output_index += 1;
+            let item_id = format!("rs_{}", Uuid::new_v4().simple());
+            self.reasoning_items.push(ReasoningState {
+                item_id: item_id.clone(),
+                accumulated_text: String::new(),
+                output_index,
+                output_status: None,
+            });
+            self.active_reasoning_index = Some(self.reasoning_items.len() - 1);
+
+            let item_added =
+                ResponseStreamEvent::ResponseOutputItemAdded(ResponseOutputItemAddedEvent {
+                    sequence_number: self.next_seq(),
+                    output_index,
+                    item: OutputItem::Reasoning(ReasoningItem {
+                        id: Some(item_id.clone()),
+                        summary: vec![],
+                        content: Some(vec![]),
+                        encrypted_content: None,
+                        status: Some(OutputStatus::InProgress),
+                    }),
+                });
+            events.push(self.make_sse_event(&item_added));
+
+            let part_added =
+                ResponseStreamEvent::ResponseContentPartAdded(ResponseContentPartAddedEvent {
+                    sequence_number: self.next_seq(),
+                    item_id,
+                    output_index,
+                    content_index: 0,
+                    part: OutputContent::ReasoningText(ReasoningTextContent {
+                        text: String::new(),
+                    }),
+                });
+            events.push(self.make_sse_event(&part_added));
+        }
+
+        let state_index = self
+            .active_reasoning_index
+            .expect("reasoning state must be active after opening it");
+        let (item_id, output_index) = {
+            let state = &mut self.reasoning_items[state_index];
+            state.accumulated_text.push_str(reasoning);
+            (state.item_id.clone(), state.output_index)
+        };
+        let delta =
+            ResponseStreamEvent::ResponseReasoningTextDelta(ResponseReasoningTextDeltaEvent {
+                sequence_number: self.next_seq(),
+                item_id,
+                output_index,
+                content_index: 0,
+                delta: reasoning.to_string(),
+            });
+        events.push(self.make_sse_event(&delta));
+    }
+
+    fn append_active_reasoning_done_events(
+        &mut self,
+        events: &mut Vec<Result<Event, anyhow::Error>>,
+        output_status: OutputStatus,
+    ) {
+        let Some(state_index) = self.active_reasoning_index.take() else {
+            return;
+        };
+        let (item_id, output_index, text, item) = {
+            let state = &mut self.reasoning_items[state_index];
+            if state.output_status.is_some() {
+                return;
+            }
+            state.output_status = Some(output_status);
+            (
+                state.item_id.clone(),
+                state.output_index,
+                state.accumulated_text.clone(),
+                state.completed_item(output_status),
+            )
+        };
+
+        let text_done =
+            ResponseStreamEvent::ResponseReasoningTextDone(ResponseReasoningTextDoneEvent {
+                sequence_number: self.next_seq(),
+                item_id: item_id.clone(),
+                output_index,
+                content_index: 0,
+                text: text.clone(),
+            });
+        events.push(self.make_sse_event(&text_done));
+
+        let part_done =
+            ResponseStreamEvent::ResponseContentPartDone(ResponseContentPartDoneEvent {
+                sequence_number: self.next_seq(),
+                item_id: item_id.clone(),
+                output_index,
+                content_index: 0,
+                part: OutputContent::ReasoningText(ReasoningTextContent { text }),
+            });
+        events.push(self.make_sse_event(&part_done));
+
+        let item_done = ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
+            sequence_number: self.next_seq(),
+            output_index,
+            item: OutputItem::Reasoning(item),
+        });
+        events.push(self.make_sse_event(&item_done));
     }
 
     fn make_response(&self, status: Status, output: Vec<OutputItem>) -> Response {
@@ -271,55 +399,10 @@ impl ResponseStreamConverter {
 
             if let Some(reasoning) = delta.reasoning_content.as_deref()
                 && !reasoning.is_empty()
-                && !self.reasoning_done
+                && !self.message_started
                 && self.params.reasoning_summary_requested()
             {
-                self.accumulated_reasoning.push_str(reasoning);
-                if !self.reasoning_started {
-                    self.reasoning_started = true;
-                    self.reasoning_output_index = self.next_output_index;
-                    let output_index = self.reasoning_output_index;
-                    self.next_output_index += 1;
-
-                    let item_added = ResponseStreamEvent::ResponseOutputItemAdded(
-                        ResponseOutputItemAddedEvent {
-                            sequence_number: self.next_seq(),
-                            output_index,
-                            item: OutputItem::Reasoning(ReasoningItem {
-                                id: Some(self.reasoning_item_id.clone()),
-                                summary: vec![],
-                                content: None,
-                                encrypted_content: None,
-                                status: Some(OutputStatus::InProgress),
-                            }),
-                        },
-                    );
-                    events.push(self.make_sse_event(&item_added));
-
-                    let part_added = ResponseStreamEvent::ResponseReasoningSummaryPartAdded(
-                        ResponseReasoningSummaryPartAddedEvent {
-                            sequence_number: self.next_seq(),
-                            item_id: self.reasoning_item_id.clone(),
-                            output_index,
-                            summary_index: 0,
-                            part: SummaryPart::SummaryText(SummaryTextContent {
-                                text: String::new(),
-                            }),
-                        },
-                    );
-                    events.push(self.make_sse_event(&part_added));
-                }
-
-                let reasoning_delta = ResponseStreamEvent::ResponseReasoningSummaryTextDelta(
-                    ResponseReasoningSummaryTextDeltaEvent {
-                        sequence_number: self.next_seq(),
-                        item_id: self.reasoning_item_id.clone(),
-                        output_index: self.reasoning_output_index,
-                        summary_index: 0,
-                        delta: reasoning.to_string(),
-                    },
-                );
-                events.push(self.make_sse_event(&reasoning_delta));
+                self.append_reasoning_delta(reasoning, events);
             }
 
             // Handle text content deltas — extract text from the enum
@@ -337,7 +420,7 @@ impl ResponseStreamConverter {
                 // Starting the answer is an explicit reasoning phase boundary.
                 // The reasoning item completed even when this same chunk also
                 // reports that the answer exhausted the output budget.
-                self.append_reasoning_done_events(events, OutputStatus::Completed);
+                self.append_active_reasoning_done_events(events, OutputStatus::Completed);
 
                 // Emit output_item.added + content_part.added on first text
                 if !self.message_started {
@@ -406,7 +489,7 @@ impl ResponseStreamConverter {
                 if tool_calls.peek().is_some() {
                     // Starting a tool call is also an explicit reasoning phase
                     // boundary, independent of this chunk's finish reason.
-                    self.append_reasoning_done_events(events, OutputStatus::Completed);
+                    self.append_active_reasoning_done_events(events, OutputStatus::Completed);
                 }
                 for tc in tool_calls {
                     let tc_index = tc.index as usize;
@@ -552,59 +635,6 @@ impl ResponseStreamConverter {
         }
     }
 
-    fn append_reasoning_done_events(
-        &mut self,
-        events: &mut Vec<Result<Event, anyhow::Error>>,
-        output_status: OutputStatus,
-    ) {
-        if self.reasoning_done {
-            return;
-        }
-        self.reasoning_done = true;
-        if !self.reasoning_started {
-            return;
-        }
-        self.reasoning_output_status = Some(output_status);
-
-        let text_done = ResponseStreamEvent::ResponseReasoningSummaryTextDone(
-            ResponseReasoningSummaryTextDoneEvent {
-                sequence_number: self.next_seq(),
-                item_id: self.reasoning_item_id.clone(),
-                output_index: self.reasoning_output_index,
-                summary_index: 0,
-                text: self.accumulated_reasoning.clone(),
-            },
-        );
-        events.push(self.make_sse_event(&text_done));
-
-        let summary = SummaryPart::SummaryText(SummaryTextContent {
-            text: self.accumulated_reasoning.clone(),
-        });
-        let part_done = ResponseStreamEvent::ResponseReasoningSummaryPartDone(
-            ResponseReasoningSummaryPartDoneEvent {
-                sequence_number: self.next_seq(),
-                item_id: self.reasoning_item_id.clone(),
-                output_index: self.reasoning_output_index,
-                summary_index: 0,
-                part: summary.clone(),
-            },
-        );
-        events.push(self.make_sse_event(&part_done));
-
-        let item_done = ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
-            sequence_number: self.next_seq(),
-            output_index: self.reasoning_output_index,
-            item: OutputItem::Reasoning(ReasoningItem {
-                id: Some(self.reasoning_item_id.clone()),
-                summary: vec![summary],
-                content: None,
-                encrypted_content: None,
-                status: Some(output_status),
-            }),
-        });
-        events.push(self.make_sse_event(&item_done));
-    }
-
     fn append_pending_function_call_done_events(
         &mut self,
         events: &mut Vec<Result<Event, anyhow::Error>>,
@@ -696,18 +726,10 @@ impl ResponseStreamConverter {
 
     fn output_with_status(&self, output_status: OutputStatus) -> Vec<OutputItem> {
         let mut output = Vec::new();
-        if self.reasoning_started {
+        for reasoning in &self.reasoning_items {
             output.push((
-                self.reasoning_output_index,
-                OutputItem::Reasoning(ReasoningItem {
-                    id: Some(self.reasoning_item_id.clone()),
-                    summary: vec![SummaryPart::SummaryText(SummaryTextContent {
-                        text: self.accumulated_reasoning.clone(),
-                    })],
-                    content: None,
-                    encrypted_content: None,
-                    status: Some(self.reasoning_output_status.unwrap_or(output_status)),
-                }),
+                reasoning.output_index,
+                OutputItem::Reasoning(reasoning.completed_item(output_status)),
             ));
         }
         if self.message_started {
@@ -788,7 +810,7 @@ impl ResponseStreamConverter {
         let output_status = self.output_status();
         // Without a later output item, the response finish reason determines
         // whether the still-open reasoning item completed or was truncated.
-        self.append_reasoning_done_events(events, output_status);
+        self.append_active_reasoning_done_events(events, output_status);
 
         self.close_open_message_item(events, output_status);
 
@@ -827,7 +849,7 @@ impl ResponseStreamConverter {
         events: &mut Vec<Result<Event, anyhow::Error>>,
     ) -> Result<Event, anyhow::Error> {
         let output_status = OutputStatus::Incomplete;
-        self.append_reasoning_done_events(events, output_status);
+        self.append_active_reasoning_done_events(events, output_status);
         self.close_open_message_item(events, output_status);
         self.append_pending_function_call_done_events(events, output_status);
 
@@ -1155,6 +1177,27 @@ mod tests {
         ResponseParams::default()
     }
 
+    fn reasoning_params() -> ResponseParams {
+        use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
+
+        ResponseParams {
+            reasoning: Some(Reasoning {
+                effort: None,
+                summary: Some(ReasoningSummary::Auto),
+            }),
+            ..default_params()
+        }
+    }
+
+    fn reasoning_text(item: &ReasoningItem) -> &str {
+        let Some(ReasoningItemContent::ReasoningText(content)) =
+            item.content.as_ref().and_then(|content| content.first())
+        else {
+            panic!("expected reasoning text content");
+        };
+        &content.text
+    }
+
     fn tool_call_chunk(
         tc_index: u32,
         id: Option<&str>,
@@ -1259,33 +1302,10 @@ mod tests {
     }
 
     fn reasoning_chunk(text: &str) -> NvCreateChatCompletionStreamResponse {
-        #[allow(deprecated)]
-        NvCreateChatCompletionStreamResponse {
-            inner: dynamo_protocols::types::CreateChatCompletionStreamResponse {
-                id: "chat-1".into(),
-                choices: vec![ChatChoiceStream {
-                    index: 0,
-                    delta: ChatCompletionStreamResponseDelta {
-                        content: None,
-                        function_call: None,
-                        tool_calls: None,
-                        role: None,
-                        refusal: None,
-                        reasoning_content: Some(text.into()),
-                    },
-                    finish_reason: None,
-                    logprobs: None,
-                }],
-                created: 0,
-                model: "test".into(),
-                service_tier: None,
-                system_fingerprint: None,
-                object: "chat.completion.chunk".into(),
-                usage: None,
-            },
-            nvext: None,
-            llm_metrics: None,
-        }
+        let mut chunk = text_chunk("");
+        chunk.inner.choices[0].delta.content = None;
+        chunk.inner.choices[0].delta.reasoning_content = Some(text.into());
+        chunk
     }
 
     fn with_finish_reason(
@@ -1642,15 +1662,18 @@ mod tests {
         assert_eq!(
             event_types(&events),
             vec![
-                "response.reasoning_summary_text.done".to_string(),
-                "response.reasoning_summary_part.done".to_string(),
+                "response.reasoning_text.done".to_string(),
+                "response.content_part.done".to_string(),
                 "response.output_item.done".to_string(),
                 "response.output_item.added".to_string(),
                 "response.content_part.added".to_string(),
                 "response.output_text.delta".to_string(),
             ]
         );
-        assert_eq!(conv.reasoning_output_status, Some(OutputStatus::Completed));
+        assert_eq!(
+            conv.reasoning_items[0].output_status,
+            Some(OutputStatus::Completed)
+        );
 
         let _ = conv.emit_end_events();
         let response = conv.make_response(conv.terminal_status(), conv.completed_output());
@@ -1689,7 +1712,10 @@ mod tests {
             FinishReason::Length,
         ));
 
-        assert_eq!(conv.reasoning_output_status, Some(OutputStatus::Completed));
+        assert_eq!(
+            conv.reasoning_items[0].output_status,
+            Some(OutputStatus::Completed)
+        );
         let _ = conv.emit_end_events();
         let response = conv.make_response(conv.terminal_status(), conv.completed_output());
         assert_eq!(response.status, Status::Incomplete);
@@ -1704,7 +1730,7 @@ mod tests {
     }
 
     #[test]
-    fn test_requested_reasoning_summary_streams_complete_event_sequence() {
+    fn test_requested_reasoning_text_streams_complete_event_sequence() {
         use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
 
         let params = ResponseParams {
@@ -1721,8 +1747,8 @@ mod tests {
             event_types(&reasoning_events),
             vec![
                 "response.output_item.added".to_string(),
-                "response.reasoning_summary_part.added".to_string(),
-                "response.reasoning_summary_text.delta".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
             ]
         );
 
@@ -1730,8 +1756,8 @@ mod tests {
         assert_eq!(
             event_types(&text_events),
             vec![
-                "response.reasoning_summary_text.done".to_string(),
-                "response.reasoning_summary_part.done".to_string(),
+                "response.reasoning_text.done".to_string(),
+                "response.content_part.done".to_string(),
                 "response.output_item.done".to_string(),
                 "response.output_item.added".to_string(),
                 "response.content_part.added".to_string(),
@@ -1744,12 +1770,8 @@ mod tests {
         let OutputItem::Reasoning(reasoning) = &response.output[0] else {
             panic!("expected reasoning output before message");
         };
-        assert_eq!(
-            reasoning.summary,
-            vec![SummaryPart::SummaryText(SummaryTextContent {
-                text: "thinking".to_string(),
-            })]
-        );
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning_text(reasoning), "thinking");
         assert!(matches!(response.output[1], OutputItem::Message(_)));
     }
 
@@ -1764,7 +1786,7 @@ mod tests {
     }
 
     #[test]
-    fn test_reasoning_summary_ignores_updates_after_completion() {
+    fn test_reasoning_text_ignores_updates_after_visible_output() {
         use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
 
         let params = ResponseParams {
@@ -1779,22 +1801,16 @@ mod tests {
         let _ = conv.process_chunk(&reasoning_chunk("summary"));
         let _ = conv.process_chunk(&text_chunk("answer"));
         let late_events = conv.process_chunk(&reasoning_chunk(" must not be appended"));
-
         assert!(late_events.is_empty());
         let output = conv.completed_output();
         let OutputItem::Reasoning(reasoning) = &output[0] else {
             panic!("expected reasoning output");
         };
-        assert_eq!(
-            reasoning.summary,
-            vec![SummaryPart::SummaryText(SummaryTextContent {
-                text: "summary".to_string(),
-            })]
-        );
+        assert_eq!(reasoning_text(reasoning), "summary");
     }
 
     #[test]
-    fn test_reasoning_summary_finishes_before_tool_call() {
+    fn test_reasoning_text_finishes_before_tool_call() {
         use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
 
         let params = ResponseParams {
@@ -1812,19 +1828,16 @@ mod tests {
         assert_eq!(
             event_types(&tool_events),
             vec![
-                "response.reasoning_summary_text.done".to_string(),
-                "response.reasoning_summary_part.done".to_string(),
+                "response.reasoning_text.done".to_string(),
+                "response.content_part.done".to_string(),
                 "response.output_item.done".to_string(),
                 "response.output_item.added".to_string(),
             ]
         );
-
-        let late_events = conv.process_chunk(&reasoning_chunk(" must not be appended"));
-        assert!(late_events.is_empty());
     }
 
     #[test]
-    fn test_reasoning_summary_does_not_start_after_visible_output() {
+    fn test_reasoning_text_does_not_start_after_visible_output() {
         use dynamo_protocols::types::responses::{Reasoning, ReasoningSummary};
 
         let params = ResponseParams {
@@ -2198,6 +2211,127 @@ mod tests {
     }
 
     #[test]
+    fn test_reasoning_stream_lifecycle_and_eof_completion() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), reasoning_params());
+        let start_events = conv.emit_start_events();
+
+        assert_eq!(
+            event_types(&conv.process_chunk(&reasoning_chunk("Let me"))),
+            vec![
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
+            ]
+        );
+        assert_eq!(
+            event_types(&conv.process_chunk(&reasoning_chunk(" think"))),
+            vec!["response.reasoning_text.delta".to_string()]
+        );
+
+        let end_events = conv.emit_end_events();
+        assert_eq!(
+            event_types(&end_events),
+            vec![
+                "response.reasoning_text.done".to_string(),
+                "response.content_part.done".to_string(),
+                "response.output_item.done".to_string(),
+                "response.completed".to_string(),
+            ]
+        );
+        assert_eq!(
+            conv.sequence_number as usize,
+            start_events.len() + 3 + 1 + end_events.len()
+        );
+
+        let output = conv.completed_output();
+        let OutputItem::Reasoning(reasoning) = &output[0] else {
+            panic!("expected reasoning output");
+        };
+        assert!(reasoning.summary.is_empty());
+        assert_eq!(reasoning_text(reasoning), "Let me think");
+    }
+
+    #[test]
+    fn test_empty_reasoning_delta_is_ignored() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), reasoning_params());
+        assert!(conv.process_chunk(&reasoning_chunk("")).is_empty());
+        assert!(conv.reasoning_items.is_empty());
+    }
+
+    #[test]
+    fn test_reasoning_closes_before_text_and_tool_output() {
+        let transitions = [
+            (text_chunk("Answer."), false),
+            (
+                tool_call_chunk(0, Some("call-1"), Some("lookup"), Some("{}")),
+                true,
+            ),
+        ];
+
+        for (transition, is_tool) in transitions {
+            let mut conv = ResponseStreamConverter::new("test-model".into(), reasoning_params());
+            let _ = conv.process_chunk(&reasoning_chunk("Thinking."));
+
+            let transition_types = event_types(&conv.process_chunk(&transition));
+            assert_eq!(
+                &transition_types[..3],
+                [
+                    "response.reasoning_text.done",
+                    "response.content_part.done",
+                    "response.output_item.done",
+                ]
+            );
+            assert!(
+                !event_types(&conv.emit_end_events())
+                    .iter()
+                    .any(|event| event == "response.reasoning_text.done")
+            );
+
+            let output = conv.completed_output();
+            assert_eq!(output.len(), 2);
+            assert!(matches!(output[0], OutputItem::Reasoning(_)));
+            assert_eq!(matches!(output[1], OutputItem::FunctionCall(_)), is_tool);
+        }
+    }
+
+    #[test]
+    fn test_interleaved_reasoning_opens_ordered_items() {
+        let mut conv = ResponseStreamConverter::new("test-model".into(), reasoning_params());
+        let _ = conv.process_chunk(&reasoning_chunk("first thought"));
+        let _ = conv.process_chunk(&tool_call_chunk(
+            0,
+            Some("call-1"),
+            Some("lookup"),
+            Some("{}"),
+        ));
+
+        let resumed_types = event_types(&conv.process_chunk(&reasoning_chunk("second thought")));
+        assert_eq!(
+            resumed_types,
+            vec![
+                "response.output_item.added".to_string(),
+                "response.content_part.added".to_string(),
+                "response.reasoning_text.delta".to_string(),
+            ]
+        );
+        let _ = conv.emit_end_events();
+
+        let output = conv.completed_output();
+        assert_eq!(output.len(), 3);
+        assert!(matches!(output[0], OutputItem::Reasoning(_)));
+        assert!(matches!(output[1], OutputItem::FunctionCall(_)));
+        assert!(matches!(output[2], OutputItem::Reasoning(_)));
+        let reasoning_texts: Vec<_> = output
+            .iter()
+            .filter_map(|item| match item {
+                OutputItem::Reasoning(reasoning) => Some(reasoning_text(reasoning)),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(reasoning_texts, vec!["first thought", "second thought"]);
+    }
+
+    #[test]
     fn test_completed_output_keeps_tool_before_later_text() {
         let mut conv = ResponseStreamConverter::new("test-model".into(), default_params());
         let _ = conv.emit_start_events();
@@ -2322,12 +2456,42 @@ mod tests {
                 arguments: "{\"q\":\"x\"}".to_string(),
             },
         );
+        let reasoning_item = OutputItem::Reasoning(ReasoningItem {
+            id: Some("rs_1".into()),
+            summary: vec![],
+            content: Some(vec![ReasoningItemContent::ReasoningText(
+                ReasoningTextContent {
+                    text: "raw reasoning".into(),
+                },
+            )]),
+            encrypted_content: None,
+            status: Some(OutputStatus::Completed),
+        });
+        let reasoning_added =
+            ResponseStreamEvent::ResponseOutputItemAdded(ResponseOutputItemAddedEvent {
+                sequence_number: conv.next_seq(),
+                output_index: 2,
+                item: reasoning_item.clone(),
+            });
+        let reasoning_done =
+            ResponseStreamEvent::ResponseOutputItemDone(ResponseOutputItemDoneEvent {
+                sequence_number: conv.next_seq(),
+                output_index: 2,
+                item: reasoning_item.clone(),
+            });
         let completed_event = ResponseStreamEvent::ResponseCompleted(ResponseCompletedEvent {
             sequence_number: conv.next_seq(),
-            response: conv.make_response(Status::Completed, vec![]),
+            response: conv.make_response(Status::Completed, vec![reasoning_item]),
         });
 
-        for event in [&response_event, &text_event, &tool_event, &completed_event] {
+        for event in [
+            &response_event,
+            &text_event,
+            &tool_event,
+            &reasoning_added,
+            &reasoning_done,
+            &completed_event,
+        ] {
             assert_eq!(
                 optimized_event_json(&conv, event),
                 legacy_event_json(event, &params)
@@ -2339,5 +2503,15 @@ mod tests {
         assert_eq!(response_json["response"]["frequency_penalty"], 0.5);
         assert_eq!(response_json["response"]["store"], true);
         assert!(response_json["response"]["max_tool_calls"].is_null());
+
+        for event in [&reasoning_added, &reasoning_done] {
+            let json = optimized_event_json(&conv, event);
+            assert_eq!(json["item"]["content"][0]["type"], "reasoning_text");
+        }
+        let completed_json = optimized_event_json(&conv, &completed_event);
+        assert_eq!(
+            completed_json["response"]["output"][0]["content"][0]["type"],
+            "reasoning_text"
+        );
     }
 }

--- a/lib/llm/src/protocols/openai/responses/stream_converter.rs
+++ b/lib/llm/src/protocols/openai/responses/stream_converter.rs
@@ -156,10 +156,9 @@ impl ResponseStreamConverter {
         let state_index = match self.active_reasoning_index {
             Some(state_index) => state_index,
             None => {
-                // Close pending tool calls first: live event order must match
-                // the final output order.
-                let output_status = self.output_status();
-                self.append_pending_function_call_done_events(events, output_status);
+                // Resumed reasoning proves pending tool calls completed, even if
+                // this chunk reports that the new reasoning exhausted the budget.
+                self.append_pending_function_call_done_events(events, OutputStatus::Completed);
 
                 let output_index = self.next_output_index;
                 self.next_output_index += 1;
@@ -2341,9 +2340,8 @@ mod tests {
         assert_eq!(reasoning_texts, vec!["first thought", "second thought"]);
     }
 
-    /// Resumed reasoning closes the pending tool call before opening the next item.
     #[test]
-    fn test_resumed_reasoning_completes_pending_tool_call_first() {
+    fn test_length_on_resumed_reasoning_keeps_prior_tool_call_completed() {
         let mut conv = ResponseStreamConverter::new("test-model".into(), reasoning_params());
 
         let _ = conv.process_chunk(&reasoning_chunk("first thought"));
@@ -2354,38 +2352,20 @@ mod tests {
             Some("{}"),
         ));
 
-        let resumed_types = event_types(&conv.process_chunk(&reasoning_chunk("second thought")));
-        assert_eq!(
-            resumed_types,
-            vec![
-                "response.function_call_arguments.done".to_string(),
-                "response.output_item.done".to_string(),
-                "response.output_item.added".to_string(),
-                "response.content_part.added".to_string(),
-                "response.reasoning_text.delta".to_string(),
-            ]
-        );
-
-        // No tool-call done events repeat at stream end.
-        let end_types = event_types(&conv.emit_end_events());
-        assert_eq!(
-            end_types,
-            vec![
-                "response.reasoning_text.done".to_string(),
-                "response.content_part.done".to_string(),
-                "response.output_item.done".to_string(),
-                "response.completed".to_string(),
-            ]
-        );
+        let resumed = with_finish_reason(reasoning_chunk("second thought"), FinishReason::Length);
+        let _ = conv.process_chunk(&resumed);
+        let _ = conv.emit_end_events();
 
         let output = conv.completed_output();
         assert_eq!(output.len(), 3);
-        assert!(matches!(output[0], OutputItem::Reasoning(_)));
         let OutputItem::FunctionCall(call) = &output[1] else {
             panic!("expected function call output");
         };
         assert_eq!(call.status, Some(OutputStatus::Completed));
-        assert!(matches!(output[2], OutputItem::Reasoning(_)));
+        let OutputItem::Reasoning(reasoning) = &output[2] else {
+            panic!("expected resumed reasoning output");
+        };
+        assert_eq!(reasoning.status, Some(OutputStatus::Incomplete));
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Preserves backend `reasoning_content` in Dynamo’s `/v1/responses` API. Non-streaming responses now use `reasoning_text` content instead of `summary_text`, and streaming responses emit the complete `v1/responses` lifecycle following the Open AI API spec.

## Details

- Emits `response.reasoning_text.delta` with the corresponding added/done events.
- Preserves reasoning, text, and tool-call ordering, including interleaved reasoning spans.
- Includes reasoning items in `response.completed.output`.
- Replays `content` while retaining `summary` as a compatibility fallback.
- Preserves the optimized borrowed serializer from #10498.


## Where should the reviewer start?

- `lib/llm/src/protocols/openai/responses/stream_converter.rs`
- `lib/llm/src/protocols/openai/responses/mod.rs`

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reasoning output to preserve the original reasoning content when available.
  * Added structured reasoning segments that support interleaved text and tool-call activity.
  * Reasoning output is now provided only when explicitly requested.
  * Streaming responses now emit reasoning text events with improved ordering and support for multiple reasoning segments.

* **Bug Fixes**
  * Improved completion, error, truncation, and serialization handling for streamed reasoning content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->