### PR TITLE
fix(kvbm): disable HMA for incompatible PdConnector children

### DIFF
--- a/components/src/dynamo/vllm/kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/kv_connector_protocols.py
@@ -124,7 +124,7 @@ def disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(
     vllm_config: Any,
 ) -> None:
     """Disable HMA before vLLM builds KV cache groups for incompatible PdConnector children."""
-    kv_cfg = vllm_config.kv_transfer_config
+    kv_cfg = getattr(vllm_config, "kv_transfer_config", None)
     if kv_cfg is None or kv_cfg.kv_connector != "PdConnector":
         return
 

--- a/components/src/dynamo/vllm/kv_connector_protocols.py
+++ b/components/src/dynamo/vllm/kv_connector_protocols.py
@@ -120,6 +120,22 @@ KV_CONNECTOR_PROTOCOLS: Dict[str, Type[KvConnectorProtocol]] = {
 MULTI_CONNECTOR_WRAPPERS: Tuple[str, ...] = ("MultiConnector", "PdConnector")
 
 
+def disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(
+    vllm_config: Any,
+) -> None:
+    """Disable HMA before vLLM builds KV cache groups for incompatible PdConnector children."""
+    kv_cfg = vllm_config.kv_transfer_config
+    if kv_cfg is None or kv_cfg.kv_connector != "PdConnector":
+        return
+
+    from vllm.distributed.kv_transfer.kv_connector.v1.multi_connector import (
+        MultiConnector,
+    )
+
+    if not MultiConnector.all_children_support_hma(kv_cfg):
+        vllm_config.scheduler_config.disable_hybrid_kv_cache_manager = True
+
+
 def make_kv_connector_protocol(vllm_config: Any) -> KvConnectorProtocol:
     """Resolve the PD protocol for the engine's configured KV connector.
 

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -63,11 +63,7 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.runtime import Endpoint
-from dynamo.vllm.args import (
-    Config,
-    configure_rl_logprobs_mode,
-    parse_args,
-)
+from dynamo.vllm.args import Config, configure_rl_logprobs_mode, parse_args
 from dynamo.vllm.cache_info import (
     configure_kv_event_block_size,
     get_configured_kv_event_block_size,

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -63,12 +63,19 @@ from dynamo.llm import (
     unregister_model,
 )
 from dynamo.runtime import Endpoint
-from dynamo.vllm.args import Config, configure_rl_logprobs_mode, parse_args
+from dynamo.vllm.args import (
+    Config,
+    configure_rl_logprobs_mode,
+    parse_args,
+)
 from dynamo.vllm.cache_info import (
     configure_kv_event_block_size,
     get_configured_kv_event_block_size,
 )
 from dynamo.vllm.capacity import per_rank_kv_blocks
+from dynamo.vllm.kv_connector_protocols import (
+    disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
+)
 
 from .handlers import (
     VllmEnginePauseController,
@@ -347,6 +354,7 @@ class VllmLLMEngine(LLMEngine):
         vllm_config = self.engine_args.create_engine_config(
             usage_context=UsageContext.OPENAI_API_SERVER
         )
+        disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
         self._vllm_config = vllm_config
         self._default_sampling_params = (
             vllm_config.model_config.get_diff_sampling_param()

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -49,7 +49,12 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs
-from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
+from .args import (
+    Config,
+    _uses_dynamo_connector,
+    configure_rl_logprobs_mode,
+    parse_args,
+)
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import (
     get_metrics_model_name,
@@ -60,6 +65,9 @@ from .constants import DisaggregationMode
 from .handlers import get_dp_range_for_worker
 from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
+from .kv_connector_protocols import (
+    disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
+)
 from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.media_config import create_frontend_media_config
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
@@ -561,6 +569,7 @@ def setup_vllm_engine(
     # Taken from build_async_engine_client_from_engine_args()
     usage_context = UsageContext.OPENAI_API_SERVER
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
+    disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -49,12 +49,7 @@ from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.vllm.worker_factory import WorkerFactory
 
 from . import envs
-from .args import (
-    Config,
-    _uses_dynamo_connector,
-    configure_rl_logprobs_mode,
-    parse_args,
-)
+from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import (
     get_metrics_model_name,


### PR DESCRIPTION
## Overview:

### Summary

Fixes DYN-3362.

`PdConnector` can wrap child connector combinations where not every child declares HMA support, e.g. `DynamoConnector + NixlConnector` or `LMCacheConnectorV1 + NixlConnector`. In vLLM 0.23.0, `MultiConnector` asserts unless HMA is disabled or all child connectors support HMA, causing KVBM/LMCache disaggregated serving to fail during EngineCore startup.

This PR disables vLLM’s hybrid KV cache manager only for `PdConnector` configurations whose child connectors are not all HMA-compatible, and does so before `AsyncLLM.from_vllm_config(...)` builds KV cache groups.

### Validation

- Ran `git diff --check`
- Ran no-write Python syntax compile for the touched files
- Confirmed CI `Pre Merge`, `codeowners`, `DCO Commenter`, `Docs link check`, and `Copyright Checks` pass on PR head `4960d7afa10599cef75eacd3aa7e62cd0dbeb37e`
- Earlier manual launch reached past the original HMA assertion; local run then failed on missing local `kvbm` package, not the HMA assertion

## Details:

- Add a targeted `PdConnector` compatibility helper in `components/src/dynamo/vllm/kv_connector_protocols.py`.
- Reuse vLLM’s `MultiConnector.all_children_support_hma(...)` check to decide whether HMA must be disabled.
- Call the helper in both Dynamo vLLM startup paths before `AsyncLLM.from_vllm_config(...)`.
- Preserve HMA for non-`PdConnector` configurations and for `PdConnector` configurations where every child connector declares HMA support.

## Where should the reviewer start?

Start with:

- `components/src/dynamo/vllm/kv_connector_protocols.py`
- `components/src/dynamo/vllm/main.py`
- `components/src/dynamo/vllm/llm_engine.py`

## Related Issues

- Fixes DYN-3362 / NVBug 6359087