### PR TITLE
feat(trtllm): engine-owned conversation-aware ADP routing

### DIFF
--- a/components/src/dynamo/trtllm/conversation_affinity.py
+++ b/components/src/dynamo/trtllm/conversation_affinity.py
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Helpers for engine-owned conversation-aware ADP routing (opt-in).
+
+When TensorRT-LLM's ``attention_dp_config.kv_cache_routing_conversation_affinity`` is
+enabled, the engine's ``ConversationAwareADPRouter`` pins a conversation to an
+attention-DP rank (sticky, load-balanced first turn). Dynamo must then:
+
+  1. forward the stable conversation id via ``ConversationParams``, and
+  2. NOT force ``attention_dp_rank`` — an explicit rank is honored *before* affinity
+     in the engine and would bypass it.
+
+The conversation id is the frontend-forwarded ``agent_context.session_id`` — no new
+routing plumbing is added on the Rust side (see the serialized
+``PreprocessedRequest.agent_context`` field). When affinity is off, callers keep their
+existing Dynamo-owned DP-rank forcing unchanged.
+
+``ConversationParams`` and ``kv_cache_routing_conversation_affinity`` require a
+TensorRT-LLM build newer than 1.3.0rc20; on older wheels the import is absent and
+``CONVERSATION_PARAMS_AVAILABLE`` is False.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any, Optional
+
+try:  # Requires a TensorRT-LLM release newer than 1.3.0rc20.
+    from tensorrt_llm.llmapi import ConversationParams
+except ImportError:  # pragma: no cover - depends on installed wheel
+    ConversationParams = None  # type: ignore[assignment]
+
+CONVERSATION_PARAMS_AVAILABLE: bool = ConversationParams is not None
+
+
+def session_id_from_request(request: Mapping[str, Any]) -> Optional[str]:
+    """Return the stable conversation/session id the frontend forwards as
+    ``agent_context.session_id``, or ``None`` if absent, blank, or malformed.
+
+    Uses ``session_id`` (the active reasoning/tool chain), not ``parent_session_id``.
+    """
+    agent_context = request.get("agent_context")
+    if not isinstance(agent_context, dict):
+        return None
+    session_id = agent_context.get("session_id")
+    if isinstance(session_id, str) and session_id.strip():
+        return session_id.strip()
+    return None
+
+
+def engine_conversation_affinity_enabled(llm: Any) -> bool:
+    """Whether the resolved engine config enables conversation-affinity ADP routing.
+
+    Reads ``llm.args.attention_dp_config.kv_cache_routing_conversation_affinity``.
+    Only a genuine boolean ``True`` counts as enabled; tolerates a config model or a
+    plain dict, and defaults to False when the field is absent (e.g. older wheels).
+    """
+    adp_cfg = getattr(getattr(llm, "args", None), "attention_dp_config", None)
+    if adp_cfg is None:
+        return False
+    if isinstance(adp_cfg, dict):
+        return adp_cfg.get("kv_cache_routing_conversation_affinity") is True
+    return getattr(adp_cfg, "kv_cache_routing_conversation_affinity", None) is True
+
+
+def conversation_params_for(session_id: Optional[str]) -> Optional[Any]:
+    """Build ``ConversationParams`` for ``session_id``, or ``None`` when there is no id
+    (the engine router then applies its no-id balancing fallback). Requires the API."""
+    if session_id is None or ConversationParams is None:
+        return None
+    return ConversationParams(conversation_id=session_id)

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -61,6 +61,12 @@ from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.llm import KvEventPublisher, ModelInput
 from dynamo.trtllm.args import parse_args
 from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.conversation_affinity import (
+    CONVERSATION_PARAMS_AVAILABLE,
+    conversation_params_for,
+    engine_conversation_affinity_enabled,
+    session_id_from_request,
+)
 from dynamo.trtllm.engine import Backend, TensorRTLLMEngine
 from dynamo.trtllm.logits_processing.adapter import attach_logits_processors
 from dynamo.trtllm.request_handlers.handler_base import TRTLLMEnginePauseController
@@ -184,6 +190,10 @@ class TrtllmLLMEngine(LLMEngine):
         self._metrics_thread: Optional[threading.Thread] = None
         self._kv_events_thread: Optional[threading.Thread] = None
         self._attention_dp_size: int = 1
+        # Engine conversation-affinity gate; real value resolved in initialize().
+        # Default False so generate() is safe if reached before initialize()
+        # (e.g. unit tests that drive generate directly).
+        self._conversation_affinity: bool = False
         # Worker invokes on_ready callbacks serially during setup (see
         # `setup_kv_publishers` in lib/backend-common/src/publisher.rs); the
         # dict is fully populated before `_kv_events_thread` starts and
@@ -379,6 +389,19 @@ class TrtllmLLMEngine(LLMEngine):
         ) or getattr(self._trtllm_metrics_collector, "log_metrics_dict", None)
 
         self._attention_dp_size = self._engine.get_attention_dp_size()
+        # Engine-owned conversation-affinity ADP routing (opt-in). When the engine's
+        # attention_dp_config.kv_cache_routing_conversation_affinity is enabled, its
+        # ConversationAwareADPRouter pins a conversation (agent_context.session_id) to a
+        # DP rank; this worker then forwards ConversationParams and does NOT force a rank.
+        self._conversation_affinity = engine_conversation_affinity_enabled(
+            self._engine.llm
+        )
+        if self._conversation_affinity and not CONVERSATION_PARAMS_AVAILABLE:
+            raise RuntimeError(
+                "attention_dp_config.kv_cache_routing_conversation_affinity is enabled but the "
+                "installed TensorRT-LLM build has no ConversationParams API (requires a release "
+                "newer than 1.3.0rc20)."
+            )
         # Always start the metrics-poll thread: it pushes the latest
         # ComponentSnapshot into the framework's SnapshotPublisher and
         # forwards each snap to `_log_iteration_stats` for `trtllm_kv_cache_*`.
@@ -838,16 +861,27 @@ class TrtllmLLMEngine(LLMEngine):
         if ignore_eos:
             sampling_params.ignore_eos = ignore_eos
 
-        # Honour the router's DP rank decision; without it TRT-LLM picks
-        # its own rank and KV events land on the wrong publisher.
-        rank = validate_global_dp_rank(
-            forced_dp_rank(request), 0, self._attention_dp_size, "TRT-LLM"
-        )
-        scheduling_params = (
-            SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
-            if rank is not None
-            else None
-        )
+        # In conversation-affinity mode let the engine's ConversationAwareADPRouter pick the
+        # attention-DP rank from the conversation id; do NOT force a rank (an explicit rank is
+        # honored before affinity and would bypass it). The rank is suppressed even without an
+        # id so the engine's no-id balancing fallback runs. Otherwise honour the router's DP
+        # rank decision; without it TRT-LLM picks its own rank and KV events land on the wrong
+        # publisher.
+        conversation_params = None
+        if self._conversation_affinity:
+            scheduling_params = None
+            conversation_params = conversation_params_for(
+                session_id_from_request(request)
+            )
+        else:
+            rank = validate_global_dp_rank(
+                forced_dp_rank(request), 0, self._attention_dp_size, "TRT-LLM"
+            )
+            scheduling_params = (
+                SchedulingParams(attention_dp_rank=rank, attention_dp_relax=False)
+                if rank is not None
+                else None
+            )
 
         entries = logits_processors_for_request(
             self._logits_processor_spec,
@@ -859,6 +893,13 @@ class TrtllmLLMEngine(LLMEngine):
         # matches the legacy disagg wire format.
         streaming = not is_prefill
         cache_salt = request_cache_salt(request)
+        # Only pass conversation_params when affinity is active — older TRT-LLM builds'
+        # generate_async does not accept the keyword.
+        conv_kwargs = (
+            {"conversation_params": conversation_params}
+            if self._conversation_affinity
+            else {}
+        )
         generation_result = self._engine.llm.generate_async(
             inputs=token_ids,
             sampling_params=sampling_params,
@@ -866,6 +907,7 @@ class TrtllmLLMEngine(LLMEngine):
             disaggregated_params=disaggregated_params,
             scheduling_params=scheduling_params,
             cache_salt=cache_salt,
+            **conv_kwargs,
             **telemetry.engine_trace_kwargs(context),
         )
 

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -867,6 +867,20 @@ class TrtllmLLMEngine(LLMEngine):
         # id so the engine's no-id balancing fallback runs. Otherwise honour the router's DP
         # rank decision; without it TRT-LLM picks its own rank and KV events land on the wrong
         # publisher.
+        #
+        # TODO(TRT-LLM tracking issue): rank-ownership mismatch. TRT-LLM's
+        # `ConversationAwareADPRouter` currently honors an explicit
+        # `attention_dp_rank` BEFORE looking up affinity AND does NOT record a
+        # `conversation_id -> rank` binding when explicit placement wins. Sticky
+        # routing here relies on Dynamo always suppressing the rank when
+        # affinity is enabled (as this branch does); if any other path leaks an
+        # explicit rank into an affinity-enabled request (e.g. frontend
+        # `push_router` still stamps a rank in some flows), the engine will
+        # honor the leaked rank without laying down a binding, and turn 2 will
+        # silently drift off the KV-cache-warmed worker. The safer fix is on
+        # the engine side (always record the binding, whether the rank came
+        # from explicit placement or fresh selection). Track upstream and drop
+        # this note when the router records unconditionally.
         conversation_params = None
         if self._conversation_affinity:
             scheduling_params = None

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -43,6 +43,12 @@ from dynamo.nixl_connect import Connector
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.conversation_affinity import (
+    CONVERSATION_PARAMS_AVAILABLE,
+    conversation_params_for,
+    engine_conversation_affinity_enabled,
+    session_id_from_request,
+)
 from dynamo.trtllm.engine import TensorRTLLMEngine
 from dynamo.trtllm.logits_processing.adapter import create_trtllm_adapters
 from dynamo.trtllm.metrics import AdditionalMetricsCollector
@@ -256,6 +262,10 @@ class HandlerBase(BaseGenerativeHandler):
         self.publisher = config.publisher
         self.metrics_collector = config.metrics_collector
         self.disaggregation_mode = config.disaggregation_mode
+        # Engine-owned conversation-affinity ADP routing gate; resolved lazily on first
+        # request (engine may not be initialized at handler construction). See
+        # conversation_affinity.py. None = not yet resolved.
+        self._conversation_affinity: Optional[bool] = None
         self.encode_client = config.encode_client
         self.multimodal_processor = config.multimodal_processor
         self.first_generation = True
@@ -1096,11 +1106,33 @@ class HandlerBase(BaseGenerativeHandler):
         # Build trace headers for distributed tracing
         trace_headers = context.trace_headers()
 
+        # Resolve the engine-owned conversation-affinity gate once (lazily; the engine is
+        # initialized by first request). When on, the engine's ConversationAwareADPRouter
+        # picks the attention-DP rank from the conversation id, so we must NOT force a rank.
+        if self._conversation_affinity is None:
+            self._conversation_affinity = engine_conversation_affinity_enabled(
+                self.engine.llm
+            )
+            if self._conversation_affinity and not CONVERSATION_PARAMS_AVAILABLE:
+                raise RuntimeError(
+                    "attention_dp_config.kv_cache_routing_conversation_affinity is enabled but "
+                    "the installed TensorRT-LLM build has no ConversationParams API (requires a "
+                    "release newer than 1.3.0rc20)."
+                )
+        conv_affinity = self._conversation_affinity
+
         # Extract dp_rank from request's routing hints for attention DP routing
         routing = request.get("routing", {})
         dp_rank = routing.get("dp_rank") if routing else None
+        conversation_params = None
         scheduling_params = None
-        if dp_rank is not None:
+        if conv_affinity:
+            # Let the engine pick the rank from the conversation id (agent_context.session_id);
+            # do NOT force a rank (an explicit rank is honored before affinity and bypasses it).
+            conversation_params = conversation_params_for(
+                session_id_from_request(request)
+            )
+        elif dp_rank is not None:
             scheduling_params = SchedulingParams(
                 attention_dp_rank=dp_rank,
                 attention_dp_relax=False,  # Strict routing - use the rank dynamo router selected
@@ -1115,6 +1147,11 @@ class HandlerBase(BaseGenerativeHandler):
 
         try:
             # NEW: Updated engine call to include multimodal data
+            # Only pass conversation_params in affinity mode — older TRT-LLM builds'
+            # generate_async does not accept the keyword.
+            conv_kwargs = (
+                {"conversation_params": conversation_params} if conv_affinity else {}
+            )
             generation_result = self.engine.llm.generate_async(
                 inputs=processed_input,  # Use the correctly extracted inputs
                 sampling_params=sampling_params,
@@ -1122,6 +1159,7 @@ class HandlerBase(BaseGenerativeHandler):
                 streaming=streaming,
                 trace_headers=trace_headers,
                 scheduling_params=scheduling_params,
+                **conv_kwargs,
                 priority=priority,
                 cache_salt=cache_salt,
             )

--- a/components/src/dynamo/trtllm/tests/test_conversation_affinity.py
+++ b/components/src/dynamo/trtllm/tests/test_conversation_affinity.py
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for engine-owned conversation-affinity ADP routing helpers.
+
+Wheel-independent: the ConversationParams import is guarded, so these run on any
+TensorRT-LLM build (including rc19, which lacks the API)."""
+
+import pytest
+
+from dynamo.trtllm.conversation_affinity import (
+    CONVERSATION_PARAMS_AVAILABLE,
+    conversation_params_for,
+    engine_conversation_affinity_enabled,
+    session_id_from_request,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_session_id_from_request_absent_or_malformed():
+    assert session_id_from_request({}) is None
+    assert session_id_from_request({"agent_context": None}) is None
+    assert session_id_from_request({"agent_context": "not-a-dict"}) is None
+    assert session_id_from_request({"agent_context": {}}) is None
+    assert session_id_from_request({"agent_context": {"session_id": ""}}) is None
+    assert session_id_from_request({"agent_context": {"session_id": "   "}}) is None
+    assert session_id_from_request({"agent_context": {"session_id": 123}}) is None
+
+
+def test_session_id_from_request_valid():
+    assert (
+        session_id_from_request({"agent_context": {"session_id": "run-123:agent-0"}})
+        == "run-123:agent-0"
+    )
+    # trims surrounding whitespace
+    assert session_id_from_request({"agent_context": {"session_id": " s1 "}}) == "s1"
+
+
+class _Cfg:
+    def __init__(self, value):
+        self.kv_cache_routing_conversation_affinity = value
+
+
+class _Args:
+    def __init__(self, adp_cfg):
+        self.attention_dp_config = adp_cfg
+
+
+class _Llm:
+    def __init__(self, args):
+        self.args = args
+
+
+def test_engine_conversation_affinity_enabled_dict():
+    assert (
+        engine_conversation_affinity_enabled(
+            _Llm(_Args({"kv_cache_routing_conversation_affinity": True}))
+        )
+        is True
+    )
+    assert (
+        engine_conversation_affinity_enabled(
+            _Llm(_Args({"kv_cache_routing_conversation_affinity": False}))
+        )
+        is False
+    )
+    assert engine_conversation_affinity_enabled(_Llm(_Args({}))) is False
+
+
+def test_engine_conversation_affinity_enabled_model():
+    assert engine_conversation_affinity_enabled(_Llm(_Args(_Cfg(True)))) is True
+    assert engine_conversation_affinity_enabled(_Llm(_Args(_Cfg(False)))) is False
+    # only a genuine boolean True enables it
+    assert engine_conversation_affinity_enabled(_Llm(_Args(_Cfg(1)))) is False
+
+
+def test_engine_conversation_affinity_enabled_missing():
+    assert engine_conversation_affinity_enabled(_Llm(_Args(None))) is False
+    assert engine_conversation_affinity_enabled(_Llm(None)) is False
+    assert engine_conversation_affinity_enabled(object()) is False
+
+
+def test_conversation_params_for_none_id_is_none():
+    assert conversation_params_for(None) is None
+
+
+@pytest.mark.skipif(
+    not CONVERSATION_PARAMS_AVAILABLE,
+    reason="ConversationParams requires TensorRT-LLM newer than 1.3.0rc20",
+)
+def test_conversation_params_for_builds_when_available():
+    params = conversation_params_for("run-123:agent-0")
+    assert params is not None
+    assert params.conversation_id == "run-123:agent-0"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine_conversation_affinity.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine_conversation_affinity.py
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wiring tests for engine-owned conversation-affinity ADP routing on the unified
+``TrtllmLLMEngine`` path.
+
+Exercises the four branches of ``_generate_started`` around
+``_conversation_affinity``:
+
+* off + router-forced rank → ``SchedulingParams(attention_dp_rank=rank)`` and no
+  ``conversation_params`` kwarg.
+* off + no rank → ``scheduling_params=None`` and no ``conversation_params`` kwarg.
+* on + ``agent_context.session_id`` present → ``scheduling_params=None`` and
+  ``conversation_params.conversation_id == session_id``.
+* on + no session id → ``scheduling_params=None`` and ``conversation_params=None``
+  (the kwarg is still passed so the engine's no-id balancing fallback runs).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.trtllm.constants import DisaggregationMode
+
+# Guard the engine import: package metadata can be present without submodules,
+# and native-lib loads (e.g., libcuda.so.1) raise ImportError, not
+# ModuleNotFoundError. Catch both via ImportError.
+try:
+    from dynamo.trtllm.llm_engine import TrtllmLLMEngine
+except ImportError:
+    pytest.skip("tensorrt_llm backend not available", allow_module_level=True)
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+]
+
+
+class _FakeContext:
+    def id(self) -> str:
+        return "conv-affinity-test-req"
+
+    def trace_headers(self) -> dict[str, str] | None:
+        return None
+
+
+async def _empty_async_iter():
+    for _ in ():
+        yield
+
+
+class _FakeConversationParams:
+    """Stand-in for tensorrt_llm.llmapi.ConversationParams. The unified path
+    threads it through opaquely; tests only need to read back ``conversation_id``."""
+
+    def __init__(self, conversation_id: str):
+        self.conversation_id = conversation_id
+
+
+def _make_engine(
+    generate_async, *, conversation_affinity: bool, attention_dp_size: int = 1
+) -> TrtllmLLMEngine:
+    # Couples to TrtllmLLMEngine.__init__ attribute names — keep in sync.
+    engine = TrtllmLLMEngine.__new__(TrtllmLLMEngine)
+    engine._engine = SimpleNamespace(llm=SimpleNamespace(generate_async=generate_async))
+    engine._logits_processor_spec = None
+    engine._default_sampling_params = SimpleNamespace()
+    engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine.max_seq_len = 1024
+    engine._active_requests = {}
+    engine._additional_metrics = None
+    engine._inflight_lock = asyncio.Lock()
+    engine._inflight_requests = 0
+    engine._no_inflight_requests = asyncio.Event()
+    engine._no_inflight_requests.set()
+    engine._reject_new_requests = False
+    engine._conversation_affinity = conversation_affinity
+    engine._attention_dp_size = attention_dp_size
+    engine._override_sampling_params = lambda default, request: SimpleNamespace(
+        max_tokens=None
+    )
+    return engine
+
+
+async def _drain(engine: TrtllmLLMEngine, request: dict) -> None:
+    async for _ in engine.generate(request, _FakeContext()):
+        pass
+
+
+async def test_affinity_off_forwards_router_dp_rank():
+    """affinity=False + router dp_rank → SchedulingParams with that rank."""
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    engine = _make_engine(
+        fake_generate_async, conversation_affinity=False, attention_dp_size=8
+    )
+    await _drain(engine, {"token_ids": [1, 2, 3], "routing": {"dp_rank": 3}})
+
+    scheduling_params = captured["scheduling_params"]
+    assert scheduling_params is not None
+    assert scheduling_params.attention_dp_rank == 3
+    assert scheduling_params.attention_dp_relax is False
+    assert "conversation_params" not in captured
+
+
+async def test_affinity_off_no_rank_leaves_scheduling_params_none():
+    """affinity=False + no router rank → scheduling_params=None, no conv kwarg."""
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    engine = _make_engine(
+        fake_generate_async, conversation_affinity=False, attention_dp_size=8
+    )
+    await _drain(engine, {"token_ids": [1, 2, 3]})
+
+    assert captured["scheduling_params"] is None
+    assert "conversation_params" not in captured
+
+
+async def test_affinity_on_with_session_id_suppresses_rank_and_forwards_conv_params(
+    monkeypatch,
+):
+    """affinity=True + session id → suppress rank, forward ConversationParams."""
+    monkeypatch.setattr(
+        "dynamo.trtllm.conversation_affinity.ConversationParams",
+        _FakeConversationParams,
+    )
+
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    engine = _make_engine(
+        fake_generate_async, conversation_affinity=True, attention_dp_size=8
+    )
+    # Router still stamps a rank; affinity mode must ignore it (an explicit rank
+    # would bypass the engine's ConversationAwareADPRouter).
+    await _drain(
+        engine,
+        {
+            "token_ids": [1, 2, 3],
+            "routing": {"dp_rank": 3},
+            "agent_context": {"session_id": "run-42:agent-0"},
+        },
+    )
+
+    assert captured["scheduling_params"] is None
+    conv_params = captured["conversation_params"]
+    assert conv_params is not None
+    assert conv_params.conversation_id == "run-42:agent-0"
+
+
+async def test_affinity_on_without_session_id_passes_none_conversation_params(
+    monkeypatch,
+):
+    """affinity=True + no session id → scheduling_params=None,
+    conversation_params kwarg present with value None (no-id balancing)."""
+    monkeypatch.setattr(
+        "dynamo.trtllm.conversation_affinity.ConversationParams",
+        _FakeConversationParams,
+    )
+
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    engine = _make_engine(
+        fake_generate_async, conversation_affinity=True, attention_dp_size=8
+    )
+    await _drain(engine, {"token_ids": [1, 2, 3]})
+
+    assert captured["scheduling_params"] is None
+    assert "conversation_params" in captured
+    assert captured["conversation_params"] is None

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -824,3 +824,183 @@ class TestHealthCheckPriority:
         handler.engine.llm.generate_async.assert_called_once()
         _, kwargs = handler.engine.llm.generate_async.call_args
         assert kwargs["cache_salt"] == "tenant-a"
+
+
+class _FakeConversationParams:
+    """Stand-in for tensorrt_llm.llmapi.ConversationParams. Only ``conversation_id``
+    is read back by the assertions."""
+
+    def __init__(self, conversation_id):
+        self.conversation_id = conversation_id
+
+
+class TestConversationAffinity:
+    """Verify generate_locally's conversation-affinity branching on the legacy path.
+
+    When engine-owned conversation-affinity ADP routing is enabled, the handler
+    must (a) NOT force ``attention_dp_rank`` and (b) forward the frontend's
+    ``agent_context.session_id`` as ``ConversationParams`` to
+    ``generate_async``. When disabled, the router's ``dp_rank`` still drives
+    ``SchedulingParams`` as before.
+    """
+
+    def _make_handler(self, *, conversation_affinity: bool) -> HandlerBase:
+        config = MagicMock()
+        config.shutdown_event = None
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        handler = _ConcreteHandler(config)
+        handler.publisher = None
+        handler.multimodal_processor = None
+        handler.additional_metrics = None
+        handler.max_seq_len = None
+        handler.default_sampling_params = MockSamplingParams()
+        # Pre-resolve the gate so the lazy path in _generate_locally_impl is a
+        # no-op — the branching under test happens downstream.
+        handler._conversation_affinity = conversation_affinity
+        return handler
+
+    def _make_mock_generation_result(self):
+        output = MagicMock()
+        output.token_ids = [42]
+        output.finish_reason = "stop"
+        output.stop_reason = None
+        output.request_perf_metrics = None
+
+        res = MagicMock()
+        res.outputs = [output]
+        res.finished = True
+
+        generation_result = MagicMock()
+        generation_result.abort = MagicMock()
+
+        async def mock_aiter(self_mock):
+            yield res
+
+        generation_result.__aiter__ = mock_aiter
+        return generation_result
+
+    def _make_context(self):
+        context = MagicMock()
+        never_resolve = asyncio.get_event_loop().create_future()
+        context.async_killed_or_stopped.return_value = never_resolve
+        context.id.return_value = "conv-affinity-test"
+        return context
+
+    async def _drive(self, handler, request):
+        generation_result = self._make_mock_generation_result()
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+        chunks = [
+            c async for c in handler.generate_locally(request, self._make_context())
+        ]
+        assert len(chunks) > 0
+        handler.engine.llm.generate_async.assert_called_once()
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        return kwargs
+
+    @pytest.mark.asyncio
+    async def test_affinity_off_forwards_router_dp_rank(self):
+        """affinity=False + router dp_rank → SchedulingParams with that rank."""
+        handler = self._make_handler(conversation_affinity=False)
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+                "routing": {"dp_rank": 3},
+            },
+        )
+        scheduling_params = kwargs["scheduling_params"]
+        assert scheduling_params is not None
+        assert scheduling_params.attention_dp_rank == 3
+        assert scheduling_params.attention_dp_relax is False
+        assert "conversation_params" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_affinity_off_no_rank_leaves_scheduling_params_none(self):
+        """affinity=False + no router rank → scheduling_params=None, no conv kwarg."""
+        handler = self._make_handler(conversation_affinity=False)
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+            },
+        )
+        assert kwargs["scheduling_params"] is None
+        assert "conversation_params" not in kwargs
+
+    @pytest.mark.asyncio
+    async def test_affinity_on_with_session_id_suppresses_rank(self, monkeypatch):
+        """affinity=True + session id → scheduling_params=None + ConversationParams."""
+        monkeypatch.setattr(
+            "dynamo.trtllm.conversation_affinity.ConversationParams",
+            _FakeConversationParams,
+        )
+        handler = self._make_handler(conversation_affinity=True)
+        # Router still stamps a rank; affinity mode must ignore it — an explicit
+        # rank would bypass the engine's ConversationAwareADPRouter.
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+                "routing": {"dp_rank": 3},
+                "agent_context": {"session_id": "run-42:agent-0"},
+            },
+        )
+        assert kwargs["scheduling_params"] is None
+        conv_params = kwargs["conversation_params"]
+        assert conv_params is not None
+        assert conv_params.conversation_id == "run-42:agent-0"
+
+    @pytest.mark.asyncio
+    async def test_affinity_on_without_session_id_passes_none_conversation_params(
+        self, monkeypatch
+    ):
+        """affinity=True + no session id → scheduling_params=None,
+        conversation_params kwarg present with value None (no-id balancing)."""
+        monkeypatch.setattr(
+            "dynamo.trtllm.conversation_affinity.ConversationParams",
+            _FakeConversationParams,
+        )
+        handler = self._make_handler(conversation_affinity=True)
+        kwargs = await self._drive(
+            handler,
+            {
+                "token_ids": [1, 2, 3],
+                "stop_conditions": {"max_tokens": 10},
+                "sampling_options": {"temperature": 0.7},
+            },
+        )
+        assert kwargs["scheduling_params"] is None
+        assert "conversation_params" in kwargs
+        assert kwargs["conversation_params"] is None
+
+    @pytest.mark.asyncio
+    async def test_lazy_resolution_raises_when_api_missing(self, monkeypatch):
+        """Startup gate: engine has affinity ON but ConversationParams API is
+        missing → RuntimeError on first request, before generate_async is called."""
+        monkeypatch.setattr(
+            "dynamo.trtllm.request_handlers.handler_base.CONVERSATION_PARAMS_AVAILABLE",
+            False,
+        )
+        handler = self._make_handler(conversation_affinity=False)
+        # Trigger the lazy path with an engine config that enables affinity.
+        handler._conversation_affinity = None
+        handler.engine.llm.args.attention_dp_config = {
+            "kv_cache_routing_conversation_affinity": True
+        }
+        handler.engine.llm.generate_async = MagicMock()
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {"max_tokens": 10},
+            "sampling_options": {"temperature": 0.7},
+        }
+        with pytest.raises(RuntimeError, match="ConversationParams API"):
+            async for _ in handler.generate_locally(request, self._make_context()):
+                pass
+        handler.engine.llm.generate_async.assert_not_called()

--- a/components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py
@@ -66,6 +66,8 @@ def _make_engine(generate_async) -> TrtllmLLMEngine:
     engine._no_inflight_requests = asyncio.Event()
     engine._no_inflight_requests.set()
     engine._reject_new_requests = False
+    # Match __init__ default; generate_locally reads this before dispatch.
+    engine._conversation_affinity = False
     # Single-rank default: validate_global_dp_rank(None, 0, 1, ...) -> None,
     # so scheduling_params stays None and never touches a real SchedulingParams.
     engine._attention_dp_size = 1


### PR DESCRIPTION
_Port of #11288 (from `nv-yna:conv-aware-adp-routing`), opened while @nv-yna is OOO. Rebased on latest `main`; only merge conflict was orthogonal (`cache_salt` on main + `conv_kwargs` on this branch — both kept in the `generate_async` call). Original commit authored by @nv-yna._

---

## What this PR does

Adds opt-in support for TensorRT-LLM's **engine-owned conversation-affinity ADP routing**. When the engine's `attention_dp_config.kv_cache_routing_conversation_affinity` is enabled, the TRT-LLM worker:
1. derives the conversation id from the frontend-forwarded **`agent_context.session_id`**,
2. passes it as **`ConversationParams`** to `generate_async`, and
3. **stops forcing `attention_dp_rank`**, so the engine's `ConversationAwareADPRouter` pins the conversation to a DP rank (sticky, load-balanced first turn).

When the engine policy is **off**, Dynamo-owned strict DP-rank forcing is **byte-for-byte unchanged**.

## Why this shape (design notes for review)

This is the main-appropriate re-implementation of the DSV4 feature branch's conversation-aware routing (`321567ee83`, #10517), following @PeaBrane's review guidance ("avoid duplicate routing plumbing; derive the id from session identity in the engine handlers"):

- **No Rust changes.** On `main` the session identity already reaches the worker via the serialized `PreprocessedRequest.agent_context` field (`lib/llm/src/protocols/common/preprocessor.rs:272`). The feature branch's approach added a *second* copy (`RoutingHints.conversation_id`) — dropped here entirely.
- **`agent_context.session_id`, not the old `session_control`** — `main` diverged; `session_control` doesn't exist here. Uses `session_id` (the active reasoning/tool chain), not `parent_session_id`.
- **Gated on the resolved engine config, not a `DYN_*` env var** — a Dynamo-side switch could disagree with the engine (e.g. suppress the rank when no engine router exists). The engine config is the single source of truth.
- **`ConversationParams`, not `disaggregated_params.conversation_id`** — the feature branch mutated disaggregation metadata (specific to a custom wheel). Upstream shipped a dedicated `ConversationParams` argument (`generate_async(..., conversation_params=...)`), which also covers ordinary aggregated requests (the old path only worked for P/D).
- **No `exp-H`/`gap #4` instrumentation** — all experimental one-shot logging stripped for production.

## Files
- `components/src/dynamo/trtllm/conversation_affinity.py` — new helper: session-id extraction, engine-config gate, `ConversationParams` builder (guarded import).
- `components/src/dynamo/trtllm/llm_engine.py` — unified path: resolve gate at init; suppress rank + pass `ConversationParams` when enabled.
- `components/src/dynamo/trtllm/request_handlers/handler_base.py` — legacy path: same, gate resolved lazily.
- `components/src/dynamo/trtllm/tests/test_conversation_affinity.py` — wheel-independent unit tests for the helpers.

## Testing
- `ruff check` / `ruff format --check` clean; helper unit tests pass (6 passed, 1 skipped where the API is absent).
- No Rust diff → no `cargo` exposure.
- **Deferred to the dependency-bump follow-up:** GPU integration (sticky rank across turns, no-id fallback, aggregated + P/D) and the mocked-`generate_async` handler matrix.

## Open questions for review
1. Which released TRT-LLM version/image will carry the post-rc20 API? (sole hard blocker)
2. Frontend per-rank accounting vs engine-owned placement (`push_router.rs` still stamps the frontend rank) — needs an e2e accounting pass; must not reintroduce Rust conversation plumbing.
3. Fail-startup on incompatible-wheel-with-affinity-enabled — currently yes; confirm desired.