### PR TITLE
feat(vllm): support multiple served model names

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -22,6 +22,7 @@ from dynamo.common.configuration.groups.runtime_args import (
     DynamoRuntimeArgGroup,
     DynamoRuntimeConfig,
 )
+from dynamo.common.configuration.utils import split_served_model_names
 from dynamo.common.utils.runtime import parse_endpoint
 from dynamo.vllm.backend_args import DynamoVllmArgGroup, DynamoVllmConfig
 from dynamo.vllm.constants import DisaggregationMode
@@ -169,13 +170,12 @@ def update_dynamo_config_with_engine(
 ) -> None:
     """Update dynamo_config fields from engine_config and worker flags."""
 
-    if getattr(engine_config, "served_model_name", None) is not None:
-        served = engine_config.served_model_name
-        if len(served) > 1:
-            raise ValueError("We do not support multiple model names.")
-        dynamo_config.served_model_name = served[0]
-    else:
-        dynamo_config.served_model_name = None
+    # vLLM's --served-model-name is nargs="+"; each token may itself pack
+    # several comma-separated names. The first is the primary served name; any
+    # remaining names are registered as aliases for the same worker.
+    served_names = split_served_model_names(engine_config.served_model_name)
+    dynamo_config.served_model_name = served_names[0] if served_names else None
+    dynamo_config.served_model_aliases = served_names[1:]
 
     # Capture user-provided --endpoint before defaults overwrite it
     user_endpoint = dynamo_config.endpoint

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -9,7 +9,7 @@ import argparse
 import logging
 import os
 import warnings
-from typing import Optional, Union
+from typing import List, Optional, Union
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
@@ -446,6 +446,10 @@ class DynamoVllmConfig(ConfigBase):
 
     # GMS shadow mode
     gms_shadow_mode: bool = False
+
+    # Extra served names beyond the primary, parsed from --served-model-name.
+    # None (not []) since ConfigBase copies class defaults by reference.
+    served_model_aliases: Optional[List[str]] = None
 
     # Benchmark / self-profiling
     benchmark_mode: Optional[str] = None

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -756,6 +756,7 @@ async def register_vllm_model(
         worker_type=worker_type,
         needs=needs,
         ignore_weights=should_register_model_ignore_weights(config),
+        model_aliases=config.served_model_aliases or None,
         # Advertise LoRA capacity on the BASE card so the frontend can place the first
         # adapter onto an idle worker. Decode, aggregated, and prefill workers all serve
         # lifecycle registration; embeddings still do not.

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -363,6 +363,39 @@ def test_parse_args_does_not_track_logprobs_mode_presence(mock_vllm_cli):
     assert not hasattr(config, "logprobs_mode_explicitly_set")
 
 
+def test_parse_args_splits_served_model_name_into_aliases(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--served-model-name",
+        "primary",
+        "alias-one",
+        "alias-two",
+    )
+    config = parse_args()
+    assert config.served_model_name == "primary"
+    assert config.served_model_aliases == ["alias-one", "alias-two"]
+
+
+def test_parse_args_splits_comma_packed_served_model_name(mock_vllm_cli):
+    mock_vllm_cli(
+        "--model",
+        "Qwen/Qwen3-0.6B",
+        "--served-model-name",
+        "primary,alias-one",
+        "alias-two",
+    )
+    config = parse_args()
+    assert config.served_model_name == "primary"
+    assert config.served_model_aliases == ["alias-one", "alias-two"]
+
+
+def test_parse_args_without_served_model_name_has_no_aliases(mock_vllm_cli):
+    mock_vllm_cli("--model", "Qwen/Qwen3-0.6B")
+    config = parse_args()
+    assert config.served_model_aliases == []
+
+
 def test_should_prefetch_model_for_default_load_format():
     from dynamo.vllm.main import should_prefetch_model
 


### PR DESCRIPTION
## Overview:

Follow-up to #11141 (SGLang multi-served-model-name), applying the same support
to the vLLM backend so a single vLLM worker can advertise a primary served name
plus additional aliases.

## Details:

vLLM's `--served-model-name` is `nargs="+"`, but the Dynamo wrapper previously
rejected more than one name (`"We do not support multiple model names."`). Now
the first name is the primary served name and any additional names are
registered as aliases for the same worker, reusing the shared
`split_served_model_names` helper and passing them through
`register_model(model_aliases=...)` — the same frontend path SGLang uses.
Alias→primary canonicalization, global name reservation, and teardown ownership
already live in the frontend (from #11141); this PR only wires the vLLM worker
into it.

- `args.py`: `update_dynamo_config_with_engine` splits the served names into
  primary + aliases instead of rejecting multiples (direct attribute access, no
  defensive `getattr`).
- `backend_args.py`: add `served_model_aliases: Optional[List[str]]`.
- `main.py`: pass `model_aliases=config.served_model_aliases or None` to
  `register_model`.

## Where should the reviewer start?

`components/src/dynamo/vllm/args.py` — `update_dynamo_config_with_engine`, where
`--served-model-name` is split into primary + aliases.

## Validation

- `black` / `isort` / `flake8` and `pre-commit` clean.
- Unit tests pass (`components/src/dynamo/vllm/tests/test_vllm_unit.py`):
  `test_parse_args_splits_served_model_name_into_aliases`,
  `test_parse_args_splits_comma_packed_served_model_name`,
  `test_parse_args_without_served_model_name_has_no_aliases`.
- End-to-end on 1×H100 with Qwen3-0.6B
  (`--served-model-name Qwen/Qwen3-0.6B alias-one alias-two`):
  - `/v1/models` lists the primary + both aliases.
  - Chat completions to the primary and to each alias return
    `response.model == "Qwen/Qwen3-0.6B"` (canonicalized) with non-empty content.
  - An unknown model name returns 404.
  - Frontend logs confirm `Registering model alias ... alias="alias-one"/"alias-two"`
    and `Adding worker set to model=alias-one/alias-two`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue