### PR TITLE
docs(profiler): clarify infeasible SLA behavior

### DIFF
--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -167,7 +167,8 @@ The profiler enforces these rules at startup:
 | `enable_throughput_scaling: true` + `pre_deployment_sweeping_mode: none` (or unset) | Allowed for planner. The perf model starts from native AIC when available or waits for enough live FPM observations. |
 | `enable_throughput_scaling: true` + `pre_deployment_sweeping_mode: rapid` + AIC unsupported | Allowed for planner. The Rust shim falls back to observed-FPM regression when native AIC estimates are unavailable. |
 | `e2eLatency` provided together with an explicitly-set `ttft` or `itl` | Rejected by SLA validator. Provide only `e2eLatency`; `ttft` and `itl` do not need to be explicitly nulled. |
-| SLA unachievable | Warning logged, SLA updated to best achievable value. |
+| All AIC rapid experiments return no SLA-feasible configuration | Profiling fails and no DGD is generated. SLA targets are not relaxed automatically. |
+| A real-GPU thorough sweep returns results, but none meet the SLA | Warning logged and the closest measured configuration is selected. |
 | Load-match needs more GPUs than available | Warning logged. |
 
 ## Support Matrix
@@ -689,7 +690,13 @@ View traces using Chrome's `chrome://tracing`, [Perfetto UI](https://ui.perfetto
 
 ### SLA Cannot Be Met
 
-The profiler logs a warning and updates the SLA to the best achievable value. To improve results:
+The behavior depends on the search strategy:
+
+- With `searchStrategy: rapid`, profiling fails when all AIC experiments return no SLA-feasible configuration. The profiler does not relax the SLA or generate a DGD.
+- With `searchStrategy: thorough`, the profiler selects the closest measured configuration and logs a warning when the sweep produces results but none meet the SLA. Profiling fails if the sweep produces no usable results.
+
+To improve results:
+
 - Relax SLA targets (increase TTFT/ITL)
 - Add more GPU resources
 - Try a different backend


### PR DESCRIPTION
## Summary

Fixes [DYN-2396](https://linear.app/nvidia/issue/DYN-2396/dynamorelease100-dgdr-tc-92-infeasible-sla-targets-silently-accepted).

DYN-2396 was previously addressed by adding an `SLA is unverified` warning to the naive fallback path. Follow-up QA verification found that the profiler documentation still described different behavior for the AIC-supported rapid path: when every AIC experiment returns no SLA-feasible configuration, profiling fails instead of relaxing the SLA and generating a DGD.

This PR:

- documents that rapid profiling fails when every AIC experiment returns no SLA-feasible configuration
- clarifies that rapid profiling does not relax the SLA or generate a DGD in this case
- distinguishes thorough profiling, which selects the closest measured configuration when sweeping produced usable results
- aligns the profiler guide and troubleshooting guidance with current runtime behavior; this PR does not change runtime behavior

## Validation

- `PYTHONPATH="$PWD/lib/bindings/kvbm/python" .venv/bin/pre-commit run --files docs/components/profiler/profiler-guide.md`
- `NODE_OPTIONS=--experimental-global-webcrypto fern check`
- `NODE_OPTIONS=--experimental-global-webcrypto fern docs broken-links`
- `git diff --check`