### PR TITLE
docs(planner): align configuration descriptions with behavior

### DIFF
--- a/components/src/dynamo/planner/config/planner_config.py
+++ b/components/src/dynamo/planner/config/planner_config.py
@@ -514,7 +514,8 @@ class PlannerConfig(BaseModel):
         validate_default=True,
         description=(
             "Path to a CA bundle for verifying the upstream Prometheus TLS certificate. "
-            "No-op unless ssl_verify is enabled."
+            "Setting this field enables TLS verification against the given bundle, "
+            "regardless of ssl_verify."
         ),
     )
 

--- a/docs/components/planner/README.md
+++ b/docs/components/planner/README.md
@@ -20,15 +20,16 @@ The Dynamo **Planner** is an autoscaler purpose-built for these constraints. It 
 
 ## Getting Started: Optimization Targets
 
-The planner offers three `optimization_target` settings that control how scaling decisions are made:
+The planner offers four `optimization_target` settings that control how scaling decisions are made:
 
 | Target | Description | Requires SLA? | Requires Profiling? |
 |--------|-------------|:-------------:|:-------------------:|
 | **`throughput`** (default) | Maximizes throughput by scaling based on queue depth and KV cache utilization. Scales up when engines are saturated, scales down when utilization drops. | No | No |
 | **`latency`** | Minimizes latency by scaling aggressively to keep queues short. Scales up at lower utilization thresholds. | No | No |
+| **`load`** | Uses user-defined prefill queue token and decode KV cache utilization thresholds. | No | No |
 | **`sla`** | Targets specific TTFT/ITL SLA values using the Rust engine perf shim: native AIC estimates when available, online FPM tuning, and FPM regression fallback. | Yes (`ttft_ms`, `itl_ms`) | Recommended |
 
-**We recommend starting with the default `throughput` target** — it works out of the box with zero configuration. Switch to `latency` if your workload is latency-sensitive, or to `sla` when you need precise SLA targeting with native AIC or FPM-based performance modeling.
+**We recommend starting with the default `throughput` target** because it requires no configuration. Switch to `latency` for latency-sensitive workloads, `load` for explicit prefill queue token and decode KV cache utilization thresholds, or `sla` for precise SLA targeting with native AIC or FPM-based performance modeling.
 
 > **New to the Planner?** Start with the [Planner Guide](planner-guide.md) for a complete workflow including profiling and deployment.
 
@@ -159,7 +160,7 @@ DGDR planner features and generated ConfigMaps are materialized into these
 | `namespace` | `$DYN_NAMESPACE` or `dynamo` | Dynamo logical namespace |
 | `backend` | `vllm` | Backend framework (`sglang`, `trtllm`, `vllm`) |
 | `mode` | `disagg` | Planner mode (`disagg`, `prefill`, `decode`, `agg`) |
-| `optimization_target` | `throughput` | Scaling target: `throughput` (queue/util thresholds), `latency` (aggressive low-latency), `sla` (Rust engine perf model SLA targeting) |
+| `optimization_target` | `throughput` | Scaling target: `throughput` (queue/util thresholds), `latency` (aggressive low-latency), `load` (user-defined prefill queue and decode KV utilization thresholds), `sla` (Rust engine perf model SLA targeting) |
 | `environment` | `kubernetes` | Deployment environment |
 | `ttft_ms` | `500.0` | Target Time To First Token (ms) |
 | `itl_ms` | `50.0` | Target Inter-Token Latency (ms) |
@@ -231,9 +232,9 @@ Planner can read these traffic signals from either the public `Frontend` or a po
 | Request duration | `dynamo_frontend_request_duration_seconds` | `dynamo_component_request_duration_seconds` until router-specific duration metrics are available |
 | Input sequence length / ISL | `dynamo_frontend_input_sequence_tokens` | `dynamo_component_router_input_sequence_tokens` |
 | Output sequence length / OSL | `dynamo_frontend_output_sequence_tokens` | `dynamo_component_router_output_sequence_tokens` |
-| KV hit rate | Not available from frontend source | `dynamo_component_router_kv_hit_rate` |
+| KV hit rate | `dynamo_component_router_kv_hit_rate` | `dynamo_component_router_kv_hit_rate` |
 
-The throughput planner uses request count, ISL, OSL, and optional KV hit rate as the core traffic forecast inputs. TTFT, ITL, and request duration are also scraped and exported as observed diagnostics.
+The throughput planner uses request count, ISL, OSL, and optional KV hit rate as the core traffic forecast inputs. The router component metric supplies KV hit rate for both traffic metric sources. TTFT, ITL, and request duration are also scraped and exported as observed diagnostics.
 
 **Load-based scaling** uses ForwardPassMetrics (FPM) from the Dynamo event plane:
 - Per-iteration wall time, scheduled prefill/decode tokens, and queued request status


### PR DESCRIPTION
## Summary

- document all four `optimization_target` values, including the `load` mode thresholds
- show that KV hit rate uses `dynamo_component_router_kv_hit_rate` for both traffic metric sources
- clarify that setting a Prometheus CA bundle enables TLS verification regardless of `ssl_verify`

The stale descriptions were not updated when the corresponding Planner behavior changed.

The `PROMETHEUS_EXTRA_QUERY_PARAMS` finding in [DYN-3477](https://linear.app/nvidia/issue/DYN-3477) applies only to the historical PR #9557 description. The shipped field description already documents URL query-string syntax with an ampersand, so no repository change is needed for that item.

## Validation

- `pre-commit run --files docs/components/planner/README.md components/src/dynamo/planner/config/planner_config.py`
- `fern check` (0 errors; two unrelated existing warnings)
- `fern docs broken-links`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11613" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that providing a Prometheus CA bundle enables TLS certificate verification.
  * Documented `load` as an available optimization target and updated configuration guidance.
  * Expanded Prometheus metrics documentation to include KV hit rate for supported metric sources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->