### PR TITLE
feat(bindings): expose Client.instances() with transport object model

### DIFF
--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -744,8 +744,8 @@ struct Client {
 /// `TransportType`. Exposes the transport `kind` ("tcp" / "nats_tcp") and its
 /// `address`; the address format is transport-specific and not a stable parse
 /// target.
-#[pyclass]
-#[derive(Clone)]
+#[pyclass(eq, hash, frozen)]
+#[derive(Clone, PartialEq, Eq, Hash)]
 struct TransportType {
     inner: rs::component::TransportType,
 }
@@ -776,8 +776,8 @@ impl TransportType {
 
 /// A read-only view of a single registered instance of an endpoint, wrapping a
 /// snapshot of the runtime `Instance`.
-#[pyclass]
-#[derive(Clone)]
+#[pyclass(eq, frozen)]
+#[derive(Clone, PartialEq, Eq)]
 struct Instance {
     inner: rs::component::Instance,
 }

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -188,6 +188,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Endpoint>()?;
     m.add_class::<ModelCardInstanceId>()?;
     m.add_class::<Client>()?;
+    m.add_class::<Instance>()?;
+    m.add_class::<TransportType>()?;
     m.add_class::<AsyncResponseStream>()?;
     m.add_class::<PyAsyncRequestStream>()?;
     m.add_class::<llm::entrypoint::EntrypointArgs>()?;
@@ -736,6 +738,95 @@ struct ModelCardInstanceId {
 struct Client {
     router: rs::pipeline::PushRouter<serde_json::Value, RsAnnotated<serde_json::Value>>,
     endpoint: rs::component::Endpoint,
+}
+
+/// A read-only view of an instance's transport, wrapping the runtime
+/// `TransportType`. Exposes the transport `kind` ("tcp" / "nats_tcp") and its
+/// `address`; the address format is transport-specific and not a stable parse
+/// target.
+#[pyclass]
+#[derive(Clone)]
+struct TransportType {
+    inner: rs::component::TransportType,
+}
+
+#[pymethods]
+impl TransportType {
+    #[getter]
+    fn kind(&self) -> &str {
+        match &self.inner {
+            rs::component::TransportType::Nats(_) => "nats_tcp",
+            rs::component::TransportType::Tcp(_) => "tcp",
+        }
+    }
+
+    #[getter]
+    fn address(&self) -> &str {
+        self.inner.address()
+    }
+
+    fn __repr__(&self) -> String {
+        format!(
+            "TransportType(kind={:?}, address={:?})",
+            self.kind(),
+            self.address()
+        )
+    }
+}
+
+/// A read-only view of a single registered instance of an endpoint, wrapping a
+/// snapshot of the runtime `Instance`.
+#[pyclass]
+#[derive(Clone)]
+struct Instance {
+    inner: rs::component::Instance,
+}
+
+#[pymethods]
+impl Instance {
+    #[getter]
+    fn instance_id(&self) -> u64 {
+        self.inner.instance_id
+    }
+
+    #[getter]
+    fn namespace(&self) -> &str {
+        &self.inner.namespace
+    }
+
+    #[getter]
+    fn component(&self) -> &str {
+        &self.inner.component
+    }
+
+    #[getter]
+    fn endpoint(&self) -> &str {
+        &self.inner.endpoint
+    }
+
+    #[getter]
+    fn transport(&self) -> TransportType {
+        TransportType {
+            inner: self.inner.transport.clone(),
+        }
+    }
+
+    /// Device type, e.g. "cpu" or "cuda", or None if unspecified.
+    #[getter]
+    fn device_type(&self) -> Option<&str> {
+        self.inner.device_type.as_ref().map(|d| match d {
+            rs::component::DeviceType::Cpu => "cpu",
+            rs::component::DeviceType::Cuda => "cuda",
+        })
+    }
+
+    fn __str__(&self) -> String {
+        self.inner.to_string()
+    }
+
+    fn __repr__(&self) -> String {
+        format!("Instance({})", self.inner)
+    }
 }
 
 #[pyclass]
@@ -1363,6 +1454,18 @@ impl Client {
     /// Replaces endpoint_ids.
     fn instance_ids(&self) -> Vec<u64> {
         self.router.client.instance_ids()
+    }
+
+    /// Get a snapshot of the current instances with full transport details.
+    /// Like `instance_ids()`, the result is a snapshot of the watched instance
+    /// set; pair with `wait_for_instances()` to block until instances exist.
+    fn instances(&self) -> Vec<Instance> {
+        self.router
+            .client
+            .instances()
+            .into_iter()
+            .map(|inner| Instance { inner })
+            .collect()
     }
 
     /// Wait for an instance to be available for work.

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -254,8 +254,10 @@ class TransportType:
     not a stable parse target.
     """
 
-    kind: str
-    address: str
+    @property
+    def kind(self) -> str: ...
+    @property
+    def address(self) -> str: ...
 
 class Instance:
     """
@@ -264,13 +266,20 @@ class Instance:
     ``"namespace/component/endpoint/instance_id"``.
     """
 
-    instance_id: int
-    namespace: str
-    component: str
-    endpoint: str
-    transport: TransportType
-    device_type: Optional[str]
-    """Device type, e.g. "cpu" or "cuda", or None if unspecified."""
+    @property
+    def instance_id(self) -> int: ...
+    @property
+    def namespace(self) -> str: ...
+    @property
+    def component(self) -> str: ...
+    @property
+    def endpoint(self) -> str: ...
+    @property
+    def transport(self) -> TransportType: ...
+    @property
+    def device_type(self) -> Optional[str]:
+        """Device type, e.g. "cpu" or "cuda", or None if unspecified."""
+        ...
 
 class Client:
     """

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -246,6 +246,32 @@ class PyAsyncRequestStream:
     def __aiter__(self) -> "PyAsyncRequestStream": ...
     async def __anext__(self) -> JsonLike: ...
 
+class TransportType:
+    """
+    A read-only view of an instance's transport, wrapping the runtime
+    ``TransportType``. ``kind`` is the transport variant ("tcp" / "nats_tcp")
+    and ``address`` is its (transport-specific) address. The address format is
+    not a stable parse target.
+    """
+
+    kind: str
+    address: str
+
+class Instance:
+    """
+    A read-only view of a single registered instance of an endpoint, wrapping a
+    snapshot of the runtime ``Instance``. ``str(instance)`` yields
+    ``"namespace/component/endpoint/instance_id"``.
+    """
+
+    instance_id: int
+    namespace: str
+    component: str
+    endpoint: str
+    transport: TransportType
+    device_type: Optional[str]
+    """Device type, e.g. "cpu" or "cuda", or None if unspecified."""
+
 class Client:
     """
     A client capable of calling served instances of an endpoint
@@ -259,6 +285,20 @@ class Client:
 
         Returns:
             A list of currently available instance IDs
+        """
+        ...
+
+    def instances(self) -> List[Instance]:
+        """
+        Get a snapshot of the current instances with full transport details.
+
+        Like ``instance_ids()``, the result is a snapshot of the watched
+        instance set; pair with ``wait_for_instances()`` to block until
+        instances exist.
+
+        Returns:
+            A list of ``Instance`` for the currently available instances,
+            across all transports (TCP, NATS, ...).
         """
         ...
 

--- a/lib/bindings/python/tests/test_request_plane_python_payload.py
+++ b/lib/bindings/python/tests/test_request_plane_python_payload.py
@@ -68,11 +68,13 @@ async def request_plane_client(runtime):
         # with a "host:port/..." address.
         instances = client.instances()
         assert {i.instance_id for i in instances} == set(client.instance_ids())
+        # On the TCP request plane every instance exposes the identity fields of
+        # the served endpoint plus a populated "tcp" transport address.
         for instance in instances:
-            assert instance.transport.kind in ("tcp", "nats_tcp")
-            assert instance.transport.address
+            assert instance.namespace == "direct-python-msgpack"
+            assert instance.component == "backend"
             assert instance.endpoint == "generate"
-        for instance in instances:
+            assert instance.device_type in (None, "cpu", "cuda")
             assert instance.transport.kind == "tcp"
             assert ":" in instance.transport.address
 

--- a/lib/bindings/python/tests/test_request_plane_python_payload.py
+++ b/lib/bindings/python/tests/test_request_plane_python_payload.py
@@ -59,13 +59,28 @@ async def request_plane_client(runtime):
         endpoint.serve_endpoint(_generate, health_check_payload=health_payload)
     )
     client = await endpoint.client()
-    await client.wait_for_instances()
+    try:
+        await client.wait_for_instances()
 
-    yield client
+        # instances() returns a structured snapshot across all transports; its
+        # instance_ids must match instance_ids(). Each entry carries transport
+        # details. On the TCP request plane every instance's transport is "tcp"
+        # with a "host:port/..." address.
+        instances = client.instances()
+        assert {i.instance_id for i in instances} == set(client.instance_ids())
+        for instance in instances:
+            assert instance.transport.kind in ("tcp", "nats_tcp")
+            assert instance.transport.address
+            assert instance.endpoint == "generate"
+        for instance in instances:
+            assert instance.transport.kind == "tcp"
+            assert ":" in instance.transport.address
 
-    server_task.cancel()
-    with contextlib.suppress(asyncio.CancelledError):
-        await server_task
+        yield client
+    finally:
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await server_task
 
 
 @pytest.mark.asyncio

--- a/lib/bindings/python/tests/test_request_plane_python_payload.py
+++ b/lib/bindings/python/tests/test_request_plane_python_payload.py
@@ -61,28 +61,33 @@ async def request_plane_client(runtime):
     client = await endpoint.client()
     try:
         await client.wait_for_instances()
-
-        # instances() returns a structured snapshot across all transports; its
-        # instance_ids must match instance_ids(). Each entry carries transport
-        # details. On the TCP request plane every instance's transport is "tcp"
-        # with a "host:port/..." address.
-        instances = client.instances()
-        assert {i.instance_id for i in instances} == set(client.instance_ids())
-        # On the TCP request plane every instance exposes the identity fields of
-        # the served endpoint plus a populated "tcp" transport address.
-        for instance in instances:
-            assert instance.namespace == "direct-python-msgpack"
-            assert instance.component == "backend"
-            assert instance.endpoint == "generate"
-            assert instance.device_type in (None, "cpu", "cuda")
-            assert instance.transport.kind == "tcp"
-            assert ":" in instance.transport.address
-
         yield client
     finally:
         server_task.cancel()
         with contextlib.suppress(asyncio.CancelledError):
             await server_task
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp", "nats"], indirect=True)
+async def test_client_instances_snapshot(request_plane, request_plane_client):
+    """Client.instances() exposes the endpoint's instances with transport
+    details on each request plane: "tcp" carries a "host:port/..." address,
+    "nats" carries a "nats_tcp" subject address."""
+    expected_kind = "nats_tcp" if request_plane == "nats" else "tcp"
+
+    instances = request_plane_client.instances()
+    assert {i.instance_id for i in instances} == set(
+        request_plane_client.instance_ids()
+    )
+    for instance in instances:
+        assert instance.namespace == "direct-python-msgpack"
+        assert instance.component == "backend"
+        assert instance.endpoint == "generate"
+        assert instance.device_type in (None, "cpu", "cuda")
+        assert instance.transport.kind == expected_kind
+        assert instance.transport.address  # populated on both planes
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Counter-proposal to #11540. Rather than `instance_tcp_addresses() -> Dict[int, str]` (TCP-only, address flattened to an opaque string), expose the runtime's instance/transport model to Python as read-only snapshot objects:

- `Client.instances() -> List[Instance]` — snapshot of the watched instance set, like `instance_ids()` (pair with `wait_for_instances()`)
- `Instance` — wraps a runtime `Instance`; attributes `instance_id`, `namespace`, `component`, `endpoint`, `transport`, `device_type`; `str(i)` yields `"namespace/component/endpoint/instance_id"`
- `TransportType` — wraps the runtime `TransportType`; attributes `kind` (`"tcp"` / `"nats_tcp"`) and `address`

Keeps **all** transports (NATS included) instead of dropping non-TCP, and exposes `instance_id`/`namespace`/`component`/`endpoint` as first-class attributes rather than re-parsing an address string. Names mirror the runtime types (parallel construction).

The peer-address use case (e.g. a startup readiness / RDMA connectivity check) becomes a caller-side one-liner:

```python
addrs = [i.transport.address for i in client.instances() if i.transport.kind == "tcp"]
```

## Scope

**Bindings-only.** The new pyclasses wrap runtime values through already-public API (`Client::instances()`, public `Instance` fields, `TransportType::address()`, `Display`). No changes to `lib/runtime` or any core crate.

## Credit

Builds directly on the approach, use case, and original PR by **@jyizheng** (#11540). This PR reshapes that contribution into a snapshot object model; @jyizheng is credited as co-author on the commit.

## Details

- `lib/bindings/python/rust/lib.rs` — `Instance` and `TransportType` pyclasses wrapping the runtime value with `#[getter]` delegation; `Client.instances()` moves each owned runtime `Instance` into a wrapper (no construction-time clone); both classes registered.
- `lib/bindings/python/src/dynamo/_core.pyi` — matching stubs.
- `lib/bindings/python/tests/test_request_plane_python_payload.py` — asserts `instances()` ids match `instance_ids()` and transport details are populated (validation wrapped in `try/finally` so fixture cleanup always runs).

## Relationship to #11540

Alternative shape for the same goal (#11543). Opening as a comparison artifact for discussion.

## Validation

- `cargo check`, `cargo fmt --check`, `cargo clippy` — clean
- `maturin develop --uv` builds + installs; `from dynamo._core import Instance, TransportType` works
- `pytest tests/test_request_plane_python_payload.py` — passes

## Related Issues

Relates to #11543, alternative to #11540

🤖 Generated with [Claude Code](https://claude.com/claude-code)

— Neelay + 🤖


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `Client.instances()` to retrieve available endpoint instance snapshots.
  * Exposed instance details including identifiers, namespace, component, endpoint, device type, and transport metadata.
  * Added transport information with transport type and address fields.

* **Tests**
  * Added validation covering instance listings, identifiers, endpoints, and transport metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->