### PR TITLE
fix(ci): gate fastokens benches behind RUN_BENCH

### DIFF
--- a/lib/llm/benches/README.md
+++ b/lib/llm/benches/README.md
@@ -8,6 +8,9 @@ Uses Criterion with local test data. Runs automatically via `cargo bench`.
 cargo bench --bench tokenizer_simple -p dynamo-llm
 ```
 
+Exception: the two `fastokens` benches download a tokenizer from HuggingFace
+Hub and skip unless `RUN_BENCH=1` is set (see `tokenizer_dataset` below).
+
 ## tokenizer_dataset
 
 Downloads a real dataset from HuggingFace Hub (LongBench-v2, ~500 samples) and

--- a/lib/llm/benches/tokenizer_simple.rs
+++ b/lib/llm/benches/tokenizer_simple.rs
@@ -142,10 +142,12 @@ pub fn tiktoken_decode(c: &mut Criterion) {
 // ---------------------------------------------------------------------------
 // Tokenizer backend benchmarks
 //
-// By default these use the in-tree TinyLlama tokenizer. Override with a
-// production-size tokenizer for more realistic numbers:
-//   TOKENIZER_PATH=/path/to/tokenizer.json cargo bench -- fastokens
-//   TOKENIZER_PATH=Qwen/Qwen3-0.6B        cargo bench -- fastokens
+// These benchmarks download a production-size tokenizer from Hugging Face,
+// so they are opt-in (RUN_BENCH=1) to avoid network access under
+// `cargo test --all-targets` in CI, matching tokenizer_dataset.rs:
+//   RUN_BENCH=1 cargo bench -- fastokens
+//   RUN_BENCH=1 TOKENIZER_PATH=/path/to/tokenizer.json cargo bench -- fastokens
+//   RUN_BENCH=1 TOKENIZER_PATH=Qwen/Qwen3-0.6B        cargo bench -- fastokens
 // ---------------------------------------------------------------------------
 
 /// Default HuggingFace model to download when TOKENIZER_PATH is not set.
@@ -178,6 +180,11 @@ fn resolve_tokenizer_path() -> String {
 const FASTOKENS_BATCH_SIZE: usize = 64;
 
 pub fn fastokens_encode(c: &mut Criterion) {
+    if std::env::var("RUN_BENCH").is_err() {
+        eprintln!("[skip] fastokens_encode benchmark skipped. Set RUN_BENCH=1 to run it.");
+        return;
+    }
+
     let tokenizer_path = resolve_tokenizer_path();
     let test_str: &str = &INPUT_STR.repeat(TARGET_ISL / INPUT_STR.len());
 
@@ -212,6 +219,11 @@ pub fn fastokens_encode(c: &mut Criterion) {
 }
 
 pub fn fastokens_batch_encode(c: &mut Criterion) {
+    if std::env::var("RUN_BENCH").is_err() {
+        eprintln!("[skip] fastokens_batch_encode benchmark skipped. Set RUN_BENCH=1 to run it.");
+        return;
+    }
+
     let tokenizer_path = resolve_tokenizer_path();
     let batch: Vec<&str> = (0..FASTOKENS_BATCH_SIZE).map(|_| INPUT_STR).collect();
     let total_bytes: u64 = batch.iter().map(|s| s.len() as u64).sum();


### PR DESCRIPTION
## Overview:

Gate the two fastokens benches in `tokenizer_simple` behind `RUN_BENCH=1` so `cargo test --all-targets` in CI no longer depends on a Hugging Face download.

## Details:

`cargo test --all-targets` executes `tokenizer_simple`, whose two fastokens benches download `Qwen/Qwen3-0.6B` from Hugging Face at runtime. A transient Hugging Face Xet/CAS 403 caused the same failure on both `main` ([run 29290753192](https://github.com/ai-dynamo/dynamo/actions/runs/29290753192)) and an unrelated PR ([run 29291246536](https://github.com/ai-dynamo/dynamo/actions/runs/29291246536)).

Per review discussion, the fix is to gate the network-dependent benches instead of caching the tokenizer in CI:

- `fastokens_encode` and `fastokens_batch_encode` now skip unless `RUN_BENCH=1` is set, matching the existing opt-in pattern in `tokenizer_dataset.rs`
- the other five benches in the file use in-tree tokenizers and keep running under `cargo test --all-targets`
- no workflow changes

Why not an in-tree tokenizer: the fastokens parity check needs a byte-level BPE tokenizer (ByteLevel pre-tokenization, GPT/Qwen style). TinyLlama (the only real tokenizer in `tests/data`) is BPE but sentencepiece-style (metaspace + byte-fallback, no pre-tokenizer), which fastokens does not handle, and the byte-level mocks have empty vocabs. If the fastokens-vs-HF parity assertion is wanted back in CI later, a small trained byte-level BPE mock in `tests/data` would be the way (possible follow-up).

Validation:

- `RUN_BENCH` unset: both fastokens benches print a skip message and return, no network access
- `RUN_BENCH=1`: behavior unchanged from before
- rustfmt clean
- signed-off, GPG-signed single commit

## Where should the reviewer start?

`lib/llm/benches/tokenizer_simple.rs`: the `RUN_BENCH` guards at the top of `fastokens_encode` and `fastokens_batch_encode`.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

