### PR TITLE
fix(tokenspeed): align FlashInfer JIT cache version

### DIFF
--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile
@@ -24,9 +24,9 @@
 #     -t <your-registry>/dynamo-tokenspeed:runtime \
 #     .
 #
-# The default BASE_IMAGE pins lightseekorg/tokenspeed-runner at a CUDA-13
-# tag (matches B200's CUDA 13.x driver, ~4.66 GB). To target a different
-# TokenSpeed runtime build, override it:
+# The default BASE_IMAGE pins lightseekorg/tokenspeed-runner at an immutable
+# CUDA-13 digest (matches B200's CUDA 13.x driver, ~4.66 GB). To target a
+# different TokenSpeed runtime build, override it:
 #   --build-arg BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu129-torch-2.11.0
 # or for arm64 base images:
 #   --build-arg ARCH=arm64
@@ -35,13 +35,14 @@
 # TokenSpeed engine itself from github.com/lightseekorg/tokenspeed, following
 # the upstream guide at lightseek.org/tokenspeed/guides/getting-started. Pin
 # the TokenSpeed source ref via --build-arg TOKENSPEED_GIT_REF=<ref>.
-ARG BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0
+ARG BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0@sha256:516a14ed701184d224e8e8700b41b8e116a687ac4c3481e13020ed5fd49e7061
 ARG ARCH=amd64
 ARG CARGO_BUILD_JOBS=16
 
 FROM ${BASE_IMAGE} AS tokenspeed_base
 ARG ARCH
-ARG TOKENSPEED_GIT_REF=main
+ARG TOKENSPEED_GIT_REF=886baafaa30f95d9a9e1b781c5906b0a89a64e98
+ARG FLASHINFER_WHEEL_INDEX=https://flashinfer.ai/whl/cu130
 ENV PIP_BREAK_SYSTEM_PACKAGES=1
 USER root
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
@@ -63,8 +64,11 @@ RUN --mount=type=cache,target=/root/.cache/pip,sharing=locked \
     set -eux; \
     git clone https://github.com/lightseekorg/tokenspeed.git /opt/tokenspeed; \
     cd /opt/tokenspeed; \
-    git checkout "${TOKENSPEED_GIT_REF}"; \
+    git checkout --detach "${TOKENSPEED_GIT_REF}"; \
     pip install -e "./python" --no-build-isolation; \
+    FLASHINFER_VERSION="$(sed -n 's/^flashinfer-python==//p' tokenspeed-kernel/python/requirements/cuda.txt)"; \
+    test -n "${FLASHINFER_VERSION}"; \
+    pip install "flashinfer-jit-cache==${FLASHINFER_VERSION}" --index-url "${FLASHINFER_WHEEL_INDEX}"; \
     pip install -e tokenspeed-kernel/python/ --no-build-isolation; \
     pip install -e tokenspeed-scheduler/
 

--- a/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
+++ b/recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md
@@ -1,3 +1,8 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # [Experimental] Kimi-K2.5 nvidia/Kimi-K2.5-NVFP4 — TokenSpeed Aggregated Deployment on Kubernetes
 
 > **Text only:** the NVFP4 export of Kimi-K2.5 ships without vision-tower weights. The
@@ -38,7 +43,7 @@ There is **no public `nvcr.io/nvidia/ai-dynamo/tokenspeed-runtime` image** at th
 this recipe was written; TokenSpeed integration in Dynamo is still in flight. This
 directory ships a [`Dockerfile`](Dockerfile) that builds a Dynamo+TokenSpeed image
 on top of `docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0` (the upstream
-TokenSpeed runtime base, pinned by tag for reproducibility).
+TokenSpeed runtime base, pinned by digest for reproducibility).
 
 The lightseek runner image is the **runtime base only** — it ships CUDA 13, PyTorch
 2.11, and mooncake, but not the TokenSpeed engine itself (the engine is not yet
@@ -64,19 +69,27 @@ docker build \
   .
 ```
 
-The Dockerfile defaults `BASE_IMAGE` to a pinned public TokenSpeed runtime tag:
+The Dockerfile defaults `BASE_IMAGE` to a public TokenSpeed runtime tag pinned to
+an immutable digest:
 
 ```
-docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0
+docker.io/lightseekorg/tokenspeed-runner:cu130-torch-2.11.0@sha256:516a14ed701184d224e8e8700b41b8e116a687ac4c3481e13020ed5fd49e7061
 ```
 
-This tag is CUDA-13-based (matches B200's CUDA 13.x driver) and ships PyTorch 2.11.0.
+This image is CUDA-13-based (matches B200's CUDA 13.x driver) and ships PyTorch 2.11.0.
 Sibling tags on the same repo: `cu130`, `cu129-torch-2.11.0`, `cu129`, `latest`. To
 target a different runtime, override the build arg:
 
 ```bash
 --build-arg BASE_IMAGE=docker.io/lightseekorg/tokenspeed-runner:cu129-torch-2.11.0
 ```
+
+TokenSpeed is pinned to commit `886baafaa30f95d9a9e1b781c5906b0a89a64e98` by
+default. Override `TOKENSPEED_GIT_REF` to test another branch, tag, or commit. The
+build reads TokenSpeed's pinned `flashinfer-python` version and installs the matching
+JIT cache before compiling the TokenSpeed kernel. When overriding the base image for
+a different CUDA release, also set `FLASHINFER_WHEEL_INDEX` to that release's
+FlashInfer wheel index.
 
 The Dockerfile has two reachable targets:
 


### PR DESCRIPTION
## Overview:

Backport f87a9877f25925fa5cd7d63d88eafa6cc351e98c to `release/1.3.0`.

## Details:

- Pins the TokenSpeed runtime image and source commit for reproducible builds.
- Installs the FlashInfer JIT cache version matching TokenSpeed's pinned `flashinfer-python` requirement.
- Documents the version and CUDA wheel-index overrides.

## Where should the reviewer start?

`recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile`, then its README.

## Related Issues

**\uD83D\uDEAB This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Original change: #11465.

## Validation

- `git diff --check HEAD~1 HEAD`
- `git show --check HEAD`
- `pre-commit run --files recipes/kimi-k2.5/tokenspeed/agg/nvidia/Dockerfile recipes/kimi-k2.5/tokenspeed/agg/nvidia/README.md` *(not run: `pre-commit` is not installed in this worktree)*
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11635" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->