### PR TITLE
fix(planner): remove ineffective prefill SLA floor

### DIFF
--- a/components/src/dynamo/planner/core/throughput_scaling.py
+++ b/components/src/dynamo/planner/core/throughput_scaling.py
@@ -181,19 +181,14 @@ class ThroughputScalingMixin:
             self._diag_throughput_reason = "model_not_ready"
             return None
         ttft_ms = capacity.ttft_ms or 0.0
-        sla_floor = 1
         if not capacity.eligible or ttft_ms > self._config.ttft_ms:
             logger.warning(
                 f"Prefill TTFT SLA not met: {ttft_ms:.1f}ms > {self._config.ttft_ms:.1f}ms"
             )
-            # Latency-driven floor
-            sla_floor = math.ceil(ttft_ms / self._config.ttft_ms)
 
         self._diag_engine_rps_prefill = engine_rps
 
-        result = max(
-            math.ceil(demand_rps / engine_rps), sla_floor, self._config.min_endpoint
-        )
+        result = max(math.ceil(demand_rps / engine_rps), self._config.min_endpoint)
         logger.info(
             f"Prefill: {demand_rps:.2f} rps / {engine_rps:.2f} = {result}, "
             f"est_ttft={ttft_ms:.1f}ms, isl_raw={isl:.1f}, "

--- a/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
+++ b/components/src/dynamo/planner/tests/unit/test_throughput_scaling.py
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.planner.core.throughput_scaling import ThroughputScalingMixin
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+class _PrefillRegression:
+    def find_engine_capacity_rps(self, **kwargs):
+        return SimpleNamespace(rps=1.0, ttft_ms=1002.0, eligible=False)
+
+
+class _ThroughputScalingHarness(ThroughputScalingMixin):
+    def __init__(self):
+        self._config = SimpleNamespace(ttft_ms=200.0, min_endpoint=1)
+        self._prefill_regression = _PrefillRegression()
+        self._diag_throughput_reason = None
+        self._diag_engine_rps_prefill = None
+
+
+def test_unreachable_prefill_ttft_does_not_create_replica_floor():
+    scaling = _ThroughputScalingHarness()
+
+    replicas = scaling._compute_prefill_replicas(
+        demand_rps=0.01,
+        isl=1000,
+        osl=150,
+    )
+
+    assert replicas == 1


### PR DESCRIPTION
## Summary

- Cherry-pick #11624 to `release/1.3.0`.
- Remove the ineffective prefill TTFT latency-ratio replica floor.
- Add regression coverage for an infeasible single-request TTFT.

Linear: [DYN-3464](https://linear.app/nvidia/issue/DYN-3464/dynamorelease130planner-sla-throughput-only-mode-prefill-sla-floor)

## Validation

- `python -m pytest -q --strict-markers components/src/dynamo/planner/tests/unit` — 416 passed
- `pre-commit run --files components/src/dynamo/planner/core/throughput_scaling.py components/src/dynamo/planner/tests/unit/test_throughput_scaling.py` — passed

Cherry-picked from commit `379a6d8d797677dae297cef83cc227965c70c553` (#11624).
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11638" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->