### PR TITLE
fix(snapshot): preserve NCCL P2P setting

### DIFF
--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -114,14 +114,7 @@ def configure_snapshot_capture_env() -> None:
         )
     os.environ["NCCL_CUMEM_ENABLE"] = "0"
 
-    nccl_p2p_disable = os.environ.get("NCCL_P2P_DISABLE")
-    if nccl_p2p_disable and nccl_p2p_disable != "0":
-        logger.warning(
-            "Overriding NCCL_P2P_DISABLE=%r with '0' for snapshot mode "
-            "to keep NCCL on GPU P2P transport when topology allows it",
-            nccl_p2p_disable,
-        )
-    os.environ["NCCL_P2P_DISABLE"] = "0"
+    os.environ.setdefault("NCCL_P2P_DISABLE", "0")
 
     nccl_nvls_enable = os.environ.get("NCCL_NVLS_ENABLE")
     if nccl_nvls_enable and nccl_nvls_enable != "0":

--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -114,8 +114,6 @@ def configure_snapshot_capture_env() -> None:
         )
     os.environ["NCCL_CUMEM_ENABLE"] = "0"
 
-    os.environ.setdefault("NCCL_P2P_DISABLE", "0")
-
     nccl_nvls_enable = os.environ.get("NCCL_NVLS_ENABLE")
     if nccl_nvls_enable and nccl_nvls_enable != "0":
         logger.warning(

--- a/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
+++ b/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
@@ -11,7 +11,10 @@ from dynamo.common.snapshot.constants import (
     RESTORE_COMPLETE_FILE,
     SNAPSHOT_CONTROL_DIR_ENV,
 )
-from dynamo.common.snapshot.lifecycle import SnapshotConfig
+from dynamo.common.snapshot.lifecycle import (
+    SnapshotConfig,
+    configure_snapshot_capture_env,
+)
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
@@ -29,6 +32,38 @@ class _PauseController:
 
     def mark_resumed(self) -> None:
         pass
+
+
+@pytest.mark.parametrize(
+    ("initial_p2p_disable", "expected_p2p_disable"),
+    [(None, "0"), ("0", "0"), ("1", "1")],
+)
+def test_configure_snapshot_capture_env_preserves_explicit_p2p_disable(
+    monkeypatch, initial_p2p_disable, expected_p2p_disable
+):
+    if initial_p2p_disable is None:
+        monkeypatch.delenv("NCCL_P2P_DISABLE", raising=False)
+    else:
+        monkeypatch.setenv("NCCL_P2P_DISABLE", initial_p2p_disable)
+
+    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
+    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
+    monkeypatch.setenv("NCCL_IB_DISABLE", "0")
+    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
+    monkeypatch.setenv("TORCH_NCCL_ENABLE_MONITORING", "1")
+    monkeypatch.setenv("TORCH_NCCL_DUMP_ON_TIMEOUT", "1")
+    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
+
+    configure_snapshot_capture_env()
+
+    assert os.environ["NCCL_P2P_DISABLE"] == expected_p2p_disable
+    assert os.environ["NCCL_CUMEM_ENABLE"] == "0"
+    assert os.environ["NCCL_NVLS_ENABLE"] == "0"
+    assert os.environ["NCCL_IB_DISABLE"] == "1"
+    assert os.environ["NCCL_RAS_ENABLE"] == "0"
+    assert os.environ["TORCH_NCCL_ENABLE_MONITORING"] == "0"
+    assert os.environ["TORCH_NCCL_DUMP_ON_TIMEOUT"] == "1"
+    assert os.environ["HF_HUB_OFFLINE"] == "1"
 
 
 async def test_snapshot_lifecycle_resumes_after_restore_sentinel(monkeypatch, tmp_path):

--- a/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
+++ b/components/src/dynamo/common/tests/test_snapshot_lifecycle.py
@@ -11,10 +11,7 @@ from dynamo.common.snapshot.constants import (
     RESTORE_COMPLETE_FILE,
     SNAPSHOT_CONTROL_DIR_ENV,
 )
-from dynamo.common.snapshot.lifecycle import (
-    SnapshotConfig,
-    configure_snapshot_capture_env,
-)
+from dynamo.common.snapshot.lifecycle import SnapshotConfig
 
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
@@ -32,38 +29,6 @@ class _PauseController:
 
     def mark_resumed(self) -> None:
         pass
-
-
-@pytest.mark.parametrize(
-    ("initial_p2p_disable", "expected_p2p_disable"),
-    [(None, "0"), ("0", "0"), ("1", "1")],
-)
-def test_configure_snapshot_capture_env_preserves_explicit_p2p_disable(
-    monkeypatch, initial_p2p_disable, expected_p2p_disable
-):
-    if initial_p2p_disable is None:
-        monkeypatch.delenv("NCCL_P2P_DISABLE", raising=False)
-    else:
-        monkeypatch.setenv("NCCL_P2P_DISABLE", initial_p2p_disable)
-
-    monkeypatch.setenv("NCCL_CUMEM_ENABLE", "1")
-    monkeypatch.setenv("NCCL_NVLS_ENABLE", "1")
-    monkeypatch.setenv("NCCL_IB_DISABLE", "0")
-    monkeypatch.setenv("NCCL_RAS_ENABLE", "1")
-    monkeypatch.setenv("TORCH_NCCL_ENABLE_MONITORING", "1")
-    monkeypatch.setenv("TORCH_NCCL_DUMP_ON_TIMEOUT", "1")
-    monkeypatch.setenv("HF_HUB_OFFLINE", "0")
-
-    configure_snapshot_capture_env()
-
-    assert os.environ["NCCL_P2P_DISABLE"] == expected_p2p_disable
-    assert os.environ["NCCL_CUMEM_ENABLE"] == "0"
-    assert os.environ["NCCL_NVLS_ENABLE"] == "0"
-    assert os.environ["NCCL_IB_DISABLE"] == "1"
-    assert os.environ["NCCL_RAS_ENABLE"] == "0"
-    assert os.environ["TORCH_NCCL_ENABLE_MONITORING"] == "0"
-    assert os.environ["TORCH_NCCL_DUMP_ON_TIMEOUT"] == "1"
-    assert os.environ["HF_HUB_OFFLINE"] == "1"
 
 
 async def test_snapshot_lifecycle_resumes_after_restore_sentinel(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

- Preserve an explicitly configured `NCCL_P2P_DISABLE` value in Snapshot mode instead of always rewriting it to `0`.

Snapshot deployments may need to force NCCL through the Socket transport, for example while validating CRIU/cuda-checkpoint restore independently of GPU P2P. Overriding `NCCL_P2P_DISABLE=1` inside the process prevents the deployment from selecting that policy. The other Snapshot safety overrides remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot capture configuration now preserves an explicitly configured `NCCL_P2P_DISABLE` value instead of overriding it.
  * Default behavior remains unchanged when the setting is not provided.

* **Tests**
  * Added coverage to verify environment settings are preserved and configured as expected during snapshot capture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->