### PR TITLE
perf(router): prototype unified active prompt tracker

### DIFF
--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -1,290 +1,82 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::sync::Arc;
+
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
-#[cfg(debug_assertions)]
-use rustc_hash::FxHashSet;
-use slotmap::{SlotMap, new_key_type};
-use std::num::NonZeroU32;
 
-new_key_type! {
-    struct BlockNodeId;
-}
+use super::unified_prompt_tracker::{UnifiedPromptTracker, UnifiedRequestHandle};
+use crate::protocols::WorkerWithDpRank;
 
-/// One node in a persistent request block chain.
-///
-/// Sequence hashes identify their lineage. Parent IDs are generational arena
-/// keys, while `incoming` counts direct request-tail and child-to-parent edges.
-#[derive(Debug)]
-struct BlockNode {
-    hash: SequenceHash,
-    depth: usize,
-    parent: Option<BlockNodeId>,
-    incoming: NonZeroU32,
-}
-
-/// The single block-chain tail retained by a request.
-///
-/// This type intentionally does not implement `Clone`. New request owners must
-/// be acquired through [`BlockTracker::acquire_prompt`], which also maintains
-/// the arena ownership counts and block index.
 #[derive(Debug, Default)]
 #[must_use = "request block chains must be retained by a request and released through BlockTracker"]
 pub(super) struct RequestBlockChain {
-    tail: Option<BlockNodeId>,
-    prompt_depth: usize,
+    prompt: UnifiedRequestHandle,
+    output_hashes: Vec<SequenceHash>,
 }
 
-impl RequestBlockChain {
-    fn new(tail: Option<BlockNodeId>, prompt_depth: usize) -> Self {
-        Self { tail, prompt_depth }
-    }
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(super) struct ReleasedPromptPath {
-    pub(super) path: Vec<SequenceHash>,
-    pub(super) remove_from: usize,
-}
-
-#[derive(Debug, Default)]
+/// Per-worker facade for request-local output state. Prompt ownership lives
+/// exclusively in the shared [`UnifiedPromptTracker`].
+#[derive(Debug)]
 pub(super) struct BlockTracker {
-    nodes: SlotMap<BlockNodeId, BlockNode>,
-    unique_blocks: FxHashMap<SequenceHash, BlockNodeId>,
-    fractional_blocks: FxHashMap<SequenceHash, f64>,
+    worker: WorkerWithDpRank,
+    prompts: Arc<UnifiedPromptTracker>,
+    output_blocks: FxHashMap<SequenceHash, f64>,
 }
 
 impl BlockTracker {
-    /// Acquire one request tail for a prompt and return the first newly present
-    /// prompt index, if any.
-    ///
-    /// # Lineage contract
-    ///
-    /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
-    /// depth. As with the KV indexer, this tracker trusts callers to maintain
-    /// that invariant and does not validate the hash recurrence in production.
-    ///
-    /// # Collision scope
-    ///
-    /// Collision handling is outside the active-sequence tracker's scope: it
-    /// assumes distinct live lineages have distinct [`SequenceHash`] values and
-    /// does not detect, prevent, or recover from true hash collisions.
-    ///
-    /// `SequenceHash` is a probabilistic 64-bit identifier, so collisions are
-    /// possible but very unlikely. A collision matters here only when both
-    /// blocks are live in the same `WorkerWithDpRank` tracker: each worker and
-    /// DP rank owns a separate `BlockTracker` and hash index. Assuming uniform
-    /// hashes, an active set of `n` blocks has collision probability of roughly
-    /// `n * (n - 1) / 2^65`. Replica sync may reproduce the same collision for
-    /// that worker on peer routers, but cannot alias arena nodes across workers.
-    pub(super) fn acquire_prompt(
-        &mut self,
-        sequence: &[SequenceHash],
-    ) -> (RequestBlockChain, Option<usize>) {
-        let Some(&tail_hash) = sequence.last() else {
-            return (RequestBlockChain::default(), None);
-        };
-
-        if let Some(tail) = self.live_node_id(tail_hash) {
-            self.debug_assert_lineage(tail, sequence);
-            self.increment_incoming(tail);
-            return (RequestBlockChain::new(Some(tail), sequence.len()), None);
+    pub(super) fn new(worker: WorkerWithDpRank, prompts: Arc<UnifiedPromptTracker>) -> Self {
+        prompts.ensure_worker(worker);
+        Self {
+            worker,
+            prompts,
+            output_blocks: FxHashMap::default(),
         }
-
-        let mut parent = None;
-        let mut first_new_idx = 0;
-
-        // Prompt liveness is prefix-closed. Search backward for the deepest
-        // live prefix, then construct only the missing suffix.
-        for idx in (0..sequence.len().saturating_sub(1)).rev() {
-            if let Some(node_id) = self.live_node_id(sequence[idx]) {
-                self.debug_assert_lineage(node_id, &sequence[..=idx]);
-                parent = Some(node_id);
-                first_new_idx = idx + 1;
-                break;
-            }
-        }
-
-        let missing = sequence.len() - first_new_idx;
-        self.nodes.reserve(missing);
-        self.unique_blocks.reserve(missing);
-        self.debug_assert_new_hashes(&sequence[first_new_idx..]);
-
-        // Adding the first new child contributes one new incoming edge to the
-        // reused prefix. Subsequent construction transfers the provisional
-        // request-tail edge into a child-to-parent edge without changing it.
-        if let Some(parent_id) = parent {
-            self.increment_incoming(parent_id);
-        }
-
-        for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
-            let node_id = self.nodes.insert(BlockNode {
-                hash,
-                depth: first_new_idx + idx + 1,
-                parent,
-                incoming: NonZeroU32::MIN,
-            });
-            let previous = self.unique_blocks.insert(hash, node_id);
-            debug_assert!(
-                previous.is_none(),
-                "new block unexpectedly replaced a live index entry"
-            );
-            parent = Some(node_id);
-        }
-
-        (
-            RequestBlockChain::new(parent, sequence.len()),
-            Some(first_new_idx),
-        )
     }
 
-    /// Append a unique output block to an existing request chain.
+    pub(super) fn acquire_prompt(&mut self, sequence: &[SequenceHash]) -> RequestBlockChain {
+        RequestBlockChain {
+            prompt: self.prompts.acquire(self.worker, sequence),
+            output_hashes: Vec::new(),
+        }
+    }
+
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
-        debug_assert!(
-            !self.unique_blocks.contains_key(&hash),
-            "random output hash unexpectedly collided with a live block"
+        assert!(
+            self.output_blocks.insert(hash, 1.0).is_none(),
+            "output block hash unexpectedly became live twice"
         );
-
-        let parent = chain.tail;
-        let depth = parent.map_or(1, |node_id| {
-            self.nodes
-                .get(node_id)
-                .expect("request tail references a missing block node")
-                .depth
-                .checked_add(1)
-                .expect("block chain depth overflowed")
-        });
-        let node_id = self.nodes.insert(BlockNode {
-            hash,
-            depth,
-            parent,
-            incoming: NonZeroU32::MIN,
-        });
-        let previous = self.unique_blocks.insert(hash, node_id);
-        debug_assert!(
-            previous.is_none(),
-            "new output unexpectedly replaced a live index entry"
-        );
-        chain.tail = Some(node_id);
+        chain.output_hashes.push(hash);
     }
 
-    /// Release a request chain and return the complete prompt path plus the
-    /// first block that became absent from the worker.
-    pub(super) fn release(&mut self, chain: RequestBlockChain) -> Option<ReleasedPromptPath> {
-        let RequestBlockChain { tail, prompt_depth } = chain;
-        let mut removed_prompt_rev = Vec::new();
-        let mut retained = None;
-        let mut current = tail;
-
-        while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get_mut(node_id)
-                .expect("request chain references a missing block node");
-            let incoming = node.incoming.get();
-            if incoming > 1 {
-                node.incoming = NonZeroU32::new(incoming - 1)
-                    .expect("shared block ownership count cannot become zero");
-                retained = Some(node_id);
-                break;
-            }
-
-            let node = self
-                .nodes
-                .remove(node_id)
-                .expect("validated block node disappeared before removal");
-            let hash = node.hash;
-            let depth = node.depth;
-            let parent = node.parent;
-
-            let indexed_node_id = self
-                .unique_blocks
+    pub(super) fn release(&mut self, chain: RequestBlockChain) {
+        for hash in chain.output_hashes {
+            self.output_blocks
                 .remove(&hash)
-                .expect("live block node is missing from the hash index");
-            debug_assert_eq!(
-                indexed_node_id, node_id,
-                "block hash index references a different live node"
-            );
-            if !self.fractional_blocks.is_empty() {
-                self.fractional_blocks.remove(&hash);
-            }
-
-            if depth <= prompt_depth {
-                removed_prompt_rev.push(hash);
-            }
-            current = parent;
+                .expect("request output hash is missing from active bookkeeping");
         }
-
-        if removed_prompt_rev.is_empty() {
-            return None;
-        }
-
-        let remove_from = prompt_depth
-            .checked_sub(removed_prompt_rev.len())
-            .expect("removed prompt suffix cannot exceed the prompt depth");
-        let mut path = Vec::with_capacity(prompt_depth);
-        let mut current = retained;
-        while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("retained prompt prefix references a missing block node");
-            if node.depth <= prompt_depth {
-                path.push(node.hash);
-            }
-            current = node.parent;
-        }
-        path.reverse();
-        assert_eq!(
-            path.len(),
-            remove_from,
-            "retained prompt prefix length differs from the released suffix boundary"
-        );
-
-        removed_prompt_rev.reverse();
-        path.extend(removed_prompt_rev);
-        assert_eq!(
-            path.len(),
-            prompt_depth,
-            "released prompt path length differs from the request prompt depth"
-        );
-
-        Some(ReleasedPromptPath { path, remove_from })
+        self.prompts.release(self.worker, chain.prompt);
     }
 
-    /// Mark the request's exclusively owned suffix as fractional.
     pub(super) fn set_unique_suffix_fractional(
         &mut self,
         chain: &RequestBlockChain,
         fraction: f64,
     ) {
-        let mut current = chain.tail;
-        while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("request chain references a missing block node");
-            if node.incoming.get() != 1 {
-                break;
-            }
-            self.fractional_blocks.insert(node.hash, fraction);
-            current = node.parent;
+        for hash in &chain.output_hashes {
+            *self
+                .output_blocks
+                .get_mut(hash)
+                .expect("request output hash is missing from active bookkeeping") = fraction;
         }
+        self.prompts
+            .set_unique_suffix_fractional(self.worker, &chain.prompt, fraction);
     }
 
     pub(super) fn active_blocks(&self) -> usize {
-        let mut count = self.unique_blocks.len() as f64;
-        for (hash, frac) in &self.fractional_blocks {
-            if self.unique_blocks.contains_key(hash) {
-                count = count - 1.0 + frac;
-            }
-        }
-        count.round() as usize
-    }
-
-    pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
-        self.live_node_id(*hash).is_some()
+        let prompt_blocks = self.prompts.active_block_weight(self.worker);
+        (prompt_blocks + self.output_blocks.values().sum::<f64>()).round() as usize
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -292,574 +84,56 @@ impl BlockTracker {
         &self,
         chains: impl IntoIterator<Item = &'a RequestBlockChain>,
     ) {
+        use rustc_hash::FxHashSet;
+
+        self.prompts.assert_consistent();
+        let expected_outputs = chains
+            .into_iter()
+            .flat_map(|chain| chain.output_hashes.iter().copied())
+            .collect::<FxHashSet<_>>();
         assert_eq!(
-            self.nodes.len(),
-            self.unique_blocks.len(),
-            "arena and live block index must have identical cardinality"
-        );
-
-        let mut expected_incoming = FxHashMap::default();
-        for (node_id, node) in &self.nodes {
-            assert!(
-                expected_incoming.insert(node_id, 0_u32).is_none(),
-                "arena yielded a duplicate node ID"
-            );
-            assert_eq!(
-                self.unique_blocks.get(&node.hash),
-                Some(&node_id),
-                "live arena node is missing its exact hash-index entry"
-            );
-
-            if let Some(parent_id) = node.parent {
-                let parent = self
-                    .nodes
-                    .get(parent_id)
-                    .expect("block node references a missing parent");
-                assert_eq!(
-                    parent.depth + 1,
-                    node.depth,
-                    "child block depth must immediately follow its parent"
-                );
-            } else {
-                assert_eq!(node.depth, 1, "root block depth must be one");
-            }
-        }
-
-        for (&hash, &node_id) in &self.unique_blocks {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("hash index references a missing arena node");
-            assert_eq!(
-                node.hash, hash,
-                "hash index key does not match its arena node"
-            );
-        }
-
-        for (_, node) in &self.nodes {
-            if let Some(parent_id) = node.parent {
-                let count = expected_incoming
-                    .get_mut(&parent_id)
-                    .expect("block node references a missing parent");
-                *count = count
-                    .checked_add(1)
-                    .expect("reconstructed child ownership count overflowed");
-            }
-        }
-
-        for chain in chains {
-            if let Some(tail_id) = chain.tail {
-                let tail = self
-                    .nodes
-                    .get(tail_id)
-                    .expect("request tail references a missing arena node");
-                assert!(
-                    chain.prompt_depth <= tail.depth,
-                    "request prompt depth cannot exceed its full block-chain depth"
-                );
-                let count = expected_incoming
-                    .get_mut(&tail_id)
-                    .expect("request tail references a missing arena node");
-                *count = count
-                    .checked_add(1)
-                    .expect("reconstructed request ownership count overflowed");
-            } else {
-                assert_eq!(
-                    chain.prompt_depth, 0,
-                    "an empty request chain cannot retain prompt depth"
-                );
-            }
-        }
-
-        for (node_id, node) in &self.nodes {
-            assert_eq!(
-                expected_incoming[&node_id],
-                node.incoming.get(),
-                "stored incoming ownership count differs from reconstructed edges"
-            );
-        }
-
-        assert!(
-            self.fractional_blocks
-                .keys()
-                .all(|hash| self.unique_blocks.contains_key(hash)),
-            "fractional blocks cannot reference non-active blocks"
+            expected_outputs,
+            self.output_blocks.keys().copied().collect(),
+            "output bookkeeping differs from request ownership"
         );
     }
 
     #[cfg(test)]
-    pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
-        self.unique_blocks.keys().copied()
+    pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> {
+        let mut hashes = self.prompts.worker_hashes(self.worker);
+        hashes.extend(self.output_blocks.keys().copied());
+        hashes.into_iter()
     }
 
     #[cfg(test)]
-    pub(super) fn prompt_hashes<'a>(
-        &'a self,
-        chain: &'a RequestBlockChain,
-    ) -> impl Iterator<Item = SequenceHash> + 'a {
-        self.node_ids_from_tail(chain).filter_map(|node_id| {
-            let node = &self.nodes[node_id];
-            (node.depth <= chain.prompt_depth).then_some(node.hash)
-        })
-    }
-
-    fn live_node_id(&self, hash: SequenceHash) -> Option<BlockNodeId> {
-        let &node_id = self.unique_blocks.get(&hash)?;
-        let node = self
-            .nodes
-            .get(node_id)
-            .expect("live block index references a stale arena ID");
-        assert_eq!(
-            node.hash, hash,
-            "live block index key does not match its arena node"
-        );
-        Some(node_id)
-    }
-
-    fn increment_incoming(&mut self, node_id: BlockNodeId) {
-        let node = self
-            .nodes
-            .get_mut(node_id)
-            .expect("cannot acquire ownership of a missing block node");
-        let incoming = node
-            .incoming
-            .get()
-            .checked_add(1)
-            .expect("block ownership count overflowed");
-        node.incoming = NonZeroU32::new(incoming).expect("incremented ownership cannot be zero");
-    }
-
-    #[cfg(debug_assertions)]
-    fn debug_assert_new_hashes(&self, hashes: &[SequenceHash]) {
-        let mut seen = FxHashSet::default();
-        for hash in hashes {
-            assert!(
-                !self.unique_blocks.contains_key(hash),
-                "sequence lineage hash unexpectedly aliases a live block"
-            );
-            assert!(
-                seen.insert(*hash),
-                "sequence lineage repeats a hash in one missing suffix"
-            );
-        }
-    }
-
-    #[cfg(not(debug_assertions))]
-    #[inline]
-    fn debug_assert_new_hashes(&self, _hashes: &[SequenceHash]) {}
-
-    #[cfg(any(test, debug_assertions))]
-    fn debug_assert_lineage(&self, tail: BlockNodeId, sequence: &[SequenceHash]) {
-        let tail_node = self
-            .nodes
-            .get(tail)
-            .expect("live sequence tail references a missing arena node");
-        assert_eq!(
-            tail_node.depth,
-            sequence.len(),
-            "sequence tail depth mismatch"
-        );
-        let mut current = Some(tail);
-        for (expected_depth, &expected_hash) in sequence.iter().enumerate().rev() {
-            let node_id = current.expect("live sequence chain ended before its expected root");
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("live sequence chain references a missing arena node");
-            assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
-            assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
-            current = node.parent;
-        }
-    }
-
-    #[cfg(not(any(test, debug_assertions)))]
-    #[inline]
-    fn debug_assert_lineage(&self, _tail: BlockNodeId, _sequence: &[SequenceHash]) {}
-
-    #[cfg(test)]
-    fn node_ids_from_tail<'a>(
-        &'a self,
-        chain: &'a RequestBlockChain,
-    ) -> impl Iterator<Item = BlockNodeId> + 'a {
-        let mut current = chain.tail;
-        std::iter::from_fn(move || {
-            let node_id = current?;
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("request chain references a missing arena node");
-            current = node.parent;
-            Some(node_id)
-        })
-    }
-
-    #[cfg(test)]
-    fn incoming_for(&self, hash: SequenceHash) -> u32 {
-        let node_id = self.live_node_id(hash).expect("expected live block hash");
-        self.nodes[node_id].incoming.get()
-    }
-
-    #[cfg(test)]
-    fn node_id_for(&self, hash: SequenceHash) -> BlockNodeId {
-        self.live_node_id(hash).expect("expected live block hash")
+    pub(super) fn prompt_hashes(
+        &self,
+        chain: &RequestBlockChain,
+    ) -> impl Iterator<Item = SequenceHash> {
+        self.prompts.prompt_hashes(&chain.prompt).into_iter()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rand::{Rng, SeedableRng, rngs::StdRng};
-    use rustc_hash::FxHashSet;
 
-    fn released(path: &[SequenceHash], remove_from: usize) -> Option<ReleasedPromptPath> {
-        Some(ReleasedPromptPath {
-            path: path.to_vec(),
-            remove_from,
-        })
-    }
-
-    fn expected_release(
-        blocks: &[SequenceHash],
-        prompt_depth: usize,
-        counts: &FxHashMap<SequenceHash, usize>,
-    ) -> Option<ReleasedPromptPath> {
-        let remove_from = blocks[..prompt_depth]
-            .iter()
-            .position(|hash| counts[hash] == 1)?;
-        released(&blocks[..prompt_depth], remove_from)
+    fn worker(id: u64) -> WorkerWithDpRank {
+        WorkerWithDpRank::new(id, 0)
     }
 
     #[test]
-    fn first_acquire_and_last_release_report_presence_transitions() {
-        let mut tracker = BlockTracker::default();
+    fn facade_delegates_prompt_lifecycle_and_keeps_outputs_local() {
+        let prompts = Arc::new(UnifiedPromptTracker::default());
+        let mut tracker = BlockTracker::new(worker(1), prompts.clone());
+        let mut chain = tracker.acquire_prompt(&[1, 2, 3]);
+        tracker.append_output(&mut chain, 42);
 
-        let (first, first_new) = tracker.acquire_prompt(&[1]);
-        let (second, second_new) = tracker.acquire_prompt(&[1]);
-
-        assert_eq!(first_new, Some(0));
-        assert_eq!(second_new, None);
-        assert_eq!(tracker.incoming_for(1), 2);
-        tracker.assert_consistent([&first, &second]);
-        assert_eq!(tracker.active_blocks(), 1);
-
-        assert_eq!(tracker.release(first), None);
-        assert_eq!(tracker.incoming_for(1), 1);
-        tracker.assert_consistent([&second]);
-        assert_eq!(tracker.active_blocks(), 1);
-
-        assert_eq!(tracker.release(second), released(&[1], 0));
-        tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn shorter_request_adds_only_a_tail_edge() {
-        let mut tracker = BlockTracker::default();
-        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (shorter, first_new) = tracker.acquire_prompt(&[1, 2]);
-
-        assert_eq!(first_new, None);
-        assert_eq!(tracker.incoming_for(1), 1);
-        assert_eq!(tracker.incoming_for(2), 2);
-        assert_eq!(tracker.incoming_for(3), 1);
-        tracker.assert_consistent([&longer, &shorter]);
-
-        assert_eq!(tracker.release(shorter), None);
-        tracker.assert_consistent([&longer]);
-        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 0));
-    }
-
-    #[test]
-    fn longer_request_adds_one_child_edge_to_a_shorter_tail() {
-        let mut tracker = BlockTracker::default();
-        let (shorter, _) = tracker.acquire_prompt(&[1, 2]);
-        let (longer, first_new) = tracker.acquire_prompt(&[1, 2, 3]);
-
-        assert_eq!(first_new, Some(2));
-        assert_eq!(tracker.incoming_for(1), 1);
-        assert_eq!(tracker.incoming_for(2), 2);
-        assert_eq!(tracker.incoming_for(3), 1);
-        tracker.assert_consistent([&shorter, &longer]);
-
-        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 2));
-        tracker.assert_consistent([&shorter]);
-        assert_eq!(tracker.release(shorter), released(&[1, 2], 0));
-    }
-
-    #[test]
-    fn release_only_removes_unique_branch_suffix() {
-        let mut tracker = BlockTracker::default();
-        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
-
-        assert_eq!(first_new, Some(2));
-        assert_eq!(tracker.incoming_for(1), 1);
-        assert_eq!(tracker.incoming_for(2), 2);
-        tracker.assert_consistent([&left, &right]);
+        assert_eq!(prompts.active_blocks(worker(1)), 3);
         assert_eq!(tracker.active_blocks(), 4);
-
-        assert_eq!(tracker.release(left), released(&[1, 2, 3], 2));
-        tracker.assert_consistent([&right]);
-        assert_eq!(tracker.active_blocks(), 3);
-        assert_eq!(tracker.release(right), released(&[1, 2, 4], 0));
-        tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn output_append_transfers_tail_ownership_to_the_child_edge() {
-        let mut tracker = BlockTracker::default();
-        let (mut chain, _) = tracker.acquire_prompt(&[1, 2]);
-
-        let before = tracker.incoming_for(2);
-        tracker.append_output(&mut chain, 42);
-
-        assert_eq!(tracker.incoming_for(2), before);
-        assert_eq!(tracker.incoming_for(42), 1);
         tracker.assert_consistent([&chain]);
-        assert_eq!(tracker.release(chain), released(&[1, 2], 0));
-    }
-
-    #[test]
-    fn output_append_preserves_a_shared_tail_count() {
-        let mut tracker = BlockTracker::default();
-        let (mut generating, _) = tracker.acquire_prompt(&[1, 2]);
-        let (shared, _) = tracker.acquire_prompt(&[1, 2]);
-
-        assert_eq!(tracker.incoming_for(2), 2);
-        tracker.append_output(&mut generating, 42);
-        assert_eq!(tracker.incoming_for(2), 2);
-        tracker.assert_consistent([&generating, &shared]);
-
-        assert_eq!(tracker.release(generating), None);
-        assert_eq!(tracker.incoming_for(2), 1);
-        tracker.assert_consistent([&shared]);
-        assert_eq!(tracker.release(shared), released(&[1, 2], 0));
-    }
-
-    #[test]
-    fn either_branch_can_be_released_first() {
-        let mut tracker = BlockTracker::default();
-        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (right, _) = tracker.acquire_prompt(&[1, 2, 4]);
-
-        assert_eq!(tracker.release(right), released(&[1, 2, 4], 2));
-        tracker.assert_consistent([&left]);
-        assert_eq!(tracker.release(left), released(&[1, 2, 3], 0));
-    }
-
-    #[test]
-    fn fractional_blocks_adjust_active_block_count() {
-        let mut tracker = BlockTracker::default();
-        let (chain, _) = tracker.acquire_prompt(&[1, 2]);
-
-        tracker.set_unique_suffix_fractional(&chain, 0.5);
-        tracker.assert_consistent([&chain]);
-        assert_eq!(tracker.active_blocks(), 1);
-
-        assert_eq!(tracker.release(chain), released(&[1, 2], 0));
-        assert!(tracker.fractional_blocks.is_empty());
-        tracker.assert_consistent(std::iter::empty());
+        tracker.release(chain);
         assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn release_cleans_fractional_unique_suffix_above_shared_prefix() {
-        let mut tracker = BlockTracker::default();
-        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (shared_prefix, _) = tracker.acquire_prompt(&[1, 2]);
-
-        tracker.set_unique_suffix_fractional(&longer, 0.5);
-        assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
-        assert!(!tracker.fractional_blocks.contains_key(&1));
-        assert!(!tracker.fractional_blocks.contains_key(&2));
-        tracker.assert_consistent([&longer, &shared_prefix]);
-
-        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 2));
-        assert!(tracker.fractional_blocks.is_empty());
-        tracker.assert_consistent([&shared_prefix]);
-        assert_eq!(tracker.active_blocks(), 2);
-
-        assert_eq!(tracker.release(shared_prefix), released(&[1, 2], 0));
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn output_only_chain_releases_without_prompt_membership() {
-        let mut tracker = BlockTracker::default();
-        let (mut chain, first_new) = tracker.acquire_prompt(&[]);
-
-        assert_eq!(first_new, None);
-        tracker.append_output(&mut chain, 42);
-        tracker.assert_consistent([&chain]);
-        assert_eq!(tracker.active_blocks(), 1);
-        assert_eq!(tracker.release(chain), None);
-        tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn removed_slot_generation_cannot_resolve_after_reuse() {
-        let mut tracker = BlockTracker::default();
-        let (first, _) = tracker.acquire_prompt(&[1]);
-        let old_id = tracker.node_id_for(1);
-        assert_eq!(tracker.release(first), released(&[1], 0));
-
-        let (second, _) = tracker.acquire_prompt(&[2]);
-        assert!(tracker.nodes.get(old_id).is_none());
-        assert_ne!(old_id, tracker.node_id_for(2));
-        tracker.assert_consistent([&second]);
-        assert_eq!(tracker.release(second), released(&[2], 0));
-    }
-
-    #[test]
-    #[should_panic(expected = "live block index references a stale arena ID")]
-    fn stale_generation_in_index_is_rejected() {
-        let mut tracker = BlockTracker::default();
-        let (first, _) = tracker.acquire_prompt(&[1]);
-        let old_id = tracker.node_id_for(1);
-        assert_eq!(tracker.release(first), released(&[1], 0));
-        let (second, _) = tracker.acquire_prompt(&[2]);
-
-        tracker.unique_blocks.insert(99, old_id);
-        let _ = tracker.contains_block(&99);
-        drop(second);
-    }
-
-    #[test]
-    #[should_panic(expected = "live block index key does not match its arena node")]
-    fn live_id_with_the_wrong_hash_is_rejected() {
-        let mut tracker = BlockTracker::default();
-        let (chain, _) = tracker.acquire_prompt(&[1]);
-        let node_id = tracker.node_id_for(1);
-
-        tracker.unique_blocks.insert(2, node_id);
-        let _ = tracker.contains_block(&2);
-        drop(chain);
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "block hash index references a different live node")]
-    fn release_rejects_hash_index_alias() {
-        let mut tracker = BlockTracker::default();
-        let (first, _) = tracker.acquire_prompt(&[1]);
-        let (_second, _) = tracker.acquire_prompt(&[2]);
-        let aliased_node_id = tracker.node_id_for(2);
-
-        tracker.unique_blocks.insert(1, aliased_node_id);
-        let _ = tracker.release(first);
-    }
-
-    #[test]
-    #[should_panic(expected = "block ownership count overflowed")]
-    fn ownership_count_overflow_panics() {
-        let mut tracker = BlockTracker::default();
-        let (chain, _) = tracker.acquire_prompt(&[1]);
-        let node_id = tracker.node_id_for(1);
-        tracker.nodes[node_id].incoming = NonZeroU32::MAX;
-        let _ = tracker.acquire_prompt(&[1]);
-        drop(chain);
-    }
-
-    #[test]
-    fn randomized_lifecycle_matches_reference_model() {
-        const SLOTS: usize = 32;
-        const STEPS: usize = 10_000;
-        let prompts = [
-            vec![1, 2, 3, 4],
-            vec![1, 2, 3, 5],
-            vec![1, 2, 6],
-            vec![1, 7],
-            vec![8, 9, 10],
-            vec![8, 9, 11],
-            vec![12],
-        ];
-        let mut rng = StdRng::seed_from_u64(0x5eed_51a7);
-        let mut tracker = BlockTracker::default();
-        let mut chains = (0..SLOTS).map(|_| None).collect::<Vec<_>>();
-        let mut reference = (0..SLOTS)
-            .map(|_| None::<(Vec<SequenceHash>, usize)>)
-            .collect::<Vec<_>>();
-        let mut counts = FxHashMap::<SequenceHash, usize>::default();
-        let mut next_output = 1_000_000_u64;
-
-        for _ in 0..STEPS {
-            let slot = rng.random_range(0..SLOTS);
-            match (&mut chains[slot], &mut reference[slot]) {
-                (chain @ None, reference @ None) => {
-                    let prompt = &prompts[rng.random_range(0..prompts.len())];
-                    let expected_first_new =
-                        prompt.iter().position(|hash| !counts.contains_key(hash));
-                    let (new_chain, first_new) = tracker.acquire_prompt(prompt);
-                    assert_eq!(first_new, expected_first_new);
-                    for &hash in prompt {
-                        *counts.entry(hash).or_default() += 1;
-                    }
-                    *chain = Some(new_chain);
-                    *reference = Some((prompt.clone(), prompt.len()));
-                }
-                (Some(chain), Some((blocks, _prompt_depth))) if rng.random_bool(0.35) => {
-                    let hash = next_output;
-                    next_output += 1;
-                    tracker.append_output(chain, hash);
-                    blocks.push(hash);
-                    counts.insert(hash, 1);
-                }
-                (chain @ Some(_), reference @ Some(_)) => {
-                    let chain = chain.take().expect("matched active chain");
-                    let (blocks, prompt_depth) = reference.take().expect("matched reference");
-                    let expected_remove = expected_release(&blocks, prompt_depth, &counts);
-                    assert_eq!(tracker.release(chain), expected_remove);
-                    for hash in blocks {
-                        let count = counts.get_mut(&hash).expect("reference block is active");
-                        *count -= 1;
-                        if *count == 0 {
-                            counts.remove(&hash);
-                        }
-                    }
-                }
-                _ => unreachable!("tracker and reference occupancy diverged"),
-            }
-
-            tracker.assert_consistent(chains.iter().filter_map(Option::as_ref));
-            let actual = tracker.active_hashes().collect::<FxHashSet<_>>();
-            let expected = counts.keys().copied().collect::<FxHashSet<_>>();
-            assert_eq!(actual, expected);
-        }
-
-        for slot in 0..SLOTS {
-            if let Some(chain) = chains[slot].take() {
-                let (blocks, prompt_depth) = reference[slot].take().expect("active reference");
-                let expected_remove = expected_release(&blocks, prompt_depth, &counts);
-                assert_eq!(tracker.release(chain), expected_remove);
-                for hash in blocks {
-                    let count = counts.get_mut(&hash).expect("reference block is active");
-                    *count -= 1;
-                    if *count == 0 {
-                        counts.remove(&hash);
-                    }
-                }
-            }
-        }
-
-        tracker.assert_consistent(std::iter::empty());
-        assert!(counts.is_empty());
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn long_chain_release_is_iterative() {
-        const DEPTH: usize = 65_536;
-        let sequence = (1..=DEPTH as u64).collect::<Vec<_>>();
-        let mut tracker = BlockTracker::default();
-        let (chain, first_new) = tracker.acquire_prompt(&sequence);
-
-        assert_eq!(first_new, Some(0));
-        tracker.assert_consistent([&chain]);
-        assert_eq!(tracker.active_blocks(), DEPTH);
-        assert_eq!(tracker.release(chain), released(&sequence, 0));
-        tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
+        assert!(prompts.is_empty());
     }
 }

--- a/lib/kv-router/src/sequences/compressed_path_arena.rs
+++ b/lib/kv-router/src/sequences/compressed_path_arena.rs
@@ -1,0 +1,235 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_tokens::SequenceHash;
+use rustc_hash::FxHashMap;
+use slotmap::{SlotMap, new_key_type};
+
+new_key_type! {
+    pub(super) struct CompressedNodeId;
+}
+
+#[derive(Debug)]
+pub(super) struct CompressedPathNode<M> {
+    pub(super) edge: Vec<SequenceHash>,
+    pub(super) parent: Option<CompressedNodeId>,
+    pub(super) children: FxHashMap<SequenceHash, CompressedNodeId>,
+    pub(super) metadata: M,
+}
+
+/// A single-owner compressed path forest with stable generational handles.
+#[derive(Debug)]
+pub(super) struct CompressedPathArena<M> {
+    pub(super) nodes: SlotMap<CompressedNodeId, CompressedPathNode<M>>,
+    pub(super) roots: FxHashMap<SequenceHash, CompressedNodeId>,
+    pub(super) splits: u64,
+    pub(super) merges: u64,
+}
+
+impl<M> Default for CompressedPathArena<M> {
+    fn default() -> Self {
+        Self {
+            nodes: SlotMap::with_key(),
+            roots: FxHashMap::default(),
+            splits: 0,
+            merges: 0,
+        }
+    }
+}
+
+impl<M> CompressedPathArena<M> {
+    pub(super) fn root(&self, first_hash: SequenceHash) -> Option<CompressedNodeId> {
+        self.roots.get(&first_hash).copied()
+    }
+
+    pub(super) fn insert_root(&mut self, edge: Vec<SequenceHash>, metadata: M) -> CompressedNodeId {
+        assert!(!edge.is_empty(), "compressed root edge cannot be empty");
+        let first = edge[0];
+        let id = self.nodes.insert(CompressedPathNode {
+            edge,
+            parent: None,
+            children: FxHashMap::default(),
+            metadata,
+        });
+        assert!(
+            self.roots.insert(first, id).is_none(),
+            "compressed root already exists"
+        );
+        id
+    }
+
+    pub(super) fn insert_child(
+        &mut self,
+        parent: CompressedNodeId,
+        edge: Vec<SequenceHash>,
+        metadata: M,
+    ) -> CompressedNodeId {
+        assert!(!edge.is_empty(), "compressed child edge cannot be empty");
+        assert!(
+            self.nodes.contains_key(parent),
+            "compressed parent is missing"
+        );
+        let first = edge[0];
+        let id = self.nodes.insert(CompressedPathNode {
+            edge,
+            parent: Some(parent),
+            children: FxHashMap::default(),
+            metadata,
+        });
+        assert!(
+            self.nodes[parent].children.insert(first, id).is_none(),
+            "compressed child already exists"
+        );
+        id
+    }
+
+    /// Split `node_id` while retaining that ID for the suffix.
+    pub(super) fn split_keep_suffix(
+        &mut self,
+        node_id: CompressedNodeId,
+        split_at: usize,
+        prefix_metadata: M,
+    ) -> CompressedNodeId {
+        let (old_parent, old_first, prefix_edge, suffix_first) = {
+            let node = self.nodes.get_mut(node_id).expect("split node is missing");
+            assert!(
+                split_at > 0 && split_at < node.edge.len(),
+                "split must be inside the edge"
+            );
+            let old_parent = node.parent;
+            let old_first = node.edge[0];
+            let suffix = node.edge.split_off(split_at);
+            let prefix = std::mem::replace(&mut node.edge, suffix);
+            let suffix_first = node.edge[0];
+            (old_parent, old_first, prefix, suffix_first)
+        };
+        let prefix_id = self.nodes.insert(CompressedPathNode {
+            edge: prefix_edge,
+            parent: old_parent,
+            children: FxHashMap::from_iter([(suffix_first, node_id)]),
+            metadata: prefix_metadata,
+        });
+        self.nodes[node_id].parent = Some(prefix_id);
+        self.splits = self.splits.saturating_add(1);
+        if let Some(parent_id) = old_parent {
+            assert_eq!(
+                self.nodes[parent_id].children.insert(old_first, prefix_id),
+                Some(node_id),
+                "parent did not reference split node"
+            );
+        } else {
+            assert_eq!(
+                self.roots.insert(old_first, prefix_id),
+                Some(node_id),
+                "roots did not reference split node"
+            );
+        }
+        prefix_id
+    }
+
+    pub(super) fn remove_leaf(&mut self, node_id: CompressedNodeId) -> CompressedPathNode<M> {
+        let node = self.nodes.remove(node_id).expect("leaf is missing");
+        assert!(node.children.is_empty(), "cannot remove a non-leaf");
+        let first = node.edge[0];
+        if let Some(parent_id) = node.parent {
+            assert_eq!(
+                self.nodes[parent_id].children.remove(&first),
+                Some(node_id),
+                "parent did not reference removed leaf"
+            );
+        } else {
+            assert_eq!(
+                self.roots.remove(&first),
+                Some(node_id),
+                "roots did not reference removed leaf"
+            );
+        }
+        node
+    }
+
+    /// Merge a unary parent into its child while retaining the child ID.
+    pub(super) fn merge_parent_into_child(
+        &mut self,
+        parent_id: CompressedNodeId,
+        child_id: CompressedNodeId,
+    ) {
+        let parent = self
+            .nodes
+            .remove(parent_id)
+            .expect("merge parent is missing");
+        assert_eq!(parent.children.len(), 1, "merge parent must be unary");
+        assert_eq!(
+            parent.children.values().next().copied(),
+            Some(child_id),
+            "merge parent references another child"
+        );
+        let parent_parent = parent.parent;
+        let old_first = parent.edge[0];
+        let child = self
+            .nodes
+            .get_mut(child_id)
+            .expect("merge child is missing");
+        assert_eq!(child.parent, Some(parent_id), "merge child parent mismatch");
+        let mut merged_edge = parent.edge;
+        merged_edge.append(&mut child.edge);
+        child.edge = merged_edge;
+        child.parent = parent_parent;
+        self.merges = self.merges.saturating_add(1);
+        if let Some(grandparent_id) = parent_parent {
+            assert_eq!(
+                self.nodes[grandparent_id]
+                    .children
+                    .insert(old_first, child_id),
+                Some(parent_id),
+                "grandparent did not reference merge parent"
+            );
+        } else {
+            assert_eq!(
+                self.roots.insert(old_first, child_id),
+                Some(parent_id),
+                "roots did not reference merge parent"
+            );
+        }
+    }
+
+    pub(super) fn path_from_root(&self, tail: CompressedNodeId) -> Vec<CompressedNodeId> {
+        let mut path = Vec::new();
+        let mut current = Some(tail);
+        while let Some(node_id) = current {
+            let node = self.nodes.get(node_id).expect("path node is missing");
+            path.push(node_id);
+            current = node.parent;
+        }
+        path.reverse();
+        path
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn assert_topology(&self) {
+        for (&first, &root_id) in &self.roots {
+            let root = self.nodes.get(root_id).expect("root node is missing");
+            assert_eq!(root.parent, None, "root has a parent");
+            assert_eq!(root.edge.first(), Some(&first), "root key mismatch");
+        }
+        for (node_id, node) in &self.nodes {
+            assert!(!node.edge.is_empty(), "compressed edge is empty");
+            match node.parent {
+                Some(parent_id) => assert_eq!(
+                    self.nodes[parent_id].children.get(&node.edge[0]),
+                    Some(&node_id),
+                    "parent-child link mismatch"
+                ),
+                None => assert_eq!(
+                    self.roots.get(&node.edge[0]),
+                    Some(&node_id),
+                    "root link mismatch"
+                ),
+            }
+            for (&first, &child_id) in &node.children {
+                let child = self.nodes.get(child_id).expect("child link is stale");
+                assert_eq!(child.parent, Some(node_id), "child parent mismatch");
+                assert_eq!(child.edge.first(), Some(&first), "child key mismatch");
+            }
+        }
+    }
+}

--- a/lib/kv-router/src/sequences/mod.rs
+++ b/lib/kv-router/src/sequences/mod.rs
@@ -2,14 +2,15 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod block_tracker;
+mod compressed_path_arena;
 pub mod multi_worker;
 mod prefill_tracker;
-mod prompt_membership_trie;
 mod prompt_registry;
 mod replica_sync;
 mod request_maps;
 pub mod single;
 pub mod topology;
+mod unified_prompt_tracker;
 
 pub use multi_worker::*;
 pub use prefill_tracker::PrefillTokenDeltas;

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -25,8 +25,9 @@ use tokio_util::sync::CancellationToken;
 use super::prefill_tracker::PrefillTimeLoad;
 use super::prompt_registry::{PromptRegistry, WorkerLoadSnapshot};
 use super::request_maps::RequestIndex;
-use super::single::{ActiveSequences, PromptMembershipDelta, RequestId};
+use super::single::{ActiveSequences, RequestId};
 use super::topology::{WorkerDpRange, WorkerTable, WorkerTopologyChange, WorkerTopologyError};
+use super::unified_prompt_tracker::UnifiedPromptTracker;
 use super::{PotentialLoadMaps, PrefillTokenDeltas, WorkerLoadProjection};
 use crate::protocols::{
     ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventData, PrefillLoadHint, WorkerId,
@@ -250,13 +251,15 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
         let (remote_state_updates, _) = watch::channel(());
-        let workers = if options.expiry_enabled {
-            WorkerTable::new(block_size, &dp_range)
-        } else {
-            WorkerTable::new_without_expiry(block_size, &dp_range)
-        };
+        let prompts = Arc::new(UnifiedPromptTracker::default());
+        let workers = WorkerTable::new_with_prompts(
+            block_size,
+            &dp_range,
+            options.expiry_enabled,
+            prompts.clone(),
+        );
         let initial_workers: Vec<_> = workers.workers().collect();
-        let prompt_registry = PromptRegistry::new(initial_workers.iter().copied());
+        let prompt_registry = PromptRegistry::new(initial_workers.iter().copied(), prompts);
         let publisher = Arc::new(publisher);
         for worker in &initial_workers {
             publisher.observe_worker_registered(worker, worker_type);
@@ -785,11 +788,8 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             let outcome = seq.force_expiry();
             if !outcome.expired_request_ids.is_empty() {
                 let load = seq.worker_load_snapshot();
-                self.prompt_registry.apply_membership_delta_and_load(
-                    slot.worker,
-                    outcome.membership_delta,
-                    load,
-                );
+                self.prompt_registry
+                    .replace_worker_load_state(slot.worker, load);
                 removed_request_count += outcome.expired_request_ids.len();
                 self.request_index
                     .remove_requests(outcome.expired_request_ids.iter());
@@ -908,11 +908,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 decay_now,
             );
             let load = seq.worker_load_snapshot();
-            self.prompt_registry.apply_membership_delta_and_load(
-                worker,
-                outcome.membership_delta,
-                load,
-            );
+            self.prompt_registry.replace_worker_load_state(worker, load);
             break (outcome.expired_request_ids, load);
         };
 
@@ -957,7 +953,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         worker: WorkerWithDpRank,
         request_id: &RequestId,
         decay_now: Instant,
-        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant) -> PromptMembershipDelta,
+        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant),
         remove_mapping: bool,
     ) -> Result<(), SequenceError> {
         let load = {
@@ -968,10 +964,9 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             };
             let slot = &table.slots[idx];
             let mut seq = slot.sequences.write();
-            let delta = mutate_fn(&mut seq, request_id, decay_now);
+            mutate_fn(&mut seq, request_id, decay_now);
             let load = seq.worker_load_snapshot();
-            self.prompt_registry
-                .apply_membership_delta_and_load(worker, delta, load);
+            self.prompt_registry.replace_worker_load_state(worker, load);
             load
         };
 
@@ -1014,7 +1009,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         request_id: &RequestId,
         decay_now: Instant,
         event_data: ActiveSequenceEventData,
-        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant) -> PromptMembershipDelta,
+        mutate_fn: impl FnOnce(&mut ActiveSequences, &RequestId, Instant),
         remove_mapping: bool,
     ) -> Result<(), SequenceError> {
         let worker = self.request_index.worker_for(request_id).ok_or_else(|| {

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -1,38 +1,28 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::collections::HashMap;
+use std::sync::Arc;
+
 use dynamo_tokens::SequenceHash;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
-#[cfg(test)]
-use rustc_hash::FxHashSet;
 use rustc_hash::{FxBuildHasher, FxHashMap};
 use seqlock::SeqLock;
-use std::collections::HashMap;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
 use tokio::time::Instant;
 
 use super::PrefillTokenDeltas;
 use super::prefill_tracker::{PrefillLoadSnapshot, PrefillTimeLoadError};
-use super::prompt_membership_trie::PromptMembershipTrie;
-use super::single::PromptMembershipDelta;
 use super::topology::WorkerTopologyChange;
+use super::unified_prompt_tracker::UnifiedPromptTracker;
 use crate::protocols::WorkerWithDpRank;
 
-/// Ephemeral, request-specific view of worker load.
-///
-/// Values are materialized for one incoming request at a specific instant and
-/// should be passed to worker selection immediately. Do not persist, reuse, or
-/// publish this projection as durable worker state.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub struct WorkerLoadProjection {
     pub active_prefill_tokens: usize,
     pub active_decode_blocks: usize,
-    /// Request blocks not already shared with active sequences on this worker.
-    ///
-    /// These blocks may still exist in an inactive cache; this field describes
-    /// additional active block footprint, not cache misses.
     pub additional_active_blocks: usize,
 }
 
@@ -48,12 +38,6 @@ pub type PotentialLoadMaps = (
     Option<FxHashMap<WorkerWithDpRank, usize>>,
 );
 
-/// Reusable snapshot of a worker's currently tracked execution state.
-///
-/// `active_blocks` is the worker's unique active decode load in blocks.
-/// `prefill` retains the decay state needed to evaluate active prefill load in
-/// tokens at a caller-provided instant. Unlike [`WorkerLoadProjection`], this
-/// snapshot contains no incoming-request-specific state.
 #[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
 pub(super) struct WorkerLoadSnapshot {
     pub(super) active_blocks: usize,
@@ -76,24 +60,6 @@ impl WorkerLoadSnapshot {
 
 #[derive(Debug)]
 struct WorkerLoadSlot {
-    // SeqLock gives the hot projection path a lock-free read of the latest
-    // whole-worker snapshot. Writers mark the sequence odd, replace the
-    // snapshot, then mark the sequence even. Readers only return after seeing
-    // the same even sequence before and after copying the `Copy` payload, so a
-    // copy that overlaps a write is retried instead of exposing a mixed
-    // snapshot. Writers still serialize with each other, but they do not wait
-    // for readers.
-    //
-    // The upstream crate implements the copy with `read_volatile`, which is
-    // technically UB under Rust/LLVM if a writer mutates the same memory at the
-    // same time: volatile is not atomic and does not by itself legalize a data
-    // race. See https://github.com/Amanieu/seqlock/issues/2#issuecomment-473606523.
-    //
-    // `WorkerLoadSnapshot` is a small `Copy` value with no references or drop
-    // state. The sequence check is what makes the read logically race-free for
-    // this slot: a reader either observes a stable whole snapshot or retries.
-    // In practice this is the same seqlock/READ_ONCE pattern the crate is
-    // designed for, while avoiding the per-worker RwLock read on every request.
     load: SeqLock<WorkerLoadSnapshot>,
 }
 
@@ -115,8 +81,6 @@ impl WorkerLoadSlot {
 
 #[derive(Debug)]
 struct WorkerLoadTable {
-    // IndexMap gives us the dense full-worker scan plus point lookup shape that was previously
-    // hand-rolled as Vec<WorkerLoadSlot> + FxHashMap<WorkerWithDpRank, usize>.
     entries: IndexMap<WorkerWithDpRank, WorkerLoadSlot, FxBuildHasher>,
 }
 
@@ -166,35 +130,28 @@ impl WorkerLoadTable {
     }
 }
 
+/// Load projection paired with the authoritative global prompt trie.
 pub(super) struct PromptRegistry {
-    // WARNING: prompt membership and worker load are only eventually consistent.
-    // Each mutation still starts from one worker-local source of truth: we mutate the chosen
-    // `ActiveSequences`, derive an exact `PromptMembershipDelta` plus `WorkerLoadSnapshot`, then
-    // publish them separately here. The trie and load map converge to the correct final state
-    // after the write finishes, but reads can still observe a mixed membership/load state that
-    // never existed atomically and make a suboptimal routing choice.
-    membership: PromptMembershipTrie,
+    prompts: Arc<UnifiedPromptTracker>,
     loads: RwLock<WorkerLoadTable>,
     #[cfg(test)]
     cleanup_attempts: AtomicUsize,
 }
 
-impl Default for PromptRegistry {
-    fn default() -> Self {
-        Self {
-            membership: PromptMembershipTrie::new(),
+impl PromptRegistry {
+    pub(super) fn new(
+        workers: impl IntoIterator<Item = WorkerWithDpRank>,
+        prompts: Arc<UnifiedPromptTracker>,
+    ) -> Self {
+        let registry = Self {
+            prompts,
             loads: RwLock::new(WorkerLoadTable::default()),
             #[cfg(test)]
             cleanup_attempts: AtomicUsize::new(0),
-        }
-    }
-}
-
-impl PromptRegistry {
-    pub(super) fn new(workers: impl IntoIterator<Item = WorkerWithDpRank>) -> Self {
-        let registry = Self::default();
+        };
         let mut loads = registry.loads.write();
         for worker in workers {
+            registry.prompts.ensure_worker(worker);
             loads.ensure_worker(worker);
         }
         drop(loads);
@@ -206,43 +163,6 @@ impl PromptRegistry {
         worker: WorkerWithDpRank,
         load: WorkerLoadSnapshot,
     ) {
-        self.upsert_worker_load(worker, load);
-    }
-
-    pub(super) fn apply_membership_delta_and_load(
-        &self,
-        worker: WorkerWithDpRank,
-        delta: PromptMembershipDelta,
-        load: WorkerLoadSnapshot,
-    ) {
-        self.apply_membership_delta_and_load_without_cleanup(worker, delta, load);
-        self.maybe_cleanup();
-    }
-
-    /// Apply one per-worker sequence mutation in lifecycle order.
-    ///
-    /// `delta` generation and application must remain serialized by the worker
-    /// slot's `sequences.write()` lock. Removals must be applied before stores
-    /// because expiry is evaluated before the new request is acquired, and both
-    /// path boundaries describe that exact intermediate state.
-    pub(super) fn apply_membership_delta_and_load_without_cleanup(
-        &self,
-        worker: WorkerWithDpRank,
-        delta: PromptMembershipDelta,
-        load: WorkerLoadSnapshot,
-    ) {
-        for remove in delta.removes {
-            self.membership
-                .remove_path(worker, &remove.path, remove.remove_from);
-        }
-        for store in delta.stores {
-            self.membership
-                .store_path(worker, &store.path, store.new_suffix_start);
-        }
-        self.upsert_worker_load(worker, load);
-    }
-
-    fn upsert_worker_load(&self, worker: WorkerWithDpRank, load: WorkerLoadSnapshot) {
         if self.loads.read().update(worker, load) {
             return;
         }
@@ -252,7 +172,6 @@ impl PromptRegistry {
     pub(super) fn maybe_cleanup(&self) {
         #[cfg(test)]
         self.cleanup_attempts.fetch_add(1, Ordering::Relaxed);
-        self.membership.maybe_cleanup();
     }
 
     #[cfg(test)]
@@ -262,16 +181,16 @@ impl PromptRegistry {
 
     pub(super) fn apply_topology_change_without_cleanup(&self, change: &WorkerTopologyChange) {
         for removed in &change.removed {
-            self.membership.remove_worker(removed.worker);
+            self.prompts.remove_worker(removed.worker);
             self.loads.write().remove(removed.worker);
         }
-
         for &worker in &change.added {
+            self.prompts.ensure_worker(worker);
             self.loads.write().ensure_worker(worker);
         }
     }
 
-    fn project_loads_from_membership<const INCLUDE_ACTIVE_REQUESTS: bool>(
+    fn project_loads<const INCLUDE_ACTIVE_REQUESTS: bool>(
         &self,
         query_len: usize,
         matched_depth: &FxHashMap<WorkerWithDpRank, usize>,
@@ -283,20 +202,20 @@ impl PromptRegistry {
         let mut potential_tokens = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
         let mut active_requests = INCLUDE_ACTIVE_REQUESTS
             .then(|| FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher));
-
         for (worker, load) in loads.iter() {
             let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
-            let new_blocks = query_len.saturating_sub(overlap_depth);
-            let active_tokens = load.active_tokens(decay_now);
-            let added_tokens = prefill_token_deltas.tokens_for(worker);
-
-            potential_blocks.insert(worker, load.active_blocks + new_blocks);
-            potential_tokens.insert(worker, active_tokens + added_tokens);
+            potential_blocks.insert(
+                worker,
+                load.active_blocks + query_len.saturating_sub(overlap_depth),
+            );
+            potential_tokens.insert(
+                worker,
+                load.active_tokens(decay_now) + prefill_token_deltas.tokens_for(worker),
+            );
             if let Some(active_requests) = active_requests.as_mut() {
                 active_requests.insert(worker, load.active_requests);
             }
         }
-
         (potential_blocks, potential_tokens, active_requests)
     }
 
@@ -307,10 +226,10 @@ impl PromptRegistry {
         decay_now: Instant,
     ) -> PotentialLoadMaps {
         let query_len = token_sequence.map_or(0, |query| query.len());
-        let matched_depth = self.membership.compute_overlap_depths(token_sequence);
-        self.project_loads_from_membership::<INCLUDE_ACTIVE_REQUESTS>(
+        let matched = self.prompts.compute_overlap_depths(token_sequence);
+        self.project_loads::<INCLUDE_ACTIVE_REQUESTS>(
             query_len,
-            &matched_depth,
+            &matched,
             prefill_token_deltas,
             decay_now,
         )
@@ -322,22 +241,20 @@ impl PromptRegistry {
         decay_now: Instant,
     ) -> FxHashMap<WorkerWithDpRank, WorkerLoadProjection> {
         let query_len = token_sequence.map_or(0, |query| query.len());
-        let matched_depth = self.membership.compute_overlap_depths(token_sequence);
+        let matched = self.prompts.compute_overlap_depths(token_sequence);
         let loads = self.loads.read();
         let mut projections = FxHashMap::with_capacity_and_hasher(loads.len(), FxBuildHasher);
-
         for (worker, load) in loads.iter() {
-            let overlap_depth = matched_depth.get(&worker).copied().unwrap_or(0);
+            let overlap = matched.get(&worker).copied().unwrap_or(0);
             projections.insert(
                 worker,
                 WorkerLoadProjection {
                     active_prefill_tokens: load.active_tokens(decay_now),
                     active_decode_blocks: load.active_blocks,
-                    additional_active_blocks: query_len.saturating_sub(overlap_depth),
+                    additional_active_blocks: query_len.saturating_sub(overlap),
                 },
             );
         }
-
         projections
     }
 
@@ -387,294 +304,32 @@ impl PromptRegistry {
             .any(|(worker, load)| predicate(worker, load.active_tokens(decay_now)))
     }
 
-    #[cfg(test)]
-    pub(super) fn assert_consistent_with_workers(
-        &self,
-        expected_loads: &FxHashMap<WorkerWithDpRank, WorkerLoadSnapshot>,
-        expected_blocks: &FxHashMap<WorkerWithDpRank, FxHashSet<SequenceHash>>,
-    ) {
-        let actual_loads: FxHashMap<_, _> = self.loads.read().iter().collect();
-        let actual_blocks = self.membership.worker_hashes();
-        assert_eq!(
-            actual_loads, *expected_loads,
-            "prompt registry worker loads drifted from per-worker state",
-        );
-        assert_eq!(
-            actual_blocks, *expected_blocks,
-            "prompt registry prompt membership drifted from per-worker state",
-        );
-    }
-
     #[cfg(any(test, feature = "bench"))]
     pub(super) fn is_block_index_empty(&self) -> bool {
-        self.membership.is_empty()
+        self.prompts.is_empty()
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::time::Duration;
-
-    use rustc_hash::{FxHashMap, FxHashSet};
-
     use super::*;
-    use crate::protocols::WorkerWithDpRank;
-    use crate::sequences::prefill_tracker::AnchoredPrefillSnapshot;
-    use crate::sequences::single::{PromptMembershipRemove, PromptMembershipStore};
-    use crate::sequences::topology::RemovedWorkerState;
-
-    fn worker(worker_id: u64, dp_rank: u32) -> WorkerWithDpRank {
-        WorkerWithDpRank::new(worker_id, dp_rank)
-    }
-
-    fn store(path: &[SequenceHash], new_suffix_start: usize) -> PromptMembershipDelta {
-        PromptMembershipDelta {
-            stores: vec![PromptMembershipStore {
-                path: path.to_vec(),
-                new_suffix_start,
-            }],
-            removes: Vec::new(),
-        }
-    }
-
-    fn worker_load_snapshot(active_blocks: usize) -> WorkerLoadSnapshot {
-        WorkerLoadSnapshot {
-            active_blocks,
-            active_requests: 0,
-            prefill: PrefillLoadSnapshot::default(),
-        }
-    }
-
-    fn anchored_load_snapshot(
-        active_blocks: usize,
-        prefill_full_tokens_sum: usize,
-        anchored_tokens: usize,
-        expected_prefill_duration: Option<Duration>,
-        anchored_since: Instant,
-    ) -> WorkerLoadSnapshot {
-        WorkerLoadSnapshot {
-            active_blocks,
-            active_requests: 0,
-            prefill: PrefillLoadSnapshot {
-                prefill_full_tokens_sum,
-                anchored_prefill: Some(AnchoredPrefillSnapshot {
-                    initial_effective_prefill_tokens: anchored_tokens,
-                    expected_prefill_duration,
-                    anchored_since,
-                }),
-                total_modeled_prefill_time_ms: expected_prefill_duration
-                    .map(|duration| duration.as_millis().min(u64::MAX as u128) as u64),
-            },
-        }
-    }
-
-    fn hash_set(hashes: &[SequenceHash]) -> FxHashSet<SequenceHash> {
-        hashes.iter().copied().collect()
-    }
-
-    fn naive_potential_loads(
-        expected_loads: &FxHashMap<WorkerWithDpRank, WorkerLoadSnapshot>,
-        expected_blocks: &FxHashMap<WorkerWithDpRank, FxHashSet<SequenceHash>>,
-        token_sequence: Option<&[SequenceHash]>,
-        prefill_token_deltas: &PrefillTokenDeltas,
-        decay_now: Instant,
-    ) -> (
-        FxHashMap<WorkerWithDpRank, usize>,
-        FxHashMap<WorkerWithDpRank, usize>,
-    ) {
-        let mut potential_blocks =
-            FxHashMap::with_capacity_and_hasher(expected_loads.len(), FxBuildHasher);
-        let mut potential_tokens =
-            FxHashMap::with_capacity_and_hasher(expected_loads.len(), FxBuildHasher);
-
-        for (&worker, load) in expected_loads {
-            let overlap_depth = token_sequence.map_or(0, |query| {
-                let worker_blocks = expected_blocks
-                    .get(&worker)
-                    .expect("worker must have a prompt membership entry");
-                query
-                    .iter()
-                    .position(|hash| !worker_blocks.contains(hash))
-                    .unwrap_or(query.len())
-            });
-            let new_blocks =
-                token_sequence.map_or(0, |query| query.len().saturating_sub(overlap_depth));
-            let added_tokens = prefill_token_deltas.tokens_for(worker);
-
-            potential_blocks.insert(worker, load.active_blocks + new_blocks);
-            potential_tokens.insert(worker, load.active_tokens(decay_now) + added_tokens);
-        }
-
-        (potential_blocks, potential_tokens)
-    }
 
     #[test]
-    fn removed_hash_can_be_restored_by_later_store() {
-        let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker]);
-        let mut expected_loads = FxHashMap::default();
-        let mut expected_blocks = FxHashMap::default();
-
-        registry.apply_membership_delta_and_load(worker, store(&[42], 0), worker_load_snapshot(1));
-        let load = worker_load_snapshot(1);
-        registry.apply_membership_delta_and_load(
+    fn projections_use_authoritative_unified_overlap() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let prompts = Arc::new(UnifiedPromptTracker::default());
+        let registry = PromptRegistry::new([worker], prompts.clone());
+        let handle = prompts.acquire(worker, &[1, 2, 3]);
+        registry.replace_worker_load_state(
             worker,
-            PromptMembershipDelta {
-                removes: vec![PromptMembershipRemove {
-                    path: vec![42],
-                    remove_from: 0,
-                }],
-                ..Default::default()
+            WorkerLoadSnapshot {
+                active_blocks: 3,
+                active_requests: 1,
+                prefill: PrefillLoadSnapshot::default(),
             },
-            load,
         );
-        registry.apply_membership_delta_and_load(worker, store(&[42], 0), load);
-        expected_loads.insert(worker, load);
-        expected_blocks.insert(worker, hash_set(&[42]));
-
-        registry.assert_consistent_with_workers(&expected_loads, &expected_blocks);
-    }
-
-    #[test]
-    fn staggered_prefix_overlap_matches_naive_projection() {
-        let worker_a = worker(1, 0);
-        let worker_b = worker(2, 0);
-        let worker_c = worker(3, 0);
-        let registry = PromptRegistry::new([worker_a, worker_b, worker_c]);
-        let decay_now = Instant::now();
-        let full_prompt: Vec<SequenceHash> = (1_u64..=96).collect();
-        let mut expected_loads = FxHashMap::default();
-        let mut expected_blocks = FxHashMap::default();
-
-        for (worker, prompt_len) in [(worker_a, 96usize), (worker_b, 64), (worker_c, 33)] {
-            let blocks = full_prompt[..prompt_len].to_vec();
-            let load = worker_load_snapshot(prompt_len);
-            registry.apply_membership_delta_and_load(worker, store(&blocks, 0), load);
-            expected_loads.insert(worker, load);
-            expected_blocks.insert(worker, blocks.into_iter().collect());
-        }
-
-        registry.assert_consistent_with_workers(&expected_loads, &expected_blocks);
-
-        let expected = naive_potential_loads(
-            &expected_loads,
-            &expected_blocks,
-            Some(&full_prompt),
-            &PrefillTokenDeltas::none(),
-            decay_now,
-        );
-        let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&full_prompt),
-            &PrefillTokenDeltas::none(),
-            decay_now,
-        );
-
-        assert_eq!(actual.0, expected.0);
-        assert_eq!(actual.1, expected.1);
-    }
-
-    #[test]
-    fn load_only_update_preserves_prompt_membership_and_active_token_projection() {
-        let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker]);
-        let now = Instant::now();
-        let anchored_since = now.checked_sub(Duration::from_secs(3)).unwrap_or(now);
-        let mut expected_loads = FxHashMap::default();
-        let mut expected_blocks = FxHashMap::default();
-
-        registry.apply_membership_delta_and_load(
-            worker,
-            store(&[1, 2, 3], 0),
-            worker_load_snapshot(3),
-        );
-        expected_blocks.insert(worker, hash_set(&[1, 2, 3]));
-
-        let updated_load =
-            anchored_load_snapshot(5, 12, 10, Some(Duration::from_secs(10)), anchored_since);
-        registry.replace_worker_load_state(worker, updated_load);
-        expected_loads.insert(worker, updated_load);
-
-        registry.assert_consistent_with_workers(&expected_loads, &expected_blocks);
-        assert_eq!(registry.active_tokens(now).get(&worker).copied(), Some(9));
-
-        let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&[1, 2, 3]),
-            &PrefillTokenDeltas::none(),
-            now,
-        );
-        assert_eq!(actual.0.get(&worker).copied(), Some(5));
-        assert_eq!(actual.1.get(&worker).copied(), Some(9));
-    }
-
-    #[test]
-    fn removing_worker_clears_prompt_membership_and_load_state() {
-        let worker_a = worker(1, 0);
-        let worker_b = worker(2, 0);
-        let registry = PromptRegistry::new([worker_a, worker_b]);
-        let mut expected_loads = FxHashMap::default();
-        let mut expected_blocks = FxHashMap::default();
-
-        let load_a = worker_load_snapshot(3);
-        let load_b = worker_load_snapshot(2);
-        registry.apply_membership_delta_and_load(worker_a, store(&[1, 2, 3], 0), load_a);
-        registry.apply_membership_delta_and_load(worker_b, store(&[1, 2], 0), load_b);
-        expected_loads.insert(worker_a, load_a);
-        expected_loads.insert(worker_b, load_b);
-        expected_blocks.insert(worker_a, hash_set(&[1, 2, 3]));
-        expected_blocks.insert(worker_b, hash_set(&[1, 2]));
-
-        registry.apply_topology_change_without_cleanup(&WorkerTopologyChange {
-            added: Vec::new(),
-            removed: vec![RemovedWorkerState { worker: worker_a }],
-        });
-        expected_loads.remove(&worker_a);
-        expected_blocks.remove(&worker_a);
-
-        registry.assert_consistent_with_workers(&expected_loads, &expected_blocks);
-        assert!(!registry.active_blocks().contains_key(&worker_a));
-
-        let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&[1, 2, 3]),
-            &PrefillTokenDeltas::none(),
-            Instant::now(),
-        );
-        assert_eq!(actual.0.get(&worker_b).copied(), Some(3));
-    }
-
-    #[test]
-    fn dp_ranks_with_same_worker_id_remain_isolated() {
-        let worker_a = worker(1, 0);
-        let worker_b = worker(1, 1);
-        let registry = PromptRegistry::new([worker_a, worker_b]);
-        let decay_now = Instant::now();
-        let mut expected_loads = FxHashMap::default();
-        let mut expected_blocks = FxHashMap::default();
-
-        let load_a = worker_load_snapshot(3);
-        let load_b = worker_load_snapshot(1);
-        registry.apply_membership_delta_and_load(worker_a, store(&[1, 2, 3], 0), load_a);
-        registry.apply_membership_delta_and_load(worker_b, store(&[1], 0), load_b);
-        expected_loads.insert(worker_a, load_a);
-        expected_loads.insert(worker_b, load_b);
-        expected_blocks.insert(worker_a, hash_set(&[1, 2, 3]));
-        expected_blocks.insert(worker_b, hash_set(&[1]));
-
-        registry.assert_consistent_with_workers(&expected_loads, &expected_blocks);
-
-        let expected = naive_potential_loads(
-            &expected_loads,
-            &expected_blocks,
-            Some(&[1, 2, 3]),
-            &PrefillTokenDeltas::none(),
-            decay_now,
-        );
-        let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&[1, 2, 3]),
-            &PrefillTokenDeltas::none(),
-            decay_now,
-        );
-
-        assert_eq!(actual.0, expected.0);
-        assert_eq!(actual.1, expected.1);
+        let projected = registry.project_worker_loads(Some(&[1, 2, 4, 5]), Instant::now());
+        assert_eq!(projected[&worker].additional_active_blocks, 2);
+        prompts.release(worker, handle);
     }
 }

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -196,11 +196,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                     );
                     let load = seq.worker_load_snapshot();
                     self.prompt_registry
-                        .apply_membership_delta_and_load_without_cleanup(
-                            event_worker,
-                            outcome.membership_delta,
-                            load,
-                        );
+                        .replace_worker_load_state(event_worker, load);
                     (outcome.expired_request_ids, load)
                 };
                 drop(table);
@@ -220,10 +216,9 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 let load = {
                     let slot = &table.slots[idx];
                     let mut seq = slot.sequences.write();
-                    let delta = seq.free(&request_id, decay_now);
+                    seq.free(&request_id, decay_now);
                     let load = seq.worker_load_snapshot();
-                    self.prompt_registry
-                        .apply_membership_delta_and_load_without_cleanup(worker, delta, load);
+                    self.prompt_registry.replace_worker_load_state(worker, load);
                     load
                 };
                 drop(table);

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -20,6 +20,7 @@
 
 use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 use std::time::Duration;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -30,9 +31,11 @@ use rustc_hash::FxHashSet;
 use super::block_tracker::{BlockTracker, RequestBlockChain};
 use super::prefill_tracker::{PrefillLoadState, PrefillLoadTracker};
 use super::prompt_registry::WorkerLoadSnapshot;
-use crate::protocols::PrefillLoadHint;
+use super::unified_prompt_tracker::UnifiedPromptTracker;
+use crate::protocols::{PrefillLoadHint, WorkerWithDpRank};
 
 /// Duration after which stale requests may be expired (5 minutes).
+#[cfg(test)]
 const EXPIRY_DURATION: Duration = Duration::from_secs(300);
 
 /// How often we *check* for stale requests (30 seconds). This is not
@@ -49,58 +52,8 @@ pub(super) struct RequestState {
     expected_output_tokens: Option<u32>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub(super) struct PromptMembershipStore {
-    pub path: Vec<SequenceHash>,
-    pub new_suffix_start: usize,
-}
-
-#[derive(Debug, PartialEq, Eq)]
-pub(super) struct PromptMembershipRemove {
-    pub path: Vec<SequenceHash>,
-    pub remove_from: usize,
-}
-
-#[derive(Debug, Default, PartialEq, Eq)]
-pub(super) struct PromptMembershipDelta {
-    pub stores: Vec<PromptMembershipStore>,
-    pub removes: Vec<PromptMembershipRemove>,
-}
-
-impl PromptMembershipDelta {
-    fn extend(&mut self, other: Self) {
-        self.stores.extend(other.stores);
-        self.removes.extend(other.removes);
-    }
-
-    fn push_store(&mut self, path: Vec<SequenceHash>, new_suffix_start: usize) {
-        assert!(
-            new_suffix_start < path.len(),
-            "prompt store suffix must start inside a non-empty path"
-        );
-        self.stores.push(PromptMembershipStore {
-            path,
-            new_suffix_start,
-        });
-    }
-
-    fn push_remove(&mut self, released: Option<super::block_tracker::ReleasedPromptPath>) {
-        if let Some(released) = released {
-            assert!(
-                released.remove_from < released.path.len(),
-                "prompt removal must remove a non-empty suffix"
-            );
-            self.removes.push(PromptMembershipRemove {
-                path: released.path,
-                remove_from: released.remove_from,
-            });
-        }
-    }
-}
-
 #[derive(Debug, Default, PartialEq, Eq)]
 pub(super) struct SequenceMutationOutcome {
-    pub membership_delta: PromptMembershipDelta,
     pub expired_request_ids: HashSet<RequestId>,
 }
 
@@ -116,21 +69,38 @@ pub struct ActiveSequences {
 
 impl ActiveSequences {
     /// Create a new SharedSequenceManager instance
+    #[cfg(test)]
     pub(super) fn new(block_size: usize) -> Self {
         Self::new_with_expiry(block_size, Some(EXPIRY_DURATION))
     }
 
+    #[cfg(test)]
     pub(super) fn new_without_expiry(block_size: usize) -> Self {
         Self::new_with_expiry(block_size, None)
     }
 
+    #[cfg(test)]
     fn new_with_expiry(block_size: usize, expiry_duration: Option<Duration>) -> Self {
+        Self::new_for_worker(
+            block_size,
+            WorkerWithDpRank::new(0, 0),
+            Arc::new(UnifiedPromptTracker::default()),
+            expiry_duration,
+        )
+    }
+
+    pub(super) fn new_for_worker(
+        block_size: usize,
+        worker: WorkerWithDpRank,
+        prompts: Arc<UnifiedPromptTracker>,
+        expiry_duration: Option<Duration>,
+    ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
 
         Self {
             requests: HashMap::new(),
             prefill: PrefillLoadTracker::default(),
-            blocks: BlockTracker::default(),
+            blocks: BlockTracker::new(worker, prompts),
             last_expiry_check_time: Instant::now(),
             expiry_duration,
         }
@@ -180,22 +150,11 @@ impl ActiveSequences {
             return SequenceMutationOutcome::default();
         }
 
-        let mut outcome = self.force_expiry();
+        let outcome = self.force_expiry();
         let started_at = Instant::now();
 
         let prompt_hashes = token_sequence.unwrap_or_default();
-        let (blocks, first_new_prompt_idx) = self.blocks.acquire_prompt(&prompt_hashes);
-
-        if let Some(first_new_prompt_idx) = first_new_prompt_idx {
-            debug_assert!(
-                prompt_hashes[first_new_prompt_idx..]
-                    .iter()
-                    .all(|hash| self.blocks.contains_block(hash))
-            );
-            outcome
-                .membership_delta
-                .push_store(prompt_hashes, first_new_prompt_idx);
-        }
+        let blocks = self.blocks.acquire_prompt(&prompt_hashes);
 
         let prefill = if track_prefill_tokens {
             prefill_load_hint.and_then(|hint| {
@@ -235,25 +194,19 @@ impl ActiveSequences {
     ///
     /// This implicitly calls [`Self::mark_prefill_completed`] first, so callers do not need
     /// to invoke both when the request is finishing.
-    pub(super) fn free(
-        &mut self,
-        request_id: &RequestId,
-        decay_now: Instant,
-    ) -> PromptMembershipDelta {
+    pub(super) fn free(&mut self, request_id: &RequestId, decay_now: Instant) {
         let _ = self.prefill.remove(request_id, decay_now);
 
         let Some(request_state) = self.requests.remove(request_id) else {
             tracing::warn!("Trying to free non-existent request {request_id}");
-            return PromptMembershipDelta::default();
+            return;
         };
 
         let blocks = request_state.blocks;
         let _ = request_state.expected_output_tokens;
-        let mut membership_delta = PromptMembershipDelta::default();
-        membership_delta.push_remove(self.blocks.release(blocks));
+        self.blocks.release(blocks);
 
         self.validate_state();
-        membership_delta
     }
 
     /// Add an output block with a random hash and optional fractional decay weight.
@@ -305,14 +258,13 @@ impl ActiveSequences {
             .map(|(request_id, _)| request_id.clone())
             .collect();
 
-        let mut outcome = SequenceMutationOutcome {
+        let outcome = SequenceMutationOutcome {
             expired_request_ids,
-            ..Default::default()
         };
 
         for request_id in &outcome.expired_request_ids {
             tracing::warn!("Expiring stale request: {}", request_id);
-            outcome.membership_delta.extend(self.free(request_id, now));
+            self.free(request_id, now);
         }
 
         self.validate_state();
@@ -383,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn test_prompt_membership_delta_only_reports_first_add_and_last_remove() {
+    fn test_unified_prompt_ownership_survives_shared_prefix_release() {
         let mut seq_manager = ActiveSequences::new(4);
         let decay_now = Instant::now();
 
@@ -395,16 +347,6 @@ mod tests {
             tracking_hint(8),
             decay_now,
         );
-        assert_eq!(
-            first.membership_delta,
-            PromptMembershipDelta {
-                stores: vec![PromptMembershipStore {
-                    path: vec![1, 2],
-                    new_suffix_start: 0,
-                }],
-                removes: Vec::new(),
-            }
-        );
         assert!(first.expired_request_ids.is_empty());
 
         let second = seq_manager.add_request_with_prefill_tracking(
@@ -415,30 +357,14 @@ mod tests {
             tracking_hint(12),
             decay_now,
         );
-        assert_eq!(
-            second.membership_delta,
-            PromptMembershipDelta {
-                stores: vec![PromptMembershipStore {
-                    path: vec![1, 2, 3],
-                    new_suffix_start: 2,
-                }],
-                removes: Vec::new(),
-            }
-        );
+        assert!(second.expired_request_ids.is_empty());
+        assert_eq!(seq_manager.active_blocks(), 3);
 
-        let first_free = seq_manager.free(&"r1".to_string(), decay_now);
-        assert!(first_free.removes.is_empty());
-        assert!(first_free.stores.is_empty());
+        seq_manager.free(&"r1".to_string(), decay_now);
+        assert_eq!(seq_manager.active_blocks(), 3);
 
-        let second_free = seq_manager.free(&"r2".to_string(), decay_now);
-        assert!(second_free.stores.is_empty());
-        assert_eq!(
-            second_free.removes,
-            vec![PromptMembershipRemove {
-                path: vec![1, 2, 3],
-                remove_from: 0,
-            }]
-        );
+        seq_manager.free(&"r2".to_string(), decay_now);
+        assert_eq!(seq_manager.active_blocks(), 0);
     }
 
     #[test]
@@ -454,13 +380,7 @@ mod tests {
             tracking_hint(12),
             decay_now,
         );
-        assert_eq!(
-            outcome.membership_delta.stores,
-            vec![PromptMembershipStore {
-                path: vec![1, 2, 3],
-                new_suffix_start: 0,
-            }]
-        );
+        assert!(outcome.expired_request_ids.is_empty());
         assert_eq!(
             seq_manager.active_block_hashes(),
             [1, 2, 3].into_iter().collect()
@@ -481,14 +401,8 @@ mod tests {
             [1, 2, 3, output_hash].into_iter().collect()
         );
 
-        let free_delta = seq_manager.free(&"r1".to_string(), decay_now);
-        assert_eq!(
-            free_delta.removes,
-            vec![PromptMembershipRemove {
-                path: vec![1, 2, 3],
-                remove_from: 0,
-            }]
-        );
+        seq_manager.free(&"r1".to_string(), decay_now);
+        assert!(seq_manager.active_block_hashes().is_empty());
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -2,11 +2,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use parking_lot::RwLock;
 use rustc_hash::{FxHashMap, FxHashSet};
 
 use super::single::ActiveSequences;
+use super::unified_prompt_tracker::UnifiedPromptTracker;
 use crate::protocols::{DpRank, WorkerId, WorkerWithDpRank};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -86,12 +88,15 @@ pub(super) struct WorkerSlot {
 }
 
 impl WorkerSlot {
-    fn new(worker: WorkerWithDpRank, block_size: usize, expiry_enabled: bool) -> Self {
-        let sequences = if expiry_enabled {
-            ActiveSequences::new(block_size)
-        } else {
-            ActiveSequences::new_without_expiry(block_size)
-        };
+    fn new(
+        worker: WorkerWithDpRank,
+        block_size: usize,
+        expiry_enabled: bool,
+        prompts: Arc<UnifiedPromptTracker>,
+    ) -> Self {
+        let expiry_duration = expiry_enabled.then_some(std::time::Duration::from_secs(300));
+        let sequences =
+            ActiveSequences::new_for_worker(block_size, worker, prompts, expiry_duration);
         Self {
             worker,
             sequences: RwLock::new(sequences),
@@ -104,24 +109,25 @@ pub(super) struct WorkerTable {
     pub(super) index: FxHashMap<WorkerWithDpRank, usize>,
     worker_ranges: HashMap<WorkerId, WorkerDpRange>,
     expiry_enabled: bool,
+    prompts: Arc<UnifiedPromptTracker>,
 }
 
 impl WorkerTable {
+    #[cfg(test)]
     pub(super) fn new(block_size: usize, dp_range: &HashMap<u64, (u32, u32)>) -> Self {
-        Self::new_with_expiry(block_size, dp_range, true)
+        Self::new_with_prompts(
+            block_size,
+            dp_range,
+            true,
+            Arc::new(UnifiedPromptTracker::default()),
+        )
     }
 
-    pub(super) fn new_without_expiry(
-        block_size: usize,
-        dp_range: &HashMap<u64, (u32, u32)>,
-    ) -> Self {
-        Self::new_with_expiry(block_size, dp_range, false)
-    }
-
-    fn new_with_expiry(
+    pub(super) fn new_with_prompts(
         block_size: usize,
         dp_range: &HashMap<u64, (u32, u32)>,
         expiry_enabled: bool,
+        prompts: Arc<UnifiedPromptTracker>,
     ) -> Self {
         let worker_ranges: HashMap<WorkerId, WorkerDpRange> = dp_range
             .iter()
@@ -137,7 +143,12 @@ impl WorkerTable {
         let mut index = FxHashMap::default();
         for worker in workers_from_ranges(worker_ranges.values().copied()) {
             let idx = slots.len();
-            slots.push(WorkerSlot::new(worker, block_size, expiry_enabled));
+            slots.push(WorkerSlot::new(
+                worker,
+                block_size,
+                expiry_enabled,
+                prompts.clone(),
+            ));
             index.insert(worker, idx);
         }
         Self {
@@ -145,6 +156,7 @@ impl WorkerTable {
             index,
             worker_ranges,
             expiry_enabled,
+            prompts,
         }
     }
 
@@ -246,7 +258,12 @@ impl WorkerTable {
         for worker in target_workers {
             let slot = old.remove(&worker).unwrap_or_else(|| {
                 added.push(worker);
-                WorkerSlot::new(worker, block_size, self.expiry_enabled)
+                WorkerSlot::new(
+                    worker,
+                    block_size,
+                    self.expiry_enabled,
+                    self.prompts.clone(),
+                )
             });
             self.slots.push(slot);
         }
@@ -274,9 +291,14 @@ impl WorkerTable {
                 added.push(worker);
             }
             let idx = self.slots.len();
-            let slot = old
-                .remove(&worker)
-                .unwrap_or_else(|| WorkerSlot::new(worker, block_size, self.expiry_enabled));
+            let slot = old.remove(&worker).unwrap_or_else(|| {
+                WorkerSlot::new(
+                    worker,
+                    block_size,
+                    self.expiry_enabled,
+                    self.prompts.clone(),
+                )
+            });
             self.slots.push(slot);
             self.index.insert(worker, idx);
         }
@@ -306,8 +328,12 @@ impl WorkerTable {
         }
 
         let idx = self.slots.len();
-        self.slots
-            .push(WorkerSlot::new(worker, block_size, self.expiry_enabled));
+        self.slots.push(WorkerSlot::new(
+            worker,
+            block_size,
+            self.expiry_enabled,
+            self.prompts.clone(),
+        ));
         self.index.insert(worker, idx);
         WorkerTopologyChange {
             added: vec![worker],
@@ -480,7 +506,8 @@ mod tests {
                 }),
                 Instant::now(),
             );
-            assert_eq!(outcome.membership_delta.stores[0].path, vec![1, 2, 3]);
+            assert!(outcome.expired_request_ids.is_empty());
+            assert_eq!(seq.active_blocks(), 3);
         }
 
         let change = table

--- a/lib/kv-router/src/sequences/unified_prompt_tracker.rs
+++ b/lib/kv-router/src/sequences/unified_prompt_tracker.rs
@@ -1,0 +1,624 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use dynamo_tokens::SequenceHash;
+use parking_lot::RwLock;
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use super::compressed_path_arena::{CompressedNodeId, CompressedPathArena};
+use crate::protocols::WorkerWithDpRank;
+
+#[derive(Debug, Clone, Default, PartialEq)]
+struct UnifiedNodeMetadata {
+    coverage: FxHashMap<WorkerWithDpRank, u32>,
+    terminals: FxHashMap<WorkerWithDpRank, u32>,
+    fractions: FxHashMap<WorkerWithDpRank, f64>,
+}
+
+#[derive(Debug, Default)]
+struct RootShard {
+    arena: RwLock<CompressedPathArena<UnifiedNodeMetadata>>,
+}
+
+#[derive(Debug, Default)]
+pub(super) struct UnifiedRequestHandle {
+    shard: Option<Arc<RootShard>>,
+    tail: Option<CompressedNodeId>,
+    prompt_depth: usize,
+}
+
+/// Authoritative request-lifecycle and cross-worker prompt-membership trie.
+#[derive(Debug, Default)]
+pub(super) struct UnifiedPromptTracker {
+    roots: RwLock<FxHashMap<SequenceHash, Arc<RootShard>>>,
+    worker_totals: RwLock<FxHashMap<WorkerWithDpRank, f64>>,
+}
+
+impl UnifiedPromptTracker {
+    pub(super) fn ensure_worker(&self, worker: WorkerWithDpRank) {
+        self.worker_totals.write().entry(worker).or_insert(0.0);
+    }
+
+    pub(super) fn acquire(
+        &self,
+        worker: WorkerWithDpRank,
+        sequence: &[SequenceHash],
+    ) -> UnifiedRequestHandle {
+        let Some(&first_hash) = sequence.first() else {
+            return UnifiedRequestHandle::default();
+        };
+        let shard = self.root_shard(first_hash);
+        let mut arena = shard.arena.write();
+
+        let tail = match arena.root(first_hash) {
+            None => arena.insert_root(sequence.to_vec(), UnifiedNodeMetadata::default()),
+            Some(root) => Self::acquire_terminal(&mut arena, root, sequence),
+        };
+
+        let path = arena.path_from_root(tail);
+        let mut total_delta = 0.0;
+        for node_id in path {
+            let node = &mut arena.nodes[node_id];
+            let coverage = node.metadata.coverage.entry(worker).or_default();
+            if *coverage == 0 {
+                total_delta += node.edge.len() as f64
+                    * node.metadata.fractions.get(&worker).copied().unwrap_or(1.0);
+            }
+            *coverage = coverage
+                .checked_add(1)
+                .expect("unified prompt coverage overflowed");
+        }
+        let terminal = arena.nodes[tail]
+            .metadata
+            .terminals
+            .entry(worker)
+            .or_default();
+        *terminal = terminal
+            .checked_add(1)
+            .expect("unified prompt terminal ownership overflowed");
+        self.apply_total_delta(worker, total_delta);
+
+        UnifiedRequestHandle {
+            shard: Some(shard.clone()),
+            tail: Some(tail),
+            prompt_depth: sequence.len(),
+        }
+    }
+
+    fn acquire_terminal(
+        arena: &mut CompressedPathArena<UnifiedNodeMetadata>,
+        mut node_id: CompressedNodeId,
+        sequence: &[SequenceHash],
+    ) -> CompressedNodeId {
+        let mut path_pos = 0;
+        loop {
+            let (edge_len, match_len) = {
+                let node = &arena.nodes[node_id];
+                let remaining = &sequence[path_pos..];
+                let matched = node
+                    .edge
+                    .iter()
+                    .zip(remaining)
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                (node.edge.len(), matched)
+            };
+            assert!(match_len > 0, "unified path selected a mismatched edge");
+            if match_len < edge_len {
+                let split_depth = path_pos + match_len;
+                let existing = &arena.nodes[node_id].metadata;
+                let prefix_metadata = UnifiedNodeMetadata {
+                    coverage: existing.coverage.clone(),
+                    terminals: FxHashMap::default(),
+                    fractions: existing.fractions.clone(),
+                };
+                let prefix = arena.split_keep_suffix(node_id, match_len, prefix_metadata);
+                if split_depth == sequence.len() {
+                    return prefix;
+                }
+                return arena.insert_child(
+                    prefix,
+                    sequence[split_depth..].to_vec(),
+                    UnifiedNodeMetadata::default(),
+                );
+            }
+            path_pos += edge_len;
+            if path_pos == sequence.len() {
+                return node_id;
+            }
+            let next_hash = sequence[path_pos];
+            match arena.nodes[node_id].children.get(&next_hash).copied() {
+                Some(next) => node_id = next,
+                None => {
+                    return arena.insert_child(
+                        node_id,
+                        sequence[path_pos..].to_vec(),
+                        UnifiedNodeMetadata::default(),
+                    );
+                }
+            }
+        }
+    }
+
+    pub(super) fn release(&self, worker: WorkerWithDpRank, handle: UnifiedRequestHandle) {
+        let Some(shard) = handle.shard else {
+            assert!(handle.tail.is_none() && handle.prompt_depth == 0);
+            return;
+        };
+        let tail = handle.tail.expect("non-empty unified handle has no tail");
+        let mut arena = shard.arena.write();
+        let path = arena.path_from_root(tail);
+        let depth: usize = path.iter().map(|id| arena.nodes[*id].edge.len()).sum();
+        assert_eq!(depth, handle.prompt_depth, "unified request depth mismatch");
+
+        Self::decrement(
+            &mut arena.nodes[tail].metadata.terminals,
+            worker,
+            "terminal",
+        );
+        let mut total_delta = 0.0;
+        for node_id in path.iter().copied() {
+            let node = &mut arena.nodes[node_id];
+            let old_fraction = node.metadata.fractions.get(&worker).copied().unwrap_or(1.0);
+            if Self::decrement(&mut node.metadata.coverage, worker, "coverage") {
+                total_delta -= node.edge.len() as f64 * old_fraction;
+                node.metadata.fractions.remove(&worker);
+            }
+        }
+
+        let mut current = Some(tail);
+        let mut retained = None;
+        while let Some(node_id) = current {
+            let node = &arena.nodes[node_id];
+            if !node.metadata.coverage.is_empty() || !node.children.is_empty() {
+                retained = Some(node_id);
+                break;
+            }
+            assert!(node.metadata.terminals.is_empty());
+            let parent = node.parent;
+            arena.remove_leaf(node_id);
+            current = parent;
+        }
+        if let Some(node_id) = retained {
+            Self::recompress_from(&mut arena, node_id);
+        }
+        self.apply_total_delta(worker, total_delta);
+    }
+
+    /// Returns true when the entry became absent.
+    fn decrement(
+        entries: &mut FxHashMap<WorkerWithDpRank, u32>,
+        worker: WorkerWithDpRank,
+        kind: &str,
+    ) -> bool {
+        let count = entries
+            .get_mut(&worker)
+            .unwrap_or_else(|| panic!("unified prompt {kind} is missing"));
+        *count = count
+            .checked_sub(1)
+            .unwrap_or_else(|| panic!("unified prompt {kind} underflowed"));
+        if *count == 0 {
+            entries.remove(&worker);
+            true
+        } else {
+            false
+        }
+    }
+
+    pub(super) fn set_unique_suffix_fractional(
+        &self,
+        worker: WorkerWithDpRank,
+        handle: &UnifiedRequestHandle,
+        fraction: f64,
+    ) {
+        let (Some(shard), Some(mut node_id)) = (&handle.shard, handle.tail) else {
+            return;
+        };
+        let mut arena = shard.arena.write();
+        let mut total_delta = 0.0;
+        loop {
+            let incoming = {
+                let node = &arena.nodes[node_id];
+                node.metadata.terminals.get(&worker).copied().unwrap_or(0) as usize
+                    + node
+                        .children
+                        .values()
+                        .filter(|child| {
+                            arena.nodes[**child].metadata.coverage.contains_key(&worker)
+                        })
+                        .count()
+            };
+            if incoming != 1 {
+                break;
+            }
+            let node = &mut arena.nodes[node_id];
+            let old = node
+                .metadata
+                .fractions
+                .insert(worker, fraction)
+                .unwrap_or(1.0);
+            total_delta += node.edge.len() as f64 * (fraction - old);
+            match node.parent {
+                Some(parent) => node_id = parent,
+                None => break,
+            }
+        }
+        self.apply_total_delta(worker, total_delta);
+    }
+
+    pub(super) fn compute_overlap_depths(
+        &self,
+        query: Option<&[SequenceHash]>,
+    ) -> FxHashMap<WorkerWithDpRank, usize> {
+        let Some(query) = query.filter(|query| !query.is_empty()) else {
+            return FxHashMap::default();
+        };
+        let Some(shard) = self.roots.read().get(&query[0]).cloned() else {
+            return FxHashMap::default();
+        };
+        let arena = shard.arena.read();
+        let Some(mut node_id) = arena.root(query[0]) else {
+            return FxHashMap::default();
+        };
+
+        let mut scores = FxHashMap::default();
+        let mut active = FxHashSet::default();
+        let mut depth = 0;
+        let mut query_pos = 0;
+        let mut first = true;
+        loop {
+            let node = &arena.nodes[node_id];
+            if first {
+                active.extend(node.metadata.coverage.keys().copied());
+                first = false;
+            } else {
+                active.retain(|worker| {
+                    if node.metadata.coverage.contains_key(worker) {
+                        true
+                    } else {
+                        scores.insert(*worker, depth);
+                        false
+                    }
+                });
+            }
+            if active.is_empty() {
+                break;
+            }
+            let matched = node
+                .edge
+                .iter()
+                .zip(&query[query_pos..])
+                .take_while(|(left, right)| left == right)
+                .count();
+            depth += matched;
+            query_pos += matched;
+            if matched < node.edge.len() || query_pos == query.len() {
+                for worker in active {
+                    scores.insert(worker, depth);
+                }
+                break;
+            }
+            let Some(next) = node.children.get(&query[query_pos]).copied() else {
+                for worker in active {
+                    scores.insert(worker, depth);
+                }
+                break;
+            };
+            node_id = next;
+        }
+        scores
+    }
+
+    pub(super) fn active_block_weight(&self, worker: WorkerWithDpRank) -> f64 {
+        self.worker_totals
+            .read()
+            .get(&worker)
+            .copied()
+            .unwrap_or(0.0)
+    }
+
+    #[cfg(test)]
+    pub(super) fn active_blocks(&self, worker: WorkerWithDpRank) -> usize {
+        self.active_block_weight(worker).round() as usize
+    }
+
+    #[cfg(test)]
+    pub(super) fn prompt_hashes(&self, handle: &UnifiedRequestHandle) -> Vec<SequenceHash> {
+        let (Some(shard), Some(tail)) = (&handle.shard, handle.tail) else {
+            return Vec::new();
+        };
+        let arena = shard.arena.read();
+        let mut hashes = Vec::with_capacity(handle.prompt_depth);
+        for node_id in arena.path_from_root(tail) {
+            hashes.extend_from_slice(&arena.nodes[node_id].edge);
+        }
+        assert_eq!(hashes.len(), handle.prompt_depth);
+        hashes
+    }
+
+    pub(super) fn remove_worker(&self, worker: WorkerWithDpRank) {
+        let shards: Vec<_> = self.roots.read().values().cloned().collect();
+        for shard in shards {
+            let mut arena = shard.arena.write();
+            for node in arena.nodes.values_mut() {
+                node.metadata.coverage.remove(&worker);
+                node.metadata.terminals.remove(&worker);
+                node.metadata.fractions.remove(&worker);
+            }
+            Self::compact_after_worker_removal(&mut arena);
+        }
+        self.worker_totals.write().remove(&worker);
+    }
+
+    fn compact_after_worker_removal(arena: &mut CompressedPathArena<UnifiedNodeMetadata>) {
+        loop {
+            let dead = arena.nodes.iter().find_map(|(node_id, node)| {
+                (node.metadata.coverage.is_empty() && node.children.is_empty()).then_some(node_id)
+            });
+            let Some(dead) = dead else { break };
+            assert!(arena.nodes[dead].metadata.terminals.is_empty());
+            arena.remove_leaf(dead);
+        }
+        loop {
+            let merge = arena.nodes.iter().find_map(|(parent_id, parent)| {
+                if parent.metadata.terminals.is_empty() && parent.children.len() == 1 {
+                    let child_id = *parent.children.values().next().unwrap();
+                    let child = &arena.nodes[child_id];
+                    (parent.metadata.coverage == child.metadata.coverage
+                        && parent.metadata.fractions == child.metadata.fractions)
+                        .then_some((parent_id, child_id))
+                } else {
+                    None
+                }
+            });
+            let Some((parent, child)) = merge else {
+                break;
+            };
+            arena.merge_parent_into_child(parent, child);
+        }
+    }
+
+    fn recompress_from(
+        arena: &mut CompressedPathArena<UnifiedNodeMetadata>,
+        mut parent_id: CompressedNodeId,
+    ) {
+        loop {
+            let child_id = {
+                let parent = &arena.nodes[parent_id];
+                if !parent.metadata.terminals.is_empty() || parent.children.len() != 1 {
+                    return;
+                }
+                *parent.children.values().next().unwrap()
+            };
+            if arena.nodes[parent_id].metadata.coverage != arena.nodes[child_id].metadata.coverage
+                || arena.nodes[parent_id].metadata.fractions
+                    != arena.nodes[child_id].metadata.fractions
+            {
+                return;
+            }
+            arena.merge_parent_into_child(parent_id, child_id);
+            parent_id = child_id;
+        }
+    }
+
+    #[cfg(any(test, feature = "bench"))]
+    pub(super) fn is_empty(&self) -> bool {
+        self.roots
+            .read()
+            .values()
+            .all(|shard| shard.arena.read().nodes.is_empty())
+            && self
+                .worker_totals
+                .read()
+                .values()
+                .all(|total| *total == 0.0)
+    }
+
+    #[cfg(test)]
+    pub(super) fn worker_hashes(&self, worker: WorkerWithDpRank) -> FxHashSet<SequenceHash> {
+        let mut hashes = FxHashSet::default();
+        for shard in self.roots.read().values() {
+            let arena = shard.arena.read();
+            for node in arena.nodes.values() {
+                if node.metadata.coverage.contains_key(&worker) {
+                    hashes.extend(node.edge.iter().copied());
+                }
+            }
+        }
+        hashes
+    }
+
+    fn root_shard(&self, first_hash: SequenceHash) -> Arc<RootShard> {
+        if let Some(shard) = self.roots.read().get(&first_hash).cloned() {
+            return shard;
+        }
+        self.roots.write().entry(first_hash).or_default().clone()
+    }
+
+    fn apply_total_delta(&self, worker: WorkerWithDpRank, delta: f64) {
+        if delta == 0.0 {
+            return;
+        }
+        let mut totals = self.worker_totals.write();
+        let total = totals.entry(worker).or_insert(0.0);
+        *total += delta;
+        assert!(
+            *total >= -f64::EPSILON,
+            "unified prompt total became negative"
+        );
+        if total.abs() < f64::EPSILON {
+            *total = 0.0;
+        }
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn assert_consistent(&self) {
+        let mut recomputed = FxHashMap::<WorkerWithDpRank, f64>::default();
+        for shard in self.roots.read().values() {
+            let arena = shard.arena.read();
+            arena.assert_topology();
+            for node in arena.nodes.values() {
+                assert!(!node.metadata.coverage.is_empty() || !node.children.is_empty());
+                for (&worker, &count) in &node.metadata.coverage {
+                    assert!(count > 0);
+                    *recomputed.entry(worker).or_default() += node.edge.len() as f64
+                        * node.metadata.fractions.get(&worker).copied().unwrap_or(1.0);
+                }
+                for (&worker, &terminals) in &node.metadata.terminals {
+                    assert!(terminals > 0);
+                    assert!(node.metadata.coverage.contains_key(&worker));
+                }
+            }
+        }
+        for (&worker, &total) in self.worker_totals.read().iter() {
+            assert!((recomputed.get(&worker).copied().unwrap_or(0.0) - total).abs() < 1e-9);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Barrier;
+    use std::thread;
+
+    use super::*;
+
+    fn worker(id: u64) -> WorkerWithDpRank {
+        WorkerWithDpRank::new(id, 0)
+    }
+
+    #[test]
+    fn duplicate_and_shared_prefix_lifecycles_are_exact() {
+        let tracker = UnifiedPromptTracker::default();
+        let w1 = worker(1);
+        let w2 = worker(2);
+        let one = tracker.acquire(w1, &[1, 2, 3]);
+        let duplicate = tracker.acquire(w1, &[1, 2, 3]);
+        let other = tracker.acquire(w2, &[1, 2, 4]);
+
+        assert_eq!(tracker.active_blocks(w1), 3);
+        assert_eq!(tracker.active_blocks(w2), 3);
+        assert_eq!(
+            tracker.compute_overlap_depths(Some(&[1, 2, 3, 9])),
+            FxHashMap::from_iter([(w1, 3), (w2, 2)])
+        );
+        tracker.release(w1, one);
+        assert_eq!(tracker.active_blocks(w1), 3);
+        tracker.release(w1, duplicate);
+        assert_eq!(tracker.active_blocks(w1), 0);
+        tracker.release(w2, other);
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn shorter_prompt_split_keeps_longer_handle_valid() {
+        let tracker = UnifiedPromptTracker::default();
+        let w = worker(1);
+        let longer = tracker.acquire(w, &[1, 2, 3, 4]);
+        let longer_tail = longer.tail;
+        let shorter = tracker.acquire(w, &[1, 2]);
+        assert_eq!(longer.tail, longer_tail);
+        tracker.release(w, shorter);
+        tracker.release(w, longer);
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn branch_release_recompression_keeps_survivor_handle_valid() {
+        let tracker = UnifiedPromptTracker::default();
+        let w = worker(1);
+        let survivor = tracker.acquire(w, &[1, 2, 3, 4]);
+        let survivor_tail = survivor.tail;
+        let branch = tracker.acquire(w, &[1, 2, 8, 9]);
+
+        tracker.release(w, branch);
+        assert_eq!(survivor.tail, survivor_tail);
+        assert_eq!(tracker.prompt_hashes(&survivor), vec![1, 2, 3, 4]);
+        tracker.release(w, survivor);
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn worker_removal_preserves_other_workers() {
+        let tracker = UnifiedPromptTracker::default();
+        let w1 = worker(1);
+        let w2 = worker(2);
+        let _one = tracker.acquire(w1, &[1, 2, 3]);
+        let two = tracker.acquire(w2, &[1, 2, 4]);
+        tracker.remove_worker(w1);
+
+        assert_eq!(tracker.worker_hashes(w1), FxHashSet::default());
+        assert_eq!(tracker.worker_hashes(w2), FxHashSet::from_iter([1, 2, 4]));
+        assert_eq!(
+            tracker.compute_overlap_depths(Some(&[1, 2, 3])),
+            FxHashMap::from_iter([(w2, 2)])
+        );
+        tracker.release(w2, two);
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn concurrent_same_root_mutations_drain_exactly() {
+        const THREADS: usize = 8;
+        const ITERATIONS: usize = 200;
+        let tracker = Arc::new(UnifiedPromptTracker::default());
+        let start = Arc::new(Barrier::new(THREADS));
+        let threads = (0..THREADS)
+            .map(|thread_id| {
+                let tracker = tracker.clone();
+                let start = start.clone();
+                thread::spawn(move || {
+                    let worker = worker(thread_id as u64);
+                    start.wait();
+                    for iteration in 0..ITERATIONS {
+                        let suffix = 10 + ((thread_id + iteration) % 4) as u64;
+                        let handle = tracker.acquire(worker, &[1, 2, suffix, 99]);
+                        assert_eq!(tracker.prompt_hashes(&handle), vec![1, 2, suffix, 99]);
+                        tracker.release(worker, handle);
+                    }
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        tracker.assert_consistent();
+        assert!(tracker.is_empty());
+    }
+
+    #[test]
+    fn concurrent_independent_roots_retain_empty_shards() {
+        const THREADS: usize = 8;
+        let tracker = Arc::new(UnifiedPromptTracker::default());
+        let start = Arc::new(Barrier::new(THREADS));
+        let threads = (0..THREADS)
+            .map(|thread_id| {
+                let tracker = tracker.clone();
+                let start = start.clone();
+                thread::spawn(move || {
+                    let worker = worker(thread_id as u64);
+                    let root = 1_000 + thread_id as u64;
+                    start.wait();
+                    let handle = tracker.acquire(worker, &[root, root + 100, root + 200]);
+                    tracker.release(worker, handle);
+                })
+            })
+            .collect::<Vec<_>>();
+
+        for thread in threads {
+            thread.join().unwrap();
+        }
+        let roots = tracker.roots.read();
+        assert_eq!(roots.len(), THREADS);
+        assert!(
+            roots
+                .values()
+                .all(|shard| shard.arena.read().nodes.is_empty())
+        );
+        drop(roots);
+        assert!(tracker.is_empty());
+    }
+}


### PR DESCRIPTION
## Overview

This is Prototype B from the compressed block-tracking study. It replaces the per-worker prompt trackers and separate `PromptMembershipTrie` with one purpose-built, root-sharded compressed trie that owns prompt lifecycle and membership state.

This remains a draft for evaluation. The initial benchmark showed a large throughput increase, but routing projection tail latency exceeded the acceptance threshold, so the prototype is not yet a promotion candidate.

## Summary

- Add a private compressed-path arena with generational node IDs and stable request handles across edge splits and recompression.
- Add a global `UnifiedPromptTracker` with per-worker edge coverage, terminal multiplicity, fractional weights, direct routing-overlap queries, and worker teardown.
- Keep prefill and output state worker-local while sourcing prompt totals and overlap directly from the unified tracker.
- Remove the prompt-membership delta pipeline and the separately maintained membership trie from the active-sequence path.
- Preserve expiry, replica replay, load projection, output-block accounting, and worker-topology behavior.

## Details

Each first prompt hash selects an independently locked root shard. Nodes store compressed hash edges plus per-worker lifecycle metadata. Request endpoints and branch points are materialized explicitly, splits retain the suffix node ID, and unary recompression retains the child node ID so live request handles survive structural changes.

`BlockTracker` is reduced to a worker/request-local facade for output blocks. Prompt acquisition, release, fractional suffix accounting, overlap lookup, and active prompt totals are handled by `UnifiedPromptTracker`. Empty root-shard shells intentionally remain until tracker teardown.

This prototype does not reuse or modify CRTC, synthesize KV events, or add request ownership to the KV indexer.

## Where should the reviewer start?

1. `lib/kv-router/src/sequences/unified_prompt_tracker.rs`
2. `lib/kv-router/src/sequences/compressed_path_arena.rs`
3. `lib/kv-router/src/sequences/block_tracker.rs`
4. `lib/kv-router/src/sequences/prompt_registry.rs`
5. `lib/kv-router/src/sequences/multi_worker.rs`

## Related Issues

- [x] Confirmed — no related issue

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-kv-router --lib -- -D warnings`
- `cargo test -p dynamo-kv-router --lib` — 717 passed, 2 ignored
- Active-sequences benchmark: one discarded warmup plus nine measured runs per arm, eight workers, eight operation lanes, block size 2, trace-length factor 512, and 3,000 exact completed events per run.
  - Prototype B median throughput: 2,573,143,913 logical block visits/s, +670.52% over baseline; paired bootstrap 95% CI [+652.41%, +918.21%].
  - All 9/9 runs drained successfully and the deterministic lifecycle/projection transcript was byte-identical across arms.
  - Project p99/p999 regressed from 11.9/46.7 us to 24.2/180.2 us, so Prototype B does **not** meet the latency acceptance gate.
  - Add p99/p999 improved from 1024.2/2771.3 us to 59.9/116.1 us; free p99/p999 improved from 786.5/1451.3 us to 26.8/101.2 us.
  - These exploratory benchmark results were collected with one-off structural counters enabled. Those counters and unconditional lock-wait timing were removed from this PR; the algorithm and lifecycle semantics are unchanged.

No AgentX or full-frontend profile was run for this prototype comparison.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Unified prompt tracking across workers improves consistency when requests share prompt prefixes.
  * Prompt overlap and active-block calculations now use a centralized view.
  * Added support for fractional ownership of unique prompt suffixes.

* **Bug Fixes**
  * Improved cleanup and lifecycle handling when requests expire, are released, or workers change.
  * Preserved shared prompt ownership correctly across request releases.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->