### PR TITLE
perf(kv-router): compress block tracker prompt paths

### DIFF
--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -103,12 +103,20 @@ impl BlockTracker {
             let (edge_len, match_len) = {
                 let node = &self.arena.nodes[node_id];
                 let remaining = &sequence[path_pos..];
-                let match_len = node
-                    .edge
-                    .iter()
-                    .zip(remaining)
-                    .take_while(|(left, right)| left == right)
-                    .count();
+                let probe_len = node.edge.len().min(remaining.len());
+                debug_assert!(probe_len > 0, "compressed path probe cannot be empty");
+                // A SequenceHash commits to its full prefix, so equality at
+                // the probe boundary implies equality before it under the
+                // trusted lineage contract documented above.
+                let match_len = if node.edge[probe_len - 1] == remaining[probe_len - 1] {
+                    probe_len
+                } else {
+                    node.edge
+                        .iter()
+                        .zip(remaining)
+                        .position(|(left, right)| left != right)
+                        .unwrap_or(probe_len)
+                };
                 (node.edge.len(), match_len)
             };
             assert!(match_len > 0, "compressed path selected a mismatched edge");
@@ -214,7 +222,6 @@ impl BlockTracker {
             tail_node.metadata.terminal_owners != 0 || !tail_node.children.is_empty()
         };
         if tail_remains_live {
-            self.recompress_from(tail);
             return None;
         }
 
@@ -231,11 +238,9 @@ impl BlockTracker {
 
         let mut removed_hashes = 0;
         let mut current = Some(tail);
-        let mut retained = None;
         while let Some(node_id) = current {
             let node = &self.arena.nodes[node_id];
             if node.metadata.terminal_owners != 0 || !node.children.is_empty() {
-                retained = Some(node_id);
                 break;
             }
             let parent = node.parent;
@@ -248,10 +253,6 @@ impl BlockTracker {
 
         if self.arena.nodes.is_empty() {
             self.prompt_total = 0.0;
-        }
-
-        if let Some(node_id) = retained {
-            self.recompress_from(node_id);
         }
 
         debug_assert!(removed_hashes > 0, "dead prompt tail removed no hashes");
@@ -309,25 +310,6 @@ impl BlockTracker {
                 .nodes
                 .values()
                 .any(|node| node.edge.contains(hash))
-    }
-
-    fn recompress_from(&mut self, mut node_id: CompressedNodeId) {
-        loop {
-            let child_id = {
-                let node = &self.arena.nodes[node_id];
-                if node.metadata.terminal_owners != 0 || node.children.len() != 1 {
-                    return;
-                }
-                node.children.values().next().copied().unwrap()
-            };
-            if self.arena.nodes[node_id].metadata.fraction
-                != self.arena.nodes[child_id].metadata.fraction
-            {
-                return;
-            }
-            self.arena.merge_parent_into_child(node_id, child_id);
-            node_id = child_id;
-        }
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -514,7 +496,7 @@ mod tests {
     }
 
     #[test]
-    fn branch_release_recompresses_while_preserving_survivor_handle() {
+    fn branch_release_preserves_split_and_survivor_handle() {
         let mut tracker = BlockTracker::default();
         let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
         let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
@@ -522,6 +504,7 @@ mod tests {
 
         assert_eq!(first_new, Some(2));
         assert_eq!(tracker.release(left), released(&[1, 2, 3], 2));
+        assert_eq!(tracker.arena.nodes.len(), 2);
         assert!(tracker.arena.nodes.contains_key(right_tail));
         tracker.assert_consistent([&right]);
         assert_eq!(tracker.release(right), released(&[1, 2, 4], 0));
@@ -569,7 +552,7 @@ mod tests {
     }
 
     #[test]
-    fn fraction_mismatch_prevents_recompression() {
+    fn fraction_mismatch_preserves_split_and_totals() {
         let mut tracker = BlockTracker::default();
         let (longer, _) = tracker.acquire_prompt(&[1, 2, 3, 4]);
         let longer_tail = longer.prompt_tail.unwrap();
@@ -591,7 +574,7 @@ mod tests {
     }
 
     #[test]
-    fn equal_fractional_edges_recompress_and_preserve_child_handle() {
+    fn equal_fractional_edges_remain_split_and_preserve_child_handle() {
         let mut tracker = BlockTracker::default();
         let (longer, _) = tracker.acquire_prompt(&[1, 2, 3, 4]);
         let longer_tail = longer.prompt_tail.unwrap();
@@ -601,7 +584,7 @@ mod tests {
         assert_eq!(tracker.arena.nodes.len(), 2);
         assert_eq!(tracker.prompt_total, 2.0);
         assert_eq!(tracker.release(shorter), None);
-        assert_eq!(tracker.arena.nodes.len(), 1);
+        assert_eq!(tracker.arena.nodes.len(), 2);
         assert!(tracker.arena.nodes.contains_key(longer_tail));
         assert_eq!(tracker.prompt_total, 2.0);
         tracker.assert_consistent([&longer]);

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -26,6 +26,10 @@ impl BlockNodeMetadata {
             .checked_add(1)
             .expect("block ownership count overflowed");
     }
+
+    fn edge_weight(self, edge_len: usize) -> f64 {
+        edge_len as f64 * self.fraction.unwrap_or(1.0)
+    }
 }
 
 /// The compressed prompt tail plus request-local output hashes.
@@ -60,15 +64,24 @@ pub(super) struct ReleasedPromptPath {
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
     arena: CompressedPathArena<BlockNodeMetadata>,
+    prompt_total: f64,
     // Output hashes remain outside the prompt topology. They are unique per
     // request, but retaining the map preserves active-hash diagnostics and
     // fractional load accounting.
     output_blocks: FxHashMap<SequenceHash, f64>,
+    output_total: f64,
 }
 
 impl BlockTracker {
     /// Acquire a request terminal and return the first block that became newly
     /// present for this worker.
+    ///
+    /// Each [`SequenceHash`] must identify one prefix ancestry and depth. This
+    /// tracker trusts callers to preserve that lineage and does not validate
+    /// the hash recurrence in production. It also assumes distinct live
+    /// lineages have distinct hashes; collision detection and recovery are out
+    /// of scope. That collision scope is local to one worker and DP-rank
+    /// tracker because each owns an independent [`BlockTracker`].
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],
@@ -81,6 +94,7 @@ impl BlockTracker {
             let tail = self
                 .arena
                 .insert_root(sequence.to_vec(), BlockNodeMetadata::terminal());
+            self.prompt_total += sequence.len() as f64;
             return (RequestBlockChain::new(Some(tail), sequence.len()), Some(0));
         };
 
@@ -124,6 +138,7 @@ impl BlockTracker {
                     sequence[split_depth..].to_vec(),
                     BlockNodeMetadata::terminal(),
                 );
+                self.prompt_total += (sequence.len() - split_depth) as f64;
                 return (
                     RequestBlockChain::new(Some(tail), sequence.len()),
                     Some(split_depth),
@@ -147,6 +162,7 @@ impl BlockTracker {
                 sequence[path_pos..].to_vec(),
                 BlockNodeMetadata::terminal(),
             );
+            self.prompt_total += (sequence.len() - path_pos) as f64;
             return (
                 RequestBlockChain::new(Some(tail), sequence.len()),
                 Some(path_pos),
@@ -156,6 +172,7 @@ impl BlockTracker {
 
     /// Append a unique output block without adding it to the prompt trie.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
+        #[cfg(any(test, debug_assertions))]
         debug_assert!(
             !self.contains_block(&hash),
             "random output hash unexpectedly collided with a live block"
@@ -164,6 +181,7 @@ impl BlockTracker {
             self.output_blocks.insert(hash, 1.0).is_none(),
             "output block hash unexpectedly became live twice"
         );
+        self.output_total += 1.0;
         chain.output_hashes.push(hash);
     }
 
@@ -171,15 +189,34 @@ impl BlockTracker {
     /// that became absent from the worker.
     pub(super) fn release(&mut self, chain: RequestBlockChain) -> Option<ReleasedPromptPath> {
         for hash in chain.output_hashes {
-            self.output_blocks
+            let weight = self
+                .output_blocks
                 .remove(&hash)
                 .expect("request output hash is missing from active bookkeeping");
+            self.output_total -= weight;
+        }
+        if self.output_blocks.is_empty() {
+            self.output_total = 0.0;
         }
 
         let Some(tail) = chain.prompt_tail else {
             assert_eq!(chain.prompt_depth, 0, "empty prompt retained a depth");
             return None;
         };
+
+        let terminal = &mut self.arena.nodes[tail].metadata.terminal_owners;
+        *terminal = terminal
+            .checked_sub(1)
+            .expect("request terminal ownership underflowed");
+
+        let tail_remains_live = {
+            let tail_node = &self.arena.nodes[tail];
+            tail_node.metadata.terminal_owners != 0 || !tail_node.children.is_empty()
+        };
+        if tail_remains_live {
+            self.recompress_from(tail);
+            return None;
+        }
 
         let path_ids = self.arena.path_from_root(tail);
         let mut path = Vec::with_capacity(chain.prompt_depth);
@@ -192,11 +229,6 @@ impl BlockTracker {
             "request terminal depth differs from its compressed path"
         );
 
-        let terminal = &mut self.arena.nodes[tail].metadata.terminal_owners;
-        *terminal = terminal
-            .checked_sub(1)
-            .expect("request terminal ownership underflowed");
-
         let mut removed_hashes = 0;
         let mut current = Some(tail);
         let mut retained = None;
@@ -207,17 +239,22 @@ impl BlockTracker {
                 break;
             }
             let parent = node.parent;
-            removed_hashes += self.arena.remove_leaf(node_id).edge.len();
+            let removed = self.arena.remove_leaf(node_id);
+            let edge_len = removed.edge.len();
+            removed_hashes += edge_len;
+            self.prompt_total -= removed.metadata.edge_weight(edge_len);
             current = parent;
+        }
+
+        if self.arena.nodes.is_empty() {
+            self.prompt_total = 0.0;
         }
 
         if let Some(node_id) = retained {
             self.recompress_from(node_id);
         }
 
-        if removed_hashes == 0 {
-            return None;
-        }
+        debug_assert!(removed_hashes > 0, "dead prompt tail removed no hashes");
         let remove_from = chain
             .prompt_depth
             .checked_sub(removed_hashes)
@@ -232,35 +269,39 @@ impl BlockTracker {
         fraction: f64,
     ) {
         for hash in &chain.output_hashes {
-            *self
+            let weight = self
                 .output_blocks
                 .get_mut(hash)
-                .expect("request output hash is missing from active bookkeeping") = fraction;
+                .expect("request output hash is missing from active bookkeeping");
+            let old_weight = std::mem::replace(weight, fraction);
+            self.output_total += fraction - old_weight;
         }
 
         let mut current = chain.prompt_tail;
         while let Some(node_id) = current {
-            let node = &self.arena.nodes[node_id];
-            let incoming = node.metadata.terminal_owners as usize + node.children.len();
+            let (parent, incoming, edge_len, old_fraction) = {
+                let node = &self.arena.nodes[node_id];
+                (
+                    node.parent,
+                    node.metadata.terminal_owners as usize + node.children.len(),
+                    node.edge.len(),
+                    node.metadata.fraction.unwrap_or(1.0),
+                )
+            };
             if incoming != 1 {
                 break;
             }
-            current = node.parent;
+            self.prompt_total += edge_len as f64 * (fraction - old_fraction);
             self.arena.nodes[node_id].metadata.fraction = Some(fraction);
+            current = parent;
         }
     }
 
     pub(super) fn active_blocks(&self) -> usize {
-        let prompt_blocks = self
-            .arena
-            .nodes
-            .values()
-            .map(|node| node.edge.len() as f64 * node.metadata.fraction.unwrap_or(1.0))
-            .sum::<f64>();
-        let output_blocks = self.output_blocks.values().sum::<f64>();
-        (prompt_blocks + output_blocks).round() as usize
+        (self.prompt_total + self.output_total).round() as usize
     }
 
+    #[cfg(any(test, debug_assertions))]
     pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
         self.output_blocks.contains_key(hash)
             || self
@@ -339,6 +380,35 @@ impl BlockTracker {
             expected_outputs,
             self.output_blocks.keys().copied().collect(),
             "output bookkeeping differs from request ownership"
+        );
+
+        let expected_prompt_total = self
+            .arena
+            .nodes
+            .values()
+            .map(|node| node.metadata.edge_weight(node.edge.len()))
+            .sum::<f64>();
+        let expected_output_total = self.output_blocks.values().sum::<f64>();
+        for (label, actual, expected) in [
+            ("prompt", self.prompt_total, expected_prompt_total),
+            ("output", self.output_total, expected_output_total),
+        ] {
+            let scale = actual.abs().max(expected.abs()).max(1.0);
+            assert!(
+                (actual - expected).abs() <= 1e-9 * scale,
+                "{label} running total differs from reconstructed weight: {actual} != {expected}"
+            );
+        }
+        if self.arena.nodes.is_empty() {
+            assert_eq!(self.prompt_total, 0.0, "drained prompt total is not zero");
+        }
+        if self.output_blocks.is_empty() {
+            assert_eq!(self.output_total, 0.0, "drained output total is not zero");
+        }
+        assert_eq!(
+            self.active_blocks(),
+            (expected_prompt_total + expected_output_total).round() as usize,
+            "constant-time active block count differs from reconstructed weight"
         );
     }
 
@@ -496,6 +566,87 @@ mod tests {
         assert_eq!(tracker.release(longer), released(&[1, 2, 3], 2));
         assert_eq!(tracker.active_blocks(), 2);
         assert_eq!(tracker.release(shared), released(&[1, 2], 0));
+    }
+
+    #[test]
+    fn fraction_mismatch_prevents_recompression() {
+        let mut tracker = BlockTracker::default();
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3, 4]);
+        let longer_tail = longer.prompt_tail.unwrap();
+        let (shorter, _) = tracker.acquire_prompt(&[1, 2]);
+
+        tracker.set_unique_suffix_fractional(&longer, 0.5);
+        assert_eq!(tracker.prompt_total, 3.0);
+        assert_eq!(tracker.active_blocks(), 3);
+
+        assert_eq!(tracker.release(shorter), None);
+        assert_eq!(tracker.arena.nodes.len(), 2);
+        assert!(tracker.arena.nodes.contains_key(longer_tail));
+        assert_eq!(tracker.prompt_total, 3.0);
+        tracker.assert_consistent([&longer]);
+
+        assert_eq!(tracker.release(longer), released(&[1, 2, 3, 4], 0));
+        assert_eq!(tracker.prompt_total, 0.0);
+        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    fn equal_fractional_edges_recompress_and_preserve_child_handle() {
+        let mut tracker = BlockTracker::default();
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3, 4]);
+        let longer_tail = longer.prompt_tail.unwrap();
+        tracker.set_unique_suffix_fractional(&longer, 0.5);
+        let (shorter, _) = tracker.acquire_prompt(&[1, 2]);
+
+        assert_eq!(tracker.arena.nodes.len(), 2);
+        assert_eq!(tracker.prompt_total, 2.0);
+        assert_eq!(tracker.release(shorter), None);
+        assert_eq!(tracker.arena.nodes.len(), 1);
+        assert!(tracker.arena.nodes.contains_key(longer_tail));
+        assert_eq!(tracker.prompt_total, 2.0);
+        tracker.assert_consistent([&longer]);
+
+        assert_eq!(tracker.release(longer), released(&[1, 2, 3, 4], 0));
+        assert_eq!(tracker.prompt_total, 0.0);
+    }
+
+    #[test]
+    fn running_totals_follow_prompt_output_and_fraction_lifecycle() {
+        let mut tracker = BlockTracker::default();
+        let (mut left, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (right, _) = tracker.acquire_prompt(&[1, 2, 4]);
+        let (duplicate_left, duplicate_new) = tracker.acquire_prompt(&[1, 2, 3]);
+
+        assert_eq!(duplicate_new, None);
+        assert_eq!(tracker.prompt_total, 4.0);
+        assert_eq!(tracker.output_total, 0.0);
+        assert_eq!(tracker.release(duplicate_left), None);
+        assert_eq!(tracker.prompt_total, 4.0);
+        tracker.append_output(&mut left, 42);
+        assert_eq!(tracker.output_total, 1.0);
+        assert_eq!(tracker.active_blocks(), 5);
+
+        tracker.set_unique_suffix_fractional(&left, 0.5);
+        assert_eq!(tracker.prompt_total, 3.5);
+        assert_eq!(tracker.output_total, 0.5);
+        assert_eq!(tracker.active_blocks(), 4);
+
+        tracker.set_unique_suffix_fractional(&left, 0.25);
+        assert_eq!(tracker.prompt_total, 3.25);
+        assert_eq!(tracker.output_total, 0.25);
+        assert_eq!(tracker.active_blocks(), 4);
+        tracker.assert_consistent([&left, &right]);
+
+        assert_eq!(tracker.release(left), released(&[1, 2, 3], 2));
+        assert_eq!(tracker.prompt_total, 3.0);
+        assert_eq!(tracker.output_total, 0.0);
+        assert_eq!(tracker.active_blocks(), 3);
+        tracker.assert_consistent([&right]);
+
+        assert_eq!(tracker.release(right), released(&[1, 2, 4], 0));
+        assert_eq!(tracker.prompt_total, 0.0);
+        assert_eq!(tracker.output_total, 0.0);
+        assert_eq!(tracker.active_blocks(), 0);
     }
 
     #[test]

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -3,42 +3,50 @@
 
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
-#[cfg(debug_assertions)]
-use rustc_hash::FxHashSet;
-use slotmap::{SlotMap, new_key_type};
-use std::num::NonZeroU32;
 
-new_key_type! {
-    struct BlockNodeId;
+use super::compressed_path_arena::{CompressedNodeId, CompressedPathArena};
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+struct BlockNodeMetadata {
+    terminal_owners: u32,
+    fraction: Option<f64>,
 }
 
-/// One node in a persistent request block chain.
-///
-/// Sequence hashes identify their lineage. Parent IDs are generational arena
-/// keys, while `incoming` counts direct request-tail and child-to-parent edges.
-#[derive(Debug)]
-struct BlockNode {
-    hash: SequenceHash,
-    depth: usize,
-    parent: Option<BlockNodeId>,
-    incoming: NonZeroU32,
+impl BlockNodeMetadata {
+    fn terminal() -> Self {
+        Self {
+            terminal_owners: 1,
+            fraction: None,
+        }
+    }
+
+    fn increment_terminal(&mut self) {
+        self.terminal_owners = self
+            .terminal_owners
+            .checked_add(1)
+            .expect("block ownership count overflowed");
+    }
 }
 
-/// The single block-chain tail retained by a request.
+/// The compressed prompt tail plus request-local output hashes.
 ///
 /// This type intentionally does not implement `Clone`. New request owners must
-/// be acquired through [`BlockTracker::acquire_prompt`], which also maintains
-/// the arena ownership counts and block index.
+/// be acquired through [`BlockTracker::acquire_prompt`].
 #[derive(Debug, Default)]
 #[must_use = "request block chains must be retained by a request and released through BlockTracker"]
 pub(super) struct RequestBlockChain {
-    tail: Option<BlockNodeId>,
+    prompt_tail: Option<CompressedNodeId>,
     prompt_depth: usize,
+    output_hashes: Vec<SequenceHash>,
 }
 
 impl RequestBlockChain {
-    fn new(tail: Option<BlockNodeId>, prompt_depth: usize) -> Self {
-        Self { tail, prompt_depth }
+    fn new(prompt_tail: Option<CompressedNodeId>, prompt_depth: usize) -> Self {
+        Self {
+            prompt_tail,
+            prompt_depth,
+            output_hashes: Vec::new(),
+        }
     }
 }
 
@@ -48,243 +56,237 @@ pub(super) struct ReleasedPromptPath {
     pub(super) remove_from: usize,
 }
 
+/// Exact per-worker prompt liveness backed by compressed arena edges.
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
-    nodes: SlotMap<BlockNodeId, BlockNode>,
-    unique_blocks: FxHashMap<SequenceHash, BlockNodeId>,
-    fractional_blocks: FxHashMap<SequenceHash, f64>,
+    arena: CompressedPathArena<BlockNodeMetadata>,
+    // Output hashes remain outside the prompt topology. They are unique per
+    // request, but retaining the map preserves active-hash diagnostics and
+    // fractional load accounting.
+    output_blocks: FxHashMap<SequenceHash, f64>,
 }
 
 impl BlockTracker {
-    /// Acquire one request tail for a prompt and return the first newly present
-    /// prompt index, if any.
-    ///
-    /// # Lineage contract
-    ///
-    /// Each [`SequenceHash`] must identify exactly one prefix ancestry and
-    /// depth. As with the KV indexer, this tracker trusts callers to maintain
-    /// that invariant and does not validate the hash recurrence in production.
-    ///
-    /// # Collision scope
-    ///
-    /// Collision handling is outside the active-sequence tracker's scope: it
-    /// assumes distinct live lineages have distinct [`SequenceHash`] values and
-    /// does not detect, prevent, or recover from true hash collisions.
-    ///
-    /// `SequenceHash` is a probabilistic 64-bit identifier, so collisions are
-    /// possible but very unlikely. A collision matters here only when both
-    /// blocks are live in the same `WorkerWithDpRank` tracker: each worker and
-    /// DP rank owns a separate `BlockTracker` and hash index. Assuming uniform
-    /// hashes, an active set of `n` blocks has collision probability of roughly
-    /// `n * (n - 1) / 2^65`. Replica sync may reproduce the same collision for
-    /// that worker on peer routers, but cannot alias arena nodes across workers.
+    /// Acquire a request terminal and return the first block that became newly
+    /// present for this worker.
     pub(super) fn acquire_prompt(
         &mut self,
         sequence: &[SequenceHash],
     ) -> (RequestBlockChain, Option<usize>) {
-        let Some(&tail_hash) = sequence.last() else {
+        let Some(&first_hash) = sequence.first() else {
             return (RequestBlockChain::default(), None);
         };
 
-        if let Some(tail) = self.live_node_id(tail_hash) {
-            self.debug_assert_lineage(tail, sequence);
-            self.increment_incoming(tail);
-            return (RequestBlockChain::new(Some(tail), sequence.len()), None);
-        }
+        let Some(mut node_id) = self.arena.root(first_hash) else {
+            let tail = self
+                .arena
+                .insert_root(sequence.to_vec(), BlockNodeMetadata::terminal());
+            return (RequestBlockChain::new(Some(tail), sequence.len()), Some(0));
+        };
 
-        let mut parent = None;
-        let mut first_new_idx = 0;
+        let mut path_pos = 0;
+        loop {
+            let (edge_len, match_len) = {
+                let node = &self.arena.nodes[node_id];
+                let remaining = &sequence[path_pos..];
+                let match_len = node
+                    .edge
+                    .iter()
+                    .zip(remaining)
+                    .take_while(|(left, right)| left == right)
+                    .count();
+                (node.edge.len(), match_len)
+            };
+            assert!(match_len > 0, "compressed path selected a mismatched edge");
 
-        // Prompt liveness is prefix-closed. Search backward for the deepest
-        // live prefix, then construct only the missing suffix.
-        for idx in (0..sequence.len().saturating_sub(1)).rev() {
-            if let Some(node_id) = self.live_node_id(sequence[idx]) {
-                self.debug_assert_lineage(node_id, &sequence[..=idx]);
-                parent = Some(node_id);
-                first_new_idx = idx + 1;
-                break;
+            if match_len < edge_len {
+                let fraction = self.arena.nodes[node_id].metadata.fraction;
+                let split_depth = path_pos + match_len;
+                let prompt_ends_at_split = split_depth == sequence.len();
+                let prefix_id = self.arena.split_keep_suffix(
+                    node_id,
+                    match_len,
+                    BlockNodeMetadata {
+                        terminal_owners: u32::from(prompt_ends_at_split),
+                        fraction,
+                    },
+                );
+
+                if prompt_ends_at_split {
+                    return (
+                        RequestBlockChain::new(Some(prefix_id), sequence.len()),
+                        None,
+                    );
+                }
+
+                let tail = self.arena.insert_child(
+                    prefix_id,
+                    sequence[split_depth..].to_vec(),
+                    BlockNodeMetadata::terminal(),
+                );
+                return (
+                    RequestBlockChain::new(Some(tail), sequence.len()),
+                    Some(split_depth),
+                );
             }
-        }
 
-        let missing = sequence.len() - first_new_idx;
-        self.nodes.reserve(missing);
-        self.unique_blocks.reserve(missing);
-        self.debug_assert_new_hashes(&sequence[first_new_idx..]);
+            path_pos += edge_len;
+            if path_pos == sequence.len() {
+                self.arena.nodes[node_id].metadata.increment_terminal();
+                return (RequestBlockChain::new(Some(node_id), sequence.len()), None);
+            }
 
-        // Adding the first new child contributes one new incoming edge to the
-        // reused prefix. Subsequent construction transfers the provisional
-        // request-tail edge into a child-to-parent edge without changing it.
-        if let Some(parent_id) = parent {
-            self.increment_incoming(parent_id);
-        }
+            let next_hash = sequence[path_pos];
+            if let Some(next) = self.arena.nodes[node_id].children.get(&next_hash).copied() {
+                node_id = next;
+                continue;
+            }
 
-        for (idx, &hash) in sequence[first_new_idx..].iter().enumerate() {
-            let node_id = self.nodes.insert(BlockNode {
-                hash,
-                depth: first_new_idx + idx + 1,
-                parent,
-                incoming: NonZeroU32::MIN,
-            });
-            let previous = self.unique_blocks.insert(hash, node_id);
-            debug_assert!(
-                previous.is_none(),
-                "new block unexpectedly replaced a live index entry"
+            let tail = self.arena.insert_child(
+                node_id,
+                sequence[path_pos..].to_vec(),
+                BlockNodeMetadata::terminal(),
             );
-            parent = Some(node_id);
+            return (
+                RequestBlockChain::new(Some(tail), sequence.len()),
+                Some(path_pos),
+            );
         }
-
-        (
-            RequestBlockChain::new(parent, sequence.len()),
-            Some(first_new_idx),
-        )
     }
 
-    /// Append a unique output block to an existing request chain.
+    /// Append a unique output block without adding it to the prompt trie.
     pub(super) fn append_output(&mut self, chain: &mut RequestBlockChain, hash: SequenceHash) {
         debug_assert!(
-            !self.unique_blocks.contains_key(&hash),
+            !self.contains_block(&hash),
             "random output hash unexpectedly collided with a live block"
         );
-
-        let parent = chain.tail;
-        let depth = parent.map_or(1, |node_id| {
-            self.nodes
-                .get(node_id)
-                .expect("request tail references a missing block node")
-                .depth
-                .checked_add(1)
-                .expect("block chain depth overflowed")
-        });
-        let node_id = self.nodes.insert(BlockNode {
-            hash,
-            depth,
-            parent,
-            incoming: NonZeroU32::MIN,
-        });
-        let previous = self.unique_blocks.insert(hash, node_id);
-        debug_assert!(
-            previous.is_none(),
-            "new output unexpectedly replaced a live index entry"
+        assert!(
+            self.output_blocks.insert(hash, 1.0).is_none(),
+            "output block hash unexpectedly became live twice"
         );
-        chain.tail = Some(node_id);
+        chain.output_hashes.push(hash);
     }
 
-    /// Release a request chain and return the complete prompt path plus the
-    /// first block that became absent from the worker.
+    /// Release outputs and the request terminal, returning the prompt suffix
+    /// that became absent from the worker.
     pub(super) fn release(&mut self, chain: RequestBlockChain) -> Option<ReleasedPromptPath> {
-        let RequestBlockChain { tail, prompt_depth } = chain;
-        let mut removed_prompt_rev = Vec::new();
-        let mut retained = None;
-        let mut current = tail;
+        for hash in chain.output_hashes {
+            self.output_blocks
+                .remove(&hash)
+                .expect("request output hash is missing from active bookkeeping");
+        }
 
+        let Some(tail) = chain.prompt_tail else {
+            assert_eq!(chain.prompt_depth, 0, "empty prompt retained a depth");
+            return None;
+        };
+
+        let path_ids = self.arena.path_from_root(tail);
+        let mut path = Vec::with_capacity(chain.prompt_depth);
+        for node_id in &path_ids {
+            path.extend_from_slice(&self.arena.nodes[*node_id].edge);
+        }
+        assert_eq!(
+            path.len(),
+            chain.prompt_depth,
+            "request terminal depth differs from its compressed path"
+        );
+
+        let terminal = &mut self.arena.nodes[tail].metadata.terminal_owners;
+        *terminal = terminal
+            .checked_sub(1)
+            .expect("request terminal ownership underflowed");
+
+        let mut removed_hashes = 0;
+        let mut current = Some(tail);
+        let mut retained = None;
         while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get_mut(node_id)
-                .expect("request chain references a missing block node");
-            let incoming = node.incoming.get();
-            if incoming > 1 {
-                node.incoming = NonZeroU32::new(incoming - 1)
-                    .expect("shared block ownership count cannot become zero");
+            let node = &self.arena.nodes[node_id];
+            if node.metadata.terminal_owners != 0 || !node.children.is_empty() {
                 retained = Some(node_id);
                 break;
             }
-
-            let node = self
-                .nodes
-                .remove(node_id)
-                .expect("validated block node disappeared before removal");
-            let hash = node.hash;
-            let depth = node.depth;
             let parent = node.parent;
-
-            let indexed_node_id = self
-                .unique_blocks
-                .remove(&hash)
-                .expect("live block node is missing from the hash index");
-            debug_assert_eq!(
-                indexed_node_id, node_id,
-                "block hash index references a different live node"
-            );
-            if !self.fractional_blocks.is_empty() {
-                self.fractional_blocks.remove(&hash);
-            }
-
-            if depth <= prompt_depth {
-                removed_prompt_rev.push(hash);
-            }
+            removed_hashes += self.arena.remove_leaf(node_id).edge.len();
             current = parent;
         }
 
-        if removed_prompt_rev.is_empty() {
+        if let Some(node_id) = retained {
+            self.recompress_from(node_id);
+        }
+
+        if removed_hashes == 0 {
             return None;
         }
-
-        let remove_from = prompt_depth
-            .checked_sub(removed_prompt_rev.len())
-            .expect("removed prompt suffix cannot exceed the prompt depth");
-        let mut path = Vec::with_capacity(prompt_depth);
-        let mut current = retained;
-        while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("retained prompt prefix references a missing block node");
-            if node.depth <= prompt_depth {
-                path.push(node.hash);
-            }
-            current = node.parent;
-        }
-        path.reverse();
-        assert_eq!(
-            path.len(),
-            remove_from,
-            "retained prompt prefix length differs from the released suffix boundary"
-        );
-
-        removed_prompt_rev.reverse();
-        path.extend(removed_prompt_rev);
-        assert_eq!(
-            path.len(),
-            prompt_depth,
-            "released prompt path length differs from the request prompt depth"
-        );
-
+        let remove_from = chain
+            .prompt_depth
+            .checked_sub(removed_hashes)
+            .expect("removed prompt suffix exceeds the request prompt");
         Some(ReleasedPromptPath { path, remove_from })
     }
 
-    /// Mark the request's exclusively owned suffix as fractional.
+    /// Mark the request's structurally exclusive suffix as fractional.
     pub(super) fn set_unique_suffix_fractional(
         &mut self,
         chain: &RequestBlockChain,
         fraction: f64,
     ) {
-        let mut current = chain.tail;
+        for hash in &chain.output_hashes {
+            *self
+                .output_blocks
+                .get_mut(hash)
+                .expect("request output hash is missing from active bookkeeping") = fraction;
+        }
+
+        let mut current = chain.prompt_tail;
         while let Some(node_id) = current {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("request chain references a missing block node");
-            if node.incoming.get() != 1 {
+            let node = &self.arena.nodes[node_id];
+            let incoming = node.metadata.terminal_owners as usize + node.children.len();
+            if incoming != 1 {
                 break;
             }
-            self.fractional_blocks.insert(node.hash, fraction);
             current = node.parent;
+            self.arena.nodes[node_id].metadata.fraction = Some(fraction);
         }
     }
 
     pub(super) fn active_blocks(&self) -> usize {
-        let mut count = self.unique_blocks.len() as f64;
-        for (hash, frac) in &self.fractional_blocks {
-            if self.unique_blocks.contains_key(hash) {
-                count = count - 1.0 + frac;
-            }
-        }
-        count.round() as usize
+        let prompt_blocks = self
+            .arena
+            .nodes
+            .values()
+            .map(|node| node.edge.len() as f64 * node.metadata.fraction.unwrap_or(1.0))
+            .sum::<f64>();
+        let output_blocks = self.output_blocks.values().sum::<f64>();
+        (prompt_blocks + output_blocks).round() as usize
     }
 
     pub(super) fn contains_block(&self, hash: &SequenceHash) -> bool {
-        self.live_node_id(*hash).is_some()
+        self.output_blocks.contains_key(hash)
+            || self
+                .arena
+                .nodes
+                .values()
+                .any(|node| node.edge.contains(hash))
+    }
+
+    fn recompress_from(&mut self, mut node_id: CompressedNodeId) {
+        loop {
+            let child_id = {
+                let node = &self.arena.nodes[node_id];
+                if node.metadata.terminal_owners != 0 || node.children.len() != 1 {
+                    return;
+                }
+                node.children.values().next().copied().unwrap()
+            };
+            if self.arena.nodes[node_id].metadata.fraction
+                != self.arena.nodes[child_id].metadata.fraction
+            {
+                return;
+            }
+            self.arena.merge_parent_into_child(node_id, child_id);
+            node_id = child_id;
+        }
     }
 
     #[cfg(any(test, debug_assertions))]
@@ -292,216 +294,97 @@ impl BlockTracker {
         &self,
         chains: impl IntoIterator<Item = &'a RequestBlockChain>,
     ) {
-        assert_eq!(
-            self.nodes.len(),
-            self.unique_blocks.len(),
-            "arena and live block index must have identical cardinality"
-        );
+        use rustc_hash::FxHashSet;
 
-        let mut expected_incoming = FxHashMap::default();
-        for (node_id, node) in &self.nodes {
-            assert!(
-                expected_incoming.insert(node_id, 0_u32).is_none(),
-                "arena yielded a duplicate node ID"
-            );
-            assert_eq!(
-                self.unique_blocks.get(&node.hash),
-                Some(&node_id),
-                "live arena node is missing its exact hash-index entry"
-            );
-
-            if let Some(parent_id) = node.parent {
-                let parent = self
-                    .nodes
-                    .get(parent_id)
-                    .expect("block node references a missing parent");
-                assert_eq!(
-                    parent.depth + 1,
-                    node.depth,
-                    "child block depth must immediately follow its parent"
-                );
-            } else {
-                assert_eq!(node.depth, 1, "root block depth must be one");
-            }
-        }
-
-        for (&hash, &node_id) in &self.unique_blocks {
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("hash index references a missing arena node");
-            assert_eq!(
-                node.hash, hash,
-                "hash index key does not match its arena node"
-            );
-        }
-
-        for (_, node) in &self.nodes {
-            if let Some(parent_id) = node.parent {
-                let count = expected_incoming
-                    .get_mut(&parent_id)
-                    .expect("block node references a missing parent");
-                *count = count
-                    .checked_add(1)
-                    .expect("reconstructed child ownership count overflowed");
-            }
-        }
-
+        self.arena.assert_topology();
+        let mut expected_terminals = FxHashMap::<CompressedNodeId, u32>::default();
+        let mut expected_outputs = FxHashSet::default();
         for chain in chains {
-            if let Some(tail_id) = chain.tail {
-                let tail = self
-                    .nodes
-                    .get(tail_id)
-                    .expect("request tail references a missing arena node");
+            match chain.prompt_tail {
+                Some(tail) => {
+                    let path = self.arena.path_from_root(tail);
+                    let depth: usize = path
+                        .iter()
+                        .map(|node_id| self.arena.nodes[*node_id].edge.len())
+                        .sum();
+                    assert_eq!(depth, chain.prompt_depth, "request prompt depth mismatch");
+                    *expected_terminals.entry(tail).or_default() += 1;
+                }
+                None => assert_eq!(chain.prompt_depth, 0, "empty prompt retained a depth"),
+            }
+            for &hash in &chain.output_hashes {
                 assert!(
-                    chain.prompt_depth <= tail.depth,
-                    "request prompt depth cannot exceed its full block-chain depth"
-                );
-                let count = expected_incoming
-                    .get_mut(&tail_id)
-                    .expect("request tail references a missing arena node");
-                *count = count
-                    .checked_add(1)
-                    .expect("reconstructed request ownership count overflowed");
-            } else {
-                assert_eq!(
-                    chain.prompt_depth, 0,
-                    "an empty request chain cannot retain prompt depth"
+                    expected_outputs.insert(hash),
+                    "output hash is owned by multiple requests"
                 );
             }
         }
 
-        for (node_id, node) in &self.nodes {
+        let mut prompt_hashes = FxHashSet::default();
+        for (node_id, node) in &self.arena.nodes {
             assert_eq!(
-                expected_incoming[&node_id],
-                node.incoming.get(),
-                "stored incoming ownership count differs from reconstructed edges"
+                node.metadata.terminal_owners,
+                expected_terminals.get(&node_id).copied().unwrap_or(0),
+                "compressed terminal ownership mismatch"
             );
+            assert!(
+                node.metadata.terminal_owners != 0 || !node.children.is_empty(),
+                "unowned compressed leaf remained live"
+            );
+            for &hash in &node.edge {
+                assert!(prompt_hashes.insert(hash), "prompt hash appears twice");
+            }
         }
-
-        assert!(
-            self.fractional_blocks
-                .keys()
-                .all(|hash| self.unique_blocks.contains_key(hash)),
-            "fractional blocks cannot reference non-active blocks"
+        assert_eq!(
+            expected_outputs,
+            self.output_blocks.keys().copied().collect(),
+            "output bookkeeping differs from request ownership"
         );
     }
 
     #[cfg(test)]
     pub(super) fn active_hashes(&self) -> impl Iterator<Item = SequenceHash> + '_ {
-        self.unique_blocks.keys().copied()
+        let mut hashes = Vec::with_capacity(self.arena.hash_count() + self.output_blocks.len());
+        for node in self.arena.nodes.values() {
+            hashes.extend_from_slice(&node.edge);
+        }
+        hashes.extend(self.output_blocks.keys().copied());
+        hashes.into_iter()
     }
 
     #[cfg(test)]
-    pub(super) fn prompt_hashes<'a>(
-        &'a self,
-        chain: &'a RequestBlockChain,
-    ) -> impl Iterator<Item = SequenceHash> + 'a {
-        self.node_ids_from_tail(chain).filter_map(|node_id| {
-            let node = &self.nodes[node_id];
-            (node.depth <= chain.prompt_depth).then_some(node.hash)
-        })
-    }
-
-    fn live_node_id(&self, hash: SequenceHash) -> Option<BlockNodeId> {
-        let &node_id = self.unique_blocks.get(&hash)?;
-        let node = self
-            .nodes
-            .get(node_id)
-            .expect("live block index references a stale arena ID");
-        assert_eq!(
-            node.hash, hash,
-            "live block index key does not match its arena node"
-        );
-        Some(node_id)
-    }
-
-    fn increment_incoming(&mut self, node_id: BlockNodeId) {
-        let node = self
-            .nodes
-            .get_mut(node_id)
-            .expect("cannot acquire ownership of a missing block node");
-        let incoming = node
-            .incoming
-            .get()
-            .checked_add(1)
-            .expect("block ownership count overflowed");
-        node.incoming = NonZeroU32::new(incoming).expect("incremented ownership cannot be zero");
-    }
-
-    #[cfg(debug_assertions)]
-    fn debug_assert_new_hashes(&self, hashes: &[SequenceHash]) {
-        let mut seen = FxHashSet::default();
-        for hash in hashes {
-            assert!(
-                !self.unique_blocks.contains_key(hash),
-                "sequence lineage hash unexpectedly aliases a live block"
-            );
-            assert!(
-                seen.insert(*hash),
-                "sequence lineage repeats a hash in one missing suffix"
-            );
+    pub(super) fn prompt_hashes(
+        &self,
+        chain: &RequestBlockChain,
+    ) -> impl Iterator<Item = SequenceHash> {
+        let mut hashes = Vec::with_capacity(chain.prompt_depth);
+        if let Some(tail) = chain.prompt_tail {
+            for node_id in self.arena.path_from_root(tail) {
+                hashes.extend_from_slice(&self.arena.nodes[node_id].edge);
+            }
         }
+        hashes.into_iter()
     }
-
-    #[cfg(not(debug_assertions))]
-    #[inline]
-    fn debug_assert_new_hashes(&self, _hashes: &[SequenceHash]) {}
-
-    #[cfg(any(test, debug_assertions))]
-    fn debug_assert_lineage(&self, tail: BlockNodeId, sequence: &[SequenceHash]) {
-        let tail_node = self
-            .nodes
-            .get(tail)
-            .expect("live sequence tail references a missing arena node");
-        assert_eq!(
-            tail_node.depth,
-            sequence.len(),
-            "sequence tail depth mismatch"
-        );
-        let mut current = Some(tail);
-        for (expected_depth, &expected_hash) in sequence.iter().enumerate().rev() {
-            let node_id = current.expect("live sequence chain ended before its expected root");
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("live sequence chain references a missing arena node");
-            assert_eq!(node.depth, expected_depth + 1, "sequence depth mismatch");
-            assert_eq!(node.hash, expected_hash, "sequence lineage hash mismatch");
-            current = node.parent;
-        }
-    }
-
-    #[cfg(not(any(test, debug_assertions)))]
-    #[inline]
-    fn debug_assert_lineage(&self, _tail: BlockNodeId, _sequence: &[SequenceHash]) {}
 
     #[cfg(test)]
-    fn node_ids_from_tail<'a>(
-        &'a self,
-        chain: &'a RequestBlockChain,
-    ) -> impl Iterator<Item = BlockNodeId> + 'a {
-        let mut current = chain.tail;
-        std::iter::from_fn(move || {
-            let node_id = current?;
-            let node = self
-                .nodes
-                .get(node_id)
-                .expect("request chain references a missing arena node");
-            current = node.parent;
-            Some(node_id)
-        })
+    fn node_id_for(&self, hash: SequenceHash) -> CompressedNodeId {
+        self.arena
+            .nodes
+            .iter()
+            .find_map(|(node_id, node)| node.edge.contains(&hash).then_some(node_id))
+            .expect("expected live block hash")
     }
 
     #[cfg(test)]
     fn incoming_for(&self, hash: SequenceHash) -> u32 {
-        let node_id = self.live_node_id(hash).expect("expected live block hash");
-        self.nodes[node_id].incoming.get()
+        let node = &self.arena.nodes[self.node_id_for(hash)];
+        node.metadata.terminal_owners + node.children.len() as u32
     }
 
     #[cfg(test)]
-    fn node_id_for(&self, hash: SequenceHash) -> BlockNodeId {
-        self.live_node_id(hash).expect("expected live block hash")
+    fn fraction_for(&self, hash: SequenceHash) -> Option<f64> {
+        let node = &self.arena.nodes[self.node_id_for(hash)];
+        node.metadata.fraction
     }
 }
 
@@ -530,236 +413,99 @@ mod tests {
     }
 
     #[test]
-    fn first_acquire_and_last_release_report_presence_transitions() {
+    fn duplicate_prompt_tracks_terminal_owners() {
         let mut tracker = BlockTracker::default();
-
-        let (first, first_new) = tracker.acquire_prompt(&[1]);
-        let (second, second_new) = tracker.acquire_prompt(&[1]);
+        let (first, first_new) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (second, second_new) = tracker.acquire_prompt(&[1, 2, 3]);
 
         assert_eq!(first_new, Some(0));
         assert_eq!(second_new, None);
-        assert_eq!(tracker.incoming_for(1), 2);
+        assert_eq!(tracker.incoming_for(3), 2);
         tracker.assert_consistent([&first, &second]);
-        assert_eq!(tracker.active_blocks(), 1);
-
         assert_eq!(tracker.release(first), None);
-        assert_eq!(tracker.incoming_for(1), 1);
-        tracker.assert_consistent([&second]);
-        assert_eq!(tracker.active_blocks(), 1);
-
-        assert_eq!(tracker.release(second), released(&[1], 0));
+        assert_eq!(tracker.release(second), released(&[1, 2, 3], 0));
         tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
     }
 
     #[test]
-    fn shorter_request_adds_only_a_tail_edge() {
+    fn shorter_prompt_splits_without_invalidating_longer_handle() {
         let mut tracker = BlockTracker::default();
-        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3, 4]);
+        let old_tail = longer.prompt_tail.unwrap();
         let (shorter, first_new) = tracker.acquire_prompt(&[1, 2]);
 
         assert_eq!(first_new, None);
-        assert_eq!(tracker.incoming_for(1), 1);
-        assert_eq!(tracker.incoming_for(2), 2);
-        assert_eq!(tracker.incoming_for(3), 1);
+        assert_eq!(longer.prompt_tail, Some(old_tail));
+        assert!(tracker.arena.nodes.contains_key(old_tail));
         tracker.assert_consistent([&longer, &shorter]);
-
         assert_eq!(tracker.release(shorter), None);
-        tracker.assert_consistent([&longer]);
-        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 0));
+        assert!(tracker.arena.nodes.contains_key(old_tail));
+        assert_eq!(tracker.release(longer), released(&[1, 2, 3, 4], 0));
     }
 
     #[test]
-    fn longer_request_adds_one_child_edge_to_a_shorter_tail() {
+    fn branch_release_recompresses_while_preserving_survivor_handle() {
         let mut tracker = BlockTracker::default();
-        let (shorter, _) = tracker.acquire_prompt(&[1, 2]);
-        let (longer, first_new) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
+        let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
+        let right_tail = right.prompt_tail.unwrap();
 
         assert_eq!(first_new, Some(2));
-        assert_eq!(tracker.incoming_for(1), 1);
-        assert_eq!(tracker.incoming_for(2), 2);
-        assert_eq!(tracker.incoming_for(3), 1);
-        tracker.assert_consistent([&shorter, &longer]);
+        assert_eq!(tracker.release(left), released(&[1, 2, 3], 2));
+        assert!(tracker.arena.nodes.contains_key(right_tail));
+        tracker.assert_consistent([&right]);
+        assert_eq!(tracker.release(right), released(&[1, 2, 4], 0));
+    }
 
-        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 2));
-        tracker.assert_consistent([&shorter]);
+    #[test]
+    fn longer_prompt_reports_only_the_new_suffix() {
+        let mut tracker = BlockTracker::default();
+        let (shorter, _) = tracker.acquire_prompt(&[1, 2]);
+        let (longer, first_new) = tracker.acquire_prompt(&[1, 2, 3, 4]);
+
+        assert_eq!(first_new, Some(2));
+        assert_eq!(tracker.active_blocks(), 4);
+        assert_eq!(tracker.release(longer), released(&[1, 2, 3, 4], 2));
         assert_eq!(tracker.release(shorter), released(&[1, 2], 0));
     }
 
     #[test]
-    fn release_only_removes_unique_branch_suffix() {
-        let mut tracker = BlockTracker::default();
-        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (right, first_new) = tracker.acquire_prompt(&[1, 2, 4]);
-
-        assert_eq!(first_new, Some(2));
-        assert_eq!(tracker.incoming_for(1), 1);
-        assert_eq!(tracker.incoming_for(2), 2);
-        tracker.assert_consistent([&left, &right]);
-        assert_eq!(tracker.active_blocks(), 4);
-
-        assert_eq!(tracker.release(left), released(&[1, 2, 3], 2));
-        tracker.assert_consistent([&right]);
-        assert_eq!(tracker.active_blocks(), 3);
-        assert_eq!(tracker.release(right), released(&[1, 2, 4], 0));
-        tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn output_append_transfers_tail_ownership_to_the_child_edge() {
+    fn output_blocks_stay_outside_prompt_arena() {
         let mut tracker = BlockTracker::default();
         let (mut chain, _) = tracker.acquire_prompt(&[1, 2]);
+        let prompt_nodes = tracker.arena.nodes.len();
 
-        let before = tracker.incoming_for(2);
         tracker.append_output(&mut chain, 42);
-
-        assert_eq!(tracker.incoming_for(2), before);
-        assert_eq!(tracker.incoming_for(42), 1);
+        assert_eq!(tracker.arena.nodes.len(), prompt_nodes);
+        assert_eq!(tracker.active_blocks(), 3);
         tracker.assert_consistent([&chain]);
         assert_eq!(tracker.release(chain), released(&[1, 2], 0));
+        assert!(tracker.output_blocks.is_empty());
     }
 
     #[test]
-    fn output_append_preserves_a_shared_tail_count() {
+    fn fractional_unique_suffix_preserves_shared_prefix() {
         let mut tracker = BlockTracker::default();
-        let (mut generating, _) = tracker.acquire_prompt(&[1, 2]);
+        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
         let (shared, _) = tracker.acquire_prompt(&[1, 2]);
 
-        assert_eq!(tracker.incoming_for(2), 2);
-        tracker.append_output(&mut generating, 42);
-        assert_eq!(tracker.incoming_for(2), 2);
-        tracker.assert_consistent([&generating, &shared]);
-
-        assert_eq!(tracker.release(generating), None);
-        assert_eq!(tracker.incoming_for(2), 1);
-        tracker.assert_consistent([&shared]);
+        tracker.set_unique_suffix_fractional(&longer, 0.5);
+        assert_eq!(tracker.fraction_for(3), Some(0.5));
+        assert_eq!(tracker.fraction_for(1), None);
+        assert_eq!(tracker.active_blocks(), 3);
+        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 2));
+        assert_eq!(tracker.active_blocks(), 2);
         assert_eq!(tracker.release(shared), released(&[1, 2], 0));
     }
 
     #[test]
-    fn either_branch_can_be_released_first() {
-        let mut tracker = BlockTracker::default();
-        let (left, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (right, _) = tracker.acquire_prompt(&[1, 2, 4]);
-
-        assert_eq!(tracker.release(right), released(&[1, 2, 4], 2));
-        tracker.assert_consistent([&left]);
-        assert_eq!(tracker.release(left), released(&[1, 2, 3], 0));
-    }
-
-    #[test]
-    fn fractional_blocks_adjust_active_block_count() {
-        let mut tracker = BlockTracker::default();
-        let (chain, _) = tracker.acquire_prompt(&[1, 2]);
-
-        tracker.set_unique_suffix_fractional(&chain, 0.5);
-        tracker.assert_consistent([&chain]);
-        assert_eq!(tracker.active_blocks(), 1);
-
-        assert_eq!(tracker.release(chain), released(&[1, 2], 0));
-        assert!(tracker.fractional_blocks.is_empty());
-        tracker.assert_consistent(std::iter::empty());
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn release_cleans_fractional_unique_suffix_above_shared_prefix() {
-        let mut tracker = BlockTracker::default();
-        let (longer, _) = tracker.acquire_prompt(&[1, 2, 3]);
-        let (shared_prefix, _) = tracker.acquire_prompt(&[1, 2]);
-
-        tracker.set_unique_suffix_fractional(&longer, 0.5);
-        assert_eq!(tracker.fractional_blocks.get(&3), Some(&0.5));
-        assert!(!tracker.fractional_blocks.contains_key(&1));
-        assert!(!tracker.fractional_blocks.contains_key(&2));
-        tracker.assert_consistent([&longer, &shared_prefix]);
-
-        assert_eq!(tracker.release(longer), released(&[1, 2, 3], 2));
-        assert!(tracker.fractional_blocks.is_empty());
-        tracker.assert_consistent([&shared_prefix]);
-        assert_eq!(tracker.active_blocks(), 2);
-
-        assert_eq!(tracker.release(shared_prefix), released(&[1, 2], 0));
-        assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn output_only_chain_releases_without_prompt_membership() {
+    fn output_only_chain_releases_without_membership_delta() {
         let mut tracker = BlockTracker::default();
         let (mut chain, first_new) = tracker.acquire_prompt(&[]);
-
-        assert_eq!(first_new, None);
         tracker.append_output(&mut chain, 42);
-        tracker.assert_consistent([&chain]);
-        assert_eq!(tracker.active_blocks(), 1);
+        assert_eq!(first_new, None);
         assert_eq!(tracker.release(chain), None);
-        tracker.assert_consistent(std::iter::empty());
         assert_eq!(tracker.active_blocks(), 0);
-    }
-
-    #[test]
-    fn removed_slot_generation_cannot_resolve_after_reuse() {
-        let mut tracker = BlockTracker::default();
-        let (first, _) = tracker.acquire_prompt(&[1]);
-        let old_id = tracker.node_id_for(1);
-        assert_eq!(tracker.release(first), released(&[1], 0));
-
-        let (second, _) = tracker.acquire_prompt(&[2]);
-        assert!(tracker.nodes.get(old_id).is_none());
-        assert_ne!(old_id, tracker.node_id_for(2));
-        tracker.assert_consistent([&second]);
-        assert_eq!(tracker.release(second), released(&[2], 0));
-    }
-
-    #[test]
-    #[should_panic(expected = "live block index references a stale arena ID")]
-    fn stale_generation_in_index_is_rejected() {
-        let mut tracker = BlockTracker::default();
-        let (first, _) = tracker.acquire_prompt(&[1]);
-        let old_id = tracker.node_id_for(1);
-        assert_eq!(tracker.release(first), released(&[1], 0));
-        let (second, _) = tracker.acquire_prompt(&[2]);
-
-        tracker.unique_blocks.insert(99, old_id);
-        let _ = tracker.contains_block(&99);
-        drop(second);
-    }
-
-    #[test]
-    #[should_panic(expected = "live block index key does not match its arena node")]
-    fn live_id_with_the_wrong_hash_is_rejected() {
-        let mut tracker = BlockTracker::default();
-        let (chain, _) = tracker.acquire_prompt(&[1]);
-        let node_id = tracker.node_id_for(1);
-
-        tracker.unique_blocks.insert(2, node_id);
-        let _ = tracker.contains_block(&2);
-        drop(chain);
-    }
-
-    #[cfg(debug_assertions)]
-    #[test]
-    #[should_panic(expected = "block hash index references a different live node")]
-    fn release_rejects_hash_index_alias() {
-        let mut tracker = BlockTracker::default();
-        let (first, _) = tracker.acquire_prompt(&[1]);
-        let (_second, _) = tracker.acquire_prompt(&[2]);
-        let aliased_node_id = tracker.node_id_for(2);
-
-        tracker.unique_blocks.insert(1, aliased_node_id);
-        let _ = tracker.release(first);
-    }
-
-    #[test]
-    #[should_panic(expected = "block ownership count overflowed")]
-    fn ownership_count_overflow_panics() {
-        let mut tracker = BlockTracker::default();
-        let (chain, _) = tracker.acquire_prompt(&[1]);
-        let node_id = tracker.node_id_for(1);
-        tracker.nodes[node_id].incoming = NonZeroU32::MAX;
-        let _ = tracker.acquire_prompt(&[1]);
-        drop(chain);
     }
 
     #[test]
@@ -799,7 +545,7 @@ mod tests {
                     *chain = Some(new_chain);
                     *reference = Some((prompt.clone(), prompt.len()));
                 }
-                (Some(chain), Some((blocks, _prompt_depth))) if rng.random_bool(0.35) => {
+                (Some(chain), Some((blocks, _))) if rng.random_bool(0.35) => {
                     let hash = next_output;
                     next_output += 1;
                     tracker.append_output(chain, hash);
@@ -807,34 +553,39 @@ mod tests {
                     counts.insert(hash, 1);
                 }
                 (chain @ Some(_), reference @ Some(_)) => {
-                    let chain = chain.take().expect("matched active chain");
-                    let (blocks, prompt_depth) = reference.take().expect("matched reference");
-                    let expected_remove = expected_release(&blocks, prompt_depth, &counts);
-                    assert_eq!(tracker.release(chain), expected_remove);
+                    let chain = chain.take().unwrap();
+                    let (blocks, prompt_depth) = reference.take().unwrap();
+                    assert_eq!(
+                        tracker.release(chain),
+                        expected_release(&blocks, prompt_depth, &counts)
+                    );
                     for hash in blocks {
-                        let count = counts.get_mut(&hash).expect("reference block is active");
+                        let count = counts.get_mut(&hash).unwrap();
                         *count -= 1;
                         if *count == 0 {
                             counts.remove(&hash);
                         }
                     }
                 }
-                _ => unreachable!("tracker and reference occupancy diverged"),
+                _ => unreachable!(),
             }
 
             tracker.assert_consistent(chains.iter().filter_map(Option::as_ref));
-            let actual = tracker.active_hashes().collect::<FxHashSet<_>>();
-            let expected = counts.keys().copied().collect::<FxHashSet<_>>();
-            assert_eq!(actual, expected);
+            assert_eq!(
+                tracker.active_hashes().collect::<FxHashSet<_>>(),
+                counts.keys().copied().collect()
+            );
         }
 
         for slot in 0..SLOTS {
             if let Some(chain) = chains[slot].take() {
-                let (blocks, prompt_depth) = reference[slot].take().expect("active reference");
-                let expected_remove = expected_release(&blocks, prompt_depth, &counts);
-                assert_eq!(tracker.release(chain), expected_remove);
+                let (blocks, prompt_depth) = reference[slot].take().unwrap();
+                assert_eq!(
+                    tracker.release(chain),
+                    expected_release(&blocks, prompt_depth, &counts)
+                );
                 for hash in blocks {
-                    let count = counts.get_mut(&hash).expect("reference block is active");
+                    let count = counts.get_mut(&hash).unwrap();
                     *count -= 1;
                     if *count == 0 {
                         counts.remove(&hash);
@@ -842,10 +593,19 @@ mod tests {
                 }
             }
         }
-
         tracker.assert_consistent(std::iter::empty());
         assert!(counts.is_empty());
-        assert_eq!(tracker.active_blocks(), 0);
+    }
+
+    #[test]
+    #[should_panic(expected = "block ownership count overflowed")]
+    fn ownership_count_overflow_panics() {
+        let mut tracker = BlockTracker::default();
+        let (chain, _) = tracker.acquire_prompt(&[1]);
+        let node_id = tracker.node_id_for(1);
+        tracker.arena.nodes[node_id].metadata.terminal_owners = u32::MAX;
+        let _ = tracker.acquire_prompt(&[1]);
+        drop(chain);
     }
 
     #[test]
@@ -856,10 +616,9 @@ mod tests {
         let (chain, first_new) = tracker.acquire_prompt(&sequence);
 
         assert_eq!(first_new, Some(0));
-        tracker.assert_consistent([&chain]);
+        assert_eq!(tracker.arena.nodes.len(), 1);
         assert_eq!(tracker.active_blocks(), DEPTH);
         assert_eq!(tracker.release(chain), released(&sequence, 0));
-        tracker.assert_consistent(std::iter::empty());
         assert_eq!(tracker.active_blocks(), 0);
     }
 }

--- a/lib/kv-router/src/sequences/compressed_path_arena.rs
+++ b/lib/kv-router/src/sequences/compressed_path_arena.rs
@@ -19,9 +19,8 @@ pub(super) struct CompressedPathNode<M> {
 
 /// A single-owner compressed path forest with generational node handles.
 ///
-/// The existing node ID always stays with the suffix during a split. During a
-/// unary merge the child ID survives. Those two rules keep request-held tail
-/// handles valid across unrelated insertions and removals.
+/// The existing node ID always stays with the suffix during a split, keeping
+/// request-held tail handles valid across unrelated insertions and removals.
 #[derive(Debug)]
 pub(super) struct CompressedPathArena<M> {
     pub(super) nodes: SlotMap<CompressedNodeId, CompressedPathNode<M>>,
@@ -156,58 +155,6 @@ impl<M> CompressedPathArena<M> {
             );
         }
         node
-    }
-
-    /// Merge a nonterminal unary parent into its child, preserving `child_id`.
-    pub(super) fn merge_parent_into_child(
-        &mut self,
-        parent_id: CompressedNodeId,
-        child_id: CompressedNodeId,
-    ) {
-        let parent = self
-            .nodes
-            .remove(parent_id)
-            .expect("compressed merge parent is missing");
-        assert_eq!(parent.children.len(), 1, "merge parent must be unary");
-        assert_eq!(
-            parent.children.values().next().copied(),
-            Some(child_id),
-            "merge parent does not reference the selected child"
-        );
-
-        let parent_parent = parent.parent;
-        let old_first = parent.edge[0];
-        let child = self
-            .nodes
-            .get_mut(child_id)
-            .expect("compressed merge child is missing");
-        assert_eq!(
-            child.parent,
-            Some(parent_id),
-            "compressed merge child has a different parent"
-        );
-        let mut merged_edge = parent.edge;
-        merged_edge.append(&mut child.edge);
-        child.edge = merged_edge;
-        child.parent = parent_parent;
-
-        if let Some(grandparent_id) = parent_parent {
-            let replaced = self.nodes[grandparent_id]
-                .children
-                .insert(old_first, child_id);
-            assert_eq!(
-                replaced,
-                Some(parent_id),
-                "compressed grandparent did not reference the merge parent"
-            );
-        } else {
-            let replaced = self.roots.insert(old_first, child_id);
-            assert_eq!(
-                replaced,
-                Some(parent_id),
-                "compressed roots did not reference the merge parent"
-            );
-        }
     }
 
     pub(super) fn path_from_root(&self, tail: CompressedNodeId) -> Vec<CompressedNodeId> {

--- a/lib/kv-router/src/sequences/compressed_path_arena.rs
+++ b/lib/kv-router/src/sequences/compressed_path_arena.rs
@@ -1,0 +1,292 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_tokens::SequenceHash;
+use rustc_hash::FxHashMap;
+use slotmap::{SlotMap, new_key_type};
+
+new_key_type! {
+    pub(super) struct CompressedNodeId;
+}
+
+#[derive(Debug)]
+pub(super) struct CompressedPathNode<M> {
+    pub(super) edge: Vec<SequenceHash>,
+    pub(super) parent: Option<CompressedNodeId>,
+    pub(super) children: FxHashMap<SequenceHash, CompressedNodeId>,
+    pub(super) metadata: M,
+}
+
+/// A single-owner compressed path forest with generational node handles.
+///
+/// The existing node ID always stays with the suffix during a split. During a
+/// unary merge the child ID survives. Those two rules keep request-held tail
+/// handles valid across unrelated insertions and removals.
+#[derive(Debug)]
+pub(super) struct CompressedPathArena<M> {
+    pub(super) nodes: SlotMap<CompressedNodeId, CompressedPathNode<M>>,
+    pub(super) roots: FxHashMap<SequenceHash, CompressedNodeId>,
+    pub(super) splits: u64,
+    pub(super) merges: u64,
+}
+
+impl<M> Default for CompressedPathArena<M> {
+    fn default() -> Self {
+        Self {
+            nodes: SlotMap::with_key(),
+            roots: FxHashMap::default(),
+            splits: 0,
+            merges: 0,
+        }
+    }
+}
+
+impl<M> CompressedPathArena<M> {
+    pub(super) fn root(&self, first_hash: SequenceHash) -> Option<CompressedNodeId> {
+        self.roots.get(&first_hash).copied()
+    }
+
+    pub(super) fn insert_root(&mut self, edge: Vec<SequenceHash>, metadata: M) -> CompressedNodeId {
+        assert!(!edge.is_empty(), "compressed root edge cannot be empty");
+        let first = edge[0];
+        let id = self.nodes.insert(CompressedPathNode {
+            edge,
+            parent: None,
+            children: FxHashMap::default(),
+            metadata,
+        });
+        assert!(
+            self.roots.insert(first, id).is_none(),
+            "compressed root already exists"
+        );
+        id
+    }
+
+    pub(super) fn insert_child(
+        &mut self,
+        parent: CompressedNodeId,
+        edge: Vec<SequenceHash>,
+        metadata: M,
+    ) -> CompressedNodeId {
+        assert!(!edge.is_empty(), "compressed child edge cannot be empty");
+        assert!(
+            self.nodes.contains_key(parent),
+            "compressed child parent is missing"
+        );
+        let first = edge[0];
+        let id = self.nodes.insert(CompressedPathNode {
+            edge,
+            parent: Some(parent),
+            children: FxHashMap::default(),
+            metadata,
+        });
+        let previous = self.nodes[parent].children.insert(first, id);
+        assert!(previous.is_none(), "compressed child already exists");
+        id
+    }
+
+    /// Split `node_id` at `split_at`, preserving `node_id` for the suffix.
+    pub(super) fn split_keep_suffix(
+        &mut self,
+        node_id: CompressedNodeId,
+        split_at: usize,
+        prefix_metadata: M,
+    ) -> CompressedNodeId {
+        let (old_parent, old_first, prefix_edge, suffix_first) = {
+            let node = self
+                .nodes
+                .get_mut(node_id)
+                .expect("compressed split node is missing");
+            assert!(
+                split_at > 0 && split_at < node.edge.len(),
+                "compressed split must be inside the edge"
+            );
+            let old_parent = node.parent;
+            let old_first = node.edge[0];
+            let suffix = node.edge.split_off(split_at);
+            let prefix = std::mem::replace(&mut node.edge, suffix);
+            let suffix_first = node.edge[0];
+            (old_parent, old_first, prefix, suffix_first)
+        };
+
+        let prefix_id = self.nodes.insert(CompressedPathNode {
+            edge: prefix_edge,
+            parent: old_parent,
+            children: FxHashMap::from_iter([(suffix_first, node_id)]),
+            metadata: prefix_metadata,
+        });
+        self.nodes[node_id].parent = Some(prefix_id);
+        self.splits = self.splits.saturating_add(1);
+
+        if let Some(parent_id) = old_parent {
+            let replaced = self.nodes[parent_id].children.insert(old_first, prefix_id);
+            assert_eq!(
+                replaced,
+                Some(node_id),
+                "compressed parent did not reference the split node"
+            );
+        } else {
+            let replaced = self.roots.insert(old_first, prefix_id);
+            assert_eq!(
+                replaced,
+                Some(node_id),
+                "compressed roots did not reference the split node"
+            );
+        }
+
+        prefix_id
+    }
+
+    /// Remove an empty leaf and detach it from its parent/root map.
+    pub(super) fn remove_leaf(&mut self, node_id: CompressedNodeId) -> CompressedPathNode<M> {
+        let node = self
+            .nodes
+            .remove(node_id)
+            .expect("compressed leaf is missing");
+        assert!(node.children.is_empty(), "cannot remove a non-leaf node");
+        let first = node.edge[0];
+        if let Some(parent_id) = node.parent {
+            let removed = self.nodes[parent_id].children.remove(&first);
+            assert_eq!(
+                removed,
+                Some(node_id),
+                "compressed parent did not reference the removed leaf"
+            );
+        } else {
+            let removed = self.roots.remove(&first);
+            assert_eq!(
+                removed,
+                Some(node_id),
+                "compressed roots did not reference the removed leaf"
+            );
+        }
+        node
+    }
+
+    /// Merge a nonterminal unary parent into its child, preserving `child_id`.
+    pub(super) fn merge_parent_into_child(
+        &mut self,
+        parent_id: CompressedNodeId,
+        child_id: CompressedNodeId,
+    ) {
+        let parent = self
+            .nodes
+            .remove(parent_id)
+            .expect("compressed merge parent is missing");
+        assert_eq!(parent.children.len(), 1, "merge parent must be unary");
+        assert_eq!(
+            parent.children.values().next().copied(),
+            Some(child_id),
+            "merge parent does not reference the selected child"
+        );
+
+        let parent_parent = parent.parent;
+        let old_first = parent.edge[0];
+        let child = self
+            .nodes
+            .get_mut(child_id)
+            .expect("compressed merge child is missing");
+        assert_eq!(
+            child.parent,
+            Some(parent_id),
+            "compressed merge child has a different parent"
+        );
+        let mut merged_edge = parent.edge;
+        merged_edge.append(&mut child.edge);
+        child.edge = merged_edge;
+        child.parent = parent_parent;
+        self.merges = self.merges.saturating_add(1);
+
+        if let Some(grandparent_id) = parent_parent {
+            let replaced = self.nodes[grandparent_id]
+                .children
+                .insert(old_first, child_id);
+            assert_eq!(
+                replaced,
+                Some(parent_id),
+                "compressed grandparent did not reference the merge parent"
+            );
+        } else {
+            let replaced = self.roots.insert(old_first, child_id);
+            assert_eq!(
+                replaced,
+                Some(parent_id),
+                "compressed roots did not reference the merge parent"
+            );
+        }
+    }
+
+    pub(super) fn path_from_root(&self, tail: CompressedNodeId) -> Vec<CompressedNodeId> {
+        let mut path = Vec::new();
+        let mut current = Some(tail);
+        while let Some(node_id) = current {
+            let node = self
+                .nodes
+                .get(node_id)
+                .expect("compressed path references a missing node");
+            path.push(node_id);
+            current = node.parent;
+        }
+        path.reverse();
+        path
+    }
+
+    #[cfg(test)]
+    pub(super) fn hash_count(&self) -> usize {
+        self.nodes.values().map(|node| node.edge.len()).sum()
+    }
+
+    #[cfg(any(test, debug_assertions))]
+    pub(super) fn assert_topology(&self) {
+        for (&first, &root_id) in &self.roots {
+            let root = self
+                .nodes
+                .get(root_id)
+                .expect("compressed roots reference a missing node");
+            assert_eq!(root.parent, None, "compressed root has a parent");
+            assert_eq!(
+                root.edge.first(),
+                Some(&first),
+                "compressed root key mismatch"
+            );
+        }
+
+        for (node_id, node) in &self.nodes {
+            assert!(!node.edge.is_empty(), "compressed node edge is empty");
+            match node.parent {
+                Some(parent_id) => {
+                    let parent = self
+                        .nodes
+                        .get(parent_id)
+                        .expect("compressed node parent is missing");
+                    assert_eq!(
+                        parent.children.get(&node.edge[0]),
+                        Some(&node_id),
+                        "compressed parent-child link mismatch"
+                    );
+                }
+                None => assert_eq!(
+                    self.roots.get(&node.edge[0]),
+                    Some(&node_id),
+                    "compressed root link mismatch"
+                ),
+            }
+            for (&first, &child_id) in &node.children {
+                let child = self
+                    .nodes
+                    .get(child_id)
+                    .expect("compressed child link is stale");
+                assert_eq!(
+                    child.parent,
+                    Some(node_id),
+                    "compressed child parent mismatch"
+                );
+                assert_eq!(
+                    child.edge.first(),
+                    Some(&first),
+                    "compressed child key mismatch"
+                );
+            }
+        }
+    }
+}

--- a/lib/kv-router/src/sequences/compressed_path_arena.rs
+++ b/lib/kv-router/src/sequences/compressed_path_arena.rs
@@ -26,8 +26,6 @@ pub(super) struct CompressedPathNode<M> {
 pub(super) struct CompressedPathArena<M> {
     pub(super) nodes: SlotMap<CompressedNodeId, CompressedPathNode<M>>,
     pub(super) roots: FxHashMap<SequenceHash, CompressedNodeId>,
-    pub(super) splits: u64,
-    pub(super) merges: u64,
 }
 
 impl<M> Default for CompressedPathArena<M> {
@@ -35,8 +33,6 @@ impl<M> Default for CompressedPathArena<M> {
         Self {
             nodes: SlotMap::with_key(),
             roots: FxHashMap::default(),
-            splits: 0,
-            merges: 0,
         }
     }
 }
@@ -116,7 +112,6 @@ impl<M> CompressedPathArena<M> {
             metadata: prefix_metadata,
         });
         self.nodes[node_id].parent = Some(prefix_id);
-        self.splits = self.splits.saturating_add(1);
 
         if let Some(parent_id) = old_parent {
             let replaced = self.nodes[parent_id].children.insert(old_first, prefix_id);
@@ -195,7 +190,6 @@ impl<M> CompressedPathArena<M> {
         merged_edge.append(&mut child.edge);
         child.edge = merged_edge;
         child.parent = parent_parent;
-        self.merges = self.merges.saturating_add(1);
 
         if let Some(grandparent_id) = parent_parent {
             let replaced = self.nodes[grandparent_id]

--- a/lib/kv-router/src/sequences/mod.rs
+++ b/lib/kv-router/src/sequences/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod block_tracker;
+mod compressed_path_arena;
 pub mod multi_worker;
 mod prefill_tracker;
 mod prompt_membership_trie;

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -187,6 +187,7 @@ impl ActiveSequences {
         let (blocks, first_new_prompt_idx) = self.blocks.acquire_prompt(&prompt_hashes);
 
         if let Some(first_new_prompt_idx) = first_new_prompt_idx {
+            #[cfg(any(test, debug_assertions))]
             debug_assert!(
                 prompt_hashes[first_new_prompt_idx..]
                     .iter()


### PR DESCRIPTION
## Summary

- Replace each worker's per-block prompt arena and reverse hash map with compressed radix-tree edges while preserving stable request handles across splits.
- Keep the arena split-only during request lifetimes: release removes dead suffixes but does not eagerly recompress retained unary paths.
- Use the trusted `SequenceHash` lineage contract to check the boundary hash before scanning a compressed edge during prompt acquisition.
- Keep active-block load accounting O(1) with running prompt and output totals, and avoid reconstructing a prompt path when release removes no prompt blocks.
- Preserve prompt-membership deltas, fractional accounting, output bookkeeping, expiry, replica replay, and routing behavior. `PromptMembershipTrie`, `PromptRegistry`, CRTC, KV events, and public APIs are unchanged.

## Validation

- `cargo fmt --all -- --check`
- `cargo test --locked -p dynamo-kv-router --lib block_tracker` (13 passed)
- `cargo test --locked -p dynamo-kv-router --lib` (741 passed, 2 ignored)
- `cargo check --locked --release -p dynamo-kv-router`
- `cargo clippy --locked -p dynamo-kv-router --lib -- -D warnings`
- Optimized Python bindings build and matched AgentX frontend end-to-end run

### End-to-end AgentX block-size-1 profile

The comparison repeats the original accepted methodology exactly: all 336 AgentX/Weka entries, concurrency 256, 32 warmups, 120 measured seconds, eight block-size-1 mock workers, frontend pinned to CPU 0, mockers and AIPerf on CPUs 1-23, fastokens with a 1 GiB tokenizer cache, jemalloc, and a 40-second `cycles:u`/99 Hz/DWARF frontend capture after 40 seconds of settling.

| Metric | Original baseline | This PR | Change |
|---|---:|---:|---:|
| Input tokens/s | 1,146,733 | 1,143,492 | -0.28% |
| Mean request latency | 15,268 ms | 15,215 ms | -0.35% |
| Frontend process CPU | 61.02% | 39.48% | **-35.30%** |
| Frontend CPU 0 aggregate busy | 66.47% | 41.11% | **-38.16%** |
| TTFT p50 | 487 ms | 398 ms | **-18.28%** |
| TTFT p95 | 2,365 ms | 1,587 ms | **-32.91%** |
| TTFT p99 | 3,054 ms | 2,216 ms | **-27.45%** |
| Frontend cycles with active-sequence frames | 25.79% | 2.04% | **-23.75 pp** |
| Absolute sampled active-sequence cycle weight | 24.67B | 1.11B | **-95.51%** |
| Total sampled frontend cycle weight | 95.68B | 54.27B | **-43.28%** |

The old per-block `HashMap::insert`, `RawTable::remove_entry`, and `BlockTracker::live_node_id` leaves disappear from the candidate's top self-time list. End-to-end input throughput and mean latency are effectively unchanged while frontend CPU, TTFT, and active-sequence tracking time fall substantially.

Both arms remain overloaded profiles rather than clean capacity measurements, and this is one matched run per arm. Event-plane lag warnings fell from 231 to 103 and skipped messages from 86,349 to 38,877. In the same run, output tokens/s was 1.43% lower and request-latency p99 was 1.09% higher.
