### PR TITLE
docs(router): clarify KV event setup and stream tuning

### DIFF
--- a/components/src/dynamo/router/README.md
+++ b/components/src/dynamo/router/README.md
@@ -11,6 +11,47 @@ The standalone router provides configurable KV-aware routing for any set of work
 
 This component is **fully configurable** and works with any Dynamo backend (vLLM, TensorRT-LLM, SGLang, etc.) and any worker endpoint.
 
+## Required KV Event Configuration
+
+Event-driven KV routing requires configuration at the frontend and each event-producing worker:
+
+1. For the embedded router, start the frontend with `--router-mode kv`.
+   The standalone `python -m dynamo.router` process is already a KV router and does not accept
+   this flag.
+2. Start each aggregated worker with the backend `--kv-events-config` shown below.
+   In a standard disaggregated deployment, add this configuration to each prefill worker.
+
+The frontend flag does not enable the engine publisher. Without the worker flag, the worker-local
+indexer receives no engine KV events. The router then cannot track the worker's actual cache
+contents.
+
+**vLLM:**
+
+```bash
+python -m dynamo.vllm --model MODEL_NAME \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+```
+
+The vLLM JSON must set `"enable_kv_cache_events":true`. If you omit the other fields, vLLM uses
+the ZMQ publisher and its default endpoint. The complete form makes the transport and endpoint
+explicit.
+
+**SGLang:**
+
+```bash
+python -m dynamo.sglang --model-path MODEL_NAME \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+```
+
+The SGLang JSON must include `"publisher":"zmq"` and `"endpoint"`. The `"topic"` field is
+optional. The vLLM-only `{"enable_kv_cache_events":true}` form does not enable SGLang events.
+
+For workers that share a network namespace, use a unique endpoint port. The engine publishes raw
+events over ZMQ to its Dynamo worker. The worker updates its worker-local indexer. It sends
+normalized state updates to the router over Dynamo's separate event plane.
+
+To route without engine events, enable approximate cache prediction with `--no-router-kv-events`.
+
 ## Usage
 
 ### Command Line
@@ -73,11 +114,14 @@ python -m dynamo.router \
 # Start decode workers
 python -m dynamo.vllm --model MODEL_NAME --block-size 64 &
 
-# Start prefill workers
-python -m dynamo.vllm --model MODEL_NAME --block-size 64 --disaggregation-mode prefill &
+# Start prefill workers with KV event publication
+python -m dynamo.vllm --model MODEL_NAME --block-size 64 --disaggregation-mode prefill \
+    --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 ```
 
-For event-driven prefix-cache state, add the backend-specific KV event publishing flags to the workers that the router indexes. Use `--no-router-kv-events` on the router only when approximate cache-state prediction is acceptable.
+The prefill command includes the required vLLM event configuration. For SGLang or more workers,
+use the guidance in [Required KV Event Configuration](#required-kv-event-configuration).
+Use `--no-router-kv-events` only for approximate cache-state prediction.
 
 >[!Note]
 > **Why `--no-router-track-active-blocks` for prefill routing?**

--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/communication-planes/request-plane.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/communication-planes/request-plane.md
@@ -29,7 +29,13 @@ Dynamo has **two independent communication planes**:
 - **Request plane** (**`DYN_REQUEST_PLANE`**): how **RPC requests** flow between components (frontend → router → worker), via `tcp`, or `nats`.
 - **KV event plane** (**`DYN_EVENT_PLANE`**): how **KV cache events** (and optional router replica sync) are distributed for KV-aware routing, via `nats` or `zmq`.
 
-**Note:** If you are using `tcp` request plane with KV events enabled on the router (the default router-side setting), the configured event plane is initialized independently. NATS-based event transport uses `NATS_SERVER` (default `nats://localhost:4222`), while ZMQ avoids external NATS infrastructure. SGLang requires explicit `--kv-events-config` and TRT-LLM requires `--publish-events-and-metrics` to publish events. For vLLM, KV events are currently auto-configured when prefix caching is active (deprecated — use `--kv-events-config` explicitly to prepare for a future release where all backends will default to off). To disable the router's KV event listener, use `--no-router-kv-events` on the frontend.
+**Note:** If you use the `tcp` request plane, the router initializes the configured event plane
+independently. The router consumes KV events by default. NATS-based event transport uses
+`NATS_SERVER` with a default value of
+`nats://localhost:4222`. ZMQ does not require external NATS infrastructure. vLLM and SGLang require
+`--kv-events-config` to expose engine KV events to their Dynamo workers. TRT-LLM requires
+`--publish-kv-events`. To disable the router KV event listener, use `--no-router-kv-events` on the
+frontend.
 
 Because they are independent, you can mix them.
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/reference-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/sglang/reference-guide.md
@@ -120,9 +120,44 @@ walkthrough, see [Metrics and Dashboards](../../../../../cli/operations/observab
 
 ### KV Events
 
-When configured with `--kv-events-config`, workers publish KV cache events (block creation/deletion) for the [KV-aware router](../../router/overview.md). Events are published via ZMQ from SGLang's scheduler and relayed through Dynamo's event plane.
+`--router-mode kv` configures the frontend router but does not enable SGLang's KV event publisher.
+For event-driven KV routing, pass `--kv-events-config` to every aggregated worker. In a standard
+disaggregated deployment, pass it to every prefill worker:
+
+```bash
+python -m dynamo.sglang --model-path Qwen/Qwen3-0.6B \
+  --stream-interval 20 \
+  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+```
+
+The SGLang JSON must include `"publisher":"zmq"` and an explicit `"endpoint"`. The `"topic"`
+field is optional. SGLang does not recognize `{"enable_kv_cache_events":true}` as event
+enablement. Do not reuse this vLLM-only form.
+
+Without `--kv-events-config`, SGLang does not publish KV events. The configuration makes SGLang emit
+raw cache events over ZMQ to its Dynamo worker. Dynamo normalizes and coalesces the events. It then
+updates the worker-local indexer and republishes the state updates to the router. This publication
+uses Dynamo's event plane. Dynamo enables the worker-local indexer after it creates the publisher.
+The worker-local indexer does not enable the SGLang event source.
+
+SGLang does not support Dynamo's experimental conditional-disaggregation bypass. Therefore,
+standard disaggregated deployments do not need KV event publication on decode workers. For workers
+that share a network namespace, use a unique ZMQ endpoint port.
+
+For approximate routing without engine events, omit `--kv-events-config` from all workers. Start
+the frontend with `--no-router-kv-events`. You can instead set `DYN_ROUTER_USE_KV_EVENTS=false`.
 
 For DP attention mode (`--enable-dp-attention`), the publisher handles multiple DP ranks per node, each with its own KV event stream.
+
+### Recommended Stream Interval
+
+Start with `--stream-interval 20` on SGLang workers. The default interval of `1` can produce one
+engine output for each generated token. An interval of `20` reduces host-side output processing
+and Dynamo bridge crossings under load. The tradeoff is coarser stream updates.
+
+The SGLang frontend processor has a separate default interval of `20`. To override this value, set
+`DYN_SGLANG_STREAM_INTERVAL` on the frontend. The worker flag does not propagate to the frontend.
+When fine-grained stream updates are more important than host efficiency, use a lower interval.
 
 ## Engine Routes
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md
@@ -25,6 +25,46 @@ The `--help` output is organized into the following groups:
 - **Dynamo vLLM Options** — Disaggregation mode, tokenizer selection, sleep mode, multimodal flags, vLLM-Omni pipeline configuration, headless mode, and ModelExpress. These use `DYN_VLLM_*` env vars. See [vLLM Configuration](../../../../../reference/backends/vllm-configuration.mdx) for the full field reference.
 - **vLLM Engine Options** — All native vLLM arguments (`--model`, `--tensor-parallel-size`, `--kv-transfer-config`, `--kv-events-config`, `--enable-prefix-caching`, etc.). See the [vLLM serve args documentation](https://docs.vllm.ai/en/stable/configuration/serve_args.html).
 
+### KV Event Publication for KV Routing
+
+`--router-mode kv` configures the frontend router but does not enable vLLM's KV event publisher.
+For event-driven KV routing, pass `--kv-events-config` to every aggregated worker. In a standard
+disaggregated deployment, pass it to every prefill worker:
+
+```bash
+python -m dynamo.vllm --model Qwen/Qwen3-0.6B \
+  --stream-interval 20 \
+  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+```
+
+The vLLM JSON must set `"enable_kv_cache_events":true`. If a worker uses vLLM's default ZMQ
+endpoint, `--kv-events-config '{"enable_kv_cache_events":true}'` is sufficient. The complete form
+makes the transport, topic, and endpoint explicit. It also lets colocated workers use unique ports.
+
+Without `--kv-events-config`, vLLM does not publish KV events. The configuration makes vLLM emit
+raw cache events over ZMQ to its Dynamo worker. Dynamo normalizes and coalesces the events. It then
+updates the worker-local indexer and republishes the state updates to the router. This publication
+uses Dynamo's event plane. Dynamo enables the worker-local indexer after it creates the publisher.
+The worker-local indexer does not enable the vLLM event source.
+
+In standard disaggregated serving, Dynamo routes decode workers by load. These workers do not need
+`--kv-events-config`. The experimental conditional-disaggregation path also evaluates decode-cache
+overlap. Its decode workers must expose KV events. For workers that share a network namespace, use
+a unique ZMQ endpoint port.
+
+For approximate routing without engine events, omit `--kv-events-config` from all workers. Start
+the frontend with `--no-router-kv-events`. You can instead set `DYN_ROUTER_USE_KV_EVENTS=false`.
+
+### Recommended Stream Interval
+
+Start with `--stream-interval 20` on vLLM workers. The default interval of `1` can produce one
+engine output for each generated token. An interval of `20` reduces host-side output processing
+and Dynamo bridge crossings under load. The tradeoff is coarser stream updates after the first chunk.
+
+Dynamo publishes the worker interval in runtime metadata. The vLLM frontend processor uses this
+value. To override the worker value, set `DYN_VLLM_STREAM_INTERVAL` on the frontend. When
+fine-grained stream updates are more important than host efficiency, use a lower interval.
+
 ### Tool and Reasoning Parsers
 
 Use `--dyn-tool-call-parser` and `--dyn-reasoning-parser` to match the model's output format when the model emits tool calls and/or reasoning content. The current supported values are documented in [Tool Call Parsing (Dynamo)](../../../../../use-cases/tool-calling-and-reasoning/tool-call-parsing.mdx#supported-tool-call-parsers) and [Reasoning Parsing (Dynamo)](../../../../../use-cases/tool-calling-and-reasoning/reasoning-parsing.md#supported-reasoning-parsers).

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/kv-event-replay-comparison.md
@@ -2,21 +2,38 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 title: KV Event Replay — Dynamo vs vLLM
-subtitle: How the two systems handle gap detection, replay, and recovery for KV cache events
+subtitle: How vLLM replay and Dynamo worker-local recovery protect different KV event hops
 ---
 
 ## Overview
 
-Both Dynamo and vLLM publish KV cache events (block stored, block removed, etc.) over a fire-and-forget transport (ZMQ PUB/SUB). Because PUB/SUB is lossy, both systems need a mechanism for consumers to detect missed messages and recover. This document compares the two approaches.
+vLLM's replay buffer and Dynamo's worker-local indexer protect different parts of the KV event
+path. vLLM can offer replay to a consumer of its raw ZMQ engine stream. Dynamo consumes and
+normalizes that engine stream inside the worker. It then uses its worker-local indexer to recover
+routers that miss events on Dynamo's separate worker-to-router event plane.
+
+Dynamo's vLLM integration subscribes to the raw PUB stream. It does not use the vLLM replay socket.
+A worker-local snapshot restores all cache state that the Dynamo worker indexed. It cannot
+reconstruct a raw engine event that did not reach the worker.
 
 ## The Problem
 
-A KV event consumer (router, cache coordinator) subscribes to a live stream of block events from workers. Events carry monotonically increasing sequence numbers. When the consumer detects a gap in the sequence (e.g., received seq 42 then seq 45), it needs to recover the missed events or it will have a stale, incorrect view of the worker's KV cache state.
+There are two possible loss boundaries:
+
+1. **Engine to Dynamo worker:** The engine publishes raw events over ZMQ. Dynamo normalizes accepted
+   events and assigns its own event IDs. The listener reads the engine sequence number for logs.
+   It does not use the engine replay socket. Therefore, the Dynamo worker-local indexer cannot
+   recover a lost raw message.
+2. **Dynamo worker to router:** The worker updates its worker-local indexer before it publishes
+   normalized events over Dynamo's event plane. If the router detects a sequence gap, it can query
+   the worker.
+   The worker returns retained events or a current tree snapshot.
 
 ## Architecture Comparison
 
 | | vLLM Replay Buffer | Dynamo Local Indexer |
 |---|---|---|
+| **Recovery boundary** | Raw vLLM publisher to a replay-aware consumer | Dynamo worker to router |
 | **Core buffer** | `collections.deque[tuple[int, bytes]]` with `maxlen` | `VecDeque<RouterEvent>` with `max_buffer_size` |
 | **Buffer semantics** | FIFO ring, old entries silently dropped | FIFO ring, old entries silently dropped |
 | **Event ordering** | Monotonic sequence number (8-byte int) | Monotonic `event_id` with consecutive-ID validation |
@@ -30,7 +47,7 @@ A KV event consumer (router, cache coordinator) subscribes to a live stream of b
 | **Transport** | ZMQ PUB/SUB + ROUTER/REQ | Dynamo service RPC (request/response) |
 | **Multi-rank** | Port offset per DP rank | Separate query endpoint per DP rank |
 | **Thread model** | Background thread with queue | Single-threaded tokio runtime on dedicated OS thread |
-| **Delivery guarantee** | Fire-and-forget live delivery; replay is bounded by retained history | Fire-and-forget live delivery; recovery can return retained events or a snapshot |
+| **Delivery guarantee** | Live delivery is fire-and-forget. Replay retains a bounded history. | Recovery can return retained normalized events or a snapshot. It does not repair engine-to-worker loss. |
 | **Duplicate/stale events** | Consumer filters by sequence number | Router filters stale event IDs and coordinates per-rank recovery |
 
 ## How Each System Works
@@ -53,7 +70,10 @@ The publisher keeps a `deque` of the last `buffer_steps` (default 10,000) serial
 
 ### Dynamo: Buffer + Indexer with Tree Dump Fallback
 
-Dynamo's `LocalKvIndexer` (in `lib/kv-router/src/indexer/local.rs`) wraps a `KvIndexer` (backed by a `RadixTree`) with a circular event buffer:
+After the Dynamo worker accepts and normalizes an engine event, it applies the resulting state
+update to `LocalKvIndexer`. It does this before publication over Dynamo's event plane.
+`LocalKvIndexer` (in `lib/kv-router/src/indexer/local.rs`) wraps a `KvIndexer` (backed by a
+`RadixTree`) with a circular event buffer:
 
 ```text
 LocalKvIndexer
@@ -77,7 +97,9 @@ The snapshot fallback makes an evicted replay range recoverable while the worker
 
 ## Gap Detection
 
-Both systems detect gaps the same way: the consumer tracks the last sequence/event ID it processed and compares it against the next one received.
+Both recovery mechanisms use increasing IDs, but they operate on different sequences. A
+replay-aware vLLM consumer tracks the engine publisher sequence. The Dynamo router tracks IDs that
+the worker assigns after it accepts and normalizes raw events.
 
 **vLLM** (from `examples/online_serving/kv_events_subscriber.py`):
 ```python
@@ -92,6 +114,9 @@ The router tracks an admission cursor per worker and data-parallel rank. Discove
 
 On success, the router transactionally replaces the rank from `TreeDump`, advances to the worker's real-event watermark, then drains buffered live events. If snapshot construction or transport fails, the router resets or fences the affected rank as appropriate and continues with degraded live-event processing. A later gap or source change can trigger another recovery.
 
+The Dynamo worker assigns this sequence after raw-event filtering. Therefore, its gap detection
+does not reveal an engine ZMQ message that was lost before ingestion.
+
 ## When to Use Which
 
 **vLLM's built-in replay** is a good fit when:
@@ -104,13 +129,19 @@ On success, the router transactionally replaces the rank from `TreeDump`, advanc
 - You are running multiple router replicas that may start at different times and should independently rebuild cache state from workers.
 - You want dedup and recovery handled by the infrastructure rather than implementing it in each consumer.
 
-The two approaches share the same core idea — a FIFO ring buffer for catching up on small, transient gaps. Dynamo adds a RadixTree underneath, which enables a current-state snapshot fallback at the cost of additional memory and complexity. vLLM keeps replay history in the buffer, which is sufficient when consumers are stable and gaps remain inside the retained window.
+Both approaches use a FIFO ring buffer to recover small, temporary gaps. They are not
+interchangeable. vLLM replay can protect the raw engine hop for consumers that use its replay
+socket. Dynamo adds a RadixTree after engine ingestion. This tree provides current-state snapshots
+for routers on the second hop.
 
-For deployments using Dynamo's KV-aware routing, the local indexer is used automatically. For standalone vLLM deployments where you want to build your own event consumer, vLLM's replay buffer provides a lightweight starting point.
+For Dynamo KV-aware routing, Dynamo enables the worker-local indexer after the worker has a KV event
+publisher. vLLM and SGLang still require `--kv-events-config` to feed that publisher. For standalone
+vLLM deployments, the replay buffer provides a lightweight base for a custom event consumer.
 
 ## See Also
 
 - **[KV Router Index Data Structures](https://github.com/ai-dynamo/dynamo/blob/main/lib/kv-router/src/indexer/README.md)**: `RadixTree`, `ConcurrentRadixTree`, and `PositionalIndexer` internals
 - **[Router Guide](router-guide.md)**: Deployment modes and quick start for KV-aware routing
 - **[Configuration and Tuning](configuration-and-tuning.md)**: Router flags and tuning details
-- **[Router Design](router-design.md)**: Architecture details and event transport modes
+- **[Router Design](router-design.md#event-flow-and-recovery)**: Engine-to-worker ingestion,
+  worker-local indexing, and router recovery

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -9,28 +9,62 @@ The Dynamo KV Router intelligently routes requests by evaluating their computati
 
 ## Quick Start
 
-To launch the Dynamo frontend with the KV Router:
+Event-driven KV routing requires configuration at the frontend and each worker whose cache state
+the router tracks.
 
-```bash
-python -m dynamo.frontend --router-mode kv --http-port 8000
-```
+> [!IMPORTANT]
+> Event-driven KV routing requires both configurations below. `--router-mode kv` enables worker
+> selection on the frontend. It does not enable KV event publication in vLLM or SGLang. Without
+> `--kv-events-config` on event-producing workers, no engine events reach the worker-local indexer
+> or router.
+
+1. Start the frontend with the KV router enabled:
+
+   ```bash
+   python -m dynamo.frontend --router-mode kv --http-port 8000
+   ```
+
+2. Enable engine KV event publication on each aggregated worker.
+   For a standard disaggregated deployment, enable publication on each prefill worker.
+
+   For vLLM:
+
+   ```bash
+   python -m dynamo.vllm --model Qwen/Qwen3-0.6B \
+     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+   ```
+
+   For SGLang:
+
+   ```bash
+   python -m dynamo.sglang --model-path Qwen/Qwen3-0.6B \
+     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+   ```
+
+   For vLLM, the JSON must set `"enable_kv_cache_events":true`. If you omit the other fields,
+   vLLM uses its ZMQ publisher and default endpoint. For SGLang, the JSON must include
+   `"publisher":"zmq"` and `"endpoint"`. The `"topic"` field is optional. Do not use the
+   vLLM-only `{"enable_kv_cache_events":true}` form for SGLang.
+
+For workers that share a network namespace, use a unique event endpoint port. The
+`--kv-events-config` flag configures the first event hop from the engine to its Dynamo worker.
+The worker normalizes the events and applies them to its worker-local indexer. It publishes the
+normalized updates to the router over Dynamo's separate event plane. See
+[Router Design](router-design.md#event-flow-and-recovery) for the full data path and recovery
+boundary.
 
 The [Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router) is the
 canonical reference for embedded-router flags, environment variables, defaults, and
 boolean forms. See [Configuration and Tuning](configuration-and-tuning.md) for behavioral
 guidance.
 
-> [!IMPORTANT]
-> `--router-mode kv` (or `DYN_ROUTER_MODE=kv`) enables KV routing on the
-> frontend, but it does not enable KV event publishing on backend workers. With
-> the default `--router-kv-events` setting, missing publishers leave the router
-> in event-driven mode without real cache state; the router does not
-> automatically switch to approximate prediction. Configure the backend-specific
-> publishing flags in [Router Operations](router-operations.md#additional-notes).
-> If workers will not publish events, use `--no-router-kv-events` for approximate
-> cache prediction or `--load-aware` for load-only routing.
+Without the worker flag, the router does not automatically switch to approximate prediction.
+If workers will not publish events, use `--no-router-kv-events` for approximate cache prediction.
+For load-only routing, use `--load-aware`.
 
-For Kubernetes, set `DYN_ROUTER_MODE=kv` on the Frontend service.
+For Kubernetes, set `DYN_ROUTER_MODE=kv` on the Frontend service. Add the backend event flag to the
+workers described above. See [Using the Dynamo Frontend](../../../../kubernetes/kv-aware-routing/dynamo-frontend.md)
+for complete `DynamoGraphDeployment` snippets.
 
 ### Standalone Router
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-design.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-design.md
@@ -173,50 +173,50 @@ In distributed deployments with multiple routers, each router initially sees onl
 
 Each event carries a unique router ID to prevent self-event processing. Publication is fire-and-forget and the bounded outbound publisher queue drops the newest event when full. These events improve cross-replica active-load estimates; they do not synchronize prefix-cache state or guarantee identical routing decisions. Output-block growth is tracked locally rather than published as a lifecycle event. Routers periodically force-expire stale synchronized requests; configure the safety timeout with `DYN_ROUTER_ACTIVE_REQUEST_EXPIRY_SECS` (default `300` seconds).
 
-## Event Transport Modes
+## Event Flow and Recovery
 
-KV cache events use fire-and-forget pub/sub through the configured event plane. Workers maintain local radix trees, and routers rebuild state by querying workers on startup. The event plane supports both NATS Core and ZMQ.
+KV event delivery has two distinct hops. vLLM and SGLang first publish raw engine events over the
+ZMQ endpoint configured by `--kv-events-config`. A Dynamo worker subscribes to that endpoint. It
+normalizes and coalesces the engine events into router state updates. It applies each accepted
+update to its worker-local indexer. It then publishes the same update over Dynamo's event plane.
+Router replicas subscribe to this second hop.
 
-### Event Plane with Local Indexers
-
-By default, workers have local indexer enabled. Each worker maintains its own local radix tree (local indexer) and publishes events over the generic event plane (NATS Core or ZMQ, depending on `--event-plane`). Each worker assigns monotonically increasing event IDs to its events. The router detects gaps in event sequences and recovers missed events by querying the worker's local indexer directly.
-
-- **Best for**: Low-latency event delivery, multi-router deployments, and deployments without NATS (using the ZMQ event plane)
-- **Tradeoffs**: State persists on workers (not centralized); recovery depends on workers being available
+Dynamo enables worker-local indexing after it creates a KV event publisher. The indexer is not an
+independent engine event listener. This default does not create an engine event source. Therefore,
+vLLM and SGLang workers need `--kv-events-config` to feed engine events to the worker.
 
 ```mermaid
-graph TD
-    subgraph Engines
-        E1[Engine 1<br/>LocalKvIndexer]
-        E2[Engine 2<br/>LocalKvIndexer]
-        E3[Engine 3<br/>LocalKvIndexer]
+flowchart LR
+    subgraph Engine
+        E["vLLM or SGLang<br/>KV cache events"]
     end
 
-    subgraph "Event Plane (NATS / ZMQ)"
-        NC[KV Events Pub/Sub<br/>- Block created<br/>- Block removed]
+    subgraph "Dynamo worker"
+        N["Event listener and normalizer"]
+        L["Worker-local indexer"]
+        P["Event-plane publisher"]
     end
 
-    subgraph "Router Replicas"
-        R1[Router 1<br/>KVIndexer]
-        R2[Router 2<br/>KVIndexer]
+    subgraph "Dynamo event plane"
+        EP["KV state updates"]
     end
 
-    E1 -->|Publish Events| NC
-    E2 -->|Publish Events| NC
-    E3 -->|Publish Events| NC
+    R["Router<br/>KV indexer"]
 
-    NC -->|Subscribe| R1
-    NC -->|Subscribe| R2
-
-    style NC fill:#e1f5fe,stroke:#333,color:#333
-    style E1 fill:#f3e5f5,stroke:#333,color:#333
-    style E2 fill:#f3e5f5,stroke:#333,color:#333
-    style E3 fill:#f3e5f5,stroke:#333,color:#333
-    style R1 fill:#2e8b57,stroke:#333,color:#fff
-    style R2 fill:#2e8b57,stroke:#333,color:#fff
-
-    linkStyle 0,1,2,3,4 stroke:#2196f3,stroke-width:2px
+    E -->|"Raw events over configured ZMQ endpoint"| N
+    N -->|"Accepted, normalized updates"| L
+    N -->|"Same updates"| P
+    P --> EP
+    EP --> R
+    R -.->|"Startup and gap recovery"| L
 ```
+
+The worker-local indexer receives each accepted state update before Dynamo publishes it to the
+router. It does not retain a one-to-one log of raw engine events. Dynamo can filter unsupported
+events and coalesce compatible updates. The engine-to-worker ZMQ hop is also best effort. If a raw
+engine message does not reach the Dynamo worker, the worker-local indexer cannot recover it. Worker
+queries recover startup state and gaps on the worker-to-router hop. They do not make the first hop
+lossless.
 
 **How gap detection works:**
 1. Each worker assigns monotonically increasing event IDs starting from 0
@@ -230,7 +230,8 @@ graph TD
 - When a worker is removed, the router removes all its blocks from the global radix tree
 
 > [!NOTE]
-> Workers enable their local indexer by default so routers can recover missed events and rebuild state after a restart.
+> Dynamo enables the worker-local indexer after it creates a KV event publisher. vLLM and SGLang
+> still require `--kv-events-config` to create the engine event source that feeds the indexer.
 
 ### Local Active Block Management with Replica Sync
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-examples.md
@@ -53,11 +53,13 @@ export PYTHONHASHSEED=0
 DYN_SYSTEM_PORT=8081 CUDA_VISIBLE_DEVICES=0 python -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
   --block-size 64 \
+  --stream-interval 20 \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
 DYN_SYSTEM_PORT=8082 CUDA_VISIBLE_DEVICES=1 python -m dynamo.vllm \
   --model Qwen/Qwen3-0.6B \
   --block-size 64 \
+  --stream-interval 20 \
   --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
 ```
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-guide.md
@@ -14,6 +14,12 @@ This guide helps you get started with using the Dynamo router and points to the 
 
 The router can be deployed using [Python / CLI](#python--cli-deployment), [Kubernetes](#kubernetes-deployment), or as a [standalone component](#standalone-router).
 
+> [!IMPORTANT]
+> Event-driven KV routing requires both `--router-mode kv` on the frontend and
+> `--kv-events-config` on each event-producing backend worker. The frontend flag does not start the
+> vLLM or SGLang event publisher. If workers do not publish events, use
+> `--no-router-kv-events` for approximate cache prediction.
+
 ### Python / CLI Deployment
 
 To launch the Dynamo frontend with the KV Router:
@@ -27,7 +33,21 @@ This command:
 - Exposes the service on port 8000 (configurable)
 - Automatically handles all backend workers registered to the Dynamo endpoint
 
-Backend workers register themselves using the `register_model` API. For accurate prefix-cache state, workers must also publish KV cache events with the backend-specific event flags; otherwise the router can run in approximate mode with `--no-router-kv-events`.
+Backend workers register with the `register_model` API. For event-driven prefix-cache state, add
+the applicable worker flag:
+
+```bash
+# vLLM: enable_kv_cache_events is required
+python -m dynamo.vllm --model MODEL_NAME \
+  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+
+# SGLang: publisher and endpoint are required; topic is optional
+python -m dynamo.sglang --model-path MODEL_NAME \
+  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+```
+
+For workers that share a network namespace, use a unique endpoint port. See the
+[Router Quick Start](overview.md#quick-start) for the event flow and backend schemas.
 
 The [Frontend Configuration Reference](../../../../reference/components/frontend-configuration.mdx#router) is the
 canonical list of embedded-router CLI arguments, environment variables, defaults,
@@ -57,7 +77,8 @@ spec:
 
 **Key Points:**
 - Set `DYN_ROUTER_MODE=kv` on the **Frontend** service only
-- Configure worker-side KV event publishing when you want event-driven prefix-cache state
+- Add the backend `--kv-events-config` to every event-producing worker
+- Frontend KV mode does not enable worker event publication
 - Use `--no-router-kv-events` for approximate cache-state prediction when workers are not publishing events
 
 For exact environment-variable mappings, see the
@@ -132,15 +153,19 @@ Use `DYN_ENCODER_CUDA_TO_CPU_RATIO` to approximate the throughput ratio of a non
 
 When only one device class is present, the policy degenerates to standard least-loaded routing.
 
-### KV Event Transport Modes (within `--router-mode kv`)
+### KV Cache State Modes (within `--router-mode kv`)
 
-When using KV routing, the router needs to know what each worker has cached. There are three ways to get this information:
+The KV router needs the cache state of each worker. Choose one of these state modes:
 
-| Event Mode | How to Enable | Description |
+| State Mode | How to Enable | Description |
 |------------|---------------|-------------|
-| **ZMQ (local indexer)** | Router default (no router flag) | Workers maintain a local indexer and publish KV events via ZMQ PUB sockets; the router recovers state by querying live workers. This is the default event plane for all backends |
-| **NATS Core (local indexer)** | `--event-plane nats` (or `DYN_EVENT_PLANE=nats`) | Same local-indexer model, but events flow over NATS Core instead of ZMQ. |
-| **Approximate (no events)** | `--no-router-kv-events` | No events consumed; router predicts cache state from its own routing decisions with TTL-based expiration |
+| **Event-driven** | Router default plus backend `--kv-events-config` | The engine emits raw events to its Dynamo worker. The worker normalizes the events and updates its worker-local indexer. The worker republishes the updates over Dynamo's event plane. The router can query the worker-local indexer to recover worker-to-router event gaps. |
+| **Approximate (no events)** | `--no-router-kv-events` | The router consumes no events. It predicts cache state from its routing decisions and uses time-based expiration. |
+
+The backend `--kv-events-config` and Dynamo's event-plane configuration control different hops.
+One configuration does not change the other. See [Router Design](router-design.md#event-flow-and-recovery)
+for the data path. See [Configuration and Tuning](configuration-and-tuning.md) for event-plane
+selection.
 
 ### Aggregated vs. Disaggregated Topology
 

--- a/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-operations.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/modular-components/router/router-operations.md
@@ -28,11 +28,14 @@ When `--no-router-kv-events` is used, the router does not consume worker KV even
 
 #### Prefix Cache Persistence and Recovery
 
-Prefix cache recovery matters because stale or missing prefix state directly affects cache-hit routing decisions. Dynamo recovers state from worker-local indexers:
+Prefix cache recovery matters because stale or missing prefix state affects cache-hit routing
+decisions. Dynamo uses worker-local indexers to recover worker-to-router event-plane gaps:
 
-- Prefix state persists on workers. Events are fire-and-forget, but workers retain their local indexer state.
+- Each worker applies accepted, normalized state updates to its worker-local indexer before
+  event-plane publication.
 - On startup, each router queries each worker's local indexer to rebuild prefix state.
 - Recovery depends on workers being available. If a worker is down, its blocks cannot be recovered until the worker returns.
+- Recovery does not cover a raw engine event that was lost before it reached the Dynamo worker.
 
 For more on gap detection and replay, see [KV Event Replay — Dynamo vs vLLM](kv-event-replay-comparison.md).
 
@@ -132,11 +135,11 @@ Request-plane transport is independent of KV event transport. The request plane 
 
 When `--router-kv-overlap-score-credit` is set to 0, no KV indexer is created and prefix matching is disabled. When `--no-router-kv-events` is set, a KV indexer is still created but no event subscriber is launched; the router predicts cache state from its own routing decisions with TTL-based expiration.
 
-Backend KV event publishing is independent of the frontend's `--no-router-kv-events` flag. The frontend flag controls whether the router consumes events; backend flags control whether workers publish them. If the router is not consuming events, workers that still publish will waste resources but cause no harm.
-
-- **vLLM**: Pass `--kv-events-config '{"enable_kv_cache_events": false}'` to disable, or `'{"enable_kv_cache_events": true, "publisher": "zmq", "endpoint": "tcp://*:5557"}'` to enable.
-- **SGLang**: Pass `--kv-events-config` with a JSON config to enable, or omit it to keep publishing disabled.
-- **TRT-LLM**: Pass `--publish-kv-events` to enable, or omit it to keep publishing disabled. The legacy `--publish-events-and-metrics` alias is accepted but deprecated.
+Backend KV event publication is independent of the frontend `--no-router-kv-events` flag. The
+frontend flag controls whether the router consumes events. Backend flags control whether workers
+publish events. If the router does not consume events, worker publication uses unnecessary
+resources. See the [Router Quick Start](overview.md#quick-start) for the vLLM and SGLang worker
+configurations. The backend reference guides explain worker roles.
 
 The CLI arg `--router-ttl-secs` controls local cache prediction lifetime when the router operates without receiving events from workers. When workers are configured to publish KV events, the router relies on worker-side eviction events and this parameter is ignored.
 

--- a/docs/fern/pages/kubernetes/auto-deployment/auto-deploy-with-dgdr.md
+++ b/docs/fern/pages/kubernetes/auto-deployment/auto-deploy-with-dgdr.md
@@ -393,6 +393,13 @@ spec:
                   value: kv
 ```
 
+This override changes only the Frontend. Event-driven KV routing also requires backend worker KV
+event publication. With `autoApply: false`, inspect `.status.profilingResults.selectedConfig`.
+Add the complete backend argument list to the applicable aggregated or prefill components. This
+list must include `--kv-events-config`. In `v1beta1`, an override of `containers[].args` replaces
+the generated argument list. See [Using the Dynamo Frontend](../kv-aware-routing/dynamo-frontend.md)
+for the vLLM and SGLang arguments and worker roles.
+
 Inspect `.status.profilingResults.selectedConfig` with `autoApply: false` to find the generated
 component names. An override can modify only components already present in that generated DGD; it
 cannot add a new worker, EPP, or other topology component.

--- a/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
+++ b/docs/fern/pages/kubernetes/kv-aware-routing/dynamo-frontend.md
@@ -34,13 +34,20 @@ spec:
           - kv
 ```
 
-That alone gives you cache-aware routing using load signals. To make routing decisions from real cache contents, complete the next step.
+This configuration enables the router. It does not enable worker KV event publication. Complete the
+next step to route requests by actual cache contents. If you do not publish events, add
+`--no-router-kv-events` for approximate cache prediction. The router does not switch modes
+automatically.
 
 </Step>
 
 <Step title="Publish KV events from the workers">
 
-For the router to track which blocks each worker holds, workers must publish KV cache events. On a vLLM worker, add `--kv-events-config`:
+Workers must publish KV cache events so that the router can track their cache blocks. Add the
+backend configuration to each aggregated worker. For a standard disaggregated deployment, add it
+to each prefill worker.
+
+For vLLM:
 
 ```yaml
   - name: VllmPrefillWorker
@@ -56,13 +63,53 @@ For the router to track which blocks each worker holds, workers must publish KV 
           args:
           - --model
           - Qwen/Qwen3-32B
+          - --stream-interval
+          - "20"
           - --kv-events-config
           - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
 ```
 
-This is the half that the [Router Guide](../../developer-guide/knowledge-base/modular-components/router/router-guide.md) does not show. Without it, the router falls back to load-only decisions even in `kv` mode.
+For SGLang:
 
-The Frontend and worker snippets above are drawn from the [disagg-kv-router recipe](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml), where six prefill workers publish KV events and the Frontend routes across them.
+```yaml
+  - name: SglangPrefillWorker
+    type: prefill
+    podTemplate:
+      spec:
+        containers:
+        - name: main
+          command:
+          - python3
+          - -m
+          - dynamo.sglang
+          args:
+          - --model-path
+          - Qwen/Qwen3-32B
+          - --stream-interval
+          - "20"
+          - --kv-events-config
+          - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+```
+
+Engine event publication requires `--kv-events-config`. The worker-local indexer does not
+activate the engine publisher. The engine publishes raw events to the Dynamo worker. The worker
+updates its worker-local indexer before it relays normalized updates to the router. This relay uses
+Dynamo's event plane. For workers that share a pod or network namespace, use a unique endpoint
+port.
+
+The backend JSON schemas differ. vLLM requires `"enable_kv_cache_events":true`. It can infer the
+ZMQ publisher and default endpoint. SGLang requires `"publisher":"zmq"` and an explicit
+`"endpoint"`. The `"topic"` field is optional. Do not copy the vLLM-only
+`{"enable_kv_cache_events":true}` form into an SGLang worker.
+
+`--stream-interval 20` is a starting value for host efficiency. KV routing does not require it. The
+value reduces host-side engine output processing and Dynamo bridge crossings. The tradeoff is
+coarser stream updates. See the [vLLM](../../developer-guide/knowledge-base/modular-components/backends/vllm/reference-guide.md#recommended-stream-interval)
+and [SGLang](../../developer-guide/knowledge-base/modular-components/backends/sglang/reference-guide.md#recommended-stream-interval)
+reference guides.
+
+The vLLM snippets above come from the [disagg-kv-router recipe](https://github.com/ai-dynamo/dynamo/blob/main/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml).
+In this recipe, six prefill workers publish KV events and the Frontend routes across them.
 
 </Step>
 

--- a/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/router/overview.md
+++ b/docs/fern/translations/zh-CN/pages/developer-guide/knowledge-base/modular-components/router/overview.md
@@ -8,13 +8,52 @@ Dynamo KV Router 通过评估不同 worker 上的计算成本来智能地路由�
 
 ## 快速开始
 
-我们可以通过 Dynamo frontend 使用 KV Router：
+事件驱动的 KV 路由需要同时配置 frontend 和 router 所跟踪 cache 状态的 backend worker。
 
-```bash
-python -m dynamo.frontend --router-mode kv --http-port 8000
-```
+> [!IMPORTANT]
+> 事件驱动的 KV 路由必须同时完成下面两项配置。`--router-mode kv` 只会在 frontend 上启用
+> worker 选择，不会启用 vLLM 或 SGLang 的 KV 事件发布。如果未在发布事件的 worker 上设置
+> `--kv-events-config`，engine 事件就不会进入 worker-local indexer 或 router。
 
-对于 Kubernetes，请在 Frontend service 上设置 `DYN_ROUTER_MODE=kv`。对于事件驱动的 KV 状态，请使用 [Router Operations](../../../../../../../pages/developer-guide/knowledge-base/modular-components/router/router-operations.md#additional-notes) 中描述的后端专用 flag，配置 backend worker 发布 KV cache 事件。仅当你希望使用近似的 cache 状态预测时，才使用 `--no-router-kv-events`。
+1. 启动 frontend 并启用 KV router：
+
+   ```bash
+   python -m dynamo.frontend --router-mode kv --http-port 8000
+   ```
+
+2. 对每个 aggregated worker，或标准 disaggregated 部署中的每个 prefill worker，启用 engine
+   KV 事件发布。
+
+   对于 vLLM：
+
+   ```bash
+   python -m dynamo.vllm --model Qwen/Qwen3-0.6B \
+     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
+   ```
+
+   对于 SGLang：
+
+   ```bash
+   python -m dynamo.sglang --model-path Qwen/Qwen3-0.6B \
+     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5557"}'
+   ```
+
+   对于 vLLM，JSON 必须设置 `"enable_kv_cache_events":true`；省略其他字段时，vLLM 可以推断
+   ZMQ publisher 并使用默认 endpoint。对于 SGLang，JSON 必须同时包含
+   `"publisher":"zmq"` 和 `"endpoint"`；`"topic"` 是可选字段。不要将仅适用于 vLLM 的
+   `{"enable_kv_cache_events":true}` 配置用于 SGLang。
+
+共享网络命名空间的 worker 必须使用不同的事件 endpoint 端口。`--kv-events-config` 配置第一段
+事件传输，即从 engine 到对应的 Dynamo worker。worker 会对这些事件进行标准化，将其应用到本地
+indexer，然后通过单独配置的 Dynamo event plane 发布给 router。有关完整的数据路径和恢复边界，
+请参阅 [Router Design](../../../../../../../pages/developer-guide/knowledge-base/modular-components/router/router-design.md#event-flow-and-recovery)。
+
+如果未设置 worker flag，router 不会自动切换到近似预测模式。如果 worker 不发布事件，
+请使用 `--no-router-kv-events` 启用近似 cache 预测，或使用 `--load-aware` 仅按负载路由。
+
+对于 Kubernetes，请在 Frontend service 上设置 `DYN_ROUTER_MODE=kv`，并将上述 backend
+事件参数添加到相应的 worker。完整的 `DynamoGraphDeployment` 片段请参阅
+[Using the Dynamo Frontend](../../../../../../../pages/kubernetes/kv-aware-routing/dynamo-frontend.md)。
 
 | 参数 | 默认值 | 描述 |
 |----------|---------|-------------|
@@ -22,7 +61,7 @@ python -m dynamo.frontend --router-mode kv --http-port 8000
 | `--load-aware` | disabled | 使用 KV 活动负载路由，不使用 cache 复用信号；在 frontend 上隐含启用 `--router-mode kv` |
 | `--router-kv-overlap-score-credit` | `1.0` | 设备本地 prefix 重叠的 credit 乘数，范围从 0.0 到 1.0 |
 | `--router-prefill-load-scale` | `1.0` | 在加入 decode block 之前，对调整后的 prompt 侧 prefill 负载进行缩放 |
-| `--router-kv-events` / `--no-router-kv-events` | `--router-kv-events` | 消费 worker KV 事件，或在没有事件时回退到近似路由 |
+| `--router-kv-events` / `--no-router-kv-events` | `--router-kv-events` | 消费 worker KV 事件；使用 `--no-router-kv-events` 可显式切换到近似路由 |
 | `--router-queue-threshold` | disabled | 背压队列阈值；设置数值后启用队列，`nvext.agent_hints.priority` 会对等待中的请求重新排序 |
 | `--router-queue-policy` | `fcfs` | 队列调度策略：`fcfs`（尾部 TTFT）、`wspt`（平均 TTFT）或 `lcfs`（仅用于比较的反向排序） |
 | `--no-router-track-prefill-tokens` | disabled | 在 router 负载统计中忽略 prompt 侧 prefill token；适用于仅 decode 的路由路径 |

--- a/examples/backends/sglang/deploy/agg_router.yaml
+++ b/examples/backends/sglang/deploy/agg_router.yaml
@@ -25,6 +25,8 @@ spec:
         - args:
           - --model-path
           - Qwen/Qwen3-0.6B
+          - --stream-interval
+          - "20"
           - --served-model-name
           - Qwen/Qwen3-0.6B
           - --page-size

--- a/examples/backends/sglang/launch/agg_router.sh
+++ b/examples/backends/sglang/launch/agg_router.sh
@@ -81,6 +81,7 @@ OTEL_SERVICE_NAME=dynamo-worker-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_WORKER1:-808
 python3 -m dynamo.sglang \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
+  --stream-interval 20 \
   --page-size 16 \
   --tp 1 \
   --trust-remote-code \
@@ -94,6 +95,7 @@ OTEL_SERVICE_NAME=dynamo-worker-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT_WORKER2:-808
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --model-path "$MODEL" \
   --served-model-name "$MODEL" \
+  --stream-interval 20 \
   --page-size 16 \
   --tp 1 \
   --trust-remote-code \

--- a/examples/backends/sglang/launch/disagg_router.sh
+++ b/examples/backends/sglang/launch/disagg_router.sh
@@ -67,6 +67,7 @@ OTEL_SERVICE_NAME=dynamo-worker-prefill-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-80
 python3 -m dynamo.sglang \
   --model-path Qwen/Qwen3-0.6B \
   --served-model-name Qwen/Qwen3-0.6B \
+  --stream-interval 20 \
   --page-size 64 \
   --tp 1 \
   --trust-remote-code \
@@ -83,6 +84,7 @@ OTEL_SERVICE_NAME=dynamo-worker-prefill-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT2:-80
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.sglang \
   --model-path Qwen/Qwen3-0.6B \
   --served-model-name Qwen/Qwen3-0.6B \
+  --stream-interval 20 \
   --page-size 64 \
   --tp 1 \
   --trust-remote-code \
@@ -99,12 +101,12 @@ OTEL_SERVICE_NAME=dynamo-worker-decode-1 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT3:-808
 CUDA_VISIBLE_DEVICES=3 python3 -m dynamo.sglang \
   --model-path Qwen/Qwen3-0.6B \
   --served-model-name Qwen/Qwen3-0.6B \
+  --stream-interval 20 \
   --page-size 64 \
   --tp 1 \
   --trust-remote-code \
   --disaggregation-mode decode \
   --host 0.0.0.0 \
-  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5560"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
   --disable-piecewise-cuda-graph \
@@ -115,12 +117,12 @@ OTEL_SERVICE_NAME=dynamo-worker-decode-2 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT4:-808
 CUDA_VISIBLE_DEVICES=2 python3 -m dynamo.sglang \
   --model-path Qwen/Qwen3-0.6B \
   --served-model-name Qwen/Qwen3-0.6B \
+  --stream-interval 20 \
   --page-size 64 \
   --tp 1 \
   --trust-remote-code \
   --disaggregation-mode decode \
   --host 0.0.0.0 \
-  --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:5559"}' \
   --disaggregation-transfer-backend nixl \
   --enable-metrics \
   --disable-piecewise-cuda-graph \

--- a/examples/backends/vllm/deploy/agg_router.yaml
+++ b/examples/backends/vllm/deploy/agg_router.yaml
@@ -25,6 +25,8 @@ spec:
         - args:
           - --model
           - Qwen/Qwen3-0.6B
+          - --stream-interval
+          - "20"
           - --kv-events-config
           - '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}'
           command:

--- a/examples/backends/vllm/deploy/disagg_router.yaml
+++ b/examples/backends/vllm/deploy/disagg_router.yaml
@@ -25,6 +25,8 @@ spec:
         - args:
           - --model
           - Qwen/Qwen3-0.6B
+          - --stream-interval
+          - "20"
           - --disaggregation-mode
           - decode
           - --kv-transfer-config
@@ -54,6 +56,8 @@ spec:
         - args:
           - --model
           - Qwen/Qwen3-0.6B
+          - --stream-interval
+          - "20"
           - --disaggregation-mode
           - prefill
           - --kv-transfer-config

--- a/examples/backends/vllm/launch/agg_router.sh
+++ b/examples/backends/vllm/launch/agg_router.sh
@@ -34,6 +34,7 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
+    --stream-interval 20 \
     --enforce-eager \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080","enable_kv_cache_events":true}' &
 
@@ -42,6 +43,7 @@ VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
+    --stream-interval 20 \
     --enforce-eager \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20081","enable_kv_cache_events":true}' &
 

--- a/examples/backends/vllm/launch/disagg_router.sh
+++ b/examples/backends/vllm/launch/disagg_router.sh
@@ -30,6 +30,7 @@ python -m dynamo.frontend \
 CUDA_VISIBLE_DEVICES=0 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
+    --stream-interval 20 \
     --enforce-eager \
     --disaggregation-mode decode \
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
@@ -38,6 +39,7 @@ VLLM_NIXL_SIDE_CHANNEL_PORT=20097 \
 CUDA_VISIBLE_DEVICES=1 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
+    --stream-interval 20 \
     --enforce-eager \
     --disaggregation-mode decode \
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' &
@@ -49,6 +51,7 @@ VLLM_NIXL_SIDE_CHANNEL_PORT=20098 \
 CUDA_VISIBLE_DEVICES=2 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
+    --stream-interval 20 \
     --enforce-eager \
     --disaggregation-mode prefill \
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \
@@ -58,6 +61,7 @@ VLLM_NIXL_SIDE_CHANNEL_PORT=20099 \
 CUDA_VISIBLE_DEVICES=3 python3 -m dynamo.vllm \
     --model $MODEL \
     --block-size $BLOCK_SIZE \
+    --stream-interval 20 \
     --enforce-eager \
     --disaggregation-mode prefill \
     --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' \

--- a/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml
+++ b/recipes/qwen3-32b/vllm/disagg-kv-router/deploy.yaml
@@ -55,6 +55,8 @@ spec:
           - --async-scheduling
           - --block-size
           - '64'
+          - --stream-interval
+          - '20'
           - --hf-overrides
           - '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
           - --max-model-len
@@ -110,6 +112,8 @@ spec:
           - --async-scheduling
           - --block-size
           - '64'
+          - --stream-interval
+          - '20'
           - --hf-overrides
           - '{"rope_scaling":{"rope_type":"yarn","factor":4.0,"original_max_position_embeddings":32768},"max_position_embeddings":131072}'
           - --max-model-len


### PR DESCRIPTION
## Summary

- **Keep the change documentation-only.** The current router and backend code already require this configuration. This PR does not change runtime defaults or event transport.
- **Put both required flags first.** The Router overview and Router Guide now pair `--router-mode kv` with worker-side `--kv-events-config`. The frontend flag does not change backend engine arguments.
- **Move worker setup to the top of the standalone README.** The README now shows vLLM and SGLang worker commands before advanced examples. The manual prefill command also includes the vLLM event configuration.
- **Define the vLLM schema.** vLLM requires `"enable_kv_cache_events":true`. It can infer the ZMQ publisher and default endpoint. The documented complete form makes the transport and port explicit.
- **Define the SGLang schema.** SGLang requires `"publisher":"zmq"` and an explicit `"endpoint"`. The `"topic":"kv-events"` field is optional. The vLLM-only enable form does not work for SGLang.
- **Keep stream tuning separate from KV indexing.** Router entry-point commands do not include `--stream-interval`. Backend guides and runnable examples recommend `--stream-interval 20` and explain the stream-update tradeoff.
- **Show complete Kubernetes worker configuration.** The page now includes vLLM and SGLang worker snippets. Each snippet has the required event JSON and the recommended stream interval.
- **Explain worker roles.** Aggregated workers and standard disaggregated prefill workers require events. Standard decode workers use load routing. The vLLM conditional-disaggregation path is the decode-cache exception.
- **Explain both event hops.** `--kv-events-config` controls engine-to-worker ZMQ ingestion. Dynamo's event-plane configuration controls normalized worker-to-router updates. One configuration does not change the other.
- **Clarify the worker-local indexer default.** Dynamo enables the worker-local indexer after it creates a KV event publisher. This default does not create an engine event source.
- **Document event order.** Dynamo normalizes, filters, coalesces, and deduplicates engine events. It applies each accepted update to `LocalKvIndexer` before event-plane publication.
- **Correct the recovery boundary.** Worker snapshots recover startup state and worker-to-router gaps. They cannot reconstruct an engine ZMQ message that did not reach the worker.
- **Separate event-driven and approximate modes.** `--no-router-kv-events` explicitly enables prediction-based routing. The router does not switch to this mode when worker publication is absent.
- **Reduce duplicate configuration details.** Router Operations now links to the exact worker commands in the setup and backend reference pages.
- **Update primary examples.** The vLLM and SGLang launch scripts, deployment examples, and Qwen recipe now include the applicable flags.
- **Correct stale backend guidance.** The docs now describe explicit vLLM event configuration and use the current TensorRT-LLM flag.
- **Keep the Chinese Router overview synchronized.** The translated page now includes both required flags and the different backend JSON schemas.
- **Apply Simplified Technical English to new prose.** The pass covers only text added or changed by this PR. Commands, flags, JSON, and unchanged surrounding text remain unchanged.

## Validation

- Live vLLM A/B test with `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.3.1`, vLLM 0.23.0, Qwen3-0.6B, and repeated-prefix requests:
  - Without `--kv-events-config`, `use_kv_events=False`. vLLM recorded prefix-cache hits, but Dynamo applied zero stored events.
  - With the complete configuration, Dynamo enabled `LocalKvIndexer` and applied stored events.
  - With only `{"enable_kv_cache_events":true}`, vLLM used ZMQ port 5557 and Dynamo applied stored events.
- Live SGLang A/B test with `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.1`, SGLang 0.5.14, Qwen3-0.6B, and repeated-prefix requests:
  - Without `--kv-events-config`, `use_kv_events=False` and Dynamo applied zero stored events.
  - With `{"publisher":"zmq","endpoint":"tcp://*:5557"}`, Dynamo enabled `LocalKvIndexer` and applied 50 stored block events.
  - With the documented `publisher+topic+endpoint` form, Dynamo enabled `LocalKvIndexer` and applied 50 stored block events.
- `cargo test -p dynamo-llm test_start_event_processor_with_local_indexer --lib`
- `cargo test -p dynamo-llm test_distributed_kvindexer_recovery_from_outage --lib`
- `bash -n` on the four changed vLLM and SGLang launch scripts
- Parsed all changed YAML manifests with `yaml.safe_load`
- Targeted broken-link test across 53 Router, backend, Kubernetes, and Chinese files. The test found 376 links and zero broken links.
- `python3 docs/fern/scripts/check_asset_paths.py`
- `git diff --check` and `git diff --cached --check`
- Reviewed current code for publisher creation, ZMQ ingestion, event processing, local indexing, and backend argument requirements.
- Reviewed PR-added English prose with the Simplified Technical English checklist. The test excludes commands and identifiers.
- The local environment does not contain the Fern or Node CLI. CI will run the remaining Fern tests.

No tool can guarantee ASD-STE100 compliance. Final approval rests with the writer. The official standard is a free download at asd-ste100.org.
