### PR TITLE
fix(operator): isolate namespaced admission and CRD ownership for 1.3

### DIFF
--- a/deploy/helm/charts/platform/Chart.yaml
+++ b/deploy/helm/charts/platform/Chart.yaml
@@ -20,6 +20,8 @@ maintainers:
 description: A Helm chart for NVIDIA Dynamo Platform.
 type: application
 version: 1.3.0
+# Kubernetes 1.30 enables CRD validation ratcheting by default; generated CRDs use optionalOldSelf.
+kubeVersion: ">=1.30.0-0"
 home: https://nvidia.com
 dependencies:
   - name: dynamo-operator

--- a/deploy/helm/charts/platform/README.md
+++ b/deploy/helm/charts/platform/README.md
@@ -33,7 +33,7 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 
 ## 📋 Prerequisites
 
-- Kubernetes cluster (v1.20+)
+- Kubernetes cluster (v1.30+)
 - Helm 3.8+
 - Sufficient cluster resources for your deployment scale
 - Container registry access (if using private images)
@@ -49,51 +49,37 @@ No action is required for most upgrades — the operator's built-in cert-control
 
 ---
 
-## ⚠️ Important: Cluster-Wide vs Namespace-Scoped Deployment
+## ⚠️ Important: Cluster-Wide and Namespace-Restricted Deployment
 
-### Single Cluster-Wide Operator (Recommended)
+Deploy one cluster-wide operator per cluster. It owns the Custom Resource Definitions (CRDs),
+conversion webhook, and conversion certificate authority (CA).
 
-**By default, the Dynamo operator runs with cluster-wide permissions and should only be deployed ONCE per cluster.**
+> [!WARNING]
+> Namespace-restricted mode is only for development and testing. It is not supported for production.
 
-- ✅ **Recommended**: Deploy one cluster-wide operator per cluster
-- ❌ **Not Recommended**: Multiple cluster-wide operators in the same cluster
+A namespace-restricted operator owns reconciliation, validation, and mutation only in its target
+namespace. Its Lease makes the cluster-wide operator skip that namespace. Install it alongside an
+existing cluster-wide operator with CRD management disabled:
 
-### Multiple Namespace-Scoped Operators (Advanced)
-
-If you need multiple operator instances (e.g., for multi-tenancy), use namespace-scoped deployment:
-
-```yaml
-# values.yaml
-dynamo-operator:
-  namespaceRestriction:
-    enabled: true
-    targetNamespace: "my-tenant-namespace"  # Optional, defaults to release namespace
+```bash
+helm install dynamo-test dynamo-platform-${RELEASE_VERSION}.tgz \
+  --namespace test-namespace \
+  --create-namespace \
+  --skip-crds \
+  --set dynamo-operator.namespaceRestriction.enabled=true \
+  --set dynamo-operator.upgradeCRD=false
 ```
 
-### Validation and Safety
-
-The chart includes built-in validation to prevent all operator conflicts:
-
-- **Automatic Detection**: Scans for existing operators (both cluster-wide and namespace-restricted) during installation
-- **Prevents Multiple Cluster-Wide**: Installation will fail if another cluster-wide operator exists
-- **Prevents Mixed Deployments (Type 1)**: Installation will fail if trying to install namespace-restricted operator when cluster-wide exists
-- **Prevents Mixed Deployments (Type 2)**: Installation will fail if trying to install cluster-wide operator when namespace-restricted operators exist
-- **Safe Defaults**: Leader election uses shared ID for proper coordination
-
-#### 🚫 **Blocked Conflict Scenarios**
-
-| Existing Operator | New Operator | Status | Reason |
-|-------------------|--------------|---------|--------|
-| None | Cluster-wide | ✅ **Allowed** | No conflicts |
-| None | Namespace-restricted | ✅ **Allowed** | No conflicts |
-| Cluster-wide | Cluster-wide | ❌ **Blocked** | Multiple cluster managers |
-| Cluster-wide | Namespace-restricted | ❌ **Blocked** | Cluster-wide already manages target namespace |
-| Namespace-restricted | Cluster-wide | ❌ **Blocked** | Would conflict with existing namespace operators |
-| Namespace-restricted A | Namespace-restricted B (diff ns) | ✅ **Allowed** | Different scopes |
+The cluster-wide operator should run the same or a newer version and provide the newest APIs in the
+cluster. A newer namespaced controller can be used for development when it remains compatible with
+the installed CRDs. Helm rejects namespace-restricted installations with `upgradeCRD=true` and
+rejects custom `webhook.namespaceSelector` values.
 
 ## 🔧 Configuration
 
 ## Requirements
+
+Kubernetes: `>=1.30.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
@@ -115,18 +101,18 @@ The chart includes built-in validation to prevent all operator conflicts:
 | global.grove.install | bool | `false` | Whether this chart should install the bundled Grove subchart. When true, deploys the Grove operator cluster-wide. Integration is automatically enabled. NOTE: For production environments, it is recommended to install Grove separately. |
 | global.grove.enabled | bool | `false` | Whether to enable Grove integration (multinode orchestration via PodCliqueSets). Set to true when Grove is available in the cluster (installed externally). Automatically true when install=true. The operator uses this to decide whether to create PodCliqueSets for multinode deployments. |
 | dynamo-operator.enabled | bool | `true` | Whether to enable the Dynamo Kubernetes operator deployment |
-| dynamo-operator.upgradeCRD | bool | `true` | Whether to manage CRDs via a pre-install/pre-upgrade hook Job. The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply. |
+| dynamo-operator.upgradeCRD | bool | `true` | Whether the cluster-wide operator applies bundled CRDs via crd-apply. This must be false for namespace-restricted installations, which must also be installed with Helm's --skip-crds flag. |
 | dynamo-operator.natsAddr | string | `""` | NATS server address for operator communication (leave empty to use the bundled NATS chart). Format: "nats://hostname:port" |
 | dynamo-operator.etcdAddr | string | `""` | etcd server address for an external etcd instance. Only needed when using external etcd without the bundled subchart. Format: "http://hostname:port" or "https://hostname:port" |
 | dynamo-operator.modelExpressURL | string | `""` | URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true). |
-| dynamo-operator.namespaceRestriction | object | `{"enabled":false,"lease":{"duration":"30s","renewInterval":"10s"},"targetNamespace":null}` | DEPRECATED: Namespace-restricted mode is deprecated and will be removed in a future release. Use cluster-wide mode (the default) instead. Do not enable this for new deployments. |
-| dynamo-operator.namespaceRestriction.enabled | bool | `false` | DEPRECATED: Do not enable for new deployments. Namespace-restricted mode is deprecated. |
-| dynamo-operator.namespaceRestriction.targetNamespace | string | `nil` | DEPRECATED: Only used in namespace-restricted mode, which is deprecated. |
-| dynamo-operator.namespaceRestriction.lease | object | `{"duration":"30s","renewInterval":"10s"}` | DEPRECATED: Only used in namespace-restricted mode, which is deprecated. |
-| dynamo-operator.namespaceRestriction.lease.duration | string | `"30s"` | DEPRECATED: Lease duration for namespace-restricted mode, which is deprecated. |
-| dynamo-operator.namespaceRestriction.lease.renewInterval | string | `"10s"` | DEPRECATED: Lease renew interval for namespace-restricted mode, which is deprecated. |
-| dynamo-operator.gpuDiscovery | object | `{"enabled":true}` | DEPRECATED: GPU discovery for namespace-scoped operators is deprecated along with namespace-restricted mode. |
-| dynamo-operator.gpuDiscovery.enabled | bool | `true` | DEPRECATED: Only relevant when namespaceRestriction is enabled, which is deprecated. |
+| dynamo-operator.namespaceRestriction | object | `{"enabled":false,"lease":{"duration":"30s","renewInterval":"10s"},"targetNamespace":null}` | DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments. |
+| dynamo-operator.namespaceRestriction.enabled | bool | `false` | DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production. |
+| dynamo-operator.namespaceRestriction.targetNamespace | string | `nil` | DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace. |
+| dynamo-operator.namespaceRestriction.lease | object | `{"duration":"30s","renewInterval":"10s"}` | DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease settings. |
+| dynamo-operator.namespaceRestriction.lease.duration | string | `"30s"` | DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease duration. |
+| dynamo-operator.namespaceRestriction.lease.renewInterval | string | `"10s"` | DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease renewal interval. |
+| dynamo-operator.gpuDiscovery | object | `{"enabled":true}` | DEVELOPMENT AND TESTING ONLY: GPU discovery settings for namespace-restricted operators. |
+| dynamo-operator.gpuDiscovery.enabled | bool | `true` | DEVELOPMENT AND TESTING ONLY: Enable GPU discovery in namespace-restricted mode. |
 | dynamo-operator.controllerManager.tolerations | list | `[]` | Node tolerations for controller manager pods |
 | dynamo-operator.controllerManager.affinity | object | `{}` | Affinity for controller manager pods |
 | dynamo-operator.controllerManager.leaderElection.id | string | `""` | Leader election ID for cluster-wide coordination. WARNING: All cluster-wide operators must use the SAME ID to prevent split-brain. Different IDs would allow multiple leaders simultaneously. |
@@ -167,7 +153,7 @@ The chart includes built-in validation to prevent all operator conflicts:
 | dynamo-operator.webhook.failurePolicy | string | `"Fail"` | Webhook failure policy controls how Kubernetes handles requests when the webhook is unavailable. 'Fail' (recommended for production) rejects requests if the webhook cannot be reached, ensuring strict validation. 'Ignore' allows requests through if the webhook is unavailable, providing availability over validation guarantees. |
 | dynamo-operator.webhook.podCheckpointRestoreFailurePolicy | string | `"Ignore"` | Failure policy for the Pod CREATE checkpoint-restore mutating webhook. Defaults to Ignore so a webhook outage falls back to cold-start instead of blocking workload Pods. |
 | dynamo-operator.webhook.timeoutSeconds | int | `10` | Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy. |
-| dynamo-operator.webhook.namespaceSelector | object | `{}` | Custom namespace selector for webhook validation. Use this to include or exclude specific namespaces from webhook validation. For CLUSTER-WIDE operators, you can exclude namespaces managed by namespace-restricted operators by using: matchExpressions: [{ key: "dynamo-operator", operator: "NotIn", values: ["namespace-restricted"] }]. For NAMESPACE-RESTRICTED operators, leave empty as it will be auto-configured to match only the operator's namespace. |
+| dynamo-operator.webhook.namespaceSelector | object | `{}` | Unsupported; must remain empty. Helm configures global admission for the cluster-wide operator and target-namespace admission for restricted operators. |
 | dynamo-operator.webhook.certManager.enabled | bool | `false` | Whether to use cert-manager for automatic certificate management. Requires cert-manager to be installed in the cluster. When enabled, cert-manager will provision and rotate certificates instead of the operator's built-in cert-controller. |
 | dynamo-operator.webhook.certManager.certificate.duration | string | `"8760h"` | Certificate duration for webhook certificates managed by cert-manager (e.g., "8760h" for 1 year). cert-manager will automatically renew the certificate before it expires. |
 | dynamo-operator.webhook.certManager.certificate.renewBefore | string | `"360h"` | Time before certificate expiration to trigger renewal (e.g., "360h" for 15 days). cert-manager will attempt to renew the certificate when this threshold is reached. |

--- a/deploy/helm/charts/platform/README.md.gotmpl
+++ b/deploy/helm/charts/platform/README.md.gotmpl
@@ -33,7 +33,7 @@ The Dynamo Platform Helm chart deploys the complete Dynamo Kubernetes Platform i
 
 ## 📋 Prerequisites
 
-- Kubernetes cluster (v1.20+)
+- Kubernetes cluster (v1.30+)
 - Helm 3.8+
 - Sufficient cluster resources for your deployment scale
 - Container registry access (if using private images)
@@ -49,47 +49,31 @@ No action is required for most upgrades — the operator's built-in cert-control
 
 ---
 
-## ⚠️ Important: Cluster-Wide vs Namespace-Scoped Deployment
+## ⚠️ Important: Cluster-Wide and Namespace-Restricted Deployment
 
-### Single Cluster-Wide Operator (Recommended)
+Deploy one cluster-wide operator per cluster. It owns the Custom Resource Definitions (CRDs),
+conversion webhook, and conversion certificate authority (CA).
 
-**By default, the Dynamo operator runs with cluster-wide permissions and should only be deployed ONCE per cluster.**
+> [!WARNING]
+> Namespace-restricted mode is only for development and testing. It is not supported for production.
 
-- ✅ **Recommended**: Deploy one cluster-wide operator per cluster
-- ❌ **Not Recommended**: Multiple cluster-wide operators in the same cluster
+A namespace-restricted operator owns reconciliation, validation, and mutation only in its target
+namespace. Its Lease makes the cluster-wide operator skip that namespace. Install it alongside an
+existing cluster-wide operator with CRD management disabled:
 
-### Multiple Namespace-Scoped Operators (Advanced)
-
-If you need multiple operator instances (e.g., for multi-tenancy), use namespace-scoped deployment:
-
-```yaml
-# values.yaml
-dynamo-operator:
-  namespaceRestriction:
-    enabled: true
-    targetNamespace: "my-tenant-namespace"  # Optional, defaults to release namespace
+```bash
+helm install dynamo-test dynamo-platform-${RELEASE_VERSION}.tgz \
+  --namespace test-namespace \
+  --create-namespace \
+  --skip-crds \
+  --set dynamo-operator.namespaceRestriction.enabled=true \
+  --set dynamo-operator.upgradeCRD=false
 ```
 
-### Validation and Safety
-
-The chart includes built-in validation to prevent all operator conflicts:
-
-- **Automatic Detection**: Scans for existing operators (both cluster-wide and namespace-restricted) during installation
-- **Prevents Multiple Cluster-Wide**: Installation will fail if another cluster-wide operator exists
-- **Prevents Mixed Deployments (Type 1)**: Installation will fail if trying to install namespace-restricted operator when cluster-wide exists
-- **Prevents Mixed Deployments (Type 2)**: Installation will fail if trying to install cluster-wide operator when namespace-restricted operators exist
-- **Safe Defaults**: Leader election uses shared ID for proper coordination
-
-#### 🚫 **Blocked Conflict Scenarios**
-
-| Existing Operator | New Operator | Status | Reason |
-|-------------------|--------------|---------|--------|
-| None | Cluster-wide | ✅ **Allowed** | No conflicts |
-| None | Namespace-restricted | ✅ **Allowed** | No conflicts |
-| Cluster-wide | Cluster-wide | ❌ **Blocked** | Multiple cluster managers |
-| Cluster-wide | Namespace-restricted | ❌ **Blocked** | Cluster-wide already manages target namespace |
-| Namespace-restricted | Cluster-wide | ❌ **Blocked** | Would conflict with existing namespace operators |
-| Namespace-restricted A | Namespace-restricted B (diff ns) | ✅ **Allowed** | Different scopes |
+The cluster-wide operator should run the same or a newer version and provide the newest APIs in the
+cluster. A newer namespaced controller can be used for development when it remains compatible with
+the installed CRDs. Helm rejects namespace-restricted installations with `upgradeCRD=true` and
+rejects custom `webhook.namespaceSelector` values.
 
 ## 🔧 Configuration
 

--- a/deploy/helm/charts/platform/components/operator/Chart.yaml
+++ b/deploy/helm/charts/platform/components/operator/Chart.yaml
@@ -28,6 +28,8 @@ type: application
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
 version: 1.3.0
+# Kubernetes 1.30 enables CRD validation ratcheting by default; generated CRDs use optionalOldSelf.
+kubeVersion: ">=1.30.0-0"
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
+++ b/deploy/helm/charts/platform/components/operator/templates/_validation.tpl
@@ -14,10 +14,8 @@
 # limitations under the License.
 
 {{/*
-Validation to prevent operator conflicts
-With the namespace scope marker lease mechanism, cluster-wide and namespace-restricted
-operators can now coexist safely. The cluster-wide operator automatically excludes
-namespaces that have namespace-restricted operators.
+Validation to prevent operator conflicts. Namespace ownership leases allow the cluster-wide
+operator to avoid namespaces managed by namespace-restricted operators.
 
 This validation only prevents:
 1. Multiple cluster-wide operators (would compete for the same resources)
@@ -74,9 +72,9 @@ This validation only prevents:
     {{- end -}}
 
     {{- if $existingOperatorNamespace -}}
-      {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' in namespace '%s' (ClusterRole: %s). Only one cluster-wide Dynamo operator should be deployed per cluster. Either:\n1. Use the existing cluster-wide operator (no need to install another), or\n2. Uninstall the existing cluster-wide operator first: %s\n\nNote: You can install namespace-restricted operators alongside the cluster-wide operator using: --set namespaceRestriction.enabled=true" $existingOperatorRelease $existingOperatorNamespace $existingOperatorRoleName $uninstallCmd) -}}
+      {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' in namespace '%s' (ClusterRole: %s). Only one cluster-wide Dynamo operator should be deployed per cluster. Either:\n1. Use the existing cluster-wide operator (no need to install another), or\n2. Uninstall the existing cluster-wide operator first: %s\n\nNote: For development and testing, a namespace-restricted operator may coexist when installed with --skip-crds, namespaceRestriction.enabled=true, and upgradeCRD=false." $existingOperatorRelease $existingOperatorNamespace $existingOperatorRoleName $uninstallCmd) -}}
     {{- else -}}
-      {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' (ClusterRole: %s). Only one cluster-wide Dynamo operator should be deployed per cluster. Either:\n1. Use the existing cluster-wide operator (no need to install another), or\n2. Uninstall the existing cluster-wide operator first: %s\n\nNote: You can install namespace-restricted operators alongside the cluster-wide operator using: --set namespaceRestriction.enabled=true" $existingOperatorRelease $existingOperatorRoleName $uninstallCmd) -}}
+      {{- fail (printf "VALIDATION ERROR: Found existing cluster-wide Dynamo operator from release '%s' (ClusterRole: %s). Only one cluster-wide Dynamo operator should be deployed per cluster. Either:\n1. Use the existing cluster-wide operator (no need to install another), or\n2. Uninstall the existing cluster-wide operator first: %s\n\nNote: For development and testing, a namespace-restricted operator may coexist when installed with --skip-crds, namespaceRestriction.enabled=true, and upgradeCRD=false." $existingOperatorRelease $existingOperatorRoleName $uninstallCmd) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -95,6 +93,13 @@ This validation only prevents:
 Validation for configuration consistency
 */}}
 {{- define "dynamo-operator.validateConfiguration" -}}
+{{/* Namespace-restricted operators must never install or update cluster-wide APIs. */}}
+{{- if and .Values.namespaceRestriction.enabled .Values.upgradeCRD -}}
+  {{- fail "VALIDATION ERROR: namespaceRestriction.enabled=true is incompatible with upgradeCRD=true. Set upgradeCRD=false and install the namespaced release with --skip-crds so it does not install or update cluster-wide CRDs." -}}
+{{- end -}}
+{{- if not (empty .Values.webhook.namespaceSelector) -}}
+  {{- fail "VALIDATION ERROR: webhook.namespaceSelector must be empty. Helm manages admission scope: cluster-wide webhooks cover every namespace and namespace-restricted webhooks cover only their target namespace." -}}
+{{- end -}}
 {{/* Validate leader election namespace setting */}}
 {{- if and (not .Values.namespaceRestriction.enabled) .Values.controllerManager.leaderElection.namespace -}}
   {{- if eq .Values.controllerManager.leaderElection.namespace .Release.Namespace -}}

--- a/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- if .Values.upgradeCRD }}
+      {{- if and (not .Values.namespaceRestriction.enabled) .Values.upgradeCRD }}
       initContainers:
       - name: crd-apply
         image: {{ .Values.controllerManager.manager.image.repository }}:{{ .Values.controllerManager.manager.image.tag | default .Chart.AppVersion }}

--- a/deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/manager-rbac.yaml
@@ -102,6 +102,7 @@ rules:
   - patch
   - update
   - watch
+{{- if not .Values.namespaceRestriction.enabled }}
 - apiGroups:
   - admissionregistration.k8s.io
   resources:
@@ -126,6 +127,7 @@ rules:
   - patch
   - update
   - watch
+{{- end }}
 - apiGroups:
   - grove.io
   resources:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-configuration.yaml
@@ -53,7 +53,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -89,7 +89,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -123,7 +123,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -157,7 +157,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -191,7 +191,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -247,7 +247,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -282,7 +282,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -316,7 +316,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:
@@ -350,7 +350,7 @@ webhooks:
   {{- else if .Values.namespaceRestriction.enabled }}
   namespaceSelector:
     matchLabels:
-      kubernetes.io/metadata.name: {{ .Release.Namespace }}
+      kubernetes.io/metadata.name: {{ default .Release.Namespace .Values.namespaceRestriction.targetNamespace | quote }}
   {{- end }}
   rules:
   - apiGroups:

--- a/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
+++ b/deploy/helm/charts/platform/components/operator/templates/webhook-rbac.yaml
@@ -64,9 +64,8 @@ subjects:
   name: {{ include "dynamo-operator.fullname" . }}-controller-manager
   namespace: {{ .Release.Namespace }}
 ---
-# ClusterRole for patching webhook configurations and CRDs (cluster-scoped resources).
-# These are cluster-scoped resources that cannot be granted via a namespace-scoped Role,
-# so they are always provided as a dedicated ClusterRole regardless of namespace-restriction mode.
+# ClusterRole for patching cluster-scoped webhook configurations.
+# Only the cluster-wide operator may also patch CRD conversion CA bundles.
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
@@ -88,6 +87,7 @@ rules:
   - watch
   - update
   - patch
+{{- if not .Values.namespaceRestriction.enabled }}
 - apiGroups:
   - apiextensions.k8s.io
   resources:
@@ -98,6 +98,7 @@ rules:
   - watch
   - update
   - patch
+{{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/helm/charts/platform/components/operator/values.yaml
+++ b/deploy/helm/charts/platform/components/operator/values.yaml
@@ -16,9 +16,9 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
-# Whether to apply CRDs via an init container on the operator Deployment.
-# Uses server-side apply with the bundled /crd-apply binary.
-# Set to false if CRDs are managed externally (e.g., via GitOps or a separate pipeline).
+# Whether the cluster-wide operator applies CRDs via an init container.
+# This must be false for namespace-restricted installations, which must also
+# be installed with Helm's --skip-crds flag.
 upgradeCRD: true
 
 featureGates:
@@ -30,21 +30,21 @@ featureGates:
 # Prefer featureGates.gmsSnapshot for the temporary GMS + Snapshot gate.
 env: []
 
-# -- DEPRECATED: Namespace-restricted mode is deprecated and will be removed in a future release. Use cluster-wide mode (the default) instead. Do not enable this for new deployments.
+# -- DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments.
 namespaceRestriction:
-  # -- DEPRECATED: Do not enable for new deployments. Namespace-restricted mode is deprecated.
+  # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production.
   enabled: false
-  # -- DEPRECATED: Only used in namespace-restricted mode, which is deprecated.
+  # -- DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace.
   targetNamespace: ""
-  # -- DEPRECATED: Only used in namespace-restricted mode, which is deprecated.
+  # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease settings.
   lease:
-    # -- DEPRECATED: Lease duration for namespace-restricted mode, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease duration.
     duration: 30s
-    # -- DEPRECATED: Lease renew interval for namespace-restricted mode, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease renewal interval.
     renewInterval: 10s
-# -- DEPRECATED: GPU discovery for namespace-scoped operators is deprecated along with namespace-restricted mode.
+# -- DEVELOPMENT AND TESTING ONLY: GPU discovery settings for namespace-restricted operators.
 gpuDiscovery:
-  # -- DEPRECATED: Only relevant when namespaceRestriction is enabled, which is deprecated.
+  # -- DEVELOPMENT AND TESTING ONLY: Enable GPU discovery in namespace-restricted mode.
   enabled: true
 controllerManager:
   tolerations: []
@@ -218,17 +218,8 @@ webhook:
   # Timeout for webhook calls (in seconds)
   timeoutSeconds: 10
 
-  # Namespace selector for webhooks
-  # Use this to exclude certain namespaces from validation
-  #
-  # For CLUSTER-WIDE operators: Exclude namespaces with namespace-restricted operators
-  # namespaceSelector:
-  #   matchExpressions:
-  #   - key: dynamo-operator
-  #     operator: NotIn
-  #     values: ["namespace-restricted"]
-  #
-  # For NAMESPACE-RESTRICTED operators: Leave empty (auto-configured)
+  # -- Unsupported; must remain empty. Helm configures global admission for the
+  # cluster-wide operator and target-namespace admission for restricted operators.
   namespaceSelector: {}
 
   # cert-manager integration (optional, alternative to built-in cert-controller)

--- a/deploy/helm/charts/platform/templates/NOTES.txt
+++ b/deploy/helm/charts/platform/templates/NOTES.txt
@@ -17,15 +17,16 @@
 {{- if $operatorValues.namespaceRestriction.enabled }}
 
 ================================================================================
-  DEPRECATION WARNING
+  DEVELOPMENT AND TESTING ONLY
 ================================================================================
-  Namespace-restricted mode (namespaceRestriction.enabled=true) is DEPRECATED
-  and will be removed in a future release.
+  Namespace-restricted mode (namespaceRestriction.enabled=true) is not
+  supported for production.
 
   The operator is configured for namespace: {{ default .Release.Namespace $operatorValues.namespaceRestriction.targetNamespace }}
 
-  Please migrate to cluster-wide mode by removing the namespaceRestriction
-  configuration from your values.
+  This release must use dynamo-operator.upgradeCRD=false and must have been
+  installed with Helm's --skip-crds flag. Use cluster-wide mode for production
+  deployments.
 
   See: https://github.com/ai-dynamo/dynamo/blob/main/docs/kubernetes/installation-guide.md
 ================================================================================

--- a/deploy/helm/charts/platform/tests/namespace_restriction_deployment_test.yaml
+++ b/deploy/helm/charts/platform/tests/namespace_restriction_deployment_test.yaml
@@ -1,0 +1,77 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: namespace restriction deployment
+templates:
+  - charts/dynamo-operator/templates/deployment.yaml
+  - charts/dynamo-operator/templates/operator-config.yaml
+tests:
+  - it: runs crd-apply for the default cluster-wide installation
+    template: charts/dynamo-operator/templates/deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: crd-apply
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: rejects CRD upgrades in namespace-restricted mode
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: true
+    asserts:
+      - failedTemplate:
+          errorPattern: "namespaceRestriction.enabled=true is incompatible with upgradeCRD=true"
+
+  - it: omits crd-apply but retains admission serving in namespace-restricted mode
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - notExists:
+          path: spec.template.spec.initContainers
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: webhook-server
+        documentSelector:
+          path: kind
+          value: Deployment
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[1].name
+          value: cert
+        documentSelector:
+          path: kind
+          value: Deployment
+
+  - it: configures the target namespace and ownership Lease
+    template: charts/dynamo-operator/templates/operator-config.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.namespaceRestriction.targetNamespace: tenant-a
+      dynamo-operator.namespaceRestriction.lease.duration: 45s
+      dynamo-operator.namespaceRestriction.lease.renewInterval: 15s
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'restricted: "tenant-a"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'leaseDuration: "45s"'
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: 'leaseRenewInterval: "15s"'
+
+  - it: rejects custom webhook namespace selectors
+    template: charts/dynamo-operator/templates/deployment.yaml
+    set:
+      dynamo-operator.webhook.namespaceSelector.matchLabels.tenant: selected
+    asserts:
+      - failedTemplate:
+          errorPattern: "webhook.namespaceSelector must be empty"

--- a/deploy/helm/charts/platform/tests/namespace_restriction_webhook_rbac_test.yaml
+++ b/deploy/helm/charts/platform/tests/namespace_restriction_webhook_rbac_test.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: namespace restriction webhook RBAC
+templates:
+  - charts/dynamo-operator/templates/webhook-rbac.yaml
+  - charts/dynamo-operator/templates/manager-rbac.yaml
+tests:
+  - it: allows the cluster-wide operator to patch CRD conversion CA bundles
+    template: charts/dynamo-operator/templates/webhook-rbac.yaml
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+        documentIndex: 2
+
+  - it: prevents a namespace-restricted operator from patching CRDs
+    template: charts/dynamo-operator/templates/webhook-rbac.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - hasDocuments:
+          count: 4
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - get
+              - list
+              - watch
+              - update
+              - patch
+        documentIndex: 2
+
+  - it: omits cluster-scoped admission and CRD rules from the namespace-restricted manager Role
+    template: charts/dynamo-operator/templates/manager-rbac.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups:
+              - apiextensions.k8s.io
+            resources:
+              - customresourcedefinitions
+            verbs:
+              - create
+              - delete
+              - get
+              - list
+              - patch
+              - update
+              - watch
+        documentIndex: 0

--- a/deploy/helm/charts/platform/tests/namespace_restriction_webhooks_test.yaml
+++ b/deploy/helm/charts/platform/tests/namespace_restriction_webhooks_test.yaml
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+suite: namespace restriction webhooks
+templates:
+  - charts/dynamo-operator/templates/webhook-configuration.yaml
+  - charts/dynamo-operator/templates/webhook-service.yaml
+  - charts/dynamo-operator/templates/webhook-certificates.yaml
+tests:
+  - it: renders global admission for the cluster-wide installation
+    template: charts/dynamo-operator/templates/webhook-configuration.yaml
+    asserts:
+      - hasDocuments:
+          count: 2
+      - notExists:
+          path: webhooks[0].namespaceSelector
+        documentIndex: 0
+      - notExists:
+          path: webhooks[1].namespaceSelector
+        documentIndex: 0
+      - notExists:
+          path: webhooks[2].namespaceSelector
+        documentIndex: 0
+      - notExists:
+          path: webhooks[3].namespaceSelector
+        documentIndex: 0
+      - notExists:
+          path: webhooks[4].namespaceSelector
+        documentIndex: 0
+      - notExists:
+          path: webhooks[0].namespaceSelector
+        documentIndex: 1
+      - notExists:
+          path: webhooks[1].namespaceSelector
+        documentIndex: 1
+      - notExists:
+          path: webhooks[2].namespaceSelector
+        documentIndex: 1
+      - notExists:
+          path: webhooks[3].namespaceSelector
+        documentIndex: 1
+
+  - it: scopes namespace-restricted admission to the target namespace
+    template: charts/dynamo-operator/templates/webhook-configuration.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      # Exercise a YAML boolean-like namespace to ensure the rendered selector stays a string.
+      dynamo-operator.namespaceRestriction.targetNamespace: "true"
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - hasDocuments:
+          count: 2
+      - equal:
+          path: webhooks[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: webhooks[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: webhooks[2].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: webhooks[3].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: webhooks[4].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: webhooks[0].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: webhooks[1].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: webhooks[2].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 1
+      - equal:
+          path: webhooks[3].namespaceSelector.matchLabels["kubernetes.io/metadata.name"]
+          value: "true"
+        documentIndex: 1
+
+  - it: renders a webhook service for a namespace-restricted installation
+    template: charts/dynamo-operator/templates/webhook-service.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+    asserts:
+      - hasDocuments:
+          count: 1
+
+  - it: renders webhook certificates for a namespace-restricted installation
+    template: charts/dynamo-operator/templates/webhook-certificates.yaml
+    set:
+      dynamo-operator.namespaceRestriction.enabled: true
+      dynamo-operator.upgradeCRD: false
+      dynamo-operator.webhook.certManager.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 4

--- a/deploy/helm/charts/platform/values.yaml
+++ b/deploy/helm/charts/platform/values.yaml
@@ -64,8 +64,9 @@ dynamo-operator:
   # -- Whether to enable the Dynamo Kubernetes operator deployment
   enabled: true
 
-  # -- Whether to manage CRDs via a pre-install/pre-upgrade hook Job.
-  # The Job runs the operator image with the crd-apply tool to apply CRDs via server-side apply.
+  # -- Whether the cluster-wide operator applies bundled CRDs via crd-apply.
+  # This must be false for namespace-restricted installations, which must also
+  # be installed with Helm's --skip-crds flag.
   upgradeCRD: true
 
   # Environment variables to pass to operator Deployment.
@@ -79,22 +80,22 @@ dynamo-operator:
 
   # -- URL for the Model Express server if not deployed by this helm chart. This is ignored if Model Express server is installed by this helm chart (global.model-express.enabled is true).
   modelExpressURL: ""
-  # -- DEPRECATED: Namespace-restricted mode is deprecated and will be removed in a future release. Use cluster-wide mode (the default) instead. Do not enable this for new deployments.
+  # -- DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production. Use cluster-wide mode for production deployments.
   namespaceRestriction:
-    # -- DEPRECATED: Do not enable for new deployments. Namespace-restricted mode is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Enable namespace-restricted reconciliation and admission. Not supported for production.
     enabled: false
-    # -- DEPRECATED: Only used in namespace-restricted mode, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Target namespace. Defaults to the Helm release namespace.
     targetNamespace:
-    # -- DEPRECATED: Only used in namespace-restricted mode, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease settings.
     lease:
-      # -- DEPRECATED: Lease duration for namespace-restricted mode, which is deprecated.
+      # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease duration.
       duration: 30s
-      # -- DEPRECATED: Lease renew interval for namespace-restricted mode, which is deprecated.
+      # -- DEVELOPMENT AND TESTING ONLY: Namespace ownership Lease renewal interval.
       renewInterval: 10s
 
-  # -- DEPRECATED: GPU discovery for namespace-scoped operators is deprecated along with namespace-restricted mode.
+  # -- DEVELOPMENT AND TESTING ONLY: GPU discovery settings for namespace-restricted operators.
   gpuDiscovery:
-    # -- DEPRECATED: Only relevant when namespaceRestriction is enabled, which is deprecated.
+    # -- DEVELOPMENT AND TESTING ONLY: Enable GPU discovery in namespace-restricted mode.
     enabled: true
 
   # -- The Dynamo discovery backend to use. Default is "kubernetes" for Kubernetes API service discovery. Set to "etcd" to use ETCD for discovery. --
@@ -236,8 +237,7 @@ dynamo-operator:
     # -- Timeout in seconds for webhook validation calls. If the webhook doesn't respond within this time, the request will be handled according to the failurePolicy.
     timeoutSeconds: 10
 
-    # Namespace selector for webhook scope control
-    # -- Custom namespace selector for webhook validation. Use this to include or exclude specific namespaces from webhook validation. For CLUSTER-WIDE operators, you can exclude namespaces managed by namespace-restricted operators by using: matchExpressions: [{ key: "dynamo-operator", operator: "NotIn", values: ["namespace-restricted"] }]. For NAMESPACE-RESTRICTED operators, leave empty as it will be auto-configured to match only the operator's namespace.
+    # -- Unsupported; must remain empty. Helm configures global admission for the cluster-wide operator and target-namespace admission for restricted operators.
     namespaceSelector: {}
 
     # cert-manager integration for automated certificate lifecycle management

--- a/deploy/operator/api/config/v1alpha1/types.go
+++ b/deploy/operator/api/config/v1alpha1/types.go
@@ -152,15 +152,14 @@ type LeaderElectionConfiguration struct {
 
 // NamespaceConfiguration determines operator namespace mode.
 type NamespaceConfiguration struct {
-	// Deprecated: Namespace-restricted mode is deprecated and will be removed in a future release.
-	// Use cluster-wide mode (leave Restricted empty) instead.
+	// Restricted enables namespace-restricted mode for development and testing.
+	// Namespace-restricted mode is not supported for production.
 	Restricted string `json:"restricted"`
-	// Deprecated: Scope is only used in namespace-restricted mode, which is deprecated.
+	// Scope configures the namespace ownership claim in namespace-restricted mode.
 	Scope NamespaceScopeConfiguration `json:"scope"`
 }
 
-// Deprecated: NamespaceScopeConfiguration is used only by the deprecated namespace-restricted
-// mode and will be removed in a future release.
+// NamespaceScopeConfiguration configures the development/test namespace ownership claim.
 type NamespaceScopeConfiguration struct {
 	// LeaseDuration is the duration of namespace scope marker lease before expiration
 	// +kubebuilder:default="30s"

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -259,6 +259,7 @@ func main() {
 	}
 
 	restrictedNamespace := operatorCfg.Namespace.Restricted
+	isClusterWide := restrictedNamespace == ""
 	if restrictedNamespace != "" {
 		mgrOpts.Cache.DefaultNamespaces = map[string]cache.Config{
 			restrictedNamespace: {},
@@ -272,12 +273,10 @@ func main() {
 
 		banner := strings.Repeat("=", 80)
 		setupLog.Error(nil, banner)
-		setupLog.Error(nil, "DEPRECATION WARNING: Namespace-restricted mode is deprecated "+
-			"and will be removed in a future release.")
+		setupLog.Error(nil, "DEVELOPMENT AND TESTING ONLY: Namespace-restricted mode is not supported for production.")
 		setupLog.Error(nil, "The operator is running in namespace-restricted mode",
 			"namespace", restrictedNamespace)
-		setupLog.Error(nil, "Please migrate to cluster-wide mode "+
-			"by removing the namespaceRestriction configuration.")
+		setupLog.Error(nil, "Use cluster-wide mode for production deployments.")
 		setupLog.Error(nil, banner)
 	} else {
 		setupLog.Info("No restricted namespace configured, launching in cluster-wide mode")
@@ -638,22 +637,25 @@ func main() {
 		os.Exit(1)
 	}
 
-	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS
-	// secrets before this point. Auto mode can therefore patch admission and
-	// conversion CAs immediately; manual mode waits for externally provided
-	// ca.crt and only patches conversion, leaving admission CA management
-	// out-of-band.
+	// CertManager.SetupAndRunOnce has already bootstrapped auto-mode TLS secrets.
+	// Auto mode patches admission and, for cluster-wide operators, conversion CAs.
+	// Manual mode patches only cluster-wide conversion CAs; admission stays out-of-band.
 	caInjector, err := internalcert.NewCABundleInjector(directClient, operatorCfg)
 	if err != nil {
 		setupLog.Error(err, "unable to create CA bundle injector")
 		os.Exit(1)
 	}
 	if operatorCfg.Server.Webhook.CertProvisionMode == configv1alpha1.CertProvisionModeAuto {
-		if err := caInjector.InjectAll(mainCtx); err != nil {
+		if isClusterWide {
+			err = caInjector.InjectAll(mainCtx)
+		} else {
+			err = caInjector.InjectAdmission(mainCtx)
+		}
+		if err != nil {
 			setupLog.Error(err, "failed to inject CA bundles into webhook configurations")
 			os.Exit(1)
 		}
-	} else {
+	} else if isClusterWide {
 		// Manual mode gets webhook CA material out-of-band. Missing ca.crt
 		// blocks startup instead of running with unauthenticated conversion.
 		if err := caInjector.InjectCRDConversionCA(mainCtx); err != nil {
@@ -854,24 +856,26 @@ func registerWebhookHandlers(
 		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest webhook: %w", err)
 	}
 
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest conversion webhook: %w", err)
-	}
+	if isClusterWide {
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoGraphDeploymentRequest conversion webhook: %w", err)
+		}
 
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeployment{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeployment conversion webhook: %w", err)
-	}
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeployment{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoGraphDeployment conversion webhook: %w", err)
+		}
 
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoComponentDeployment{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoComponentDeployment conversion webhook: %w", err)
-	}
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoComponentDeployment{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoComponentDeployment conversion webhook: %w", err)
+		}
 
-	if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}).
-		Complete(); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentScalingAdapter conversion webhook: %w", err)
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoGraphDeploymentScalingAdapter conversion webhook: %w", err)
+		}
 	}
 
 	setupLog.Info("Registering defaulting webhooks")

--- a/deploy/operator/internal/cert/cert.go
+++ b/deploy/operator/internal/cert/cert.go
@@ -351,10 +351,7 @@ func (i *CABundleInjector) InjectAll(ctx context.Context) error {
 		return fmt.Errorf("reading CA bundle from secret %s/%s: %w", i.namespace, i.cfg.Server.Webhook.SecretName, err)
 	}
 
-	if err := i.injectIntoValidatingWebhooks(ctx, caBundle); err != nil {
-		return err
-	}
-	if err := i.injectIntoMutatingWebhooks(ctx, caBundle); err != nil {
+	if err := i.injectAdmission(ctx, caBundle); err != nil {
 		return err
 	}
 	if err := i.ensureCRDConversionCA(ctx, caBundle); err != nil {
@@ -363,6 +360,29 @@ func (i *CABundleInjector) InjectAll(ctx context.Context) error {
 
 	i.logger.Info("CA bundle injected into all webhook configurations")
 	return nil
+}
+
+// InjectAdmission reads the CA bundle from the cert secret and injects it only
+// into admission webhook configurations owned by this operator instance.
+func (i *CABundleInjector) InjectAdmission(ctx context.Context) error {
+	caBundle, err := i.readCABundle(ctx)
+	if err != nil {
+		return fmt.Errorf("reading CA bundle from secret %s/%s: %w", i.namespace, i.cfg.Server.Webhook.SecretName, err)
+	}
+
+	if err := i.injectAdmission(ctx, caBundle); err != nil {
+		return err
+	}
+
+	i.logger.Info("CA bundle injected into admission webhook configurations")
+	return nil
+}
+
+func (i *CABundleInjector) injectAdmission(ctx context.Context, caBundle []byte) error {
+	if err := i.injectIntoValidatingWebhooks(ctx, caBundle); err != nil {
+		return err
+	}
+	return i.injectIntoMutatingWebhooks(ctx, caBundle)
 }
 
 // InjectCRDConversionCA reads the CA bundle from the cert secret and patches it

--- a/deploy/operator/internal/cert/cert_test.go
+++ b/deploy/operator/internal/cert/cert_test.go
@@ -435,6 +435,69 @@ func TestInjectIntoMutatingWebhooks(t *testing.T) {
 	}
 }
 
+func TestInjectAdmissionDoesNotPatchCRDConversion(t *testing.T) {
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: testSecretName},
+		Data:       map[string][]byte{defaultCACertName: []byte("admission-ca")},
+	}
+	validating := &admissionregistrationv1.ValidatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-validating",
+			Labels: map[string]string{partOfLabel: partOfValue, operatorNamespaceLabel: testNamespace},
+		},
+		Webhooks: []admissionregistrationv1.ValidatingWebhook{{
+			Name:         "validate.webhook.io",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+		}},
+	}
+	mutating := &admissionregistrationv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "test-mutating",
+			Labels: map[string]string{partOfLabel: partOfValue, operatorNamespaceLabel: testNamespace},
+		},
+		Webhooks: []admissionregistrationv1.MutatingWebhook{{
+			Name:         "mutate.webhook.io",
+			ClientConfig: admissionregistrationv1.WebhookClientConfig{},
+		}},
+	}
+	crd := newDGDConversionCRD()
+
+	cfg := &configv1alpha1.OperatorConfiguration{}
+	cfg.Server.Webhook.SecretName = testSecretName
+	injector := newTestInjector(
+		fake.NewClientBuilder().WithScheme(newScheme()).WithObjects(secret, validating, mutating, crd),
+		cfg,
+	)
+	ctx := context.Background()
+	if err := injector.InjectAdmission(ctx); err != nil {
+		t.Fatalf("injecting admission CA: %v", err)
+	}
+
+	updatedValidating := &admissionregistrationv1.ValidatingWebhookConfiguration{}
+	if err := injector.client.Get(ctx, types.NamespacedName{Name: validating.Name}, updatedValidating); err != nil {
+		t.Fatalf("getting validating webhook: %v", err)
+	}
+	if string(updatedValidating.Webhooks[0].ClientConfig.CABundle) != "admission-ca" {
+		t.Fatalf("validating webhook CA = %q, want admission-ca", updatedValidating.Webhooks[0].ClientConfig.CABundle)
+	}
+
+	updatedMutating := &admissionregistrationv1.MutatingWebhookConfiguration{}
+	if err := injector.client.Get(ctx, types.NamespacedName{Name: mutating.Name}, updatedMutating); err != nil {
+		t.Fatalf("getting mutating webhook: %v", err)
+	}
+	if string(updatedMutating.Webhooks[0].ClientConfig.CABundle) != "admission-ca" {
+		t.Fatalf("mutating webhook CA = %q, want admission-ca", updatedMutating.Webhooks[0].ClientConfig.CABundle)
+	}
+
+	updatedCRD := &apiextensionsv1.CustomResourceDefinition{}
+	if err := injector.client.Get(ctx, types.NamespacedName{Name: crd.Name}, updatedCRD); err != nil {
+		t.Fatalf("getting CRD: %v", err)
+	}
+	if updatedCRD.Spec.Conversion.Webhook.ClientConfig.CABundle != nil {
+		t.Fatalf("CRD conversion CA was modified: %q", updatedCRD.Spec.Conversion.Webhook.ClientConfig.CABundle)
+	}
+}
+
 func newConversionCRD(name, plural, singular, kind string) *apiextensionsv1.CustomResourceDefinition {
 	path := testManifestPath
 	return &apiextensionsv1.CustomResourceDefinition{

--- a/deploy/operator/internal/controller_common/predicate.go
+++ b/deploy/operator/internal/controller_common/predicate.go
@@ -222,7 +222,8 @@ func EphemeralDeploymentEventFilter(config *configv1alpha1.OperatorConfiguration
 			return objMeta.GetNamespace() == config.Namespace.Restricted
 		}
 
-		// Cluster-wide mode: check if namespace is excluded
+		// Namespace exclusion filters new events, not requests already in the reconcile queue.
+		// This best-effort isolation is acceptable for the development-and-testing-only mode.
 		if runtimeConfig.ExcludedNamespaces != nil && runtimeConfig.ExcludedNamespaces.Contains(objMeta.GetNamespace()) {
 			l.V(1).Info("Skipping resource - namespace is excluded",
 				"namespace", objMeta.GetNamespace(),

--- a/deploy/operator/internal/namespace_scope/lease_manager.go
+++ b/deploy/operator/internal/namespace_scope/lease_manager.go
@@ -181,6 +181,7 @@ func (lm *LeaseManager) createOrUpdateLease(ctx context.Context) error {
 			HolderIdentity:       &lm.holderIdentity,
 			LeaseDurationSeconds: &leaseDurationSeconds,
 			AcquireTime:          &now,
+			RenewTime:            &now,
 		},
 	}
 

--- a/deploy/operator/internal/namespace_scope/lease_manager_test.go
+++ b/deploy/operator/internal/namespace_scope/lease_manager_test.go
@@ -43,14 +43,12 @@ func TestLeaseManager_CreateOrUpdateLease(t *testing.T) {
 		namespace       string
 		operatorVersion string
 		existingLease   *coordinationv1.Lease
-		wantRenewTime   bool // Whether RenewTime should be set
 	}{
 		{
 			name:            "creates lease when it doesn't exist",
 			namespace:       testNamespace,
 			operatorVersion: testOperatorVersion,
 			existingLease:   nil,
-			wantRenewTime:   false, // RenewTime should be nil on creation
 		},
 		{
 			name:            "updates existing lease",
@@ -68,7 +66,6 @@ func TestLeaseManager_CreateOrUpdateLease(t *testing.T) {
 					RenewTime:            &metav1.MicroTime{Time: time.Now().Add(-1 * time.Minute)},
 				},
 			},
-			wantRenewTime: true, // RenewTime should be set on update
 		},
 	}
 
@@ -133,29 +130,23 @@ func TestLeaseManager_CreateOrUpdateLease(t *testing.T) {
 				t.Errorf("lease duration = %v, want %v", *lease.Spec.LeaseDurationSeconds, 30)
 			}
 
-			// Verify renew time and acquire time based on operation
-			if tt.wantRenewTime {
-				// Update case: RenewTime should be set and newer than before
-				if lease.Spec.RenewTime == nil {
-					t.Error("lease renew time should be set on update")
-				} else if tt.existingLease != nil && !lease.Spec.RenewTime.After(tt.existingLease.Spec.RenewTime.Time) {
+			if lease.Spec.RenewTime == nil {
+				t.Fatal("lease renew time should be set")
+			}
+			if tt.existingLease != nil {
+				if !lease.Spec.RenewTime.After(tt.existingLease.Spec.RenewTime.Time) {
 					t.Error("renew time was not updated")
 				}
-				// AcquireTime should be preserved from existing lease
-				if tt.existingLease != nil && tt.existingLease.Spec.AcquireTime != nil {
-					if lease.Spec.AcquireTime == nil {
-						t.Error("acquire time should be preserved on update")
-					} else if !lease.Spec.AcquireTime.Equal(tt.existingLease.Spec.AcquireTime) {
-						t.Error("acquire time should not change on update")
-					}
+				if lease.Spec.AcquireTime == nil {
+					t.Error("acquire time should be preserved on update")
+				} else if !lease.Spec.AcquireTime.Equal(tt.existingLease.Spec.AcquireTime) {
+					t.Error("acquire time should not change on update")
 				}
 			} else {
-				// Create case: RenewTime should be nil, AcquireTime should be set
-				if lease.Spec.RenewTime != nil {
-					t.Error("lease renew time should be nil on initial creation")
-				}
 				if lease.Spec.AcquireTime == nil {
 					t.Error("lease acquire time should be set on initial creation")
+				} else if !lease.Spec.RenewTime.Equal(lease.Spec.AcquireTime) {
+					t.Error("initial renew time should match acquire time")
 				}
 			}
 		})
@@ -264,17 +255,17 @@ func TestLeaseManager_StartAndStop_CompleteLifecycle(t *testing.T) {
 		t.Errorf("lease name = %v, want %v", lease.Name, LeaseName)
 	}
 
-	// Verify initial lease has no renew time (since it was just created)
-	if lease.Spec.RenewTime != nil {
-		t.Error("initial lease should not have renew time set on creation")
+	if lease.Spec.RenewTime == nil {
+		t.Fatal("initial lease should have renew time set on creation")
 	}
+	initialRenewTime := lease.Spec.RenewTime.Time
 
 	// Poll for renewal with timeout (more robust than fixed sleep)
 	renewalDetected := false
 	deadline := time.Now().Add(500 * time.Millisecond)
 	for time.Now().Before(deadline) {
 		updatedLease, err := client.CoordinationV1().Leases(namespace).Get(ctx, LeaseName, metav1.GetOptions{})
-		if err == nil && updatedLease.Spec.RenewTime != nil {
+		if err == nil && updatedLease.Spec.RenewTime != nil && updatedLease.Spec.RenewTime.After(initialRenewTime) {
 			renewalDetected = true
 			break
 		}

--- a/deploy/operator/internal/webhook/common.go
+++ b/deploy/operator/internal/webhook/common.go
@@ -38,8 +38,8 @@ type ExcludedNamespacesChecker interface {
 	Contains(namespace string) bool
 }
 
-// webhookExcludedNamespaces holds the excluded namespaces checker (usually leaseWatcher)
-// This is set by main.go and shared across all webhook validators
+// webhookExcludedNamespaces holds the excluded namespaces checker (usually leaseWatcher).
+// This is set by main.go and shared across admission handlers.
 var webhookExcludedNamespaces ExcludedNamespacesChecker
 
 // SetExcludedNamespaces sets the excluded namespaces checker for all webhooks.
@@ -64,6 +64,12 @@ type LeaseAwareValidator struct {
 	excludedNamespaces ExcludedNamespacesChecker
 }
 
+// LeaseAwareDefaulter skips defaulting in namespaces owned by namespace-restricted operators.
+type LeaseAwareDefaulter struct {
+	defaulter          admission.Defaulter[runtime.Object]
+	excludedNamespaces ExcludedNamespacesChecker
+}
+
 // NewLeaseAwareValidator creates a new LeaseAwareValidator that wraps the given validator.
 // If excludedNamespaces is nil, the wrapper acts as a pass-through (no filtering).
 func NewLeaseAwareValidator(validator admission.CustomValidator, excludedNamespaces ExcludedNamespacesChecker) admission.CustomValidator {
@@ -77,9 +83,21 @@ func NewLeaseAwareValidator(validator admission.CustomValidator, excludedNamespa
 	}
 }
 
+// NewLeaseAwareDefaulter creates a defaulter that skips namespaces claimed by a Lease.
+// If excludedNamespaces is nil, the defaulter is returned unchanged.
+func NewLeaseAwareDefaulter(defaulter admission.Defaulter[runtime.Object], excludedNamespaces ExcludedNamespacesChecker) admission.Defaulter[runtime.Object] {
+	if excludedNamespaces == nil {
+		return defaulter
+	}
+	return &LeaseAwareDefaulter{
+		defaulter:          defaulter,
+		excludedNamespaces: excludedNamespaces,
+	}
+}
+
 // ValidateCreate implements admission.CustomValidator
 func (v *LeaseAwareValidator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	if v.shouldSkipValidation(obj) {
+	if shouldSkipAdmission(obj, v.excludedNamespaces) {
 		return nil, nil
 	}
 	return v.validator.ValidateCreate(ctx, obj)
@@ -87,7 +105,7 @@ func (v *LeaseAwareValidator) ValidateCreate(ctx context.Context, obj runtime.Ob
 
 // ValidateUpdate implements admission.CustomValidator
 func (v *LeaseAwareValidator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
-	if v.shouldSkipValidation(newObj) {
+	if shouldSkipAdmission(newObj, v.excludedNamespaces) {
 		return nil, nil
 	}
 	return v.validator.ValidateUpdate(ctx, oldObj, newObj)
@@ -95,14 +113,21 @@ func (v *LeaseAwareValidator) ValidateUpdate(ctx context.Context, oldObj, newObj
 
 // ValidateDelete implements admission.CustomValidator
 func (v *LeaseAwareValidator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	if v.shouldSkipValidation(obj) {
+	if shouldSkipAdmission(obj, v.excludedNamespaces) {
 		return nil, nil
 	}
 	return v.validator.ValidateDelete(ctx, obj)
 }
 
-// shouldSkipValidation checks if validation should be skipped for the given object
-func (v *LeaseAwareValidator) shouldSkipValidation(obj runtime.Object) bool {
+// Default implements admission.CustomDefaulter.
+func (d *LeaseAwareDefaulter) Default(ctx context.Context, obj runtime.Object) error {
+	if shouldSkipAdmission(obj, d.excludedNamespaces) {
+		return nil
+	}
+	return d.defaulter.Default(ctx, obj)
+}
+
+func shouldSkipAdmission(obj runtime.Object, excludedNamespaces ExcludedNamespacesChecker) bool {
 	// Try to extract namespace from object using client.Object interface
 	clientObj, ok := obj.(client.Object)
 	if !ok {
@@ -111,8 +136,8 @@ func (v *LeaseAwareValidator) shouldSkipValidation(obj runtime.Object) bool {
 	}
 
 	namespace := clientObj.GetNamespace()
-	if v.excludedNamespaces.Contains(namespace) {
-		webhookCommonLog.Info("skipping validation - namespace has namespace-restricted operator",
+	if excludedNamespaces.Contains(namespace) {
+		webhookCommonLog.Info("skipping admission - namespace has namespace-restricted operator",
 			"name", clientObj.GetName(),
 			"namespace", namespace,
 			"kind", obj.GetObjectKind().GroupVersionKind().Kind)

--- a/deploy/operator/internal/webhook/common_test.go
+++ b/deploy/operator/internal/webhook/common_test.go
@@ -6,10 +6,60 @@
 package webhook
 
 import (
+	"context"
 	"testing"
 
 	authenticationv1 "k8s.io/api/authentication/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
+
+type testExcludedNamespaces map[string]bool
+
+func (e testExcludedNamespaces) Contains(namespace string) bool {
+	return e[namespace]
+}
+
+type countingDefaulter struct {
+	calls int
+}
+
+func (d *countingDefaulter) Default(context.Context, runtime.Object) error {
+	d.calls++
+	return nil
+}
+
+func TestLeaseAwareDefaulter(t *testing.T) {
+	defaulter := &countingDefaulter{}
+	wrapped := NewLeaseAwareDefaulter(defaulter, testExcludedNamespaces{"claimed": true})
+
+	if err := wrapped.Default(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "claimed"},
+	}); err != nil {
+		t.Fatalf("defaulting excluded namespace: %v", err)
+	}
+	if defaulter.calls != 0 {
+		t.Fatalf("excluded namespace called defaulter %d times, want 0", defaulter.calls)
+	}
+
+	if err := wrapped.Default(context.Background(), &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "unclaimed"},
+	}); err != nil {
+		t.Fatalf("defaulting unclaimed namespace: %v", err)
+	}
+	if defaulter.calls != 1 {
+		t.Fatalf("unclaimed namespace called defaulter %d times, want 1", defaulter.calls)
+	}
+}
+
+func TestLeaseAwareDefaulterWithoutChecker(t *testing.T) {
+	defaulter := &countingDefaulter{}
+	wrapped := NewLeaseAwareDefaulter(defaulter, nil)
+	if wrapped != defaulter {
+		t.Fatal("defaulter without a checker should be returned unchanged")
+	}
+}
 
 func TestCanModifyDGDReplicas(t *testing.T) {
 	tests := []struct {

--- a/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamocomponentdeployment_handler.go
@@ -78,8 +78,9 @@ func (d *DCDDefaulter) Default(ctx context.Context, obj runtime.Object) error {
 
 // RegisterWithManager registers the DCD defaulting webhook with the manager.
 func (d *DCDDefaulter) RegisterWithManager(mgr manager.Manager) error {
+	defaulter := internalwebhook.NewLeaseAwareDefaulter(d, internalwebhook.GetExcludedNamespaces())
 	webhook := admission.
-		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoComponentDeployment{}, d).
+		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoComponentDeployment{}, defaulter).
 		WithRecoverPanic(true)
 	mgr.GetWebhookServer().Register(dcdDefaultingWebhookPath, webhook)
 	return nil

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeployment_handler.go
@@ -134,8 +134,9 @@ func (d *DGDDefaulter) isGrovePathway(dgd *nvidiacomv1beta1.DynamoGraphDeploymen
 
 // RegisterWithManager registers the defaulting webhook with the manager.
 func (d *DGDDefaulter) RegisterWithManager(mgr manager.Manager) error {
+	betaDefaulter := internalwebhook.NewLeaseAwareDefaulter(d, internalwebhook.GetExcludedNamespaces())
 	betaWebhook := admission.
-		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoGraphDeployment{}, d).
+		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoGraphDeployment{}, betaDefaulter).
 		WithRecoverPanic(true)
 	mgr.GetWebhookServer().Register(dgdV1Beta1DefaultingWebhookPath, betaWebhook)
 
@@ -143,8 +144,9 @@ func (d *DGDDefaulter) RegisterWithManager(mgr manager.Manager) error {
 	// moves to v1beta1. This lets an upgrade switch the registration only after
 	// all running operators already serve both endpoints.
 	alphaDefaulter := &dgdV1Alpha1Defaulter{defaulter: d}
+	alphaDefaulterWithLease := internalwebhook.NewLeaseAwareDefaulter(alphaDefaulter, internalwebhook.GetExcludedNamespaces())
 	alphaWebhook := admission.
-		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1alpha1.DynamoGraphDeployment{}, alphaDefaulter).
+		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1alpha1.DynamoGraphDeployment{}, alphaDefaulterWithLease).
 		WithRecoverPanic(true)
 	mgr.GetWebhookServer().Register(dgdV1Alpha1DefaultingWebhookPath, alphaWebhook)
 	return nil

--- a/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
+++ b/deploy/operator/internal/webhook/defaulting/dynamographdeploymentrequest_handler.go
@@ -110,8 +110,9 @@ func (d *DGDRDefaulter) defaultImageFor() string {
 
 // RegisterWithManager registers the DGDR defaulting webhook with the manager.
 func (d *DGDRDefaulter) RegisterWithManager(mgr manager.Manager) error {
+	defaulter := internalwebhook.NewLeaseAwareDefaulter(d, internalwebhook.GetExcludedNamespaces())
 	webhook := admission.
-		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}, d).
+		WithCustomDefaulter(mgr.GetScheme(), &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}, defaulter).
 		WithRecoverPanic(true)
 	mgr.GetWebhookServer().Register(dgdrDefaultingWebhookPath, webhook)
 	return nil

--- a/docs/benchmarks/kv-router-ab-testing.md
+++ b/docs/benchmarks/kv-router-ab-testing.md
@@ -87,7 +87,9 @@ kubectl create secret generic hf-token-secret \
 
 Follow the [Dynamo Kubernetes Installation Guide](../kubernetes/installation-guide.md) to install the platform in `dynamo-bench`.
 
-> **Note:** Namespace-restricted mode (`namespaceRestriction.enabled=true`) is deprecated and will be removed in a future release. Use cluster-wide mode for new deployments.
+> [!WARNING]
+> Namespace-restricted mode (`namespaceRestriction.enabled=true`) is only for development and
+> testing. It is not supported for production.
 
 **Key Configuration Notes:**
 - Adjust version tags to match your cluster's available Dynamo versions

--- a/docs/components/profiler/profiler-guide.md
+++ b/docs/components/profiler/profiler-guide.md
@@ -338,11 +338,12 @@ The operator automatically discovers GPU resources from cluster nodes, providing
 **Requirements:**
 - **Cluster-scoped operators** (recommended): Have node read permissions by default. GPU discovery works automatically.
 
-> **DEPRECATED:** The following applies only to namespace-scoped operators, which are deprecated and will be removed in a future release. Use cluster-wide mode for new deployments.
+> [!WARNING]
+> Namespace-restricted operators are only for development and testing. They are not supported for production.
 
-- **Namespace-scoped operators** (deprecated): GPU discovery is enabled by default when installing via Helm — the chart provisions the required ClusterRole/ClusterRoleBinding automatically
+- **Namespace-restricted operators**: GPU discovery is enabled by default when installing with Helm. The chart provisions the required ClusterRole and ClusterRoleBinding.
 
-**For namespace-scoped operators (deprecated)**, GPU discovery is controlled by a Helm value:
+For namespace-restricted operators, control GPU discovery with a Helm value:
 
 ```bash
 # GPU discovery enabled (default) — Helm provisions read-only node access automatically

--- a/docs/kubernetes/README.md
+++ b/docs/kubernetes/README.md
@@ -18,8 +18,8 @@ path for shared GPU clusters and multi-node serving.
 
 ## Prerequisites
 
-- Kubernetes cluster (v1.24+) with GPU nodes
-- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) (v1.24+)
+- Kubernetes cluster (v1.30+) with GPU nodes
+- [kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl) (v1.30+)
 - [Helm](https://helm.sh/docs/intro/install/) (v3.0+) installed
 - [NVIDIA GPU Operator](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html) installed on the cluster
 - HuggingFace token secret on cluster

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -3451,16 +3451,15 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `restricted` _string_ | Deprecated: Namespace-restricted mode is deprecated and will be removed in a future release.<br />Use cluster-wide mode (leave Restricted empty) instead. |  |  |
-| `scope` _[NamespaceScopeConfiguration](#namespacescopeconfiguration)_ | Deprecated: Scope is only used in namespace-restricted mode, which is deprecated. |  |  |
+| `restricted` _string_ | Restricted enables namespace-restricted mode for development and testing.<br />Namespace-restricted mode is not supported for production. |  |  |
+| `scope` _[NamespaceScopeConfiguration](#namespacescopeconfiguration)_ | Scope configures the namespace ownership claim in namespace-restricted mode. |  |  |
 
 
 #### NamespaceScopeConfiguration
 
 
 
-Deprecated: NamespaceScopeConfiguration is used only by the deprecated namespace-restricted
-mode and will be removed in a future release.
+NamespaceScopeConfiguration configures the development/test namespace ownership claim.
 
 
 

--- a/docs/kubernetes/cloud-providers/aks/azure-lustre-csi.md
+++ b/docs/kubernetes/cloud-providers/aks/azure-lustre-csi.md
@@ -9,7 +9,7 @@ This guide covers installing and configuring the [Azure Lustre CSI driver](https
 ## Prerequisites
 
 **AKS cluster requirements**
-- Kubernetes 1.21 or later
+- Kubernetes 1.30 or later
 - Node pools must use the **Ubuntu** OS SKU — Windows and Azure Linux (CBL Mariner) nodes are not supported
 - AKS is the only supported Kubernetes distribution (self-managed clusters are not supported)
 

--- a/docs/kubernetes/deployment/multinode-deployment.md
+++ b/docs/kubernetes/deployment/multinode-deployment.md
@@ -18,7 +18,7 @@ Dynamo supports multinode deployments through the `multinode` section in resourc
 
 ## Basic requirements
 
-- **Kubernetes Cluster**: Version 1.24 or later
+- **Kubernetes Cluster**: Version 1.30 or later
 - **GPU Nodes**: Multiple nodes with NVIDIA GPUs
 - **High-Speed Networking**: InfiniBand, RoCE, or high-bandwidth Ethernet (recommended for optimal performance)
 

--- a/docs/kubernetes/dynamo-operator.md
+++ b/docs/kubernetes/dynamo-operator.md
@@ -30,75 +30,79 @@ Dynamo operator is a Kubernetes operator that simplifies the deployment, configu
 
 ## Deployment Modes
 
-The Dynamo operator supports three deployment modes to accommodate different cluster environments and use cases:
+The Dynamo operator has one supported production mode and one development/test mode.
 
-### 1. Cluster-Wide Mode (Default, Recommended)
+### Cluster-Wide Mode
 
 The operator monitors and manages DynamoGraph resources across **all namespaces** in the cluster.
+It owns the cluster-wide Custom Resource Definitions (CRDs), conversion webhook, and conversion
+certificate authority (CA). Deploy exactly one cluster-wide operator per cluster.
 
 **When to Use:**
+
 - You have full cluster admin access
 - You want centralized management of all Dynamo workloads
 - Standard production deployment on a dedicated cluster
 
----
+### Namespace-Restricted Mode
 
-### 2. Namespace-Scoped Mode (DEPRECATED)
+> [!WARNING]
+> Namespace-restricted mode is only for development and testing. It is not supported for production.
 
-> **DEPRECATED:** Namespace-scoped mode (`namespaceRestriction.enabled=true`) is deprecated and will be removed in a future release. Use cluster-wide mode instead. Do not use this for new deployments.
+A namespace-restricted operator reconciles, validates, and mutates resources only in its target
+namespace. It creates a Lease that makes the cluster-wide operator skip reconciliation and
+admission in that namespace. The namespace-restricted operator serves its own admission webhooks
+using its local feature settings.
 
-The operator monitors and manages DynamoGraph resources **only in a specific namespace**. A lease marker is created to signal the operator's presence to any cluster-wide operators.
-
-**When to Use:**
-- You're on a shared/multi-tenant cluster
-- You only have namespace-level permissions
-- You want to test a new operator version in isolation
-- You need to avoid conflicts with other operators
-
-**Installation:**
-```bash
-helm install dynamo-platform dynamo-platform-${RELEASE_VERSION}.tgz \
-  --namespace my-namespace \
-  --create-namespace \
-  --set dynamo-operator.namespaceRestriction.enabled=true
-```
-
----
-
-### 3. Hybrid Mode (DEPRECATED)
-
-> **DEPRECATED:** Hybrid mode relies on namespace-scoped operators, which are deprecated and will be removed in a future release. Use a single cluster-wide operator instead.
-
-A **cluster-wide operator** manages most namespaces, while **one or more namespace-scoped operators** run in specific namespaces (e.g., for testing new versions). The cluster-wide operator automatically detects and excludes namespaces with namespace-scoped operators using lease markers.
-
-**When to Use:**
-- Running production workloads with a stable operator version
-- Testing new operator versions in isolated namespaces without affecting production
-- Gradual rollout of operator updates
-- Development/staging environments on production clusters
+Use this mode to test controller changes or feature settings in one namespace on a development
+cluster. It is not a multi-tenancy boundary.
 
 **How It Works:**
-1. Namespace-scoped operator creates a lease named `dynamo-operator-namespace-scope` in its namespace
-2. Cluster-wide operator watches for these lease markers across all namespaces
-3. Cluster-wide operator automatically excludes any namespace with a lease marker
-4. If namespace-scoped operator stops, its lease expires (TTL: 30s by default)
-5. Cluster-wide operator automatically resumes managing that namespace
 
-**Setup Example:**
+1. The namespace-restricted operator creates a Lease named `dynamo-operator-namespace-scope`.
+2. The cluster-wide operator watches these Leases and skips the claimed namespace.
+3. The namespace-restricted ValidatingWebhookConfiguration and MutatingWebhookConfiguration select
+   only the target namespace.
+4. The namespace-restricted operator manages the TLS certificate and CA bundles for its own
+   admission configurations.
+5. The cluster-wide operator remains the only owner of CRDs, conversion, and conversion CA bundles.
+
+If the namespace-restricted Pod becomes unavailable, Lease expiration lets the cluster-wide operator
+resume reconciliation, but does not remove the namespace-restricted webhook configurations. Admission
+continues to target the unavailable Service. Recover the Pod to restore namespace-restricted admission,
+or uninstall the release to remove its webhook configurations. Cluster-wide admission resumes after the
+Lease is deleted or expires.
+
+> [!CAUTION]
+> Pass `--skip-crds` and set `dynamo-operator.upgradeCRD=false`. Helm installs the chart's `crds/`
+> directory before rendering templates, so the chart cannot detect a missing `--skip-crds` flag.
 
 ```bash
-# 1. Install cluster-wide operator (production, v1.0.0)
+# Install the cluster-wide operator first
 helm install dynamo-platform dynamo-platform-${RELEASE_VERSION}.tgz \
   --namespace dynamo-system \
   --create-namespace
 
-# 2. Install namespace-scoped operator (testing, v2.0.0-beta)
+# Install a namespace-restricted operator for development or testing
 helm install dynamo-test dynamo-platform-${RELEASE_VERSION}.tgz \
   --namespace test-namespace \
   --create-namespace \
+  --skip-crds \
   --set dynamo-operator.namespaceRestriction.enabled=true \
+  --set dynamo-operator.upgradeCRD=false \
   --set dynamo-operator.controllerManager.manager.image.tag=v2.0.0-beta
 ```
+
+Set `dynamo-operator.namespaceRestriction.targetNamespace` when the target differs from the Helm
+release namespace.
+
+Install every operator Helm release in a separate namespace. Multiple Dynamo operator releases in
+the same Helm release namespace are not supported.
+
+Run the same operator version in parallel whenever possible. The cluster-wide operator should be
+the same version or newer and must provide the newest APIs in the cluster. A newer namespaced
+controller can be used for development when it does not require CRD fields absent from the
+cluster-wide installation.
 
 **Observability:**
 
@@ -196,7 +200,9 @@ helm fetch https://helm.ngc.nvidia.com/nvidia/ai-dynamo/charts/dynamo-platform-$
 helm install dynamo-platform dynamo-platform-${RELEASE_VERSION}.tgz --namespace ${NAMESPACE} --create-namespace
 ```
 
-> **Note:** Namespace-scoped and hybrid deployment modes are deprecated. Use cluster-wide mode for all new deployments. See [Deployment Modes](#deployment-modes) above if you need backward-compatible configurations.
+> [!NOTE]
+> Namespace-restricted mode is only for development and testing. Use cluster-wide mode for
+> production deployments.
 
 ### Building from Source
 

--- a/docs/kubernetes/installation-guide.md
+++ b/docs/kubernetes/installation-guide.md
@@ -11,10 +11,10 @@ This guide walks you through installing everything needed to deploy models with 
 
 Before you begin, make sure you have:
 
-- A **Kubernetes cluster (v1.24+)** with GPU-capable nodes. See the cloud provider guides if you need to create one:
+- A **Kubernetes cluster (v1.30+)** with GPU-capable nodes. See the cloud provider guides if you need to create one:
   - [Amazon EKS](cloud-providers/eks/eks.md) | [Azure AKS](cloud-providers/aks/aks.md) | [Google GKE](cloud-providers/gke/gke.md)
   - For local development: [Minikube Setup](deployment/minikube.md)
-- **kubectl** v1.24+ — [Install kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
+- **kubectl** v1.30+ — [Install kubectl](https://kubernetes.io/docs/tasks/tools/#kubectl)
 - **Helm** v3.0+ — [Install Helm](https://helm.sh/docs/intro/install/)
 
 > [!IMPORTANT]
@@ -23,7 +23,7 @@ Before you begin, make sure you have:
 Verify your tools:
 
 ```bash
-kubectl version --client  # Should show v1.24+
+kubectl version --client  # Should show v1.30+
 helm version              # Should show v3.0+
 ```
 
@@ -117,7 +117,9 @@ helm install dynamo-platform dynamo-platform-$RELEASE_VERSION.tgz \
 > ```
 
 > [!WARNING]
-> **Namespace-restricted mode** (`namespaceRestriction.enabled=true`) is deprecated and will be removed in a future release. Use the default cluster-wide mode for all new deployments.
+> **Namespace-restricted mode** (`namespaceRestriction.enabled=true`) is only for development and
+> testing. It is not supported for production. Install it with `--skip-crds` and
+> `dynamo-operator.upgradeCRD=false`; see [Dynamo Operator](dynamo-operator.md#namespace-restricted-mode).
 
 Verify the Dynamo platform is running:
 
@@ -246,7 +248,8 @@ Found existing namespace-restricted Dynamo operators in namespaces: ...
 
 Cause: Attempting cluster-wide install on a shared cluster with existing namespace-restricted operators.
 
-Solution: Migrate the existing namespace-restricted operators to cluster-wide mode. Namespace-restricted mode is deprecated.
+Solution: Remove the development/test namespace-restricted operators, then install one cluster-wide
+operator for production use.
 
 **CRDs already exist**
 

--- a/docs/kubernetes/webhooks.md
+++ b/docs/kubernetes/webhooks.md
@@ -127,8 +127,8 @@ dynamo-operator:
     failurePolicy: Fail        # Fail (reject on error) or Ignore (allow on error)
     timeoutSeconds: 10         # Webhook timeout
 
-    # Namespace filtering (advanced)
-    namespaceSelector: {}      # Kubernetes label selector for namespaces
+    # User-configured namespace filtering is unsupported
+    namespaceSelector: {}
 ```
 
 #### Failure Policy
@@ -147,25 +147,10 @@ webhook:
 
 #### Namespace Filtering
 
-Control which namespaces are validated (applies to **cluster-wide operator** only):
-
-```yaml
-# Only validate resources in namespaces with specific labels
-webhook:
-  namespaceSelector:
-    matchLabels:
-      dynamo-validation: enabled
-
-# Or exclude specific namespaces
-webhook:
-  namespaceSelector:
-    matchExpressions:
-    - key: dynamo-validation
-      operator: NotIn
-      values: ["disabled"]
-```
-
-**Note:** For **namespace-restricted operators** (deprecated), the namespace selector is automatically set to validate only the operator's namespace. This configuration is ignored in namespace-restricted mode.
+User-configured webhook namespace filtering is not supported. Helm rejects a non-empty
+`webhook.namespaceSelector` value. The cluster-wide webhook configurations cover every namespace,
+while namespace-restricted webhook configurations use a Helm-generated selector for their target
+namespace. The cluster-wide handlers skip namespaces claimed by an active ownership Lease.
 
 ---
 
@@ -335,61 +320,45 @@ helm install dynamo-platform . -n <namespace> -f values.yaml
 
 ---
 
-## Multi-Operator Deployments (DEPRECATED)
+## Development and Test Multi-Operator Deployments
 
-> **DEPRECATED:** Namespace-restricted mode and multi-operator deployments are deprecated and will be removed in a future release. Use a single cluster-wide operator instead.
+> [!WARNING]
+> Namespace-restricted and multi-operator configurations are only for development and testing.
+> They are not supported for production. Use one cluster-wide operator in production.
 
-The operator supports running both **cluster-wide** and **namespace-restricted** instances simultaneously using a **lease-based coordination mechanism**.
+The operator can run one cluster-wide instance and namespace-restricted instances using a
+Lease-based ownership mechanism.
 
 ### Scenario
 
-```
+```text
 Cluster:
 ├─ Operator A (cluster-wide, namespace: platform-system)
-│  └─ Validates all namespaces EXCEPT team-a
+│  └─ Skips reconciliation and admission in team-a
 └─ Operator B (namespace-restricted, namespace: team-a)
-   └─ Validates only team-a namespace
+   └─ Reconciles, validates, and mutates only team-a
 ```
 
 ### How It Works
 
-1. **Namespace-restricted operator** creates a Lease in its namespace
-2. **Cluster-wide operator** watches for Leases named `dynamo-operator-ns-lock`
-3. **Cluster-wide operator** skips validation for namespaces with active Leases
-4. **Namespace-restricted operator** validates resources in its namespace
-
-### Lease Configuration
-
-The lease mechanism is **automatically configured** based on deployment mode:
-
-```yaml
-# Cluster-wide operator (default)
-namespaceRestriction:
-  enabled: false
-# → Watches for leases in all namespaces
-# → Skips validation for namespaces with active leases
-
-# Namespace-restricted operator
-namespaceRestriction:
-  enabled: true
-  namespace: team-a
-# → Creates lease in team-a namespace
-# → Does NOT check for leases (no cluster permissions)
-```
+1. The namespace-restricted operator creates a Lease named `dynamo-operator-namespace-scope`.
+2. The cluster-wide operator skips reconciliation, validation, and mutation for that namespace.
+3. The namespace-restricted operator's webhook configurations select only its target namespace.
+4. Each operator manages the certificate and CA bundles for its own admission configurations.
+5. Only the cluster-wide operator updates CRDs, conversion service references, and conversion CA bundles.
 
 ### Deployment Example
 
 ```bash
-# 1. Deploy cluster-wide operator
-helm install platform-operator dynamo-platform \
-  -n platform-system \
-  --set namespaceRestriction.enabled=false
+# 1. Deploy the cluster-wide operator
+helm install platform-operator dynamo-platform -n platform-system
 
-# 2. Deploy namespace-restricted operator for team-a
+# 2. Deploy a namespace-restricted operator for team-a
 helm install team-a-operator dynamo-platform \
   -n team-a \
-  --set namespaceRestriction.enabled=true \
-  --set namespaceRestriction.namespace=team-a
+  --skip-crds \
+  --set dynamo-operator.namespaceRestriction.enabled=true \
+  --set dynamo-operator.upgradeCRD=false
 ```
 
 ### ValidatingWebhookConfiguration Naming
@@ -409,13 +378,21 @@ platform-operator-validating
 team-a-operator-validating-team-a
 ```
 
-This allows multiple webhook configurations to coexist without conflicts.
+Helm fixes every webhook in the namespace-restricted configurations to the target namespace. Do not
+set `webhook.namespaceSelector` manually.
 
 ### Lease Health
 
-If the namespace-restricted operator is deleted or becomes unhealthy:
-- Lease expires after `leaseDuration + gracePeriod` (default: ~30 seconds)
-- Cluster-wide operator automatically resumes validation for that namespace
+After you uninstall the namespace-restricted release, its webhook configurations are removed and
+its Lease expires. Cluster-wide reconciliation and admission then resume for the namespace. If only
+the operator Pod is unhealthy, its webhook configurations remain and can block admission according
+to `failurePolicy` until the release recovers or is uninstalled.
+
+Run the same operator version in parallel whenever possible. The cluster-wide operator should be
+the same version or newer and must provide the newest APIs. A newer namespaced controller is
+acceptable for development when it remains compatible with the installed CRDs.
+Install every operator Helm release in a separate namespace so each release owns a distinct
+admission certificate and webhook configuration set.
 
 ---
 
@@ -440,7 +417,7 @@ kubectl get validatingwebhookconfiguration <name> -o yaml
 # Verify:
 # - caBundle is present and non-empty
 # - clientConfig.service points to correct service
-# - webhooks[].namespaceSelector matches your namespace
+# - webhooks[].namespaceSelector is absent for cluster-wide admission or matches the target namespace
 ```
 
 3. **Verify webhook service exists**:
@@ -642,7 +619,7 @@ helm upgrade <release> dynamo-platform -n <namespace>
 ### Multi-Tenant Deployments
 
 1. ✅ **Deploy one cluster-wide operator** for platform-wide validation
-2. ~~Deploy namespace-restricted operators for tenant-specific namespaces~~ (**DEPRECATED** - use cluster-wide mode instead)
+2. Use namespace-restricted operators only for development or testing, never as a production tenant-isolation mechanism
 
 ---
 
@@ -661,4 +638,3 @@ For issues or questions:
 - Check [Troubleshooting](#troubleshooting) section
 - Review operator logs: `kubectl logs -n <namespace> deployment/<release>-dynamo-operator`
 - Open an issue on GitHub
-


### PR DESCRIPTION
## Summary

- cherry-pick #11597 to `release/1.3.0`
- keep namespace-restricted admission and reconciliation isolated through the existing namespace ownership Lease
- keep CRD application, conversion, and conversion CA ownership exclusively cluster-wide
- classify namespace-restricted mode as development/test only and document the required `--skip-crds` installation flag

## Dependency

Depends on #11597, which is merged to `main` as `43788706ec7623a89c3ce37251e86af79c1f70f9`. No remaining PR dependency.

## Conflict resolution

- preserved the release branch manager RBAC and applied only the intended cluster-wide guard around admission configuration and CRD permissions
- preserved release-specific NATS and etcd documentation while taking the namespace-restriction documentation updates
- adapted the namespace exclusion comment without importing an unrelated `main` predicate refactoring

## Validation

- `source ../../.venv/bin/activate && make test` in `deploy/operator`
- `make test lint` in `deploy/helm/charts/platform` (30 tests passed)
- `fern check`
- `fern docs broken-links`
- pre-commit hooks during cherry-pick
- `git verify-commit HEAD`

Linear: https://linear.app/nvidia/issue/DYN-3412
Related conversion CA bug: https://linear.app/nvidia/issue/DYN-3444
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11651" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->