### PR TITLE
fix(ci): correct lychee on main by repointing dead sglang diffusion links

### DIFF
--- a/docs/backends/sglang/sglang-diffusion.md
+++ b/docs/backends/sglang/sglang-diffusion.md
@@ -23,7 +23,7 @@ If you see a CuDNN version mismatch error on startup (`cuDNN frontend 1.8.1 requ
 
 Diffusion Language Models generate text through iterative refinement rather than autoregressive token-by-token generation. The model starts with masked tokens and progressively replaces them with predictions, refining low-confidence tokens each step.
 
-LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/text_generation/diffusion_language_models.md).
+LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://docs.sglang.ai/supported_models/text_generation/diffusion_language_models.html).
 
 ### Launch
 
@@ -112,4 +112,4 @@ curl http://localhost:8000/v1/videos \
 
 - **[Examples](sglang-examples.md)**: Launch scripts for all deployment patterns
 - **[Reference Guide](sglang-reference-guide.md)**: Worker types and argument reference
-- **[SGLang Diffusion LMs (upstream)](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/text_generation/diffusion_language_models.md)**: SGLang diffusion documentation
+- **[SGLang Diffusion LMs (upstream)](https://docs.sglang.ai/supported_models/text_generation/diffusion_language_models.html)**: SGLang diffusion documentation


### PR DESCRIPTION
## Overview:

Repoint the two sglang diffusion-docs links at the rendered SGLang docs site, fixing the lychee docs link check that is currently failing on `main` and on every open PR.

## Details:

`sgl-project/sglang` removed its legacy Sphinx `docs/` tree on 2026-07-13 (sgl-project/sglang@50ed4c01, Mintlify cutover). The two GitHub-blob links in `docs/backends/sglang/sglang-diffusion.md` (lines 26 and 115) now return 404, and the `Docs link check` (lychee) workflow fails repo-wide — e.g. [this main run](https://github.com/ai-dynamo/dynamo/actions/runs/29324534790).

Both references now point at the rendered docs page, which currently resolves (HTTP 200); upstream's redirect map (`docs_new/scripts/gen_redirects.py`) suggests it will survive their Mintlify cutover:

`https://docs.sglang.ai/supported_models/text_generation/diffusion_language_models.html`

(The new Mintlify-native paths are not deployed yet — probed several and all 404 — so the stable rendered URL is the correct target today.)

Validation:

- new URL returns 200 with the expected page ("Diffusion language models")
- every other external link in the file probed: all 200 (localhost URLs are excluded by the lychee config)

## Where should the reviewer start?

`docs/backends/sglang/sglang-diffusion.md` — the two link updates.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SGLang Diffusion documentation links to point to the official SGLang documentation site.
  * Applied the updated link in both the LLM Diffusion and See Also sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
