### PR TITLE
docs(sglang): fix broken lychee link in sglang-diffusion.md

### DIFF
--- a/docs/backends/sglang/sglang-diffusion.md
+++ b/docs/backends/sglang/sglang-diffusion.md
@@ -23,7 +23,7 @@ If you see a CuDNN version mismatch error on startup (`cuDNN frontend 1.8.1 requ
 
 Diffusion Language Models generate text through iterative refinement rather than autoregressive token-by-token generation. The model starts with masked tokens and progressively replaces them with predictions, refining low-confidence tokens each step.
 
-LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/text_generation/diffusion_language_models.md).
+LLM diffusion is auto-detected: when `--dllm-algorithm` is set, the worker automatically uses `DiffusionWorkerHandler` without needing a separate flag. For more details on diffusion algorithms, see the [SGLang Diffusion Language Models documentation](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/supported-models/diffusion_language_models.mdx).
 
 ### Launch
 
@@ -112,4 +112,4 @@ curl http://localhost:8000/v1/videos \
 
 - **[Examples](sglang-examples.md)**: Launch scripts for all deployment patterns
 - **[Reference Guide](sglang-reference-guide.md)**: Worker types and argument reference
-- **[SGLang Diffusion LMs (upstream)](https://github.com/sgl-project/sglang/blob/main/docs/supported_models/text_generation/diffusion_language_models.md)**: SGLang diffusion documentation
+- **[SGLang Diffusion LMs (upstream)](https://github.com/sgl-project/sglang/blob/main/docs_new/docs/supported-models/diffusion_language_models.mdx)**: SGLang diffusion documentation


### PR DESCRIPTION
## Summary

- SGLang reorganized their docs; `docs/supported_models/text_generation/diffusion_language_models.md` was removed
- Updated both occurrences in `docs/backends/sglang/sglang-diffusion.md` to the new location: `docs_new/docs/supported-models/diffusion_language_models.mdx`
- Fixes lychee link check failure on main: https://github.com/ai-dynamo/dynamo/actions/runs/29337619880/job/87100776729

## Validation

- Old URL returns 404, new URL returns 200
- No content changes — link text is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SGLang diffusion documentation links to point to the latest upstream resources.
  * Refreshed the “See Also” reference for text generation model support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->