### PR TITLE
fix(snapshot): pin CRIU revision

### DIFF
--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -17,12 +17,12 @@
 # =============================================================================
 ARG DOCKER_PROXY
 ARG GO_VERSION=1.26.3
-# Default to upstream CRIU development branch. Custom forks can override both
+# Default to a pinned upstream CRIU commit. Custom forks can override both
 # args at build time, for example:
 #   --build-arg CRIU_REPO=<git-remote-url>
 #   --build-arg CRIU_REF=<fork-branch-or-sha>
 ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
-ARG CRIU_REF=criu-dev
+ARG CRIU_REF=b47c692bb3a73ae45ee1c4ab215a8f6869d40efd
 ARG AGENT_BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04
 
 # For placeholder target only - this default allows agent builds to succeed,


### PR DESCRIPTION
## Summary

- pin the snapshot image CRIU build to `b47c692bb3a73ae45ee1c4ab215a8f6869d40efd` instead of following the `criu-dev` branch
- retain support for overriding `CRIU_REPO` and `CRIU_REF` at build time

## Validation

- `git diff --check`
- verified the Dockerfile has exactly one default `ARG CRIU_REF=b47c692bb3a73ae45ee1c4ab215a8f6869d40efd`
- verified the build-stage argument and fetch/checkout path continue to honor `--build-arg CRIU_REF=...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned the CRIU dependency to a specific upstream version for more consistent and reproducible deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->