### PR TITLE
chore(codeowners): assign snapshot common code to GMS

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -425,7 +425,7 @@ areas:
 - label: gms
   github_team: '@ai-dynamo/dynamo-gms-codeowners'
   path_globs:
-  - components/src/dynamo/common/utils/snapshot.py
+  - components/src/dynamo/common/snapshot/
   - deploy/helm/charts/snapshot/
   - deploy/operator/internal/checkpoint/
   - deploy/operator/internal/gms/

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -238,6 +238,7 @@
 /dev/observability/prometheus-xpu.yml                                                         @ai-dynamo/dynamo-xpu-codeowners
 /dev/observability/xpu-alert-rules.yml                                                        @ai-dynamo/dynamo-xpu-codeowners
 /dev/observability/xpu_smi_exporter.py                                                        @ai-dynamo/dynamo-xpu-codeowners
+/components/src/dynamo/common/snapshot/                                                       @ai-dynamo/dynamo-gms-codeowners
 /lib/llm/tests/test_reasoning_parser.rs                                                       @ai-dynamo/dynamo-frontend-codeowners
 /components/src/dynamo/common/protocols/                                                      @ai-dynamo/dynamo-frontend-codeowners
 /deploy/operator/internal/observability/                                                      @ai-dynamo/dynamo-observability-codeowners


### PR DESCRIPTION
## Summary
- Assign `components/src/dynamo/common/snapshot/` to `@ai-dynamo/dynamo-gms-codeowners`.
- Regenerate the root `CODEOWNERS`.

## Validation
- Strict CODEOWNERS coverage: 4549/4549 files (100%).
- `who_owns.py` resolves the snapshot directory and `__init__.py` to `@ai-dynamo/dynamo-gms-codeowners`.
- Repeat generation is byte-identical (no drift).
- `git diff --check` passes.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11660" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership rules for the snapshot components directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->