### PR TITLE
fix(profiler): remove invalid AIPerf nvext input

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_aiperf.py
+++ b/components/src/dynamo/profiler/tests/unit/test_aiperf.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the AIPerf command and failure diagnostics."""
+
+import logging
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dynamo.profiler.utils.aiperf import (
+    _get_common_aiperf_cmd,
+    benchmark_decode,
+    benchmark_prefill,
+)
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def test_common_command_only_uses_supported_ignore_eos_input():
+    command = _get_common_aiperf_cmd("artifacts")
+    extra_inputs = [
+        command[index + 1]
+        for index, argument in enumerate(command)
+        if argument == "--extra-inputs"
+    ]
+
+    assert extra_inputs == ["ignore_eos:true"]
+
+
+def _failed_process(stdout: str, stderr: str) -> MagicMock:
+    process = MagicMock(returncode=1)
+    process.communicate.return_value = (stdout, stderr)
+    return process
+
+
+def test_benchmark_prefill_logs_stdout_and_stderr(caplog):
+    process = _failed_process("request rejected", "profile failed")
+
+    with (
+        patch("dynamo.profiler.utils.aiperf.subprocess.Popen", return_value=process),
+        caplog.at_level(logging.ERROR, logger="dynamo.profiler.utils.aiperf"),
+    ):
+        result = benchmark_prefill(
+            100,
+            "artifacts",
+            "test-model",
+            "test-tokenizer",
+        )
+
+    assert result is None
+    assert "stdout: request rejected" in caplog.text
+    assert "stderr: profile failed" in caplog.text
+
+
+def test_benchmark_decode_logs_stdout_and_stderr(caplog):
+    warmup_process = MagicMock(returncode=0)
+    warmup_process.communicate.return_value = ("", "")
+    profile_process = _failed_process("request rejected", "profile failed")
+
+    with (
+        patch(
+            "dynamo.profiler.utils.aiperf.subprocess.Popen",
+            side_effect=[warmup_process, profile_process],
+        ),
+        caplog.at_level(logging.ERROR, logger="dynamo.profiler.utils.aiperf"),
+    ):
+        result = benchmark_decode(
+            100,
+            10,
+            1,
+            "artifacts",
+            "test-model",
+            "test-tokenizer",
+        )
+
+    assert result is None
+    assert "stdout: request rejected" in caplog.text
+    assert "stderr: profile failed" in caplog.text
+
+
+def test_benchmark_decode_stops_when_warmup_fails(caplog):
+    warmup_process = _failed_process("warmup rejected", "warmup failed")
+
+    with (
+        patch(
+            "dynamo.profiler.utils.aiperf.subprocess.Popen",
+            return_value=warmup_process,
+        ) as mock_popen,
+        caplog.at_level(logging.ERROR, logger="dynamo.profiler.utils.aiperf"),
+    ):
+        result = benchmark_decode(
+            100,
+            10,
+            1,
+            "artifacts",
+            "test-model",
+            "test-tokenizer",
+        )
+
+    assert result is None
+    mock_popen.assert_called_once()
+    assert "AIPerf warm-up failed with error code: 1" in caplog.text
+    assert "stdout: warmup rejected" in caplog.text
+    assert "stderr: warmup failed" in caplog.text

--- a/components/src/dynamo/profiler/utils/aiperf.py
+++ b/components/src/dynamo/profiler/utils/aiperf.py
@@ -61,8 +61,6 @@ def _get_common_aiperf_cmd(
         base_url,
         "--extra-inputs",
         "ignore_eos:true",
-        "--extra-inputs",
-        '{"nvext":{"ignore_eos":true}}',
         "--warmup-request-count",
         str(warmup_request_count),
         "--artifact-dir",
@@ -203,8 +201,9 @@ def benchmark_prefill(
         aiperf_result = get_aiperf_result(aiperf_artifact_dir)
         return aiperf_result
     else:
-        logger.error(f"AIPerf failed with error code: {aiperf_process.returncode}")
-        logger.error(f"stderr: {stderr}")
+        logger.error("AIPerf failed with error code: %s", aiperf_process.returncode)
+        logger.error("stdout: %s", stdout)
+        logger.error("stderr: %s", stderr)
         return None
 
 
@@ -345,7 +344,15 @@ def benchmark_decode(
         stderr=subprocess.PIPE,
         text=True,
     )
-    aiperf_process.communicate()
+    stdout, stderr = aiperf_process.communicate()
+    if aiperf_process.returncode != 0:
+        logger.error(
+            "AIPerf warm-up failed with error code: %s", aiperf_process.returncode
+        )
+        logger.error("stdout: %s", stdout)
+        logger.error("stderr: %s", stderr)
+        return None
+
     # then send out the real requests, hopefully, this will skip all prefill computation
     aiperf_cmd = get_decode_aiperf_cmd(
         isl,
@@ -370,6 +377,7 @@ def benchmark_decode(
         aiperf_result = get_aiperf_result(aiperf_artifact_dir)
         return aiperf_result
     else:
-        logger.error(f"AIPerf failed with error code: {aiperf_process.returncode}")
-        logger.error(f"stderr: {stderr}")
+        logger.error("AIPerf failed with error code: %s", aiperf_process.returncode)
+        logger.error("stdout: %s", stdout)
+        logger.error("stderr: %s", stderr)
         return None


### PR DESCRIPTION
## Overview:

Backport [#11629](https://github.com/ai-dynamo/dynamo/pull/11629) to `release/1.3.0` to fix thorough-path AIPerf requests that fail with HTTP 400 before reaching the worker.

This issue was reproduced against release/1.3.0 in the `hzhou` namespace and is tracked by [DYN-3357](https://linear.app/nvidia/issue/DYN-3357/dynamorelease130dgdr-thorough-path-aiperf-fails-when-pvc-model-cache) / NVBug 6407209.

## Details:

- remove the unsupported `nvext.ignore_eos` AIPerf input while retaining the supported top-level `ignore_eos` input
- log stdout and stderr for prefill, decode, and decode warm-up failures
- stop decode profiling when cache warm-up fails
- add GPU-free regression coverage for the request shape and failure paths

This is a clean cherry-pick of main commit `15a63299e66ab1149a64ffac5b1b1c5bafa25494`.

## Where should the reviewer start?

Start with `components/src/dynamo/profiler/utils/aiperf.py`, followed by `components/src/dynamo/profiler/tests/unit/test_aiperf.py`.

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:

- [x] Confirmed — tracked externally by [DYN-3357](https://linear.app/nvidia/issue/DYN-3357/dynamorelease130dgdr-thorough-path-aiperf-fails-when-pvc-model-cache) and NVBug 6407209

## Validation

- `python3 -m pytest -q components/src/dynamo/profiler/tests/unit`: 215 passed, 1 optional-dependency test skipped
- targeted `test_aiperf.py`: 4 passed
- file-level pre-commit hooks passed with `pytest-marker-report` excluded; that repository-wide collection hook cannot import the locally unavailable optional `kvbm.trtllm_integration` module
