### PR TITLE
fix(snapshot): pin CRIU revision (#11659) [cherry-pick → release/1.3.0]

### DIFF
--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -16,12 +16,12 @@
 # =============================================================================
 ARG DOCKER_PROXY
 ARG GO_VERSION=1.26.3
-# Default to upstream CRIU development branch. Custom forks can override both
+# Default to a pinned upstream CRIU commit. Custom forks can override both
 # args at build time, for example:
 #   --build-arg CRIU_REPO=<git-remote-url>
 #   --build-arg CRIU_REF=<fork-branch-or-sha>
 ARG CRIU_REPO=https://github.com/checkpoint-restore/criu.git
-ARG CRIU_REF=criu-dev
+ARG CRIU_REF=b47c692bb3a73ae45ee1c4ab215a8f6869d40efd
 ARG AGENT_BASE_IMAGE=nvcr.io/nvidia/cuda-dl-base:25.11-cuda13.0-devel-ubuntu24.04
 
 # For placeholder target only - this default allows agent builds to succeed,


### PR DESCRIPTION
## Overview:

Cherry-pick of #11659 into `release/1.3.0`.

## Details:

Backports `fix(snapshot): pin CRIU revision` (#11659), changing the default Snapshot CRIU source revision from the moving `criu-dev` branch to the reviewed commit `b47c692bb3a73ae45ee1c4ab215a8f6869d40efd`. The existing `CRIU_REPO` and `CRIU_REF` build-argument overrides remain available.

This applies cleanly with no conflicts from merged commit `8d4d281b1a71ca3b67af1b74e469f0523be6afe1`.

## Where should the reviewer start?

- `deploy/snapshot/Dockerfile` — the pinned default `CRIU_REF` and the associated comment.

## Validation:

- [x] `git diff --check`
- [x] Confirmed the Dockerfile has one default `ARG CRIU_REF=b47c692bb3a73ae45ee1c4ab215a8f6869d40efd`
- [x] Confirmed the build-stage argument and fetch/checkout path continue to honor `--build-arg CRIU_REF=...`
- [ ] CI passes

## Related Issues:

**This PR is not linked to an issue.**