### PR TITLE
fix(snapshot): preserve NCCL P2P setting (#11639) [cherry-pick → release/1.3.0]

### DIFF
--- a/components/src/dynamo/common/snapshot/lifecycle.py
+++ b/components/src/dynamo/common/snapshot/lifecycle.py
@@ -114,15 +114,6 @@ def configure_snapshot_capture_env() -> None:
         )
     os.environ["NCCL_CUMEM_ENABLE"] = "0"
 
-    nccl_p2p_disable = os.environ.get("NCCL_P2P_DISABLE")
-    if nccl_p2p_disable and nccl_p2p_disable != "0":
-        logger.warning(
-            "Overriding NCCL_P2P_DISABLE=%r with '0' for snapshot mode "
-            "to keep NCCL on GPU P2P transport when topology allows it",
-            nccl_p2p_disable,
-        )
-    os.environ["NCCL_P2P_DISABLE"] = "0"
-
     nccl_nvls_enable = os.environ.get("NCCL_NVLS_ENABLE")
     if nccl_nvls_enable and nccl_nvls_enable != "0":
         logger.warning(


### PR DESCRIPTION
## Overview:

Cherry-pick of #11639 into `release/1.3.0`.

## Details:

Backports `fix(snapshot): preserve NCCL P2P setting` (#11639). Snapshot capture now preserves an explicitly configured `NCCL_P2P_DISABLE` value instead of always rewriting it to `0`; when it is unset, the existing safe default remains unchanged. The associated tests cover explicit and unset values and the related environment settings.

This applies cleanly with no conflicts from merged squash commit `c6eeb95cacf8022b44a0af0e285d050aca8b435f`.

## Where should the reviewer start?

- `components/src/dynamo/common/snapshot/lifecycle.py` — `configure_snapshot_capture_env()` preserves an explicitly configured `NCCL_P2P_DISABLE` value.
- `components/src/dynamo/common/tests/test_snapshot_lifecycle.py` — coverage for explicit and unset `NCCL_P2P_DISABLE` values and related environment variables.

## Validation:

- [x] `git diff --check`
- [x] Source PR #11639 passed its required CI, including the Dynamo status gate
- [ ] CI passes

## Related Issues:

**This PR is not linked to an issue.**
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11667" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->