### PR TITLE
test: upload worker/engine logs for failed serve tests

### DIFF
--- a/.github/actions/pytest-local/action.yml
+++ b/.github/actions/pytest-local/action.yml
@@ -308,3 +308,15 @@ runs:
         path: test-results/allure-results/
         retention-days: 7
         if-no-files-found: ignore
+
+    # Worker/engine logs for FAILED serve tests (populated by the
+    # pytest_runtest_makereport hook in tests/conftest.py). These hold the real
+    # engine traceback that health-check timeouts otherwise hide.
+    - name: Upload Worker Logs (failed tests)
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+      if: always()
+      with:
+        name: worker-logs-${{ inputs.framework }}-${{ env.STR_TEST_TYPE }}-${{ inputs.platform_arch }}-${{ github.run_id }}-${{ job.check_run_id }}
+        path: test-results/worker-logs/
+        retention-days: 7
+        if-no-files-found: ignore

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,6 +53,39 @@ def _is_xdist_worker(config: pytest.Config) -> bool:
     return hasattr(config, "workerinput")
 
 
+@pytest.hookimpl(hookwrapper=True)
+def pytest_runtest_makereport(item, call):
+    """On a failed test, copy managed-process worker logs into the CI artifacts dir.
+
+    Serve/e2e tests run engines via ManagedProcess, which writes the real
+    worker/engine traceback to /tmp/dynamo_tests/<node>/<cmd>.log.txt (plus a
+    <node>_frontend/ sibling). Those files live only on the runner and are lost
+    when it's reclaimed, so worker crashes surface in CI only as a health-check
+    timeout. Copy them (failure-only) under $GITHUB_WORKSPACE/test-results/
+    worker-logs/<node>/ so the existing upload-artifact step preserves them.
+    """
+    outcome = yield
+    report = outcome.get_result()
+    if report.when not in ("setup", "call") or not report.failed:
+        return
+    workspace = os.environ.get("GITHUB_WORKSPACE")
+    if not workspace:
+        return  # only relevant in CI, where test-results/ is uploaded
+    dest = Path(workspace) / "test-results" / "worker-logs" / item.name
+    try:
+        for suffix, prefix in (("", ""), ("_frontend", "frontend_")):
+            src = Path(resolve_test_output_path(item.name + suffix))
+            if not src.is_dir():
+                continue
+            for log in src.glob("*.log*"):
+                dest.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(log, dest / (prefix + log.name))
+    except Exception as exc:  # never let log copying fail the run
+        logging.getLogger(__name__).warning(
+            "Could not copy worker logs for %s: %s", item.name, exc
+        )
+
+
 @pytest.hookimpl(tryfirst=True)
 def pytest_sessionstart(session: pytest.Session) -> None:
     if not collection_env_guard_disabled():


### PR DESCRIPTION
## Problem
Serve/e2e tests launch engines via `ManagedProcess`, which writes the real worker/engine traceback to `/tmp/dynamo_tests/<node>/<cmd>.log.txt` (plus a `<node>_frontend/` sibling). Those files live **only on the runner** and are reclaimed after the job, so a worker crash (engine-core init failure, OOM, connector handshake error, …) shows up in CI only as an opaque `Main server process exited with code 1 while waiting for health check` — the actual cause is unrecoverable.

This has repeatedly blocked debugging of serve launch scenarios (diffusion_llada, aggregated_spec_decoding, disaggregated_lmcache) where the root cause was never visible in the uploaded logs.

## Change
- **`tests/conftest.py`**: a failure-only `pytest_runtest_makereport` hook copies `/tmp/dynamo_tests/<node>/*.log*` (+ the `_frontend` sibling) into `$GITHUB_WORKSPACE/test-results/worker-logs/<node>/`.
- **`.github/actions/pytest-local/action.yml`**: one `upload-artifact` step (`if: always()`, `if-no-files-found: ignore`) that preserves `test-results/worker-logs/`.

Failure-only (no artifact bloat), CI-only (guarded on `GITHUB_WORKSPACE`, so local runs are unaffected), and reuses the harness's own `resolve_test_output_path` so the source paths always match where the logs are actually written.

## Validation
Unit-tested the copy logic against a simulated failed-test log layout (worker + frontend logs both land under `test-results/worker-logs/<node>/`). Any failing serve test on this branch will now attach its engine log as a downloadable artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11668" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostics for failed serve tests by collecting worker and engine logs in CI environments.
  * Preserved both standard and frontend-specific logs when available.

* **Chores**
  * Failed-test log artifacts are retained for seven days and safely skipped when no logs are found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->