### PR TITLE
Add minimal vllm /classify endpoint for sequence-classification models

### DIFF
--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -238,6 +238,8 @@ def _unsupported_fpm_trace_role(dynamo_config: Config) -> Optional[str]:
     """Return the worker role when trace-based FPM activation is unsupported."""
     if dynamo_config.embedding_worker:
         return "embedding"
+    if dynamo_config.classify_worker:
+        return "classify"
     if dynamo_config.headless:
         return "headless"
     if dynamo_config.disaggregation_mode == DisaggregationMode.ENCODE:

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -190,6 +190,18 @@ class DynamoVllmArgGroup(ArgGroup):
             "and InstrumentedScheduler injection (none apply to pooling models).",
         )
 
+        add_negatable_bool_argument(
+            g,
+            flag_name="--classify-worker",
+            env_var="DYN_VLLM_CLASSIFY_WORKER",
+            default=False,
+            help="Run as a sequence-classification worker (cross-encoder / "
+            "NLI / sentiment), registering the model as ModelType.Classify so "
+            "the frontend mounts POST /classify. Engine must be started with "
+            "vLLM's --runner pooling. Like --embedding-worker, skips KV-events, "
+            "KV router registration, and InstrumentedScheduler injection.",
+        )
+
         # Headless mode for multi-node TP/PP
         add_negatable_bool_argument(
             g,
@@ -434,6 +446,7 @@ class DynamoVllmConfig(ConfigBase):
         str, EmbeddingTransferMode
     ]  # resolved to enum in validate()
     embedding_worker: bool = False
+    classify_worker: bool = False
 
     # CustomEncoder (image-only embeddings; worker assembles mixed prompt)
     custom_encoder_class: Optional[str] = None
@@ -475,6 +488,7 @@ class DynamoVllmConfig(ConfigBase):
         self._validate_multimodal_role_exclusivity()
         self._validate_multimodal_requires_flag()
         self._validate_embedding_worker_exclusivity()
+        self._validate_classify_worker_exclusivity()
         self._validate_custom_encoder()
         self._resolve_legacy_benchmark_sampling()
         self._validate_benchmark_sampling()
@@ -805,4 +819,32 @@ class DynamoVllmConfig(ConfigBase):
                 "generation scheduler and not compatible with pooling engines. "
                 "Embedding workers do not run generation, so prefill/decode "
                 "benchmark sweeps are not meaningful."
+            )
+
+    def _validate_classify_worker_exclusivity(self) -> None:
+        """Classify worker is aggregated-only and exclusive of multimodal /
+        embedding roles. Mirrors the embedding-worker constraints — both are
+        pooling roles with no prefill/decode phases."""
+        if not self.classify_worker:
+            return
+        if self.embedding_worker:
+            raise ValueError(
+                "--classify-worker and --embedding-worker are mutually exclusive; "
+                "a worker registers exactly one pooling model type."
+            )
+        if self.disaggregation_mode != DisaggregationMode.AGGREGATED:
+            raise ValueError(
+                "--classify-worker is only valid with --disaggregation-mode=agg "
+                f"(got {self.disaggregation_mode.value if isinstance(self.disaggregation_mode, DisaggregationMode) else self.disaggregation_mode}). "
+                "Pooling models do not have prefill/decode phases."
+            )
+        if self._count_multimodal_roles() > 0 or self.enable_multimodal:
+            raise ValueError(
+                "--classify-worker cannot be combined with multimodal flags."
+            )
+        if self.benchmark_mode is not None:
+            raise ValueError(
+                "--classify-worker cannot be combined with --benchmark-mode. "
+                "Benchmark mode injects InstrumentedScheduler, which is a "
+                "generation scheduler and not compatible with pooling engines."
             )

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3780,6 +3780,142 @@ class EmbeddingWorkerHandler:
         }
 
 
+class ClassifyWorkerHandler(EmbeddingWorkerHandler):
+    """Standalone handler for ``/classify`` requests on vLLM.
+
+    Sequence classification (cross-encoder / NLI / sentiment) is a pooling
+    task, so this shares all of ``EmbeddingWorkerHandler``'s engine plumbing
+    (pooling ``AsyncLLM``, abort monitor, engine-death monitor) and only
+    overrides ``generate`` to:
+
+      - run ``PoolingParams(task="classify")`` instead of ``task="embed"``, and
+      - shape the per-input probability vectors into the ``/classify``
+        response (``{index, label, probs, num_classes}``) instead of the
+        embedding response.
+
+    The ``label`` is resolved from the model's HF ``id2label`` map (argmax of
+    the probability vector), matching vLLM's own ``/classify`` server
+    (``vllm/entrypoints/pooling/classify/serving.py``). ``label`` is ``None``
+    when the model config exposes no ``id2label``.
+    """
+
+    def __init__(
+        self,
+        runtime,
+        engine: Any,
+        config: Config,
+        model_config: "ModelConfig | None" = None,
+        shutdown_event: Optional[asyncio.Event] = None,
+    ) -> None:
+        super().__init__(
+            runtime=runtime,
+            engine=engine,
+            config=config,
+            shutdown_event=shutdown_event,
+        )
+        self.model_config = model_config
+        logger.info("Classify worker handler initialized")
+
+    def _id2label(self) -> dict[int, str]:
+        """Best-effort HF ``id2label`` lookup. Keys may arrive as str or int
+        depending on how the HF config was loaded; normalize to int."""
+        hf_config = getattr(self.model_config, "hf_config", None)
+        raw = getattr(hf_config, "id2label", None) or {}
+        normalized: dict[int, str] = {}
+        for k, v in raw.items():
+            try:
+                normalized[int(k)] = str(v)
+            except (TypeError, ValueError):
+                continue
+        return normalized
+
+    async def generate(
+        self, request: dict, context: Context
+    ) -> AsyncIterator[Dict[str, Any]]:
+        """Handle one ``/classify`` request.
+
+        The Rust frontend forwards the request dict directly. Expected keys:
+        ``model: str``, ``input: str | list[str]``. Mirrors vLLM 0.24.0's
+        ``ClassificationRequest`` → ``ClassificationResponse`` contract.
+        """
+        model_name = request.get("model") or self.config.served_model_name or ""
+        input_field = request.get("input")
+        if input_field is None:
+            raise ValueError("Classify request missing required 'input' field")
+
+        prompts: list[Any] = _classify_embedding_input(input_field)
+
+        # Sequence classification is a pooling pass with the model's configured
+        # classification pooler. ``use_activation`` is left at the pooler
+        # default (vLLM applies sigmoid/softmax per the model's config) so
+        # per-model behaviour isn't overridden — matching bare ``vllm serve``.
+        pooling_params = PoolingParams(task="classify")
+
+        base_request_id = context.id()
+
+        async def _encode_one(idx: int, prompt: Any):
+            request_id = f"{base_request_id}-{idx}"
+            encode_arg: Any = (
+                prompt
+                if isinstance(prompt, str)
+                else TokensPrompt(prompt_token_ids=prompt)
+            )
+            final_output = None
+            async with self._abort_monitor(context, request_id):
+                async for out in self.engine_client.encode(
+                    prompt=encode_arg,
+                    pooling_params=pooling_params,
+                    request_id=request_id,
+                ):
+                    final_output = out
+            if final_output is None:
+                raise RuntimeError(
+                    f"vLLM engine.encode produced no output for input index {idx}"
+                )
+            return final_output
+
+        tasks = [asyncio.create_task(_encode_one(i, p)) for i, p in enumerate(prompts)]
+        try:
+            outputs = await asyncio.gather(*tasks)
+        finally:
+            pending = [t for t in tasks if not t.done()]
+            for t in pending:
+                t.cancel()
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        id2label = self._id2label()
+        data: list[Dict[str, Any]] = []
+        prompt_tokens = 0
+        for idx, final_output in enumerate(outputs):
+            # ``final_output.outputs.data`` is the 1-D probability vector for a
+            # classification pooler (shape ``(num_classes,)``); flatten defensively.
+            probs = _pooling_output_to_list(final_output.outputs.data)
+            predicted_index = max(range(len(probs)), key=probs.__getitem__) if probs else 0
+            data.append(
+                {
+                    "index": idx,
+                    "label": id2label.get(predicted_index),
+                    "probs": probs,
+                    "num_classes": len(probs),
+                }
+            )
+            token_ids = getattr(final_output, "prompt_token_ids", None) or []
+            prompt_tokens += len(token_ids)
+
+        yield {
+            "id": f"classify-{base_request_id}",
+            "object": "list",
+            "created": int(time.time()),
+            "model": model_name,
+            "data": data,
+            "usage": {
+                "prompt_tokens": prompt_tokens,
+                "total_tokens": prompt_tokens,
+            },
+        }
+
+
 def _is_token_id(x: Any) -> bool:
     """True iff ``x`` is an int that could be a vLLM token id.
 

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -757,13 +757,18 @@ async def register_vllm_model(
         # loaded here. Only generative decode/aggregated workers serve the LoRA load endpoints
         # (load_lora/unload_lora). Prefill and embedding workers register through this same path
         # but do NOT serve them, so they must not advertise capacity they cannot fulfill — gate on
-        # the model type rather than worker_type (vLLM embedding registers as Aggregated). None
-        # (no capacity) for non-LoRA, prefill, or embedding workers.
+        # the model type rather than worker_type (vLLM embedding/classify register as Aggregated).
+        # None (no capacity) for non-LoRA, prefill, embedding, or classify workers.
         max_gpu_lora_count=(
             config.engine_args.max_loras
             if (
                 getattr(config.engine_args, "enable_lora", False)
-                and model_type not in (ModelType.Prefill, ModelType.Embedding)
+                and model_type
+                not in (
+                    ModelType.Prefill,
+                    ModelType.Embedding,
+                    ModelType.Classify,
+                )
             )
             else None
         ),

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -33,6 +33,7 @@ from .capacity import per_rank_kv_blocks
 from .constants import DisaggregationMode
 from .handlers import (
     BaseWorkerHandler,
+    ClassifyWorkerHandler,
     DecodeWorkerHandler,
     EmbeddingWorkerHandler,
     PrefillWorkerHandler,
@@ -573,6 +574,15 @@ class WorkerFactory:
             )
             return
 
+        # Classify worker: same pooling-AsyncLLM shape as embedding, but
+        # registers ModelType.Classify (frontend mounts POST /classify).
+        # Aggregated-only — enforced in _validate_classify_worker_exclusivity.
+        if config.classify_worker:
+            await self._create_classify_worker(
+                runtime, config, shutdown_event, shutdown_endpoints
+            )
+            return
+
         # NOTE: --benchmark-mode is only supported for prefill/decode workers.
         # The encode worker path does not wire benchmark waiting or
         # the get_perf_metrics endpoint.
@@ -751,6 +761,82 @@ class WorkerFactory:
             )
         except Exception as e:
             logger.error(f"Failed to serve embedding worker endpoint: {e}")
+            raise
+        finally:
+            handler.cleanup()
+
+    async def _create_classify_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,  # mutated in place
+    ) -> None:
+        """Initialize an aggregated sequence-classification worker.
+
+        Structurally identical to ``_create_embedding_worker`` — pooling
+        ``AsyncLLM``, no KV cache / decode / stat-logger — but the handler
+        runs ``task="classify"`` and registers the model as
+        ``ModelType.Classify`` so the frontend mounts ``POST /classify``.
+        See ``_create_embedding_worker`` for the rationale behind the
+        skipped decode-worker machinery (all of it applies here too).
+        """
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        shutdown_endpoints[:] = [generate_endpoint]
+
+        fpm_worker_id = str(generate_endpoint.connection_id())
+        factory = StatLoggerFactory(
+            endpoint=generate_endpoint,
+            embedding_worker=True,
+        )
+        (
+            engine_client,
+            vllm_config,
+            _default_sampling_params,
+            _prometheus_temp_dir,
+            _component_gauges,
+        ) = self.setup_vllm_engine(config, factory, fpm_worker_id=fpm_worker_id)
+
+        handler = ClassifyWorkerHandler(
+            runtime=runtime,
+            engine=engine_client,
+            config=config,
+            model_config=getattr(vllm_config, "model_config", None),
+            shutdown_event=shutdown_event,
+        )
+
+        # The embedding health probe (`{"input": "probe"}`) matches the
+        # /classify request shape too, so we reuse it — the canary runs a real
+        # pooling forward pass.
+        classify_health_check_payload = VllmEmbeddingHealthCheckPayload(
+            model_name=config.served_model_name or config.model
+        ).to_dict()
+
+        logger.info("Starting to serve the classify worker endpoint...")
+        try:
+            await asyncio.gather(
+                generate_endpoint.serve_endpoint(
+                    handler.generate,
+                    metrics_labels=[("model", config.model)],
+                    health_check_payload=classify_health_check_payload,
+                ),
+                self.register_vllm_model(
+                    ModelInput.Text,
+                    ModelType.Classify,
+                    generate_endpoint,
+                    config,
+                    engine_client,
+                    vllm_config,
+                    # Classification is a single pooling pass — no prefill/decode
+                    # split — so it advertises as Aggregated with no peers.
+                    worker_type=WorkerType.Aggregated,
+                    needs=[],
+                ),
+            )
+        except Exception as e:
+            logger.error(f"Failed to serve classify worker endpoint: {e}")
             raise
         finally:
             handler.cleanup()

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -799,6 +799,10 @@ impl ModelType {
     const Realtime: Self = ModelType {
         inner: llm_rs::model_type::ModelType::Realtime,
     };
+    #[classattr]
+    const Classify: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Classify,
+    };
 
     fn supports_chat(&self) -> bool {
         self.inner.supports_chat()

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1561,6 +1561,8 @@ class ModelType:
     Audios: ModelType
     Videos: ModelType
     Realtime: ModelType
+    # Sequence-classification / cross-encoder pooling models served on /classify.
+    Classify: ModelType
 
     def __or__(self, other: ModelType) -> ModelType:
         ...

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -23,6 +23,7 @@ use crate::types::{
     openai::{
         audios::OpenAIAudiosStreamingEngine,
         chat_completions::OpenAIChatCompletionsStreamingEngine,
+        classify::OpenAIClassifyStreamingEngine,
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
         generate::GenerateStreamingEngine, images::OpenAIImagesStreamingEngine,
         videos::OpenAIVideosStreamingEngine,
@@ -197,6 +198,13 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_embeddings_engine())
+    }
+
+    /// Check if any WorkerSet has a classify engine.
+    pub fn has_classify_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_classify_engine())
     }
 
     /// Check if any WorkerSet has a tensor engine.
@@ -555,6 +563,13 @@ impl Model {
     ) -> Result<OpenAIEmbeddingsStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.embeddings_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_embeddings_engine()))
+    }
+
+    pub fn get_classify_engine(
+        &self,
+    ) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.classify_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_classify_engine()))
     }
 
     pub fn get_images_engine(&self) -> Result<OpenAIImagesStreamingEngine, ModelManagerError> {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -38,6 +38,7 @@ use crate::{
         openai::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
+            classify::OpenAIClassifyStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
             images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
@@ -501,6 +502,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_classify_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_classify_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_tensor_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -565,6 +574,16 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_embeddings_engine()
+    }
+
+    pub fn get_classify_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAIClassifyStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_classify_engine()
     }
 
     pub fn get_completions_engine(
@@ -778,6 +797,27 @@ impl ModelManager {
         Ok(())
     }
 
+    pub fn add_classify_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAIClassifyStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_classify_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_classify_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.classify_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
     pub fn add_tensor_model(
         &self,
         model: &str,
@@ -956,6 +996,13 @@ impl ModelManager {
 
     pub fn remove_embeddings_model(&self, model: &str) -> Result<(), ModelManagerError> {
         let namespace = format!("__local_embeddings_{}", model);
+        self.remove_worker_set(model, &namespace)
+            .map(|_| ())
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))
+    }
+
+    pub fn remove_classify_model(&self, model: &str) -> Result<(), ModelManagerError> {
+        let namespace = format!("__local_classify_{}", model);
         self.remove_worker_set(model, &namespace)
             .map(|_| ())
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -50,6 +50,7 @@ use crate::{
             chat_completions::{
                 NvCreateChatCompletionRequest, NvCreateChatCompletionStreamResponse,
             },
+            classify::{NvCreateClassifyRequest, NvCreateClassifyResponse},
             completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
             embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
             images::{NvCreateImageRequest, NvImagesResponse},
@@ -242,6 +243,7 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Videos,
     ModelType::TensorBased,
     ModelType::Realtime,
+    ModelType::Classify,
 ];
 
 /// Returns true if no models in the manager support the given model type.
@@ -262,6 +264,8 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_tensor_models().is_empty()
     } else if model_type == ModelType::Realtime {
         manager.list_realtime_models().is_empty()
+    } else if model_type == ModelType::Classify {
+        manager.list_classify_models().is_empty()
     } else {
         true
     }
@@ -1804,6 +1808,18 @@ impl ModelWatcher {
             )
             .await?;
             worker_set.embeddings_engine = Some(Arc::new(push_router));
+        } else if card.model_input == ModelInput::Text && card.model_type.supports_classify() {
+            // Case: Text + Classify (sequence-classification / cross-encoder pooling).
+            // Like Text + Embeddings, the worker tokenizes in-backend, so no
+            // frontend preprocessor pipeline is needed — just a router.
+            let push_router = PushRouter::<
+                NvCreateClassifyRequest,
+                Annotated<NvCreateClassifyResponse>,
+            >::from_client_with_monitor(
+                client, router_config.router_mode, None
+            )
+            .await?;
+            worker_set.classify_engine = Some(Arc::new(push_router));
         }
         // Case: Text + (Images, Audio, Videos)
         // Must come before the plain Text+Chat / Text+Completions branches because

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -20,6 +20,7 @@ use crate::{
             audios::OpenAIAudiosStreamingEngine,
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
+            classify::OpenAIClassifyStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
             images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
         },
@@ -41,6 +42,7 @@ pub struct WorkerSet {
     pub(crate) chat_engine: Option<OpenAIChatCompletionsStreamingEngine>,
     pub(crate) completions_engine: Option<OpenAICompletionsStreamingEngine>,
     pub(crate) embeddings_engine: Option<OpenAIEmbeddingsStreamingEngine>,
+    pub(crate) classify_engine: Option<OpenAIClassifyStreamingEngine>,
     pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
@@ -76,6 +78,7 @@ impl WorkerSet {
             chat_engine: None,
             completions_engine: None,
             embeddings_engine: None,
+            classify_engine: None,
             images_engine: None,
             videos_engine: None,
             audios_engine: None,
@@ -112,6 +115,10 @@ impl WorkerSet {
 
     pub fn has_embeddings_engine(&self) -> bool {
         self.embeddings_engine.is_some()
+    }
+
+    pub fn has_classify_engine(&self) -> bool {
+        self.classify_engine.is_some()
     }
 
     pub fn has_images_engine(&self) -> bool {
@@ -151,6 +158,7 @@ impl WorkerSet {
         self.has_chat_engine()
             || self.has_completions_engine()
             || self.has_embeddings_engine()
+            || self.has_classify_engine()
             || self.has_images_engine()
             || self.has_tensor_engine()
             || self.has_videos_engine()
@@ -226,6 +234,7 @@ mod tests {
     use crate::types::openai::completions::{
         NvCreateCompletionRequest, NvCreateCompletionResponse,
     };
+    use crate::types::openai::classify::{NvCreateClassifyRequest, NvCreateClassifyResponse};
     use crate::types::openai::embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse};
     use crate::types::openai::images::{NvCreateImageRequest, NvImagesResponse};
     use crate::types::openai::videos::{NvCreateVideoRequest, NvVideosResponse};
@@ -279,6 +288,7 @@ mod tests {
         assert!(!ws.has_chat_engine());
         assert!(!ws.has_completions_engine());
         assert!(!ws.has_embeddings_engine());
+        assert!(!ws.has_classify_engine());
         assert!(!ws.has_images_engine());
         assert!(!ws.has_videos_engine());
         assert!(!ws.has_audios_engine());
@@ -326,6 +336,12 @@ mod tests {
             has_embeddings_engine,
             StubEngine::<NvCreateEmbeddingRequest, NvCreateEmbeddingResponse>::new(),
             "embeddings"
+        );
+        check!(
+            classify_engine,
+            has_classify_engine,
+            StubEngine::<NvCreateClassifyRequest, NvCreateClassifyResponse>::new(),
+            "classify"
         );
         check!(
             images_engine,

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -20,6 +20,8 @@ pub enum EndpointType {
     Videos,
     /// Realtime API (bidirectional streaming over WebSocket)
     Realtime,
+    /// Classification API (sequence classification / cross-encoder pooling)
+    Classify,
     /// Responses API
     Responses,
     /// Anthropic Messages API
@@ -38,6 +40,7 @@ impl EndpointType {
             Self::Audios => "audios",
             Self::Videos => "videos",
             Self::Realtime => "realtime",
+            Self::Classify => "classify",
             Self::Responses => "responses",
             Self::AnthropicMessages => "anthropic_messages",
             Self::Generate => "generate",
@@ -53,6 +56,7 @@ impl EndpointType {
             Self::Audios,
             Self::Videos,
             Self::Realtime,
+            Self::Classify,
             Self::Responses,
             Self::AnthropicMessages,
             Self::Generate,

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -448,6 +448,9 @@ pub enum Endpoint {
     /// OAI Embeddings
     Embeddings,
 
+    /// Classification (sequence classification / cross-encoder pooling)
+    Classify,
+
     /// OAI Images
     Images,
 
@@ -1467,6 +1470,7 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Completions => write!(f, "completions"),
             Endpoint::ChatCompletions => write!(f, "chat_completions"),
             Endpoint::Embeddings => write!(f, "embeddings"),
+            Endpoint::Classify => write!(f, "classify"),
             Endpoint::Images => write!(f, "images"),
             Endpoint::Videos => write!(f, "videos"),
             Endpoint::Audios => write!(f, "audios"),
@@ -1484,6 +1488,7 @@ impl Endpoint {
             Endpoint::Completions => "completions",
             Endpoint::ChatCompletions => "chat_completions",
             Endpoint::Embeddings => "embeddings",
+            Endpoint::Classify => "classify",
             Endpoint::Images => "images",
             Endpoint::Videos => "videos",
             Endpoint::Audios => "audios",

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -58,6 +58,7 @@ use crate::protocols::openai::{
         NvCreateChatCompletionRequest, NvCreateChatCompletionResponse,
         NvCreateChatCompletionStreamResponse,
     },
+    classify::{NvCreateClassifyRequest, NvCreateClassifyResponse},
     completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
     embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
     images::{NvCreateImageRequest, NvImagesResponse},
@@ -1242,6 +1243,102 @@ fn decode_base64_embedding_to_floats(s: &str) -> Result<Vec<f32>, anyhow::Error>
         floats.push(f32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]));
     }
     Ok(floats)
+}
+
+#[tracing::instrument(skip_all)]
+async fn classify(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    Json(mut request): Json<NvCreateClassifyRequest>,
+) -> Result<Response, ErrorResponse> {
+    // return a 503 if the service or model is not ready
+    check_ready(&state)?;
+    check_model_serving_ready(&state, &request.model)?;
+
+    if !state.nvext_enabled() {
+        warn_nvext_disabled("classify", request.nvext.is_some(), &headers);
+        request.nvext = None;
+    }
+
+    // Resolve alias → primary served name before wrapping the request, so
+    // engine routing, metrics, and the response model all use the canonical
+    // primary (mirrors `embeddings` / `completions_single`).
+    let canonical = state.manager().resolve_canonical_name(&request.model);
+    if canonical != request.model {
+        request.model = canonical;
+    }
+    let request_id = get_or_create_request_id(&headers);
+    let request = context_from_headers(request, request_id, &headers)?;
+    let request_id = request.id().to_string();
+
+    // Classification, like embeddings, is a pooling task returned as a single
+    // (non-streaming) response.
+    let streaming = false;
+
+    let model = &request.model;
+    let metric_model = state.manager().metric_model_for(model).to_string();
+
+    // Create inflight_guard early to ensure all errors are counted
+    let mut inflight = state.metrics_clone().create_inflight_guard(
+        &metric_model,
+        Endpoint::Classify,
+        streaming,
+        &request_id,
+    );
+
+    // Create http_queue_guard early - tracks time waiting to be processed
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
+
+    let engine = state.manager().get_classify_engine(model).map_err(|e| {
+        let err_response = ErrorMessage::from_model_error(&e);
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
+    let model_name = model.to_string();
+
+    // issue the generate call on the engine
+    let stream = engine.generate(request).await.map_err(|e| {
+        if super::metrics::request_was_rejected(e.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&model_name, super::metrics::Endpoint::Classify);
+        }
+        let err_response = ErrorMessage::from_anyhow(e, "Failed to generate classification");
+        inflight.mark_error(extract_error_type_from_response(&err_response));
+        err_response
+    })?;
+
+    // Process stream to collect metrics and drop http_queue_guard on first token
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+
+    // Fold the (single-response) stream into one classification response.
+    let response = NvCreateClassifyResponse::from_annotated_stream(stream)
+        .await
+        .map_err(|e| {
+            tracing::error!(
+                "Failed to fold classification stream for {}: {:?}",
+                request_id,
+                e
+            );
+            let err_response =
+                ErrorMessage::internal_server_error("Failed to fold classification stream");
+            inflight.mark_error(extract_error_type_from_response(&err_response));
+            err_response
+        })?;
+
+    inflight.mark_ok();
+    Ok(Json(response).into_response())
 }
 
 async fn handler_chat_completions(
@@ -2812,6 +2909,23 @@ pub fn embeddings_router(
     let doc = RouteDoc::new(axum::http::Method::POST, &path);
     let router = Router::new()
         .route(&path, post(embeddings))
+        .layer(middleware::from_fn(smart_json_error_middleware))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
+}
+
+/// Create an Axum [`Router`] for the `/classify` endpoint (sequence
+/// classification / cross-encoder pooling). If no path is provided, the
+/// default path is `/classify`.
+pub fn classify_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or("/classify".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(classify))
         .layer(middleware::from_fn(smart_json_error_middleware))
         .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
         .with_state(state);

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -282,6 +282,7 @@ struct StateFlags {
     chat_endpoints_enabled: AtomicBool,
     cmpl_endpoints_enabled: AtomicBool,
     embeddings_endpoints_enabled: AtomicBool,
+    classify_endpoints_enabled: AtomicBool,
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
     audios_endpoints_enabled: AtomicBool,
@@ -297,6 +298,7 @@ impl StateFlags {
             EndpointType::Chat => self.chat_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Completion => self.cmpl_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Embedding => self.embeddings_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Classify => self.classify_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
@@ -319,6 +321,9 @@ impl StateFlags {
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Embedding => self
                 .embeddings_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Classify => self
+                .classify_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Images => self
                 .images_endpoints_enabled
@@ -362,6 +367,7 @@ impl State {
                 chat_endpoints_enabled: AtomicBool::new(false),
                 cmpl_endpoints_enabled: AtomicBool::new(false),
                 embeddings_endpoints_enabled: AtomicBool::new(false),
+                classify_endpoints_enabled: AtomicBool::new(false),
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
                 audios_endpoints_enabled: AtomicBool::new(false),
@@ -879,6 +885,8 @@ static HTTP_SVC_CHAT_PATH_ENV: &str = "DYN_HTTP_SVC_CHAT_PATH";
 static HTTP_SVC_CMP_PATH_ENV: &str = "DYN_HTTP_SVC_CMP_PATH";
 /// Environment variable to set the embeddings endpoint path (default: `/v1/embeddings`)
 static HTTP_SVC_EMB_PATH_ENV: &str = "DYN_HTTP_SVC_EMB_PATH";
+/// Environment variable to set the classify endpoint path (default: `/classify`)
+static HTTP_SVC_CLASSIFY_PATH_ENV: &str = "DYN_HTTP_SVC_CLASSIFY_PATH";
 /// Environment variable to set the responses endpoint path (default: `/v1/responses`)
 static HTTP_SVC_RESPONSES_PATH_ENV: &str = "DYN_HTTP_SVC_RESPONSES_PATH";
 /// Environment variable to set the anthropic messages endpoint path (default: `/v1/messages`)
@@ -1174,6 +1182,8 @@ impl HttpServiceConfigBuilder {
             super::openai::completions_router(state.clone(), var(HTTP_SVC_CMP_PATH_ENV).ok());
         let (embed_docs, embed_route) =
             super::openai::embeddings_router(state.clone(), var(HTTP_SVC_EMB_PATH_ENV).ok());
+        let (classify_docs, classify_route) =
+            super::openai::classify_router(state.clone(), var(HTTP_SVC_CLASSIFY_PATH_ENV).ok());
         let (images_docs, images_route) = super::openai::images_router(state.clone(), None);
         let (videos_docs, videos_route) = super::openai::videos_router(state.clone(), None);
         let (audios_docs, audios_route) = super::openai::audios_router(state.clone(), None);
@@ -1187,6 +1197,7 @@ impl HttpServiceConfigBuilder {
         endpoint_routes.insert(EndpointType::Chat, (chat_docs, chat_route));
         endpoint_routes.insert(EndpointType::Completion, (cmpl_docs, cmpl_route));
         endpoint_routes.insert(EndpointType::Embedding, (embed_docs, embed_route));
+        endpoint_routes.insert(EndpointType::Classify, (classify_docs, classify_route));
         endpoint_routes.insert(EndpointType::Images, (images_docs, images_route));
         endpoint_routes.insert(EndpointType::Videos, (videos_docs, videos_route));
         endpoint_routes.insert(EndpointType::Audios, (audios_docs, audios_route));

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -52,6 +52,10 @@ bitflags! {
         const Audios = 1 << 6;
         const Videos = 1 << 7;
         const Realtime = 1 << 8;
+        /// Sequence-classification / cross-encoder pooling models served on
+        /// the `/classify` endpoint (e.g. NLI, sentiment). Like `Embedding`,
+        /// this is a pooling capability, not a token-generating surface.
+        const Classify = 1 << 9;
     }
 }
 
@@ -91,6 +95,9 @@ impl ModelType {
     pub fn supports_realtime(&self) -> bool {
         self.contains(ModelType::Realtime)
     }
+    pub fn supports_classify(&self) -> bool {
+        self.contains(ModelType::Classify)
+    }
 
     pub fn as_vec(&self) -> Vec<&'static str> {
         let mut result = Vec::new();
@@ -120,6 +127,9 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push("realtime");
+        }
+        if self.supports_classify() {
+            result.push("classify");
         }
         result
     }
@@ -154,6 +164,9 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push(ModelType::Realtime);
+        }
+        if self.supports_classify() {
+            result.push(ModelType::Classify);
         }
         result
     }
@@ -198,6 +211,9 @@ impl ModelType {
         }
         if self.contains(Self::Realtime) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Realtime);
+        }
+        if self.contains(Self::Classify) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Classify);
         }
         // [gluo NOTE] ModelType::Tensor doesn't map to any endpoint type,
         // current use of endpoint type is LLM specific and so does the HTTP
@@ -319,6 +335,32 @@ mod tests {
         let endpoints = (ModelType::Chat | ModelType::Realtime).as_endpoint_types();
         assert!(endpoints.contains(&EndpointType::Chat));
         assert!(endpoints.contains(&EndpointType::Realtime));
+    }
+
+    #[test]
+    fn classify_bit_position() {
+        assert_eq!(ModelType::Classify.bits(), 1 << 9);
+    }
+
+    #[test]
+    fn classify_supports_classify() {
+        assert!(ModelType::Classify.supports_classify());
+        assert!(!ModelType::Chat.supports_classify());
+        assert!(!ModelType::Embedding.supports_classify());
+    }
+
+    #[test]
+    fn classify_in_as_vec_and_units() {
+        assert_eq!(ModelType::Classify.as_vec(), vec!["classify"]);
+        assert_eq!(ModelType::Classify.units(), vec![ModelType::Classify]);
+    }
+
+    #[test]
+    fn classify_endpoint_mapping() {
+        assert_eq!(
+            ModelType::Classify.as_endpoint_types(),
+            vec![EndpointType::Classify]
+        );
     }
 
     #[test]

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -14,6 +14,7 @@ use crate::types::TokenIdType;
 
 pub mod audios;
 pub mod chat_completions;
+pub mod classify;
 pub mod common_ext;
 pub mod completions;
 pub(crate) mod delta_common;

--- a/lib/llm/src/protocols/openai/classify.rs
+++ b/lib/llm/src/protocols/openai/classify.rs
@@ -1,0 +1,163 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Protocol types for the `/classify` endpoint (sequence-classification /
+//! cross-encoder pooling models, e.g. NLI or sentiment).
+//!
+//! There is no OpenAI-native classification schema, so — unlike embeddings,
+//! which wraps `dynamo_protocols::types::CreateEmbeddingRequest` — these types
+//! are defined fully in-repo. The wire shape mirrors vLLM's `/classify`
+//! endpoint (`vllm/entrypoints/pooling/classify/protocol.py`, vLLM 0.24.0):
+//! request `{model, input}` → response
+//! `{id, object, created, model, data:[{index, label, probs, num_classes}], usage}`.
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::Validate;
+
+mod aggregator;
+mod nvext;
+
+pub use nvext::{NvExt, NvExtProvider};
+
+/// Classification input — a single string or a batch of strings. Mirrors the
+/// `input` field of vLLM's classification request.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+#[serde(untagged)]
+pub enum ClassificationInput {
+    /// A single text to classify.
+    Single(String),
+    /// A batch of texts to classify.
+    Batch(Vec<String>),
+}
+
+/// Request for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyRequest {
+    /// The model to use for classification.
+    pub model: String,
+
+    /// The text (or texts) to classify.
+    pub input: ClassificationInput,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nvext: Option<NvExt>,
+}
+
+/// One classification result within a [`NvCreateClassifyResponse`].
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone)]
+pub struct ClassificationData {
+    /// Index of this item within the request batch.
+    pub index: u32,
+
+    /// Predicted label (from the model's `id2label`), if available.
+    #[serde(default)]
+    pub label: Option<String>,
+
+    /// Per-class probability vector.
+    pub probs: Vec<f32>,
+
+    /// Number of classes (== `probs.len()`).
+    pub num_classes: u32,
+}
+
+/// Usage information for a classification response.
+#[derive(ToSchema, Serialize, Deserialize, Debug, Clone, Default)]
+pub struct ClassificationUsage {
+    pub prompt_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Response for the `/classify` endpoint.
+#[derive(ToSchema, Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateClassifyResponse {
+    pub id: String,
+    pub object: String,
+    pub created: u64,
+    pub model: String,
+    pub data: Vec<ClassificationData>,
+    pub usage: ClassificationUsage,
+}
+
+impl NvCreateClassifyResponse {
+    pub fn empty() -> Self {
+        Self {
+            id: String::new(),
+            object: "list".to_string(),
+            created: 0,
+            model: "classify".to_string(),
+            data: vec![],
+            usage: ClassificationUsage::default(),
+        }
+    }
+}
+
+/// Implements `NvExtProvider` for `NvCreateClassifyRequest`,
+/// providing access to NVIDIA-specific extensions.
+impl NvExtProvider for NvCreateClassifyRequest {
+    fn nvext(&self) -> Option<&NvExt> {
+        self.nvext.as_ref()
+    }
+}
+
+/// Implements `AnnotationsProvider` for `NvCreateClassifyRequest`,
+/// enabling retrieval and management of request annotations.
+impl AnnotationsProvider for NvCreateClassifyRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.clone())
+    }
+
+    fn has_annotation(&self, annotation: &str) -> bool {
+        self.nvext
+            .as_ref()
+            .and_then(|nvext| nvext.annotations.as_ref())
+            .map(|annotations| annotations.contains(&annotation.to_string()))
+            .unwrap_or(false)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn single_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello world"
+        }))
+        .unwrap();
+        assert!(matches!(request.input, ClassificationInput::Single(_)));
+        let value = serde_json::to_value(&request).unwrap();
+        assert_eq!(value["input"], "hello world");
+    }
+
+    #[test]
+    fn batch_input_round_trips() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": ["a", "b"]
+        }))
+        .unwrap();
+        match &request.input {
+            ClassificationInput::Batch(v) => assert_eq!(v.len(), 2),
+            _ => panic!("expected batch input"),
+        }
+    }
+
+    #[test]
+    fn omitted_nvext_is_not_serialized() {
+        let request: NvCreateClassifyRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "input": "hello"
+        }))
+        .unwrap();
+        assert!(request.nvext.is_none());
+        let value = serde_json::to_value(request).unwrap();
+        assert!(value.get("nvext").is_none());
+    }
+}

--- a/lib/llm/src/protocols/openai/classify/aggregator.rs
+++ b/lib/llm/src/protocols/openai/classify/aggregator.rs
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::NvCreateClassifyResponse;
+use crate::protocols::{
+    Annotated,
+    codec::{Message, SseCodecError},
+    convert_sse_stream,
+    openai::stream_aggregator::{StreamAggregable, aggregate_stream},
+};
+
+use dynamo_runtime::engine::DataStream;
+use futures::Stream;
+
+impl StreamAggregable for NvCreateClassifyResponse {
+    fn empty() -> Self {
+        Self::empty()
+    }
+
+    fn merge(&mut self, next: Self) {
+        // Preserve identity/model from the first non-empty response.
+        if self.id.is_empty() {
+            self.id = next.id;
+        }
+        if self.created == 0 {
+            self.created = next.created;
+        }
+        if self.model == "classify" && next.model != "classify" {
+            self.model = next.model;
+        }
+        self.data.extend(next.data);
+        self.usage.prompt_tokens += next.usage.prompt_tokens;
+        self.usage.total_tokens += next.usage.total_tokens;
+    }
+}
+
+impl NvCreateClassifyResponse {
+    /// Converts an SSE stream into a [`NvCreateClassifyResponse`].
+    pub async fn from_sse_stream(
+        stream: DataStream<Result<Message, SseCodecError>>,
+    ) -> Result<NvCreateClassifyResponse, String> {
+        let stream = convert_sse_stream::<NvCreateClassifyResponse>(stream);
+        NvCreateClassifyResponse::from_annotated_stream(stream).await
+    }
+
+    /// Aggregates an annotated stream of classification responses into a final response.
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvCreateClassifyResponse>>,
+    ) -> Result<NvCreateClassifyResponse, String> {
+        aggregate_stream(stream).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocols::openai::classify::ClassificationData;
+    use futures::stream;
+
+    fn make_response(
+        index: u32,
+        label: &str,
+        probs: Vec<f32>,
+        prompt_tokens: u32,
+    ) -> Annotated<NvCreateClassifyResponse> {
+        let response = NvCreateClassifyResponse {
+            id: "classify-test".to_string(),
+            object: "list".to_string(),
+            created: 1,
+            model: "test-model".to_string(),
+            data: vec![ClassificationData {
+                index,
+                label: Some(label.to_string()),
+                num_classes: probs.len() as u32,
+                probs,
+            }],
+            usage: super::super::ClassificationUsage {
+                prompt_tokens,
+                total_tokens: prompt_tokens,
+            },
+        };
+        Annotated::from_data(response)
+    }
+
+    #[tokio::test]
+    async fn test_empty_stream() {
+        let stream = stream::empty();
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 0);
+        assert_eq!(response.object, "list");
+    }
+
+    #[tokio::test]
+    async fn test_single_classification() {
+        let annotated = make_response(0, "entailment", vec![0.1, 0.7, 0.2], 5);
+        let stream = stream::iter(vec![annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 1);
+        assert_eq!(response.data[0].label.as_deref(), Some("entailment"));
+        assert_eq!(response.data[0].num_classes, 3);
+        assert_eq!(response.usage.prompt_tokens, 5);
+        assert_eq!(response.model, "test-model");
+    }
+
+    #[tokio::test]
+    async fn test_multiple_classifications() {
+        let a = make_response(0, "entailment", vec![0.8, 0.2], 4);
+        let b = make_response(1, "contradiction", vec![0.3, 0.7], 6);
+        let stream = stream::iter(vec![a, b]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_ok());
+        let response = result.unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].index, 0);
+        assert_eq!(response.data[1].index, 1);
+        assert_eq!(response.usage.total_tokens, 10);
+    }
+
+    #[tokio::test]
+    async fn test_error_in_stream() {
+        let error_annotated =
+            Annotated::<NvCreateClassifyResponse>::from_error("Test error".to_string());
+        let stream = stream::iter(vec![error_annotated]);
+        let result = NvCreateClassifyResponse::from_annotated_stream(Box::pin(stream)).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Test error"));
+    }
+}

--- a/lib/llm/src/protocols/openai/classify/nvext.rs
+++ b/lib/llm/src/protocols/openai/classify/nvext.rs
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use derive_builder::Builder;
+use serde::{Deserialize, Serialize};
+use utoipa::ToSchema;
+use validator::{Validate, ValidationError};
+
+pub trait NvExtProvider {
+    fn nvext(&self) -> Option<&NvExt>;
+}
+
+/// NVIDIA LLM extensions to the OpenAI API
+#[derive(ToSchema, Serialize, Deserialize, Builder, Validate, Debug, Clone)]
+#[validate(schema(function = "validate_nv_ext"))]
+pub struct NvExt {
+    /// Annotations
+    /// User requests triggers which result in the request issue back out-of-band information in the SSE
+    /// stream using the `event:` field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[builder(default, setter(strip_option))]
+    pub annotations: Option<Vec<String>>,
+}
+
+impl Default for NvExt {
+    fn default() -> Self {
+        NvExt::builder().build().unwrap()
+    }
+}
+
+impl NvExt {
+    pub fn builder() -> NvExtBuilder {
+        NvExtBuilder::default()
+    }
+}
+
+fn validate_nv_ext(_nv_ext: &NvExt) -> Result<(), ValidationError> {
+    Ok(())
+}
+
+impl NvExtBuilder {
+    pub fn add_annotation(&mut self, annotation: impl Into<String>) -> &mut Self {
+        self.annotations
+            .get_or_insert_with(|| Some(vec![]))
+            .as_mut()
+            .expect("stop should always be Some(Vec)")
+            .push(annotation.into());
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_nv_ext_builder_default() {
+        let nv_ext = NvExt::builder().build().unwrap();
+        assert_eq!(nv_ext.annotations, None);
+    }
+}

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -78,6 +78,22 @@ pub mod openai {
             ServerStreamingEngine<NvCreateEmbeddingRequest, Annotated<NvCreateEmbeddingResponse>>;
     }
 
+    pub mod classify {
+        use super::*;
+
+        pub use protocols::openai::classify::{
+            NvCreateClassifyRequest, NvCreateClassifyResponse,
+        };
+
+        /// A [`UnaryEngine`] implementation for the `/classify` API
+        pub type OpenAIClassifyUnaryEngine =
+            UnaryEngine<NvCreateClassifyRequest, NvCreateClassifyResponse>;
+
+        /// A [`ServerStreamingEngine`] implementation for the `/classify` API
+        pub type OpenAIClassifyStreamingEngine =
+            ServerStreamingEngine<NvCreateClassifyRequest, Annotated<NvCreateClassifyResponse>>;
+    }
+
     pub mod images {
         use super::*;
 

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -209,6 +209,7 @@ fn compute_index(endpoint: &Endpoint, request_type: &RequestType, status: &Statu
         Endpoint::Completions => 0,
         Endpoint::ChatCompletions => 1,
         Endpoint::Embeddings => todo!(),
+        Endpoint::Classify => todo!(),
         Endpoint::Responses => todo!(),
         Endpoint::AnthropicMessages => todo!(),
         Endpoint::Tensor => todo!(),


### PR DESCRIPTION
Adds a new ModelType::Classify capability and a /classify OpenAI-style endpoint so cross-encoder / sequence-classification / NLI pooling models (e.g. tasksource/ModernBERT-large-nli) can be served through Dynamo, on par with vanilla vLLM's /classify.

Rust (lib/llm):
- ModelType::Classify (bit 1<<9) + EndpointType::Classify, mapped so discovery auto-enables the route.
- New protocols/openai/classify.rs (request/response, nvext, aggregator) matching vLLM 0.24.0's ClassificationRequest/Response shape.
- classify_engine plumbed through WorkerSet / Model / ModelManager and the watcher's Text+Classify registration branch.
- classify HTTP handler + /classify router + StateFlags + Endpoint metric.

Python bindings: ModelType.Classify classattr + .pyi stub.

vLLM backend (components):
- --classify-worker flag + validation (agg-only, exclusive with --embedding-worker), _create_classify_worker, and ClassifyWorkerHandler (PoolingParams(task=classify); label from hf_config.id2label[argmax]).
- Exclude ModelType.Classify from LoRA slot advertisement.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
