### PR TITLE
fix(trtllm): handle visible stop tokens in unified backend

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -75,6 +75,7 @@ from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParamsCodec,
 )
 from dynamo.trtllm.utils.request_utils import (
+    apply_stop_conditions_to_sampling_params,
     request_cache_salt,
     stored_event_cache_salt,
 )
@@ -855,11 +856,7 @@ class TrtllmLLMEngine(LLMEngine):
             elif self.max_seq_len is not None:
                 sampling_params.max_tokens = max(1, self.max_seq_len - len(token_ids))
 
-        # TODO: mirror visible/hidden stop-token handling from the disagg
-        # path (handler_base.py) into a shared helper. See PR #9778.
-        ignore_eos = stop_conditions.get("ignore_eos")
-        if ignore_eos:
-            sampling_params.ignore_eos = ignore_eos
+        apply_stop_conditions_to_sampling_params(sampling_params, stop_conditions)
 
         # In conversation-affinity mode let the engine's ConversationAwareADPRouter pick the
         # attention-DP rank from the conversation id; do NOT force a rank (an explicit rank is

--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -856,7 +856,8 @@ class TrtllmLLMEngine(LLMEngine):
             elif self.max_seq_len is not None:
                 sampling_params.max_tokens = max(1, self.max_seq_len - len(token_ids))
 
-        apply_stop_conditions_to_sampling_params(sampling_params, stop_conditions)
+        if is_generation_stage(_TRTLLM_TO_COMMON_DISAGG[self.disaggregation_mode]):
+            apply_stop_conditions_to_sampling_params(sampling_params, stop_conditions)
 
         # In conversation-affinity mode let the engine's ConversationAwareADPRouter pick the
         # attention-DP rank from the conversation id; do NOT force a rank (an explicit rank is

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -35,6 +35,8 @@ from tensorrt_llm.scheduling_params import SchedulingParams
 
 from dynamo._core import Client, Context
 from dynamo.common.backend import logprobs as _shared_logprobs
+from dynamo.common.backend.engine import is_generation_stage
+from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
@@ -1064,9 +1066,10 @@ class HandlerBase(BaseGenerativeHandler):
                 dynamic_default = max(1, self.max_seq_len - input_length)
                 sampling_params.max_tokens = dynamic_default
 
-        apply_stop_conditions_to_sampling_params(
-            sampling_params, request["stop_conditions"]
-        )
+        if is_generation_stage(CommonDisaggregationMode[self.disaggregation_mode.name]):
+            apply_stop_conditions_to_sampling_params(
+                sampling_params, request["stop_conditions"]
+            )
 
         # TODO: Instead of True, we should use streaming from the request.
         # However, currently dynamo run does not send streaming in the request.

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -59,7 +59,10 @@ from dynamo.trtllm.utils.disagg_utils import (
     DisaggregatedParams,
     DisaggregatedParamsCodec,
 )
-from dynamo.trtllm.utils.request_utils import request_cache_salt
+from dynamo.trtllm.utils.request_utils import (
+    apply_stop_conditions_to_sampling_params,
+    request_cache_salt,
+)
 
 if TYPE_CHECKING:
     # tensorrt_llm may use a different version that doesn't have MetricsCollector,
@@ -1061,35 +1064,9 @@ class HandlerBase(BaseGenerativeHandler):
                 dynamic_default = max(1, self.max_seq_len - input_length)
                 sampling_params.max_tokens = dynamic_default
 
-        stop_conditions = request["stop_conditions"]
-        ignore_eos = stop_conditions.get("ignore_eos")
-        visible_stop_token_ids = set(
-            stop_conditions.get("stop_token_ids_visible") or []
+        apply_stop_conditions_to_sampling_params(
+            sampling_params, request["stop_conditions"]
         )
-        # TRT-LLM PyTorch backend has no per-token "visible stop" hook, so
-        # visible stop tokens (e.g. Harmony's `<|call|>` for gpt-oss) are
-        # stripped before Dynamo sees them. Force `ignore_eos=True` to disable
-        # engine-side stopping and let backend.rs (`VisibleStopTokenDetected` /
-        # `HiddenStopTokenDetected`) own all stopping.
-        #
-        # TODO: revisit once TRT-LLM exposes a per-token visible-stop hook.
-        if ignore_eos or visible_stop_token_ids:
-            sampling_params.ignore_eos = True
-
-        min_tokens = stop_conditions.get("min_tokens")
-        if min_tokens:
-            sampling_params.min_tokens = min_tokens
-
-        stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
-        if stop_token_ids:
-            existing = sampling_params.stop_token_ids or []
-            engine_stop_token_ids = set(existing).union(stop_token_ids)
-            engine_stop_token_ids.difference_update(visible_stop_token_ids)
-            sampling_params.stop_token_ids = list(engine_stop_token_ids)
-        elif visible_stop_token_ids and sampling_params.stop_token_ids:
-            sampling_params.stop_token_ids = list(
-                set(sampling_params.stop_token_ids) - visible_stop_token_ids
-            )
 
         # TODO: Instead of True, we should use streaming from the request.
         # However, currently dynamo run does not send streaming in the request.

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -52,6 +52,9 @@ class MockSamplingParams:
     best_of: int = 1
     ignore_eos: bool = False
     guided_decoding: object | None = None
+    max_tokens: int | None = None
+    min_tokens: int | None = None
+    stop_token_ids: list[int] | None = None
 
     def __post_init__(self):
         """Called after dataclass initialization (including via replace())."""
@@ -895,6 +898,47 @@ class TestHealthCheckPriority:
         handler.engine.llm.generate_async.assert_called_once()
         _, kwargs = handler.engine.llm.generate_async.call_args
         assert kwargs["cache_salt"] == "tenant-a"
+
+    @pytest.mark.asyncio
+    async def test_prefill_skips_generation_stop_conditions(self):
+        handler = self._make_handler()
+        handler.disaggregation_mode = DisaggregationMode.PREFILL
+        handler.disagg_machine_id = 0
+        handler.default_sampling_params = MockSamplingParams(stop_token_ids=[300])
+        generation_result = MagicMock()
+
+        async def empty_aiter(_self):
+            for _ in ():
+                yield
+
+        generation_result.__aiter__ = empty_aiter
+        handler.engine.llm.generate_async = MagicMock(return_value=generation_result)
+
+        request = {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {
+                "max_tokens": 10,
+                "min_tokens": 8,
+                "ignore_eos": True,
+                "stop_token_ids_hidden": [100],
+                "stop_token_ids_visible": [200],
+            },
+            "sampling_options": {},
+        }
+
+        chunks = [
+            c async for c in handler.generate_locally(request, self._make_context())
+        ]
+        assert chunks == []
+
+        handler.engine.llm.generate_async.assert_called_once()
+        _, kwargs = handler.engine.llm.generate_async.call_args
+        sampling_params = kwargs["sampling_params"]
+        assert sampling_params.max_tokens == 1
+        assert sampling_params.min_tokens is None
+        assert sampling_params.ignore_eos is False
+        assert sampling_params.stop_token_ids == [300]
+        assert kwargs["streaming"] is False
 
 
 class _FakeConversationParams:

--- a/components/src/dynamo/trtllm/tests/test_trtllm_request_utils.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_request_utils.py
@@ -1,9 +1,12 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 import pytest
 
 from dynamo.trtllm.utils.request_utils import (
+    apply_stop_conditions_to_sampling_params,
     request_cache_salt,
     stored_event_cache_salt,
 )
@@ -11,6 +14,7 @@ from dynamo.trtllm.utils.request_utils import (
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.trtllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
@@ -80,3 +84,39 @@ def test_stored_event_cache_salt_rejects_conflicting_blocks() -> None:
 
     with pytest.raises(ValueError, match="conflicting cache_salt"):
         stored_event_cache_salt(data)
+
+
+def test_visible_stop_tokens_disable_engine_stopping() -> None:
+    sampling_params = SimpleNamespace(
+        ignore_eos=False,
+        min_tokens=None,
+        stop_token_ids=[200, 300],
+    )
+
+    apply_stop_conditions_to_sampling_params(
+        sampling_params,
+        {
+            "stop_token_ids_visible": [200],
+            "stop_token_ids_hidden": [100, 200],
+        },
+    )
+
+    assert sampling_params.ignore_eos is True
+    assert set(sampling_params.stop_token_ids) == {100, 300}
+
+
+def test_hidden_stop_tokens_keep_engine_stopping_enabled() -> None:
+    sampling_params = SimpleNamespace(
+        ignore_eos=False,
+        min_tokens=None,
+        stop_token_ids=[300],
+    )
+
+    apply_stop_conditions_to_sampling_params(
+        sampling_params,
+        {"stop_token_ids_hidden": [100], "min_tokens": 2},
+    )
+
+    assert sampling_params.ignore_eos is False
+    assert sampling_params.min_tokens == 2
+    assert set(sampling_params.stop_token_ids) == {100, 300}

--- a/components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py
@@ -25,6 +25,7 @@ pytestmark = [
     pytest.mark.asyncio,
     pytest.mark.unit,
     pytest.mark.trtllm,
+    pytest.mark.core,
     pytest.mark.gpu_1,
     pytest.mark.pre_merge,
 ]
@@ -131,3 +132,37 @@ async def test_forwards_routing_cache_salt():
     )
 
     assert captured["cache_salt"] == "tenant-a"
+
+
+async def test_visible_stop_tokens_use_dynamo_stopping():
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    sampling_params = SimpleNamespace(
+        max_tokens=None,
+        ignore_eos=False,
+        min_tokens=None,
+        stop_token_ids=[200, 300],
+    )
+    engine = _make_engine(fake_generate_async)
+    engine._override_sampling_params = lambda _default, _request: sampling_params
+
+    await _drain(
+        engine,
+        _FakeContext(),
+        {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {
+                "max_tokens": 4,
+                "stop_token_ids_hidden": [100, 200],
+                "stop_token_ids_visible": [200],
+            },
+        },
+    )
+
+    assert captured["sampling_params"] is sampling_params
+    assert sampling_params.ignore_eos is True
+    assert set(sampling_params.stop_token_ids) == {100, 300}

--- a/components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py
@@ -59,6 +59,7 @@ def _make_engine(generate_async) -> TrtllmLLMEngine:
     engine._logits_processor_spec = None
     engine._default_sampling_params = SimpleNamespace()
     engine.disaggregation_mode = DisaggregationMode.AGGREGATED
+    engine._disagg_machine_id = 0
     engine.max_seq_len = 1024
     engine._active_requests = {}
     engine._additional_metrics = None
@@ -166,3 +167,43 @@ async def test_visible_stop_tokens_use_dynamo_stopping():
     assert captured["sampling_params"] is sampling_params
     assert sampling_params.ignore_eos is True
     assert set(sampling_params.stop_token_ids) == {100, 300}
+
+
+async def test_prefill_skips_generation_stop_conditions():
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    sampling_params = SimpleNamespace(
+        max_tokens=None,
+        ignore_eos=False,
+        min_tokens=None,
+        stop_token_ids=[300],
+    )
+    engine = _make_engine(fake_generate_async)
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    engine._override_sampling_params = lambda _default, _request: sampling_params
+
+    await _drain(
+        engine,
+        _FakeContext(),
+        {
+            "token_ids": [1, 2, 3],
+            "stop_conditions": {
+                "max_tokens": 10,
+                "min_tokens": 8,
+                "ignore_eos": True,
+                "stop_token_ids_hidden": [100],
+                "stop_token_ids_visible": [200],
+            },
+        },
+    )
+
+    assert captured["sampling_params"] is sampling_params
+    assert sampling_params.max_tokens == 1
+    assert sampling_params.min_tokens is None
+    assert sampling_params.ignore_eos is False
+    assert sampling_params.stop_token_ids == [300]
+    assert captured["streaming"] is False

--- a/components/src/dynamo/trtllm/utils/request_utils.py
+++ b/components/src/dynamo/trtllm/utils/request_utils.py
@@ -48,3 +48,34 @@ def stored_event_cache_salt(data: Mapping[str, Any]) -> Optional[str]:
         raise ValueError("stored KV event contains conflicting cache_salt values")
 
     return next(iter(cache_salts), None)
+
+
+def apply_stop_conditions_to_sampling_params(
+    sampling_params: Any, stop_conditions: Mapping[str, Any]
+) -> None:
+    """Apply Dynamo stop conditions using TRT-LLM stopping semantics.
+
+    TRT-LLM cannot return a token that it consumes as an engine-side stop. If
+    Dynamo marks a stop token as visible, disable TRT-LLM stopping and let the
+    Dynamo decoder return the token and terminate the request. TRT-LLM maps
+    ``ignore_eos=True`` to both ``end_id=-1`` and an empty stop-word list when
+    it builds the executor request.
+    """
+    visible_stop_token_ids = set(stop_conditions.get("stop_token_ids_visible") or [])
+    if stop_conditions.get("ignore_eos") or visible_stop_token_ids:
+        sampling_params.ignore_eos = True
+
+    min_tokens = stop_conditions.get("min_tokens")
+    if min_tokens:
+        sampling_params.min_tokens = min_tokens
+
+    hidden_stop_token_ids = stop_conditions.get("stop_token_ids_hidden")
+    if hidden_stop_token_ids:
+        engine_stop_token_ids = set(sampling_params.stop_token_ids or [])
+        engine_stop_token_ids.update(hidden_stop_token_ids)
+        engine_stop_token_ids.difference_update(visible_stop_token_ids)
+        sampling_params.stop_token_ids = list(engine_stop_token_ids)
+    elif visible_stop_token_ids and sampling_params.stop_token_ids:
+        sampling_params.stop_token_ids = list(
+            set(sampling_params.stop_token_ids) - visible_stop_token_ids
+        )


### PR DESCRIPTION
## Overview:

Apply TRT-LLM visible and hidden stop-token handling consistently in both the legacy and unified backend paths.

TRT-LLM's `ignore_eos` behavior disables both `end_id` and stop words. Without this normalization, the unified backend can consume an overlapping EOS/visible-stop token before Dynamo sees it. GPT-OSS Harmony's `<|call|>` token is the known example, but the issue applies to any model with overlapping EOS and visible-stop tokens.

## Details:

- Extract the existing TRT-LLM stop-condition normalization into a shared `apply_stop_conditions_to_sampling_params` helper.
- Use the helper from both the legacy request handler and `TrtllmLLMEngine`.
- When visible stop tokens are present:
  - set `ignore_eos=True`, which TRT-LLM maps to `end_id=-1` and an empty stop-word list;
  - remove visible tokens from engine-side stop IDs;
  - let Dynamo's decoder remain the authoritative stopping layer.
- Preserve existing hidden stop-token merging and `min_tokens` handling.
- Add unit coverage for visible and hidden stop-token normalization.
- Add a regression test covering the unified backend request path.

This follows up on the original TRT-LLM workaround in #9778. The related Harmony parser recovery was added in #10366.

## Where should the reviewer start?

- `components/src/dynamo/trtllm/utils/request_utils.py`
- `components/src/dynamo/trtllm/llm_engine.py`
- `components/src/dynamo/trtllm/tests/test_trtllm_trace_propagation.py`

## Related Issues

- DIS-2219

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved handling of stop conditions during text generation.
  * Visible stop tokens are now managed by the application, while hidden stop tokens continue to support engine-level stopping.
  * Minimum token requirements are applied consistently when configured.

* **Bug Fixes**
  * Corrected stop-token and end-of-sequence behavior across generation pathways.
  * Added coverage for visible and hidden stop-token scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->