### PR TITLE
docs(snapshot): update snapshot/resiliency support matrix

### DIFF
--- a/docs/kubernetes/cold-start-and-resiliency.md
+++ b/docs/kubernetes/cold-start-and-resiliency.md
@@ -17,7 +17,7 @@ Dynamo is building composable primitives across two themes:
 This document tracks backend support across three composable projects in this workstream:
 
 - **[GPU Memory Service (GMS)](#gpu-memory-service-gms)**: out-of-process GPU memory manager for zero-copy sharing of weights and KV across worker processes.
-- **[Dynamo Bulwark](#dynamo-bulwark-shadow-engine-failover)**: pre-initialized "shadow" engines sharing weights and KV cache can be quickly failed over to on software and hardware failures.
+- **[Shadow Engine Failover](#shadow-engine-failover)**: pre-initialized "shadow" engines sharing weights and KV cache can be quickly failed over to on software and hardware failures.
 - **[Dynamo Snapshot](./snapshot.md)**: CRIU-based checkpoint/restore of initialized workers, cutting cold starts from minutes to seconds.
 
 **Legend:**
@@ -28,7 +28,7 @@ This document tracks backend support across three composable projects in this wo
 
 ## Support Matrix
 
-| Backend | [GPU Memory Service](#gpu-memory-service-gms) | [Dynamo Bulwark](#dynamo-bulwark-shadow-engine-failover) | [Dynamo Snapshot](./snapshot.md) |
+| Backend | [GPU Memory Service](#gpu-memory-service-gms) | [Shadow Engine Failover](#shadow-engine-failover) | [Dynamo Snapshot](./snapshot.md) |
 | :--- | :---: | :---: | :---: |
 | **vLLM** | ✅ | ✅ | ✅ |
 | **SGLang** | ✅ | 🚧 | ✅ |
@@ -40,7 +40,7 @@ See the per-feature sections below for detailed per-backend status.
 
 ### GPU Memory Service (GMS)
 
-- Out-of-process GPU memory manager for zero-copy sharing of weights and KV across workers on the same GPU; foundation for Dynamo Bulwark. [Architecture](../../lib/gpu_memory_service/README.md)
+- Out-of-process GPU memory manager for zero-copy sharing of weights and KV across workers on the same GPU; foundation for Shadow Engine Failover. [Architecture](../../lib/gpu_memory_service/README.md)
 - In Kubernetes, GMS is wired in via [Dynamic Resource Allocation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/), configured through the `gpuMemoryService` field on the `DynamoGraphDeployment` CR.
 
 #### Status
@@ -54,7 +54,7 @@ See the per-feature sections below for detailed per-backend status.
 **Notes:**
 - vLLM, SGLang, and TensorRT-LLM require upstream changes to inference that are currently being upstreamed.
 
-### Dynamo Bulwark (Shadow Engine Failover)
+### Shadow Engine Failover
 
 - Shadow engines share weights (and soon KV) with a primary via [GMS](#gpu-memory-service-gms) and take over within seconds on primary failure using a kernel-mediated flock for leader election.
 - In Kubernetes, configured through the `failover` field on the `DynamoGraphDeployment` CR (on top of `gpuMemoryService`).
@@ -75,6 +75,8 @@ See the per-feature sections below for detailed per-backend status.
 
 Dynamo Snapshot uses CRIU and CUDA checkpointing capabilities to capture a worker's initialized state once (including GPU memory and CUDA contexts) and restore subsequent workers from that checkpoint, reducing cold starts from minutes to seconds for large LLMs. This feature is enabled via the DynamoCheckpoint custom resource and is natively supported via the Dynamo Graph Deployments (DGDs).
 
+When used with GMS, weights can be restored in parallel with the CRIU/CUDA checkpoint. Currently, weights are saved/restored via experimental transfer backends implemented via NIXL. [ModelExpress](https://github.com/ai-dynamo/modelexpress) backend integration with GMS is coming soon in a future Dynamo release.
+
 #### Status
 
 | Backend | Single GPU | Multi-GPU, Single Node | Multinode |
@@ -84,5 +86,6 @@ Dynamo Snapshot uses CRIU and CUDA checkpointing capabilities to capture a worke
 | **TensorRT-LLM** | ✅ | 🚧 | 🚧 |
 
 **Notes:**
-- GMS integration is currently disabled by default. CUDA Driver r610 is the minimum required version for Dynamo Snapshot + GMS integration.
+- Dynamo Snapshot + GMS integration is currently disabled by default (override via `DYN_OPERATOR_ALLOW_GMS_SNAPSHOT=1`)
+- CUDA Driver r610 is the minimum required version for Dynamo Snapshot + GMS integration.
 - Multi-GPU, Single Node is available in a highly experimental/slightly limited path that uses legacy IPC only for P2P.

--- a/docs/kubernetes/cold-start-and-resiliency.md
+++ b/docs/kubernetes/cold-start-and-resiliency.md
@@ -26,6 +26,8 @@ This document tracks backend support across three composable projects in this wo
 - 🚧 : Work in Progress / Experimental / Limited
 - ❌ : Not started
 
+**How to read this matrix:** ✅ means Dynamo has a supported path for the backend and scope shown in the row or column; it does not mean every deployment topology, workload shape, or integration is generally available. 🚧 covers work in progress, preview, experimental, or narrowly validated paths. Use the per-feature notes and linked guides for setup steps, prerequisites, and limitations.
+
 ## Support Matrix
 
 | Backend | [GPU Memory Service](#gpu-memory-service-gms) | [Shadow Engine Failover](#shadow-engine-failover) | [Dynamo Snapshot](./snapshot.md) |
@@ -86,6 +88,6 @@ When used with GMS, weights can be restored in parallel with the CRIU/CUDA check
 | **TensorRT-LLM** | ✅ | 🚧 | 🚧 |
 
 **Notes:**
-- Dynamo Snapshot + GMS integration is currently disabled by default (override via `DYN_OPERATOR_ALLOW_GMS_SNAPSHOT=1`)
-- CUDA Driver r610 is the minimum required version for Dynamo Snapshot + GMS integration.
+- Dynamo Snapshot + GMS integration is currently disabled by default and requires both the operator gate `DYN_OPERATOR_ALLOW_GMS_SNAPSHOT=1` and CUDA Driver r610 or later.
+- TensorRT-LLM Snapshot is supported only for the experimental single-GPU aggregated text worker path; broader TensorRT-LLM coverage remains work in progress. See [Snapshotting GPU Workers](./snapshot.md) for setup steps, prerequisites, and limitations.
 - Multi-GPU, Single Node is available in a highly experimental/slightly limited path that uses legacy IPC only for P2P.

--- a/docs/kubernetes/cold-start-and-resiliency.md
+++ b/docs/kubernetes/cold-start-and-resiliency.md
@@ -32,7 +32,7 @@ This document tracks backend support across three composable projects in this wo
 | :--- | :---: | :---: | :---: |
 | **vLLM** | ✅ | ✅ | ✅ |
 | **SGLang** | ✅ | 🚧 | ✅ |
-| **TensorRT-LLM** | 🚧 | 🚧 | 🚧 |
+| **TensorRT-LLM** | 🚧 | 🚧 | ✅ |
 
 See the per-feature sections below for detailed per-backend status.
 
@@ -73,7 +73,7 @@ See the per-feature sections below for detailed per-backend status.
 
 ### Dynamo Snapshot
 
-Dynamo Snapshot uses CRIU and NVIDIA's `cuda-checkpoint` utility to capture a worker's initialized state once (including GPU memory and CUDA contexts) and restore subsequent workers from that checkpoint, reducing cold starts from minutes to seconds for large LLMs. This feature is enabled via the DynamoCheckpoint custom resource and is natively supported via the Dynamo Graph Deployments (DGDs).
+Dynamo Snapshot uses CRIU and CUDA checkpointing capabilities to capture a worker's initialized state once (including GPU memory and CUDA contexts) and restore subsequent workers from that checkpoint, reducing cold starts from minutes to seconds for large LLMs. This feature is enabled via the DynamoCheckpoint custom resource and is natively supported via the Dynamo Graph Deployments (DGDs).
 
 #### Status
 
@@ -81,9 +81,8 @@ Dynamo Snapshot uses CRIU and NVIDIA's `cuda-checkpoint` utility to capture a wo
 | :--- | :---: | :---: | :---: |
 | **vLLM** | ✅ | ✅ (highly experimental) | 🚧 |
 | **SGLang** | ✅ | 🚧 | 🚧 |
-| **TensorRT-LLM** | 🚧 | 🚧 | 🚧 |
+| **TensorRT-LLM** | ✅ | 🚧 | 🚧 |
 
 **Notes:**
-- GMS integration is currently gated on a pending driver release.
-- CRIU performance is only optimal with the following patches folded into criu-dev: [AIO support](https://github.com/checkpoint-restore/criu/pull/3022) and [parallel memfd support](https://github.com/checkpoint-restore/criu/pull/3021)
+- GMS integration is currently disabled by default. CUDA Driver r610 is the minimum required version for Dynamo Snapshot + GMS integration.
 - Multi-GPU, Single Node is available in a highly experimental/slightly limited path that uses legacy IPC only for P2P.


### PR DESCRIPTION
## Overview:

Update support matrix

## Details:

TRTLLM Snapshot is now available for single-GPU, and specify 610 minimum driver for GMS. CRIU changes are merged upstream.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11674" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the Kubernetes cold-start and resiliency support matrix to show TensorRT-LLM support for Dynamo Snapshot on single-GPU deployments.
  - Clarified that GMS integration is disabled by default and requires CUDA Driver r610 or later.
  - Removed outdated notes about pending driver releases and performance patches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->