### PR TITLE
test(sglang): cover aggregated OTLP tracing

### DIFF
--- a/tests/frontend/test_unified_worker_otlp_export.py
+++ b/tests/frontend/test_unified_worker_otlp_export.py
@@ -13,17 +13,10 @@ with its attributes intact.
 
 from __future__ import annotations
 
-import threading
 import time
-from concurrent import futures
 
-import grpc
 import pytest
 import requests
-from opentelemetry.proto.collector.trace.v1 import (
-    trace_service_pb2,
-    trace_service_pb2_grpc,
-)
 
 from tests.frontend.conftest import (
     SampleUnifiedWorkerProcess,
@@ -32,6 +25,9 @@ from tests.frontend.conftest import (
 from tests.frontend.test_request_tracing_logs import _send_chat_completions
 from tests.utils.constants import QWEN
 from tests.utils.managed_process import DynamoFrontendProcess
+from tests.utils.otel import wait_for_engine_generate_count
+
+pytest_plugins = ("tests.utils.otel",)
 
 TEST_MODEL = QWEN
 
@@ -43,47 +39,6 @@ pytestmark = [
     pytest.mark.model(TEST_MODEL),
     pytest.mark.timeout(180),
 ]
-
-
-class InProcOtlpCollector(trace_service_pb2_grpc.TraceServiceServicer):
-    """Minimal in-process OTLP/gRPC trace collector.
-
-    Stores every received Span proto for the test to assert on. Thread-safe;
-    the gRPC server runs on a worker thread pool.
-    """
-
-    def __init__(self):
-        self.spans = []
-        self._lock = threading.Lock()
-
-    def Export(self, request, context):
-        with self._lock:
-            for resource_spans in request.resource_spans:
-                for scope_spans in resource_spans.scope_spans:
-                    self.spans.extend(scope_spans.spans)
-        return trace_service_pb2.ExportTraceServiceResponse()
-
-    def engine_generate_spans(self):
-        with self._lock:
-            return [s for s in self.spans if s.name == "engine.generate"]
-
-    def spans_for_trace_id(self, trace_id_hex):
-        trace_id = bytes.fromhex(trace_id_hex)
-        with self._lock:
-            return [s for s in self.spans if s.trace_id == trace_id]
-
-    def has_span(self, name):
-        with self._lock:
-            return any(s.name == name for s in self.spans)
-
-    def clear(self):
-        with self._lock:
-            self.spans.clear()
-
-    def snapshot(self):
-        """Return a stable copy of `self.spans` for assertions."""
-        with self._lock:
-            return list(self.spans)
 
 
 def _get_attr(span, key):
@@ -120,37 +75,6 @@ def _send_chat_completions_with_headers(
         json=payload,
         timeout=60,
     )
-
-
-def _wait_for_engine_generate_count(
-    collector: InProcOtlpCollector,
-    *,
-    min_count: int,
-    timeout: float = 15.0,
-) -> int:
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        count = len(collector.engine_generate_spans())
-        if count >= min_count:
-            return count
-        time.sleep(0.5)
-    return len(collector.engine_generate_spans())
-
-
-@pytest.fixture
-def otlp_collector():
-    """Spin up an in-process OTLP gRPC server on a random port. Yields
-    (collector, port). Cleans up on test exit.
-    """
-    collector = InProcOtlpCollector()
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
-    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(collector, server)
-    port = server.add_insecure_port("127.0.0.1:0")
-    server.start()
-    try:
-        yield collector, port
-    finally:
-        server.stop(grace=1)
 
 
 def test_unified_worker_exports_engine_generate_span_over_otlp(
@@ -361,7 +285,7 @@ def test_traceidratio_sampler_controls_otlp_exports(
                     resp.status_code == 200
                 ), f"curl failed: {resp.status_code} {resp.text!r}"
 
-            count = _wait_for_engine_generate_count(
+            count = wait_for_engine_generate_count(
                 collector,
                 min_count=expected_min if expected_max is None else expected_max + 1,
             )

--- a/tests/frontend/test_unified_worker_otlp_export.py
+++ b/tests/frontend/test_unified_worker_otlp_export.py
@@ -27,7 +27,7 @@ from tests.utils.constants import QWEN
 from tests.utils.managed_process import DynamoFrontendProcess
 from tests.utils.otel import wait_for_engine_generate_count
 
-pytest_plugins = ("tests.utils.otel",)
+pytest_plugins = ("tests.utils.otel_plugin",)
 
 TEST_MODEL = QWEN
 

--- a/tests/serve/common.py
+++ b/tests/serve/common.py
@@ -10,7 +10,7 @@ import logging
 import os
 import signal
 import time
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from copy import deepcopy
 from typing import Any, Dict, Optional
 
@@ -466,12 +466,14 @@ def run_serve_deployment(
     *,
     ports: ServicePorts | None = None,  # pass `dynamo_dynamic_ports` here
     extra_env: Optional[Dict[str, str]] = None,
+    post_validation: Optional[Callable[[], None]] = None,
 ) -> None:
     """Run a standard serve deployment test for any EngineConfig.
 
     - Launches the engine via EngineProcess.from_script
     - Builds a payload (with optional override/mutator)
     - Iterates configured endpoints and validates responses and logs
+    - Optionally runs a final assertion while the deployment is still alive
     """
 
     logger = logging.getLogger(request.node.name)
@@ -604,6 +606,9 @@ def run_serve_deployment(
                 # Call final_validation if the payload has one (e.g., CachedTokensChatPayload)
                 if hasattr(payload, "final_validation"):
                     payload.final_validation()
+
+            if post_validation is not None:
+                post_validation()
     finally:
         if disagg_bootstrap_port is not None:
             deallocate_port(disagg_bootstrap_port)

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -927,9 +927,7 @@ def _assert_engine_generate_span_exported(collector) -> None:
 @pytest.mark.profiled_vram_gib(3.7)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
-# TODO: revert to pytest.mark.nightly after pre_merge validation
-# on this PR (see .ai/ci-guidelines.md).
-@pytest.mark.pre_merge
+@pytest.mark.nightly
 @pytest.mark.unified
 @pytest.mark.parametrize("num_system_ports", [2], indirect=True)
 def test_aggregated_otel_exports_engine_generate_span(

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import functools
 import logging
 import os
 from dataclasses import dataclass, field
@@ -24,6 +25,7 @@ from tests.serve.multimodal_profiles.sglang import (
 from tests.utils.constants import DefaultPort
 from tests.utils.engine_process import EngineConfig
 from tests.utils.multimodal import make_image_payload_b64, make_multimodal_configs
+from tests.utils.otel import wait_for_engine_generate_count
 from tests.utils.payload_builder import (
     anthropic_messages_payload_default,
     anthropic_messages_stream_payload_default,
@@ -46,6 +48,8 @@ from tests.utils.payloads import (
 )
 
 logger = logging.getLogger(__name__)
+
+pytest_plugins = ("tests.utils.otel",)
 
 
 def _is_cuda13() -> bool:
@@ -894,6 +898,65 @@ def test_sglang_deployment(
         sglang_config_test, frontend_port=dynamo_dynamic_ports.frontend_port
     )
     run_serve_deployment(config, request, ports=dynamo_dynamic_ports)
+
+
+_AGGREGATED_OTEL_CONFIG = SGLangConfig(
+    name="aggregated_otel",
+    directory=sglang_dir,
+    script_name="agg.sh",
+    script_args=["--enable-otel", "--unified"],
+    marks=[],  # applied on the dedicated test below
+    model="Qwen/Qwen3-0.6B",
+    request_payloads=[chat_payload_default(repeat_count=1)],
+)
+
+
+def _assert_engine_generate_span_exported(collector) -> None:
+    count = wait_for_engine_generate_count(collector, min_count=1)
+    assert count >= 1, (
+        "OTLP collector received no `engine.generate` span from the "
+        "SGLang aggregated deployment"
+    )
+
+
+@pytest.mark.sglang
+@pytest.mark.core
+@pytest.mark.e2e
+@pytest.mark.gpu_1
+@pytest.mark.model("Qwen/Qwen3-0.6B")
+@pytest.mark.profiled_vram_gib(3.7)
+@pytest.mark.requested_sglang_kv_tokens(2048)
+@pytest.mark.timeout(360)
+@pytest.mark.pre_merge
+@pytest.mark.nightly
+@pytest.mark.unified
+@pytest.mark.parametrize("num_system_ports", [2], indirect=True)
+def test_aggregated_otel_exports_engine_generate_span(
+    request,
+    runtime_services_dynamic_ports,
+    dynamo_dynamic_ports,
+    num_system_ports,
+    predownload_models,
+    otlp_collector,
+):
+    """The aggregated launch flag must export worker spans over OTLP/gRPC."""
+    assert num_system_ports >= 2
+    collector, otlp_port = otlp_collector
+    config = dataclasses.replace(
+        _AGGREGATED_OTEL_CONFIG,
+        frontend_port=dynamo_dynamic_ports.frontend_port,
+    )
+    run_serve_deployment(
+        config,
+        request,
+        ports=dynamo_dynamic_ports,
+        extra_env={
+            "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": (f"http://127.0.0.1:{otlp_port}"),
+        },
+        post_validation=functools.partial(
+            _assert_engine_generate_span_exported, collector
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -927,7 +927,6 @@ def _assert_engine_generate_span_exported(collector) -> None:
 @pytest.mark.profiled_vram_gib(3.7)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
-@pytest.mark.pre_merge
 @pytest.mark.nightly
 @pytest.mark.unified
 @pytest.mark.parametrize("num_system_ports", [2], indirect=True)

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -49,7 +49,7 @@ from tests.utils.payloads import (
 
 logger = logging.getLogger(__name__)
 
-pytest_plugins = ("tests.utils.otel",)
+pytest_plugins = ("tests.utils.otel_plugin",)
 
 
 def _is_cuda13() -> bool:

--- a/tests/serve/test_sglang.py
+++ b/tests/serve/test_sglang.py
@@ -927,7 +927,9 @@ def _assert_engine_generate_span_exported(collector) -> None:
 @pytest.mark.profiled_vram_gib(3.7)
 @pytest.mark.requested_sglang_kv_tokens(2048)
 @pytest.mark.timeout(360)
-@pytest.mark.nightly
+# TODO: revert to pytest.mark.nightly after pre_merge validation
+# on this PR (see .ai/ci-guidelines.md).
+@pytest.mark.pre_merge
 @pytest.mark.unified
 @pytest.mark.parametrize("num_system_ports", [2], indirect=True)
 def test_aggregated_otel_exports_engine_generate_span(

--- a/tests/utils/otel.py
+++ b/tests/utils/otel.py
@@ -7,9 +7,6 @@ from __future__ import annotations
 
 import threading
 import time
-from concurrent import futures
-
-import pytest
 
 
 class InProcOtlpCollector:
@@ -65,20 +62,3 @@ def wait_for_engine_generate_count(
             return count
         time.sleep(0.5)
     return len(collector.engine_generate_spans())
-
-
-@pytest.fixture
-def otlp_collector():
-    """Run an in-process OTLP/gRPC server on an ephemeral port."""
-    import grpc
-    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2_grpc
-
-    collector = InProcOtlpCollector()
-    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
-    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(collector, server)
-    port = server.add_insecure_port("127.0.0.1:0")
-    server.start()
-    try:
-        yield collector, port
-    finally:
-        server.stop(grace=1)

--- a/tests/utils/otel.py
+++ b/tests/utils/otel.py
@@ -1,0 +1,84 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared OpenTelemetry test collector utilities."""
+
+from __future__ import annotations
+
+import threading
+import time
+from concurrent import futures
+
+import pytest
+
+
+class InProcOtlpCollector:
+    """Minimal thread-safe in-process OTLP/gRPC trace collector."""
+
+    def __init__(self):
+        self.spans = []
+        self._lock = threading.Lock()
+
+    def Export(self, request, context):
+        from opentelemetry.proto.collector.trace.v1 import trace_service_pb2
+
+        with self._lock:
+            for resource_spans in request.resource_spans:
+                for scope_spans in resource_spans.scope_spans:
+                    self.spans.extend(scope_spans.spans)
+        return trace_service_pb2.ExportTraceServiceResponse()
+
+    def engine_generate_spans(self):
+        with self._lock:
+            return [span for span in self.spans if span.name == "engine.generate"]
+
+    def spans_for_trace_id(self, trace_id_hex):
+        trace_id = bytes.fromhex(trace_id_hex)
+        with self._lock:
+            return [span for span in self.spans if span.trace_id == trace_id]
+
+    def has_span(self, name):
+        with self._lock:
+            return any(span.name == name for span in self.spans)
+
+    def clear(self):
+        with self._lock:
+            self.spans.clear()
+
+    def snapshot(self):
+        """Return a stable copy of the received spans for assertions."""
+        with self._lock:
+            return list(self.spans)
+
+
+def wait_for_engine_generate_count(
+    collector: InProcOtlpCollector,
+    *,
+    min_count: int,
+    timeout: float = 15.0,
+) -> int:
+    """Wait until the collector receives the requested number of engine spans."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        count = len(collector.engine_generate_spans())
+        if count >= min_count:
+            return count
+        time.sleep(0.5)
+    return len(collector.engine_generate_spans())
+
+
+@pytest.fixture
+def otlp_collector():
+    """Run an in-process OTLP/gRPC server on an ephemeral port."""
+    import grpc
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2_grpc
+
+    collector = InProcOtlpCollector()
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(collector, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    try:
+        yield collector, port
+    finally:
+        server.stop(grace=1)

--- a/tests/utils/otel_plugin.py
+++ b/tests/utils/otel_plugin.py
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pytest fixtures for OpenTelemetry collector tests."""
+
+from concurrent import futures
+
+import pytest
+
+from tests.utils.otel import InProcOtlpCollector
+
+
+@pytest.fixture
+def otlp_collector():
+    """Run an in-process OTLP/gRPC server on an ephemeral port."""
+    import grpc
+    from opentelemetry.proto.collector.trace.v1 import trace_service_pb2_grpc
+
+    collector = InProcOtlpCollector()
+    server = grpc.server(futures.ThreadPoolExecutor(max_workers=4))
+    trace_service_pb2_grpc.add_TraceServiceServicer_to_server(collector, server)
+    port = server.add_insecure_port("127.0.0.1:0")
+    server.start()
+    try:
+        yield collector, port
+    finally:
+        server.stop(grace=1)


### PR DESCRIPTION
## Overview:

Adds automated coverage for the SGLang aggregated OpenTelemetry launch scenario tracked by [OPS-7595](https://linear.app/nvidia/issue/OPS-7595/automate-launch-scenario-agg-tracing-otel-enabled).

The new one-GPU E2E launches `agg.sh --enable-otel --unified`, sends a chat completion, and asserts that the worker's `engine.generate` span reaches an ephemeral in-process OTLP/gRPC collector.

## Details:

- Extracts the existing OTLP collector from the unified-worker regression test into a reusable, lazy-loaded test utility.
- Adds an optional post-validation callback to the shared serve deployment helper so asynchronous exporter assertions run while the managed deployment is still alive.
- Adds a profiled SGLang `gpu_1` test intended for the nightly CI pipeline.
- Uses `Qwen/Qwen3-0.6B`, dynamic ports, and the existing SGLang KV-token/VRAM limits.
- Validated the test with the temporary `pre_merge` marker following `.ai/ci-guidelines.md`, then restored the final `nightly` marker.

## Where should the reviewer start?

1. `tests/serve/test_sglang.py` — launch scenario and span assertion.
2. `tests/utils/otel.py` — reusable in-process collector.
3. `tests/serve/common.py` — narrow post-validation hook.

## Validation:

- `SKIP=pytest-marker-report pre-commit run --files tests/utils/otel.py tests/frontend/test_unified_worker_otlp_export.py tests/serve/common.py tests/serve/test_sglang.py`
- `uvx --python 3.12 --from black==23.1.0 black --check ...`
- `python3 -m compileall -q ...`
- Isolated OTLP/gRPC collector smoke test: passed.
- Final marker set (`nightly`, `e2e`, `gpu_1`) is valid and selects the test for nightly CI.
- Structural comparison confirms all four original frontend OTLP tests and all collector behaviors remain.
- DCO sign-offs verified on all commits.
- SGLang GPU E2E: passed on the trusted AMD64 runner (`test_aggregated_otel_exports_engine_generate_span[2]`, 66s) in [run 29444287790](https://github.com/ai-dynamo/dynamo/actions/runs/29444287790/job/87451894040).
- Final nightly-marker SHA trusted CI: passed in [run 29447202208](https://github.com/ai-dynamo/dynamo/actions/runs/29447202208).

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:
- [x] Confirmed — no related GitHub issue

Internal tracking: [OPS-7595](https://linear.app/nvidia/issue/OPS-7595/automate-launch-scenario-agg-tracing-otel-enabled)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage confirming aggregated deployments export `engine.generate` OpenTelemetry spans.
  * Introduced shared test utilities for collecting and validating OTLP traces.
  * Added support for final deployment assertions while the deployment remains active.
  * Consolidated existing OTLP test coverage around the shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->