### PR TITLE
fix: add AgentHeaderMapping lookup in session_affinity_header_value()

### DIFF
--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -96,7 +96,20 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
 }
 
 pub(crate) fn session_affinity_header_value(headers: &HeaderMap) -> Option<String> {
-    header_value(headers, HEADER_DYNAMO_SESSION_ID)
+    if let Some(session_id) = header_value(headers, HEADER_DYNAMO_SESSION_ID) {
+        return Some(session_id);
+    }
+    for mapping in AGENT_HEADER_MAPPINGS {
+        let Some(root_session_id) = header_value(headers, mapping.root_session_header) else {
+            continue;
+        };
+        let session_id = mapping
+            .child_session_header
+            .and_then(|child_session_header| header_value(headers, child_session_header))
+            .unwrap_or_else(|| root_session_id.clone());
+        return Some(session_id);
+    }
+    None
 }
 
 fn header_bool(headers: &HeaderMap, header_name: &str) -> Option<bool> {

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -971,7 +971,7 @@ mod tests {
     }
 
     #[test]
-    fn session_affinity_requires_explicit_dynamo_header() {
+    fn session_affinity_prefers_dynamo_header_over_agent_mappings() {
         let mut headers = HeaderMap::new();
         headers.insert(
             HEADER_CLAUDE_CODE_SESSION_ID,
@@ -982,20 +982,30 @@ mod tests {
             HEADER_OPENCODE_SESSION_ID,
             "opencode-session".parse().unwrap(),
         );
-        assert!(session_affinity_from_headers(&headers).is_none());
+        // Without a canonical header, affinity falls back to the first matching
+        // agent mapping. Claude precedes Codex and OpenCode in AGENT_HEADER_MAPPINGS.
+        assert_eq!(
+            session_affinity_from_headers(&headers).unwrap().as_str(),
+            "claude-session"
+        );
 
+        // The explicit Dynamo session header always wins over agent mappings.
         headers.insert(HEADER_DYNAMO_SESSION_ID, "canonical".parse().unwrap());
         assert_eq!(
             session_affinity_from_headers(&headers).unwrap().as_str(),
             "canonical"
         );
 
+        // A blank Dynamo header is ignored and affinity falls back to the mapping.
         headers.insert(HEADER_DYNAMO_SESSION_ID, "   ".parse().unwrap());
-        assert!(session_affinity_from_headers(&headers).is_none());
+        assert_eq!(
+            session_affinity_from_headers(&headers).unwrap().as_str(),
+            "claude-session"
+        );
     }
 
     #[test]
-    fn native_agent_session_does_not_enable_affinity() {
+    fn session_affinity_uses_agent_child_session_when_present() {
         let mut headers = HeaderMap::new();
         headers.insert(
             HEADER_CLAUDE_CODE_SESSION_ID,
@@ -1003,10 +1013,16 @@ mod tests {
         );
         headers.insert(HEADER_CLAUDE_CODE_AGENT_ID, "claude-agent".parse().unwrap());
 
+        // Affinity keys on the same id the agent context resolves to: the child
+        // (sub-agent) session when present, not the root session.
         let agent_context = agent_context_from_headers(&headers).unwrap();
         assert_eq!(agent_context.session_id, "claude-agent");
-        assert!(session_affinity_from_headers(&headers).is_none());
+        assert_eq!(
+            session_affinity_from_headers(&headers).unwrap().as_str(),
+            "claude-agent"
+        );
 
+        // The explicit Dynamo session header still takes precedence.
         headers.insert(
             HEADER_DYNAMO_SESSION_ID,
             "affinity-session".parse().unwrap(),
@@ -1017,6 +1033,16 @@ mod tests {
             session_affinity_from_headers(&headers).unwrap().as_str(),
             "affinity-session"
         );
+    }
+
+    #[test]
+    fn session_affinity_absent_without_any_session_header() {
+        let mut headers = HeaderMap::new();
+        assert!(session_affinity_from_headers(&headers).is_none());
+
+        // A blank canonical header with no agent headers yields no affinity.
+        headers.insert(HEADER_DYNAMO_SESSION_ID, "   ".parse().unwrap());
+        assert!(session_affinity_from_headers(&headers).is_none());
     }
 
     #[test]

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -112,6 +112,11 @@ impl AffinityCoordinator {
             waiter_observed: Arc::new(Notify::new()),
         });
         Self::spawn_reaper(&inner);
+        tracing::info!(
+            ttl_secs = ttl.as_secs(),
+            max_entries,
+            "session affinity enabled"
+        );
         Ok(Self { inner })
     }
 
@@ -184,6 +189,10 @@ impl AffinityCoordinator {
             match self.inner.entries.entry(session_id.clone()) {
                 Entry::Vacant(entry) => {
                     self.reserve_entry()?;
+                    tracing::info!(
+                        session_id = %session_id,
+                        "session affinity miss: new session, pinning after worker selection"
+                    );
                     return Ok(AffinityAcquire::Initialize(entry.insert_initializing(
                         &self.inner,
                         session_id,
@@ -219,6 +228,10 @@ impl AffinityCoordinator {
                         active_leases,
                         idle_deadline,
                     } if *active_leases == 0 && *idle_deadline <= now => {
+                        tracing::info!(
+                            session_id = %session_id,
+                            "session affinity miss: pin expired (idle past TTL), re-selecting worker"
+                        );
                         let revision = self.inner.next_revision.fetch_add(1, Ordering::Relaxed);
                         let notify = Arc::new(Notify::new());
                         *entry.get_mut() = AffinityEntry::Initializing {
@@ -242,6 +255,13 @@ impl AffinityCoordinator {
                         ..
                     } => {
                         validate_bound_target(&session_id, *target, requested_target)?;
+                        tracing::info!(
+                            session_id = %session_id,
+                            worker_id = target.worker_id,
+                            dp_rank = ?target.dp_rank,
+                            active_leases = *active_leases + 1,
+                            "session affinity hit: reusing pinned worker"
+                        );
                         *active_leases += 1;
                         let lease = AffinityLease {
                             coordinator: Arc::downgrade(&self.inner),
@@ -281,6 +301,14 @@ impl AffinityCoordinator {
             return Ok(None);
         }
         validate_bound_target(session_id.as_str(), *target, requested_target)?;
+        tracing::info!(
+            session_id = %session_id.as_str(),
+            worker_id = target.worker_id,
+            dp_rank = ?target.dp_rank,
+            active_leases = *active_leases + 1,
+            "session affinity hit: reusing pinned worker"
+        );
+
         Ok(Some(*target))
     }
 

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -189,7 +189,7 @@ impl AffinityCoordinator {
             match self.inner.entries.entry(session_id.clone()) {
                 Entry::Vacant(entry) => {
                     self.reserve_entry()?;
-                    tracing::info!(
+                    tracing::debug!(
                         session_id = %session_id,
                         "session affinity miss: new session, pinning after worker selection"
                     );
@@ -228,7 +228,7 @@ impl AffinityCoordinator {
                         active_leases,
                         idle_deadline,
                     } if *active_leases == 0 && *idle_deadline <= now => {
-                        tracing::info!(
+                        tracing::debug!(
                             session_id = %session_id,
                             "session affinity miss: pin expired (idle past TTL), re-selecting worker"
                         );
@@ -255,7 +255,7 @@ impl AffinityCoordinator {
                         ..
                     } => {
                         validate_bound_target(&session_id, *target, requested_target)?;
-                        tracing::info!(
+                        tracing::debug!(
                             session_id = %session_id,
                             worker_id = target.worker_id,
                             dp_rank = ?target.dp_rank,
@@ -301,11 +301,10 @@ impl AffinityCoordinator {
             return Ok(None);
         }
         validate_bound_target(session_id.as_str(), *target, requested_target)?;
-        tracing::info!(
+        tracing::debug!(
             session_id = %session_id.as_str(),
             worker_id = target.worker_id,
             dp_rank = ?target.dp_rank,
-            active_leases = *active_leases + 1,
             "session affinity hit: reusing pinned worker"
         );
 


### PR DESCRIPTION
Signed-off-by: Guan Luo <41310872+GuanLuo@users.noreply.github.com>

#### Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

#### Details:

<!-- Describe the changes made in this PR. -->

#### Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)

- closes #xxx


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session affinity handling to consistently identify sessions from inbound headers, including child-session and root-session headers.
  * Ensured unmatched sessions are handled cleanly without producing an affinity value.

* **Observability**
  * Added detailed logging for session affinity configuration, cache misses, expired worker assignments, and successful worker reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->