### PR TITLE
[cherry-pick → release/1.3.0] docs(snapshot): update support matrix (#11674)

### DIFF
--- a/docs/kubernetes/cold-start-and-resiliency.md
+++ b/docs/kubernetes/cold-start-and-resiliency.md
@@ -17,7 +17,7 @@ Dynamo is building composable primitives across two themes:
 This document tracks backend support across three composable projects in this workstream:
 
 - **[GPU Memory Service (GMS)](#gpu-memory-service-gms)**: out-of-process GPU memory manager for zero-copy sharing of weights and KV across worker processes.
-- **[Dynamo Bulwark](#dynamo-bulwark-shadow-engine-failover)**: pre-initialized "shadow" engines sharing weights and KV cache can be quickly failed over to on software and hardware failures.
+- **[Shadow Engine Failover](#shadow-engine-failover)**: pre-initialized "shadow" engines sharing weights and KV cache can be quickly failed over to on software and hardware failures.
 - **[Dynamo Snapshot](./snapshot.md)**: CRIU-based checkpoint/restore of initialized workers, cutting cold starts from minutes to seconds.
 
 **Legend:**
@@ -26,13 +26,15 @@ This document tracks backend support across three composable projects in this wo
 - 🚧 : Work in Progress / Experimental / Limited
 - ❌ : Not started
 
+**How to read this matrix:** ✅ means Dynamo has a supported path for the backend and scope shown in the row or column; it does not mean every deployment topology, workload shape, or integration is generally available. 🚧 covers work in progress, preview, experimental, or narrowly validated paths. Use the per-feature notes and linked guides for setup steps, prerequisites, and limitations.
+
 ## Support Matrix
 
-| Backend | [GPU Memory Service](#gpu-memory-service-gms) | [Dynamo Bulwark](#dynamo-bulwark-shadow-engine-failover) | [Dynamo Snapshot](./snapshot.md) |
+| Backend | [GPU Memory Service](#gpu-memory-service-gms) | [Shadow Engine Failover](#shadow-engine-failover) | [Dynamo Snapshot](./snapshot.md) |
 | :--- | :---: | :---: | :---: |
 | **vLLM** | ✅ | ✅ | ✅ |
 | **SGLang** | ✅ | 🚧 | ✅ |
-| **TensorRT-LLM** | 🚧 | 🚧 | 🚧 |
+| **TensorRT-LLM** | 🚧 | 🚧 | ✅ |
 
 See the per-feature sections below for detailed per-backend status.
 
@@ -40,7 +42,7 @@ See the per-feature sections below for detailed per-backend status.
 
 ### GPU Memory Service (GMS)
 
-- Out-of-process GPU memory manager for zero-copy sharing of weights and KV across workers on the same GPU; foundation for Dynamo Bulwark. [Architecture](../../lib/gpu_memory_service/README.md)
+- Out-of-process GPU memory manager for zero-copy sharing of weights and KV across workers on the same GPU; foundation for Shadow Engine Failover. [Architecture](../../lib/gpu_memory_service/README.md)
 - In Kubernetes, GMS is wired in via [Dynamic Resource Allocation](https://kubernetes.io/docs/concepts/scheduling-eviction/dynamic-resource-allocation/), configured through the `gpuMemoryService` field on the `DynamoGraphDeployment` CR.
 
 #### Status
@@ -54,7 +56,7 @@ See the per-feature sections below for detailed per-backend status.
 **Notes:**
 - vLLM, SGLang, and TensorRT-LLM require upstream changes to inference that are currently being upstreamed.
 
-### Dynamo Bulwark (Shadow Engine Failover)
+### Shadow Engine Failover
 
 - Shadow engines share weights (and soon KV) with a primary via [GMS](#gpu-memory-service-gms) and take over within seconds on primary failure using a kernel-mediated flock for leader election.
 - In Kubernetes, configured through the `failover` field on the `DynamoGraphDeployment` CR (on top of `gpuMemoryService`).
@@ -73,7 +75,9 @@ See the per-feature sections below for detailed per-backend status.
 
 ### Dynamo Snapshot
 
-Dynamo Snapshot uses CRIU and NVIDIA's `cuda-checkpoint` utility to capture a worker's initialized state once (including GPU memory and CUDA contexts) and restore subsequent workers from that checkpoint, reducing cold starts from minutes to seconds for large LLMs. This feature is enabled via the DynamoCheckpoint custom resource and is natively supported via the Dynamo Graph Deployments (DGDs).
+Dynamo Snapshot uses CRIU and CUDA checkpointing capabilities to capture a worker's initialized state once (including GPU memory and CUDA contexts) and restore subsequent workers from that checkpoint, reducing cold starts from minutes to seconds for large LLMs. This feature is enabled via the DynamoCheckpoint custom resource and is natively supported via the Dynamo Graph Deployments (DGDs).
+
+When used with GMS, weights can be restored in parallel with the CRIU/CUDA checkpoint. Currently, weights are saved/restored via experimental transfer backends implemented via NIXL. [ModelExpress](https://github.com/ai-dynamo/modelexpress) backend integration with GMS is coming soon in a future Dynamo release.
 
 #### Status
 
@@ -81,9 +85,9 @@ Dynamo Snapshot uses CRIU and NVIDIA's `cuda-checkpoint` utility to capture a wo
 | :--- | :---: | :---: | :---: |
 | **vLLM** | ✅ | ✅ (highly experimental) | 🚧 |
 | **SGLang** | ✅ | 🚧 | 🚧 |
-| **TensorRT-LLM** | 🚧 | 🚧 | 🚧 |
+| **TensorRT-LLM** | ✅ | 🚧 | 🚧 |
 
 **Notes:**
-- GMS integration is currently gated on a pending driver release.
-- CRIU performance is only optimal with the following patches folded into criu-dev: [AIO support](https://github.com/checkpoint-restore/criu/pull/3022) and [parallel memfd support](https://github.com/checkpoint-restore/criu/pull/3021)
+- Dynamo Snapshot + GMS integration is currently disabled by default and requires both the operator gate `DYN_OPERATOR_ALLOW_GMS_SNAPSHOT=1` and CUDA Driver r610 or later.
+- TensorRT-LLM Snapshot is supported only for the experimental single-GPU aggregated text worker path; broader TensorRT-LLM coverage remains work in progress. See [Snapshotting GPU Workers](./snapshot.md) for setup steps, prerequisites, and limitations.
 - Multi-GPU, Single Node is available in a highly experimental/slightly limited path that uses legacy IPC only for P2P.


### PR DESCRIPTION
## Summary

Cherry-pick the documentation support-matrix update from [#11674](https://github.com/ai-dynamo/dynamo/pull/11674) onto `release/1.3.0`.

- Clarifies the Shadow Engine Failover terminology and links.
- Marks TensorRT-LLM Snapshot support for the documented single-GPU path.
- Documents the support-matrix legend, GMS Snapshot prerequisites, and current limitations.

Source merge commit: `cdfddeedf135d797a5b30c0193895d7362944a2e`

## Validation

- Cherry-picked with `git cherry-pick --signoff`.
- `git diff --check` passes.
- Documentation-only change; no runtime or test changes.

Dependencies: None.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11679" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->