### PR TITLE
test(vllm): re-enable agg-router and agg-router-approx serve tests

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -364,9 +364,6 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.router,
             pytest.mark.pre_merge,
-            # DYN-2263 skip was stale collateral from PR #6704's bulk post-merge
-            # skip (systemic infra failure, not agg-router). The same agg_router.sh
-            # recipe runs green for sglang (kv_events) and trtllm (aggregated_router).
             pytest.mark.timeout(600),
         ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
@@ -384,8 +381,6 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.router,
             pytest.mark.pre_merge,
-            # DYN-2264 skip was stale collateral from PR #6704's bulk post-merge
-            # skip (systemic infra failure, not agg-router-approx).
             pytest.mark.timeout(600),
         ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -364,8 +364,11 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.router,
             pytest.mark.pre_merge,
-            pytest.mark.skip(reason="DYN-2263"),
-        ],  # TODO: profile to get max_vram and timeout
+            # DYN-2263 skip was stale collateral from PR #6704's bulk post-merge
+            # skip (systemic infra failure, not agg-router). The same agg_router.sh
+            # recipe runs green for sglang (kv_events) and trtllm (aggregated_router).
+            pytest.mark.timeout(600),
+        ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
             router_selection_chat_payload_default(),
@@ -381,8 +384,10 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.router,
             pytest.mark.pre_merge,
-            pytest.mark.skip(reason="DYN-2264"),
-        ],  # TODO: profile to get max_vram and timeout
+            # DYN-2264 skip was stale collateral from PR #6704's bulk post-merge
+            # skip (systemic infra failure, not agg-router-approx).
+            pytest.mark.timeout(600),
+        ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
             # Test approximate KV routing (--no-kv-events mode)


### PR DESCRIPTION
re-enable `agg-router` and `agg-router-approx`

Both configs in `tests/serve/test_vllm.py` were `pytest.mark.skip`'d with bare ticket IDs. Investigation shows **the skips are stale — not a real bug**:

- The referenced CI run (`22474807544`) is expired, but its metadata shows a **systemic 2026-02-27 post-merge breakage** in which nearly every amd64 test job failed across vLLM **and** sglang **and** trtllm — an environment failure, not agg-router-specific.
- The skips were added by **PR #6704 "chore: fix post merge"** (description: *"skip failing tests"*), which **bulk-skipped DYN-2260..2265** in one commit. There was never an agg-router root-cause diagnosis.
- The **identical aggregated-KV-router recipe runs green today for other backends**: sglang `kv_events` (same `agg_router.sh` + payloads + marks, not skipped) and trtllm `aggregated_router` (same worker_id assertion, enabled).
- The `require_router_worker_id` assertion **is** satisfiable for aggregated workers — the KV router records both `prefill_worker_id` and `decode_worker_id` under the Aggregated phase (`timing.rs`).

## Change
Remove both `skip` marks; add `timeout(600)` to each (matching the sibling router configs, so a hang fails fast instead of stalling the job).

## Validated
Both tests PASSED in CI once CI recovered — `agg-router-2` and `agg-router-approx-2`:
https://github.com/ai-dynamo/dynamo/actions/runs/29366004817/job/87198254419

## Validation
`py_compile` clean. These are `gpu_2` (2-GPU), so not locally reproducible, and the shared CI infra currently has a global `startup_failure` — so this is opened as a draft. When CI recovers, the new **worker-log-upload artifact** will surface any residual failure. Given the identical recipe passes for sglang/trtllm, the expected outcome is green.

Non-blocking follow-up (not in this PR): `agg_router.sh` hardcodes the ZMQ kv-event ports (`20080/20081`) and `VLLM_NIXL_SIDE_CHANNEL_PORT=20097` instead of the `DYN_VLLM_KV_EVENT_PORT` / `DYN_VLLM_NIXL_SIDE_CHANNEL_PORT{1,2}` the harness provides — harmless on the sequential gpu_2 lane, an xdist hazard only if it ever parallelizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enabled vLLM test configurations for agg-router and agg-router-approx in automated test runs.
  * Added a 10-minute timeout to prevent tests from running indefinitely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Linear: https://linear.app/nvidia/issue/OPS-7568 · https://linear.app/nvidia/issue/OPS-7579