### PR TITLE
chore(runtime): consolidate truthy/bool flag parsing into one helper

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -261,6 +261,7 @@ areas:
   - lib/runtime/src/transports/
   - lib/runtime/src/utils/
   - lib/runtime/tests/
+  - lib/truthy/
   - tests/
   - tests/CLAUDE.md
   - tests/README.md

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -177,6 +177,7 @@
 # === runtime  (@ai-dynamo/dynamo-runtime-codeowners) ===
 /tests/                                                                      @ai-dynamo/dynamo-runtime-codeowners
 /lib/llm/                                                                    @ai-dynamo/dynamo-runtime-codeowners
+/lib/truthy/                                                                 @ai-dynamo/dynamo-runtime-codeowners
 /lib/llm/bin/                                                                @ai-dynamo/dynamo-runtime-codeowners
 /lib/runtime/                                                                @ai-dynamo/dynamo-runtime-codeowners
 /tests/basic/                                                                @ai-dynamo/dynamo-runtime-codeowners

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2500,6 +2500,7 @@ dependencies = [
  "dynamo-kv-hashing",
  "dynamo-runtime",
  "dynamo-tokens",
+ "dynamo-truthy",
  "flume 0.12.0",
  "indexmap 2.14.0",
  "ordered-float 4.6.0",
@@ -2644,6 +2645,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "cudarc",
+ "dynamo-truthy",
  "libc",
  "libloading 0.8.9",
  "nix 0.30.1",
@@ -2669,6 +2671,7 @@ dependencies = [
  "dynamo-data-gen",
  "dynamo-kv-router",
  "dynamo-tokens",
+ "dynamo-truthy",
  "futures",
  "indicatif 0.18.4",
  "kvbm-common",
@@ -2827,6 +2830,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-truthy",
  "educe",
  "either",
  "etcd-client",
@@ -2938,6 +2942,13 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "xxhash-rust",
+]
+
+[[package]]
+name = "dynamo-truthy"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "lib/rl",
     "lib/runtime",
     "lib/tokens",
+    "lib/truthy",
     "lib/data-gen",
     "lib/kv-hashing",
     "lib/mocker",
@@ -48,6 +49,7 @@ dynamo-rl = { path = "lib/rl", version = "1.3.0" }
 dynamo-tokenizers = { version = "=1.5.0" }
 dynamo-renderer = { version = "=1.3.8" }
 dynamo-tokens = { path = "lib/tokens", version = "1.3.0" }
+dynamo-truthy = { path = "lib/truthy", version = "1.3.0" }
 dynamo-data-gen = { path = "lib/data-gen", version = "1.3.0" }
 dynamo-kv-hashing = { path = "lib/kv-hashing", version = "1.3.0" }
 dynamo-memory = { path = "lib/memory", version = "1.3.0" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1548,6 +1548,7 @@ dependencies = [
  "dynamo-kv-hashing",
  "dynamo-runtime",
  "dynamo-tokens",
+ "dynamo-truthy",
  "flume",
  "indexmap 2.14.0",
  "ordered-float 4.6.0",
@@ -1665,6 +1666,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "cudarc",
+ "dynamo-truthy",
  "libc",
  "libloading 0.8.9",
  "nix 0.30.1",
@@ -1687,6 +1689,7 @@ dependencies = [
  "dynamo-data-gen",
  "dynamo-kv-router",
  "dynamo-tokens",
+ "dynamo-truthy",
  "futures",
  "indicatif 0.18.4",
  "kvbm-logical",
@@ -1815,6 +1818,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-truthy",
  "educe",
  "either",
  "etcd-client",
@@ -1896,6 +1900,13 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "xxhash-rust",
+]
+
+[[package]]
+name = "dynamo-truthy"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/lib/bindings/kvbm/src/block_manager.rs
+++ b/lib/bindings/kvbm/src/block_manager.rs
@@ -58,9 +58,8 @@ fn create_disk_offload_filter(
     runtime: &tokio::runtime::Handle,
 ) -> Result<Option<Arc<FrequencyFilter>>> {
     // Check if disk offload filter is disabled via environment variable
-    let disable_filter = std::env::var(env_kvbm::DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER)
-        .map(|v| v == "true" || v == "1")
-        .unwrap_or(false);
+    let disable_filter =
+        dynamo_runtime::config::env_is_truthy(env_kvbm::DYN_KVBM_DISABLE_DISK_OFFLOAD_FILTER);
 
     if disable_filter {
         return Ok(None);

--- a/lib/bindings/kvbm/src/block_manager/vllm/connector/leader.rs
+++ b/lib/bindings/kvbm/src/block_manager/vllm/connector/leader.rs
@@ -679,9 +679,8 @@ impl PyKvConnectorLeader {
         // Initialize logging for the vLLM connector
         dynamo_runtime::logging::init();
 
-        let enable_kvbm_record = std::env::var(env_kvbm::DYN_KVBM_ENABLE_RECORD)
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+        let enable_kvbm_record =
+            dynamo_runtime::config::env_is_truthy(env_kvbm::DYN_KVBM_ENABLE_RECORD);
 
         let connector_leader: Box<dyn Leader> = if enable_kvbm_record {
             Box::new(recorder::KvConnectorLeaderRecorder::new(
@@ -756,9 +755,7 @@ impl PyKvConnectorLeader {
 }
 
 pub fn kvbm_metrics_endpoint_enabled() -> bool {
-    std::env::var(env_kvbm::DYN_KVBM_METRICS)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
+    dynamo_runtime::config::env_is_truthy(env_kvbm::DYN_KVBM_METRICS)
 }
 
 pub fn parse_kvbm_metrics_port() -> u16 {

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -2147,6 +2147,7 @@ dependencies = [
  "dynamo-kv-hashing",
  "dynamo-runtime",
  "dynamo-tokens",
+ "dynamo-truthy",
  "flume",
  "indexmap 2.14.0",
  "ordered-float 4.6.0",
@@ -2273,6 +2274,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "cudarc",
+ "dynamo-truthy",
  "libc",
  "libloading 0.8.9",
  "nix 0.30.1",
@@ -2296,6 +2298,7 @@ dependencies = [
  "dynamo-data-gen",
  "dynamo-kv-router",
  "dynamo-tokens",
+ "dynamo-truthy",
  "futures",
  "indicatif 0.18.4",
  "kvbm-common",
@@ -2469,6 +2472,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-truthy",
  "educe",
  "either",
  "etcd-client",
@@ -2572,6 +2576,13 @@ dependencies = [
  "thiserror 2.0.18",
  "uuid",
  "xxhash-rust",
+]
+
+[[package]]
+name = "dynamo-truthy"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/lib/kv-router/Cargo.toml
+++ b/lib/kv-router/Cargo.toml
@@ -28,6 +28,7 @@ standalone-selection = ["standalone-indexer"]
 dynamo-runtime = { workspace = true, optional = true }
 dynamo-kv-hashing = { workspace = true }
 dynamo-tokens = { workspace = true }
+dynamo-truthy = { workspace = true }
 
 # workspace
 anyhow = { workspace = true }

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -110,11 +110,8 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
     }
 
     fn parse_bool(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<bool> {
-        get_env(key).and_then(|value| match value.to_ascii_lowercase().as_str() {
-            "true" | "1" | "yes" | "on" => Some(true),
-            "false" | "0" | "no" | "off" => Some(false),
-            _ => None,
-        })
+        // Empty or unrecognized values yield None so the default is preserved.
+        get_env(key).and_then(|value| dynamo_truthy::parse_bool_opt(&value))
     }
 
     let mut config = KvRouterConfig::default();

--- a/lib/kv-router/src/services/indexer/server.rs
+++ b/lib/kv-router/src/services/indexer/server.rs
@@ -31,14 +31,7 @@ const QUERY_REQUEST_BODY_LIMIT_BYTES: usize = 8 * 1024 * 1024;
 const DYN_KV_INDEXER_TEST_ENDPOINTS: &str = "DYN_KV_INDEXER_TEST_ENDPOINTS";
 
 fn test_endpoints_enabled() -> bool {
-    matches!(
-        std::env::var(DYN_KV_INDEXER_TEST_ENDPOINTS)
-            .unwrap_or_default()
-            .trim()
-            .to_ascii_lowercase()
-            .as_str(),
-        "1" | "true" | "yes" | "on"
-    )
+    dynamo_truthy::env_is_truthy(DYN_KV_INDEXER_TEST_ENDPOINTS)
 }
 
 use super::logging::{AccessLogModel, AccessLogSink};

--- a/lib/llm/src/block_manager/numa_allocator.rs
+++ b/lib/llm/src/block_manager/numa_allocator.rs
@@ -24,14 +24,7 @@ pub fn is_numa_enabled() -> bool {
     if dynamo_memory::numa::is_numa_disabled() {
         return false;
     }
-    env_is_truthy("DYN_KVBM_ENABLE_NUMA")
-}
-
-fn env_is_truthy(env: &str) -> bool {
-    match std::env::var(env) {
-        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "on" | "yes"),
-        Err(_) => false,
-    }
+    dynamo_runtime::config::env_is_truthy("DYN_KVBM_ENABLE_NUMA")
 }
 
 #[cfg(test)]

--- a/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/config.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/nixl_agent/config.rs
@@ -7,7 +7,7 @@
 //! environment variables with the pattern: `DYN_KVBM_NIXL_BACKEND_<backend>_<key>=<value>`
 
 use anyhow::{Result, bail};
-use dynamo_runtime::config::parse_bool;
+use dynamo_runtime::config::parse_bool_opt;
 use std::collections::HashSet;
 
 /// Configuration for NIXL backends.
@@ -66,17 +66,23 @@ impl NixlBackendConfig {
                     );
                 }
 
-                // Simple backend enablement (e.g., DYN_KVBM_NIXL_BACKEND_UCX=true)
+                // Simple backend enablement (e.g., DYN_KVBM_NIXL_BACKEND_UCX=true).
+                // Empty or unrecognized values are rejected rather than treated
+                // as false: silently dropping a backend hides misconfiguration.
                 let backend_name = remainder.to_uppercase();
-                match parse_bool(&value) {
-                    Ok(true) => {
+                match parse_bool_opt(&value) {
+                    Some(true) => {
                         backends.insert(backend_name);
                     }
-                    Ok(false) => {
+                    Some(false) => {
                         // Explicitly disabled, don't add to backends
                         continue;
                     }
-                    Err(e) => bail!("Invalid value for {}: {}", key, e),
+                    None => bail!(
+                        "Invalid value for {}: '{}'. Expected one of: true/false, 1/0, on/off, yes/no",
+                        key,
+                        value
+                    ),
                 }
             }
         }

--- a/lib/llm/src/fpm_trace/config.rs
+++ b/lib/llm/src/fpm_trace/config.rs
@@ -4,6 +4,7 @@
 use std::sync::OnceLock;
 
 use dynamo_runtime::config::environment_names::llm::fpm_trace as env_fpm_trace;
+use dynamo_runtime::config::parse_bool;
 
 pub const DEFAULT_OUTPUT_PATH: &str = "/tmp/dynamo-fpm";
 pub const DEFAULT_SAMPLE_INTERVAL_MS: u64 = 5_000;
@@ -43,17 +44,6 @@ impl Default for FpmTracePolicy {
             jsonl_gz_roll_bytes: DEFAULT_JSONL_GZ_ROLL_BYTES,
             max_segments: DEFAULT_MAX_SEGMENTS,
         }
-    }
-}
-
-fn parse_bool(value: &str) -> anyhow::Result<bool> {
-    match value.trim().to_ascii_lowercase().as_str() {
-        "1" | "true" | "on" | "yes" => Ok(true),
-        "0" | "false" | "off" | "no" => Ok(false),
-        _ => anyhow::bail!(
-            "{} must be one of true/false, 1/0, on/off, or yes/no",
-            env_fpm_trace::DYN_FPM_TRACE
-        ),
     }
 }
 
@@ -273,10 +263,11 @@ mod tests {
         for value in ["true", "TRUE", "1", "on", "ON", "yes"] {
             assert!(parse_bool(value).unwrap(), "value={value}");
         }
-        for value in ["false", "FALSE", "0", "off", "OFF", "no"] {
+        // Empty counts as falsey: DYN_FPM_TRACE="" disables tracing.
+        for value in ["false", "FALSE", "0", "off", "OFF", "no", ""] {
             assert!(!parse_bool(value).unwrap(), "value={value}");
         }
-        for value in ["", "enabled", "2"] {
+        for value in ["enabled", "2"] {
             assert!(parse_bool(value).is_err(), "value={value}");
         }
     }

--- a/lib/llm/src/hub.rs
+++ b/lib/llm/src/hub.rs
@@ -107,9 +107,7 @@ fn shard_files_present(index_path: &Path) -> bool {
 
 /// Check if offline mode is enabled via HF_HUB_OFFLINE environment variable.
 fn is_offline_mode() -> bool {
-    env::var(env_model::huggingface::HF_HUB_OFFLINE)
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false)
+    dynamo_runtime::config::env_is_truthy(env_model::huggingface::HF_HUB_OFFLINE)
 }
 
 /// Check if shared-storage mode is disabled via MODEL_EXPRESS_NO_SHARED_STORAGE.
@@ -118,9 +116,7 @@ fn is_offline_mode() -> bool {
 /// server and worker pods do not share a filesystem (e.g. RWO PVCs, cross-namespace
 /// deployments).
 fn is_no_shared_storage() -> bool {
-    env::var(env_model::model_express::MODEL_EXPRESS_NO_SHARED_STORAGE)
-        .map(|v| v == "1" || v.to_lowercase() == "true")
-        .unwrap_or(false)
+    dynamo_runtime::config::env_is_truthy(env_model::model_express::MODEL_EXPRESS_NO_SHARED_STORAGE)
 }
 
 /// Download a model using ModelExpress client. The client first requests for the model

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -46,12 +46,7 @@ fn env_self_host_metadata_default() -> bool {
 }
 
 fn self_host_metadata_default(value: Option<&str>) -> bool {
-    value.is_some_and(|value| {
-        matches!(
-            value.trim().to_lowercase().as_str(),
-            "1" | "true" | "yes" | "on"
-        )
-    })
+    value.is_some_and(dynamo_runtime::config::is_truthy)
 }
 
 pub struct LocalModelBuilder {

--- a/lib/llm/src/lora.rs
+++ b/lib/llm/src/lora.rs
@@ -35,12 +35,12 @@ pub use routing::{
 pub use source::{LoRASource, LocalLoRASource, S3LoRASource};
 pub use state_tracker::LoraStateTracker;
 
-/// Returns true when LoRA serving is enabled via the `DYN_LORA_ENABLED` env var
-/// (`true`/`1`/`yes`, case-insensitive). This gates the request-time LoRA filter on
+/// Returns true when LoRA serving is enabled via a truthy `DYN_LORA_ENABLED` env var
+/// (`1`/`true`/`on`/`yes`, case-insensitive). This gates the request-time LoRA filter on
 /// both the KV and non-KV routing paths, so non-LoRA deployments keep the unmodified
 /// routing path with zero added overhead.
 pub fn lora_serving_enabled() -> bool {
-    std::env::var(dynamo_runtime::config::environment_names::llm::DYN_LORA_ENABLED)
-        .map(|v| matches!(v.to_lowercase().as_str(), "true" | "1" | "yes"))
-        .unwrap_or(false)
+    dynamo_runtime::config::env_is_truthy(
+        dynamo_runtime::config::environment_names::llm::DYN_LORA_ENABLED,
+    )
 }

--- a/lib/llm/src/lora/config.rs
+++ b/lib/llm/src/lora/config.rs
@@ -141,15 +141,11 @@ impl LoraAllocationConfig {
     pub fn from_env() -> Self {
         let defaults = Self::default();
 
-        // Map recognised values; unknown strings fall through to None so the
-        // default is preserved instead of silently disabling allocation.
+        // Map recognised values; empty or unknown strings fall through to None
+        // so the default is preserved instead of silently disabling allocation.
         let enabled = std::env::var(llm::DYN_LORA_ALLOCATION_ENABLED)
             .ok()
-            .and_then(|v| match v.to_lowercase().as_str() {
-                "true" | "1" | "yes" => Some(true),
-                "false" | "0" | "no" => Some(false),
-                _ => None,
-            })
+            .and_then(|v| dynamo_runtime::config::parse_bool_opt(&v))
             .unwrap_or(defaults.enabled);
 
         let algorithm = std::env::var(llm::DYN_LORA_ALLOCATION_ALGORITHM)

--- a/lib/llm/src/lora/source.rs
+++ b/lib/llm/src/lora/source.rs
@@ -196,10 +196,7 @@ impl S3LoRASource {
                 .with_endpoint(endpoint)
                 .with_virtual_hosted_style_request(false);
 
-            if std::env::var("AWS_ALLOW_HTTP")
-                .map(|v| v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false)
-            {
+            if dynamo_runtime::config::env_is_truthy("AWS_ALLOW_HTTP") {
                 builder = builder.with_allow_http(true);
             }
         }

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -114,9 +114,5 @@ pub(crate) fn session_affinity_header_value(headers: &HeaderMap) -> Option<Strin
 
 fn header_bool(headers: &HeaderMap, header_name: &str) -> Option<bool> {
     let value = header_value(headers, header_name)?;
-    match value.to_ascii_lowercase().as_str() {
-        "true" | "1" | "yes" => Some(true),
-        "false" | "0" | "no" => Some(false),
-        _ => None,
-    }
+    dynamo_runtime::config::parse_bool_opt(&value)
 }

--- a/lib/llm/tests/postprocessor_parsing_stream.rs
+++ b/lib/llm/tests/postprocessor_parsing_stream.rs
@@ -2231,9 +2231,7 @@ async fn tool_calls_qwen3_coder_auto_routes_through_experimental_gate() {
         ..
     } = drain_stream(output_stream).await;
 
-    let path = if std::env::var("DYN_ENABLE_EXPERIMENTAL_PARSERS_V2")
-        .is_ok_and(|v| matches!(v.trim(), "1" | "true" | "yes" | "on"))
-    {
+    let path = if dynamo_runtime::config::env_is_truthy("DYN_ENABLE_EXPERIMENTAL_PARSERS_V2") {
         "qwen3_coder auto -> dynamo-parsers-v2 (DYN_ENABLE_EXPERIMENTAL_PARSERS_V2 on)"
     } else {
         "qwen3_coder auto -> v1 jail (flag off)"

--- a/lib/memory/Cargo.toml
+++ b/lib/memory/Cargo.toml
@@ -23,6 +23,8 @@ testing-nixl = []
 testing-all = ["testing-cuda", "testing-nixl"]
 
 [dependencies]
+dynamo-truthy = { workspace = true }
+
 anyhow = { workspace = true }
 cudarc = { workspace = true }
 nixl-sys = { version = "=1.0.1" }

--- a/lib/memory/src/lib.rs
+++ b/lib/memory/src/lib.rs
@@ -300,42 +300,7 @@ impl MemoryRegion {
     }
 }
 
-/// Check if an environment variable is truthy
-pub fn env_is_truthy(env: &str) -> bool {
-    match std::env::var(env) {
-        Ok(val) => matches!(val.to_lowercase().as_str(), "1" | "true" | "on" | "yes"),
-        Err(_) => false,
-    }
-}
-
-/// Parse a string as a boolean value, returning an error if invalid.
-/// Do not use this unless you really need to support vague values. Prefer only allowing a specific
-/// value.
-///
-/// This function strictly validates that the input is a valid boolean representation.
-///
-/// # Arguments
-/// * `val` - The string value to parse
-///
-/// # Returns
-/// * `Ok(true)` - For truthy values: "1", "true", "on", "yes" (case-insensitive)
-/// * `Ok(false)` - For falsey values: "0", "false", "off", "no" (case-insensitive)
-/// * `Err(_)` - For any other value
-///
-/// # Example
-/// ```ignore
-/// assert_eq!(parse_bool("true")?, true);
-/// assert_eq!(parse_bool("0")?, false);
-/// assert!(parse_bool("maybe").is_err());
-/// ```
-pub fn parse_bool(val: &str) -> anyhow::Result<bool> {
-    if matches!(val.to_lowercase().as_str(), "1" | "true" | "on" | "yes") {
-        Ok(true)
-    } else if matches!(val.to_lowercase().as_str(), "0" | "false" | "off" | "no") {
-        Ok(false)
-    } else {
-        anyhow::bail!(
-            "Invalid boolean value: '{val}'. Expected one of: true/false, 1/0, on/off, yes/no",
-        )
-    }
-}
+// Canonical truthy/bool parsing, re-exported from the shared `dynamo-truthy`
+// crate (this crate cannot depend on `dynamo-runtime`, whose `config` module
+// re-exports the same helpers).
+pub use dynamo_truthy::{env_is_truthy, parse_bool, parse_bool_opt};

--- a/lib/memory/src/nixl/config.rs
+++ b/lib/memory/src/nixl/config.rs
@@ -78,17 +78,23 @@ impl NixlBackendConfig {
                     );
                 }
 
-                // Simple backend enablement (e.g., DYN_KVBM_NIXL_BACKEND_UCX=true)
+                // Simple backend enablement (e.g., DYN_KVBM_NIXL_BACKEND_UCX=true).
+                // Empty or unrecognized values are rejected rather than treated
+                // as false: silently dropping a backend hides misconfiguration.
                 let backend_name = remainder.to_uppercase();
-                match crate::parse_bool(&value) {
-                    Ok(true) => {
+                match crate::parse_bool_opt(&value) {
+                    Some(true) => {
                         backends.insert(backend_name, HashMap::new());
                     }
-                    Ok(false) => {
+                    Some(false) => {
                         // Explicitly disabled, don't add to backends
                         continue;
                     }
-                    Err(e) => bail!("Invalid value for {}: {}", key, e),
+                    None => bail!(
+                        "Invalid value for {}: '{}'. Expected one of: true/false, 1/0, on/off, yes/no",
+                        key,
+                        value
+                    ),
                 }
             }
         }

--- a/lib/mocker/Cargo.toml
+++ b/lib/mocker/Cargo.toml
@@ -24,6 +24,7 @@ kvbm-offload = ["dep:kvbm-engine", "dep:kvbm-physical", "dep:kvbm-common", "dep:
 dynamo-data-gen = { workspace = true }
 dynamo-kv-router = { workspace = true }
 dynamo-tokens = { workspace = true }
+dynamo-truthy = { workspace = true }
 kvbm-logical = { workspace = true }
 
 # kvbm-offload feature dependencies (G1↔G2 transport simulation)

--- a/lib/mocker/src/common/kv_cache_trace.rs
+++ b/lib/mocker/src/common/kv_cache_trace.rs
@@ -5,18 +5,14 @@
 //!
 //! Enabled by setting `DYN_MOCKER_KV_CACHE_TRACE=1` or `true`.
 
-use std::env;
 use std::sync::LazyLock;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const DYN_MOCKER_KV_CACHE_TRACE: &str = "DYN_MOCKER_KV_CACHE_TRACE";
 
 /// Check the env var to enable KV cache allocation/eviction trace logs.
-pub static KV_CACHE_TRACE_ENABLED: LazyLock<bool> = LazyLock::new(|| {
-    env::var(DYN_MOCKER_KV_CACHE_TRACE)
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false)
-});
+pub static KV_CACHE_TRACE_ENABLED: LazyLock<bool> =
+    LazyLock::new(|| dynamo_truthy::env_is_truthy(DYN_MOCKER_KV_CACHE_TRACE));
 
 fn timestamp_ms() -> u64 {
     SystemTime::now()

--- a/lib/runtime/Cargo.toml
+++ b/lib/runtime/Cargo.toml
@@ -26,6 +26,9 @@ tcp-low-latency = [] # Enable Linux-specific TCP optimizations (TCP_QUICKACK, SO
 nvtx = ["dep:cudarc"]
 
 [dependencies]
+# repo
+dynamo-truthy = { workspace = true }
+
 # Use workspace dependencies where available
 anyhow = { workspace = true }
 async-nats = { workspace = true }

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -808,6 +808,7 @@ dependencies = [
  "dashmap",
  "derive-getters",
  "derive_builder",
+ "dynamo-truthy",
  "educe",
  "either",
  "etcd-client",
@@ -853,6 +854,13 @@ dependencies = [
  "uuid",
  "validator",
  "xxhash-rust",
+]
+
+[[package]]
+name = "dynamo-truthy"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
 ]
 
 [[package]]

--- a/lib/runtime/src/config.rs
+++ b/lib/runtime/src/config.rs
@@ -418,50 +418,14 @@ impl RuntimeConfigBuilder {
     }
 }
 
-/// Check if a string is truthy
-/// This will be used to evaluate environment variables or any other subjective
-/// configuration parameters that can be set by the user that should be evaluated
-/// as a boolean value.
-pub fn is_truthy(val: &str) -> bool {
-    matches!(val.to_lowercase().as_str(), "1" | "true" | "on" | "yes")
-}
-
-pub fn parse_bool(val: &str) -> anyhow::Result<bool> {
-    if is_truthy(val) {
-        Ok(true)
-    } else if is_falsey(val) {
-        Ok(false)
-    } else {
-        anyhow::bail!(
-            "Invalid boolean value: '{}'. Expected one of: true/false, 1/0, on/off, yes/no",
-            val
-        )
-    }
-}
-
-/// Check if a string is falsey
-/// This will be used to evaluate environment variables or any other subjective
-/// configuration parameters that can be set by the user that should be evaluated
-/// as a boolean value (opposite of is_truthy).
-pub fn is_falsey(val: &str) -> bool {
-    matches!(val.to_lowercase().as_str(), "0" | "false" | "off" | "no")
-}
-
-/// Check if an environment variable is truthy
-pub fn env_is_truthy(env: &str) -> bool {
-    match std::env::var(env) {
-        Ok(val) => is_truthy(val.as_str()),
-        Err(_) => false,
-    }
-}
-
-/// Check if an environment variable is falsey
-pub fn env_is_falsey(env: &str) -> bool {
-    match std::env::var(env) {
-        Ok(val) => is_falsey(val.as_str()),
-        Err(_) => false,
-    }
-}
+// Canonical truthy/falsy/bool parsing for user-supplied configuration
+// (environment variables, headers, config values). The single implementation
+// lives in the zero-dependency `dynamo-truthy` crate so that crates which
+// cannot depend on `dynamo-runtime` share it too; this re-export is the
+// canonical import path for everything that can.
+pub use dynamo_truthy::{
+    env_is_falsey, env_is_truthy, is_falsey, is_truthy, parse_bool, parse_bool_opt,
+};
 
 /// Check whether JSONL logging enabled
 /// Set the `DYN_LOGGING_JSONL` environment variable a [`is_truthy`] value

--- a/lib/runtime/src/nvtx.rs
+++ b/lib/runtime/src/nvtx.rs
@@ -43,9 +43,7 @@ static NVTX_ENABLED: AtomicBool = AtomicBool::new(false);
 pub fn init() {
     #[cfg(feature = "nvtx")]
     {
-        let enabled = std::env::var("DYN_ENABLE_RUST_NVTX")
-            .map(|v| matches!(v.to_lowercase().as_str(), "1" | "true" | "yes" | "on"))
-            .unwrap_or(false);
+        let enabled = crate::config::env_is_truthy("DYN_ENABLE_RUST_NVTX");
         NVTX_ENABLED.store(enabled, Ordering::Relaxed);
         if enabled {
             tracing::info!("NVTX annotations enabled (DYN_ENABLE_RUST_NVTX)");

--- a/lib/runtime/src/pipeline/network/egress/tcp_client.rs
+++ b/lib/runtime/src/pipeline/network/egress/tcp_client.rs
@@ -79,9 +79,7 @@ const WRITE_VECTORED_CHUNKS: usize = 64;
 
 /// Check if latency tracing is enabled via environment
 fn latency_trace_enabled() -> bool {
-    std::env::var("DYN_TCP_LATENCY_TRACE")
-        .ok()
-        .is_some_and(|v| v == "1" || v == "true")
+    crate::config::env_is_truthy("DYN_TCP_LATENCY_TRACE")
 }
 
 /// TCP request plane configuration

--- a/lib/runtime/src/system_status_server.rs
+++ b/lib/runtime/src/system_status_server.rs
@@ -152,9 +152,8 @@ pub async fn spawn_system_status_server(
         .to_string();
 
     // Check if LoRA feature is enabled
-    let lora_enabled = std::env::var(crate::config::environment_names::llm::DYN_LORA_ENABLED)
-        .map(|v| v.to_lowercase() == "true")
-        .unwrap_or(false);
+    let lora_enabled =
+        crate::config::env_is_truthy(crate::config::environment_names::llm::DYN_LORA_ENABLED);
 
     let mut app = Router::new()
         .route(

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -120,11 +120,10 @@ async fn resolve_zmq_broker(
         }));
     }
 
-    // Priority 2: Discovery-based lookup if DYN_ZMQ_BROKER_ENABLED=true
-    if std::env::var(crate::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_ENABLED)
-        .unwrap_or_default()
-        == "true"
-    {
+    // Priority 2: Discovery-based lookup if DYN_ZMQ_BROKER_ENABLED is truthy
+    if crate::config::env_is_truthy(
+        crate::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_ENABLED,
+    ) {
         let query = DiscoveryQuery::EventChannels(EventChannelQuery::component(
             scope.namespace().to_string(),
             "zmq_broker".to_string(),
@@ -150,7 +149,7 @@ async fn resolve_zmq_broker(
 
         if xsub_endpoints.is_empty() {
             anyhow::bail!(
-                "DYN_ZMQ_BROKER_ENABLED=true but no broker found in discovery for namespace '{}'",
+                "DYN_ZMQ_BROKER_ENABLED is set but no broker found in discovery for namespace '{}'",
                 scope.namespace()
             );
         }

--- a/lib/truthy/Cargo.toml
+++ b/lib/truthy/Cargo.toml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-truthy"
+description = "Canonical truthy/falsy boolean flag parsing for Dynamo"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true }

--- a/lib/truthy/src/lib.rs
+++ b/lib/truthy/src/lib.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Canonical truthy/falsy flag parsing for Dynamo.
+//!
+//! Single owner of the boolean vocabulary accepted from user-supplied
+//! configuration (environment variables, HTTP headers, config values):
+//! truthy = `1 | true | on | yes`, falsy = `0 | false | off | no` or empty,
+//! case-insensitive, surrounding whitespace ignored.
+//!
+//! `dynamo_runtime::config` re-exports these helpers and is the canonical
+//! import path for crates that already depend on `dynamo-runtime`. Crates that
+//! cannot (e.g. `dynamo-memory`, `dynamo-kv-router`, `dynamo-mocker`) depend on
+//! this crate directly. Do not hand-roll new bool parsers — a divergent
+//! accepted set means `SOMEFLAG=on` works for one flag and silently not
+//! another. `tests/no_bool_parse_forks.rs` greps the workspace for forks.
+
+/// Check if a string is truthy: `1 | true | on | yes`, case-insensitive,
+/// surrounding whitespace ignored. Everything else is not truthy.
+pub fn is_truthy(val: &str) -> bool {
+    matches!(
+        val.trim().to_lowercase().as_str(),
+        "1" | "true" | "on" | "yes"
+    )
+}
+
+/// Check if a string is falsey: `0 | false | off | no` or empty,
+/// case-insensitive, surrounding whitespace ignored.
+pub fn is_falsey(val: &str) -> bool {
+    matches!(
+        val.trim().to_lowercase().as_str(),
+        "" | "0" | "false" | "off" | "no"
+    )
+}
+
+/// Parse a string as a boolean value, returning an error if it is neither
+/// truthy nor falsey.
+///
+/// # Returns
+/// * `Ok(true)` - for truthy values ([`is_truthy`])
+/// * `Ok(false)` - for falsey values ([`is_falsey`]), including empty
+/// * `Err(_)` - for any other value
+pub fn parse_bool(val: &str) -> anyhow::Result<bool> {
+    if is_truthy(val) {
+        Ok(true)
+    } else if is_falsey(val) {
+        Ok(false)
+    } else {
+        anyhow::bail!(
+            "Invalid boolean value: '{}'. Expected one of: true/false, 1/0, on/off, yes/no",
+            val
+        )
+    }
+}
+
+/// Tri-state parse for call sites that preserve their own default unless the
+/// value is a deliberate boolean choice.
+///
+/// Unlike [`parse_bool`], an empty (or whitespace-only) value yields `None` —
+/// a variable declared without a value (common in Kubernetes manifests and
+/// Docker Compose files) must not override a default — and so does any
+/// unrecognized value.
+///
+/// # Returns
+/// * `Some(true)` - for truthy values ([`is_truthy`])
+/// * `Some(false)` - for `0 | false | off | no`
+/// * `None` - for empty or unrecognized values
+pub fn parse_bool_opt(val: &str) -> Option<bool> {
+    if is_truthy(val) {
+        Some(true)
+    } else if val.trim().is_empty() {
+        None
+    } else if is_falsey(val) {
+        Some(false)
+    } else {
+        None
+    }
+}
+
+/// Check if an environment variable is set to a truthy value.
+/// Unset (or non-unicode) variables are not truthy.
+pub fn env_is_truthy(env: &str) -> bool {
+    match std::env::var(env) {
+        Ok(val) => is_truthy(val.as_str()),
+        Err(_) => false,
+    }
+}
+
+/// Check if an environment variable is set to a falsey value (including set
+/// but empty). Unset (or non-unicode) variables are not falsey.
+pub fn env_is_falsey(env: &str) -> bool {
+    match std::env::var(env) {
+        Ok(val) => is_falsey(val.as_str()),
+        Err(_) => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const TRUTHY: &[&str] = &[
+        "1", "true", "TRUE", "True", "on", "ON", "On", "yes", "YES", "Yes", " true ", "\tyes\n",
+    ];
+    const FALSEY: &[&str] = &[
+        "0", "false", "FALSE", "False", "off", "OFF", "Off", "no", "NO", "No", "", "  ", " false ",
+    ];
+    const NEITHER: &[&str] = &[
+        "2", "enabled", "disabled", "maybe", "y", "n", "t", "f", "-1",
+    ];
+
+    #[test]
+    fn truthy_spellings() {
+        for val in TRUTHY {
+            assert!(is_truthy(val), "value={val:?}");
+            assert!(!is_falsey(val), "value={val:?}");
+            assert!(parse_bool(val).unwrap(), "value={val:?}");
+        }
+    }
+
+    #[test]
+    fn falsey_spellings() {
+        for val in FALSEY {
+            assert!(is_falsey(val), "value={val:?}");
+            assert!(!is_truthy(val), "value={val:?}");
+            assert!(!parse_bool(val).unwrap(), "value={val:?}");
+        }
+    }
+
+    #[test]
+    fn invalid_spellings() {
+        for val in NEITHER {
+            assert!(!is_truthy(val), "value={val:?}");
+            assert!(!is_falsey(val), "value={val:?}");
+            assert!(parse_bool(val).is_err(), "value={val:?}");
+        }
+    }
+
+    #[test]
+    fn parse_bool_opt_spellings() {
+        for val in TRUTHY {
+            assert_eq!(parse_bool_opt(val), Some(true), "value={val:?}");
+        }
+        for val in FALSEY {
+            let expected = if val.trim().is_empty() {
+                None // declared-but-empty is not a deliberate choice
+            } else {
+                Some(false)
+            };
+            assert_eq!(parse_bool_opt(val), expected, "value={val:?}");
+        }
+        for val in NEITHER {
+            assert_eq!(parse_bool_opt(val), None, "value={val:?}");
+        }
+    }
+
+    #[test]
+    fn env_helpers() {
+        // Each test uses its own variable name: tests run concurrently and
+        // the process environment is shared.
+        const UNSET: &str = "DYN_TRUTHY_TEST_UNSET";
+        assert!(!env_is_truthy(UNSET));
+        assert!(!env_is_falsey(UNSET));
+
+        const SET: &str = "DYN_TRUTHY_TEST_SET";
+        for (val, truthy, falsey) in [("on", true, false), ("off", false, true), ("", false, true)]
+        {
+            // SAFETY: single-threaded with respect to this variable name.
+            unsafe { std::env::set_var(SET, val) };
+            assert_eq!(env_is_truthy(SET), truthy, "value={val:?}");
+            assert_eq!(env_is_falsey(SET), falsey, "value={val:?}");
+        }
+    }
+}

--- a/lib/truthy/tests/no_bool_parse_forks.rs
+++ b/lib/truthy/tests/no_bool_parse_forks.rs
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Grep-guard: no hand-rolled truthy/bool string parsing outside this crate.
+//!
+//! Dynamo once had 8+ divergent copies of `matches!(v, "1" | "true" | ...)`
+//! with different accepted sets, so `SOMEFLAG=on` worked for some flags and
+//! silently not others. All bool parsing of user-supplied strings
+//! must go through `dynamo-truthy` (re-exported as
+//! `dynamo_runtime::config::{is_truthy, is_falsey, parse_bool, parse_bool_opt,
+//! env_is_truthy, env_is_falsey}`). Use strict `parse_bool` when an invalid
+//! value should be an error, and `parse_bool_opt` when the call site preserves
+//! its own default (tri-state: empty/unrecognized yield `None`) — do not swap
+//! one for the other, they have different default/error semantics. If this
+//! test flags your new code, call those helpers instead; if the match is a
+//! false positive (e.g. a string that genuinely is not a boolean flag), add it
+//! to `ALLOWED` with a justification.
+
+use std::path::{Path, PathBuf};
+
+/// Known non-fork matches, as (path suffix, line substring) pairs. A multiline
+/// (file-level) match is allowed when any entry's path suffix matches the file.
+const ALLOWED: &[(&str, &str)] = &[];
+
+/// Substring patterns that indicate a hand-rolled bool parser. Matched against
+/// lowercased text, so `"TRUE"` / `"False"` variants are caught too.
+const FORK_PATTERNS: &[&str] = &[
+    r#"eq_ignore_ascii_case("true")"#,
+    r#"eq_ignore_ascii_case("false")"#,
+    r#"== "true""#,
+    r#"== "false""#,
+    r#"!= "true""#,
+    r#"!= "false""#,
+    r#""true" |"#,
+    r#"| "true""#,
+    r#""false" |"#,
+    r#"| "false""#,
+];
+
+fn text_is_fork(text: &str) -> bool {
+    let text = text.to_lowercase();
+    FORK_PATTERNS.iter().any(|p| text.contains(p))
+        || (text.contains("matches!") && text.contains(r#""true""#))
+}
+
+/// Whole-file check with whitespace collapsed, so a parser split across lines
+/// (e.g. a match arm ending in `"true"` with `| "1"` on the next line) cannot
+/// slip past the per-line scan. The `matches!` heuristic is limited to a
+/// proximity window here — at file scope, `matches!` and `"true"` merely
+/// coexisting is not evidence of a bool parser.
+fn normalized_content_is_fork(content: &str) -> bool {
+    let squashed = content
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase();
+    if FORK_PATTERNS.iter().any(|p| squashed.contains(p)) {
+        return true;
+    }
+    squashed.match_indices("matches!").any(|(i, _)| {
+        let mut end = squashed.len().min(i + 160);
+        while !squashed.is_char_boundary(end) {
+            end += 1;
+        }
+        squashed[i..end].contains(r#""true""#)
+    })
+}
+
+fn scan_dir(dir: &Path, offenders: &mut Vec<String>) {
+    for entry in std::fs::read_dir(dir).unwrap_or_else(|e| panic!("read_dir {dir:?}: {e}")) {
+        let path = entry.expect("dir entry").path();
+        let name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+        if path.is_dir() {
+            // Skip build output and the canonical implementation itself.
+            if name == "target" || name == "node_modules" || path.ends_with("lib/truthy") {
+                continue;
+            }
+            scan_dir(&path, offenders);
+        } else if name.ends_with(".rs") {
+            scan_file(&path, offenders);
+        }
+    }
+}
+
+fn scan_file(path: &Path, offenders: &mut Vec<String>) {
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return;
+    };
+    let mut line_hit = false;
+    for (idx, line) in content.lines().enumerate() {
+        if !text_is_fork(line) {
+            continue;
+        }
+        line_hit = true;
+        let allowed = ALLOWED.iter().any(|(suffix, substr)| {
+            path.to_string_lossy().ends_with(suffix) && line.contains(substr)
+        });
+        if !allowed {
+            offenders.push(format!("{}:{}: {}", path.display(), idx + 1, line.trim()));
+        }
+    }
+    // Backstop: catch forks formatted across multiple lines. Only report at
+    // file level when no line-level hit already pinpointed the offender.
+    if !line_hit && normalized_content_is_fork(&content) {
+        let allowed = ALLOWED
+            .iter()
+            .any(|(suffix, _)| path.to_string_lossy().ends_with(suffix));
+        if !allowed {
+            offenders.push(format!(
+                "{}: multiline or case-variant bool-parse fork (whitespace-normalized match)",
+                path.display()
+            ));
+        }
+    }
+}
+
+#[test]
+fn no_bool_parse_forks_outside_canonical_crate() {
+    // lib/truthy/ -> repo root
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(Path::parent)
+        .expect("repo root")
+        .to_path_buf();
+    // Only meaningful inside the repo checkout (not a published crate).
+    if !repo_root.join("Cargo.toml").is_file() || !repo_root.join("lib").is_dir() {
+        eprintln!("skipping: not running inside the dynamo repo");
+        return;
+    }
+
+    let mut offenders = Vec::new();
+    for dir in ["lib", "deploy/inference-gateway"] {
+        let dir = repo_root.join(dir);
+        if dir.is_dir() {
+            scan_dir(&dir, &mut offenders);
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "Hand-rolled truthy/bool parsing found; use dynamo_runtime::config::{{is_truthy, \
+         parse_bool, parse_bool_opt, env_is_truthy}} (or dynamo-truthy directly if the crate \
+         cannot depend on dynamo-runtime):\n{}",
+        offenders.join("\n")
+    );
+}
+
+#[test]
+fn detector_catches_case_variants() {
+    assert!(text_is_fork(r#"if v == "TRUE" {"#));
+    assert!(text_is_fork(r#"v.eq_ignore_ascii_case("True")"#));
+    assert!(text_is_fork(r#"matches!(v, "TRUE" | "1")"#));
+}
+
+#[test]
+fn detector_catches_multiline_forks() {
+    let src = "match v {\n    \"true\"\n        | \"1\" => true,\n    _ => false,\n}";
+    // The per-line pass alone misses this shape; the normalized pass must not.
+    assert!(!src.lines().any(text_is_fork));
+    assert!(normalized_content_is_fork(src));
+}
+
+#[test]
+fn detector_ignores_canonical_usage() {
+    for src in [
+        "let enabled = is_truthy(&v);",
+        "let enabled = parse_bool(&v)?;",
+        "let enabled = parse_bool_opt(&v).unwrap_or(default);",
+        "tracing::info!(\"flag is true\");",
+    ] {
+        assert!(!text_is_fork(src), "false positive on: {src}");
+        assert!(!normalized_content_is_fork(src), "false positive on: {src}");
+    }
+}


### PR DESCRIPTION
#### Overview:

This PR makes every boolean flag in Dynamo accept the same spellings. We had 8+ hand-rolled truthy parsers with divergent accepted sets, so `SOMEFLAG=on` (or `=yes`) enabled some flags and silently not others.

#### Example (before → after):

Input: `DYN_LORA_ENABLED=1`

```
before:  lib/llm/src/lora.rs enables LoRA, but lib/runtime/src/system_status_server.rs (== "true") silently reports it disabled
after:   both accept the one canonical set: 1|true|on|yes (falsy: 0|false|off|no or empty; case-insensitive, whitespace-trimmed)
```

#### Details:

- New zero-dependency `dynamo-truthy` crate owns `is_truthy`/`is_falsey`/`parse_bool`/`env_is_truthy`/`env_is_falsey`; `dynamo_runtime::config` re-exports it as the canonical import path, and crates that can't depend on dynamo-runtime (`dynamo-memory`, `dynamo-kv-router`, `dynamo-mocker`) use it directly — `dynamo_memory::{env_is_truthy, parse_bool}` is now a re-export, not a fork
- 17 fork sites re-routed across runtime, llm, memory, kv-router, mocker, and the kvbm bindings; behavior change: `parse_bool("")` is now `Ok(false)` instead of an error, and tri-state call sites that preserve their own default (LoRA allocation, router env overrides, agent headers) use the new `parse_bool_opt`, where empty/unrecognized values yield `None`; the strict NIXL backend flags route that `None` to their existing error path so misconfiguration still fails loudly
- Grep-guard test `lib/truthy/tests/no_bool_parse_forks.rs` fails the build if a new hand-rolled bool parser appears anywhere under `lib/`

#### Verification:

`cargo clippy --workspace` clean; unit tests pass for dynamo-truthy, runtime, llm (1649), memory, kv-router, mocker; `lib/bindings/kvbm` compiles.

#### Where should the reviewer start?

`lib/truthy/src/lib.rs`, then `lib/runtime/src/config.rs`, `lib/truthy/tests/no_bool_parse_forks.rs`

/coderabbit profile chill




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consistent boolean parsing for configuration values, supporting common forms such as `true`, `false`, `yes`, `no`, `on`, `off`, `1`, and `0`.
  * Expanded support for truthy values across runtime, routing, model, LoRA, storage, and tracing settings.

* **Bug Fixes**
  * Invalid boolean configuration values now produce clearer, standardized errors in affected components.
  * Empty values are handled consistently according to each setting’s optional configuration behavior.

* **Tests**
  * Added coverage for supported boolean formats and safeguards against inconsistent parsing implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->