### PR TITLE
test: Prefill Router Bootstrap to check Prefill request delivery succeeded

### DIFF
--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -24,6 +24,7 @@ from tests.router.helper import (
     get_runtime,
     managed_runtime,
     poll_for_worker_instances,
+    prometheus_metric_value,
     send_inflight_requests,
     send_request_via_python_kv_router,
     verify_response_timing,
@@ -1547,6 +1548,208 @@ def _test_disagg_router_overload_529(
         )
 
         _probe_overload_529_and_assert(frontend_port, test_payload, max_tokens)
+
+
+def _test_bootstrap_prefill_rejection_gates_decode(
+    frontend_port: int,
+    prefill_system_port: int,
+    test_payload: dict[str, Any],
+) -> None:
+    """Verify rejected prefill admission fails before a decode hop is dispatched."""
+
+    def request_payload(tag: str) -> dict[str, Any]:
+        return {
+            **test_payload,
+            "messages": [
+                {
+                    **test_payload["messages"][0],
+                    "content": f'{test_payload["messages"][0]["content"]} {tag}',
+                }
+            ],
+            "max_tokens": 1,
+            "stream": True,
+        }
+
+    async def exercise_gate() -> None:
+        frontend_url = f"http://localhost:{frontend_port}"
+        chat_url = f"{frontend_url}/v1/chat/completions"
+        frontend_metrics_url = f"{frontend_url}/metrics"
+        prefill_metrics_url = f"http://localhost:{prefill_system_port}/metrics"
+
+        async with aiohttp.ClientSession() as session:
+
+            async def wait_for_model() -> None:
+                deadline = asyncio.get_running_loop().time() + 60
+                last_error: Optional[Exception] = None
+                while asyncio.get_running_loop().time() < deadline:
+                    try:
+                        async with session.get(f"{frontend_url}/v1/models") as response:
+                            if response.status == 200:
+                                models = (await response.json()).get("data", [])
+                                if models:
+                                    return
+                            last_error = RuntimeError(
+                                f"/v1/models returned HTTP {response.status}"
+                            )
+                    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+                        last_error = error
+                    await asyncio.sleep(0.05)
+                raise AssertionError(
+                    f"Timed out waiting for frontend model; last_error={last_error}"
+                )
+
+            async def metric(
+                url: str,
+                name: str,
+                labels: Optional[dict[str, str]] = None,
+            ) -> float:
+                async with session.get(url) as response:
+                    response.raise_for_status()
+                    return prometheus_metric_value(
+                        await response.text(),
+                        name,
+                        labels,
+                    )
+
+            async def wait_for_metric(
+                url: str,
+                name: str,
+                predicate,
+                *,
+                labels: Optional[dict[str, str]] = None,
+                timeout: float = 10.0,
+            ) -> float:
+                deadline = asyncio.get_running_loop().time() + timeout
+                last_value = 0.0
+                last_error: Optional[Exception] = None
+                while asyncio.get_running_loop().time() < deadline:
+                    try:
+                        last_value = await metric(url, name, labels)
+                        last_error = None
+                        if predicate(last_value):
+                            return last_value
+                    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+                        last_error = error
+                    await asyncio.sleep(0.05)
+                raise AssertionError(
+                    f"Timed out waiting for {name}; "
+                    f"last_value={last_value}, last_error={last_error}"
+                )
+
+            first_response: Optional[aiohttp.ClientResponse] = None
+            filler_tasks: list[asyncio.Task] = []
+            try:
+                await wait_for_model()
+                frontend_send_baseline = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+
+                first_response = await asyncio.wait_for(
+                    session.post(chat_url, json=request_payload("active")),
+                    timeout=15,
+                )
+                if first_response.status != 200:
+                    body = await first_response.text()
+                    raise AssertionError(
+                        f"Active bootstrap request returned "
+                        f"{first_response.status}: {body}"
+                    )
+
+                await wait_for_metric(
+                    prefill_metrics_url,
+                    "dynamo_work_handler_pool_active_tasks",
+                    lambda value: value >= 1,
+                )
+                frontend_send_after_first = await wait_for_metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= frontend_send_baseline + 2,
+                )
+
+                # The HTTP 200/decode ingress arrives while prefill is still
+                # active, preserving the bootstrap overlap optimization.
+                assert frontend_send_after_first >= frontend_send_baseline + 2
+
+                frontend_ack_baseline = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+
+                dispatcher_task = asyncio.create_task(
+                    session.post(chat_url, json=request_payload("dispatcher-held"))
+                )
+                filler_tasks.append(dispatcher_task)
+                await wait_for_metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= frontend_ack_baseline + 1,
+                )
+                if dispatcher_task.done():
+                    raise AssertionError(
+                        "dispatcher-held request unexpectedly established a response stream"
+                    )
+
+                queued_task = asyncio.create_task(
+                    session.post(chat_url, json=request_payload("queued"))
+                )
+                filler_tasks.append(queued_task)
+                await wait_for_metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= frontend_ack_baseline + 2,
+                )
+                await wait_for_metric(
+                    prefill_metrics_url,
+                    "dynamo_work_handler_queue_depth",
+                    lambda value: value >= 1,
+                )
+                if queued_task.done():
+                    raise AssertionError(
+                        "queued request unexpectedly established a response stream"
+                    )
+
+                frontend_send_before_probe = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+                probe_response = await asyncio.wait_for(
+                    session.post(chat_url, json=request_payload("probe")),
+                    timeout=5,
+                )
+                probe_body = await probe_response.text()
+                probe_status = probe_response.status
+                probe_response.release()
+
+                assert probe_status == 529, (
+                    f"Expected prefill admission rejection (529), got "
+                    f"{probe_status}: {probe_body}"
+                )
+
+                # Give any wrongly-detached decode dispatch time to add a
+                # second request-plane send, then prove only prefill was attempted.
+                await asyncio.sleep(0.25)
+                frontend_send_after_probe = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+                assert frontend_send_after_probe == frontend_send_before_probe + 1, (
+                    "rejected prefill dispatched an extra request-plane send: "
+                    f"before={frontend_send_before_probe}, "
+                    f"after={frontend_send_after_probe}"
+                )
+            finally:
+                if first_response is not None:
+                    first_response.close()
+                for task in filler_tasks:
+                    if not task.done():
+                        task.cancel()
+                results = await asyncio.gather(*filler_tasks, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, aiohttp.ClientResponse):
+                        result.close()
+
+    asyncio.run(exercise_gate())
 
 
 def _test_router_threshold_none_disables_rejection(

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1554,6 +1554,7 @@ def _test_bootstrap_prefill_rejection_gates_decode(
     frontend_port: int,
     prefill_system_port: int,
     test_payload: dict[str, Any],
+    request_timeout_seconds: float,
 ) -> None:
     """Verify rejected prefill admission fails before a decode hop is dispatched."""
 
@@ -1766,18 +1767,41 @@ def _test_bootstrap_prefill_rejection_gates_decode(
                     f"{probe_status}: {probe_body}"
                 )
 
-                # Give any wrongly-detached decode dispatch time to add a
-                # second request-plane send, then prove only prefill was attempted.
-                await asyncio.sleep(0.25)
-                frontend_send_after_probe = await metric(
+                expected_frontend_sends = frontend_send_before_probe + 1
+                frontend_send_after_probe = await wait_for_metric(
                     frontend_metrics_url,
                     "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= expected_frontend_sends,
+                    timeout=request_timeout_seconds,
                 )
-                assert frontend_send_after_probe == frontend_send_before_probe + 1, (
+                assert frontend_send_after_probe == expected_frontend_sends, (
                     "rejected prefill dispatched an extra request-plane send: "
                     f"before={frontend_send_before_probe}, "
                     f"after={frontend_send_after_probe}"
                 )
+
+                # A detached decode dispatch may outlive the rejected prefill
+                # response. Keep polling for the complete TCP request-timeout
+                # window and fail as soon as another send appears.
+                quiet_period_deadline = (
+                    asyncio.get_running_loop().time() + request_timeout_seconds
+                )
+                while True:
+                    frontend_send_after_probe = await metric(
+                        frontend_metrics_url,
+                        "dynamo_request_plane_send_seconds_count",
+                    )
+                    assert frontend_send_after_probe == expected_frontend_sends, (
+                        "rejected prefill dispatched an extra request-plane send: "
+                        f"before={frontend_send_before_probe}, "
+                        f"after={frontend_send_after_probe}"
+                    )
+                    remaining = (
+                        quiet_period_deadline - asyncio.get_running_loop().time()
+                    )
+                    if remaining <= 0:
+                        break
+                    await asyncio.sleep(min(0.05, remaining))
             finally:
                 if first_response is not None:
                     first_response.close()

--- a/tests/router/common.py
+++ b/tests/router/common.py
@@ -1640,27 +1640,58 @@ def _test_bootstrap_prefill_rejection_gates_decode(
             filler_tasks: list[asyncio.Task] = []
             try:
                 await wait_for_model()
-                frontend_send_baseline = await metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                )
-
-                first_response = await asyncio.wait_for(
-                    session.post(chat_url, json=request_payload("active")),
-                    timeout=15,
-                )
-                if first_response.status != 200:
-                    body = await first_response.text()
-                    raise AssertionError(
-                        f"Active bootstrap request returned "
-                        f"{first_response.status}: {body}"
+                # Worker registration can make /v1/models ready just before the
+                # asynchronously-created prefill router becomes active. Close
+                # any request that lands in that narrow aggregated-routing
+                # window, and retain the first request proven to have reached
+                # the prefill TCP handler.
+                activation_deadline = asyncio.get_running_loop().time() + 15
+                activation_attempt = 0
+                while first_response is None:
+                    activation_attempt += 1
+                    frontend_send_baseline = await metric(
+                        frontend_metrics_url,
+                        "dynamo_request_plane_send_seconds_count",
                     )
+                    candidate_response = await asyncio.wait_for(
+                        session.post(
+                            chat_url,
+                            json=request_payload(f"active-{activation_attempt}"),
+                        ),
+                        timeout=15,
+                    )
+                    if candidate_response.status != 200:
+                        body = await candidate_response.text()
+                        raise AssertionError(
+                            f"Active bootstrap request returned "
+                            f"{candidate_response.status}: {body}"
+                        )
 
-                await wait_for_metric(
-                    prefill_metrics_url,
-                    "dynamo_work_handler_pool_active_tasks",
-                    lambda value: value >= 1,
-                )
+                    frontend_send_after_candidate = await wait_for_metric(
+                        frontend_metrics_url,
+                        "dynamo_request_plane_send_seconds_count",
+                        lambda value: value >= frontend_send_baseline + 1,
+                    )
+                    try:
+                        await wait_for_metric(
+                            prefill_metrics_url,
+                            "dynamo_work_handler_pool_active_tasks",
+                            lambda value: value >= 1,
+                            timeout=0.5,
+                        )
+                    except AssertionError:
+                        if (
+                            frontend_send_after_candidate == frontend_send_baseline + 1
+                            and asyncio.get_running_loop().time() < activation_deadline
+                        ):
+                            candidate_response.close()
+                            await asyncio.sleep(0.05)
+                            continue
+                        candidate_response.close()
+                        raise
+
+                    first_response = candidate_response
+
                 frontend_send_after_first = await wait_for_metric(
                     frontend_metrics_url,
                     "dynamo_request_plane_send_seconds_count",
@@ -1689,6 +1720,15 @@ def _test_bootstrap_prefill_rejection_gates_decode(
                     raise AssertionError(
                         "dispatcher-held request unexpectedly established a response stream"
                     )
+
+                # An ACK proves enqueueing, not that the dispatcher has drained
+                # the item. Wait for zero queue depth so the first filler is
+                # dispatcher-held before placing the second filler in the queue.
+                await wait_for_metric(
+                    prefill_metrics_url,
+                    "dynamo_work_handler_queue_depth",
+                    lambda value: value == 0,
+                )
 
                 queued_task = asyncio.create_task(
                     session.post(chat_url, json=request_payload("queued"))

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -24,6 +24,32 @@ NUM_REQUESTS = 100
 BLOCK_SIZE = 16
 
 
+def prometheus_metric_value(
+    metrics_text: str,
+    metric_name: str,
+    labels: Optional[Dict[str, str]] = None,
+) -> float:
+    """Return the sum of exact matching Prometheus samples, or zero when absent."""
+    total = 0.0
+    for line in metrics_text.splitlines():
+        if not (
+            line.startswith(f"{metric_name} ") or line.startswith(f"{metric_name}{{")
+        ):
+            continue
+        sample, _, raw_value = line.rpartition(" ")
+        if not sample or not raw_value:
+            continue
+        if labels and not all(
+            f'{key}="{value}"' in sample for key, value in labels.items()
+        ):
+            continue
+        try:
+            total += float(raw_value)
+        except ValueError:
+            continue
+    return total
+
+
 def _nats_server() -> str:
     # Prefer dynamically-started NATS from per-test fixtures when present.
     return os.environ.get("NATS_SERVER", "nats://localhost:4222")

--- a/tests/router/helper.py
+++ b/tests/router/helper.py
@@ -14,6 +14,7 @@ from typing import Any, Dict, Optional
 
 import aiohttp
 import nats
+from prometheus_client.parser import text_string_to_metric_families
 
 from dynamo.llm import KvRouter
 from dynamo.runtime import DistributedRuntime
@@ -31,22 +32,15 @@ def prometheus_metric_value(
 ) -> float:
     """Return the sum of exact matching Prometheus samples, or zero when absent."""
     total = 0.0
-    for line in metrics_text.splitlines():
-        if not (
-            line.startswith(f"{metric_name} ") or line.startswith(f"{metric_name}{{")
-        ):
-            continue
-        sample, _, raw_value = line.rpartition(" ")
-        if not sample or not raw_value:
-            continue
-        if labels and not all(
-            f'{key}="{value}"' in sample for key, value in labels.items()
-        ):
-            continue
-        try:
-            total += float(raw_value)
-        except ValueError:
-            continue
+    for family in text_string_to_metric_families(metrics_text):
+        for sample in family.samples:
+            if sample.name != metric_name:
+                continue
+            if labels and not all(
+                sample.labels.get(key) == value for key, value in labels.items()
+            ):
+                continue
+            total += sample.value
     return total
 
 

--- a/tests/router/mocker_process.py
+++ b/tests/router/mocker_process.py
@@ -64,6 +64,8 @@ def _build_mocker_command(
     elif worker_type == "decode":
         command.extend(["--disaggregation-mode", "decode"])
 
+    if "engine_type" in mocker_args:
+        command.extend(["--engine-type", str(mocker_args["engine_type"])])
     if "speedup_ratio" in mocker_args:
         command.extend(["--speedup-ratio", str(mocker_args["speedup_ratio"])])
     if "block_size" in mocker_args:
@@ -687,6 +689,8 @@ def launch_disagg_workers(
     request_plane: str = "nats",
     event_plane: Optional[str] = None,
     raw_kv_events: bool = False,
+    prefill_env_overrides: Optional[Dict[str, str]] = None,
+    decode_env_overrides: Optional[Dict[str, str]] = None,
 ) -> Iterator[tuple[DisaggMockerProcess, DisaggMockerProcess]]:
     if registration_order not in ("prefill_first", "decode_first"):
         raise ValueError(f"Unexpected registration order: {registration_order}")
@@ -704,6 +708,7 @@ def launch_disagg_workers(
             enable_bootstrap=enable_disagg_bootstrap,
             event_plane=event_plane,
             raw_kv_events=raw_kv_events,
+            env_overrides=prefill_env_overrides,
         ) as prefill_workers:
             logger.info("Prefill workers using endpoint: %s", prefill_workers.endpoint)
             _wait_for_disagg_workers(
@@ -722,6 +727,7 @@ def launch_disagg_workers(
                 request_plane=request_plane,
                 event_plane=event_plane,
                 raw_kv_events=raw_kv_events,
+                env_overrides=decode_env_overrides,
             ) as decode_workers:
                 logger.info(
                     "Decode workers using endpoint: %s", decode_workers.endpoint
@@ -743,6 +749,7 @@ def launch_disagg_workers(
         request_plane=request_plane,
         event_plane=event_plane,
         raw_kv_events=raw_kv_events,
+        env_overrides=decode_env_overrides,
     ) as decode_workers:
         logger.info("Decode workers using endpoint: %s", decode_workers.endpoint)
         _wait_for_disagg_workers(
@@ -762,6 +769,7 @@ def launch_disagg_workers(
             enable_bootstrap=enable_disagg_bootstrap,
             event_plane=event_plane,
             raw_kv_events=raw_kv_events,
+            env_overrides=prefill_env_overrides,
         ) as prefill_workers:
             logger.info("Prefill workers using endpoint: %s", prefill_workers.endpoint)
             _wait_for_disagg_workers(

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -977,6 +977,7 @@ def test_router_decisions_disagg(
     )
 
 
+@pytest.mark.sglang
 @pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
 @pytest.mark.parametrize("num_system_ports", [2], indirect=True)
 @pytest.mark.timeout(120)
@@ -1006,7 +1007,9 @@ def test_bootstrap_prefill_rejection_gates_decode(
     before opening HTTP 200. The first request also proves that accepted
     bootstrap traffic still overlaps prefill and decode.
     """
-    monkeypatch.setenv("DYN_TCP_REQUEST_TIMEOUT", "2")
+    request_timeout_seconds = 2
+    monkeypatch.setenv("DYN_TCP_REQUEST_TIMEOUT", str(request_timeout_seconds))
+    monkeypatch.delenv("DYN_EVENT_PLANE", raising=False)
 
     namespace_suffix = generate_random_suffix()
     shared_namespace = f"test-namespace-{namespace_suffix}"
@@ -1046,7 +1049,6 @@ def test_bootstrap_prefill_rejection_gates_decode(
         num_decode_mockers=1,
         enable_disagg_bootstrap=True,
         request_plane=request_plane,
-        event_plane="nats",
         prefill_env_overrides=prefill_env,
         decode_env_overrides=decode_env,
     ) as (_prefill_workers, _decode_workers):
@@ -1062,6 +1064,7 @@ def test_bootstrap_prefill_rejection_gates_decode(
                 frontend_port=frontend_port,
                 prefill_system_port=prefill_system_port,
                 test_payload=TEST_PAYLOAD,
+                request_timeout_seconds=request_timeout_seconds,
             )
 
 

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -1055,7 +1055,6 @@ def test_bootstrap_prefill_rejection_gates_decode(
             block_size=1,
             frontend_port=frontend_port,
             namespace=shared_namespace,
-            enforce_disagg=True,
             request_plane=request_plane,
             min_initial_workers=1,
         ):

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -16,10 +16,10 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-import aiohttp
 import pytest
 
 from tests.router.common import (
+    _test_bootstrap_prefill_rejection_gates_decode,
     _test_busy_threshold_endpoint,
     _test_disagg_direct_mode,
     _test_disagg_router_overload_529,
@@ -196,30 +196,6 @@ SOAK_TEST_PAYLOAD: Dict[str, Any] = {
     "stream": False,
     "max_tokens": 1,
 }
-
-
-def _prometheus_metric_value(
-    metrics_text: str,
-    metric_name: str,
-    labels: Optional[Dict[str, str]] = None,
-) -> float:
-    """Return the sum of matching Prometheus samples, or zero when absent."""
-    total = 0.0
-    for line in metrics_text.splitlines():
-        if not line.startswith(metric_name):
-            continue
-        sample, _, raw_value = line.rpartition(" ")
-        if not sample or not raw_value:
-            continue
-        if labels and not all(
-            f'{key}="{value}"' in sample for key, value in labels.items()
-        ):
-            continue
-        try:
-            total += float(raw_value)
-        except ValueError:
-            continue
-    return total
 
 
 class CounterWorkerProcess:
@@ -1060,194 +1036,6 @@ def test_bootstrap_prefill_rejection_gates_decode(
     }
     decode_env = {"DYN_SYSTEM_PORT": str(decode_system_port)}
 
-    def request_payload(tag: str) -> Dict[str, Any]:
-        return {
-            **TEST_PAYLOAD,
-            "messages": [
-                {
-                    **TEST_PAYLOAD["messages"][0],
-                    "content": f'{TEST_PAYLOAD["messages"][0]["content"]} {tag}',
-                }
-            ],
-            "max_tokens": 1,
-            "stream": True,
-        }
-
-    async def exercise_gate() -> None:
-        frontend_url = f"http://localhost:{frontend_port}"
-        chat_url = f"{frontend_url}/v1/chat/completions"
-        frontend_metrics_url = f"{frontend_url}/metrics"
-        prefill_metrics_url = f"http://localhost:{prefill_system_port}/metrics"
-
-        async with aiohttp.ClientSession() as session:
-
-            async def wait_for_model() -> None:
-                deadline = asyncio.get_running_loop().time() + 60
-                last_error: Optional[Exception] = None
-                while asyncio.get_running_loop().time() < deadline:
-                    try:
-                        async with session.get(f"{frontend_url}/v1/models") as response:
-                            if response.status == 200:
-                                models = (await response.json()).get("data", [])
-                                if models:
-                                    return
-                            last_error = RuntimeError(
-                                f"/v1/models returned HTTP {response.status}"
-                            )
-                    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
-                        last_error = error
-                    await asyncio.sleep(0.05)
-                raise AssertionError(
-                    f"Timed out waiting for frontend model; last_error={last_error}"
-                )
-
-            async def metric(
-                url: str,
-                name: str,
-                labels: Optional[Dict[str, str]] = None,
-            ) -> float:
-                async with session.get(url) as response:
-                    response.raise_for_status()
-                    return _prometheus_metric_value(await response.text(), name, labels)
-
-            async def wait_for_metric(
-                url: str,
-                name: str,
-                predicate,
-                *,
-                labels: Optional[Dict[str, str]] = None,
-                timeout: float = 10.0,
-            ) -> float:
-                deadline = asyncio.get_running_loop().time() + timeout
-                last_value = 0.0
-                last_error: Optional[Exception] = None
-                while asyncio.get_running_loop().time() < deadline:
-                    try:
-                        last_value = await metric(url, name, labels)
-                        last_error = None
-                        if predicate(last_value):
-                            return last_value
-                    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
-                        last_error = error
-                    await asyncio.sleep(0.05)
-                raise AssertionError(
-                    f"Timed out waiting for {name}; "
-                    f"last_value={last_value}, last_error={last_error}"
-                )
-
-            first_response: Optional[aiohttp.ClientResponse] = None
-            filler_tasks: list[asyncio.Task] = []
-            try:
-                await wait_for_model()
-                frontend_send_baseline = await metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                )
-
-                first_response = await asyncio.wait_for(
-                    session.post(chat_url, json=request_payload("active")),
-                    timeout=15,
-                )
-                if first_response.status != 200:
-                    body = await first_response.text()
-                    raise AssertionError(
-                        f"Active bootstrap request returned "
-                        f"{first_response.status}: {body}"
-                    )
-
-                await wait_for_metric(
-                    prefill_metrics_url,
-                    "dynamo_work_handler_pool_active_tasks",
-                    lambda value: value >= 1,
-                )
-                frontend_send_after_first = await wait_for_metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                    lambda value: value >= frontend_send_baseline + 2,
-                )
-
-                # The HTTP 200/decode ingress arrives while prefill is still
-                # active, preserving the bootstrap overlap optimization.
-                assert frontend_send_after_first >= frontend_send_baseline + 2
-
-                frontend_ack_baseline = await metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                )
-
-                dispatcher_task = asyncio.create_task(
-                    session.post(chat_url, json=request_payload("dispatcher-held"))
-                )
-                filler_tasks.append(dispatcher_task)
-                await wait_for_metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                    lambda value: value >= frontend_ack_baseline + 1,
-                )
-                if dispatcher_task.done():
-                    raise AssertionError(
-                        "dispatcher-held request unexpectedly established a response stream"
-                    )
-
-                queued_task = asyncio.create_task(
-                    session.post(chat_url, json=request_payload("queued"))
-                )
-                filler_tasks.append(queued_task)
-                await wait_for_metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                    lambda value: value >= frontend_ack_baseline + 2,
-                )
-                await wait_for_metric(
-                    prefill_metrics_url,
-                    "dynamo_work_handler_queue_depth",
-                    lambda value: value >= 1,
-                )
-                if queued_task.done():
-                    raise AssertionError(
-                        "queued request unexpectedly established a response stream"
-                    )
-
-                frontend_send_before_probe = await metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                )
-                probe_response = await asyncio.wait_for(
-                    session.post(chat_url, json=request_payload("probe")),
-                    timeout=5,
-                )
-                probe_body = await probe_response.text()
-                probe_status = probe_response.status
-                probe_response.release()
-
-                assert probe_status == 529, (
-                    f"Expected prefill admission rejection (529), got "
-                    f"{probe_status}: {probe_body}"
-                )
-
-                # Give any wrongly-detached decode dispatch time to add a
-                # second request-plane send, then prove only prefill was attempted.
-                await asyncio.sleep(0.25)
-                frontend_send_after_probe = await metric(
-                    frontend_metrics_url,
-                    "dynamo_request_plane_send_seconds_count",
-                )
-                assert frontend_send_after_probe == frontend_send_before_probe + 1, (
-                    "rejected prefill dispatched an extra request-plane send: "
-                    f"before={frontend_send_before_probe}, "
-                    f"after={frontend_send_after_probe}"
-                )
-            finally:
-                if first_response is not None:
-                    first_response.close()
-                for task in filler_tasks:
-                    if not task.done():
-                        task.cancel()
-                results = await asyncio.gather(*filler_tasks, return_exceptions=True)
-                for result in results:
-                    if isinstance(result, aiohttp.ClientResponse):
-                        result.close()
-
     with launch_disagg_workers(
         request,
         shared_namespace,
@@ -1261,7 +1049,7 @@ def test_bootstrap_prefill_rejection_gates_decode(
         event_plane="nats",
         prefill_env_overrides=prefill_env,
         decode_env_overrides=decode_env,
-    ) as (prefill_workers, decode_workers):
+    ) as (_prefill_workers, _decode_workers):
         with FrontendRouterProcess(
             request=request,
             block_size=1,
@@ -1271,7 +1059,11 @@ def test_bootstrap_prefill_rejection_gates_decode(
             request_plane=request_plane,
             min_initial_workers=1,
         ):
-            asyncio.run(exercise_gate())
+            _test_bootstrap_prefill_rejection_gates_decode(
+                frontend_port=frontend_port,
+                prefill_system_port=prefill_system_port,
+                test_payload=TEST_PAYLOAD,
+            )
 
 
 @pytest.mark.parametrize(

--- a/tests/router/test_router_e2e_with_mockers.py
+++ b/tests/router/test_router_e2e_with_mockers.py
@@ -16,6 +16,7 @@ import tempfile
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import aiohttp
 import pytest
 
 from tests.router.common import (
@@ -53,6 +54,7 @@ from tests.router.mocker_process import (
     MockerProcess,
     launch_disagg_workers,
 )
+from tests.router.router_process import FrontendRouterProcess
 from tests.utils.constants import ROUTER_MODEL_NAME
 from tests.utils.managed_process import ManagedProcess
 
@@ -194,6 +196,30 @@ SOAK_TEST_PAYLOAD: Dict[str, Any] = {
     "stream": False,
     "max_tokens": 1,
 }
+
+
+def _prometheus_metric_value(
+    metrics_text: str,
+    metric_name: str,
+    labels: Optional[Dict[str, str]] = None,
+) -> float:
+    """Return the sum of matching Prometheus samples, or zero when absent."""
+    total = 0.0
+    for line in metrics_text.splitlines():
+        if not line.startswith(metric_name):
+            continue
+        sample, _, raw_value = line.rpartition(" ")
+        if not sample or not raw_value:
+            continue
+        if labels and not all(
+            f'{key}="{value}"' in sample for key, value in labels.items()
+        ):
+            continue
+        try:
+            total += float(raw_value)
+        except ValueError:
+            continue
+    return total
 
 
 class CounterWorkerProcess:
@@ -973,6 +999,279 @@ def test_router_decisions_disagg(
         test_payload=TEST_PAYLOAD,
         test_kwargs={"enable_bootstrap": enable_disagg_bootstrap},
     )
+
+
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+@pytest.mark.parametrize("num_system_ports", [2], indirect=True)
+@pytest.mark.timeout(120)
+def test_bootstrap_prefill_rejection_gates_decode(
+    request,
+    runtime_services_dynamic_ports,
+    predownload_tokenizers,
+    request_plane,
+    dynamo_dynamic_ports,
+    monkeypatch,
+):
+    """A rejected bootstrap prefill must fail before decode dispatch.
+
+    This is a scaled regression for the statusless phase-barrier bug. The
+    production defaults admit 10,000 active TCP handlers plus a 40,000-item
+    queue, so a 10,001-request test does not saturate ACK admission. Restricting
+    the prefill process to one active handler and one queued item reproduces the
+    same state with four requests:
+
+    1. one slow prefill is active;
+    2. one request is held by the dispatcher waiting for the active permit;
+    3. one request occupies the bounded queue; and
+    4. the probe receives a request-plane rejection.
+
+    The old detached prefill task swallowed that rejection, released the phase
+    barrier, and routed the probe to decode. The fixed path surfaces the error
+    before opening HTTP 200. The first request also proves that accepted
+    bootstrap traffic still overlaps prefill and decode.
+    """
+    monkeypatch.setenv("DYN_TCP_REQUEST_TIMEOUT", "2")
+
+    namespace_suffix = generate_random_suffix()
+    shared_namespace = f"test-namespace-{namespace_suffix}"
+    prefill_system_port, decode_system_port = dynamo_dynamic_ports.system_ports
+    frontend_port = dynamo_dynamic_ports.frontend_port
+
+    prefill_mocker_args = {
+        "engine_type": "sglang",
+        "speedup_ratio": 0.000001,
+        "block_size": 1,
+        "durable_kv_events": False,
+    }
+    decode_mocker_args = {
+        "engine_type": "sglang",
+        "speedup_ratio": 1000.0,
+        "block_size": 1,
+        "durable_kv_events": False,
+    }
+    prefill_env = {
+        "DYN_SYSTEM_PORT": str(prefill_system_port),
+        # Empty explicit-admission knobs make resolve_sizing() use the legacy
+        # pool/queue knobs below even if the outer test environment set them.
+        "DYN_ENGINE_REQUEST_LIMIT": "",
+        "DYN_DYNAMO_REQUEST_QUEUE_LIMIT": "",
+        "DYN_TCP_WORKER_POOL_SIZE": "1",
+        "DYN_TCP_WORK_QUEUE_SIZE": "1",
+    }
+    decode_env = {"DYN_SYSTEM_PORT": str(decode_system_port)}
+
+    def request_payload(tag: str) -> Dict[str, Any]:
+        return {
+            **TEST_PAYLOAD,
+            "messages": [
+                {
+                    **TEST_PAYLOAD["messages"][0],
+                    "content": f'{TEST_PAYLOAD["messages"][0]["content"]} {tag}',
+                }
+            ],
+            "max_tokens": 1,
+            "stream": True,
+        }
+
+    async def exercise_gate() -> None:
+        frontend_url = f"http://localhost:{frontend_port}"
+        chat_url = f"{frontend_url}/v1/chat/completions"
+        frontend_metrics_url = f"{frontend_url}/metrics"
+        prefill_metrics_url = f"http://localhost:{prefill_system_port}/metrics"
+
+        async with aiohttp.ClientSession() as session:
+
+            async def wait_for_model() -> None:
+                deadline = asyncio.get_running_loop().time() + 60
+                last_error: Optional[Exception] = None
+                while asyncio.get_running_loop().time() < deadline:
+                    try:
+                        async with session.get(f"{frontend_url}/v1/models") as response:
+                            if response.status == 200:
+                                models = (await response.json()).get("data", [])
+                                if models:
+                                    return
+                            last_error = RuntimeError(
+                                f"/v1/models returned HTTP {response.status}"
+                            )
+                    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+                        last_error = error
+                    await asyncio.sleep(0.05)
+                raise AssertionError(
+                    f"Timed out waiting for frontend model; last_error={last_error}"
+                )
+
+            async def metric(
+                url: str,
+                name: str,
+                labels: Optional[Dict[str, str]] = None,
+            ) -> float:
+                async with session.get(url) as response:
+                    response.raise_for_status()
+                    return _prometheus_metric_value(await response.text(), name, labels)
+
+            async def wait_for_metric(
+                url: str,
+                name: str,
+                predicate,
+                *,
+                labels: Optional[Dict[str, str]] = None,
+                timeout: float = 10.0,
+            ) -> float:
+                deadline = asyncio.get_running_loop().time() + timeout
+                last_value = 0.0
+                last_error: Optional[Exception] = None
+                while asyncio.get_running_loop().time() < deadline:
+                    try:
+                        last_value = await metric(url, name, labels)
+                        last_error = None
+                        if predicate(last_value):
+                            return last_value
+                    except (aiohttp.ClientError, asyncio.TimeoutError) as error:
+                        last_error = error
+                    await asyncio.sleep(0.05)
+                raise AssertionError(
+                    f"Timed out waiting for {name}; "
+                    f"last_value={last_value}, last_error={last_error}"
+                )
+
+            first_response: Optional[aiohttp.ClientResponse] = None
+            filler_tasks: list[asyncio.Task] = []
+            try:
+                await wait_for_model()
+                frontend_send_baseline = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+
+                first_response = await asyncio.wait_for(
+                    session.post(chat_url, json=request_payload("active")),
+                    timeout=15,
+                )
+                if first_response.status != 200:
+                    body = await first_response.text()
+                    raise AssertionError(
+                        f"Active bootstrap request returned "
+                        f"{first_response.status}: {body}"
+                    )
+
+                await wait_for_metric(
+                    prefill_metrics_url,
+                    "dynamo_work_handler_pool_active_tasks",
+                    lambda value: value >= 1,
+                )
+                frontend_send_after_first = await wait_for_metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= frontend_send_baseline + 2,
+                )
+
+                # The HTTP 200/decode ingress arrives while prefill is still
+                # active, preserving the bootstrap overlap optimization.
+                assert frontend_send_after_first >= frontend_send_baseline + 2
+
+                frontend_ack_baseline = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+
+                dispatcher_task = asyncio.create_task(
+                    session.post(chat_url, json=request_payload("dispatcher-held"))
+                )
+                filler_tasks.append(dispatcher_task)
+                await wait_for_metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= frontend_ack_baseline + 1,
+                )
+                if dispatcher_task.done():
+                    raise AssertionError(
+                        "dispatcher-held request unexpectedly established a response stream"
+                    )
+
+                queued_task = asyncio.create_task(
+                    session.post(chat_url, json=request_payload("queued"))
+                )
+                filler_tasks.append(queued_task)
+                await wait_for_metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                    lambda value: value >= frontend_ack_baseline + 2,
+                )
+                await wait_for_metric(
+                    prefill_metrics_url,
+                    "dynamo_work_handler_queue_depth",
+                    lambda value: value >= 1,
+                )
+                if queued_task.done():
+                    raise AssertionError(
+                        "queued request unexpectedly established a response stream"
+                    )
+
+                frontend_send_before_probe = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+                probe_response = await asyncio.wait_for(
+                    session.post(chat_url, json=request_payload("probe")),
+                    timeout=5,
+                )
+                probe_body = await probe_response.text()
+                probe_status = probe_response.status
+                probe_response.release()
+
+                assert probe_status == 529, (
+                    f"Expected prefill admission rejection (529), got "
+                    f"{probe_status}: {probe_body}"
+                )
+
+                # Give any wrongly-detached decode dispatch time to add a
+                # second request-plane send, then prove only prefill was attempted.
+                await asyncio.sleep(0.25)
+                frontend_send_after_probe = await metric(
+                    frontend_metrics_url,
+                    "dynamo_request_plane_send_seconds_count",
+                )
+                assert frontend_send_after_probe == frontend_send_before_probe + 1, (
+                    "rejected prefill dispatched an extra request-plane send: "
+                    f"before={frontend_send_before_probe}, "
+                    f"after={frontend_send_after_probe}"
+                )
+            finally:
+                if first_response is not None:
+                    first_response.close()
+                for task in filler_tasks:
+                    if not task.done():
+                        task.cancel()
+                results = await asyncio.gather(*filler_tasks, return_exceptions=True)
+                for result in results:
+                    if isinstance(result, aiohttp.ClientResponse):
+                        result.close()
+
+    with launch_disagg_workers(
+        request,
+        shared_namespace,
+        registration_order="prefill_first",
+        prefill_mocker_args=prefill_mocker_args,
+        decode_mocker_args=decode_mocker_args,
+        num_prefill_mockers=1,
+        num_decode_mockers=1,
+        enable_disagg_bootstrap=True,
+        request_plane=request_plane,
+        event_plane="nats",
+        prefill_env_overrides=prefill_env,
+        decode_env_overrides=decode_env,
+    ) as (prefill_workers, decode_workers):
+        with FrontendRouterProcess(
+            request=request,
+            block_size=1,
+            frontend_port=frontend_port,
+            namespace=shared_namespace,
+            enforce_disagg=True,
+            request_plane=request_plane,
+            min_initial_workers=1,
+        ):
+            asyncio.run(exercise_gate())
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Overview:

This PR adds deterministic end-to-end regression coverage for bootstrap-mode Prefill Router delivery.

The test verifies that successful delivery of the prefill request—not completion of prefill execution—is required before the router dispatches the concurrent decode hop. If prefill admission is rejected, the frontend returns an error without sending the request to decode.

## Details:

- Adds a 1-prefill/1-decode SGLang mocker E2E for the TCP request plane.
- Uses test-only `DYN_TCP_WORKER_POOL_SIZE=1` and `DYN_TCP_WORK_QUEUE_SIZE=1` overrides to reproduce admission saturation with four requests:
  1. one request occupies the active prefill handler;
  2. one waits behind the active handler after being drained by the dispatcher;
  3. one occupies the bounded work queue;
  4. the probe is rejected by prefill admission.
- Confirms the accepted bootstrap path still overlaps prefill and decode execution.
- Confirms the rejected probe returns HTTP 529 and increments the frontend request-plane send metric exactly once, proving no decode hop was dispatched.
- Adds explicit barriers for asynchronous Prefill Router activation and dispatcher queue draining to keep the test deterministic.
- Extends the mocker harness with worker-specific environment overrides and metric parsing needed by the test.
- Does not change production TCP worker-pool or work-queue defaults.

Verification:
- At identified fix at main `39d2a6899609`: test passed twice — 22.36s and 22.35s.
- Immediate parent `e42724131aea`: test failed twice — 25.48s and 25.45s.

## Where should the reviewer start?

1. `tests/router/test_router_e2e_with_mockers.py::test_bootstrap_prefill_rejection_gates_decode`
   - Defines the 1P/1D SGLang deployment and test-only TCP admission limits.
2. `tests/router/common.py::_test_bootstrap_prefill_rejection_gates_decode`
   - Implements the saturation sequence, readiness barriers, HTTP 529 assertion, and no-decode oracle.
3. `tests/router/mocker_process.py` and `tests/router/helper.py`
   - Provide the worker-specific harness configuration and exact Prometheus metric parsing used by the test.

## Related Issues

Closes DIS-2413

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling during bootstrap prefill overload conditions.
  * Requests are now rejected promptly with HTTP 529 when prefill capacity is unavailable, preventing them from reaching decode processing.

* **Tests**
  * Added end-to-end coverage for bootstrap prefill rejection and request-queue behavior.
  * Added validation using Prometheus metrics to confirm active tasks and queue depth.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->