### PR TITLE
fix(observability): migrate Grafana dashboards from deprecated frontend gauges to replacements [cherry-pick → release/1.3.0] (DYN-3447)

### DIFF
--- a/benchmarks/frontend/scripts/scaling-test.md
+++ b/benchmarks/frontend/scripts/scaling-test.md
@@ -310,8 +310,8 @@ Key metrics for saturation analysis:
 
 - `dynamo_frontend_stage_duration_seconds{stage="preprocess"}` -- tokenization time
 - `dynamo_frontend_stage_duration_seconds{stage="transport_roundtrip"}` -- backend latency
-- `dynamo_frontend_queued_requests` -- requests waiting in HTTP queue (should be 0 below saturation)
-- `dynamo_frontend_inflight_requests` -- concurrent in-flight requests
+- `sum(dynamo_frontend_stage_requests{stage=~"preprocess|route|dispatch"})` -- requests waiting in pipeline stages (should be 0 below saturation)
+- `dynamo_frontend_active_requests` -- concurrent active requests
 - `dynamo_frontend_time_to_first_token_seconds` -- TTFT histogram buckets
 
 ---

--- a/deploy/observability/grafana-disagg-dashboard-configmap.yaml
+++ b/deploy/observability/grafana-disagg-dashboard-configmap.yaml
@@ -574,8 +574,8 @@ data:
           "targets": [
             {
               "editorMode": "code",
-              "expr": "((dynamo_frontend_queued_requests)) * on(pod, namespace) group_left() kube_pod_status_phase{phase=\"Running\"}",
-              "legendFormat": "{{model}}",
+              "expr": "((sum by(pod, namespace) (dynamo_frontend_stage_requests{stage=~\"preprocess|route|dispatch\", namespace=\"$namespace\"}))) * on(pod, namespace) group_left() kube_pod_status_phase{phase=\"Running\"}",
+              "legendFormat": "{{pod}}",
               "range": true,
               "refId": "A"
             }

--- a/deploy/observability/grafana-dynamo-dashboard-configmap.yaml
+++ b/deploy/observability/grafana-dynamo-dashboard-configmap.yaml
@@ -1115,7 +1115,7 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(dynamo_frontend_queued_requests{model=\"$model\"})",
+              "expr": "sum(dynamo_frontend_stage_requests{stage=~\"preprocess|route|dispatch\"})",
               "legendFormat": "queued",
               "range": true,
               "refId": "B"

--- a/deploy/observability/grafana-dynamo-dashboard-configmap.yaml
+++ b/deploy/observability/grafana-dynamo-dashboard-configmap.yaml
@@ -1104,8 +1104,8 @@ data:
                 "uid": "${datasource}"
               },
               "editorMode": "code",
-              "expr": "sum(dynamo_frontend_inflight_requests{model=\"$model\"})",
-              "legendFormat": "inflight",
+              "expr": "sum(dynamo_frontend_active_requests{model=\"$model\"})",
+              "legendFormat": "active",
               "range": true,
               "refId": "A"
             },
@@ -1121,7 +1121,7 @@ data:
               "refId": "B"
             }
           ],
-          "title": "Inflight vs Queued Requests",
+          "title": "Active vs Queued Requests",
           "type": "timeseries"
         },
         {

--- a/dev/observability/grafana_dashboards/DASHBOARD_METRICS.md
+++ b/dev/observability/grafana_dashboards/DASHBOARD_METRICS.md
@@ -41,7 +41,8 @@ These metrics come from the `dynamo_frontend_*` namespace and are collected from
 | **Frontend Avg Request Duration** | `dynamo_frontend_request_duration_seconds_{sum,count}` | `1000 * (rate(sum[5m]) / rate(count[5m]))` | Total end-to-end request duration in milliseconds over the last 5 minutes |
 | **Frontend Avg Inter-Token Latency** | `dynamo_frontend_inter_token_latency_seconds_{sum,count}` | `1000 * (rate(sum[5m]) / rate(count[5m]))` | Average time (in ms) between token generations during decode phase over the last 5 minutes |
 | **Frontend Avg Input/Output Sequence Length** | `dynamo_frontend_input_sequence_tokens_{sum,count}` & `dynamo_frontend_output_sequence_tokens_{sum,count}` | `rate(sum[5m]) / rate(count[5m])` for each | Average input prompt length (ISL) and output generation length (OSL) in tokens over the last 5 minutes |
-| **Frontend Queued Requests** ⭐⭐⭐ | `dynamo_frontend_queued_requests` | Raw value | Number of requests waiting in queue. **THE key metric for diagnosing worker saturation.** High values (>10) indicate workers cannot keep up with load. Yellow threshold at 10, red at 50 |
+| **Frontend Active Requests** | `dynamo_frontend_active_requests` | Raw value | Number of requests currently being handled by the frontend, from HTTP handler entry to response completion, labeled by model |
+| **Frontend Queued Requests** ⭐⭐⭐ | `dynamo_frontend_stage_requests{stage=~"preprocess\|route\|dispatch"}` | `sum(...)` | Number of requests in the preprocess/route/dispatch stages (waiting before a worker is dispatched). **THE key metric for diagnosing worker saturation.** High values (>10) indicate workers cannot keep up with load. Yellow threshold at 10, red at 50 |
 
 ### GPU Metrics (from DCGM Exporter)
 These metrics come from the DCGM (Data Center GPU Manager) exporter running as a DaemonSet in the `gpu-operator` namespace. DCGM collects hardware-level GPU metrics.

--- a/dev/observability/grafana_dashboards/disagg-dashboard.json
+++ b/dev/observability/grafana_dashboards/disagg-dashboard.json
@@ -562,8 +562,8 @@
       "targets": [
         {
           "editorMode": "code",
-          "expr": "((dynamo_frontend_queued_requests)) * on(pod, namespace) group_left() kube_pod_status_phase{phase=\"Running\"}",
-          "legendFormat": "{{model}}",
+          "expr": "((sum by(pod, namespace) (dynamo_frontend_stage_requests{stage=~\"preprocess|route|dispatch\", namespace=\"$namespace\"}))) * on(pod, namespace) group_left() kube_pod_status_phase{phase=\"Running\"}",
+          "legendFormat": "{{pod}}",
           "range": true,
           "refId": "A"
         }

--- a/dev/observability/grafana_dashboards/dynamo.json
+++ b/dev/observability/grafana_dashboards/dynamo.json
@@ -1092,8 +1092,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(dynamo_frontend_inflight_requests{model=\"$model\"})",
-          "legendFormat": "inflight",
+          "expr": "sum(dynamo_frontend_active_requests{model=\"$model\"})",
+          "legendFormat": "active",
           "range": true,
           "refId": "A"
         },
@@ -1109,7 +1109,7 @@
           "refId": "B"
         }
       ],
-      "title": "Inflight vs Queued Requests",
+      "title": "Active vs Queued Requests",
       "type": "timeseries"
     },
     {

--- a/dev/observability/grafana_dashboards/dynamo.json
+++ b/dev/observability/grafana_dashboards/dynamo.json
@@ -1103,7 +1103,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(dynamo_frontend_queued_requests{model=\"$model\"})",
+          "expr": "sum(dynamo_frontend_stage_requests{stage=~\"preprocess|route|dispatch\"})",
           "legendFormat": "queued",
           "range": true,
           "refId": "B"

--- a/dev/observability/grafana_dashboards/sglang.json
+++ b/dev/observability/grafana_dashboards/sglang.json
@@ -823,8 +823,8 @@
     {
       "id": 14,
       "type": "timeseries",
-      "title": "Inflight vs Queued Requests",
-      "description": "DYN: dynamo_frontend_inflight_requests / queued_requests gauges. Inflight = currently being processed (dispatched to a worker, awaiting completion). Queued = received by the frontend but not yet dispatched (waiting on router scheduling / worker permit). Inflight pinned at the worker concurrency limit while queued grows means workers are saturated and the gateway is buffering.",
+      "title": "Active vs Queued Requests",
+      "description": "DYN: dynamo_frontend_active_requests / stage_requests gauges. Active = currently being processed (dispatched to a worker, awaiting completion). Queued = sum of stage_requests across the preprocess, route, and dispatch stages (requests received but not yet sent to a worker). Active pinned at the worker concurrency limit while queued grows means workers are saturated and the gateway is buffering.",
       "datasource": {
         "type": "prometheus",
         "uid": "${datasource}"
@@ -895,8 +895,8 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(dynamo_frontend_inflight_requests)",
-          "legendFormat": "inflight",
+          "expr": "sum(dynamo_frontend_active_requests)",
+          "legendFormat": "active",
           "range": true,
           "refId": "A"
         },
@@ -906,7 +906,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(dynamo_frontend_queued_requests)",
+          "expr": "sum(dynamo_frontend_stage_requests{stage=~\"preprocess|route|dispatch\"})",
           "legendFormat": "queued",
           "range": true,
           "refId": "B"

--- a/lib/llm/tests/http_metrics.rs
+++ b/lib/llm/tests/http_metrics.rs
@@ -116,7 +116,7 @@ async fn test_metrics_prefix_default() {
         // Assert metrics that are actually present in the default configuration
         assert!(body.contains("dynamo_frontend_requests_started_total"));
         assert!(body.contains("dynamo_frontend_requests_total"));
-        assert!(body.contains("dynamo_frontend_inflight_requests"));
+        assert!(body.contains("dynamo_frontend_active_requests"));
         assert!(body.contains("dynamo_frontend_request_duration_seconds"));
         assert!(body.contains("dynamo_frontend_disconnected_clients"));
 
@@ -302,7 +302,7 @@ async fn test_metrics_with_mock_model() {
         // Assert that key metrics are present with the mockmodel
         assert!(metrics_body.contains("dynamo_frontend_requests_total"));
         assert!(metrics_body.contains("model=\"mockmodel\""));
-        assert!(metrics_body.contains("dynamo_frontend_inflight_requests"));
+        assert!(metrics_body.contains("dynamo_frontend_active_requests"));
         assert!(metrics_body.contains("dynamo_frontend_request_duration_seconds"));
         assert!(metrics_body.contains("dynamo_frontend_output_sequence_tokens"));
         assert!(metrics_body.contains("dynamo_frontend_queued_requests"));
@@ -626,7 +626,7 @@ mod integration_tests {
         assert!(metrics_body.contains("dynamo_frontend_requests_started_total"));
         assert!(metrics_body.contains("dynamo_frontend_requests_total"));
         assert!(metrics_body.contains(&format!("model=\"{}\"", model_name)));
-        assert!(metrics_body.contains("dynamo_frontend_inflight_requests"));
+        assert!(metrics_body.contains("dynamo_frontend_active_requests"));
         assert!(metrics_body.contains("dynamo_frontend_request_duration_seconds"));
         assert!(metrics_body.contains("dynamo_frontend_output_sequence_tokens"));
         assert!(metrics_body.contains("dynamo_frontend_queued_requests"));

--- a/lib/llm/tests/kserve_service.rs
+++ b/lib/llm/tests/kserve_service.rs
@@ -1947,8 +1947,8 @@ pub mod kserve_test {
 
         // Verify metrics are present and have correct values
         assert!(
-            metrics_body.contains("dynamo_frontend_inflight_requests"),
-            "Metrics should contain inflight gauge"
+            metrics_body.contains("dynamo_frontend_active_requests"),
+            "Metrics should contain active requests gauge"
         );
         assert_metric_value(&metrics_body, "test_model", "completions", 1);
         assert_metric_value(&metrics_body, "test_tensor_model", "tensor", 1);

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -46,7 +46,7 @@
 //! - ✅ `dynamo_frontend_request_duration_seconds` - Request duration histogram (not `response_time`)
 //! - ✅ `dynamo_component_errors_total` - Total error counter (not `total_errors`)
 //! - ✅ `dynamo_component_memory_usage_bytes` - Memory usage gauge
-//! - ✅ `dynamo_frontend_inflight_requests` - Current inflight requests gauge
+//! - ✅ `dynamo_frontend_active_requests` - Current active requests gauge
 //! - ✅ `dynamo_component_cpu_usage_percent` - CPU usage percentage
 //! - ✅ `dynamo_frontend_tokens_per_second` - Token generation rate
 //! - ✅ `dynamo_messaging_client_connection_duration_ms` - Connection time in milliseconds


### PR DESCRIPTION
## Summary

Cherry-pick of #11497 to `release/1.3.0`.

- Replaces `dynamo_frontend_inflight_requests` → `dynamo_frontend_active_requests` across all dashboard artifacts
- Replaces `dynamo_frontend_queued_requests` → `dynamo_frontend_stage_requests{stage=~"preprocess|route|dispatch"}` (disagg/dynamo dashboards)
- Updates panel descriptions and test assertions to match new metric names
- Affected files: 2 Grafana ConfigMaps under `deploy/observability/`, 3 dashboard JSONs under `dev/observability/`, docs, and test fixtures

The deprecated gauges are still emitted on 1.3.0-rc.4 so panels currently render, but the official dashboards were modeling usage the docs tell users to migrate away from. This fixes the forward-looking blank-panel risk and the guidance inconsistency.

Refs: DYN-3447

## Test plan

- [ ] Verify `grep -rn "frontend_inflight_requests\|frontend_queued_requests" deploy/observability dev/observability` returns no hits after merge
- [ ] Confirm Grafana dashboards load and panels populate against a live 1.3.0 frontend