### PR TITLE
fix(trtllm): log deprecation notices so operators see them

### DIFF
--- a/components/src/dynamo/trtllm/args.py
+++ b/components/src/dynamo/trtllm/args.py
@@ -16,7 +16,11 @@ from dynamo.common.configuration.groups.runtime_args import (
     DynamoRuntimeConfig,
 )
 from dynamo.common.utils.runtime import parse_endpoint
-from dynamo.trtllm.backend_args import DynamoTrtllmArgGroup, DynamoTrtllmConfig
+from dynamo.trtllm.backend_args import (
+    DynamoTrtllmArgGroup,
+    DynamoTrtllmConfig,
+    _warn_deprecated,
+)
 from dynamo.trtllm.constants import DisaggregationMode, Modality
 from dynamo.trtllm.dynamic_flags import parse_dynamic_flags
 
@@ -88,26 +92,18 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> Config:
         in ("--publish-events-and-metrics", "--no-publish-events-and-metrics")
         for a in cli_args
     ):
-        import warnings
-
-        warnings.warn(
+        _warn_deprecated(
             "--publish-events-and-metrics is deprecated; use --publish-kv-events. "
-            "The old flag stays as an alias for one release.",
-            DeprecationWarning,
-            stacklevel=2,
+            "The old flag stays as an alias for one release."
         )
     if (
         "DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS" in os.environ
         and "DYN_TRTLLM_PUBLISH_KV_EVENTS" not in os.environ
     ):
-        import warnings
-
-        warnings.warn(
+        _warn_deprecated(
             "DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS is deprecated; use "
             "DYN_TRTLLM_PUBLISH_KV_EVENTS. The old env var stays as an "
-            "alias for one release.",
-            DeprecationWarning,
-            stacklevel=2,
+            "alias for one release."
         )
         os.environ["DYN_TRTLLM_PUBLISH_KV_EVENTS"] = os.environ[
             "DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS"

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -4,6 +4,7 @@
 """Unit tests for TRTLLM backend components."""
 
 import asyncio
+import os
 import re
 import warnings
 from pathlib import Path
@@ -114,6 +115,46 @@ def test_config_use_kv_events_derived_from_publish_events(monkeypatch):
     config_off = parse_args(["--no-publish-events"])
     assert config_off.publish_events_and_metrics is False
     assert config_off.use_kv_events is False
+
+
+def test_deprecated_publish_events_flag_alias_maps_and_logs(monkeypatch, caplog):
+    """The deprecated --publish-events-and-metrics alias must still map to
+    publish_events_and_metrics AND surface its deprecation notice on the log
+    stream, which is visible under CPython's default warning filters (a bare
+    warnings.warn(DeprecationWarning) from library code is not)."""
+    monkeypatch.delenv("DYN_TRTLLM_PUBLISH_KV_EVENTS", raising=False)
+    monkeypatch.delenv("DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS", raising=False)
+    with caplog.at_level("WARNING"):
+        config = parse_args(["--publish-events-and-metrics"])
+    assert config.publish_events_and_metrics is True
+    assert config.use_kv_events is True
+    assert any(
+        "--publish-events-and-metrics is deprecated" in r.message
+        for r in caplog.records
+    )
+
+
+def test_deprecated_publish_events_env_alias_maps_and_logs(monkeypatch, caplog):
+    """The deprecated DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS env var must still
+    map to the new env var AND surface its deprecation notice on the log
+    stream."""
+    monkeypatch.delenv("DYN_TRTLLM_PUBLISH_KV_EVENTS", raising=False)
+    monkeypatch.setenv("DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS", "true")
+    with caplog.at_level("WARNING"):
+        config = parse_args([])
+    try:
+        assert config.publish_events_and_metrics is True
+        assert config.use_kv_events is True
+        # parse_args copies the deprecated env var into the new one via a direct
+        # os.environ write, which monkeypatch does not track — pop it so it does
+        # not leak into later tests.
+        assert os.environ["DYN_TRTLLM_PUBLISH_KV_EVENTS"] == "true"
+        assert any(
+            "DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS is deprecated" in r.message
+            for r in caplog.records
+        )
+    finally:
+        os.environ.pop("DYN_TRTLLM_PUBLISH_KV_EVENTS", None)
 
 
 @pytest.mark.asyncio

--- a/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_unit.py
@@ -124,7 +124,9 @@ def test_deprecated_publish_events_flag_alias_maps_and_logs(monkeypatch, caplog)
     warnings.warn(DeprecationWarning) from library code is not)."""
     monkeypatch.delenv("DYN_TRTLLM_PUBLISH_KV_EVENTS", raising=False)
     monkeypatch.delenv("DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS", raising=False)
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING"), pytest.warns(
+        DeprecationWarning, match="--publish-events-and-metrics is deprecated"
+    ):
         config = parse_args(["--publish-events-and-metrics"])
     assert config.publish_events_and_metrics is True
     assert config.use_kv_events is True
@@ -138,23 +140,23 @@ def test_deprecated_publish_events_env_alias_maps_and_logs(monkeypatch, caplog):
     """The deprecated DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS env var must still
     map to the new env var AND surface its deprecation notice on the log
     stream."""
+    # parse_args copies the deprecated env var into the new one via a direct
+    # os.environ write. Swap in a throwaway copy so monkeypatch restores the real
+    # environment on teardown and that write does not leak into later tests.
+    monkeypatch.setattr(os, "environ", os.environ.copy())
     monkeypatch.delenv("DYN_TRTLLM_PUBLISH_KV_EVENTS", raising=False)
     monkeypatch.setenv("DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS", "true")
-    with caplog.at_level("WARNING"):
+    with caplog.at_level("WARNING"), pytest.warns(
+        DeprecationWarning, match="DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS is deprecated"
+    ):
         config = parse_args([])
-    try:
-        assert config.publish_events_and_metrics is True
-        assert config.use_kv_events is True
-        # parse_args copies the deprecated env var into the new one via a direct
-        # os.environ write, which monkeypatch does not track — pop it so it does
-        # not leak into later tests.
-        assert os.environ["DYN_TRTLLM_PUBLISH_KV_EVENTS"] == "true"
-        assert any(
-            "DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS is deprecated" in r.message
-            for r in caplog.records
-        )
-    finally:
-        os.environ.pop("DYN_TRTLLM_PUBLISH_KV_EVENTS", None)
+    assert config.publish_events_and_metrics is True
+    assert config.use_kv_events is True
+    assert os.environ["DYN_TRTLLM_PUBLISH_KV_EVENTS"] == "true"
+    assert any(
+        "DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS is deprecated" in r.message
+        for r in caplog.records
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

PR #9586 renamed `--publish-events-and-metrics` → `--publish-kv-events` (and the matching env var), keeping the old names as a one-release alias documented to emit a `DeprecationWarning` at startup. The warning was raised via `warnings.warn(..., DeprecationWarning)` from `dynamo.trtllm.args`, but CPython's default filter (`default::DeprecationWarning:main`) only shows `DeprecationWarning`s attributed to the `main` module. In the real deployment shape (`python -m dynamo.trtllm`, parse call inside a package module) the warning is attributed to `dynamo.trtllm.args`, so it is **silently filtered** — operators running the old flag/env got no signal during the deprecation window and would hard-fail when the alias is removed next release.

This routes both notices through `backend_args._warn_deprecated`, which additionally logs at `WARNING` via the module logger (visible by default in a server process), while keeping the `warnings.warn` channel for anyone who has configured filters. This matches the other deprecation shim already in the same package (`backend_args._warn_deprecated`), so the engine now has one consistent, operator-visible mechanism instead of one visible and one silent.

Fix approach follows Option A from the issue analysis (switch to logging; reuse the existing helper).

## Validation

- Added two regression tests in `test_trtllm_unit.py`:
  - `test_deprecated_publish_events_flag_alias_maps_and_logs` — the deprecated `--publish-events-and-metrics` flag still maps to `publish_events_and_metrics`/`use_kv_events` **and** the notice reaches the log stream (asserted via `caplog`).
  - `test_deprecated_publish_events_env_alias_maps_and_logs` — same for the `DYN_TRTLLM_PUBLISH_EVENTS_AND_METRICS` env var alias, including the env copy into the new var.
- Both tests pass via `pytest` against the real `parse_args` code path.
- Confirmed the deprecation notice now appears on the log stream under CPython's default warning filters (no `PYTHONWARNINGS` set).
- `pre-commit` (isort, black, flake8, ruff, codespell, pytest-marker report, …) passes clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprecation warnings for legacy TensorRT-LLM command-line and environment-variable options.
  * Preserved compatibility with existing aliases and their configuration behavior.

* **Tests**
  * Added coverage confirming legacy options continue to work and generate appropriate warnings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->