### PR TITLE
fix(profiler): mocker workers load from PVC path offline (DGH-1124)

### DIFF
--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -15,14 +15,17 @@ try:
     from dynamo.profiler.utils.dgd_generation import (
         _build_planner_config,
         _inject_mocker_aic_args,
+        _mocker_worker_names,
         build_aic_interpolation_spec,
         build_aic_perf_model_spec,
         enable_vllm_benchmark_mode,
+        generate_mocker_config,
     )
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
         FeaturesSpec,
         MockerSpec,
+        ModelCacheSpec,
     )
 except ImportError as e:
     pytest.skip(f"Missing dependency: {e}", allow_module_level=True)
@@ -526,3 +529,60 @@ class TestEnableVllmBenchmarkMode:
         assert (
             _benchmark_mode(cfg["spec"]["services"]["VllmPrefillWorker"]) == "prefill"
         )
+
+
+class TestMockerModelCachePvc:
+    """DGH-1124: mocker workers must load from the local PVC path (not the HF
+    id) and get the model-cache PVC mounted, so offline deployments work."""
+
+    def _mocker_worker_args(self, cfg, worker):
+        svc = cfg["spec"]["services"][worker]
+        return svc, svc["extraPodSpec"]["mainContainer"]["args"]
+
+    def test_mocker_offline_pvc_uses_local_path_and_mounts_pvc(self, tmp_path):
+        # Stage a local model dir with config.json on the "PVC" so
+        # resolve_model_path prefers it over the HF id.
+        mount = tmp_path / "models"
+        model_dir = mount / "org" / "model"
+        model_dir.mkdir(parents=True)
+        (model_dir / "config.json").write_text("{}")
+
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            model="org/model",
+            features=FeaturesSpec(mocker=MockerSpec(enabled=True)),
+            modelCache=ModelCacheSpec(
+                pvcName="model-cache",
+                pvcMountPath=str(mount),
+                pvcModelPath="org/model",
+            ),
+        )
+
+        cfg = generate_mocker_config(dgdr, aic_spec=None)
+
+        for worker in _mocker_worker_names():
+            svc, args = self._mocker_worker_args(cfg, worker)
+            # served name stays the model id so requests match
+            assert args[args.index("--model-name") + 1] == "org/model"
+            # load path is the local PVC path, not the HF id
+            assert args[args.index("--model-path") + 1] == str(model_dir)
+            # the model-cache PVC is mounted onto the worker
+            mounts = svc["extraPodSpec"]["mainContainer"]["volumeMounts"]
+            assert any(m["mountPath"] == str(mount) for m in mounts)
+            volumes = svc["extraPodSpec"]["volumes"]
+            assert any(
+                v.get("persistentVolumeClaim", {}).get("claimName") == "model-cache"
+                for v in volumes
+            )
+
+    def test_mocker_without_pvc_falls_back_to_model_id(self):
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            model="org/model",
+            features=FeaturesSpec(mocker=MockerSpec(enabled=True)),
+        )
+        cfg = generate_mocker_config(dgdr, aic_spec=None)
+        for worker in _mocker_worker_names():
+            svc, args = self._mocker_worker_args(cfg, worker)
+            assert args[args.index("--model-path") + 1] == "org/model"
+            # no PVC configured -> no model-cache mount added
+            mounts = svc["extraPodSpec"]["mainContainer"].get("volumeMounts", [])
+            assert not any(m.get("name") == "model-cache" for m in mounts)

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -532,7 +532,7 @@ class TestEnableVllmBenchmarkMode:
 
 
 class TestMockerModelCachePvc:
-    """DGH-1124: mocker workers must load from the local PVC path (not the HF
+    """#11650: mocker workers must load from the local PVC path (not the HF
     id) and get the model-cache PVC mounted, so offline deployments work."""
 
     def _mocker_worker_args(self, cfg, worker):
@@ -565,12 +565,16 @@ class TestMockerModelCachePvc:
             assert args[args.index("--model-name") + 1] == "org/model"
             # load path is the local PVC path, not the HF id
             assert args[args.index("--model-path") + 1] == str(model_dir)
-            # the model-cache PVC is mounted onto the worker
+            # the model-cache PVC is mounted read-only onto the worker
             mounts = svc["extraPodSpec"]["mainContainer"]["volumeMounts"]
-            assert any(m["mountPath"] == str(mount) for m in mounts)
+            assert any(
+                m["mountPath"] == str(mount) and m.get("readOnly") is True
+                for m in mounts
+            )
             volumes = svc["extraPodSpec"]["volumes"]
             assert any(
                 v.get("persistentVolumeClaim", {}).get("claimName") == "model-cache"
+                and v.get("persistentVolumeClaim", {}).get("readOnly") is True
                 for v in volumes
             )
 

--- a/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
+++ b/components/src/dynamo/profiler/tests/unit/test_dgd_generation_aic.py
@@ -565,18 +565,42 @@ class TestMockerModelCachePvc:
             assert args[args.index("--model-name") + 1] == "org/model"
             # load path is the local PVC path, not the HF id
             assert args[args.index("--model-path") + 1] == str(model_dir)
-            # the model-cache PVC is mounted read-only onto the worker
+            # the model-cache PVC is mounted onto the worker
             mounts = svc["extraPodSpec"]["mainContainer"]["volumeMounts"]
-            assert any(
-                m["mountPath"] == str(mount) and m.get("readOnly") is True
-                for m in mounts
-            )
+            assert any(m["mountPath"] == str(mount) for m in mounts)
             volumes = svc["extraPodSpec"]["volumes"]
             assert any(
                 v.get("persistentVolumeClaim", {}).get("claimName") == "model-cache"
-                and v.get("persistentVolumeClaim", {}).get("readOnly") is True
                 for v in volumes
             )
+            # weights mode (pvcModelPath set): no HF_HOME injected
+            env = svc["extraPodSpec"]["mainContainer"].get("env", [])
+            assert not any(e.get("name") == "HF_HOME" for e in env)
+
+    def test_mocker_hf_cache_pvc_mounts_and_sets_hf_home(self):
+        # PVC configured without pvcModelPath -> HF-cache mode: mount the PVC
+        # and point HF_HOME at it, but keep --model-path as the HF id.
+        dgdr = DynamoGraphDeploymentRequestSpec(
+            model="org/model",
+            features=FeaturesSpec(mocker=MockerSpec(enabled=True)),
+            modelCache=ModelCacheSpec(
+                pvcName="model-cache",
+                pvcMountPath="/opt/model-cache",
+            ),
+        )
+
+        cfg = generate_mocker_config(dgdr, aic_spec=None)
+
+        for worker in _mocker_worker_names():
+            svc, args = self._mocker_worker_args(cfg, worker)
+            # no explicit checkpoint dir -> load path stays the HF id
+            assert args[args.index("--model-path") + 1] == "org/model"
+            # the PVC is still mounted
+            mounts = svc["extraPodSpec"]["mainContainer"]["volumeMounts"]
+            assert any(m["mountPath"] == "/opt/model-cache" for m in mounts)
+            # HF_HOME points at the mount so the worker uses the PVC as HF cache
+            env = svc["extraPodSpec"]["mainContainer"]["env"]
+            assert {"name": "HF_HOME", "value": "/opt/model-cache"} in env
 
     def test_mocker_without_pvc_falls_back_to_model_id(self):
         dgdr = DynamoGraphDeploymentRequestSpec(

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -262,17 +262,14 @@ def generate_mocker_config(
 def _mount_model_cache_pvc(service_dict: dict, dgdr) -> None:
     """Mount the DGDR's model-cache PVC into a service's mainContainer.
 
-    No-op unless the model-cache PVC is fully specified — the same fields
-    resolve_model_path needs to point --model-path at the mount, so we never
-    add a mount the worker's load path won't reference.
+    Mirrors the real-backend path (protocol.py): mount whenever the PVC is
+    configured. When pvcModelPath is set the weights live at a known path and
+    --model-path already points there (resolve_model_path); when it is absent
+    the PVC is an HF cache, so point HF_HOME at the mount so an offline worker
+    reads from it instead of fetching from HuggingFace.
     """
     model_cache = dgdr.modelCache
-    if not (
-        model_cache
-        and model_cache.pvcName
-        and model_cache.pvcMountPath
-        and model_cache.pvcModelPath
-    ):
+    if not (model_cache and model_cache.pvcName and model_cache.pvcMountPath):
         return
 
     volume_name = "model-cache"
@@ -280,20 +277,22 @@ def _mount_model_cache_pvc(service_dict: dict, dgdr) -> None:
     extra_pod_spec.setdefault("volumes", []).append(
         {
             "name": volume_name,
-            "persistentVolumeClaim": {
-                "claimName": model_cache.pvcName,
-                "readOnly": True,
-            },
+            "persistentVolumeClaim": {"claimName": model_cache.pvcName},
         }
     )
     main_container = extra_pod_spec.setdefault("mainContainer", {})
     main_container.setdefault("volumeMounts", []).append(
-        {
-            "name": volume_name,
-            "mountPath": model_cache.pvcMountPath,
-            "readOnly": True,
-        }
+        {"name": volume_name, "mountPath": model_cache.pvcMountPath}
     )
+
+    if not model_cache.pvcModelPath:
+        # HF-cache PVC mode: no explicit checkpoint dir, so --model-path stays
+        # the HF id and the PVC serves as the HF cache. Point HF_HOME at it.
+        env = main_container.setdefault("env", [])
+        env[:] = [
+            e for e in env if not (isinstance(e, dict) and e.get("name") == "HF_HOME")
+        ]
+        env.append({"name": "HF_HOME", "value": model_cache.pvcMountPath})
 
 
 def enable_planner_worker_scaling_adapters(

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -233,7 +233,7 @@ def generate_mocker_config(
             ].get("mainContainer"):
                 service_config["extraPodSpec"]["mainContainer"]["image"] = image
 
-    # DGH-1124: the served name stays the model id (so requests match), but the
+    # #11650: the served name stays the model id (so requests match), but the
     # load path must prefer the local PVC mount — otherwise an offline mocker
     # worker tries to fetch the tokenizer from HuggingFace, fails, and never
     # registers. resolve_model_path returns the local PVC path when the model
@@ -256,7 +256,7 @@ def generate_mocker_config(
             if pick is not None and aic_spec is not None:
                 args_list = _inject_mocker_aic_args(args_list, aic_spec, pick)
             main_container["args"] = args_list
-            # DGH-1124: mount the model-cache PVC so an offline mocker worker can
+            # #11650: mount the model-cache PVC so an offline mocker worker can
             # read the model from the PVC instead of reaching for HuggingFace.
             _mount_model_cache_pvc(service_config, dgdr)
 
@@ -269,7 +269,7 @@ def _mount_model_cache_pvc(service_dict: dict, dgdr) -> None:
     No-op when no model cache PVC is configured. Idempotent — skips if a volume
     or mount for the PVC is already present (e.g. user override).
     """
-    model_cache = getattr(dgdr, "modelCache", None)
+    model_cache = dgdr.modelCache
     if not (model_cache and model_cache.pvcName and model_cache.pvcMountPath):
         return
 

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -233,11 +233,8 @@ def generate_mocker_config(
             ].get("mainContainer"):
                 service_config["extraPodSpec"]["mainContainer"]["image"] = image
 
-    # #11650: the served name stays the model id (so requests match), but the
-    # load path must prefer the local PVC mount — otherwise an offline mocker
-    # worker tries to fetch the tokenizer from HuggingFace, fails, and never
-    # registers. resolve_model_path returns the local PVC path when the model
-    # is present there, else the model id (mirrors the real-backend path).
+    # #11650: served name stays the model id (so requests match); load path
+    # prefers the local PVC mount so an offline worker doesn't reach for HF.
     model_name = dgdr.model
     model_path = resolve_model_path(dgdr)
     aic_workers = _mocker_aic_worker_picks(aic_spec)
@@ -256,8 +253,7 @@ def generate_mocker_config(
             if pick is not None and aic_spec is not None:
                 args_list = _inject_mocker_aic_args(args_list, aic_spec, pick)
             main_container["args"] = args_list
-            # #11650: mount the model-cache PVC so an offline mocker worker can
-            # read the model from the PVC instead of reaching for HuggingFace.
+            # #11650: mount the model-cache PVC so the offline worker reads from it.
             _mount_model_cache_pvc(service_config, dgdr)
 
     return mocker_config
@@ -266,36 +262,38 @@ def generate_mocker_config(
 def _mount_model_cache_pvc(service_dict: dict, dgdr) -> None:
     """Mount the DGDR's model-cache PVC into a service's mainContainer.
 
-    No-op when no model cache PVC is configured. Idempotent — skips if a volume
-    or mount for the PVC is already present (e.g. user override).
+    No-op unless the model-cache PVC is fully specified — the same fields
+    resolve_model_path needs to point --model-path at the mount, so we never
+    add a mount the worker's load path won't reference.
     """
     model_cache = dgdr.modelCache
-    if not (model_cache and model_cache.pvcName and model_cache.pvcMountPath):
+    if not (
+        model_cache
+        and model_cache.pvcName
+        and model_cache.pvcMountPath
+        and model_cache.pvcModelPath
+    ):
         return
 
     volume_name = "model-cache"
     extra_pod_spec = service_dict.setdefault("extraPodSpec", {})
-    volumes = extra_pod_spec.setdefault("volumes", [])
-    if not any(v.get("name") == volume_name for v in volumes):
-        volumes.append(
-            {
-                "name": volume_name,
-                "persistentVolumeClaim": {
-                    "claimName": model_cache.pvcName,
-                    "readOnly": True,
-                },
-            }
-        )
-    main_container = extra_pod_spec.setdefault("mainContainer", {})
-    volume_mounts = main_container.setdefault("volumeMounts", [])
-    if not any(m.get("name") == volume_name for m in volume_mounts):
-        volume_mounts.append(
-            {
-                "name": volume_name,
-                "mountPath": model_cache.pvcMountPath,
+    extra_pod_spec.setdefault("volumes", []).append(
+        {
+            "name": volume_name,
+            "persistentVolumeClaim": {
+                "claimName": model_cache.pvcName,
                 "readOnly": True,
-            }
-        )
+            },
+        }
+    )
+    main_container = extra_pod_spec.setdefault("mainContainer", {})
+    main_container.setdefault("volumeMounts", []).append(
+        {
+            "name": volume_name,
+            "mountPath": model_cache.pvcMountPath,
+            "readOnly": True,
+        }
+    )
 
 
 def enable_planner_worker_scaling_adapters(

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -44,6 +44,7 @@ from dynamo.profiler.utils.profile_common import (
     is_mocker_enabled,
     is_planner_enabled,
     needs_profile_data,
+    resolve_model_path,
 )
 
 logger = logging.getLogger(__name__)
@@ -232,7 +233,13 @@ def generate_mocker_config(
             ].get("mainContainer"):
                 service_config["extraPodSpec"]["mainContainer"]["image"] = image
 
-    model = dgdr.model
+    # DGH-1124: the served name stays the model id (so requests match), but the
+    # load path must prefer the local PVC mount — otherwise an offline mocker
+    # worker tries to fetch the tokenizer from HuggingFace, fails, and never
+    # registers. resolve_model_path returns the local PVC path when the model
+    # is present there, else the model id (mirrors the real-backend path).
+    model_name = dgdr.model
+    model_path = resolve_model_path(dgdr)
     aic_workers = _mocker_aic_worker_picks(aic_spec)
     for worker_name in _mocker_worker_names():
         service_config = (
@@ -243,14 +250,52 @@ def generate_mocker_config(
                 "mainContainer", {}
             )
             args_list = main_container.get("args", [])
-            args_list = set_argument_value(args_list, "--model-path", model)
-            args_list = set_argument_value(args_list, "--model-name", model)
+            args_list = set_argument_value(args_list, "--model-path", model_path)
+            args_list = set_argument_value(args_list, "--model-name", model_name)
             pick = aic_workers.get(worker_name) if aic_workers else None
             if pick is not None and aic_spec is not None:
                 args_list = _inject_mocker_aic_args(args_list, aic_spec, pick)
             main_container["args"] = args_list
+            # DGH-1124: mount the model-cache PVC so an offline mocker worker can
+            # read the model from the PVC instead of reaching for HuggingFace.
+            _mount_model_cache_pvc(service_config, dgdr)
 
     return mocker_config
+
+
+def _mount_model_cache_pvc(service_dict: dict, dgdr) -> None:
+    """Mount the DGDR's model-cache PVC into a service's mainContainer.
+
+    No-op when no model cache PVC is configured. Idempotent — skips if a volume
+    or mount for the PVC is already present (e.g. user override).
+    """
+    model_cache = getattr(dgdr, "modelCache", None)
+    if not (model_cache and model_cache.pvcName and model_cache.pvcMountPath):
+        return
+
+    volume_name = "model-cache"
+    extra_pod_spec = service_dict.setdefault("extraPodSpec", {})
+    volumes = extra_pod_spec.setdefault("volumes", [])
+    if not any(v.get("name") == volume_name for v in volumes):
+        volumes.append(
+            {
+                "name": volume_name,
+                "persistentVolumeClaim": {
+                    "claimName": model_cache.pvcName,
+                    "readOnly": True,
+                },
+            }
+        )
+    main_container = extra_pod_spec.setdefault("mainContainer", {})
+    volume_mounts = main_container.setdefault("volumeMounts", [])
+    if not any(m.get("name") == volume_name for m in volume_mounts):
+        volume_mounts.append(
+            {
+                "name": volume_name,
+                "mountPath": model_cache.pvcMountPath,
+                "readOnly": True,
+            }
+        )
 
 
 def enable_planner_worker_scaling_adapters(


### PR DESCRIPTION
Closes #11650

## Summary

Fixes DGH-1124 / #11650. In an **offline / model-cache-PVC** deployment with the mocker enabled, inference requests return `model not found` even though the model dir is mounted.

Root cause is **mocker-specific** (not a general frontend/offline issue). `generate_mocker_config` set the mocker workers' `--model-path` to the raw model id (`spec.model`, an HF id) and never mounted the `modelCache` PVC onto the mocker worker pods. Offline, the mocker worker then tries to fetch the tokenizer from HuggingFace, fails with no network, and never registers — so the frontend has no worker card for the model and reports `model not found`.

The real (vLLM) backend path already does the right thing via `resolve_model_path` + a PVC mount, which is why it serves offline. This change mirrors that in the mocker path:

- `--model-path` = `resolve_model_path(dgdr)` — the **local PVC path** when the model is present there, else the model id.
- `--model-name` = `dgdr.model` unchanged, so the **served name** still matches incoming requests.
- Mount the `modelCache` PVC onto the mocker workers (idempotent helper).

## Validation

- Reproduced the failure and the fix at the worker level with the literal `python -m dynamo.mocker` offline (empty HF cache, `HF_HUB_OFFLINE=1`): HF-id `--model-path` crashes at startup (`Model snapshots ... not found in cache`, never registers); local PVC path loads the tokenizer and registers `dynamo.backend.generate`.
- New generator unit tests in `test_dgd_generation_aic.py` (`TestMockerModelCachePvc`): offline+PVC uses the local path and mounts the PVC; no-PVC falls back to the model id.
- `pytest` profiler unit suite: 31 passed. isort/black/flake8 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11696" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added offline model loading support for mocker deployments.
  * Mocker workers now use locally mounted model-cache PVC paths when configured.
  * Preserved model identifiers for serving while loading models from local storage.

* **Bug Fixes**
  * Added fallback behavior to continue using the model identifier when no PVC is configured.
  * Prevented duplicate model-cache volume and mount entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->