### PR TITLE
fix(kvbm): preserve multimodal consolidator events

### DIFF
--- a/lib/kvbm-consolidator/src/egress/zmq_publisher.rs
+++ b/lib/kvbm-consolidator/src/egress/zmq_publisher.rs
@@ -96,6 +96,7 @@ fn consolidated_to_event(ev: ConsolidatedEvent) -> anyhow::Result<Event> {
             block_size,
             lora_name,
             cache_namespace,
+            block_mm_info,
             source: _,
         } => {
             let token_ids_i32: Vec<i32> = token_ids
@@ -118,6 +119,7 @@ fn consolidated_to_event(ev: ConsolidatedEvent) -> anyhow::Result<Event> {
                 block_size: block_size_i32,
                 lora_name,
                 cache_namespace,
+                block_mm_infos: block_mm_info.map(|info| vec![Some(info)]),
                 medium: None,
             })
         }
@@ -217,6 +219,7 @@ mod sort_tests {
             block_size: 0,
             lora_name: None,
             cache_namespace: None,
+            block_mm_info: None,
             source: EventSource::Vllm,
         }
     }

--- a/lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs
+++ b/lib/kvbm-consolidator/src/ingress/zmq_subscriber.rs
@@ -121,18 +121,14 @@ fn process_event(tracker: &mut Tracker, event: RawKvEvent, engine_source: EventS
                 return;
             }
 
-            // Multimodal info participates in the per-block hash (the placeholder slots
-            // are encoded with their `mm_hash`, not their raw token IDs). We don't yet
-            // thread `block_mm_infos` through to `kv_hashing::Request::mm_info`, so
-            // hashing as plain tokens would produce the wrong PLH and silently break
-            // cross-source dedup. Drop until plumbed through.
             if block_mm_infos
                 .as_ref()
-                .is_some_and(|v| v.iter().any(Option::is_some))
+                .is_some_and(|infos| infos.len() != block_hashes.len())
             {
                 tracing::warn!(
-                    "Multimodal BlockStored event not supported by consolidator yet; skipping ({} hashes)",
-                    block_hashes.len()
+                    "Multimodal metadata ({}) doesn't match block hashes ({}), skipping event",
+                    block_mm_infos.as_ref().map_or(0, Vec::len),
+                    block_hashes.len(),
                 );
                 return;
             }
@@ -164,6 +160,11 @@ fn process_event(tracker: &mut Tracker, event: RawKvEvent, engine_source: EventS
                     block_size,
                     lora_name.clone(),
                     cache_namespace.clone(),
+                    block_mm_infos
+                        .as_ref()
+                        .and_then(|infos| infos.get(i))
+                        .cloned()
+                        .flatten(),
                 ));
                 current_parent = Some(hash_str);
             }

--- a/lib/kvbm-consolidator/src/tracker.rs
+++ b/lib/kvbm-consolidator/src/tracker.rs
@@ -25,6 +25,7 @@ use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::Arc;
 
 use dynamo_kv_hashing::Request;
+use dynamo_kv_router::protocols::BlockExtraInfo;
 use dynamo_tokens::PositionalLineageHash;
 use kvbm_logical::{BlockRegistry, SequenceHash, registry::BlockRegistrationHandle};
 
@@ -40,6 +41,7 @@ pub enum ConsolidatedEvent {
         block_size: usize,
         lora_name: Option<String>,
         cache_namespace: Option<Arc<str>>,
+        block_mm_info: Option<BlockExtraInfo>,
         source: EventSource,
     },
     Remove {
@@ -58,6 +60,7 @@ pub(crate) struct StoreInput {
     block_size: usize,
     lora_name: Option<String>,
     cache_namespace: Option<Arc<str>>,
+    block_mm_info: Option<BlockExtraInfo>,
 }
 
 impl StoreInput {
@@ -69,6 +72,7 @@ impl StoreInput {
         block_size: usize,
         lora_name: Option<String>,
         cache_namespace: Option<Arc<str>>,
+        block_mm_info: Option<BlockExtraInfo>,
     ) -> Self {
         Self {
             source,
@@ -78,8 +82,28 @@ impl StoreInput {
             block_size,
             lora_name,
             cache_namespace,
+            block_mm_info,
         }
     }
+}
+
+fn mm_cache_salt(
+    cache_namespace: Option<&str>,
+    block_mm_info: Option<&BlockExtraInfo>,
+) -> Option<String> {
+    let Some(block_mm_info) = block_mm_info else {
+        return cache_namespace.map(str::to_owned);
+    };
+    let mut objects: Vec<_> = block_mm_info.mm_objects.iter().collect();
+    objects.sort_unstable_by_key(|object| (object.mm_hash, &object.offsets));
+
+    let mut salt = cache_namespace.unwrap_or_default().to_owned();
+    salt.push_str("\u{1f}dynamo-mm:");
+    for object in objects {
+        use std::fmt::Write as _;
+        let _ = write!(&mut salt, "{:016x}:{:?};", object.mm_hash, object.offsets);
+    }
+    Some(salt)
 }
 
 /// Per-block state: which sources have it, an optional registry handle keeping the
@@ -139,11 +163,13 @@ impl Tracker {
         block_size: usize,
         lora_name: Option<&str>,
         cache_namespace: Option<&str>,
+        block_mm_info: Option<&BlockExtraInfo>,
     ) -> Option<PositionalLineageHash> {
+        let cache_salt = mm_cache_salt(cache_namespace, block_mm_info);
         let request = Request::builder()
             .tokens(token_ids.to_vec())
             .lora_name(lora_name.map(str::to_string))
-            .salt(cache_namespace.map(str::to_string))
+            .salt(cache_salt)
             .build()
             .ok()?;
         let blocks = request.into_blocks(block_size as u32).ok()?;
@@ -175,6 +201,7 @@ impl Tracker {
             block_size,
             lora_name,
             None,
+            None,
         ))
     }
 
@@ -188,6 +215,7 @@ impl Tracker {
             block_size,
             lora_name,
             cache_namespace,
+            block_mm_info,
         } = input;
         let parent_key = parent_external_hash
             .as_ref()
@@ -222,6 +250,7 @@ impl Tracker {
             block_size,
             lora_name.as_deref(),
             cache_namespace.as_deref(),
+            block_mm_info.as_ref(),
         ) {
             Some(h) => h,
             None => {
@@ -260,6 +289,7 @@ impl Tracker {
                         block_size,
                         lora_name,
                         cache_namespace,
+                        block_mm_info,
                         source,
                     });
                     return true;
@@ -288,6 +318,7 @@ impl Tracker {
                     block_size,
                     lora_name,
                     cache_namespace,
+                    block_mm_info,
                     source,
                 });
                 true
@@ -361,6 +392,7 @@ impl Tracker {
                         block_size,
                         lora_name,
                         cache_namespace: None,
+                        block_mm_info: None,
                         source: EventSource::Kvbm,
                     });
                     return true;
@@ -390,6 +422,7 @@ impl Tracker {
                         block_size,
                         lora_name,
                         cache_namespace: None,
+                        block_mm_info: None,
                         source: EventSource::Kvbm,
                     });
                     true
@@ -890,6 +923,7 @@ mod tests {
             4,
             None,
             Some(Arc::from("tenant-a")),
+            None,
         ));
         t.handle_store_input(StoreInput::new(
             EventSource::Vllm,
@@ -899,6 +933,7 @@ mod tests {
             4,
             None,
             Some(Arc::from("tenant-b")),
+            None,
         ));
 
         let events = t.drain_events();
@@ -944,6 +979,7 @@ mod tests {
             4,
             None,
             Some(Arc::clone(&namespace)),
+            None,
         ));
         t.handle_store_input(StoreInput::new(
             EventSource::Vllm,
@@ -951,6 +987,7 @@ mod tests {
             Some("parent".into()),
             vec![5, 6, 7, 8],
             4,
+            None,
             None,
             None,
         ));

--- a/lib/kvbm-consolidator/src/wire/router_out.rs
+++ b/lib/kvbm-consolidator/src/wire/router_out.rs
@@ -9,6 +9,8 @@
 use serde::Serialize;
 use std::sync::Arc;
 
+use dynamo_kv_router::protocols::BlockExtraInfo;
+
 /// Batch envelope: `(timestamp, events, data_parallel_rank)`.
 #[derive(Debug, Serialize)]
 pub struct EventBatch(pub f64, pub Vec<Event>, pub Option<i32>);
@@ -32,6 +34,8 @@ pub enum Event {
             skip_serializing_if = "Option::is_none"
         )]
         cache_namespace: Option<Arc<str>>,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         medium: Option<String>,
     },

--- a/lib/kvbm-consolidator/tests/common/mod.rs
+++ b/lib/kvbm-consolidator/tests/common/mod.rs
@@ -18,6 +18,7 @@
 use std::sync::OnceLock;
 use std::time::Duration;
 
+use dynamo_kv_router::protocols::BlockExtraInfo;
 use futures::StreamExt as _;
 use kvbm_consolidator::wire::vllm_in::RawKvEvent;
 use kvbm_consolidator::zmq_util::{SharedPubSocket, bind_pub_socket, connect_sub_socket};
@@ -59,6 +60,8 @@ pub enum EventMirror {
         lora_name: Option<String>,
         #[serde(default, rename = "cache_salt")]
         cache_namespace: Option<String>,
+        #[serde(default)]
+        block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
         #[serde(default)]
         medium: Option<String>,
     },

--- a/lib/kvbm-consolidator/tests/e2e.rs
+++ b/lib/kvbm-consolidator/tests/e2e.rs
@@ -176,6 +176,7 @@ fn convert_event(e: common::EventMirror) -> SnapEvent {
             lora_name,
             cache_namespace,
             medium,
+            ..
         } => SnapEvent::BlockStored {
             block_hashes,
             parent_block_hash,

--- a/lib/kvbm-consolidator/tests/zmq_ingress.rs
+++ b/lib/kvbm-consolidator/tests/zmq_ingress.rs
@@ -10,6 +10,7 @@ mod common;
 use std::time::Duration;
 
 use common::{EventMirror, TestBatch, ZmqPubHandle, ZmqSubHandle, init_tracing, sync_pulse};
+use dynamo_kv_router::protocols::{BlockExtraInfo, BlockMmObjectInfo};
 use kvbm_consolidator::wire::vllm_in::{BlockHashValue, KvEventBatch, RawKvEvent};
 use kvbm_consolidator::{ConsolidatorBuilder, EventSource};
 
@@ -50,6 +51,52 @@ fn bs_event_with_cache_namespace(
         kv_cache_spec_kind: None,
         kv_cache_spec_sliding_window: None,
     }
+}
+
+#[tokio::test]
+async fn zmq_multimodal_metadata_is_forwarded() {
+    init_tracing();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        let pub_handle = ZmqPubHandle::spawn().await;
+        let egress_ep = common::make_endpoint(common::pick_port());
+        let consolidator = ConsolidatorBuilder::new(&egress_ep, EventSource::Trtllm)
+            .zmq_in(&pub_handle.endpoint)
+            .poll_interval(Duration::from_millis(20))
+            .build()
+            .await
+            .expect("build consolidator");
+        let mut sub = ZmqSubHandle::spawn(&egress_ep).await.expect("spawn sub");
+        assert!(sync_pulse(&pub_handle, &mut sub, Duration::from_secs(4)).await);
+
+        let mut event = bs_event(vec![101], None, vec![10, 20, 30, 40], 4, None);
+        if let RawKvEvent::BlockStored { block_mm_infos, .. } = &mut event {
+            *block_mm_infos = Some(vec![Some(BlockExtraInfo {
+                mm_objects: vec![BlockMmObjectInfo {
+                    mm_hash: 42,
+                    offsets: vec![],
+                }],
+            })]);
+        }
+        let payload = rmp_serde::to_vec_named(&TestBatch(1.0, vec![event], None))
+            .expect("encode multimodal event");
+        pub_handle
+            .send_frames(vec![vec![], vec![0u8; 8], payload])
+            .await
+            .unwrap();
+
+        let messages = sub.recv_n(1, Duration::from_secs(3)).await.unwrap();
+        assert!(matches!(
+            &messages[0].1.1[0],
+            EventMirror::BlockStored {
+                block_mm_infos: Some(infos),
+                ..
+            } if infos[0].as_ref().unwrap().mm_objects[0].mm_hash == 42
+        ));
+        consolidator.shutdown().await;
+    })
+    .await
+    .expect("test timed out");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- preserve per-block multimodal metadata through the KVBM consolidator
- include multimodal metadata in consolidator dedup identity
- forward metadata to the downstream KV-event normalizer

## Validation
- `cargo test -p kvbm-consolidator --features testing`

Refs INFH-1388