### PR TITLE
feat(router): add active sequence sparsity

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -302,7 +302,9 @@ class KvRouterArgGroup(ArgGroup):
             help=(
                 "KV Router: Retain one active-sequence hash for every N complete prompt "
                 "blocks. A value of 1 disables sparsity. All router replicas must use "
-                "the same value."
+                "the same value. Active-block counts become estimates; prompts shorter "
+                "than N complete blocks and incomplete trailing groups contribute no "
+                "prompt hashes."
             ),
             arg_type=_positive_int,
         )

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -35,6 +35,7 @@ _KV_ROUTER_FIELDS: tuple[str, ...] = (
     "use_kv_events",
     "router_replica_sync",
     "router_track_active_blocks",
+    "router_active_sequence_stride",
     "router_track_output_blocks",
     "router_assume_kv_reuse",
     "router_track_prefill_tokens",
@@ -101,6 +102,13 @@ def _default_prefill_load_scale() -> float:
     return 1.0
 
 
+def _positive_int(value: str) -> int:
+    parsed = int(value)
+    if parsed < 1:
+        raise argparse.ArgumentTypeError("value must be at least 1")
+    return parsed
+
+
 class KvRouterConfigBase(ConfigBase):
     """Mixin carrying the shared KvRouterConfig fields."""
 
@@ -114,6 +122,7 @@ class KvRouterConfigBase(ConfigBase):
     use_kv_events: bool
     router_replica_sync: bool
     router_track_active_blocks: bool
+    router_active_sequence_stride: int
     router_track_output_blocks: bool
     router_assume_kv_reuse: bool
     router_track_prefill_tokens: bool
@@ -283,6 +292,19 @@ class KvRouterArgGroup(ArgGroup):
                 "By default, active blocks are tracked for load balancing."
             ),
             obsolete_flag="--track-active-blocks",
+        )
+        add_argument(
+            g,
+            flag_name="--router-active-sequence-stride",
+            env_var="DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE",
+            default=1,
+            dest="router_active_sequence_stride",
+            help=(
+                "KV Router: Retain one active-sequence hash for every N complete prompt "
+                "blocks. A value of 1 disables sparsity. All router replicas must use "
+                "the same value."
+            ),
+            arg_type=_positive_int,
         )
         add_negatable_bool_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -131,6 +131,43 @@ def test_overlap_score_credit_decay_cli_uses_kv_router_config_field() -> None:
     assert config.kv_router_kwargs()["overlap_score_credit_decay"] == 0.5
 
 
+def test_active_sequence_stride_defaults_and_flows_to_binding_kwargs() -> None:
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    default_config = KvRouterConfigBase.from_cli_args(parser.parse_args([]))
+    assert default_config.kv_router_kwargs()["router_active_sequence_stride"] == 1
+
+    explicit_config = KvRouterConfigBase.from_cli_args(
+        parser.parse_args(["--router-active-sequence-stride", "4"])
+    )
+    assert explicit_config.kv_router_kwargs()["router_active_sequence_stride"] == 4
+
+
+def test_active_sequence_stride_env_flows_to_binding_kwargs(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE", "5")
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    config = KvRouterConfigBase.from_cli_args(parser.parse_args([]))
+    assert config.kv_router_kwargs()["router_active_sequence_stride"] == 5
+
+
+def test_active_sequence_stride_rejects_zero() -> None:
+    parser = argparse.ArgumentParser()
+    KvRouterArgGroup().add_arguments(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--router-active-sequence-stride", "0"])
+
+
+def test_active_sequence_stride_env_rejects_zero(monkeypatch) -> None:
+    monkeypatch.setenv("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE", "0")
+
+    with pytest.raises(argparse.ArgumentTypeError, match="value must be at least 1"):
+        KvRouterArgGroup().add_arguments(argparse.ArgumentParser())
+
+
 def test_deprecated_overlap_score_weight_cli_flows_to_binding_kwargs() -> None:
     parser = argparse.ArgumentParser()
     KvRouterArgGroup().add_arguments(parser)

--- a/components/src/dynamo/router/__main__.py
+++ b/components/src/dynamo/router/__main__.py
@@ -208,6 +208,7 @@ async def worker(runtime: DistributedRuntime):
         f"use_kv_events={config.use_kv_events}, "
         f"router_replica_sync={config.router_replica_sync}, "
         f"router_track_active_blocks={config.router_track_active_blocks}, "
+        f"router_active_sequence_stride={config.router_active_sequence_stride}, "
         f"router_track_output_blocks={config.router_track_output_blocks}, "
         f"router_assume_kv_reuse={config.router_assume_kv_reuse}, "
         f"router_track_prefill_tokens={config.router_track_prefill_tokens}, "

--- a/deploy/inference-gateway/ext-proc/src/epp.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp.rs
@@ -121,7 +121,7 @@ impl Router {
 
         // TODO(epp-rolling-namespace): Rebind both routers when the active
         // generation-suffixed worker namespace changes during a rolling update.
-        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        let mut kv_router_config = kv_router_config_from_dynamo_env()?;
         // TODO(epp-multi-replica): Provide authoritative admission across EPP
         // replicas; replica-sync alone does not close the selection-to-booking race.
         kv_router_config.skip_initial_worker_wait = true;

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -217,10 +217,31 @@ For Kubernetes deployment examples, see [Kubernetes Topology-Aware KV Transfer](
 ## Block Tracking
 
 - `--no-router-track-active-blocks`: Disables tracking of active blocks used for ongoing generation or decode phases. Disable this when routing to workers that only perform prefill.
+- `--router-active-sequence-stride`: Retains one active-sequence hash for every N complete prompt blocks. The equivalent environment variable is `DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE`. The default of `1` retains every block.
 - `--router-track-output-blocks`: **Experimental.** Enables tracking of output blocks during generation. When enabled, the router adds placeholder blocks as tokens are generated and applies fractional decay based on progress toward the expected output sequence length (`agent_hints.osl` in `nvext`). For the cost-model behavior, see [Decode Load Modeling](router-concepts.md#decode-load-modeling).
 - `--no-router-assume-kv-reuse`: When tracking active blocks, disables the assumption of KV cache reuse. This is useful in disaggregated setups where transferred blocks are not actually deduplicated on the decode side.
 - `--no-router-track-prefill-tokens`: Disables prompt-side prefill token accounting in the router's active load model. Use this for decode-only routing paths where prompt processing already happened elsewhere.
 - `--router-replica-sync`: Disabled by default. Enables best-effort Runtime event-plane synchronization of KV active-sequence state. Session-affinity synchronization is independent and starts when `--router-session-affinity-ttl-secs` is set.
+
+Values above `1` reduce active-sequence event payloads and tracker state. The router converts each
+retained prompt unit back into an estimated physical-block count by multiplying it by the stride;
+output blocks remain unscaled. A prompt with fewer than N complete blocks contributes no prompt
+hashes, and the final incomplete group is omitted. Request counts and prefill-token accounting remain
+active. Prefixes that diverge inside a retained group can be conservatively overcounted because the
+retained rolling hash commits to every preceding block.
+
+> [!WARNING]
+> Configure the same stride on every frontend. Deploy the new binary everywhere with stride `1`
+> before enabling sparsity, then restart all frontends with one common value. An old receiver can
+> ignore the stride field while consuming a sparse sequence, so mixed old and new binaries are unsafe
+> after setting a value above `1`.
+
+When replica synchronization receives a different or malformed stride, it drops only that event and
+increments `router_active_sequence_stride_mismatches_total`. It logs the first mismatch for each
+source-router and received-stride pair. If a mismatched `Free` event is dropped, the receiving
+frontend retains phantom active load until the request crosses the active-sequence tracker's
+five-minute stale threshold and the next periodic sweep, which runs once per minute. This cleanup is
+independent of `--router-ttl-secs`, which controls predicted KV cache state.
 
 ## KV Indexer / Approx KV Indexer
 

--- a/lib/bench/kv_router/active_sequences_open_loop.rs
+++ b/lib/bench/kv_router/active_sequences_open_loop.rs
@@ -13,7 +13,8 @@ use dynamo_bench::kv_router_common::replay::NoopSequencePublisher;
 use dynamo_bench::kv_router_common::trace_gen::WorkerTimelines;
 use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
 use dynamo_kv_router::{
-    ActiveSequencesMultiWorker, SequenceError, SequenceRequest, WorkerLoadProjection,
+    ActiveSequenceStride, ActiveSequencesMultiWorker, SequenceError, SequenceRequest,
+    WorkerLoadProjection,
 };
 use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
@@ -378,8 +379,8 @@ impl PreparedActiveSequencesTrial {
                         for byte in request.request_id.as_bytes() {
                             checksum ^= u64::from(*byte);
                         }
-                        if let Some(hashes) = request.token_sequence.as_deref() {
-                            for hash in hashes {
+                        if let Some(hashes) = request.token_sequence.as_ref() {
+                            for hash in hashes.as_slice() {
                                 checksum ^= *hash;
                             }
                         }
@@ -492,7 +493,7 @@ pub(crate) fn prepare_active_sequences_trial(
                     .to_vec();
                 LanePayload::ProjectAndAdd(SequenceRequest {
                     request_id: request.request_id.clone(),
-                    token_sequence: Some(token_sequence),
+                    token_sequence: Some(ActiveSequenceStride::ONE.sample_dense(token_sequence)),
                     track_prefill_tokens: true,
                     expected_output_tokens: Some(request.output_length),
                     prefill_load_hint: Some(PrefillLoadHint {
@@ -703,7 +704,7 @@ fn execute_payload(
     match payload {
         LanePayload::ProjectAndAdd(request) => {
             let projections =
-                sequences.project_worker_loads(request.token_sequence.as_deref(), decay_now);
+                sequences.project_worker_loads(request.token_sequence.as_ref(), decay_now);
             let projection_count = projections.len() as u64;
             let (projection_inspected, projection_digest) =
                 summarize_worker_projections(&projections);
@@ -1616,7 +1617,7 @@ mod tests {
     use crate::active_sequences_shared::{SequenceTrace, SequenceTraceEntry};
     use dynamo_bench::kv_router_common::replay::NoopSequencePublisher;
     use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
-    use dynamo_kv_router::{ActiveSequencesMultiWorker, SequenceRequest};
+    use dynamo_kv_router::{ActiveSequenceStride, ActiveSequencesMultiWorker, SequenceRequest};
 
     fn add(request_id: &str, hashes: &[u64], timestamp_us: u64) -> SequenceTrace {
         SequenceTrace {
@@ -1651,7 +1652,7 @@ mod tests {
     fn request(request_id: &str, hashes: &[u64]) -> SequenceRequest {
         SequenceRequest {
             request_id: request_id.to_string(),
-            token_sequence: Some(hashes.to_vec()),
+            token_sequence: Some(ActiveSequenceStride::ONE.sample_dense(hashes.to_vec())),
             track_prefill_tokens: true,
             expected_output_tokens: Some(8),
             prefill_load_hint: Some(PrefillLoadHint {

--- a/lib/bench/tests/active_sequences_trace.rs
+++ b/lib/bench/tests/active_sequences_trace.rs
@@ -17,7 +17,7 @@ use active_sequences_open_loop::{
 use active_sequences_shared::{SequenceTrace, SequenceTraceEntry, generate_sequence_events};
 use dynamo_bench::kv_router_common::replay::{NoopSequencePublisher, process_mooncake_trace};
 use dynamo_kv_router::protocols::{PrefillLoadHint, WorkerWithDpRank};
-use dynamo_kv_router::{ActiveSequencesMultiWorker, SequenceRequest};
+use dynamo_kv_router::{ActiveSequenceStride, ActiveSequencesMultiWorker, SequenceRequest};
 
 const BLOCK_SIZE: u32 = 128;
 const NUM_GPU_BLOCKS: usize = 16384;
@@ -138,7 +138,7 @@ async fn active_sequences_replay_matches_sequential_direct_oracle() -> anyhow::R
         "bench",
     );
     let now = tokio::time::Instant::now();
-    let hashes = vec![1, 2];
+    let hashes = ActiveSequenceStride::ONE.sample_dense(vec![1, 2]);
     let projections = oracle.project_worker_loads(Some(&hashes), now);
     let projection_count = projections.len() as u64;
     let (projection_inspected, projection_digest) = summarize_worker_projections(&projections);

--- a/lib/bindings/c/src/lib.rs
+++ b/lib/bindings/c/src/lib.rs
@@ -737,7 +737,13 @@ pub unsafe extern "C" fn create_routers(
             );
         }
 
-        let mut kv_router_config = kv_router_config_from_dynamo_env();
+        let mut kv_router_config = match kv_router_config_from_dynamo_env() {
+            Ok(config) => config,
+            Err(error) => {
+                tracing::error!(%error, "Invalid KV router environment configuration");
+                return Err(QueryRouterResult::ErrInitFailed);
+            }
+        };
         kv_router_config.skip_initial_worker_wait = true;
 
         // Build endpoint using the actual namespace discovered from workers,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -17,6 +17,7 @@ use dynamo_kv_router::config::{
     KvRouterConfig as RsKvRouterConfig, RouterPrefillLoadModel as RsRouterPrefillLoadModel,
     apply_deprecated_overlap_score_weight_override,
 };
+use dynamo_kv_router::ActiveSequenceStride;
 use dynamo_llm::discovery::LoadThresholdConfig as RsLoadThresholdConfig;
 use dynamo_llm::entrypoint::EngineConfig as RsEngineConfig;
 use dynamo_llm::entrypoint::RouterConfig as RsRouterConfig;
@@ -273,6 +274,11 @@ impl KvRouterConfig {
                 &mut prefill_load_scale,
             );
         }
+
+        let router_active_sequence_stride =
+            ActiveSequenceStride::new(router_active_sequence_stride).map_err(|error| {
+                PyValueError::new_err(format!("router_active_sequence_stride: {error}"))
+            })?;
 
         let inner = RsKvRouterConfig {
             overlap_score_credit,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -237,7 +237,7 @@ impl AicPerfConfig {
 #[pymethods]
 impl KvRouterConfig {
     #[new]
-    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None))]
+    #[pyo3(signature = (overlap_score_weight=None, host_cache_hit_weight=0.75, disk_cache_hit_weight=0.25, router_temperature=0.0, use_kv_events=true, *, router_replica_sync=false, router_track_active_blocks=true, router_track_output_blocks=false, router_assume_kv_reuse=true, router_track_prefill_tokens=true, router_prefill_load_model="none", router_ttl_secs=120.0, router_queue_threshold=None, router_event_threads=4, router_queue_policy="fcfs", use_remote_indexer=false, serve_indexer=false, shared_cache_multiplier=0.0, shared_cache_type="none", router_predicted_ttl_secs=None, overlap_score_credit=1.0, overlap_score_credit_decay=0.0, prefill_load_scale=1.0, router_policy_config=None, router_active_sequence_stride=1))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         overlap_score_weight: Option<f64>,
@@ -264,6 +264,7 @@ impl KvRouterConfig {
         overlap_score_credit_decay: f64,
         mut prefill_load_scale: f64,
         router_policy_config: Option<String>,
+        router_active_sequence_stride: usize,
     ) -> PyResult<Self> {
         if let Some(value) = overlap_score_weight {
             apply_deprecated_overlap_score_weight(
@@ -283,6 +284,7 @@ impl KvRouterConfig {
             use_kv_events,
             router_replica_sync,
             router_track_active_blocks,
+            router_active_sequence_stride,
             router_track_output_blocks,
             router_assume_kv_reuse,
             router_track_prefill_tokens,

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -389,7 +389,7 @@ where
             indexer_peers: cli.indexer_peers,
             replica_sync_port: cli.replica_sync_port,
             replica_sync_peers: cli.replica_sync_peers,
-            kv_router_config: kv_router_config_from_dynamo_env(),
+            kv_router_config: kv_router_config_from_dynamo_env()?,
             selection_cache: selection_cache_config_from_overrides(
                 cli.selection_cache_ttl_secs,
                 cli.selection_cache_max_entries,
@@ -497,7 +497,9 @@ impl SelectionService {
                 "replica_sync_peers requires replica_sync_port",
             ));
         }
-        let mut builder = SelectionServiceBuilder::new(kv_router_config_from_dynamo_env())
+        let kv_router_config = kv_router_config_from_dynamo_env()
+            .map_err(|error| PyValueError::new_err(error.to_string()))?;
+        let mut builder = SelectionServiceBuilder::new(kv_router_config)
             .indexer_threads(indexer_threads)
             .indexer_peers(indexer_peers.unwrap_or_default())
             .selection_cache(selection_cache.unwrap_or_default().inner);

--- a/lib/kv-router/src/active_sequence.rs
+++ b/lib/kv-router/src/active_sequence.rs
@@ -1,0 +1,211 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::fmt;
+use std::num::NonZeroUsize;
+
+use dynamo_tokens::SequenceHash;
+use serde::{Deserialize, Serialize};
+
+/// Number of physical prompt blocks represented by one tracked sequence hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct ActiveSequenceStride(NonZeroUsize);
+
+impl ActiveSequenceStride {
+    /// Dense active-sequence tracking with one hash per complete prompt block.
+    pub const ONE: Self = Self(NonZeroUsize::MIN);
+
+    /// Create a validated active-sequence stride.
+    pub const fn new(value: usize) -> Result<Self, ActiveSequenceStrideError> {
+        match NonZeroUsize::new(value) {
+            Some(value) => Ok(Self(value)),
+            None => Err(ActiveSequenceStrideError::Zero),
+        }
+    }
+
+    /// Return the stride as a primitive integer.
+    pub const fn get(self) -> usize {
+        self.0.get()
+    }
+
+    /// Encode the stride for replica events, omitting the legacy stride of one.
+    pub const fn event_value(self) -> Option<usize> {
+        if self.get() == 1 {
+            None
+        } else {
+            Some(self.get())
+        }
+    }
+
+    /// Return the number of retained hashes for a count of complete prompt blocks.
+    pub const fn tracked_len(self, complete_blocks: usize) -> usize {
+        complete_blocks / self.get()
+    }
+
+    /// Convert a complete dense rolling-hash chain into tracked active-sequence hashes.
+    pub fn sample_dense(self, sequence: Vec<SequenceHash>) -> TrackedSequenceHashes {
+        if self == Self::ONE {
+            return TrackedSequenceHashes(sequence);
+        }
+        TrackedSequenceHashes(
+            sequence
+                .into_iter()
+                .skip(self.get() - 1)
+                .step_by(self.get())
+                .collect(),
+        )
+    }
+
+    /// Generate one independent tracked hash for each complete stride group.
+    pub fn generate_for_complete_blocks(
+        self,
+        complete_blocks: usize,
+        mut generate: impl FnMut() -> SequenceHash,
+    ) -> TrackedSequenceHashes {
+        TrackedSequenceHashes(
+            (0..self.tracked_len(complete_blocks))
+                .map(|_| generate())
+                .collect(),
+        )
+    }
+
+    /// Normalize a replica-event stride, treating a missing field as legacy stride one.
+    pub(crate) const fn from_event_value(
+        value: Option<usize>,
+    ) -> Result<Self, ActiveSequenceStrideError> {
+        match value {
+            None => Ok(Self::ONE),
+            Some(value) => Self::new(value),
+        }
+    }
+}
+
+impl Default for ActiveSequenceStride {
+    fn default() -> Self {
+        Self::ONE
+    }
+}
+
+impl TryFrom<usize> for ActiveSequenceStride {
+    type Error = ActiveSequenceStrideError;
+
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        Self::new(value)
+    }
+}
+
+impl From<NonZeroUsize> for ActiveSequenceStride {
+    fn from(value: NonZeroUsize) -> Self {
+        Self(value)
+    }
+}
+
+impl fmt::Display for ActiveSequenceStride {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.get().fmt(formatter)
+    }
+}
+
+/// Rolling hashes that have crossed the active-sequence stride boundary exactly once.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TrackedSequenceHashes(Vec<SequenceHash>);
+
+impl TrackedSequenceHashes {
+    /// Borrow the tracked hashes as a slice.
+    pub fn as_slice(&self) -> &[SequenceHash] {
+        &self.0
+    }
+
+    /// Return the number of tracked hashes.
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    /// Return whether no prompt hashes are tracked.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Accept already-sampled hashes after their replica-event stride was validated.
+    pub(crate) fn from_validated_event(sequence: Vec<SequenceHash>) -> Self {
+        Self(sequence)
+    }
+
+    /// Consume the wrapper at the final sparsity-agnostic tracker boundary.
+    pub(crate) fn into_inner(self) -> Vec<SequenceHash> {
+        self.0
+    }
+}
+
+impl AsRef<[SequenceHash]> for TrackedSequenceHashes {
+    fn as_ref(&self) -> &[SequenceHash] {
+        self.as_slice()
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn tracked_sequence_hashes(sequence: Vec<SequenceHash>) -> TrackedSequenceHashes {
+    ActiveSequenceStride::ONE.sample_dense(sequence)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum ActiveSequenceStrideError {
+    #[error("active-sequence stride must be greater than zero")]
+    Zero,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stride_rejects_zero_and_defaults_to_one() {
+        assert_eq!(ActiveSequenceStride::default(), ActiveSequenceStride::ONE);
+        assert_eq!(
+            ActiveSequenceStride::new(0),
+            Err(ActiveSequenceStrideError::Zero)
+        );
+    }
+
+    #[test]
+    fn sampling_retains_stride_endpoints_and_omits_trailing_group() {
+        let stride = ActiveSequenceStride::new(3).unwrap();
+        let tracked = stride.sample_dense((0..10).collect());
+        assert_eq!(tracked.as_slice(), &[2, 5, 8]);
+        assert_eq!(stride.tracked_len(10), 3);
+    }
+
+    #[test]
+    fn stride_one_preserves_the_dense_chain() {
+        let dense = vec![1, 2, 3];
+        let allocation = dense.as_ptr();
+        let tracked = ActiveSequenceStride::ONE.sample_dense(dense);
+        assert_eq!(tracked.as_slice(), &[1, 2, 3]);
+        assert_eq!(tracked.as_slice().as_ptr(), allocation);
+        assert_eq!(ActiveSequenceStride::ONE.event_value(), None);
+    }
+
+    #[test]
+    fn direct_generation_uses_the_tracked_length() {
+        let stride = ActiveSequenceStride::new(3).unwrap();
+        let mut next = 0;
+        let tracked = stride.generate_for_complete_blocks(10, || {
+            next += 1;
+            next
+        });
+        assert_eq!(tracked.as_slice(), &[1, 2, 3]);
+        assert_eq!(next, 3);
+    }
+
+    #[test]
+    fn stride_serializes_as_an_integer() {
+        let stride = ActiveSequenceStride::new(4).unwrap();
+        assert_eq!(serde_json::to_string(&stride).unwrap(), "4");
+        assert_eq!(
+            serde_json::from_str::<ActiveSequenceStride>("4").unwrap(),
+            stride
+        );
+        assert!(serde_json::from_str::<ActiveSequenceStride>("0").is_err());
+    }
+}

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -37,7 +37,7 @@ pub mod test_utils;
 // Re-export key types for convenience
 pub use self::multi_worker_sequence::{
     ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequenceError, SequencePublisher,
-    SequenceRequest, SequenceSubscriber,
+    SequenceRequest, SequenceSubscriber, SequenceTrackerOptions,
 };
 pub use self::sequence::{ActiveSequences, RequestId};
 pub use self::sequences::{PrefillTokenDeltas, WorkerLoadProjection};

--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -6,6 +6,7 @@
 //! This crate provides the core radix tree implementation and protocols for
 //! efficient KV cache lookup and routing in distributed LLM inference systems.
 
+pub mod active_sequence;
 mod active_set;
 pub(crate) mod cleanup;
 mod lookup_update;
@@ -41,6 +42,7 @@ pub use self::multi_worker_sequence::{
 };
 pub use self::sequence::{ActiveSequences, RequestId};
 pub use self::sequences::{PrefillTokenDeltas, WorkerLoadProjection};
+pub use active_sequence::{ActiveSequenceStride, ActiveSequenceStrideError, TrackedSequenceHashes};
 pub use concurrent_radix_tree::ConcurrentRadixTree;
 pub use concurrent_radix_tree_compressed::ConcurrentRadixTreeCompressed;
 pub use config::{

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -3,7 +3,6 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::num::NonZeroUsize;
 use std::ops::Range;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -12,6 +11,9 @@ use dynamo_tokens::{SequenceHash, Token, compute_hash_v2, compute_next_sequence_
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 use xxhash_rust::xxh3;
+
+use crate::active_sequence::ActiveSequenceStride;
+pub use crate::active_sequence::ActiveSequenceStrideError;
 
 const fn default_track_prefill_tokens() -> bool {
     true
@@ -633,18 +635,9 @@ pub struct ActiveSequenceEvent {
 
 impl ActiveSequenceEvent {
     /// Normalize the sender's stride, treating a missing value as the legacy stride of 1.
-    pub fn normalized_stride(&self) -> Result<NonZeroUsize, ActiveSequenceStrideError> {
-        match self.stride {
-            None => Ok(NonZeroUsize::MIN),
-            Some(stride) => NonZeroUsize::new(stride).ok_or(ActiveSequenceStrideError::Zero),
-        }
+    pub fn normalized_stride(&self) -> Result<ActiveSequenceStride, ActiveSequenceStrideError> {
+        ActiveSequenceStride::from_event_value(self.stride)
     }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
-pub enum ActiveSequenceStrideError {
-    #[error("active-sequence stride must be greater than zero")]
-    Zero,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -2073,7 +2066,7 @@ mod tests {
         let serialized = serde_json::to_value(&event).unwrap();
         assert!(serialized.get("stride").is_none());
         let decoded: ActiveSequenceEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(decoded.normalized_stride(), Ok(NonZeroUsize::MIN));
+        assert_eq!(decoded.normalized_stride(), Ok(ActiveSequenceStride::ONE));
     }
 
     #[test]
@@ -2092,7 +2085,10 @@ mod tests {
             serialized.get("stride").and_then(|value| value.as_u64()),
             Some(4)
         );
-        assert_eq!(event.normalized_stride(), Ok(NonZeroUsize::new(4).unwrap()));
+        assert_eq!(
+            event.normalized_stride(),
+            Ok(ActiveSequenceStride::new(4).unwrap())
+        );
 
         event.stride = Some(0);
         assert_eq!(

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -622,8 +622,23 @@ pub struct ActiveSequenceEvent {
     pub worker: WorkerWithDpRank,
     pub data: ActiveSequenceEventData,
     pub router_id: u64,
+    /// Active-sequence sampling stride used by the sender. `None` is the
+    /// backwards-compatible representation of stride 1.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stride: Option<usize>,
     #[serde(default)]
     pub lora_name: Option<String>,
+}
+
+impl ActiveSequenceEvent {
+    /// Return the sender's effective stride, or `None` for a malformed zero.
+    pub fn effective_stride(&self) -> Option<usize> {
+        match self.stride {
+            None | Some(1) => Some(1),
+            Some(0) => None,
+            Some(stride) => Some(stride),
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -2036,5 +2051,67 @@ mod tests {
             serde_json::to_string(&load).unwrap(),
             r#"{"worker_id":1,"dp_rank":0,"potential_prefill_tokens":16,"potential_decode_blocks":4,"active_requests":2}"#
         );
+    }
+
+    #[test]
+    fn active_sequence_event_stride_is_backwards_compatible() {
+        let event = ActiveSequenceEvent {
+            request_id: "request".to_string(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::Free,
+            router_id: 7,
+            stride: None,
+            lora_name: None,
+        };
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert!(serialized.get("stride").is_none());
+        let decoded: ActiveSequenceEvent = serde_json::from_value(serialized).unwrap();
+        assert_eq!(decoded.effective_stride(), Some(1));
+    }
+
+    #[test]
+    fn active_sequence_event_stride_encodes_sparse_and_rejects_zero() {
+        let mut event = ActiveSequenceEvent {
+            request_id: "request".to_string(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::Free,
+            router_id: 7,
+            stride: Some(4),
+            lora_name: None,
+        };
+
+        let serialized = serde_json::to_value(&event).unwrap();
+        assert_eq!(
+            serialized.get("stride").and_then(|value| value.as_u64()),
+            Some(4)
+        );
+        assert_eq!(event.effective_stride(), Some(4));
+
+        event.stride = Some(0);
+        assert_eq!(event.effective_stride(), None);
+    }
+
+    #[test]
+    fn sparse_active_sequence_event_reduces_serialized_payload() {
+        let make_event = |token_sequence: Vec<SequenceHash>, stride| ActiveSequenceEvent {
+            request_id: "request".to_string(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(token_sequence),
+                track_prefill_tokens: true,
+                expected_output_tokens: None,
+                prefill_load_hint: None,
+            },
+            router_id: 7,
+            stride,
+            lora_name: None,
+        };
+        let full = make_event((0..12).collect(), None);
+        let sparse = make_event(vec![3, 7, 11], Some(4));
+
+        let full_payload = rmp_serde::to_vec_named(&full).unwrap();
+        let sparse_payload = rmp_serde::to_vec_named(&sparse).unwrap();
+        assert!(sparse_payload.len() < full_payload.len());
     }
 }

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -3,6 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::ops::Range;
 use std::sync::LazyLock;
 use std::time::Duration;
@@ -631,14 +632,19 @@ pub struct ActiveSequenceEvent {
 }
 
 impl ActiveSequenceEvent {
-    /// Return the sender's effective stride, or `None` for a malformed zero.
-    pub fn effective_stride(&self) -> Option<usize> {
+    /// Normalize the sender's stride, treating a missing value as the legacy stride of 1.
+    pub fn normalized_stride(&self) -> Result<NonZeroUsize, ActiveSequenceStrideError> {
         match self.stride {
-            None | Some(1) => Some(1),
-            Some(0) => None,
-            Some(stride) => Some(stride),
+            None => Ok(NonZeroUsize::MIN),
+            Some(stride) => NonZeroUsize::new(stride).ok_or(ActiveSequenceStrideError::Zero),
         }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, thiserror::Error)]
+pub enum ActiveSequenceStrideError {
+    #[error("active-sequence stride must be greater than zero")]
+    Zero,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
@@ -2067,7 +2073,7 @@ mod tests {
         let serialized = serde_json::to_value(&event).unwrap();
         assert!(serialized.get("stride").is_none());
         let decoded: ActiveSequenceEvent = serde_json::from_value(serialized).unwrap();
-        assert_eq!(decoded.effective_stride(), Some(1));
+        assert_eq!(decoded.normalized_stride(), Ok(NonZeroUsize::MIN));
     }
 
     #[test]
@@ -2086,10 +2092,13 @@ mod tests {
             serialized.get("stride").and_then(|value| value.as_u64()),
             Some(4)
         );
-        assert_eq!(event.effective_stride(), Some(4));
+        assert_eq!(event.normalized_stride(), Ok(NonZeroUsize::new(4).unwrap()));
 
         event.stride = Some(0);
-        assert_eq!(event.effective_stride(), None);
+        assert_eq!(
+            event.normalized_stride(),
+            Err(ActiveSequenceStrideError::Zero)
+        );
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -8,6 +8,7 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 use derive_builder::Builder;
+use dynamo_tokens::SequenceHash;
 use serde::{Deserialize, Serialize};
 
 use crate::protocols::{
@@ -16,6 +17,22 @@ use crate::protocols::{
 
 const fn default_track_prefill_tokens() -> bool {
     true
+}
+
+const fn default_active_sequence_stride() -> usize {
+    1
+}
+
+fn sample_active_sequence(sequence: Vec<u64>, stride: usize) -> Vec<u64> {
+    assert!(stride > 0, "active sequence stride must be non-zero");
+    if stride == 1 {
+        return sequence;
+    }
+    sequence
+        .into_iter()
+        .skip(stride - 1)
+        .step_by(stride)
+        .collect()
 }
 
 pub const DYN_ROUTER_MIN_INITIAL_WORKERS: &str = "DYN_ROUTER_MIN_INITIAL_WORKERS";
@@ -104,6 +121,7 @@ pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
         use_kv_events = config.use_kv_events,
         router_replica_sync = config.router_replica_sync,
         router_track_active_blocks = config.router_track_active_blocks,
+        router_active_sequence_stride = config.router_active_sequence_stride,
         router_track_output_blocks = config.router_track_output_blocks,
         router_track_prefill_tokens = config.router_track_prefill_tokens,
         router_queue_threshold = ?config.router_queue_threshold,
@@ -160,6 +178,18 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_ACTIVE_BLOCKS") {
         config.router_track_active_blocks = value;
+    }
+    if let Some(raw_value) = get_env("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE") {
+        let value = raw_value.parse::<usize>().unwrap_or_else(|_| {
+            panic!(
+                "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE must be an integer greater than or equal to 1"
+            )
+        });
+        assert!(
+            value >= 1,
+            "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE must be greater than or equal to 1"
+        );
+        config.router_active_sequence_stride = value;
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
         config.router_track_output_blocks = value;
@@ -395,6 +425,7 @@ struct KvRouterConfigSerde {
     use_kv_events: bool,
     router_replica_sync: bool,
     router_track_active_blocks: bool,
+    router_active_sequence_stride: usize,
     router_track_output_blocks: bool,
     router_assume_kv_reuse: bool,
     router_track_prefill_tokens: bool,
@@ -427,6 +458,7 @@ impl Default for KvRouterConfigSerde {
             use_kv_events: config.use_kv_events,
             router_replica_sync: config.router_replica_sync,
             router_track_active_blocks: config.router_track_active_blocks,
+            router_active_sequence_stride: config.router_active_sequence_stride,
             router_track_output_blocks: config.router_track_output_blocks,
             router_assume_kv_reuse: config.router_assume_kv_reuse,
             router_track_prefill_tokens: config.router_track_prefill_tokens,
@@ -478,6 +510,12 @@ pub struct KvRouterConfig {
 
     /// Whether to track active blocks in the router (default: true)
     pub router_track_active_blocks: bool,
+
+    /// Retain one active-sequence hash for every N complete prompt blocks.
+    /// A value of 1 disables sparsity.
+    #[serde(default = "default_active_sequence_stride")]
+    #[validate(range(min = 1))]
+    pub router_active_sequence_stride: usize,
 
     /// Whether to track output blocks during generation (default: false)
     /// When enabled, the router adds placeholder blocks as tokens are generated
@@ -575,6 +613,7 @@ impl Default for KvRouterConfig {
             use_kv_events: true,
             router_replica_sync: false,
             router_track_active_blocks: true,
+            router_active_sequence_stride: default_active_sequence_stride(),
             router_track_output_blocks: false,
             router_assume_kv_reuse: true,
             router_track_prefill_tokens: default_track_prefill_tokens(),
@@ -621,6 +660,7 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             use_kv_events: compat.use_kv_events,
             router_replica_sync: compat.router_replica_sync,
             router_track_active_blocks: compat.router_track_active_blocks,
+            router_active_sequence_stride: compat.router_active_sequence_stride,
             router_track_output_blocks: compat.router_track_output_blocks,
             router_assume_kv_reuse: compat.router_assume_kv_reuse,
             router_track_prefill_tokens: compat.router_track_prefill_tokens,
@@ -671,6 +711,13 @@ fn validate_kv_router_config(config: &KvRouterConfig) -> Result<(), String> {
 }
 
 impl KvRouterConfig {
+    pub(crate) fn sample_active_sequence_hashes(
+        &self,
+        sequence: Vec<SequenceHash>,
+    ) -> Vec<SequenceHash> {
+        sample_active_sequence(sequence, self.router_active_sequence_stride)
+    }
+
     fn loaded_policy_config(
         &self,
     ) -> Result<
@@ -796,6 +843,9 @@ impl KvRouterConfig {
     /// - `None` if `router_track_active_blocks` is false
     /// - Random hashes if `router_track_active_blocks` is true but `router_assume_kv_reuse` is false
     /// - Actual sequence hashes if both are true
+    ///
+    /// The complete rolling chain is computed first, then every configured
+    /// stride endpoint is retained. Any incomplete trailing group is omitted.
     pub fn compute_seq_hashes_for_tracking(
         &self,
         tokens: &[u32],
@@ -815,18 +865,22 @@ impl KvRouterConfig {
 
         let assume_kv_reuse = self.assume_kv_reuse(config_override);
 
-        if assume_kv_reuse {
+        let sequence = if assume_kv_reuse {
             let block_hashes = match precomputed_block_hashes {
                 Some(block_hashes) => block_hashes,
                 None => {
                     let computed = compute_block_hash_for_seq(tokens, block_size, hash_options);
-                    return Some(compute_seq_hash_for_block(&computed));
+                    return Some(
+                        self.sample_active_sequence_hashes(compute_seq_hash_for_block(&computed)),
+                    );
                 }
             };
-            Some(compute_seq_hash_for_block(block_hashes))
+            compute_seq_hash_for_block(block_hashes)
         } else {
-            Some((0..num_blocks).map(|_| fastrand::u64(..)).collect())
-        }
+            (0..num_blocks).map(|_| fastrand::u64(..)).collect()
+        };
+
+        Some(self.sample_active_sequence_hashes(sequence))
     }
 
     /// Check if KV event subscription should be started.
@@ -863,6 +917,7 @@ mod tests {
             ("DYN_USE_KV_EVENTS", "false"),
             ("DYN_ROUTER_REPLICA_SYNC", "yes"),
             ("DYN_ROUTER_TRACK_ACTIVE_BLOCKS", "0"),
+            ("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE", "4"),
             ("DYN_ROUTER_TRACK_OUTPUT_BLOCKS", "on"),
             ("DYN_ROUTER_TRACK_PREFILL_TOKENS", "false"),
             ("DYN_ROUTER_QUEUE_THRESHOLD", "4.5"),
@@ -875,6 +930,7 @@ mod tests {
         assert!(!config.use_kv_events);
         assert!(config.router_replica_sync);
         assert!(!config.router_track_active_blocks);
+        assert_eq!(config.router_active_sequence_stride, 4);
         assert!(config.router_track_output_blocks);
         assert!(!config.router_track_prefill_tokens);
         assert_eq!(config.router_queue_threshold, Some(4.5));
@@ -882,6 +938,14 @@ mod tests {
         let predicted = config_from_values(&[("DYN_ROUTER_PREDICTED_TTL_SECS", "60")]);
         assert_eq!(predicted.router_predicted_ttl_secs, Some(60.0));
         assert!(predicted.validate_config().is_ok());
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE must be greater than or equal to 1"
+    )]
+    fn dynamo_env_config_rejects_zero_active_sequence_stride() {
+        config_from_values(&[("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE", "0")]);
     }
 
     #[test]
@@ -975,6 +1039,99 @@ mod tests {
         );
 
         assert_eq!(seq_hashes, Some(compute_seq_hash_for_block(&precomputed)));
+    }
+
+    #[test]
+    fn compute_seq_hashes_for_tracking_samples_complete_stride_groups() {
+        let config = KvRouterConfig {
+            router_active_sequence_stride: 3,
+            ..Default::default()
+        };
+        let tokens: Vec<u32> = (0..10).collect();
+        let block_hashes: Vec<LocalBlockHash> = (1..=10).map(LocalBlockHash).collect();
+        let full_sequence = compute_seq_hash_for_block(&block_hashes);
+
+        let sampled = config
+            .compute_seq_hashes_for_tracking(
+                &tokens,
+                1,
+                None,
+                BlockHashOptions::default(),
+                Some(&block_hashes),
+            )
+            .unwrap();
+
+        assert_eq!(
+            sampled,
+            vec![full_sequence[2], full_sequence[5], full_sequence[8]]
+        );
+    }
+
+    #[test]
+    fn compute_seq_hashes_for_tracking_omits_short_and_trailing_groups() {
+        let config = KvRouterConfig {
+            router_active_sequence_stride: 4,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            config.compute_seq_hashes_for_tracking(
+                &[1, 2, 3],
+                1,
+                None,
+                BlockHashOptions::default(),
+                None,
+            ),
+            Some(Vec::new())
+        );
+
+        let sampled = config
+            .compute_seq_hashes_for_tracking(
+                &(0..10).collect::<Vec<_>>(),
+                1,
+                None,
+                BlockHashOptions::default(),
+                None,
+            )
+            .unwrap();
+        assert_eq!(sampled.len(), 2);
+    }
+
+    #[test]
+    fn compute_seq_hashes_for_tracking_samples_no_reuse_hashes() {
+        let config = KvRouterConfig {
+            router_active_sequence_stride: 3,
+            router_assume_kv_reuse: false,
+            ..Default::default()
+        };
+
+        let sampled = config
+            .compute_seq_hashes_for_tracking(
+                &(0..8).collect::<Vec<_>>(),
+                1,
+                None,
+                BlockHashOptions::default(),
+                None,
+            )
+            .unwrap();
+        assert_eq!(sampled.len(), 2);
+    }
+
+    #[test]
+    fn active_sequence_stride_defaults_from_legacy_json_and_rejects_zero() {
+        let config: KvRouterConfig = serde_json::from_str("{}").unwrap();
+        assert_eq!(config.router_active_sequence_stride, 1);
+
+        assert!(
+            serde_json::from_str::<KvRouterConfig>(r#"{"router_active_sequence_stride":0}"#)
+                .is_err()
+        );
+
+        let invalid = KvRouterConfig {
+            router_active_sequence_stride: 0,
+            ..Default::default()
+        };
+        assert!(invalid.validate().is_err());
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -36,6 +36,7 @@ fn sample_active_sequence(sequence: Vec<u64>, stride: usize) -> Vec<u64> {
 }
 
 pub const DYN_ROUTER_MIN_INITIAL_WORKERS: &str = "DYN_ROUTER_MIN_INITIAL_WORKERS";
+pub const DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE: &str = "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE";
 
 pub fn min_initial_workers_from_env() -> anyhow::Result<usize> {
     match env::var(DYN_ROUTER_MIN_INITIAL_WORKERS) {
@@ -110,9 +111,29 @@ pub fn apply_deprecated_overlap_score_weight_override(
     }
 }
 
+fn active_sequence_stride_env_value(
+    value: Result<String, VarError>,
+) -> anyhow::Result<Option<String>> {
+    match value {
+        Ok(value) => Ok(Some(value)),
+        Err(VarError::NotPresent) => Ok(None),
+        Err(VarError::NotUnicode(_)) => {
+            anyhow::bail!("{DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE} must be valid unicode")
+        }
+    }
+}
+
 /// Build a [`KvRouterConfig`] from defaults and standard Dynamo environment variables.
-pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
-    let config = kv_router_config_from_lookup(|key| env::var(key).ok());
+pub fn kv_router_config_from_dynamo_env() -> anyhow::Result<KvRouterConfig> {
+    let active_sequence_stride =
+        active_sequence_stride_env_value(env::var(DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE))?;
+    let config = kv_router_config_from_lookup(|key| {
+        if key == DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE {
+            active_sequence_stride.clone()
+        } else {
+            env::var(key).ok()
+        }
+    })?;
     tracing::info!(
         overlap_score_credit = config.overlap_score_credit,
         overlap_score_credit_decay = config.overlap_score_credit_decay,
@@ -129,10 +150,12 @@ pub fn kv_router_config_from_dynamo_env() -> KvRouterConfig {
         router_predicted_ttl_secs = ?config.router_predicted_ttl_secs,
         "KvRouterConfig initialized (DYN_* env overrides applied)"
     );
-    config
+    Ok(config)
 }
 
-fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvRouterConfig {
+fn kv_router_config_from_lookup(
+    get_env: impl Fn(&str) -> Option<String>,
+) -> anyhow::Result<KvRouterConfig> {
     fn parse_f64(get_env: &impl Fn(&str) -> Option<String>, key: &str) -> Option<f64> {
         get_env(key).and_then(|value| value.parse().ok())
     }
@@ -179,16 +202,15 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_ACTIVE_BLOCKS") {
         config.router_track_active_blocks = value;
     }
-    if let Some(raw_value) = get_env("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE") {
-        let value = raw_value.parse::<usize>().unwrap_or_else(|_| {
-            panic!(
-                "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE must be an integer greater than or equal to 1"
+    if let Some(raw_value) = get_env(DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE) {
+        let value = raw_value.parse::<usize>().map_err(|error| {
+            anyhow::anyhow!(
+                "{DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE} must be an integer greater than or equal to 1, got {raw_value:?}: {error}"
             )
-        });
-        assert!(
-            value >= 1,
-            "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE must be greater than or equal to 1"
-        );
+        })?;
+        if value == 0 {
+            anyhow::bail!("{DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE} must be greater than or equal to 1");
+        }
         config.router_active_sequence_stride = value;
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
@@ -207,7 +229,7 @@ fn kv_router_config_from_lookup(get_env: impl Fn(&str) -> Option<String>) -> KvR
         config.router_predicted_ttl_secs = Some(value);
     }
 
-    config
+    Ok(config)
 }
 
 fn apply_deprecated_overlap_score_weight_override_option(
@@ -513,7 +535,6 @@ pub struct KvRouterConfig {
 
     /// Retain one active-sequence hash for every N complete prompt blocks.
     /// A value of 1 disables sparsity.
-    #[serde(default = "default_active_sequence_stride")]
     #[validate(range(min = 1))]
     pub router_active_sequence_stride: usize,
 
@@ -877,10 +898,16 @@ impl KvRouterConfig {
             };
             compute_seq_hash_for_block(block_hashes)
         } else {
-            (0..num_blocks).map(|_| fastrand::u64(..)).collect()
+            (0..num_blocks / self.router_active_sequence_stride)
+                .map(|_| fastrand::u64(..))
+                .collect()
         };
 
-        Some(self.sample_active_sequence_hashes(sequence))
+        Some(if assume_kv_reuse {
+            self.sample_active_sequence_hashes(sequence)
+        } else {
+            sequence
+        })
     }
 
     /// Check if KV event subscription should be started.
@@ -903,6 +930,10 @@ mod tests {
     use std::collections::HashMap;
 
     fn config_from_values(values: &[(&str, &str)]) -> KvRouterConfig {
+        try_config_from_values(values).unwrap()
+    }
+
+    fn try_config_from_values(values: &[(&str, &str)]) -> anyhow::Result<KvRouterConfig> {
         let values: HashMap<&str, &str> = values.iter().copied().collect();
         kv_router_config_from_lookup(|key| values.get(key).map(|value| (*value).to_string()))
     }
@@ -941,11 +972,31 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE must be greater than or equal to 1"
-    )]
-    fn dynamo_env_config_rejects_zero_active_sequence_stride() {
-        config_from_values(&[("DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE", "0")]);
+    fn dynamo_env_config_returns_errors_for_invalid_active_sequence_stride() {
+        let zero = try_config_from_values(&[(DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE, "0")])
+            .unwrap_err()
+            .to_string();
+        assert!(zero.contains("must be greater than or equal to 1"));
+
+        let malformed = try_config_from_values(&[(DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE, "oops")])
+            .unwrap_err()
+            .to_string();
+        assert!(malformed.contains("must be an integer greater than or equal to 1"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dynamo_env_config_rejects_non_unicode_active_sequence_stride() {
+        use std::ffi::OsString;
+        use std::os::unix::ffi::OsStringExt;
+
+        let error =
+            active_sequence_stride_env_value(Err(VarError::NotUnicode(OsString::from_vec(vec![
+                0xff,
+            ]))))
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("must be valid unicode"));
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -11,28 +11,13 @@ use derive_builder::Builder;
 use dynamo_tokens::SequenceHash;
 use serde::{Deserialize, Serialize};
 
+use crate::active_sequence::{ActiveSequenceStride, TrackedSequenceHashes};
 use crate::protocols::{
     BlockHashOptions, LocalBlockHash, compute_block_hash_for_seq, compute_seq_hash_for_block,
 };
 
 const fn default_track_prefill_tokens() -> bool {
     true
-}
-
-const fn default_active_sequence_stride() -> usize {
-    1
-}
-
-fn sample_active_sequence(sequence: Vec<u64>, stride: usize) -> Vec<u64> {
-    assert!(stride > 0, "active sequence stride must be non-zero");
-    if stride == 1 {
-        return sequence;
-    }
-    sequence
-        .into_iter()
-        .skip(stride - 1)
-        .step_by(stride)
-        .collect()
 }
 
 pub const DYN_ROUTER_MIN_INITIAL_WORKERS: &str = "DYN_ROUTER_MIN_INITIAL_WORKERS";
@@ -142,7 +127,7 @@ pub fn kv_router_config_from_dynamo_env() -> anyhow::Result<KvRouterConfig> {
         use_kv_events = config.use_kv_events,
         router_replica_sync = config.router_replica_sync,
         router_track_active_blocks = config.router_track_active_blocks,
-        router_active_sequence_stride = config.router_active_sequence_stride,
+        router_active_sequence_stride = config.router_active_sequence_stride.get(),
         router_track_output_blocks = config.router_track_output_blocks,
         router_track_prefill_tokens = config.router_track_prefill_tokens,
         router_queue_threshold = ?config.router_queue_threshold,
@@ -208,10 +193,11 @@ fn kv_router_config_from_lookup(
                 "{DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE} must be an integer greater than or equal to 1, got {raw_value:?}: {error}"
             )
         })?;
-        if value == 0 {
-            anyhow::bail!("{DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE} must be greater than or equal to 1");
-        }
-        config.router_active_sequence_stride = value;
+        config.router_active_sequence_stride = ActiveSequenceStride::new(value).map_err(|_| {
+            anyhow::anyhow!(
+                "{DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE} must be greater than or equal to 1"
+            )
+        })?;
     }
     if let Some(value) = parse_bool(&get_env, "DYN_ROUTER_TRACK_OUTPUT_BLOCKS") {
         config.router_track_output_blocks = value;
@@ -480,7 +466,7 @@ impl Default for KvRouterConfigSerde {
             use_kv_events: config.use_kv_events,
             router_replica_sync: config.router_replica_sync,
             router_track_active_blocks: config.router_track_active_blocks,
-            router_active_sequence_stride: config.router_active_sequence_stride,
+            router_active_sequence_stride: config.router_active_sequence_stride.get(),
             router_track_output_blocks: config.router_track_output_blocks,
             router_assume_kv_reuse: config.router_assume_kv_reuse,
             router_track_prefill_tokens: config.router_track_prefill_tokens,
@@ -535,8 +521,7 @@ pub struct KvRouterConfig {
 
     /// Retain one active-sequence hash for every N complete prompt blocks.
     /// A value of 1 disables sparsity.
-    #[validate(range(min = 1))]
-    pub router_active_sequence_stride: usize,
+    pub router_active_sequence_stride: ActiveSequenceStride,
 
     /// Whether to track output blocks during generation (default: false)
     /// When enabled, the router adds placeholder blocks as tokens are generated
@@ -634,7 +619,7 @@ impl Default for KvRouterConfig {
             use_kv_events: true,
             router_replica_sync: false,
             router_track_active_blocks: true,
-            router_active_sequence_stride: default_active_sequence_stride(),
+            router_active_sequence_stride: ActiveSequenceStride::ONE,
             router_track_output_blocks: false,
             router_assume_kv_reuse: true,
             router_track_prefill_tokens: default_track_prefill_tokens(),
@@ -681,7 +666,10 @@ impl TryFrom<KvRouterConfigSerde> for KvRouterConfig {
             use_kv_events: compat.use_kv_events,
             router_replica_sync: compat.router_replica_sync,
             router_track_active_blocks: compat.router_track_active_blocks,
-            router_active_sequence_stride: compat.router_active_sequence_stride,
+            router_active_sequence_stride: ActiveSequenceStride::new(
+                compat.router_active_sequence_stride,
+            )
+            .map_err(|error| format!("router_active_sequence_stride: {error}"))?,
             router_track_output_blocks: compat.router_track_output_blocks,
             router_assume_kv_reuse: compat.router_assume_kv_reuse,
             router_track_prefill_tokens: compat.router_track_prefill_tokens,
@@ -735,8 +723,8 @@ impl KvRouterConfig {
     pub(crate) fn sample_active_sequence_hashes(
         &self,
         sequence: Vec<SequenceHash>,
-    ) -> Vec<SequenceHash> {
-        sample_active_sequence(sequence, self.router_active_sequence_stride)
+    ) -> TrackedSequenceHashes {
+        self.router_active_sequence_stride.sample_dense(sequence)
     }
 
     fn loaded_policy_config(
@@ -874,14 +862,14 @@ impl KvRouterConfig {
         config_override: Option<&RouterConfigOverride>,
         hash_options: BlockHashOptions<'_>,
         precomputed_block_hashes: Option<&[LocalBlockHash]>,
-    ) -> Option<Vec<u64>> {
+    ) -> Option<TrackedSequenceHashes> {
         if !self.router_track_active_blocks {
             return None;
         }
 
         let num_blocks = tokens.len() / block_size as usize;
         if num_blocks == 0 {
-            return Some(Vec::new());
+            return Some(TrackedSequenceHashes::default());
         }
 
         let assume_kv_reuse = self.assume_kv_reuse(config_override);
@@ -898,16 +886,13 @@ impl KvRouterConfig {
             };
             compute_seq_hash_for_block(block_hashes)
         } else {
-            (0..num_blocks / self.router_active_sequence_stride)
-                .map(|_| fastrand::u64(..))
-                .collect()
+            return Some(
+                self.router_active_sequence_stride
+                    .generate_for_complete_blocks(num_blocks, || fastrand::u64(..)),
+            );
         };
 
-        Some(if assume_kv_reuse {
-            self.sample_active_sequence_hashes(sequence)
-        } else {
-            sequence
-        })
+        Some(self.sample_active_sequence_hashes(sequence))
     }
 
     /// Check if KV event subscription should be started.
@@ -961,7 +946,7 @@ mod tests {
         assert!(!config.use_kv_events);
         assert!(config.router_replica_sync);
         assert!(!config.router_track_active_blocks);
-        assert_eq!(config.router_active_sequence_stride, 4);
+        assert_eq!(config.router_active_sequence_stride.get(), 4);
         assert!(config.router_track_output_blocks);
         assert!(!config.router_track_prefill_tokens);
         assert_eq!(config.router_queue_threshold, Some(4.5));
@@ -1089,13 +1074,16 @@ mod tests {
             Some(&precomputed),
         );
 
-        assert_eq!(seq_hashes, Some(compute_seq_hash_for_block(&precomputed)));
+        assert_eq!(
+            seq_hashes.unwrap().as_slice(),
+            compute_seq_hash_for_block(&precomputed)
+        );
     }
 
     #[test]
     fn compute_seq_hashes_for_tracking_samples_complete_stride_groups() {
         let config = KvRouterConfig {
-            router_active_sequence_stride: 3,
+            router_active_sequence_stride: ActiveSequenceStride::new(3).unwrap(),
             ..Default::default()
         };
         let tokens: Vec<u32> = (0..10).collect();
@@ -1113,15 +1101,15 @@ mod tests {
             .unwrap();
 
         assert_eq!(
-            sampled,
-            vec![full_sequence[2], full_sequence[5], full_sequence[8]]
+            sampled.as_slice(),
+            &[full_sequence[2], full_sequence[5], full_sequence[8]]
         );
     }
 
     #[test]
     fn compute_seq_hashes_for_tracking_omits_short_and_trailing_groups() {
         let config = KvRouterConfig {
-            router_active_sequence_stride: 4,
+            router_active_sequence_stride: ActiveSequenceStride::new(4).unwrap(),
             ..Default::default()
         };
 
@@ -1133,7 +1121,7 @@ mod tests {
                 BlockHashOptions::default(),
                 None,
             ),
-            Some(Vec::new())
+            Some(TrackedSequenceHashes::default())
         );
 
         let sampled = config
@@ -1151,7 +1139,7 @@ mod tests {
     #[test]
     fn compute_seq_hashes_for_tracking_samples_no_reuse_hashes() {
         let config = KvRouterConfig {
-            router_active_sequence_stride: 3,
+            router_active_sequence_stride: ActiveSequenceStride::new(3).unwrap(),
             router_assume_kv_reuse: false,
             ..Default::default()
         };
@@ -1171,18 +1159,29 @@ mod tests {
     #[test]
     fn active_sequence_stride_defaults_from_legacy_json_and_rejects_zero() {
         let config: KvRouterConfig = serde_json::from_str("{}").unwrap();
-        assert_eq!(config.router_active_sequence_stride, 1);
+        assert_eq!(
+            config.router_active_sequence_stride,
+            ActiveSequenceStride::ONE
+        );
+
+        let config = KvRouterConfig {
+            router_active_sequence_stride: ActiveSequenceStride::new(4).unwrap(),
+            ..Default::default()
+        };
+        let encoded = serde_json::to_value(&config).unwrap();
+        assert_eq!(encoded["router_active_sequence_stride"], 4);
+        let decoded: KvRouterConfig = serde_json::from_value(encoded).unwrap();
+        assert_eq!(
+            decoded.router_active_sequence_stride,
+            ActiveSequenceStride::new(4).unwrap()
+        );
 
         assert!(
             serde_json::from_str::<KvRouterConfig>(r#"{"router_active_sequence_stride":0}"#)
                 .is_err()
         );
 
-        let invalid = KvRouterConfig {
-            router_active_sequence_stride: 0,
-            ..Default::default()
-        };
-        assert!(invalid.validate().is_err());
+        assert!(ActiveSequenceStride::new(0).is_err());
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -22,6 +22,7 @@ use super::types::{
     KvSchedulerError, OverloadedWorkerProvider, PotentialLoad, ScheduleMode, ScheduleRequest,
     SchedulingRequest, SchedulingResponse, TierOverlapBlocks,
 };
+use crate::TrackedSequenceHashes;
 use crate::protocols::RoutingConstraints;
 use crate::protocols::{LocalBlockHash, WorkerConfigLike, WorkerId, WorkerWithDpRank};
 use crate::sequences::topology::WorkerDpRange;
@@ -29,7 +30,6 @@ use crate::sequences::{
     ActiveSequencesMultiWorker, PrefillTokenDeltas, SequenceError, SequencePublisher,
     SequenceRequest,
 };
-use dynamo_tokens::SequenceHash;
 
 pub struct LocalScheduler<P, C, Sel = DefaultWorkerSelector, RF = NoopOverlapScoresRefresh>
 where
@@ -354,7 +354,7 @@ where
         &self,
         maybe_request_id: Option<String>,
         isl_tokens: usize,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         tier_overlap_blocks: TierOverlapBlocks,
         effective_overlap_blocks: HashMap<WorkerWithDpRank, f64>,
         effective_cached_tokens: HashMap<WorkerWithDpRank, usize>,
@@ -400,7 +400,7 @@ where
         &self,
         maybe_request_id: Option<String>,
         isl_tokens: usize,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         block_hashes: Option<Vec<LocalBlockHash>>,
         tier_overlap_blocks: TierOverlapBlocks,
         effective_overlap_blocks: HashMap<WorkerWithDpRank, f64>,
@@ -444,7 +444,7 @@ where
         &self,
         maybe_request_id: Option<String>,
         isl_tokens: usize,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         block_hashes: Option<Vec<LocalBlockHash>>,
         tier_overlap_blocks: TierOverlapBlocks,
         effective_overlap_blocks: HashMap<WorkerWithDpRank, f64>,
@@ -567,7 +567,7 @@ where
 
     pub fn get_potential_loads(
         &self,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         isl_tokens: usize,
         effective_cached_tokens: HashMap<WorkerWithDpRank, usize>,
         track_prefill_tokens: bool,
@@ -588,7 +588,7 @@ where
         };
         let (decode_blocks, prefill_tokens, active_requests) =
             self.slots.potential_blocks_and_tokens_at::<true>(
-                token_seq.as_deref(),
+                token_seq.as_ref(),
                 &prefill_token_deltas,
                 decay_now,
             );
@@ -775,6 +775,10 @@ mod tests {
     use crate::sequences::SequenceSubscriber;
     use crate::test_utils::{NoopSequencePublisher, SimpleWorkerConfig};
 
+    fn tracked(sequence: Vec<u64>) -> Option<TrackedSequenceHashes> {
+        Some(crate::active_sequence::tracked_sequence_hashes(sequence))
+    }
+
     struct TestSequenceSubscriber {
         rx: mpsc::UnboundedReceiver<ActiveSequenceEvent>,
     }
@@ -871,7 +875,7 @@ mod tests {
     fn request(mode: ScheduleMode) -> ScheduleRequest {
         ScheduleRequest {
             mode,
-            token_seq: Some(vec![1, 2, 3, 4]),
+            token_seq: tracked(vec![1, 2, 3, 4]),
             block_hashes: None,
             isl_tokens: 64,
             lora_name: None,
@@ -912,7 +916,8 @@ mod tests {
             scheduler.get_active_lora_counts(),
             HashMap::from([(String::from("adapter-a"), 1)])
         );
-        let loads = scheduler.get_potential_loads(Some(vec![1, 2, 3, 4]), 64, HashMap::new(), true);
+        let loads =
+            scheduler.get_potential_loads(tracked(vec![1, 2, 3, 4]), 64, HashMap::new(), true);
         let worker_load = loads
             .iter()
             .find(|load| load.worker_id == response.best_worker.worker_id && load.dp_rank == 0)
@@ -986,7 +991,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1035,7 +1040,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::from([(worker, 0.75)]),
                 HashMap::from([(worker, 48)]),
@@ -1082,7 +1087,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1107,7 +1112,7 @@ mod tests {
                     .schedule(
                         Some("req-2".to_string()),
                         64,
-                        Some(vec![5, 6, 7, 8]),
+                        tracked(vec![5, 6, 7, 8]),
                         TierOverlapBlocks::default(),
                         HashMap::new(),
                         HashMap::new(),
@@ -1153,7 +1158,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1178,7 +1183,7 @@ mod tests {
                     .schedule(
                         Some("req-2".to_string()),
                         64,
-                        Some(vec![5, 6, 7, 8]),
+                        tracked(vec![5, 6, 7, 8]),
                         TierOverlapBlocks::default(),
                         HashMap::new(),
                         HashMap::new(),
@@ -1239,7 +1244,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1264,7 +1269,7 @@ mod tests {
                     .schedule(
                         Some("req-2".to_string()),
                         64,
-                        Some(vec![5, 6, 7, 8]),
+                        tracked(vec![5, 6, 7, 8]),
                         TierOverlapBlocks::default(),
                         HashMap::new(),
                         HashMap::new(),
@@ -1324,7 +1329,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1349,7 +1354,7 @@ mod tests {
                     .schedule(
                         Some("req-2".to_string()),
                         64,
-                        Some(vec![5, 6, 7, 8]),
+                        tracked(vec![5, 6, 7, 8]),
                         TierOverlapBlocks::default(),
                         HashMap::new(),
                         HashMap::new(),
@@ -1407,7 +1412,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1608,7 +1613,7 @@ mod tests {
             },
         );
         let (scheduler, slots, _cfg_tx, cancel_token) = make_scheduler(workers, None, true, None);
-        let token_seq = vec![11, 22, 33, 44];
+        let token_seq = tracked(vec![11, 22, 33, 44]).unwrap();
 
         let prefill_token_deltas = PrefillTokenDeltas::uniform(128);
         let (decode_blocks, prefill_tokens, _) =
@@ -1666,7 +1671,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 100,
-                Some(vec![1, 2, 3, 4]),
+                tracked(vec![1, 2, 3, 4]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),
@@ -1902,7 +1907,7 @@ mod tests {
             .schedule(
                 Some("req-1".to_string()),
                 64,
-                Some(vec![11, 22]),
+                tracked(vec![11, 22]),
                 TierOverlapBlocks::default(),
                 HashMap::new(),
                 HashMap::new(),

--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -1205,6 +1205,7 @@ mod tests {
                 worker: WorkerWithDpRank::new(0, 0),
                 data: ActiveSequenceEventData::MarkPrefillCompleted,
                 router_id: 1,
+                stride: None,
                 lora_name: None,
             })
             .unwrap();
@@ -1290,6 +1291,7 @@ mod tests {
                 worker: WorkerWithDpRank::new(0, 0),
                 data: ActiveSequenceEventData::Free,
                 router_id: 1,
+                stride: None,
                 lora_name: None,
             })
             .unwrap();
@@ -1374,6 +1376,7 @@ mod tests {
                 worker: WorkerWithDpRank::new(0, 0),
                 data: ActiveSequenceEventData::Free,
                 router_id: 1,
+                stride: None,
                 lora_name: None,
             })
             .unwrap();

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1504,7 +1504,7 @@ impl<
         });
         request.worker_loads = self
             .slots
-            .project_worker_loads(request.token_seq.as_deref(), decay_now);
+            .project_worker_loads(request.token_seq.as_ref(), decay_now);
 
         let selection = {
             let workers = self.workers_with_configs.borrow();

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -4,7 +4,6 @@
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 
-use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
 use serde::{Deserialize, Serialize};
 
@@ -12,6 +11,7 @@ use super::config::RouterConfigOverride;
 use super::filter::RoutingEligibility;
 use super::overlap::{OverlapSignals, SelectedWorkerTierSnapshot};
 use super::prefill_load::effective_prefill_tokens;
+use crate::active_sequence::TrackedSequenceHashes;
 pub use crate::protocols::PotentialLoad;
 use crate::protocols::{
     LocalBlockHash, RoutingConstraints, SharedCacheHits, WorkerConfigLike, WorkerId,
@@ -154,7 +154,7 @@ impl ScheduleMode {
 /// Validated request accepted by [`LocalScheduler`](super::LocalScheduler).
 pub struct ScheduleRequest {
     pub mode: ScheduleMode,
-    pub token_seq: Option<Vec<SequenceHash>>,
+    pub token_seq: Option<TrackedSequenceHashes>,
     pub block_hashes: Option<Vec<LocalBlockHash>>,
     pub isl_tokens: usize,
     pub lora_name: Option<String>,
@@ -179,7 +179,7 @@ pub struct ScheduleRequest {
 pub struct SchedulingRequest {
     // Request identity and payload.
     pub mode: ScheduleMode,
-    pub token_seq: Option<Vec<SequenceHash>>,
+    pub token_seq: Option<TrackedSequenceHashes>,
     pub isl_tokens: usize,
     pub lora_name: Option<String>,
     pub expected_output_tokens: Option<u32>,

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -66,12 +66,6 @@ pub(super) struct BlockLoad {
     pub(super) output_blocks: f64,
 }
 
-impl BlockLoad {
-    pub(super) fn active_blocks(self, prompt_stride: usize) -> usize {
-        (self.prompt_units * prompt_stride as f64 + self.output_blocks).round() as usize
-    }
-}
-
 /// Exact per-worker prompt liveness backed by compressed arena edges.
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
@@ -311,7 +305,8 @@ impl BlockTracker {
     }
 
     pub(super) fn active_blocks(&self) -> usize {
-        self.load().active_blocks(1)
+        let load = self.load();
+        super::estimate_physical_active_blocks(load.prompt_units, load.output_blocks, 1)
     }
 
     pub(super) fn load(&self) -> BlockLoad {

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -306,7 +306,11 @@ impl BlockTracker {
 
     pub(super) fn active_blocks(&self) -> usize {
         let load = self.load();
-        super::estimate_physical_active_blocks(load.prompt_units, load.output_blocks, 1)
+        super::estimate_physical_active_blocks(
+            load.prompt_units,
+            load.output_blocks,
+            crate::ActiveSequenceStride::ONE,
+        )
     }
 
     pub(super) fn load(&self) -> BlockLoad {

--- a/lib/kv-router/src/sequences/block_tracker.rs
+++ b/lib/kv-router/src/sequences/block_tracker.rs
@@ -60,6 +60,18 @@ pub(super) struct ReleasedPromptPath {
     pub(super) remove_from: usize,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub(super) struct BlockLoad {
+    pub(super) prompt_units: f64,
+    pub(super) output_blocks: f64,
+}
+
+impl BlockLoad {
+    pub(super) fn active_blocks(self, prompt_stride: usize) -> usize {
+        (self.prompt_units * prompt_stride as f64 + self.output_blocks).round() as usize
+    }
+}
+
 /// Exact per-worker prompt liveness backed by compressed arena edges.
 #[derive(Debug, Default)]
 pub(super) struct BlockTracker {
@@ -299,7 +311,14 @@ impl BlockTracker {
     }
 
     pub(super) fn active_blocks(&self) -> usize {
-        (self.prompt_total + self.output_total).round() as usize
+        self.load().active_blocks(1)
+    }
+
+    pub(super) fn load(&self) -> BlockLoad {
+        BlockLoad {
+            prompt_units: self.prompt_total,
+            output_blocks: self.output_total,
+        }
     }
 
     #[cfg(any(test, debug_assertions))]

--- a/lib/kv-router/src/sequences/mod.rs
+++ b/lib/kv-router/src/sequences/mod.rs
@@ -16,3 +16,11 @@ pub use multi_worker::*;
 pub use prefill_tracker::PrefillTokenDeltas;
 pub use prompt_registry::{PotentialLoadMaps, WorkerLoadProjection};
 pub use single::*;
+
+pub(super) fn estimate_physical_active_blocks(
+    prompt_units: f64,
+    output_blocks: f64,
+    prompt_stride: usize,
+) -> usize {
+    (prompt_units * prompt_stride as f64 + output_blocks).round() as usize
+}

--- a/lib/kv-router/src/sequences/mod.rs
+++ b/lib/kv-router/src/sequences/mod.rs
@@ -17,10 +17,12 @@ pub use prefill_tracker::PrefillTokenDeltas;
 pub use prompt_registry::{PotentialLoadMaps, WorkerLoadProjection};
 pub use single::*;
 
+use crate::active_sequence::ActiveSequenceStride;
+
 pub(super) fn estimate_physical_active_blocks(
     prompt_units: f64,
     output_blocks: f64,
-    prompt_stride: usize,
+    prompt_stride: ActiveSequenceStride,
 ) -> usize {
-    (prompt_units * prompt_stride as f64 + output_blocks).round() as usize
+    (prompt_units * prompt_stride.get() as f64 + output_blocks).round() as usize
 }

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -9,12 +9,12 @@
 //! transport (e.g., NATS EventPublisher, Prometheus gauges) so that all business logic lives in
 //! this crate while the runtime glue stays in `lib/llm`.
 
+#[cfg(test)]
 use dynamo_tokens::SequenceHash;
 use parking_lot::{Mutex, RwLock};
 use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashMap;
 use std::future::Future;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -29,6 +29,7 @@ use super::request_maps::RequestIndex;
 use super::single::{ActiveSequences, PromptMembershipDelta, RequestId};
 use super::topology::{WorkerDpRange, WorkerTable, WorkerTopologyChange, WorkerTopologyError};
 use super::{PotentialLoadMaps, PrefillTokenDeltas, WorkerLoadProjection};
+use crate::active_sequence::{ActiveSequenceStride, TrackedSequenceHashes};
 use crate::protocols::{
     ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventData, ActiveSequenceStrideError,
     PrefillLoadHint, WorkerId, WorkerWithDpRank,
@@ -84,8 +85,8 @@ pub trait SequencePublisher: Send + Sync {
     /// match the local tracker configuration.
     fn observe_replica_stride_mismatch(
         &self,
-        _expected: usize,
-        _received: Result<NonZeroUsize, ActiveSequenceStrideError>,
+        _expected: ActiveSequenceStride,
+        _received: Result<ActiveSequenceStride, ActiveSequenceStrideError>,
         _worker_type: &str,
     ) {
     }
@@ -130,7 +131,7 @@ pub struct SequenceTrackerOptions {
     /// Whether local lifecycle events are published for replica synchronization.
     pub replica_sync: bool,
     /// Number of physical prompt blocks represented by each retained sequence hash.
-    pub active_sequence_stride: NonZeroUsize,
+    pub active_sequence_stride: ActiveSequenceStride,
 }
 
 impl Default for SequenceTrackerOptions {
@@ -139,7 +140,7 @@ impl Default for SequenceTrackerOptions {
             replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
             expiry_enabled: true,
             replica_sync: false,
-            active_sequence_stride: NonZeroUsize::MIN,
+            active_sequence_stride: ActiveSequenceStride::ONE,
         }
     }
 }
@@ -166,7 +167,7 @@ pub enum SequenceError {
 /// Bundled parameters for adding a request to the sequence tracker.
 pub struct SequenceRequest {
     pub request_id: RequestId,
-    pub token_sequence: Option<Vec<SequenceHash>>,
+    pub token_sequence: Option<TrackedSequenceHashes>,
     pub track_prefill_tokens: bool,
     pub expected_output_tokens: Option<u32>,
     pub prefill_load_hint: Option<PrefillLoadHint>,
@@ -188,7 +189,7 @@ pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
     pub(super) request_index: RequestIndex,
     pub(super) prompt_registry: PromptRegistry,
     block_size: usize,
-    pub(super) active_sequence_stride: usize,
+    pub(super) active_sequence_stride: ActiveSequenceStride,
     pub(super) router_id: u64,
     pub(super) publisher: Arc<P>,
     remote_state_updates: watch::Sender<()>,
@@ -196,7 +197,7 @@ pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
     remote_state_update_count: AtomicUsize,
     replica_sync: bool,
     pub(super) warned_replica_stride_mismatches:
-        Mutex<FxHashSet<(u64, Result<NonZeroUsize, ActiveSequenceStrideError>)>>,
+        Mutex<FxHashSet<(u64, Result<ActiveSequenceStride, ActiveSequenceStrideError>)>>,
     pub(super) replica_worker_policy: ReplicaWorkerPolicy,
     worker_type: &'static str,
 }
@@ -283,7 +284,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         options: SequenceTrackerOptions,
     ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
-        let active_sequence_stride = options.active_sequence_stride.get();
+        let active_sequence_stride = options.active_sequence_stride;
         let (remote_state_updates, _) = watch::channel(());
         let workers = if options.expiry_enabled {
             WorkerTable::new(block_size, &dp_range)
@@ -403,7 +404,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     }
 
     fn event_stride(&self) -> Option<usize> {
-        (self.active_sequence_stride > 1).then_some(self.active_sequence_stride)
+        self.active_sequence_stride.event_value()
     }
 
     /// Subscribe to remote lifecycle updates that were applied through replica sync.
@@ -565,7 +566,10 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             request_id: req.request_id.clone(),
             worker: req.worker,
             data: ActiveSequenceEventData::AddRequest {
-                token_sequence: req.token_sequence.clone(),
+                token_sequence: req
+                    .token_sequence
+                    .as_ref()
+                    .map(|sequence| sequence.as_slice().to_vec()),
                 track_prefill_tokens: req.track_prefill_tokens,
                 expected_output_tokens: req.expected_output_tokens,
                 prefill_load_hint: req.prefill_load_hint,
@@ -682,7 +686,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     /// Query all workers for the potential blocks and tokens.
     pub fn potential_blocks_and_tokens<const INCLUDE_ACTIVE_REQUESTS: bool>(
         &self,
-        token_sequence: Option<&[SequenceHash]>,
+        token_sequence: Option<&TrackedSequenceHashes>,
         prefill_token_deltas: &PrefillTokenDeltas,
     ) -> PotentialLoadMaps {
         self.potential_blocks_and_tokens_at::<INCLUDE_ACTIVE_REQUESTS>(
@@ -694,7 +698,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 
     pub fn potential_blocks_and_tokens_at<const INCLUDE_ACTIVE_REQUESTS: bool>(
         &self,
-        token_sequence: Option<&[SequenceHash]>,
+        token_sequence: Option<&TrackedSequenceHashes>,
         prefill_token_deltas: &PrefillTokenDeltas,
         decay_now: Instant,
     ) -> PotentialLoadMaps {
@@ -727,7 +731,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
 
     pub fn project_worker_loads(
         &self,
-        token_sequence: Option<&[SequenceHash]>,
+        token_sequence: Option<&TrackedSequenceHashes>,
         decay_now: Instant,
     ) -> FxHashMap<WorkerWithDpRank, WorkerLoadProjection> {
         #[cfg(feature = "bench")]
@@ -1134,6 +1138,14 @@ mod tests {
     use crate::sequences::prefill_tracker::PrefillTimeLoadError;
     use crate::test_utils::NoopSequencePublisher;
 
+    fn tracked_hashes(sequence: Vec<SequenceHash>) -> TrackedSequenceHashes {
+        crate::active_sequence::tracked_sequence_hashes(sequence)
+    }
+
+    fn tracked(sequence: Vec<SequenceHash>) -> Option<TrackedSequenceHashes> {
+        Some(tracked_hashes(sequence))
+    }
+
     fn make_sequences() -> ActiveSequencesMultiWorker<NoopSequencePublisher> {
         ActiveSequencesMultiWorker::new(
             NoopSequencePublisher,
@@ -1320,7 +1332,12 @@ mod tests {
         observations: Mutex<Vec<(WorkerWithDpRank, usize, usize)>>,
         registered: Mutex<Vec<WorkerWithDpRank>>,
         removed: Mutex<Vec<WorkerWithDpRank>>,
-        stride_mismatches: Mutex<Vec<(usize, Result<NonZeroUsize, ActiveSequenceStrideError>)>>,
+        stride_mismatches: Mutex<
+            Vec<(
+                ActiveSequenceStride,
+                Result<ActiveSequenceStride, ActiveSequenceStrideError>,
+            )>,
+        >,
     }
 
     impl RecordingPublisherState {
@@ -1384,8 +1401,8 @@ mod tests {
 
         fn observe_replica_stride_mismatch(
             &self,
-            expected: usize,
-            received: Result<NonZeroUsize, ActiveSequenceStrideError>,
+            expected: ActiveSequenceStride,
+            received: Result<ActiveSequenceStride, ActiveSequenceStrideError>,
             _worker_type: &str,
         ) {
             self.state
@@ -1434,7 +1451,7 @@ mod tests {
             "test",
             SequenceTrackerOptions {
                 replica_sync: true,
-                active_sequence_stride: NonZeroUsize::new(active_sequence_stride).unwrap(),
+                active_sequence_stride: ActiveSequenceStride::new(active_sequence_stride).unwrap(),
                 ..Default::default()
             },
         );
@@ -1529,7 +1546,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-1".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -1559,7 +1576,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: a_oldest.clone(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: modeled_hint(100, 10),
@@ -1573,7 +1590,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "a-later".to_string(),
-                    token_sequence: Some(vec![4, 5, 6]),
+                    token_sequence: tracked(vec![4, 5, 6]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: modeled_hint(60, 4),
@@ -1587,7 +1604,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "b-unmodeled".to_string(),
-                    token_sequence: Some(vec![7, 8, 9]),
+                    token_sequence: tracked(vec![7, 8, 9]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
@@ -1628,7 +1645,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "oldest".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: modeled_hint(100, 10),
@@ -1642,7 +1659,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: later.clone(),
-                    token_sequence: Some(vec![4, 5, 6]),
+                    token_sequence: tracked(vec![4, 5, 6]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: modeled_hint(40, 4),
@@ -1697,7 +1714,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-a".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
@@ -1718,7 +1735,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-b".to_string(),
-                    token_sequence: Some(vec![1, 2, 4]),
+                    token_sequence: tracked(vec![1, 2, 4]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
@@ -1736,13 +1753,14 @@ mod tests {
         let prefill_token_deltas = PrefillTokenDeltas::new(16, deltas);
         let expected =
             naive_potential_loads(&sequences, Some(&prompt), &prefill_token_deltas, decay_now);
+        let tracked_prompt = tracked_hashes(prompt);
 
         let actual = sequences.potential_blocks_and_tokens_at::<false>(
-            Some(&prompt),
+            Some(&tracked_prompt),
             &prefill_token_deltas,
             decay_now,
         );
-        let projections = sequences.project_worker_loads(Some(&prompt), decay_now);
+        let projections = sequences.project_worker_loads(Some(&tracked_prompt), decay_now);
 
         assert_eq!(actual.0, expected.0);
         assert_eq!(actual.1, expected.1);
@@ -1774,7 +1792,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-a".to_string(),
-                    token_sequence: Some(vec![1, 2, 4, 5]),
+                    token_sequence: tracked(vec![1, 2, 4, 5]),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -1785,8 +1803,9 @@ mod tests {
             )
             .unwrap();
 
+        let query = tracked_hashes(vec![1, 2, 3, 5]);
         let (potential_blocks, _, _) = sequences.potential_blocks_and_tokens_at::<false>(
-            Some(&[1, 2, 3, 5]),
+            Some(&query),
             &PrefillTokenDeltas::none(),
             decay_now,
         );
@@ -1810,7 +1829,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "base".to_string(),
-                    token_sequence: Some(base_prompt.clone()),
+                    token_sequence: tracked(base_prompt.clone()),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -1824,7 +1843,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "lora".to_string(),
-                    token_sequence: Some(lora_prompt),
+                    token_sequence: tracked(lora_prompt),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -1841,8 +1860,9 @@ mod tests {
             &PrefillTokenDeltas::none(),
             decay_now,
         );
+        let tracked_base_prompt = tracked_hashes(base_prompt.clone());
         let actual = sequences.potential_blocks_and_tokens_at::<false>(
-            Some(&base_prompt),
+            Some(&tracked_base_prompt),
             &PrefillTokenDeltas::none(),
             decay_now,
         );
@@ -1870,7 +1890,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-a".to_string(),
-                    token_sequence: Some(prompt_a.clone()),
+                    token_sequence: tracked(prompt_a.clone()),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -1884,7 +1904,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-b".to_string(),
-                    token_sequence: Some(prompt_b.clone()),
+                    token_sequence: tracked(prompt_b.clone()),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -1901,8 +1921,9 @@ mod tests {
             &PrefillTokenDeltas::none(),
             decay_now,
         );
+        let tracked_prompt_b = tracked_hashes(prompt_b.clone());
         let actual = sequences.potential_blocks_and_tokens_at::<false>(
-            Some(&prompt_b),
+            Some(&tracked_prompt_b),
             &PrefillTokenDeltas::none(),
             decay_now,
         );
@@ -1920,7 +1941,7 @@ mod tests {
             decay_now,
         );
         let actual_after_free = sequences.potential_blocks_and_tokens_at::<false>(
-            Some(&prompt_b),
+            Some(&tracked_prompt_b),
             &PrefillTokenDeltas::none(),
             decay_now,
         );
@@ -1942,7 +1963,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-1".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
@@ -1972,7 +1993,7 @@ mod tests {
             "test",
             SequenceTrackerOptions {
                 expiry_enabled: false,
-                active_sequence_stride: NonZeroUsize::new(3).unwrap(),
+                active_sequence_stride: ActiveSequenceStride::new(3).unwrap(),
                 ..Default::default()
             },
         );
@@ -1990,7 +2011,7 @@ mod tests {
                 .add_request(
                     SequenceRequest {
                         request_id: request_id.to_string(),
-                        token_sequence: Some(token_sequence),
+                        token_sequence: tracked(token_sequence),
                         track_prefill_tokens: true,
                         expected_output_tokens: None,
                         prefill_load_hint: tracking_hint(4),
@@ -2025,7 +2046,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-1".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
@@ -2042,7 +2063,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-2".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: tracking_hint(12),
@@ -2062,8 +2083,9 @@ mod tests {
             &PrefillTokenDeltas::none(),
             Instant::now(),
         );
+        let query = tracked_hashes(vec![1, 2, 3]);
         let actual = sequences.potential_blocks_and_tokens_at::<false>(
-            Some(&[1, 2, 3]),
+            Some(&query),
             &PrefillTokenDeltas::none(),
             Instant::now(),
         );
@@ -2350,7 +2372,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: request_id.clone(),
-                    token_sequence: Some(vec![10, 20]),
+                    token_sequence: tracked(vec![10, 20]),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -2435,9 +2457,18 @@ mod tests {
         assert_eq!(
             *publisher.stride_mismatches.lock().unwrap(),
             vec![
-                (2, Ok(NonZeroUsize::new(3).unwrap())),
-                (2, Ok(NonZeroUsize::new(3).unwrap())),
-                (2, Err(ActiveSequenceStrideError::Zero)),
+                (
+                    ActiveSequenceStride::new(2).unwrap(),
+                    Ok(ActiveSequenceStride::new(3).unwrap()),
+                ),
+                (
+                    ActiveSequenceStride::new(2).unwrap(),
+                    Ok(ActiveSequenceStride::new(3).unwrap()),
+                ),
+                (
+                    ActiveSequenceStride::new(2).unwrap(),
+                    Err(ActiveSequenceStrideError::Zero),
+                ),
             ]
         );
         assert_eq!(sequences.warned_replica_stride_mismatches.lock().len(), 2);
@@ -2774,7 +2805,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-1".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -2816,7 +2847,7 @@ mod tests {
             add_sequences.add_request_if_registered(
                 SequenceRequest {
                     request_id: "req-1".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -2851,7 +2882,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: request_id.clone(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: false,
                     expected_output_tokens: None,
                     prefill_load_hint: None,
@@ -2899,7 +2930,7 @@ mod tests {
             .add_request(
                 SequenceRequest {
                     request_id: "req-1".to_string(),
-                    token_sequence: Some(vec![1, 2, 3]),
+                    token_sequence: tracked(vec![1, 2, 3]),
                     track_prefill_tokens: true,
                     expected_output_tokens: None,
                     prefill_load_hint: Some(PrefillLoadHint {

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -10,10 +10,11 @@
 //! this crate while the runtime glue stays in `lib/llm`.
 
 use dynamo_tokens::SequenceHash;
-use parking_lot::RwLock;
-use rustc_hash::FxHashMap;
+use parking_lot::{Mutex, RwLock};
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashMap;
 use std::future::Future;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 #[cfg(test)]
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -29,8 +30,8 @@ use super::single::{ActiveSequences, PromptMembershipDelta, RequestId};
 use super::topology::{WorkerDpRange, WorkerTable, WorkerTopologyChange, WorkerTopologyError};
 use super::{PotentialLoadMaps, PrefillTokenDeltas, WorkerLoadProjection};
 use crate::protocols::{
-    ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventData, PrefillLoadHint, WorkerId,
-    WorkerWithDpRank,
+    ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventData, ActiveSequenceStrideError,
+    PrefillLoadHint, WorkerId, WorkerWithDpRank,
 };
 
 // How often we force expire stale requests across all workers. See the comment
@@ -84,7 +85,7 @@ pub trait SequencePublisher: Send + Sync {
     fn observe_replica_stride_mismatch(
         &self,
         _expected: usize,
-        _received: usize,
+        _received: Result<NonZeroUsize, ActiveSequenceStrideError>,
         _worker_type: &str,
     ) {
     }
@@ -119,11 +120,28 @@ pub enum ReplicaWorkerPolicy {
     RequireRegistered,
 }
 
+/// Construction options for a multi-worker active-sequence tracker.
 #[derive(Debug, Clone, Copy)]
-struct SequenceTrackerOptions {
-    replica_worker_policy: ReplicaWorkerPolicy,
-    expiry_enabled: bool,
-    active_sequence_stride: usize,
+pub struct SequenceTrackerOptions {
+    /// How replica events for workers outside the current topology are handled.
+    pub replica_worker_policy: ReplicaWorkerPolicy,
+    /// Whether stale requests are eligible for time-based expiry.
+    pub expiry_enabled: bool,
+    /// Whether local lifecycle events are published for replica synchronization.
+    pub replica_sync: bool,
+    /// Number of physical prompt blocks represented by each retained sequence hash.
+    pub active_sequence_stride: NonZeroUsize,
+}
+
+impl Default for SequenceTrackerOptions {
+    fn default() -> Self {
+        Self {
+            replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
+            expiry_enabled: true,
+            replica_sync: false,
+            active_sequence_stride: NonZeroUsize::MIN,
+        }
+    }
 }
 
 /// Errors that can occur during sequence management operations.
@@ -177,6 +195,8 @@ pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
     #[cfg(test)]
     remote_state_update_count: AtomicUsize,
     replica_sync: bool,
+    pub(super) warned_replica_stride_mismatches:
+        Mutex<FxHashSet<(u64, Result<NonZeroUsize, ActiveSequenceStrideError>)>>,
     pub(super) replica_worker_policy: ReplicaWorkerPolicy,
     worker_type: &'static str,
 }
@@ -193,38 +213,15 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         router_id: u64,
         worker_type: &'static str,
     ) -> Self {
-        Self::new_with_replica_worker_policy(
-            publisher,
-            block_size,
-            dp_range,
-            replica_sync,
-            router_id,
-            worker_type,
-            ReplicaWorkerPolicy::LazyRegister,
-        )
-    }
-
-    /// Create a new multi-worker sequence tracker with a uniform prompt-hash stride.
-    pub fn new_with_active_sequence_stride(
-        publisher: P,
-        block_size: usize,
-        dp_range: HashMap<u64, (u32, u32)>,
-        replica_sync: bool,
-        router_id: u64,
-        worker_type: &'static str,
-        active_sequence_stride: usize,
-    ) -> Self {
         Self::new_with_options(
             publisher,
             block_size,
             dp_range,
-            replica_sync,
             router_id,
             worker_type,
             SequenceTrackerOptions {
-                replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
-                expiry_enabled: true,
-                active_sequence_stride,
+                replica_sync,
+                ..Default::default()
             },
         )
     }
@@ -242,13 +239,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             publisher,
             block_size,
             dp_range,
-            replica_sync,
             router_id,
             worker_type,
             SequenceTrackerOptions {
-                replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
                 expiry_enabled: false,
-                active_sequence_stride: 1,
+                replica_sync,
+                ..Default::default()
             },
         )
     }
@@ -263,59 +259,31 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         worker_type: &'static str,
         replica_worker_policy: ReplicaWorkerPolicy,
     ) -> Self {
-        Self::new_with_replica_worker_policy_and_active_sequence_stride(
-            publisher,
-            block_size,
-            dp_range,
-            replica_sync,
-            router_id,
-            worker_type,
-            replica_worker_policy,
-            1,
-        )
-    }
-
-    /// Create a tracker with explicit replica admission and prompt-hash stride.
-    #[allow(clippy::too_many_arguments)]
-    pub fn new_with_replica_worker_policy_and_active_sequence_stride(
-        publisher: P,
-        block_size: usize,
-        dp_range: HashMap<u64, (u32, u32)>,
-        replica_sync: bool,
-        router_id: u64,
-        worker_type: &'static str,
-        replica_worker_policy: ReplicaWorkerPolicy,
-        active_sequence_stride: usize,
-    ) -> Self {
         Self::new_with_options(
             publisher,
             block_size,
             dp_range,
-            replica_sync,
             router_id,
             worker_type,
             SequenceTrackerOptions {
                 replica_worker_policy,
-                expiry_enabled: true,
-                active_sequence_stride,
+                replica_sync,
+                ..Default::default()
             },
         )
     }
 
-    fn new_with_options(
+    /// Create a tracker with explicit lifecycle, replication, and sparsity options.
+    pub fn new_with_options(
         publisher: P,
         block_size: usize,
         dp_range: HashMap<u64, (u32, u32)>,
-        replica_sync: bool,
         router_id: u64,
         worker_type: &'static str,
         options: SequenceTrackerOptions,
     ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
-        assert!(
-            options.active_sequence_stride > 0,
-            "active sequence stride must be greater than 0"
-        );
+        let active_sequence_stride = options.active_sequence_stride.get();
         let (remote_state_updates, _) = watch::channel(());
         let workers = if options.expiry_enabled {
             WorkerTable::new(block_size, &dp_range)
@@ -323,10 +291,8 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             WorkerTable::new_without_expiry(block_size, &dp_range)
         };
         let initial_workers: Vec<_> = workers.workers().collect();
-        let prompt_registry = PromptRegistry::new(
-            initial_workers.iter().copied(),
-            options.active_sequence_stride,
-        );
+        let prompt_registry =
+            PromptRegistry::new(initial_workers.iter().copied(), active_sequence_stride);
         let publisher = Arc::new(publisher);
         for worker in &initial_workers {
             publisher.observe_worker_registered(worker, worker_type);
@@ -337,13 +303,14 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             request_index: RequestIndex::default(),
             prompt_registry,
             block_size,
-            active_sequence_stride: options.active_sequence_stride,
+            active_sequence_stride,
             router_id,
             publisher,
             remote_state_updates,
             #[cfg(test)]
             remote_state_update_count: AtomicUsize::new(0),
-            replica_sync,
+            replica_sync: options.replica_sync,
+            warned_replica_stride_mismatches: Mutex::new(FxHashSet::default()),
             replica_worker_policy: options.replica_worker_policy,
             worker_type,
         }
@@ -1353,7 +1320,7 @@ mod tests {
         observations: Mutex<Vec<(WorkerWithDpRank, usize, usize)>>,
         registered: Mutex<Vec<WorkerWithDpRank>>,
         removed: Mutex<Vec<WorkerWithDpRank>>,
-        stride_mismatches: Mutex<Vec<(usize, usize)>>,
+        stride_mismatches: Mutex<Vec<(usize, Result<NonZeroUsize, ActiveSequenceStrideError>)>>,
     }
 
     impl RecordingPublisherState {
@@ -1418,7 +1385,7 @@ mod tests {
         fn observe_replica_stride_mismatch(
             &self,
             expected: usize,
-            received: usize,
+            received: Result<NonZeroUsize, ActiveSequenceStrideError>,
             _worker_type: &str,
         ) {
             self.state
@@ -1457,16 +1424,19 @@ mod tests {
         Arc<RecordingPublisherState>,
     ) {
         let state = Arc::new(RecordingPublisherState::default());
-        let sequences = ActiveSequencesMultiWorker::new_with_active_sequence_stride(
+        let sequences = ActiveSequencesMultiWorker::new_with_options(
             RecordingPublisher {
                 state: Arc::clone(&state),
             },
             4,
             workers,
-            true,
             0,
             "test",
-            active_sequence_stride,
+            SequenceTrackerOptions {
+                replica_sync: true,
+                active_sequence_stride: NonZeroUsize::new(active_sequence_stride).unwrap(),
+                ..Default::default()
+            },
         );
         (sequences, state)
     }
@@ -1993,14 +1963,18 @@ mod tests {
     }
 
     #[tokio::test(start_paused = true)]
-    async fn disabled_expiry_requires_explicit_cleanup_for_all_workers() {
-        let sequences = ActiveSequencesMultiWorker::new_without_expiry(
+    async fn sparse_tracker_without_expiry_requires_explicit_cleanup_for_all_workers() {
+        let sequences = ActiveSequencesMultiWorker::new_with_options(
             NoopSequencePublisher,
             4,
             HashMap::from([(1_u64, (0_u32, 1_u32))]),
-            false,
             0,
             "test",
+            SequenceTrackerOptions {
+                expiry_enabled: false,
+                active_sequence_stride: NonZeroUsize::new(3).unwrap(),
+                ..Default::default()
+            },
         );
         let initial_worker = WorkerWithDpRank::new(1, 0);
         let dynamic_worker = WorkerWithDpRank::new(2, 0);
@@ -2033,8 +2007,8 @@ mod tests {
 
         assert_eq!(active_request_count(&sequences, initial_worker), 1);
         assert_eq!(active_request_count(&sequences, dynamic_worker), 1);
-        assert_eq!(sequences.active_blocks().get(&initial_worker), Some(&2));
-        assert_eq!(sequences.active_blocks().get(&dynamic_worker), Some(&1));
+        assert_eq!(sequences.active_blocks().get(&initial_worker), Some(&6));
+        assert_eq!(sequences.active_blocks().get(&dynamic_worker), Some(&3));
 
         let now = Instant::now();
         sequences.free(&"initial".to_string(), now).unwrap();
@@ -2460,8 +2434,13 @@ mod tests {
         );
         assert_eq!(
             *publisher.stride_mismatches.lock().unwrap(),
-            vec![(2, 3), (2, 3), (2, 0)]
+            vec![
+                (2, Ok(NonZeroUsize::new(3).unwrap())),
+                (2, Ok(NonZeroUsize::new(3).unwrap())),
+                (2, Err(ActiveSequenceStrideError::Zero)),
+            ]
         );
+        assert_eq!(sequences.warned_replica_stride_mismatches.lock().len(), 2);
 
         sequences
             .run_replica_sync(
@@ -2492,6 +2471,7 @@ mod tests {
         assert!(sequences.request_worker(&good_request).is_none());
         assert_eq!(sequences.active_blocks().get(&worker), Some(&0));
         assert_eq!(publisher.stride_mismatches.lock().unwrap().len(), 4);
+        assert_eq!(sequences.warned_replica_stride_mismatches.lock().len(), 2);
     }
 
     #[tokio::test(start_paused = true)]

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -78,6 +78,16 @@ pub trait SequencePublisher: Send + Sync {
 
     /// Observe that a worker/dp_rank was removed from the router.
     fn observe_worker_removed(&self, _worker: &WorkerWithDpRank, _worker_type: &str) {}
+
+    /// Record a replica event dropped because its active-sequence stride does not
+    /// match the local tracker configuration.
+    fn observe_replica_stride_mismatch(
+        &self,
+        _expected: usize,
+        _received: usize,
+        _worker_type: &str,
+    ) {
+    }
 }
 
 /// Abstraction over event subscription for replica sync.
@@ -113,6 +123,7 @@ pub enum ReplicaWorkerPolicy {
 struct SequenceTrackerOptions {
     replica_worker_policy: ReplicaWorkerPolicy,
     expiry_enabled: bool,
+    active_sequence_stride: usize,
 }
 
 /// Errors that can occur during sequence management operations.
@@ -159,6 +170,7 @@ pub struct ActiveSequencesMultiWorker<P: SequencePublisher> {
     pub(super) request_index: RequestIndex,
     pub(super) prompt_registry: PromptRegistry,
     block_size: usize,
+    pub(super) active_sequence_stride: usize,
     pub(super) router_id: u64,
     pub(super) publisher: Arc<P>,
     remote_state_updates: watch::Sender<()>,
@@ -192,6 +204,31 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         )
     }
 
+    /// Create a new multi-worker sequence tracker with a uniform prompt-hash stride.
+    pub fn new_with_active_sequence_stride(
+        publisher: P,
+        block_size: usize,
+        dp_range: HashMap<u64, (u32, u32)>,
+        replica_sync: bool,
+        router_id: u64,
+        worker_type: &'static str,
+        active_sequence_stride: usize,
+    ) -> Self {
+        Self::new_with_options(
+            publisher,
+            block_size,
+            dp_range,
+            replica_sync,
+            router_id,
+            worker_type,
+            SequenceTrackerOptions {
+                replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
+                expiry_enabled: true,
+                active_sequence_stride,
+            },
+        )
+    }
+
     /// Create a tracker that relies exclusively on explicit request lifecycle events.
     pub fn new_without_expiry(
         publisher: P,
@@ -211,6 +248,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             SequenceTrackerOptions {
                 replica_worker_policy: ReplicaWorkerPolicy::LazyRegister,
                 expiry_enabled: false,
+                active_sequence_stride: 1,
             },
         )
     }
@@ -225,6 +263,30 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         worker_type: &'static str,
         replica_worker_policy: ReplicaWorkerPolicy,
     ) -> Self {
+        Self::new_with_replica_worker_policy_and_active_sequence_stride(
+            publisher,
+            block_size,
+            dp_range,
+            replica_sync,
+            router_id,
+            worker_type,
+            replica_worker_policy,
+            1,
+        )
+    }
+
+    /// Create a tracker with explicit replica admission and prompt-hash stride.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new_with_replica_worker_policy_and_active_sequence_stride(
+        publisher: P,
+        block_size: usize,
+        dp_range: HashMap<u64, (u32, u32)>,
+        replica_sync: bool,
+        router_id: u64,
+        worker_type: &'static str,
+        replica_worker_policy: ReplicaWorkerPolicy,
+        active_sequence_stride: usize,
+    ) -> Self {
         Self::new_with_options(
             publisher,
             block_size,
@@ -235,6 +297,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             SequenceTrackerOptions {
                 replica_worker_policy,
                 expiry_enabled: true,
+                active_sequence_stride,
             },
         )
     }
@@ -249,6 +312,10 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         options: SequenceTrackerOptions,
     ) -> Self {
         assert!(block_size > 0, "block_size must be greater than 0");
+        assert!(
+            options.active_sequence_stride > 0,
+            "active sequence stride must be greater than 0"
+        );
         let (remote_state_updates, _) = watch::channel(());
         let workers = if options.expiry_enabled {
             WorkerTable::new(block_size, &dp_range)
@@ -256,7 +323,10 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             WorkerTable::new_without_expiry(block_size, &dp_range)
         };
         let initial_workers: Vec<_> = workers.workers().collect();
-        let prompt_registry = PromptRegistry::new(initial_workers.iter().copied());
+        let prompt_registry = PromptRegistry::new(
+            initial_workers.iter().copied(),
+            options.active_sequence_stride,
+        );
         let publisher = Arc::new(publisher);
         for worker in &initial_workers {
             publisher.observe_worker_registered(worker, worker_type);
@@ -267,6 +337,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             request_index: RequestIndex::default(),
             prompt_registry,
             block_size,
+            active_sequence_stride: options.active_sequence_stride,
             router_id,
             publisher,
             remote_state_updates,
@@ -330,7 +401,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         load: WorkerLoadSnapshot,
         decay_now: Instant,
     ) -> ActiveLoad {
-        let active_blocks = load.active_blocks;
+        let active_blocks = load.active_decode_blocks(self.active_sequence_stride);
         let active_tokens = load.active_tokens(decay_now);
 
         self.publisher
@@ -362,6 +433,10 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 );
             }
         });
+    }
+
+    fn event_stride(&self) -> Option<usize> {
+        (self.active_sequence_stride > 1).then_some(self.active_sequence_stride)
     }
 
     /// Subscribe to remote lifecycle updates that were applied through replica sync.
@@ -529,6 +604,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 prefill_load_hint: req.prefill_load_hint,
             },
             router_id: self.router_id,
+            stride: self.event_stride(),
             lora_name: req.lora_name.clone(),
         });
         self.add_request_local(req, decay_now, lazily_register_worker)?;
@@ -710,7 +786,11 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         result
     }
 
-    /// Query all workers for their current number of active blocks.
+    /// Query all workers for their estimated current number of active blocks.
+    /// Sparse prompt units are expanded by the configured stride; output blocks
+    /// remain at their physical count. Retained groups are fully represented,
+    /// shared prefixes that diverge inside a group may be conservatively
+    /// overcounted, and the final incomplete group is omitted.
     pub fn active_blocks(&self) -> HashMap<WorkerWithDpRank, usize> {
         self.prompt_registry.active_blocks()
     }
@@ -1036,6 +1116,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             worker,
             data: event_data,
             router_id: self.router_id,
+            stride: self.event_stride(),
             lora_name,
         });
         Ok(())
@@ -1061,6 +1142,7 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             worker,
             data: event_data,
             router_id: self.router_id,
+            stride: self.event_stride(),
             lora_name,
         });
         Ok(())
@@ -1265,11 +1347,13 @@ mod tests {
 
     #[derive(Default)]
     struct RecordingPublisherState {
+        events: Mutex<Vec<ActiveSequenceEvent>>,
         single_loads: Mutex<Vec<ActiveLoad>>,
         load_batches: Mutex<Vec<Vec<ActiveLoad>>>,
         observations: Mutex<Vec<(WorkerWithDpRank, usize, usize)>>,
         registered: Mutex<Vec<WorkerWithDpRank>>,
         removed: Mutex<Vec<WorkerWithDpRank>>,
+        stride_mismatches: Mutex<Vec<(usize, usize)>>,
     }
 
     impl RecordingPublisherState {
@@ -1278,11 +1362,13 @@ mod tests {
         }
 
         fn clear(&self) {
+            self.events.lock().unwrap().clear();
             self.single_loads.lock().unwrap().clear();
             self.load_batches.lock().unwrap().clear();
             self.observations.lock().unwrap().clear();
             self.registered.lock().unwrap().clear();
             self.removed.lock().unwrap().clear();
+            self.stride_mismatches.lock().unwrap().clear();
         }
     }
 
@@ -1293,8 +1379,9 @@ mod tests {
     impl SequencePublisher for RecordingPublisher {
         fn publish_event(
             &self,
-            _event: &ActiveSequenceEvent,
+            event: &ActiveSequenceEvent,
         ) -> impl Future<Output = anyhow::Result<()>> + Send {
+            self.state.events.lock().unwrap().push(event.clone());
             future::ready(Ok(()))
         }
 
@@ -1327,6 +1414,19 @@ mod tests {
         fn observe_worker_removed(&self, worker: &WorkerWithDpRank, _worker_type: &str) {
             self.state.removed.lock().unwrap().push(*worker);
         }
+
+        fn observe_replica_stride_mismatch(
+            &self,
+            expected: usize,
+            received: usize,
+            _worker_type: &str,
+        ) {
+            self.state
+                .stride_mismatches
+                .lock()
+                .unwrap()
+                .push((expected, received));
+        }
     }
 
     fn make_recording_sequences(
@@ -1345,6 +1445,28 @@ mod tests {
             true,
             0,
             "test",
+        );
+        (sequences, state)
+    }
+
+    fn make_recording_sequences_with_stride(
+        workers: HashMap<u64, (u32, u32)>,
+        active_sequence_stride: usize,
+    ) -> (
+        ActiveSequencesMultiWorker<RecordingPublisher>,
+        Arc<RecordingPublisherState>,
+    ) {
+        let state = Arc::new(RecordingPublisherState::default());
+        let sequences = ActiveSequencesMultiWorker::new_with_active_sequence_stride(
+            RecordingPublisher {
+                state: Arc::clone(&state),
+            },
+            4,
+            workers,
+            true,
+            0,
+            "test",
+            active_sequence_stride,
         );
         (sequences, state)
     }
@@ -1389,8 +1511,14 @@ mod tests {
                 prefill_load_hint: tracking_hint(12),
             },
             router_id: 99,
+            stride: None,
             lora_name: None,
         }
+    }
+
+    fn with_stride(mut event: ActiveSequenceEvent, stride: usize) -> ActiveSequenceEvent {
+        event.stride = (stride > 1).then_some(stride);
+        event
     }
 
     fn replica_free(
@@ -1402,6 +1530,7 @@ mod tests {
             worker: payload_worker,
             data: ActiveSequenceEventData::Free,
             router_id: 99,
+            stride: None,
             lora_name: None,
         }
     }
@@ -1415,6 +1544,7 @@ mod tests {
             worker: payload_worker,
             data: ActiveSequenceEventData::MarkPrefillCompleted,
             router_id: 99,
+            stride: None,
             lora_name: None,
         }
     }
@@ -2210,6 +2340,7 @@ mod tests {
                         prefill_load_hint: tracking_hint(12),
                     },
                     router_id: 99,
+                    stride: None,
                     lora_name: None,
                 }),
                 Ok(ActiveSequenceEvent {
@@ -2217,6 +2348,7 @@ mod tests {
                     worker,
                     data: ActiveSequenceEventData::Free,
                     router_id: 99,
+                    stride: None,
                     lora_name: None,
                 }),
             ]),
@@ -2231,6 +2363,135 @@ mod tests {
         assert!(sequences.prompt_registry.is_block_index_empty());
         assert_eq!(sequences.active_blocks().get(&worker).copied(), Some(0));
         assert_eq!(active_request_count(&sequences, worker), 0);
+    }
+
+    #[tokio::test]
+    async fn sparse_local_events_carry_stride_and_publish_corrected_load() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences_with_stride(HashMap::from([(1, (0, 1))]), 3);
+        let request_id = "local-request".to_string();
+
+        sequences
+            .add_request(
+                SequenceRequest {
+                    request_id: request_id.clone(),
+                    token_sequence: Some(vec![10, 20]),
+                    track_prefill_tokens: false,
+                    expected_output_tokens: None,
+                    prefill_load_hint: None,
+                    worker,
+                    lora_name: None,
+                },
+                Instant::now(),
+            )
+            .unwrap();
+        assert_eq!(sequences.active_blocks().get(&worker), Some(&6));
+        sequences.add_output_block(&request_id, None).unwrap();
+        assert_eq!(sequences.active_blocks().get(&worker), Some(&7));
+
+        sequences
+            .mark_prefill_completed(&request_id, Instant::now())
+            .unwrap();
+        sequences.free(&request_id, Instant::now()).unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if publisher.events.lock().unwrap().len() == 3 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .unwrap();
+
+        let events = publisher.events.lock().unwrap();
+        assert!(events.iter().all(|event| event.stride == Some(3)));
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(&event.data, ActiveSequenceEventData::AddRequest { .. }))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(&event.data, ActiveSequenceEventData::MarkPrefillCompleted))
+        );
+        assert!(
+            events
+                .iter()
+                .any(|event| matches!(&event.data, ActiveSequenceEventData::Free))
+        );
+    }
+
+    #[tokio::test]
+    async fn replica_sync_drops_only_mismatched_stride_events() {
+        let worker = WorkerWithDpRank::new(1, 0);
+        let (sequences, publisher) =
+            make_recording_sequences_with_stride(HashMap::from([(1, (0, 1))]), 2);
+        let good_request = "good-request".to_string();
+
+        let mut malformed = replica_add("malformed", worker, vec![7]);
+        malformed.stride = Some(0);
+        let subscriber = VecSubscriber {
+            events: VecDeque::from(vec![
+                Ok(with_stride(replica_add("wrong", worker, vec![1]), 3)),
+                Ok(with_stride(
+                    replica_add(good_request.clone(), worker, vec![10, 20]),
+                    2,
+                )),
+                Ok(with_stride(replica_mark(good_request.clone(), worker), 3)),
+                Ok(malformed),
+            ]),
+        };
+        sequences
+            .run_replica_sync(subscriber, CancellationToken::new())
+            .await
+            .unwrap();
+
+        assert!(sequences.request_worker(&"wrong".to_string()).is_none());
+        assert!(sequences.request_worker(&"malformed".to_string()).is_none());
+        assert_eq!(sequences.request_worker(&good_request), Some(worker));
+        assert_eq!(sequences.active_blocks().get(&worker), Some(&4));
+        assert_eq!(
+            sequences.active_tokens(Instant::now()).get(&worker),
+            Some(&12)
+        );
+        assert_eq!(
+            *publisher.stride_mismatches.lock().unwrap(),
+            vec![(2, 3), (2, 3), (2, 0)]
+        );
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![Ok(with_stride(
+                        replica_free(good_request.clone(), worker),
+                        3,
+                    ))]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(sequences.request_worker(&good_request), Some(worker));
+
+        sequences
+            .run_replica_sync(
+                VecSubscriber {
+                    events: VecDeque::from(vec![
+                        Ok(with_stride(replica_mark(good_request.clone(), worker), 2)),
+                        Ok(with_stride(replica_free(good_request.clone(), worker), 2)),
+                    ]),
+                },
+                CancellationToken::new(),
+            )
+            .await
+            .unwrap();
+        assert!(sequences.request_worker(&good_request).is_none());
+        assert_eq!(sequences.active_blocks().get(&worker), Some(&0));
+        assert_eq!(publisher.stride_mismatches.lock().unwrap().len(), 4);
     }
 
     #[tokio::test(start_paused = true)]
@@ -2258,6 +2519,7 @@ mod tests {
                             prefill_load_hint: modeled_hint(12, 10),
                         },
                         router_id: 99,
+                        stride: None,
                         lora_name: None,
                     })]),
                 },
@@ -2277,6 +2539,7 @@ mod tests {
                         worker,
                         data: ActiveSequenceEventData::MarkPrefillCompleted,
                         router_id: 99,
+                        stride: None,
                         lora_name: None,
                     })]),
                 },
@@ -2301,6 +2564,7 @@ mod tests {
                             prefill_load_hint: modeled_hint(12, 6),
                         },
                         router_id: 99,
+                        stride: None,
                         lora_name: None,
                     })]),
                 },
@@ -2320,6 +2584,7 @@ mod tests {
                         worker,
                         data: ActiveSequenceEventData::Free,
                         router_id: 99,
+                        stride: None,
                         lora_name: None,
                     })]),
                 },
@@ -2359,6 +2624,7 @@ mod tests {
                                 prefill_load_hint: modeled_hint(100, 10),
                             },
                             router_id: 99,
+                            stride: None,
                             lora_name: None,
                         }),
                         Ok(ActiveSequenceEvent {
@@ -2371,6 +2637,7 @@ mod tests {
                                 prefill_load_hint: modeled_hint(40, 4),
                             },
                             router_id: 99,
+                            stride: None,
                             lora_name: None,
                         }),
                     ]),
@@ -2397,6 +2664,7 @@ mod tests {
                         worker,
                         data: ActiveSequenceEventData::Free,
                         router_id: 99,
+                        stride: None,
                         lora_name: None,
                     })]),
                 },
@@ -2435,6 +2703,7 @@ mod tests {
                     prefill_load_hint: tracking_hint(12),
                 },
                 router_id: 99,
+                stride: None,
                 lora_name: None,
             })]),
         };

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -50,18 +50,26 @@ pub type PotentialLoadMaps = (
 
 /// Reusable snapshot of a worker's currently tracked execution state.
 ///
-/// `active_blocks` is the worker's unique active decode load in blocks.
-/// `prefill` retains the decay state needed to evaluate active prefill load in
-/// tokens at a caller-provided instant. Unlike [`WorkerLoadProjection`], this
-/// snapshot contains no incoming-request-specific state.
-#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+/// Prompt load is retained in sampled units while output load remains in
+/// physical blocks. The outer registry applies the configured prompt stride
+/// before exposing decode-block estimates. `prefill` retains the decay state
+/// needed to evaluate active prefill load in tokens at a caller-provided
+/// instant. Unlike [`WorkerLoadProjection`], this snapshot contains no
+/// incoming-request-specific state.
+#[derive(Debug, Default, Clone, Copy, PartialEq)]
 pub(super) struct WorkerLoadSnapshot {
-    pub(super) active_blocks: usize,
+    pub(super) active_prompt_units: f64,
+    pub(super) active_output_blocks: f64,
     pub(super) active_requests: usize,
     pub(super) prefill: PrefillLoadSnapshot,
 }
 
 impl WorkerLoadSnapshot {
+    pub(super) fn active_decode_blocks(&self, prompt_stride: usize) -> usize {
+        (self.active_prompt_units * prompt_stride as f64 + self.active_output_blocks).round()
+            as usize
+    }
+
     pub(super) fn active_tokens(&self, decay_now: Instant) -> usize {
         self.prefill.active_tokens_at(decay_now)
     }
@@ -175,6 +183,7 @@ pub(super) struct PromptRegistry {
     // never existed atomically and make a suboptimal routing choice.
     membership: PromptMembershipTrie,
     loads: RwLock<WorkerLoadTable>,
+    active_sequence_stride: usize,
     #[cfg(test)]
     cleanup_attempts: AtomicUsize,
 }
@@ -184,6 +193,7 @@ impl Default for PromptRegistry {
         Self {
             membership: PromptMembershipTrie::new(),
             loads: RwLock::new(WorkerLoadTable::default()),
+            active_sequence_stride: 1,
             #[cfg(test)]
             cleanup_attempts: AtomicUsize::new(0),
         }
@@ -191,8 +201,18 @@ impl Default for PromptRegistry {
 }
 
 impl PromptRegistry {
-    pub(super) fn new(workers: impl IntoIterator<Item = WorkerWithDpRank>) -> Self {
-        let registry = Self::default();
+    pub(super) fn new(
+        workers: impl IntoIterator<Item = WorkerWithDpRank>,
+        active_sequence_stride: usize,
+    ) -> Self {
+        assert!(
+            active_sequence_stride > 0,
+            "active sequence stride must be greater than zero"
+        );
+        let registry = Self {
+            active_sequence_stride,
+            ..Self::default()
+        };
         let mut loads = registry.loads.write();
         for worker in workers {
             loads.ensure_worker(worker);
@@ -290,7 +310,11 @@ impl PromptRegistry {
             let active_tokens = load.active_tokens(decay_now);
             let added_tokens = prefill_token_deltas.tokens_for(worker);
 
-            potential_blocks.insert(worker, load.active_blocks + new_blocks);
+            potential_blocks.insert(
+                worker,
+                load.active_decode_blocks(self.active_sequence_stride)
+                    .saturating_add(new_blocks.saturating_mul(self.active_sequence_stride)),
+            );
             potential_tokens.insert(worker, active_tokens + added_tokens);
             if let Some(active_requests) = active_requests.as_mut() {
                 active_requests.insert(worker, load.active_requests);
@@ -332,8 +356,10 @@ impl PromptRegistry {
                 worker,
                 WorkerLoadProjection {
                     active_prefill_tokens: load.active_tokens(decay_now),
-                    active_decode_blocks: load.active_blocks,
-                    additional_active_blocks: query_len.saturating_sub(overlap_depth),
+                    active_decode_blocks: load.active_decode_blocks(self.active_sequence_stride),
+                    additional_active_blocks: query_len
+                        .saturating_sub(overlap_depth)
+                        .saturating_mul(self.active_sequence_stride),
                 },
             );
         }
@@ -345,7 +371,12 @@ impl PromptRegistry {
         self.loads
             .read()
             .iter()
-            .map(|(worker, load)| (worker, load.active_blocks))
+            .map(|(worker, load)| {
+                (
+                    worker,
+                    load.active_decode_blocks(self.active_sequence_stride),
+                )
+            })
             .collect()
     }
 
@@ -439,7 +470,8 @@ mod tests {
 
     fn worker_load_snapshot(active_blocks: usize) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
-            active_blocks,
+            active_prompt_units: active_blocks as f64,
+            active_output_blocks: 0.0,
             active_requests: 0,
             prefill: PrefillLoadSnapshot::default(),
         }
@@ -453,7 +485,8 @@ mod tests {
         anchored_since: Instant,
     ) -> WorkerLoadSnapshot {
         WorkerLoadSnapshot {
-            active_blocks,
+            active_prompt_units: active_blocks as f64,
+            active_output_blocks: 0.0,
             active_requests: 0,
             prefill: PrefillLoadSnapshot {
                 prefill_full_tokens_sum,
@@ -501,7 +534,7 @@ mod tests {
                 token_sequence.map_or(0, |query| query.len().saturating_sub(overlap_depth));
             let added_tokens = prefill_token_deltas.tokens_for(worker);
 
-            potential_blocks.insert(worker, load.active_blocks + new_blocks);
+            potential_blocks.insert(worker, load.active_decode_blocks(1) + new_blocks);
             potential_tokens.insert(worker, load.active_tokens(decay_now) + added_tokens);
         }
 
@@ -511,7 +544,7 @@ mod tests {
     #[test]
     fn removed_hash_can_be_restored_by_later_store() {
         let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker]);
+        let registry = PromptRegistry::new([worker], 1);
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
 
@@ -540,7 +573,7 @@ mod tests {
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
         let worker_c = worker(3, 0);
-        let registry = PromptRegistry::new([worker_a, worker_b, worker_c]);
+        let registry = PromptRegistry::new([worker_a, worker_b, worker_c], 1);
         let decay_now = Instant::now();
         let full_prompt: Vec<SequenceHash> = (1_u64..=96).collect();
         let mut expected_loads = FxHashMap::default();
@@ -576,7 +609,7 @@ mod tests {
     #[test]
     fn load_only_update_preserves_prompt_membership_and_active_token_projection() {
         let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker]);
+        let registry = PromptRegistry::new([worker], 1);
         let now = Instant::now();
         let anchored_since = now.checked_sub(Duration::from_secs(3)).unwrap_or(now);
         let mut expected_loads = FxHashMap::default();
@@ -610,7 +643,7 @@ mod tests {
     fn removing_worker_clears_prompt_membership_and_load_state() {
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
-        let registry = PromptRegistry::new([worker_a, worker_b]);
+        let registry = PromptRegistry::new([worker_a, worker_b], 1);
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
 
@@ -645,7 +678,7 @@ mod tests {
     fn dp_ranks_with_same_worker_id_remain_isolated() {
         let worker_a = worker(1, 0);
         let worker_b = worker(1, 1);
-        let registry = PromptRegistry::new([worker_a, worker_b]);
+        let registry = PromptRegistry::new([worker_a, worker_b], 1);
         let decay_now = Instant::now();
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
@@ -676,5 +709,41 @@ mod tests {
 
         assert_eq!(actual.0, expected.0);
         assert_eq!(actual.1, expected.1);
+    }
+
+    #[test]
+    fn sparse_projection_scales_prompt_units_and_preserves_output_blocks() {
+        let worker = worker(1, 0);
+        let registry = PromptRegistry::new([worker], 4);
+        let load = WorkerLoadSnapshot {
+            active_prompt_units: 2.5,
+            active_output_blocks: 1.5,
+            active_requests: 1,
+            prefill: PrefillLoadSnapshot::default(),
+        };
+        registry.apply_membership_delta_and_load(worker, store(&[10, 20], 0), load);
+
+        assert_eq!(registry.active_blocks().get(&worker), Some(&12));
+
+        let identical = registry.project_worker_loads(Some(&[10, 20]), Instant::now());
+        assert_eq!(
+            identical.get(&worker),
+            Some(&WorkerLoadProjection {
+                active_prefill_tokens: 0,
+                active_decode_blocks: 12,
+                additional_active_blocks: 0,
+            })
+        );
+
+        let diverged = registry.project_worker_loads(Some(&[10, 99]), Instant::now());
+        assert_eq!(diverged[&worker].active_decode_blocks, 12);
+        assert_eq!(diverged[&worker].additional_active_blocks, 4);
+
+        let (potential_blocks, _, _) = registry.potential_blocks_and_tokens::<false>(
+            Some(&[10, 99]),
+            &PrefillTokenDeltas::none(),
+            Instant::now(),
+        );
+        assert_eq!(potential_blocks.get(&worker), Some(&16));
     }
 }

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -66,8 +66,11 @@ pub(super) struct WorkerLoadSnapshot {
 
 impl WorkerLoadSnapshot {
     pub(super) fn active_decode_blocks(&self, prompt_stride: usize) -> usize {
-        (self.active_prompt_units * prompt_stride as f64 + self.active_output_blocks).round()
-            as usize
+        super::estimate_physical_active_blocks(
+            self.active_prompt_units,
+            self.active_output_blocks,
+            prompt_stride,
+        )
     }
 
     pub(super) fn active_tokens(&self, decay_now: Instant) -> usize {

--- a/lib/kv-router/src/sequences/prompt_registry.rs
+++ b/lib/kv-router/src/sequences/prompt_registry.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(test)]
 use dynamo_tokens::SequenceHash;
 use indexmap::IndexMap;
 use parking_lot::RwLock;
@@ -18,6 +19,7 @@ use super::prefill_tracker::{PrefillLoadSnapshot, PrefillTimeLoadError};
 use super::prompt_membership_trie::PromptMembershipTrie;
 use super::single::PromptMembershipDelta;
 use super::topology::WorkerTopologyChange;
+use crate::active_sequence::{ActiveSequenceStride, TrackedSequenceHashes};
 use crate::protocols::WorkerWithDpRank;
 
 /// Ephemeral, request-specific view of worker load.
@@ -65,7 +67,7 @@ pub(super) struct WorkerLoadSnapshot {
 }
 
 impl WorkerLoadSnapshot {
-    pub(super) fn active_decode_blocks(&self, prompt_stride: usize) -> usize {
+    pub(super) fn active_decode_blocks(&self, prompt_stride: ActiveSequenceStride) -> usize {
         super::estimate_physical_active_blocks(
             self.active_prompt_units,
             self.active_output_blocks,
@@ -186,7 +188,7 @@ pub(super) struct PromptRegistry {
     // never existed atomically and make a suboptimal routing choice.
     membership: PromptMembershipTrie,
     loads: RwLock<WorkerLoadTable>,
-    active_sequence_stride: usize,
+    active_sequence_stride: ActiveSequenceStride,
     #[cfg(test)]
     cleanup_attempts: AtomicUsize,
 }
@@ -196,7 +198,7 @@ impl Default for PromptRegistry {
         Self {
             membership: PromptMembershipTrie::new(),
             loads: RwLock::new(WorkerLoadTable::default()),
-            active_sequence_stride: 1,
+            active_sequence_stride: ActiveSequenceStride::ONE,
             #[cfg(test)]
             cleanup_attempts: AtomicUsize::new(0),
         }
@@ -206,12 +208,8 @@ impl Default for PromptRegistry {
 impl PromptRegistry {
     pub(super) fn new(
         workers: impl IntoIterator<Item = WorkerWithDpRank>,
-        active_sequence_stride: usize,
+        active_sequence_stride: ActiveSequenceStride,
     ) -> Self {
-        assert!(
-            active_sequence_stride > 0,
-            "active sequence stride must be greater than zero"
-        );
         let registry = Self {
             active_sequence_stride,
             ..Self::default()
@@ -316,7 +314,7 @@ impl PromptRegistry {
             potential_blocks.insert(
                 worker,
                 load.active_decode_blocks(self.active_sequence_stride)
-                    .saturating_add(new_blocks.saturating_mul(self.active_sequence_stride)),
+                    .saturating_add(new_blocks.saturating_mul(self.active_sequence_stride.get())),
             );
             potential_tokens.insert(worker, active_tokens + added_tokens);
             if let Some(active_requests) = active_requests.as_mut() {
@@ -329,10 +327,11 @@ impl PromptRegistry {
 
     pub(super) fn potential_blocks_and_tokens<const INCLUDE_ACTIVE_REQUESTS: bool>(
         &self,
-        token_sequence: Option<&[SequenceHash]>,
+        token_sequence: Option<&TrackedSequenceHashes>,
         prefill_token_deltas: &PrefillTokenDeltas,
         decay_now: Instant,
     ) -> PotentialLoadMaps {
+        let token_sequence = token_sequence.map(TrackedSequenceHashes::as_slice);
         let query_len = token_sequence.map_or(0, |query| query.len());
         let matched_depth = self.membership.compute_overlap_depths(token_sequence);
         self.project_loads_from_membership::<INCLUDE_ACTIVE_REQUESTS>(
@@ -345,9 +344,10 @@ impl PromptRegistry {
 
     pub(super) fn project_worker_loads(
         &self,
-        token_sequence: Option<&[SequenceHash]>,
+        token_sequence: Option<&TrackedSequenceHashes>,
         decay_now: Instant,
     ) -> FxHashMap<WorkerWithDpRank, WorkerLoadProjection> {
+        let token_sequence = token_sequence.map(TrackedSequenceHashes::as_slice);
         let query_len = token_sequence.map_or(0, |query| query.len());
         let matched_depth = self.membership.compute_overlap_depths(token_sequence);
         let loads = self.loads.read();
@@ -362,7 +362,7 @@ impl PromptRegistry {
                     active_decode_blocks: load.active_decode_blocks(self.active_sequence_stride),
                     additional_active_blocks: query_len
                         .saturating_sub(overlap_depth)
-                        .saturating_mul(self.active_sequence_stride),
+                        .saturating_mul(self.active_sequence_stride.get()),
                 },
             );
         }
@@ -457,6 +457,10 @@ mod tests {
     use crate::sequences::single::{PromptMembershipRemove, PromptMembershipStore};
     use crate::sequences::topology::RemovedWorkerState;
 
+    fn tracked(sequence: Vec<SequenceHash>) -> TrackedSequenceHashes {
+        crate::active_sequence::tracked_sequence_hashes(sequence)
+    }
+
     fn worker(worker_id: u64, dp_rank: u32) -> WorkerWithDpRank {
         WorkerWithDpRank::new(worker_id, dp_rank)
     }
@@ -537,7 +541,10 @@ mod tests {
                 token_sequence.map_or(0, |query| query.len().saturating_sub(overlap_depth));
             let added_tokens = prefill_token_deltas.tokens_for(worker);
 
-            potential_blocks.insert(worker, load.active_decode_blocks(1) + new_blocks);
+            potential_blocks.insert(
+                worker,
+                load.active_decode_blocks(ActiveSequenceStride::ONE) + new_blocks,
+            );
             potential_tokens.insert(worker, load.active_tokens(decay_now) + added_tokens);
         }
 
@@ -547,7 +554,7 @@ mod tests {
     #[test]
     fn removed_hash_can_be_restored_by_later_store() {
         let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker], 1);
+        let registry = PromptRegistry::new([worker], ActiveSequenceStride::ONE);
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
 
@@ -576,9 +583,11 @@ mod tests {
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
         let worker_c = worker(3, 0);
-        let registry = PromptRegistry::new([worker_a, worker_b, worker_c], 1);
+        let registry =
+            PromptRegistry::new([worker_a, worker_b, worker_c], ActiveSequenceStride::ONE);
         let decay_now = Instant::now();
         let full_prompt: Vec<SequenceHash> = (1_u64..=96).collect();
+        let tracked_full_prompt = tracked(full_prompt.clone());
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
 
@@ -600,7 +609,7 @@ mod tests {
             decay_now,
         );
         let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&full_prompt),
+            Some(&tracked_full_prompt),
             &PrefillTokenDeltas::none(),
             decay_now,
         );
@@ -612,7 +621,7 @@ mod tests {
     #[test]
     fn load_only_update_preserves_prompt_membership_and_active_token_projection() {
         let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker], 1);
+        let registry = PromptRegistry::new([worker], ActiveSequenceStride::ONE);
         let now = Instant::now();
         let anchored_since = now.checked_sub(Duration::from_secs(3)).unwrap_or(now);
         let mut expected_loads = FxHashMap::default();
@@ -634,7 +643,7 @@ mod tests {
         assert_eq!(registry.active_tokens(now).get(&worker).copied(), Some(9));
 
         let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&[1, 2, 3]),
+            Some(&tracked(vec![1, 2, 3])),
             &PrefillTokenDeltas::none(),
             now,
         );
@@ -646,7 +655,7 @@ mod tests {
     fn removing_worker_clears_prompt_membership_and_load_state() {
         let worker_a = worker(1, 0);
         let worker_b = worker(2, 0);
-        let registry = PromptRegistry::new([worker_a, worker_b], 1);
+        let registry = PromptRegistry::new([worker_a, worker_b], ActiveSequenceStride::ONE);
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
 
@@ -670,7 +679,7 @@ mod tests {
         assert!(!registry.active_blocks().contains_key(&worker_a));
 
         let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&[1, 2, 3]),
+            Some(&tracked(vec![1, 2, 3])),
             &PrefillTokenDeltas::none(),
             Instant::now(),
         );
@@ -681,7 +690,7 @@ mod tests {
     fn dp_ranks_with_same_worker_id_remain_isolated() {
         let worker_a = worker(1, 0);
         let worker_b = worker(1, 1);
-        let registry = PromptRegistry::new([worker_a, worker_b], 1);
+        let registry = PromptRegistry::new([worker_a, worker_b], ActiveSequenceStride::ONE);
         let decay_now = Instant::now();
         let mut expected_loads = FxHashMap::default();
         let mut expected_blocks = FxHashMap::default();
@@ -705,7 +714,7 @@ mod tests {
             decay_now,
         );
         let actual = registry.potential_blocks_and_tokens::<false>(
-            Some(&[1, 2, 3]),
+            Some(&tracked(vec![1, 2, 3])),
             &PrefillTokenDeltas::none(),
             decay_now,
         );
@@ -717,7 +726,7 @@ mod tests {
     #[test]
     fn sparse_projection_scales_prompt_units_and_preserves_output_blocks() {
         let worker = worker(1, 0);
-        let registry = PromptRegistry::new([worker], 4);
+        let registry = PromptRegistry::new([worker], ActiveSequenceStride::new(4).unwrap());
         let load = WorkerLoadSnapshot {
             active_prompt_units: 2.5,
             active_output_blocks: 1.5,
@@ -728,7 +737,7 @@ mod tests {
 
         assert_eq!(registry.active_blocks().get(&worker), Some(&12));
 
-        let identical = registry.project_worker_loads(Some(&[10, 20]), Instant::now());
+        let identical = registry.project_worker_loads(Some(&tracked(vec![10, 20])), Instant::now());
         assert_eq!(
             identical.get(&worker),
             Some(&WorkerLoadProjection {
@@ -738,12 +747,12 @@ mod tests {
             })
         );
 
-        let diverged = registry.project_worker_loads(Some(&[10, 99]), Instant::now());
+        let diverged = registry.project_worker_loads(Some(&tracked(vec![10, 99])), Instant::now());
         assert_eq!(diverged[&worker].active_decode_blocks, 12);
         assert_eq!(diverged[&worker].additional_active_blocks, 4);
 
         let (potential_blocks, _, _) = registry.potential_blocks_and_tokens::<false>(
-            Some(&[10, 99]),
+            Some(&tracked(vec![10, 99])),
             &PrefillTokenDeltas::none(),
             Instant::now(),
         );

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::future::poll_fn;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::task::Poll;
 
@@ -150,15 +151,24 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
             return;
         }
 
-        let received_stride = event.effective_stride().unwrap_or(0);
-        if received_stride != self.active_sequence_stride {
-            tracing::warn!(
-                source_router_id = event.router_id,
-                request_id = %event.request_id,
-                expected_stride = self.active_sequence_stride,
-                received_stride,
-                "Dropping active-sequence replica event with incompatible stride"
-            );
+        let received_stride = event.normalized_stride();
+        if received_stride.map(NonZeroUsize::get) != Ok(self.active_sequence_stride) {
+            if self
+                .warned_replica_stride_mismatches
+                .lock()
+                .insert((event.router_id, received_stride))
+            {
+                let received_stride_label = received_stride
+                    .map(|stride| stride.get().to_string())
+                    .unwrap_or_else(|_| "malformed".to_string());
+                tracing::warn!(
+                    source_router_id = event.router_id,
+                    request_id = %event.request_id,
+                    expected_stride = self.active_sequence_stride,
+                    received_stride = %received_stride_label,
+                    "Dropping active-sequence replica event with incompatible stride"
+                );
+            }
             self.publisher.observe_replica_stride_mismatch(
                 self.active_sequence_stride,
                 received_stride,

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -146,17 +146,36 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
     }
 
     fn apply_replica_event(&self, event: ActiveSequenceEvent, effects: &mut ReplicaBatchEffects) {
+        if event.router_id == self.router_id {
+            return;
+        }
+
+        let received_stride = event.effective_stride().unwrap_or(0);
+        if received_stride != self.active_sequence_stride {
+            tracing::warn!(
+                source_router_id = event.router_id,
+                request_id = %event.request_id,
+                expected_stride = self.active_sequence_stride,
+                received_stride,
+                "Dropping active-sequence replica event with incompatible stride"
+            );
+            self.publisher.observe_replica_stride_mismatch(
+                self.active_sequence_stride,
+                received_stride,
+                self.worker_type(),
+            );
+            return;
+        }
+
         let ActiveSequenceEvent {
             request_id,
             worker: event_worker,
             data,
             router_id,
+            stride: _,
             lora_name,
         } = event;
-
-        if router_id == self.router_id {
-            return;
-        }
+        debug_assert_ne!(router_id, self.router_id);
 
         // ActiveSequenceEvent does not carry prompt-load decay timestamps yet.
         // Peer routers still approximate decay anchoring with local receive time.

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::future::poll_fn;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::task::Poll;
 
@@ -14,6 +13,7 @@ use super::multi_worker::{
     ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequencePublisher, SequenceSubscriber,
 };
 use super::prompt_registry::WorkerLoadSnapshot;
+use crate::active_sequence::TrackedSequenceHashes;
 use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
 
 const MAX_REPLICA_BATCH_EVENTS: usize = 256;
@@ -152,19 +152,19 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         }
 
         let received_stride = event.normalized_stride();
-        if received_stride.map(NonZeroUsize::get) != Ok(self.active_sequence_stride) {
+        if received_stride != Ok(self.active_sequence_stride) {
             if self
                 .warned_replica_stride_mismatches
                 .lock()
                 .insert((event.router_id, received_stride))
             {
                 let received_stride_label = received_stride
-                    .map(|stride| stride.get().to_string())
+                    .map(|stride| stride.to_string())
                     .unwrap_or_else(|_| "malformed".to_string());
                 tracing::warn!(
                     source_router_id = event.router_id,
                     request_id = %event.request_id,
-                    expected_stride = self.active_sequence_stride,
+                    expected_stride = %self.active_sequence_stride,
                     received_stride = %received_stride_label,
                     "Dropping active-sequence replica event with incompatible stride"
                 );
@@ -198,6 +198,8 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
                 expected_output_tokens,
                 prefill_load_hint,
             } => {
+                let token_sequence =
+                    token_sequence.map(TrackedSequenceHashes::from_validated_event);
                 if self.replica_worker_policy == ReplicaWorkerPolicy::LazyRegister {
                     self.ensure_worker_registered(event_worker);
                 }

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -30,6 +30,7 @@ use rustc_hash::FxHashSet;
 use super::block_tracker::{BlockTracker, RequestBlockChain};
 use super::prefill_tracker::{PrefillLoadState, PrefillLoadTracker};
 use super::prompt_registry::WorkerLoadSnapshot;
+use crate::active_sequence::TrackedSequenceHashes;
 use crate::protocols::PrefillLoadHint;
 
 /// Duration after which stale requests may be expired (5 minutes).
@@ -170,7 +171,7 @@ impl ActiveSequences {
     pub(super) fn add_request_with_prefill_tracking(
         &mut self,
         request_id: RequestId,
-        token_sequence: Option<Vec<SequenceHash>>,
+        token_sequence: Option<TrackedSequenceHashes>,
         expected_output_tokens: Option<u32>,
         track_prefill_tokens: bool,
         prefill_load_hint: Option<PrefillLoadHint>,
@@ -184,7 +185,9 @@ impl ActiveSequences {
         let mut outcome = self.force_expiry();
         let started_at = Instant::now();
 
-        let prompt_hashes = token_sequence.unwrap_or_default();
+        let prompt_hashes = token_sequence
+            .map(TrackedSequenceHashes::into_inner)
+            .unwrap_or_default();
         let (blocks, first_new_prompt_idx) = self.blocks.acquire_prompt(&prompt_hashes);
 
         if let Some(first_new_prompt_idx) = first_new_prompt_idx {
@@ -348,7 +351,12 @@ impl ActiveSequences {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::active_sequence::{TrackedSequenceHashes, tracked_sequence_hashes};
     use std::collections::VecDeque;
+
+    fn tracked(sequence: Vec<SequenceHash>) -> Option<TrackedSequenceHashes> {
+        Some(tracked_sequence_hashes(sequence))
+    }
 
     fn prefill_hint(tokens: usize, duration_secs: u64) -> PrefillLoadHint {
         PrefillLoadHint {
@@ -376,7 +384,7 @@ mod tests {
         let mut sequences = ActiveSequences::new_without_expiry(1);
         sequences.add_request_with_prefill_tracking(
             "long-lived".to_string(),
-            Some((1..=DEPTH as u64).collect()),
+            tracked((1..=DEPTH as u64).collect()),
             None,
             false,
             None,
@@ -393,7 +401,7 @@ mod tests {
 
         let first = seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1, 2]),
+            tracked(vec![1, 2]),
             None,
             true,
             tracking_hint(8),
@@ -413,7 +421,7 @@ mod tests {
 
         let second = seq_manager.add_request_with_prefill_tracking(
             "r2".to_string(),
-            Some(vec![1, 2, 3]),
+            tracked(vec![1, 2, 3]),
             None,
             true,
             tracking_hint(12),
@@ -452,7 +460,7 @@ mod tests {
 
         let outcome = seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1, 2, 3]),
+            tracked(vec![1, 2, 3]),
             None,
             true,
             tracking_hint(12),
@@ -503,7 +511,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "request_1".to_string(),
-            Some(vec![1, 2, 3]),
+            tracked(vec![1, 2, 3]),
             None,
             true,
             tracking_hint(12),
@@ -514,7 +522,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "request_2".to_string(),
-            Some(vec![5]),
+            tracked(vec![5]),
             None,
             true,
             tracking_hint(4),
@@ -525,7 +533,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "request_3".to_string(),
-            Some(vec![1, 2, 3, 4]),
+            tracked(vec![1, 2, 3, 4]),
             None,
             true,
             tracking_hint(0),
@@ -555,7 +563,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1, 2, 3]),
+            tracked(vec![1, 2, 3]),
             None,
             true,
             tracking_hint(12),
@@ -572,7 +580,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r2".to_string(),
-            Some(vec![1, 2]),
+            tracked(vec![1, 2]),
             None,
             true,
             tracking_hint(8),
@@ -601,7 +609,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1, 2, 3]),
+            tracked(vec![1, 2, 3]),
             None,
             true,
             tracking_hint(12),
@@ -617,7 +625,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r2".to_string(),
-            Some(vec![4, 5]),
+            tracked(vec![4, 5]),
             None,
             true,
             tracking_hint(8),
@@ -636,7 +644,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1, 2, 3]),
+            tracked(vec![1, 2, 3]),
             None,
             false,
             None,
@@ -660,7 +668,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1]),
+            tracked(vec![1]),
             None,
             true,
             Some(prefill_hint(50, 10)),
@@ -668,7 +676,7 @@ mod tests {
         );
         seq_manager.add_request_with_prefill_tracking(
             "r2".to_string(),
-            Some(vec![2]),
+            tracked(vec![2]),
             None,
             true,
             Some(prefill_hint(30, 10)),
@@ -710,7 +718,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1, 2]),
+            tracked(vec![1, 2]),
             None,
             true,
             tracking_hint(8),
@@ -718,7 +726,7 @@ mod tests {
         );
         seq_manager.add_request_with_prefill_tracking(
             "r2".to_string(),
-            Some(vec![3, 4]),
+            tracked(vec![3, 4]),
             None,
             true,
             tracking_hint(8),
@@ -756,7 +764,7 @@ mod tests {
         tokio::time::advance(Duration::from_secs(31)).await;
         let expired = seq_manager.add_request_with_prefill_tracking(
             "r3".to_string(),
-            Some(vec![5]),
+            tracked(vec![5]),
             None,
             true,
             tracking_hint(4),
@@ -775,7 +783,7 @@ mod tests {
 
         seq_manager.add_request_with_prefill_tracking(
             "r1".to_string(),
-            Some(vec![1]),
+            tracked(vec![1]),
             None,
             true,
             Some(prefill_hint(40, 100)),
@@ -784,7 +792,7 @@ mod tests {
         tokio::time::advance(Duration::from_secs(250)).await;
         seq_manager.add_request_with_prefill_tracking(
             "r2".to_string(),
-            Some(vec![2]),
+            tracked(vec![2]),
             None,
             true,
             Some(prefill_hint(30, 100)),

--- a/lib/kv-router/src/sequences/single.rs
+++ b/lib/kv-router/src/sequences/single.rs
@@ -155,6 +155,7 @@ impl ActiveSequences {
         self.assert_consistent();
     }
 
+    #[cfg(test)]
     pub(super) fn active_blocks(&self) -> usize {
         self.blocks.active_blocks()
     }
@@ -321,8 +322,10 @@ impl ActiveSequences {
     }
 
     pub(super) fn worker_load_snapshot(&self) -> WorkerLoadSnapshot {
+        let block_load = self.blocks.load();
         WorkerLoadSnapshot {
-            active_blocks: self.active_blocks(),
+            active_prompt_units: block_load.prompt_units,
+            active_output_blocks: block_load.output_blocks,
             active_requests: self.requests.len(),
             prefill: self.prefill.snapshot(),
         }

--- a/lib/kv-router/src/sequences/topology.rs
+++ b/lib/kv-router/src/sequences/topology.rs
@@ -471,7 +471,9 @@ mod tests {
             let mut seq = table.slots[idx].sequences.write();
             let outcome = seq.add_request_with_prefill_tracking(
                 "req-1".to_string(),
-                Some(vec![1, 2, 3]),
+                Some(crate::active_sequence::tracked_sequence_hashes(vec![
+                    1, 2, 3,
+                ])),
                 None,
                 true,
                 Some(crate::protocols::PrefillLoadHint {

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -528,6 +528,8 @@ fn handle_replica_message<F>(
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[cfg(feature = "standalone-slot-tracker")]
+    use crate::ActiveSequenceStride;
     use crate::protocols::{ActiveSequenceEventData, WorkerWithDpRank};
     #[cfg(feature = "standalone-slot-tracker")]
     use crate::services::slot_tracker::registry::{SlotTrackerRegistry, TrackerKey};
@@ -688,7 +690,13 @@ mod tests {
         for attempt in 0..40 {
             let request_id = format!("warmup-{attempt}");
             registry_a
-                .add_request(&key, request_id.clone(), worker, vec![attempt], 0)
+                .add_request(
+                    &key,
+                    request_id.clone(),
+                    worker,
+                    ActiveSequenceStride::ONE.sample_dense(vec![attempt]),
+                    0,
+                )
                 .unwrap();
             warmup_requests.push(request_id);
             tokio::time::sleep(std::time::Duration::from_millis(25)).await;
@@ -704,7 +712,13 @@ mod tests {
         wait_for_load(&registry_b, 0, 0).await;
 
         registry_a
-            .add_request(&key, "target".to_string(), worker, vec![1, 2, 3], 8)
+            .add_request(
+                &key,
+                "target".to_string(),
+                worker,
+                ActiveSequenceStride::ONE.sample_dense(vec![1, 2, 3]),
+                8,
+            )
             .unwrap();
         wait_for_load(&registry_b, 3, 8).await;
 

--- a/lib/kv-router/src/services/common/replica_sync.rs
+++ b/lib/kv-router/src/services/common/replica_sync.rs
@@ -542,6 +542,7 @@ mod tests {
                 worker: WorkerWithDpRank::new(1, 0),
                 data: ActiveSequenceEventData::Free,
                 router_id: 42,
+                stride: None,
                 lora_name: None,
             },
         }

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -443,15 +443,18 @@ impl SelectionCore {
             &key.routing_group,
             block_size,
         );
-        let slots = Arc::new(ActiveSequencesMultiWorker::new_with_replica_worker_policy(
-            scoped_replica_sync.publisher,
-            block_size as usize,
-            HashMap::new(),
-            scoped_replica_sync.enabled,
-            scoped_replica_sync.process_id,
-            WORKER_TYPE,
-            ReplicaWorkerPolicy::RequireRegistered,
-        ));
+        let slots = Arc::new(
+            ActiveSequencesMultiWorker::new_with_replica_worker_policy_and_active_sequence_stride(
+                scoped_replica_sync.publisher,
+                block_size as usize,
+                HashMap::new(),
+                scoped_replica_sync.enabled,
+                scoped_replica_sync.process_id,
+                WORKER_TYPE,
+                ReplicaWorkerPolicy::RequireRegistered,
+                self.kv_router_config.router_active_sequence_stride,
+            ),
+        );
         let replica_tx = scoped_replica_sync.channel.map(|(replica_tx, subscriber)| {
             slots.start_replica_sync(subscriber, self.cancel_token.child_token());
             replica_tx
@@ -689,6 +692,9 @@ impl SelectionCore {
             isl_tokens,
             overlap,
         } = self.prepare_selection_inputs(&entry, &prompt).await?;
+        let active_sequence_hashes = self
+            .kv_router_config
+            .sample_active_sequence_hashes(sequence_hashes);
         let mode = if book {
             ScheduleMode::Tracked {
                 request_id: selection_id.clone().ok_or_else(|| {
@@ -711,14 +717,14 @@ impl SelectionCore {
                 .unwrap_or(self.kv_router_config.router_track_prefill_tokens);
             (
                 id,
-                sequence_hashes.clone(),
+                active_sequence_hashes.clone(),
                 prompt.lora_name.clone(),
                 track_prefill_tokens,
             )
         });
         let schedule_request = ScheduleRequest {
             mode,
-            token_seq: Some(sequence_hashes),
+            token_seq: Some(active_sequence_hashes),
             block_hashes: Some(block_hashes),
             isl_tokens,
             overlap,
@@ -922,7 +928,9 @@ impl SelectionCore {
                 key,
                 selection_id: req.selection_id,
                 worker,
-                sequence_hashes: normalized.sequence_hashes,
+                sequence_hashes: self
+                    .kv_router_config
+                    .sample_active_sequence_hashes(normalized.sequence_hashes),
                 prefill_load_hint,
                 expected_output_tokens: req.expected_output_tokens,
                 track_prefill_tokens,
@@ -1076,8 +1084,11 @@ impl SelectionCore {
             .as_ref()
             .and_then(|cfg| cfg.track_prefill_tokens)
             .unwrap_or(self.kv_router_config.router_track_prefill_tokens);
+        let active_sequence_hashes = self
+            .kv_router_config
+            .sample_active_sequence_hashes(prepared.sequence_hashes);
         Ok(entry.scheduler.get_potential_loads(
-            Some(prepared.sequence_hashes),
+            Some(active_sequence_hashes),
             prepared.isl_tokens,
             prepared.overlap.effective_cached_tokens,
             track_prefill_tokens,

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{HashMap, HashSet};
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -11,6 +10,7 @@ use parking_lot::RwLock;
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
+use crate::TrackedSequenceHashes;
 use crate::indexer::TieredMatchDetails;
 use crate::protocols::{
     ActiveSequenceEvent, LocalBlockHash, PrefillLoadHint, RoutingConstraints, WorkerId,
@@ -91,7 +91,7 @@ struct ReservationBooking {
     key: SelectionKey,
     selection_id: String,
     worker: WorkerWithDpRank,
-    sequence_hashes: Vec<SequenceHash>,
+    sequence_hashes: TrackedSequenceHashes,
     prefill_load_hint: Option<PrefillLoadHint>,
     expected_output_tokens: Option<u32>,
     track_prefill_tokens: bool,
@@ -445,9 +445,6 @@ impl SelectionCore {
             &key.routing_group,
             block_size,
         );
-        let active_sequence_stride =
-            NonZeroUsize::new(self.kv_router_config.router_active_sequence_stride)
-                .expect("KvRouterConfig validates active-sequence stride");
         let slots = Arc::new(ActiveSequencesMultiWorker::new_with_options(
             scoped_replica_sync.publisher,
             block_size as usize,
@@ -457,7 +454,7 @@ impl SelectionCore {
             SequenceTrackerOptions {
                 replica_worker_policy: ReplicaWorkerPolicy::RequireRegistered,
                 replica_sync: scoped_replica_sync.enabled,
-                active_sequence_stride,
+                active_sequence_stride: self.kv_router_config.router_active_sequence_stride,
                 ..Default::default()
             },
         ));

--- a/lib/kv-router/src/services/selection/core/mod.rs
+++ b/lib/kv-router/src/services/selection/core/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -24,6 +25,7 @@ use crate::scheduling::{
 };
 use crate::sequences::{
     ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequenceError, SequenceRequest,
+    SequenceTrackerOptions,
 };
 use crate::services::common::replica_sync::{
     ReplicaSyncConfig, ScopedReplicaEvent, ScopedSequencePublisher, setup_scoped_replica_sync,
@@ -443,18 +445,22 @@ impl SelectionCore {
             &key.routing_group,
             block_size,
         );
-        let slots = Arc::new(
-            ActiveSequencesMultiWorker::new_with_replica_worker_policy_and_active_sequence_stride(
-                scoped_replica_sync.publisher,
-                block_size as usize,
-                HashMap::new(),
-                scoped_replica_sync.enabled,
-                scoped_replica_sync.process_id,
-                WORKER_TYPE,
-                ReplicaWorkerPolicy::RequireRegistered,
-                self.kv_router_config.router_active_sequence_stride,
-            ),
-        );
+        let active_sequence_stride =
+            NonZeroUsize::new(self.kv_router_config.router_active_sequence_stride)
+                .expect("KvRouterConfig validates active-sequence stride");
+        let slots = Arc::new(ActiveSequencesMultiWorker::new_with_options(
+            scoped_replica_sync.publisher,
+            block_size as usize,
+            HashMap::new(),
+            scoped_replica_sync.process_id,
+            WORKER_TYPE,
+            SequenceTrackerOptions {
+                replica_worker_policy: ReplicaWorkerPolicy::RequireRegistered,
+                replica_sync: scoped_replica_sync.enabled,
+                active_sequence_stride,
+                ..Default::default()
+            },
+        ));
         let replica_tx = scoped_replica_sync.channel.map(|(replica_tx, subscriber)| {
             slots.start_replica_sync(subscriber, self.cancel_token.child_token());
             replica_tx

--- a/lib/kv-router/src/services/selection/pending.rs
+++ b/lib/kv-router/src/services/selection/pending.rs
@@ -12,6 +12,7 @@ use std::time::{Duration, Instant};
 use dynamo_tokens::SequenceHash;
 use parking_lot::Mutex;
 
+use crate::TrackedSequenceHashes;
 use crate::protocols::WorkerWithDpRank;
 
 use super::types::SelectionKey;
@@ -51,7 +52,7 @@ impl Default for SelectionCacheConfig {
 pub(super) struct PendingSelection {
     pub key: SelectionKey,
     pub worker: WorkerWithDpRank,
-    pub sequence_hashes: Vec<SequenceHash>,
+    pub sequence_hashes: TrackedSequenceHashes,
     pub isl_tokens: usize,
     pub effective_prefill_tokens: usize,
     pub expected_output_tokens: Option<u32>,
@@ -238,6 +239,7 @@ impl SelectionCache {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ActiveSequenceStride;
 
     const TTL: Duration = Duration::from_secs(10);
     const CAP: usize = 2;
@@ -262,7 +264,7 @@ mod tests {
         PendingSelection {
             key: key(),
             worker: WorkerWithDpRank::new(worker_id, 0),
-            sequence_hashes: vec![1, 2, 3],
+            sequence_hashes: ActiveSequenceStride::ONE.sample_dense(vec![1, 2, 3]),
             isl_tokens: 12,
             effective_prefill_tokens: 8,
             expected_output_tokens: Some(16),

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -64,6 +64,10 @@ impl SelectionServiceBuilder {
     }
 
     pub async fn build(self) -> anyhow::Result<SelectionService> {
+        self.kv_router_config
+            .validate_config()
+            .map_err(|error| anyhow::anyhow!("invalid KV router configuration: {error}"))?;
+
         let cancel_token = CancellationToken::new();
         let mut startup_guard = StartupGuard::new(cancel_token.clone());
         let replica_runtime = setup_replica_sync(
@@ -399,6 +403,21 @@ mod tests {
         })
         .await
         .expect("replica port was not released")
+    }
+
+    #[tokio::test]
+    async fn builder_rejects_zero_active_sequence_stride() {
+        let mut config = test_config();
+        config.router_active_sequence_stride = 0;
+
+        let error = SelectionServiceBuilder::new(config)
+            .build()
+            .await
+            .err()
+            .expect("zero active-sequence stride must fail during service construction");
+        let message = error.to_string();
+        assert!(message.contains("invalid KV router configuration"));
+        assert!(message.contains("router_active_sequence_stride"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/lib/kv-router/src/services/selection/service.rs
+++ b/lib/kv-router/src/services/selection/service.rs
@@ -406,18 +406,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn builder_rejects_zero_active_sequence_stride() {
+    async fn builder_rejects_invalid_router_configuration() {
         let mut config = test_config();
-        config.router_active_sequence_stride = 0;
+        config.router_temperature = -1.0;
 
         let error = SelectionServiceBuilder::new(config)
             .build()
             .await
             .err()
-            .expect("zero active-sequence stride must fail during service construction");
+            .expect("invalid router configuration must fail during service construction");
         let message = error.to_string();
         assert!(message.contains("invalid KV router configuration"));
-        assert!(message.contains("router_active_sequence_stride"));
+        assert!(message.contains("router_temperature"));
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]

--- a/lib/kv-router/src/services/selection/tests.rs
+++ b/lib/kv-router/src/services/selection/tests.rs
@@ -13,6 +13,7 @@ use tower::ServiceExt;
 use super::input::{MmRoutingInfoRequest, PromptRequest};
 use super::server::create_router;
 use super::*;
+use crate::ActiveSequenceStride;
 use crate::indexer::{LowerTierMatchDetails, MatchDetails, TieredMatchDetails};
 use crate::protocols::{
     BlockExtraInfo, BlockHashOptions, BlockMmObjectInfo, OverlapScores, StorageTier,
@@ -744,6 +745,95 @@ async fn cached_reservation_books_from_select() {
     )
     .await;
     assert_eq!(replay.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn sparse_selection_reservations_and_potential_loads_sample_once() {
+    let config = crate::config::KvRouterConfig {
+        router_active_sequence_stride: ActiveSequenceStride::new(3).unwrap(),
+        ..test_config()
+    };
+    let service = Arc::new(SelectionService::new_local_for_test(config, 1));
+    let app = create_router(Arc::new(AppState { service }));
+    assert_eq!(
+        register_worker(app.clone(), None).await.status(),
+        StatusCode::CREATED
+    );
+
+    let first_tokens: Vec<u32> = (0..40).collect();
+    let select = post(
+        app.clone(),
+        "/select",
+        &serde_json::json!({
+            "model_name": "model",
+            "selection_id": "sparse-cached",
+            "token_ids": first_tokens,
+        })
+        .to_string(),
+    )
+    .await;
+    assert_eq!(select.status(), StatusCode::OK);
+    let reserve = post(
+        app.clone(),
+        "/reservations",
+        r#"{"model_name":"model","selection_id":"sparse-cached"}"#,
+    )
+    .await;
+    assert_eq!(reserve.status(), StatusCode::CREATED);
+
+    let loads = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/loads")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    let loads = response_json(loads).await;
+    assert_eq!(loads[0]["loads"][0]["potential_decode_blocks"], 9);
+
+    let freed = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri("/reservations/sparse-cached")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(freed.status(), StatusCode::OK);
+
+    let explicit = post(
+        app.clone(),
+        "/reservations",
+        &serde_json::json!({
+            "model_name": "model",
+            "selection_id": "sparse-explicit",
+            "worker_id": 1,
+            "token_ids": (0..40).collect::<Vec<u32>>(),
+        })
+        .to_string(),
+    )
+    .await;
+    assert_eq!(explicit.status(), StatusCode::CREATED);
+
+    let potential = post(
+        app,
+        "/potential_loads",
+        &serde_json::json!({
+            "model_name": "model",
+            "token_ids": (100..140).collect::<Vec<u32>>(),
+        })
+        .to_string(),
+    )
+    .await;
+    assert_eq!(potential.status(), StatusCode::OK);
+    let potential = response_json(potential).await;
+    assert_eq!(potential[0]["potential_decode_blocks"], 18);
 }
 
 #[tokio::test]

--- a/lib/kv-router/src/services/slot_tracker/registry.rs
+++ b/lib/kv-router/src/services/slot_tracker/registry.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use dynamo_tokens::SequenceHash;
 use parking_lot::Mutex;
 use rustc_hash::FxHashSet;
 use serde::Serialize;
@@ -12,6 +11,7 @@ use tokio::sync::mpsc;
 use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
+use crate::TrackedSequenceHashes;
 use crate::protocols::{PrefillLoadHint, WorkerId, WorkerWithDpRank};
 use crate::scheduling::PotentialLoad;
 use crate::sequences::topology::{WorkerDpRange, WorkerTopologyError};
@@ -299,7 +299,7 @@ impl SlotTrackerRegistry {
         key: &TrackerKey,
         request_id: String,
         worker: WorkerWithDpRank,
-        sequence_hashes: Vec<SequenceHash>,
+        sequence_hashes: TrackedSequenceHashes,
         new_isl_tokens: usize,
     ) -> Result<(), ServiceError> {
         let entry = self.entry(key)?;
@@ -384,7 +384,7 @@ impl SlotTrackerRegistry {
     pub fn potential_loads(
         &self,
         key: &TrackerKey,
-        sequence_hashes: &[SequenceHash],
+        sequence_hashes: &TrackedSequenceHashes,
         new_isl_tokens: usize,
     ) -> Result<Vec<PotentialLoad>, RegistryError> {
         let entry = self.entry(key)?;
@@ -525,7 +525,13 @@ fn matches_filters(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::ActiveSequenceStride;
     use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData};
+    use dynamo_tokens::SequenceHash;
+
+    fn tracked(sequence: Vec<SequenceHash>) -> TrackedSequenceHashes {
+        ActiveSequenceStride::ONE.sample_dense(sequence)
+    }
 
     fn registry() -> SlotTrackerRegistry {
         SlotTrackerRegistry::new(CancellationToken::new())
@@ -555,6 +561,7 @@ mod tests {
                     prefill_load_hint: None,
                 },
                 router_id,
+                stride: None,
                 lora_name: None,
             },
         }
@@ -624,7 +631,7 @@ mod tests {
                 &key,
                 "req-1".to_string(),
                 WorkerWithDpRank::new(1, 0),
-                vec![1, 2],
+                tracked(vec![1, 2]),
                 8,
             )
             .unwrap();
@@ -758,7 +765,7 @@ mod tests {
                 &key,
                 "bad-rank".to_string(),
                 WorkerWithDpRank::new(1, 1),
-                vec![1],
+                tracked(vec![1]),
                 0,
             ),
             Err(ServiceError::Sequence(SequenceError::WorkerNotFound { .. }))
@@ -769,7 +776,7 @@ mod tests {
                 &key,
                 "early-free".to_string(),
                 WorkerWithDpRank::new(1, 0),
-                vec![1, 2],
+                tracked(vec![1, 2]),
                 8,
             )
             .unwrap();
@@ -778,7 +785,7 @@ mod tests {
                 &key,
                 "early-free".to_string(),
                 WorkerWithDpRank::new(1, 0),
-                vec![1, 2],
+                tracked(vec![1, 2]),
                 8,
             ),
             Err(ServiceError::Sequence(
@@ -795,7 +802,7 @@ mod tests {
                 &key,
                 "early-complete".to_string(),
                 WorkerWithDpRank::new(1, 0),
-                vec![3],
+                tracked(vec![3]),
                 8,
             )
             .unwrap();
@@ -815,12 +822,13 @@ mod tests {
                 &key,
                 "req-1".to_string(),
                 WorkerWithDpRank::new(1, 0),
-                vec![1, 2, 3],
+                tracked(vec![1, 2, 3]),
                 8,
             )
             .unwrap();
 
-        let loads = registry.potential_loads(&key, &[1, 2, 4], 5).unwrap();
+        let query = tracked(vec![1, 2, 4]);
+        let loads = registry.potential_loads(&key, &query, 5).unwrap();
         assert_eq!(loads.len(), 1);
         assert_eq!(loads[0].worker_id, 1);
         assert_eq!(loads[0].dp_rank, 0);
@@ -839,7 +847,7 @@ mod tests {
                 &key,
                 "req-1".to_string(),
                 WorkerWithDpRank::new(1, 0),
-                vec![1, 2, 3],
+                tracked(vec![1, 2, 3]),
                 8,
             )
             .unwrap();

--- a/lib/kv-router/src/services/slot_tracker/server.rs
+++ b/lib/kv-router/src/services/slot_tracker/server.rs
@@ -14,6 +14,7 @@ use dynamo_tokens::SequenceHash;
 use serde::de::{SeqAccess, Visitor};
 use serde::{Deserialize, Deserializer};
 
+use crate::ActiveSequenceStride;
 use crate::protocols::WorkerWithDpRank;
 use crate::sequences::SequenceError;
 use crate::services::common::replica_sync::PeerManager;
@@ -178,7 +179,7 @@ async fn add(
         &key,
         req.request_id,
         WorkerWithDpRank::new(req.worker_id, req.dp_rank),
-        req.sequence_hashes,
+        ActiveSequenceStride::ONE.sample_dense(req.sequence_hashes),
         req.new_isl_tokens,
     ) {
         Ok(()) => json_ok(StatusCode::CREATED),
@@ -236,9 +237,10 @@ async fn potential_loads(
         Err(error) => return json_rejection(error),
     };
     let key = TrackerKey::new(req.model_name, Some(req.routing_group));
+    let sequence_hashes = ActiveSequenceStride::ONE.sample_dense(req.sequence_hashes);
     match state
         .registry
-        .potential_loads(&key, &req.sequence_hashes, req.new_isl_tokens)
+        .potential_loads(&key, &sequence_hashes, req.new_isl_tokens)
     {
         Ok(loads) => Json(loads).into_response(),
         Err(error) => registry_error(error),

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -43,10 +43,10 @@
 //!
 //! See also: `docs/observability/metrics.md` (Router Metrics section).
 
-use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
+use dynamo_kv_router::ActiveSequenceStride;
 use dynamo_kv_router::protocols::ActiveSequenceStrideError;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::metrics::MetricsHierarchy;
@@ -284,8 +284,8 @@ impl RouterWorkerStatusMetrics {
 
     pub fn increment_active_sequence_stride_mismatch(
         &self,
-        expected: usize,
-        received: Result<NonZeroUsize, ActiveSequenceStrideError>,
+        expected: ActiveSequenceStride,
+        received: Result<ActiveSequenceStride, ActiveSequenceStrideError>,
         worker_type: &str,
     ) {
         let expected = expected.to_string();
@@ -968,12 +968,12 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
         metrics.set_kv_event_source_mismatch_workers("model-a", "decode", "ns-a", "decode", 2);
         metrics.set_kv_event_source_mismatch_workers("model-a", "prefill", "ns-a", "prefill", 0);
         metrics.increment_active_sequence_stride_mismatch(
-            4,
-            Ok(NonZeroUsize::new(2).unwrap()),
+            ActiveSequenceStride::new(4).unwrap(),
+            Ok(ActiveSequenceStride::new(2).unwrap()),
             "decode",
         );
         metrics.increment_active_sequence_stride_mismatch(
-            4,
+            ActiveSequenceStride::new(4).unwrap(),
             Err(ActiveSequenceStrideError::Zero),
             "decode",
         );

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -43,9 +43,11 @@
 //!
 //! See also: `docs/observability/metrics.md` (Router Metrics section).
 
+use std::num::NonZeroUsize;
 use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
+use dynamo_kv_router::protocols::ActiveSequenceStrideError;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::metrics::prometheus_names::{
@@ -283,11 +285,13 @@ impl RouterWorkerStatusMetrics {
     pub fn increment_active_sequence_stride_mismatch(
         &self,
         expected: usize,
-        received: usize,
+        received: Result<NonZeroUsize, ActiveSequenceStrideError>,
         worker_type: &str,
     ) {
         let expected = expected.to_string();
-        let received = received.to_string();
+        let received = received
+            .map(|stride| stride.get().to_string())
+            .unwrap_or_else(|_| "malformed".to_string());
         self.active_sequence_stride_mismatches_total
             .with_label_values(&[&expected, &received, worker_type])
             .inc();
@@ -963,7 +967,16 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
         metrics.set_registered(123, 0, "decode");
         metrics.set_kv_event_source_mismatch_workers("model-a", "decode", "ns-a", "decode", 2);
         metrics.set_kv_event_source_mismatch_workers("model-a", "prefill", "ns-a", "prefill", 0);
-        metrics.increment_active_sequence_stride_mismatch(4, 2, "decode");
+        metrics.increment_active_sequence_stride_mismatch(
+            4,
+            Ok(NonZeroUsize::new(2).unwrap()),
+            "decode",
+        );
+        metrics.increment_active_sequence_stride_mismatch(
+            4,
+            Err(ActiveSequenceStrideError::Zero),
+            "decode",
+        );
 
         let output = gather_pef(&registry);
         assert!(
@@ -987,6 +1000,12 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
         assert!(
             output.contains(
                 "dynamo_component_router_active_sequence_stride_mismatches_total{expected_stride=\"4\",received_stride=\"2\",worker_type=\"decode\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_active_sequence_stride_mismatches_total{expected_stride=\"4\",received_stride=\"malformed\",worker_type=\"decode\"} 1"
             ),
             "\nActual PEF:\n{output}"
         );

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -199,6 +199,7 @@ pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
 pub(crate) struct RouterWorkerStatusMetrics {
     pub registered: IntGaugeVec,
     pub kv_event_source_mismatch_workers: IntGaugeVec,
+    pub active_sequence_stride_mismatches_total: IntCounterVec,
 }
 
 static ROUTER_WORKER_STATUS_METRICS: OnceLock<Arc<RouterWorkerStatusMetrics>> = OnceLock::new();
@@ -234,10 +235,19 @@ impl RouterWorkerStatusMetrics {
                         &[],
                     )
                     .expect("failed to create router_kv_event_source_mismatch_workers gauge");
+                let active_sequence_stride_mismatches_total = metrics
+                    .create_intcountervec(
+                        "router_active_sequence_stride_mismatches_total",
+                        "Total active-sequence replica events dropped because the sender stride did not match the local stride",
+                        &["expected_stride", "received_stride", labels::WORKER_TYPE],
+                        &[],
+                    )
+                    .expect("failed to create router_active_sequence_stride_mismatches_total counter");
 
                 Arc::new(Self {
                     registered,
                     kv_event_source_mismatch_workers,
+                    active_sequence_stride_mismatches_total,
                 })
             })
             .clone()
@@ -268,6 +278,19 @@ impl RouterWorkerStatusMetrics {
         self.kv_event_source_mismatch_workers
             .with_label_values(&[model, worker_type, target_namespace, target_component])
             .set(count as i64);
+    }
+
+    pub fn increment_active_sequence_stride_mismatch(
+        &self,
+        expected: usize,
+        received: usize,
+        worker_type: &str,
+    ) {
+        let expected = expected.to_string();
+        let received = received.to_string();
+        self.active_sequence_stride_mismatches_total
+            .with_label_values(&[&expected, &received, worker_type])
+            .inc();
     }
 }
 
@@ -916,6 +939,14 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
                 ],
             )
             .unwrap(),
+            active_sequence_stride_mismatches_total: IntCounterVec::new(
+                Opts::new(
+                    "dynamo_component_router_active_sequence_stride_mismatches_total",
+                    "Total active-sequence replica events dropped because the sender stride did not match the local stride",
+                ),
+                &["expected_stride", "received_stride", labels::WORKER_TYPE],
+            )
+            .unwrap(),
         };
         registry
             .register(Box::new(metrics.registered.clone()))
@@ -923,10 +954,16 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
         registry
             .register(Box::new(metrics.kv_event_source_mismatch_workers.clone()))
             .unwrap();
+        registry
+            .register(Box::new(
+                metrics.active_sequence_stride_mismatches_total.clone(),
+            ))
+            .unwrap();
 
         metrics.set_registered(123, 0, "decode");
         metrics.set_kv_event_source_mismatch_workers("model-a", "decode", "ns-a", "decode", 2);
         metrics.set_kv_event_source_mismatch_workers("model-a", "prefill", "ns-a", "prefill", 0);
+        metrics.increment_active_sequence_stride_mismatch(4, 2, "decode");
 
         let output = gather_pef(&registry);
         assert!(
@@ -944,6 +981,12 @@ dynamo_frontend_worker_active_prefill_tokens{dp_rank=\"0\",worker_id=\"123\",wor
         assert!(
             output.contains(
                 "dynamo_component_router_kv_event_source_mismatch_workers{model=\"model-a\",target_component=\"prefill\",target_namespace=\"ns-a\",worker_type=\"prefill\"} 0"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_active_sequence_stride_mismatches_total{expected_stride=\"4\",received_stride=\"2\",worker_type=\"decode\"} 1"
             ),
             "\nActual PEF:\n{output}"
         );

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -674,7 +674,7 @@ mod tests {
     };
 
     use dynamo_kv_router::{
-        ActiveSequencesMultiWorker, DefaultWorkerSelector, SequencePublisher,
+        ActiveSequenceStride, ActiveSequencesMultiWorker, DefaultWorkerSelector, SequencePublisher,
         config::{KvRouterConfig, RouterQueuePolicy},
         protocols::{ActiveLoad, ActiveSequenceEvent, RoutingConstraints},
         scheduling::{
@@ -818,7 +818,7 @@ mod tests {
                     mode: ScheduleMode::TrackedWithAdmission {
                         request_id: request_id.clone(),
                     },
-                    token_seq: Some(vec![1]),
+                    token_seq: Some(ActiveSequenceStride::ONE.sample_dense(vec![1])),
                     block_hashes: None,
                     isl_tokens: 1,
                     lora_name: None,

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -29,6 +29,7 @@ use dynamo_runtime::component::Component;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
 use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -100,15 +101,25 @@ where
             workers_with_configs.borrow().clone();
 
         let router_id = component.drt().discovery().instance_id();
+        let active_sequence_stride =
+            NonZeroUsize::new(kv_router_config.router_active_sequence_stride).ok_or_else(|| {
+                KvSchedulerError::InitFailed(
+                    "router active-sequence stride must be greater than zero".to_string(),
+                )
+            })?;
+        let tracker_options = super::sequence::SequenceTrackerOptions {
+            replica_sync: kv_router_config.router_replica_sync,
+            active_sequence_stride,
+            ..Default::default()
+        };
         let slots = create_multi_worker_sequences(
             component.clone(),
             block_size as usize,
-            kv_router_config.router_active_sequence_stride,
             initial_workers,
-            kv_router_config.router_replica_sync,
             router_id,
             worker_type,
             cancellation_token.child_token(),
+            tracker_options,
         )
         .await
         .map_err(|e| KvSchedulerError::InitFailed(e.to_string()))?;

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -103,6 +103,7 @@ where
         let slots = create_multi_worker_sequences(
             component.clone(),
             block_size as usize,
+            kv_router_config.router_active_sequence_stride,
             initial_workers,
             kv_router_config.router_replica_sync,
             router_id,

--- a/lib/llm/src/kv_router/scheduler.rs
+++ b/lib/llm/src/kv_router/scheduler.rs
@@ -21,15 +21,13 @@ use crate::discovery::RuntimeConfigWatch;
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 use anyhow::Result;
 use dynamo_kv_router::{
-    PrefillLoadEstimator,
+    PrefillLoadEstimator, TrackedSequenceHashes,
     config::{KvRouterConfig, RouterConfigOverride},
     protocols::{RoutingConstraints, WorkerId, WorkerWithDpRank},
 };
 use dynamo_runtime::component::Component;
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use dynamo_tokens::SequenceHash;
 use std::collections::{HashMap, HashSet};
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio_util::sync::CancellationToken;
@@ -101,15 +99,9 @@ where
             workers_with_configs.borrow().clone();
 
         let router_id = component.drt().discovery().instance_id();
-        let active_sequence_stride =
-            NonZeroUsize::new(kv_router_config.router_active_sequence_stride).ok_or_else(|| {
-                KvSchedulerError::InitFailed(
-                    "router active-sequence stride must be greater than zero".to_string(),
-                )
-            })?;
         let tracker_options = super::sequence::SequenceTrackerOptions {
             replica_sync: kv_router_config.router_replica_sync,
-            active_sequence_stride,
+            active_sequence_stride: kv_router_config.router_active_sequence_stride,
             ..Default::default()
         };
         let slots = create_multi_worker_sequences(
@@ -215,7 +207,7 @@ where
         &self,
         maybe_request_id: Option<String>,
         isl_tokens: usize,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         tier_overlap_blocks: TierOverlapBlocks,
         effective_overlap_blocks: HashMap<dynamo_kv_router::protocols::WorkerWithDpRank, f64>,
         effective_cached_tokens: HashMap<dynamo_kv_router::protocols::WorkerWithDpRank, usize>,
@@ -260,7 +252,7 @@ where
         &self,
         maybe_request_id: Option<String>,
         isl_tokens: usize,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         block_hashes: Option<Vec<LocalBlockHash>>,
         tier_overlap_blocks: TierOverlapBlocks,
         effective_overlap_blocks: HashMap<dynamo_kv_router::protocols::WorkerWithDpRank, f64>,
@@ -304,7 +296,7 @@ where
         &self,
         maybe_request_id: Option<String>,
         isl_tokens: usize,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         block_hashes: Option<Vec<LocalBlockHash>>,
         tier_overlap_blocks: TierOverlapBlocks,
         effective_overlap_blocks: HashMap<dynamo_kv_router::protocols::WorkerWithDpRank, f64>,
@@ -416,7 +408,7 @@ where
 
     pub fn get_potential_loads(
         &self,
-        token_seq: Option<Vec<SequenceHash>>,
+        token_seq: Option<TrackedSequenceHashes>,
         isl_tokens: usize,
         effective_cached_tokens: HashMap<dynamo_kv_router::protocols::WorkerWithDpRank, usize>,
         track_prefill_tokens: bool,

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -9,15 +9,18 @@
 
 pub use dynamo_kv_router::multi_worker_sequence::{
     ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
-    SequenceSubscriber,
+    SequenceSubscriber, SequenceTrackerOptions,
 };
-use dynamo_kv_router::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
+use dynamo_kv_router::protocols::{
+    ActiveLoad, ActiveSequenceEvent, ActiveSequenceStrideError, WorkerWithDpRank,
+};
 pub use dynamo_kv_router::sequence::{ActiveSequences, RequestId};
 
 use anyhow::Result;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber};
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio_util::sync::CancellationToken;
@@ -94,7 +97,12 @@ impl SequencePublisher for RuntimeSequencePublisher {
             .remove_worker(worker.worker_id, worker.dp_rank, worker_type);
     }
 
-    fn observe_replica_stride_mismatch(&self, expected: usize, received: usize, worker_type: &str) {
+    fn observe_replica_stride_mismatch(
+        &self,
+        expected: usize,
+        received: Result<NonZeroUsize, ActiveSequenceStrideError>,
+        worker_type: &str,
+    ) {
         self.worker_status_metrics
             .increment_active_sequence_stride_mismatch(expected, received, worker_type);
     }
@@ -134,12 +142,11 @@ pub type ActiveSequencesMulti = ActiveSequencesMultiWorker<RuntimeSequencePublis
 pub async fn create_multi_worker_sequences(
     component: Component,
     block_size: usize,
-    active_sequence_stride: usize,
     workers_with_configs: HashMap<u64, ModelRuntimeConfig>,
-    replica_sync: bool,
     router_id: u64,
     worker_type: &'static str,
     cancellation_token: CancellationToken,
+    options: SequenceTrackerOptions,
 ) -> Result<Arc<ActiveSequencesMulti>> {
     let event_publisher =
         EventPublisher::for_component(&component, ACTIVE_SEQUENCES_SUBJECT).await?;
@@ -163,19 +170,18 @@ pub async fn create_multi_worker_sequences(
         })
         .collect();
 
-    let multi_worker = ActiveSequencesMultiWorker::new_with_active_sequence_stride(
+    let multi_worker = ActiveSequencesMultiWorker::new_with_options(
         publisher,
         block_size,
         dp_range,
-        replica_sync,
         router_id,
         worker_type,
-        active_sequence_stride,
+        options,
     );
 
     let arc = Arc::new(multi_worker);
 
-    if replica_sync {
+    if options.replica_sync {
         let subscriber = EventSubscriber::for_component(&component, ACTIVE_SEQUENCES_SUBJECT)
             .await?
             .typed::<ActiveSequenceEvent>();
@@ -226,23 +232,29 @@ mod tests {
         let seq_manager_1 = create_multi_worker_sequences(
             component.clone(),
             block_size,
-            1,
             workers_with_configs.clone(),
-            true,
             1,
             crate::discovery::WORKER_TYPE_DECODE,
             CancellationToken::new(),
+            SequenceTrackerOptions {
+                replica_sync: true,
+                active_sequence_stride: NonZeroUsize::new(3).unwrap(),
+                ..Default::default()
+            },
         )
         .await?;
         let seq_manager_2 = create_multi_worker_sequences(
             component,
             block_size,
-            1,
             workers_with_configs,
-            true,
             2,
             crate::discovery::WORKER_TYPE_DECODE,
             CancellationToken::new(),
+            SequenceTrackerOptions {
+                replica_sync: true,
+                active_sequence_stride: NonZeroUsize::new(3).unwrap(),
+                ..Default::default()
+            },
         )
         .await?;
 
@@ -298,16 +310,16 @@ mod tests {
         let worker_1_dp0 = WorkerWithDpRank::new(1, 0);
 
         assert_eq!(
-            blocks_phase1[&worker_0_dp0], 3,
-            "Worker 0 dp_rank 0 should have 3 active blocks (from request_0)"
+            blocks_phase1[&worker_0_dp0], 9,
+            "Worker 0 dp_rank 0 should estimate 9 active blocks (from request_0)"
         );
         assert_eq!(
-            blocks_phase1[&worker_0_dp1], 2,
-            "Worker 0 dp_rank 1 should have 2 active blocks (from request_1)"
+            blocks_phase1[&worker_0_dp1], 6,
+            "Worker 0 dp_rank 1 should estimate 6 active blocks (from request_1)"
         );
         assert_eq!(
-            blocks_phase1[&worker_1_dp0], 4,
-            "Worker 1 dp_rank 0 should have 4 active blocks (from request_2 added by seq_manager_2)"
+            blocks_phase1[&worker_1_dp0], 12,
+            "Worker 1 dp_rank 0 should estimate 12 active blocks (from request_2 added by seq_manager_2)"
         );
         assert_eq!(
             tokens_phase1[&worker_0_dp0], 12,
@@ -320,6 +332,17 @@ mod tests {
         assert_eq!(
             tokens_phase1[&worker_1_dp0], 16,
             "Worker 1 dp_rank 0 should have 16 active tokens (from request_2 added by seq_manager_2)"
+        );
+
+        seq_manager_1.mark_prefill_completed(&"request_0".to_string(), Instant::now())?;
+        tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+        assert_eq!(
+            seq_manager_1.active_tokens(Instant::now())[&worker_0_dp0],
+            0
+        );
+        assert_eq!(
+            seq_manager_2.active_tokens(Instant::now())[&worker_0_dp0],
+            0
         );
 
         seq_manager_1.free(&"request_2".to_string(), Instant::now())?;
@@ -384,23 +407,27 @@ mod tests {
         let seq_manager_1 = create_multi_worker_sequences(
             component.clone(),
             block_size,
-            1,
             workers_with_configs.clone(),
-            true,
             1,
             crate::discovery::WORKER_TYPE_DECODE,
             CancellationToken::new(),
+            SequenceTrackerOptions {
+                replica_sync: true,
+                ..Default::default()
+            },
         )
         .await?;
         let seq_manager_2 = create_multi_worker_sequences(
             component,
             block_size,
-            1,
             workers_with_configs,
-            true,
             2,
             crate::discovery::WORKER_TYPE_DECODE,
             CancellationToken::new(),
+            SequenceTrackerOptions {
+                replica_sync: true,
+                ..Default::default()
+            },
         )
         .await?;
 

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -93,6 +93,11 @@ impl SequencePublisher for RuntimeSequencePublisher {
         self.worker_status_metrics
             .remove_worker(worker.worker_id, worker.dp_rank, worker_type);
     }
+
+    fn observe_replica_stride_mismatch(&self, expected: usize, received: usize, worker_type: &str) {
+        self.worker_status_metrics
+            .increment_active_sequence_stride_mismatch(expected, received, worker_type);
+    }
 }
 
 /// Concrete [`SequenceSubscriber`] backed by NATS typed event stream.
@@ -129,6 +134,7 @@ pub type ActiveSequencesMulti = ActiveSequencesMultiWorker<RuntimeSequencePublis
 pub async fn create_multi_worker_sequences(
     component: Component,
     block_size: usize,
+    active_sequence_stride: usize,
     workers_with_configs: HashMap<u64, ModelRuntimeConfig>,
     replica_sync: bool,
     router_id: u64,
@@ -157,13 +163,14 @@ pub async fn create_multi_worker_sequences(
         })
         .collect();
 
-    let multi_worker = ActiveSequencesMultiWorker::new(
+    let multi_worker = ActiveSequencesMultiWorker::new_with_active_sequence_stride(
         publisher,
         block_size,
         dp_range,
         replica_sync,
         router_id,
         worker_type,
+        active_sequence_stride,
     );
 
     let arc = Arc::new(multi_worker);
@@ -219,6 +226,7 @@ mod tests {
         let seq_manager_1 = create_multi_worker_sequences(
             component.clone(),
             block_size,
+            1,
             workers_with_configs.clone(),
             true,
             1,
@@ -229,6 +237,7 @@ mod tests {
         let seq_manager_2 = create_multi_worker_sequences(
             component,
             block_size,
+            1,
             workers_with_configs,
             true,
             2,
@@ -375,6 +384,7 @@ mod tests {
         let seq_manager_1 = create_multi_worker_sequences(
             component.clone(),
             block_size,
+            1,
             workers_with_configs.clone(),
             true,
             1,
@@ -385,6 +395,7 @@ mod tests {
         let seq_manager_2 = create_multi_worker_sequences(
             component,
             block_size,
+            1,
             workers_with_configs,
             true,
             2,

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -7,6 +7,7 @@
 //! implementations that wire the runtime-agnostic business logic (in `dynamo_kv_router`)
 //! to NATS event transport and Prometheus metrics.
 
+use dynamo_kv_router::ActiveSequenceStride;
 pub use dynamo_kv_router::multi_worker_sequence::{
     ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
     SequenceSubscriber, SequenceTrackerOptions,
@@ -20,7 +21,6 @@ use anyhow::Result;
 use dynamo_runtime::component::Component;
 use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber};
 use std::collections::HashMap;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio_util::sync::CancellationToken;
@@ -99,8 +99,8 @@ impl SequencePublisher for RuntimeSequencePublisher {
 
     fn observe_replica_stride_mismatch(
         &self,
-        expected: usize,
-        received: Result<NonZeroUsize, ActiveSequenceStrideError>,
+        expected: ActiveSequenceStride,
+        received: Result<ActiveSequenceStride, ActiveSequenceStrideError>,
         worker_type: &str,
     ) {
         self.worker_status_metrics
@@ -219,6 +219,7 @@ mod tests {
 
         let namespace = distributed.namespace("test_cross_instance_sync")?;
         let component = namespace.component("sequences")?;
+        let active_sequence_stride = ActiveSequenceStride::new(3).unwrap();
 
         let mut workers_with_configs = HashMap::new();
 
@@ -238,7 +239,7 @@ mod tests {
             CancellationToken::new(),
             SequenceTrackerOptions {
                 replica_sync: true,
-                active_sequence_stride: NonZeroUsize::new(3).unwrap(),
+                active_sequence_stride,
                 ..Default::default()
             },
         )
@@ -252,7 +253,7 @@ mod tests {
             CancellationToken::new(),
             SequenceTrackerOptions {
                 replica_sync: true,
-                active_sequence_stride: NonZeroUsize::new(3).unwrap(),
+                active_sequence_stride,
                 ..Default::default()
             },
         )
@@ -264,7 +265,7 @@ mod tests {
         seq_manager_1.add_request(
             SequenceRequest {
                 request_id: "request_0".to_string(),
-                token_sequence: Some(vec![0, 1, 2]),
+                token_sequence: Some(active_sequence_stride.sample_dense((0..9).collect())),
                 track_prefill_tokens: true,
                 expected_output_tokens: None,
                 prefill_load_hint: tracking_hint(12),
@@ -277,7 +278,7 @@ mod tests {
         seq_manager_1.add_request(
             SequenceRequest {
                 request_id: "request_1".to_string(),
-                token_sequence: Some(vec![3, 4]),
+                token_sequence: Some(active_sequence_stride.sample_dense((9..15).collect())),
                 track_prefill_tokens: true,
                 expected_output_tokens: None,
                 prefill_load_hint: tracking_hint(8),
@@ -290,7 +291,7 @@ mod tests {
         seq_manager_2.add_request(
             SequenceRequest {
                 request_id: "request_2".to_string(),
-                token_sequence: Some(vec![0, 1, 2, 3]),
+                token_sequence: Some(active_sequence_stride.sample_dense((0..12).collect())),
                 track_prefill_tokens: true,
                 expected_output_tokens: None,
                 prefill_load_hint: tracking_hint(16),

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -497,22 +497,16 @@ impl OfflineReplayRouter {
         let (priority_jump, strict_priority) = request.router_priorities();
         let (overlaps, token_seq) = match replay_hashes {
             Some(replay_hashes) => {
+                let token_seq = self.config.compute_seq_hashes_for_tracking(
+                    &request.tokens,
+                    self.block_size,
+                    None,
+                    BlockHashOptions::default(),
+                    Some(&replay_hashes.local_block_hashes),
+                );
                 let overlaps = self
                     .indexer
                     .find_matches_for_hashes(replay_hashes.local_block_hashes);
-                let token_seq = if !self.config.router_track_active_blocks {
-                    None
-                } else if self.config.router_assume_kv_reuse {
-                    Some(replay_hashes.sequence_hashes)
-                } else {
-                    self.config.compute_seq_hashes_for_tracking(
-                        &request.tokens,
-                        self.block_size,
-                        None,
-                        BlockHashOptions::default(),
-                        None,
-                    )
-                };
                 (overlaps, token_seq)
             }
             None => {
@@ -710,9 +704,9 @@ mod tests {
     use dynamo_kv_router::PrefillTokenDeltas;
     use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel, RouterQueuePolicy};
     use dynamo_kv_router::protocols::{
-        BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData,
-        KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier,
-        WorkerId, WorkerWithDpRank,
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerId,
+        WorkerWithDpRank,
     };
     use rustc_hash::FxHashMap;
     use uuid::Uuid;
@@ -854,24 +848,23 @@ mod tests {
         };
         let mut router = OfflineReplayRouter::new(&replay_args(), Some(config), None, 1).unwrap();
         let first = request_with_priorities(1, 7, 10 * 64, 0, 0);
+        let first_hashes = ReplayRequestHashes::from_tokens(&first.tokens, router.block_size);
 
-        router.on_request_arrival(&first, None, 0.0).unwrap();
+        router
+            .on_request_arrival(&first, Some(first_hashes), 0.0)
+            .unwrap();
         assert_eq!(
             router.debug_snapshot(0.0).active_blocks_by_worker,
             vec![(0, 9)]
         );
 
         let second = request_with_priorities(2, 8, 10 * 64, 0, 0);
-        let second_sequence = router
-            .config
-            .compute_seq_hashes_for_tracking(
-                &second.tokens,
-                router.block_size,
-                None,
-                BlockHashOptions::default(),
-                None,
-            )
+        let second_hashes = ReplayRequestHashes::from_tokens(&second.tokens, router.block_size);
+        let second_pending = router
+            .build_pending_request(&second, Some(second_hashes), None)
             .unwrap();
+        let second_sequence = second_pending.token_seq.unwrap();
+        assert_eq!(second_sequence.len(), 3);
         let (potential_blocks, _, _) = router.slots.potential_blocks_and_tokens::<false>(
             Some(&second_sequence),
             &PrefillTokenDeltas::none(),

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -214,7 +215,9 @@ impl OfflineReplayRouter {
         let config = replay_router_config(args, router_config);
         let worker_config_template = replay_worker_config(args);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
-        let slots = replay_slots(args, &workers_with_configs);
+        let active_sequence_stride = NonZeroUsize::new(config.router_active_sequence_stride)
+            .ok_or_else(|| anyhow!("router active-sequence stride must be greater than zero"))?;
+        let slots = replay_slots(args, &workers_with_configs, active_sequence_stride);
         let selector = replay_selector(&config);
         let profile = config
             .configured_policy_profile()
@@ -704,10 +707,12 @@ mod tests {
     use std::time::Duration;
 
     use dynamo_kv_router::PrefillLoadEstimator;
+    use dynamo_kv_router::PrefillTokenDeltas;
     use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel, RouterQueuePolicy};
     use dynamo_kv_router::protocols::{
-        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
-        KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerId,
+        BlockHashOptions, ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData,
+        KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier,
+        WorkerId, WorkerWithDpRank,
     };
     use rustc_hash::FxHashMap;
     use uuid::Uuid;
@@ -839,6 +844,39 @@ mod tests {
         let scheduling_request = pending.scheduling_request(64, FxHashMap::default());
 
         assert_eq!(scheduling_request.session_id.as_deref(), Some("session-a"));
+    }
+
+    #[test]
+    fn sparse_replay_corrects_active_and_potential_decode_blocks() {
+        let config = KvRouterConfig {
+            router_active_sequence_stride: 3,
+            ..Default::default()
+        };
+        let mut router = OfflineReplayRouter::new(&replay_args(), Some(config), None, 1).unwrap();
+        let first = request_with_priorities(1, 7, 10 * 64, 0, 0);
+
+        router.on_request_arrival(&first, None, 0.0).unwrap();
+        assert_eq!(
+            router.debug_snapshot(0.0).active_blocks_by_worker,
+            vec![(0, 9)]
+        );
+
+        let second = request_with_priorities(2, 8, 10 * 64, 0, 0);
+        let second_sequence = router
+            .config
+            .compute_seq_hashes_for_tracking(
+                &second.tokens,
+                router.block_size,
+                None,
+                BlockHashOptions::default(),
+                None,
+            )
+            .unwrap();
+        let (potential_blocks, _, _) = router.slots.potential_blocks_and_tokens::<false>(
+            Some(&second_sequence),
+            &PrefillTokenDeltas::none(),
+        );
+        assert_eq!(potential_blocks[&WorkerWithDpRank::new(0, 0)], 18);
     }
 
     #[test]

--- a/lib/mocker/src/replay/offline/components/router.rs
+++ b/lib/mocker/src/replay/offline/components/router.rs
@@ -2,7 +2,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use std::collections::HashMap;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -21,9 +20,9 @@ use dynamo_kv_router::scheduling::{
 use dynamo_kv_router::sequences::topology::WorkerDpRange;
 use dynamo_kv_router::{
     ActiveSequencesMultiWorker, DefaultWorkerSelector, RadixTree, SchedulingRequest,
-    SequenceRequest, WorkerLoadProjection, WorkerSelector, scheduling::TierOverlapBlocks,
+    SequenceRequest, TrackedSequenceHashes, WorkerLoadProjection, WorkerSelector,
+    scheduling::TierOverlapBlocks,
 };
-use dynamo_tokens::SequenceHash;
 use rustc_hash::FxHashMap;
 use tokio::time::Instant;
 use uuid::Uuid;
@@ -128,7 +127,7 @@ impl SyncReplayIndexer {
 
 struct PendingRequest {
     uuid: Uuid,
-    token_seq: Option<Vec<SequenceHash>>,
+    token_seq: Option<TrackedSequenceHashes>,
     isl_tokens: usize,
     overlaps: OverlapScores,
     track_prefill_tokens: bool,
@@ -215,9 +214,11 @@ impl OfflineReplayRouter {
         let config = replay_router_config(args, router_config);
         let worker_config_template = replay_worker_config(args);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
-        let active_sequence_stride = NonZeroUsize::new(config.router_active_sequence_stride)
-            .ok_or_else(|| anyhow!("router active-sequence stride must be greater than zero"))?;
-        let slots = replay_slots(args, &workers_with_configs, active_sequence_stride);
+        let slots = replay_slots(
+            args,
+            &workers_with_configs,
+            config.router_active_sequence_stride,
+        );
         let selector = replay_selector(&config);
         let profile = config
             .configured_policy_profile()
@@ -546,7 +547,7 @@ impl OfflineReplayRouter {
     ) -> Result<AdmitOutcome> {
         let worker_loads = self
             .slots
-            .project_worker_loads(request.token_seq.as_deref(), decay_now);
+            .project_worker_loads(request.token_seq.as_ref(), decay_now);
         let scheduling_request = request.scheduling_request(self.block_size as usize, worker_loads);
         let eligibility = scheduling_request.eligibility();
         let selection = self.selector.select_worker(
@@ -700,14 +701,13 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use dynamo_kv_router::PrefillLoadEstimator;
-    use dynamo_kv_router::PrefillTokenDeltas;
     use dynamo_kv_router::config::{KvRouterConfig, RouterPrefillLoadModel, RouterQueuePolicy};
     use dynamo_kv_router::protocols::{
         ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
         KvCacheStoredBlockData, LocalBlockHash, RouterEvent, StorageTier, WorkerId,
         WorkerWithDpRank,
     };
+    use dynamo_kv_router::{ActiveSequenceStride, PrefillLoadEstimator, PrefillTokenDeltas};
     use rustc_hash::FxHashMap;
     use uuid::Uuid;
 
@@ -843,7 +843,7 @@ mod tests {
     #[test]
     fn sparse_replay_corrects_active_and_potential_decode_blocks() {
         let config = KvRouterConfig {
-            router_active_sequence_stride: 3,
+            router_active_sequence_stride: ActiveSequenceStride::new(3).unwrap(),
             ..Default::default()
         };
         let mut router = OfflineReplayRouter::new(&replay_args(), Some(config), None, 1).unwrap();

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -1,7 +1,6 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -149,9 +148,11 @@ impl KvReplayRouter {
         let indexer =
             create_replay_indexer(args.block_size as u32, config.router_event_threads as usize);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
-        let active_sequence_stride = NonZeroUsize::new(config.router_active_sequence_stride)
-            .ok_or_else(|| anyhow!("router active-sequence stride must be greater than zero"))?;
-        let slots = replay_slots(args, &workers_with_configs, active_sequence_stride);
+        let slots = replay_slots(
+            args,
+            &workers_with_configs,
+            config.router_active_sequence_stride,
+        );
         let (_worker_config_tx, worker_config_rx) =
             tokio::sync::watch::channel(workers_with_configs);
         let selector = replay_selector(&config);
@@ -401,6 +402,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
+    use dynamo_kv_router::ActiveSequenceStride;
     use dynamo_kv_router::config::RouterQueuePolicy;
     use dynamo_kv_router::protocols::{
         ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
@@ -422,6 +424,40 @@ mod tests {
             strict_priority,
             policy_class: None,
         }
+    }
+
+    #[tokio::test]
+    async fn online_replay_samples_active_sequence_hashes_once() {
+        let args = MockEngineArgs::builder()
+            .block_size(64)
+            .max_num_batched_tokens(Some(1024))
+            .build()
+            .unwrap();
+        let config = KvRouterConfig {
+            router_active_sequence_stride: ActiveSequenceStride::new(3).unwrap(),
+            ..KvRouterConfig::default()
+        };
+        let router =
+            ReplayRouter::new(ReplayRouterMode::KvRouter, &args, Some(config), None, 1).unwrap();
+        let request = DirectRequest {
+            tokens: (0..10 * 64).collect(),
+            max_output_tokens: 1,
+            output_token_ids: None,
+            uuid: Some(Uuid::from_u128(100)),
+            dp_rank: 0,
+            arrival_timestamp_ms: Some(0.0),
+            priority: 0,
+            strict_priority: 0,
+            policy_class: None,
+        };
+
+        assert_eq!(router.select_worker(&request, 1).await.unwrap(), 0);
+        let loads = router.debug_potential_loads(0, false);
+        assert_eq!(loads.len(), 1);
+        assert_eq!(loads[0].potential_decode_blocks, 9);
+
+        router.on_complete(Uuid::from_u128(100)).await.unwrap();
+        router.shutdown().await.unwrap();
     }
 
     #[tokio::test]

--- a/lib/mocker/src/replay/online/router.rs
+++ b/lib/mocker/src/replay/online/router.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -148,7 +149,9 @@ impl KvReplayRouter {
         let indexer =
             create_replay_indexer(args.block_size as u32, config.router_event_threads as usize);
         let workers_with_configs = replay_workers_with_configs(args, num_workers);
-        let slots = replay_slots(args, &workers_with_configs);
+        let active_sequence_stride = NonZeroUsize::new(config.router_active_sequence_stride)
+            .ok_or_else(|| anyhow!("router active-sequence stride must be greater than zero"))?;
+        let slots = replay_slots(args, &workers_with_configs, active_sequence_stride);
         let (_worker_config_tx, worker_config_rx) =
             tokio::sync::watch::channel(workers_with_configs);
         let selector = replay_selector(&config);

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -3,7 +3,6 @@
 
 use std::collections::HashMap;
 use std::future;
-use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use crate::common::protocols::MockEngineArgs;
@@ -13,8 +12,8 @@ use dynamo_kv_router::protocols::{
 };
 use dynamo_kv_router::scheduling::queue::DEFAULT_MAX_BATCHED_TOKENS;
 use dynamo_kv_router::{
-    ActiveSequencesMultiWorker, DefaultWorkerSelector, LocalScheduler, SequencePublisher,
-    SequenceTrackerOptions,
+    ActiveSequenceStride, ActiveSequencesMultiWorker, DefaultWorkerSelector, LocalScheduler,
+    SequencePublisher, SequenceTrackerOptions,
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -87,7 +86,7 @@ pub(super) fn replay_workers_with_configs(
 pub(super) fn replay_slots(
     args: &MockEngineArgs,
     workers_with_configs: &HashMap<WorkerId, ReplayWorkerConfig>,
-    active_sequence_stride: NonZeroUsize,
+    active_sequence_stride: ActiveSequenceStride,
 ) -> Arc<ActiveSequencesMultiWorker<ReplayNoopPublisher>> {
     let dp_range = workers_with_configs
         .iter()

--- a/lib/mocker/src/replay/router_shared.rs
+++ b/lib/mocker/src/replay/router_shared.rs
@@ -3,6 +3,7 @@
 
 use std::collections::HashMap;
 use std::future;
+use std::num::NonZeroUsize;
 use std::sync::Arc;
 
 use crate::common::protocols::MockEngineArgs;
@@ -13,6 +14,7 @@ use dynamo_kv_router::protocols::{
 use dynamo_kv_router::scheduling::queue::DEFAULT_MAX_BATCHED_TOKENS;
 use dynamo_kv_router::{
     ActiveSequencesMultiWorker, DefaultWorkerSelector, LocalScheduler, SequencePublisher,
+    SequenceTrackerOptions,
 };
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -85,6 +87,7 @@ pub(super) fn replay_workers_with_configs(
 pub(super) fn replay_slots(
     args: &MockEngineArgs,
     workers_with_configs: &HashMap<WorkerId, ReplayWorkerConfig>,
+    active_sequence_stride: NonZeroUsize,
 ) -> Arc<ActiveSequencesMultiWorker<ReplayNoopPublisher>> {
     let dp_range = workers_with_configs
         .iter()
@@ -100,13 +103,17 @@ pub(super) fn replay_slots(
     // healthy replay may spend minutes of wall time advancing seconds of virtual time. Keep
     // expiry disabled here until replay has a liveness-aware definition of a stale request; do
     // not mask replay dead ends by expiring requests that are still live in virtual time.
-    Arc::new(ActiveSequencesMultiWorker::new_without_expiry(
+    Arc::new(ActiveSequencesMultiWorker::new_with_options(
         ReplayNoopPublisher,
         args.block_size,
         dp_range,
-        false,
         0,
         "replay",
+        SequenceTrackerOptions {
+            expiry_enabled: false,
+            active_sequence_stride,
+            ..Default::default()
+        },
     ))
 }
 


### PR DESCRIPTION
## Summary

- Add `--router-active-sequence-stride` / `DYN_ROUTER_ACTIVE_SEQUENCE_STRIDE` as a startup-only setting, defaulting to `1` and rejecting values below `1`.
- Retain rolling active-sequence hashes at stride endpoints while leaving KV-indexer hashes, routing-decision hashes, overlap signals, and token accounting unchanged.
- Correct externally visible active and potential decode-block estimates by scaling sparse prompt units while keeping generated-output blocks in physical units.
- Carry the stride on active-sequence add, free, and prefill-complete events; incompatible or malformed replica events are dropped before mutation and recorded through structured warnings and a Prometheus counter.

## Details

Active-sequence replica synchronization currently broadcasts the complete rolling-hash chain for every request. This makes payload size proportional to the full prompt length on every frontend.

This change computes the complete rolling chain first and then samples block positions `n, 2n, 3n, ...`. The sampled vector is used for local active-sequence tracking and is broadcast without receiver-side resampling. `BlockTracker` and `PromptMembershipTrie` remain sparsity-agnostic; outer load projection stores prompt and output components separately and converts sparse prompt units back into estimated physical blocks.

The corrected counts are estimates. Retained stride groups are fully represented, divergence inside a group can conservatively overcount overlap, and an incomplete trailing group is omitted.

`ActiveSequenceEvent.stride` is optional for wire compatibility: missing means stride `1`, while zero is malformed. A receiver drops only an incompatible event and continues processing subsequent compatible events.

Rollout must be coordinated. Deploy this binary everywhere with stride `1` first, then enable a common stride through a coordinated frontend restart. Older receivers may ignore the new field while still consuming the sparse vector.

## Where should the reviewer start?

- `lib/kv-router/src/scheduling/config.rs` for configuration and hash sampling.
- `lib/kv-router/src/sequences/prompt_registry.rs` and `multi_worker.rs` for load correction and event emission.
- `lib/kv-router/src/sequences/replica_sync.rs` and `lib/kv-router/src/protocols.rs` for compatibility enforcement.
- `lib/llm/src/kv_router/sequence.rs` and `metrics.rs` for frontend propagation and observability.

## Validation

- `cargo test -p dynamo-kv-router` — 752 passed, 2 ignored.
- `cargo test -p dynamo-llm`.
- `cargo check --manifest-path lib/bindings/python/Cargo.toml`.
- Shared KV-router configuration tests — 49 passed in an isolated CPU-only pytest environment.
- `cargo fmt --all -- --check`.
- Ruff lint and format checks for the changed Python files.
- `git diff --check`.

## Related Issues

- [x] Confirmed — no related issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added configurable active-sequence sampling stride, available through CLI, environment variables, Python bindings, and router configuration.
  - Added stride-aware routing, load estimation, replay behavior, and replica synchronization.
  - Added validation to reject invalid stride values and incompatible replica events.
  - Added metrics for stride mismatches.

- **Bug Fixes**
  - Configuration errors now fail clearly instead of proceeding with invalid settings.

- **Documentation**
  - Documented stride behavior, synchronization requirements, upgrade considerations, and monitoring details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->