### PR TITLE
perf(vllm): add opt-in synchronous in-process engine client

### DIFF
--- a/benchmarks/multimodal/sweep/experiments/engine_client/__init__.py
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/__init__.py
@@ -1,0 +1,4 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Text engine-client benchmark experiment."""

--- a/benchmarks/multimodal/sweep/experiments/engine_client/generate_text_workload.py
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/generate_text_workload.py
@@ -1,0 +1,157 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Generate and audit the deterministic Qwen2.5 text workload."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+from transformers import AutoTokenizer
+
+MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
+BASE_PROMPT = "Summarize the benchmark request in one concise sentence."
+FILLER = " benchmark"
+
+
+def sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def rendered_token_count(tokenizer: Any, prompt: str) -> int:
+    rendered = tokenizer.apply_chat_template(
+        [{"role": "user", "content": prompt}],
+        tokenize=True,
+        add_generation_prompt=True,
+    )
+    token_ids = rendered["input_ids"] if isinstance(rendered, Mapping) else rendered
+    if token_ids and isinstance(token_ids[0], list):
+        token_ids = token_ids[0]
+    return len(token_ids)
+
+
+def calibrate_prompt(tokenizer: Any, target_isl: int) -> str:
+    for repeat_count in range(target_isl * 2):
+        prompt = BASE_PROMPT + FILLER * repeat_count
+        token_count = rendered_token_count(tokenizer, prompt)
+        if token_count == target_isl:
+            return prompt
+        if token_count > target_isl:
+            break
+    raise ValueError(f"could not calibrate an exact rendered ISL of {target_isl}")
+
+
+def validate_workload(
+    dataset_path: Path,
+    manifest_path: Path,
+    tokenizer: Any,
+) -> dict[str, Any]:
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    rows: list[dict[str, Any]] = []
+    with dataset_path.open("r", encoding="utf-8") as dataset:
+        for line in dataset:
+            rows.append(json.loads(line))
+
+    expected_rows = int(manifest["request_count"])
+    target_isl = int(manifest["target_isl"])
+    if len(rows) != expected_rows:
+        raise ValueError(f"expected {expected_rows} rows, found {len(rows)}")
+    if any(set(row) != {"session_id", "text"} for row in rows):
+        raise ValueError("text workload rows must contain only session_id and text")
+
+    prompts = {str(row["text"]) for row in rows}
+    session_ids = {str(row["session_id"]) for row in rows}
+    if len(prompts) != 1:
+        raise ValueError("text workload must use one byte-identical prompt")
+    if len(session_ids) != expected_rows:
+        raise ValueError("text workload session IDs must be unique")
+
+    prompt = next(iter(prompts))
+    actual_isl = rendered_token_count(tokenizer, prompt)
+    if actual_isl != target_isl:
+        raise ValueError(f"expected rendered ISL {target_isl}, found {actual_isl}")
+    if sha256(dataset_path) != manifest["dataset_sha256"]:
+        raise ValueError("text workload hash does not match its manifest")
+
+    audit = {
+        "model": manifest["model"],
+        "request_count": expected_rows,
+        "target_isl": target_isl,
+        "dataset_sha256": manifest["dataset_sha256"],
+    }
+    print(
+        "WORKLOAD_AUDIT=PASS "
+        f"rows={expected_rows} isl={target_isl} sha256={audit['dataset_sha256']}"
+    )
+    return audit
+
+
+def generate_workload(
+    output_dir: Path,
+    model: str = MODEL,
+    request_count: int = 1000,
+    target_isl: int = 740,
+) -> tuple[Path, Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    tokenizer = AutoTokenizer.from_pretrained(model)
+    prompt = calibrate_prompt(tokenizer, target_isl)
+    dataset_path = output_dir / f"text_{request_count}_isl{target_isl}.jsonl"
+    with dataset_path.open("w", encoding="utf-8") as dataset:
+        for request_index in range(request_count):
+            row = {
+                "session_id": f"text-request-{request_index:04d}",
+                "text": prompt,
+            }
+            dataset.write(json.dumps(row, separators=(",", ":")) + "\n")
+
+    manifest = {
+        "model": model,
+        "request_count": request_count,
+        "target_isl": target_isl,
+        "dataset": str(dataset_path.resolve()),
+        "dataset_sha256": sha256(dataset_path),
+        "prompt_sha256": hashlib.sha256(prompt.encode("utf-8")).hexdigest(),
+        "media_fields": [],
+    }
+    manifest_path = output_dir / "workload_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    validate_workload(dataset_path, manifest_path, tokenizer)
+    return dataset_path, manifest_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--model", default=MODEL)
+    parser.add_argument("--request-count", type=int, default=1000)
+    parser.add_argument("--target-isl", type=int, default=740)
+    parser.add_argument("--validate", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    output_dir = args.output_dir.resolve()
+    if args.validate:
+        tokenizer = AutoTokenizer.from_pretrained(args.model)
+        validate_workload(
+            output_dir / f"text_{args.request_count}_isl{args.target_isl}.jsonl",
+            output_dir / "workload_manifest.json",
+            tokenizer,
+        )
+        return
+    generate_workload(
+        output_dir=output_dir,
+        model=args.model,
+        request_count=args.request_count,
+        target_isl=args.target_isl,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/multimodal/sweep/experiments/engine_client/report_text_results.py
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/report_text_results.py
@@ -1,0 +1,235 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Create CSV and Markdown reports for the text engine-client benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Iterable
+
+from benchmarks.multimodal.sweep.experiments.engine_client.validate_text_results import (
+    metric,
+)
+
+RUNTIME_ORDER = ("vllm-serve", "dynamo-async", "dynamo-sync")
+T_CRITICAL_95_N5 = 2.776
+
+
+def result_rows(root: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for path in sorted(root.rglob("profile_export_aiperf.json")):
+        document = json.loads(path.read_text(encoding="utf-8"))
+        rows.append(
+            {
+                "trial": int(path.parents[2].name.removeprefix("trial-")),
+                "runtime": path.parents[1].name,
+                "request_throughput_rps": metric(document, "request_throughput"),
+                "output_throughput_tps": metric(document, "output_token_throughput"),
+                "ttft_p50_ms": metric(document, "time_to_first_token", "p50"),
+                "ttft_p90_ms": metric(document, "time_to_first_token", "p90"),
+                "ttft_p99_ms": metric(document, "time_to_first_token", "p99"),
+                "itl_p50_ms": metric(document, "inter_token_latency", "p50"),
+                "itl_p90_ms": metric(document, "inter_token_latency", "p90"),
+                "itl_p99_ms": metric(document, "inter_token_latency", "p99"),
+                "e2e_p50_ms": metric(document, "request_latency", "p50"),
+                "e2e_p90_ms": metric(document, "request_latency", "p90"),
+                "e2e_p99_ms": metric(document, "request_latency", "p99"),
+                "artifact": str(path.parent.relative_to(root)),
+                "command": str((path.parent / "command.txt").relative_to(root)),
+            }
+        )
+    return rows
+
+
+def means_by_runtime(rows: list[dict[str, Any]]) -> dict[str, dict[str, float]]:
+    values: dict[str, dict[str, list[float]]] = defaultdict(lambda: defaultdict(list))
+    for row in rows:
+        for name, value in row.items():
+            if name not in {"trial", "runtime"} and isinstance(value, (int, float)):
+                values[str(row["runtime"])][name].append(float(value))
+    return {
+        runtime: {name: statistics.mean(samples) for name, samples in metrics.items()}
+        for runtime, metrics in values.items()
+    }
+
+
+def paired_interval(
+    rows: list[dict[str, Any]],
+    candidate: str,
+    metric_name: str,
+) -> tuple[float, float, float]:
+    by_trial = {
+        (int(row["trial"]), str(row["runtime"])): float(row[metric_name])
+        for row in rows
+    }
+    deltas = [
+        (by_trial[(trial, candidate)] / by_trial[(trial, "dynamo-async")] - 1.0) * 100.0
+        for trial in range(1, 6)
+    ]
+    mean = statistics.mean(deltas)
+    half_width = T_CRITICAL_95_N5 * statistics.stdev(deltas) / math.sqrt(len(deltas))
+    return mean, mean - half_width, mean + half_width
+
+
+def format_value(
+    value: float,
+    *,
+    best: bool,
+    precision: int = 3,
+) -> str:
+    rendered = f"{value:.{precision}f}"
+    return f"**{rendered}**" if best else rendered
+
+
+def best_runtime(
+    means: dict[str, dict[str, float]], metric_name: str, higher: bool
+) -> str:
+    selector = max if higher else min
+    return selector(RUNTIME_ORDER, key=lambda runtime: means[runtime][metric_name])
+
+
+def markdown_report(root: Path, rows: list[dict[str, Any]]) -> str:
+    means = means_by_runtime(rows)
+    lines = [
+        "# Qwen2.5-1.5B engine-client benchmark",
+        "",
+        "Five fresh-server trials; concurrency 1; 1,000 measured requests plus 20 warmups; exact ISL 740 / OSL 70.",
+        "",
+        "## Throughput",
+        "",
+        "| Runtime | Request throughput (req/s) | Output throughput (tok/s) | Paired request delta vs async (95% CI) |",
+        "|---|---:|---:|---:|",
+    ]
+    best_request = best_runtime(means, "request_throughput_rps", True)
+    best_output = best_runtime(means, "output_throughput_tps", True)
+    for runtime in RUNTIME_ORDER:
+        if runtime == "dynamo-async":
+            delta = "baseline"
+        else:
+            mean, low, high = paired_interval(rows, runtime, "request_throughput_rps")
+            delta = f"{mean:+.2f}% [{low:+.2f}, {high:+.2f}]"
+        lines.append(
+            "| "
+            + " | ".join(
+                (
+                    runtime,
+                    format_value(
+                        means[runtime]["request_throughput_rps"],
+                        best=runtime == best_request,
+                    ),
+                    format_value(
+                        means[runtime]["output_throughput_tps"],
+                        best=runtime == best_output,
+                    ),
+                    delta,
+                )
+            )
+            + " |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## TTFT and ITL",
+            "",
+            "| Runtime | TTFT p50 | TTFT p90 | TTFT p99 | ITL p50 | ITL p90 | ITL p99 |",
+            "|---|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    latency_metrics = (
+        "ttft_p50_ms",
+        "ttft_p90_ms",
+        "ttft_p99_ms",
+        "itl_p50_ms",
+        "itl_p90_ms",
+        "itl_p99_ms",
+    )
+    latency_bests = {name: best_runtime(means, name, False) for name in latency_metrics}
+    for runtime in RUNTIME_ORDER:
+        rendered = [
+            format_value(means[runtime][name], best=latency_bests[name] == runtime)
+            for name in latency_metrics
+        ]
+        lines.append(f"| {runtime} | " + " | ".join(rendered) + " |")
+
+    lines.extend(
+        [
+            "",
+            "## End-to-end latency",
+            "",
+            "| Runtime | p50 (ms) | p90 (ms) | p99 (ms) | Paired p99 delta vs async (95% CI) |",
+            "|---|---:|---:|---:|---:|",
+        ]
+    )
+    e2e_metrics = ("e2e_p50_ms", "e2e_p90_ms", "e2e_p99_ms")
+    e2e_bests = {name: best_runtime(means, name, False) for name in e2e_metrics}
+    for runtime in RUNTIME_ORDER:
+        if runtime == "dynamo-async":
+            delta = "baseline"
+        else:
+            mean, low, high = paired_interval(rows, runtime, "e2e_p99_ms")
+            delta = f"{mean:+.2f}% [{low:+.2f}, {high:+.2f}]"
+        rendered = [
+            format_value(means[runtime][name], best=e2e_bests[name] == runtime)
+            for name in e2e_metrics
+        ]
+        lines.append(f"| {runtime} | " + " | ".join([*rendered, delta]) + " |")
+
+    lines.extend(
+        [
+            "",
+            "## Artifacts and commands",
+            "",
+            "| Trial | Runtime | Artifact | Command |",
+            "|---:|---|---|---|",
+        ]
+    )
+    for row in sorted(rows, key=lambda item: (item["trial"], item["runtime"])):
+        lines.append(
+            f"| {row['trial']} | {row['runtime']} | "
+            f"[{row['artifact']}]({row['artifact']}) | "
+            f"[command]({row['command']}) |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def write_csv(path: Path, rows: Iterable[dict[str, Any]]) -> None:
+    materialized = list(rows)
+    with path.open("w", encoding="utf-8", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=list(materialized[0]))
+        writer.writeheader()
+        writer.writerows(materialized)
+
+
+def report(root: Path) -> tuple[Path, Path]:
+    rows = result_rows(root)
+    if len(rows) != 15:
+        raise ValueError(f"expected 15 audited results, found {len(rows)}")
+    csv_path = root / "benchmark.csv"
+    markdown_path = root / "benchmark.md"
+    write_csv(csv_path, rows)
+    markdown_path.write_text(markdown_report(root, rows), encoding="utf-8")
+    print(f"benchmark={markdown_path}")
+    print(f"csv={csv_path}")
+    return markdown_path, csv_path
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    report(parse_args().root.resolve())
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/multimodal/sweep/experiments/engine_client/run_text_sweep.py
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/run_text_sweep.py
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the five-trial Qwen2.5 text engine-client benchmark."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import platform
+import shlex
+import subprocess
+from dataclasses import replace
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import torch
+import transformers
+import vllm
+
+from benchmarks.multimodal.sweep.experiments.engine_client.generate_text_workload import (
+    sha256,
+)
+from benchmarks.multimodal.sweep.experiments.engine_client.text_config import (
+    TextSweepConfig,
+)
+from benchmarks.multimodal.sweep.server import ServerManager
+
+REPO_ROOT = Path(__file__).resolve().parents[5]
+SMOKE_ORDER = ("vllm-serve", "dynamo-async", "dynamo-sync")
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def git_value(*args: str) -> str:
+    return subprocess.check_output(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stderr=subprocess.DEVNULL,
+    ).strip()
+
+
+def source_revision() -> tuple[str, str]:
+    requested_commit = os.environ.get("DYNAMO_BENCHMARK_COMMIT")
+    requested_branch = os.environ.get("DYNAMO_BENCHMARK_BRANCH")
+    try:
+        git_commit = git_value("rev-parse", "HEAD")
+        git_branch = git_value("branch", "--show-current")
+        git_status = git_value("status", "--porcelain")
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        if not requested_commit or not requested_branch:
+            raise ValueError(
+                "container has no Git metadata; set DYNAMO_BENCHMARK_COMMIT "
+                "and DYNAMO_BENCHMARK_BRANCH from the clean source worktree"
+            ) from None
+        return requested_commit, requested_branch
+
+    if git_status:
+        raise ValueError("benchmark source worktree must be clean and committed")
+    if requested_commit and requested_commit != git_commit:
+        raise ValueError("DYNAMO_BENCHMARK_COMMIT does not match source HEAD")
+    if requested_branch and git_branch and requested_branch != git_branch:
+        raise ValueError("DYNAMO_BENCHMARK_BRANCH does not match the source branch")
+    branch = requested_branch or git_branch
+    if not branch:
+        raise ValueError("set DYNAMO_BENCHMARK_BRANCH for a detached source revision")
+    return requested_commit or git_commit, branch
+
+
+def command_value(*args: str) -> str:
+    return subprocess.check_output(list(args), text=True).strip()
+
+
+def aiperf_command(
+    config: TextSweepConfig,
+    dataset_path: Path,
+    artifact_dir: Path,
+) -> list[str]:
+    return [
+        "aiperf",
+        "profile",
+        "--model",
+        config.model,
+        "--url",
+        f"http://127.0.0.1:{config.port}",
+        "--endpoint-type",
+        "chat",
+        "--streaming",
+        "--request-count",
+        str(config.request_count),
+        "--warmup-request-count",
+        str(config.warmup_count),
+        "--concurrency",
+        str(config.concurrency),
+        "--osl",
+        str(config.osl),
+        "--extra-inputs",
+        "ignore_eos:true",
+        "--extra-inputs",
+        "temperature:0.0",
+        "--extra-inputs",
+        "seed:0",
+        "--random-seed",
+        "42",
+        "--input-file",
+        str(dataset_path),
+        "--custom-dataset-type",
+        "single_turn",
+        "--artifact-dir",
+        str(artifact_dir),
+        "--use-server-token-count",
+        "--no-server-metrics",
+        "--ui",
+        "none",
+    ]
+
+
+def run_aiperf(
+    config: TextSweepConfig,
+    dataset_path: Path,
+    artifact_dir: Path,
+) -> None:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    command = aiperf_command(config, dataset_path, artifact_dir)
+    (artifact_dir / "command.txt").write_text(
+        shlex.join(command) + "\n", encoding="utf-8"
+    )
+    with (artifact_dir / "aiperf.log").open("w", encoding="utf-8") as output:
+        subprocess.run(
+            command,
+            stdout=output,
+            stderr=subprocess.STDOUT,
+            check=True,
+        )
+
+
+def shared_engine_args(config: TextSweepConfig) -> list[str]:
+    args = [
+        "--max-model-len",
+        str(config.max_model_len),
+        "--max-num-seqs",
+        str(config.max_num_seqs),
+    ]
+    if config.prefix_caching:
+        args.append("--enable-prefix-caching")
+    return args
+
+
+def benchmark_metadata(
+    config: TextSweepConfig,
+    dataset_path: Path,
+    workload_manifest: dict[str, Any],
+    *,
+    commit: str,
+    branch: str,
+    smoke: bool,
+) -> dict[str, Any]:
+    return {
+        "model": config.model,
+        "commit": commit,
+        "branch": branch,
+        "container_image": os.environ.get("DYNAMO_BENCHMARK_IMAGE", "unknown"),
+        "physical_gpu": os.environ.get("DYNAMO_BENCHMARK_PHYSICAL_GPU", "unknown"),
+        "gpu_identity": command_value(
+            "nvidia-smi",
+            "--query-gpu=name,uuid,driver_version,memory.total",
+            "--format=csv,noheader",
+        ),
+        "host": platform.node(),
+        "versions": {
+            "aiperf": command_value("aiperf", "--version"),
+            "torch": torch.__version__,
+            "transformers": transformers.__version__,
+            "vllm": vllm.__version__,
+        },
+        "config": str(config.source_path),
+        "config_sha256": config.source_sha256,
+        "dataset": str(dataset_path.resolve()),
+        "dataset_sha256": sha256(dataset_path),
+        "workload_manifest": workload_manifest,
+        "smoke": smoke,
+        "concurrency": config.concurrency,
+        "request_count": config.request_count,
+        "warmup_count": config.warmup_count,
+        "target_isl": config.target_isl,
+        "osl": config.osl,
+        "repeats": config.repeats,
+        "trial_order": config.trial_order,
+        "max_model_len": config.max_model_len,
+        "max_num_seqs": config.max_num_seqs,
+        "kv_cache_memory_bytes": config.kv_cache_memory_bytes,
+        "prefix_caching": config.prefix_caching,
+        "created_at": utc_now(),
+    }
+
+
+def write_metadata(path: Path, metadata: dict[str, Any]) -> None:
+    normalized = json.loads(json.dumps(metadata))
+    if path.exists():
+        existing = json.loads(path.read_text(encoding="utf-8"))
+        comparable_keys = set(metadata) - {"created_at"}
+        if any(existing.get(key) != normalized.get(key) for key in comparable_keys):
+            raise ValueError("refusing to resume with different benchmark provenance")
+        return
+    path.write_text(json.dumps(normalized, indent=2) + "\n", encoding="utf-8")
+
+
+def run_sweep(
+    config: TextSweepConfig,
+    dataset_path: Path,
+    manifest_path: Path,
+    output_dir: Path,
+    *,
+    smoke: bool = False,
+) -> None:
+    commit, branch = source_revision()
+    workload_manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    if workload_manifest["model"] != config.model:
+        raise ValueError("workload model does not match benchmark model")
+    if sha256(dataset_path) != workload_manifest["dataset_sha256"]:
+        raise ValueError("workload hash does not match its manifest")
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if smoke:
+        config = replace(
+            config,
+            request_count=3,
+            warmup_count=1,
+            repeats=1,
+            trial_order=(SMOKE_ORDER,),
+        )
+    metadata = benchmark_metadata(
+        config,
+        dataset_path,
+        workload_manifest,
+        commit=commit,
+        branch=branch,
+        smoke=smoke,
+    )
+    if "0.8.0" not in metadata["versions"]["aiperf"]:
+        raise ValueError("text engine-client benchmark requires AIPerf 0.8.0")
+    write_metadata(output_dir / "benchmark_metadata.json", metadata)
+
+    environment = {
+        "DYN_HTTP_PORT": str(config.port),
+        "DYN_FRONTEND_SYSTEM_PORT": str(config.port + 1),
+        "DYN_WORKER_SYSTEM_PORT": str(config.port + 2),
+        "MAX_MODEL_LEN": str(config.max_model_len),
+        "MAX_NUM_SEQS": str(config.max_num_seqs),
+        "_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES": str(config.kv_cache_memory_bytes),
+        "CUDA_VISIBLE_DEVICES": os.environ.get("CUDA_VISIBLE_DEVICES", "0"),
+    }
+    server = ServerManager(port=config.port, timeout=config.timeout)
+
+    try:
+        for trial_index, order in enumerate(config.trial_order, start=1):
+            for order_index, runtime_label in enumerate(order, start=1):
+                runtime = config.runtimes[runtime_label]
+                run_dir = output_dir / f"trial-{trial_index:02d}" / runtime_label
+                artifact_dir = run_dir / f"concurrency{config.concurrency}"
+                result_path = artifact_dir / "profile_export_aiperf.json"
+                if result_path.exists():
+                    print(f"SKIP trial={trial_index} runtime={runtime_label}")
+                    continue
+                if run_dir.exists():
+                    raise RuntimeError(
+                        f"incomplete run directory must be removed before retry: {run_dir}"
+                    )
+
+                run_dir.mkdir(parents=True)
+                workflow = (REPO_ROOT / runtime.workflow).resolve()
+                extra_args = [*shared_engine_args(config), *runtime.extra_args]
+                server_command = [
+                    "bash",
+                    str(workflow),
+                    "--model",
+                    config.model,
+                    *extra_args,
+                ]
+                (run_dir / "server_command.txt").write_text(
+                    shlex.join(server_command) + "\n", encoding="utf-8"
+                )
+                run_metadata = {
+                    "trial": trial_index,
+                    "order_index": order_index,
+                    "runtime": runtime_label,
+                    "started_at": utc_now(),
+                    "config_sha256": config.source_sha256,
+                    "dataset_sha256": sha256(dataset_path),
+                }
+                (run_dir / "run_metadata.json").write_text(
+                    json.dumps(run_metadata, indent=2) + "\n", encoding="utf-8"
+                )
+
+                print(
+                    f"START trial={trial_index} order={order_index} "
+                    f"runtime={runtime_label}",
+                    flush=True,
+                )
+                server.start(
+                    workflow_script=str(workflow),
+                    model=config.model,
+                    extra_args=extra_args,
+                    env_overrides=environment,
+                )
+                try:
+                    run_aiperf(config, dataset_path, artifact_dir)
+                finally:
+                    server.stop()
+                print(f"DONE trial={trial_index} runtime={runtime_label}", flush=True)
+    finally:
+        if server.is_running:
+            server.stop()
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--smoke",
+        action="store_true",
+        help="run three measured requests plus one warmup for every runtime",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    run_sweep(
+        config=TextSweepConfig.load(args.config.resolve()),
+        dataset_path=args.dataset.resolve(),
+        manifest_path=args.manifest.resolve(),
+        output_dir=args.output_dir.resolve(),
+        smoke=args.smoke,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/multimodal/sweep/experiments/engine_client/text_concurrency1.yaml
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/text_concurrency1.yaml
@@ -1,0 +1,31 @@
+model: Qwen/Qwen2.5-1.5B-Instruct
+concurrency: 1
+request_count: 1000
+warmup_count: 20
+target_isl: 740
+osl: 70
+repeats: 5
+port: 8000
+timeout: 600
+max_model_len: 4096
+max_num_seqs: 1
+kv_cache_memory_bytes: 4294967296
+prefix_caching: true
+runtimes:
+  vllm-serve:
+    workflow: benchmarks/multimodal/sweep/workflows/vllm_serve.sh
+    extra_args: []
+  dynamo-async:
+    workflow: benchmarks/multimodal/sweep/workflows/dynamo_agg.sh
+    extra_args: []
+  dynamo-sync:
+    workflow: benchmarks/multimodal/sweep/workflows/dynamo_agg.sh
+    extra_args:
+      - --engine-client-mode
+      - sync-inproc
+trial_order:
+  - [vllm-serve, dynamo-async, dynamo-sync]
+  - [dynamo-sync, dynamo-async, vllm-serve]
+  - [dynamo-async, dynamo-sync, vllm-serve]
+  - [vllm-serve, dynamo-sync, dynamo-async]
+  - [dynamo-sync, vllm-serve, dynamo-async]

--- a/benchmarks/multimodal/sweep/experiments/engine_client/text_concurrency1.yaml
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/text_concurrency1.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
 model: Qwen/Qwen2.5-1.5B-Instruct
 concurrency: 1
 request_count: 1000

--- a/benchmarks/multimodal/sweep/experiments/engine_client/text_config.py
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/text_config.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration contract for the text engine-client benchmark."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+EXPECTED_RUNTIMES = {"vllm-serve", "dynamo-async", "dynamo-sync"}
+
+
+@dataclass(frozen=True)
+class RuntimeConfig:
+    workflow: str
+    extra_args: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TextSweepConfig:
+    model: str
+    concurrency: int
+    request_count: int
+    warmup_count: int
+    target_isl: int
+    osl: int
+    repeats: int
+    port: int
+    timeout: int
+    max_model_len: int
+    max_num_seqs: int
+    kv_cache_memory_bytes: int
+    prefix_caching: bool
+    runtimes: dict[str, RuntimeConfig]
+    trial_order: tuple[tuple[str, ...], ...]
+    source_path: Path
+    source_sha256: str
+
+    @classmethod
+    def load(cls, path: Path) -> "TextSweepConfig":
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        runtimes = {
+            str(label): RuntimeConfig(
+                workflow=str(value["workflow"]),
+                extra_args=tuple(str(arg) for arg in value.get("extra_args", [])),
+            )
+            for label, value in raw["runtimes"].items()
+        }
+        config = cls(
+            model=str(raw["model"]),
+            concurrency=int(raw["concurrency"]),
+            request_count=int(raw["request_count"]),
+            warmup_count=int(raw["warmup_count"]),
+            target_isl=int(raw["target_isl"]),
+            osl=int(raw["osl"]),
+            repeats=int(raw["repeats"]),
+            port=int(raw["port"]),
+            timeout=int(raw["timeout"]),
+            max_model_len=int(raw["max_model_len"]),
+            max_num_seqs=int(raw["max_num_seqs"]),
+            kv_cache_memory_bytes=int(raw["kv_cache_memory_bytes"]),
+            prefix_caching=bool(raw["prefix_caching"]),
+            runtimes=runtimes,
+            trial_order=tuple(
+                tuple(str(label) for label in order) for order in raw["trial_order"]
+            ),
+            source_path=path.resolve(),
+            source_sha256=hashlib.sha256(path.read_bytes()).hexdigest(),
+        )
+        config.validate()
+        return config
+
+    def validate(self) -> None:
+        if self.model != "Qwen/Qwen2.5-1.5B-Instruct":
+            raise ValueError("text engine-client benchmark requires Qwen2.5-1.5B")
+        if self.concurrency != 1:
+            raise ValueError("text engine-client benchmark requires concurrency 1")
+        fixed_controls = {
+            "request_count": (self.request_count, 1000),
+            "warmup_count": (self.warmup_count, 20),
+            "target_isl": (self.target_isl, 740),
+            "osl": (self.osl, 70),
+        }
+        changed = [
+            f"{name}={actual} (expected {expected})"
+            for name, (actual, expected) in fixed_controls.items()
+            if actual != expected
+        ]
+        if changed:
+            raise ValueError(
+                "text engine-client benchmark fixed controls changed: "
+                + ", ".join(changed)
+            )
+        if self.repeats != 5 or len(self.trial_order) != self.repeats:
+            raise ValueError("text engine-client benchmark requires five trial orders")
+        if set(self.runtimes) != EXPECTED_RUNTIMES:
+            raise ValueError(f"runtimes must be exactly {sorted(EXPECTED_RUNTIMES)}")
+        for order in self.trial_order:
+            if len(order) != len(EXPECTED_RUNTIMES) or set(order) != EXPECTED_RUNTIMES:
+                raise ValueError(
+                    "each trial order must contain every runtime exactly once"
+                )
+        positive_fields: dict[str, Any] = {
+            "request_count": self.request_count,
+            "warmup_count": self.warmup_count,
+            "target_isl": self.target_isl,
+            "osl": self.osl,
+            "port": self.port,
+            "timeout": self.timeout,
+            "max_model_len": self.max_model_len,
+            "max_num_seqs": self.max_num_seqs,
+            "kv_cache_memory_bytes": self.kv_cache_memory_bytes,
+        }
+        invalid = [name for name, value in positive_fields.items() if int(value) <= 0]
+        if invalid:
+            raise ValueError(f"benchmark values must be positive: {invalid}")

--- a/benchmarks/multimodal/sweep/experiments/engine_client/validate_text_results.py
+++ b/benchmarks/multimodal/sweep/experiments/engine_client/validate_text_results.py
@@ -1,0 +1,182 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Audit the complete Qwen2.5 text engine-client result matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from benchmarks.multimodal.sweep.experiments.engine_client.generate_text_workload import (
+    sha256,
+)
+from benchmarks.multimodal.sweep.experiments.engine_client.text_config import (
+    EXPECTED_RUNTIMES,
+    TextSweepConfig,
+)
+
+
+def metric(document: dict[str, Any], name: str, statistic: str = "avg") -> float:
+    value = document.get(name)
+    if not isinstance(value, dict) or statistic not in value:
+        raise ValueError(f"missing metric {name}.{statistic}")
+    return float(value[statistic])
+
+
+def profiling_concurrency(document: dict[str, Any]) -> int:
+    phases = document.get("input_config", {}).get("phases", [])
+    for phase in phases:
+        if isinstance(phase, dict) and phase.get("name") == "profiling":
+            return int(phase["concurrency"])
+    loadgen = document.get("input_config", {}).get("loadgen", {})
+    if "concurrency" in loadgen:
+        return int(loadgen["concurrency"])
+    raise ValueError("missing profiling concurrency")
+
+
+def validate_result(
+    path: Path,
+    config: TextSweepConfig,
+    expected_config_sha: str,
+    expected_dataset_sha: str,
+) -> dict[str, Any]:
+    runtime = path.parents[1].name
+    trial_dir = path.parents[2].name
+    trial = int(trial_dir.removeprefix("trial-"))
+    document = json.loads(path.read_text(encoding="utf-8"))
+    failures: list[str] = []
+
+    if runtime not in EXPECTED_RUNTIMES:
+        failures.append("runtime")
+    if trial not in range(1, config.repeats + 1):
+        failures.append("trial")
+    if metric(document, "request_count") != float(config.request_count):
+        failures.append("request_count")
+    if document.get("error_summary"):
+        failures.append("errors")
+    if document.get("was_cancelled"):
+        failures.append("cancelled")
+    if not document.get("input_config", {}).get("endpoint", {}).get("streaming", False):
+        failures.append("streaming")
+    if profiling_concurrency(document) != config.concurrency:
+        failures.append("concurrency")
+
+    for name, expected in (
+        ("input_sequence_length", config.target_isl),
+        ("output_sequence_length", config.osl),
+    ):
+        for statistic in ("min", "avg", "max"):
+            if metric(document, name, statistic) != float(expected):
+                failures.append(f"{name}_{statistic}")
+
+    for name in (
+        "request_throughput",
+        "output_token_throughput",
+        "time_to_first_token",
+        "inter_token_latency",
+        "request_latency",
+    ):
+        metric(document, name)
+
+    command_path = path.parent / "command.txt"
+    command = command_path.read_text(encoding="utf-8")
+    required_command_parts = (
+        f"--concurrency {config.concurrency}",
+        f"--request-count {config.request_count}",
+        f"--warmup-request-count {config.warmup_count}",
+        "--use-server-token-count",
+        "--random-seed 42",
+    )
+    if any(part not in command for part in required_command_parts):
+        failures.append("command")
+    if "--request-rate" in command:
+        failures.append("request_rate")
+
+    run_metadata = json.loads(
+        (path.parents[1] / "run_metadata.json").read_text(encoding="utf-8")
+    )
+    if run_metadata.get("config_sha256") != expected_config_sha:
+        failures.append("config_provenance")
+    if run_metadata.get("dataset_sha256") != expected_dataset_sha:
+        failures.append("dataset_provenance")
+
+    return {
+        "trial": trial,
+        "runtime": runtime,
+        "path": str(path),
+        "accepted": not failures,
+        "failures": failures,
+    }
+
+
+def validate_matrix(
+    root: Path,
+    config: TextSweepConfig,
+    dataset_path: Path,
+    manifest_path: Path,
+) -> list[dict[str, Any]]:
+    metadata = json.loads(
+        (root / "benchmark_metadata.json").read_text(encoding="utf-8")
+    )
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    dataset_sha = sha256(dataset_path)
+    if manifest.get("model") != config.model or metadata.get("model") != config.model:
+        raise AssertionError("benchmark model provenance mismatch")
+    if manifest.get("media_fields") != []:
+        raise AssertionError("pure-text workload must not contain media fields")
+    if manifest.get("dataset_sha256") != dataset_sha:
+        raise AssertionError("workload manifest hash mismatch")
+    if metadata.get("dataset_sha256") != dataset_sha:
+        raise AssertionError("benchmark dataset hash mismatch")
+    if metadata.get("config_sha256") != config.source_sha256:
+        raise AssertionError("benchmark config hash mismatch")
+
+    results = [
+        validate_result(path, config, config.source_sha256, dataset_sha)
+        for path in sorted(root.rglob("profile_export_aiperf.json"))
+    ]
+    expected = {
+        (trial, runtime)
+        for trial in range(1, config.repeats + 1)
+        for runtime in EXPECTED_RUNTIMES
+    }
+    observed = {(result["trial"], result["runtime"]) for result in results}
+    if observed != expected or len(results) != len(expected):
+        raise AssertionError(
+            f"expected {len(expected)} trials, found {len(results)}; "
+            f"missing={sorted(expected - observed)} extra={sorted(observed - expected)}"
+        )
+    rejected = [result for result in results if not result["accepted"]]
+    if rejected:
+        raise AssertionError(f"rejected benchmark artifacts: {rejected}")
+
+    output = root / "validation.json"
+    output.write_text(json.dumps(results, indent=2) + "\n", encoding="utf-8")
+    print("BENCHMARK_AUDIT=PASS cells=3 trials=15")
+    return results
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("root", type=Path)
+    parser.add_argument("--config", type=Path, required=True)
+    parser.add_argument("--dataset", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    validate_matrix(
+        root=args.root.resolve(),
+        config=TextSweepConfig.load(args.config.resolve()),
+        dataset_path=args.dataset.resolve(),
+        manifest_path=args.manifest.resolve(),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/multimodal/sweep/tests/test_engine_client_text_experiment.py
+++ b/benchmarks/multimodal/sweep/tests/test_engine_client_text_experiment.py
@@ -1,0 +1,176 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the text engine-client benchmark contract."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from benchmarks.multimodal.sweep.experiments.engine_client.generate_text_workload import (
+    generate_workload,
+    rendered_token_count,
+)
+from benchmarks.multimodal.sweep.experiments.engine_client.report_text_results import (
+    paired_interval,
+)
+from benchmarks.multimodal.sweep.experiments.engine_client.text_config import (
+    TextSweepConfig,
+)
+from benchmarks.multimodal.sweep.experiments.engine_client.validate_text_results import (
+    validate_result,
+)
+
+pytestmark = [pytest.mark.unit, pytest.mark.pre_merge, pytest.mark.gpu_0]
+
+CONFIG_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "experiments/engine_client/text_concurrency1.yaml"
+)
+
+
+class FakeTokenizer:
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tokenize: bool,
+        add_generation_prompt: bool,
+    ) -> list[int]:
+        assert tokenize
+        assert add_generation_prompt
+        token_count = 10 + messages[0]["content"].count(" benchmark")
+        return list(range(token_count))
+
+
+class FakeBatchEncodingTokenizer(FakeTokenizer):
+    def apply_chat_template(
+        self,
+        messages: list[dict[str, str]],
+        *,
+        tokenize: bool,
+        add_generation_prompt: bool,
+    ) -> dict[str, list[int]]:
+        return {
+            "input_ids": super().apply_chat_template(
+                messages,
+                tokenize=tokenize,
+                add_generation_prompt=add_generation_prompt,
+            )
+        }
+
+
+def test_rendered_token_count_accepts_batch_encoding_shape() -> None:
+    assert rendered_token_count(FakeBatchEncodingTokenizer(), "x benchmark") == 11
+
+
+def test_generate_workload_is_text_only_and_exact(tmp_path: Path) -> None:
+    with patch(
+        "benchmarks.multimodal.sweep.experiments.engine_client."
+        "generate_text_workload.AutoTokenizer.from_pretrained",
+        return_value=FakeTokenizer(),
+    ):
+        dataset_path, manifest_path = generate_workload(
+            tmp_path,
+            request_count=3,
+            target_isl=15,
+        )
+
+    rows = [
+        json.loads(line)
+        for line in dataset_path.read_text(encoding="utf-8").splitlines()
+    ]
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert len(rows) == 3
+    assert all(set(row) == {"session_id", "text"} for row in rows)
+    assert len({row["text"] for row in rows}) == 1
+    assert manifest["media_fields"] == []
+
+
+def test_config_locks_concurrency_one_matrix() -> None:
+    config = TextSweepConfig.load(CONFIG_PATH)
+    assert config.concurrency == 1
+    assert config.repeats == 5
+    assert set(config.runtimes) == {
+        "vllm-serve",
+        "dynamo-async",
+        "dynamo-sync",
+    }
+
+
+def metric_document() -> dict[str, Any]:
+    document: dict[str, Any] = {
+        "request_count": {"avg": 1000},
+        "input_sequence_length": {"min": 740, "avg": 740, "max": 740},
+        "output_sequence_length": {"min": 70, "avg": 70, "max": 70},
+        "request_throughput": {"avg": 10},
+        "output_token_throughput": {"avg": 700},
+        "time_to_first_token": {"avg": 5, "p50": 4, "p90": 6, "p99": 7},
+        "inter_token_latency": {"avg": 2, "p50": 1, "p90": 3, "p99": 4},
+        "request_latency": {"avg": 150, "p50": 140, "p90": 160, "p99": 170},
+        "input_config": {
+            "endpoint": {"streaming": True},
+            "phases": [{"name": "profiling", "concurrency": 1}],
+        },
+        "error_summary": [],
+        "was_cancelled": False,
+    }
+    return document
+
+
+def test_validate_result_accepts_audited_cell(tmp_path: Path) -> None:
+    config = TextSweepConfig.load(CONFIG_PATH)
+    artifact_dir = tmp_path / "trial-01/dynamo-async/concurrency1"
+    artifact_dir.mkdir(parents=True)
+    result_path = artifact_dir / "profile_export_aiperf.json"
+    result_path.write_text(json.dumps(metric_document()), encoding="utf-8")
+    (artifact_dir / "command.txt").write_text(
+        "aiperf profile --concurrency 1 --request-count 1000 "
+        "--warmup-request-count 20 --use-server-token-count --random-seed 42\n",
+        encoding="utf-8",
+    )
+    (artifact_dir.parent / "run_metadata.json").write_text(
+        json.dumps(
+            {
+                "config_sha256": config.source_sha256,
+                "dataset_sha256": "dataset-sha",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = validate_result(
+        result_path,
+        config,
+        config.source_sha256,
+        "dataset-sha",
+    )
+    assert result["accepted"]
+
+
+def test_paired_interval_uses_each_trial() -> None:
+    rows: list[dict[str, Any]] = []
+    for trial in range(1, 6):
+        rows.extend(
+            [
+                {
+                    "trial": trial,
+                    "runtime": "dynamo-async",
+                    "request_throughput_rps": 10.0,
+                },
+                {
+                    "trial": trial,
+                    "runtime": "dynamo-sync",
+                    "request_throughput_rps": 11.0,
+                },
+            ]
+        )
+    mean, low, high = paired_interval(rows, "dynamo-sync", "request_throughput_rps")
+    assert mean == pytest.approx(10.0)
+    assert low == pytest.approx(10.0)
+    assert high == pytest.approx(10.0)

--- a/benchmarks/multimodal/sweep/workflows/dynamo_agg.sh
+++ b/benchmarks/multimodal/sweep/workflows/dynamo_agg.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+trap 'kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../../examples/common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../../examples/common/launch_utils.sh"
+
+MODEL=""
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [[ -z "$MODEL" ]]; then
+    echo "ERROR: --model is required" >&2
+    exit 1
+fi
+
+MAX_MODEL_LEN="${MAX_MODEL_LEN:-4096}"
+MAX_NUM_SEQS="${MAX_NUM_SEQS:-1}"
+: "${_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES:=4294967296}"
+GPU_MEM_ARGS="$(build_vllm_gpu_mem_args)"
+
+python -m dynamo.frontend &
+
+DYN_SYSTEM_PORT="${DYN_WORKER_SYSTEM_PORT:-8082}" \
+    python -m dynamo.vllm \
+        --model "$MODEL" \
+        --disaggregation-mode agg \
+        --max-model-len "$MAX_MODEL_LEN" \
+        --max-num-seqs "$MAX_NUM_SEQS" \
+        --enable-prefix-caching \
+        $GPU_MEM_ARGS \
+        "${EXTRA_ARGS[@]}" &
+
+wait_any_exit

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -172,6 +172,19 @@ class DynamoVllmArgGroup(ArgGroup):
 
         add_argument(
             g,
+            flag_name="--engine-client-mode",
+            env_var="DYN_VLLM_ENGINE_CLIENT_MODE",
+            default="async-mp",
+            choices=["async-mp", "sync-inproc"],
+            help=(
+                "vLLM engine client topology. 'async-mp' is the supported "
+                "default; 'sync-inproc' is an experimental single-GPU mode "
+                "for aggregated text or CustomEncoder serving."
+            ),
+        )
+
+        add_argument(
+            g,
             flag_name="--embedding-transfer-mode",
             env_var="DYN_VLLM_EMBEDDING_TRANSFER_MODE",
             default=EmbeddingTransferMode.NIXL_WRITE.value,
@@ -437,6 +450,7 @@ class DynamoVllmConfig(ConfigBase):
 
     # CustomEncoder (image-only embeddings; worker assembles mixed prompt)
     custom_encoder_class: Optional[str] = None
+    engine_client_mode: str = "async-mp"
 
     # Headless mode for multi-node TP/PP
     headless: bool = False
@@ -476,8 +490,38 @@ class DynamoVllmConfig(ConfigBase):
         self._validate_multimodal_requires_flag()
         self._validate_embedding_worker_exclusivity()
         self._validate_custom_encoder()
+        self._validate_engine_client_mode()
         self._resolve_legacy_benchmark_sampling()
         self._validate_benchmark_sampling()
+
+    def _validate_engine_client_mode(self) -> None:
+        if self.engine_client_mode == "async-mp":
+            return
+        if self.engine_client_mode != "sync-inproc":
+            raise ValueError("--engine-client-mode must be 'async-mp' or 'sync-inproc'")
+
+        incompatible: list[str] = []
+        if self.disaggregation_mode != DisaggregationMode.AGGREGATED:
+            incompatible.append("disaggregated serving")
+        if self.route_to_encoder:
+            incompatible.append("--route-to-encoder")
+        if self.multimodal_worker:
+            incompatible.append("--multimodal-worker")
+        if self.embedding_worker:
+            incompatible.append("--embedding-worker")
+        if self.enable_rl:
+            incompatible.append("--enable-rl")
+        if self.headless:
+            incompatible.append("--headless")
+        if self.gms_shadow_mode:
+            incompatible.append("--gms-shadow-mode")
+        if self.benchmark_mode is not None:
+            incompatible.append("--benchmark-mode")
+        if incompatible:
+            raise ValueError(
+                "--engine-client-mode=sync-inproc is incompatible with "
+                + ", ".join(incompatible)
+            )
 
     def _resolve_legacy_benchmark_sampling(self) -> None:
         if self.benchmark_mode is None:

--- a/components/src/dynamo/vllm/cache_info.py
+++ b/components/src/dynamo/vllm/cache_info.py
@@ -5,7 +5,8 @@ import logging
 from typing import Any
 
 from vllm.config import VllmConfig
-from vllm.v1.engine.async_llm import AsyncLLM
+
+from .engine_client import VllmEngineClient
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +43,7 @@ def select_main_attention_block_size(
 
 
 async def configure_kv_event_block_size(
-    engine: AsyncLLM,
+    engine: VllmEngineClient,
     vllm_config: VllmConfig,
 ) -> int:
     """Fetch engine cache-group metadata and cache the KV event block size on vLLM config."""

--- a/components/src/dynamo/vllm/engine_client.py
+++ b/components/src/dynamo/vllm/engine_client.py
@@ -1,0 +1,32 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Structural engine-client types shared by legacy vLLM integrations."""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from vllm.config import VllmConfig
+
+
+class EngineCoreClient(Protocol):
+    async def call_utility_async(self, method: str, *args: Any) -> Any:
+        ...
+
+
+class VllmEngineClient(Protocol):
+    vllm_config: VllmConfig
+    model_config: Any
+    engine_core: EngineCoreClient
+    tokenizer: Any
+    log_stats: bool
+
+    async def check_health(self) -> None:
+        ...
+
+    async def do_log_stats(self) -> None:
+        ...
+
+    def shutdown(self, *args: Any, **kwargs: Any) -> None:
+        ...

--- a/components/src/dynamo/vllm/engine_monitor.py
+++ b/components/src/dynamo/vllm/engine_monitor.py
@@ -8,12 +8,13 @@ import os
 import signal
 import traceback
 
-from vllm.v1.engine.async_llm import AsyncLLM
 from vllm.v1.engine.exceptions import EngineDeadError
 
 from dynamo.common.engine_monitor import EngineHealthMonitorConfig
 from dynamo.runtime import DistributedRuntime
 from dynamo.runtime.logging import configure_dynamo_logging
+
+from .engine_client import VllmEngineClient
 
 configure_dynamo_logging
 logger = logging.getLogger(__name__)
@@ -27,18 +28,13 @@ class VllmEngineMonitor:
     def __init__(
         self,
         runtime: DistributedRuntime,
-        engine_client: AsyncLLM,
+        engine_client: VllmEngineClient,
         shutdown_event: asyncio.Event | None = None,
     ):
         if not isinstance(runtime, DistributedRuntime):
             raise ValueError(
                 f"{self.__class__.__name__} requires an instance of DistributedRuntime."
             )
-        if not isinstance(engine_client, AsyncLLM):
-            raise ValueError(
-                f"{self.__class__.__name__} requires an instance of AsyncLLM."
-            )
-
         self.runtime = runtime
         self.engine_client = engine_client
         self.shutdown_event = shutdown_event

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2403,6 +2403,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             # Run backend.close() on the actor thread, then stop it — executor
             # GC would only end the thread, never call close().
             self._custom_encoder.shutdown()
+        if self.config.engine_client_mode == "sync-inproc":
+            self.engine_client.shutdown()
         for temp_dir in self.temp_dirs:
             try:
                 temp_dir.cleanup()

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -255,6 +255,12 @@ class VllmLLMEngine(LLMEngine):
         if config is None:
             config = parse_args(argv, fpm_trace_relay_supported=False)
 
+        if config.engine_client_mode != "async-mp":
+            raise NotImplementedError(
+                "--engine-client-mode=sync-inproc is supported only by the legacy "
+                "`python -m dynamo.vllm` entry point"
+            )
+
         if config.disaggregation_mode == DisaggregationMode.ENCODE:
             raise NotImplementedError(
                 "ENCODE is not supported by the unified vLLM entry point; "

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -57,6 +57,7 @@ from .capacity import (
     per_rank_kv_blocks,
 )
 from .constants import DisaggregationMode
+from .engine_client import VllmEngineClient
 from .handlers import get_dp_range_for_worker
 from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
@@ -67,6 +68,7 @@ from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.media_config import create_frontend_media_config
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
 from .snapshot import prepare_snapshot_engine
+from .sync_inproc_engine import SyncInprocEngineClient, validate_sync_inproc_config
 
 configure_dynamo_logging()
 logger = logging.getLogger(__name__)
@@ -479,7 +481,7 @@ def setup_vllm_engine(
     config: Config,
     stat_logger: Optional[StatLoggerFactory] = None,
     fpm_worker_id: Optional[str] = None,
-) -> tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]:
+) -> tuple[VllmEngineClient, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]:
     # vLLM v0.11.0 bug: vllm/v1.metrics/prometheus.py:79 passes TemporaryDirectory object
     # instead of .name string, causing false error on exit. Set PROMETHEUS_MULTIPROC_DIR
     # ourselves to avoid this and handle cleanup properly.
@@ -527,6 +529,10 @@ def setup_vllm_engine(
     os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 
     engine_args = config.engine_args
+    engine_client_mode = config.engine_client_mode
+
+    if engine_client_mode == "sync-inproc":
+        os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
 
     if engine_args.enable_lora:
         if "VLLM_ALLOW_RUNTIME_LORA_UPDATING" not in os.environ:
@@ -566,6 +572,9 @@ def setup_vllm_engine(
     vllm_config = engine_args.create_engine_config(usage_context=usage_context)
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector(vllm_config)
     default_sampling_params = vllm_config.model_config.get_diff_sampling_param()
+
+    if engine_client_mode == "sync-inproc":
+        validate_sync_inproc_config(engine_args, vllm_config)
 
     # Set up consolidator endpoints if KVBM (DynamoConnector) is enabled
     consolidator_endpoints = None
@@ -608,13 +617,22 @@ def setup_vllm_engine(
 
     # Time engine initialization
     start_time = time.time()
-    engine_client = AsyncLLM.from_vllm_config(
-        vllm_config=vllm_config,
-        usage_context=usage_context,
-        stat_loggers=factory,
-        enable_log_requests=engine_args.enable_log_requests,
-        disable_log_stats=engine_args.disable_log_stats,
-    )
+    engine_client: VllmEngineClient
+    if engine_client_mode == "sync-inproc":
+        engine_client = SyncInprocEngineClient.from_vllm_config(
+            vllm_config=vllm_config,
+            usage_context=usage_context,
+            stat_loggers=factory,
+            disable_log_stats=engine_args.disable_log_stats,
+        )
+    else:
+        engine_client = AsyncLLM.from_vllm_config(
+            vllm_config=vllm_config,
+            usage_context=usage_context,
+            stat_loggers=factory,
+            enable_log_requests=engine_args.enable_log_requests,
+            disable_log_stats=engine_args.disable_log_stats,
+        )
     load_time = time.time() - start_time
 
     # Record model load time. ``component_gauges`` is None on the
@@ -644,7 +662,7 @@ async def register_vllm_model(
     model_type: ModelType,
     generate_endpoint: Endpoint,
     config: Config,
-    engine_client: AsyncLLM,
+    engine_client: VllmEngineClient,
     vllm_config: VllmConfig,
     worker_type: WorkerType,
     needs: list[list[WorkerType]] | None = None,
@@ -774,7 +792,7 @@ async def register_vllm_model(
     )
 
 
-def get_engine_cache_info(engine: AsyncLLM) -> dict[str, Any]:
+def get_engine_cache_info(engine: VllmEngineClient) -> dict[str, Any]:
     """Return vLLM cache and scheduler limits used for model registration."""
 
     try:

--- a/components/src/dynamo/vllm/publisher.py
+++ b/components/src/dynamo/vllm/publisher.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import concurrent.futures
 import logging
 from typing import Optional
 
@@ -27,14 +28,27 @@ class DynamoStatLoggerPublisher(StatLoggerBase):
         endpoint: Endpoint,
         dp_rank: int = 0,
         component_gauges: Optional[LLMBackendMetrics] = None,
+        event_loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         self.inner = WorkerMetricsPublisher()
         self._endpoint = endpoint
         self.dp_rank = dp_rank
         self.component_gauges = component_gauges or LLMBackendMetrics()
         self.num_gpu_block = 1
-        # Schedule async endpoint creation
-        self._endpoint_task = asyncio.create_task(self._create_endpoint())
+        # vLLM's synchronous in-process engine constructs stat loggers on its
+        # owner thread. Schedule endpoint creation back on Dynamo's runtime
+        # loop rather than requiring that thread to own an asyncio loop.
+        self._endpoint_task: asyncio.Task[None] | concurrent.futures.Future[None]
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if event_loop is None or event_loop is running_loop:
+            self._endpoint_task = asyncio.create_task(self._create_endpoint())
+        else:
+            self._endpoint_task = asyncio.run_coroutine_threadsafe(
+                self._create_endpoint(), event_loop
+            )
 
     async def _create_endpoint(self) -> None:
         """Create the NATS endpoint asynchronously."""
@@ -137,10 +151,17 @@ class StatLoggerFactory:
         endpoint: Endpoint,
         component_gauges: Optional[LLMBackendMetrics] = None,
         embedding_worker: bool = False,
+        event_loop: Optional[asyncio.AbstractEventLoop] = None,
     ) -> None:
         self.endpoint = endpoint
         self.component_gauges = component_gauges
         self.embedding_worker = embedding_worker
+        if event_loop is None:
+            try:
+                event_loop = asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+        self.event_loop = event_loop
         self.created_logger: Optional[DynamoStatLoggerPublisher] = None
 
     def create_stat_logger(self, dp_rank: int) -> StatLoggerBase:
@@ -158,6 +179,7 @@ class StatLoggerFactory:
             endpoint=self.endpoint,
             dp_rank=dp_rank,
             component_gauges=self.component_gauges,
+            event_loop=self.event_loop,
         )
         self.created_logger = logger
 

--- a/components/src/dynamo/vllm/sync_inproc_engine.py
+++ b/components/src/dynamo/vllm/sync_inproc_engine.py
@@ -1,0 +1,606 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental async facade for vLLM's synchronous in-process engine."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import queue
+import threading
+import warnings
+from collections.abc import Iterable
+from concurrent.futures import Future
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, AsyncGenerator, Callable, Literal, Mapping, Optional
+
+from vllm.config import VllmConfig
+from vllm.engine.arg_utils import EngineArgs
+from vllm.inputs import EngineInput, PromptType
+from vllm.lora.request import LoRARequest
+from vllm.outputs import RequestOutput
+from vllm.sampling_params import SamplingParams
+from vllm.usage.usage_lib import UsageContext
+from vllm.v1.engine.exceptions import EngineDeadError
+from vllm.v1.engine.llm_engine import LLMEngine
+from vllm.v1.engine.output_processor import RequestOutputCollector
+from vllm.v1.executor import Executor
+from vllm.v1.metrics.prometheus import shutdown_prometheus
+
+logger = logging.getLogger(__name__)
+
+_COMMAND_QUEUE_CAPACITY = 1024
+_MAX_COMMANDS_PER_STEP = 64
+
+
+class _DriverState(Enum):
+    STARTING = auto()
+    RUNNING = auto()
+    CLOSED = auto()
+    FAILED = auto()
+
+
+class _RequestState(Enum):
+    PENDING_ADD = auto()
+    ACTIVE = auto()
+    FINISHED = auto()
+    ABORTED = auto()
+
+
+class _CommandKind(Enum):
+    ADD = auto()
+    ABORT = auto()
+    CALL = auto()
+    CORE_CALL = auto()
+    RENDERER_CALL = auto()
+    HEALTH = auto()
+    SHUTDOWN = auto()
+
+
+@dataclass
+class _RequestContext:
+    request_id: str
+    collector: RequestOutputCollector
+    loop: asyncio.AbstractEventLoop
+    state: _RequestState = _RequestState.PENDING_ADD
+
+
+@dataclass
+class _Command:
+    kind: _CommandKind
+    result: Future[Any]
+    args: tuple[Any, ...] = ()
+    kwargs: Optional[dict[str, Any]] = None
+    request: Optional[_RequestContext] = None
+
+
+class _EngineCoreAsyncProxy:
+    """Compatibility surface used by Dynamo's cache metadata setup."""
+
+    def __init__(self, owner: "SyncInprocEngineClient") -> None:
+        self._owner = owner
+
+    async def call_utility_async(self, method: str, *args: Any) -> Any:
+        return await self._owner._submit_async(
+            _CommandKind.CORE_CALL,
+            args=(method, *args),
+        )
+
+
+class SyncInprocEngineClient:
+    """Drive ``LLMEngine`` on one thread while exposing AsyncLLM-like methods.
+
+    This class is intentionally narrow and experimental. It preserves online
+    continuous batching by admitting queued commands between every engine step,
+    while never blocking for commands as long as vLLM reports unfinished work.
+    """
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        *,
+        usage_context: UsageContext,
+        disable_log_stats: bool,
+        stat_loggers: Optional[list[Any]] = None,
+    ) -> None:
+        self.vllm_config = vllm_config
+        self.model_config = vllm_config.model_config
+        self.log_stats = not disable_log_stats
+        self.engine_core = _EngineCoreAsyncProxy(self)
+
+        self._usage_context = usage_context
+        self._disable_log_stats = disable_log_stats
+        self._stat_loggers = stat_loggers
+        self._commands: queue.Queue[_Command] = queue.Queue(
+            maxsize=_COMMAND_QUEUE_CAPACITY
+        )
+        self._state = _DriverState.STARTING
+        self._state_lock = threading.Lock()
+        self._failure: Optional[BaseException] = None
+        self._startup: Future[None] = Future()
+        self._terminated = threading.Event()
+        self._tokenizer: Any = None
+        self._thread = threading.Thread(
+            target=self._run,
+            name="vllm-sync-inproc",
+            daemon=False,
+        )
+        self._thread.start()
+        self._startup.result()
+
+    @classmethod
+    def from_vllm_config(
+        cls,
+        vllm_config: VllmConfig,
+        *,
+        usage_context: UsageContext = UsageContext.ENGINE_CONTEXT,
+        disable_log_stats: bool = False,
+        stat_loggers: Optional[list[Any]] = None,
+    ) -> "SyncInprocEngineClient":
+        return cls(
+            vllm_config,
+            usage_context=usage_context,
+            disable_log_stats=disable_log_stats,
+            stat_loggers=stat_loggers,
+        )
+
+    @property
+    def tokenizer(self) -> Any:
+        return self._tokenizer
+
+    def _run(self) -> None:
+        engine: Optional[LLMEngine] = None
+        requests: dict[str, _RequestContext] = {}
+        try:
+            engine = LLMEngine(
+                vllm_config=self.vllm_config,
+                executor_class=Executor.get_class(self.vllm_config),
+                log_stats=not self._disable_log_stats,
+                usage_context=self._usage_context,
+                stat_loggers=self._stat_loggers,
+                multiprocess_mode=False,
+            )
+            self._tokenizer = engine.tokenizer
+            with self._state_lock:
+                self._state = _DriverState.RUNNING
+            self._complete(self._startup, None)
+
+            stop = False
+            while not stop:
+                commands = self._collect_commands(engine)
+                for command in commands:
+                    stop = self._process_command(
+                        command,
+                        engine,
+                        requests,
+                    )
+                    if stop:
+                        break
+
+                if not stop and self._engine_has_work(engine):
+                    outputs = engine.step()
+                    self._route_outputs(outputs, requests)
+        except BaseException as exc:
+            self._fail(exc, requests)
+        finally:
+            try:
+                self._fail_live_requests(EngineDeadError(), requests)
+                self._fail_queued_commands(EngineDeadError())
+                if engine is not None:
+                    self._shutdown_engine(engine)
+            finally:
+                with self._state_lock:
+                    if self._state is not _DriverState.FAILED:
+                        self._state = _DriverState.CLOSED
+                self._terminated.set()
+
+    def _collect_commands(self, engine: LLMEngine) -> list[_Command]:
+        commands: list[_Command] = []
+        if not self._engine_has_work(engine):
+            commands.append(self._commands.get())
+        while len(commands) < _MAX_COMMANDS_PER_STEP:
+            try:
+                commands.append(self._commands.get_nowait())
+            except queue.Empty:
+                break
+        return commands
+
+    @staticmethod
+    def _engine_has_work(engine: LLMEngine) -> bool:
+        if engine.has_unfinished_requests():
+            return True
+        # With vLLM async scheduling, aborting the last request can empty the
+        # OutputProcessor while a GPU future is still queued in EngineCore. Keep
+        # stepping until that internal queue drains or shutdown can strand it.
+        batch_queue = engine.engine_core.engine_core.batch_queue
+        return batch_queue is not None and bool(batch_queue)
+
+    def _process_command(
+        self,
+        command: _Command,
+        engine: LLMEngine,
+        requests: dict[str, _RequestContext],
+    ) -> bool:
+        try:
+            if command.kind is _CommandKind.ADD:
+                if command.request is None:
+                    raise RuntimeError("ADD command is missing request context")
+                actual_request_id = engine.add_request(
+                    *command.args, **(command.kwargs or {})
+                )
+                command.request.state = _RequestState.ACTIVE
+                # LLMEngine returns its internal wave-suffixed ID, but its
+                # RequestOutputs and abort_request() use the public ID.
+                requests[command.request.request_id] = command.request
+                self._complete(command.result, actual_request_id)
+                return False
+
+            if command.kind is _CommandKind.ABORT:
+                requested_ids = command.args[0]
+                active_ids: list[str] = []
+                for request_id in requested_ids:
+                    context = requests.pop(request_id, None)
+                    if context is not None:
+                        context.state = _RequestState.ABORTED
+                        active_ids.append(request_id)
+                if active_ids:
+                    engine.abort_request(active_ids)
+                self._complete(command.result, None)
+                return False
+
+            if command.kind is _CommandKind.CALL:
+                method = command.args[0]
+                call_args = command.args[1:]
+                result = getattr(engine, method)(*call_args, **(command.kwargs or {}))
+                self._complete(command.result, result)
+                return False
+
+            if command.kind is _CommandKind.CORE_CALL:
+                method = command.args[0]
+                call_args = command.args[1:]
+                core = engine.engine_core.engine_core
+                result = getattr(core, method)(*call_args, **(command.kwargs or {}))
+                self._complete_or_chain(command.result, result)
+                return False
+
+            if command.kind is _CommandKind.RENDERER_CALL:
+                method = command.args[0]
+                call_args = command.args[1:]
+                result = getattr(engine.renderer, method)(
+                    *call_args, **(command.kwargs or {})
+                )
+                self._complete_or_chain(command.result, result)
+                return False
+
+            if command.kind is _CommandKind.HEALTH:
+                self._complete(command.result, None)
+                return False
+
+            if command.kind is _CommandKind.SHUTDOWN:
+                self._complete(command.result, None)
+                return True
+
+            raise RuntimeError(f"unknown sync engine command: {command.kind}")
+        except Exception as exc:
+            self._complete_exception(command.result, exc)
+            if command.request is not None:
+                self._deliver(command.request, exc)
+            return False
+
+    def _route_outputs(
+        self,
+        outputs: list[RequestOutput],
+        requests: dict[str, _RequestContext],
+    ) -> None:
+        for output in outputs:
+            context = requests.get(output.request_id)
+            if context is None:
+                logger.debug(
+                    "sync-inproc received output for unknown request %s; active=%s",
+                    output.request_id,
+                    list(requests),
+                )
+                continue
+            if output.finished:
+                context.state = _RequestState.FINISHED
+                requests.pop(output.request_id, None)
+            self._deliver(context, output)
+
+    def _deliver(self, context: _RequestContext, value: Any) -> None:
+        try:
+            context.loop.call_soon_threadsafe(context.collector.put, value)
+        except RuntimeError:
+            logger.debug(
+                "Dropping sync-engine output for request %s because its event loop closed",
+                context.request_id,
+            )
+
+    def _fail(self, exc: BaseException, requests: dict[str, _RequestContext]) -> None:
+        with self._state_lock:
+            self._state = _DriverState.FAILED
+            self._failure = exc
+        self._complete_exception(self._startup, exc)
+        self._fail_live_requests(exc, requests)
+        logger.error(
+            "Synchronous in-process vLLM driver failed",
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+    def _fail_live_requests(
+        self,
+        exc: BaseException,
+        requests: dict[str, _RequestContext],
+    ) -> None:
+        for context in list(requests.values()):
+            self._deliver(context, exc)
+        requests.clear()
+
+    def _fail_queued_commands(self, exc: BaseException) -> None:
+        while True:
+            try:
+                command = self._commands.get_nowait()
+            except queue.Empty:
+                return
+            self._complete_exception(command.result, exc)
+
+    @staticmethod
+    def _shutdown_engine(engine: LLMEngine) -> None:
+        try:
+            engine.renderer.shutdown()
+        finally:
+            try:
+                engine.engine_core.shutdown()
+            finally:
+                shutdown_prometheus()
+
+    @staticmethod
+    def _complete(result: Future[Any], value: Any) -> None:
+        if not result.done():
+            result.set_result(value)
+
+    @staticmethod
+    def _complete_exception(result: Future[Any], exc: BaseException) -> None:
+        if not result.done():
+            result.set_exception(exc)
+
+    @classmethod
+    def _complete_or_chain(cls, result: Future[Any], value: Any) -> None:
+        if isinstance(value, Future):
+            value.add_done_callback(
+                lambda completed: cls._copy_future_result(completed, result)
+            )
+        else:
+            cls._complete(result, value)
+
+    @classmethod
+    def _copy_future_result(
+        cls,
+        source: Future[Any],
+        destination: Future[Any],
+    ) -> None:
+        try:
+            cls._complete(destination, source.result())
+        except BaseException as exc:
+            cls._complete_exception(destination, exc)
+
+    def _enqueue(self, command: _Command) -> None:
+        with self._state_lock:
+            if self._state is _DriverState.FAILED:
+                raise EngineDeadError() from self._failure
+            if self._state is not _DriverState.RUNNING:
+                raise EngineDeadError()
+            try:
+                self._commands.put_nowait(command)
+            except queue.Full as exc:
+                raise RuntimeError("sync-inproc engine command queue is full") from exc
+
+    async def _submit_async(
+        self,
+        kind: _CommandKind,
+        *,
+        args: tuple[Any, ...] = (),
+        kwargs: Optional[dict[str, Any]] = None,
+        request: Optional[_RequestContext] = None,
+    ) -> Any:
+        result: Future[Any] = Future()
+        self._enqueue(
+            _Command(
+                kind=kind,
+                result=result,
+                args=args,
+                kwargs=kwargs,
+                request=request,
+            )
+        )
+        return await asyncio.wrap_future(result)
+
+    async def generate(
+        self,
+        prompt: PromptType | EngineInput,
+        sampling_params: SamplingParams,
+        request_id: str,
+        *,
+        prompt_text: Optional[str] = None,
+        lora_request: Optional[LoRARequest] = None,
+        tokenization_kwargs: Optional[dict[str, Any]] = None,
+        trace_headers: Optional[Mapping[str, str]] = None,
+        priority: int = 0,
+        data_parallel_rank: Optional[int] = None,
+        reasoning_ended: Optional[bool] = None,
+        reasoning_parser_kwargs: Optional[dict[str, Any]] = None,
+    ) -> AsyncGenerator[RequestOutput, None]:
+        if sampling_params.n != 1:
+            raise ValueError("sync-inproc mode supports sampling_params.n=1 only")
+        if data_parallel_rank is not None:
+            raise ValueError("sync-inproc mode does not support data_parallel_rank")
+        if reasoning_ended is not None or reasoning_parser_kwargs is not None:
+            raise ValueError("sync-inproc mode does not support reasoning state inputs")
+
+        collector = RequestOutputCollector(sampling_params.output_kind, request_id)
+        context = _RequestContext(
+            request_id=request_id,
+            collector=collector,
+            loop=asyncio.get_running_loop(),
+        )
+        try:
+            await self._submit_async(
+                _CommandKind.ADD,
+                args=(request_id, prompt, sampling_params),
+                kwargs={
+                    "lora_request": lora_request,
+                    "tokenization_kwargs": tokenization_kwargs,
+                    "trace_headers": trace_headers,
+                    "priority": priority,
+                    "prompt_text": prompt_text,
+                },
+                request=context,
+            )
+            finished = False
+            while not finished:
+                output = collector.get_nowait() or await collector.get()
+                if not isinstance(output, RequestOutput):
+                    raise RuntimeError(
+                        f"sync-inproc generated unexpected output type {type(output)!r}"
+                    )
+                finished = output.finished
+                yield output
+        except (asyncio.CancelledError, GeneratorExit):
+            await asyncio.shield(self.abort(request_id, internal=True))
+            raise
+        finally:
+            collector.close()
+
+    async def abort(
+        self,
+        request_id: str | Iterable[str],
+        internal: bool = False,
+    ) -> None:
+        del internal
+        request_ids = [request_id] if isinstance(request_id, str) else list(request_id)
+        await self._submit_async(_CommandKind.ABORT, args=(request_ids,))
+
+    async def check_health(self) -> None:
+        await self._submit_async(_CommandKind.HEALTH)
+
+    async def do_log_stats(self) -> None:
+        if self.log_stats:
+            await self._submit_async(_CommandKind.CALL, args=("do_log_stats",))
+
+    async def start_profile(self, profile_prefix: Optional[str] = None) -> None:
+        await self._submit_async(
+            _CommandKind.CALL,
+            args=("start_profile", profile_prefix),
+        )
+
+    async def stop_profile(self) -> None:
+        await self._submit_async(_CommandKind.CALL, args=("stop_profile",))
+
+    async def reset_prefix_cache(
+        self,
+        reset_running_requests: bool = False,
+        reset_connector: bool = False,
+    ) -> bool:
+        return await self._submit_async(
+            _CommandKind.CALL,
+            args=("reset_prefix_cache", reset_running_requests, reset_connector),
+        )
+
+    async def sleep(
+        self,
+        level: int = 1,
+        mode: Literal["abort", "wait", "keep"] = "abort",
+    ) -> None:
+        await self._submit_async(_CommandKind.CALL, args=("sleep", level, mode))
+
+    async def wake_up(self, tags: Optional[list[str]] = None) -> None:
+        await self._submit_async(_CommandKind.CALL, args=("wake_up", tags))
+
+    async def pause_generation(
+        self,
+        *,
+        mode: Literal["abort", "wait", "keep"] = "abort",
+        wait_for_inflight_requests: Optional[bool] = None,
+        clear_cache: bool = True,
+    ) -> None:
+        if wait_for_inflight_requests:
+            warnings.warn(
+                "wait_for_inflight_requests is deprecated; use mode='wait'",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            mode = "wait"
+        if clear_cache:
+            await self._submit_async(
+                _CommandKind.RENDERER_CALL,
+                args=("clear_mm_cache",),
+            )
+        await self._submit_async(
+            _CommandKind.CORE_CALL,
+            args=("pause_scheduler",),
+            kwargs={"mode": mode, "clear_cache": clear_cache},
+        )
+        await asyncio.sleep(0.02)
+
+    async def resume_generation(self) -> None:
+        await self._submit_async(
+            _CommandKind.CORE_CALL,
+            args=("resume_scheduler",),
+        )
+
+    async def collective_rpc(
+        self,
+        method: str | Callable[..., Any],
+        timeout: Optional[float] = None,
+        args: tuple[Any, ...] = (),
+        kwargs: Optional[dict[str, Any]] = None,
+    ) -> list[Any]:
+        return await self._submit_async(
+            _CommandKind.CORE_CALL,
+            args=("collective_rpc", method, timeout, args, kwargs),
+        )
+
+    async def scale_elastic_ep(self, new_data_parallel_size: int) -> None:
+        del new_data_parallel_size
+        raise RuntimeError(
+            "sync-inproc mode does not support elastic expert parallelism"
+        )
+
+    def shutdown(self, timeout: Optional[float] = None) -> None:
+        enqueue_shutdown = False
+        with self._state_lock:
+            if self._state is _DriverState.RUNNING:
+                self._state = _DriverState.CLOSED
+                enqueue_shutdown = True
+        if enqueue_shutdown:
+            self._commands.put(
+                _Command(kind=_CommandKind.SHUTDOWN, result=Future()),
+            )
+        wait_timeout = timeout if timeout is not None else 30.0
+        self._terminated.wait(wait_timeout)
+        if self._thread.is_alive():
+            raise TimeoutError("sync-inproc vLLM driver did not stop before timeout")
+
+
+def validate_sync_inproc_config(
+    engine_args: EngineArgs,
+    vllm_config: VllmConfig,
+) -> None:
+    """Fail fast on vLLM features outside the experimental adapter's scope."""
+
+    parallel = vllm_config.parallel_config
+    unsupported: list[str] = []
+    if parallel.tensor_parallel_size != 1:
+        unsupported.append("tensor parallelism")
+    if parallel.pipeline_parallel_size != 1:
+        unsupported.append("pipeline parallelism")
+    if parallel.data_parallel_size != 1:
+        unsupported.append("data parallelism")
+    if engine_args.enable_lora:
+        unsupported.append("LoRA")
+    if unsupported:
+        raise ValueError(
+            "--engine-client-mode=sync-inproc does not support "
+            + ", ".join(unsupported)
+        )

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_client_mode.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_client_mode.py
@@ -1,0 +1,70 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for selecting the legacy vLLM engine-client topology."""
+
+from types import SimpleNamespace
+
+import pytest
+
+pytest.importorskip("vllm.usage.usage_lib")
+
+from dynamo.vllm.backend_args import DisaggregationMode, DynamoVllmConfig  # noqa: E402
+from dynamo.vllm.llm_engine import VllmLLMEngine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+def make_config() -> DynamoVllmConfig:
+    config = DynamoVllmConfig()
+    config.engine_client_mode = "sync-inproc"
+    config.disaggregation_mode = DisaggregationMode.AGGREGATED
+    config.route_to_encoder = False
+    config.multimodal_worker = False
+    config.embedding_worker = False
+    config.enable_rl = False
+    config.headless = False
+    config.gms_shadow_mode = False
+    config.benchmark_mode = None
+    return config
+
+
+def test_sync_inproc_accepts_pure_text_aggregated_serving() -> None:
+    make_config()._validate_engine_client_mode()
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("disaggregation_mode", DisaggregationMode.DECODE, "disaggregated"),
+        ("route_to_encoder", True, "route-to-encoder"),
+        ("multimodal_worker", True, "multimodal-worker"),
+        ("embedding_worker", True, "embedding-worker"),
+        ("enable_rl", True, "enable-rl"),
+        ("headless", True, "headless"),
+        ("gms_shadow_mode", True, "gms-shadow-mode"),
+        ("benchmark_mode", "agg", "benchmark-mode"),
+    ],
+)
+def test_sync_inproc_rejects_unsupported_modes(
+    field: str,
+    value: object,
+    message: str,
+) -> None:
+    config = make_config()
+    setattr(config, field, value)
+    with pytest.raises(ValueError, match=message):
+        config._validate_engine_client_mode()
+
+
+@pytest.mark.asyncio
+async def test_unified_entrypoint_rejects_sync_inproc() -> None:
+    config = SimpleNamespace(engine_client_mode="sync-inproc")
+    with pytest.raises(NotImplementedError, match="legacy"):
+        await VllmLLMEngine.from_args(config=config)  # type: ignore[arg-type]

--- a/components/src/dynamo/vllm/tests/test_vllm_publisher.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_publisher.py
@@ -11,6 +11,7 @@ so it is also the seam where the embedding worker must short-circuit
 the chat-shaped pipeline.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -125,3 +126,25 @@ def test_factory_default_is_chat_path(monkeypatch):
     assert constructed[0]["endpoint"] is endpoint
     assert constructed[0]["dp_rank"] == 3
     assert constructed[0]["component_gauges"] is component_gauges
+
+
+@pytest.mark.asyncio
+async def test_factory_preserves_runtime_loop_for_engine_thread(monkeypatch):
+    """Sync-engine stat loggers schedule endpoint setup on Dynamo's loop."""
+    constructed = []
+
+    def _fake_publisher(*args, **kwargs):
+        constructed.append(kwargs)
+        return Mock(spec=DynamoStatLoggerPublisher)
+
+    monkeypatch.setattr(publisher_mod, "DynamoStatLoggerPublisher", _fake_publisher)
+    runtime_loop = asyncio.get_running_loop()
+    factory = StatLoggerFactory(
+        endpoint=SimpleNamespace(),
+        component_gauges=SimpleNamespace(),
+    )
+
+    await asyncio.to_thread(factory.create_stat_logger, 0)
+
+    assert factory.event_loop is runtime_loop
+    assert constructed[0]["event_loop"] is runtime_loop

--- a/components/src/dynamo/vllm/tests/test_vllm_sync_inproc_engine.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_sync_inproc_engine.py
@@ -1,0 +1,374 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for the experimental synchronous in-process vLLM facade."""
+
+import asyncio
+import queue
+import threading
+from concurrent.futures import Future
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from vllm.sampling_params import SamplingParams
+
+usage_lib = pytest.importorskip("vllm.usage.usage_lib")
+UsageContext = usage_lib.UsageContext
+
+from dynamo.vllm import sync_inproc_engine as sync_engine  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+]
+
+
+class FakeRequestOutput(sync_engine.RequestOutput):
+    def __init__(self, request_id: str, finished: bool) -> None:
+        self.request_id = request_id
+        self.finished = finished
+        self.outputs = []
+
+    def add(self, other: Any, aggregate: bool = False) -> None:
+        del aggregate
+        self.finished = other.finished
+
+
+class FakeRenderer:
+    def __init__(self, owner: "FakeLLMEngine") -> None:
+        self.owner = owner
+
+    def shutdown(self) -> None:
+        self.owner.method_threads.append(threading.get_ident())
+
+    def clear_mm_cache(self) -> None:
+        self.owner.method_threads.append(threading.get_ident())
+
+
+class FakeEngineCore:
+    def __init__(self, owner: "FakeLLMEngine") -> None:
+        self.owner = owner
+        self.batch_queue = None
+
+    def get_kv_cache_group_metadata(self) -> list[dict[str, Any]]:
+        self.owner.method_threads.append(threading.get_ident())
+        return [{"kind": "full_attention", "block_size": 16}]
+
+    def pause_scheduler(self, *args, **kwargs) -> Future[None]:
+        del args, kwargs
+        self.owner.method_threads.append(threading.get_ident())
+        result: Future[None] = Future()
+        result.set_result(None)
+        return result
+
+    def resume_scheduler(self) -> None:
+        self.owner.method_threads.append(threading.get_ident())
+
+    def collective_rpc(self, *args):
+        del args
+        self.owner.method_threads.append(threading.get_ident())
+        return []
+
+
+class FakeEngineCoreClient:
+    def __init__(self, owner: "FakeLLMEngine") -> None:
+        self.owner = owner
+        self.engine_core = FakeEngineCore(owner)
+
+    def shutdown(self) -> None:
+        self.owner.method_threads.append(threading.get_ident())
+
+
+class FakeLLMEngine:
+    latest: "FakeLLMEngine | None" = None
+    block_first_step = False
+    fail_step = False
+    outputless_steps = 0
+    steps_per_request = 1
+
+    def __init__(self, **kwargs) -> None:
+        del kwargs
+        type(self).latest = self
+        self.constructor_thread = threading.get_ident()
+        self.method_threads: list[int] = []
+        self.active: dict[str, int] = {}
+        self.aborted: list[str] = []
+        self.step_calls = 0
+        self.active_counts: list[int] = []
+        self.first_step_entered = threading.Event()
+        self.release_first_step = threading.Event()
+        self.tokenizer = SimpleNamespace(tokenizer=SimpleNamespace(bos_token_id=1))
+        self.renderer = FakeRenderer(self)
+        self.engine_core = FakeEngineCoreClient(self)
+
+    def has_unfinished_requests(self) -> bool:
+        return bool(self.active)
+
+    def add_request(
+        self,
+        request_id: str,
+        prompt: Any,
+        params: Any,
+        **kwargs: Any,
+    ) -> str:
+        del prompt, params, kwargs
+        self.method_threads.append(threading.get_ident())
+        self.active[request_id] = type(self).steps_per_request
+        # vLLM may return a wave-suffixed EngineCore ID while public
+        # RequestOutputs and abort_request() retain the caller's request ID.
+        return f"{request_id}-internal"
+
+    def abort_request(self, request_ids: list[str]) -> None:
+        self.method_threads.append(threading.get_ident())
+        for request_id in request_ids:
+            self.active.pop(request_id, None)
+            self.aborted.append(request_id)
+
+    def step(self) -> list[FakeRequestOutput]:
+        self.method_threads.append(threading.get_ident())
+        self.step_calls += 1
+        self.active_counts.append(len(self.active))
+        if type(self).block_first_step and self.step_calls == 1:
+            self.first_step_entered.set()
+            self.release_first_step.wait(timeout=2)
+        if type(self).fail_step:
+            raise RuntimeError("step failed")
+        if type(self).outputless_steps > 0:
+            type(self).outputless_steps -= 1
+            return []
+
+        outputs = []
+        for request_id in list(self.active):
+            remaining = self.active[request_id] - 1
+            finished = remaining == 0
+            outputs.append(FakeRequestOutput(request_id, finished))
+            if finished:
+                self.active.pop(request_id)
+            else:
+                self.active[request_id] = remaining
+        return outputs
+
+    def do_log_stats(self) -> None:
+        self.method_threads.append(threading.get_ident())
+
+    def reset_prefix_cache(self, *args: Any) -> bool:
+        del args
+        self.method_threads.append(threading.get_ident())
+        return True
+
+    def start_profile(self, profile_prefix: str | None = None) -> None:
+        del profile_prefix
+        self.method_threads.append(threading.get_ident())
+
+    def stop_profile(self) -> None:
+        self.method_threads.append(threading.get_ident())
+
+    def sleep(self, level: int = 1, mode: str = "abort") -> None:
+        del level, mode
+        self.method_threads.append(threading.get_ident())
+
+    def wake_up(self, tags: list[str] | None = None) -> None:
+        del tags
+        self.method_threads.append(threading.get_ident())
+
+
+@pytest.fixture(autouse=True)
+def fake_vllm(monkeypatch: pytest.MonkeyPatch) -> None:
+    FakeLLMEngine.latest = None
+    FakeLLMEngine.block_first_step = False
+    FakeLLMEngine.fail_step = False
+    FakeLLMEngine.outputless_steps = 0
+    FakeLLMEngine.steps_per_request = 1
+    monkeypatch.setattr(sync_engine, "LLMEngine", FakeLLMEngine)
+    monkeypatch.setattr(sync_engine, "RequestOutput", FakeRequestOutput)
+    monkeypatch.setattr(sync_engine.Executor, "get_class", lambda config: object)
+    monkeypatch.setattr(sync_engine, "shutdown_prometheus", lambda: None)
+
+
+def make_client() -> sync_engine.SyncInprocEngineClient:
+    config = SimpleNamespace(model_config=SimpleNamespace())
+    return sync_engine.SyncInprocEngineClient.from_vllm_config(
+        config,
+        usage_context=UsageContext.ENGINE_CONTEXT,
+        disable_log_stats=True,
+    )
+
+
+async def collect(
+    client: sync_engine.SyncInprocEngineClient,
+    request_id: str,
+) -> list[sync_engine.RequestOutput]:
+    params = SamplingParams(max_tokens=2)
+    return [
+        output
+        async for output in client.generate(
+            {"prompt_token_ids": [1]},
+            params,
+            request_id,
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_outputless_step_keeps_engine_running() -> None:
+    FakeLLMEngine.outputless_steps = 1
+    client = make_client()
+    try:
+        outputs = await asyncio.wait_for(collect(client, "request-1"), timeout=2)
+        assert outputs[-1].finished
+        assert FakeLLMEngine.latest.step_calls == 2
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_new_request_joins_between_steps() -> None:
+    FakeLLMEngine.block_first_step = True
+    FakeLLMEngine.steps_per_request = 2
+    client = make_client()
+    try:
+        first = asyncio.create_task(collect(client, "request-1"))
+        await asyncio.to_thread(FakeLLMEngine.latest.first_step_entered.wait, 2)
+        second = asyncio.create_task(collect(client, "request-2"))
+        FakeLLMEngine.latest.release_first_step.set()
+        await asyncio.wait_for(asyncio.gather(first, second), timeout=2)
+        assert 2 in FakeLLMEngine.latest.active_counts
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_aborts_active_request() -> None:
+    FakeLLMEngine.block_first_step = True
+    FakeLLMEngine.steps_per_request = 2
+    client = make_client()
+    task = asyncio.create_task(collect(client, "request-1"))
+    await asyncio.to_thread(FakeLLMEngine.latest.first_step_entered.wait, 2)
+    task.cancel()
+    FakeLLMEngine.latest.release_first_step.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert "request-1" in FakeLLMEngine.latest.aborted
+    client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancellation_before_add_is_admitted_then_aborted() -> None:
+    FakeLLMEngine.block_first_step = True
+    FakeLLMEngine.steps_per_request = 2
+    client = make_client()
+    try:
+        first = asyncio.create_task(collect(client, "request-1"))
+        await asyncio.to_thread(FakeLLMEngine.latest.first_step_entered.wait, 2)
+
+        pending = asyncio.create_task(collect(client, "request-2"))
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if client._commands.qsize() == 1:
+                break
+        assert client._commands.qsize() == 1
+        pending.cancel()
+        for _ in range(100):
+            await asyncio.sleep(0)
+            if client._commands.qsize() == 2:
+                break
+        assert client._commands.qsize() == 2
+        FakeLLMEngine.latest.release_first_step.set()
+
+        with pytest.raises(asyncio.CancelledError):
+            await pending
+        await asyncio.wait_for(first, timeout=2)
+        assert "request-2" in FakeLLMEngine.latest.aborted
+    finally:
+        client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_driver_failure_reaches_waiter() -> None:
+    FakeLLMEngine.fail_step = True
+    client = make_client()
+    with pytest.raises(RuntimeError, match="step failed"):
+        await asyncio.wait_for(collect(client, "request-1"), timeout=2)
+    client.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_admin_and_shutdown_stay_on_driver_thread() -> None:
+    client = make_client()
+    engine = FakeLLMEngine.latest
+    await client.check_health()
+    await client.reset_prefix_cache()
+    await client.sleep(mode="keep")
+    await client.pause_generation(mode="keep")
+    await client.resume_generation()
+    await client.collective_rpc("ping")
+    metadata = await client.engine_core.call_utility_async(
+        "get_kv_cache_group_metadata"
+    )
+    assert metadata[0]["block_size"] == 16
+    client.shutdown()
+    assert engine.method_threads
+    assert set(engine.method_threads) == {engine.constructor_thread}
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("tensor_parallel_size", 2, "tensor parallelism"),
+        ("pipeline_parallel_size", 2, "pipeline parallelism"),
+        ("data_parallel_size", 2, "data parallelism"),
+    ],
+)
+def test_validate_sync_inproc_rejects_parallelism(
+    field: str,
+    value: int,
+    message: str,
+) -> None:
+    parallel = SimpleNamespace(
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        data_parallel_size=1,
+    )
+    setattr(parallel, field, value)
+    engine_args = SimpleNamespace(enable_lora=False)
+    config = SimpleNamespace(parallel_config=parallel)
+    with pytest.raises(ValueError, match=message):
+        sync_engine.validate_sync_inproc_config(engine_args, config)
+
+
+def test_validate_sync_inproc_rejects_lora() -> None:
+    parallel = SimpleNamespace(
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        data_parallel_size=1,
+    )
+    engine_args = SimpleNamespace(enable_lora=True)
+    config = SimpleNamespace(parallel_config=parallel)
+    with pytest.raises(ValueError, match="LoRA"):
+        sync_engine.validate_sync_inproc_config(engine_args, config)
+
+
+def test_full_command_queue_fails_fast() -> None:
+    client = object.__new__(sync_engine.SyncInprocEngineClient)
+    client._state = sync_engine._DriverState.RUNNING
+    client._state_lock = threading.Lock()
+    client._failure = None
+    client._commands = queue.Queue(maxsize=1)
+    command = sync_engine._Command(
+        kind=sync_engine._CommandKind.HEALTH,
+        result=Future(),
+    )
+    client._commands.put(command)
+
+    with pytest.raises(RuntimeError, match="command queue is full"):
+        client._enqueue(command)
+
+
+def test_shutdown_is_idempotent() -> None:
+    client = make_client()
+    client.shutdown()
+    client.shutdown()

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -15,7 +15,6 @@ from pathlib import Path
 from typing import Any, Optional
 
 from vllm.config import VllmConfig
-from vllm.v1.engine.async_llm import AsyncLLM
 
 from dynamo import prometheus_names
 from dynamo.common.rl import first_endpoint_response, register_rl_routes
@@ -31,6 +30,7 @@ from .args import Config
 from .cache_info import configure_kv_event_block_size
 from .capacity import per_rank_kv_blocks
 from .constants import DisaggregationMode
+from .engine_client import VllmEngineClient
 from .handlers import (
     BaseWorkerHandler,
     DecodeWorkerHandler,
@@ -59,7 +59,13 @@ BENCHMARK_SOFT_TIMEOUT_GRACE_SECONDS = 90
 # component_gauges is None on the embedding-worker path: pooling engines
 # have no KV cache / scheduler gauges, so setup_vllm_engine() skips the
 # LLMBackendMetrics registration there.
-EngineSetupResult = tuple[AsyncLLM, VllmConfig, Any, Any, Optional[LLMBackendMetrics]]
+EngineSetupResult = tuple[
+    VllmEngineClient,
+    VllmConfig,
+    Any,
+    Any,
+    Optional[LLMBackendMetrics],
+]
 
 
 def _benchmark_rank_path(base_path: Path, dp_rank: int) -> Path:


### PR DESCRIPTION
## Why

Dynamo's vLLM backend only exposes the multiprocess `AsyncLLM` client, so aggregated text deployments cannot evaluate an in-process engine that removes the EngineCore IPC boundary. This adds an opt-in synchronous path while preserving `async-mp` as the default and failing fast for unsupported topologies. A controlled concurrency-1 benchmark shows parity, so this PR makes no speedup claim.

## Effect

Local RTX PRO 6000, Qwen2.5-1.5B-Instruct, five fresh-server trials, 1,000 requests plus 20 warmups, ISL 740 / OSL 70:

| Mode | req/s | output tok/s | paired req/s delta vs async |
|---|---:|---:|---:|
| async | 4.798 | 335.866 | baseline |
| sync | 4.798 | 335.842 | -0.01% [-0.07%, +0.05%] |

Benchmark source: `37361077`; the subsequent commit only adds the required YAML SPDX header.

## What Change

- Add an owner-thread synchronous vLLM engine facade with async-compatible request handling.
- Gate sync mode behind `--engine-client-mode sync-inproc` and validate supported configurations.
- Add an audited, repetition-aware pure-text AIPerf experiment and report.

## Test Plan

- Pre-commit hooks and 66 focused tests pass.
- Audited all 15 local benchmark cells with zero workload errors.