### PR TITLE
docs(rl): add ModelExpress weight refit guide

### DIFF
--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -34,10 +34,11 @@ Include `nvext` as a top-level field alongside standard OpenAI-compatible fields
 | `use_raw_prompt` | `bool` | `None` | Preprocessor | Bypasses the prompt template and passes the prompt directly to the tokenizer. |
 | `annotations` | `string[]` | `None` | Preprocessor | Triggers out-of-band information in the SSE stream via the `event:` field. |
 | `backend_instance_id` | `u64` | `None` | Router | Routes the request to a specific backend instance. |
-| `token_data` | `u32[]` | `None` | Preprocessor | Pre-tokenized prompt tokens. When provided with `backend_instance_id`, tokenization is skipped. |
+| `token_data` | `u32[]` | `None` | Preprocessor | Pre-tokenized prompt tokens. When present, the frontend skips tokenization. |
 | `max_thinking_tokens` | `u32` | `None` | Backend | Maximum thinking tokens allowed (passed through to backends). |
 | `cache_salt` | `string` | `None` | Router / supported backends | Namespaces Dynamo KV routing. vLLM and TensorRT-LLM also isolate backend KV-cache reuse; see [Backend support](#backend-support). This is the recommended cache-isolation input. |
-| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`, `"engine_data"`, `"stop_reason"`. |
+| `extra_fields` | `string[]` | `None` | Response builder | Fields to include in the response `nvext`. Supported: `"worker_id"`, `"timing"`, `"routed_experts"`, `"engine_data"`, `"stop_reason"`, `"completion_token_ids"`, `"prompt_logprobs"`. |
+| `metadata_upload` | object | `None` | SGLang backend | Uploads final cumulative SGLang `meta_info` out of band. The object accepts one required `url` field. Requires an RL-enabled SGLang worker. |
 | `prefill_worker_id` | `u64` | `None` | Router | Routes the request to a specific prefill worker (disaggregated serving). |
 | `decode_worker_id` | `u64` | `None` | Router | Routes the request to a specific decode worker (disaggregated serving). |
 | `dp_rank` | `u32` | `None` | Router/backend | Data-parallel rank for the decode worker. Typically set by EPP routing headers. |
@@ -237,9 +238,11 @@ When the client requests response metadata via `extra_fields`, the response incl
 |-------|---------------|-------------|
 | `worker_id` | `extra_fields: ["worker_id"]` | Prefill/decode worker IDs and data parallel ranks that processed the request. |
 | `timing` | `extra_fields: ["timing"]` | Per-request timing information (TTFT, ITL, queue time, etc.). |
-| `routed_experts` | `extra_fields: ["routed_experts"]` | Routed expert capture payload returned by SGLang-backed requests. |
+| `routed_experts` | `extra_fields: ["routed_experts"]` | Backend-specific routed expert capture payload returned by compatible vLLM and SGLang engines. |
 | `engine_data` | `extra_fields: ["engine_data"]` | Opaque backend-provided engine metadata. |
 | `stop_reason` | `extra_fields: ["stop_reason"]` | Backend-specific matched stop condition, returned under `nvext` because it is not part of the OpenAI completions schema. Dynamo currently serves this as a response-level field for single-choice requests; supporting `n > 1` will require an indexed per-choice shape. |
+| `completion_token_ids` | `extra_fields: ["completion_token_ids"]` | Generated token IDs. Requires a single prompt and one generated choice. |
+| `prompt_logprobs` | `extra_fields: ["prompt_logprobs"]` | Prompt log probabilities requested with the top-level `prompt_logprobs` field. Emitted on the final response. |
 | `token_ids` | Automatic (GAIE Stage 1) | Tokenized prompt for reuse in Stage 2 query-only mode. |
 
 ### Example response `nvext`
@@ -266,6 +269,7 @@ When the client requests response metadata via `extra_fields`, the response incl
 | Document | Description |
 |----------|-------------|
 | [Frontend Guide](frontend-guide.md) | KServe gRPC configuration and integration |
+| [Reinforcement Learning Integration](../../features/rl/README.md) | Token-level rollout data, worker discovery, direct engine routes, and SGLang metadata upload |
 | [Configuration and Tuning](../router/router-configuration.md) | Full router configuration and CLI arguments |
 | [Session IDs](../../agents/session-ids.md) | Passive session identity |
 | [Agent Tracing](../../agents/agent-tracing.md) | JSONL request traces, inferred tool-call metadata, and harness tool-event ingestion |

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -27,6 +27,7 @@ Most deployments start with the core performance loop:
 | Reproduce traffic without a full engine | [Mocker Engine Simulation](../mocker/mocker.md) |
 | Add structured model outputs | [Tool Calling](../tool-calling/README.md) and [Reasoning](../reasoning/README.md) |
 | Build agent workloads | [Agents](../agents/README.md) |
+| Connect an RL orchestrator | [Reinforcement Learning Integration](rl/README.md) |
 | Serve specialized workloads | [LoRA Adapters](lora/README.md), [Multimodal](multimodal/README.md), and [Diffusion](diffusion/README.md) |
 
 For cluster deployments, pair these guides with the [Kubernetes Deployment](../kubernetes/README.md) docs. The same features can be explored locally, then expressed through Dynamo's Kubernetes-native CRDs and operator when you move to a shared GPU cluster.

--- a/docs/features/rl/README.md
+++ b/docs/features/rl/README.md
@@ -17,6 +17,7 @@ updates directly to the selected engine.
 | Run rollouts | `POST /v1/completions` or `POST /v1/chat/completions` | `8000` | Routes inference through the Dynamo frontend. |
 | Discover RL workers | `GET /v1/rl/workers` | `8001` | Returns live workers, their advertised routes, and direct system URLs. |
 | Administer one engine | `POST <system_url>/engine/<route>` | Worker-specific | Calls one worker without frontend routing or fan-out. |
+| Refit weights with ModelExpress | `POST <system_url>/engine/update_weights_via_mx` | Worker-specific | Pulls a published policy version directly from trainer GPUs when the worker advertises the route. |
 
 The discovery API runs on a dedicated frontend listener. It is not mounted on the main frontend
 port, and it does not proxy `/engine/` calls. The request-plane URL in its response is used
@@ -308,6 +309,19 @@ both the HTTP status and the JSON result before advancing the rollout state.
 The `/v1/rl/workers` endpoint is read-only. It intentionally does not expose `/v1/rl/engine` or
 `/v1/rl/engines` proxy routes, which prevents an accidental frontend fan-out of a mutating engine
 operation.
+
+### Refit Weights with ModelExpress
+
+ModelExpress is an optional mid-training weight-update path for RL jobs whose
+trainer and rollout workers run on separate GPUs or use different parallel
+layouts. Trainer owner ranks publish native local tensors; rollout workers
+discover the requested version and pull selected GPU ranges over NIXL.
+
+Use the worker's advertised `update_weights_via_mx` route rather than assuming
+the integration is present. The dedicated
+[ModelExpress Weight Refit](model-express-weight-refit.md) guide covers
+publisher requirements, worker configuration, partial updates, resharding,
+cache invalidation, failure handling, and timing.
 
 ## Register a Custom Engine Route
 

--- a/docs/features/rl/README.md
+++ b/docs/features/rl/README.md
@@ -1,0 +1,329 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: Reinforcement Learning Integration
+subtitle: Connect RL orchestrators to Dynamo inference and engine administration interfaces
+---
+
+**Experimental.** NVIDIA Dynamo exposes rollout data through the frontend and engine administration
+through per-worker routes. Reinforcement learning (RL) orchestrators should use the frontend for
+inference, discover workers through the read-only RL discovery API, and send lifecycle or weight
+updates directly to the selected engine.
+
+## Choose an Interface
+
+| Task | Interface | Default Port | Behavior |
+|---|---|---:|---|
+| Run rollouts | `POST /v1/completions` or `POST /v1/chat/completions` | `8000` | Routes inference through the Dynamo frontend. |
+| Discover RL workers | `GET /v1/rl/workers` | `8001` | Returns live workers, their advertised routes, and direct system URLs. |
+| Administer one engine | `POST <system_url>/engine/<route>` | Worker-specific | Calls one worker without frontend routing or fan-out. |
+
+The discovery API runs on a dedicated frontend listener. It is not mounted on the main frontend
+port, and it does not proxy `/engine/` calls. The request-plane URL in its response is used
+internally to query route descriptors; an RL orchestrator should use the returned `system_url` for
+administration.
+
+> [!WARNING]
+> The worker system server does not add an authentication layer to `/engine/` routes. Restrict the
+> system port to the orchestrator network and do not expose it through a public inference gateway.
+
+## Frontend Feature Support
+
+The OpenAI-compatible completion routes provide the current token-in/token-out interface.
+
+| Feature | Request | Response | Notes |
+|---|---|---|---|
+| Token input | Set `prompt` to an integer array on `/v1/completions`, or set `nvext.token_data` on a chat or completion request. | Standard completion response | `nvext.token_data` bypasses frontend tokenization. |
+| Completion token IDs | Add `"completion_token_ids"` to `nvext.extra_fields`. | `nvext.completion_token_ids` | Requires one prompt and one generated choice. Streaming responses contain token deltas; non-streaming responses contain the concatenated IDs. |
+| Completion log probabilities | Set `logprobs` on `/v1/completions`, or set `logprobs: true` and `top_logprobs` on `/v1/chat/completions`. | Standard `choices[].logprobs` | The selected engine must support the requested log probability mode. |
+| Prompt log probabilities | Set top-level `prompt_logprobs` and add `"prompt_logprobs"` to `nvext.extra_fields`. | `nvext.prompt_logprobs` on the final response | The first prompt position is `null` because it has no preceding-token probability. |
+| Prefix-cache salt | Set `nvext.cache_salt`. | No response field | vLLM includes the opaque salt in prompt cache keys, separating reuse between requests with different salts. |
+| Routed expert data | Add `"routed_experts"` to `nvext.extra_fields`. | `nvext.routed_experts` on the final response | Requires routed-expert capture in the engine build and configuration. |
+| Raw engine metadata | Add `"engine_data"` to `nvext.extra_fields`. | `nvext.engine_data` | Backend-specific and not a stable cross-backend schema. Prefer named fields when available. |
+| SGLang `meta_info` upload | Set `nvext.metadata_upload.url`. | Out-of-band object per choice | Requires an RL-enabled SGLang worker and fsspec support. |
+
+See [NVIDIA Request Extensions](../../components/frontend/nvext.md) for the complete `nvext`
+reference.
+
+Backend RL flags also select engine-specific behavior:
+
+- On vLLM, `--enable-rl` registers the discovery and administration routes, selects processed log
+  probabilities, and prevents model `generation_config.json` sampling overrides from changing
+  RL token-in requests marked with `nvext.token_data`. Explicit request sampling values still
+  apply.
+- On SGLang, `--enable-rl` enables out-of-band `meta_info` upload and the
+  `/engine/call_tokenizer_manager` passthrough route. SGLang workers do not currently register with
+  `/v1/rl/workers`.
+
+### Token-In/Token-Out Example
+
+Send pre-tokenized input and request token IDs plus prompt and completion log probabilities:
+
+```bash
+curl http://localhost:8000/v1/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "Qwen/Qwen3-0.6B",
+    "prompt": "",
+    "max_tokens": 32,
+    "temperature": 0,
+    "logprobs": 5,
+    "prompt_logprobs": 5,
+    "nvext": {
+      "token_data": [151644, 8948, 198],
+      "extra_fields": ["completion_token_ids", "prompt_logprobs"]
+    }
+  }'
+```
+
+The relevant response fields have this shape:
+
+```json
+{
+  "choices": [
+    {
+      "index": 0,
+      "text": "...",
+      "logprobs": {}
+    }
+  ],
+  "nvext": {
+    "completion_token_ids": [9707, 11],
+    "prompt_logprobs": [null, {"8948": {"logprob": -0.42}}]
+  }
+}
+```
+
+To use the chat route while retaining pre-tokenized input, provide the normal `messages` field and
+set `nvext.token_data` to the complete token sequence that the engine should receive. The frontend
+uses `token_data` instead of rendering and tokenizing `messages`.
+
+### Routed Expert Data
+
+Opt into routed-expert data per request:
+
+```json
+{
+  "model": "my-moe-model",
+  "prompt": [1, 2, 3],
+  "max_tokens": 16,
+  "nvext": {
+    "extra_fields": ["completion_token_ids", "routed_experts"]
+  }
+}
+```
+
+The payload format is backend-specific:
+
+- vLLM-compatible builds return an object containing base64 `data`, `shape`, `dtype`, and `start`.
+  The `start` offset identifies the first returned routing row in the full prompt-plus-completion
+  sequence.
+- SGLang builds whose `async_generate` API supports `return_routed_experts` return the engine's
+  base64 string. Start SGLang with `--enable-return-routed-experts` to request capture. Builds that
+  omit this engine argument do not return the field.
+- TensorRT-LLM does not currently return routed-expert data through this frontend extension.
+
+Use `nvext.engine_data` only when the orchestrator must consume other backend-specific data. The
+named `completion_token_ids`, `prompt_logprobs`, and `routed_experts` fields provide more stable
+contracts.
+
+## Upload SGLang Metadata
+
+SGLang can upload the final cumulative `meta_info` for each choice to any filesystem supported by
+the installed fsspec backend. This path keeps large log probability tensors, routed-expert data,
+and custom metadata out of the HTTP response.
+
+Start the worker with RL support. Add the routed-expert flag only when the SGLang engine build
+supports it:
+
+```bash
+DYN_SYSTEM_PORT=8081 python -m dynamo.sglang \
+  --model-path Qwen/Qwen3-0.6B \
+  --enable-rl \
+  --enable-return-routed-experts
+```
+
+Set a unique upload directory for each request:
+
+```json
+{
+  "model": "Qwen/Qwen3-0.6B",
+  "prompt": [151644, 8948, 198],
+  "max_tokens": 32,
+  "logprobs": 5,
+  "nvext": {
+    "metadata_upload": {
+      "url": "s3://rl-rollouts/run-42/request-7"
+    }
+  }
+}
+```
+
+The worker writes `choice_0.msgpack.zst`, `choice_1.msgpack.zst`, and so on beneath the URL. Each
+file contains a Zstandard-compressed MessagePack object:
+
+```json
+{
+  "schema_version": 1,
+  "metadata": {
+    "id": "...",
+    "finish_reason": {"type": "stop"},
+    "output_token_logprobs": [],
+    "output_top_logprobs": [],
+    "routed_experts": "..."
+  }
+}
+```
+
+Install the matching fsspec extra for remote storage, such as `fsspec[s3]` for S3. The worker also
+requires `msgspec` and `zstandard`. Local URLs such as `file:///tmp/rollouts/request-7` are useful
+for development.
+
+When `metadata_upload` is present, SGLang uploads only the final cumulative `meta_info` for each
+choice and omits inline log probabilities and routed-expert metadata. The final response waits for
+the upload. An upload failure fails the request, so use a durable destination and a unique URL to
+avoid overwriting another request's `choice_<index>.msgpack.zst` objects.
+
+## Discover RL Workers
+
+RL discovery currently covers RL-enabled vLLM workers. Start the frontend discovery listener and a
+vLLM worker with its system server enabled:
+
+```bash
+DYN_ENABLE_RL=true DYN_RL_PORT=8001 python -m dynamo.frontend
+```
+
+```bash
+DYN_SYSTEM_PORT=8081 python -m dynamo.vllm \
+  --model Qwen/Qwen3-0.6B \
+  --enable-rl
+```
+
+Query the dedicated discovery port:
+
+```bash
+curl http://localhost:8001/v1/rl/workers
+```
+
+The response describes each live worker and probes it for the routes available in that process:
+
+```json
+{
+  "namespace": "dynamo",
+  "workers": [
+    {
+      "namespace": "dynamo",
+      "component": "backend",
+      "endpoint": "rl",
+      "instance_id": 12345,
+      "transport": {"tcp": "10.0.0.12:1234/..."},
+      "request_plane_url": "dyn://dynamo.backend.rl",
+      "system_url": "http://10.0.0.12:8081",
+      "model": "Qwen/Qwen3-0.6B",
+      "routes": [
+        "get_weight_version",
+        "liveness_probe",
+        "pause_generation",
+        "resume_generation",
+        "update_weights_from_disk"
+      ]
+    }
+  ]
+}
+```
+
+Treat `routes` as the capability list for that worker instead of assuming every engine exposes the
+same methods. Optional features such as Low-Rank Adaptation (LoRA) add routes only when enabled.
+Discovery can also return a worker with an `error` and an empty route list when its descriptor probe
+times out or fails.
+
+The discovery listener uses these environment variables:
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DYN_ENABLE_RL` | `false` | Enables the frontend RL discovery listener. |
+| `DYN_RL_PORT` | `8001` | Sets the dedicated discovery port. |
+| `DYN_NAMESPACE` | `dynamo` | Limits discovery to one Dynamo namespace. |
+| `DYN_RL_ENDPOINT` | `rl` | Selects the worker endpoint name. |
+| `DYN_RL_COMPONENTS` | all components | Limits discovery to a comma-separated component list. |
+| `DYN_RL_REQUEST_TIMEOUT_SECS` | `30` | Bounds each worker descriptor probe. |
+| `DYN_RL_MAX_CONCURRENT_PROBES` | `32` | Limits concurrent worker probes across discovery requests. |
+
+## Call Engine Routes Directly
+
+Read `system_url` and `routes` from the discovery response, then call the selected worker. Send a
+JSON object even when the route does not require arguments:
+
+```bash
+curl http://10.0.0.12:8081/engine/liveness_probe \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+For a weight update cycle, pause the selected worker, call one of its advertised weight-update
+routes, and resume generation:
+
+```bash
+curl http://10.0.0.12:8081/engine/pause_generation \
+  -H 'Content-Type: application/json' \
+  -d '{"mode": "keep", "clear_cache": false}'
+
+curl http://10.0.0.12:8081/engine/resume_generation \
+  -H 'Content-Type: application/json' \
+  -d '{}'
+```
+
+Route request bodies and response fields are engine-specific. A callback can return
+`{"status":"error"}` with HTTP 200, while an exception in the callback produces HTTP 500. Check
+both the HTTP status and the JSON result before advancing the rollout state.
+
+The `/v1/rl/workers` endpoint is read-only. It intentionally does not expose `/v1/rl/engine` or
+`/v1/rl/engines` proxy routes, which prevents an accidental frontend fan-out of a mutating engine
+operation.
+
+## Register a Custom Engine Route
+
+Register an asynchronous Python callback on the worker's `DistributedRuntime`. The route name is
+appended to `/engine/` on the system server:
+
+```python
+from typing import Any
+
+
+async def set_rollout_state(body: dict[str, Any]) -> dict[str, Any]:
+    rollout_id = body.get("rollout_id")
+    if not isinstance(rollout_id, str) or not rollout_id:
+        return {"status": "error", "message": "rollout_id is required"}
+
+    await engine.set_rollout_state(rollout_id)
+    return {"status": "ok", "rollout_id": rollout_id}
+
+
+runtime.register_engine_route("rl/set_rollout_state", set_rollout_state)
+```
+
+Enable the system server with `DYN_SYSTEM_PORT`, then call the route directly:
+
+```bash
+curl http://worker-host:8081/engine/rl/set_rollout_state \
+  -H 'Content-Type: application/json' \
+  -d '{"rollout_id": "run-42-step-7"}'
+```
+
+`register_engine_route` makes the HTTP route callable but does not automatically advertise it in
+the RL discovery response. When extending an RL-enabled vLLM worker, register and advertise the
+route together with the shared helper:
+
+```python
+from dynamo.common.rl import register_rl_routes
+
+
+register_rl_routes(
+    runtime,
+    handler.rl_route_registry,
+    {"rl/set_rollout_state": set_rollout_state},
+    enable_dispatch=handler.config.enable_rl,
+)
+```
+
+The next `GET /v1/rl/workers` probe includes `rl/set_rollout_state` in that worker's `routes` list.

--- a/docs/features/rl/README.md
+++ b/docs/features/rl/README.md
@@ -89,7 +89,11 @@ The relevant response fields have this shape:
   ],
   "nvext": {
     "completion_token_ids": [9707, 11],
-    "prompt_logprobs": [null, {"8948": {"logprob": -0.42}}]
+    "prompt_logprobs": [
+      null,
+      {"8948": {"logprob": -0.42}},
+      {"198": {"logprob": -0.31}}
+    ]
   }
 }
 ```
@@ -132,6 +136,12 @@ contracts.
 SGLang can upload the final cumulative `meta_info` for each choice to any filesystem supported by
 the installed fsspec backend. This path keeps large log probability tensors, routed-expert data,
 and custom metadata out of the HTTP response.
+
+> [!WARNING]
+> Treat `metadata_upload.url` as trusted RL control-plane input. The worker trims the value, checks
+> that it is a non-empty string, and passes it to fsspec without restricting the storage scheme or
+> destination. Do not allow untrusted inference callers to set this URL; fsspec can access local or
+> remote storage with the worker's permissions and credentials.
 
 Start the worker with RL support. Add the routed-expert flag only when the SGLang engine build
 supports it:
@@ -261,16 +271,34 @@ curl http://10.0.0.12:8081/engine/liveness_probe \
 ```
 
 For a weight update cycle, pause the selected worker, call one of its advertised weight-update
-routes, and resume generation:
+routes, validate the result, and resume generation. Install `jq` before running this example. The
+exit trap attempts to resume the worker if the update or another command fails:
 
 ```bash
-curl http://10.0.0.12:8081/engine/pause_generation \
-  -H 'Content-Type: application/json' \
-  -d '{"mode": "keep", "clear_cache": false}'
+set -euo pipefail
 
-curl http://10.0.0.12:8081/engine/resume_generation \
+worker_url=http://10.0.0.12:8081
+
+resume_generation() {
+  response=$(curl --fail-with-body "$worker_url/engine/resume_generation" \
+    -H 'Content-Type: application/json' \
+    -d '{}')
+  jq -e '.status == "ok"' <<<"$response" >/dev/null
+}
+
+pause_response=$(curl --fail-with-body "$worker_url/engine/pause_generation" \
   -H 'Content-Type: application/json' \
-  -d '{}'
+  -d '{"mode": "keep", "clear_cache": false}')
+jq -e '.status == "ok"' <<<"$pause_response" >/dev/null
+trap resume_generation EXIT
+
+update_response=$(curl --fail-with-body "$worker_url/engine/update_weights_from_disk" \
+  -H 'Content-Type: application/json' \
+  -d '{"model_path": "/models/checkpoint-42", "weight_version": "42"}')
+jq -e '.status == "ok"' <<<"$update_response" >/dev/null
+
+resume_generation
+trap - EXIT
 ```
 
 Route request bodies and response fields are engine-specific. A callback can return

--- a/docs/features/rl/model-express-weight-refit.md
+++ b/docs/features/rl/model-express-weight-refit.md
@@ -1,0 +1,241 @@
+---
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+title: ModelExpress Weight Refit
+subtitle: Move updated RL policy weights from trainer GPUs into live vLLM rollout workers
+---
+
+**Experimental.** ModelExpress (MX) weight refit is an opt-in integration for
+mid-training policy updates. It requires a Dynamo vLLM runtime that includes the
+ModelExpress refit adapter and the `modelexpress` Python package.
+
+Track the integration work in
+[ModelExpress #482](https://github.com/ai-dynamo/modelexpress/pull/482) and
+[NeMo-RL #3068](https://github.com/NVIDIA-NeMo/RL/pull/3068). Released runtime
+availability can differ; use the worker's advertised route list as the source of
+truth.
+
+This guide covers the RL update loop. For cold-start model distribution and
+Kubernetes platform configuration, see
+[ModelExpress](../../kubernetes/modelexpress.md).
+
+## When to Use It
+
+Use ModelExpress refit when:
+
+- trainer weights already reside on GPUs;
+- rollout workers run on separate nodes;
+- policy updates occur repeatedly during an RL job;
+- trainer and rollout parallelism may differ;
+- rollout replicas may join or recover independently; or
+- only selected layers or experts need an update.
+
+The ModelExpress server is a metadata control plane. Weight bytes do not pass
+through it. Rollout workers discover source metadata through gRPC, then pull
+selected GPU ranges directly with NIXL over RDMA or another configured
+transport.
+
+## Architecture
+
+```mermaid
+flowchart LR
+    O[RL orchestrator] -->|publish version N| T[Trainer owner ranks]
+    T -->|tensor metadata + READY| S[ModelExpress server]
+    O -->|pause and update version N| D[Dynamo vLLM worker]
+    D -->|discover sources| S
+    D -->|NIXL GPU read| T
+    D --> R[Reshard and translate]
+    R --> L[Install into live model]
+    L --> C[Reset cache and commit version]
+    C -->|resume| O
+```
+
+The integration separates four responsibilities:
+
+1. **Trainer publisher:** registers the tensors owned by each trainer rank and
+   publishes a version after the optimizer step.
+2. **ModelExpress server:** tracks source identity, readiness, version,
+   topology signature, and worker liveness.
+3. **Rollout receiver:** selects source ranks, transfers tensors with NIXL,
+   translates layouts, and installs the update.
+4. **Dynamo:** exposes the direct engine route and coordinates pause, update,
+   cache reset, version commit, and resume.
+
+## Publish Trainer Weights
+
+The trainer integration is framework-specific. A publisher should:
+
+1. Register stable GPU tensor addresses once.
+2. Publish only tensors owned by the local rank.
+3. Attach TP, PP, EP, tensor-role, shape, dtype, and expert-ownership metadata.
+4. Publish a monotonically increasing training step.
+5. Mark the version `READY` only after registration is complete.
+6. Keep the source alive until all readers finish.
+
+Megatron and DTensor publishers should publish native local shards rather than
+materializing a full checkpoint on rank 0. This avoids an all-gather and lets
+multiple trainer NICs serve rollout workers in parallel.
+
+The publisher computes a stable layout signature from the world layout, rank
+coordinates, tensor shapes and roles, expert ownership, and translation
+metadata. A normal training-step change preserves the signature. An in-place
+topology or registry change produces a new signature and forces receivers to
+refresh cached metadata.
+
+## Configure a vLLM Rollout Worker
+
+The worker image must include the matching ModelExpress client and vLLM weight
+transfer adapter. Set the ModelExpress server URL and enable the native refit
+path:
+
+```yaml
+env:
+  - name: MODEL_EXPRESS_URL
+    value: modelexpress-server.rl.svc.cluster.local:8001
+  - name: DYN_MX_REFIT_ENABLED
+    value: "1"
+  - name: DYN_MX_NATIVE_WEIGHT_TRANSFER
+    value: "1"
+  - name: MX_LOAD_MODE
+    value: direct
+```
+
+Enable the Dynamo system server and RL routes as described in
+[Reinforcement Learning Integration](README.md). When the integration is
+available, `GET /v1/rl/workers` advertises `update_weights_via_mx` in the
+worker's `routes` list. Treat this capability list as authoritative.
+
+Do not enable the native MX and NCCL weight-transfer backends simultaneously.
+Select one backend for a worker lifecycle.
+
+## Run a Failure-Safe Refit Cycle
+
+Call the selected worker directly through its `system_url`. Always resume the
+worker in a cleanup path and verify the update response before advancing the RL
+policy version.
+
+```bash
+set -euo pipefail
+
+worker_url=http://10.0.0.12:8081
+version=42
+
+resume() {
+  curl --fail-with-body "$worker_url/engine/resume_generation" \
+    -H 'Content-Type: application/json' \
+    -d '{}' >/dev/null
+}
+
+curl --fail-with-body "$worker_url/engine/pause_generation" \
+  -H 'Content-Type: application/json' \
+  -d '{"mode":"keep","clear_cache":false}' >/dev/null
+trap resume EXIT
+
+response=$(curl --fail-with-body \
+  "$worker_url/engine/update_weights_via_mx" \
+  -H 'Content-Type: application/json' \
+  -d "{\"version\":$version}")
+jq -e '.status == "ok" and .version == 42' <<<"$response" >/dev/null
+
+resume
+trap - EXIT
+```
+
+The worker must not commit the requested version when transfer or installation
+fails. The orchestrator should keep the previous policy version active and
+decide whether to retry, replace the worker, or abort the rollout.
+
+## Partial Refit
+
+The update route can scope a warm update to parameter names, transformer layers,
+or layer groups when supported by the runtime:
+
+```json
+{
+  "version": 43,
+  "mx_config": {
+    "subset_layers": [0, 1, 2, 3, 4, 5]
+  }
+}
+```
+
+The first cycle remains a full cold update so the receiver can build a complete
+destination map. Later cycles prune the selected names before NIXL transfer and
+install only those tensors. A fused group must include all of its members; for
+example, Q, K, and V or gate and up weights and their quantization scales.
+
+## Resharding and Descriptor Policy
+
+Trainer and rollout layouts do not need to match:
+
+- EP publishers identify the global experts owned by each source rank.
+- Replicated tensors are pulled from one source instead of every EP rank.
+- Contiguous TP ranges can be transferred directly.
+- A strided axis-1 TP range is not decomposed into one network operation per
+  row. The receiver pulls the containing contiguous source tensor and slices it
+  locally.
+
+This policy bounds descriptor count and prevents small-transfer overhead from
+dominating RDMA. The fallback requests only the tensor names that require
+scratch and preserves their multidimensional registry shapes for local slicing.
+
+## Installation
+
+The receiver can use the stock vLLM loader or an optional mapped direct-load
+path. Direct loading resolves destination parameters on the cold cycle and
+reuses those mappings for warm updates, including fused QKV, gated MLP, MoE
+expert, and FP8 scale destinations.
+
+Device staging can remove a GPU-to-CPU-to-GPU round trip for large EP gathers,
+but it increases HBM use. Keep host staging as the compatibility choice unless
+the rollout has enough memory headroom.
+
+## Discovery and Cache Safety
+
+The ModelExpress server filters lightweight source rows by model, rank, status,
+minimum training step, and freshness before returning heavy tensor metadata.
+Receivers cache stable layout metadata by model, worker ID, and layout
+signature. Either a publisher restart or a topology change invalidates the
+cache.
+
+Configure realistic heartbeat and garbage-collection timeouts. Leaving old
+benchmark sources permanently `READY` increases catalog scan cost and can route
+receivers to dead NIXL agents.
+
+## Observability
+
+With timing enabled, each TP worker emits one `MX_REFIT_TIMING` JSON record per
+version. The normalized stages are:
+
+- control discovery;
+- source preparation;
+- registration;
+- transfer planning;
+- wire transfer;
+- receive synchronization;
+- transformation;
+- installation;
+- post-install; and
+- rollout readiness.
+
+Aggregate TP runs by taking the slowest rank for each version, then compute
+statistics across measured warm cycles. Keep publisher preparation and cold
+registration separate from recurring refit latency.
+
+## Limitations
+
+- Route names and request fields are available only when the runtime includes
+  the ModelExpress refit integration.
+- Exact NCCL broadcast, unpack, and installation timing is not exposed by the
+  same interface and should not be inferred from MX stage boundaries.
+- Direct translation into persistent TP-local destinations is still an
+  optimization area for large EP gathers.
+- Same-domain NVLink/IMEX and cross-datacenter configurations require separate
+  validation.
+
+## See Also
+
+- [Reinforcement Learning Integration](README.md)
+- [Kubernetes ModelExpress](../../kubernetes/modelexpress.md)
+- [ModelExpress repository](https://github.com/ai-dynamo/modelexpress)
+- [NeMo-RL](https://github.com/NVIDIA-NeMo/RL)

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -321,8 +321,13 @@ navigation:
                 path: agents/agent-harnesses.md
               - page: ThunderAgent Program Scheduler
                 path: agents/thunderagent-router.md
-          - page: Reinforcement Learning
+          - section: Reinforcement Learning
             path: features/rl/README.md
+            contents:
+              - page: Integration Overview
+                path: features/rl/README.md
+              - page: ModelExpress Weight Refit
+                path: features/rl/model-express-weight-refit.md
           - page: LoRA Adapters
             path: features/lora/README.md
           - section: Multimodal

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -321,6 +321,8 @@ navigation:
                 path: agents/agent-harnesses.md
               - page: ThunderAgent Program Scheduler
                 path: agents/thunderagent-router.md
+          - page: Reinforcement Learning
+            path: features/rl/README.md
           - page: LoRA Adapters
             path: features/lora/README.md
           - section: Multimodal


### PR DESCRIPTION
## Overview

Extend the new reinforcement learning integration guide with an experimental ModelExpress mid-training weight refit guide.

## Details

- Describe trainer-native shard publication, source discovery, NIXL transfer, resharding, and live vLLM installation.
- Document capability-based `update_weights_via_mx` administration with a failure-safe pause/update/resume cycle.
- Cover partial refit, descriptor-explosion avoidance, topology-signature cache invalidation, staging trade-offs, and normalized timing.
- Separate RL refit from the existing Kubernetes ModelExpress cold-start distribution guide.
- Add the ModelExpress page beneath the Reinforcement Learning navigation section.

## Where should the reviewer start?

Start with `docs/features/rl/model-express-weight-refit.md`, then review the small integration links in `docs/features/rl/README.md` and `docs/index.yml`.

## Related implementation

- https://github.com/ai-dynamo/modelexpress/pull/482
- https://github.com/NVIDIA-NeMo/RL/pull/3068

## Validation

- [x] `python3 .github/workflows/detect_broken_links.py docs/features/rl --output /tmp/mx-rl-doc-links.json`
- [x] Validated all added JSON examples parse.
- [x] Validated all added Bash examples with `bash -n`.
- [x] `git diff --check`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11701" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->