### PR TITLE
feat(frontend): configure and validate session affinity headers

### DIFF
--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -16,6 +16,7 @@ import argparse
 import logging
 import math
 import os
+import re
 from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
@@ -35,7 +36,11 @@ _ROUTER_FIELDS: tuple[str, ...] = (
     "active_prefill_tokens_threshold",
     "active_prefill_tokens_threshold_frac",
     "session_affinity_ttl_secs",
+    "session_affinity_header_key",
 )
+
+_DEFAULT_SESSION_AFFINITY_HEADER_KEY = "x-dynamo-session-id"
+_HTTP_HEADER_NAME_RE = re.compile(r"^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$")
 
 _ENFORCE_DISAGG_DEPRECATION = (
     "--enforce-disagg and DYN_ENFORCE_DISAGG are deprecated and ignored; "
@@ -62,6 +67,15 @@ class _IgnoredAdmissionControlAction(argparse.Action):
         logger.warning(_ADMISSION_CONTROL_FLAG_REMOVAL_WARNING)
 
 
+def http_header_name(value: str) -> str:
+    """Validate an HTTP header field name accepted by the frontend."""
+    if not _HTTP_HEADER_NAME_RE.fullmatch(value):
+        raise argparse.ArgumentTypeError(
+            "--router-session-header-key must be a valid HTTP header name"
+        )
+    return value
+
+
 class RouterConfigBase(ConfigBase):
     """Mixin carrying the shared router configuration fields."""
 
@@ -69,6 +83,7 @@ class RouterConfigBase(ConfigBase):
     min_initial_workers: int
     enforce_disagg: bool
     session_affinity_ttl_secs: Optional[int]
+    session_affinity_header_key: str
     active_decode_blocks_threshold: Optional[float]
     active_prefill_tokens_threshold: Optional[int]
     active_prefill_tokens_threshold_frac: Optional[float]
@@ -201,6 +216,18 @@ class RouterArgGroup(ArgGroup):
             ),
             arg_type=int,
             dest="session_affinity_ttl_secs",
+        )
+        add_argument(
+            g,
+            flag_name="--router-session-header-key",
+            env_var="DYN_ROUTER_SESSION_HEADER_KEY",
+            default=_DEFAULT_SESSION_AFFINITY_HEADER_KEY,
+            help=(
+                "HTTP header used as the router-local session-affinity key. "
+                "Defaults to X-Dynamo-Session-ID."
+            ),
+            arg_type=http_header_name,
+            dest="session_affinity_header_key",
         )
         add_negatable_bool_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -378,6 +378,7 @@ def test_frontend_rejection_thresholds_default_to_none(
         "active_decode_blocks_threshold": None,
         "active_prefill_tokens_threshold": None,
         "active_prefill_tokens_threshold_frac": None,
+        "session_affinity_header_key": "x-dynamo-session-id",
         "session_affinity_ttl_secs": None,
     }
     assert "busy-worker rejection disabled" in caplog.text
@@ -506,6 +507,7 @@ def test_all_rejection_thresholds_and_queue_override_are_forwarded(
         "active_decode_blocks_threshold": 0.5,
         "active_prefill_tokens_threshold": 1000,
         "active_prefill_tokens_threshold_frac": 2.0,
+        "session_affinity_header_key": "x-dynamo-session-id",
         "session_affinity_ttl_secs": None,
     }
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
@@ -647,6 +649,7 @@ def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     config.validate()
     assert config.session_affinity_ttl_secs is None
     assert config.router_kwargs()["session_affinity_ttl_secs"] is None
+    assert config.router_kwargs()["session_affinity_header_key"] == "x-dynamo-session-id"
 
     monkeypatch.setenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", "600")
     parser = argparse.ArgumentParser()
@@ -663,6 +666,39 @@ def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     )
     config.validate()
     assert config.session_affinity_ttl_secs == 900
+
+
+def test_session_affinity_header_key_cli_and_environment(monkeypatch) -> None:
+    monkeypatch.delenv("DYN_ROUTER_SESSION_HEADER_KEY", raising=False)
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    config.validate()
+    assert config.session_affinity_header_key == "x-dynamo-session-id"
+
+    monkeypatch.setenv("DYN_ROUTER_SESSION_HEADER_KEY", "X-Customer-Session")
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(parser.parse_args([]))
+    config.validate()
+    assert config.session_affinity_header_key == "X-Customer-Session"
+    assert config.router_kwargs()["session_affinity_header_key"] == "X-Customer-Session"
+
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+    config = FrontendConfig.from_cli_args(
+        parser.parse_args(["--router-session-header-key", "x-request-session"])
+    )
+    config.validate()
+    assert config.session_affinity_header_key == "x-request-session"
+
+
+def test_session_affinity_header_key_rejects_invalid_http_header_name() -> None:
+    parser = argparse.ArgumentParser()
+    FrontendArgGroup().add_arguments(parser)
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["--router-session-header-key", "x customer session"])
 
 
 @pytest.mark.parametrize("ttl", [0, 31_536_001])

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -649,7 +649,9 @@ def test_session_affinity_ttl_cli_and_environment(monkeypatch) -> None:
     config.validate()
     assert config.session_affinity_ttl_secs is None
     assert config.router_kwargs()["session_affinity_ttl_secs"] is None
-    assert config.router_kwargs()["session_affinity_header_key"] == "x-dynamo-session-id"
+    assert (
+        config.router_kwargs()["session_affinity_header_key"] == "x-dynamo-session-id"
+    )
 
     monkeypatch.setenv("DYN_ROUTER_SESSION_AFFINITY_TTL_SECS", "600")
     parser = argparse.ArgumentParser()

--- a/docs/components/frontend/nvext.md
+++ b/docs/components/frontend/nvext.md
@@ -116,7 +116,8 @@ session headers described in [Session IDs](../../agents/session-ids.md);
 `nvext` does not accept session identity fields.
 
 When session affinity is enabled with `--router-session-affinity-ttl-secs`, the
-router also uses `X-Dynamo-Session-ID` for router-local affinity. See
+router uses the header configured by `--router-session-header-key` (default:
+`X-Dynamo-Session-ID`) for router-local affinity. See
 [Configuration and Tuning](../router/router-configuration.md#session-affinity)
 for routing behavior and TTL settings.
 

--- a/docs/components/router/router-configuration.md
+++ b/docs/components/router/router-configuration.md
@@ -108,9 +108,12 @@ For `--router-mode device-aware-weighted`, set `DYN_ENCODER_CUDA_TO_CPU_RATIO` t
 
 Session affinity is disabled by default. On the frontend, set
 `--router-session-affinity-ttl-secs` or `DYN_ROUTER_SESSION_AFFINITY_TTL_SECS` to
-a value from `1` through `31536000` to enable it, then send
-`X-Dynamo-Session-ID` to keep related requests on one worker. Supplying the header
-without the TTL option provides session identity but does not enable router affinity.
+a value from `1` through `31536000` to enable it. The affinity header defaults to
+`X-Dynamo-Session-ID`; set `--router-session-header-key` or
+`DYN_ROUTER_SESSION_HEADER_KEY` to use another HTTP header, then send that header on
+related requests to keep them on one worker. For example,
+`--router-session-header-key X-Customer-Session` selects `X-Customer-Session`.
+Supplying the selected header without the TTL option does not enable router affinity.
 
 The first successfully dispatched request binds the session ID to its selected
 worker and, when available, data-parallel rank. Later requests exact-dispatch to
@@ -128,10 +131,10 @@ If the bound worker disappears, Dynamo invalidates the binding so a subsequent
 selection can bind an available worker. Router restart clears all bindings. Bindings
 are not shared between frontend replicas. In a multi-frontend deployment, configure
 the ingress or load balancer to consistently route a session to one frontend. Hash
-the raw session header received at ingress, not Dynamo's normalized internal
-`session_id`: canonical clients send `X-Dynamo-Session-ID`, while agent-native
-clients use the corresponding header listed in [Session IDs](../../agents/session-ids.md).
-Agent-native identity is normalized only after the request reaches the frontend.
+the configured raw session header received at ingress, not Dynamo's normalized internal
+`session_id`. A custom affinity header affects routing only; it does not become
+agent-session metadata. The default `X-Dynamo-Session-ID` retains its existing agent-session
+normalization described in [Session IDs](../../agents/session-ids.md).
 
 Direct mode still requires the phase-appropriate explicit worker ID on every
 affinity request. The stored binding validates that target but does not supply a
@@ -141,7 +144,8 @@ created.
 
 Session affinity does not create a backend session or send lifecycle RPCs. There is
 no explicit unbind; idle expiry removes only router-local state. The same session
-ID is available to tracing and other explicitly configured consumers.
+header controls router-local affinity. When using a custom header, send the canonical
+session headers separately if tracing or agent features need session identity.
 
 ### AIC Prefill Load Model
 

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -439,6 +439,7 @@ pub struct RouterConfig {
 impl RouterConfig {
     #[new]
     #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None, session_affinity_header_key=None))]
+    #[allow(clippy::too_many_arguments)] // Python constructor parameters are part of the public API.
     pub fn new(
         mode: RouterMode,
         config: Option<KvRouterConfig>,

--- a/lib/bindings/python/rust/llm/entrypoint.rs
+++ b/lib/bindings/python/rust/llm/entrypoint.rs
@@ -432,12 +432,13 @@ pub struct RouterConfig {
     /// Threshold for active prefill tokens as fraction of max_num_batched_tokens
     active_prefill_tokens_threshold_frac: Option<f64>,
     session_affinity_ttl_secs: Option<u64>,
+    session_affinity_header_key: Option<String>,
 }
 
 #[pymethods]
 impl RouterConfig {
     #[new]
-    #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None))]
+    #[pyo3(signature = (mode, config=None, active_decode_blocks_threshold=None, active_prefill_tokens_threshold=None, active_prefill_tokens_threshold_frac=None, enforce_disagg=false, session_affinity_ttl_secs=None, session_affinity_header_key=None))]
     pub fn new(
         mode: RouterMode,
         config: Option<KvRouterConfig>,
@@ -446,6 +447,7 @@ impl RouterConfig {
         active_prefill_tokens_threshold_frac: Option<f64>,
         enforce_disagg: bool,
         session_affinity_ttl_secs: Option<u64>,
+        session_affinity_header_key: Option<String>,
     ) -> PyResult<Self> {
         if enforce_disagg {
             static WARN_ONCE: std::sync::Once = std::sync::Once::new();
@@ -474,6 +476,7 @@ impl RouterConfig {
             active_prefill_tokens_threshold,
             active_prefill_tokens_threshold_frac,
             session_affinity_ttl_secs,
+            session_affinity_header_key,
         })
     }
 }
@@ -490,6 +493,7 @@ impl From<RouterConfig> for RsRouterConfig {
             },
             enforce_disagg: false,
             session_affinity_ttl_secs: rc.session_affinity_ttl_secs,
+            session_affinity_header_key: rc.session_affinity_header_key,
         }
     }
 }

--- a/lib/llm/src/entrypoint.rs
+++ b/lib/llm/src/entrypoint.rs
@@ -52,6 +52,8 @@ pub struct RouterConfig {
     pub enforce_disagg: bool,
     #[serde(default)]
     pub session_affinity_ttl_secs: Option<u64>,
+    #[serde(default)]
+    pub session_affinity_header_key: Option<String>,
 }
 
 impl RouterConfig {
@@ -62,6 +64,7 @@ impl RouterConfig {
             load_threshold_config: LoadThresholdConfig::default(),
             enforce_disagg: false,
             session_affinity_ttl_secs: None,
+            session_affinity_header_key: None,
         }
     }
 

--- a/lib/llm/src/entrypoint/input/http.rs
+++ b/lib/llm/src/entrypoint/input/http.rs
@@ -57,7 +57,13 @@ pub async fn run(
         http_service_builder.with_request_template(engine_config.local_model().request_template());
     http_service_builder = http_service_builder
         .metrics_config(local_model.metrics_config().clone())
-        .frontend_api_config(local_model.frontend_api_config().clone());
+        .frontend_api_config(local_model.frontend_api_config().clone())
+        .session_affinity_header_key(
+            local_model
+                .router_config()
+                .session_affinity_header_key
+                .clone(),
+        );
     // Inject the DRT's metrics registry so that component-scoped metrics
     // (e.g. KvIndexerMetrics) are exposed (default port 8000 if not overridden).
     http_service_builder =

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -132,6 +132,17 @@ async fn anthropic_error_middleware(request: Request<Body>, next: Next) -> Respo
 // Handlers
 // ---------------------------------------------------------------------------
 
+/// Attach router-local session affinity using the header configured for this service.
+fn attach_session_affinity_from_headers<T: Send + Sync + 'static>(
+    request: &mut Context<T>,
+    headers: &HeaderMap,
+    header_name: &axum::http::HeaderName,
+) {
+    if let Some(session_affinity) = session_affinity_from_headers(headers, header_name) {
+        request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_affinity);
+    }
+}
+
 /// Top-level HTTP handler for POST /v1/messages.
 async fn handler_anthropic_messages(
     State((state, template)): State<(Arc<service_v2::State>, Option<RequestTemplate>)>,
@@ -181,11 +192,11 @@ async fn handler_anthropic_messages(
     if let Some(agent_context) = agent_context_from_headers(&headers) {
         request.insert(AGENT_CONTEXT_CONTEXT_KEY, agent_context);
     }
-    if let Some(session_affinity) =
-        session_affinity_from_headers(&headers, state.session_affinity_header_name())
-    {
-        request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_affinity);
-    }
+    attach_session_affinity_from_headers(
+        &mut request,
+        &headers,
+        state.session_affinity_header_name(),
+    );
     let context = request.context();
 
     // Create connection handles
@@ -891,7 +902,7 @@ fn anthropic_error(status: StatusCode, error_type: &str, message: &str) -> Respo
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::protocols::common::extensions::parse_nvext;
+    use crate::protocols::common::extensions::{SessionAffinityId, parse_nvext};
 
     fn request_with_nvext() -> AnthropicCreateMessageRequest {
         serde_json::from_value(serde_json::json!({
@@ -937,6 +948,25 @@ mod tests {
         .unwrap_err();
 
         assert!(err.to_string().contains("unknown field `agent_context`"));
+    }
+
+    #[test]
+    fn anthropic_context_uses_configured_session_affinity_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-customer-session", "session-456".parse().unwrap());
+        headers.insert("x-dynamo-session-id", "ignored".parse().unwrap());
+        let mut request = Context::new(());
+
+        attach_session_affinity_from_headers(
+            &mut request,
+            &headers,
+            &axum::http::HeaderName::from_static("x-customer-session"),
+        );
+
+        let affinity = request
+            .get::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
+            .expect("session affinity attached");
+        assert_eq!(affinity.as_str(), "session-456");
     }
 
     #[test]

--- a/lib/llm/src/http/service/anthropic.rs
+++ b/lib/llm/src/http/service/anthropic.rs
@@ -181,7 +181,9 @@ async fn handler_anthropic_messages(
     if let Some(agent_context) = agent_context_from_headers(&headers) {
         request.insert(AGENT_CONTEXT_CONTEXT_KEY, agent_context);
     }
-    if let Some(session_affinity) = session_affinity_from_headers(&headers) {
+    if let Some(session_affinity) =
+        session_affinity_from_headers(&headers, state.session_affinity_header_name())
+    {
         request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_affinity);
     }
     let context = request.context();

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -341,11 +341,15 @@ async fn handler_generate(
     };
 
     let request_id = request_context.request_id;
-    let context: Context<PreprocessedRequest> =
-        match context_from_headers(preprocessed, request_id.clone(), &headers) {
-            Ok(context) => context,
-            Err(response) => return response.into_response(),
-        };
+    let context: Context<PreprocessedRequest> = match context_from_headers(
+        preprocessed,
+        request_id.clone(),
+        &headers,
+        state.session_affinity_header_name(),
+    ) {
+        Ok(context) => context,
+        Err(response) => return response.into_response(),
+    };
     let engine_context = context.context();
     let cancellation_labels = CancellationLabels {
         model: state.manager().metric_model_for(&model).to_string(),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -13,7 +13,7 @@ use axum::{
     body::Body,
     extract::State,
     http::Request,
-    http::{HeaderMap, StatusCode},
+    http::{HeaderMap, StatusCode, header::HeaderName},
     middleware::{self, Next},
     response::{
         IntoResponse, Response,
@@ -543,6 +543,7 @@ pub(super) fn context_from_headers<T: Send + Sync + 'static>(
     request: T,
     request_id: String,
     headers: &HeaderMap,
+    session_affinity_header_name: &HeaderName,
 ) -> Result<Context<T>, ErrorResponse> {
     let metadata = extract_metadata_from_http(headers)
         .map_err(|err| ErrorMessage::request_headers_too_large(&err.to_string()))?;
@@ -551,7 +552,9 @@ pub(super) fn context_from_headers<T: Send + Sync + 'static>(
     if let Some(agent_context) = agent_context_from_headers(headers) {
         request.insert(AGENT_CONTEXT_CONTEXT_KEY, agent_context);
     }
-    if let Some(session_affinity) = session_affinity_from_headers(headers) {
+    if let Some(session_affinity) =
+        session_affinity_from_headers(headers, session_affinity_header_name)
+    {
         request.insert(SESSION_AFFINITY_CONTEXT_KEY, session_affinity);
     }
     Ok(request)
@@ -655,7 +658,12 @@ async fn handler_completions(
         endpoint: Endpoint::Completions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
-    let request = context_from_headers(request, request_id, &headers)?;
+    let request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     let context = request.context();
 
     // create the connection handles
@@ -1095,7 +1103,12 @@ async fn embeddings(
         request.inner.model = canonical;
     }
     let request_id = get_or_create_request_id(&headers);
-    let request = context_from_headers(request, request_id, &headers)?;
+    let request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     let request_id = request.id().to_string();
 
     // The worker always emits base64-encoded vectors over NATS so we
@@ -1283,7 +1296,12 @@ async fn handler_chat_completions(
         endpoint: Endpoint::ChatCompletions.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
-    let mut request = context_from_headers(request, request_id, &headers)?;
+    let mut request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     if let Some(captured) = crate::request_trace::payload::capture_http_headers(&headers) {
         request.insert(
             crate::request_trace::payload::HTTP_HEADERS_CONTEXT_KEY,
@@ -2238,7 +2256,12 @@ async fn handler_responses(
         endpoint: Endpoint::Responses.to_string(),
         request_type: if streaming { "stream" } else { "unary" }.to_string(),
     };
-    let mut request = context_from_headers(request, request_id, &headers)?;
+    let mut request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     if let Some(captured) = crate::request_trace::payload::capture_http_headers(&headers) {
         request.insert(
             crate::request_trace::payload::HTTP_HEADERS_CONTEXT_KEY,
@@ -2971,7 +2994,12 @@ async fn images(
     check_ready(&state)?;
 
     let request_id = get_or_create_request_id(&headers);
-    let request = context_from_headers(request, request_id, &headers)?;
+    let request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     let request_id = request.id().to_string();
 
     // Images are typically not streamed, so we default to non-streaming
@@ -3109,7 +3137,12 @@ async fn videos(
     check_model_serving_ready(&state, &request.model)?;
 
     let request_id = get_or_create_request_id(&headers);
-    let request = context_from_headers(request, request_id, &headers)?;
+    let request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     let request_id = request.id().to_string();
 
     let streaming = request.stream.unwrap_or(false);
@@ -3230,7 +3263,12 @@ async fn video_stream(
     check_model_serving_ready(&state, &request.model)?;
 
     let request_id = get_or_create_request_id(&headers);
-    let request = context_from_headers(request, request_id, &headers)?;
+    let request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     let model = request.model.clone();
     let metric_model = state.manager().metric_model_for(&model).to_string();
 
@@ -3399,7 +3437,12 @@ async fn audio_speech(
     check_ready(&state)?;
 
     let request_id = get_or_create_request_id(&headers);
-    let request = context_from_headers(request, request_id, &headers)?;
+    let request = context_from_headers(
+        request,
+        request_id,
+        &headers,
+        state.session_affinity_header_name(),
+    )?;
     let request_id = request.id().to_string();
 
     let streaming = false;
@@ -3728,7 +3771,13 @@ mod tests {
     fn test_context_metadata_preserves_session_affinity() {
         let mut headers = HeaderMap::new();
         headers.insert("x-dynamo-session-id", "session-123".parse().unwrap());
-        let source = context_from_headers((), "request-1".to_string(), &headers).unwrap();
+        let source = context_from_headers(
+            (),
+            "request-1".to_string(),
+            &headers,
+            &HeaderName::from_static("x-dynamo-session-id"),
+        )
+        .unwrap();
         let affinity = source
             .get::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
             .expect("session affinity attached");
@@ -3740,6 +3789,26 @@ mod tests {
             .get::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
             .expect("session affinity copied");
         assert_eq!(affinity.as_str(), "session-123");
+    }
+
+    #[test]
+    fn test_context_metadata_uses_configured_session_affinity_header() {
+        let mut headers = HeaderMap::new();
+        headers.insert("x-customer-session", "session-456".parse().unwrap());
+        headers.insert("x-dynamo-session-id", "ignored".parse().unwrap());
+
+        let source = context_from_headers(
+            (),
+            "request-1".to_string(),
+            &headers,
+            &HeaderName::from_static("x-customer-session"),
+        )
+        .unwrap();
+        let affinity = source
+            .get::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
+            .expect("session affinity attached");
+
+        assert_eq!(affinity.as_str(), "session-456");
     }
 
     #[test]

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -3792,6 +3792,28 @@ mod tests {
     }
 
     #[test]
+    fn test_x_session_id_populates_agent_context_and_affinity() {
+        let literal = "conversation-17:request-42";
+        let mut headers = HeaderMap::new();
+        headers.insert("x-session-id", literal.parse().unwrap());
+        let source = context_from_headers(
+            (),
+            "request-1".to_string(),
+            &headers,
+            &HeaderName::from_static("x-session-id"),
+        )
+        .unwrap();
+        let agent = source
+            .get::<AgentContext>(AGENT_CONTEXT_CONTEXT_KEY)
+            .expect("agent context attached");
+        let affinity = source
+            .get::<SessionAffinityId>(SESSION_AFFINITY_CONTEXT_KEY)
+            .expect("session affinity attached");
+        assert_eq!(agent.session_id, literal);
+        assert_eq!(affinity.as_str(), literal);
+    }
+
+    #[test]
     fn test_context_metadata_uses_configured_session_affinity_header() {
         let mut headers = HeaderMap::new();
         headers.insert("x-customer-session", "session-456".parse().unwrap());

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -12,7 +12,7 @@ use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use axum::body::Body;
-use axum::http::Response;
+use axum::http::{Response, header::HeaderName};
 use axum::response::IntoResponse;
 
 use super::Metrics;
@@ -46,6 +46,7 @@ use tokio_util::sync::CancellationToken;
 use tower_http::trace::TraceLayer;
 
 use crate::frontend_config::{FrontendApiConfig, MetricsConfig};
+use crate::protocols::agents::HEADER_DYNAMO_SESSION_ID;
 
 /// Middleware that echoes `x-request-id` from request to response headers.
 async fn echo_request_id_header(
@@ -102,6 +103,7 @@ pub struct State {
     // Frontend API behavior read by request handlers after the service is built.
     frontend_api_config: FrontendApiConfig,
     nvext_enabled: bool,
+    session_affinity_header_name: HeaderName,
 }
 
 /// Typed config needed only to construct HTTP shared state.
@@ -112,6 +114,7 @@ struct StateConfig {
     metrics_config: MetricsConfig,
     frontend_api_config: FrontendApiConfig,
     nvext_enabled: bool,
+    session_affinity_header_name: HeaderName,
 }
 
 /// Lifecycle stage for the HTTP frontend.
@@ -372,6 +375,7 @@ impl State {
             },
             cancel_token,
             frontend_api_config: config.frontend_api_config,
+            session_affinity_header_name: config.session_affinity_header_name,
         }
     }
 
@@ -436,6 +440,12 @@ impl State {
     #[inline]
     pub fn nvext_enabled(&self) -> bool {
         self.nvext_enabled
+    }
+
+    /// Header used to derive the router-local session-affinity key.
+    #[inline]
+    pub fn session_affinity_header_name(&self) -> &HeaderName {
+        &self.session_affinity_header_name
     }
 
     /// Get the cancellation token
@@ -548,6 +558,10 @@ pub struct HttpServiceConfig {
     #[builder(default)]
     frontend_api_config: FrontendApiConfig,
 
+    /// HTTP header used for router-local session affinity.
+    #[builder(default = "None")]
+    session_affinity_header_key: Option<String>,
+
     #[builder(default = "None")]
     request_template: Option<RequestTemplate>,
 
@@ -596,6 +610,12 @@ fn default_rl_port() -> u16 {
         .ok()
         .and_then(|s| s.parse().ok())
         .unwrap_or(8001)
+}
+
+fn parse_session_affinity_header_name(header_key: Option<&str>) -> Result<HeaderName> {
+    let header_key = header_key.unwrap_or(HEADER_DYNAMO_SESSION_ID);
+    HeaderName::from_bytes(header_key.as_bytes())
+        .map_err(|_| anyhow::anyhow!("invalid session affinity header name: {header_key:?}"))
 }
 
 impl HttpService {
@@ -896,6 +916,8 @@ impl HttpServiceConfigBuilder {
         let anthropic_endpoints_enabled = frontend_api_config.anthropic().enabled();
         let generate_endpoint_enabled =
             config.enable_engine_apis || env_is_truthy(VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV);
+        let session_affinity_header_name =
+            parse_session_affinity_header_name(config.session_affinity_header_key.as_deref())?;
 
         let model_manager = Arc::new(ModelManager::new());
         let cancel_token = config.cancel_token.unwrap_or_default();
@@ -923,6 +945,7 @@ impl HttpServiceConfigBuilder {
                 metrics_config,
                 frontend_api_config,
                 nvext_enabled,
+                session_affinity_header_name,
             },
         ));
         state
@@ -1246,6 +1269,28 @@ mod tests {
     use super::*;
     use std::sync::Arc;
     use tokio_util::sync::CancellationToken;
+
+    #[test]
+    fn session_affinity_header_name_defaults_and_validates() {
+        assert_eq!(
+            parse_session_affinity_header_name(None).unwrap(),
+            HeaderName::from_static(HEADER_DYNAMO_SESSION_ID)
+        );
+        assert_eq!(
+            parse_session_affinity_header_name(Some("X-Customer-Session")).unwrap(),
+            HeaderName::from_static("x-customer-session")
+        );
+        assert!(parse_session_affinity_header_name(Some("x customer session")).is_err());
+
+        let service = HttpService::builder()
+            .session_affinity_header_key(Some("X-Customer-Session".to_string()))
+            .build()
+            .unwrap();
+        assert_eq!(
+            service.state().session_affinity_header_name(),
+            &HeaderName::from_static("x-customer-session")
+        );
+    }
 
     async fn wait_for_service_stage(state: &State, expected: ServiceStage) {
         let deadline = tokio::time::Instant::now() + Duration::from_secs(1);

--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -173,6 +173,7 @@ impl KvPushRouter {
             Ok(selection) => Ok((selection, Some(operation))),
             Err(error) if is_cancelled(&error) => Err(error),
             Err(_) if operation.target().is_some() && explicit.is_none() => {
+                operation.trace_bound_target_fallback_rebind();
                 operation.invalidate();
                 let retry = affinity
                     .acquire_with_context(&session_id, None, request_context.as_ref())
@@ -457,7 +458,10 @@ impl KvPushRouter {
         let Some(operation) = operation else {
             return Ok((metadata, stream));
         };
-        Ok((metadata, operation.into_stream(selected_target, stream)?))
+        Ok((
+            metadata,
+            operation.into_stream(selected_target, phase, stream)?,
+        ))
     }
 }
 
@@ -567,7 +571,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             }
         };
         match operation {
-            Some(operation) => operation.into_stream(selected_target, stream),
+            Some(operation) => operation.into_stream(selected_target, phase, stream),
             None => Ok(stream),
         }
     }

--- a/lib/llm/src/protocols/agents.rs
+++ b/lib/llm/src/protocols/agents.rs
@@ -3,7 +3,7 @@
 
 //! Coding-agent request metadata recognized at Dynamo's HTTP boundary.
 
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, header::HeaderName};
 
 pub(crate) const HEADER_CLAUDE_CODE_SESSION_ID: &str = "x-claude-code-session-id";
 pub(crate) const HEADER_CLAUDE_CODE_AGENT_ID: &str = "x-claude-code-agent-id";
@@ -95,8 +95,12 @@ pub(crate) fn agent_context_header_values(headers: &HeaderMap) -> Option<AgentCo
     None
 }
 
-pub(crate) fn session_affinity_header_value(headers: &HeaderMap) -> Option<String> {
-    header_value(headers, HEADER_DYNAMO_SESSION_ID)
+pub(crate) fn session_affinity_header_value(
+    headers: &HeaderMap,
+    header_name: &HeaderName,
+) -> Option<String> {
+    let value = headers.get(header_name)?.to_str().ok()?.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 fn header_bool(headers: &HeaderMap, header_name: &str) -> Option<bool> {

--- a/lib/llm/src/protocols/common/extensions.rs
+++ b/lib/llm/src/protocols/common/extensions.rs
@@ -3,7 +3,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use axum::http::HeaderMap;
+use axum::http::{HeaderMap, header::HeaderName};
 use derive_builder::Builder;
 use dynamo_protocols::types::StopReason;
 use serde::{Deserialize, Serialize};
@@ -287,8 +287,11 @@ pub fn agent_context_from_headers(headers: &HeaderMap) -> Option<AgentContext> {
     agent_context_header_values(headers).map(AgentContext::from)
 }
 
-pub fn session_affinity_from_headers(headers: &HeaderMap) -> Option<SessionAffinityId> {
-    session_affinity_header_value(headers).map(SessionAffinityId::new)
+pub fn session_affinity_from_headers(
+    headers: &HeaderMap,
+    header_name: &HeaderName,
+) -> Option<SessionAffinityId> {
+    session_affinity_header_value(headers, header_name).map(SessionAffinityId::new)
 }
 
 /// Apply HTTP routing header overrides to nvext.
@@ -971,8 +974,9 @@ mod tests {
     }
 
     #[test]
-    fn session_affinity_requires_explicit_dynamo_header() {
+    fn session_affinity_uses_configured_header() {
         let mut headers = HeaderMap::new();
+        let header_name = HeaderName::from_static(HEADER_DYNAMO_SESSION_ID);
         headers.insert(
             HEADER_CLAUDE_CODE_SESSION_ID,
             "claude-session".parse().unwrap(),
@@ -982,21 +986,24 @@ mod tests {
             HEADER_OPENCODE_SESSION_ID,
             "opencode-session".parse().unwrap(),
         );
-        assert!(session_affinity_from_headers(&headers).is_none());
+        assert!(session_affinity_from_headers(&headers, &header_name).is_none());
 
         headers.insert(HEADER_DYNAMO_SESSION_ID, "canonical".parse().unwrap());
         assert_eq!(
-            session_affinity_from_headers(&headers).unwrap().as_str(),
+            session_affinity_from_headers(&headers, &header_name)
+                .unwrap()
+                .as_str(),
             "canonical"
         );
 
         headers.insert(HEADER_DYNAMO_SESSION_ID, "   ".parse().unwrap());
-        assert!(session_affinity_from_headers(&headers).is_none());
+        assert!(session_affinity_from_headers(&headers, &header_name).is_none());
     }
 
     #[test]
     fn native_agent_session_does_not_enable_affinity() {
         let mut headers = HeaderMap::new();
+        let header_name = HeaderName::from_static(HEADER_DYNAMO_SESSION_ID);
         headers.insert(
             HEADER_CLAUDE_CODE_SESSION_ID,
             "claude-session".parse().unwrap(),
@@ -1005,7 +1012,7 @@ mod tests {
 
         let agent_context = agent_context_from_headers(&headers).unwrap();
         assert_eq!(agent_context.session_id, "claude-agent");
-        assert!(session_affinity_from_headers(&headers).is_none());
+        assert!(session_affinity_from_headers(&headers, &header_name).is_none());
 
         headers.insert(
             HEADER_DYNAMO_SESSION_ID,
@@ -1014,7 +1021,9 @@ mod tests {
         let agent_context = agent_context_from_headers(&headers).unwrap();
         assert_eq!(agent_context.session_id, "affinity-session");
         assert_eq!(
-            session_affinity_from_headers(&headers).unwrap().as_str(),
+            session_affinity_from_headers(&headers, &header_name)
+                .unwrap()
+                .as_str(),
             "affinity-session"
         );
     }

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -23,7 +23,7 @@ use tokio_util::sync::CancellationToken;
 
 use super::{
     LlmResponse, MAX_SESSION_AFFINITY_ENTRIES, MAX_SESSION_AFFINITY_ID_BYTES,
-    MAX_SESSION_AFFINITY_TTL_SECS,
+    MAX_SESSION_AFFINITY_TTL_SECS, trace,
 };
 use crate::{
     preprocessor::PreprocessedRequest,
@@ -184,11 +184,15 @@ impl AffinityCoordinator {
             match self.inner.entries.entry(session_id.clone()) {
                 Entry::Vacant(entry) => {
                     self.reserve_entry()?;
-                    return Ok(AffinityAcquire::Initialize(entry.insert_initializing(
-                        &self.inner,
-                        session_id,
+                    let initialization =
+                        entry.insert_initializing(&self.inner, session_id, requested_target);
+                    trace::initialize(
+                        &initialization.session_id,
+                        initialization.revision,
                         requested_target,
-                    )));
+                        "new_session",
+                    );
+                    return Ok(AffinityAcquire::Initialize(initialization));
                 }
                 Entry::Occupied(mut entry) => match entry.get_mut() {
                     AffinityEntry::Initializing { notify, .. } => {
@@ -226,14 +230,21 @@ impl AffinityCoordinator {
                             notify: notify.clone(),
                         };
                         drop(entry);
-                        return Ok(AffinityAcquire::Initialize(AffinityInitialization {
+                        let initialization = AffinityInitialization {
                             coordinator: Arc::downgrade(&self.inner),
                             session_id,
                             revision,
                             notify,
                             requested_target,
                             active: true,
-                        }));
+                        };
+                        trace::initialize(
+                            &initialization.session_id,
+                            initialization.revision,
+                            requested_target,
+                            "idle_ttl_expired",
+                        );
+                        return Ok(AffinityAcquire::Initialize(initialization));
                     }
                     AffinityEntry::Bound {
                         target,
@@ -243,6 +254,7 @@ impl AffinityCoordinator {
                     } => {
                         validate_bound_target(&session_id, *target, requested_target)?;
                         *active_leases += 1;
+                        trace::bound_reuse(&session_id, *revision, *target, *active_leases);
                         let lease = AffinityLease {
                             coordinator: Arc::downgrade(&self.inner),
                             session_id,
@@ -399,11 +411,16 @@ impl AffinityAcquire {
     pub(crate) fn into_stream(
         self,
         selected_target: AffinityTarget,
+        phase: RequestPhase,
         stream: ManyOut<LlmResponse>,
     ) -> Result<ManyOut<LlmResponse>, Error> {
         match self {
             Self::Initialize(initialization) => {
-                Ok(initialization.commit(selected_target)?.into_stream(stream))
+                let session_id = initialization.session_id.clone();
+                let revision = initialization.revision;
+                let lease = initialization.commit(selected_target)?;
+                trace::bound_dispatch(&session_id, revision, selected_target, phase, "initialize");
+                Ok(lease.into_stream(stream))
             }
             Self::Bound { target, mut lease } => {
                 if let Err(error) = validate_bound_target("session", target, Some(selected_target))
@@ -411,8 +428,21 @@ impl AffinityAcquire {
                     lease.invalidate();
                     return Err(error);
                 }
+                trace::bound_dispatch(
+                    &lease.session_id,
+                    lease.revision,
+                    selected_target,
+                    phase,
+                    "bound",
+                );
                 Ok(lease.into_stream(stream))
             }
+        }
+    }
+
+    pub(crate) fn trace_bound_target_fallback_rebind(&self) {
+        if let Self::Bound { target, lease } = self {
+            trace::bound_target_fallback_rebind(&lease.session_id, lease.revision, *target);
         }
     }
 
@@ -456,6 +486,7 @@ impl AffinityInitialization {
             idle_deadline: Instant::now() + inner.ttl,
         };
         drop(entry);
+        trace::commit(&self.session_id, self.revision, target);
         self.active = false;
         self.notify.notify_waiters();
         Ok(AffinityLease {

--- a/lib/llm/src/session_affinity/mod.rs
+++ b/lib/llm/src/session_affinity/mod.rs
@@ -3,6 +3,7 @@
 
 mod coordinator;
 mod push_router;
+mod trace;
 
 pub(crate) use coordinator::{AffinityAcquire, affinity_id};
 pub use coordinator::{AffinityCoordinator, AffinityTarget, explicit_target};

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -118,6 +118,7 @@ impl SessionAffinityPushRouter {
             return Ok(operation);
         }
 
+        operation.trace_bound_target_fallback_rebind();
         operation.invalidate();
         affinity
             .acquire_with_context(session_id, explicit, request_context)
@@ -229,7 +230,7 @@ impl SessionAffinityPushRouter {
                 return Err(error);
             }
         };
-        let stream = operation.into_stream(target, stream)?;
+        let stream = operation.into_stream(target, RequestPhase::Prefill, stream)?;
         Self::record_target(tracker.as_deref(), target);
         Ok((metadata, stream))
     }
@@ -349,7 +350,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                 return Err(error);
             }
         };
-        let stream = operation.into_stream(target, stream)?;
+        let stream = operation.into_stream(target, phase, stream)?;
         Self::record_target(tracker.as_deref(), target);
         Ok(stream)
     }

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -330,7 +330,11 @@ async fn session_affinity_committed_binding_survives_cancelled_stream_until_ttl(
     let coordinator = coordinator();
     let operation = coordinator.acquire(&session_id(), None).await.unwrap();
     let mut stream = operation
-        .into_stream(target(7, Some(0)), cancelled_response_stream())
+        .into_stream(
+            target(7, Some(0)),
+            RequestPhase::Aggregated,
+            cancelled_response_stream(),
+        )
         .unwrap();
     tokio::time::advance(Duration::from_secs(9)).await;
     assert!(stream.next().await.is_none());

--- a/lib/llm/src/session_affinity/trace.rs
+++ b/lib/llm/src/session_affinity/trace.rs
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
+
+use super::AffinityTarget;
+use crate::protocols::common::timing::RequestPhase;
+
+const TRACE_ENV: &str = "DYN_ROUTER_SESSION_AFFINITY_TRACE";
+const TRACE_PREFIX_ENV: &str = "DYN_ROUTER_SESSION_AFFINITY_TRACE_PREFIX";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TraceConfig {
+    enabled: bool,
+    session_prefix: Option<String>,
+}
+
+impl TraceConfig {
+    fn from_values(enabled: Option<&str>, session_prefix: Option<&str>) -> Self {
+        Self {
+            enabled: parse_enabled(enabled),
+            session_prefix: session_prefix
+                .map(str::trim)
+                .filter(|prefix| !prefix.is_empty())
+                .map(str::to_string),
+        }
+    }
+
+    fn matches(&self, session_id: &str) -> bool {
+        self.enabled
+            && self
+                .session_prefix
+                .as_deref()
+                .is_none_or(|prefix| session_id.starts_with(prefix))
+    }
+}
+
+static TRACE_CONFIG: OnceLock<TraceConfig> = OnceLock::new();
+static INITIALIZE_COUNT: AtomicU64 = AtomicU64::new(0);
+static COMMIT_COUNT: AtomicU64 = AtomicU64::new(0);
+static BOUND_REUSE_COUNT: AtomicU64 = AtomicU64::new(0);
+static BOUND_DISPATCH_COUNT: AtomicU64 = AtomicU64::new(0);
+static FALLBACK_REBIND_COUNT: AtomicU64 = AtomicU64::new(0);
+
+fn parse_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "on" | "yes"
+        )
+    })
+}
+
+fn config() -> &'static TraceConfig {
+    TRACE_CONFIG.get_or_init(|| {
+        let enabled = std::env::var(TRACE_ENV).ok();
+        let prefix = std::env::var(TRACE_PREFIX_ENV).ok();
+        TraceConfig::from_values(enabled.as_deref(), prefix.as_deref())
+    })
+}
+
+fn next(counter: &AtomicU64) -> u64 {
+    counter.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+fn fallback_rebind_count() -> u64 {
+    FALLBACK_REBIND_COUNT.load(Ordering::Relaxed)
+}
+
+pub(super) fn initialize(
+    session_id: &str,
+    revision: u64,
+    requested_target: Option<AffinityTarget>,
+    reason: &str,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let requested_worker_bound = requested_target.is_some();
+    let requested_worker_id = requested_target.map(|target| target.worker_id).unwrap_or(0);
+    let requested_dp_rank = requested_target
+        .and_then(|target| target.dp_rank)
+        .map(i64::from)
+        .unwrap_or(-1);
+    let requested_dp_rank_bound = requested_dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let initialize_count = next(&INITIALIZE_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "initialize",
+        session_id,
+        revision,
+        reason,
+        trace_prefix,
+        requested_worker_bound,
+        requested_worker_id,
+        requested_dp_rank_bound,
+        requested_dp_rank,
+        initialize_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn commit(session_id: &str, revision: u64, target: AffinityTarget) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let commit_count = next(&COMMIT_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "commit",
+        session_id,
+        revision,
+        trace_prefix,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        commit_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn bound_reuse(
+    session_id: &str,
+    revision: u64,
+    target: AffinityTarget,
+    active_leases: usize,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let bound_reuse_count = next(&BOUND_REUSE_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "bound_reuse",
+        session_id,
+        revision,
+        trace_prefix,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        active_leases,
+        bound_reuse_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn bound_dispatch(
+    session_id: &str,
+    revision: u64,
+    target: AffinityTarget,
+    phase: RequestPhase,
+    acquisition_kind: &str,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let role = match phase {
+        RequestPhase::Prefill => "context",
+        RequestPhase::Decode => "generation",
+        RequestPhase::Aggregated => "aggregated",
+    };
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let bound_dispatch_count = next(&BOUND_DISPATCH_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "bound_dispatch",
+        session_id,
+        revision,
+        trace_prefix,
+        acquisition_kind,
+        phase = %phase,
+        role,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        bound_dispatch_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn bound_target_fallback_rebind(
+    session_id: &str,
+    revision: u64,
+    target: AffinityTarget,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let fallback_rebind_count = next(&FALLBACK_REBIND_COUNT);
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "bound_target_fallback_rebind",
+        session_id,
+        revision,
+        trace_prefix,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TraceConfig, parse_enabled};
+
+    #[test]
+    fn session_affinity_trace_gate_is_opt_in_and_prefix_filtered() {
+        for value in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("off"),
+            Some("no"),
+            Some("invalid"),
+        ] {
+            assert!(!parse_enabled(value), "unexpected enabled value: {value:?}");
+        }
+        for value in ["1", "true", "TRUE", " on ", "yes"] {
+            assert!(parse_enabled(Some(value)), "disabled truthy value: {value}");
+        }
+
+        assert!(TraceConfig::from_values(Some("true"), None).matches("any-session"));
+        assert!(TraceConfig::from_values(Some("true"), Some("  ")).matches("any-session"));
+
+        let filtered = TraceConfig::from_values(Some("true"), Some(" dyn-affinity-trace- "));
+        assert!(filtered.matches("dyn-affinity-trace-0001"));
+        assert!(!filtered.matches("benchmark-session-0001"));
+
+        let disabled = TraceConfig::from_values(Some("false"), Some("dyn-affinity-trace-"));
+        assert!(!disabled.matches("dyn-affinity-trace-0001"));
+    }
+}


### PR DESCRIPTION
## Overview:

Make the router-local session-affinity HTTP header configurable instead of requiring `X-Dynamo-Session-ID`, and add endpoint/context regressions for custom headers such as `X-Session-ID`.

This draft intentionally carries the two commits from #11682 so the complete change can be reviewed and validated together. Those commits retain Biswa Panda's authorship, DCO sign-off, and cherry-pick provenance:

- `dac6ae1b1c` from `e5e2af8a44`
- `1cdf43df5b` from `dd2b64eb33`

The two additional signed commits add Anthropic custom-header coverage and verify that a single `X-Session-ID` value populates both `AgentContext` and `SessionAffinityId`.

## Details:

- Add `--router-session-header-key` / `DYN_ROUTER_SESSION_HEADER_KEY`, defaulting to `X-Dynamo-Session-ID`.
- Validate configured header names and propagate the selected key through the Python binding and frontend HTTP state.
- Use the configured header for OpenAI, Anthropic, and Generate request paths while retaining the existing opt-in affinity TTL behavior.
- Document the default and custom-header configuration.
- Cover a custom Anthropic affinity header at the handler boundary.
- Cover `X-Session-ID=conversation-17:request-42` in the production header-context helper and assert that both routing context extensions receive the exact value.

Validation on current `main` (`b0b778678f`):

- `cargo test -p dynamo-llm session_affinity --no-fail-fast` — 34 passed, 0 failed.
- Focused `X-Session-ID` dual-context regression — 1 passed, 0 failed.
- Focused Python router session-affinity configuration tests — 5 passed, 42 deselected.
- `cargo check --manifest-path lib/bindings/python/Cargo.toml` — passed.
- `cargo fmt --all -- --check` — passed.
- `git diff --check origin/main...HEAD` — passed.
- `pre-commit run --all-files` — all hooks passed.

## Where should the reviewer start?

- `components/src/dynamo/common/configuration/groups/router_args.py` for the CLI/env contract.
- `lib/llm/src/http/service/service_v2.rs` for header validation and HTTP-state propagation.
- `lib/llm/src/protocols/common/extensions.rs` for shared header extraction and the dual-context regression.
- `lib/llm/src/http/service/anthropic.rs` for endpoint-specific propagation and coverage.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Related pull request: #11682.
