### PR TITLE
feat(frontend): honor continuous_usage_stats in vLLM chat processor

### DIFF
--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -549,6 +549,124 @@ class TestRoutedEnginePath:
         }
 
     @pytest.mark.asyncio
+    async def test_continuous_usage_stats_off_omits_intermediate_usage(
+        self, vllm_processor_module
+    ):
+        # Without stream_options.continuous_usage_stats, intermediate chunks
+        # carry no usage (only a final engine-provided completion_usage would).
+        routed_engine = _FakeRoutedEngine(
+            [{"token_ids": [101], "index": 0, "finish_reason": None}]
+        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
+
+        chunks = await _run_generate(processor, _base_preproc())
+
+        assert "usage" not in chunks[0]["data"]
+
+    @pytest.mark.asyncio
+    async def test_continuous_usage_stats_on_emits_per_chunk_usage(
+        self, vllm_processor_module
+    ):
+        # With continuous_usage_stats, every chunk carries running usage counts
+        # synthesized from input + cumulative output tokens.
+        routed_engine = _FakeRoutedEngine(
+            [
+                {"token_ids": [101, 102], "index": 0, "finish_reason": None},
+                {"token_ids": [103], "index": 0, "finish_reason": None},
+            ]
+        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
+
+        request = {
+            "model": MODEL,
+            "stream_options": {
+                "include_usage": True,
+                "continuous_usage_stats": True,
+            },
+        }
+        preproc = _base_preproc()  # token_ids == [1, 2, 3] -> 3 prompt tokens
+        chunks = [
+            item
+            async for item in processor._generate_and_stream(
+                "request-id",
+                request,
+                preproc,
+                preproc["token_ids"],
+                SimpleNamespace(
+                    sampling_params=SimpleNamespace(n=1),
+                    request_id="vllm-request",
+                    external_req_id=None,
+                ),
+                {0: _FakePostProcessor()},
+                mm_routing_info=None,
+                context=None,
+            )
+        ]
+
+        # First chunk: 3 prompt + 2 completion; second: 3 prompt + 3 cumulative.
+        assert chunks[0]["data"]["usage"] == {
+            "prompt_tokens": 3,
+            "completion_tokens": 2,
+            "total_tokens": 5,
+        }
+        assert chunks[1]["data"]["usage"] == {
+            "prompt_tokens": 3,
+            "completion_tokens": 3,
+            "total_tokens": 6,
+        }
+
+    @pytest.mark.asyncio
+    async def test_continuous_usage_stats_prefers_engine_completion_usage(
+        self, vllm_processor_module
+    ):
+        # When the engine provides completion_usage (final chunk), use it
+        # verbatim rather than the synthesized running counts.
+        engine_usage = {
+            "prompt_tokens": 3,
+            "completion_tokens": 1,
+            "total_tokens": 4,
+        }
+        routed_engine = _FakeRoutedEngine(
+            [
+                {
+                    "token_ids": [101],
+                    "index": 0,
+                    "finish_reason": "stop",
+                    "completion_usage": engine_usage,
+                }
+            ]
+        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
+
+        request = {
+            "model": MODEL,
+            "stream_options": {
+                "include_usage": True,
+                "continuous_usage_stats": True,
+            },
+        }
+        preproc = _base_preproc()
+        chunks = [
+            item
+            async for item in processor._generate_and_stream(
+                "request-id",
+                request,
+                preproc,
+                preproc["token_ids"],
+                SimpleNamespace(
+                    sampling_params=SimpleNamespace(n=1),
+                    request_id="vllm-request",
+                    external_req_id=None,
+                ),
+                {0: _FakePostProcessor()},
+                mm_routing_info=None,
+                context=None,
+            )
+        ]
+
+        assert chunks[0]["data"]["usage"] == engine_usage
+
+    @pytest.mark.asyncio
     async def test_routed_stream_emits_multimodal_counts(self, vllm_processor_module):
         # The Rust postprocessor is bypassed on this path, so the processor must
         # emit per-request multimodal content-part counts itself.

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -564,6 +564,42 @@ class TestRoutedEnginePath:
         assert "usage" not in chunks[0]["data"]
 
     @pytest.mark.asyncio
+    async def test_continuous_usage_stats_requires_include_usage(
+        self, vllm_processor_module
+    ):
+        # continuous_usage_stats is a sub-option of include_usage; without
+        # include_usage=True it must not emit per-chunk usage.
+        routed_engine = _FakeRoutedEngine(
+            [{"token_ids": [101], "index": 0, "finish_reason": None}]
+        )
+        processor = _make_processor(vllm_processor_module, routed_engine)
+
+        request = {
+            "model": MODEL,
+            "stream_options": {"continuous_usage_stats": True},
+        }
+        preproc = _base_preproc()
+        chunks = [
+            item
+            async for item in processor._generate_and_stream(
+                "request-id",
+                request,
+                preproc,
+                preproc["token_ids"],
+                SimpleNamespace(
+                    sampling_params=SimpleNamespace(n=1),
+                    request_id="vllm-request",
+                    external_req_id=None,
+                ),
+                {0: _FakePostProcessor()},
+                mm_routing_info=None,
+                context=None,
+            )
+        ]
+
+        assert "usage" not in chunks[0]["data"]
+
+    @pytest.mark.asyncio
     async def test_continuous_usage_stats_on_emits_per_chunk_usage(
         self, vllm_processor_module
     ):

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -671,14 +671,21 @@ class VllmProcessor:
         # content-part counts here too (else frontend metrics report zero media).
         input_tokens = len(tokens)
         cumulative_output_tokens = 0
-        # When stream_options.continuous_usage_stats is set, OpenAI/vLLM emit a
-        # usage object on every streamed chunk (not just the final one). The
-        # underlying engine only reports completion_usage on the final chunk, so
-        # synthesize per-chunk usage here from the running token counters.
+        # When stream_options.include_usage and continuous_usage_stats are both
+        # set, OpenAI/vLLM emit a usage object on every streamed chunk (not just
+        # the final one). continuous_usage_stats is a sub-option of include_usage,
+        # so it only takes effect when include_usage is also true. The underlying
+        # engine only reports completion_usage on the final chunk, so synthesize
+        # per-chunk usage here from the running token counters.
         stream_options = request.get("stream_options") or {}
         continuous_usage_stats = bool(
-            stream_options.get("continuous_usage_stats", False)
-        )
+            stream_options.get("include_usage", False)
+        ) and bool(stream_options.get("continuous_usage_stats", False))
+        # Per-choice completion-token counters keyed by output index. The
+        # request-wide cumulative counter is used for metrics, but continuous
+        # usage must report each choice's own running total (n > 1 streams
+        # interleave choices).
+        per_choice_output_tokens: dict[int, int] = {}
         _mm_counts = extract_mm_urls(request.get("messages") or []) or {}
         image_count = len(_mm_counts.get("image_url", []))
         video_count = len(_mm_counts.get("video_url", []))
@@ -737,6 +744,10 @@ class VllmProcessor:
                         }
                     }
                     break
+
+                per_choice_output_tokens[output_idx] = (
+                    per_choice_output_tokens.get(output_idx, 0) + chunk_tokens
+                )
 
                 raw_finish_reason = engine_response.get("finish_reason")
                 finish_reason = map_finish_reason(raw_finish_reason)
@@ -805,11 +816,15 @@ class VllmProcessor:
                         dynamo_out["usage"] = usage
                     elif continuous_usage_stats:
                         # No engine-provided usage on this chunk, but the client
-                        # asked for per-chunk stats: emit running counts.
+                        # asked for per-chunk stats: emit this choice's running
+                        # counts.
+                        choice_output_tokens = per_choice_output_tokens.get(
+                            output_idx, 0
+                        )
                         dynamo_out["usage"] = {
                             "prompt_tokens": input_tokens,
-                            "completion_tokens": cumulative_output_tokens,
-                            "total_tokens": input_tokens + cumulative_output_tokens,
+                            "completion_tokens": choice_output_tokens,
+                            "total_tokens": input_tokens + choice_output_tokens,
                         }
                     envelope["data"] = dynamo_out
 

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -671,6 +671,14 @@ class VllmProcessor:
         # content-part counts here too (else frontend metrics report zero media).
         input_tokens = len(tokens)
         cumulative_output_tokens = 0
+        # When stream_options.continuous_usage_stats is set, OpenAI/vLLM emit a
+        # usage object on every streamed chunk (not just the final one). The
+        # underlying engine only reports completion_usage on the final chunk, so
+        # synthesize per-chunk usage here from the running token counters.
+        stream_options = request.get("stream_options") or {}
+        continuous_usage_stats = bool(
+            stream_options.get("continuous_usage_stats", False)
+        )
         _mm_counts = extract_mm_urls(request.get("messages") or []) or {}
         image_count = len(_mm_counts.get("image_url", []))
         video_count = len(_mm_counts.get("video_url", []))
@@ -795,6 +803,14 @@ class VllmProcessor:
                     }
                     if usage := engine_response.get("completion_usage"):
                         dynamo_out["usage"] = usage
+                    elif continuous_usage_stats:
+                        # No engine-provided usage on this chunk, but the client
+                        # asked for per-chunk stats: emit running counts.
+                        dynamo_out["usage"] = {
+                            "prompt_tokens": input_tokens,
+                            "completion_tokens": cumulative_output_tokens,
+                            "total_tokens": input_tokens + cumulative_output_tokens,
+                        }
                     envelope["data"] = dynamo_out
 
                 metrics = {


### PR DESCRIPTION
## Overview

`stream_options.continuous_usage_stats=true` had no effect when the frontend
runs with `--dyn-chat-processor vllm`: every intermediate streamed chunk came
back with `usage: null`, and usage was reported only once on the final chunk.
vLLM's and SGLang's native OpenAI servers emit a `usage` object on every chunk
when this flag is set, so the vLLM chat processor path diverged from expected
OpenAI-compatible behavior.

## Details

Root cause is in `VllmProcessor._generate_and_stream`
(`components/src/dynamo/frontend/vllm_processor.py`). A chunk only received a
`usage` field when the engine reported `completion_usage`, which the vLLM engine
sends on the final chunk only:

```python
if usage := engine_response.get("completion_usage"):
    dynamo_out["usage"] = usage
```

The flag was never read on this path, so it was silently ignored.

The fix reads `stream_options.continuous_usage_stats` from the request and, when
set, synthesizes a per-chunk `usage` object from the running token counters the
processor already maintains (`input_tokens` + `cumulative_output_tokens`).
Engine-provided `completion_usage` still takes precedence on the final chunk, so
authoritative counts are preserved and the OpenAI-required final usage chunk is
unchanged.

Scope is intentionally minimal (8 lines of logic); it reuses existing counters
and adds no new abstractions.

## Where should the reviewer start?

`components/src/dynamo/frontend/vllm_processor.py` — the two edited blocks in
`_generate_and_stream`.

## Related Issues

N/A

## Summary by CodeRabbit

- **New Features**
  - Streaming chat responses via the vLLM processor now include per-chunk token
    usage statistics when `stream_options.continuous_usage_stats` is enabled,
    matching vLLM/SGLang native OpenAI-server behavior.

## Validation

- `pre-commit run --files components/src/dynamo/frontend/vllm_processor.py components/src/dynamo/frontend/tests/test_vllm_processor_unit.py` — all hooks pass (isort, black, flake8, ruff, codespell, pytest-marker report).
- Added three unit tests to `TestRoutedEnginePath` in
  `test_vllm_processor_unit.py`, driving `_generate_and_stream` with the existing
  `FakeRoutedEngine` harness (CPU-only, no GPU/model):
  - flag off → intermediate chunks omit `usage`
  - flag on → every chunk carries running `{prompt_tokens, completion_tokens, total_tokens}`
  - flag on + engine `completion_usage` on final chunk → engine value used verbatim
- Reproduced the original bug and confirmed the fix against a live deployment
  (`--dyn-chat-processor vllm`): before, all content chunks returned
  `"usage":null`; after, per-chunk usage is populated while the final chunk is
  unchanged.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11708" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added continuous usage statistics for streaming responses.
  * When enabled, each streamed chunk includes running prompt, completion, and total token counts.
  * Preserves usage data provided by the backend when available.

* **Bug Fixes**
  * Ensured intermediate streaming chunks omit usage data when continuous statistics are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->