### PR TITLE
docs(disaggregated-serving): fix broken aiconfigurator support-matrix link (OPS-7722)

### DIFF
--- a/docs/features/disaggregated-serving/aiconfigurator.md
+++ b/docs/features/disaggregated-serving/aiconfigurator.md
@@ -531,7 +531,7 @@ AIConfigurator's default predictions assume no prefix caching. Enable it post-de
 
 ### Backends and Versions
 
-For a comprehensive breakdown of which model/system/backend/version combinations are supported in both aggregated and disaggregated modes, refer to the [**support matrix**](https://ai-dynamo.github.io/aiconfigurator/support-matrix/). The raw data is available as [per-system CSV files](https://github.com/ai-dynamo/aiconfigurator/tree/main/src/aiconfigurator/systems/support_matrix), which are automatically generated and tested to ensure accuracy across all supported configurations.
+For a comprehensive breakdown of which model/system/backend/version combinations are supported in both aggregated and disaggregated modes, refer to the [**support matrix**](https://ai-dynamo.github.io/aiconfigurator/support-matrix/). The raw data is available as [per-system CSV files](https://github.com/ai-dynamo/aiconfigurator/tree/main/aic-core/src/aiconfigurator_core/systems/support_matrix), which are automatically generated and tested to ensure accuracy across all supported configurations.
 
 You can also check if a system / framework version is supported via the `aiconfigurator cli support` command. For example:
 ```bash


### PR DESCRIPTION
## Summary

`docs/features/disaggregated-serving/aiconfigurator.md` linked the AIConfigurator "per-system CSV files" to `.../tree/main/src/aiconfigurator/systems/support_matrix`, which returns **404**.

In the aiconfigurator repo, `src/aiconfigurator/systems` is now a **symlink** (→ `../../aic-core/src/aiconfigurator_core/systems`). GitHub `/tree/` URLs don't resolve symlinks, so the old path 404s even though the files exist — the CSVs moved into the `aic-core` package. This points the link at the real directory:

`.../tree/main/aic-core/src/aiconfigurator_core/systems/support_matrix`

## Validation

- New `/tree/` URL → HTTP **200**; old path → **404** (both curl-checked).
- GitHub contents API confirms the new directory holds the per-system CSVs (`a100_sxm`, `b200_sxm`, `b300_sxm`, `b60`, `gb200`, `gb300`, `h100_sxm`, `h200_sxm`, `l40s`, `rtx_pro_6000_server`) plus `index.json`.
- `grep` confirms no other occurrences of the stale path under `docs/`, `recipes/`, or `examples/`.

Linear: OPS-7722

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11711" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the AI Configurator documentation to link to the current location of per-system support matrix data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->