### PR TITLE
feat(snapshot): restore rootfs from SquashFS

### DIFF
--- a/deploy/helm/charts/snapshot/README.md
+++ b/deploy/helm/charts/snapshot/README.md
@@ -28,6 +28,10 @@ namespace-local workload PVCs, or it can require that they already exist.
 - **containerd** or **CRI-O** (chart defaults to containerd; see below for CRI-O / OpenShift)
 - Dynamo Platform already installed with `dynamo-operator.checkpoint.enabled=true`
 - a cluster where a privileged DaemonSet with `hostPID`, `hostIPC`, and `hostNetwork` is acceptable
+- host loop driver and `/dev/loop-control`, SquashFS with LZ4, and OverlayFS
+- Linux support for `open_tree`/`move_mount` (5.2), `openat2` (5.6), and
+  `LOOP_CONFIGURE` (5.8). Linux 5.8 is the first upstream release with the full
+  set, but enterprise backports make capability probing authoritative.
 
 In the default `agentMount` mode, the snapshot-agent DaemonSet mounts the
 checkpoint PVC directly. On a multi-node GPU cluster that means agent pods on
@@ -52,7 +56,8 @@ fail or defer that attempt until reconciliation sees a fresh container.
 For CRI-O nodes set `runtime.type=crio`. Only set `runtime.socketPath` if the CRI
 socket is not the default for that type (see `values.yaml`). On OpenShift, set
 `openshift.enabled=true` so the chart emits the extra RBAC and pod annotations
-the agent needs. Example:
+the agent needs. The privileged SCC grants permission; it does not load the host
+loop driver or provide `/dev/loop-control`. Example:
 
 ```bash
 helm upgrade --install snapshot ./deploy/helm/charts/snapshot \

--- a/deploy/helm/charts/snapshot/templates/daemonset.yaml
+++ b/deploy/helm/charts/snapshot/templates/daemonset.yaml
@@ -149,6 +149,9 @@ spec:
             # Mount host cgroup for CRIU (write access needed for cgroup freezer)
             - name: host-cgroup
               mountPath: /sys/fs/cgroup
+            # The agent allocates loop numbers through the only host device it receives.
+            - name: host-loop-control
+              mountPath: /host/dev/loop-control
             # Kubelet PodResources API socket (for GPU UUID discovery)
             - name: kubelet-pod-resources
               mountPath: /var/lib/kubelet/pod-resources
@@ -214,6 +217,11 @@ spec:
           hostPath:
             path: /sys/fs/cgroup
             type: Directory
+        # Individual loop block nodes are created in the agent's ephemeral root.
+        - name: host-loop-control
+          hostPath:
+            path: /dev/loop-control
+            type: CharDevice
         # Kubelet PodResources API socket directory
         - name: kubelet-pod-resources
           hostPath:

--- a/deploy/helm/charts/snapshot/values.yaml
+++ b/deploy/helm/charts/snapshot/values.yaml
@@ -160,9 +160,8 @@ rbac:
 # Dynamic values (NODE_NAME, RESTRICTED_NAMESPACE, etc.) come from environment variables
 config:
   overlay:
-    # Rootfs diff tar exclusions. Absolute-looking paths are normalized
-    # relative to the tar root, and patterns starting with * are passed
-    # through as tar globs unchanged.
+    # Rootfs SquashFS exclusions. Absolute-looking paths are normalized
+    # relative to the OverlayFS upperdir; wildcard patterns match recursively.
     exclusions:
       - /proc
       - /sys

--- a/deploy/snapshot/Dockerfile
+++ b/deploy/snapshot/Dockerfile
@@ -170,14 +170,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \
     procps \
     uuid-runtime \
-    tar \
+    squashfs-tools \
     ca-certificates \
     util-linux \
     && rm -rf /var/lib/apt/lists/*
 
+COPY --from=criu-builder /tmp/criu/COPYING /legal/CRIU/COPYING
+RUN mkdir -p /legal/squashfs-tools \
+    && cp /usr/share/doc/squashfs-tools/copyright /legal/squashfs-tools/copyright
+
 # Copy CRIU from builder
 COPY --from=criu-builder /criu-install/usr/local /usr/local
-COPY --from=criu-builder /tmp/criu/COPYING /legal/CRIU/COPYING
 RUN criu --version
 
 # Copy CUDA checkpoint binaries
@@ -191,7 +194,7 @@ COPY --from=builder /snapshot-agent /usr/local/bin/snapshot-agent
 COPY --from=builder /nsrestore /usr/local/bin/nsrestore
 
 # Create directories
-RUN mkdir -p /checkpoints /var/run/snapshot
+RUN mkdir -p /checkpoints /host/dev /var/run/snapshot
 
 USER root
 
@@ -231,7 +234,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     iptables \
     procps \
     uuid-runtime \
-    tar \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -250,5 +252,6 @@ RUN chmod +x /usr/local/sbin/cuda-checkpoint /usr/local/bin/cuda-checkpoint-help
 COPY --from=builder /nsrestore /usr/local/bin/nsrestore
 RUN chmod +x /usr/local/bin/nsrestore
 
-# Create directories
-RUN mkdir -p /checkpoints /var/run/criu /var/criu-work
+# The backing path is a pod-managed emptyDir in restore pods.
+RUN mkdir -p /checkpoints /var/run/criu /var/criu-work \
+    /.dynamo-snapshot-backing

--- a/deploy/snapshot/cmd/nsrestore/main.go
+++ b/deploy/snapshot/cmd/nsrestore/main.go
@@ -20,10 +20,15 @@ func main() {
 	cudaDeviceMap := flag.String("cuda-device-map", "", "CUDA device map for cuda-checkpoint-helper restore")
 	cgroupRoot := flag.String("cgroup-root", "", "CRIU cgroup root remap path")
 	targetPodIP := flag.String("target-pod-ip", "", "Restore pod IP for CRIU TCP socket remapping")
+	rootfsMountFD := flag.Int("rootfs-mount-fd", -1, "Inherited detached SquashFS mount FD")
+	rootfsWorkspaceFD := flag.Int("rootfs-workspace-fd", -1, "Inherited rootfs backing mount FD")
 	flag.Parse()
 
 	if *checkpointPath == "" {
 		fatal(log, nil, "--checkpoint-path is required")
+	}
+	if *rootfsMountFD < 3 || *rootfsWorkspaceFD < 3 {
+		fatal(log, nil, "--rootfs-mount-fd and --rootfs-workspace-fd are required")
 	}
 
 	opts := executor.RestoreOptions{
@@ -31,6 +36,8 @@ func main() {
 		CUDADeviceMap:  *cudaDeviceMap,
 		CgroupRoot:     *cgroupRoot,
 		TargetPodIP:    *targetPodIP,
+		RootfsMountFD:  *rootfsMountFD,
+		WorkspaceFD:    *rootfsWorkspaceFD,
 	}
 
 	result, err := executor.RestoreInNamespace(context.Background(), opts, log)

--- a/deploy/snapshot/internal/controller/podsnapshotcontent.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent.go
@@ -197,6 +197,10 @@ func (w *NodeController) reconcileSourcePod(ctx context.Context, pod *corev1.Pod
 	// status write did not. The artifact dir exists only after the executor's atomic rename,
 	// so its presence means a completed dump.
 	if artifactPresent(loc.HostPath) {
+		if err := snapshotruntime.ValidateCheckpointArtifact(loc.HostPath, id); err != nil {
+			return w.setSnapshotContentFailed(ctx, content, "InvalidCheckpointArtifact",
+				fmt.Errorf("validate existing checkpoint artifact: %w", err))
+		}
 		return w.setSnapshotContentSucceeded(ctx, content)
 	}
 
@@ -417,8 +421,8 @@ func (w *NodeController) setSnapshotContentFailed(ctx context.Context, content *
 
 // executorCheckpoint is the production checkpointFn. The reconciler has already resolved the
 // container ID and host PID. It runs executor.Checkpoint to the destination, verifies the
-// artifact directory, and writes the snapshot-complete sentinel. On dump or verification
-// failure it SIGKILLs the CUDA-locked process before returning the error.
+// artifact directory, and writes the snapshot-complete sentinel. On dump or directory
+// verification or sentinel failure it SIGKILLs the CUDA-locked process before returning the error.
 func (w *NodeController) executorCheckpoint(ctx context.Context, params CheckpointParams) error {
 	log := logr.FromContextOrDiscard(ctx)
 
@@ -447,7 +451,6 @@ func (w *NodeController) executorCheckpoint(ctx context.Context, params Checkpoi
 		}
 		return fmt.Errorf("verify checkpoint path %s: not a directory", params.HostPath)
 	}
-
 	if err := snapshotruntime.WriteControlSentinel(params.ContainerPID, snapshotprotocol.SnapshotCompleteFile); err != nil {
 		w.killCheckpointProcess(log, params.ContainerPID, "checkpoint sentinel failed")
 		return fmt.Errorf("write snapshot-complete sentinel: %w", err)

--- a/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
+++ b/deploy/snapshot/internal/controller/podsnapshotcontent_test.go
@@ -5,7 +5,9 @@ package controller
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
@@ -27,6 +29,7 @@ import (
 	crfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	snapshotruntime "github.com/ai-dynamo/dynamo/deploy/snapshot/internal/runtime"
 	snapshottypes "github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
@@ -138,6 +141,27 @@ func makeSourcePod(checkpointID string) *corev1.Pod {
 			},
 		},
 	}
+}
+
+func writeValidCheckpointArtifact(t *testing.T, destination, checkpointID string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(destination, 0o755))
+
+	image := []byte("rootfs image")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(destination, snapshotruntime.RootfsDiffFilename),
+		image,
+		0o600,
+	))
+
+	manifest := snapshottypes.NewCheckpointManifest(
+		checkpointID,
+		snapshottypes.CRIUDumpManifest{},
+		snapshottypes.SourcePodManifest{},
+		snapshottypes.OverlayManifest{},
+	)
+	manifest.RootFSSHA256 = fmt.Sprintf("%x", sha256.Sum256(image))
+	require.NoError(t, snapshottypes.WriteManifest(destination, manifest))
 }
 
 // getContent reads a PodSnapshotContent back from the fake client.
@@ -355,13 +379,62 @@ func TestReconcileSnapshotContent_ResumeWritesReady(t *testing.T) {
 	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
 	// Pre-create the artifact directory at the resolved destination so the resume check fires.
 	dest := filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1")
-	require.NoError(t, os.MkdirAll(dest, 0o755))
+	writeValidCheckpointArtifact(t, dest, "abc")
 
 	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
 	assert.False(t, fc.wasCalled())
 	got := getContent(t, w, content.Name)
 	cond := meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionReady)
 	require.NotNil(t, cond)
+}
+
+func TestReconcileSnapshotContent_ResumeDigestMismatchFails(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := makeSourcePod("abc")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
+	dest := filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1")
+	writeValidCheckpointArtifact(t, dest, "abc")
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dest, snapshotruntime.RootfsDiffFilename),
+		[]byte("corrupted rootfs image"),
+		0o600,
+	))
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionReady))
+	cond := meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "InvalidCheckpointArtifact", cond.Reason)
+	assert.Contains(t, cond.Message, "rootfs SHA-256 mismatch")
+}
+
+func TestReconcileSnapshotContent_ResumeRejectsTarOnlyArtifact(t *testing.T) {
+	content := makeWorkOrder("podsnapshotcontent-abc", "node-a", "abc")
+	pod := makeSourcePod("abc")
+	fc := &fakeCheckpointer{}
+	w := makeNodeController(t, fc, content, pod)
+	w.runtime = &fakeRuntime{resolveContainerPID: 4242}
+	dest := filepath.Join(w.config.Storage.BasePath, "abc", "versions", "1")
+	require.NoError(t, os.MkdirAll(dest, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dest, "rootfs-diff.tar"), nil, 0o600))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(dest, "manifest.yaml"),
+		[]byte("checkpointId: abc\n"),
+		0o600,
+	))
+
+	require.NoError(t, w.reconcileSourcePod(context.Background(), pod))
+	assert.False(t, fc.wasCalled())
+	got := getContent(t, w, content.Name)
+	assert.Nil(t, meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionReady))
+	cond := meta.FindStatusCondition(got.Status.Conditions, nvidiacomv1alpha1.PodSnapshotConditionFailed)
+	require.NotNil(t, cond)
+	assert.Equal(t, "InvalidCheckpointArtifact", cond.Reason)
+	assert.Contains(t, cond.Message, "checkpoint manifest has invalid rootfsSha256")
 }
 
 func TestReconcileSnapshotContent_PodMountResolvesContainerPID(t *testing.T) {

--- a/deploy/snapshot/internal/criu/restore.go
+++ b/deploy/snapshot/internal/criu/restore.go
@@ -74,17 +74,23 @@ func ExecuteRestore(
 	log.V(1).Info("Executing go-criu Restore call")
 	if err := c.Restore(criuOpts, notify); err != nil {
 		log.Error(err, "go-criu Restore returned error")
-		logging.LogRestoreErrors(checkpointPath, settings.WorkDir, log)
+		summary := logging.LogRestoreErrors(checkpointPath, settings.WorkDir, log)
+		if summary != "" {
+			return 0, fmt.Errorf("CRIU restore failed: %w\nrestore.log: %s", err, summary)
+		}
 		return 0, fmt.Errorf("CRIU restore failed: %w", err)
 	}
 
 	return notify.restoredPID, nil
 }
 
-// BuildRestoreOpts assembles CriuOpts for a CRIU restore from the checkpoint manifest.
+// BuildRestoreOpts assembles CriuOpts for a CRIU restore into rootPath.
 // ImagesDirFd and WorkDirFd are left unset — ExecuteRestore opens them at restore time.
-func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroupRoot string, log logr.Logger) (*criurpc.CriuOpts, error) {
-	extMounts, err := buildRestoreExtMounts(m)
+func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, rootPath string, cgroupRoot string, log logr.Logger) (*criurpc.CriuOpts, error) {
+	if !filepath.IsAbs(rootPath) {
+		return nil, fmt.Errorf("CRIU restore root must be absolute: %q", rootPath)
+	}
+	extMounts, err := buildRestoreExtMounts(m, rootPath)
 	if err != nil {
 		return nil, err
 	}
@@ -93,7 +99,7 @@ func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroup
 	settings := m.CRIUDump.CRIU
 	criuOpts := &criurpc.CriuOpts{
 		LogFile: proto.String(RestoreLogFilename),
-		Root:    proto.String("/"),
+		Root:    proto.String(rootPath),
 		ExtMnt:  extMounts,
 	}
 	if err := applyCommonSettings(criuOpts, &settings); err != nil {
@@ -120,15 +126,18 @@ func BuildRestoreOpts(m *types.CheckpointManifest, checkpointPath string, cgroup
 	return criuOpts, nil
 }
 
-func buildRestoreExtMounts(m *types.CheckpointManifest) ([]*criurpc.ExtMountMap, error) {
+func buildRestoreExtMounts(m *types.CheckpointManifest, rootPath string) ([]*criurpc.ExtMountMap, error) {
 	if len(m.CRIUDump.ExtMnt) == 0 {
 		return nil, fmt.Errorf("checkpoint manifest is missing criuDump.extMnt")
 	}
 
-	restoreMap := map[string]string{"/": "."}
+	restoreMap := map[string]string{"/": rootPath}
 	for _, val := range m.CRIUDump.ExtMnt {
 		if val == "" || val == "/" {
 			continue
+		}
+		if !filepath.IsAbs(val) {
+			return nil, fmt.Errorf("external mount source must be absolute: %q", val)
 		}
 		restoreMap[val] = val
 	}

--- a/deploy/snapshot/internal/criu/util_test.go
+++ b/deploy/snapshot/internal/criu/util_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
+	"github.com/go-logr/logr"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
@@ -186,6 +187,8 @@ func TestApplyCommonSettings(t *testing.T) {
 }
 
 func TestBuildRestoreExtMounts(t *testing.T) {
+	rootPath := "/.dynamo-snapshot-backing/root"
+
 	t.Run("normal manifest with ExtMnt", func(t *testing.T) {
 		m := &types.CheckpointManifest{
 			CRIUDump: types.CRIUDumpManifest{
@@ -195,19 +198,19 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 				},
 			},
 		}
-		mounts, err := buildRestoreExtMounts(m)
+		mounts, err := buildRestoreExtMounts(m, rootPath)
 		if err != nil {
 			t.Fatalf("buildRestoreExtMounts: %v", err)
 		}
 
-		// Should contain value→value self-mappings plus "/" → "."
+		// Restore sources remain on the placeholder/control root.
 		mountMap := make(map[string]string, len(mounts))
 		for _, em := range mounts {
 			mountMap[em.GetKey()] = em.GetVal()
 		}
 
-		if mountMap["/"] != "." {
-			t.Errorf("root mapping: got %q, want %q", mountMap["/"], ".")
+		if mountMap["/"] != rootPath {
+			t.Errorf("root mapping: got %q, want %q", mountMap["/"], rootPath)
 		}
 		if mountMap["/etc/hostname"] != "/etc/hostname" {
 			t.Errorf("/etc/hostname mapping: got %q", mountMap["/etc/hostname"])
@@ -227,7 +230,7 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 				},
 			},
 		}
-		mounts, err := buildRestoreExtMounts(m)
+		mounts, err := buildRestoreExtMounts(m, rootPath)
 		if err != nil {
 			t.Fatalf("buildRestoreExtMounts: %v", err)
 		}
@@ -237,9 +240,9 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 			mountMap[em.GetKey()] = em.GetVal()
 		}
 
-		// "/" and "" values should be skipped from the value→value mapping
-		// but "/" → "." root mapping always exists
-		if mountMap["/"] != "." {
+		// "/" and "" values should be skipped from individual mappings,
+		// but the existing root identifier mapping always exists.
+		if mountMap["/"] != rootPath {
 			t.Errorf("root mapping missing")
 		}
 		if _, ok := mountMap[""]; ok {
@@ -254,9 +257,42 @@ func TestBuildRestoreExtMounts(t *testing.T) {
 		m := &types.CheckpointManifest{
 			CRIUDump: types.CRIUDumpManifest{},
 		}
-		_, err := buildRestoreExtMounts(m)
+		_, err := buildRestoreExtMounts(m, rootPath)
 		if err == nil {
 			t.Error("expected error for empty ExtMnt")
 		}
 	})
+}
+
+func TestBuildRestoreOptsUsesStagedRootAndControlMountSources(t *testing.T) {
+	rootPath := "/.dynamo-snapshot-backing/root"
+	m := &types.CheckpointManifest{
+		CRIUDump: types.CRIUDumpManifest{
+			ExtMnt: map[string]string{"/etc/hostname": "/etc/hostname"},
+		},
+	}
+
+	opts, err := BuildRestoreOpts(
+		m,
+		t.TempDir(),
+		rootPath,
+		"",
+		logr.Discard(),
+	)
+	if err != nil {
+		t.Fatalf("BuildRestoreOpts: %v", err)
+	}
+	if opts.GetRoot() != rootPath {
+		t.Fatalf("CRIU Root = %q, want %q", opts.GetRoot(), rootPath)
+	}
+	mountMap := make(map[string]string, len(opts.GetExtMnt()))
+	for _, mount := range opts.GetExtMnt() {
+		mountMap[mount.GetKey()] = mount.GetVal()
+	}
+	if mountMap["/"] != opts.GetRoot() {
+		t.Fatalf("CRIU ExtMnt[/] = %q, want Root %q", mountMap["/"], opts.GetRoot())
+	}
+	if mountMap["/etc/hostname"] != "/etc/hostname" {
+		t.Fatalf("CRIU ExtMnt = %v, want self-mapped /etc/hostname", opts.GetExtMnt())
+	}
 }

--- a/deploy/snapshot/internal/executor/checkpoint.go
+++ b/deploy/snapshot/internal/executor/checkpoint.go
@@ -84,6 +84,9 @@ func Checkpoint(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger
 	if err != nil {
 		return err
 	}
+	if err := snapshotruntime.PreflightRootfsCapture(); err != nil {
+		return fmt.Errorf("rootfs capture preflight failed: %w", err)
+	}
 	phaseTimings.PrepareDuration = time.Since(prepareStart)
 
 	// Phase 3: Capture — CRIU dump, rootfs diff
@@ -243,10 +246,6 @@ func configureCheckpoint(
 		m.CUDA = types.NewCUDAManifest(state.CUDANSPIDs, state.GPUUUIDs)
 	}
 
-	if err := types.WriteManifest(checkpointDir, m); err != nil {
-		return nil, nil, fmt.Errorf("failed to write checkpoint manifest: %w", err)
-	}
-
 	return criuOpts, m, nil
 }
 
@@ -268,19 +267,22 @@ func captureCheckpoint(ctx context.Context, criuOpts *criurpc.CriuOpts, criuSett
 	}
 	timings.CRIUDumpDuration = criuDumpDuration
 
-	// Overlay rootfs diff capture is best-effort. Failures are logged but not
-	// propagated — a checkpoint without overlay diffs is still valid for restore
-	// (the base container image provides the filesystem).
-	if state.UpperDir != "" {
-		overlayCaptureStart := time.Now()
-		if _, err := snapshotruntime.CaptureRootfsDiff(state.UpperDir, checkpointDir, data.Overlay.Exclusions, data.Overlay.BindMountDests); err != nil {
-			log.Error(err, "Failed to capture rootfs diff")
-		}
-		if _, err := snapshotruntime.CaptureDeletedFiles(state.UpperDir, checkpointDir); err != nil {
-			log.Error(err, "Failed to capture deleted files")
-		}
-		timings.OverlayCaptureDuration = time.Since(overlayCaptureStart)
+	overlayCaptureStart := time.Now()
+	digest, err := snapshotruntime.CaptureRootfsDiff(
+		ctx,
+		state.UpperDir,
+		checkpointDir,
+		data.Overlay.Exclusions,
+		data.Overlay.BindMountDests,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("rootfs diff capture failed: %w", err)
 	}
+	data.RootFSSHA256 = digest
+	if err := types.WriteManifest(checkpointDir, data); err != nil {
+		return nil, fmt.Errorf("failed to write checkpoint manifest: %w", err)
+	}
+	timings.OverlayCaptureDuration = time.Since(overlayCaptureStart)
 
 	return timings, nil
 }

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -2,6 +2,7 @@ package executor
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -99,8 +100,8 @@ type nsrestorePhaseTimings struct {
 	cudaDuration           time.Duration
 }
 
-func executeRestore(ctx context.Context, m *types.CheckpointManifest, opts RestoreOptions, log logr.Logger) (*nsrestorePhaseTimings, int, error) {
-	timings := &nsrestorePhaseTimings{}
+func executeRestore(ctx context.Context, m *types.CheckpointManifest, opts RestoreOptions, log logr.Logger) (timings *nsrestorePhaseTimings, resultPID int, retErr error) {
+	timings = &nsrestorePhaseTimings{}
 
 	nsrestoreSetupStart := time.Now()
 	deletedFile, err := snapshotruntime.OpenDeletedFiles(opts.CheckpointPath)
@@ -120,6 +121,9 @@ func executeRestore(ctx context.Context, m *types.CheckpointManifest, opts Resto
 	if err != nil {
 		return nil, 0, fmt.Errorf("compose rootfs: %w", err)
 	}
+	defer func() {
+		retErr = errors.Join(retErr, composition.Close())
+	}()
 	log.V(1).Info(
 		"Root composition timing",
 		"root_path", composition.RootPath,

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -3,10 +3,12 @@ package executor
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 
-	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
 	"github.com/go-logr/logr"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/criu"
@@ -21,17 +23,17 @@ type RestoreOptions struct {
 	CUDADeviceMap  string
 	CgroupRoot     string
 	TargetPodIP    string
+	RootfsMountFD  int
+	WorkspaceFD    int
 }
 
 type RestoreInNamespaceResult struct {
-	RestoredPID            int           `json:"restoredPID"`
-	NSRestoreSetupDuration time.Duration `json:"nsrestoreSetupDuration"`
-	CRIURestoreDuration    time.Duration `json:"criuRestoreDuration"`
-	CUDADuration           time.Duration `json:"cudaDuration"`
+	RestoredPID int `json:"restoredPID"`
 }
 
 // RestoreInNamespace performs a full restore from inside the target container's namespaces.
 func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logger) (*RestoreInNamespaceResult, error) {
+	opts.CheckpointPath = canonicalizeCheckpointPath(opts.CheckpointPath)
 	restoreStart := time.Now()
 	log.Info("Starting nsrestore workflow",
 		"checkpoint_path", opts.CheckpointPath,
@@ -53,37 +55,42 @@ func RestoreInNamespace(ctx context.Context, opts RestoreOptions, log logr.Logge
 		"checkpoint_has_cuda", !m.CUDA.IsEmpty(),
 	)
 
-	// Phase 1: Configure — build CRIU opts from manifest
+	// Phase 1: Configure checkpoint metadata that does not depend on the staged root.
 	configureStart := time.Now()
 	if err := criu.ConfigureInetRemap(m, opts.TargetPodIP, log); err != nil {
-		return nil, err
-	}
-	criuOpts, err := criu.BuildRestoreOpts(m, opts.CheckpointPath, opts.CgroupRoot, log)
-	if err != nil {
 		return nil, err
 	}
 	configureDuration := time.Since(configureStart)
 
 	// Phase 2: Execute — rootfs, CRIU restore, CUDA restore
-	executeTimings, restoredPID, err := executeRestore(ctx, criuOpts, m, opts, log)
+	executeTimings, restoredPID, err := executeRestore(ctx, m, opts, log)
 	if err != nil {
 		return nil, err
 	}
 
 	result := &RestoreInNamespaceResult{
-		RestoredPID:            restoredPID,
-		NSRestoreSetupDuration: manifestReadDuration + configureDuration + executeTimings.nsrestoreSetupDuration,
-		CRIURestoreDuration:    executeTimings.criuRestoreDuration,
-		CUDADuration:           executeTimings.cudaDuration,
+		RestoredPID: restoredPID,
 	}
-	log.V(1).Info("nsrestore timing summary",
+	log.Info("nsrestore timing summary",
 		"restored_pid", restoredPID,
-		"nsrestore_setup_duration", result.NSRestoreSetupDuration,
-		"criu_restore_duration", result.CRIURestoreDuration,
-		"cuda_duration", result.CUDADuration,
+		"manifest_read_duration", manifestReadDuration,
+		"configure_duration", configureDuration,
+		"root_setup_duration", executeTimings.nsrestoreSetupDuration,
+		"criu_restore_duration", executeTimings.criuRestoreDuration,
+		"cuda_duration", executeTimings.cudaDuration,
 		"total_duration", time.Since(restoreStart),
 	)
 	return result, nil
+}
+
+func canonicalizeCheckpointPath(checkpointPath string) string {
+	const procSelfFDPrefix = "/proc/self/fd/"
+
+	fd, err := strconv.Atoi(strings.TrimPrefix(checkpointPath, procSelfFDPrefix))
+	if err != nil || fd < 0 || !strings.HasPrefix(checkpointPath, procSelfFDPrefix) {
+		return checkpointPath
+	}
+	return fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), fd)
 }
 
 type nsrestorePhaseTimings struct {
@@ -92,20 +99,35 @@ type nsrestorePhaseTimings struct {
 	cudaDuration           time.Duration
 }
 
-func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.CheckpointManifest, opts RestoreOptions, log logr.Logger) (*nsrestorePhaseTimings, int, error) {
+func executeRestore(ctx context.Context, m *types.CheckpointManifest, opts RestoreOptions, log logr.Logger) (*nsrestorePhaseTimings, int, error) {
 	timings := &nsrestorePhaseTimings{}
 
-	// Apply rootfs diff inside the namespace (target root is /)
 	nsrestoreSetupStart := time.Now()
-	if err := snapshotruntime.ApplyRootfsDiff(opts.CheckpointPath, "/", log); err != nil {
-		return nil, 0, fmt.Errorf("rootfs diff failed: %w", err)
+	deletedFile, err := snapshotruntime.OpenDeletedFiles(opts.CheckpointPath)
+	if err != nil {
+		return nil, 0, err
 	}
-
-	if err := snapshotruntime.ApplyDeletedFiles(opts.CheckpointPath, "/", log); err != nil {
-		log.Error(err, "Failed to apply deleted files")
+	deletedFD := -1
+	if deletedFile != nil {
+		deletedFD = int(deletedFile.Fd())
+		defer deletedFile.Close()
 	}
+	composition, err := snapshotruntime.ComposeRoot(
+		opts.RootfsMountFD,
+		opts.WorkspaceFD,
+		deletedFD,
+	)
+	if err != nil {
+		return nil, 0, fmt.Errorf("compose rootfs: %w", err)
+	}
+	log.V(1).Info(
+		"Root composition timing",
+		"root_path", composition.RootPath,
+		"mount_attach_duration", composition.MountAttachDuration,
+		"overlay_setup_duration", composition.OverlaySetupDuration,
+	)
 
-	// Unmount placeholder's /dev/shm so CRIU can recreate tmpfs with checkpointed content
+	// Unmount placeholder's /dev/shm so CRIU can recreate tmpfs with checkpointed content.
 	if err := syscall.Unmount("/dev/shm", 0); err != nil {
 		return nil, 0, fmt.Errorf("failed to unmount /dev/shm before restore: %w", err)
 	}
@@ -113,12 +135,22 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 	if err := snapshotruntime.RemountProcSys(true); err != nil {
 		return nil, 0, fmt.Errorf("failed to remount /proc/sys read-write for restore: %w", err)
 	}
-	timings.nsrestoreSetupDuration = time.Since(nsrestoreSetupStart)
 	defer func() {
 		if err := snapshotruntime.RemountProcSys(false); err != nil {
 			log.Error(err, "Failed to remount /proc/sys read-only after restore")
 		}
 	}()
+	criuOpts, err := criu.BuildRestoreOpts(
+		m,
+		opts.CheckpointPath,
+		composition.RootPath,
+		opts.CgroupRoot,
+		log,
+	)
+	if err != nil {
+		return nil, 0, err
+	}
+	timings.nsrestoreSetupDuration = time.Since(nsrestoreSetupStart)
 
 	// CRIU restore
 	criuRestoreStart := time.Now()

--- a/deploy/snapshot/internal/executor/restore.go
+++ b/deploy/snapshot/internal/executor/restore.go
@@ -5,14 +5,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
 	"k8s.io/client-go/kubernetes"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/criu"
@@ -62,20 +65,45 @@ func Restore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Logger, r
 	}
 	hostInspectDuration := time.Since(hostInspectStart)
 
+	image, err := snapshotruntime.OpenValidatedRootfs(snap.CheckpointPath, req.CheckpointID)
+	if err != nil {
+		return 0, fmt.Errorf("validate rootfs artifact: %w", err)
+	}
+	defer image.Close()
+	rootfsMount, err := snapshotruntime.PrepareDetachedRootfsMount(image)
+	if err != nil {
+		return 0, fmt.Errorf("prepare rootfs mount: %w", err)
+	}
+	defer rootfsMount.Close()
+	workspace, err := openRootfsBackingWorkspace(snap.PlaceholderPID)
+	if err != nil {
+		return 0, err
+	}
+	defer workspace.Close()
+	checkpoint, err := openCheckpointDirectory(snap.CheckpointPath)
+	if err != nil {
+		return 0, err
+	}
+	defer checkpoint.Close()
+
 	// Phase 2: Execute — nsrestore handles rootfs, CRIU restore, and CUDA restore inside namespace
-	result, err := execNSRestore(ctx, log, req, snap)
+	result, err := execNSRestore(
+		ctx,
+		log,
+		req,
+		snap,
+		rootfsMount,
+		workspace,
+		checkpoint,
+	)
 	if err != nil {
 		return 0, fmt.Errorf("nsrestore failed: %w", err)
 	}
-	restoreDuration := hostInspectDuration + result.NSRestoreSetupDuration + result.CRIURestoreDuration + result.CUDADuration
 	log.Info("Restore timing summary",
 		"restore", map[string]any{
-			"duration": restoreDuration.String(),
+			"duration": time.Since(restoreStart).String(),
 			"phases": map[string]string{
-				"host_inspect_duration":    hostInspectDuration.String(),
-				"nsrestore_setup_duration": result.NSRestoreSetupDuration.String(),
-				"criu_restore_duration":    result.CRIURestoreDuration.String(),
-				"cuda_duration":            result.CUDADuration.String(),
+				"host_inspect_duration": hostInspectDuration.String(),
 			},
 		},
 	)
@@ -192,22 +220,24 @@ func inspectRestore(ctx context.Context, rt snapshotruntime.Runtime, log logr.Lo
 
 // execNSRestore launches the nsrestore binary inside the placeholder container's
 // namespaces via nsenter and parses the restored PID from stdout JSON.
-func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, snap *types.RestoreContainerSnapshot) (*RestoreInNamespaceResult, error) {
-	checkpointPath := req.ContainerCheckpointLocation
-	if checkpointPath != "" && !filepath.IsAbs(checkpointPath) {
-		return nil, fmt.Errorf("container checkpoint location must be absolute: %q", checkpointPath)
+func execNSRestore(
+	ctx context.Context,
+	log logr.Logger,
+	req RestoreRequest,
+	snap *types.RestoreContainerSnapshot,
+	rootfsMount, workspace, checkpoint *os.File,
+) (*RestoreInNamespaceResult, error) {
+	if rootfsMount == nil || workspace == nil || checkpoint == nil {
+		return nil, fmt.Errorf("rootfs mount, backing workspace, and checkpoint are required")
 	}
-	if checkpointPath == "" {
-		checkpointPath = snap.CheckpointPath
-	}
-	args := []string{
-		"-t", strconv.Itoa(snap.PlaceholderPID),
-		// Intentionally exclude cgroup namespace (-C): CRIU must manage cgroups
-		// from the host-visible hierarchy so --cgroup-root remap works.
-		"-m", "-u", "-i", "-n", "-p",
+	checkpointPath := "/proc/self/fd/5"
+	args := append(
+		nsenterTargetArgs(snap.PlaceholderPID),
 		"--", req.NSRestorePath,
 		"--checkpoint-path", checkpointPath,
-	}
+		"--rootfs-mount-fd", "3",
+		"--rootfs-workspace-fd", "4",
+	)
 	if snap.CUDADeviceMap != "" {
 		args = append(args, "--cuda-device-map", snap.CUDADeviceMap)
 	}
@@ -219,16 +249,22 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	}
 
 	cmd := exec.CommandContext(ctx, "nsenter", args...)
+	cmd.ExtraFiles = []*os.File{rootfsMount, workspace, checkpoint}
 	// Inherit the agent environment so nsrestore uses the same logger settings.
 	cmd.Env = os.Environ()
 	log.V(1).Info("Executing nsenter + nsrestore", "cmd", cmd.String())
 
-	var stdout bytes.Buffer
+	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stderr = io.MultiWriter(os.Stderr, &stderr)
 
 	if err := cmd.Run(); err != nil {
-		return nil, fmt.Errorf("nsrestore failed: %w\nstdout: %s", err, stdout.String())
+		return nil, fmt.Errorf(
+			"nsrestore failed: %w\nstdout: %s\nstderr tail: %s",
+			err,
+			stdout.String(),
+			stderrTail(stderr.Bytes()),
+		)
 	}
 
 	var result RestoreInNamespaceResult
@@ -240,4 +276,58 @@ func execNSRestore(ctx context.Context, log logr.Logger, req RestoreRequest, sna
 	}
 
 	return &result, nil
+}
+
+func nsenterTargetArgs(targetPID int) []string {
+	return []string{
+		"-t", strconv.Itoa(targetPID),
+		// Intentionally exclude cgroup namespace (-C): CRIU must manage cgroups
+		// from the host-visible hierarchy so --cgroup-root remap works.
+		"-m", "-u", "-i", "-n", "-p",
+	}
+}
+
+// Kubernetes Event messages are limited to 1 KiB. Leave room for the
+// surrounding restore error while preserving the final nsrestore log lines.
+const nsRestoreStderrTailLimit = 768
+
+func stderrTail(stderr []byte) []byte {
+	if len(stderr) <= nsRestoreStderrTailLimit {
+		return stderr
+	}
+	tail := stderr[len(stderr)-nsRestoreStderrTailLimit:]
+	for len(tail) > 0 && !utf8.RuneStart(tail[0]) {
+		tail = tail[1:]
+	}
+	return tail
+}
+
+func openRootfsBackingWorkspace(placeholderPID int) (*os.File, error) {
+	path := filepath.Join(
+		snapshotruntime.HostProcPath,
+		strconv.Itoa(placeholderPID),
+		"root",
+		strings.TrimPrefix(snapshotruntime.RootfsBackingWorkspaceMountPath, "/"),
+	)
+	fd, err := unix.Open(
+		path,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open rootfs backing workspace: %w", err)
+	}
+	return os.NewFile(uintptr(fd), "rootfs-backing-workspace"), nil
+}
+
+func openCheckpointDirectory(path string) (*os.File, error) {
+	fd, err := unix.Open(
+		path,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open checkpoint directory: %w", err)
+	}
+	return os.NewFile(uintptr(fd), "checkpoint-directory"), nil
 }

--- a/deploy/snapshot/internal/executor/restore_test.go
+++ b/deploy/snapshot/internal/executor/restore_test.go
@@ -1,10 +1,16 @@
 package executor
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/go-logr/logr/testr"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -15,6 +21,119 @@ import (
 type restoreFakeRuntime struct {
 	resolvedID      string
 	resolveByPodHit bool
+}
+
+func TestCanonicalizeCheckpointPathSurvivesNestedExtraFiles(t *testing.T) {
+	if os.Getenv("DYNAMO_SNAPSHOT_CHECKPOINT_PATH_HELPER") == "1" {
+		stable, err := os.ReadFile(os.Getenv("DYNAMO_SNAPSHOT_STABLE_PATH"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read stable checkpoint path: %v", err)
+			os.Exit(1)
+		}
+		self, err := os.ReadFile(os.Getenv("DYNAMO_SNAPSHOT_SELF_PATH"))
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "read child checkpoint path: %v", err)
+			os.Exit(1)
+		}
+		fmt.Printf("%s|%s", stable, self)
+		os.Exit(0)
+	}
+
+	checkpointDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(checkpointDir, "marker"), []byte("checkpoint"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	checkpoint, err := os.Open(checkpointDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer checkpoint.Close()
+
+	selfPath := fmt.Sprintf("/proc/self/fd/%d", checkpoint.Fd())
+	stablePath := canonicalizeCheckpointPath(selfPath)
+	wantStablePath := fmt.Sprintf("/proc/%d/fd/%d", os.Getpid(), checkpoint.Fd())
+	if stablePath != wantStablePath {
+		t.Fatalf("canonicalizeCheckpointPath(%q) = %q, want %q", selfPath, stablePath, wantStablePath)
+	}
+	if _, err := os.Stat(fmt.Sprintf("/proc/%d", os.Getpid())); err != nil {
+		t.Fatalf("current PID is not visible in the active proc mount: %v", err)
+	}
+
+	childDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(childDir, "marker"), []byte("nested-child"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	childCheckpoint, err := os.Open(childDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer childCheckpoint.Close()
+
+	extraFileCount := max(3, int(checkpoint.Fd())-2)
+	extraFiles := make([]*os.File, extraFileCount)
+	for i := range extraFiles {
+		extraFiles[i] = childCheckpoint
+	}
+	command := exec.Command(os.Args[0], "-test.run=^TestCanonicalizeCheckpointPathSurvivesNestedExtraFiles$")
+	command.Env = append(
+		os.Environ(),
+		"DYNAMO_SNAPSHOT_CHECKPOINT_PATH_HELPER=1",
+		"DYNAMO_SNAPSHOT_STABLE_PATH="+filepath.Join(stablePath, "marker"),
+		"DYNAMO_SNAPSHOT_SELF_PATH="+filepath.Join(selfPath, "marker"),
+	)
+	command.ExtraFiles = extraFiles
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("nested child: %v\n%s", err, output)
+	}
+	if string(output) != "checkpoint|nested-child" {
+		t.Fatalf("nested child paths resolved to %q, want %q", output, "checkpoint|nested-child")
+	}
+}
+
+func TestNSenterTargetSyntaxPreservesInheritedFD(t *testing.T) {
+	args := nsenterTargetArgs(os.Getpid())
+	for _, arg := range args {
+		if arg == "-r" || strings.HasPrefix(arg, "--root") ||
+			strings.HasPrefix(arg, "--wd") {
+			t.Fatalf("nsenter unexpectedly changes caller root/cwd: %q", arg)
+		}
+	}
+
+	if os.Getenv("DYNAMO_SNAPSHOT_PRIVILEGED_TEST") != "1" || os.Geteuid() != 0 {
+		t.Skip("privileged nsenter test requires root and DYNAMO_SNAPSHOT_PRIVILEGED_TEST=1")
+	}
+	file, err := os.CreateTemp(t.TempDir(), "nsenter-fd")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := file.WriteString("inherited"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		t.Fatal(err)
+	}
+	rootfs, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rootfs.Close()
+	workspace, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workspace.Close()
+	args = append(args, "--", "cat", "/proc/self/fd/5")
+	command := exec.Command("nsenter", args...)
+	command.ExtraFiles = []*os.File{rootfs, workspace, file}
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("nsenter: %v\n%s", err, output)
+	}
+	if string(output) != "inherited" {
+		t.Fatalf("inherited FD output = %q", output)
+	}
 }
 
 func (r *restoreFakeRuntime) ResolveContainer(ctx context.Context, id string) (int, *specs.Spec, error) {
@@ -33,24 +152,49 @@ func (r *restoreFakeRuntime) ResolveContainerByPod(ctx context.Context, pod, ns,
 
 func (r *restoreFakeRuntime) Close() error { return nil }
 
-func TestExecNSRestoreRejectsRelativeContainerCheckpointLocation(t *testing.T) {
-	_, err := execNSRestore(
+func TestExecNSRestoreRequiresInheritedFiles(t *testing.T) {
+	rootfs, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rootfs.Close()
+	workspace, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer workspace.Close()
+	_, err = execNSRestore(
 		context.Background(),
 		testr.New(t),
-		RestoreRequest{
-			ContainerCheckpointLocation: "relative/checkpoint",
-			NSRestorePath:               "/usr/local/bin/nsrestore",
-		},
+		RestoreRequest{NSRestorePath: "/usr/local/bin/nsrestore"},
 		&types.RestoreContainerSnapshot{
 			CheckpointPath: "/host/checkpoints/abc123",
 			PlaceholderPID: 1,
 		},
+		rootfs,
+		workspace,
+		nil,
 	)
 	if err == nil {
-		t.Fatal("expected relative container checkpoint location to be rejected")
+		t.Fatal("expected missing inherited checkpoint directory to be rejected")
 	}
-	if !strings.Contains(err.Error(), "absolute") {
-		t.Fatalf("expected absolute-path validation error, got: %v", err)
+	if !strings.Contains(err.Error(), "checkpoint") {
+		t.Fatalf("expected inherited-file validation error, got: %v", err)
+	}
+}
+
+func TestStderrTail(t *testing.T) {
+	stderr := append([]byte("€"), bytes.Repeat([]byte("x"), nsRestoreStderrTailLimit-1)...)
+	got := stderrTail(stderr)
+
+	if len(got) > nsRestoreStderrTailLimit {
+		t.Fatalf("stderrTail returned %d bytes, limit is %d", len(got), nsRestoreStderrTailLimit)
+	}
+	if !utf8.Valid(got) {
+		t.Fatalf("stderrTail split a UTF-8 rune: %q", got)
+	}
+	if want := bytes.Repeat([]byte("x"), nsRestoreStderrTailLimit-1); !bytes.Equal(got, want) {
+		t.Fatal("stderrTail did not preserve the final complete bytes")
 	}
 }
 
@@ -62,6 +206,7 @@ func TestInspectRestoreUsesContainerIDWhenProvided(t *testing.T) {
 		types.NewSourcePodManifest("source-id", 456, "node-1", "source-pod", "default", "10.0.0.11", nil),
 		types.OverlayManifest{},
 	)
+	manifest.RootFSSHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	if err := types.WriteManifest(checkpointDir, manifest); err != nil {
 		t.Fatalf("WriteManifest: %v", err)
 	}

--- a/deploy/snapshot/internal/logging/diagnostics.go
+++ b/deploy/snapshot/internal/logging/diagnostics.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/go-logr/logr"
 
@@ -44,26 +45,26 @@ func LogProcessDiagnostics(procRoot string, pid int, restoreLogPath string, log 
 	logRestoreLog(restoreLogPath, entry)
 }
 
-// LogRestoreErrors finds the CRIU restore.log and logs key lines from it.
-func LogRestoreErrors(checkpointPath, workDir string, log logr.Logger) {
+// LogRestoreErrors logs the CRIU restore.log and returns a bounded failure summary.
+func LogRestoreErrors(checkpointPath, workDir string, log logr.Logger) string {
 	// Try workdir first, then checkpoint dir
 	for _, dir := range []string{workDir, checkpointPath} {
 		if dir == "" {
 			continue
 		}
 		logPath := filepath.Join(dir, "restore.log")
-		if _, err := os.Stat(logPath); err == nil {
-			logRestoreLog(logPath, log)
-			return
+		if summary := logRestoreLog(logPath, log); summary != "" {
+			return summary
 		}
 	}
+	return ""
 }
 
 // logRestoreLog extracts key lines and tail from a CRIU restore log file.
-func logRestoreLog(path string, log logr.Logger) {
+func logRestoreLog(path string, log logr.Logger) string {
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return
+		return ""
 	}
 
 	lines := strings.Split(string(data), "\n")
@@ -102,4 +103,81 @@ func logRestoreLog(path string, log logr.Logger) {
 	if len(tail) > 0 {
 		log.Info("CRIU restore tail", "path", path, "lines", strings.Join(tail, " | "))
 	}
+
+	return restoreLogSummary(lines)
+}
+
+const (
+	restoreLogSummaryLimit = 320
+	restoreLogSummaryLines = 4
+	restoreLogSeparator    = " | "
+)
+
+func restoreLogSummary(lines []string) string {
+	end := len(lines)
+	for i := len(lines) - 1; i >= 0; i-- {
+		if strings.Contains(strings.ToLower(lines[i]), "restoring failed") {
+			end = i
+			break
+		}
+	}
+
+	var selected []string
+	var fallback string
+	for _, rawLine := range lines[:end] {
+		line := normalizeRestoreLogLine(rawLine)
+		if line == "" {
+			continue
+		}
+		fallback = line
+		lower := strings.ToLower(line)
+		if strings.Contains(lower, "error") ||
+			strings.Contains(lower, "warn") ||
+			strings.Contains(lower, "fail") {
+			selected = append(selected, line)
+			if len(selected) > restoreLogSummaryLines {
+				selected = selected[1:]
+			}
+		}
+	}
+
+	if len(selected) == 0 && fallback != "" {
+		selected = append(selected, fallback)
+	}
+	if len(selected) == 0 {
+		return ""
+	}
+	return boundRestoreLogSummary(selected)
+}
+
+func normalizeRestoreLogLine(line string) string {
+	return strings.Join(strings.Fields(strings.ToValidUTF8(line, "�")), " ")
+}
+
+func boundRestoreLogSummary(lines []string) string {
+	remaining := restoreLogSummaryLimit - len(restoreLogSeparator)*(len(lines)-1)
+	for i := range lines {
+		lineLimit := remaining / (len(lines) - i)
+		lines[i] = truncateRestoreLogLine(lines[i], lineLimit)
+		remaining -= len(lines[i])
+	}
+	return strings.Join(lines, restoreLogSeparator)
+}
+
+func truncateRestoreLogLine(line string, limit int) string {
+	if len(line) <= limit {
+		return line
+	}
+
+	const omission = "..."
+	remaining := limit - len(omission)
+	headEnd := remaining / 2
+	for headEnd > 0 && !utf8.RuneStart(line[headEnd]) {
+		headEnd--
+	}
+	tailStart := len(line) - (remaining - remaining/2)
+	for tailStart < len(line) && !utf8.RuneStart(line[tailStart]) {
+		tailStart++
+	}
+	return line[:headEnd] + omission + line[tailStart:]
 }

--- a/deploy/snapshot/internal/logging/diagnostics_test.go
+++ b/deploy/snapshot/internal/logging/diagnostics_test.go
@@ -1,0 +1,88 @@
+package logging
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/go-logr/logr"
+)
+
+func TestRestoreLogSummary(t *testing.T) {
+	log := []string{
+		"(00.000) Error: an older unrelated failure",
+		"(00.001) Error splicing data: Operation not supported",
+		"(00.002) Error: Can't open file /tmp/model.bin on restore",
+		"(00.003) Error: Unable to open fd=7 id=0x123",
+		"(00.004) Error: 42 exited, status=1",
+		"(00.005) Error: Restoring FAILED.",
+		"(00.006) Error: teardown failed",
+	}
+
+	want := "(00.001) Error splicing data: Operation not supported" +
+		" | (00.002) Error: Can't open file /tmp/model.bin on restore" +
+		" | (00.003) Error: Unable to open fd=7 id=0x123" +
+		" | (00.004) Error: 42 exited, status=1"
+	if got := restoreLogSummary(log); got != want {
+		t.Fatalf("restoreLogSummary() = %q, want %q", got, want)
+	}
+
+	fallback := restoreLogSummary([]string{"initializing", "  last\tstatus  "})
+	if fallback != "last status" {
+		t.Fatalf("restoreLogSummary() fallback = %q, want %q", fallback, "last status")
+	}
+}
+
+func TestRestoreLogSummaryIsBoundedValidUTF8(t *testing.T) {
+	first := append([]byte("Error first \xff "+strings.Repeat("界", 100)), []byte(" tail-one")...)
+	second := append([]byte("Warning second \xfe "+strings.Repeat("界", 100)), []byte(" tail-two")...)
+
+	got := restoreLogSummary([]string{string(first), string(second)})
+	if len(got) > restoreLogSummaryLimit {
+		t.Fatalf("restoreLogSummary() returned %d bytes, limit is %d", len(got), restoreLogSummaryLimit)
+	}
+	if !utf8.ValidString(got) {
+		t.Fatalf("restoreLogSummary() returned invalid UTF-8: %q", got)
+	}
+	for _, want := range []string{"Error first �", "tail-one", "Warning second �", "tail-two", "界"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("restoreLogSummary() = %q, want retained %q", got, want)
+		}
+	}
+}
+
+func TestLogRestoreErrorsFallbackAndPrecedence(t *testing.T) {
+	checkpointPath := t.TempDir()
+	workDir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(workDir, "restore.log"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(checkpointPath, "restore.log"),
+		[]byte("Error: checkpoint fallback"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := LogRestoreErrors(checkpointPath, workDir, logr.Discard()); !strings.Contains(got, "checkpoint fallback") {
+		t.Fatalf("LogRestoreErrors() = %q, want checkpoint fallback", got)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(workDir, "restore.log"),
+		[]byte("Warning: preferred workdir cause"),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if got := LogRestoreErrors(checkpointPath, workDir, logr.Discard()); got != "Warning: preferred workdir cause" {
+		t.Fatalf("LogRestoreErrors() = %q, want preferred workdir cause", got)
+	}
+
+	if got := LogRestoreErrors(t.TempDir(), t.TempDir(), logr.Discard()); got != "" {
+		t.Fatalf("LogRestoreErrors() = %q with no readable logs, want empty", got)
+	}
+}

--- a/deploy/snapshot/internal/runtime/overlay.go
+++ b/deploy/snapshot/internal/runtime/overlay.go
@@ -1,22 +1,41 @@
 package runtime
 
 import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 
-	"github.com/go-logr/logr"
+	"golang.org/x/sys/unix"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
 
 const (
-	rootfsDiffFilename   = "rootfs-diff.tar"
+	RootfsDiffFilename   = "rootfs-diff.squashfs"
 	deletedFilesFilename = "deleted-files.json"
+	// Bounds untrusted metadata while allowing at least ~4,000 PATH_MAX-sized entries and far more normal paths.
+	maxDeletedFilesSidecarSize = 16 << 20
 )
+
+type deletedFiles struct {
+	Whiteouts       []string `json:"whiteouts,omitempty"`
+	OpaqueDirectory []string `json:"opaqueDirectories,omitempty"`
+}
+
+func PreflightRootfsCapture() error {
+	if _, err := exec.LookPath("mksquashfs"); err != nil {
+		return fmt.Errorf("mksquashfs is required: %w", err)
+	}
+	return preflightRootfsMountCapability()
+}
 
 // GetRootFS returns the container's root filesystem path via /host/proc.
 func GetRootFS(pid int) (string, error) {
@@ -33,184 +52,438 @@ func GetOverlayUpperDir(pid int) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to parse mountinfo: %w", err)
 	}
-
 	for _, mount := range mountInfo {
 		if mount.MountPoint != "/" || mount.FSType != "overlay" {
 			continue
 		}
-
-		for _, opt := range strings.Split(mount.VFSOptions, ",") {
-			if strings.HasPrefix(opt, "upperdir=") {
-				return strings.TrimPrefix(opt, "upperdir="), nil
+		var upperDir string
+		for _, option := range strings.Split(mount.VFSOptions, ",") {
+			switch {
+			case strings.HasPrefix(option, "upperdir="):
+				upperDir = strings.TrimPrefix(option, "upperdir=")
+			case option == "metacopy=on", strings.HasPrefix(option, "redirect_dir="):
+				return "", fmt.Errorf("unsupported overlay root option %q", option)
 			}
 		}
+		if upperDir != "" {
+			return upperDir, nil
+		}
 	}
-
 	return "", fmt.Errorf("overlay upperdir not found for pid %d", pid)
 }
 
-// CaptureRootfsDiff captures the overlay upperdir to a tar file.
-func CaptureRootfsDiff(upperDir, checkpointDir string, exclusions types.OverlaySettings, bindMountDests []string) (string, error) {
+// CaptureRootfsDiff writes the mandatory SquashFS diff and deletion sidecar.
+// It hashes the image once and verifies that the kernel can mount it before
+// returning the manifest digest.
+func CaptureRootfsDiff(
+	ctx context.Context,
+	upperDir, checkpointDir string,
+	exclusions types.OverlaySettings,
+	bindMountDests []string,
+) (string, error) {
 	if upperDir == "" {
-		return "", fmt.Errorf("upperdir is empty")
+		return "", errors.New("upperdir is empty")
 	}
-
-	rootfsDiffPath := filepath.Join(checkpointDir, rootfsDiffFilename)
-
-	tarArgs := []string{"--xattrs"}
-	for _, excl := range buildExclusions(exclusions) {
-		tarArgs = append(tarArgs, "--exclude="+excl)
-	}
-	for _, dest := range bindMountDests {
-		tarArgs = append(tarArgs, "--exclude=."+dest)
-	}
-	tarArgs = append(tarArgs, "-C", upperDir, "-cf", rootfsDiffPath, ".")
-
-	cmd := exec.Command("tar", tarArgs...)
-	output, err := cmd.CombinedOutput()
+	deletions, overlayEntries, err := scanOverlayUpper(upperDir)
 	if err != nil {
-		return "", fmt.Errorf("tar failed: %w (output: %s)", err, string(output))
+		return "", err
+	}
+	if err := writeDeletedFiles(checkpointDir, deletions); err != nil {
+		return "", err
 	}
 
-	return rootfsDiffPath, nil
+	rootfsPath := filepath.Join(checkpointDir, RootfsDiffFilename)
+	if err := runMksquashfs(
+		ctx,
+		upperDir,
+		rootfsPath,
+		buildExclusions(exclusions, bindMountDests, overlayEntries),
+	); err != nil {
+		return "", err
+	}
+	image, digest, err := openAndValidateRootfs(rootfsPath, "")
+	if err != nil {
+		return "", err
+	}
+	defer image.Close()
+	mount, err := PrepareDetachedRootfsMount(image)
+	if err != nil {
+		return "", fmt.Errorf("kernel rejected captured SquashFS: %w", err)
+	}
+	if err := mount.Close(); err != nil {
+		return "", fmt.Errorf("close captured SquashFS verification mount: %w", err)
+	}
+	return digest, nil
 }
 
-// buildExclusions merges exclusion lists and normalizes paths for tar --exclude patterns.
-func buildExclusions(s types.OverlaySettings) []string {
-	exclusions := append([]string(nil), s.Exclusions...)
-	for i, p := range exclusions {
-		if strings.HasPrefix(p, "*") {
-			continue
-		}
-		p = strings.TrimPrefix(p, ".")
-		p = strings.TrimPrefix(p, "/")
-		exclusions[i] = "./" + p
+func runMksquashfs(
+	ctx context.Context,
+	source, output string,
+	exclusions []string,
+) error {
+	args := []string{
+		source,
+		output,
+		"-comp", "lz4",
+		"-b", "1M",
+		"-processors", "8",
+		"-noappend",
+		"-no-progress",
+		"-exit-on-error",
+		"-one-file-system-x",
+		"-xattrs",
+		"-xattrs-exclude", `^(trusted|user)\.overlay\.`,
+		"-wildcards",
 	}
-	return exclusions
-}
-
-// CaptureDeletedFiles finds whiteout files and saves them to a JSON file.
-func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
-	if upperDir == "" {
-		return false, nil
+	if len(exclusions) > 0 {
+		args = append(args, "-e")
+		args = append(args, exclusions...)
 	}
-
-	whiteouts, err := findWhiteoutFiles(upperDir)
+	outputBytes, err := exec.CommandContext(ctx, "mksquashfs", args...).CombinedOutput()
 	if err != nil {
-		return false, fmt.Errorf("failed to find whiteout files: %w", err)
-	}
-
-	if len(whiteouts) == 0 {
-		return false, nil
-	}
-
-	deletedFilesPath := filepath.Join(checkpointDir, deletedFilesFilename)
-	data, err := json.Marshal(whiteouts)
-	if err != nil {
-		return false, fmt.Errorf("failed to marshal whiteouts: %w", err)
-	}
-
-	if err := os.WriteFile(deletedFilesPath, data, 0644); err != nil {
-		return false, fmt.Errorf("failed to write deleted files: %w", err)
-	}
-
-	return true, nil
-}
-
-// ApplyRootfsDiff extracts rootfs-diff.tar into the target root.
-func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
-	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
-	if _, err := os.Stat(rootfsDiffPath); os.IsNotExist(err) {
-		log.V(1).Info("No rootfs-diff.tar, skipping")
-		return nil
-	}
-
-	// --skip-old-files: silently skip files that already exist in the restore target.
-	// The rootfs diff only contains overlay upperdir changes (runtime-generated files
-	// like triton caches, tmp files) — base image files should not be overwritten.
-	log.Info("Applying rootfs diff", "target", targetRoot)
-	cmd := exec.Command("tar", "--skip-old-files", "-C", targetRoot, "-xf", rootfsDiffPath)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("tar extract failed: %w", err)
+		_ = os.Remove(output)
+		return fmt.Errorf("mksquashfs failed: %w (output: %s)", err, outputBytes)
 	}
 	return nil
 }
 
-// ApplyDeletedFiles removes files marked as deleted in the checkpoint.
-func ApplyDeletedFiles(checkpointPath, targetRoot string, log logr.Logger) error {
-	deletedFilesPath := filepath.Join(checkpointPath, deletedFilesFilename)
-	data, err := os.ReadFile(deletedFilesPath)
-	if os.IsNotExist(err) {
-		return nil
-	}
-	if err != nil {
-		return fmt.Errorf("failed to read deleted files: %w", err)
-	}
-
-	var deletedFiles []string
-	if err := json.Unmarshal(data, &deletedFiles); err != nil {
-		return fmt.Errorf("failed to parse deleted files: %w", err)
-	}
-
-	count := 0
-	targetRootAbs, err := filepath.Abs(targetRoot)
-	if err != nil {
-		return fmt.Errorf("failed to resolve target root %s: %w", targetRoot, err)
-	}
-	targetRootPrefix := targetRootAbs + string(os.PathSeparator)
-	for _, f := range deletedFiles {
-		if f == "" {
+func buildExclusions(
+	settings types.OverlaySettings,
+	bindMountDests, overlayEntries []string,
+) []string {
+	var result []string
+	for _, exclusion := range settings.Exclusions {
+		exclusion = strings.TrimPrefix(filepath.Clean(exclusion), "/")
+		exclusion = strings.TrimPrefix(exclusion, "./")
+		if exclusion == "" || exclusion == "." {
 			continue
 		}
-		target := filepath.Join(targetRoot, f)
-		targetAbs, err := filepath.Abs(target)
-		if err != nil || (targetAbs != targetRootAbs && !strings.HasPrefix(targetAbs, targetRootPrefix)) {
-			log.V(1).Info("Skipping out-of-root deleted file entry", "entry", f)
-			continue
+		if strings.ContainsAny(exclusion, "*?[") {
+			exclusion = strings.TrimPrefix(exclusion, "*/")
+			result = append(result, exclusion, "... "+exclusion)
+		} else {
+			result = append(result, exclusion)
 		}
-		if _, err := os.Stat(target); os.IsNotExist(err) {
-			continue
-		} else if err != nil {
-			log.V(1).Info("Could not stat deleted file target", "path", target, "error", err)
-			continue
-		}
-		if err := os.RemoveAll(target); err != nil {
-			log.V(1).Info("Could not delete file", "path", target, "error", err)
-			continue
-		}
-		count++
 	}
-	log.Info("Deleted files applied", "count", count)
-	return nil
+	for _, path := range append(bindMountDests, overlayEntries...) {
+		path = strings.TrimPrefix(filepath.Clean(path), "/")
+		if path != "" && path != "." {
+			result = append(result, escapeSquashfsWildcardLiteral(path))
+		}
+	}
+	return result
 }
 
-// findWhiteoutFiles finds overlay whiteout files in the upperdir.
-func findWhiteoutFiles(upperDir string) ([]string, error) {
-	var whiteouts []string
+func escapeSquashfsWildcardLiteral(path string) string {
+	var escaped strings.Builder
+	escaped.Grow(len(path) * 2)
+	for i := range len(path) {
+		if path[i] != '/' {
+			escaped.WriteByte('\\')
+		}
+		escaped.WriteByte(path[i])
+	}
+	return escaped.String()
+}
 
-	err := filepath.Walk(upperDir, func(path string, info os.FileInfo, err error) error {
+func scanOverlayUpper(upperDir string) (*deletedFiles, []string, error) {
+	result := &deletedFiles{}
+	var overlayEntries []string
+	err := filepath.Walk(upperDir, func(path string, info os.FileInfo, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		relative, err := filepath.Rel(upperDir, path)
 		if err != nil {
 			return err
 		}
+		for _, name := range []string{
+			"trusted.overlay.metacopy",
+			"user.overlay.metacopy",
+			"trusted.overlay.redirect",
+			"user.overlay.redirect",
+		} {
+			if value, present, err := readXattr(path, name); err != nil {
+				return err
+			} else if present {
+				return fmt.Errorf("unsupported overlay xattr %s=%q on %s", name, value, relative)
+			}
+		}
+		if info.IsDir() {
+			for _, name := range []string{"trusted.overlay.opaque", "user.overlay.opaque"} {
+				value, present, err := readXattr(path, name)
+				if err != nil {
+					return err
+				}
+				if present && value == "y" {
+					result.OpaqueDirectory = append(
+						result.OpaqueDirectory,
+						filepath.ToSlash(relative),
+					)
+				} else if present && value != "x" {
+					return fmt.Errorf("invalid overlay opaque value %q on %s", value, relative)
+				}
+			}
+		}
+		if path == upperDir {
+			return nil
+		}
 
 		name := info.Name()
-		if strings.HasPrefix(name, ".wh.") {
-			relPath, err := filepath.Rel(upperDir, path)
+		switch {
+		case name == ".wh..wh..opq":
+			parent := filepath.Dir(relative)
+			if parent != "." {
+				result.OpaqueDirectory = append(result.OpaqueDirectory, filepath.ToSlash(parent))
+			}
+			overlayEntries = append(overlayEntries, filepath.ToSlash(relative))
+		case strings.HasPrefix(name, ".wh."):
+			deleted := filepath.Join(filepath.Dir(relative), strings.TrimPrefix(name, ".wh."))
+			result.Whiteouts = append(result.Whiteouts, filepath.ToSlash(deleted))
+			overlayEntries = append(overlayEntries, filepath.ToSlash(relative))
+		default:
+			whiteout, err := isOverlayWhiteout(path, info)
 			if err != nil {
-				return fmt.Errorf("failed to compute relative path for %s: %w", path, err)
+				return err
 			}
-			dir := filepath.Dir(relPath)
-			deletedFile := strings.TrimPrefix(name, ".wh.")
-			deletedPath := deletedFile
-			if dir != "." {
-				deletedPath = filepath.Join(dir, deletedFile)
+			if whiteout {
+				result.Whiteouts = append(result.Whiteouts, filepath.ToSlash(relative))
+				overlayEntries = append(overlayEntries, filepath.ToSlash(relative))
 			}
-			whiteouts = append(whiteouts, deletedPath)
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, nil, fmt.Errorf("scan overlay upperdir: %w", err)
+	}
+	return result, overlayEntries, nil
+}
 
-	return whiteouts, err
+func isOverlayWhiteout(path string, info os.FileInfo) (bool, error) {
+	if stat, ok := info.Sys().(*unix.Stat_t); ok &&
+		stat.Mode&unix.S_IFMT == unix.S_IFCHR &&
+		unix.Major(uint64(stat.Rdev)) == 0 &&
+		unix.Minor(uint64(stat.Rdev)) == 0 {
+		return true, nil
+	}
+	for _, name := range []string{"trusted.overlay.whiteout", "user.overlay.whiteout"} {
+		_, present, err := readXattr(path, name)
+		if err != nil {
+			return false, err
+		}
+		if present {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func readXattr(path, name string) (string, bool, error) {
+	size, err := unix.Lgetxattr(path, name, nil)
+	if errors.Is(err, unix.ENODATA) || errors.Is(err, unix.ENOTSUP) {
+		return "", false, nil
+	}
+	if err != nil {
+		return "", false, fmt.Errorf("read xattr %s on %s: %w", name, path, err)
+	}
+	value := make([]byte, size)
+	if _, err := unix.Lgetxattr(path, name, value); err != nil {
+		return "", false, fmt.Errorf("read xattr %s on %s: %w", name, path, err)
+	}
+	return string(value), true, nil
+}
+
+func writeDeletedFiles(checkpointDir string, files *deletedFiles) error {
+	path := filepath.Join(checkpointDir, deletedFilesFilename)
+	if len(files.Whiteouts) == 0 && len(files.OpaqueDirectory) == 0 {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("remove empty deletion sidecar: %w", err)
+		}
+		return nil
+	}
+	data, err := json.Marshal(files)
+	if err != nil {
+		return fmt.Errorf("marshal deletion sidecar: %w", err)
+	}
+	if len(data) > maxDeletedFilesSidecarSize {
+		return fmt.Errorf(
+			"deletion sidecar exceeds %d-byte limit",
+			maxDeletedFilesSidecarSize,
+		)
+	}
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		return fmt.Errorf("write deletion sidecar: %w", err)
+	}
+	return nil
+}
+
+// OpenValidatedRootfs opens the fixed artifact without following its final
+// component, validates the manifest digest, and returns the same FD for loop
+// configuration.
+func OpenValidatedRootfs(checkpointDir, checkpointID string) (*os.File, error) {
+	manifest, err := types.ReadManifest(checkpointDir)
+	if err != nil {
+		return nil, err
+	}
+	if checkpointID != "" && manifest.CheckpointID != checkpointID {
+		return nil, fmt.Errorf(
+			"checkpoint manifest ID %q does not match %q",
+			manifest.CheckpointID,
+			checkpointID,
+		)
+	}
+	image, _, err := openAndValidateRootfs(
+		filepath.Join(checkpointDir, RootfsDiffFilename),
+		manifest.RootFSSHA256,
+	)
+	return image, err
+}
+
+// ValidateCheckpointArtifact validates the fixed artifact files used for
+// controller resume.
+func ValidateCheckpointArtifact(checkpointDir, checkpointID string) error {
+	image, err := OpenValidatedRootfs(checkpointDir, checkpointID)
+	if err != nil {
+		return err
+	}
+	if err := image.Close(); err != nil {
+		return fmt.Errorf("close validated rootfs image: %w", err)
+	}
+	sidecar, err := OpenDeletedFiles(checkpointDir)
+	if err != nil {
+		return err
+	}
+	if sidecar == nil {
+		return nil
+	}
+	defer sidecar.Close()
+	_, err = readDeletedFilesFile(sidecar)
+	return err
+}
+
+func openAndValidateRootfs(path, expectedDigest string) (*os.File, string, error) {
+	if expectedDigest != "" {
+		if len(expectedDigest) != sha256.Size*2 {
+			return nil, "", errors.New("checkpoint manifest has invalid rootfsSha256")
+		}
+		if _, err := hex.DecodeString(expectedDigest); err != nil {
+			return nil, "", fmt.Errorf("checkpoint manifest has invalid rootfsSha256: %w", err)
+		}
+	}
+	fd, err := unix.Open(path, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, "", fmt.Errorf("open %s: %w", RootfsDiffFilename, err)
+	}
+	image := os.NewFile(uintptr(fd), RootfsDiffFilename)
+	closeWithError := func(err error) (*os.File, string, error) {
+		image.Close()
+		return nil, "", err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstat(fd, &stat); err != nil {
+		return closeWithError(fmt.Errorf("stat %s: %w", RootfsDiffFilename, err))
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFREG {
+		return closeWithError(fmt.Errorf("%s is not a regular file", RootfsDiffFilename))
+	}
+	if _, err := image.Seek(0, io.SeekStart); err != nil {
+		return closeWithError(fmt.Errorf("seek rootfs image: %w", err))
+	}
+	sum := sha256.New()
+	if _, err := io.Copy(sum, image); err != nil {
+		return closeWithError(fmt.Errorf("hash rootfs image: %w", err))
+	}
+	digest := hex.EncodeToString(sum.Sum(nil))
+	if expectedDigest != "" && digest != expectedDigest {
+		return closeWithError(fmt.Errorf("rootfs SHA-256 mismatch: got %s", digest))
+	}
+	if _, err := image.Seek(0, io.SeekStart); err != nil {
+		return closeWithError(fmt.Errorf("rewind rootfs image: %w", err))
+	}
+	return image, digest, nil
+}
+
+func OpenDeletedFiles(checkpointDir string) (*os.File, error) {
+	fd, err := unix.Open(
+		filepath.Join(checkpointDir, deletedFilesFilename),
+		unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW|unix.O_NONBLOCK,
+		0,
+	)
+	if errors.Is(err, unix.ENOENT) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open deletion sidecar: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), deletedFilesFilename)
+	if err := validateDeletedFilesFile(file); err != nil {
+		file.Close()
+		return nil, err
+	}
+	return file, nil
+}
+
+func readDeletedFilesFile(file *os.File) (*deletedFiles, error) {
+	if file == nil {
+		return &deletedFiles{}, nil
+	}
+	if err := validateDeletedFilesFile(file); err != nil {
+		return nil, err
+	}
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return nil, fmt.Errorf("seek deletion sidecar: %w", err)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxDeletedFilesSidecarSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("read deletion sidecar: %w", err)
+	}
+	if len(data) > maxDeletedFilesSidecarSize {
+		return nil, fmt.Errorf(
+			"deletion sidecar exceeds %d-byte limit",
+			maxDeletedFilesSidecarSize,
+		)
+	}
+	var result deletedFiles
+	if err := json.Unmarshal(data, &result); err != nil {
+		return nil, fmt.Errorf("decode deletion sidecar: %w", err)
+	}
+	for _, entry := range result.Whiteouts {
+		if err := validateRelativeArtifactPath(entry); err != nil {
+			return nil, fmt.Errorf("invalid deletion entry %q: %w", entry, err)
+		}
+	}
+	for _, entry := range result.OpaqueDirectory {
+		if entry != "." {
+			if err := validateRelativeArtifactPath(entry); err != nil {
+				return nil, fmt.Errorf("invalid opaque directory entry %q: %w", entry, err)
+			}
+		}
+	}
+	return &result, nil
+}
+
+func validateDeletedFilesFile(file *os.File) error {
+	info, err := file.Stat()
+	if err != nil {
+		return fmt.Errorf("stat deletion sidecar: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return errors.New("deletion sidecar is not a regular file")
+	}
+	if info.Size() > maxDeletedFilesSidecarSize {
+		return fmt.Errorf(
+			"deletion sidecar exceeds %d-byte limit",
+			maxDeletedFilesSidecarSize,
+		)
+	}
+	return nil
+}
+
+func validateRelativeArtifactPath(path string) error {
+	if path == "" || filepath.IsAbs(path) || filepath.Clean(path) != path ||
+		path == "." || path == ".." ||
+		strings.HasPrefix(path, ".."+string(os.PathSeparator)) {
+		return errors.New("path must be clean and relative")
+	}
+	return nil
 }

--- a/deploy/snapshot/internal/runtime/overlay_test.go
+++ b/deploy/snapshot/internal/runtime/overlay_test.go
@@ -1,309 +1,325 @@
 package runtime
 
 import (
-	"encoding/json"
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
-	"github.com/go-logr/logr/testr"
+	"golang.org/x/sys/unix"
 
 	"github.com/ai-dynamo/dynamo/deploy/snapshot/internal/types"
 )
 
 func TestBuildExclusions(t *testing.T) {
-	tests := []struct {
-		name     string
-		settings types.OverlaySettings
-		want     map[string]bool // expected entries (true = must be present)
-	}{
-		{
-			name: "normalizes rooted paths",
-			settings: types.OverlaySettings{
-				Exclusions: []string{"/proc", "/sys", "/root/.cache", "/tmp"},
-			},
-			want: map[string]bool{
-				"./proc":        true,
-				"./sys":         true,
-				"./root/.cache": true,
-				"./tmp":         true,
-			},
-		},
-		{
-			name: "strips leading dot and slash before prepending ./",
-			settings: types.OverlaySettings{
-				Exclusions: []string{"./proc", "/sys", "tmp"},
-			},
-			want: map[string]bool{
-				"./proc": true,
-				"./sys":  true,
-				"./tmp":  true,
-			},
-		},
-		{
-			name: "glob patterns starting with * are untouched",
-			settings: types.OverlaySettings{
-				Exclusions: []string{"*/.cache/huggingface", "*.pyc", "*/__pycache__"},
-			},
-			want: map[string]bool{
-				"*/.cache/huggingface": true,
-				"*.pyc":                true,
-				"*/__pycache__":        true,
-			},
-		},
-		{
-			name:     "empty settings produces empty slice",
-			settings: types.OverlaySettings{},
-			want:     map[string]bool{},
-		},
+	got := buildExclusions(
+		types.OverlaySettings{Exclusions: []string{
+			"/proc",
+			"*/.cache/huggingface",
+			"*/__pycache__",
+			"*.pyc",
+		}},
+		[]string{"/mounted[ab]"},
+		[]string{".wh.removed"},
+	)
+	want := []string{
+		"proc",
+		".cache/huggingface", "... .cache/huggingface",
+		"__pycache__", "... __pycache__",
+		"*.pyc", "... *.pyc",
+		`\m\o\u\n\t\e\d\[\a\b\]`,
+		`\.\w\h\.\r\e\m\o\v\e\d`,
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			got := buildExclusions(tc.settings)
-			gotSet := make(map[string]bool, len(got))
-			for _, v := range got {
-				gotSet[v] = true
-			}
-			for expected := range tc.want {
-				if !gotSet[expected] {
-					t.Errorf("expected %q in exclusions, got %v", expected, got)
-				}
-			}
-			if len(got) != len(tc.want) {
-				t.Errorf("len(exclusions) = %d, want %d; got %v", len(got), len(tc.want), got)
-			}
-		})
+	if strings.Join(got, "|") != strings.Join(want, "|") {
+		t.Fatalf("buildExclusions() = %#v, want %#v", got, want)
 	}
 }
 
-func TestFindWhiteoutFiles(t *testing.T) {
-	tests := []struct {
-		name  string
-		setup func(t *testing.T, dir string) // create files in temp dir
-		want  []string
-	}{
-		{
-			name: "top-level whiteout",
-			setup: func(t *testing.T, dir string) {
-				t.Helper()
-				if err := os.WriteFile(filepath.Join(dir, ".wh.somefile"), nil, 0644); err != nil {
-					t.Fatalf("write whiteout: %v", err)
-				}
-			},
-			want: []string{"somefile"},
-		},
-		{
-			name: "nested whiteout returns relative path",
-			setup: func(t *testing.T, dir string) {
-				t.Helper()
-				sub := filepath.Join(dir, "subdir")
-				if err := os.MkdirAll(sub, 0755); err != nil {
-					t.Fatalf("mkdir subdir: %v", err)
-				}
-				if err := os.WriteFile(filepath.Join(sub, ".wh.nested"), nil, 0644); err != nil {
-					t.Fatalf("write nested whiteout: %v", err)
-				}
-			},
-			want: []string{"subdir/nested"},
-		},
-		{
-			name: "no whiteouts returns empty",
-			setup: func(t *testing.T, dir string) {
-				t.Helper()
-				if err := os.WriteFile(filepath.Join(dir, "regular"), nil, 0644); err != nil {
-					t.Fatalf("write regular file: %v", err)
-				}
-			},
-			want: nil,
-		},
-		{
-			name:  "empty dir returns empty",
-			setup: func(*testing.T, string) {},
-			want:  nil,
-		},
+func TestCaptureRootfsDiffIsMandatory(t *testing.T) {
+	upper := t.TempDir()
+	checkpoint := t.TempDir()
+	t.Setenv("PATH", t.TempDir())
+	if _, err := CaptureRootfsDiff(
+		context.Background(),
+		upper,
+		checkpoint,
+		types.OverlaySettings{},
+		nil,
+	); err == nil {
+		t.Fatal("expected missing mksquashfs to fail capture")
 	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := t.TempDir()
-			tc.setup(t, dir)
-			got, err := findWhiteoutFiles(dir)
-			if err != nil {
-				t.Fatalf("findWhiteoutFiles: %v", err)
-			}
-			if len(got) != len(tc.want) {
-				t.Fatalf("got %v, want %v", got, tc.want)
-			}
-			for i := range tc.want {
-				if got[i] != tc.want[i] {
-					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
-				}
-			}
-		})
+	if _, err := os.Stat(filepath.Join(checkpoint, RootfsDiffFilename)); !os.IsNotExist(err) {
+		t.Fatalf("failed capture left a rootfs artifact: %v", err)
 	}
 }
 
-func TestCaptureDeletedFiles(t *testing.T) {
-	t.Run("dir with whiteouts writes JSON and returns true", func(t *testing.T) {
-		upperDir := t.TempDir()
-		checkpointDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(upperDir, ".wh.removed"), nil, 0644); err != nil {
-			t.Fatalf("write whiteout: %v", err)
+func TestRunMksquashfsExclusions(t *testing.T) {
+	requireTool(t, "mksquashfs")
+	requireTool(t, "unsquashfs")
+	source := t.TempDir()
+	for _, path := range []string{
+		".cache/huggingface",
+		"__pycache__",
+		"nested/.cache/huggingface",
+		"nested/__pycache__",
+		"literal[ab]",
+		"literala",
+	} {
+		if err := os.MkdirAll(filepath.Join(source, path), 0o755); err != nil {
+			t.Fatal(err)
 		}
-
-		found, err := CaptureDeletedFiles(upperDir, checkpointDir)
-		if err != nil {
-			t.Fatalf("CaptureDeletedFiles: %v", err)
+	}
+	for _, path := range []string{
+		".cache/huggingface/root",
+		"__pycache__/root",
+		"nested/.cache/huggingface/child",
+		"nested/__pycache__/child",
+		"top.pyc",
+		"nested/child.pyc",
+		"nested/keep",
+		"literal[ab]/excluded",
+		"literala/decoy",
+	} {
+		if err := os.WriteFile(filepath.Join(source, path), nil, 0o600); err != nil {
+			t.Fatal(err)
 		}
-		if !found {
-			t.Fatal("expected found=true")
-		}
-
-		data, err := os.ReadFile(filepath.Join(checkpointDir, deletedFilesFilename))
-		if err != nil {
-			t.Fatalf("read deleted-files.json: %v", err)
-		}
-		var files []string
-		if err := json.Unmarshal(data, &files); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-		if len(files) != 1 || files[0] != "removed" {
-			t.Errorf("got %v, want [removed]", files)
-		}
-	})
-
-	t.Run("dir with no whiteouts returns false and no file", func(t *testing.T) {
-		upperDir := t.TempDir()
-		checkpointDir := t.TempDir()
-		if err := os.WriteFile(filepath.Join(upperDir, "normalfile"), nil, 0644); err != nil {
-			t.Fatalf("write regular file: %v", err)
-		}
-
-		found, err := CaptureDeletedFiles(upperDir, checkpointDir)
-		if err != nil {
-			t.Fatalf("CaptureDeletedFiles: %v", err)
-		}
-		if found {
-			t.Fatal("expected found=false")
-		}
-		if _, err := os.Stat(filepath.Join(checkpointDir, deletedFilesFilename)); !os.IsNotExist(err) {
-			t.Error("deleted-files.json should not exist")
-		}
-	})
-
-	t.Run("empty upperDir returns false", func(t *testing.T) {
-		found, err := CaptureDeletedFiles("", t.TempDir())
-		if err != nil {
-			t.Fatalf("CaptureDeletedFiles: %v", err)
-		}
-		if found {
-			t.Fatal("expected found=false for empty upperDir")
-		}
-	})
+	}
+	image := filepath.Join(t.TempDir(), RootfsDiffFilename)
+	exclusions := buildExclusions(types.OverlaySettings{Exclusions: []string{
+		"*/.cache/huggingface",
+		"*/__pycache__",
+		"*.pyc",
+	}}, []string{"/literal[ab]"}, nil)
+	if err := runMksquashfs(context.Background(), source, image, exclusions); err != nil {
+		t.Fatal(err)
+	}
+	output, err := exec.Command("unsquashfs", "-ll", image).CombinedOutput()
+	if err != nil {
+		t.Fatalf("unsquashfs: %v\n%s", err, output)
+	}
+	listing := string(output)
+	if strings.Contains(listing, ".cache/huggingface") ||
+		strings.Contains(listing, "__pycache__") ||
+		strings.Contains(listing, ".pyc") ||
+		strings.Contains(listing, "literal[ab]") ||
+		!strings.Contains(listing, "nested/keep") ||
+		!strings.Contains(listing, "literala/decoy") {
+		t.Fatalf("unexpected SquashFS listing:\n%s", listing)
+	}
 }
 
-func TestApplyDeletedFiles(t *testing.T) {
-	log := testr.New(t)
+func TestRunMksquashfsCancellationRemovesOutput(t *testing.T) {
+	binDir := t.TempDir()
+	mksquashfs := filepath.Join(binDir, "mksquashfs")
+	if err := os.WriteFile(
+		mksquashfs,
+		[]byte("#!/bin/sh\n: > \"$2\"\n: > \"$FAKE_MKSQUASHFS_STARTED\"\nexec sleep 60\n"),
+		0o755,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	started := filepath.Join(t.TempDir(), "started")
+	t.Setenv("FAKE_MKSQUASHFS_STARTED", started)
+	output := filepath.Join(t.TempDir(), RootfsDiffFilename)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
 
-	t.Run("deletes listed files from target", func(t *testing.T) {
-		checkpointDir := t.TempDir()
-		targetRoot := t.TempDir()
+	if err := runMksquashfs(ctx, t.TempDir(), output, nil); err == nil {
+		t.Fatal("expected cancellation to fail mksquashfs")
+	}
+	if _, err := os.Stat(started); err != nil {
+		t.Fatalf("fake mksquashfs did not start: %v", err)
+	}
+	if _, err := os.Stat(output); !os.IsNotExist(err) {
+		t.Fatalf("cancelled mksquashfs left output: %v", err)
+	}
+}
 
-		// Create target file that should be deleted
-		if err := os.WriteFile(filepath.Join(targetRoot, "old-cache"), []byte("data"), 0644); err != nil {
-			t.Fatalf("write target file: %v", err)
+func TestScanOverlayUpperHandlesOpaqueXAndY(t *testing.T) {
+	upper := t.TempDir()
+	for _, path := range []string{"opaque-x", "opaque-y", "nested"} {
+		if err := os.Mkdir(filepath.Join(upper, path), 0o755); err != nil {
+			t.Fatal(err)
 		}
+	}
+	if err := unix.Lsetxattr(
+		filepath.Join(upper, "opaque-x"),
+		"user.overlay.opaque",
+		[]byte("x"),
+		0,
+	); err != nil {
+		t.Skipf("overlay xattr not supported by test filesystem: %v", err)
+	}
+	if err := unix.Lsetxattr(
+		filepath.Join(upper, "opaque-y"),
+		"user.overlay.opaque",
+		[]byte("y"),
+		0,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(upper, "nested", ".wh.removed"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
 
-		// Write deleted-files.json
-		data, err := json.Marshal([]string{"old-cache"})
-		if err != nil {
-			t.Fatalf("marshal deleted files: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(checkpointDir, deletedFilesFilename), data, 0644); err != nil {
-			t.Fatalf("write deleted-files.json: %v", err)
-		}
+	deletions, excluded, err := scanOverlayUpper(upper)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deletions.OpaqueDirectory) != 1 ||
+		deletions.OpaqueDirectory[0] != "opaque-y" {
+		t.Fatalf("opaque directories = %#v, want [opaque-y]", deletions.OpaqueDirectory)
+	}
+	if len(deletions.Whiteouts) != 1 ||
+		deletions.Whiteouts[0] != "nested/removed" {
+		t.Fatalf("whiteouts = %#v, want [nested/removed]", deletions.Whiteouts)
+	}
+	if len(excluded) != 1 || excluded[0] != "nested/.wh.removed" {
+		t.Fatalf("excluded overlay entries = %#v", excluded)
+	}
+}
 
-		if err := ApplyDeletedFiles(checkpointDir, targetRoot, log); err != nil {
-			t.Fatalf("ApplyDeletedFiles: %v", err)
-		}
+func TestOpenAndValidateRootfsUsesManifestDigestAndNoFollow(t *testing.T) {
+	requireTool(t, "mksquashfs")
+	source := t.TempDir()
+	if err := os.WriteFile(filepath.Join(source, "file"), []byte("rootfs"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(t.TempDir(), RootfsDiffFilename)
+	if err := runMksquashfs(context.Background(), source, imagePath, nil); err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sum := sha256.Sum256(content)
+	digest := hex.EncodeToString(sum[:])
+	image, got, err := openAndValidateRootfs(imagePath, digest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	image.Close()
+	if got != digest {
+		t.Fatalf("digest = %s, want %s", got, digest)
+	}
+	if _, _, err := openAndValidateRootfs(imagePath, strings.Repeat("1", 64)); err == nil {
+		t.Fatal("expected digest mismatch")
+	}
 
-		if _, err := os.Stat(filepath.Join(targetRoot, "old-cache")); !os.IsNotExist(err) {
-			t.Error("old-cache should have been deleted")
-		}
-	})
+	link := filepath.Join(t.TempDir(), RootfsDiffFilename)
+	if err := os.Symlink(imagePath, link); err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := openAndValidateRootfs(link, digest); err == nil {
+		t.Fatal("expected final-component symlink to be rejected")
+	}
+}
 
-	t.Run("missing deleted-files.json is a no-op", func(t *testing.T) {
-		if err := ApplyDeletedFiles(t.TempDir(), t.TempDir(), log); err != nil {
-			t.Fatalf("ApplyDeletedFiles: %v", err)
-		}
-	})
+func TestReadDeletedFilesRejectsTraversal(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), deletedFilesFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	if _, err := file.WriteString(`{"whiteouts":["../escape"]}`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readDeletedFilesFile(file); err == nil {
+		t.Fatal("expected traversal to be rejected")
+	}
+}
 
-	t.Run("path traversal entry is skipped", func(t *testing.T) {
-		checkpointDir := t.TempDir()
-		targetRoot := t.TempDir()
+func TestValidateRelativeArtifactPathRejectsParent(t *testing.T) {
+	if err := validateRelativeArtifactPath(".."); err == nil {
+		t.Fatal("expected bare parent path to be rejected")
+	}
+}
 
-		// Create a file outside targetRoot that the traversal would try to delete
-		outsideDir := t.TempDir()
-		secretFile := filepath.Join(outsideDir, "passwd")
-		if err := os.WriteFile(secretFile, []byte("secret"), 0644); err != nil {
-			t.Fatalf("write secret file: %v", err)
-		}
+func TestDeletedFilesSidecarRoundTrip(t *testing.T) {
+	checkpoint := t.TempDir()
+	if err := writeDeletedFiles(
+		checkpoint,
+		&deletedFiles{Whiteouts: []string{"removed"}},
+	); err != nil {
+		t.Fatal(err)
+	}
+	file, err := OpenDeletedFiles(checkpoint)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer file.Close()
+	files, err := readDeletedFilesFile(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files.Whiteouts) != 1 || files.Whiteouts[0] != "removed" {
+		t.Fatalf("whiteouts = %#v, want [removed]", files.Whiteouts)
+	}
+}
 
-		// Construct a relative path that escapes targetRoot
-		rel, err := filepath.Rel(targetRoot, secretFile)
-		if err != nil {
-			t.Fatalf("build relative path: %v", err)
+func TestDeletedFilesSidecarNonregularBoundaries(t *testing.T) {
+	checkpoint := t.TempDir()
+	path := filepath.Join(checkpoint, deletedFilesFilename)
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	result := make(chan error, 1)
+	go func() {
+		file, err := OpenDeletedFiles(checkpoint)
+		if file != nil {
+			file.Close()
 		}
-		data, err := json.Marshal([]string{rel})
-		if err != nil {
-			t.Fatalf("marshal deleted files: %v", err)
+		result <- err
+	}()
+	select {
+	case err := <-result:
+		if err == nil {
+			t.Fatal("expected FIFO sidecar to be rejected")
 		}
-		if err := os.WriteFile(filepath.Join(checkpointDir, deletedFilesFilename), data, 0644); err != nil {
-			t.Fatalf("write deleted-files.json: %v", err)
-		}
+	case <-time.After(time.Second):
+		t.Fatal("opening FIFO sidecar blocked")
+	}
 
-		if err := ApplyDeletedFiles(checkpointDir, targetRoot, log); err != nil {
-			t.Fatalf("ApplyDeletedFiles: %v", err)
-		}
+	fd, err := unix.Open(path, unix.O_RDWR|unix.O_NONBLOCK|unix.O_CLOEXEC, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer unix.Close(fd)
+	if _, err := readDeletedFilesFD(fd); err == nil {
+		t.Fatal("expected inherited FIFO FD to be rejected")
+	}
+}
 
-		// The file outside targetRoot must still exist
-		if _, err := os.Stat(secretFile); err != nil {
-			t.Error("path traversal should have been blocked, but file was deleted")
-		}
-	})
+func TestOpenDeletedFilesRejectsOversizedSparseFile(t *testing.T) {
+	checkpoint := t.TempDir()
+	path := filepath.Join(checkpoint, deletedFilesFilename)
+	file, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := file.Truncate(maxDeletedFilesSidecarSize + 1); err != nil {
+		file.Close()
+		t.Fatal(err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if file, err := OpenDeletedFiles(checkpoint); err == nil {
+		file.Close()
+		t.Fatal("expected oversized deletion sidecar to be rejected")
+	}
+}
 
-	t.Run("already-missing file causes no error", func(t *testing.T) {
-		checkpointDir := t.TempDir()
-		targetRoot := t.TempDir()
-
-		data, err := json.Marshal([]string{"nonexistent"})
-		if err != nil {
-			t.Fatalf("marshal deleted files: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(checkpointDir, deletedFilesFilename), data, 0644); err != nil {
-			t.Fatalf("write deleted-files.json: %v", err)
-		}
-
-		if err := ApplyDeletedFiles(checkpointDir, targetRoot, log); err != nil {
-			t.Fatalf("ApplyDeletedFiles: %v", err)
-		}
-	})
-
-	t.Run("empty entry is skipped", func(t *testing.T) {
-		checkpointDir := t.TempDir()
-		targetRoot := t.TempDir()
-
-		data, err := json.Marshal([]string{""})
-		if err != nil {
-			t.Fatalf("marshal deleted files: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(checkpointDir, deletedFilesFilename), data, 0644); err != nil {
-			t.Fatalf("write deleted-files.json: %v", err)
-		}
-
-		if err := ApplyDeletedFiles(checkpointDir, targetRoot, log); err != nil {
-			t.Fatalf("ApplyDeletedFiles: %v", err)
-		}
-	})
+func requireTool(t *testing.T, name string) {
+	t.Helper()
+	if _, err := exec.LookPath(name); err != nil {
+		t.Skipf("%s is not installed", name)
+	}
 }

--- a/deploy/snapshot/internal/runtime/root_compose.go
+++ b/deploy/snapshot/internal/runtime/root_compose.go
@@ -427,6 +427,10 @@ func mkdirAllAt(
 		sourceFD, sourceErr := openDirectoryAt(snapshotRootFD, relative)
 		if errors.Is(sourceErr, unix.ENOENT) {
 			sourceFD, sourceErr = openDirectoryAt(placeholderRootFD, relative)
+			if errors.Is(sourceErr, unix.ENOENT) {
+				current = next
+				continue
+			}
 		}
 		if sourceErr != nil {
 			unix.Close(next)

--- a/deploy/snapshot/internal/runtime/root_compose.go
+++ b/deploy/snapshot/internal/runtime/root_compose.go
@@ -22,7 +22,7 @@ const (
 	restoreWork                     = RootfsBackingWorkspaceMountPath + "/work"
 )
 
-// RootComposition identifies the staged root and its setup phases.
+// RootComposition identifies the staged root and owns its backing mount.
 type RootComposition struct {
 	RootPath             string
 	MountAttachDuration  time.Duration
@@ -30,8 +30,11 @@ type RootComposition struct {
 }
 
 // ComposeRoot consumes a detached rootfs mount and workspace path handle,
-// and stages a placeholder-first OverlayFS without changing the caller root.
-func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootComposition, error) {
+// and stages a snapshot-over-placeholder OverlayFS without changing the caller root.
+func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (result *RootComposition, retErr error) {
+	if rootfsMountFD >= 3 {
+		defer unix.Close(rootfsMountFD)
+	}
 	if rootfsMountFD < 3 || workspaceFD < 3 {
 		return nil, errors.New("rootfs mount and workspace FDs are required")
 	}
@@ -50,7 +53,6 @@ func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootCompositi
 	if err != nil {
 		return nil, err
 	}
-	composition := &RootComposition{RootPath: restoreRoot}
 
 	// Clone only the placeholder root mount. CRIU reconstructs child mounts.
 	placeholderFD, err := unix.OpenTree(
@@ -77,6 +79,22 @@ func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootCompositi
 		return nil, fmt.Errorf("attach rootfs backing workspace: %w", err)
 	}
 	unix.Close(backingTarget)
+	composition := &RootComposition{RootPath: restoreRoot}
+	defer func() {
+		if retErr != nil {
+			retErr = errors.Join(retErr, composition.Close())
+			result = nil
+		}
+	}()
+	entries, err := os.ReadDir(RootfsBackingWorkspaceMountPath)
+	if err != nil {
+		return nil, fmt.Errorf("read rootfs backing workspace for reset: %w", err)
+	}
+	for _, entry := range entries {
+		if err := os.RemoveAll(filepath.Join(RootfsBackingWorkspaceMountPath, entry.Name())); err != nil {
+			return nil, fmt.Errorf("reset rootfs backing workspace entry %q: %w", entry.Name(), err)
+		}
+	}
 
 	for _, path := range []string{
 		restoreRoot,
@@ -102,7 +120,6 @@ func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootCompositi
 		return nil, fmt.Errorf("attach inherited SquashFS mount: %w", err)
 	}
 	unix.Close(snapshotTarget)
-	unix.Close(rootfsMountFD)
 
 	placeholderTarget, err := unix.Open(
 		restorePlaceholder,
@@ -117,17 +134,32 @@ func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootCompositi
 		return nil, fmt.Errorf("attach placeholder root: %w", err)
 	}
 	unix.Close(placeholderTarget)
-	if err := copyDirectoryMetadataAt(workspaceMountFD, "placeholder", "upper"); err != nil {
-		return nil, fmt.Errorf("copy placeholder root metadata: %w", err)
+	snapshotRootFD, err := openDirectoryAt(workspaceMountFD, "snapshot")
+	if err != nil {
+		return nil, fmt.Errorf("open snapshot root metadata source: %w", err)
 	}
+	defer unix.Close(snapshotRootFD)
+	upperRootFD, err := openDirectoryAt(workspaceMountFD, "upper")
+	if err != nil {
+		return nil, fmt.Errorf("open restore upper root: %w", err)
+	}
+	defer unix.Close(upperRootFD)
+	if err := copyDirectoryOwnerAndMode(snapshotRootFD, upperRootFD); err != nil {
+		return nil, fmt.Errorf("copy snapshot root owner and mode: %w", err)
+	}
+	placeholderRootFD, err := openDirectoryAt(workspaceMountFD, "placeholder")
+	if err != nil {
+		return nil, fmt.Errorf("open placeholder root metadata source: %w", err)
+	}
+	defer unix.Close(placeholderRootFD)
 	composition.MountAttachDuration = time.Since(attachStart)
 
 	overlayStart := time.Now()
 	if err := replayDeletions(
 		deletions,
-		restoreUpper,
-		restorePlaceholder,
-		restoreSnapshotLower,
+		upperRootFD,
+		snapshotRootFD,
+		placeholderRootFD,
 	); err != nil {
 		return nil, err
 	}
@@ -135,15 +167,23 @@ func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootCompositi
 		return nil, fmt.Errorf("hide rootfs backing workspace: %w", err)
 	}
 	options := strings.Join([]string{
-		"lowerdir=" + restorePlaceholder + ":" + restoreSnapshotLower,
+		"lowerdir=" + restoreSnapshotLower + ":" + restorePlaceholder,
 		"upperdir=" + restoreUpper,
 		"workdir=" + restoreWork,
 	}, ",")
 	if err := unix.Mount("overlay", restoreRoot, "overlay", 0, options); err != nil {
-		return nil, fmt.Errorf("mount placeholder-first composed root: %w", err)
+		return nil, fmt.Errorf("mount snapshot-over-placeholder composed root: %w", err)
 	}
 	composition.OverlaySetupDuration = time.Since(overlayStart)
 	return composition, nil
+}
+
+// Close lazily disconnects the composed mount tree.
+func (composition *RootComposition) Close() error {
+	if err := unmountPath(RootfsBackingWorkspaceMountPath, unix.MNT_DETACH); err != nil {
+		return fmt.Errorf("unmount rootfs backing workspace: %w", err)
+	}
+	return nil
 }
 
 func moveMountToFD(sourceFD, targetFD int) error {
@@ -156,28 +196,16 @@ func moveMountToFD(sourceFD, targetFD int) error {
 	)
 }
 
-func copyDirectoryMetadataAt(rootFD int, source, target string) error {
-	const flags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
-	sourceFD, err := unix.Openat(rootFD, source, flags, 0)
-	if err != nil {
-		return fmt.Errorf("open source directory %q: %w", source, err)
-	}
-	defer unix.Close(sourceFD)
-	targetFD, err := unix.Openat(rootFD, target, flags, 0)
-	if err != nil {
-		return fmt.Errorf("open target directory %q: %w", target, err)
-	}
-	defer unix.Close(targetFD)
-
+func copyDirectoryOwnerAndMode(sourceFD, targetFD int) error {
 	var stat unix.Stat_t
 	if err := unix.Fstat(sourceFD, &stat); err != nil {
-		return fmt.Errorf("stat source directory %q: %w", source, err)
+		return fmt.Errorf("stat source directory: %w", err)
 	}
 	if err := unix.Fchown(targetFD, int(stat.Uid), int(stat.Gid)); err != nil {
-		return fmt.Errorf("set target directory %q ownership: %w", target, err)
+		return fmt.Errorf("set target directory ownership: %w", err)
 	}
 	if err := unix.Fchmod(targetFD, stat.Mode&0o7777); err != nil {
-		return fmt.Errorf("set target directory %q mode: %w", target, err)
+		return fmt.Errorf("set target directory mode: %w", err)
 	}
 	return nil
 }
@@ -212,30 +240,26 @@ func readDeletedFilesFD(deletedFilesFD int) (*deletedFiles, error) {
 
 func replayDeletions(
 	deletions *deletedFiles,
-	upperDir, placeholderRoot, snapshotRoot string,
+	upperRootFD, snapshotRootFD, placeholderRootFD int,
 ) error {
-	rootFD, err := unix.Open(
-		upperDir,
-		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-		0,
-	)
-	if err != nil {
-		return fmt.Errorf("open restore upperdir: %w", err)
-	}
-	defer unix.Close(rootFD)
 	for _, entry := range deletions.OpaqueDirectory {
 		if err := replayOpaqueDirectory(
-			rootFD,
+			upperRootFD,
 			entry,
-			placeholderRoot,
-			snapshotRoot,
+			snapshotRootFD,
+			placeholderRootFD,
 		); err != nil {
 			return err
 		}
 	}
 	for _, entry := range deletions.Whiteouts {
 		parent, name := filepath.Split(entry)
-		parentFD, err := mkdirAllAt(rootFD, strings.TrimSuffix(parent, "/"))
+		parentFD, err := mkdirAllAt(
+			upperRootFD,
+			strings.TrimSuffix(parent, "/"),
+			snapshotRootFD,
+			placeholderRootFD,
+		)
 		if err != nil {
 			return fmt.Errorf("create whiteout parent for %q: %w", entry, err)
 		}
@@ -248,39 +272,48 @@ func replayDeletions(
 	return nil
 }
 
-// An opaque directory hides the placeholder layer but must not hide files
-// supplied by the SquashFS layer below it.
+// An opaque directory hides placeholder children absent from the snapshot.
 func replayOpaqueDirectory(
 	upperRootFD int,
-	relative, placeholderRoot, snapshotRoot string,
+	relative string,
+	snapshotRootFD, placeholderRootFD int,
 ) error {
 	if relative == "." {
 		relative = ""
 	}
-	if info, err := os.Lstat(filepath.Join(placeholderRoot, relative)); err == nil {
-		if !info.IsDir() {
-			return nil
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("inspect placeholder opaque path %q: %w", relative, err)
-	}
-	if info, err := os.Lstat(filepath.Join(snapshotRoot, relative)); err == nil {
-		if !info.IsDir() {
-			return fmt.Errorf("snapshot opaque path %q is not a directory", relative)
-		}
-	} else if !errors.Is(err, os.ErrNotExist) {
+	snapshotIsDirectory := false
+	snapshotFD, err := openDirectoryAt(snapshotRootFD, relative)
+	if err == nil {
+		snapshotIsDirectory = true
+		unix.Close(snapshotFD)
+	} else if !errors.Is(err, unix.ENOENT) {
 		return fmt.Errorf("inspect snapshot opaque path %q: %w", relative, err)
 	}
-	upperFD, err := mkdirAllAt(upperRootFD, relative)
+	placeholderFD, err := openDirectoryAt(placeholderRootFD, relative)
+	if err == nil {
+		unix.Close(placeholderFD)
+	} else if snapshotIsDirectory &&
+		(errors.Is(err, unix.ENOTDIR) || errors.Is(err, unix.ELOOP)) {
+		// The snapshot directory wins, and there is no placeholder directory to traverse.
+		return nil
+	} else if !errors.Is(err, unix.ENOENT) {
+		return fmt.Errorf("inspect placeholder opaque path %q: %w", relative, err)
+	}
+	upperFD, err := mkdirAllAt(
+		upperRootFD,
+		relative,
+		snapshotRootFD,
+		placeholderRootFD,
+	)
 	if err != nil {
 		return fmt.Errorf("create opaque directory %q: %w", relative, err)
 	}
 	defer unix.Close(upperFD)
-	placeholderEntries, err := directoryEntries(placeholderRoot, relative)
+	placeholderEntries, err := directoryEntriesAt(placeholderRootFD, relative)
 	if err != nil {
 		return err
 	}
-	snapshotEntries, err := directoryEntries(snapshotRoot, relative)
+	snapshotEntries, err := directoryEntriesAt(snapshotRootFD, relative)
 	if err != nil {
 		return err
 	}
@@ -294,8 +327,8 @@ func replayOpaqueDirectory(
 			if err := replayOpaqueDirectory(
 				upperRootFD,
 				filepath.Join(relative, name),
-				placeholderRoot,
-				snapshotRoot,
+				snapshotRootFD,
+				placeholderRootFD,
 			); err != nil {
 				return err
 			}
@@ -304,27 +337,8 @@ func replayOpaqueDirectory(
 	return nil
 }
 
-func directoryEntries(root, relative string) (map[string]uint32, error) {
-	rootFD, err := unix.Open(
-		root,
-		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-		0,
-	)
-	if err != nil {
-		return nil, err
-	}
-	defer unix.Close(rootFD)
-	fd, err := unix.Dup(rootFD)
-	if err != nil {
-		return nil, err
-	}
-	if relative != "" {
-		unix.Close(fd)
-		fd, err = unix.Openat2(rootFD, relative, &unix.OpenHow{
-			Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW,
-			Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
-		})
-	}
+func directoryEntriesAt(rootFD int, relative string) (map[string]uint32, error) {
+	fd, err := openDirectoryAt(rootFD, relative)
 	if errors.Is(err, unix.ENOENT) {
 		return map[string]uint32{}, nil
 	}
@@ -353,6 +367,16 @@ func directoryEntries(root, relative string) (map[string]uint32, error) {
 	return result, nil
 }
 
+func openDirectoryAt(rootFD int, relative string) (int, error) {
+	if relative == "" {
+		return unix.Dup(rootFD)
+	}
+	return unix.Openat2(rootFD, relative, &unix.OpenHow{
+		Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW,
+		Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
+	})
+}
+
 func createWhiteoutAt(parentFD int, name string) error {
 	err := unix.Mknodat(parentFD, name, unix.S_IFCHR, int(unix.Mkdev(0, 0)))
 	if !errors.Is(err, unix.EEXIST) {
@@ -368,7 +392,11 @@ func createWhiteoutAt(parentFD int, name string) error {
 	return nil
 }
 
-func mkdirAllAt(rootFD int, path string) (int, error) {
+func mkdirAllAt(
+	rootFD int,
+	path string,
+	snapshotRootFD, placeholderRootFD int,
+) (int, error) {
 	current, err := unix.Dup(rootFD)
 	if err != nil {
 		return -1, err
@@ -376,29 +404,39 @@ func mkdirAllAt(rootFD int, path string) (int, error) {
 	if path == "" {
 		return current, nil
 	}
+	var relative string
 	for _, component := range strings.Split(path, "/") {
 		if component == "" || component == "." || component == ".." {
 			unix.Close(current)
 			return -1, fmt.Errorf("invalid path component %q", component)
 		}
-		next, err := unix.Openat2(current, component, &unix.OpenHow{
-			Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC,
-			Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
-		})
+		relative = filepath.Join(relative, component)
+		next, err := openDirectoryAt(current, component)
 		if errors.Is(err, unix.ENOENT) {
 			if err := unix.Mkdirat(current, component, 0o755); err != nil &&
 				!errors.Is(err, unix.EEXIST) {
 				unix.Close(current)
 				return -1, err
 			}
-			next, err = unix.Openat2(current, component, &unix.OpenHow{
-				Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC,
-				Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
-			})
+			next, err = openDirectoryAt(current, component)
 		}
 		unix.Close(current)
 		if err != nil {
 			return -1, err
+		}
+		sourceFD, sourceErr := openDirectoryAt(snapshotRootFD, relative)
+		if errors.Is(sourceErr, unix.ENOENT) {
+			sourceFD, sourceErr = openDirectoryAt(placeholderRootFD, relative)
+		}
+		if sourceErr != nil {
+			unix.Close(next)
+			return -1, fmt.Errorf("open winning lower directory %q: %w", relative, sourceErr)
+		}
+		copyErr := copyDirectoryOwnerAndMode(sourceFD, next)
+		unix.Close(sourceFD)
+		if copyErr != nil {
+			unix.Close(next)
+			return -1, fmt.Errorf("copy lower directory owner and mode for %q: %w", relative, copyErr)
 		}
 		current = next
 	}

--- a/deploy/snapshot/internal/runtime/root_compose.go
+++ b/deploy/snapshot/internal/runtime/root_compose.go
@@ -1,0 +1,406 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/unix"
+
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
+)
+
+const (
+	RootfsBackingWorkspaceMountPath = snapshotprotocol.RootfsBackingWorkspaceMountPath
+	restoreRoot                     = RootfsBackingWorkspaceMountPath + "/root"
+	restoreSnapshotLower            = RootfsBackingWorkspaceMountPath + "/snapshot"
+	restorePlaceholder              = RootfsBackingWorkspaceMountPath + "/placeholder"
+	restoreUpper                    = RootfsBackingWorkspaceMountPath + "/upper"
+	restoreWork                     = RootfsBackingWorkspaceMountPath + "/work"
+)
+
+// RootComposition identifies the staged root and its setup phases.
+type RootComposition struct {
+	RootPath             string
+	MountAttachDuration  time.Duration
+	OverlaySetupDuration time.Duration
+}
+
+// ComposeRoot consumes a detached rootfs mount and workspace path handle,
+// and stages a placeholder-first OverlayFS without changing the caller root.
+func ComposeRoot(rootfsMountFD, workspaceFD, deletedFilesFD int) (*RootComposition, error) {
+	if rootfsMountFD < 3 || workspaceFD < 3 {
+		return nil, errors.New("rootfs mount and workspace FDs are required")
+	}
+	workspaceMountFD, err := unix.OpenTree(
+		workspaceFD,
+		"",
+		unix.AT_EMPTY_PATH|unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC,
+	)
+	unix.Close(workspaceFD)
+	if err != nil {
+		return nil, fmt.Errorf("clone rootfs backing workspace: %w", err)
+	}
+	defer unix.Close(workspaceMountFD)
+
+	deletions, err := readDeletedFilesFD(deletedFilesFD)
+	if err != nil {
+		return nil, err
+	}
+	composition := &RootComposition{RootPath: restoreRoot}
+
+	// Clone only the placeholder root mount. CRIU reconstructs child mounts.
+	placeholderFD, err := unix.OpenTree(
+		unix.AT_FDCWD,
+		"/",
+		unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("clone placeholder root: %w", err)
+	}
+	defer unix.Close(placeholderFD)
+
+	attachStart := time.Now()
+	backingTarget, err := unix.Open(
+		RootfsBackingWorkspaceMountPath,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open rootfs backing mountpoint: %w", err)
+	}
+	if err := moveMountToFD(workspaceMountFD, backingTarget); err != nil {
+		unix.Close(backingTarget)
+		return nil, fmt.Errorf("attach rootfs backing workspace: %w", err)
+	}
+	unix.Close(backingTarget)
+
+	for _, path := range []string{
+		restoreRoot,
+		restoreSnapshotLower,
+		restorePlaceholder,
+		restoreUpper,
+		restoreWork,
+	} {
+		if err := os.Mkdir(path, 0o700); err != nil && !errors.Is(err, os.ErrExist) {
+			return nil, fmt.Errorf("create root composition directory %s: %w", path, err)
+		}
+	}
+	snapshotTarget, err := unix.Open(
+		restoreSnapshotLower,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open SquashFS mountpoint: %w", err)
+	}
+	if err := moveMountToFD(rootfsMountFD, snapshotTarget); err != nil {
+		unix.Close(snapshotTarget)
+		return nil, fmt.Errorf("attach inherited SquashFS mount: %w", err)
+	}
+	unix.Close(snapshotTarget)
+	unix.Close(rootfsMountFD)
+
+	placeholderTarget, err := unix.Open(
+		restorePlaceholder,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("open placeholder mountpoint: %w", err)
+	}
+	if err := moveMountToFD(placeholderFD, placeholderTarget); err != nil {
+		unix.Close(placeholderTarget)
+		return nil, fmt.Errorf("attach placeholder root: %w", err)
+	}
+	unix.Close(placeholderTarget)
+	if err := copyDirectoryMetadataAt(workspaceMountFD, "placeholder", "upper"); err != nil {
+		return nil, fmt.Errorf("copy placeholder root metadata: %w", err)
+	}
+	composition.MountAttachDuration = time.Since(attachStart)
+
+	overlayStart := time.Now()
+	if err := replayDeletions(
+		deletions,
+		restoreUpper,
+		restorePlaceholder,
+		restoreSnapshotLower,
+	); err != nil {
+		return nil, err
+	}
+	if err := createWhiteout(filepath.Join(restoreUpper, strings.TrimPrefix(RootfsBackingWorkspaceMountPath, "/"))); err != nil {
+		return nil, fmt.Errorf("hide rootfs backing workspace: %w", err)
+	}
+	options := strings.Join([]string{
+		"lowerdir=" + restorePlaceholder + ":" + restoreSnapshotLower,
+		"upperdir=" + restoreUpper,
+		"workdir=" + restoreWork,
+	}, ",")
+	if err := unix.Mount("overlay", restoreRoot, "overlay", 0, options); err != nil {
+		return nil, fmt.Errorf("mount placeholder-first composed root: %w", err)
+	}
+	composition.OverlaySetupDuration = time.Since(overlayStart)
+	return composition, nil
+}
+
+func moveMountToFD(sourceFD, targetFD int) error {
+	return unix.MoveMount(
+		sourceFD,
+		"",
+		targetFD,
+		"",
+		unix.MOVE_MOUNT_F_EMPTY_PATH|unix.MOVE_MOUNT_T_EMPTY_PATH,
+	)
+}
+
+func copyDirectoryMetadataAt(rootFD int, source, target string) error {
+	const flags = unix.O_RDONLY | unix.O_DIRECTORY | unix.O_NOFOLLOW | unix.O_CLOEXEC
+	sourceFD, err := unix.Openat(rootFD, source, flags, 0)
+	if err != nil {
+		return fmt.Errorf("open source directory %q: %w", source, err)
+	}
+	defer unix.Close(sourceFD)
+	targetFD, err := unix.Openat(rootFD, target, flags, 0)
+	if err != nil {
+		return fmt.Errorf("open target directory %q: %w", target, err)
+	}
+	defer unix.Close(targetFD)
+
+	var stat unix.Stat_t
+	if err := unix.Fstat(sourceFD, &stat); err != nil {
+		return fmt.Errorf("stat source directory %q: %w", source, err)
+	}
+	if err := unix.Fchown(targetFD, int(stat.Uid), int(stat.Gid)); err != nil {
+		return fmt.Errorf("set target directory %q ownership: %w", target, err)
+	}
+	if err := unix.Fchmod(targetFD, stat.Mode&0o7777); err != nil {
+		return fmt.Errorf("set target directory %q mode: %w", target, err)
+	}
+	return nil
+}
+
+func createWhiteout(path string) error {
+	err := unix.Mknod(path, unix.S_IFCHR, int(unix.Mkdev(0, 0)))
+	if !errors.Is(err, unix.EEXIST) {
+		return err
+	}
+	var stat unix.Stat_t
+	if err := unix.Lstat(path, &stat); err != nil {
+		return err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFCHR || stat.Rdev != unix.Mkdev(0, 0) {
+		return fmt.Errorf("%s collides with reserved rootfs backing path", path)
+	}
+	return nil
+}
+
+func readDeletedFilesFD(deletedFilesFD int) (*deletedFiles, error) {
+	if deletedFilesFD < 0 {
+		return &deletedFiles{}, nil
+	}
+	duplicate, err := unix.Dup(deletedFilesFD)
+	if err != nil {
+		return nil, fmt.Errorf("duplicate deletion sidecar FD: %w", err)
+	}
+	file := os.NewFile(uintptr(duplicate), deletedFilesFilename)
+	defer file.Close()
+	return readDeletedFilesFile(file)
+}
+
+func replayDeletions(
+	deletions *deletedFiles,
+	upperDir, placeholderRoot, snapshotRoot string,
+) error {
+	rootFD, err := unix.Open(
+		upperDir,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open restore upperdir: %w", err)
+	}
+	defer unix.Close(rootFD)
+	for _, entry := range deletions.OpaqueDirectory {
+		if err := replayOpaqueDirectory(
+			rootFD,
+			entry,
+			placeholderRoot,
+			snapshotRoot,
+		); err != nil {
+			return err
+		}
+	}
+	for _, entry := range deletions.Whiteouts {
+		parent, name := filepath.Split(entry)
+		parentFD, err := mkdirAllAt(rootFD, strings.TrimSuffix(parent, "/"))
+		if err != nil {
+			return fmt.Errorf("create whiteout parent for %q: %w", entry, err)
+		}
+		err = createWhiteoutAt(parentFD, name)
+		unix.Close(parentFD)
+		if err != nil {
+			return fmt.Errorf("create whiteout %q: %w", entry, err)
+		}
+	}
+	return nil
+}
+
+// An opaque directory hides the placeholder layer but must not hide files
+// supplied by the SquashFS layer below it.
+func replayOpaqueDirectory(
+	upperRootFD int,
+	relative, placeholderRoot, snapshotRoot string,
+) error {
+	if relative == "." {
+		relative = ""
+	}
+	if info, err := os.Lstat(filepath.Join(placeholderRoot, relative)); err == nil {
+		if !info.IsDir() {
+			return nil
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect placeholder opaque path %q: %w", relative, err)
+	}
+	if info, err := os.Lstat(filepath.Join(snapshotRoot, relative)); err == nil {
+		if !info.IsDir() {
+			return fmt.Errorf("snapshot opaque path %q is not a directory", relative)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("inspect snapshot opaque path %q: %w", relative, err)
+	}
+	upperFD, err := mkdirAllAt(upperRootFD, relative)
+	if err != nil {
+		return fmt.Errorf("create opaque directory %q: %w", relative, err)
+	}
+	defer unix.Close(upperFD)
+	placeholderEntries, err := directoryEntries(placeholderRoot, relative)
+	if err != nil {
+		return err
+	}
+	snapshotEntries, err := directoryEntries(snapshotRoot, relative)
+	if err != nil {
+		return err
+	}
+	for name, placeholderType := range placeholderEntries {
+		snapshotType, suppliedBySnapshot := snapshotEntries[name]
+		if !suppliedBySnapshot {
+			if err := createWhiteoutAt(upperFD, name); err != nil {
+				return err
+			}
+		} else if placeholderType == unix.S_IFDIR && snapshotType == unix.S_IFDIR {
+			if err := replayOpaqueDirectory(
+				upperRootFD,
+				filepath.Join(relative, name),
+				placeholderRoot,
+				snapshotRoot,
+			); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func directoryEntries(root, relative string) (map[string]uint32, error) {
+	rootFD, err := unix.Open(
+		root,
+		unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(rootFD)
+	fd, err := unix.Dup(rootFD)
+	if err != nil {
+		return nil, err
+	}
+	if relative != "" {
+		unix.Close(fd)
+		fd, err = unix.Openat2(rootFD, relative, &unix.OpenHow{
+			Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC | unix.O_NOFOLLOW,
+			Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
+		})
+	}
+	if errors.Is(err, unix.ENOENT) {
+		return map[string]uint32{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	file := os.NewFile(uintptr(fd), relative)
+	defer file.Close()
+	entries, err := file.ReadDir(-1)
+	if err != nil {
+		return nil, err
+	}
+	result := make(map[string]uint32, len(entries))
+	for _, entry := range entries {
+		var stat unix.Stat_t
+		if err := unix.Fstatat(
+			int(file.Fd()),
+			entry.Name(),
+			&stat,
+			unix.AT_SYMLINK_NOFOLLOW,
+		); err != nil {
+			return nil, err
+		}
+		result[entry.Name()] = stat.Mode & unix.S_IFMT
+	}
+	return result, nil
+}
+
+func createWhiteoutAt(parentFD int, name string) error {
+	err := unix.Mknodat(parentFD, name, unix.S_IFCHR, int(unix.Mkdev(0, 0)))
+	if !errors.Is(err, unix.EEXIST) {
+		return err
+	}
+	var stat unix.Stat_t
+	if err := unix.Fstatat(parentFD, name, &stat, unix.AT_SYMLINK_NOFOLLOW); err != nil {
+		return err
+	}
+	if stat.Mode&unix.S_IFMT != unix.S_IFCHR || stat.Rdev != unix.Mkdev(0, 0) {
+		return unix.EEXIST
+	}
+	return nil
+}
+
+func mkdirAllAt(rootFD int, path string) (int, error) {
+	current, err := unix.Dup(rootFD)
+	if err != nil {
+		return -1, err
+	}
+	if path == "" {
+		return current, nil
+	}
+	for _, component := range strings.Split(path, "/") {
+		if component == "" || component == "." || component == ".." {
+			unix.Close(current)
+			return -1, fmt.Errorf("invalid path component %q", component)
+		}
+		next, err := unix.Openat2(current, component, &unix.OpenHow{
+			Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC,
+			Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
+		})
+		if errors.Is(err, unix.ENOENT) {
+			if err := unix.Mkdirat(current, component, 0o755); err != nil &&
+				!errors.Is(err, unix.EEXIST) {
+				unix.Close(current)
+				return -1, err
+			}
+			next, err = unix.Openat2(current, component, &unix.OpenHow{
+				Flags:   unix.O_RDONLY | unix.O_DIRECTORY | unix.O_CLOEXEC,
+				Resolve: unix.RESOLVE_BENEATH | unix.RESOLVE_NO_SYMLINKS,
+			})
+		}
+		unix.Close(current)
+		if err != nil {
+			return -1, err
+		}
+		current = next
+	}
+	return current, nil
+}

--- a/deploy/snapshot/internal/runtime/root_compose_test.go
+++ b/deploy/snapshot/internal/runtime/root_compose_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -141,7 +142,7 @@ func TestPrivilegedWorkspaceHandleCloneAcrossMountNamespaces(t *testing.T) {
 	}
 }
 
-func TestPrivilegedPlaceholderFirstRootComposition(t *testing.T) {
+func TestPrivilegedSnapshotOverPlaceholderRootComposition(t *testing.T) {
 	if os.Getenv("DYNAMO_SNAPSHOT_PRIVILEGED_TEST") != "1" {
 		t.Skip("set DYNAMO_SNAPSHOT_PRIVILEGED_TEST=1 and run as root")
 	}
@@ -150,17 +151,30 @@ func TestPrivilegedPlaceholderFirstRootComposition(t *testing.T) {
 		if os.Geteuid() != 0 {
 			t.Skip("privileged root composition test requires root")
 		}
+		requireTool(t, "mksquashfs")
 		root = filepath.Join(t.TempDir(), "root")
 		if err := os.Mkdir(root, 0o755); err != nil {
 			t.Fatal(err)
 		}
+		probeXattr := "user.dynamo-snapshot-xattr-probe"
+		if err := unix.Setxattr(root, probeXattr, []byte("probe"), 0); err != nil {
+			if errors.Is(err, unix.ENOTSUP) {
+				t.Skipf("test filesystem does not support user xattrs: %v", err)
+			}
+			t.Fatal(err)
+		}
+		if err := unix.Removexattr(root, probeXattr); err != nil {
+			t.Fatal(err)
+		}
+		stagingDir := t.TempDir()
 		command := exec.Command(
 			os.Args[0],
-			"-test.run=^TestPrivilegedPlaceholderFirstRootComposition$",
+			"-test.run=^TestPrivilegedSnapshotOverPlaceholderRootComposition$",
 		)
 		command.Env = append(
 			os.Environ(),
 			"DYNAMO_SNAPSHOT_PRIVILEGED_HELPER_ROOT="+root,
+			"DYNAMO_SNAPSHOT_PRIVILEGED_STAGING_DIR="+stagingDir,
 		)
 		command.SysProcAttr = &unix.SysProcAttr{Cloneflags: unix.CLONE_NEWNS}
 		output, err := command.CombinedOutput()
@@ -169,16 +183,27 @@ func TestPrivilegedPlaceholderFirstRootComposition(t *testing.T) {
 		}
 		return
 	}
-	runPrivilegedRootComposition(t, root)
+	stagingDir := os.Getenv("DYNAMO_SNAPSHOT_PRIVILEGED_STAGING_DIR")
+	if stagingDir == "" {
+		t.Fatal("privileged staging directory is required")
+	}
+	runPrivilegedRootComposition(t, root, stagingDir)
 }
 
-func runPrivilegedRootComposition(t *testing.T, root string) {
+func runPrivilegedRootComposition(t *testing.T, root, stagingDir string) {
 	t.Helper()
 	const (
 		placeholderUID  = 1234
 		placeholderGID  = 2345
 		placeholderMode = 0o7751
-		backingGID      = 3456
+		snapshotUID     = 3456
+		snapshotGID     = 4567
+		snapshotMode    = 0o3750
+		opaqueUID       = 5678
+		opaqueGID       = 6789
+		opaqueMode      = 0o1750
+		fileXattr       = "user.dynamo-snapshot-test"
+		fileXattrValue  = "checkpoint"
 	)
 	requireTool(t, "mksquashfs")
 	if err := unix.Mount("", "/", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
@@ -212,15 +237,42 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 		}
 	}
 	write(placeholderLower, "collision", "placeholder")
+	write(placeholderLower, "placeholder-only", "placeholder")
 	write(placeholderLower, "delete-me", "placeholder")
+	write(placeholderLower, "recreated/old-child", "placeholder")
 	write(placeholderLower, "opaque/placeholder-only", "placeholder")
 	write(placeholderLower, "opaque/shared/placeholder-nested", "placeholder")
 	write(placeholderLower, "file-mount", "")
 	write(placeholderLower, "mount-source", "file-mount")
 	write(snapshotSource, "collision", "snapshot")
 	write(snapshotSource, "snapshot-only", "snapshot")
+	write(snapshotSource, "recreated", "snapshot-file")
 	write(snapshotSource, "opaque/snapshot-only", "snapshot")
 	write(snapshotSource, "opaque/shared/snapshot-nested", "snapshot")
+	if err := unix.Setxattr(
+		filepath.Join(snapshotSource, "snapshot-only"),
+		fileXattr,
+		[]byte(fileXattrValue),
+		0,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chown(
+		filepath.Join(snapshotSource, "opaque"),
+		opaqueUID,
+		opaqueGID,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chmod(filepath.Join(snapshotSource, "opaque"), opaqueMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chown(snapshotSource, snapshotUID, snapshotGID); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chmod(snapshotSource, snapshotMode); err != nil {
+		t.Fatal(err)
+	}
 	if err := os.WriteFile(
 		filepath.Join(checkpoint, deletedFilesFilename),
 		[]byte(`{"whiteouts":["delete-me","mounted/user-data"],"opaqueDirectories":["opaque"]}`),
@@ -229,19 +281,13 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 		t.Fatal(err)
 	}
 	imagePath := filepath.Join(checkpoint, RootfsDiffFilename)
-	command := exec.CommandContext(
+	if err := runMksquashfs(
 		context.Background(),
-		"mksquashfs",
 		snapshotSource,
 		imagePath,
-		"-comp", "zstd",
-		"-b", "1M",
-		"-processors", "2",
-		"-noappend",
-		"-no-progress",
-	)
-	if output, err := command.CombinedOutput(); err != nil {
-		t.Fatalf("mksquashfs: %v\n%s", err, output)
+		nil,
+	); err != nil {
+		t.Fatal(err)
 	}
 
 	// Match the agent pod: only loop-control is host-mounted. Loop nodes live
@@ -264,15 +310,58 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 		t.Fatal(err)
 	}
 	defer image.Close()
-	rootfsMount, err := PrepareDetachedRootfsMount(image)
+	deleted, err := os.Open(filepath.Join(checkpoint, deletedFilesFilename))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rootfsMount.Close()
+	defer deleted.Close()
+	type mountResult struct {
+		mount *os.File
+		err   error
+	}
+	results := make(chan mountResult, 9)
+	for range 9 {
+		go func() {
+			mount, err := prepareDetachedRootfsMount(image, stagingDir)
+			results <- mountResult{mount, err}
+		}()
+	}
+	var preparationErr error
+	var preparedMounts []*os.File
+	for range 9 {
+		result := <-results
+		if result.err != nil {
+			preparationErr = errors.Join(preparationErr, result.err)
+			continue
+		}
+		preparedMounts = append(preparedMounts, result.mount)
+	}
+	for _, mount := range preparedMounts {
+		if err := mount.Close(); err != nil {
+			preparationErr = errors.Join(preparationErr, err)
+		}
+	}
+	if preparationErr != nil {
+		t.Fatal(preparationErr)
+	}
+	mountinfo, err := os.ReadFile("/proc/self/mountinfo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(mountinfo), " "+stagingDir+"/") {
+		t.Fatal("concurrent preparation leaked a staging mount")
+	}
+	assertDirectoryEmpty(t, stagingDir)
+	firstRootfsMount, err := prepareDetachedRootfsMount(image, stagingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRootfsMount, err := prepareDetachedRootfsMount(image, stagingDir)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	for _, path := range []string{
-		"checkpoint",
-		"proc",
 		"mounted",
 		strings.TrimPrefix(RootfsBackingWorkspaceMountPath, "/"),
 	} {
@@ -286,24 +375,6 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 		"workdir=" + placeholderWork,
 	}, ",")
 	if err := unix.Mount("overlay", root, "overlay", 0, options); err != nil {
-		t.Fatal(err)
-	}
-	if err := unix.Mount(
-		checkpoint,
-		filepath.Join(root, "checkpoint"),
-		"",
-		unix.MS_BIND,
-		"",
-	); err != nil {
-		t.Fatal(err)
-	}
-	if err := unix.Mount(
-		"/proc",
-		filepath.Join(root, "proc"),
-		"",
-		unix.MS_BIND|unix.MS_REC,
-		"",
-	); err != nil {
 		t.Fatal(err)
 	}
 	mounted := filepath.Join(root, "mounted")
@@ -324,29 +395,11 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 	if err := unix.Mount("tmpfs", backing, "tmpfs", 0, "mode=700"); err != nil {
 		t.Fatal(err)
 	}
-	if err := unix.Chown(backing, 0, backingGID); err != nil {
+	procMountinfo, err := os.Open("/proc/self/mountinfo")
+	if err != nil {
 		t.Fatal(err)
 	}
-	if err := unix.Chmod(backing, 0o2700); err != nil {
-		t.Fatal(err)
-	}
-	inheritanceProbe := filepath.Join(backing, "inheritance-probe")
-	if err := os.Mkdir(inheritanceProbe, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	var inherited unix.Stat_t
-	if err := unix.Stat(inheritanceProbe, &inherited); err != nil {
-		t.Fatal(err)
-	}
-	if got := inherited.Mode & 0o7777; got != 0o2700 {
-		t.Fatalf("setgid-inherited directory mode = %#o, want 02700", got)
-	}
-	if inherited.Gid != backingGID {
-		t.Fatalf("setgid-inherited directory gid = %d, want %d", inherited.Gid, backingGID)
-	}
-	if err := os.Remove(inheritanceProbe); err != nil {
-		t.Fatal(err)
-	}
+	defer procMountinfo.Close()
 	if err := unix.Chown(root, placeholderUID, placeholderGID); err != nil {
 		t.Fatal(err)
 	}
@@ -380,26 +433,75 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 			placeholderMode,
 		)
 	}
-	workspaceFD, err := unix.Open(
-		RootfsBackingWorkspaceMountPath,
-		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-		0,
-	)
-	if err != nil {
+	mountCount := func() int {
+		t.Helper()
+		if _, err := procMountinfo.Seek(0, 0); err != nil {
+			t.Fatal(err)
+		}
+		data, err := io.ReadAll(procMountinfo)
+		if err != nil {
+			t.Fatal(err)
+		}
+		count := 0
+		for _, line := range strings.Split(string(data), "\n") {
+			fields := strings.Fields(line)
+			if len(fields) >= 5 &&
+				(fields[4] == RootfsBackingWorkspaceMountPath ||
+					strings.HasPrefix(fields[4], RootfsBackingWorkspaceMountPath+"/")) {
+				count++
+			}
+		}
+		return count
+	}
+	baselineMounts := mountCount()
+	compose := func(rootfsMount *os.File) *RootComposition {
+		t.Helper()
+		rootfsMountFD, err := unix.Dup(int(rootfsMount.Fd()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		workspaceFD, err := unix.Open(
+			RootfsBackingWorkspaceMountPath,
+			unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if err != nil {
+			unix.Close(rootfsMountFD)
+			t.Fatal(err)
+		}
+		composition, composeErr := ComposeRoot(
+			rootfsMountFD,
+			workspaceFD,
+			int(deleted.Fd()),
+		)
+		closeErr := rootfsMount.Close()
+		if composeErr != nil {
+			t.Fatal(composeErr)
+		}
+		if closeErr != nil {
+			t.Fatal(closeErr)
+		}
+		return composition
+	}
+	firstComposition := compose(firstRootfsMount)
+	staleName := fmt.Sprintf("stale-after-failed-restore-%d", os.Getpid())
+	if err := os.WriteFile(
+		filepath.Join(firstComposition.RootPath, staleName),
+		[]byte("stale"),
+		0o600,
+	); err != nil {
 		t.Fatal(err)
 	}
-	deleted, err := os.Open("/checkpoint/" + deletedFilesFilename)
-	if err != nil {
+	if err := firstComposition.Close(); err != nil {
 		t.Fatal(err)
 	}
-	defer deleted.Close()
-	composition, err := ComposeRoot(
-		int(rootfsMount.Fd()),
-		workspaceFD,
-		int(deleted.Fd()),
-	)
-	if err != nil {
-		t.Fatal(err)
+	if got := mountCount(); got != baselineMounts {
+		t.Fatalf("mounts after failed restore cleanup = %d, want %d", got, baselineMounts)
+	}
+
+	composition := compose(secondRootfsMount)
+	if _, err := os.Stat(filepath.Join(composition.RootPath, staleName)); !os.IsNotExist(err) {
+		t.Fatalf("stale file survived retry composition: %v", err)
 	}
 	if composition.RootPath != restoreRoot {
 		t.Fatalf("composed root = %q, want %q", composition.RootPath, restoreRoot)
@@ -420,39 +522,22 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 	if _, err := os.Stat(RootfsBackingWorkspaceMountPath); err != nil {
 		t.Fatalf("caller backing workspace is unavailable: %v", err)
 	}
-	for _, path := range []string{restoreUpper, composition.RootPath} {
-		var got unix.Stat_t
-		if err := unix.Stat(path, &got); err != nil {
-			t.Fatal(err)
-		}
-		if got.Uid != placeholderMetadata.Uid ||
-			got.Gid != placeholderMetadata.Gid ||
-			got.Mode&0o7777 != placeholderMetadata.Mode&0o7777 {
-			t.Fatalf(
-				"%s metadata = uid %d gid %d mode %#o, want uid %d gid %d mode %#o",
-				path,
-				got.Uid,
-				got.Gid,
-				got.Mode&0o7777,
-				placeholderMetadata.Uid,
-				placeholderMetadata.Gid,
-				placeholderMetadata.Mode&0o7777,
-			)
-		}
-	}
-	var replayedOpaque unix.Stat_t
-	if err := unix.Stat(filepath.Join(restoreUpper, "opaque"), &replayedOpaque); err != nil {
+	var composedRoot unix.Stat_t
+	if err := unix.Stat(composition.RootPath, &composedRoot); err != nil {
 		t.Fatal(err)
 	}
-	if replayedOpaque.Gid != placeholderMetadata.Gid {
+	if composedRoot.Uid != snapshotUID ||
+		composedRoot.Gid != snapshotGID ||
+		composedRoot.Mode&0o7777 != snapshotMode {
 		t.Fatalf(
-			"replayed opaque directory gid = %d, want placeholder gid %d",
-			replayedOpaque.Gid,
-			placeholderMetadata.Gid,
+			"composed root metadata = uid %d gid %d mode %#o, want uid %d gid %d mode %#o",
+			composedRoot.Uid,
+			composedRoot.Gid,
+			composedRoot.Mode&0o7777,
+			snapshotUID,
+			snapshotGID,
+			snapshotMode,
 		)
-	}
-	if replayedOpaque.Mode&unix.S_ISGID == 0 {
-		t.Fatalf("replayed opaque directory mode = %#o, want setgid", replayedOpaque.Mode&0o7777)
 	}
 
 	assertContent := func(path, want string) {
@@ -468,19 +553,52 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 	staged := func(path string) string {
 		return filepath.Join(composition.RootPath, strings.TrimPrefix(path, "/"))
 	}
+	var replayedOpaque unix.Stat_t
+	if err := unix.Stat(staged("/opaque"), &replayedOpaque); err != nil {
+		t.Fatal(err)
+	}
+	if replayedOpaque.Uid != opaqueUID ||
+		replayedOpaque.Gid != opaqueGID ||
+		replayedOpaque.Mode&0o7777 != opaqueMode {
+		t.Fatalf(
+			"replayed opaque metadata = uid %d gid %d mode %#o, want uid %d gid %d mode %#o",
+			replayedOpaque.Uid,
+			replayedOpaque.Gid,
+			replayedOpaque.Mode&0o7777,
+			opaqueUID,
+			opaqueGID,
+			opaqueMode,
+		)
+	}
+	value := make([]byte, len(fileXattrValue))
+	size, err := unix.Getxattr(staged("/snapshot-only"), fileXattr, value)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(value[:size]) != fileXattrValue {
+		t.Fatalf("snapshot file xattr = %q, want %q", value[:size], fileXattrValue)
+	}
 	assertContent("/mounted/child-only", "mounted")
 	assertContent("/file-mount", "file-mount")
-	assertContent(staged("/collision"), "placeholder")
+	assertContent(staged("/collision"), "snapshot")
+	assertContent(staged("/placeholder-only"), "placeholder")
 	assertContent(staged("/snapshot-only"), "snapshot")
+	assertContent(staged("/recreated"), "snapshot-file")
+	var recreated unix.Stat_t
+	if err := unix.Lstat(staged("/recreated"), &recreated); err != nil {
+		t.Fatal(err)
+	}
+	if recreated.Mode&unix.S_IFMT != unix.S_IFREG {
+		t.Fatalf("recreated path mode = %#o, want regular file", recreated.Mode)
+	}
 	assertContent(staged("/opaque/snapshot-only"), "snapshot")
 	assertContent(staged("/opaque/shared/snapshot-nested"), "snapshot")
 	assertContent(staged("/file-mount"), "")
 	for _, path := range []string{
-		"/checkpoint/" + deletedFilesFilename,
 		"/delete-me",
 		"/mounted/child-only",
 		"/opaque/placeholder-only",
-		"/proc/self",
+		"/opaque/shared/placeholder-nested",
 	} {
 		if _, err := os.Lstat(staged(path)); !os.IsNotExist(err) {
 			t.Fatalf("%s should be hidden, got %v", path, err)
@@ -495,9 +613,15 @@ func runPrivilegedRootComposition(t *testing.T, root string) {
 			t.Fatalf("rootfs backing path %s should be inaccessible, got %v", path, err)
 		}
 	}
-	for _, path := range []string{"/checkpoint", "/proc", "/mounted", "/file-mount"} {
+	for _, path := range []string{"/mounted", "/file-mount"} {
 		if _, err := os.Stat(staged(path)); err != nil {
 			t.Fatalf("placeholder mountpoint %s is unavailable: %v", path, err)
 		}
+	}
+	if err := composition.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if got := mountCount(); got != baselineMounts {
+		t.Fatalf("mounts after composition close = %d, want %d", got, baselineMounts)
 	}
 }

--- a/deploy/snapshot/internal/runtime/root_compose_test.go
+++ b/deploy/snapshot/internal/runtime/root_compose_test.go
@@ -1,0 +1,503 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPrivilegedWorkspaceHandleCloneAcrossMountNamespaces(t *testing.T) {
+	const (
+		ownerRootEnv = "DYNAMO_SNAPSHOT_WORKSPACE_OWNER_ROOT"
+		cloneEnv     = "DYNAMO_SNAPSHOT_WORKSPACE_CLONE_HELPER"
+	)
+	if os.Getenv(cloneEnv) == "1" {
+		fd, err := unix.OpenTree(
+			4,
+			"",
+			unix.AT_EMPTY_PATH|unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC,
+		)
+		if err != nil {
+			t.Fatalf("clone workspace handle in owning mount namespace: %v", err)
+		}
+		unix.Close(fd)
+		return
+	}
+	if root := os.Getenv(ownerRootEnv); root != "" {
+		if err := unix.Mount("", "/", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+			t.Fatal(err)
+		}
+		workspace := filepath.Join(root, "workspace")
+		if err := unix.Mount("tmpfs", workspace, "tmpfs", 0, "mode=700"); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(root, "ready"), nil, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		release := filepath.Join(root, "release")
+		for {
+			if _, err := os.Stat(release); err == nil {
+				return
+			} else if !errors.Is(err, os.ErrNotExist) {
+				t.Fatal(err)
+			}
+			time.Sleep(10 * time.Millisecond)
+		}
+	}
+	if os.Getenv("DYNAMO_SNAPSHOT_PRIVILEGED_TEST") != "1" || os.Geteuid() != 0 {
+		t.Skip("set DYNAMO_SNAPSHOT_PRIVILEGED_TEST=1 and run as root")
+	}
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	if err := os.Mkdir(workspace, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var ownerOutput bytes.Buffer
+	owner := exec.Command(
+		os.Args[0],
+		"-test.run=^TestPrivilegedWorkspaceHandleCloneAcrossMountNamespaces$",
+	)
+	owner.Env = append(os.Environ(), ownerRootEnv+"="+root)
+	owner.SysProcAttr = &unix.SysProcAttr{Cloneflags: unix.CLONE_NEWNS}
+	owner.Stdout = &ownerOutput
+	owner.Stderr = &ownerOutput
+	if err := owner.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := os.WriteFile(filepath.Join(root, "release"), nil, 0o600); err != nil {
+			t.Error(err)
+			_ = owner.Process.Kill()
+		}
+		if err := owner.Wait(); err != nil {
+			t.Errorf("workspace owner: %v\n%s", err, ownerOutput.Bytes())
+		}
+	}()
+
+	ready := filepath.Join(root, "ready")
+	deadline := time.Now().Add(5 * time.Second)
+	for {
+		if _, err := os.Stat(ready); err == nil {
+			break
+		} else if !errors.Is(err, os.ErrNotExist) {
+			t.Fatal(err)
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("workspace owner did not become ready\n%s", ownerOutput.Bytes())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	foreignPath := fmt.Sprintf("/proc/%d/root%s", owner.Process.Pid, workspace)
+	fd, err := unix.OpenTree(
+		unix.AT_FDCWD,
+		foreignPath,
+		unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC,
+	)
+	if err == nil {
+		unix.Close(fd)
+		t.Fatal("foreign mount namespace clone unexpectedly succeeded")
+	}
+	if !errors.Is(err, unix.EINVAL) {
+		t.Fatalf("foreign mount namespace clone error = %v, want EINVAL", err)
+	}
+
+	workspaceFD, err := unix.Open(
+		foreignPath,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	workspaceHandle := os.NewFile(uintptr(workspaceFD), "workspace-handle")
+	defer workspaceHandle.Close()
+	dummy, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer dummy.Close()
+	clone := exec.Command(
+		"nsenter",
+		"-t", fmt.Sprint(owner.Process.Pid),
+		"-m",
+		"--", os.Args[0],
+		"-test.run=^TestPrivilegedWorkspaceHandleCloneAcrossMountNamespaces$",
+	)
+	clone.Env = append(os.Environ(), cloneEnv+"=1")
+	clone.ExtraFiles = []*os.File{dummy, workspaceHandle}
+	if output, err := clone.CombinedOutput(); err != nil {
+		t.Fatalf("clone inherited workspace handle after nsenter: %v\n%s", err, output)
+	}
+}
+
+func TestPrivilegedPlaceholderFirstRootComposition(t *testing.T) {
+	if os.Getenv("DYNAMO_SNAPSHOT_PRIVILEGED_TEST") != "1" {
+		t.Skip("set DYNAMO_SNAPSHOT_PRIVILEGED_TEST=1 and run as root")
+	}
+	root := os.Getenv("DYNAMO_SNAPSHOT_PRIVILEGED_HELPER_ROOT")
+	if root == "" {
+		if os.Geteuid() != 0 {
+			t.Skip("privileged root composition test requires root")
+		}
+		root = filepath.Join(t.TempDir(), "root")
+		if err := os.Mkdir(root, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		command := exec.Command(
+			os.Args[0],
+			"-test.run=^TestPrivilegedPlaceholderFirstRootComposition$",
+		)
+		command.Env = append(
+			os.Environ(),
+			"DYNAMO_SNAPSHOT_PRIVILEGED_HELPER_ROOT="+root,
+		)
+		command.SysProcAttr = &unix.SysProcAttr{Cloneflags: unix.CLONE_NEWNS}
+		output, err := command.CombinedOutput()
+		if err != nil {
+			t.Fatalf("privileged root composition helper: %v\n%s", err, output)
+		}
+		return
+	}
+	runPrivilegedRootComposition(t, root)
+}
+
+func runPrivilegedRootComposition(t *testing.T, root string) {
+	t.Helper()
+	const (
+		placeholderUID  = 1234
+		placeholderGID  = 2345
+		placeholderMode = 0o7751
+		backingGID      = 3456
+	)
+	requireTool(t, "mksquashfs")
+	if err := unix.Mount("", "/", "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Dir(root)
+	placeholderLower := filepath.Join(base, "placeholder-lower")
+	placeholderUpper := filepath.Join(base, "placeholder-upper")
+	placeholderWork := filepath.Join(base, "placeholder-work")
+	checkpoint := filepath.Join(base, "checkpoint")
+	snapshotSource := filepath.Join(base, "snapshot")
+	for _, path := range []string{
+		placeholderLower,
+		placeholderUpper,
+		placeholderWork,
+		checkpoint,
+		filepath.Join(snapshotSource, "opaque/shared"),
+	} {
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write := func(root, name, content string) {
+		t.Helper()
+		path := filepath.Join(root, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	write(placeholderLower, "collision", "placeholder")
+	write(placeholderLower, "delete-me", "placeholder")
+	write(placeholderLower, "opaque/placeholder-only", "placeholder")
+	write(placeholderLower, "opaque/shared/placeholder-nested", "placeholder")
+	write(placeholderLower, "file-mount", "")
+	write(placeholderLower, "mount-source", "file-mount")
+	write(snapshotSource, "collision", "snapshot")
+	write(snapshotSource, "snapshot-only", "snapshot")
+	write(snapshotSource, "opaque/snapshot-only", "snapshot")
+	write(snapshotSource, "opaque/shared/snapshot-nested", "snapshot")
+	if err := os.WriteFile(
+		filepath.Join(checkpoint, deletedFilesFilename),
+		[]byte(`{"whiteouts":["delete-me","mounted/user-data"],"opaqueDirectories":["opaque"]}`),
+		0o600,
+	); err != nil {
+		t.Fatal(err)
+	}
+	imagePath := filepath.Join(checkpoint, RootfsDiffFilename)
+	command := exec.CommandContext(
+		context.Background(),
+		"mksquashfs",
+		snapshotSource,
+		imagePath,
+		"-comp", "zstd",
+		"-b", "1M",
+		"-processors", "2",
+		"-noappend",
+		"-no-progress",
+	)
+	if output, err := command.CombinedOutput(); err != nil {
+		t.Fatalf("mksquashfs: %v\n%s", err, output)
+	}
+
+	// Match the agent pod: only loop-control is host-mounted. Loop nodes live
+	// in the test namespace's ephemeral tmpfs.
+	if err := os.MkdirAll(hostDevicePath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mount("tmpfs", hostDevicePath, "tmpfs", 0, "mode=700"); err != nil {
+		t.Fatal(err)
+	}
+	loopControl := filepath.Join(hostDevicePath, "loop-control")
+	if err := os.WriteFile(loopControl, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mount("/dev/loop-control", loopControl, "", unix.MS_BIND, ""); err != nil {
+		t.Fatal(err)
+	}
+	image, err := os.Open(imagePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer image.Close()
+	rootfsMount, err := PrepareDetachedRootfsMount(image)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rootfsMount.Close()
+
+	for _, path := range []string{
+		"checkpoint",
+		"proc",
+		"mounted",
+		strings.TrimPrefix(RootfsBackingWorkspaceMountPath, "/"),
+	} {
+		if err := os.MkdirAll(filepath.Join(placeholderLower, path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	options := strings.Join([]string{
+		"lowerdir=" + placeholderLower,
+		"upperdir=" + placeholderUpper,
+		"workdir=" + placeholderWork,
+	}, ",")
+	if err := unix.Mount("overlay", root, "overlay", 0, options); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mount(
+		checkpoint,
+		filepath.Join(root, "checkpoint"),
+		"",
+		unix.MS_BIND,
+		"",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Mount(
+		"/proc",
+		filepath.Join(root, "proc"),
+		"",
+		unix.MS_BIND|unix.MS_REC,
+		"",
+	); err != nil {
+		t.Fatal(err)
+	}
+	mounted := filepath.Join(root, "mounted")
+	if err := unix.Mount("tmpfs", mounted, "tmpfs", 0, "mode=700"); err != nil {
+		t.Fatal(err)
+	}
+	write(mounted, "child-only", "mounted")
+	if err := unix.Mount(
+		filepath.Join(root, "mount-source"),
+		filepath.Join(root, "file-mount"),
+		"",
+		unix.MS_BIND,
+		"",
+	); err != nil {
+		t.Fatal(err)
+	}
+	backing := filepath.Join(root, RootfsBackingWorkspaceMountPath)
+	if err := unix.Mount("tmpfs", backing, "tmpfs", 0, "mode=700"); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chown(backing, 0, backingGID); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chmod(backing, 0o2700); err != nil {
+		t.Fatal(err)
+	}
+	inheritanceProbe := filepath.Join(backing, "inheritance-probe")
+	if err := os.Mkdir(inheritanceProbe, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	var inherited unix.Stat_t
+	if err := unix.Stat(inheritanceProbe, &inherited); err != nil {
+		t.Fatal(err)
+	}
+	if got := inherited.Mode & 0o7777; got != 0o2700 {
+		t.Fatalf("setgid-inherited directory mode = %#o, want 02700", got)
+	}
+	if inherited.Gid != backingGID {
+		t.Fatalf("setgid-inherited directory gid = %d, want %d", inherited.Gid, backingGID)
+	}
+	if err := os.Remove(inheritanceProbe); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chown(root, placeholderUID, placeholderGID); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chmod(root, placeholderMode); err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Chroot(root); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir("/"); err != nil {
+		t.Fatal(err)
+	}
+	callerRoot, err := os.Stat("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var placeholderMetadata unix.Stat_t
+	if err := unix.Stat("/", &placeholderMetadata); err != nil {
+		t.Fatal(err)
+	}
+	if placeholderMetadata.Uid != placeholderUID ||
+		placeholderMetadata.Gid != placeholderGID ||
+		placeholderMetadata.Mode&0o7777 != placeholderMode {
+		t.Fatalf(
+			"placeholder root metadata = uid %d gid %d mode %#o, want uid %d gid %d mode %#o",
+			placeholderMetadata.Uid,
+			placeholderMetadata.Gid,
+			placeholderMetadata.Mode&0o7777,
+			placeholderUID,
+			placeholderGID,
+			placeholderMode,
+		)
+	}
+	workspaceFD, err := unix.Open(
+		RootfsBackingWorkspaceMountPath,
+		unix.O_PATH|unix.O_DIRECTORY|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	deleted, err := os.Open("/checkpoint/" + deletedFilesFilename)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer deleted.Close()
+	composition, err := ComposeRoot(
+		int(rootfsMount.Fd()),
+		workspaceFD,
+		int(deleted.Fd()),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if composition.RootPath != restoreRoot {
+		t.Fatalf("composed root = %q, want %q", composition.RootPath, restoreRoot)
+	}
+	if cwd, err := os.Getwd(); err != nil || cwd != "/" {
+		t.Fatalf("caller cwd = %q, %v; want /", cwd, err)
+	}
+	currentRoot, err := os.Stat("/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(callerRoot, currentRoot) {
+		t.Fatal("composition changed the caller root")
+	}
+	if _, err := os.Stat("/snapshot-only"); !os.IsNotExist(err) {
+		t.Fatalf("snapshot content leaked into caller root: %v", err)
+	}
+	if _, err := os.Stat(RootfsBackingWorkspaceMountPath); err != nil {
+		t.Fatalf("caller backing workspace is unavailable: %v", err)
+	}
+	for _, path := range []string{restoreUpper, composition.RootPath} {
+		var got unix.Stat_t
+		if err := unix.Stat(path, &got); err != nil {
+			t.Fatal(err)
+		}
+		if got.Uid != placeholderMetadata.Uid ||
+			got.Gid != placeholderMetadata.Gid ||
+			got.Mode&0o7777 != placeholderMetadata.Mode&0o7777 {
+			t.Fatalf(
+				"%s metadata = uid %d gid %d mode %#o, want uid %d gid %d mode %#o",
+				path,
+				got.Uid,
+				got.Gid,
+				got.Mode&0o7777,
+				placeholderMetadata.Uid,
+				placeholderMetadata.Gid,
+				placeholderMetadata.Mode&0o7777,
+			)
+		}
+	}
+	var replayedOpaque unix.Stat_t
+	if err := unix.Stat(filepath.Join(restoreUpper, "opaque"), &replayedOpaque); err != nil {
+		t.Fatal(err)
+	}
+	if replayedOpaque.Gid != placeholderMetadata.Gid {
+		t.Fatalf(
+			"replayed opaque directory gid = %d, want placeholder gid %d",
+			replayedOpaque.Gid,
+			placeholderMetadata.Gid,
+		)
+	}
+	if replayedOpaque.Mode&unix.S_ISGID == 0 {
+		t.Fatalf("replayed opaque directory mode = %#o, want setgid", replayedOpaque.Mode&0o7777)
+	}
+
+	assertContent := func(path, want string) {
+		t.Helper()
+		content, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", path, err)
+		}
+		if string(content) != want {
+			t.Fatalf("%s = %q, want %q", path, content, want)
+		}
+	}
+	staged := func(path string) string {
+		return filepath.Join(composition.RootPath, strings.TrimPrefix(path, "/"))
+	}
+	assertContent("/mounted/child-only", "mounted")
+	assertContent("/file-mount", "file-mount")
+	assertContent(staged("/collision"), "placeholder")
+	assertContent(staged("/snapshot-only"), "snapshot")
+	assertContent(staged("/opaque/snapshot-only"), "snapshot")
+	assertContent(staged("/opaque/shared/snapshot-nested"), "snapshot")
+	assertContent(staged("/file-mount"), "")
+	for _, path := range []string{
+		"/checkpoint/" + deletedFilesFilename,
+		"/delete-me",
+		"/mounted/child-only",
+		"/opaque/placeholder-only",
+		"/proc/self",
+	} {
+		if _, err := os.Lstat(staged(path)); !os.IsNotExist(err) {
+			t.Fatalf("%s should be hidden, got %v", path, err)
+		}
+	}
+	for _, path := range []string{
+		RootfsBackingWorkspaceMountPath,
+		RootfsBackingWorkspaceMountPath + "/upper",
+		RootfsBackingWorkspaceMountPath + "/work",
+	} {
+		if _, err := os.Stat(staged(path)); !os.IsNotExist(err) {
+			t.Fatalf("rootfs backing path %s should be inaccessible, got %v", path, err)
+		}
+	}
+	for _, path := range []string{"/checkpoint", "/proc", "/mounted", "/file-mount"} {
+		if _, err := os.Stat(staged(path)); err != nil {
+			t.Fatalf("placeholder mountpoint %s is unavailable: %v", path, err)
+		}
+	}
+}

--- a/deploy/snapshot/internal/runtime/root_compose_test.go
+++ b/deploy/snapshot/internal/runtime/root_compose_test.go
@@ -16,6 +16,52 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+func TestMkdirAllAtWithoutLowerMetadata(t *testing.T) {
+	root := t.TempDir()
+	upper := filepath.Join(root, "upper")
+	snapshot := filepath.Join(root, "snapshot")
+	placeholder := filepath.Join(root, "placeholder")
+	for _, path := range []string{upper, snapshot, placeholder} {
+		if err := os.Mkdir(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	open := func(path string) int {
+		t.Helper()
+		fd, err := unix.Open(path, unix.O_RDONLY|unix.O_DIRECTORY|unix.O_CLOEXEC, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
+		t.Cleanup(func() { unix.Close(fd) })
+		return fd
+	}
+	upperFD := open(upper)
+	snapshotFD := open(snapshot)
+	placeholderFD := open(placeholder)
+
+	const missing = "home/dynamo/.cache/huggingface"
+	createdFD, err := mkdirAllAt(upperFD, missing, snapshotFD, placeholderFD)
+	if err != nil {
+		t.Fatal(err)
+	}
+	unix.Close(createdFD)
+	if info, err := os.Stat(filepath.Join(upper, missing)); err != nil {
+		t.Fatal(err)
+	} else if !info.IsDir() {
+		t.Fatalf("created path mode = %v, want directory", info.Mode())
+	}
+
+	if err := os.Symlink(".", filepath.Join(placeholder, "symlink")); err != nil {
+		t.Fatal(err)
+	}
+	if fd, err := mkdirAllAt(upperFD, "symlink/child", snapshotFD, placeholderFD); err == nil {
+		unix.Close(fd)
+		t.Fatal("mkdirAllAt unexpectedly ignored lower symlink")
+	} else if !errors.Is(err, unix.ENOTDIR) && !errors.Is(err, unix.ELOOP) {
+		t.Fatalf("mkdirAllAt lower symlink error = %v, want ENOTDIR or ELOOP", err)
+	}
+}
+
 func TestPrivilegedWorkspaceHandleCloneAcrossMountNamespaces(t *testing.T) {
 	const (
 		ownerRootEnv = "DYNAMO_SNAPSHOT_WORKSPACE_OWNER_ROOT"

--- a/deploy/snapshot/internal/runtime/squashfs_mount.go
+++ b/deploy/snapshot/internal/runtime/squashfs_mount.go
@@ -1,0 +1,182 @@
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/google/uuid"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	hostDevicePath  = "/host/dev"
+	mountStagingDir = "/var/run/snapshot/mounts"
+)
+
+var (
+	openLoopControl = unix.Open
+	loopIoctlRetInt = unix.IoctlRetInt
+	openLoopDevice  = unix.Open
+	createLoopNode  = unix.Mknod
+	statLoopDevice  = unix.Fstat
+	configureLoop   = unix.IoctlLoopConfigure
+	clearLoop       = unix.IoctlSetInt
+	mountSquashfs   = unix.Mount
+	unmountPath     = unix.Unmount
+	openMountTree   = unix.OpenTree
+)
+
+const loopAllocationAttempts = 8
+
+func preflightRootfsMountCapability() error {
+	fd, err := unix.Open(
+		filepath.Join(hostDevicePath, "loop-control"),
+		unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+		0,
+	)
+	if err != nil {
+		return fmt.Errorf("open loop-control for rootfs preflight: %w", err)
+	}
+	if err := unix.Close(fd); err != nil {
+		return fmt.Errorf("close loop-control after rootfs preflight: %w", err)
+	}
+	return nil
+}
+
+// PrepareDetachedRootfsMount loop-mounts and detaches an already-validated image.
+func PrepareDetachedRootfsMount(image *os.File) (*os.File, error) {
+	if image == nil {
+		return nil, errors.New("validated rootfs image is required")
+	}
+	loopFD, loopPath, err := configureAvailableLoop(image)
+	if err != nil {
+		return nil, err
+	}
+	defer unix.Close(loopFD)
+	loopConfigured := true
+	defer func() {
+		if loopConfigured {
+			_ = clearLoop(loopFD, unix.LOOP_CLR_FD, 0)
+		}
+	}()
+
+	if err := os.MkdirAll(mountStagingDir, 0o700); err != nil {
+		return nil, fmt.Errorf("create SquashFS mount staging root: %w", err)
+	}
+	mountpoint := filepath.Join(mountStagingDir, uuid.NewString())
+	if err := os.Mkdir(mountpoint, 0o700); err != nil {
+		return nil, fmt.Errorf("create SquashFS mountpoint: %w", err)
+	}
+	defer os.Remove(mountpoint)
+
+	if err := mountSquashfs(loopPath, mountpoint, "squashfs", unix.MS_RDONLY, ""); err != nil {
+		return nil, fmt.Errorf("mount SquashFS image read-only: %w", err)
+	}
+	mounted := true
+	defer func() {
+		if mounted {
+			_ = unmountPath(mountpoint, unix.MNT_DETACH)
+		}
+	}()
+
+	mountFD, err := openMountTree(
+		unix.AT_FDCWD,
+		mountpoint,
+		unix.OPEN_TREE_CLONE|unix.OPEN_TREE_CLOEXEC,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("clone SquashFS mount with open_tree: %w", err)
+	}
+	detached := os.NewFile(uintptr(mountFD), "rootfs-squashfs-mount")
+
+	if err := unmountPath(mountpoint, unix.MNT_DETACH); err != nil {
+		detached.Close()
+		return nil, fmt.Errorf("detach SquashFS staging mount: %w", err)
+	}
+	mounted = false
+	loopConfigured = false // Autoclear now owns cleanup when the detached mount closes.
+
+	return detached, nil
+}
+
+func configureAvailableLoop(image *os.File) (int, string, error) {
+	config := &unix.LoopConfig{
+		Fd: uint32(image.Fd()),
+		Info: unix.LoopInfo64{
+			Flags: unix.LO_FLAGS_READ_ONLY | unix.LO_FLAGS_AUTOCLEAR,
+		},
+	}
+	var lastErr error
+	for range loopAllocationAttempts {
+		loopControl, err := openLoopControl(
+			filepath.Join(hostDevicePath, "loop-control"),
+			unix.O_RDWR|unix.O_CLOEXEC,
+			0,
+		)
+		if err != nil {
+			return -1, "", fmt.Errorf("open loop-control: %w", err)
+		}
+		loopNumber, err := loopIoctlRetInt(loopControl, unix.LOOP_CTL_GET_FREE)
+		unix.Close(loopControl)
+		if err != nil {
+			return -1, "", fmt.Errorf("allocate loop device: %w", err)
+		}
+		if loopNumber < 0 || loopNumber > 1<<20 {
+			return -1, "", fmt.Errorf("loop-control returned invalid device number %d", loopNumber)
+		}
+		loopPath := filepath.Join(hostDevicePath, fmt.Sprintf("loop%d", loopNumber))
+		loopFD, err := openLoopDevice(
+			loopPath,
+			unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+			0,
+		)
+		if errors.Is(err, unix.ENOENT) {
+			err = createLoopNode(
+				loopPath,
+				unix.S_IFBLK|0o600,
+				int(unix.Mkdev(7, uint32(loopNumber))),
+			)
+			if err == nil || errors.Is(err, unix.EEXIST) {
+				loopFD, err = openLoopDevice(
+					loopPath,
+					unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW,
+					0,
+				)
+			}
+		}
+		if err != nil {
+			if errors.Is(err, unix.EBUSY) || errors.Is(err, unix.ENOENT) {
+				lastErr = err
+				continue
+			}
+			return -1, "", fmt.Errorf("open allocated loop device %s: %w", loopPath, err)
+		}
+		var stat unix.Stat_t
+		if err := statLoopDevice(loopFD, &stat); err != nil {
+			unix.Close(loopFD)
+			return -1, "", fmt.Errorf("stat allocated loop device %s: %w", loopPath, err)
+		}
+		if stat.Mode&unix.S_IFMT != unix.S_IFBLK ||
+			unix.Major(uint64(stat.Rdev)) != 7 ||
+			unix.Minor(uint64(stat.Rdev)) != uint32(loopNumber) {
+			unix.Close(loopFD)
+			return -1, "", fmt.Errorf("%s is not loop block device %d", loopPath, loopNumber)
+		}
+		if err := configureLoop(loopFD, config); err != nil {
+			unix.Close(loopFD)
+			if errors.Is(err, unix.EBUSY) {
+				lastErr = err
+				continue
+			}
+			return -1, "", fmt.Errorf("configure loop device %s: %w", loopPath, err)
+		}
+		return loopFD, loopPath, nil
+	}
+	return -1, "", fmt.Errorf(
+		"configure a free loop device after %d attempts: %w",
+		loopAllocationAttempts,
+		lastErr,
+	)
+}

--- a/deploy/snapshot/internal/runtime/squashfs_mount.go
+++ b/deploy/snapshot/internal/runtime/squashfs_mount.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
+	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/sys/unix"
@@ -26,27 +28,55 @@ var (
 	mountSquashfs   = unix.Mount
 	unmountPath     = unix.Unmount
 	openMountTree   = unix.OpenTree
+
+	loopAllocationMu sync.Mutex
 )
 
-const loopAllocationAttempts = 8
+const (
+	loopAllocationAttempts   = 16
+	loopAllocationRetryDelay = 10 * time.Millisecond
+)
 
-func preflightRootfsMountCapability() error {
-	fd, err := unix.Open(
-		filepath.Join(hostDevicePath, "loop-control"),
-		unix.O_RDWR|unix.O_CLOEXEC|unix.O_NOFOLLOW,
-		0,
-	)
+func preflightRootfsMountCapability() (retErr error) {
+	image, err := os.CreateTemp("", "dynamo-snapshot-loop-preflight-*")
 	if err != nil {
-		return fmt.Errorf("open loop-control for rootfs preflight: %w", err)
+		return fmt.Errorf("create scratch file for rootfs loop preflight: %w", err)
 	}
-	if err := unix.Close(fd); err != nil {
-		return fmt.Errorf("close loop-control after rootfs preflight: %w", err)
+	imagePath := image.Name()
+	loopFD := -1
+	defer func() {
+		if loopFD >= 0 {
+			retErr = errors.Join(
+				retErr,
+				clearLoop(loopFD, unix.LOOP_CLR_FD, 0),
+				unix.Close(loopFD),
+			)
+		}
+		retErr = errors.Join(retErr, image.Close(), os.Remove(imagePath))
+	}()
+
+	if err := image.Truncate(4096); err != nil {
+		return fmt.Errorf("size scratch file for rootfs loop preflight: %w", err)
+	}
+	loopFD, _, err = configureAvailableLoop(image)
+	if err != nil {
+		return fmt.Errorf(
+			"LOOP_CONFIGURE preflight failed; enable host loop support and permit loop ioctls: %w",
+			err,
+		)
 	}
 	return nil
 }
 
 // PrepareDetachedRootfsMount loop-mounts and detaches an already-validated image.
-func PrepareDetachedRootfsMount(image *os.File) (*os.File, error) {
+func PrepareDetachedRootfsMount(image *os.File) (detached *os.File, retErr error) {
+	return prepareDetachedRootfsMount(image, mountStagingDir)
+}
+
+func prepareDetachedRootfsMount(
+	image *os.File,
+	stagingDir string,
+) (detached *os.File, retErr error) {
 	if image == nil {
 		return nil, errors.New("validated rootfs image is required")
 	}
@@ -54,32 +84,50 @@ func PrepareDetachedRootfsMount(image *os.File) (*os.File, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer unix.Close(loopFD)
 	loopConfigured := true
+	mounted := false
+	mountpoint := ""
+	mountpointCreated := false
 	defer func() {
+		if mounted {
+			if err := unmountPath(mountpoint, unix.MNT_DETACH); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("unmount SquashFS staging mount: %w", err))
+			}
+		}
+		if mountpointCreated {
+			if err := os.Remove(mountpoint); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("remove SquashFS mountpoint: %w", err))
+			}
+		}
 		if loopConfigured {
-			_ = clearLoop(loopFD, unix.LOOP_CLR_FD, 0)
+			if err := clearLoop(loopFD, unix.LOOP_CLR_FD, 0); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("clear loop device: %w", err))
+			}
+		}
+		if err := unix.Close(loopFD); err != nil {
+			retErr = errors.Join(retErr, fmt.Errorf("close loop device: %w", err))
+		}
+		if retErr != nil && detached != nil {
+			if err := detached.Close(); err != nil {
+				retErr = errors.Join(retErr, fmt.Errorf("close detached SquashFS mount: %w", err))
+			}
+			detached = nil
 		}
 	}()
 
-	if err := os.MkdirAll(mountStagingDir, 0o700); err != nil {
+	if err := os.MkdirAll(stagingDir, 0o700); err != nil {
 		return nil, fmt.Errorf("create SquashFS mount staging root: %w", err)
 	}
-	mountpoint := filepath.Join(mountStagingDir, uuid.NewString())
+	mountpoint = filepath.Join(stagingDir, uuid.NewString())
 	if err := os.Mkdir(mountpoint, 0o700); err != nil {
 		return nil, fmt.Errorf("create SquashFS mountpoint: %w", err)
 	}
-	defer os.Remove(mountpoint)
+	mountpointCreated = true
 
 	if err := mountSquashfs(loopPath, mountpoint, "squashfs", unix.MS_RDONLY, ""); err != nil {
 		return nil, fmt.Errorf("mount SquashFS image read-only: %w", err)
 	}
-	mounted := true
-	defer func() {
-		if mounted {
-			_ = unmountPath(mountpoint, unix.MNT_DETACH)
-		}
-	}()
+	mounted = true
 
 	mountFD, err := openMountTree(
 		unix.AT_FDCWD,
@@ -89,11 +137,11 @@ func PrepareDetachedRootfsMount(image *os.File) (*os.File, error) {
 	if err != nil {
 		return nil, fmt.Errorf("clone SquashFS mount with open_tree: %w", err)
 	}
-	detached := os.NewFile(uintptr(mountFD), "rootfs-squashfs-mount")
+	detached = os.NewFile(uintptr(mountFD), "rootfs-squashfs-mount")
 
 	if err := unmountPath(mountpoint, unix.MNT_DETACH); err != nil {
-		detached.Close()
-		return nil, fmt.Errorf("detach SquashFS staging mount: %w", err)
+		retErr = fmt.Errorf("detach SquashFS staging mount: %w", err)
+		return
 	}
 	mounted = false
 	loopConfigured = false // Autoclear now owns cleanup when the detached mount closes.
@@ -102,6 +150,9 @@ func PrepareDetachedRootfsMount(image *os.File) (*os.File, error) {
 }
 
 func configureAvailableLoop(image *os.File) (int, string, error) {
+	loopAllocationMu.Lock()
+	defer loopAllocationMu.Unlock()
+
 	config := &unix.LoopConfig{
 		Fd: uint32(image.Fd()),
 		Info: unix.LoopInfo64{
@@ -109,7 +160,7 @@ func configureAvailableLoop(image *os.File) (int, string, error) {
 		},
 	}
 	var lastErr error
-	for range loopAllocationAttempts {
+	for attempt := range loopAllocationAttempts {
 		loopControl, err := openLoopControl(
 			filepath.Join(hostDevicePath, "loop-control"),
 			unix.O_RDWR|unix.O_CLOEXEC,
@@ -121,6 +172,10 @@ func configureAvailableLoop(image *os.File) (int, string, error) {
 		loopNumber, err := loopIoctlRetInt(loopControl, unix.LOOP_CTL_GET_FREE)
 		unix.Close(loopControl)
 		if err != nil {
+			if retryLoopAllocation(attempt, err) {
+				lastErr = err
+				continue
+			}
 			return -1, "", fmt.Errorf("allocate loop device: %w", err)
 		}
 		if loopNumber < 0 || loopNumber > 1<<20 {
@@ -147,7 +202,7 @@ func configureAvailableLoop(image *os.File) (int, string, error) {
 			}
 		}
 		if err != nil {
-			if errors.Is(err, unix.EBUSY) || errors.Is(err, unix.ENOENT) {
+			if retryLoopAllocation(attempt, err) {
 				lastErr = err
 				continue
 			}
@@ -166,11 +221,11 @@ func configureAvailableLoop(image *os.File) (int, string, error) {
 		}
 		if err := configureLoop(loopFD, config); err != nil {
 			unix.Close(loopFD)
-			if errors.Is(err, unix.EBUSY) {
+			if retryLoopAllocation(attempt, err) {
 				lastErr = err
 				continue
 			}
-			return -1, "", fmt.Errorf("configure loop device %s: %w", loopPath, err)
+			return -1, "", fmt.Errorf("configure loop device %s with LOOP_CONFIGURE: %w", loopPath, err)
 		}
 		return loopFD, loopPath, nil
 	}
@@ -179,4 +234,15 @@ func configureAvailableLoop(image *os.File) (int, string, error) {
 		loopAllocationAttempts,
 		lastErr,
 	)
+}
+
+func retryLoopAllocation(attempt int, err error) bool {
+	if attempt+1 >= loopAllocationAttempts ||
+		(!errors.Is(err, unix.EBUSY) &&
+			!errors.Is(err, unix.ENOENT) &&
+			!errors.Is(err, unix.ENXIO)) {
+		return false
+	}
+	time.Sleep(loopAllocationRetryDelay)
+	return true
 }

--- a/deploy/snapshot/internal/runtime/squashfs_mount_test.go
+++ b/deploy/snapshot/internal/runtime/squashfs_mount_test.go
@@ -1,0 +1,78 @@
+package runtime
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestPrepareDetachedRootfsMountCleansLoopOnMountFailure(t *testing.T) {
+	oldOpenControl := openLoopControl
+	oldRetInt := loopIoctlRetInt
+	oldOpenDevice := openLoopDevice
+	oldCreateNode := createLoopNode
+	oldStatDevice := statLoopDevice
+	oldConfigure := configureLoop
+	oldClear := clearLoop
+	oldMount := mountSquashfs
+	t.Cleanup(func() {
+		openLoopControl = oldOpenControl
+		loopIoctlRetInt = oldRetInt
+		openLoopDevice = oldOpenDevice
+		createLoopNode = oldCreateNode
+		statLoopDevice = oldStatDevice
+		configureLoop = oldConfigure
+		clearLoop = oldClear
+		mountSquashfs = oldMount
+	})
+
+	control, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	device, err := os.Open("/dev/null")
+	if err != nil {
+		t.Fatal(err)
+	}
+	openLoopControl = func(string, int, uint32) (int, error) {
+		return unix.Dup(int(control.Fd()))
+	}
+	loopIoctlRetInt = func(int, uint) (int, error) { return 7, nil }
+	openLoopDevice = func(string, int, uint32) (int, error) {
+		return unix.Dup(int(device.Fd()))
+	}
+	statLoopDevice = func(_ int, stat *unix.Stat_t) error {
+		stat.Mode = unix.S_IFBLK
+		stat.Rdev = unix.Mkdev(7, 7)
+		return nil
+	}
+	configureLoop = func(_ int, config *unix.LoopConfig) error {
+		want := uint32(unix.LO_FLAGS_READ_ONLY | unix.LO_FLAGS_AUTOCLEAR)
+		if config.Info.Flags != want {
+			t.Fatalf("loop flags = %#x, want %#x", config.Info.Flags, want)
+		}
+		return nil
+	}
+	cleared := false
+	clearLoop = func(int, uint, int) error {
+		cleared = true
+		return nil
+	}
+	mountSquashfs = func(string, string, string, uintptr, string) error {
+		return errors.New("mount failed")
+	}
+
+	image, err := os.CreateTemp(t.TempDir(), "image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer image.Close()
+	if _, err := PrepareDetachedRootfsMount(image); err == nil {
+		t.Fatal("expected mount failure")
+	}
+	if !cleared {
+		t.Fatal("loop device was not cleared after mount failure")
+	}
+}

--- a/deploy/snapshot/internal/runtime/squashfs_mount_test.go
+++ b/deploy/snapshot/internal/runtime/squashfs_mount_test.go
@@ -8,7 +8,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func TestPrepareDetachedRootfsMountCleansLoopOnMountFailure(t *testing.T) {
+func stubLoopAllocation(t *testing.T) {
+	t.Helper()
 	oldOpenControl := openLoopControl
 	oldRetInt := loopIoctlRetInt
 	oldOpenDevice := openLoopDevice
@@ -17,6 +18,8 @@ func TestPrepareDetachedRootfsMountCleansLoopOnMountFailure(t *testing.T) {
 	oldConfigure := configureLoop
 	oldClear := clearLoop
 	oldMount := mountSquashfs
+	oldUnmount := unmountPath
+	oldOpenTree := openMountTree
 	t.Cleanup(func() {
 		openLoopControl = oldOpenControl
 		loopIoctlRetInt = oldRetInt
@@ -26,16 +29,20 @@ func TestPrepareDetachedRootfsMountCleansLoopOnMountFailure(t *testing.T) {
 		configureLoop = oldConfigure
 		clearLoop = oldClear
 		mountSquashfs = oldMount
+		unmountPath = oldUnmount
+		openMountTree = oldOpenTree
 	})
 
 	control, err := os.Open("/dev/null")
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { control.Close() })
 	device, err := os.Open("/dev/null")
 	if err != nil {
 		t.Fatal(err)
 	}
+	t.Cleanup(func() { device.Close() })
 	openLoopControl = func(string, int, uint32) (int, error) {
 		return unix.Dup(int(control.Fd()))
 	}
@@ -48,31 +55,134 @@ func TestPrepareDetachedRootfsMountCleansLoopOnMountFailure(t *testing.T) {
 		stat.Rdev = unix.Mkdev(7, 7)
 		return nil
 	}
-	configureLoop = func(_ int, config *unix.LoopConfig) error {
-		want := uint32(unix.LO_FLAGS_READ_ONLY | unix.LO_FLAGS_AUTOCLEAR)
-		if config.Info.Flags != want {
-			t.Fatalf("loop flags = %#x, want %#x", config.Info.Flags, want)
+}
+
+func testRootfsImage(t *testing.T) *os.File {
+	t.Helper()
+	image, err := os.CreateTemp(t.TempDir(), "image")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { image.Close() })
+	return image
+}
+
+func assertDirectoryEmpty(t *testing.T, path string) {
+	t.Helper()
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("staging directory contains %d entries, want empty", len(entries))
+	}
+}
+
+func TestConfigureAvailableLoopRetriesPastEightBusyDevices(t *testing.T) {
+	stubLoopAllocation(t)
+	attempts := 0
+	configureLoop = func(_ int, _ *unix.LoopConfig) error {
+		attempts++
+		if attempts <= 9 {
+			return unix.EBUSY
 		}
 		return nil
 	}
+
+	fd, _, err := configureAvailableLoop(testRootfsImage(t))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := unix.Close(fd); err != nil {
+		t.Fatal(err)
+	}
+	if attempts != 10 {
+		t.Fatalf("LOOP_CONFIGURE attempts = %d, want 10", attempts)
+	}
+}
+
+func TestPrepareDetachedRootfsMountClearsConfiguredLoopOnMountFailure(t *testing.T) {
+	stubLoopAllocation(t)
+	stagingDir := t.TempDir()
+	mountErr := errors.New("mount failed")
+	configuredFD := -1
+	configureLoop = func(fd int, _ *unix.LoopConfig) error {
+		configuredFD = fd
+		return nil
+	}
+	clearedFD := -1
+	clearLoop = func(fd int, request uint, value int) error {
+		if request != unix.LOOP_CLR_FD || value != 0 {
+			t.Fatalf("clear loop request = (%d, %d)", request, value)
+		}
+		clearedFD = fd
+		return nil
+	}
+	mountSquashfs = func(string, string, string, uintptr, string) error {
+		return mountErr
+	}
+
+	_, err := prepareDetachedRootfsMount(testRootfsImage(t), stagingDir)
+	if !errors.Is(err, mountErr) {
+		t.Fatalf("prepare error = %v, want %v", err, mountErr)
+	}
+	if clearedFD != configuredFD {
+		t.Fatalf("cleared loop FD = %d, want configured FD %d", clearedFD, configuredFD)
+	}
+	assertDirectoryEmpty(t, stagingDir)
+}
+
+func TestPrepareDetachedRootfsMountUnmountsStagingOnOpenTreeFailure(t *testing.T) {
+	stubLoopAllocation(t)
+	stagingDir := t.TempDir()
+	openTreeErr := errors.New("open_tree failed")
+	configureLoop = func(int, *unix.LoopConfig) error { return nil }
 	cleared := false
 	clearLoop = func(int, uint, int) error {
 		cleared = true
 		return nil
 	}
-	mountSquashfs = func(string, string, string, uintptr, string) error {
-		return errors.New("mount failed")
+	mountSquashfs = func(string, string, string, uintptr, string) error { return nil }
+	openMountTree = func(int, string, uint) (int, error) { return -1, openTreeErr }
+	unmounted := false
+	unmountPath = func(path string, flags int) error {
+		if path == "" || flags != unix.MNT_DETACH {
+			t.Fatalf("unmount staging = (%q, %d)", path, flags)
+		}
+		unmounted = true
+		return nil
 	}
 
-	image, err := os.CreateTemp(t.TempDir(), "image")
-	if err != nil {
-		t.Fatal(err)
+	_, err := prepareDetachedRootfsMount(testRootfsImage(t), stagingDir)
+	if !errors.Is(err, openTreeErr) {
+		t.Fatalf("prepare error = %v, want %v", err, openTreeErr)
 	}
-	defer image.Close()
-	if _, err := PrepareDetachedRootfsMount(image); err == nil {
-		t.Fatal("expected mount failure")
+	if !unmounted {
+		t.Fatal("staging mount was not unmounted")
 	}
 	if !cleared {
-		t.Fatal("loop device was not cleared after mount failure")
+		t.Fatal("configured loop was not cleared")
 	}
+	assertDirectoryEmpty(t, stagingDir)
+}
+
+func TestPrepareDetachedRootfsMountJoinsCleanupErrors(t *testing.T) {
+	stubLoopAllocation(t)
+	stagingDir := t.TempDir()
+	openTreeErr := errors.New("open_tree failed")
+	unmountErr := errors.New("unmount failed")
+	clearErr := errors.New("clear failed")
+	configureLoop = func(int, *unix.LoopConfig) error { return nil }
+	clearLoop = func(int, uint, int) error { return clearErr }
+	mountSquashfs = func(string, string, string, uintptr, string) error { return nil }
+	openMountTree = func(int, string, uint) (int, error) { return -1, openTreeErr }
+	unmountPath = func(string, int) error { return unmountErr }
+
+	_, err := prepareDetachedRootfsMount(testRootfsImage(t), stagingDir)
+	for _, want := range []error{openTreeErr, unmountErr, clearErr} {
+		if !errors.Is(err, want) {
+			t.Fatalf("prepare error = %v, want joined %v", err, want)
+		}
+	}
+	assertDirectoryEmpty(t, stagingDir)
 }

--- a/deploy/snapshot/internal/types/manifest.go
+++ b/deploy/snapshot/internal/types/manifest.go
@@ -1,7 +1,9 @@
 package types
 
 import (
+	"encoding/hex"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -9,6 +11,7 @@ import (
 
 	criurpc "github.com/checkpoint-restore/go-criu/v8/rpc"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
+	"golang.org/x/sys/unix"
 	"gopkg.in/yaml.v3"
 )
 
@@ -18,6 +21,7 @@ const manifestFilename = "manifest.yaml"
 type CheckpointManifest struct {
 	CheckpointID string    `yaml:"checkpointId"`
 	CreatedAt    time.Time `yaml:"createdAt"`
+	RootFSSHA256 string    `yaml:"rootfsSha256"`
 
 	CRIUDump CRIUDumpManifest  `yaml:"criuDump"`
 	K8s      SourcePodManifest `yaml:"k8s"`
@@ -149,6 +153,9 @@ func WriteManifest(checkpointDir string, data *CheckpointManifest) error {
 	if strings.TrimSpace(data.CheckpointID) == "" {
 		return fmt.Errorf("checkpoint manifest is missing checkpointId")
 	}
+	if err := validateRootFSSHA256(data.RootFSSHA256); err != nil {
+		return err
+	}
 
 	content, err := yaml.Marshal(data)
 	if err != nil {
@@ -167,7 +174,13 @@ func WriteManifest(checkpointDir string, data *CheckpointManifest) error {
 func ReadManifest(checkpointDir string) (*CheckpointManifest, error) {
 	manifestPath := filepath.Join(checkpointDir, manifestFilename)
 
-	content, err := os.ReadFile(manifestPath)
+	fd, err := unix.Open(manifestPath, unix.O_RDONLY|unix.O_CLOEXEC|unix.O_NOFOLLOW, 0)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read checkpoint manifest: %w", err)
+	}
+	file := os.NewFile(uintptr(fd), manifestFilename)
+	defer file.Close()
+	content, err := io.ReadAll(file)
 	if err != nil {
 		return nil, fmt.Errorf("failed to read checkpoint manifest: %w", err)
 	}
@@ -179,6 +192,19 @@ func ReadManifest(checkpointDir string) (*CheckpointManifest, error) {
 	if strings.TrimSpace(data.CheckpointID) == "" {
 		return nil, fmt.Errorf("checkpoint manifest is missing checkpointId")
 	}
+	if err := validateRootFSSHA256(data.RootFSSHA256); err != nil {
+		return nil, err
+	}
 
 	return &data, nil
+}
+
+func validateRootFSSHA256(digest string) error {
+	if len(digest) != 64 {
+		return fmt.Errorf("checkpoint manifest has invalid rootfsSha256")
+	}
+	if _, err := hex.DecodeString(digest); err != nil {
+		return fmt.Errorf("checkpoint manifest has invalid rootfsSha256: %w", err)
+	}
+	return nil
 }

--- a/deploy/snapshot/internal/types/manifest_test.go
+++ b/deploy/snapshot/internal/types/manifest_test.go
@@ -32,6 +32,7 @@ func TestManifestRoundTrip(t *testing.T) {
 			BindMountDests: []string{"/data"},
 		},
 	)
+	original.RootFSSHA256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 	original.CUDA = NewCUDAManifest([]int{42, 43}, []string{"GPU-aaa", "GPU-bbb"})
 
 	if err := WriteManifest(dir, original); err != nil {
@@ -46,6 +47,9 @@ func TestManifestRoundTrip(t *testing.T) {
 	// Verify key fields survived the round-trip
 	if loaded.CheckpointID != original.CheckpointID {
 		t.Errorf("CheckpointID = %q, want %q", loaded.CheckpointID, original.CheckpointID)
+	}
+	if loaded.RootFSSHA256 != original.RootFSSHA256 {
+		t.Errorf("RootFSSHA256 = %q, want %q", loaded.RootFSSHA256, original.RootFSSHA256)
 	}
 	if loaded.CRIUDump.CRIU.LogLevel != 4 {
 		t.Errorf("CRIU.LogLevel = %d, want 4", loaded.CRIUDump.CRIU.LogLevel)

--- a/deploy/snapshot/protocol/restore.go
+++ b/deploy/snapshot/protocol/restore.go
@@ -5,6 +5,7 @@ package protocol
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -20,6 +21,9 @@ const (
 	SnapshotAgentContainerName = "agent"
 	SnapshotAgentVolumeName    = "checkpoints"
 	SnapshotAgentLabelSelector = SnapshotAgentLabelKey + "=" + SnapshotAgentLabelValue
+
+	RootfsBackingWorkspaceMountPath = "/.dynamo-snapshot-backing"
+	rootfsBackingVolumePrefix       = "snapshot-rootfs-"
 )
 
 type PodOptions struct {
@@ -28,6 +32,110 @@ type PodOptions struct {
 	ArtifactVersion string
 	Storage         Storage
 	SeccompProfile  string
+}
+
+func validateRootfsBackingIsolation(
+	podSpec *corev1.PodSpec,
+	targetName, volumeName string,
+) error {
+	for _, candidate := range podSpec.Containers {
+		if candidate.Name == targetName {
+			continue
+		}
+		for _, mount := range candidate.VolumeMounts {
+			if mount.Name == volumeName {
+				return fmt.Errorf(
+					"rootfs backing volume %q is also mounted by container %q",
+					volumeName,
+					candidate.Name,
+				)
+			}
+		}
+	}
+	for _, candidate := range podSpec.InitContainers {
+		for _, mount := range candidate.VolumeMounts {
+			if mount.Name == volumeName {
+				return fmt.Errorf(
+					"rootfs backing volume %q is also mounted by init container %q",
+					volumeName,
+					candidate.Name,
+				)
+			}
+		}
+	}
+	for _, candidate := range podSpec.EphemeralContainers {
+		for _, mount := range candidate.VolumeMounts {
+			if mount.Name == volumeName {
+				return fmt.Errorf(
+					"rootfs backing volume %q is also mounted by ephemeral container %q",
+					volumeName,
+					candidate.Name,
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func ensureRootfsBackingVolume(podSpec *corev1.PodSpec, container *corev1.Container) error {
+	name := rootfsBackingVolumeName(container.Name)
+	if err := validateRootfsBackingIsolation(podSpec, container.Name, name); err != nil {
+		return err
+	}
+	foundVolume := false
+	for _, volume := range podSpec.Volumes {
+		if volume.Name == name {
+			if volume.EmptyDir == nil {
+				return fmt.Errorf("rootfs backing volume %q must be an emptyDir", name)
+			}
+			foundVolume = true
+			break
+		}
+	}
+	if !foundVolume {
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name: name,
+			VolumeSource: corev1.VolumeSource{
+				EmptyDir: &corev1.EmptyDirVolumeSource{},
+			},
+		})
+	}
+	hasBackingMount := false
+	for _, volumeMount := range container.VolumeMounts {
+		if volumeMount.MountPath == RootfsBackingWorkspaceMountPath &&
+			volumeMount.Name != name {
+			return fmt.Errorf(
+				"reserved rootfs backing path %s is already mounted by volume %q",
+				RootfsBackingWorkspaceMountPath,
+				volumeMount.Name,
+			)
+		}
+		if volumeMount.Name == name {
+			if volumeMount.MountPath != RootfsBackingWorkspaceMountPath ||
+				volumeMount.SubPath != "" ||
+				volumeMount.SubPathExpr != "" ||
+				volumeMount.ReadOnly {
+				return fmt.Errorf("rootfs backing volume %q has conflicting mount settings", name)
+			}
+			if hasBackingMount {
+				return fmt.Errorf("rootfs backing volume %q is mounted more than once", name)
+			}
+			hasBackingMount = true
+		}
+	}
+	if hasBackingMount {
+		return nil
+	}
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      name,
+		MountPath: RootfsBackingWorkspaceMountPath,
+	})
+	return nil
+}
+
+func rootfsBackingVolumeName(containerName string) string {
+	sum := sha256.Sum256([]byte(containerName))
+	return fmt.Sprintf("%s%x", rootfsBackingVolumePrefix, sum[:16])
 }
 
 const (
@@ -95,6 +203,9 @@ func PrepareRestorePodSpec(
 			InjectCheckpointVolumeMount(container, storage.BasePath)
 		}
 		EnsureControlVolume(podSpec, container)
+		if err := ensureRootfsBackingVolume(podSpec, container); err != nil {
+			return fmt.Errorf("restore target container %q: %w", name, err)
+		}
 		if isCheckpointReady {
 			// Dynamo standby entrypoints honor this env by writing restore
 			// context and sleeping. Keep command/args intact so generic images
@@ -204,6 +315,23 @@ func ValidateRestorePodSpec(
 		if container == nil {
 			return fmt.Errorf("restore target container %q not found in pod spec (from %s annotation)", name, TargetContainersAnnotation)
 		}
+		hasBackingVolume := false
+		for _, volume := range podSpec.Volumes {
+			if volume.Name == rootfsBackingVolumeName(name) && volume.EmptyDir != nil {
+				hasBackingVolume = true
+				break
+			}
+		}
+		if !hasBackingVolume {
+			return fmt.Errorf("missing dedicated rootfs backing emptyDir for container %q", name)
+		}
+		if err := validateRootfsBackingIsolation(
+			podSpec,
+			name,
+			rootfsBackingVolumeName(name),
+		); err != nil {
+			return err
+		}
 		if storage.BasePath != "" {
 			hasMount := false
 			for _, mount := range container.VolumeMounts {
@@ -217,17 +345,36 @@ func ValidateRestorePodSpec(
 			}
 		}
 		hasControlMount := false
+		hasBackingMount := false
 		for _, mount := range container.VolumeMounts {
+			if mount.MountPath == RootfsBackingWorkspaceMountPath &&
+				mount.Name != rootfsBackingVolumeName(name) {
+				return fmt.Errorf("reserved rootfs backing path on container %q uses volume %q", name, mount.Name)
+			}
+			if mount.Name == rootfsBackingVolumeName(name) {
+				if mount.MountPath != RootfsBackingWorkspaceMountPath ||
+					mount.SubPath != "" ||
+					mount.SubPathExpr != "" ||
+					mount.ReadOnly {
+					return fmt.Errorf("rootfs backing mount on container %q must be writable and use no subPath or subPathExpr", name)
+				}
+				if hasBackingMount {
+					return fmt.Errorf("rootfs backing volume on container %q is mounted more than once", name)
+				}
+				hasBackingMount = true
+			}
 			if mount.Name == SnapshotControlVolumeName && mount.MountPath == SnapshotControlMountPath {
 				hasControlMount = true
 				if mount.SubPath != name {
 					return fmt.Errorf("expected SubPath %q for %s at %s on container %q, got %q", name, SnapshotControlVolumeName, SnapshotControlMountPath, name, mount.SubPath)
 				}
-				break
 			}
 		}
 		if !hasControlMount {
 			return fmt.Errorf("missing %s mount at %s on container %q", SnapshotControlVolumeName, SnapshotControlMountPath, name)
+		}
+		if !hasBackingMount {
+			return fmt.Errorf("missing rootfs backing mount at %s on container %q", RootfsBackingWorkspaceMountPath, name)
 		}
 		hasControlEnv := false
 		for _, env := range container.Env {

--- a/deploy/snapshot/protocol/restore_test.go
+++ b/deploy/snapshot/protocol/restore_test.go
@@ -97,11 +97,11 @@ func TestNewRestorePod(t *testing.T) {
 	if restorePod.Spec.SecurityContext == nil || restorePod.Spec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", restorePod.Spec.SecurityContext)
 	}
-	if len(restorePod.Spec.Volumes) != 2 {
-		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", restorePod.Spec.Volumes)
+	if len(restorePod.Spec.Volumes) != 3 {
+		t.Fatalf("expected checkpoint, control, and rootfs backing volumes, got %#v", restorePod.Spec.Volumes)
 	}
-	if len(main.VolumeMounts) != 2 {
-		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", main.VolumeMounts)
+	if len(main.VolumeMounts) != 3 {
+		t.Fatalf("expected checkpoint, control, and rootfs backing mounts, got %#v", main.VolumeMounts)
 	}
 	foundMount := false
 	for _, m := range main.VolumeMounts {
@@ -205,8 +205,9 @@ func TestNewRestorePodShapesMultipleTargets(t *testing.T) {
 		t.Fatalf("sidecar command must not be rewritten, got %#v", sidecar.Command)
 	}
 	for _, m := range sidecar.VolumeMounts {
-		if m.Name == SnapshotControlVolumeName {
-			t.Fatalf("sidecar must not get a control mount: %#v", sidecar.VolumeMounts)
+		if m.Name == SnapshotControlVolumeName ||
+			m.MountPath == RootfsBackingWorkspaceMountPath {
+			t.Fatalf("sidecar must not get snapshot-private mounts: %#v", sidecar.VolumeMounts)
 		}
 	}
 	for _, e := range sidecar.Env {
@@ -285,12 +286,12 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 	if podSpec.SecurityContext == nil || podSpec.SecurityContext.SeccompProfile == nil {
 		t.Fatalf("expected seccomp profile to be injected: %#v", podSpec.SecurityContext)
 	}
-	if len(podSpec.Volumes) != 2 {
-		t.Fatalf("expected checkpoint and snapshot-control volumes, got %#v", podSpec.Volumes)
+	if len(podSpec.Volumes) != 3 {
+		t.Fatalf("expected checkpoint, control, and rootfs backing volumes, got %#v", podSpec.Volumes)
 	}
 	container := &podSpec.Containers[0]
-	if len(container.VolumeMounts) != 2 {
-		t.Fatalf("expected checkpoint and snapshot-control mounts, got %#v", container.VolumeMounts)
+	if len(container.VolumeMounts) != 3 {
+		t.Fatalf("expected checkpoint, control, and rootfs backing mounts, got %#v", container.VolumeMounts)
 	}
 	volCount := 0
 	for _, v := range podSpec.Volumes {
@@ -351,6 +352,34 @@ func TestPrepareRestorePodSpec(t *testing.T) {
 		t.Fatalf("expected startup probe to gate restore completion")
 	}
 	assertRestoreStartupGate(t, container.StartupProbe)
+}
+
+func TestPrepareRestorePodSpecRejectsRootfsBackingSubPathExpr(t *testing.T) {
+	name := rootfsBackingVolumeName("main")
+	podSpec := corev1.PodSpec{
+		Containers: []corev1.Container{{
+			Name: "main",
+			VolumeMounts: []corev1.VolumeMount{{
+				Name:        name,
+				MountPath:   RootfsBackingWorkspaceMountPath,
+				SubPathExpr: "$(POD_NAME)",
+			}},
+		}},
+		Volumes: []corev1.Volume{{
+			Name:         name,
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		}},
+	}
+	err := PrepareRestorePodSpec(
+		&podSpec,
+		map[string]string{TargetContainersAnnotation: "main"},
+		Storage{},
+		"",
+		false,
+	)
+	if err == nil || !strings.Contains(err.Error(), "conflicting mount settings") {
+		t.Fatalf("expected rootfs backing subPathExpr rejection, got %v", err)
+	}
 }
 
 func TestPrepareRestorePodSpecSynthesizesStartupProbeFromLiveness(t *testing.T) {
@@ -488,13 +517,14 @@ func validRestoreSpecFixture(profile string, targets ...string) (*corev1.PodSpec
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: CheckpointVolumeName, MountPath: "/checkpoints"},
 				{Name: SnapshotControlVolumeName, MountPath: SnapshotControlMountPath, SubPath: name},
+				{Name: rootfsBackingVolumeName(name), MountPath: RootfsBackingWorkspaceMountPath},
 			},
 			Env: []corev1.EnvVar{{Name: SnapshotControlDirEnv, Value: SnapshotControlMountPath}},
 		}
 		ensureRestoreStartupProbe(&container)
 		containers = append(containers, container)
 	}
-	return &corev1.PodSpec{
+	podSpec := &corev1.PodSpec{
 		SecurityContext: &corev1.PodSecurityContext{
 			SeccompProfile: &corev1.SeccompProfile{
 				Type:             corev1.SeccompProfileTypeLocalhost,
@@ -516,7 +546,14 @@ func validRestoreSpecFixture(profile string, targets ...string) (*corev1.PodSpec
 			},
 		},
 		Containers: containers,
-	}, map[string]string{TargetContainersAnnotation: FormatTargetContainers(targets)}
+	}
+	for _, name := range targets {
+		podSpec.Volumes = append(podSpec.Volumes, corev1.Volume{
+			Name:         rootfsBackingVolumeName(name),
+			VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+		})
+	}
+	return podSpec, map[string]string{TargetContainersAnnotation: FormatTargetContainers(targets)}
 }
 
 func TestValidateRestorePodSpec(t *testing.T) {
@@ -584,6 +621,12 @@ func TestValidateRestorePodSpec(t *testing.T) {
 	}
 
 	badSpec = podSpec.DeepCopy()
+	badSpec.Containers[0].VolumeMounts[2].SubPathExpr = "$(POD_NAME)"
+	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || !strings.Contains(err.Error(), "subPathExpr") {
+		t.Fatalf("expected rootfs backing subPathExpr rejection, got %v", err)
+	}
+
+	badSpec = podSpec.DeepCopy()
 	badSpec.SecurityContext = nil
 	if err := ValidateRestorePodSpec(badSpec, annotations, storage, DefaultSeccompLocalhostProfile); err == nil || err.Error() != "missing localhost seccomp profile" {
 		t.Fatalf("expected missing seccomp error, got %v", err)
@@ -603,6 +646,23 @@ func TestValidateRestorePodSpecMultipleTargets(t *testing.T) {
 	}
 	if err := ValidateRestorePodSpec(podSpec, annotations, storage, DefaultSeccompLocalhostProfile); err != nil {
 		t.Fatalf("expected multi-target validation to pass, got %v", err)
+	}
+
+	backingAlias := podSpec.DeepCopy()
+	backingAlias.Containers[0].VolumeMounts = append(
+		backingAlias.Containers[0].VolumeMounts,
+		corev1.VolumeMount{
+			Name:      rootfsBackingVolumeName("engine-0"),
+			MountPath: "/visible-backing",
+		},
+	)
+	if err := ValidateRestorePodSpec(
+		backingAlias,
+		annotations,
+		storage,
+		DefaultSeccompLocalhostProfile,
+	); err == nil || !strings.Contains(err.Error(), "rootfs backing") {
+		t.Fatalf("expected visible backing alias rejection, got %v", err)
 	}
 
 	// Drop the engine-1 control mount → validation should fail for that target specifically.

--- a/tests/deploy/test_dynamocheckpoint.py
+++ b/tests/deploy/test_dynamocheckpoint.py
@@ -64,8 +64,9 @@ GPU_TOLERATIONS = [
     {"key": "dedicated", "operator": "Exists", "effect": "NoSchedule"},
 ]
 
-TEST_PROMPT = "Reply with one short sentence confirming this restored worker can serve."
-DEFAULT_MAX_TOKENS = 24
+TEST_RESPONSE = "RESTORE_OK"
+TEST_PROMPT = f"Reply with exactly {TEST_RESPONSE} and nothing else. /no_think"
+DEFAULT_MAX_TOKENS = 16
 DEFAULT_TEMPERATURE = 0.0
 DEFAULT_REQUEST_TIMEOUT = 120
 CHECKPOINT_READY_TIMEOUT = 300
@@ -523,11 +524,14 @@ def _assert_chat_response(response: requests.Response, expected_model: str) -> N
             f"Expected assistant message, got response: {data}",
             pytrace=False,
         )
-    if not message.get("content"):
+    content = message.get("content", "").strip()
+    if TEST_RESPONSE not in content:
         pytest.fail(
-            f"Expected non-empty assistant content, got response: {data}",
+            f"Expected assistant content to contain {TEST_RESPONSE!r}, "
+            f"got response: {data}",
             pytrace=False,
         )
+    logger.info("Assistant content: %s", content)
 
 
 def _assert_inference(base_url: str, endpoint: str, model: str) -> None:


### PR DESCRIPTION
## Summary

- replace eager tar extraction of the captured container rootfs diff with a read-only SquashFS lower layer
- compose the restored root transparently with OverlayFS while preserving Kubernetes-managed child mounts and a pod-local writable upper layer
- keep `nsrestore` and CRIU on the stable placeholder control root, and pass the staged composed root to CRIU as the restored workload root
- preserve overlay whiteout/opaque-directory semantics and validate the mandatory SquashFS artifact with its manifest SHA-256
- pass detached rootfs, workspace, and checkpoint descriptors safely into namespace-scoped restore without exposing host loop devices beyond `/dev/loop-control`

This intentionally introduces the SquashFS artifact directly without a tar compatibility path or artifact schema framework. The checkpoint generation directory continues to provide atomic generation pinning, not format versioning.

## Validation

Validated at `3576bb21db`:

- `cd deploy/snapshot && go test -count=1 ./...`
- `cd deploy/snapshot && go test -race -count=1 ./internal/runtime ./internal/executor`
- `cd deploy/snapshot && go vet ./...`
- `git diff --check` and `gofmt -l` on all changed Go files
- focused unprivileged loop allocation and cleanup tests
- privileged `TestPrivilegedSnapshotOverPlaceholderRootComposition` (four passes)
- privileged `TestPrivilegedWorkspaceHandleCloneAcrossMountNamespaces`
- privileged `TestNSenterTargetSyntaxPreservesInheritedFD`

The privileged tests used Linux `6.17.0-35-generic`, real loop devices, SquashFS, and OverlayFS. They cover nine simultaneously live detached mounts, contention beyond eight allocation attempts, cleanup after mount and `open_tree` failures, snapshot-over-placeholder precedence, deletion and recursive opaque-directory semantics, owner/mode and ordinary-file xattr preservation, Kubernetes child-mount exclusion, and a same-workspace restore retry that removes stale upper-layer state.

Upstream Linux first provides the complete required syscall set in 5.8 (`open_tree`/`move_mount` in 5.2, `openat2` in 5.6, and `LOOP_CONFIGURE` in 5.8). Enterprise kernels may backport these independently, so rootfs preflight now performs a real scratch-file `LOOP_CONFIGURE` operation instead of relying on the reported kernel version.

The earlier [`DynamoCheckpoint` CI deploy flow](https://github.com/ai-dynamo/dynamo/actions/runs/29478775288) passed vLLM, SGLang, and TensorRT-LLM checkpoint/restore with coherent post-restore `RESTORE_OK` inference at `8678ad97837a2d6da3b9af6ee4f216c6879c052f`.

For current rebased head `3576bb21db`, [Pre Merge](https://github.com/ai-dynamo/dynamo/actions/runs/29582741286) passed, including the Snapshot job. The [PR workflow](https://github.com/ai-dynamo/dynamo/actions/runs/29582743422) could not start any DynamoCheckpoint deploy test because host Kyverno policy denied the synchronized operator ConfigMap in all three backend vClusters and the ordinary deploy vCluster. This reproduced the same shared-infrastructure failure as the pre-rebase attempt; no current-head post-restore inference ran. The separate ARM64 router synchronization failure is timing-sensitive and unrelated to the Snapshot paths changed here.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11712" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Snapshots now use validated, compressed root filesystem artifacts for improved restore handling.
  * Restore operations support dedicated root filesystem backing storage and safer filesystem composition.
  * Restore configuration now enforces isolated backing volumes for each target container.
  * Added support for loop-device-backed root filesystem mounts.

* **Bug Fixes**
  * Existing checkpoint artifacts are validated before resumed snapshots are marked successful.
  * Detects corrupted, incomplete, malformed, or unsafe checkpoint artifacts.
  * Restore failures now clean up loop devices reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

