### PR TITLE
feat(kv-router): allow amplified overlap credit [DYN-3583]

### DIFF
--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -177,8 +177,8 @@ class KvRouterArgGroup(ArgGroup):
             default=1.0,
             help=(
                 "KV Router: Credit multiplier for device-local prefix overlap. "
-                "Range: 0.0 to 1.0; higher values more strongly prefer KV cache reuse. "
-                "Use router-prefill-load-scale above 1.0 to weigh TTFT/prompt-side load more heavily."
+                "Must be non-negative; values above 1.0 give device overlap extra "
+                "credit and can make the adjusted prefill cost negative."
             ),
             arg_type=float,
             dest="overlap_score_credit",

--- a/components/src/dynamo/common/configuration/groups/kv_router_args.py
+++ b/components/src/dynamo/common/configuration/groups/kv_router_args.py
@@ -177,8 +177,8 @@ class KvRouterArgGroup(ArgGroup):
             default=1.0,
             help=(
                 "KV Router: Credit multiplier for device-local prefix overlap. "
-                "Must be non-negative; values above 1.0 give device overlap extra "
-                "credit and can make the adjusted prefill cost negative."
+                "Must be finite and non-negative; values above 1.0 give device "
+                "overlap extra credit and can make the adjusted prefill cost negative."
             ),
             arg_type=float,
             dest="overlap_score_credit",

--- a/components/src/dynamo/profiler/tests/test_replay_optimize.py
+++ b/components/src/dynamo/profiler/tests/test_replay_optimize.py
@@ -776,12 +776,13 @@ def test_disagg_optimizer_rejects_invalid_objective() -> None:
         )
 
 
-def test_router_spec_rejects_out_of_range_overlap_credits() -> None:
-    with pytest.raises(ValueError, match="prefill_load_scale"):
-        _agg_spec(overlap_credits=[0.0, 1.1])
+def test_router_spec_accepts_amplified_and_rejects_invalid_overlap_credits() -> None:
+    spec = _agg_spec(overlap_credits=[0.0, 1.1])
 
-    with pytest.raises(ValueError, match="overlapCredits must be between 0.0 and 1.0"):
-        _disagg_spec(overlap_credits=[-0.1, 1.0])
+    assert spec.router.effectiveOverlapCredits == (0.0, 1.1)
+    for invalid in [-0.1, float("nan"), float("inf")]:
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            _disagg_spec(overlap_credits=[invalid, 1.0])
 
 
 def test_router_spec_rejects_invalid_prefill_load_scales() -> None:
@@ -1045,27 +1046,23 @@ def test_evaluate_agg_state_prefers_normalized_metrics_over_report_payload() -> 
     assert record["violation_penalty"] == 0.0
 
 
-def test_kv_router_config_rejects_out_of_range_overlap_credit() -> None:
-    config = KvRouterConfig(overlap_score_credit=1.0)
+def test_kv_router_config_validates_amplified_overlap_credit() -> None:
+    config = KvRouterConfig(overlap_score_credit=1.1)
 
-    with pytest.raises(ValueError, match="prefill_load_scale"):
-        KvRouterConfig(overlap_score_credit=1.1)
+    assert config.overlap_score_credit == 1.1
+    config.overlap_score_credit = 1.5
+    assert config.overlap_score_credit == 1.5
+    assert config.with_overrides(overlap_score_credit=2.0).overlap_score_credit == 2.0
 
-    with pytest.raises(
-        ValueError, match="overlap_score_credit must be between 0.0 and 1.0"
-    ):
-        config.overlap_score_credit = -1.0
+    for invalid in [-1.0, float("nan"), float("inf")]:
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            KvRouterConfig(overlap_score_credit=invalid)
 
-    with pytest.raises(ValueError, match="prefill_load_scale"):
-        config.overlap_score_credit = 1.1
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            config.overlap_score_credit = invalid
 
-    with pytest.raises(
-        ValueError, match="overlap_score_credit must be between 0.0 and 1.0"
-    ):
-        config.with_overrides(overlap_score_credit=-1.0)
-
-    with pytest.raises(ValueError, match="prefill_load_scale"):
-        config.with_overrides(overlap_score_credit=1.1)
+        with pytest.raises(ValueError, match="finite, non-negative"):
+            config.with_overrides(overlap_score_credit=invalid)
 
 
 def test_kv_router_config_preserves_positional_overlap_weight_alias() -> None:

--- a/components/src/dynamo/profiler/utils/replay_optimize/specs.py
+++ b/components/src/dynamo/profiler/utils/replay_optimize/specs.py
@@ -44,12 +44,8 @@ from .constants import (
     DEFAULT_PREFILL_LOAD_SCALES,
 )
 
-_OVERLAP_CREDITS_RANGE_ERROR = "overlapCredits must be between 0.0 and 1.0"
-_OVERLAP_CREDITS_MIGRATION_ERROR = (
-    "overlapCredits must be between 0.0 and 1.0; values above 1.0 are probably "
-    "not what you intended. If you want to weigh TTFT/prompt-side prefill load "
-    "more heavily, keep overlapCredits <= 1.0 and use that larger value for "
-    "prefillLoadScales instead; prefill_load_scale is applied after overlap credits."
+_OVERLAP_CREDITS_RANGE_ERROR = (
+    "overlapCredits must contain only finite, non-negative values"
 )
 
 
@@ -352,9 +348,7 @@ class RouterSpec(BaseModel):
         if len(credits) == 0:
             raise ValueError("overlapCredits must not be empty")
         parsed = [float(credit) for credit in credits]
-        if any(credit > 1.0 for credit in parsed):
-            raise ValueError(_OVERLAP_CREDITS_MIGRATION_ERROR)
-        if any(not 0.0 <= credit <= 1.0 for credit in parsed):
+        if any(not math.isfinite(credit) or credit < 0.0 for credit in parsed):
             raise ValueError(_OVERLAP_CREDITS_RANGE_ERROR)
         return credits
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1825,7 +1825,7 @@ class KvRouterConfig:
 
         Args:
             overlap_score_weight: Deprecated positional/keyword alias for prefill_load_scale. When present, it takes precedence over prefill_load_scale; a value of 0 also sets overlap_score_credit to 0.
-            overlap_score_credit: Credit multiplier for device-local prefix overlap, from 0.0 to 1.0 (default: 1.0). Use prefill_load_scale above 1.0 to weigh TTFT/prompt-side load more heavily.
+            overlap_score_credit: Non-negative credit multiplier for device-local prefix overlap (default: 1.0). Values above 1.0 give device overlap extra credit and can make adjusted prefill cost negative.
             prefill_load_scale: Scale for adjusted prompt-side prefill load after cache-hit credits (default: 1.0)
             host_cache_hit_weight: Credit multiplier for host-pinned cache hits (default: 0.75)
             disk_cache_hit_weight: Credit multiplier for disk/external cache hits (default: 0.25)

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1825,7 +1825,7 @@ class KvRouterConfig:
 
         Args:
             overlap_score_weight: Deprecated positional/keyword alias for prefill_load_scale. When present, it takes precedence over prefill_load_scale; a value of 0 also sets overlap_score_credit to 0.
-            overlap_score_credit: Non-negative credit multiplier for device-local prefix overlap (default: 1.0). Values above 1.0 give device overlap extra credit and can make adjusted prefill cost negative.
+            overlap_score_credit: Finite, non-negative credit multiplier for device-local prefix overlap (default: 1.0). Values above 1.0 give device overlap extra credit and can make adjusted prefill cost negative.
             prefill_load_scale: Scale for adjusted prompt-side prefill load after cache-hit credits (default: 1.0)
             host_cache_hit_weight: Credit multiplier for host-pinned cache hits (default: 0.75)
             disk_cache_hit_weight: Credit multiplier for disk/external cache hits (default: 0.25)

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -318,8 +318,8 @@ struct RouterConfigOverrideSerde {
 #[validate(schema(function = "validate_router_config_override"))]
 pub struct RouterConfigOverride {
     /// Device-local prefix-overlap credit multiplier applied to the prefill
-    /// load before sampling. Values above 1.0 give device overlap extra credit.
-    /// Set to 0.0 to ignore prefix matching.
+    /// load before sampling. Values must be finite and non-negative. Values above
+    /// 1.0 give device overlap extra credit. Set to 0.0 to ignore prefix matching.
     #[builder(default)]
     pub overlap_score_credit: Option<f64>,
 
@@ -447,8 +447,8 @@ impl Default for KvRouterConfigSerde {
 #[validate(schema(function = "validate_kv_router_config"))]
 pub struct KvRouterConfig {
     /// Device-local prefix-overlap credit multiplier applied to the prefill
-    /// load before sampling. Values above 1.0 give device overlap extra credit.
-    /// Set to 0.0 to ignore prefix matching.
+    /// load before sampling. Values must be finite and non-negative. Values above
+    /// 1.0 give device overlap extra credit. Set to 0.0 to ignore prefix matching.
     #[validate(custom(function = "validate_overlap_score_credit"))]
     pub overlap_score_credit: f64,
 
@@ -1371,14 +1371,6 @@ models:
 
     #[test]
     fn test_router_config_override_accepts_credit_above_one() {
-        let too_small = RouterConfigOverride {
-            overlap_score_credit: Some(-0.1),
-            prefill_load_scale: None,
-            router_temperature: None,
-            assume_kv_reuse: None,
-            track_prefill_tokens: None,
-            shared_cache_multiplier: None,
-        };
         let amplified = RouterConfigOverride {
             overlap_score_credit: Some(1.1),
             prefill_load_scale: None,
@@ -1388,8 +1380,18 @@ models:
             shared_cache_multiplier: None,
         };
 
-        assert!(too_small.validate().is_err());
         assert!(amplified.validate().is_ok());
+        for value in [-0.1, f64::NAN, f64::INFINITY] {
+            let invalid = RouterConfigOverride {
+                overlap_score_credit: Some(value),
+                prefill_load_scale: None,
+                router_temperature: None,
+                assume_kv_reuse: None,
+                track_prefill_tokens: None,
+                shared_cache_multiplier: None,
+            };
+            assert!(invalid.validate().is_err());
+        }
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/config.rs
+++ b/lib/kv-router/src/scheduling/config.rs
@@ -53,19 +53,11 @@ const fn default_overlap_score_credit_decay() -> f64 {
 }
 
 pub const OVERLAP_SCORE_CREDIT_RANGE_ERROR: &str =
-    "overlap_score_credit must be between 0.0 and 1.0";
-pub const OVERLAP_SCORE_CREDIT_MIGRATION_ERROR: &str = concat!(
-    "overlap_score_credit must be between 0.0 and 1.0; values above 1.0 are probably not what ",
-    "you intended. If you want to weigh TTFT/prompt-side prefill load more heavily, keep ",
-    "overlap_score_credit <= 1.0 and use that larger value for prefill_load_scale instead; ",
-    "prefill_load_scale is applied after overlap credits."
-);
+    "overlap_score_credit must be a finite, non-negative number";
 
 pub fn overlap_score_credit_error_message(value: f64) -> Option<&'static str> {
-    if (0.0..=1.0).contains(&value) {
+    if value.is_finite() && value >= 0.0 {
         None
-    } else if value > 1.0 {
-        Some(OVERLAP_SCORE_CREDIT_MIGRATION_ERROR)
     } else {
         Some(OVERLAP_SCORE_CREDIT_RANGE_ERROR)
     }
@@ -326,7 +318,8 @@ struct RouterConfigOverrideSerde {
 #[validate(schema(function = "validate_router_config_override"))]
 pub struct RouterConfigOverride {
     /// Device-local prefix-overlap credit multiplier applied to the prefill
-    /// load before sampling (0.0 to 1.0). Set to 0.0 to ignore prefix matching.
+    /// load before sampling. Values above 1.0 give device overlap extra credit.
+    /// Set to 0.0 to ignore prefix matching.
     #[builder(default)]
     pub overlap_score_credit: Option<f64>,
 
@@ -454,7 +447,8 @@ impl Default for KvRouterConfigSerde {
 #[validate(schema(function = "validate_kv_router_config"))]
 pub struct KvRouterConfig {
     /// Device-local prefix-overlap credit multiplier applied to the prefill
-    /// load before sampling (0.0 to 1.0). Set to 0.0 to ignore prefix matching.
+    /// load before sampling. Values above 1.0 give device overlap extra credit.
+    /// Set to 0.0 to ignore prefix matching.
     #[validate(custom(function = "validate_overlap_score_credit"))]
     pub overlap_score_credit: f64,
 
@@ -926,8 +920,14 @@ mod tests {
             default.router_track_active_blocks
         );
 
-        let out_of_range = config_from_values(&[("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "1.5")]);
-        assert!(out_of_range.validate_config().is_err());
+        let amplified = config_from_values(&[("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", "1.5")]);
+        assert!(amplified.validate_config().is_ok());
+
+        for value in ["-0.5", "NaN", "inf"] {
+            let invalid_credit =
+                config_from_values(&[("DYN_ROUTER_KV_OVERLAP_SCORE_CREDIT", value)]);
+            assert!(invalid_credit.validate_config().is_err());
+        }
     }
 
     #[test]
@@ -1203,19 +1203,20 @@ models:
     }
 
     #[test]
-    fn test_kv_router_config_rejects_out_of_range_overlap_score_credit() {
-        let too_small = KvRouterConfig {
-            overlap_score_credit: -0.1,
-            ..Default::default()
-        };
-        let too_large = KvRouterConfig {
+    fn test_kv_router_config_accepts_credit_above_one() {
+        let amplified = KvRouterConfig {
             overlap_score_credit: 1.1,
             ..Default::default()
         };
 
-        assert!(too_small.validate().is_err());
-        let error = too_large.validate().unwrap_err().to_string();
-        assert!(error.contains("prefill_load_scale"));
+        assert!(amplified.validate().is_ok());
+        for value in [-0.1, f64::NAN, f64::INFINITY] {
+            let invalid = KvRouterConfig {
+                overlap_score_credit: value,
+                ..Default::default()
+            };
+            assert!(invalid.validate().is_err());
+        }
     }
 
     #[test]
@@ -1260,16 +1261,19 @@ models:
     }
 
     #[test]
-    fn test_kv_router_config_deserialize_rejects_invalid_values() {
+    fn test_kv_router_config_deserialize_accepts_credit_above_one() {
+        let amplified: KvRouterConfig =
+            serde_json::from_str(r#"{"overlap_score_credit":1.5}"#).unwrap();
         let credit_error =
-            serde_json::from_str::<KvRouterConfig>(r#"{"overlap_score_credit":1.1}"#)
+            serde_json::from_str::<KvRouterConfig>(r#"{"overlap_score_credit":-0.1}"#)
                 .unwrap_err()
                 .to_string();
         let scale_error = serde_json::from_str::<KvRouterConfig>(r#"{"prefill_load_scale":-0.1}"#)
             .unwrap_err()
             .to_string();
 
-        assert!(credit_error.contains("prefill_load_scale"));
+        assert_eq!(amplified.overlap_score_credit, 1.5);
+        assert!(credit_error.contains("overlap_score_credit"));
         assert!(scale_error.contains("prefill_load_scale"));
     }
 
@@ -1314,9 +1318,11 @@ models:
     }
 
     #[test]
-    fn test_router_config_override_deserialize_rejects_invalid_values() {
+    fn test_router_config_override_deserialize_accepts_credit_above_one() {
+        let amplified: RouterConfigOverride =
+            serde_json::from_str(r#"{"overlap_score_credit":1.5}"#).unwrap();
         let credit_error =
-            serde_json::from_str::<RouterConfigOverride>(r#"{"overlap_score_credit":1.1}"#)
+            serde_json::from_str::<RouterConfigOverride>(r#"{"overlap_score_credit":-0.1}"#)
                 .unwrap_err()
                 .to_string();
         let scale_error =
@@ -1324,7 +1330,8 @@ models:
                 .unwrap_err()
                 .to_string();
 
-        assert!(credit_error.contains("prefill_load_scale"));
+        assert_eq!(amplified.overlap_score_credit, Some(1.5));
+        assert!(credit_error.contains("overlap_score_credit"));
         assert!(scale_error.contains("prefill_load_scale"));
     }
 
@@ -1363,7 +1370,7 @@ models:
     }
 
     #[test]
-    fn test_router_config_override_rejects_out_of_range_overlap_score_credit() {
+    fn test_router_config_override_accepts_credit_above_one() {
         let too_small = RouterConfigOverride {
             overlap_score_credit: Some(-0.1),
             prefill_load_scale: None,
@@ -1372,7 +1379,7 @@ models:
             track_prefill_tokens: None,
             shared_cache_multiplier: None,
         };
-        let too_large = RouterConfigOverride {
+        let amplified = RouterConfigOverride {
             overlap_score_credit: Some(1.1),
             prefill_load_scale: None,
             router_temperature: None,
@@ -1382,8 +1389,7 @@ models:
         };
 
         assert!(too_small.validate().is_err());
-        let error = too_large.validate().unwrap_err().to_string();
-        assert!(error.contains("prefill_load_scale"));
+        assert!(amplified.validate().is_ok());
     }
 
     #[test]

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -362,6 +362,8 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 .routing_constraints
                 .preferred_taint_multiplier(config.taints())
             {
+                // NOTE: This multiplicative bias assumes a non-negative score. Negative
+                // overlap scores expose its pre-existing sign sensitivity; keep it for now.
                 Some(multiplier) => base_score * multiplier,
                 None => base_score,
             }

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -202,7 +202,7 @@ impl DefaultWorkerSelector {
             + self.kv_router_config.host_cache_hit_weight * host_overlap_blocks
             + self.kv_router_config.disk_cache_hit_weight * disk_overlap_blocks
             + shared_overlap_blocks;
-        let adjusted_prefill_blocks = (raw_prefill_blocks - overlap_credit_blocks).max(0.0);
+        let adjusted_prefill_blocks = raw_prefill_blocks - overlap_credit_blocks;
         let prefill_cost_blocks = weights.prefill_load_scale * adjusted_prefill_blocks;
         let worker_load = worker_load.unwrap_or_default();
         let decode_cost_blocks = worker_load.potential_decode_blocks() as f64;
@@ -1255,7 +1255,68 @@ mod tests {
     }
 
     #[test]
-    fn test_worker_logit_preserves_prefill_accounting_edges() {
+    fn test_overlap_credit_above_one_can_prefer_colocated_worker() {
+        use crate::test_utils::SimpleWorkerConfig;
+
+        let block_size = 16u32;
+        let warm_worker = WorkerWithDpRank::from_worker_id(0);
+        let cold_worker = WorkerWithDpRank::from_worker_id(1);
+        let workers = HashMap::from([
+            (warm_worker.worker_id, SimpleWorkerConfig::default()),
+            (cold_worker.worker_id, SimpleWorkerConfig::default()),
+        ]);
+
+        let mut request = base_request(64);
+        request
+            .overlap
+            .tier_overlap_blocks
+            .device
+            .insert(warm_worker, 4);
+        request
+            .overlap
+            .effective_cached_tokens
+            .insert(warm_worker, 64);
+        request.worker_loads.insert(
+            warm_worker,
+            crate::sequences::WorkerLoadProjection {
+                active_decode_blocks: 5,
+                ..Default::default()
+            },
+        );
+
+        let normal_credit = DefaultWorkerSelector::new(
+            Some(KvRouterConfig {
+                overlap_score_credit: 1.0,
+                ..Default::default()
+            }),
+            "test",
+        );
+        let amplified_credit = DefaultWorkerSelector::new(
+            Some(KvRouterConfig {
+                overlap_score_credit: 1.5,
+                ..Default::default()
+            }),
+            "test",
+        );
+
+        assert_eq!(
+            normal_credit
+                .select_worker(&workers, &request, request.eligibility(), block_size)
+                .unwrap()
+                .worker,
+            cold_worker
+        );
+        assert_eq!(
+            amplified_credit
+                .select_worker(&workers, &request, request.eligibility(), block_size)
+                .unwrap()
+                .worker,
+            warm_worker
+        );
+    }
+
+    #[test]
+    fn test_worker_logit_does_not_clamp_negative_prefill_cost() {
         let worker = WorkerWithDpRank::from_worker_id(0);
         let mut request = base_request(64);
         request.overlap.effective_cached_tokens.insert(worker, 96);
@@ -1284,7 +1345,7 @@ mod tests {
         request.track_prefill_tokens = false;
         assert_eq!(
             selector.worker_logit(&request, worker, 16, 0, weights, "test"),
-            5.0
+            -7.0
         );
     }
 


### PR DESCRIPTION
## Summary

- Allow the existing device-local `overlap_score_credit` to exceed `1.0` while continuing to reject negative and non-finite values.
- Remove the zero floor from adjusted prefill blocks so amplified overlap credit can offset decode load.
- Reuse the existing `--router-kv-overlap-score-credit` interface; no new CLI or configuration field is added.

## Seven-worker agentic-trace tuning

Post-merge validation used this PR's final head, `47a8602e3d508667395d7f6adf4121226d5d47fb`, on one SC01 node with seven H100 PCIe GPUs and seven TP1 BF16 `Qwen/Qwen2.5-14B-Instruct` workers. The controlled workload used 12 retained source traces, concurrency 8, a 450-second sending window, and closed-loop agentic replay. These are preliminary tuning results, not statistical-confidence or official submission results; throughput includes each arm's post-window long-tail drain.

| Routing configuration | TTFT p50 / p95 | Request latency p50 / p95 | ITL p50 / p95 | Requests/s | Output tokens/s | Completed | Actual cache hit |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| KV credit `1.0`, prefill scale `1.0` | 0.819 / 18.23 s | 12.65 / 70.54 s | 29.99 / 38.33 ms | 0.2459 | 171.9 | 186 | 82.34% |
| KV credit `1.5`, prefill scale `1.0` | 0.875 / **15.89 s** | 11.67 / 70.41 s | 30.11 / 37.90 ms | **0.2743** | **191.4** | **195** | 84.12% |
| KV credit `1.5`, prefill scale `1.5` | 0.822 / 18.58 s | 10.95 / **69.11 s** | 28.96 / **37.31 ms** | 0.2685 | 184.5 | 190 | 84.96% |
| KV credit `1.5`, prefill scale `10.0` | **0.715** / 16.00 s | **10.12** / 75.61 s | **28.74** / 37.46 ms | 0.2645 | 181.7 | 194 | **86.33%** |

Credit `1.5` with prefill scale `1.0` was the best balanced tuning point: versus credit `1.0`, it increased completed request throughput by 11.6%, improved TTFT p95 by 12.8%, and raised actual local-cache hit rate by 1.77 points. Scale `10.0` produced the best median TTFT, median request latency, median ITL, and cache-hit rate, but its request-latency p95 was worse.

All four arms covered all 12 selected source traces and exercised child traffic. Each completed with zero request/session cancellation, request errors, context overflow, vLLM preemption, or router backpressure. Sampled maximum worker KV usage ranged from 95.98% to 98.47%, and every arm emitted 4,085–4,471 successful KV-removal events, confirming real cache pressure.

For device-only scoring with overlap-credit decay disabled, the earlier prototype bonus maps to the existing credit as:

```text
new_credit = old_credit + bonus / prefill_load_scale
```

At prefill scale `1.0`, prototype weights `0.5` and `1.0` therefore map to credits `1.5` and `2.0`.

### Benchmark setup

- Dynamo: final PR head `47a8602e3d508667395d7f6adf4121226d5d47fb`.
- AIPerf: agentic-replay base `60bce6b092641398d443627d31165219233ac441`, with campaign correctness fixes frozen at `3ad7ff9df612b002f1da5b24acd606b633f75d57` for end-to-start mmap cache identity, zero-output replay, repeated-prompt reset, and duration-cutoff child draining.
- Runtime: `nvcr.io/nvidia/ai-dynamo/vllm-runtime:1.2.0`, with the exact Dynamo source and Python binding overlaid.
- Model: BF16 `Qwen/Qwen2.5-14B-Instruct`, revision `cf98f3b3bbb457ad9e2bb7baf9a0125b6b88caa8`.
- Workers: seven TP1 workers, max model length 131,072, GPU memory utilization 0.85, prefix caching, block size 32, and max batched tokens 8,192.
- Router: KV mode, seven initial workers, KV events/reset enabled, overlap-credit decay 0, temperature 0, four event threads, active-block and prefill-token tracking enabled, output-block tracking disabled, and assume-KV-reuse enabled.
- Queue threshold, admission control, engine request limit, and session affinity were unset. `dynamo_headers` remained enabled in the load generator for identical request construction.
- Workload: `semianalysis_cc_traces_weka_062126`, an agentic replay scenario, max context 131,072, first 34 raw entries yielding 12 retained source traces, sequential sampling, concurrency 8, duration 450 seconds, explicit grace 600 seconds, request timeout 600 seconds, and seed `20260715`.

### Reproduction

1. Stage the pinned model on the compute node. Build exact Dynamo head `47a8602e...`, then verify the binding accepts `KvRouterConfig(overlap_score_credit=1.5)`.
2. Launch a shared etcd and seven workers on CUDA devices 0–6, with unique system, KV-event, vLLM, and cache paths. Use the following engine controls:

   ```text
   --dtype bfloat16
   --tensor-parallel-size 1
   --max-model-len 131072
   --gpu-memory-utilization 0.85
   --enable-prefix-caching
   --block-size 32
   --max-num-batched-tokens 8192
   ```

3. Launch the frontend with the common router controls below, substituting the table's credit and scale:

   ```text
   python -m dynamo.frontend \
     --http-host 0.0.0.0 \
     --http-port 8000 \
     --router-mode kv \
     --router-min-initial-workers 7 \
     --kv-cache-block-size 32 \
     --router-kv-events \
     --router-reset-states \
     --router-kv-overlap-score-credit <credit> \
     --router-kv-overlap-score-credit-decay 0 \
     --router-prefill-load-scale <scale> \
     --router-temperature 0 \
     --router-event-threads 4 \
     --router-track-active-blocks \
     --router-track-prefill-tokens \
     --no-router-track-output-blocks \
     --router-assume-kv-reuse
   ```

4. After all worker and frontend health checks pass, capture pre-run metrics and run:

   ```text
   AIPERF_VERSION=60bce6b-e2s-key1-zeroosl1-noopreset1-cutoff1 \
   AIPERF_DATASET_MMAP_CACHE_ENABLED=true \
   aiperf profile \
     --scenario <agentic-replay-scenario> \
     --unsafe-override \
     --url http://127.0.0.1:8000 \
     --model Qwen/Qwen2.5-14B-Instruct \
     --tokenizer /path/to/Qwen2.5-14B-Instruct \
     --endpoint-type chat \
     --public-dataset semianalysis_cc_traces_weka_062126 \
     --max-context-length 131072 \
     --num-dataset-entries 34 \
     --dataset-sampling-strategy sequential \
     --concurrency 8 \
     --benchmark-duration 450 \
     --benchmark-grace-period 600 \
     --request-timeout-seconds 600 \
     --random-seed 20260715 \
     --session-routing dynamo_headers \
     --use-server-token-count \
     --export-level records \
     --no-server-metrics \
     --no-gpu-telemetry \
     --no-fixed-schedule
   ```

5. Recreate worker/frontend containers between arms so KV state starts empty. Require 12/12 successful source-trace coverage, child traffic, a clean profiling-complete lifecycle, zero errors/cancellation/overflow/preemption/backpressure, healthy containers, and positive KV-removal evidence before comparing.

## Reviewer guide

- `lib/kv-router/src/scheduling/selector.rs`: core scoring change and worker-selection regression coverage.
- `lib/kv-router/src/scheduling/config.rs`: finite nonnegative validation, values-above-one contract, environment/serde/override coverage.
- `components/src/dynamo/common/configuration/groups/kv_router_args.py` and `lib/bindings/python/src/dynamo/_core.pyi`: documentation for the existing interface only.

## Validation

- `cargo test -p dynamo-kv-router --lib` — 746 passed, 2 ignored.
- Focused exact-candidate overlap-credit tests on SC01 — 4 passed.
- `cargo clippy --no-deps --all-targets -- -D warnings` in `lib/kv-router`.
- `cargo fmt` in `lib/kv-router`.
- `.venv/bin/python -m pytest components/src/dynamo/common/tests/configuration/test_kv_router_args.py` — 45 passed.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11714" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Overlap score credits above `1.0` are now supported, allowing additional credit for KV cache reuse.
  * Higher credit values can reduce adjusted prefill cost below zero and influence worker selection toward more colocated workers.

* **Bug Fixes**
  * Configuration validation now consistently accepts finite, non-negative credit values while rejecting negative, infinite, and invalid values.
  * Updated CLI and Python configuration documentation to reflect the expanded accepted range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
