### PR TITLE
feat(gms): surface scratch-KV engagement in shadow worker logs

### DIFF
--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -737,6 +737,17 @@ class GMSClientMemoryManager:
         )
         return va
 
+    def scratch_summary(self) -> tuple[int, int]:
+        """Return (count, total_logical_bytes) of live scratch-aliased mappings.
+
+        The per-mapping "[GMS] Reserved ... scratch" line is logged at INFO on
+        this module's logger, which the vLLM worker subprocess suppresses.
+        Callers use this to emit a single visible summary confirming that KV was
+        scratch-aliased (VA-reserved, physically cheap) rather than fully backed.
+        """
+        total = sum(m.size for m in self._scratch_mappings.values())
+        return len(self._scratch_mappings), total
+
     def prepare_scratch_for_reallocation(self) -> None:
         """Move scratch bookkeeping into _mappings as preserved-VA records.
 

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -737,16 +737,24 @@ class GMSClientMemoryManager:
         )
         return va
 
-    def scratch_summary(self) -> tuple[int, int]:
-        """Return (count, total_logical_bytes) of live scratch-aliased mappings.
+    def scratch_summary(self) -> tuple[int, int, int]:
+        """Return (count, virtual_bytes, physical_bytes) of live scratch mappings.
+
+        virtual_bytes is the total VA range reserved (what the engine addresses
+        as KV). physical_bytes is the real DRAM committed: each mapping aliases
+        one ``scratch_size`` block across its whole range, so distinct backing
+        blocks * scratch_size — far smaller than virtual_bytes.
 
         The per-mapping "[GMS] Reserved ... scratch" line is logged at INFO on
         this module's logger, which the vLLM worker subprocess suppresses.
         Callers use this to emit a single visible summary confirming that KV was
         scratch-aliased (VA-reserved, physically cheap) rather than fully backed.
         """
-        total = sum(m.size for m in self._scratch_mappings.values())
-        return len(self._scratch_mappings), total
+        mappings = self._scratch_mappings.values()
+        virtual = sum(m.size for m in mappings)
+        live_blocks = {m.scratch_handle for m in mappings if m.scratch_handle}
+        physical = len(live_blocks) * self.scratch_size
+        return len(self._scratch_mappings), virtual, physical
 
     def prepare_scratch_for_reallocation(self) -> None:
         """Move scratch bookkeeping into _mappings as preserved-VA records.

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -729,7 +729,7 @@ class GMSClientMemoryManager:
             scratch_handle=scratch_handle,
         )
         logger.info(
-            "[GMS] Reserved %d MiB VA at 0x%x, aliased 1x %d MiB scratch across %d chunks",
+            "[GMS] Reserved %d MiB VA at 0x%x, aliased a %d MiB scratch block across %d chunks",
             va_reserved_size // (1 << 20),
             va,
             self.scratch_size // (1 << 20),
@@ -740,15 +740,9 @@ class GMSClientMemoryManager:
     def scratch_summary(self) -> tuple[int, int, int]:
         """Return (count, virtual_bytes, physical_bytes) of live scratch mappings.
 
-        virtual_bytes is the total VA range reserved (what the engine addresses
-        as KV). physical_bytes is the real DRAM committed: each mapping aliases
-        one ``scratch_size`` block across its whole range, so distinct backing
-        blocks * scratch_size — far smaller than virtual_bytes.
-
-        The per-mapping "[GMS] Reserved ... scratch" line is logged at INFO on
-        this module's logger, which the vLLM worker subprocess suppresses.
-        Callers use this to emit a single visible summary confirming that KV was
-        scratch-aliased (VA-reserved, physically cheap) rather than fully backed.
+        virtual_bytes is the VA range reserved; physical_bytes is the DRAM
+        actually committed (distinct scratch blocks * scratch_size), far smaller
+        since each mapping aliases one block across its whole range.
         """
         mappings = self._scratch_mappings.values()
         virtual = sum(m.size for m in mappings)

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -275,12 +275,9 @@ class GMSWorker(Worker):
             # The scratch pool is scoped to the KV tensors by
             # patch_kv_cache_pool_scope(), not the whole initialize_kv_cache.
             self.model_runner.initialize_kv_cache(kv_cache_config)
-            # The per-mapping "[GMS] Reserved ... scratch" line is logged at INFO
-            # on the gpu_memory_service logger, which the vLLM worker subprocess
-            # suppresses, so scratch engagement is invisible in engine logs. Emit
-            # one visible summary (logger + print, matching the accounting message
-            # above) so operators and failover harnesses can confirm the KV was
-            # scratch-aliased (VA-reserved, physically cheap) rather than fully backed.
+            # Visible summary of scratch engagement; per-mapping GMS INFO is
+            # suppressed in the vLLM worker subprocess, so print() for now (a
+            # worker-logging fix is a follow-up).
             n_scratch, virtual_bytes, physical_bytes = scratch_mgr.scratch_summary()
             msg = (
                 f"[GMS] Scratch-KV engaged: {n_scratch} allocations, "
@@ -290,11 +287,11 @@ class GMSWorker(Worker):
             )
             logger.info(msg)
             print(msg, flush=True)
-            # Fail closed: if the model has a KV cache but nothing was routed
-            # through scratch, the shadow has fully backed its KV — defeating
-            # colocation and risking ~2x KV OOM at scale. Surface it loudly
-            # instead of silently degrading.
-            if n_scratch == 0 and kv_cache_config.kv_cache_groups:
+            # Fail closed: KV tensors expected but none scratch-aliased means the
+            # shadow fully backed its KV (defeats colocation, risks ~2x KV OOM).
+            # kv_cache_tensors is the list _allocate_kv_cache iterates to emit the
+            # torch.zeros, so it is the direct signal that KV backing was expected.
+            if n_scratch == 0 and kv_cache_config.kv_cache_tensors:
                 raise RuntimeError(
                     "[GMS] Scratch-KV enabled but no KV allocation was routed "
                     "through scratch; the shadow would fully back its KV cache. "

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -271,10 +271,24 @@ class GMSWorker(Worker):
         if is_scratch_kv_enabled():
             # Client-local scratch only — no GMS server session at init.
             # wake_up will connect RW and allocate fresh server backing.
-            get_or_create_scratch_manager(socket, device, tag="kv_cache")
+            scratch_mgr = get_or_create_scratch_manager(socket, device, tag="kv_cache")
             # The scratch pool is scoped to the KV tensors by
             # patch_kv_cache_pool_scope(), not the whole initialize_kv_cache.
             self.model_runner.initialize_kv_cache(kv_cache_config)
+            # The per-mapping "[GMS] Reserved ... scratch" line is logged at INFO
+            # on the gpu_memory_service logger, which the vLLM worker subprocess
+            # suppresses, so scratch engagement is invisible in engine logs. Emit
+            # one visible summary (logger + print, matching the accounting message
+            # above) so operators and failover harnesses can confirm the KV was
+            # scratch-aliased rather than fully backed.
+            n_scratch, logical_bytes = scratch_mgr.scratch_summary()
+            msg = (
+                f"[GMS] Scratch-KV engaged: {n_scratch} aliased mappings, "
+                f"{logical_bytes / (1 << 30):.2f} GiB logical KV reserved "
+                f"on device {device}"
+            )
+            logger.info(msg)
+            print(msg, flush=True)
         elif self.vllm_config.model_config.enable_sleep_mode:
             get_or_create_gms_client_memory_manager(
                 socket,

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -275,18 +275,17 @@ class GMSWorker(Worker):
             # The scratch pool is scoped to the KV tensors by
             # patch_kv_cache_pool_scope(), not the whole initialize_kv_cache.
             self.model_runner.initialize_kv_cache(kv_cache_config)
-            # Visible summary of scratch engagement; per-mapping GMS INFO is
-            # suppressed in the vLLM worker subprocess, so print() for now (a
-            # worker-logging fix is a follow-up).
+            # Visible summary of scratch engagement (GMS worker logs are routed
+            # through vLLM's handler by configure_gms_worker_logging()).
             n_scratch, virtual_bytes, physical_bytes = scratch_mgr.scratch_summary()
-            msg = (
-                f"[GMS] Scratch-KV engaged: {n_scratch} allocations, "
-                f"{virtual_bytes / (1 << 30):.2f} GiB virtual reserved, "
-                f"{physical_bytes / (1 << 30):.2f} GiB physical backing "
-                f"on device {device}"
+            logger.info(
+                "[GMS] Scratch-KV engaged: %d allocations, %.2f GiB virtual "
+                "reserved, %.2f GiB physical backing on device %d",
+                n_scratch,
+                virtual_bytes / (1 << 30),
+                physical_bytes / (1 << 30),
+                device,
             )
-            logger.info(msg)
-            print(msg, flush=True)
             # Fail closed: KV tensors expected but none scratch-aliased means the
             # shadow fully backed its KV (defeats colocation, risks ~2x KV OOM).
             # kv_cache_tensors is the list _allocate_kv_cache iterates to emit the

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -280,15 +280,27 @@ class GMSWorker(Worker):
             # suppresses, so scratch engagement is invisible in engine logs. Emit
             # one visible summary (logger + print, matching the accounting message
             # above) so operators and failover harnesses can confirm the KV was
-            # scratch-aliased rather than fully backed.
-            n_scratch, logical_bytes = scratch_mgr.scratch_summary()
+            # scratch-aliased (VA-reserved, physically cheap) rather than fully backed.
+            n_scratch, virtual_bytes, physical_bytes = scratch_mgr.scratch_summary()
             msg = (
-                f"[GMS] Scratch-KV engaged: {n_scratch} aliased mappings, "
-                f"{logical_bytes / (1 << 30):.2f} GiB logical KV reserved "
+                f"[GMS] Scratch-KV engaged: {n_scratch} allocations, "
+                f"{virtual_bytes / (1 << 30):.2f} GiB virtual reserved, "
+                f"{physical_bytes / (1 << 30):.2f} GiB physical backing "
                 f"on device {device}"
             )
             logger.info(msg)
             print(msg, flush=True)
+            # Fail closed: if the model has a KV cache but nothing was routed
+            # through scratch, the shadow has fully backed its KV — defeating
+            # colocation and risking ~2x KV OOM at scale. Surface it loudly
+            # instead of silently degrading.
+            if n_scratch == 0 and kv_cache_config.kv_cache_groups:
+                raise RuntimeError(
+                    "[GMS] Scratch-KV enabled but no KV allocation was routed "
+                    "through scratch; the shadow would fully back its KV cache. "
+                    "Check that initialize_kv_cache allocates under "
+                    "gms_use_mem_pool."
+                )
         elif self.vllm_config.model_config.enable_sleep_mode:
             get_or_create_gms_client_memory_manager(
                 socket,


### PR DESCRIPTION
Present a clean summary of the scratch KV footprint when engaged during failover.

`[GMS] Scratch-KV engaged: 33 allocations, 69.65 GiB virtual reserved, 16.50 GiB physical backing on device 0`