### PR TITLE
fix(frontend): apply --default-chat-template-kwargs in vLLM processor

### DIFF
--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -142,11 +142,14 @@ def _prepare_request(
     raw_template_args = (
         request.get("chat_template_args") if isinstance(request, dict) else None
     )
-    # Reuse vLLM's merge so unset request values (None/"auto") keep the
-    # server default instead of erasing it.
-    chat_template_kwargs = merge_kwargs(
-        default_chat_template_kwargs,
-        request_for_sampling.chat_template_kwargs or raw_template_args or {},
+    # Reuse vLLM's merge so unset request values (None/"auto") keep the server
+    # default; copy the result since the default dict is shared across requests
+    # and we mutate reasoning_effort below.
+    chat_template_kwargs = dict(
+        merge_kwargs(
+            default_chat_template_kwargs,
+            request_for_sampling.chat_template_kwargs or raw_template_args or {},
+        )
     )
     # Don't let an absent top-level field clobber a nested reasoning_effort.
     if request_for_sampling.reasoning_effort is not None:

--- a/components/src/dynamo/frontend/prepost.py
+++ b/components/src/dynamo/frontend/prepost.py
@@ -17,7 +17,7 @@ from vllm.entrypoints.openai.engine.protocol import (
     DeltaToolCall,
 )
 from vllm.reasoning import ReasoningParser
-from vllm.renderers import ChatParams
+from vllm.renderers import ChatParams, merge_kwargs
 from vllm.sampling_params import SamplingParams
 from vllm.tokenizers import TokenizerLike
 from vllm.tool_parsers import ToolParser
@@ -93,6 +93,7 @@ def _prepare_request(
     tool_parser_class: type[ToolParser] | None,
     exclude_tools_when_tool_choice_none: bool = True,
     enable_auto_tool_choice: bool = False,
+    default_chat_template_kwargs: dict[str, Any] | None = None,
 ) -> tuple[ChatCompletionRequest, ToolParser | None, dict[str, Any], Any, ChatParams]:
     """Validate request and build arguments for template rendering.
 
@@ -141,8 +142,11 @@ def _prepare_request(
     raw_template_args = (
         request.get("chat_template_args") if isinstance(request, dict) else None
     )
-    chat_template_kwargs = dict(
-        request_for_sampling.chat_template_kwargs or raw_template_args or {}
+    # Reuse vLLM's merge so unset request values (None/"auto") keep the
+    # server default instead of erasing it.
+    chat_template_kwargs = merge_kwargs(
+        default_chat_template_kwargs,
+        request_for_sampling.chat_template_kwargs or raw_template_args or {},
     )
     # Don't let an absent top-level field clobber a nested reasoning_effort.
     if request_for_sampling.reasoning_effort is not None:
@@ -193,6 +197,7 @@ async def preprocess_chat_request(
     tool_parser_class: type[ToolParser] | None,
     exclude_tools_when_tool_choice_none: bool = True,
     enable_auto_tool_choice: bool = False,
+    default_chat_template_kwargs: dict[str, Any] | None = None,
 ) -> PreprocessResult:
     (
         request_for_sampling,
@@ -206,6 +211,7 @@ async def preprocess_chat_request(
         tool_parser_class=tool_parser_class,
         exclude_tools_when_tool_choice_none=exclude_tools_when_tool_choice_none,
         enable_auto_tool_choice=enable_auto_tool_choice,
+        default_chat_template_kwargs=default_chat_template_kwargs,
     )
 
     _, engine_prompt = await renderer.render_messages_async(messages, chat_params)

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -278,6 +278,21 @@ class TestServerDefaultChatTemplateKwargs:
         )
         assert chat_params.chat_template_kwargs.get("enable_thinking") is False
 
+    def test_server_default_is_not_mutated(self, tokenizer):
+        """Processing must not mutate the shared server-default dict."""
+        default = {"enable_thinking": False}
+        _prepare_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "reasoning_effort": "high",
+            },
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+            default_chat_template_kwargs=default,
+        )
+        assert default == {"enable_thinking": False}
+
 
 class TestMultimodalFeatureMetadata:
     def _feature(

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -237,6 +237,48 @@ class TestChatTemplateArgsPassthrough:
         assert chat_params.chat_template_kwargs["documents"] is None
 
 
+class TestServerDefaultChatTemplateKwargs:
+    """The server-wide --default-chat-template-kwargs must reach the template."""
+
+    def test_server_default_applied_when_request_omits_kwargs(self, tokenizer):
+        """A server default reaches the template when the request carries no kwargs."""
+        _, _, _, _, chat_params = _prepare_request(
+            {"model": MODEL, "messages": [{"role": "user", "content": "Hello"}]},
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+            default_chat_template_kwargs={"enable_thinking": False},
+        )
+        assert chat_params.chat_template_kwargs.get("enable_thinking") is False
+
+    def test_request_kwargs_override_server_default(self, tokenizer):
+        """A per-request kwarg takes precedence over the server default."""
+        _, _, _, _, chat_params = _prepare_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "chat_template_args": {"enable_thinking": True},
+            },
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+            default_chat_template_kwargs={"enable_thinking": False},
+        )
+        assert chat_params.chat_template_kwargs.get("enable_thinking") is True
+
+    def test_unset_request_value_keeps_server_default(self, tokenizer):
+        """A None/unset request value must not erase the server default (vLLM parity)."""
+        _, _, _, _, chat_params = _prepare_request(
+            {
+                "model": MODEL,
+                "messages": [{"role": "user", "content": "Hello"}],
+                "chat_template_args": {"enable_thinking": None},
+            },
+            tokenizer=tokenizer,
+            tool_parser_class=None,
+            default_chat_template_kwargs={"enable_thinking": False},
+        )
+        assert chat_params.chat_template_kwargs.get("enable_thinking") is False
+
+
 class TestMultimodalFeatureMetadata:
     def _feature(
         self, modality, mm_hash, offset, length, data=_DEFAULT_MM_DATA, is_embed=None

--- a/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
+++ b/components/src/dynamo/frontend/tests/test_vllm_processor_unit.py
@@ -240,43 +240,32 @@ class TestChatTemplateArgsPassthrough:
 class TestServerDefaultChatTemplateKwargs:
     """The server-wide --default-chat-template-kwargs must reach the template."""
 
-    def test_server_default_applied_when_request_omits_kwargs(self, tokenizer):
-        """A server default reaches the template when the request carries no kwargs."""
+    def _enable_thinking(self, tokenizer, request_args):
+        """Return the template's enable_thinking under a `{enable_thinking: False}` default."""
+        request = {"model": MODEL, "messages": [{"role": "user", "content": "Hello"}]}
+        if request_args is not None:
+            request["chat_template_args"] = request_args
         _, _, _, _, chat_params = _prepare_request(
-            {"model": MODEL, "messages": [{"role": "user", "content": "Hello"}]},
+            request,
             tokenizer=tokenizer,
             tool_parser_class=None,
             default_chat_template_kwargs={"enable_thinking": False},
         )
-        assert chat_params.chat_template_kwargs.get("enable_thinking") is False
+        return chat_params.chat_template_kwargs.get("enable_thinking")
 
-    def test_request_kwargs_override_server_default(self, tokenizer):
-        """A per-request kwarg takes precedence over the server default."""
-        _, _, _, _, chat_params = _prepare_request(
-            {
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "Hello"}],
-                "chat_template_args": {"enable_thinking": True},
-            },
-            tokenizer=tokenizer,
-            tool_parser_class=None,
-            default_chat_template_kwargs={"enable_thinking": False},
-        )
-        assert chat_params.chat_template_kwargs.get("enable_thinking") is True
-
-    def test_unset_request_value_keeps_server_default(self, tokenizer):
-        """A None/unset request value must not erase the server default (vLLM parity)."""
-        _, _, _, _, chat_params = _prepare_request(
-            {
-                "model": MODEL,
-                "messages": [{"role": "user", "content": "Hello"}],
-                "chat_template_args": {"enable_thinking": None},
-            },
-            tokenizer=tokenizer,
-            tool_parser_class=None,
-            default_chat_template_kwargs={"enable_thinking": False},
-        )
-        assert chat_params.chat_template_kwargs.get("enable_thinking") is False
+    @pytest.mark.parametrize(
+        "request_args, expected",
+        [
+            (None, False),  # omitted request kwargs: the server default applies
+            ({"enable_thinking": True}, True),  # a request kwarg overrides the default
+            (
+                {"enable_thinking": None},
+                False,
+            ),  # unset (None) request value keeps the default
+        ],
+    )
+    def test_server_default_precedence(self, tokenizer, request_args, expected):
+        assert self._enable_thinking(tokenizer, request_args) is expected
 
     def test_server_default_is_not_mutated(self, tokenizer):
         """Processing must not mutate the shared server-default dict."""

--- a/components/src/dynamo/frontend/vllm_processor.py
+++ b/components/src/dynamo/frontend/vllm_processor.py
@@ -201,6 +201,7 @@ class VllmProcessor:
         routed_engine: RoutedEngine,
         block_size: int = 16,
         enable_auto_tool_choice: bool = False,
+        default_chat_template_kwargs: dict[str, Any] | None = None,
     ):
         self.tokenizer = tokenizer
         self.input_processor = input_processor
@@ -211,6 +212,7 @@ class VllmProcessor:
         self.exclude_tools_when_tool_choice_none = True
         self.block_size = block_size
         self.enable_auto_tool_choice = enable_auto_tool_choice
+        self.default_chat_template_kwargs = default_chat_template_kwargs
         # Sender for mm_kwargs transfer — instantiated lazily on first MM request.
         # MmKwargsShmSender for same-node transfers (default), MmKwargsNixlSender
         # for cross-node RDMA. Controlled by DYNAMO_MM_TRANSFER env var.
@@ -412,6 +414,7 @@ class VllmProcessor:
                 tool_parser_class=self.tool_parser_class,
                 exclude_tools_when_tool_choice_none=self.exclude_tools_when_tool_choice_none,
                 enable_auto_tool_choice=self.enable_auto_tool_choice,
+                default_chat_template_kwargs=self.default_chat_template_kwargs,
             )
 
         request_for_sampling = pre.request_for_sampling
@@ -986,6 +989,9 @@ class EngineFactory:
             routed_engine,
             block_size=block_size,
             enable_auto_tool_choice=enable_auto_tool_choice,
+            default_chat_template_kwargs=getattr(
+                self.flags, "default_chat_template_kwargs", None
+            ),
         )
         gen.exclude_tools_when_tool_choice_none = (
             self.config.exclude_tools_when_tool_choice_none


### PR DESCRIPTION
#### Overview
With `--dyn-chat-processor=vllm`, the server-wide `--default-chat-template-kwargs` flag was parsed into vLLM's `FrontendArgs` but never read by dynamo, so it had no effect: server-wide chat-template defaults (e.g. disabling reasoning fleet-wide) were silently discarded. This threads the flag through to template rendering and merges it with vLLM's own semantics (per-request kwargs override the default; unset request values keep it).

Repro:
```
python -m dynamo.frontend --dyn-chat-processor=vllm --reasoning-parser qwen3 \
  --default-chat-template-kwargs '{"enable_thinking": false}'
# then, a request with NO body kwargs:
curl http://localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "Qwen/Qwen3.6-27B-FP8",
  "messages": [{"role":"user","content":"9.11 and 9.8, which is greater?"}]
}'
```

Before (server default ignored, model still reasons):
```json
"message": {
  "role": "assistant",
  "content": "**9.8 is greater** ...",
  "reasoning_content": "Here's a thinking process ..."
}
```

After (server default honored):
```json
"message": {
  "role": "assistant",
  "content": "To determine which is greater ...",
  "reasoning_content": null
}
```

#### Details
`EngineFactory` now reads `default_chat_template_kwargs` off `self.flags` and threads it through `VllmProcessor` and `preprocess_chat_request` into `_prepare_request` (mirroring how `enable_auto_tool_choice` is already passed), where it seeds the template kwargs as the low-precedence base. The merge reuses vLLM's own `merge_kwargs` (from `vllm.renderers`) rather than a hand-rolled dict update, so precedence matches vLLM exactly: per-request kwargs override the server default, and unset request values (`None`/`"auto"`) retain the default instead of erasing it. Adds unit tests in `test_vllm_processor_unit.py::TestServerDefaultChatTemplateKwargs` covering the default being applied, a request overriding it, and a `None` request value preserving it.

#### Related Issues
- Resolves #11703

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11731" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for server-configured default chat template settings.
  * Requests can now provide chat template arguments using supported request fields.
  * Request-specific values override defaults when provided, while unset values retain server defaults.
  * Improved handling of reasoning and thinking options during chat processing.
* **Bug Fixes**
  * Prevented renderer-managed settings from being overridden by conflicting request arguments.
  * Preserved shared default settings without modifying them during request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->