### PR TITLE
fix(profiler): cap aiconfigurator <0.10 and defer replay AIC import

### DIFF
--- a/components/src/dynamo/profiler/utils/replay_optimize/bench.py
+++ b/components/src/dynamo/profiler/utils/replay_optimize/bench.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Any
 
 import pandas as pd
-from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
 from .scoring import _pick_best_record
 from .search import optimize_dense_agg_with_replay, optimize_dense_disagg_with_replay
@@ -28,6 +27,10 @@ def compare_aic_and_replay_disagg(
             "compare_aic_and_replay_disagg requires synthetic WorkloadSpec with "
             "requestCount and concurrency"
         )
+
+    # Deferred: aiconfigurator is optional, so the package must import without it
+    # (mirrors aic._load_aiconfigurator_modules). Only this function needs AIC.
+    from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
     aic_task = TaskConfig(
         serving_mode="disagg",

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,10 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator>=0.9.0
+# Cap below 0.10: the 0.10 SDK renamed/removed APIs (sdk.task, cli.main
+# helpers) and changed the AIC Rust engine wire-format, breaking the
+# profiler until the 0.10 migration lands. Remove the cap with that port.
+aiconfigurator>=0.9.0,<0.10.0
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ sglang = [
 
 mocker = [
     # No direct URL: it blocks the wheel release (PyPI/Warehouse rejects direct references).
-    "aiconfigurator>=0.9.0",
+    # Cap below 0.10: the 0.10 SDK/CLI API and AIC Rust engine wire-format
+    # broke the profiler; lift the cap when the 0.10 migration lands.
+    "aiconfigurator>=0.9.0,<0.10.0",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
#### Overview
The CI image silently upgraded aiconfigurator (AIC) to 0.10 because the dependency was pinned with a floating floor (`aiconfigurator>=0.9.0`, no upper bound). AIC 0.10 renamed/removed SDK + CLI symbols and changed its Rust engine wire-format, but Dynamo's profiler code on `main` still targets the 0.9 API — so the dependency landed ahead of the code that adapts to it, turning several profiler jobs red across unrelated PRs.

This PR stops the bleeding at the dependency layer: it caps AIC below 0.10 (`>=0.9.0,<0.10.0`) in both pin sites, restoring the 0.9 API the code speaks. It also hardens the one file whose eager import turned a skippable missing-dependency into a hard collection error. The cap is explicitly temporary — it should be lifted when the AIC 0.10 migration (`simonec/aic-core-0.10.0-rc4`) lands and ports the code to the new API.

Root cause is AIC 0.10 API drift, not any product logic change. Safety check: `grep` for AIC 0.10-only symbols (`task_v2`, `_execute_tasks`, `build_default_tasks`) across `components/` + `lib/` on `main` returns nothing, so capping at 0.9 breaks no current caller.

#### Failures fixed (before / after)

**1. `dynamo-runtime / test / gpu` — collection error**
Failing run: https://github.com/ai-dynamo/dynamo/actions/runs/29451064221/job/87475694090

Before:
```
bench.py:9: from aiconfigurator.sdk.task import TaskConfig, TaskRunner
E   ModuleNotFoundError: No module named 'aiconfigurator.sdk.task'
-> test_replay_optimize.py collection ERROR, job fails
```
After: AIC 0.9 provides `sdk.task`, so the import resolves and the module collects. Independently, `bench.py` now defers that import into the one function that uses it, so a future absence of AIC yields a graceful `importorskip` skip (matching every sibling profiler test) instead of a collection error.

**2. `planner / CPU Test` — `rapid.py` import error (1 test)**
Failing run: https://github.com/ai-dynamo/dynamo/actions/runs/29453859648/job/87483814306

Before:
```
rapid.py:22: from aiconfigurator.cli.main import _execute_task_configs, build_default_task_configs
E   ImportError: cannot import name '_execute_task_configs' from 'aiconfigurator.cli.main'
-> test_profiler_protocol.py::test_run_profile_applies_override_once_to_each_consumed_dgd FAILED
```
After: AIC 0.9 still exports `_execute_task_configs` / `build_default_task_configs` from `cli.main`, so `rapid.py` imports and the test passes.

**3. `planner / CPU Test` — AIC Rust engine wire-format error (12 tests)**
Failing run: https://github.com/ai-dynamo/dynamo/actions/runs/29453859648/job/87483814306

Before:
```
test_replay_aic_parity.py -> dynamo.replay.api.run_synthetic_trace_replay
E   Exception: Failed to create AIC callback (--aic-perf-model was requested):
    RuntimeError: AIC: failed to build the Rust engine for Qwen/Qwen3-32B / h200_sxm / vllm:
    engine spec wire-format error: bincode decode: io error
```
After: AIC 0.9's Rust engine matches the engine spec Dynamo's mocker serializes, so the bincode decode succeeds and all 12 parametrized cases pass.

All three failures are the same AIC-0.10 drift and are pre-existing on `main@b0c9d0e07d` (identical signatures: 6x `_execute_task_configs`, 24x `bincode decode`), i.e. not introduced by this PR.

#### Details
- `container/deps/requirements.planner.txt` and `pyproject.toml` (`mocker` extra): `aiconfigurator>=0.9.0` -> `aiconfigurator>=0.9.0,<0.10.0`, matching the existing floor+cap precedent in the same requirements file (`aiohttp>=3.9.0,<4.0`, `scipy>=1.14.0,<2.0`). A comment marks the cap temporary and points at the 0.10 migration.
- `components/src/dynamo/profiler/utils/replay_optimize/bench.py`: the top-level `from aiconfigurator.sdk.task import TaskConfig, TaskRunner` moves into `compare_aic_and_replay_disagg`, the only function that uses them, mirroring the deferred `_load_aiconfigurator_modules()` pattern already in the sibling `aic.py`.

#### Where should the reviewer start?
The two one-line pin edits are the substantive fix; confirm `>=0.9.0,<0.10.0` is the intended interim policy (vs. landing the 0.10 migration instead). The `bench.py` defer is complementary hardening.

#### Test Plan
- Reproduced the GPU collection error on `origin/main@b0c9d0e07d`: package import dies at `bench.py:9` (`ModuleNotFoundError`).
- Confirmed the CPU-test failures are pre-existing on `main@b0c9d0e07d` (job `planner / CPU Test`, both arches) with identical signatures to this PR's run.
- Verified no `main` caller uses AIC 0.10-only APIs, so the cap is safe.
- After fix: `bench.py` imports without AIC (surgical before/after harness, siblings stubbed) and `compare_aic_and_replay_disagg` is defined.
- Pending: green CI run on this branch once a maintainer issues `/ok to test`; will link the passing `test / gpu` and `planner / CPU Test` runs here as the confirmed "after".

#### Related Issues
None. Interim cap for the in-flight AIC 0.10 migration (`simonec/aic-core-0.10.0-rc4`).
