### PR TITLE
fix(benchmarks): drop synthetic-only flag from trace runs [DYN-3379]

### DIFF
--- a/benchmarks/router/agent_benchmark.py
+++ b/benchmarks/router/agent_benchmark.py
@@ -73,8 +73,6 @@ def get_aiperf_cmd(
         str(concurrency),
         "--request-count",
         str(request_count),
-        "--prompt-input-tokens-block-size",
-        str(block_size),
         "--random-seed",
         str(seed),
         "--artifact-dir",

--- a/benchmarks/router/common.py
+++ b/benchmarks/router/common.py
@@ -196,8 +196,6 @@ def get_aiperf_cmd_for_trace(
         "mooncake_trace",
         "--fixed-schedule",
         "--fixed-schedule-auto-offset",
-        "--prompt-input-tokens-block-size",
-        str(block_size),
         "--random-seed",
         str(seed),
         "--artifact-dir",


### PR DESCRIPTION
## Summary

- Remove `--prompt-input-tokens-block-size` from AIPerf commands that use Mooncake trace input files.
- Unblock the router real-data, priority, and agent benchmarks with the repo-pinned `aiperf==0.10.0`.
- Address DYN-3379 / NVBug 6414352.

## Root cause

The trace benchmark commands combined `--input-file` with a synthetic-dataset-only prompt shaping flag. AIPerf 0.10.0 rejects that combination during argument validation before sending any benchmark traffic.

## Validation

- `git diff --check`
- Commit-time formatting and static-analysis hooks passed.
- Test suite not run, per request; this change only removes the incompatible CLI argument pairs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated benchmark command generation to omit the prompt input token block-size option.
  * Preserved existing concurrency, request scheduling, random seed, and artifact settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->