### PR TITLE
feat(vllm): support native Qwen custom encoder inputs

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -733,9 +733,10 @@ class DynamoVllmConfig(ConfigBase):
         """Validate the aggregated CustomEncoder configuration.
 
         The encoder runs in-process in a single aggregated worker on the
-        token-in/token-out path and produces image embeds for the mixed
-        EmbedsPrompt, so it is a multimodal, aggregated-only, token-mode
-        component. Enforce those here (fail fast) instead of silently bypassing
+        token-in/token-out path and produces encoded image media for either a
+        mixed EmbedsPrompt or a model-native multimodal TokensPrompt, so it is a
+        multimodal, aggregated-only, token-mode component. Enforce those here
+        (fail fast) instead of silently bypassing
         the multimodal gate at request time, no-op'ing in a decode worker that
         never reaches the custom-encoder branch, or loading the encoder in
         --use-vllm-tokenizer text mode where it is never invoked.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -88,13 +88,20 @@ from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
 from .multimodal_utils.async_vision_encoder import AsyncVisionEncoder
-from .multimodal_utils.embed_assembler import build_mixed_embeds
+from .multimodal_utils.custom_encoder_adapter import (
+    BoundCustomEncoderAdapter,
+    MixedEmbedsPlan,
+    NativeMMPlan,
+    PromptPlan,
+)
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from .multimodal_utils.request_processor import (
     IMAGE_URL_KEY,
     URL_VARIANT_KEY,
     MissingMultimodalHandoffError,
+    MultimodalUUIDPolicy,
     VllmMultimodalRequestProcessor,
+    get_mm_processor_kwargs,
 )
 from .multimodal_utils.vision_encoder_backend import VisionEncoderBackend
 
@@ -1022,6 +1029,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # always safe; the encoder itself is loaded last in __init__ (it starts
         # the actor thread) — see _load_custom_encoder below for why.
         self._custom_encoder: Optional[AsyncVisionEncoder] = None
+        self._custom_encoder_adapter: Optional[BoundCustomEncoderAdapter] = None
 
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
@@ -1080,15 +1088,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         custom_encoder_class = config.custom_encoder_class
         if not custom_encoder_class:
             return
-        # The custom encoder path only ever submits a mixed EmbedsPrompt, so fail
-        # fast here if prompt-embeds are disabled rather than loading the encoder
-        # and then rejecting every image request at runtime.
-        if not config.engine_args.enable_prompt_embeds:
-            raise ValueError(
-                "--custom-encoder-class requires --enable-prompt-embeds: the "
-                "custom encoder submits a mixed EmbedsPrompt, which the engine "
-                "cannot accept without prompt-embeds enabled."
-            )
         module_path, _, class_name = custom_encoder_class.rpartition(".")
         backend_cls = getattr(importlib.import_module(module_path), class_name)
         if not (
@@ -1103,11 +1102,19 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # AsyncVisionEncoder glue, which owns the preprocess pool and
         # ThreadedMicroBatcher actor thread. load() runs backend.build() there
         # (the backend picks its own device) and cleans that thread up on failure.
-        encoder = AsyncVisionEncoder(backend_cls())
+        backend = backend_cls()
+        adapter = BoundCustomEncoderAdapter(
+            backend,
+            self.model_config,
+            config.engine_args,
+            self.engine_client.vllm_config,
+        )
+        encoder = AsyncVisionEncoder(backend)
         encoder.load(config.model)
         # Assign only after a successful load so a failed load (which already shut
         # its own thread down) leaves _custom_encoder None.
         self._custom_encoder = encoder
+        self._custom_encoder_adapter = adapter
         logger.info(
             "Loaded CustomEncoder %s from %s",
             custom_encoder_class,
@@ -2403,6 +2410,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             # Run backend.close() on the actor thread, then stop it — executor
             # GC would only end the thread, never call close().
             self._custom_encoder.shutdown()
+            self._custom_encoder = None
+            self._custom_encoder_adapter = None
         for temp_dir in self.temp_dirs:
             try:
                 temp_dir.cleanup()
@@ -2482,6 +2491,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         log_prefix: str = "",
         mm_processor_kwargs: Dict[str, Any] | None = None,
         mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None,
+        suppress_mm_uuids: bool = False,
     ) -> tuple[TokensPrompt | EmbedsPrompt | None, int | None, Dict[str, Any] | None]:
         """
         Build a prompt from request, handling both prompt_embeds and token_ids.
@@ -2496,6 +2506,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             mixed_embeds: Optional ``(prompt_embeds, prompt_token_ids,
                 prompt_is_token_ids)`` assembled by the aggregated CustomEncoder
                 path. When present, takes the EmbedsPrompt fast path below.
+            suppress_mm_uuids: Omit frontend raw-media hashes when the prompt
+                contains externally encoded media rather than those raw objects.
 
         Returns:
             Tuple of (prompt, embedding_sequence_length, error_dict) where:
@@ -2572,11 +2584,19 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # not in EPD mode — in EPD mode multi_modal_data carries pre-computed
         # embeddings from the encode worker, not raw images, and raw-image
         # identity lives upstream at the Router / URL-keyed encoder cache.
-        prompt = self._multimodal_request_processor.build_tokens_prompt(
-            request,
-            multi_modal_data,
-            mm_processor_kwargs,
-        )
+        if suppress_mm_uuids:
+            prompt = self._multimodal_request_processor.build_tokens_prompt(
+                request,
+                multi_modal_data,
+                mm_processor_kwargs,
+                uuid_policy=MultimodalUUIDPolicy.EXTERNAL_ARTIFACT,
+            )
+        else:
+            prompt = self._multimodal_request_processor.build_tokens_prompt(
+                request,
+                multi_modal_data,
+                mm_processor_kwargs,
+            )
         return prompt, embedding_sequence_length, None
 
     @staticmethod
@@ -2896,19 +2916,15 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         request: Dict[str, Any],
         request_id: str,
         context,
-    ) -> tuple[
-        tuple[torch.Tensor, list[int], list[bool]] | None,
-        Dict[str, Any] | None,
-        Dict[str, Any] | None,
-    ]:
-        """Run the in-process CustomEncoder and assemble a mixed EmbedsPrompt.
+    ) -> tuple[PromptPlan | None, Dict[str, Any] | None]:
+        """Run the in-process CustomEncoder and prepare its engine prompt plan.
 
-        The CustomEncoder consumes image URLs directly and emits embeds. Returns
-        ``(mixed_embeds, multi_modal_data, error)``:
-        - images present: ``(mixed_embeds, None, None)``,
-        - no image content: ``(None, None, None)`` — text-only request, nothing
+        The CustomEncoder consumes image URLs directly and emits typed media.
+        Returns ``(plan, error)``:
+        - images present: a mixed-embeds or native-multimodal plan,
+        - no image content: ``(None, None)`` — text-only request, nothing
           to assemble or extract (non-image modalities are rejected above),
-        - failure: ``(None, None, error_dict)`` for the caller to yield.
+        - failure: ``(None, error_dict)`` for the caller to yield.
         """
         # Internal invariant: callers guard on `self._custom_encoder is not None`
         # before reaching here. Use an explicit raise (not assert, which is
@@ -2916,6 +2932,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         if self._custom_encoder is None:
             raise RuntimeError(
                 "_assemble_custom_encoder_prompt called without a CustomEncoder"
+            )
+        if self._custom_encoder_adapter is None:
+            raise RuntimeError(
+                "_assemble_custom_encoder_prompt called without a bound adapter"
             )
         mm_map = request.get("multi_modal_data") or {}
         # CustomEncoder handles images only. Reject any non-image modality
@@ -2927,7 +2947,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 f"unsupported multimodal data: {unsupported}"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, {"finish_reason": {"error": msg}, "token_ids": []}
 
         image_items = mm_map.get(IMAGE_URL_KEY) or []
         image_urls = [
@@ -2945,12 +2965,21 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 "'Url'; each item must be a dict with a 'Url' key"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, {"finish_reason": {"error": msg}, "token_ids": []}
 
         if not image_urls:
             # No image items at all — and non-image modalities were already
             # rejected above — so there is nothing to assemble → text-only.
-            return None, None, None
+            return None, None
+
+        mm_processor_kwargs = get_mm_processor_kwargs(request)
+        if self._custom_encoder_adapter.uses_native_multimodal and mm_processor_kwargs:
+            msg = (
+                "native-multimodal CustomEncoder requests do not support "
+                "mm_processor_kwargs; apply geometry options inside the encoder"
+            )
+            logger.error("Request %s: %s", request_id, msg)
+            return None, {"finish_reason": {"error": msg}, "token_ids": []}
 
         token_ids: list[int] = request.get("token_ids") or []
         # encode() is user-supplied code (any exception) and
@@ -2961,26 +2990,23 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
-            img_tensors: list[torch.Tensor] = await self._custom_encoder.encode(
-                image_urls
-            )
-            placeholder_id = self._custom_encoder.get_image_placeholder_token_id()
-            prompt_embeds, mixed_token_ids, is_token_ids = build_mixed_embeds(
-                token_ids, img_tensors, placeholder_id
+            encodings = await self._custom_encoder.encode(image_urls)
+            plan = self._custom_encoder_adapter.prepare_prompt_plan(
+                token_ids,
+                encodings,
             )
         except Exception as exc:
             msg = f"CustomEncoder failed: {exc}"
             logger.exception("Request %s: %s", request_id, msg)
-            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, {"finish_reason": {"error": msg}, "token_ids": []}
 
         logger.debug(
-            "Request %s: CustomEncoder assembled %d image(s) → seq_len=%d dtype=%s",
+            "Request %s: CustomEncoder prepared %s for %d image(s)",
             request_id,
-            len(img_tensors),
-            prompt_embeds.shape[0],
-            prompt_embeds.dtype,
+            type(plan).__name__,
+            len(encodings),
         )
-        return (prompt_embeds, mixed_token_ids, is_token_ids), None, None
+        return plan, None
 
     async def _generate_token_mode(self, request, context, request_id):
         """Generate tokens using internal protocol format (token-in-token-out)."""
@@ -3000,6 +3026,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         is_decode_only = mode == DisaggregationMode.DECODE
         has_mm_data = request.get("multi_modal_data") is not None
         mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None
+        suppress_mm_uuids = False
 
         if (
             mode == DisaggregationMode.AGGREGATED
@@ -3007,12 +3034,8 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             and has_mm_data
         ):
             # A configured CustomEncoder owns the aggregated image path. Bypass
-            # the normal NIXL/HF request processor and assemble an EmbedsPrompt.
-            (
-                mixed_embeds,
-                multi_modal_data,
-                assemble_error,
-            ) = await self._assemble_custom_encoder_prompt(
+            # raw-media loading and prepare its declared engine-input plan.
+            prompt_plan, assemble_error = await self._assemble_custom_encoder_prompt(
                 request,
                 request_id,
                 context,
@@ -3020,6 +3043,18 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             if assemble_error is not None:
                 yield assemble_error
                 return
+            if isinstance(prompt_plan, MixedEmbedsPlan):
+                mixed_embeds = (
+                    prompt_plan.prompt_embeds,
+                    prompt_plan.prompt_token_ids,
+                    prompt_plan.prompt_is_token_ids,
+                )
+                multi_modal_data = None
+            elif isinstance(prompt_plan, NativeMMPlan):
+                multi_modal_data = prompt_plan.multi_modal_data
+                suppress_mm_uuids = True
+            else:
+                multi_modal_data = None
             mm_processor_kwargs = None
             pre_rendered = None
         else:
@@ -3072,6 +3107,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     multi_modal_data,
                     mm_processor_kwargs=mm_processor_kwargs,
                     mixed_embeds=mixed_embeds,
+                    suppress_mm_uuids=suppress_mm_uuids,
                 )
         if error is not None:
             yield error

--- a/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/async_vision_encoder.py
@@ -5,7 +5,7 @@
 
 ``AsyncVisionEncoder`` is the **Dynamo-owned** layer the worker talks to. It
 turns the author's synchronous, thread-affine backend into an awaitable
-``encode(raws) -> list[tensor]`` by:
+``encode(raws) -> list[encoded_media]`` by:
 
 - running ``backend.preprocess`` **off the event loop** on a bounded
   ``ThreadPoolExecutor`` (CPU-heavy fetch / resize / patchify must not serialize
@@ -17,7 +17,10 @@ turns the author's synchronous, thread-affine backend into an awaitable
   result;
 - handing the preprocessed items (with their off-thread-computed scalar ``cost``)
   to a ``ThreadedMicroBatcher``, which coalesces across concurrent ``encode`` calls
-  by cost and runs ``backend.forward_batch`` on the single actor thread.
+  by cost and runs ``backend.forward_batch`` on the single actor thread; and
+- for typed backends, correlation-tagging each physical batch, restoring input
+  order, validating the declared schema, and cloning owned CPU results before
+  positional scatter.
 
 The backend's ``build`` runs on the batcher's actor thread (so a CUDA graph it
 captures is replayed on the same thread) and its ``close`` runs there at
@@ -30,12 +33,19 @@ from __future__ import annotations
 
 import asyncio
 from concurrent.futures import ThreadPoolExecutor
-from typing import Generic, List
+from typing import Any, Generic, List
+from uuid import uuid4
 
 import torch
 
+from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
+    reconcile_and_canonicalize,
+)
 from dynamo.vllm.multimodal_utils.threaded_micro_batcher import ThreadedMicroBatcher
 from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    BackendEncodingSpecV1,
+    EncodedMediaV1,
+    ForwardItemV1,
     ItemT,
     Preprocessed,
     RawT,
@@ -96,10 +106,20 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
                 "drop the override and do the prep inside forward_batch."
             )
         self._backend = backend
+        encoding_spec = getattr(backend, "encoding_spec", None)
+        if encoding_spec is not None and not isinstance(
+            encoding_spec, BackendEncodingSpecV1
+        ):
+            raise TypeError(
+                "VisionEncoderBackend.encoding_spec must be a "
+                f"BackendEncodingSpecV1 or None, got {encoding_spec!r}"
+            )
+        self._encoding_spec = encoding_spec
         self._preprocess_concurrency = conc
         self._name = name
         self._batcher: ThreadedMicroBatcher | None = None
         self._pool: ThreadPoolExecutor | None = None
+        self._closing = False
 
     # ---- lifecycle ---------------------------------------------------------
 
@@ -120,7 +140,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         # nothing to reap in that case.
         try:
             self._batcher = ThreadedMicroBatcher(
-                self._backend.forward_batch,
+                self._forward_batch,
                 max_batch_cost=self._backend.max_batch_cost,
                 on_start=lambda: self._backend.build(model_id),
                 on_stop=self._backend.close,
@@ -142,8 +162,12 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
             raise
 
     def validate(self) -> None:
-        """Fail-fast check run by ``load`` after ``build``: the author hardcoded a
-        usable ``image_token_id``."""
+        """Fail fast on the legacy linear placeholder contract."""
+        if (
+            self._encoding_spec is not None
+            and self._encoding_spec.adapter_abi != "linear-rows-v1"
+        ):
+            return
         tid = getattr(self._backend, "image_token_id", None)
         if not isinstance(tid, int) or isinstance(tid, bool):
             raise ValueError(
@@ -153,28 +177,56 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
 
     def get_image_placeholder_token_id(self) -> int:
         """The token id marking image positions (the backend's hardcoded value)."""
+        if (
+            self._encoding_spec is not None
+            and self._encoding_spec.adapter_abi != "linear-rows-v1"
+        ):
+            raise RuntimeError(
+                "native multimodal CustomEncoder output does not use the legacy "
+                "image placeholder splice"
+            )
         return self._backend.image_token_id
+
+    @property
+    def encoding_spec(self) -> BackendEncodingSpecV1 | None:
+        """The backend's setup-time encoded-media contract, if declared."""
+        return self._encoding_spec
+
+    def _forward_batch(self, items: list[ItemT]) -> list[torch.Tensor | EncodedMediaV1]:
+        """Run one physical batch and reconcile typed results on the actor."""
+        spec = self._encoding_spec
+        if spec is None:
+            return self._backend.forward_batch(items)
+
+        tagged_items = [
+            ForwardItemV1(correlation_id=uuid4().bytes, item=item) for item in items
+        ]
+        returned: Any = self._backend.forward_batch(tagged_items)  # type: ignore[arg-type]
+        if not isinstance(returned, list):
+            raise TypeError("typed CustomEncoder forward_batch must return a list")
+        return reconcile_and_canonicalize(spec, tagged_items, returned)
 
     # ---- request path ------------------------------------------------------
 
-    async def encode(self, raws: List[RawT]) -> List[torch.Tensor]:
+    async def encode(self, raws: List[RawT]) -> List[torch.Tensor | EncodedMediaV1]:
         """Optionally preprocess (off-loop, with a request-atomicity barrier) then
         batched-encode.
 
         With no preprocess pool (``preprocess_concurrency == 0``) raws go straight
         to the batcher (the backend folds any prep into ``forward_batch``). Returns
-        one ``(n_visual_tokens, lm_hidden_dim)`` tensor per raw input, in order.
-        Raises if any image's preprocess fails (submitting nothing) or if the
-        batched forward fails.
+        one legacy tensor or typed encoded-media value per raw input, in order.
+        Raises if any image's preprocess fails (submitting nothing), correlation
+        reconciliation fails, or the batched forward fails.
         """
-        if self._batcher is None:
+        batcher = self._batcher
+        if batcher is None or self._closing:
             raise RuntimeError("AsyncVisionEncoder.encode() called before load()")
         if not raws:
             return []
         if self._pool is None:
             # No preprocess phase: raw IS the item (cost defaults to 1). No
             # barrier needed — the batched forward is all-or-nothing per request.
-            return await self._batcher.submit(list(raws))  # type: ignore[arg-type]
+            return await batcher.submit(list(raws))  # type: ignore[arg-type]
         loop = asyncio.get_running_loop()
         # Request-atomicity barrier: preprocess all images concurrently, wait for
         # EVERY one to settle, and submit only if all succeeded. return_exceptions=True makes
@@ -190,16 +242,21 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
                 # Fail the whole request atomically; no item was submitted (no GPU
                 # work). Surface the first failure, in order.
                 raise result
+        if self._closing:
+            raise RuntimeError("AsyncVisionEncoder shut down during preprocess")
         # No exception above ⇒ every settled entry is a Preprocessed. Alias the
         # list gather() already returned rather than copying it.
         preprocessed: List[Preprocessed] = settled  # type: ignore[assignment]
         items = [p.item for p in preprocessed]
         costs = [p.cost for p in preprocessed]
-        return await self._batcher.submit(items, costs)
+        return await batcher.submit(items, costs)
 
     def shutdown(self) -> None:
         """Stop the actor thread (running ``backend.close`` on it) and the
         preprocess pool. Safe before ``load`` and idempotent."""
+        # Close admission before waiting for preprocessing. An encode call that
+        # was already in the pool rechecks this flag before submitting GPU work.
+        self._closing = True
         # Detach both resources before teardown so repeated cleanup is a no-op,
         # including if teardown itself raises.
         batcher = self._batcher
@@ -207,7 +264,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         self._batcher = None
         self._pool = None
 
+        if pool is not None:
+            pool.shutdown(wait=True, cancel_futures=True)
         if batcher is not None:
             batcher.shutdown()  # runs backend.close() on the actor thread
-        if pool is not None:
-            pool.shutdown(wait=False)

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder_adapter.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder_adapter.py
@@ -1,0 +1,494 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Model-aware adapters for in-process custom vision encoders."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from importlib.metadata import version
+from typing import Any, Sequence
+
+import torch
+
+from dynamo.vllm.multimodal_utils.embed_assembler import build_mixed_embeds
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    BackendEncodingSpecV1,
+    EncodedMediaResultV1,
+    EncodedMediaV1,
+    ForwardItemV1,
+    LinearRowsV1,
+    Qwen2VLImageEncodingV1,
+    VisionEncoderBackend,
+)
+
+_QWEN2_ABI = "vllm-qwen2-vl-external-v1"
+_QWEN2_VLLM_VERSIONS = frozenset({"0.24.0", "0.25.1"})
+_QWEN2_ARCHITECTURES = frozenset(
+    {
+        "Qwen2VLForConditionalGeneration",
+        "Qwen2_5_VLForConditionalGeneration",
+    }
+)
+_DTYPES = {
+    "float16": torch.float16,
+    "bfloat16": torch.bfloat16,
+    "float32": torch.float32,
+}
+
+
+@dataclass(frozen=True)
+class MixedEmbedsPlan:
+    """Worker-private plan for the legacy mixed prompt-embeddings route."""
+
+    prompt_embeds: torch.Tensor
+    prompt_token_ids: list[int]
+    prompt_is_token_ids: list[bool]
+
+
+@dataclass(frozen=True)
+class NativeMMPlan:
+    """Worker-private plan for vLLM's native external multimodal route."""
+
+    multi_modal_data: dict[str, Any]
+
+
+PromptPlan = MixedEmbedsPlan | NativeMMPlan
+
+
+def _model_architectures(model_config: Any) -> tuple[str, ...]:
+    hf_config = getattr(model_config, "hf_config", None)
+    architectures = getattr(hf_config, "architectures", None)
+    if architectures is None:
+        architectures = getattr(model_config, "architectures", None)
+    return tuple(str(architecture) for architecture in (architectures or ()))
+
+
+def _hidden_size(model_config: Any) -> int:
+    getter = getattr(model_config, "get_hidden_size", None)
+    value = getter() if callable(getter) else None
+    if value is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        text_config = getattr(hf_config, "text_config", None)
+        value = getattr(text_config, "hidden_size", None)
+        if value is None:
+            value = getattr(hf_config, "hidden_size", None)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError("CustomEncoder could not resolve the decoder hidden size")
+    return value
+
+
+def _spatial_merge_size(model_config: Any) -> int:
+    hf_config = getattr(model_config, "hf_config", None)
+    vision_config = getattr(hf_config, "vision_config", None)
+    value = getattr(vision_config, "spatial_merge_size", None)
+    if value is None:
+        value = getattr(hf_config, "spatial_merge_size", None)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError("CustomEncoder could not resolve Qwen spatial_merge_size")
+    return value
+
+
+def _required_token_id(model_config: Any, name: str) -> int:
+    hf_config = getattr(model_config, "hf_config", None)
+    value = getattr(hf_config, name, None)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ValueError(f"CustomEncoder could not resolve Qwen {name}")
+    return value
+
+
+def _decoder_fingerprint(
+    model_config: Any,
+    architecture: str,
+    hidden_size: int,
+    spatial_merge_size: int,
+    dtype: torch.dtype,
+) -> str:
+    return (
+        f"model={getattr(model_config, 'model', None)}:"
+        f"revision={getattr(model_config, 'revision', None)}:{architecture}:"
+        f"hidden={hidden_size}:merge={spatial_merge_size}:dtype={dtype}"
+    )
+
+
+class BoundCustomEncoderAdapter:
+    """A setup-time binding from one backend contract to one engine model."""
+
+    def __init__(
+        self,
+        backend: VisionEncoderBackend,
+        model_config: Any,
+        engine_args: Any,
+        vllm_config: Any | None = None,
+    ) -> None:
+        self.spec = getattr(backend, "encoding_spec", None)
+        self._image_token_id: int | None = None
+        self._vision_start_token_id: int | None = None
+        self._vision_end_token_id: int | None = None
+        self._video_token_id: int | None = None
+        if self.spec is not None and not isinstance(self.spec, BackendEncodingSpecV1):
+            raise TypeError(
+                "VisionEncoderBackend.encoding_spec must be a "
+                f"BackendEncodingSpecV1 or None, got {self.spec!r}"
+            )
+
+        if self.spec is None or self.spec.adapter_abi == "linear-rows-v1":
+            qwen_architectures = set(_model_architectures(model_config)) & set(
+                _QWEN2_ARCHITECTURES
+            )
+            if qwen_architectures:
+                raise ValueError(
+                    "Qwen2/2.5-VL CustomEncoder output requires the native "
+                    "vllm-qwen2-vl-external-v1 adapter, not linear-rows-v1"
+                )
+            if not getattr(engine_args, "enable_prompt_embeds", False):
+                raise ValueError(
+                    "linear CustomEncoder output requires --enable-prompt-embeds"
+                )
+            token_id = getattr(backend, "image_token_id", None)
+            if not isinstance(token_id, int) or isinstance(token_id, bool):
+                raise ValueError(
+                    "linear CustomEncoder output requires an integer image_token_id"
+                )
+            self._image_token_id = token_id
+            if self.spec is not None:
+                self._validate_common_spec(self.spec)
+            return
+
+        self._validate_qwen2_binding(model_config, engine_args, vllm_config)
+
+    @property
+    def uses_typed_results(self) -> bool:
+        return self.spec is not None
+
+    @property
+    def uses_native_multimodal(self) -> bool:
+        return self.spec is not None and self.spec.adapter_abi == _QWEN2_ABI
+
+    def _validate_common_spec(self, spec: BackendEncodingSpecV1) -> None:
+        if not spec.producer_fingerprint.strip():
+            raise ValueError("CustomEncoder producer_fingerprint must not be empty")
+        if spec.output_dtype not in _DTYPES:
+            raise ValueError(
+                f"CustomEncoder output_dtype {spec.output_dtype!r} is unsupported"
+            )
+        if spec.hidden_size < 1:
+            raise ValueError("CustomEncoder hidden_size must be positive")
+
+    def _validate_qwen2_binding(
+        self, model_config: Any, engine_args: Any, vllm_config: Any | None
+    ) -> None:
+        spec = self.spec
+        if spec is None or spec.adapter_abi != _QWEN2_ABI:
+            raise ValueError(
+                f"Unsupported CustomEncoder adapter ABI: {getattr(spec, 'adapter_abi', None)!r}"
+            )
+        self._validate_common_spec(spec)
+        vllm_version = version("vllm").split("+", 1)[0]
+        if vllm_version not in _QWEN2_VLLM_VERSIONS:
+            raise ValueError(
+                "Qwen CustomEncoder has no validated adapter for vLLM "
+                f"{vllm_version}; supported versions are "
+                f"{sorted(_QWEN2_VLLM_VERSIONS)}"
+            )
+        if model_config is None:
+            raise ValueError(
+                "Qwen CustomEncoder requires the resolved vLLM ModelConfig"
+            )
+        if not getattr(engine_args, "enable_mm_embeds", False):
+            raise ValueError("Qwen CustomEncoder output requires --enable-mm-embeds")
+        if getattr(engine_args, "language_model_only", False):
+            raise ValueError(
+                "Qwen CustomEncoder MVP does not yet support --language-model-only"
+            )
+        if getattr(engine_args, "tensor_parallel_size", 1) != 1:
+            raise ValueError("Qwen CustomEncoder MVP requires tensor_parallel_size=1")
+        if getattr(engine_args, "pipeline_parallel_size", 1) != 1:
+            raise ValueError("Qwen CustomEncoder MVP requires pipeline_parallel_size=1")
+        if getattr(engine_args, "data_parallel_size", 1) != 1:
+            raise ValueError("Qwen CustomEncoder MVP requires data_parallel_size=1")
+        compilation_config = getattr(engine_args, "compilation_config", None)
+        encoder_cudagraphs = (
+            compilation_config.get("cudagraph_mm_encoder", False)
+            if isinstance(compilation_config, dict)
+            else getattr(compilation_config, "cudagraph_mm_encoder", False)
+        )
+        if encoder_cudagraphs:
+            raise ValueError(
+                "Qwen CustomEncoder external embeddings are incompatible with "
+                "vLLM multimodal encoder CUDA graphs"
+            )
+        cache_config = getattr(vllm_config, "cache_config", None)
+        prefix_caching = getattr(
+            cache_config,
+            "enable_prefix_caching",
+            getattr(engine_args, "enable_prefix_caching", False),
+        )
+        if prefix_caching:
+            raise ValueError(
+                "Qwen CustomEncoder MVP requires --no-enable-prefix-caching"
+            )
+        scheduler_config = getattr(vllm_config, "scheduler_config", None)
+        chunked_prefill = getattr(
+            scheduler_config,
+            "enable_chunked_prefill",
+            getattr(engine_args, "enable_chunked_prefill", False),
+        )
+        if chunked_prefill:
+            raise ValueError(
+                "Qwen CustomEncoder MVP requires --no-enable-chunked-prefill"
+            )
+
+        architectures = _model_architectures(model_config)
+        matches = [arch for arch in architectures if arch in _QWEN2_ARCHITECTURES]
+        if len(matches) != 1:
+            raise ValueError(
+                "Qwen CustomEncoder requires exactly one supported architecture "
+                f"from {sorted(_QWEN2_ARCHITECTURES)}, got {architectures}"
+            )
+        hidden_size = _hidden_size(model_config)
+        if hidden_size != spec.hidden_size:
+            raise ValueError(
+                "CustomEncoder hidden size does not match the decoder: "
+                f"encoder={spec.hidden_size}, decoder={hidden_size}"
+            )
+        merge_size = _spatial_merge_size(model_config)
+        if spec.spatial_merge_size != merge_size:
+            raise ValueError(
+                "CustomEncoder spatial merge size does not match the decoder: "
+                f"encoder={spec.spatial_merge_size}, decoder={merge_size}"
+            )
+        model_dtype = getattr(model_config, "dtype", None)
+        expected_dtype = _DTYPES[spec.output_dtype]
+        if model_dtype != expected_dtype:
+            raise ValueError(
+                "CustomEncoder output dtype does not match the decoder: "
+                f"encoder={expected_dtype}, decoder={model_dtype}"
+            )
+        actual_fingerprint = _decoder_fingerprint(
+            model_config, matches[0], hidden_size, merge_size, model_dtype
+        )
+        if spec.expected_decoder_config_fingerprint is None:
+            raise ValueError(
+                "Qwen CustomEncoder requires expected_decoder_config_fingerprint"
+            )
+        if spec.expected_decoder_config_fingerprint != actual_fingerprint:
+            raise ValueError(
+                "CustomEncoder decoder fingerprint mismatch: "
+                f"expected={spec.expected_decoder_config_fingerprint!r}, "
+                f"actual={actual_fingerprint!r}"
+            )
+
+        self._image_token_id = _required_token_id(model_config, "image_token_id")
+        self._vision_start_token_id = _required_token_id(
+            model_config, "vision_start_token_id"
+        )
+        self._vision_end_token_id = _required_token_id(
+            model_config, "vision_end_token_id"
+        )
+        self._video_token_id = _required_token_id(model_config, "video_token_id")
+
+    def prepare_prompt_plan(
+        self,
+        token_ids: list[int],
+        encodings: Sequence[torch.Tensor | EncodedMediaV1],
+    ) -> PromptPlan:
+        """Convert canonical encoder results to a closed worker prompt plan."""
+        if not self.uses_native_multimodal:
+            rows: list[torch.Tensor] = []
+            for encoding in encodings:
+                if isinstance(encoding, torch.Tensor):
+                    rows.append(encoding)
+                elif isinstance(encoding, LinearRowsV1):
+                    rows.append(encoding.rows)
+                else:
+                    raise TypeError(
+                        "linear CustomEncoder returned a non-linear media result"
+                    )
+            if self._image_token_id is None:
+                raise RuntimeError("linear CustomEncoder adapter is not bound")
+            prompt_embeds, mixed_token_ids, is_token_ids = build_mixed_embeds(
+                token_ids, rows, self._image_token_id
+            )
+            return MixedEmbedsPlan(
+                prompt_embeds=prompt_embeds,
+                prompt_token_ids=mixed_token_ids,
+                prompt_is_token_ids=is_token_ids,
+            )
+
+        qwen_encodings: list[Qwen2VLImageEncodingV1] = []
+        for encoding in encodings:
+            if not isinstance(encoding, Qwen2VLImageEncodingV1):
+                raise TypeError("Qwen CustomEncoder returned a non-Qwen media result")
+            qwen_encodings.append(encoding)
+        self._validate_qwen_placeholders(token_ids, len(qwen_encodings))
+        return NativeMMPlan(
+            multi_modal_data={
+                "image": {
+                    "image_embeds": torch.cat(
+                        [encoding.projected for encoding in qwen_encodings], dim=0
+                    ),
+                    "image_grid_thw": torch.tensor(
+                        [encoding.grid_thw for encoding in qwen_encodings],
+                        dtype=torch.int64,
+                        device="cpu",
+                    ),
+                }
+            }
+        )
+
+    def _validate_qwen_placeholders(
+        self, token_ids: list[int], image_count: int
+    ) -> None:
+        image_token_id = self._image_token_id
+        start_token_id = self._vision_start_token_id
+        end_token_id = self._vision_end_token_id
+        video_token_id = self._video_token_id
+        if None in (image_token_id, start_token_id, end_token_id, video_token_id):
+            raise RuntimeError("Qwen CustomEncoder adapter is not bound")
+        if video_token_id in token_ids:
+            raise ValueError("Qwen CustomEncoder image MVP rejects video placeholders")
+        start_positions = [
+            index
+            for index, token_id in enumerate(token_ids)
+            if token_id == start_token_id
+        ]
+        image_positions = [
+            index
+            for index, token_id in enumerate(token_ids)
+            if token_id == image_token_id
+        ]
+        end_positions = [
+            index
+            for index, token_id in enumerate(token_ids)
+            if token_id == end_token_id
+        ]
+        if not (
+            len(start_positions)
+            == len(image_positions)
+            == len(end_positions)
+            == image_count
+        ):
+            raise ValueError(
+                "Qwen CustomEncoder requires exactly one canonical vision triple "
+                f"per image: images={image_count}, starts={len(start_positions)}, "
+                f"placeholders={len(image_positions)}, ends={len(end_positions)}"
+            )
+        for index in start_positions:
+            if token_ids[index : index + 3] != [
+                start_token_id,
+                image_token_id,
+                end_token_id,
+            ]:
+                raise ValueError(
+                    "Qwen CustomEncoder requires one canonical unexpanded "
+                    "<vision_start><image_pad><vision_end> group per image"
+                )
+
+
+def reconcile_and_canonicalize(
+    spec: BackendEncodingSpecV1,
+    submitted: Sequence[ForwardItemV1[Any]],
+    returned: Sequence[EncodedMediaResultV1],
+) -> list[EncodedMediaV1]:
+    """Validate correlation IDs, restore input order, and own result storage."""
+    expected_ids = [item.correlation_id for item in submitted]
+    if len(returned) != len(expected_ids):
+        raise ValueError(
+            "CustomEncoder returned the wrong number of results: "
+            f"expected={len(expected_ids)}, actual={len(returned)}"
+        )
+    by_id: dict[bytes, EncodedMediaV1] = {}
+    expected_set = set(expected_ids)
+    for result in returned:
+        if not isinstance(result, EncodedMediaResultV1):
+            raise TypeError(
+                "typed CustomEncoder must return EncodedMediaResultV1 values"
+            )
+        correlation_id = result.correlation_id
+        if correlation_id not in expected_set:
+            raise ValueError("CustomEncoder returned an unknown correlation_id")
+        if correlation_id in by_id:
+            raise ValueError("CustomEncoder returned a duplicate correlation_id")
+        by_id[correlation_id] = result.media
+    if by_id.keys() != expected_set:
+        raise ValueError("CustomEncoder omitted one or more correlation IDs")
+    return [
+        _canonicalize_media(spec, by_id[correlation_id])
+        for correlation_id in expected_ids
+    ]
+
+
+def _canonicalize_media(
+    spec: BackendEncodingSpecV1, media: EncodedMediaV1
+) -> EncodedMediaV1:
+    if spec.adapter_abi == "linear-rows-v1":
+        if not isinstance(media, LinearRowsV1):
+            raise TypeError("linear-rows-v1 requires LinearRowsV1 results")
+        return LinearRowsV1(rows=_canonicalize_tensor(spec, media.rows))
+    if spec.adapter_abi != _QWEN2_ABI:
+        raise ValueError(f"Unsupported CustomEncoder adapter ABI: {spec.adapter_abi!r}")
+    if not isinstance(media, Qwen2VLImageEncodingV1):
+        raise TypeError(
+            "vllm-qwen2-vl-external-v1 requires Qwen2VLImageEncodingV1 results"
+        )
+    grid = media.grid_thw
+    if (
+        not isinstance(grid, tuple)
+        or len(grid) != 3
+        or any(not isinstance(value, int) or isinstance(value, bool) for value in grid)
+        or any(value < 1 for value in grid)
+    ):
+        raise ValueError(
+            f"Qwen image grid_thw must be three positive integers, got {grid!r}"
+        )
+    temporal, height, width = grid
+    if temporal != 1:
+        raise ValueError("Qwen CustomEncoder MVP supports image T == 1 only")
+    merge_size = spec.spatial_merge_size
+    if merge_size is None or merge_size < 1:
+        raise ValueError("Qwen CustomEncoder requires a positive spatial_merge_size")
+    if height % merge_size or width % merge_size:
+        raise ValueError(
+            "Qwen image grid height and width must each be divisible by "
+            f"spatial_merge_size={merge_size}; got {grid}"
+        )
+    projected = _canonicalize_tensor(spec, media.projected)
+    expected_rows = temporal * height * width // (merge_size**2)
+    if projected.shape[0] != expected_rows:
+        raise ValueError(
+            "Qwen projected row count does not match image_grid_thw: "
+            f"expected={expected_rows}, actual={projected.shape[0]}, grid={grid}"
+        )
+    return Qwen2VLImageEncodingV1(projected=projected, grid_thw=grid)
+
+
+def _canonicalize_tensor(
+    spec: BackendEncodingSpecV1, tensor: torch.Tensor
+) -> torch.Tensor:
+    if not isinstance(tensor, torch.Tensor):
+        raise TypeError("CustomEncoder media rows must be a torch.Tensor")
+    if tensor.device.type != "cpu":
+        raise ValueError("CustomEncoder media rows must be on CPU before return")
+    if tensor.layout is not torch.strided or not tensor.is_contiguous():
+        raise ValueError("CustomEncoder media rows must be dense and contiguous")
+    if tensor.requires_grad:
+        raise ValueError("CustomEncoder media rows must have requires_grad=False")
+    if tensor.ndim != 2 or tensor.shape[0] < 1:
+        raise ValueError(
+            "CustomEncoder media rows must have shape [positive_tokens, hidden_size]"
+        )
+    if tensor.shape[1] != spec.hidden_size:
+        raise ValueError(
+            "CustomEncoder media hidden width mismatch: "
+            f"expected={spec.hidden_size}, actual={tensor.shape[1]}"
+        )
+    expected_dtype = _DTYPES[spec.output_dtype]
+    if tensor.dtype != expected_dtype:
+        raise ValueError(
+            "CustomEncoder media dtype mismatch: "
+            f"expected={expected_dtype}, actual={tensor.dtype}"
+        )
+    if not torch.isfinite(tensor).all().item():
+        raise ValueError("CustomEncoder media rows contain NaN or Inf")
+    return tensor.detach().clone(memory_format=torch.contiguous_format)

--- a/components/src/dynamo/vllm/multimodal_utils/request_processor.py
+++ b/components/src/dynamo/vllm/multimodal_utils/request_processor.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import pickle
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any, Optional
 
 import torch
@@ -47,6 +48,13 @@ IMAGE_URL_KEY = "image_url"
 VIDEO_URL_KEY = "video_url"
 AUDIO_URL_KEY = "audio_url"
 URL_VARIANT_KEY = "Url"
+
+
+class MultimodalUUIDPolicy(Enum):
+    """Select which artifact owns multimodal cache identity."""
+
+    RAW_MEDIA = auto()
+    EXTERNAL_ARTIFACT = auto()
 
 
 def pad_mm_hashes_to_64(mm_hashes: list[str]) -> list[str]:
@@ -546,20 +554,30 @@ class VllmMultimodalRequestProcessor:
         request: dict[str, Any],
         multi_modal_data: Optional[dict[str, Any]],
         mm_processor_kwargs: Optional[dict[str, Any]],
+        *,
+        uuid_policy: MultimodalUUIDPolicy = MultimodalUUIDPolicy.RAW_MEDIA,
     ) -> TokensPrompt:
         """Create a TokensPrompt with stable multimodal UUIDs."""
-        extra_args = request.get("extra_args") or {}
-        mm_uuids = _build_forwarded_mm_uuids(
-            extra_args,
-            self.use_unified_vision_chunk,
-        )
-        if mm_uuids is None and self.embedding_loader is None:
-            mm_uuids = compute_mm_uuids(multi_modal_data)
-            if mm_uuids is not None:
-                logger.warning(
-                    "No frontend multimodal hashes were provided; recomputed "
-                    "image UUIDs may not match routing decisions"
-                )
+        if uuid_policy is MultimodalUUIDPolicy.RAW_MEDIA:
+            extra_args = request.get("extra_args") or {}
+            mm_uuids = _build_forwarded_mm_uuids(
+                extra_args,
+                self.use_unified_vision_chunk,
+            )
+            if mm_uuids is None and self.embedding_loader is None:
+                mm_uuids = compute_mm_uuids(multi_modal_data)
+                if mm_uuids is not None:
+                    logger.warning(
+                        "No frontend multimodal hashes were provided; recomputed "
+                        "image UUIDs may not match routing decisions"
+                    )
+        elif uuid_policy is MultimodalUUIDPolicy.EXTERNAL_ARTIFACT:
+            # Never reuse request-controlled/raw-media hashes for a transformed
+            # artifact. Omitting UUIDs makes vLLM hash each immutable external
+            # embedding slice together with its grid metadata.
+            mm_uuids = None
+        else:
+            raise ValueError(f"Unsupported multimodal UUID policy: {uuid_policy!r}")
 
         prompt_kwargs: dict[str, Any] = {
             "prompt_token_ids": request["token_ids"],

--- a/components/src/dynamo/vllm/multimodal_utils/threaded_micro_batcher.py
+++ b/components/src/dynamo/vllm/multimodal_utils/threaded_micro_batcher.py
@@ -96,8 +96,9 @@ class ThreadedMicroBatcher(Generic[T, R]):
         on_start: Optional callable run once on the worker thread before serving
             (model build / warmup); its failure surfaces from ``start()``.
         on_stop: Optional callable run once on the worker thread at teardown (after
-            the serving loop ends), iff ``on_start`` succeeded. Its failure is
-            logged, never raised.
+            the serving loop ends), or after a failed ``on_start`` so partially
+            allocated resources can be released. Its failure is logged, never
+            raised. The callback must therefore tolerate partial initialization.
         name: Worker thread name.
         join_timeout_s: Seconds ``shutdown()`` waits for an in-flight ``fn``.
     """
@@ -280,6 +281,10 @@ class ThreadedMicroBatcher(Generic[T, R]):
                 self._on_start()  # build / warmup / CUDA-graph capture HERE
         except BaseException as exc:  # noqa: BLE001 — surface to start()
             self._started.set_exception(exc)
+            # build() may have allocated CPU/GPU state before raising. Teardown
+            # on the same actor thread and require close() to tolerate a partial
+            # initialization rather than leaking until process exit.
+            self._run_on_stop()
             return
         self._started.set_result(None)
         try:
@@ -301,8 +306,7 @@ class ThreadedMicroBatcher(Generic[T, R]):
             for req in live:
                 self._abort(req, exc)
         finally:
-            # on_stop runs on the actor thread (so CUDA teardown is same-thread),
-            # only after on_start succeeded (this finally is unreachable otherwise).
+            # on_stop runs on the actor thread (so CUDA teardown is same-thread).
             self._run_on_stop()
 
     def _run_on_stop(self) -> None:

--- a/components/src/dynamo/vllm/multimodal_utils/vision_encoder_backend.py
+++ b/components/src/dynamo/vllm/multimodal_utils/vision_encoder_backend.py
@@ -6,15 +6,15 @@
 ``VisionEncoderBackend`` is the **single surface an encoder author implements**.
 It is a pure policy + compute backend: no threads, no futures, no event loop.
 Dynamo owns all the *driving* — the dedicated actor thread, cross-request
-coalescing, the embeds splice, and the lifecycle — via ``ThreadedMicroBatcher``
+coalescing, engine-input adaptation, and the lifecycle — via ``ThreadedMicroBatcher``
 (the generic cross-request batcher) and ``AsyncVisionEncoder`` (the async
 request-API glue). This module defines only the contract those drivers call.
 
 The encoder runs in the **same process** as the aggregated vLLM worker (no
 separate encode worker, no NIXL transfer): it turns image inputs into the
-visual-token embeddings for each image, and Dynamo splices those embeds into a
-mixed ``EmbedsPrompt`` at the placeholder positions (see
-``embed_assembler.build_mixed_embeds``) for a text-only LM.
+visual-token embeddings for each image. Linear-position models use a mixed
+``EmbedsPrompt``; metadata-dependent models such as Qwen2/2.5-VL use vLLM's
+native external multimodal-embedding input so grid-driven M-RoPE is preserved.
 
 Division of labour (author vs. Dynamo):
 
@@ -32,18 +32,17 @@ Division of labour (author vs. Dynamo):
   there is no preprocess phase — ``preprocess`` is never called and raws go
   straight to ``forward_batch``. A mismatch (overridden ``preprocess`` with
   ``preprocess_concurrency`` left at ``0``) fails fast at startup.
-- ``forward_batch(items, target_bucket=None) -> list[torch.Tensor]`` — **actor
-  thread, serialized.** ``items`` are a cost-bounded batch (summed ``cost`` within
-  the budget). Fence (stream event + sync) and **copy outputs to CPU** before
-  returning, so results are safe to consume from another thread and splice
-  directly. Returns one ``(n_visual_tokens, lm_hidden_dim)`` **CPU** tensor per
-  item, in input order. ``target_bucket`` is reserved for CUDA-graph batching,
-  once supported (the ladder rung to pad to); it is ``None`` until then.
-- ``close()`` — actor thread, on teardown. Release any thread-affine resources.
+- ``forward_batch(items, target_bucket=None)`` — **actor thread, serialized.**
+  Legacy backends receive raw items and return one CPU tensor per item. Backends
+  declaring ``encoding_spec`` receive ``ForwardItemV1`` values and return
+  correlation-echoing ``EncodedMediaResultV1`` values. The driver validates and
+  restores their input order, then freezes tensor storage on the actor thread.
+- ``close()`` — actor thread, on teardown, including after a partially failed
+  ``build``. Release any initialized thread-affine resources idempotently.
 
 Attributes read **once at setup** (never per-request):
 
-- ``image_token_id`` — the token id marking image positions in the prompt;
+- ``image_token_id`` — for the linear route, the token id marking image positions;
   **hardcode it for your model** (e.g. ``151655`` for Qwen3-VL's ``<|image_pad|>``).
   Dynamo uses it to locate each image span for the splice.
 - ``max_batch_cost`` — the scalar dispatch ceiling the batcher packs up to; a
@@ -55,6 +54,9 @@ Attributes read **once at setup** (never per-request):
   ``preprocess`` on. ``0`` (the **default**) ⇒ no preprocess phase: raws go
   straight to ``forward_batch``. Set ``> 0`` (with an overridden ``preprocess``)
   for off-loop fetch / resize / patchify.
+- ``encoding_spec`` — optional typed result/adapter handshake. ``None`` keeps the
+  legacy tensor route; Qwen2/2.5 backends declare
+  ``vllm-qwen2-vl-external-v1`` and return projected rows plus ``grid_thw``.
 
 Batching is **one-dimensional**: Dynamo packs by scalar ``cost`` up to
 ``max_batch_cost`` and never inspects item shape — the author owns any
@@ -65,7 +67,7 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Generic, List, Optional, Sequence, TypeVar
+from typing import Generic, List, Literal, Optional, Sequence, TypeAlias, TypeVar
 
 import torch
 
@@ -93,6 +95,65 @@ class Preprocessed(Generic[ItemT]):
     cost: int = 1
 
 
+@dataclass(frozen=True)
+class BackendEncodingSpecV1:
+    """Setup-time declaration of the backend's encoded-media contract.
+
+    Backends that do not declare a spec retain the legacy ``list[Tensor]``
+    contract. A backend that declares a spec receives correlation-tagged forward
+    items and must return ``EncodedMediaResultV1`` values.
+    """
+
+    adapter_abi: Literal["linear-rows-v1", "vllm-qwen2-vl-external-v1"]
+    producer_fingerprint: str
+    expected_decoder_config_fingerprint: Optional[str]
+    output_dtype: Literal["float16", "bfloat16", "float32"]
+    hidden_size: int
+    spatial_merge_size: Optional[int] = None
+
+
+@dataclass(frozen=True)
+class LinearRowsV1:
+    """External media rows with ordinary one-dimensional positions."""
+
+    rows: torch.Tensor
+
+
+@dataclass(frozen=True)
+class Qwen2VLImageEncodingV1:
+    """One canonical Qwen2/2.5-VL image artifact.
+
+    ``projected`` is the output *after* the vision projector/patch merger.
+    ``grid_thw`` is the positive pre-spatial-merge patch grid. Rows are ordered
+    in canonical ``(t, merged_h, merged_w)`` raster order; Qwen2.5 producers must
+    apply the model's inverse window permutation before returning. Shape checks
+    cannot detect a pre-inverse tensor, which would attach valid M-RoPE values to
+    the wrong spatial patches while still producing fluent output.
+    """
+
+    projected: torch.Tensor
+    grid_thw: tuple[int, int, int]
+
+
+EncodedMediaV1: TypeAlias = LinearRowsV1 | Qwen2VLImageEncodingV1
+
+
+@dataclass(frozen=True)
+class ForwardItemV1(Generic[ItemT]):
+    """One backend item tagged for order-independent result reconciliation."""
+
+    correlation_id: bytes
+    item: ItemT
+
+
+@dataclass(frozen=True)
+class EncodedMediaResultV1:
+    """A typed media result echoing its input correlation identifier."""
+
+    correlation_id: bytes
+    media: EncodedMediaV1
+
+
 class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     """Author-written, in-process vision encoder contract.
 
@@ -100,8 +161,8 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     on a dedicated actor thread (``ThreadedMicroBatcher``) and exposes the async
     request API (``AsyncVisionEncoder``). Subclasses implement ``build`` and
     ``forward_batch`` and set ``image_token_id``; ``preprocess`` (default identity
-    passthrough), ``max_batch_cost``, ``buckets``, and ``preprocess_concurrency``
-    are overridden only as needed.
+    passthrough), ``max_batch_cost``, ``buckets``, ``preprocess_concurrency``, and
+    ``encoding_spec`` are overridden only as needed.
     """
 
     #: Image placeholder token id — **hardcode it for your model** (e.g. ``151655``
@@ -129,6 +190,10 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     #: encoder needs off-loop prep is a property of the encoder, so it lives here;
     #: the driver takes an optional override for tuning.
     preprocess_concurrency: int = 0
+
+    #: Optional typed encoded-media contract. ``None`` preserves the original
+    #: untagged ``list[Tensor]`` behavior for existing backends.
+    encoding_spec: Optional[BackendEncodingSpecV1] = None
 
     # ---- subclass contract -------------------------------------------------
 
@@ -159,17 +224,20 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     def forward_batch(
         self, items: List[ItemT], target_bucket: Optional[int] = None
     ) -> List[torch.Tensor]:
-        """Encode one cost-bounded batch (actor thread); one tensor per item, in order.
+        """Encode one cost-bounded batch on the actor thread.
 
-        Fence (stream event + sync) and **copy outputs to CPU** before returning,
-        so results are safe to consume from another thread and splice directly.
-        Return one ``(n_visual_tokens, lm_hidden_dim)`` **CPU** tensor per item, in
-        input order. ``target_bucket`` is reserved for CUDA-graph batching, once
-        supported (the ladder rung to pad to), and is ``None`` until then.
+        With no ``encoding_spec``, return one CPU tensor per input in order. With
+        a spec, Dynamo passes ``ForwardItemV1`` values and requires one
+        ``EncodedMediaResultV1`` per input; results may be returned in any order
+        because correlation IDs are reconciled before positional scatter. Fence
+        device work and copy outputs to CPU before returning.
         """
         ...
 
     def close(self) -> None:
-        """Release thread-affine resources on teardown (actor thread). No-op by
-        default; override to free graphs / pools / weights."""
+        """Release initialized thread-affine resources on the actor thread.
+
+        Called after normal serving and after a partially failed ``build``;
+        overrides must be idempotent and tolerate incomplete initialization.
+        """
         return None

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_async_vision_encoder.py
@@ -16,7 +16,11 @@ import torch
 
 from dynamo.vllm.multimodal_utils.async_vision_encoder import AsyncVisionEncoder
 from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    BackendEncodingSpecV1,
+    EncodedMediaResultV1,
+    ForwardItemV1,
     Preprocessed,
+    Qwen2VLImageEncodingV1,
     VisionEncoderBackend,
 )
 
@@ -270,3 +274,50 @@ def test_load_bad_batch_cost_fails_without_spawning_pool():
         enc.load("m")
     assert enc._pool is None
     assert enc._batcher is None
+
+
+class _TypedQwenBackend(VisionEncoderBackend):
+    encoding_spec = BackendEncodingSpecV1(
+        adapter_abi="vllm-qwen2-vl-external-v1",
+        producer_fingerprint="test-backend-v1",
+        expected_decoder_config_fingerprint=None,
+        output_dtype="bfloat16",
+        hidden_size=4,
+        spatial_merge_size=2,
+    )
+
+    def build(self, model_id):
+        pass
+
+    def forward_batch(self, items, target_bucket=None):
+        assert all(isinstance(item, ForwardItemV1) for item in items)
+        results = [
+            EncodedMediaResultV1(
+                correlation_id=item.correlation_id,
+                media=Qwen2VLImageEncodingV1(
+                    projected=torch.full(
+                        (1, 4), float(len(item.item)), dtype=torch.bfloat16
+                    ),
+                    grid_thw=(1, 2, 2),
+                ),
+            )
+            for item in items
+        ]
+        return list(reversed(results))
+
+
+async def test_typed_backend_uses_correlation_tags_and_restores_request_order():
+    enc = AsyncVisionEncoder(_TypedQwenBackend())
+    enc.load("m")
+    try:
+        outputs = await enc.encode(["a", "three"])
+    finally:
+        enc.shutdown()
+
+    assert [output.projected[0, 0].item() for output in outputs] == [1, 5]
+
+
+def test_native_multimodal_backend_does_not_require_legacy_image_token_id():
+    enc = AsyncVisionEncoder(_TypedQwenBackend())
+    enc.load("m")
+    enc.shutdown()

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_custom_encoder_adapter.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_custom_encoder_adapter.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for model-aware custom-encoder engine adapters."""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
+    BoundCustomEncoderAdapter,
+    MixedEmbedsPlan,
+    NativeMMPlan,
+    reconcile_and_canonicalize,
+)
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    BackendEncodingSpecV1,
+    EncodedMediaResultV1,
+    ForwardItemV1,
+    Qwen2VLImageEncodingV1,
+    VisionEncoderBackend,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+_START = 100
+_IMAGE = 101
+_END = 102
+
+
+def _decoder_fingerprint(
+    architecture: str = "Qwen2_5_VLForConditionalGeneration",
+) -> str:
+    return (
+        f"model=None:revision=None:{architecture}:hidden=4:merge=2:"
+        "dtype=torch.bfloat16"
+    )
+
+
+def _qwen_spec(
+    architecture: str = "Qwen2_5_VLForConditionalGeneration", **overrides
+) -> BackendEncodingSpecV1:
+    values = {
+        "adapter_abi": "vllm-qwen2-vl-external-v1",
+        "producer_fingerprint": "encoder-revision-1",
+        "expected_decoder_config_fingerprint": _decoder_fingerprint(architecture),
+        "output_dtype": "bfloat16",
+        "hidden_size": 4,
+        "spatial_merge_size": 2,
+    }
+    values.update(overrides)
+    return BackendEncodingSpecV1(**values)
+
+
+def _model_config(
+    architecture: str = "Qwen2_5_VLForConditionalGeneration",
+):
+    return SimpleNamespace(
+        dtype=torch.bfloat16,
+        get_hidden_size=lambda: 4,
+        hf_config=SimpleNamespace(
+            architectures=[architecture],
+            image_token_id=_IMAGE,
+            vision_start_token_id=_START,
+            vision_end_token_id=_END,
+            video_token_id=103,
+            vision_config=SimpleNamespace(spatial_merge_size=2),
+        ),
+    )
+
+
+def _engine_args(**overrides):
+    values = {
+        "enable_mm_embeds": True,
+        "enable_prompt_embeds": False,
+        "language_model_only": False,
+        "tensor_parallel_size": 1,
+        "pipeline_parallel_size": 1,
+        "data_parallel_size": 1,
+        "compilation_config": SimpleNamespace(cudagraph_mm_encoder=False),
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _Backend(VisionEncoderBackend):
+    def __init__(self, encoding_spec=None, image_token_id=None):
+        self.encoding_spec = encoding_spec
+        self.image_token_id = image_token_id
+
+    def build(self, model_id):
+        pass
+
+    def forward_batch(self, items, target_bucket=None):
+        raise NotImplementedError
+
+
+@pytest.mark.parametrize(
+    "architecture",
+    [
+        "Qwen2VLForConditionalGeneration",
+        "Qwen2_5_VLForConditionalGeneration",
+    ],
+)
+def test_qwen2_family_architectures_bind_to_native_adapter(architecture):
+    adapter = BoundCustomEncoderAdapter(
+        _Backend(_qwen_spec(architecture)),
+        _model_config(architecture),
+        _engine_args(),
+    )
+
+    assert adapter.uses_native_multimodal is True
+
+
+def test_qwen_adapter_builds_native_tokens_prompt_payload_in_image_order():
+    backend = _Backend(_qwen_spec())
+    adapter = BoundCustomEncoderAdapter(backend, _model_config(), _engine_args())
+    token_ids = [_START, _IMAGE, _END, 7, _START, _IMAGE, _END]
+    first = torch.full((1, 4), 1, dtype=torch.bfloat16)
+    second = torch.full((2, 4), 2, dtype=torch.bfloat16)
+
+    plan = adapter.prepare_prompt_plan(
+        token_ids,
+        [
+            Qwen2VLImageEncodingV1(first, (1, 2, 2)),
+            Qwen2VLImageEncodingV1(second, (1, 2, 4)),
+        ],
+    )
+
+    assert isinstance(plan, NativeMMPlan)
+    image = plan.multi_modal_data["image"]
+    assert image["image_embeds"].shape == (3, 4)
+    assert image["image_embeds"][:, 0].tolist() == [1, 2, 2]
+    assert image["image_grid_thw"].tolist() == [[1, 2, 2], [1, 2, 4]]
+    assert token_ids == [_START, _IMAGE, _END, 7, _START, _IMAGE, _END]
+
+
+def test_typed_results_are_reordered_by_correlation_and_cloned():
+    spec = _qwen_spec()
+    submitted = [ForwardItemV1(b"first", "a"), ForwardItemV1(b"second", "b")]
+    first = torch.full((1, 4), 1, dtype=torch.bfloat16)
+    second = torch.full((2, 4), 2, dtype=torch.bfloat16)
+    returned = [
+        EncodedMediaResultV1(b"second", Qwen2VLImageEncodingV1(second, (1, 2, 4))),
+        EncodedMediaResultV1(b"first", Qwen2VLImageEncodingV1(first, (1, 2, 2))),
+    ]
+
+    outputs = reconcile_and_canonicalize(spec, submitted, returned)
+
+    assert [output.projected[0, 0].item() for output in outputs] == [1, 2]
+    assert outputs[0].projected.data_ptr() != first.data_ptr()
+    first.fill_(9)
+    assert outputs[0].projected[0, 0].item() == 1
+
+
+def test_qwen_result_rejects_grid_row_count_mismatch():
+    with pytest.raises(ValueError, match="row count"):
+        reconcile_and_canonicalize(
+            _qwen_spec(),
+            [ForwardItemV1(b"id", "item")],
+            [
+                EncodedMediaResultV1(
+                    b"id",
+                    Qwen2VLImageEncodingV1(
+                        torch.zeros((2, 4), dtype=torch.bfloat16),
+                        (1, 2, 2),
+                    ),
+                )
+            ],
+        )
+
+
+def test_typed_results_reject_duplicate_correlation_id():
+    submitted = [ForwardItemV1(b"a", 1), ForwardItemV1(b"b", 2)]
+    media = Qwen2VLImageEncodingV1(torch.zeros((1, 4), dtype=torch.bfloat16), (1, 2, 2))
+    with pytest.raises(ValueError, match="duplicate"):
+        reconcile_and_canonicalize(
+            _qwen_spec(),
+            submitted,
+            [EncodedMediaResultV1(b"a", media), EncodedMediaResultV1(b"a", media)],
+        )
+
+
+def test_qwen_adapter_requires_mm_embeds_flag():
+    with pytest.raises(ValueError, match="enable-mm-embeds"):
+        BoundCustomEncoderAdapter(
+            _Backend(_qwen_spec()),
+            _model_config(),
+            _engine_args(enable_mm_embeds=False),
+        )
+
+
+def test_qwen_adapter_requires_decoder_fingerprint():
+    with pytest.raises(ValueError, match="expected_decoder_config_fingerprint"):
+        BoundCustomEncoderAdapter(
+            _Backend(_qwen_spec(expected_decoder_config_fingerprint=None)),
+            _model_config(),
+            _engine_args(),
+        )
+
+
+def test_qwen_adapter_rejects_encoder_cuda_graphs():
+    with pytest.raises(ValueError, match="encoder CUDA graphs"):
+        BoundCustomEncoderAdapter(
+            _Backend(_qwen_spec()),
+            _model_config(),
+            _engine_args(compilation_config=SimpleNamespace(cudagraph_mm_encoder=True)),
+        )
+
+
+@pytest.mark.parametrize(
+    "vllm_config, message",
+    [
+        (
+            SimpleNamespace(
+                cache_config=SimpleNamespace(enable_prefix_caching=True),
+                scheduler_config=SimpleNamespace(enable_chunked_prefill=False),
+            ),
+            "no-enable-prefix-caching",
+        ),
+        (
+            SimpleNamespace(
+                cache_config=SimpleNamespace(enable_prefix_caching=False),
+                scheduler_config=SimpleNamespace(enable_chunked_prefill=True),
+            ),
+            "no-enable-chunked-prefill",
+        ),
+    ],
+)
+def test_qwen_adapter_rejects_unproven_resolved_engine_modes(vllm_config, message):
+    with pytest.raises(ValueError, match=message):
+        BoundCustomEncoderAdapter(
+            _Backend(_qwen_spec()),
+            _model_config(),
+            _engine_args(),
+            vllm_config,
+        )
+
+
+def test_qwen_adapter_rejects_unvalidated_vllm_version(monkeypatch):
+    monkeypatch.setattr(
+        "dynamo.vllm.multimodal_utils.custom_encoder_adapter.version",
+        lambda package: "99.0.0",
+    )
+    with pytest.raises(ValueError, match="no validated adapter"):
+        BoundCustomEncoderAdapter(
+            _Backend(_qwen_spec()),
+            _model_config(),
+            _engine_args(),
+        )
+
+
+def test_qwen_architecture_rejects_linear_adapter():
+    with pytest.raises(ValueError, match="requires the native"):
+        BoundCustomEncoderAdapter(
+            _Backend(encoding_spec=None, image_token_id=_IMAGE),
+            _model_config(),
+            _engine_args(enable_prompt_embeds=True),
+        )
+
+
+@pytest.mark.parametrize(
+    "token_ids, message",
+    [
+        ([_START, _IMAGE, _IMAGE, _END], "canonical vision triple"),
+        ([_START, _IMAGE, _END, _START], "canonical vision triple"),
+        ([_START, _IMAGE, _END, 103], "video placeholders"),
+    ],
+)
+def test_qwen_adapter_rejects_noncanonical_placeholders(token_ids, message):
+    adapter = BoundCustomEncoderAdapter(
+        _Backend(_qwen_spec()), _model_config(), _engine_args()
+    )
+    media = Qwen2VLImageEncodingV1(torch.zeros((1, 4), dtype=torch.bfloat16), (1, 2, 2))
+    media_items = [media] * token_ids.count(_IMAGE)
+    with pytest.raises(ValueError, match=message):
+        adapter.prepare_prompt_plan(token_ids, media_items)
+
+
+def test_legacy_linear_backend_keeps_mixed_embeds_plan():
+    adapter = BoundCustomEncoderAdapter(
+        _Backend(encoding_spec=None, image_token_id=42),
+        _model_config("Qwen2ForCausalLM"),
+        _engine_args(enable_prompt_embeds=True),
+    )
+
+    plan = adapter.prepare_prompt_plan(
+        [1, 42, 2], [torch.zeros((2, 4), dtype=torch.float32)]
+    )
+
+    assert isinstance(plan, MixedEmbedsPlan)
+    assert plan.prompt_token_ids == [1, 42, 42, 2]

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_request_processor.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+import torch
 from PIL import Image
 
 from dynamo.common.constants import DisaggregationMode
@@ -308,6 +309,28 @@ def test_build_tokens_prompt_preserves_grouped_forwarded_hashes():
         "image": ["image_hash".ljust(64, "0")],
         "audio": ["audio_hash".ljust(64, "0")],
     }
+
+
+def test_build_tokens_prompt_can_suppress_forwarded_raw_media_hashes():
+    embedding_payload = {
+        "image": {
+            "image_embeds": torch.zeros((1, 4)),
+            "image_grid_thw": torch.tensor([[1, 2, 2]]),
+        }
+    }
+
+    prompt = _processor().build_tokens_prompt(
+        {
+            "token_ids": [1, 2, 3],
+            "extra_args": {"mm_hashes": ["raw-image-hash"]},
+        },
+        embedding_payload,
+        None,
+        uuid_policy=mod.MultimodalUUIDPolicy.EXTERNAL_ARTIFACT,
+    )
+
+    assert prompt["multi_modal_data"] is embedding_payload
+    assert "multi_modal_uuids" not in prompt
 
 
 def test_build_tokens_prompt_remaps_grouped_image_hashes_to_vision_chunk():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_threaded_micro_batcher.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_threaded_micro_batcher.py
@@ -118,7 +118,7 @@ async def test_on_start_fn_and_on_stop_share_one_non_main_thread():
     assert rec.stop_thread == rec.start_thread
 
 
-def test_on_stop_not_run_if_on_start_failed():
+def test_on_stop_runs_if_on_start_partially_failed():
     ran = {"stop": False}
 
     def bad_start():
@@ -130,7 +130,7 @@ def test_on_stop_not_run_if_on_start_failed():
     b = ThreadedMicroBatcher(_echo, on_start=bad_start, on_stop=on_stop)
     with pytest.raises(RuntimeError, match="start failed"):
         b.start()
-    assert ran["stop"] is False
+    assert ran["stop"] is True
 
 
 async def test_eager_drain_pulls_all_queued_when_free():

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Handler tests for custom-encoder prompt-plan selection."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import torch
+
+from dynamo.vllm.handlers import DecodeWorkerHandler
+from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
+    BoundCustomEncoderAdapter,
+    NativeMMPlan,
+)
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    BackendEncodingSpecV1,
+    Qwen2VLImageEncodingV1,
+    VisionEncoderBackend,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+class _QwenBackend(VisionEncoderBackend):
+    encoding_spec = BackendEncodingSpecV1(
+        adapter_abi="vllm-qwen2-vl-external-v1",
+        producer_fingerprint="handler-test-v1",
+        expected_decoder_config_fingerprint=(
+            "model=None:revision=None:Qwen2_5_VLForConditionalGeneration:"
+            "hidden=4:merge=2:dtype=torch.bfloat16"
+        ),
+        output_dtype="bfloat16",
+        hidden_size=4,
+        spatial_merge_size=2,
+    )
+
+    def build(self, model_id):
+        pass
+
+    def forward_batch(self, items, target_bucket=None):
+        raise NotImplementedError
+
+
+def _adapter() -> BoundCustomEncoderAdapter:
+    model_config = SimpleNamespace(
+        dtype=torch.bfloat16,
+        get_hidden_size=lambda: 4,
+        hf_config=SimpleNamespace(
+            architectures=["Qwen2_5_VLForConditionalGeneration"],
+            image_token_id=101,
+            vision_start_token_id=100,
+            vision_end_token_id=102,
+            video_token_id=103,
+            vision_config=SimpleNamespace(spatial_merge_size=2),
+        ),
+    )
+    engine_args = SimpleNamespace(
+        enable_mm_embeds=True,
+        enable_prompt_embeds=False,
+        language_model_only=False,
+        tensor_parallel_size=1,
+        pipeline_parallel_size=1,
+        data_parallel_size=1,
+        compilation_config=SimpleNamespace(cudagraph_mm_encoder=False),
+    )
+    return BoundCustomEncoderAdapter(_QwenBackend(), model_config, engine_args)
+
+
+async def test_native_qwen_custom_encoder_prepares_external_mm_plan():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(
+        encode=AsyncMock(
+            return_value=[
+                Qwen2VLImageEncodingV1(
+                    torch.zeros((1, 4), dtype=torch.bfloat16),
+                    (1, 2, 2),
+                )
+            ]
+        )
+    )
+
+    plan, error = await handler._assemble_custom_encoder_prompt(
+        {
+            "token_ids": [100, 101, 102],
+            "multi_modal_data": {
+                "image_url": [{"Url": "data:image/png;base64,unused"}]
+            },
+        },
+        "request-id",
+        None,
+    )
+
+    assert error is None
+    assert isinstance(plan, NativeMMPlan)
+    assert plan.multi_modal_data["image"]["image_grid_thw"].tolist() == [[1, 2, 2]]
+
+
+async def test_native_qwen_custom_encoder_rejects_processor_kwargs():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(encode=AsyncMock())
+
+    plan, error = await handler._assemble_custom_encoder_prompt(
+        {
+            "token_ids": [100, 101, 102],
+            "multi_modal_data": {
+                "image_url": [{"Url": "data:image/png;base64,unused"}]
+            },
+            "mm_processor_kwargs": {"min_pixels": 1},
+        },
+        "request-id",
+        None,
+    )
+
+    assert plan is None
+    assert error is not None
+    assert "mm_processor_kwargs" in error["finish_reason"]["error"]
+    handler._custom_encoder.encode.assert_not_awaited()

--- a/docs/features/multimodal/custom-vision-encoder.md
+++ b/docs/features/multimodal/custom-vision-encoder.md
@@ -7,9 +7,9 @@ subtitle: Run a bespoke vision tower in an aggregated Dynamo vLLM worker
 
 A custom vision encoder lets an aggregated `dynamo.vllm` worker use an
 author-provided vision tower or projector instead of vLLM's built-in multimodal
-encoder. The encoder runs in the worker process, produces one embedding tensor
-per image, and Dynamo inserts those embeddings at the image-placeholder positions
-of a mixed prompt.
+encoder. The encoder runs in the worker process and produces encoded media for
+each image. Dynamo chooses a mixed prompt-embedding route or a model-native
+external multimodal route from the backend's setup-time contract.
 
 Use this path when the language model can consume external prompt embeddings but
 the vision encoder is private, experimental, or otherwise unavailable in vLLM.
@@ -24,14 +24,31 @@ process and GPU, and no embedding transfer occurs.
 | Topology | Aggregated only |
 | Input | `image_url` content |
 | Video and audio | Not supported |
-| Language-model input | Mixed token IDs and prompt embeddings |
+| Language-model input | Mixed prompt embeddings, or native Qwen2/2.5 multimodal embeddings |
 | Cross-request batching | Yes |
 | CUDA graph bucket selection | Reserved for future support; current dispatch is eager |
 
-The custom-encoder path requires `--enable-multimodal` and
-`--enable-prompt-embeds`. It is incompatible with frontend decoding, the vLLM
+The custom-encoder path requires `--enable-multimodal`. Linear-row backends also
+require `--enable-prompt-embeds`; Qwen2/2.5 native-multimodal backends require
+`--enable-mm-embeds`. It is incompatible with frontend decoding, the vLLM
 tokenizer mode, legacy multimodal worker roles, and non-aggregated disaggregation
 modes. Dynamo validates these combinations during startup.
+
+The native Qwen adapter is currently validated against vLLM 0.24.0 and 0.25.1
+(current Dynamo main pins 0.25.1). It requires TP=PP=DP=1 and rejects
+`--language-model-only` and vLLM multimodal-encoder CUDA graphs. The latter graph
+path expects pixel inputs and is not compatible with external image embeddings.
+Prefix caching and chunked prefill are also rejected in the correctness MVP until
+their image-span boundary and cache-identity parity matrices are complete; the
+included launcher disables both in native mode.
+
+| Backend result | Engine request | Position semantics |
+| --- | --- | --- |
+| Legacy tensor or `LinearRowsV1` | `EmbedsPrompt` | Ordinary one-dimensional positions |
+| `Qwen2VLImageEncodingV1(projected, grid_thw)` | `TokensPrompt` with `image_embeds` and `image_grid_thw` | Qwen grid-driven M-RoPE |
+
+Qwen backends must use the native route. A mixed `EmbedsPrompt` has no place for
+`image_grid_thw`, so vLLM would assign ordinary text positions to the image rows.
 
 ## Run the Included Path
 
@@ -55,9 +72,27 @@ DYN_ENCODER_CLASS=my_package.encoders.MyVisionEncoder \
 bash examples/custom_encoder/launch/agg_custom.sh --gpu 0
 ```
 
-The launcher supplies the required multimodal and prompt-embedding flags. If the
+The launcher supplies the required multimodal and selected engine-input flag. If the
 language model's chat template does not render an image-placeholder token, also
 provide `DYN_CUSTOM_JINJA_TEMPLATE` or `--custom-jinja-template`.
+
+To run the eager Qwen2.5-VL correctness backend with the registered full model
+wrapper, select the native input mode:
+
+```bash
+DYN_MODEL=Qwen/Qwen2.5-VL-3B-Instruct \
+DYN_ENCODER_CLASS=examples.custom_encoder.qwen2_5_vl_vision_encoder.Qwen2_5VLVisionEncoder \
+DYN_ENCODER_INPUT_MODE=native \
+bash examples/custom_encoder/launch/agg_custom.sh --gpu 0 \
+  --revision 66285546d2b821cf421d4f5eb2576359d3770cd3
+```
+
+The included backend accepts base64 image data URLs and is intentionally eager.
+It loads the stock vision tower outside vLLM for parity testing. The full Qwen
+wrapper remains resident inside vLLM, but supplying external image embeddings
+skips that wrapper's vision forward for the request. vLLM may still execute its
+resident tower during startup profiling; this MVP does not claim zero tower
+forwards across the entire process lifecycle.
 
 <Warning>
 The backend owns any media retrieval performed by `preprocess()`. Apply Dynamo's
@@ -74,16 +109,41 @@ implement the following contract:
 
 | Member | Execution context | Responsibility |
 | --- | --- | --- |
-| `image_token_id` | Configuration | Hardcoded placeholder token ID used by the model or custom template |
+| `encoding_spec` | Configuration | Optional typed output/engine-adapter handshake; omitted for legacy tensor backends |
+| `image_token_id` | Configuration | Placeholder token ID for the linear route; unused by native Qwen adapters |
 | `build(model_id)` | Encoder actor thread, once | Load the encoder, choose its device, and initialize thread-affine resources |
 | `preprocess(raw)` | Optional CPU thread pool | Fetch, decode, resize, or patchify one image and return `Preprocessed(item, cost)` |
-| `forward_batch(items, target_bucket=None)` | Encoder actor thread | Run one synchronous batched forward and return one CPU tensor per item, in order |
+| `forward_batch(items, target_bucket=None)` | Encoder actor thread | Return legacy CPU tensors, or correlation-tagged typed media declared by `encoding_spec` |
 | `close()` | Encoder actor thread, once | Release thread-affine resources |
 
 `forward_batch()` returns one tensor shaped
 `(number_of_visual_tokens, language_model_hidden_size)` for every input item. It
 must synchronize any device work and copy the results to CPU before returning;
 the request coroutine consumes them from a different thread.
+
+A typed backend declares `BackendEncodingSpecV1`. Dynamo then passes
+`ForwardItemV1(correlation_id, item)` values and expects
+`EncodedMediaResultV1(correlation_id, media)` values. Results may be returned in
+any order: Dynamo verifies a complete correlation-ID bijection, restores input
+order, validates every tensor, and clones it into owned CPU storage before the
+batcher resolves request futures.
+
+For Qwen2/2.5, set `adapter_abi="vllm-qwen2-vl-external-v1"` and return one
+`Qwen2VLImageEncodingV1` per image. Its `projected` tensor has shape
+`(T * H * W / spatial_merge_size**2, decoder_hidden_size)` and `grid_thw` is the
+corresponding positive `(T, H, W)` tuple. The initial image-only contract requires
+`T == 1` and CPU, dense, contiguous, finite tensors in the declared dtype.
+The tensor is after the vision projector/patch merger and is in canonical
+`(t, merged_h, merged_w)` raster order. In particular, Qwen2.5 producers must
+apply the model's inverse window permutation before returning it. A tensor in the
+temporary window order has the right shape but receives spatially incorrect
+M-RoPE positions.
+
+Native Qwen specs must provide `expected_decoder_config_fingerprint`; matching
+only hidden width and dtype is not sufficient to establish projector/decoder
+compatibility. The producer fingerprint should bind the encoder/projector
+weights, processor and tokenizer revisions, resize/normalization policy, and row
+layout version used to produce the artifact.
 
 Preprocessing is disabled by default. To enable it, override `preprocess()` and
 set `preprocess_concurrency` to a positive value. The method must be synchronous,
@@ -131,6 +191,11 @@ The encoder and vLLM share GPU memory. Leave enough memory outside vLLM's
 `gpu_memory_utilization` for the encoder weights and the peak activation memory
 at `max_batch_cost`, and exercise that maximum legal batch during startup or
 deployment validation.
+
+The included Qwen2.5 correctness backend runs a near-maximum square-image canary
+during `build()`, after the vLLM engine has allocated its model and KV cache. A
+co-residency failure therefore stops startup instead of becoming the first legal
+request's OOM.
 
 ### Failure and Cancellation Behavior
 

--- a/docs/features/multimodal/custom-vision-encoder.md
+++ b/docs/features/multimodal/custom-vision-encoder.md
@@ -50,6 +50,114 @@ included launcher disables both in native mode.
 Qwen backends must use the native route. A mixed `EmbedsPrompt` has no place for
 `image_grid_thw`, so vLLM would assign ordinary text positions to the image rows.
 
+## How `BoundCustomEncoderAdapter` Fits
+
+`BoundCustomEncoderAdapter` is the compatibility boundary between an
+author-provided backend and the loaded vLLM model. "Bound" means it validates one
+backend's setup-time contract against one resolved model configuration. It then
+translates that backend's canonical request results into a closed engine prompt
+plan. It does not fetch images, schedule batches, execute the vision model, or
+calculate M-RoPE.
+
+At startup:
+
+```
+ +---------------------------+       +---------------------------+
+ | VisionEncoderBackend      |       | resolved vLLM config      |
+ | - encoding_spec           |       | - architecture            |
+ | - producer fingerprint    |       | - hidden size / dtype     |
+ | - output geometry         |       | - merge size / token IDs  |
+ +-------------+-------------+       | - flags and TP/PP/DP      |
+               |                     +-------------+-------------+
+               |                                   |
+               +------------------+----------------+
+                                  |
+                                  v
+                   +-------------------------------+
+                   | BoundCustomEncoderAdapter     |
+                   | - validate ABI/model match    |
+                   | - validate vLLM version       |
+                   | - validate flags/topology     |
+                   | - select prompt route         |
+                   | - remember Qwen token IDs     |
+                   +---------------+---------------+
+                                   |
+                          mismatch | match
+                            +------+------+
+                            |             |
+                            v             v
+                      fail startup   load encoder
+```
+
+For each request:
+
+```
+ token IDs + image inputs
+           |
+           v
+ +---------------------------+
+ | AsyncVisionEncoder        |
+ | preprocess all-or-nothing |
+ +-------------+-------------+
+               |
+               v
+ +---------------------------+
+ | ThreadedMicroBatcher      |
+ | cross-request actor       |
+ +-------------+-------------+
+               |
+               v
+ +---------------------------+
+ | VisionEncoderBackend      |
+ | forward_batch             |
+ +-------------+-------------+
+               |
+               | tagged encoded-media results
+               v
+ +---------------------------+
+ | reconcile_and_canonicalize|
+ | validate, reorder, clone  |
+ +-------------+-------------+
+               |
+               v
+ +---------------------------+
+ | BoundCustomEncoderAdapter |
+ | prepare_prompt_plan       |
+ +-------------+-------------+
+               |
+       +-------+-------+
+       |               |
+       v               v
+ MixedEmbedsPlan   NativeMMPlan
+       |               |
+       v               v
+ EmbedsPrompt      TokensPrompt
+                       |
+                       v
+              vLLM computes Qwen M-RoPE
+```
+
+The adapter selects the route from `encoding_spec.adapter_abi`:
+
+```
+ linear-rows-v1
+     |
+     +--> splice visual rows into the text embedding sequence
+     +--> MixedEmbedsPlan --> EmbedsPrompt
+
+ vllm-qwen2-vl-external-v1
+     |
+     +--> concatenate projected image rows in request order
+     +--> stack image_grid_thw in the same order
+     +--> NativeMMPlan --> TokensPrompt
+     +--> vLLM expands placeholders and constructs grid-driven M-RoPE
+```
+
+Actor-side correlation and tensor-ownership checks are implemented by the
+separate `reconcile_and_canonicalize()` helper in the same adapter module. This
+keeps `ThreadedMicroBatcher` generic and torch-free while ensuring a backend
+cannot accidentally associate one image's rows with another image's grid.
+
 ## Run the Included Path
 
 From the repository root, launch the aggregated worker:

--- a/examples/custom_encoder/launch/agg_custom.sh
+++ b/examples/custom_encoder/launch/agg_custom.sh
@@ -9,10 +9,11 @@
 #   - Worker:   dynamo.vllm with a CustomEncoder loaded in-process
 #
 # The CustomEncoder is called for each multimodal request:
-#   1. encoder.encode(image_urls) → list[(n_visual_tokens, lm_hidden_dim)]
-#   2. Dynamo builds a mixed token-ids/embeds EmbedsPrompt: vLLM embeds the text
-#      itself and substitutes the encoder's image embeds at the placeholder span.
-#   3. vLLM engine runs transformer layers on the EmbedsPrompt.
+#   1. encoder.encode(image_urls) → typed encoded-media results
+#   2. Dynamo selects the backend-declared engine adapter:
+#      - linear rows → mixed token-ids/embeds EmbedsPrompt
+#      - Qwen2/2.5 rows + grid → native multimodal TokensPrompt
+#   3. vLLM runs the language model without invoking a custom backend's tower.
 #
 # No separate encode worker, no NIXL inter-process transfer.
 #
@@ -42,6 +43,7 @@ source "$SCRIPT_DIR/../../common/launch_utils.sh"
 # ── Defaults ──────────────────────────────────────────────────────────────────
 MODEL="${DYN_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}"
 ENCODER_CLASS="${DYN_ENCODER_CLASS:-examples.custom_encoder.hitchhikers_vision_encoder.HitchhikersVisionEncoder}"
+ENCODER_INPUT_MODE="${DYN_ENCODER_INPUT_MODE:-linear}"
 # Precedence: explicit DYN_WORKER_GPU/--gpu > harness-set CUDA_VISIBLE_DEVICES
 # (e.g. the pytest profile runner) > device 0 (portable default; on a generic
 # host or single-GPU container, GPU 0 is the natural choice).
@@ -50,7 +52,7 @@ HTTP_PORT="${DYN_HTTP_PORT:-8000}"
 MAX_MODEL_LEN="${DYN_MAX_MODEL_LEN:-16384}"
 # A text-only LM's own chat template can't render image content parts, so default
 # to the bundled minimal template that emits the <|image_pad|> placeholder.
-CUSTOM_JINJA_TEMPLATE="${DYN_CUSTOM_JINJA_TEMPLATE:-$SCRIPT_DIR/../templates/qwen_vl.jinja}"
+CUSTOM_JINJA_TEMPLATE="${DYN_CUSTOM_JINJA_TEMPLATE-}"
 EXTRA_ARGS=()
 
 # ── Argument parsing ──────────────────────────────────────────────────────────
@@ -60,6 +62,8 @@ while [[ $# -gt 0 ]]; do
             MODEL=$2; shift 2 ;;
         --encoder-class)
             ENCODER_CLASS=$2; shift 2 ;;
+        --encoder-input-mode)
+            ENCODER_INPUT_MODE=$2; shift 2 ;;
         --gpu)
             WORKER_GPU=$2; shift 2 ;;
         -h|--help)
@@ -71,15 +75,19 @@ Aggregated serving with a CustomEncoder (no separate encode worker).
 Options:
   --model <id>           LLM checkpoint (default: Qwen/Qwen2.5-1.5B-Instruct)
   --encoder-class <path> Dotted module.ClassName for CustomEncoder subclass
+  --encoder-input-mode <linear|native>
+                         Engine input route (default: linear)
   --gpu <index>          GPU index for the worker (default: 0)
   -h, --help             Show this help
 
 Environment variables:
   DYN_MODEL                      LLM model checkpoint
   DYN_ENCODER_CLASS              Dotted class path for the CustomEncoder subclass
+  DYN_ENCODER_INPUT_MODE         linear or native (default: linear)
   DYN_WORKER_GPU                 GPU index (default: 0)
-  DYN_CUSTOM_JINJA_TEMPLATE      Path to a .jinja chat template (defaults to the
-                                 bundled templates/qwen_vl.jinja)
+  DYN_CUSTOM_JINJA_TEMPLATE      Path to a .jinja chat template (linear mode
+                                 defaults to bundled templates/qwen_vl.jinja;
+                                 native mode uses the model default)
   DYN_CUSTOM_PHRASE             Phrase the HitchhikersEncoder embeds as the "image"
 EOF
             exit 0 ;;
@@ -87,6 +95,23 @@ EOF
             EXTRA_ARGS+=("$1"); shift ;;
     esac
 done
+
+if [[ "$ENCODER_INPUT_MODE" != "linear" && "$ENCODER_INPUT_MODE" != "native" ]]; then
+    echo "--encoder-input-mode must be 'linear' or 'native'" >&2
+    exit 2
+fi
+if [[ -z "$CUSTOM_JINJA_TEMPLATE" && "$ENCODER_INPUT_MODE" == "linear" ]]; then
+    CUSTOM_JINJA_TEMPLATE="$SCRIPT_DIR/../templates/qwen_vl.jinja"
+fi
+if [[ "$ENCODER_INPUT_MODE" == "native" ]]; then
+    ENCODER_ENGINE_ARGS=(
+        --enable-mm-embeds
+        --no-enable-prefix-caching
+        --no-enable-chunked-prefill
+    )
+else
+    ENCODER_ENGINE_ARGS=(--enable-prompt-embeds)
+fi
 
 # VRAM sizing: honors the profiler/test-harness override
 # (_PROFILE_OVERRIDE_VLLM_KV_CACHE_BYTES) when set, else falls back to a sane
@@ -97,6 +122,7 @@ GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
 print_launch_banner --no-curl "CustomEncoder — Aggregated Serving" "$MODEL" "$HTTP_PORT" \
     "Worker GPU:  $WORKER_GPU" \
     "Encoder:     $ENCODER_CLASS" \
+    "Input mode:  $ENCODER_INPUT_MODE" \
     "Jinja tmpl:  ${CUSTOM_JINJA_TEMPLATE:-(model default)}" \
     "NOTE: HitchhikersVisionEncoder fakes an image as a fixed-phrase embedding;" \
     "      replace with a real CustomEncoder subclass for production use."
@@ -119,7 +145,7 @@ python -m dynamo.vllm \
     --model "$MODEL" \
     --custom-encoder-class "$ENCODER_CLASS" \
     --enable-multimodal \
-    --enable-prompt-embeds \
+    "${ENCODER_ENGINE_ARGS[@]}" \
     --max-model-len "$MAX_MODEL_LEN" \
     $GPU_MEM_ARGS \
     "${JINJA_ARG[@]}" \

--- a/examples/custom_encoder/qwen2_5_vl_vision_encoder.py
+++ b/examples/custom_encoder/qwen2_5_vl_vision_encoder.py
@@ -1,0 +1,273 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Eager Qwen2.5-VL tower for validating native custom-encoder inputs."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import gc
+import io
+import logging
+import math
+import os
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import urlparse
+
+import torch
+from PIL import Image
+from transformers import AutoProcessor, Qwen2_5_VLForConditionalGeneration
+
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
+    BackendEncodingSpecV1,
+    EncodedMediaResultV1,
+    ForwardItemV1,
+    Preprocessed,
+    Qwen2VLImageEncodingV1,
+    VisionEncoderBackend,
+)
+
+logger = logging.getLogger(__name__)
+
+_MODEL_ID = "Qwen/Qwen2.5-VL-3B-Instruct"
+_MODEL_REVISION = "66285546d2b821cf421d4f5eb2576359d3770cd3"
+
+
+@dataclass(frozen=True)
+class Qwen2_5VLImageInputs:
+    """CPU processor output for one image."""
+
+    pixel_values: torch.Tensor
+    image_grid_thw: torch.Tensor
+
+
+class Qwen2_5VLVisionEncoder(VisionEncoderBackend[str, Qwen2_5VLImageInputs]):
+    """Run the public Qwen2.5-VL ViT/projector outside vLLM.
+
+    This correctness backend intentionally remains eager. It accepts base64 image
+    data URLs so the parity path does not introduce a second network-fetch policy;
+    production backends that fetch HTTP URLs must apply Dynamo's media URL policy.
+    """
+
+    encoding_spec = BackendEncodingSpecV1(
+        adapter_abi="vllm-qwen2-vl-external-v1",
+        producer_fingerprint=(
+            f"qwen2.5-vl-3b@{_MODEL_REVISION}:"
+            "hf-auto-processor-same-revision:post-merger-canonical-raster-v1"
+        ),
+        expected_decoder_config_fingerprint=(
+            f"model={_MODEL_ID}:revision={_MODEL_REVISION}:"
+            "Qwen2_5_VLForConditionalGeneration:hidden=2048:merge=2:"
+            "dtype=torch.bfloat16"
+        ),
+        output_dtype="bfloat16",
+        hidden_size=2048,
+        spatial_merge_size=2,
+    )
+    preprocess_concurrency = int(
+        os.environ.get("DYN_QWEN2_5_VL_PREPROCESS_CONCURRENCY", "4")
+    )
+    max_batch_cost = int(os.environ.get("DYN_QWEN2_5_VL_MAX_BATCH_TOKENS", "2048"))
+
+    def __init__(self) -> None:
+        self._device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self._processor: Any | None = None
+        self._visual: Any | None = None
+
+    def build(self, model_id: str) -> None:
+        if model_id != _MODEL_ID:
+            raise ValueError(
+                f"{type(self).__name__} is validated only for {_MODEL_ID}; "
+                f"got {model_id}"
+            )
+        if self.preprocess_concurrency < 1:
+            raise ValueError("DYN_QWEN2_5_VL_PREPROCESS_CONCURRENCY must be positive")
+        if self.max_batch_cost is None or self.max_batch_cost < 1:
+            raise ValueError("DYN_QWEN2_5_VL_MAX_BATCH_TOKENS must be positive")
+
+        self._processor = AutoProcessor.from_pretrained(
+            model_id, revision=_MODEL_REVISION
+        )
+        full_model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
+            model_id,
+            revision=_MODEL_REVISION,
+            torch_dtype=torch.bfloat16,
+            low_cpu_mem_usage=True,
+            attn_implementation="eager",
+        )
+        model = getattr(full_model, "model", full_model)
+        visual = getattr(model, "visual", None)
+        if visual is None:
+            visual = getattr(full_model, "visual", None)
+        if visual is None:
+            raise RuntimeError("Qwen2.5-VL checkpoint does not expose a vision tower")
+        self._visual = visual.eval().to(self._device)
+
+        if hasattr(model, "visual"):
+            model.visual = None
+        elif hasattr(full_model, "visual"):
+            full_model.visual = None
+        del model, full_model
+        gc.collect()
+        self._run_startup_canary()
+        logger.info(
+            "%s loaded %s on %s",
+            type(self).__name__,
+            model_id,
+            self._device,
+        )
+
+    def preprocess(self, raw: str) -> Preprocessed[Qwen2_5VLImageInputs]:
+        image = self._decode_data_url(raw)
+        return self._process_image(image)
+
+    def _process_image(self, image: Image.Image) -> Preprocessed[Qwen2_5VLImageInputs]:
+        processor = self._require_processor()
+        inputs = processor.image_processor(images=[image], return_tensors="pt")
+        grid = inputs["image_grid_thw"].to(dtype=torch.int64, device="cpu")
+        if grid.shape != (1, 3):
+            raise ValueError(
+                "Qwen2.5-VL processor must return one image_grid_thw row; "
+                f"got {tuple(grid.shape)}"
+            )
+        merge_size = self.encoding_spec.spatial_merge_size
+        if merge_size is None:
+            raise RuntimeError("Qwen2.5-VL spatial_merge_size is not configured")
+        cost = int(grid.prod().item() // (merge_size**2))
+        return Preprocessed(
+            item=Qwen2_5VLImageInputs(
+                pixel_values=inputs["pixel_values"].contiguous(),
+                image_grid_thw=grid,
+            ),
+            cost=cost,
+        )
+
+    def _run_startup_canary(self) -> None:
+        """Exercise a near-maximum square image with both GPU tenants resident."""
+        visual = self._require_visual()
+        processor = self._require_processor()
+        image_processor = processor.image_processor
+        patch_size = getattr(image_processor, "patch_size", None)
+        merge_size = self.encoding_spec.spatial_merge_size
+        max_cost = self.max_batch_cost
+        if (
+            not isinstance(patch_size, int)
+            or isinstance(patch_size, bool)
+            or patch_size < 1
+            or merge_size is None
+            or max_cost is None
+        ):
+            raise RuntimeError("Qwen2.5-VL startup canary configuration is invalid")
+        grid_side = math.isqrt(max_cost * (merge_size**2))
+        grid_side -= grid_side % merge_size
+        if grid_side < merge_size:
+            raise RuntimeError("Qwen2.5-VL batch budget is too small for one image")
+        image_side = grid_side * patch_size
+        prepared = self._process_image(
+            Image.new("RGB", (image_side, image_side), color=(127, 127, 127))
+        )
+        if prepared.cost > max_cost:
+            raise RuntimeError(
+                "Qwen2.5-VL startup canary exceeded max_batch_cost: "
+                f"cost={prepared.cost}, max={max_cost}"
+            )
+        result = self.forward_batch(
+            [ForwardItemV1(correlation_id=b"startup-canary", item=prepared.item)]
+        )[0]
+        if result.media.projected.shape[0] != prepared.cost:
+            raise RuntimeError("Qwen2.5-VL startup canary returned the wrong row count")
+        del result, prepared
+        if visual.dtype != torch.bfloat16:
+            raise RuntimeError(
+                f"Qwen2.5-VL visual tower must use bfloat16, got {visual.dtype}"
+            )
+        if torch.cuda.is_available():
+            torch.cuda.synchronize(self._device)
+            torch.cuda.empty_cache()
+        logger.info(
+            "%s startup co-residency canary passed at %dx%d",
+            type(self).__name__,
+            image_side,
+            image_side,
+        )
+
+    def forward_batch(
+        self,
+        items: list[ForwardItemV1[Qwen2_5VLImageInputs]],
+        target_bucket: int | None = None,
+    ) -> list[EncodedMediaResultV1]:
+        if target_bucket is not None:
+            raise ValueError(
+                "Qwen2.5-VL correctness backend does not use graph buckets"
+            )
+        if not items:
+            raise ValueError("forward_batch requires at least one image")
+        visual = self._require_visual()
+        raw_items = [item.item for item in items]
+        grid_cpu = torch.cat(
+            [item.image_grid_thw for item in raw_items], dim=0
+        ).contiguous()
+        pixel_values = torch.cat([item.pixel_values for item in raw_items], dim=0).to(
+            device=self._device, dtype=visual.dtype
+        )
+        grid_device = grid_cpu.to(self._device)
+
+        with torch.inference_mode():
+            image_embeds = visual(pixel_values, grid_thw=grid_device)
+            image_embeds = getattr(image_embeds, "pooler_output", image_embeds)
+        merge_size = self.encoding_spec.spatial_merge_size
+        if merge_size is None:
+            raise RuntimeError("Qwen2.5-VL spatial_merge_size is not configured")
+        split_sizes = (grid_cpu.prod(dim=-1) // (merge_size**2)).tolist()
+        host_embeds = image_embeds.to(dtype=torch.bfloat16, device="cpu").contiguous()
+        split_embeds = torch.split(host_embeds, split_sizes)
+
+        return [
+            EncodedMediaResultV1(
+                correlation_id=tagged.correlation_id,
+                media=Qwen2VLImageEncodingV1(
+                    projected=projected,
+                    grid_thw=tuple(int(value) for value in raw.image_grid_thw[0]),
+                ),
+            )
+            for tagged, raw, projected in zip(items, raw_items, split_embeds)
+        ]
+
+    def close(self) -> None:
+        self._visual = None
+        self._processor = None
+        gc.collect()
+        if torch.cuda.is_available():
+            torch.cuda.empty_cache()
+
+    def _require_processor(self) -> Any:
+        if self._processor is None:
+            raise RuntimeError("Qwen2.5-VL processor is not loaded")
+        return self._processor
+
+    def _require_visual(self) -> Any:
+        if self._visual is None:
+            raise RuntimeError("Qwen2.5-VL vision tower is not loaded")
+        return self._visual
+
+    @staticmethod
+    def _decode_data_url(source: str) -> Image.Image:
+        parsed = urlparse(source)
+        if parsed.scheme != "data" or not parsed.path.startswith("image/"):
+            raise ValueError(
+                "Qwen2.5-VL correctness backend accepts base64 image data URLs only"
+            )
+        try:
+            media_type, payload = parsed.path.split(",", 1)
+        except ValueError as exc:
+            raise ValueError("invalid image data URL: missing comma") from exc
+        if ";base64" not in media_type:
+            raise ValueError("image data URL must be base64 encoded")
+        try:
+            image_bytes = base64.b64decode(payload, validate=True)
+        except binascii.Error as exc:
+            raise ValueError("image data URL contains invalid base64") from exc
+        with Image.open(io.BytesIO(image_bytes)) as image:
+            return image.convert("RGB")


### PR DESCRIPTION
## Why

Qwen2/2.5-VL cannot safely consume custom vision outputs through the existing mixed `EmbedsPrompt` path because that request omits `image_grid_thw`, so vLLM cannot construct grid-driven M-RoPE. This adds a fail-closed native external-multimodal route while preserving legacy linear backends. The first correctness slice keeps the full wrapper resident and narrowly validates one Qwen2.5 configuration; tower-free and Qwen3 DeepStack remain follow-ups.

## Effect

`TokensPrompt` retains canonical token IDs and carries:

- `image_embeds: [sum visual tokens, hidden]`
- `image_grid_thw: [images, 3]`

## What Change

- Add typed encoded-media contracts and model-aware prompt adapters.
- Add exact eager Qwen2.5 backend with startup co-residency canary.
- Preserve legacy mixed embeddings and harden lifecycle/cache identity.

## Test Plan

- 103 focused vLLM custom-encoder tests.
- Full Qwen2.5 native-embedding request on vLLM 0.25.1.