### PR TITLE
fix(trtllm): honor conversation-affinity override on unified engine path

### DIFF
--- a/components/src/dynamo/trtllm/llm_engine.py
+++ b/components/src/dynamo/trtllm/llm_engine.py
@@ -142,6 +142,7 @@ class TrtllmLLMEngine(LLMEngine):
         disaggregation_mode: DisaggregationMode = DisaggregationMode.AGGREGATED,
         component: str = "backend",
         publish_events_and_metrics: bool = False,
+        conversation_affinity: bool = False,
     ):
         self.engine_args = engine_args
         self.model_name = model_name
@@ -195,6 +196,9 @@ class TrtllmLLMEngine(LLMEngine):
         # Default False so generate() is safe if reached before initialize()
         # (e.g. unit tests that drive generate directly).
         self._conversation_affinity: bool = False
+        # Manual override (--conversation-affinity / DYN_ENGINE_CONV_AFFINITY) to force
+        # engine-side conversation-affinity assignment regardless of engine detection.
+        self._engine_conversation_affinity_override: bool = conversation_affinity
         # Worker invokes on_ready callbacks serially during setup (see
         # `setup_kv_publishers` in lib/backend-common/src/publisher.rs); the
         # dict is fully populated before `_kv_events_thread` starts and
@@ -330,6 +334,7 @@ class TrtllmLLMEngine(LLMEngine):
             disaggregation_mode=config.disaggregation_mode,
             component=config.component,
             publish_events_and_metrics=config.publish_events_and_metrics,
+            conversation_affinity=config.conversation_affinity,
         )
         worker_config = WorkerConfig.from_runtime_config(
             config,
@@ -879,8 +884,24 @@ class TrtllmLLMEngine(LLMEngine):
         # the engine side (always record the binding, whether the rank came
         # from explicit placement or fresh selection). Track upstream and drop
         # this note when the router records unconditionally.
+        # Force engine-side conversation-affinity assignment when the operator set
+        # --conversation-affinity / DYN_ENGINE_CONV_AFFINITY, even if the engine did
+        # not advertise the capability at initialize() time. Mirrors the legacy
+        # HandlerBase path so both entry points behave identically.
+        conv_affinity = (
+            self._conversation_affinity or self._engine_conversation_affinity_override
+        )
+        if (
+            self._engine_conversation_affinity_override
+            and not CONVERSATION_PARAMS_AVAILABLE
+        ):
+            raise RuntimeError(
+                "--conversation-affinity / DYN_ENGINE_CONV_AFFINITY is set but "
+                "the installed TensorRT-LLM build has no ConversationParams API (requires a "
+                "release newer than 1.3.0rc20)."
+            )
         conversation_params = None
-        if self._conversation_affinity:
+        if conv_affinity:
             scheduling_params = None
             conversation_params = conversation_params_for(
                 session_id_from_request(request)
@@ -908,9 +929,7 @@ class TrtllmLLMEngine(LLMEngine):
         # Only pass conversation_params when affinity is active — older TRT-LLM builds'
         # generate_async does not accept the keyword.
         conv_kwargs = (
-            {"conversation_params": conversation_params}
-            if self._conversation_affinity
-            else {}
+            {"conversation_params": conversation_params} if conv_affinity else {}
         )
         generation_result = self._engine.llm.generate_async(
             inputs=token_ids,

--- a/components/src/dynamo/trtllm/tests/test_trtllm_engine_conversation_affinity.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_engine_conversation_affinity.py
@@ -14,6 +14,11 @@ Exercises the four branches of ``_generate_started`` around
   ``conversation_params.conversation_id == session_id``.
 * on + no session id → ``scheduling_params=None`` and ``conversation_params=None``
   (the kwarg is still passed so the engine's no-id balancing fallback runs).
+
+Plus the manual ``--conversation-affinity`` / ``DYN_ENGINE_CONV_AFFINITY`` override
+(``_engine_conversation_affinity_override``), which forces the affinity branch even when
+engine detection is off and raises when the ConversationParams API is missing — matching
+the legacy ``HandlerBase`` override tests.
 """
 
 from __future__ import annotations
@@ -81,6 +86,9 @@ def _make_engine(
     engine._no_inflight_requests.set()
     engine._reject_new_requests = False
     engine._conversation_affinity = conversation_affinity
+    # Manual override (--conversation-affinity / DYN_ENGINE_CONV_AFFINITY); off by
+    # default, individual tests flip it to exercise the override path.
+    engine._engine_conversation_affinity_override = False
     engine._attention_dp_size = attention_dp_size
     engine._override_sampling_params = lambda default, request: SimpleNamespace(
         max_tokens=None
@@ -189,3 +197,68 @@ async def test_affinity_on_without_session_id_passes_none_conversation_params(
     assert captured["scheduling_params"] is None
     assert "conversation_params" in captured
     assert captured["conversation_params"] is None
+
+
+async def test_override_suppresses_dp_rank_and_forwards_conversation_params(
+    monkeypatch,
+):
+    """DYN_ENGINE_CONV_AFFINITY override=True + engine detection disabled →
+    dp_rank suppressed, conversation_params forwarded. Mirrors the legacy
+    HandlerBase override test so both entry points stay in lockstep."""
+    monkeypatch.setattr(
+        "dynamo.trtllm.conversation_affinity.ConversationParams",
+        _FakeConversationParams,
+    )
+
+    captured: dict = {}
+
+    def fake_generate_async(**kwargs):
+        captured.update(kwargs)
+        return _empty_async_iter()
+
+    # Engine detection returns False (no engine-side affinity config)...
+    engine = _make_engine(
+        fake_generate_async, conversation_affinity=False, attention_dp_size=8
+    )
+    # ...but the operator forced it via DYN_ENGINE_CONV_AFFINITY.
+    engine._engine_conversation_affinity_override = True
+    # Router still stamps a rank; the override must ignore it just like
+    # auto-detection does.
+    await _drain(
+        engine,
+        {
+            "token_ids": [1, 2, 3],
+            "routing": {"dp_rank": 3},
+            "agent_context": {"session_id": "run-99:agent-0"},
+        },
+    )
+
+    assert captured["scheduling_params"] is None
+    conv_params = captured["conversation_params"]
+    assert conv_params is not None
+    assert conv_params.conversation_id == "run-99:agent-0"
+
+
+async def test_override_raises_when_conversation_params_api_missing(monkeypatch):
+    """DYN_ENGINE_CONV_AFFINITY=true on a build without ConversationParams →
+    RuntimeError in _generate_started, before generate_async is called."""
+    monkeypatch.setattr(
+        "dynamo.trtllm.llm_engine.CONVERSATION_PARAMS_AVAILABLE",
+        False,
+    )
+
+    called = False
+
+    def fake_generate_async(**kwargs):
+        nonlocal called
+        called = True
+        return _empty_async_iter()
+
+    engine = _make_engine(
+        fake_generate_async, conversation_affinity=False, attention_dp_size=8
+    )
+    engine._engine_conversation_affinity_override = True
+
+    with pytest.raises(RuntimeError, match="DYN_ENGINE_CONV_AFFINITY"):
+        await _drain(engine, {"token_ids": [1, 2, 3]})
+    assert called is False


### PR DESCRIPTION
## Summary

Follow-up to #11705. That PR exposed `--conversation-affinity` / `DYN_ENGINE_CONV_AFFINITY` to force engine-side conversation-affinity ADP routing — suppress the dynamo-router-selected attention-DP rank and let the engine assign it from the conversation id — but only wired the override into the **legacy** `HandlerBase` path (`python -m dynamo.trtllm` → `init_llm_worker`).

The **unified** `TrtllmLLMEngine` path (`python -m dynamo.trtllm.unified_main`, selected by the launch scripts' `--unified` flag) parses the same flag via the shared `parse_args` / `DynamoTrtllmConfig` but never consumed it — `_generate_started` gated solely on the engine-detected `self._conversation_affinity`. So `--unified --conversation-affinity` was a silent no-op.

This PR plumbs the override through the unified path, mirroring `HandlerBase` exactly:

- `TrtllmLLMEngine.__init__` accepts `conversation_affinity` → `self._engine_conversation_affinity_override`
- `from_args` passes `conversation_affinity=config.conversation_affinity`
- `_generate_started` computes `conv_affinity = self._conversation_affinity or self._engine_conversation_affinity_override`, raises if the override is set on a build without the `ConversationParams` API, and uses `conv_affinity` for both the affinity branch and the `conversation_params` kwarg gate

Test coverage is aligned with the legacy path: two override tests added to `test_trtllm_engine_conversation_affinity.py` mirror the legacy `TestConversationAffinity` override tests — override suppresses the router rank + forwards `conversation_params`, and override + missing API → `RuntimeError`.

## Validation

- `python -m py_compile` clean on both files
- `black --check` and `ruff check` pass
- Two new unit tests mirror the legacy override tests (`test_override_suppresses_dp_rank_and_forwards_conversation_params`, `test_override_raises_when_conversation_params_api_missing`); run in the trtllm CI container under `pytest -m "unit and trtllm"`, skipped locally where `tensorrt_llm` isn't importable

> Stacked on `gluo/env_overwrite` (#11705) — depends on that PR's `conversation_affinity` config field. Base will auto-retarget to `main` when #11705 merges.
