### PR TITLE
fix(benchmarks): drop synthetic-only flag from trace runs [DYN-3379] [cherry-pick → release/1.3.0]

### DIFF
--- a/benchmarks/router/agent_benchmark.py
+++ b/benchmarks/router/agent_benchmark.py
@@ -73,8 +73,6 @@ def get_aiperf_cmd(
         str(concurrency),
         "--request-count",
         str(request_count),
-        "--prompt-input-tokens-block-size",
-        str(block_size),
         "--random-seed",
         str(seed),
         "--artifact-dir",

--- a/benchmarks/router/common.py
+++ b/benchmarks/router/common.py
@@ -196,8 +196,6 @@ def get_aiperf_cmd_for_trace(
         "mooncake_trace",
         "--fixed-schedule",
         "--fixed-schedule-auto-offset",
-        "--prompt-input-tokens-block-size",
-        str(block_size),
         "--random-seed",
         str(seed),
         "--artifact-dir",


### PR DESCRIPTION
## Summary

- Backport #11733 to release/1.3.0.
- Remove the synthetic-only prompt block-size flag from trace benchmark AIPerf commands.

## Validation

Not run (argument removal only); source PR #11733 passed full CI.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11746" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->