### PR TITLE
fix(frontend): preserve SGLang reasoning delimiters

### DIFF
--- a/components/src/dynamo/frontend/sglang_prepost.py
+++ b/components/src/dynamo/frontend/sglang_prepost.py
@@ -950,9 +950,9 @@ class SglangStreamingPostProcessor:
             tool_call_parser_name
         )
         self._fast_plain_text = tool_call_parser is None and reasoning_parser is None
-        # Preserve special tokens when a tool call parser is active so
-        # delimiter tokens (e.g. <|tool_call|>) remain visible to the parser.
-        self._skip_special_tokens = tool_call_parser is None
+        # Preserve special tokens when a parser is active so tool-call and
+        # reasoning delimiters remain visible during incremental decoding.
+        self._skip_special_tokens = self._fast_plain_text
         self._is_json_array_parser = isinstance(tool_call_parser, JsonArrayParser)
         # Required/named guided output may be either bare JSON or
         # reasoning followed by JSON. Delay only the ambiguous bracket-leading

--- a/components/src/dynamo/frontend/sglang_processor.py
+++ b/components/src/dynamo/frontend/sglang_processor.py
@@ -25,6 +25,7 @@ from dynamo.llm import ModelCardInstanceId, PythonAsyncEngine, RoutedEngine
 from dynamo.llm.exceptions import InvalidArgument, Unknown
 
 from .sglang_prepost import (
+    ReasoningParser,
     SglangStreamingPostProcessor,
     ToolCallParserType,
     _client_wants_separate_reasoning,
@@ -231,6 +232,7 @@ def _preprocess_worker(
         eos_token_ids,
         pre.guided_decoding,
         pre.tool_call_parser,
+        pre.reasoning_parser,
         require_reasoning=_guided_tool_choice_requires_reasoning(
             request, pre.force_reasoning
         ),
@@ -256,6 +258,7 @@ def _build_dynamo_preproc(
     eos_token_ids: int | list[int] | None,
     guided_decoding: dict[str, Any] | None = None,
     tool_call_parser: ToolCallParserType | None = None,
+    reasoning_parser: ReasoningParser | None = None,
     require_reasoning: bool = False,
 ) -> dict[str, Any]:
     """Build the Dynamo preprocessed request dict from request fields."""
@@ -311,11 +314,11 @@ def _build_dynamo_preproc(
         "output_options": {
             "logprobs": logprobs_val,
             "prompt_logprobs": None,
-            # Preserve special tokens only when a tool-call parser is
-            # actually active — the parser needs delimiter tokens
-            # (e.g. <|tool_call|>) to detect calls. Mirrors the
-            # post-processor's _skip_special_tokens logic.
-            "skip_special_tokens": tool_call_parser is None,
+            # Preserve special tokens when a parser is active so delimiters
+            # remain visible. Mirrors the post-processor's decode behavior.
+            "skip_special_tokens": (
+                tool_call_parser is None and reasoning_parser is None
+            ),
             "return_tokens_as_token_ids": request.get("return_tokens_as_token_ids"),
         },
         "eos_token_ids": _normalize_eos_token_ids(eos_token_ids),
@@ -453,6 +456,7 @@ class SglangProcessor:
                 self.eos_token_ids,
                 pre.guided_decoding,
                 pre.tool_call_parser,
+                pre.reasoning_parser,
                 require_reasoning=_guided_tool_choice_requires_reasoning(
                     request, pre.force_reasoning
                 ),


### PR DESCRIPTION
## Summary

Preserve special delimiter tokens in the custom SGLang chat processor when either a tool-call or reasoning parser is active.

## Details

- Forward the active reasoning parser into backend output options.
- Keep parser delimiters visible during incremental detokenization so reasoning can populate `reasoning_content`.

## Validation

Not run; this PR intentionally contains no tests.

## Where should the reviewer start?

`components/src/dynamo/frontend/sglang_processor.py` and `components/src/dynamo/frontend/sglang_prepost.py`.

## Related Issues

- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming output handling when reasoning or tool-call parsing is enabled.
  * Special tokens are now preserved consistently during incremental text generation.
  * Aligned behavior across worker-based and single-process request processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->