### PR TITLE
fix(frontend): reject nested chat_template in chat_template_args

### DIFF
--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -531,6 +531,7 @@ impl OpenAIOutputOptionsProvider for NvCreateChatCompletionRequest {
 impl ValidateRequest for NvCreateChatCompletionRequest {
     fn validate(&self) -> Result<(), anyhow::Error> {
         validate::validate_no_unsupported_fields(&self.unsupported_fields)?;
+        validate::validate_chat_template_args(self.chat_template_args.as_ref())?;
         validate::validate_messages(&self.inner.messages)?;
         validate::validate_model(&self.inner.model)?;
         // none for store

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -804,6 +804,19 @@ where
     Ok(Some(value))
 }
 
+/// A nested `chat_template` bypasses Dynamo's top-level rejection and is
+/// promoted into the rendered template, so block it for every chat processor.
+pub fn validate_chat_template_args(
+    chat_template_args: Option<&std::collections::HashMap<String, serde_json::Value>>,
+) -> Result<(), anyhow::Error> {
+    if let Some(args) = chat_template_args
+        && args.contains_key("chat_template")
+    {
+        anyhow::bail!("`chat_template` is not supported inside `chat_template_args`");
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use std::collections::HashMap;
@@ -814,6 +827,23 @@ mod tests {
 
     fn unknown_fields() -> HashMap<String, serde_json::Value> {
         HashMap::from([("experimental_field".to_string(), json!("value"))])
+    }
+
+    #[test]
+    fn validate_chat_template_args_rejects_nested_chat_template() {
+        let args = HashMap::from([(
+            "chat_template".to_string(),
+            json!("{% for _ in range(10**9) %}x{% endfor %}"),
+        )]);
+        let err = validate_chat_template_args(Some(&args)).unwrap_err();
+        assert!(err.to_string().contains("chat_template"));
+    }
+
+    #[test]
+    fn validate_chat_template_args_accepts_other_keys() {
+        let args = HashMap::from([("enable_thinking".to_string(), json!(false))]);
+        validate_chat_template_args(Some(&args)).unwrap();
+        validate_chat_template_args(None).unwrap();
     }
 
     #[test]


### PR DESCRIPTION
#### Overview
Dynamo rejects a top-level `chat_template` field (it is not a trusted per-request input), but a `chat_template` nested inside `chat_template_args` / `chat_template_kwargs` bypassed that check: the renderer promotes the nested value into the actual chat template. That lets a client supply an arbitrary Jinja template and trigger the resource-exhaustion path of CVE-2025-61620 (vLLM's own serving gates this behind `trust_request_chat_template`; Dynamo calls the renderer directly and skipped it). This rejects the nested key during request validation, closing the bypass for every chat processor (vLLM, SGLang, default) at one boundary.

Repro:
```
curl http://localhost:8080/v1/chat/completions -H 'Content-Type: application/json' -d '{
  "model": "Qwen/Qwen3-0.6B",
  "messages": [{"role":"user","content":"hi"}],
  "chat_template_kwargs": {"chat_template": "{% for _ in range(10**9) %}x{% endfor %}"}
}'
```

Before: request is accepted and the attacker-supplied template is rendered.
After: `400` with Validation: `chat_template` is not supported inside `chat_template_args`.

#### Details
Adds `validate::validate_chat_template_args` in `lib/llm/src/protocols/openai/validate.rs`, which errors when the `chat_template_args` map (both public spellings deserialize into this one field) contains a `chat_template` key. It is called from `NvCreateChatCompletionRequest::validate()` right beside the existing top-level unsupported-field rejection, so it runs at the HTTP boundary before any processor or renderer sees the request. Two Rust unit tests cover the rejection and that unrelated keys / absent args still pass.

#### Related Issues
- Hardens against CVE-2025-61620 (nested chat-template injection); addresses a security finding raised in review of #11729.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for chat template arguments in chat completion requests.
  * Prevented nested `chat_template` values from being supplied through per-request arguments.
  * Invalid arguments now return a validation error earlier, while valid optional arguments continue to be accepted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->