### PR TITLE
perf(benchmarks): add vLLM prompt-embedding nsys profiler

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -489,6 +489,7 @@ areas:
   - benchmarks/mocker/bench_aic_rust_callback.py
   - benchmarks/nat_trace/
   - benchmarks/prefix_data_generator/
+  - benchmarks/profiling/
   - benchmarks/pyproject.toml
   - benchmarks/request_trace/README.md
   - benchmarks/request_trace/__init__.py

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -427,6 +427,7 @@
 /recipes/qwen3.6-35b/                                                        @ai-dynamo/dynamo-performance-codeowners
 /benchmarks/incluster/                                                       @ai-dynamo/dynamo-performance-codeowners
 /benchmarks/nat_trace/                                                       @ai-dynamo/dynamo-performance-codeowners
+/benchmarks/profiling/                                                       @ai-dynamo/dynamo-performance-codeowners
 /lib/bench/src/coding/                                                       @ai-dynamo/dynamo-performance-codeowners
 /lib/mocker/src/cache/                                                       @ai-dynamo/dynamo-performance-codeowners
 /recipes/gpt-oss-120b/                                                       @ai-dynamo/dynamo-performance-codeowners

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -54,6 +54,7 @@ aiperf plot artifacts/my-benchmark
 ## Directory Contents
 
 - **`incluster/`** — Kubernetes Job manifest for running benchmarks inside the cluster
+- **`profiling/`** — Reproducible GPU and runtime profiling utilities
 - **`router/`** — KV Router benchmarking scripts (prefix ratio, trace replay, agent, priority queue)
 - **`prefix_data_generator/`** — Tools for analyzing and synthesizing prefix-structured data
 

--- a/benchmarks/profiling/__init__.py
+++ b/benchmarks/profiling/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/profiling/vllm_prompt_embeddings/README.md
+++ b/benchmarks/profiling/vllm_prompt_embeddings/README.md
@@ -1,0 +1,76 @@
+<!-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved. -->
+<!-- SPDX-License-Identifier: Apache-2.0 -->
+
+# vLLM prompt-embedding nsys profiler
+
+This benchmark profiles the synchronous, offline vLLM `LLM.generate` path on
+one GPU. It creates one deterministic BF16 CPU tensor with shape
+`[515, hidden_size]`, reuses that exact tensor for every request, and requires
+75 greedily decoded output tokens. It does not call an HTTP API or tokenize
+text; the tensor is synthetic engine input intended for controlled profiling.
+
+The defaults run 20 unprofiled warmup requests followed by 100 sequential,
+batch-one measured requests with prefix caching enabled. Full CUDA graphs are
+requested for batch size one, the prefix-cache remainder, and the complete
+515-token prefill. The post-run audit fails unless every measured prefill and
+decode range contains a CUDA graph launch.
+
+## Requirements
+
+- One CUDA GPU supported by vLLM; the reference workload targets an H100.
+- vLLM with prompt embeddings and full CUDA graph support.
+- NVIDIA Nsight Systems (`nsys`) available on `PATH`.
+- The model already available locally when offline mode is enabled.
+
+## Run with nsys
+
+From the Dynamo repository root:
+
+```bash
+benchmarks/profiling/vllm_prompt_embeddings/run_nsys.sh \
+    qwen25-1.5b-prompt-embeds
+```
+
+The run directory defaults to
+`logs/nsys/vllm_prompt_embeddings/<run-id>` and must not already exist. Pass a
+second positional argument or set `DYN_NSYS_OUTPUT_BASE` to store it elsewhere.
+
+Common overrides are environment variables:
+
+```bash
+DYN_PROMPT_EMBEDS_REQUESTS=2 \
+DYN_PROMPT_EMBEDS_WARMUP_REQUESTS=0 \
+benchmarks/profiling/vllm_prompt_embeddings/run_nsys.sh smoke
+```
+
+The remaining overrides are `DYN_PROMPT_EMBEDS_MODEL`,
+`DYN_PROMPT_EMBEDS_PROMPT_TOKENS`, `DYN_PROMPT_EMBEDS_OUTPUT_TOKENS`,
+`DYN_PROMPT_EMBEDS_BLOCK_SIZE`, `DYN_PROMPT_EMBEDS_MAX_MODEL_LEN`,
+`DYN_PROMPT_EMBEDS_GPU_MEMORY_UTILIZATION`, and `DYN_PROMPT_EMBEDS_SEED`.
+Use `DYN_NSYS_STAGING_ROOT` when nsys needs a larger temporary filesystem.
+
+## Outputs
+
+Each run retains:
+
+- `requests.jsonl` and `summary.json` with per-request and aggregate latency.
+- The finalized `.nsys-rep` and exported SQLite database under `nsys/`.
+- `nsys-audit.json`, which records prefill and decode CUDA graph coverage.
+- Exact Python and nsys commands, source/dependency/GPU provenance, and hashes.
+- A copy and hashes of the exact profiling recipe used for the run.
+
+Open the `.nsys-rep` in Nsight Systems for timeline analysis, or query the
+SQLite export for repeatable attribution. A successful run prints
+`NSYS_AUDIT=PASS` followed by the observed prefill and decode graph counts.
+
+## Run without nsys
+
+The underlying experiment is also directly callable:
+
+```bash
+python3 -m benchmarks.profiling.vllm_prompt_embeddings.main \
+    --output-dir logs/prompt-embeddings
+```
+
+This still enforces the requested engine configuration and exact output length,
+but it does not produce or audit an nsys trace.

--- a/benchmarks/profiling/vllm_prompt_embeddings/__init__.py
+++ b/benchmarks/profiling/vllm_prompt_embeddings/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/benchmarks/profiling/vllm_prompt_embeddings/audit_nsys.py
+++ b/benchmarks/profiling/vllm_prompt_embeddings/audit_nsys.py
@@ -1,0 +1,244 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Fail closed unless prefill and decode use CUDA graphs in an nsys trace."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sqlite3
+from pathlib import Path
+from typing import Any
+
+EXECUTE_CONTEXT_RE = re.compile(
+    r"^execute_context_(?P<context_requests>\d+)\((?P<context_tokens>\d+)\)_"
+    r"generation_(?P<generation_requests>\d+)\((?P<generation_tokens>\d+)\)$"
+)
+
+
+def row_count(connection: sqlite3.Connection, table: str) -> int:
+    quoted = table.replace('"', '""')
+    return int(connection.execute(f'SELECT COUNT(*) FROM "{quoted}"').fetchone()[0])
+
+
+def load_execute_ranges(
+    connection: sqlite3.Connection,
+) -> list[dict[str, int | str]]:
+    rows = connection.execute(
+        """
+        SELECT N.start, N."end", N.globalTid, COALESCE(N.text, S.value)
+        FROM NVTX_EVENTS AS N
+        LEFT JOIN StringIds AS S ON S.id = N.textId
+        WHERE N."end" IS NOT NULL
+          AND COALESCE(N.text, S.value) LIKE 'execute_context_%'
+        """
+    ).fetchall()
+    ranges: list[dict[str, int | str]] = []
+    for start, end, global_tid, name in rows:
+        match = EXECUTE_CONTEXT_RE.match(str(name))
+        if match is None:
+            continue
+        ranges.append(
+            {
+                "start": int(start),
+                "end": int(end),
+                "global_tid": int(global_tid),
+                "name": str(name),
+                **{key: int(value) for key, value in match.groupdict().items()},
+            }
+        )
+    return ranges
+
+
+def graph_launches(connection: sqlite3.Connection) -> list[tuple[int, int]]:
+    return [
+        (int(start), int(global_tid))
+        for start, global_tid in connection.execute(
+            """
+            SELECT R.start, R.globalTid
+            FROM CUPTI_ACTIVITY_KIND_RUNTIME AS R
+            JOIN StringIds AS S ON S.id = R.nameId
+            WHERE S.value LIKE 'cudaGraphLaunch%'
+            """
+        )
+    ]
+
+
+def phase_graph_audit(
+    ranges: list[dict[str, int | str]],
+    launches: list[tuple[int, int]],
+) -> dict[str, Any]:
+    prefill_ranges = [
+        item
+        for item in ranges
+        if item["context_requests"] > 0 and item["generation_requests"] == 0
+    ]
+    decode_ranges = [item for item in ranges if item["generation_requests"] > 0]
+
+    def count_launches(item: dict[str, int | str]) -> int:
+        return sum(
+            1
+            for launch_start, global_tid in launches
+            if global_tid == item["global_tid"]
+            and item["start"] <= launch_start <= item["end"]
+        )
+
+    prefill_counts = [count_launches(item) for item in prefill_ranges]
+    decode_counts = [count_launches(item) for item in decode_ranges]
+    return {
+        "prefill_ranges": len(prefill_ranges),
+        "prefill_tokens": sorted(
+            {int(item["context_tokens"]) for item in prefill_ranges}
+        ),
+        "prefill_graph_launches": sum(prefill_counts),
+        "prefill_ranges_without_graph": sum(count == 0 for count in prefill_counts),
+        "decode_ranges": len(decode_ranges),
+        "decode_graph_launches": sum(decode_counts),
+        "decode_ranges_without_graph": sum(count == 0 for count in decode_counts),
+    }
+
+
+def audit(rep_path: Path, sqlite_path: Path, summary_path: Path) -> dict[str, Any]:
+    """Validate a finalized report, its SQLite export, and experiment summary."""
+    failures: list[str] = []
+    if rep_path.suffix != ".nsys-rep" or not rep_path.is_file():
+        failures.append(f"missing finalized nsys report: {rep_path}")
+    elif rep_path.stat().st_size <= 0:
+        failures.append(f"empty nsys report: {rep_path}")
+    if not sqlite_path.is_file() or sqlite_path.stat().st_size <= 0:
+        failures.append(f"missing nsys SQLite export: {sqlite_path}")
+    if not summary_path.is_file():
+        failures.append(f"missing experiment summary: {summary_path}")
+    if failures:
+        return {"accepted": False, "failures": failures}
+
+    summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    expected_requests = int(summary["config"]["requests"])
+    expected_output_tokens = int(summary["config"]["output_tokens"])
+    expected_prefill_ranges = expected_requests
+    expected_decode_ranges = expected_requests * (expected_output_tokens - 1)
+    resolved = summary["resolved_engine"]
+    prompt_tokens = int(summary["config"]["prompt_tokens"])
+    block_size = int(summary["config"]["block_size"])
+    prefix_cache_remainder = prompt_tokens % block_size or block_size
+    requested_capture_sizes = {1, prefix_cache_remainder, prompt_tokens}
+
+    with sqlite3.connect(sqlite_path) as connection:
+        tables = {
+            str(row[0])
+            for row in connection.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        required_tables = {
+            "StringIds",
+            "NVTX_EVENTS",
+            "CUPTI_ACTIVITY_KIND_RUNTIME",
+            "CUDA_GRAPH_NODE_EVENTS",
+        }
+        missing_tables = sorted(required_tables - tables)
+        if missing_tables:
+            failures.append(f"nsys SQLite is missing tables {missing_tables}")
+            return {"accepted": False, "failures": failures}
+
+        runtime_count = row_count(connection, "CUPTI_ACTIVITY_KIND_RUNTIME")
+        kernel_tables = sorted(
+            table for table in tables if table.startswith("CUPTI_ACTIVITY_KIND_KERNEL")
+        )
+        kernel_count = sum(row_count(connection, table) for table in kernel_tables)
+        graph_node_count = row_count(connection, "CUDA_GRAPH_NODE_EVENTS")
+        launches = graph_launches(connection)
+        phase_graphs = phase_graph_audit(load_execute_ranges(connection), launches)
+
+    if not summary.get("accepted"):
+        failures.append("experiment summary was not accepted")
+    if resolved["cuda_graph_mode"] != "FULL":
+        failures.append(
+            f"resolved CUDA graph mode is {resolved['cuda_graph_mode']!r}, not FULL"
+        )
+    if resolved["enforce_eager"]:
+        failures.append("resolved engine enabled enforce_eager")
+    if not resolved["prefix_caching"]:
+        failures.append("resolved engine disabled prefix caching")
+    missing_capture_sizes = sorted(
+        requested_capture_sizes - set(resolved["cuda_graph_capture_sizes"])
+    )
+    if missing_capture_sizes:
+        failures.append(f"resolved capture sizes are missing {missing_capture_sizes}")
+    if runtime_count <= 0:
+        failures.append("nsys trace has no CUDA runtime events")
+    if kernel_count <= 0:
+        failures.append("nsys trace has no CUDA kernel events")
+    if graph_node_count <= 0:
+        failures.append("nsys trace has no CUDA graph node events")
+    if not launches:
+        failures.append("nsys trace has no cudaGraphLaunch calls")
+    if phase_graphs["prefill_ranges"] != expected_prefill_ranges:
+        failures.append(
+            f"prefill ranges={phase_graphs['prefill_ranges']}, "
+            f"expected {expected_prefill_ranges}"
+        )
+    if phase_graphs["decode_ranges"] != expected_decode_ranges:
+        failures.append(
+            f"decode ranges={phase_graphs['decode_ranges']}, "
+            f"expected {expected_decode_ranges}"
+        )
+    if phase_graphs["prefill_ranges_without_graph"]:
+        failures.append(
+            f"{phase_graphs['prefill_ranges_without_graph']} prefill ranges "
+            "did not launch a CUDA graph"
+        )
+    if phase_graphs["decode_ranges_without_graph"]:
+        failures.append(
+            f"{phase_graphs['decode_ranges_without_graph']} decode ranges "
+            "did not launch a CUDA graph"
+        )
+
+    return {
+        "accepted": not failures,
+        "report": str(rep_path.resolve()),
+        "report_bytes": rep_path.stat().st_size,
+        "sqlite": str(sqlite_path.resolve()),
+        "cuda_runtime_events": runtime_count,
+        "cuda_kernel_events": kernel_count,
+        "cuda_graph_node_events": graph_node_count,
+        "cuda_graph_launches": len(launches),
+        "phase_graphs": phase_graphs,
+        "kernel_tables": kernel_tables,
+        "failures": failures,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit prefill and decode CUDA graph use in an nsys trace."
+    )
+    parser.add_argument("rep", type=Path)
+    parser.add_argument("sqlite", type=Path)
+    parser.add_argument("--summary", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    result = audit(args.rep, args.sqlite, args.summary)
+    args.output.write_text(
+        json.dumps(result, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    if not result["accepted"]:
+        raise SystemExit("NSYS_AUDIT_FAILED: " + "; ".join(result["failures"]))
+    phase_graphs = result["phase_graphs"]
+    print(
+        "NSYS_AUDIT=PASS "
+        f"prefill_ranges={phase_graphs['prefill_ranges']} "
+        f"prefill_graph_launches={phase_graphs['prefill_graph_launches']} "
+        f"decode_ranges={phase_graphs['decode_ranges']} "
+        f"decode_graph_launches={phase_graphs['decode_graph_launches']}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/profiling/vllm_prompt_embeddings/main.py
+++ b/benchmarks/profiling/vllm_prompt_embeddings/main.py
@@ -1,0 +1,400 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Profile sequential synchronous vLLM generation from prompt embeddings."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+import torch
+
+try:
+    from vllm import LLM, SamplingParams
+except (ImportError, AttributeError):  # vLLM is optional for CPU-only tests.
+    LLM = None  # type: ignore[assignment,misc]
+    SamplingParams = None  # type: ignore[assignment,misc]
+
+
+@dataclass(frozen=True)
+class ExperimentConfig:
+    """Configuration for one synchronous prompt-embedding experiment."""
+
+    model: str = "Qwen/Qwen2.5-1.5B-Instruct"
+    requests: int = 100
+    warmup_requests: int = 20
+    prompt_tokens: int = 515
+    output_tokens: int = 75
+    seed: int = 0
+    block_size: int = 16
+    max_model_len: int = 1024
+    gpu_memory_utilization: float = 0.90
+
+    @property
+    def prefix_cache_remainder_tokens(self) -> int:
+        remainder = self.prompt_tokens % self.block_size
+        return remainder or self.block_size
+
+    @property
+    def cudagraph_capture_sizes(self) -> list[int]:
+        return sorted({1, self.prefix_cache_remainder_tokens, self.prompt_tokens})
+
+    def validate(self) -> None:
+        if self.requests <= 0:
+            raise ValueError("requests must be positive")
+        if self.warmup_requests < 0:
+            raise ValueError("warmup_requests cannot be negative")
+        if self.prompt_tokens <= 0 or self.output_tokens <= 0:
+            raise ValueError("prompt_tokens and output_tokens must be positive")
+        if self.block_size <= 0:
+            raise ValueError("block_size must be positive")
+        if self.prompt_tokens + self.output_tokens > self.max_model_len:
+            raise ValueError("prompt and output tokens exceed max_model_len")
+        if not 0 < self.gpu_memory_utilization < 1:
+            raise ValueError("gpu_memory_utilization must be between zero and one")
+
+
+def enum_name(value: Any) -> str:
+    return str(getattr(value, "name", value))
+
+
+def tensor_sha256(tensor: torch.Tensor) -> str:
+    byte_view = tensor.detach().cpu().contiguous().view(torch.uint8)
+    return hashlib.sha256(byte_view.numpy().tobytes()).hexdigest()
+
+
+def create_prompt_embeddings(
+    *,
+    prompt_tokens: int,
+    hidden_dimension: int,
+    dtype: torch.dtype,
+    seed: int,
+) -> torch.Tensor:
+    """Create one deterministic CPU tensor that every request reuses."""
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    embeddings = torch.randn(
+        (prompt_tokens, hidden_dimension),
+        generator=generator,
+        dtype=torch.float32,
+        device="cpu",
+    )
+    return embeddings.mul_(0.02).to(dtype=dtype).contiguous()
+
+
+def create_sampling_params(
+    output_tokens: int,
+    seed: int,
+    sampling_params_factory: Callable[..., Any],
+) -> Any:
+    return sampling_params_factory(
+        temperature=0.0,
+        max_tokens=output_tokens,
+        min_tokens=output_tokens,
+        ignore_eos=True,
+        seed=seed,
+        detokenize=False,
+    )
+
+
+def validate_generation(outputs: Any, expected_output_tokens: int) -> dict[str, Any]:
+    output_count = len(outputs) if isinstance(outputs, list) else 0
+    if output_count != 1:
+        raise ValueError(f"expected one RequestOutput, received {output_count}")
+    candidates = getattr(outputs[0], "outputs", None)
+    candidate_count = len(candidates) if isinstance(candidates, list) else 0
+    if candidate_count != 1:
+        raise ValueError(f"expected one completion, received {candidate_count}")
+    completion = candidates[0]
+    token_ids = list(getattr(completion, "token_ids", []))
+    if len(token_ids) != expected_output_tokens:
+        raise ValueError(
+            f"OSL mismatch: received {len(token_ids)}, "
+            f"expected {expected_output_tokens}"
+        )
+    return {
+        "request_id": str(getattr(outputs[0], "request_id", "")),
+        "output_tokens": len(token_ids),
+        "finish_reason": getattr(completion, "finish_reason", None),
+        "token_ids_sha256": hashlib.sha256(
+            json.dumps(token_ids, separators=(",", ":")).encode("utf-8")
+        ).hexdigest(),
+    }
+
+
+def execute_requests(
+    llm: Any,
+    prompt_embeddings: torch.Tensor,
+    sampling_params: Any,
+    *,
+    count: int,
+    expected_output_tokens: int,
+    phase: str,
+) -> list[dict[str, Any]]:
+    records: list[dict[str, Any]] = []
+    for request_index in range(count):
+        started_ns = time.perf_counter_ns()
+        outputs = llm.generate(
+            [{"prompt_embeds": prompt_embeddings}],
+            sampling_params,
+            use_tqdm=False,
+        )
+        elapsed_ns = time.perf_counter_ns() - started_ns
+        record = validate_generation(outputs, expected_output_tokens)
+        record.update(
+            {
+                "phase": phase,
+                "request_index": request_index,
+                "latency_ms": elapsed_ns / 1_000_000,
+            }
+        )
+        records.append(record)
+    return records
+
+
+def percentile(values: list[float], percentage: float) -> float:
+    if not values:
+        raise ValueError("cannot calculate a percentile of an empty list")
+    ordered = sorted(values)
+    position = (len(ordered) - 1) * percentage / 100
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1 - fraction) + ordered[upper] * fraction
+
+
+def resolved_engine_config(llm: Any) -> dict[str, Any]:
+    vllm_config = llm.llm_engine.vllm_config
+    compilation = vllm_config.compilation_config
+    model = vllm_config.model_config
+    cache = vllm_config.cache_config
+    return {
+        "cuda_graph_mode": enum_name(compilation.cudagraph_mode),
+        "cuda_graph_capture_sizes": list(compilation.cudagraph_capture_sizes),
+        "enforce_eager": bool(model.enforce_eager),
+        "prefix_caching": bool(cache.enable_prefix_caching),
+        "block_size": int(cache.block_size),
+        "model_revision": getattr(model.hf_config, "_commit_hash", None),
+    }
+
+
+def validate_resolved_engine(
+    resolved: dict[str, Any], config: ExperimentConfig
+) -> None:
+    failures: list[str] = []
+    if resolved["cuda_graph_mode"] != "FULL":
+        failures.append(
+            f"cuda_graph_mode={resolved['cuda_graph_mode']!r}, expected 'FULL'"
+        )
+    missing_sizes = sorted(
+        set(config.cudagraph_capture_sizes) - set(resolved["cuda_graph_capture_sizes"])
+    )
+    if missing_sizes:
+        failures.append(f"CUDA graph capture sizes are missing {missing_sizes}")
+    if resolved["enforce_eager"]:
+        failures.append("enforce_eager unexpectedly resolved to true")
+    if not resolved["prefix_caching"]:
+        failures.append("prefix caching unexpectedly resolved to false")
+    if resolved["block_size"] != config.block_size:
+        failures.append(
+            f"block_size={resolved['block_size']}, expected {config.block_size}"
+        )
+    if failures:
+        raise RuntimeError("; ".join(failures))
+
+
+def write_results(
+    output_dir: Path,
+    records: list[dict[str, Any]],
+    summary: dict[str, Any],
+) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "requests.jsonl").write_text(
+        "".join(json.dumps(record, sort_keys=True) + "\n" for record in records),
+        encoding="utf-8",
+    )
+    (output_dir / "summary.json").write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def run_experiment(
+    config: ExperimentConfig,
+    output_dir: Path,
+    *,
+    llm_factory: Callable[..., Any],
+    sampling_params_factory: Callable[..., Any],
+) -> dict[str, Any]:
+    """Run warmups, profile measured requests, and write validated results."""
+    config.validate()
+    llm = llm_factory(
+        model=config.model,
+        tensor_parallel_size=1,
+        max_model_len=config.max_model_len,
+        max_num_batched_tokens=config.max_model_len,
+        max_num_seqs=1,
+        gpu_memory_utilization=config.gpu_memory_utilization,
+        block_size=config.block_size,
+        enable_prompt_embeds=True,
+        enable_prefix_caching=True,
+        generation_config="vllm",
+        enforce_eager=False,
+        seed=config.seed,
+        profiler_config={"profiler": "cuda"},
+        compilation_config={
+            "cudagraph_mode": "FULL",
+            "cudagraph_capture_sizes": config.cudagraph_capture_sizes,
+        },
+    )
+    model_config = llm.model_config
+    hidden_dimension = int(model_config.get_hidden_size())
+    inputs_embeds_size = int(model_config.get_inputs_embeds_size())
+    if inputs_embeds_size != hidden_dimension:
+        raise RuntimeError(
+            "the model input embedding width does not equal its hidden dimension: "
+            f"{inputs_embeds_size} != {hidden_dimension}"
+        )
+    prompt_embeddings = create_prompt_embeddings(
+        prompt_tokens=config.prompt_tokens,
+        hidden_dimension=hidden_dimension,
+        dtype=model_config.dtype,
+        seed=config.seed,
+    )
+    if prompt_embeddings.shape != (config.prompt_tokens, hidden_dimension):
+        raise RuntimeError(f"unexpected embedding shape {prompt_embeddings.shape}")
+    if prompt_embeddings.device.type != "cpu" or not prompt_embeddings.is_contiguous():
+        raise RuntimeError("prompt embeddings must be contiguous CPU tensors")
+
+    resolved = resolved_engine_config(llm)
+    validate_resolved_engine(resolved, config)
+    sampling_params = create_sampling_params(
+        config.output_tokens,
+        config.seed,
+        sampling_params_factory,
+    )
+
+    execute_requests(
+        llm,
+        prompt_embeddings,
+        sampling_params,
+        count=config.warmup_requests,
+        expected_output_tokens=config.output_tokens,
+        phase="warmup",
+    )
+
+    profile_started = False
+    try:
+        llm.start_profile()
+        profile_started = True
+        measured_started_ns = time.perf_counter_ns()
+        records = execute_requests(
+            llm,
+            prompt_embeddings,
+            sampling_params,
+            count=config.requests,
+            expected_output_tokens=config.output_tokens,
+            phase="measured",
+        )
+        measured_elapsed_s = (time.perf_counter_ns() - measured_started_ns) / 1e9
+    finally:
+        if profile_started:
+            llm.stop_profile()
+
+    latencies = [float(record["latency_ms"]) for record in records]
+    summary = {
+        "accepted": len(records) == config.requests
+        and all(record["output_tokens"] == config.output_tokens for record in records),
+        "config": asdict(config),
+        "embedding": {
+            "shape": list(prompt_embeddings.shape),
+            "dtype": str(prompt_embeddings.dtype),
+            "device": prompt_embeddings.device.type,
+            "contiguous": prompt_embeddings.is_contiguous(),
+            "sha256": tensor_sha256(prompt_embeddings),
+        },
+        "resolved_engine": resolved,
+        "sampling": {
+            "temperature": 0.0,
+            "min_tokens": config.output_tokens,
+            "max_tokens": config.output_tokens,
+            "ignore_eos": True,
+            "seed": config.seed,
+            "detokenize": False,
+        },
+        "results": {
+            "requests": len(records),
+            "total_seconds": measured_elapsed_s,
+            "request_throughput": len(records) / measured_elapsed_s,
+            "latency_ms": {
+                "avg": sum(latencies) / len(latencies),
+                "p50": percentile(latencies, 50),
+                "p90": percentile(latencies, 90),
+                "p99": percentile(latencies, 99),
+            },
+        },
+    }
+    write_results(output_dir, records, summary)
+    return summary
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Profile synchronous vLLM generation from prompt embeddings."
+    )
+    parser.add_argument("--model", default="Qwen/Qwen2.5-1.5B-Instruct")
+    parser.add_argument("--requests", type=int, default=100)
+    parser.add_argument("--warmup-requests", type=int, default=20)
+    parser.add_argument("--prompt-tokens", type=int, default=515)
+    parser.add_argument("--output-tokens", type=int, default=75)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--block-size", type=int, default=16)
+    parser.add_argument("--max-model-len", type=int, default=1024)
+    parser.add_argument("--gpu-memory-utilization", type=float, default=0.90)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if LLM is None or SamplingParams is None:
+        raise SystemExit("vLLM is required to run this experiment")
+    config = ExperimentConfig(
+        model=args.model,
+        requests=args.requests,
+        warmup_requests=args.warmup_requests,
+        prompt_tokens=args.prompt_tokens,
+        output_tokens=args.output_tokens,
+        seed=args.seed,
+        block_size=args.block_size,
+        max_model_len=args.max_model_len,
+        gpu_memory_utilization=args.gpu_memory_utilization,
+    )
+    summary = run_experiment(
+        config,
+        args.output_dir,
+        llm_factory=LLM,
+        sampling_params_factory=SamplingParams,
+    )
+    results = summary["results"]
+    latency = results["latency_ms"]
+    print(
+        "EXPERIMENT_COMPLETE "
+        f"requests={results['requests']} "
+        f"osl={config.output_tokens} "
+        f"avg_ms={latency['avg']:.3f} "
+        f"throughput={results['request_throughput']:.3f}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/profiling/vllm_prompt_embeddings/run_nsys.sh
+++ b/benchmarks/profiling/vllm_prompt_embeddings/run_nsys.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -Eeuo pipefail
+
+RUN_ID="${1:?usage: run_nsys.sh RUN_ID [OUTPUT_BASE]}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+OUTPUT_BASE="${2:-${DYN_NSYS_OUTPUT_BASE:-$REPO_ROOT/logs/nsys/vllm_prompt_embeddings}}"
+RUN_DIR="$OUTPUT_BASE/$RUN_ID"
+
+MODEL="${DYN_PROMPT_EMBEDS_MODEL:-Qwen/Qwen2.5-1.5B-Instruct}"
+REQUESTS="${DYN_PROMPT_EMBEDS_REQUESTS:-100}"
+WARMUP_REQUESTS="${DYN_PROMPT_EMBEDS_WARMUP_REQUESTS:-20}"
+PROMPT_TOKENS="${DYN_PROMPT_EMBEDS_PROMPT_TOKENS:-515}"
+OUTPUT_TOKENS="${DYN_PROMPT_EMBEDS_OUTPUT_TOKENS:-75}"
+BLOCK_SIZE="${DYN_PROMPT_EMBEDS_BLOCK_SIZE:-16}"
+MAX_MODEL_LEN="${DYN_PROMPT_EMBEDS_MAX_MODEL_LEN:-1024}"
+GPU_MEMORY_UTILIZATION="${DYN_PROMPT_EMBEDS_GPU_MEMORY_UTILIZATION:-0.90}"
+SEED="${DYN_PROMPT_EMBEDS_SEED:-0}"
+CONTAINER_IMAGE="${DYN_CONTAINER_IMAGE:-unknown}"
+PYTHON_BIN="${DYN_PYTHON_BIN:-python3}"
+NSYS_PID=""
+
+if [[ -e "$RUN_DIR" ]]; then
+    echo "refusing to overwrite existing run directory: $RUN_DIR" >&2
+    exit 2
+fi
+mkdir -p "$RUN_DIR/nsys" "$RUN_DIR/recipe"
+cp "$SCRIPT_DIR"/*.py "$SCRIPT_DIR"/*.sh "$RUN_DIR/recipe/"
+sha256sum "$RUN_DIR"/recipe/* > "$RUN_DIR/recipe-sha256sums.txt"
+
+NSYS_STAGING_ROOT="${DYN_NSYS_STAGING_ROOT:-${TMPDIR:-/tmp}/dynamo-nsys-staging}"
+NSYS_STAGING="$NSYS_STAGING_ROOT/${RUN_ID:0:32}"
+mkdir -p "$NSYS_STAGING"
+export TMPDIR="$NSYS_STAGING"
+export HF_HUB_OFFLINE="${HF_HUB_OFFLINE:-1}"
+export TRANSFORMERS_OFFLINE="${TRANSFORMERS_OFFLINE:-1}"
+export VLLM_USE_V1=1
+export VLLM_WORKER_MULTIPROC_METHOD=spawn
+export VLLM_NVTX_SCOPES_FOR_PROFILING=1
+export PYTHONPATH="$REPO_ROOT${PYTHONPATH:+:$PYTHONPATH}"
+
+NSYS_BIN="$(command -v nsys || true)"
+if [[ -z "$NSYS_BIN" ]] || ! "$NSYS_BIN" --version >/dev/null 2>&1; then
+    echo "missing working nsys executable" >&2
+    exit 2
+fi
+
+PREFIX_CACHE_REMAINDER=$((PROMPT_TOKENS % BLOCK_SIZE))
+if [[ "$PREFIX_CACHE_REMAINDER" -eq 0 ]]; then
+    PREFIX_CACHE_REMAINDER="$BLOCK_SIZE"
+fi
+if git -C "$REPO_ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    SOURCE_REVISION="$(git -C "$REPO_ROOT" rev-parse HEAD)"
+    if [[ -n "$(git -C "$REPO_ROOT" status --short)" ]]; then
+        SOURCE_DIRTY=true
+    else
+        SOURCE_DIRTY=false
+    fi
+else
+    SOURCE_REVISION=unknown
+    SOURCE_DIRTY=unknown
+fi
+
+forward_signal() {
+    local signal="$1"
+    local exit_code="$2"
+    if [[ -n "$NSYS_PID" ]] && kill -0 "$NSYS_PID" 2>/dev/null; then
+        kill -INT "$NSYS_PID" 2>/dev/null || true
+        for _ in $(seq 1 180); do
+            kill -0 "$NSYS_PID" 2>/dev/null || break
+            sleep 1
+        done
+    fi
+    exit "$exit_code"
+}
+trap 'forward_signal INT 130' INT
+trap 'forward_signal TERM 143' TERM
+
+PYTHON_COMMAND=(
+    "$PYTHON_BIN" -m benchmarks.profiling.vllm_prompt_embeddings.main
+    --model "$MODEL"
+    --requests "$REQUESTS"
+    --warmup-requests "$WARMUP_REQUESTS"
+    --prompt-tokens "$PROMPT_TOKENS"
+    --output-tokens "$OUTPUT_TOKENS"
+    --block-size "$BLOCK_SIZE"
+    --max-model-len "$MAX_MODEL_LEN"
+    --gpu-memory-utilization "$GPU_MEMORY_UTILIZATION"
+    --seed "$SEED"
+    --output-dir "$RUN_DIR"
+)
+NSYS_COMMAND=(
+    "$NSYS_BIN" profile
+    --output "$RUN_DIR/nsys/vllm-prompt-embeds"
+    --trace=cuda,nvtx,cublas,cudnn,osrt
+    --cuda-memory-usage=true
+    --backtrace=dwarf
+    --sample=process-tree
+    --cpuctxsw=process-tree
+    --trace-fork-before-exec=true
+    --cuda-graph-trace=node
+    --capture-range=cudaProfilerApi
+    --capture-range-end=stop
+    --kill=sigterm
+    --wait=primary
+    --
+    "${PYTHON_COMMAND[@]}"
+)
+printf '%q ' "${PYTHON_COMMAND[@]}" > "$RUN_DIR/python-command.txt"
+printf '\n' >> "$RUN_DIR/python-command.txt"
+printf '%q ' "${NSYS_COMMAND[@]}" > "$RUN_DIR/nsys-command.txt"
+printf '\n' >> "$RUN_DIR/nsys-command.txt"
+
+{
+    echo "run_id=$RUN_ID"
+    echo "model=$MODEL"
+    echo "requests=$REQUESTS"
+    echo "warmup_requests=$WARMUP_REQUESTS"
+    echo "prompt_tokens=$PROMPT_TOKENS"
+    echo "output_tokens=$OUTPUT_TOKENS"
+    echo "block_size=$BLOCK_SIZE"
+    echo "cuda_graph_mode=FULL"
+    echo "cuda_graph_capture_sizes=1,$PREFIX_CACHE_REMAINDER,$PROMPT_TOKENS"
+    echo "prefix_caching=true"
+    echo "container_image=$CONTAINER_IMAGE"
+    echo "nsys=$($NSYS_BIN --version | sed -n '1p')"
+    echo "vllm=$($PYTHON_BIN -c 'import vllm; print(vllm.__version__)')"
+    echo "torch=$($PYTHON_BIN -c 'import torch; print(torch.__version__)')"
+    echo "transformers=$($PYTHON_BIN -c 'import transformers; print(transformers.__version__)')"
+    echo "source_revision=$SOURCE_REVISION"
+    echo "source_dirty=$SOURCE_DIRTY"
+    echo "started_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    nvidia-smi \
+        --query-gpu=name,uuid,memory.total,driver_version \
+        --format=csv,noheader
+} > "$RUN_DIR/provenance.txt"
+
+cd "$REPO_ROOT"
+"${NSYS_COMMAND[@]}" > "$RUN_DIR/stdout.log" 2> "$RUN_DIR/stderr.log" &
+NSYS_PID=$!
+set +e
+wait "$NSYS_PID"
+NSYS_RC=$?
+set -e
+NSYS_PID=""
+trap - INT TERM
+if [[ "$NSYS_RC" -ne 0 ]]; then
+    echo "nsys profile failed with exit code $NSYS_RC" >&2
+    exit "$NSYS_RC"
+fi
+
+mapfile -t REPORTS < <(compgen -G "$RUN_DIR/nsys/*.nsys-rep" || true)
+if [[ "${#REPORTS[@]}" -ne 1 ]]; then
+    echo "expected one .nsys-rep, found ${#REPORTS[@]}" >&2
+    exit 1
+fi
+REP="${REPORTS[0]}"
+SQLITE="${REP%.nsys-rep}.sqlite"
+"$NSYS_BIN" export \
+    --type=sqlite \
+    --force-overwrite=true \
+    --output "$SQLITE" \
+    "$REP" > "$RUN_DIR/nsys-export.log" 2>&1
+"$PYTHON_BIN" -m benchmarks.profiling.vllm_prompt_embeddings.audit_nsys \
+    "$REP" \
+    "$SQLITE" \
+    --summary "$RUN_DIR/summary.json" \
+    --output "$RUN_DIR/nsys-audit.json"
+
+sha256sum "$REP" "$SQLITE" "$RUN_DIR/summary.json" \
+    > "$RUN_DIR/sha256sums.txt"
+echo "completed_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    >> "$RUN_DIR/provenance.txt"
+echo "RUN_COMPLETE run_dir=$RUN_DIR rep=$REP sqlite=$SQLITE"

--- a/tests/benchmarks/profiling/__init__.py
+++ b/tests/benchmarks/profiling/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/benchmarks/profiling/vllm_prompt_embeddings/__init__.py
+++ b/tests/benchmarks/profiling/vllm_prompt_embeddings/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/benchmarks/profiling/vllm_prompt_embeddings/test_vllm_main.py
+++ b/tests/benchmarks/profiling/vllm_prompt_embeddings/test_vllm_main.py
@@ -1,0 +1,206 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+import torch
+
+from benchmarks.profiling.vllm_prompt_embeddings.main import (
+    ExperimentConfig,
+    create_prompt_embeddings,
+    run_experiment,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+class FakeSamplingParams:
+    def __init__(self, **kwargs: Any) -> None:
+        self.values = kwargs
+
+
+class FakeLLM:
+    latest: FakeLLM
+    wrong_output = False
+
+    def __init__(self, **kwargs: Any) -> None:
+        type(self).latest = self
+        self.kwargs = kwargs
+        self.events: list[str] = []
+        self.generate_calls: list[dict[str, Any]] = []
+        self.model_config = SimpleNamespace(
+            dtype=torch.float32,
+            get_hidden_size=lambda: 8,
+            get_inputs_embeds_size=lambda: 8,
+        )
+        compilation = SimpleNamespace(
+            cudagraph_mode=SimpleNamespace(name="FULL"),
+            cudagraph_capture_sizes=kwargs["compilation_config"][
+                "cudagraph_capture_sizes"
+            ],
+        )
+        model = SimpleNamespace(
+            enforce_eager=kwargs["enforce_eager"],
+            hf_config=SimpleNamespace(_commit_hash="revision"),
+        )
+        cache = SimpleNamespace(
+            enable_prefix_caching=kwargs["enable_prefix_caching"],
+            block_size=kwargs["block_size"],
+        )
+        self.llm_engine = SimpleNamespace(
+            vllm_config=SimpleNamespace(
+                compilation_config=compilation,
+                model_config=model,
+                cache_config=cache,
+            )
+        )
+
+    def generate(
+        self, prompts: list[dict[str, torch.Tensor]], params: Any, *, use_tqdm: bool
+    ) -> list[Any]:
+        self.events.append("generate")
+        self.generate_calls.append(
+            {"prompts": prompts, "params": params, "use_tqdm": use_tqdm}
+        )
+        output_tokens = params.values["max_tokens"] - int(self.wrong_output)
+        completion = SimpleNamespace(
+            token_ids=list(range(output_tokens)), finish_reason="length"
+        )
+        return [
+            SimpleNamespace(
+                request_id=f"request-{len(self.generate_calls)}",
+                outputs=[completion],
+            )
+        ]
+
+    def start_profile(self) -> None:
+        self.events.append("start_profile")
+
+    def stop_profile(self) -> None:
+        self.events.append("stop_profile")
+
+
+def test_prompt_embeddings_are_deterministic_and_contiguous() -> None:
+    first = create_prompt_embeddings(
+        prompt_tokens=515,
+        hidden_dimension=8,
+        dtype=torch.bfloat16,
+        seed=7,
+    )
+    second = create_prompt_embeddings(
+        prompt_tokens=515,
+        hidden_dimension=8,
+        dtype=torch.bfloat16,
+        seed=7,
+    )
+    assert first.shape == (515, 8)
+    assert first.dtype == torch.bfloat16
+    assert first.device.type == "cpu"
+    assert first.is_contiguous()
+    assert torch.equal(first, second)
+
+
+def test_run_experiment_uses_sequential_single_request_calls(tmp_path: Path) -> None:
+    config = ExperimentConfig(
+        requests=3,
+        warmup_requests=2,
+        prompt_tokens=35,
+        output_tokens=4,
+        max_model_len=64,
+    )
+    summary = run_experiment(
+        config,
+        tmp_path,
+        llm_factory=FakeLLM,
+        sampling_params_factory=FakeSamplingParams,
+    )
+    engine = FakeLLM.latest
+    assert engine.events == [
+        "generate",
+        "generate",
+        "start_profile",
+        "generate",
+        "generate",
+        "generate",
+        "stop_profile",
+    ]
+    assert len(engine.generate_calls) == 5
+    prompt_tensor = engine.generate_calls[0]["prompts"][0]["prompt_embeds"]
+    assert prompt_tensor.shape == (35, 8)
+    assert all(len(call["prompts"]) == 1 for call in engine.generate_calls)
+    assert all(
+        call["prompts"][0]["prompt_embeds"] is prompt_tensor
+        for call in engine.generate_calls
+    )
+    assert all(call["use_tqdm"] is False for call in engine.generate_calls)
+    assert engine.generate_calls[0]["params"].values == {
+        "temperature": 0.0,
+        "max_tokens": 4,
+        "min_tokens": 4,
+        "ignore_eos": True,
+        "seed": 0,
+        "detokenize": False,
+    }
+    assert engine.kwargs["compilation_config"] == {
+        "cudagraph_mode": "FULL",
+        "cudagraph_capture_sizes": [1, 3, 35],
+    }
+    assert engine.kwargs["enforce_eager"] is False
+    assert summary["accepted"] is True
+    assert summary["results"]["requests"] == 3
+    assert (tmp_path / "requests.jsonl").read_text().count("\n") == 3
+
+
+def test_profile_stops_when_exact_osl_validation_fails(tmp_path: Path) -> None:
+    FakeLLM.wrong_output = True
+    try:
+        with pytest.raises(ValueError, match="OSL mismatch"):
+            run_experiment(
+                ExperimentConfig(
+                    requests=1,
+                    warmup_requests=0,
+                    prompt_tokens=35,
+                    output_tokens=4,
+                    max_model_len=64,
+                ),
+                tmp_path,
+                llm_factory=FakeLLM,
+                sampling_params_factory=FakeSamplingParams,
+            )
+        assert FakeLLM.latest.events == [
+            "start_profile",
+            "generate",
+            "stop_profile",
+        ]
+    finally:
+        FakeLLM.wrong_output = False
+
+
+@pytest.mark.parametrize(
+    ("config", "message"),
+    [
+        (ExperimentConfig(requests=0), "requests must be positive"),
+        (
+            ExperimentConfig(prompt_tokens=1000, output_tokens=75),
+            "exceed max_model_len",
+        ),
+        (
+            ExperimentConfig(gpu_memory_utilization=1.0),
+            "must be between zero and one",
+        ),
+    ],
+)
+def test_invalid_configuration_is_rejected(
+    config: ExperimentConfig, message: str
+) -> None:
+    with pytest.raises(ValueError, match=message):
+        config.validate()

--- a/tests/benchmarks/profiling/vllm_prompt_embeddings/test_vllm_nsys_audit.py
+++ b/tests/benchmarks/profiling/vllm_prompt_embeddings/test_vllm_nsys_audit.py
@@ -1,0 +1,125 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from benchmarks.profiling.vllm_prompt_embeddings.audit_nsys import audit
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.gpu_0,
+]
+
+
+def write_fixture(
+    root: Path,
+    *,
+    graph_prefill: bool = True,
+    graph_decode: bool = True,
+    include_decode: bool = True,
+) -> tuple[Path, Path, Path]:
+    rep = root / "trace.nsys-rep"
+    rep.write_bytes(b"rep")
+    sqlite_path = root / "trace.sqlite"
+    with sqlite3.connect(sqlite_path) as connection:
+        connection.execute("CREATE TABLE StringIds (id INTEGER, value TEXT)")
+        connection.execute(
+            "CREATE TABLE NVTX_EVENTS "
+            "(start INTEGER, end INTEGER, globalTid INTEGER, text TEXT, textId INTEGER)"
+        )
+        connection.execute(
+            "CREATE TABLE CUPTI_ACTIVITY_KIND_RUNTIME "
+            "(start INTEGER, end INTEGER, globalTid INTEGER, nameId INTEGER)"
+        )
+        connection.execute("CREATE TABLE CUPTI_ACTIVITY_KIND_KERNEL (id INTEGER)")
+        connection.execute("CREATE TABLE CUDA_GRAPH_NODE_EVENTS (id INTEGER)")
+        connection.executemany(
+            "INSERT INTO StringIds VALUES (?, ?)",
+            [
+                (1, "cudaGraphLaunch_v10000"),
+                (2, "execute_context_1(515)_generation_0(0)"),
+                (3, "execute_context_0(0)_generation_1(1)"),
+            ],
+        )
+        ranges = [(100, 200, 7, None, 2)]
+        if include_decode:
+            ranges.append((300, 400, 7, None, 3))
+        connection.executemany("INSERT INTO NVTX_EVENTS VALUES (?, ?, ?, ?, ?)", ranges)
+        if graph_prefill:
+            connection.execute(
+                "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (150, 151, 7, 1)"
+            )
+        if graph_decode:
+            connection.execute(
+                "INSERT INTO CUPTI_ACTIVITY_KIND_RUNTIME VALUES (350, 351, 7, 1)"
+            )
+        connection.execute("INSERT INTO CUPTI_ACTIVITY_KIND_KERNEL VALUES (1)")
+        connection.execute("INSERT INTO CUDA_GRAPH_NODE_EVENTS VALUES (1)")
+
+    summary_path = root / "summary.json"
+    summary_path.write_text(
+        json.dumps(
+            {
+                "accepted": True,
+                "config": {
+                    "requests": 1,
+                    "output_tokens": 2,
+                    "prompt_tokens": 515,
+                    "block_size": 16,
+                },
+                "resolved_engine": {
+                    "cuda_graph_mode": "FULL",
+                    "cuda_graph_capture_sizes": [1, 3, 515],
+                    "enforce_eager": False,
+                    "prefix_caching": True,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    return rep, sqlite_path, summary_path
+
+
+def test_audit_accepts_graphed_prefill_and_decode(tmp_path: Path) -> None:
+    rep, sqlite_path, summary = write_fixture(tmp_path)
+    result = audit(rep, sqlite_path, summary)
+    assert result["accepted"] is True
+    assert result["phase_graphs"]["prefill_graph_launches"] == 1
+    assert result["phase_graphs"]["decode_graph_launches"] == 1
+
+
+@pytest.mark.parametrize(
+    ("graph_prefill", "graph_decode", "expected_failure"),
+    [
+        (False, True, "prefill ranges"),
+        (True, False, "decode ranges"),
+    ],
+)
+def test_audit_rejects_phase_without_graph_launch(
+    tmp_path: Path,
+    graph_prefill: bool,
+    graph_decode: bool,
+    expected_failure: str,
+) -> None:
+    rep, sqlite_path, summary = write_fixture(
+        tmp_path,
+        graph_prefill=graph_prefill,
+        graph_decode=graph_decode,
+    )
+    result = audit(rep, sqlite_path, summary)
+    assert result["accepted"] is False
+    assert any(expected_failure in failure for failure in result["failures"])
+
+
+def test_audit_rejects_incomplete_phase_ranges(tmp_path: Path) -> None:
+    rep, sqlite_path, summary = write_fixture(tmp_path, include_decode=False)
+    result = audit(rep, sqlite_path, summary)
+    assert result["accepted"] is False
+    assert "decode ranges=0, expected 1" in result["failures"]


### PR DESCRIPTION
## Why

Dynamo lacks a reproducible way to profile offline vLLM prompt-embedding generation and verify that CUDA graphs cover both prefill and decode. Reusing one deterministic 515-token BF16 tensor with exact OSL 75 isolates engine behavior from tokenization and workload variance. A fail-closed nsys audit prevents eager fallback traces from being mistaken for optimized results.

## Effect

```text
NSYS_AUDIT=PASS prefill_ranges=100 prefill_graph_launches=100 decode_ranges=7400 decode_graph_launches=7400
```

## What Change

- Add deterministic synchronous prompt-embedding generation with full CUDA graph capture.
- Audit nsys traces and retain commands, provenance, recipe hashes, and artifacts.
- Document the workflow and assign performance ownership.

## Test Plan

- `pytest -q tests/benchmarks/profiling/vllm_prompt_embeddings` — 10 passed.
- H100 nsys: 100 prefills and 7,400 decode ranges fully graphed.
