### PR TITLE
fix(vllm): normalize engine abort finish_reason to wire-compatible stop

### DIFF
--- a/components/src/dynamo/common/utils/engine_response.py
+++ b/components/src/dynamo/common/utils/engine_response.py
@@ -10,12 +10,21 @@ def normalize_finish_reason(finish_reason: str) -> str:
     """
     Normalize engine finish reasons to Dynamo-compatible values.
 
-    Engine may return finish reasons that aren't recognized by Dynamo's Rust layer.
-    This method maps them to compatible values.
+    Engine may return finish reasons that aren't recognized by Dynamo's Rust
+    layer OR by the OpenAI-wire FinishReason schema (only stop/length/
+    tool_calls/content_filter/function_call are valid on the wire). This
+    method maps them to compatible values.
     [TODO]: Remove this method and add the right code in the Rust layer.
     """
-    # Map engine's "abort" to Dynamo's "cancelled"
+    # Map engine's "abort" to the wire-compatible "stop". Note: mapping to
+    # "cancelled" (as before) is NOT sufficient — while Dynamo's internal
+    # FinishReason enum (protocols::common::FinishReason) accepts
+    # "cancelled" via a serde alias, the external dynamo-protocols crate's
+    # FinishReason (used for the actual OpenAI response/stream chunk) has
+    # no Cancelled/Abort variant at all, so "cancelled" still crashes at
+    # that later deserialization boundary. "stop" is lossy (loses the
+    # abort signal) but is valid everywhere downstream.
     if finish_reason and finish_reason.startswith("abort"):
-        logging.debug(f"Normalizing finish reason: {finish_reason} to cancelled")
-        return "cancelled"
+        logging.debug(f"Normalizing finish reason: {finish_reason} to stop")
+        return "stop"
     return finish_reason

--- a/components/src/dynamo/common/utils/tests/test_engine_response.py
+++ b/components/src/dynamo/common/utils/tests/test_engine_response.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unit tests for dynamo.common.utils.engine_response."""
+
+import pytest
+
+from dynamo.common.utils.engine_response import normalize_finish_reason
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.core,
+]
+
+
+def test_abort_normalizes_to_stop():
+    # Regression test for the crash observed in production logs:
+    # "unknown variant `abort`, expected one of `stop`, `length`,
+    # `tool_calls`, `content_filter`, `function_call`" -- the external
+    # dynamo-protocols FinishReason enum has no Cancelled/Abort variant,
+    # so the normalized value MUST be one of its 5 valid variants.
+    assert normalize_finish_reason("abort") == "stop"
+
+
+def test_abort_with_suffix_normalizes_to_stop():
+    # startswith("abort") guard must remain permissive for any
+    # "abort: <detail>"-style value the engine might emit.
+    assert normalize_finish_reason("abort: preempted") == "stop"
+
+
+def test_stop_passes_through_unchanged():
+    assert normalize_finish_reason("stop") == "stop"
+
+
+def test_length_passes_through_unchanged():
+    assert normalize_finish_reason("length") == "length"
+
+
+def test_none_passes_through_unchanged():
+    assert normalize_finish_reason(None) is None
+
+
+def test_empty_string_passes_through_unchanged():
+    assert normalize_finish_reason("") == ""
+
+
+def test_normalized_value_is_wire_compatible():
+    # Explicit assertion of the actual invariant this fix protects:
+    # the output must be a member of the external wire schema's 5
+    # valid finish_reason values (stop/length/tool_calls/
+    # content_filter/function_call) -- never "cancelled" or "abort".
+    wire_compatible_values = {
+        "stop",
+        "length",
+        "tool_calls",
+        "content_filter",
+        "function_call",
+    }
+    assert normalize_finish_reason("abort") in wire_compatible_values

--- a/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
+++ b/components/src/dynamo/tokenspeed/tests/test_tokenspeed_llm_engine.py
@@ -176,7 +176,7 @@ def test_convert_output_to_chunk_normalizes_abort_finish_reason():
         }
     )
 
-    assert chunk["finish_reason"] == "cancelled"
+    assert chunk["finish_reason"] == "stop"
 
 
 def test_validate_single_choice_sampling_rejects_n_greater_than_one():

--- a/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
+++ b/components/src/dynamo/vllm/tests/omni/test_output_formatter.py
@@ -77,7 +77,7 @@ class TestTextFormatter:
         f = TextFormatter(model_name="test-model")
         ro = _make_request_output("done", finish_reason="abort")
         chunk = f.format(ro, "req-1")
-        assert chunk["choices"][0]["finish_reason"] == "cancelled"
+        assert chunk["choices"][0]["finish_reason"] == "stop"
 
     def test_finish_reason_none_when_not_finished(self):
         f = TextFormatter(model_name="test-model")

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -487,6 +487,53 @@ class TestReasoningParserForwarding:
         # start=99 clamped to prompt_len=3
         assert chunks[-1]["engine_data"]["routed_experts"]["start"] == 3
 
+    @pytest.mark.asyncio
+    async def test_generate_tokens_normalizes_engine_side_abort_to_stop(self):
+        """Regression test for the production crash: when vLLM internally
+        aborts an in-flight request (finish_reason="abort", not a client
+        disconnect), generate_tokens must normalize it to "stop" -- a value
+        valid on the OpenAI-wire FinishReason enum -- rather than the old
+        "cancelled" mapping, which has no matching wire-schema variant and
+        crashed Rust-side deserialization with "unknown variant `abort`,
+        expected one of `stop`, `length`, `tool_calls`, `content_filter`,
+        `function_call`", discarding all already-generated output."""
+        from vllm.sampling_params import SamplingParams
+
+        handler = _make_handler()
+        handler._extract_logprobs = MagicMock(return_value=(None, None))
+
+        async def fake_generate(*args, **kwargs):
+            yield SimpleNamespace(
+                outputs=[
+                    SimpleNamespace(
+                        index=0,
+                        token_ids=[42],
+                        routed_experts=None,
+                        finish_reason="abort",
+                        stop_reason=None,
+                    )
+                ],
+                prompt_token_ids=[1, 2],
+                prompt_logprobs=None,
+            )
+
+        handler.engine_client = MagicMock()
+        handler.engine_client.generate = fake_generate
+
+        chunks = []
+        async for chunk in handler.generate_tokens(
+            PatchedTokensPrompt(prompt_token_ids=[1]),
+            SamplingParams(max_tokens=1),
+            "req-abort",
+        ):
+            chunks.append(chunk)
+
+        assert len(chunks) == 1
+        # Content must survive the abort, not be discarded.
+        assert chunks[0]["token_ids"] == [42]
+        assert chunks[0]["finish_reason"] == "stop"
+        assert chunks[0]["finish_reason"] != "cancelled"
+
 
 # ── Tests ────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Overview:

Normalize the vLLM engine's abort `finish_reason` to the wire-compatible `"stop"` so that already-generated output is preserved instead of being discarded by a Rust-side deserialization crash.

## Details:

`normalize_finish_reason()` previously mapped the engine's `abort*` finish reasons to `"cancelled"`. While Dynamo's internal `protocols::common::FinishReason` enum accepts `"cancelled"` via a serde alias, the **external `dynamo-protocols` crate's `FinishReason`** — the one used to build the actual OpenAI response/stream chunk — has no `Cancelled`/`Abort` variant at all. As a result `"cancelled"` still crashed at that later deserialization boundary, discarding output that had already been generated.

This PR maps `abort*` to `"stop"` instead. `"stop"` is lossy (it drops the abort signal) but is valid at every downstream boundary, including the OpenAI wire schema (which only accepts `stop` / `length` / `tool_calls` / `content_filter` / `function_call`).

Changes:
- `engine_response.py` — map `abort*` → `"stop"`; expanded the docstring/comment explaining the two distinct `FinishReason` boundaries.
- `test_engine_response.py` — unit coverage for the normalization mapping.
- `test_vllm_worker_handler.py` — worker-handler coverage exercising the abort path.

## Where should the reviewer start?

- `components/src/dynamo/common/utils/engine_response.py` — the one-line behavior change plus the rationale comment.
- `components/src/dynamo/common/utils/tests/test_engine_response.py` and `components/src/dynamo/vllm/tests/test_vllm_worker_handler.py` — the accompanying tests.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11760" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Engine-aborted generations now report a compatible `stop` finish reason.
  * Improved handling of cases where the vLLM engine returns no output by surfacing a retryable service error.
  * Preserved generated token data when normalizing aborted requests.

* **Tests**
  * Added coverage for finish-reason normalization and empty engine responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->