### PR TITLE
fix(router): use prefill EAGLE mode for KV routing

### DIFF
--- a/lib/llm/src/kv_router/prefill_router/activation.rs
+++ b/lib/llm/src/kv_router/prefill_router/activation.rs
@@ -10,7 +10,9 @@ use tokio::sync::oneshot;
 use dynamo_kv_router::{PrefillLoadEstimator, config::KvRouterConfig};
 use dynamo_runtime::{
     component::{Client, Endpoint},
+    discovery::DiscoveryQuery,
     pipeline::{PushRouter, RouterMode},
+    prelude::DistributedRuntimeProvider,
     protocols::annotated::Annotated,
 };
 
@@ -18,6 +20,7 @@ use super::{InnerPrefillRouter, PrefillLifecycleState, PrefillRouter};
 use crate::{
     discovery::ModelManager,
     kv_router::KvPushRouter,
+    model_card::ModelDeploymentCard,
     protocols::common::{
         llm_backend::{LLMEngineOutput, PreprocessedRequest},
         timing::WORKER_TYPE_PREFILL,
@@ -132,6 +135,28 @@ impl PrefillRouter {
             .await?;
 
         let inner_router = if self.router_mode.is_kv_routing() {
+            let endpoint_id = endpoint.id();
+            let discovered_cards = endpoint
+                .component()
+                .drt()
+                .discovery()
+                .list(DiscoveryQuery::EndpointModels {
+                    namespace: endpoint_id.namespace,
+                    component: endpoint_id.component,
+                    endpoint: endpoint_id.name,
+                })
+                .await;
+            let is_eagle = match discovered_cards {
+                Ok(instances) => instances
+                    .into_iter()
+                    .find_map(|instance| instance.deserialize_model::<ModelDeploymentCard>().ok())
+                    .map_or(self.is_eagle, |card| card.runtime_config.enable_eagle),
+                Err(error) => {
+                    tracing::warn!(%error, "Failed to read prefill model card; using configured EAGLE mode");
+                    self.is_eagle
+                }
+            };
+
             // Create KV chooser using the endpoint (this is a prefill router)
             let kv_chooser = model_manager
                 .kv_chooser_for(
@@ -141,7 +166,7 @@ impl PrefillRouter {
                     prefill_load_estimator,
                     WORKER_TYPE_PREFILL,
                     Some(self.model_name.clone()),
-                    self.is_eagle,
+                    is_eagle,
                 )
                 .await?;
 


### PR DESCRIPTION
## Overview:

Fix prefill KV routing when SGLang prefill workers enable EAGLE/MTP.

To avoid inheriting a decode-only speculative setting, the prefill router previously constructed its KV chooser with EAGLE hash mode explicitly disabled. That is correct when prefill does not enable EAGLE, including decode-only deployments, but it was also applied whenever prefill enabled EAGLE. In that case prefill workers publish EAGLE bigram hashes while Dynamo queries the prefix index with unigram hashes and predicts zero reusable cache blocks.

## Details:

- Read the prefill endpoint ModelDeploymentCard during router activation.
- Configure the prefill KV chooser from the prefill endpoint's runtime_config.enable_eagle value.
- Fall back to the existing configured mode (false at the production call site) if the discovery query fails or yields no deserializable model card; emit a warning on query errors.
- Keep public APIs and lifecycle state transitions unchanged; a model-card lookup failure does not fail activation.
- Preserve the intended decode-only behavior: a non-EAGLE prefill endpoint continues to use unigram hashes even when decode enables EAGLE.

## Validation:

On this PR branch (based on main at validation time):

- cargo fmt --all -- --check
- cargo check -p dynamo-llm --no-default-features
- cargo clippy -p dynamo-llm --no-default-features --no-deps --all-targets -- -D warnings
- cargo test -p dynamo-llm --no-default-features discovery::model_manager::tests (57 passed)
- targeted pre-commit hooks for the changed file

On the affected 64-GPU GB300 disaggregated workload (c1024, P6 x DEP8 + D1 x DEP16, prefill/decode EAGLE step 3):

- Session-pinned prefill selections with nonzero effective_cached_blocks: 0/42,328 (0%) to 59,928/60,419 (99.19%)
- Median effective_cached_blocks for those selections: 0 to 396
- Actual SGLang cache hit rate over profiling start through backend drain: 95.36% to 95.41%
- Total throughput: 3.703M to 5.140M tokens/s (+38.8%)
- Output throughput: 23.76K to 33.94K tokens/s (+42.9%)
- Result is within 1.29% total throughput and 1.57% output throughput of the decode-only EAGLE control

The performance A/B used the affected deployment revision and the same revision plus this patch to isolate the change. This PR branch is based on main at f5b1c1cce; compatibility on that base is covered by the Rust validation above.

## Where should the reviewer start?

lib/llm/src/kv_router/prefill_router/activation.rs

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * KV-routing activation now automatically detects EAGLE support from deployed model configurations.
  * Added a fallback to the configured routing behavior when deployment discovery is unavailable or invalid.
* **Bug Fixes**
  * Improved routing accuracy by using the active deployment’s runtime settings instead of relying solely on static configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->