### PR TITLE
fix(trtllm): update how to pull engine arg default for TRTLLM API change (#11741) [cherry-pick → release/1.3.0]

### DIFF
--- a/components/src/dynamo/trtllm/backend_args.py
+++ b/components/src/dynamo/trtllm/backend_args.py
@@ -10,7 +10,12 @@ import logging
 import warnings
 from typing import Optional
 
-from tensorrt_llm.llmapi import BuildConfig
+# trtllm >= 1.3.0rc21 removed BuildConfig; its fields moved to BaseLlmArgs
+# Remove this try-except once we bump trtllm version to >= 1.3.0rc21
+try:
+    from tensorrt_llm.llmapi import BuildConfig
+except ImportError:
+    from tensorrt_llm.llmapi.llm_args import BaseLlmArgs as BuildConfig
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase


### PR DESCRIPTION
Cherry-pick of #11741 onto `release/1.3.0`.

**Original PR:** #11741 — `fix(trtllm): update how to pull engine arg default for TRTLLM API change`
**Original commit:** `9b3024655c30` (author @GuanLuo)

### What
Defensive import so `backend_args.py` works across the TRTLLM API change: `trtllm >= 1.3.0rc21` removed `BuildConfig` and moved its fields to `BaseLlmArgs`. Falls back to `BaseLlmArgs as BuildConfig` on `ImportError`.

```python
try:
    from tensorrt_llm.llmapi import BuildConfig
except ImportError:
    from tensorrt_llm.llmapi.llm_args import BaseLlmArgs as BuildConfig
```

Single file, `components/src/dynamo/trtllm/backend_args.py` (+6/-1). Cherry-pick applied cleanly (no conflicts).

⚠️ **Note:** the source PR #11741 is **still open on `main`** (not yet merged) as of this cherry-pick. If the policy is main-first, hold this until #11741 merges; otherwise it can ride an RC in parallel. Flagging for the release owner.
