### PR TITLE
fix(llm): avoid panic on dropped transfer notification

### DIFF
--- a/lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs
+++ b/lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs
@@ -267,26 +267,23 @@ fn execute_two_hop_transfer(params: TwoHopTransferParams) -> Result<TransferComp
     let ctx_clone = ctx.clone();
     handle.spawn(async move {
         let Some(ref bounce_buffer_spec) = options_clone.bounce_buffer else {
-            tx.send(Err(anyhow::anyhow!(
+            let _ = tx.send(Err(anyhow::anyhow!(
                 "Two-hop transfers require a bounce buffer."
-            )))
-            .unwrap();
+            )));
             return;
         };
 
         if bounce_buffer_spec.layout().location() != bounce_location {
-            tx.send(Err(anyhow::anyhow!(
+            let _ = tx.send(Err(anyhow::anyhow!(
                 "Bounce buffer layout does not match bounce location."
-            )))
-            .unwrap();
+            )));
             return;
         }
 
         if bounce_buffer_spec.block_ids().is_empty() {
-            tx.send(Err(anyhow::anyhow!(
+            let _ = tx.send(Err(anyhow::anyhow!(
                 "Bounce buffer must have at least one block."
-            )))
-            .unwrap();
+            )));
             return;
         }
 
@@ -313,7 +310,7 @@ fn execute_two_hop_transfer(params: TwoHopTransferParams) -> Result<TransferComp
                     return;
                 }
             }
-            tx.send(Ok(())).unwrap();
+            let _ = tx.send(Ok(()));
         } else {
             if let Err(e) = handle_buffered_transfer(
                 &src_clone,


### PR DESCRIPTION
## Summary

Avoid panicking in the two-hop transfer executor when a transfer completion notification receiver has already been dropped.

## Overview

This PR replaces the remaining `oneshot::Sender::send(...).unwrap()` calls in the two-hop transfer executor with ignored send results.

## Details

The two-hop transfer executor reports validation failures and completion through a `tokio::sync::oneshot` channel stored in `TransferCompleteNotification`.

A failed `oneshot::Sender::send(...)` means the `TransferCompleteNotification` receiver was dropped, not that the transfer itself failed. Other transfer notification paths already treat dropped receivers as non-fatal, so this aligns the two-hop executor with the surrounding behavior and avoids unnecessary background task panics during cancellation or shutdown.

This does not change transfer execution, error propagation for active waiters, public APIs, or retry behavior.

## Reviewer Start

Start with `lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs`, specifically the `execute_two_hop_transfer` spawned task.

## Related Issues

None. This is an XS/S cleanup under the contribution guide threshold for opening an issue.

## Validation

- `rustfmt +1.93.1 --edition 2024 --check lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs`
- `cargo test -p dynamo-llm --lib block_manager::v2::physical::transfer::executor`
- `git diff --check -- lib/llm/src/block_manager/v2/physical/transfer/executor/mod.rs`

Note: full `pre-commit run --all-files` was not run locally; CI `pre-commit` passed.