### PR TITLE
perf(kv-router): batch event-plane KV events

### DIFF
--- a/lib/llm/benches/kv_router_bench.rs
+++ b/lib/llm/benches/kv_router_bench.rs
@@ -37,10 +37,9 @@ use dynamo_kv_router::protocols::{
     compute_seq_hash_for_block,
 };
 use dynamo_llm::model_card::ModelDeploymentCard;
-use dynamo_llm::preprocessor::prompt::{
-    ChatTemplate, ContextMixins, OAIChatLikeRequest, PromptFormatter,
-};
+use dynamo_llm::preprocessor::prompt::prompt_formatter_from_mdc;
 use dynamo_mocker::loadgen::RouterSequence;
+use dynamo_renderer::{ChatTemplate, ContextMixins, OAIChatLikeRequest, PromptFormatter};
 
 /// KV Router event subject suffix (appended to Component.subject())
 /// Full subject format: namespace.{namespace}.component.{component}.kv-events
@@ -319,7 +318,7 @@ fn try_load_prompt_renderer(model_or_path: &str) -> Option<PromptRenderer> {
     }
 
     let card = ModelDeploymentCard::load_from_disk(path, None).ok()?;
-    let formatter = PromptFormatter::from_mdc(&card).ok()?;
+    let formatter = prompt_formatter_from_mdc(&card).ok()?;
     Some(PromptRenderer::Formatter(formatter))
 }
 
@@ -744,7 +743,8 @@ async fn build_tree_via_nats(
 
     for (event_id, seq) in sequences.iter().enumerate() {
         let event = sequence_to_router_event(seq, event_id as u64);
-        let data = encode_event_with_envelope(&event, KV_EVENT_SUBJECT)?;
+        let event_batch = vec![event];
+        let data = encode_event_with_envelope(&event_batch, KV_EVENT_SUBJECT)?;
         nats_client
             .publish(subject.clone(), data.into())
             .await
@@ -1160,8 +1160,9 @@ async fn publish_events_at_rate(
     while start.elapsed() < duration {
         let seq = &sequences[(event_id as usize) % sequences.len()];
         let event = sequence_to_router_event(seq, event_id);
+        let event_batch = vec![event];
 
-        match encode_event_with_envelope(&event, KV_EVENT_SUBJECT) {
+        match encode_event_with_envelope(&event_batch, KV_EVENT_SUBJECT) {
             Ok(data) => {
                 if let Err(e) = nats_client.publish(subject.clone(), data.into()).await {
                     publish_failures += 1;

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -10,9 +10,12 @@ use dynamo_kv_router::{
     protocols::{KV_EVENT_SUBJECT, RouterEvent},
 };
 use dynamo_runtime::{
-    component::Component, discovery::EventTransportKind, prelude::*,
-    transports::event_plane::EventSubscriber,
+    component::Component,
+    discovery::EventTransportKind,
+    prelude::*,
+    transports::event_plane::{EventEnvelope, EventSubscriber, TypedEventSubscriber},
 };
+use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
 
 /// Start a simplified background task for event consumption using the event plane.
@@ -38,10 +41,9 @@ async fn start_kv_router_background_event_plane(
     // This ensures no events are lost between the initial dump fetch and the
     // subscription becoming active — the tree state at fetch time is guaranteed
     // to be a subset of what the subscription will deliver.
-    let mut subscriber =
+    let subscriber =
         EventSubscriber::for_component_with_transport(&component, KV_EVENT_SUBJECT, transport_kind)
-            .await?
-            .typed::<RouterEvent>();
+            .await?;
 
     // Brief delay to let the subscription fully establish with the NATS server
     // before recovery fetches the initial dump from workers.
@@ -81,46 +83,103 @@ async fn start_kv_router_background_event_plane(
     }
 
     tokio::spawn(async move {
-        loop {
-            tokio::select! {
-                biased;
-
-                _ = cancellation_token.cancelled() => {
-                    tracing::debug!("KV Router event plane background task received cancellation signal");
-                    break;
-                }
-
-                // Handle event consumption from event plane subscription
-                Some(result) = subscriber.next() => {
-                    let (envelope, event) = match result {
-                        Ok((envelope, event)) => (envelope, event),
-                        Err(e) => {
-                            tracing::warn!("Failed to receive RouterEvent from event plane: {e:?}");
-                            continue;
-                        }
-                    };
-
-                    tracing::trace!(
-                        "Received event from publisher {} (seq {})",
-                        envelope.publisher_id,
-                        envelope.sequence
-                    );
-
-                    tracing::trace!(
-                        "Forwarding live event to recovery coordinator for worker {} dp_rank {} event_id {}",
-                        event.worker_id,
-                        event.event.dp_rank,
-                        event.event.event_id
-                    );
-                    worker_query_client.handle_live_event(event).await;
-                }
+        let subscriber = match transport_kind {
+            EventTransportKind::Nats => {
+                RouterEventSubscriber::Singleton(subscriber.typed::<RouterEvent>())
             }
-        }
-
-        tracing::debug!("KV Router event plane background task exiting");
+            EventTransportKind::Zmq => {
+                RouterEventSubscriber::Batch(subscriber.typed::<Vec<RouterEvent>>())
+            }
+        };
+        consume_events(subscriber, worker_query_client, cancellation_token).await;
     });
 
     Ok(())
+}
+
+enum RouterEventSubscriber {
+    Singleton(TypedEventSubscriber<RouterEvent>),
+    Batch(TypedEventSubscriber<Vec<RouterEvent>>),
+}
+
+enum RouterEventPayload {
+    Singleton(RouterEvent),
+    Batch(Vec<RouterEvent>),
+}
+
+impl RouterEventSubscriber {
+    async fn next(&mut self) -> Option<Result<(EventEnvelope, RouterEventPayload)>> {
+        match self {
+            Self::Singleton(subscriber) => subscriber.next().await.map(|result| {
+                result.map(|(envelope, event)| (envelope, RouterEventPayload::Singleton(event)))
+            }),
+            Self::Batch(subscriber) => subscriber.next().await.map(|result| {
+                result.map(|(envelope, events)| (envelope, RouterEventPayload::Batch(events)))
+            }),
+        }
+    }
+}
+
+async fn consume_events(
+    mut subscriber: RouterEventSubscriber,
+    worker_query_client: Arc<WorkerQueryClient>,
+    cancellation_token: CancellationToken,
+) {
+    loop {
+        tokio::select! {
+            biased;
+
+            _ = cancellation_token.cancelled() => {
+                tracing::debug!("KV Router event plane background task received cancellation signal");
+                break;
+            }
+
+            Some(result) = subscriber.next() => {
+                let (envelope, payload) = match result {
+                    Ok((envelope, payload)) => (envelope, payload),
+                    Err(e) => {
+                        tracing::warn!("Failed to receive RouterEvent payload from event plane: {e:?}");
+                        continue;
+                    }
+                };
+
+                tracing::trace!(
+                    event_count = match &payload {
+                        RouterEventPayload::Singleton(_) => 1,
+                        RouterEventPayload::Batch(events) => events.len(),
+                    },
+                    "Received event payload from publisher {} (seq {})",
+                    envelope.publisher_id,
+                    envelope.sequence
+                );
+                match payload {
+                    RouterEventPayload::Singleton(event) => {
+                        forward_live_event(&worker_query_client, event).await;
+                    }
+                    RouterEventPayload::Batch(events) => {
+                        for event in events {
+                            if cancellation_token.is_cancelled() {
+                                break;
+                            }
+                            forward_live_event(&worker_query_client, event).await;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    tracing::debug!("KV Router event plane background task exiting");
+}
+
+async fn forward_live_event(worker_query_client: &Arc<WorkerQueryClient>, event: RouterEvent) {
+    tracing::trace!(
+        "Forwarding live event to recovery coordinator for worker {} dp_rank {} event_id {}",
+        event.worker_id,
+        event.event.dp_rank,
+        event.event.event_id
+    );
+    worker_query_client.handle_live_event(event).await;
 }
 
 /// Helper to decide which subscriber (JetStream or Event Plane) to start based on config

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -104,11 +104,17 @@ async fn consume_events(
                 break;
             }
 
-            Some(result) = subscriber.next() => {
+            result = subscriber.next() => {
+                let Some(result) = result else {
+                    tracing::warn!("KV Router event-plane stream closed");
+                    break;
+                };
                 let (envelope, events) = match result {
                     Ok((envelope, events)) => (envelope, events),
                     Err(e) => {
-                        tracing::warn!("Failed to receive RouterEvent payload from event plane: {e:?}");
+                        tracing::warn!(
+                            "Failed to receive RouterEvent batch from event plane; publisher/subscriber versions or payload formats may not match: {e:?}"
+                        );
                         continue;
                     }
                 };

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -13,7 +13,7 @@ use dynamo_runtime::{
     component::Component,
     discovery::EventTransportKind,
     prelude::*,
-    transports::event_plane::{EventEnvelope, EventSubscriber, TypedEventSubscriber},
+    transports::event_plane::{EventSubscriber, TypedEventSubscriber},
 };
 use std::sync::Arc;
 use tokio_util::sync::CancellationToken;
@@ -43,7 +43,8 @@ async fn start_kv_router_background_event_plane(
     // to be a subset of what the subscription will deliver.
     let subscriber =
         EventSubscriber::for_component_with_transport(&component, KV_EVENT_SUBJECT, transport_kind)
-            .await?;
+            .await?
+            .typed::<Vec<RouterEvent>>();
 
     // Brief delay to let the subscription fully establish with the NATS server
     // before recovery fetches the initial dump from workers.
@@ -83,45 +84,14 @@ async fn start_kv_router_background_event_plane(
     }
 
     tokio::spawn(async move {
-        let subscriber = match transport_kind {
-            EventTransportKind::Nats => {
-                RouterEventSubscriber::Singleton(subscriber.typed::<RouterEvent>())
-            }
-            EventTransportKind::Zmq => {
-                RouterEventSubscriber::Batch(subscriber.typed::<Vec<RouterEvent>>())
-            }
-        };
         consume_events(subscriber, worker_query_client, cancellation_token).await;
     });
 
     Ok(())
 }
 
-enum RouterEventSubscriber {
-    Singleton(TypedEventSubscriber<RouterEvent>),
-    Batch(TypedEventSubscriber<Vec<RouterEvent>>),
-}
-
-enum RouterEventPayload {
-    Singleton(RouterEvent),
-    Batch(Vec<RouterEvent>),
-}
-
-impl RouterEventSubscriber {
-    async fn next(&mut self) -> Option<Result<(EventEnvelope, RouterEventPayload)>> {
-        match self {
-            Self::Singleton(subscriber) => subscriber.next().await.map(|result| {
-                result.map(|(envelope, event)| (envelope, RouterEventPayload::Singleton(event)))
-            }),
-            Self::Batch(subscriber) => subscriber.next().await.map(|result| {
-                result.map(|(envelope, events)| (envelope, RouterEventPayload::Batch(events)))
-            }),
-        }
-    }
-}
-
 async fn consume_events(
-    mut subscriber: RouterEventSubscriber,
+    mut subscriber: TypedEventSubscriber<Vec<RouterEvent>>,
     worker_query_client: Arc<WorkerQueryClient>,
     cancellation_token: CancellationToken,
 ) {
@@ -135,8 +105,8 @@ async fn consume_events(
             }
 
             Some(result) = subscriber.next() => {
-                let (envelope, payload) = match result {
-                    Ok((envelope, payload)) => (envelope, payload),
+                let (envelope, events) = match result {
+                    Ok((envelope, events)) => (envelope, events),
                     Err(e) => {
                         tracing::warn!("Failed to receive RouterEvent payload from event plane: {e:?}");
                         continue;
@@ -144,26 +114,16 @@ async fn consume_events(
                 };
 
                 tracing::trace!(
-                    event_count = match &payload {
-                        RouterEventPayload::Singleton(_) => 1,
-                        RouterEventPayload::Batch(events) => events.len(),
-                    },
+                    event_count = events.len(),
                     "Received event payload from publisher {} (seq {})",
                     envelope.publisher_id,
                     envelope.sequence
                 );
-                match payload {
-                    RouterEventPayload::Singleton(event) => {
-                        forward_live_event(&worker_query_client, event).await;
+                for event in events {
+                    if cancellation_token.is_cancelled() {
+                        break;
                     }
-                    RouterEventPayload::Batch(events) => {
-                        for event in events {
-                            if cancellation_token.is_cancelled() {
-                                break;
-                            }
-                            forward_live_event(&worker_query_client, event).await;
-                        }
-                    }
+                    forward_live_event(&worker_query_client, event).await;
                 }
             }
         }

--- a/lib/llm/src/kv_router/publisher/batching.rs
+++ b/lib/llm/src/kv_router/publisher/batching.rs
@@ -4,10 +4,9 @@
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
-use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::{
-    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, StorageTier,
+    KvCacheEvent, KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, RouterEvent, StorageTier,
 };
 
 use super::dedup::EventDedupFilter;
@@ -71,12 +70,12 @@ impl BatchingState {
         self.remaining_timeout(timeout_ms) == Duration::ZERO
     }
 
-    pub(super) async fn flush<P: RouterEventSink + Send + Sync + 'static>(
+    pub(super) async fn flush(
         &mut self,
-        publisher: &P,
         local_indexer: &Option<Arc<LocalKvIndexer>>,
         worker_id: u64,
         dedup: &mut EventDedupFilter,
+        output: &mut Vec<RouterEvent>,
     ) {
         if !self.has_pending() {
             return;
@@ -87,7 +86,6 @@ impl BatchingState {
             && let Some(filtered) = dedup.filter_remove(dp_rank, self.last_storage_tier, data)
         {
             emit(
-                publisher,
                 local_indexer,
                 worker_id,
                 self.last_storage_tier,
@@ -96,6 +94,7 @@ impl BatchingState {
                     data: KvCacheEventData::Removed(filtered),
                     dp_rank,
                 },
+                output,
             )
             .await;
             emitted = true;
@@ -103,7 +102,6 @@ impl BatchingState {
         if let Some(data) = self.pending_stored.take() {
             dedup.track_store(dp_rank, self.last_storage_tier, &data);
             emit(
-                publisher,
                 local_indexer,
                 worker_id,
                 self.last_storage_tier,
@@ -112,6 +110,7 @@ impl BatchingState {
                     data: KvCacheEventData::Stored(data),
                     dp_rank,
                 },
+                output,
             )
             .await;
             emitted = true;

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -187,7 +187,12 @@ async fn publish_output<P: RouterEventBatchSink>(
         return;
     }
     if let Err(e) = publisher.publish_events(output).await {
-        tracing::error!(worker_id, event_count = output.len(), error = %e, "Failed to publish events");
+        tracing::error!(
+            worker_id,
+            attempted_event_count = output.len(),
+            error = %e,
+            "One or more KV event publishes failed"
+        );
     }
 }
 

--- a/lib/llm/src/kv_router/publisher/event_processor.rs
+++ b/lib/llm/src/kv_router/publisher/event_processor.rs
@@ -7,7 +7,6 @@ use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
-use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::*;
 use dynamo_runtime::transports::nats::NatsQueue;
@@ -17,9 +16,9 @@ use crate::kv_router::metrics::kv_publisher_metrics;
 use super::DEFAULT_MAX_BATCH_BLOCKS;
 use super::batching::BatchingState;
 use super::dedup::EventDedupFilter;
-use super::sinks::{JetStreamPublisher, emit};
+use super::sinks::{JetStreamPublisher, RouterEventBatchSink, emit};
 
-pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 'static>(
+pub(super) async fn run_event_processor_loop<P: RouterEventBatchSink + 'static>(
     publisher: P,
     worker_id: u64,
     cancellation_token: CancellationToken,
@@ -36,15 +35,20 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
         tokio::select! {
             _ = cancellation_token.cancelled() => {
                 tracing::info!("KV Event source received cancellation signal");
-                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                let mut output = Vec::new();
+                batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
+                publish_output(&publisher, worker_id, &output).await;
                 break;
             }
             event_batch = rx.recv() => {
                 let Some(event_batch) = event_batch else {
                     tracing::debug!("Event processor channel closed.");
-                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                    let mut output = Vec::new();
+                    batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
+                    publish_output(&publisher, worker_id, &output).await;
                     break;
                 };
+                let mut output = Vec::new();
 
                 // Process the complete source list before returning to `select!` so
                 // another channel item, the timeout, or cancellation cannot split it.
@@ -92,7 +96,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                 || dp_rank_changed
                                 || storage_tier_changed
                             {
-                                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                                batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                             }
                             match &mut batching_state.pending_removed {
                                 Some(pending) => pending.block_hashes.extend(data.block_hashes),
@@ -109,7 +113,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                     data.parent_hash != p.blocks.last().map(|b| b.block_hash)
                                 });
                             if should_flush {
-                                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                                batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                             }
                             match &mut batching_state.pending_stored {
                                 Some(pending) => pending.blocks.extend(data.blocks),
@@ -119,10 +123,9 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                             }
                         }
                         KvCacheEventData::Cleared => {
-                            batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                            batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                             dedup.clear();
                             emit(
-                                &publisher,
                                 &local_indexer,
                                 worker_id,
                                 storage_tier,
@@ -131,6 +134,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                                     data: KvCacheEventData::Cleared,
                                     dp_rank: event.dp_rank,
                                 },
+                                &mut output,
                             )
                             .await;
                             batching_state.next_publish_id += 1;
@@ -145,7 +149,7 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                     if batching_state.has_pending()
                         && batching_state.pending_block_count() >= max_batch_blocks
                     {
-                        batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                        batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                     }
                 }
 
@@ -157,21 +161,37 @@ pub(super) async fn run_event_processor_loop<P: RouterEventSink + Send + Sync + 
                         Some(ms) => batching_state.is_timeout_elapsed(ms),
                     }
                 {
-                    batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                    batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
                 }
+                publish_output(&publisher, worker_id, &output).await;
             }
             _ = tokio::time::sleep(
                 timeout_ms
                     .map(|ms| batching_state.remaining_timeout(ms))
                     .unwrap_or(Duration::from_secs(3600))
             ), if timeout_ms.is_some() && batching_state.has_pending() => {
-                batching_state.flush(&publisher, &local_indexer, worker_id, &mut dedup).await;
+                let mut output = Vec::new();
+                batching_state.flush(&local_indexer, worker_id, &mut dedup, &mut output).await;
+                publish_output(&publisher, worker_id, &output).await;
             }
         }
     }
 }
 
-pub(super) async fn start_event_processor<P: RouterEventSink + Send + Sync + 'static>(
+async fn publish_output<P: RouterEventBatchSink>(
+    publisher: &P,
+    worker_id: u64,
+    output: &[RouterEvent],
+) {
+    if output.is_empty() {
+        return;
+    }
+    if let Err(e) = publisher.publish_events(output).await {
+        tracing::error!(worker_id, event_count = output.len(), error = %e, "Failed to publish events");
+    }
+}
+
+pub(super) async fn start_event_processor<P: RouterEventBatchSink + 'static>(
     publisher: P,
     worker_id: u64,
     cancellation_token: CancellationToken,

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -9,6 +9,7 @@ use anyhow::Result;
 use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
 use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, StorageTier};
+use dynamo_runtime::discovery::EventTransportKind;
 use dynamo_runtime::transports::event_plane::EventPublisher;
 use dynamo_runtime::transports::nats::NatsQueue;
 
@@ -16,10 +17,86 @@ use crate::kv_router::KV_EVENT_SUBJECT;
 
 pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
 
-impl RouterEventSink for EventPlanePublisher {
-    fn publish_event(&self, event: &RouterEvent) -> impl Future<Output = Result<()>> + Send {
-        self.0.publish(event)
+pub(super) const MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+pub(super) trait RouterEventBatchSink: Send + Sync {
+    fn publish_events(&self, events: &[RouterEvent]) -> impl Future<Output = Result<()>> + Send;
+}
+
+impl<P: RouterEventSink + Send + Sync> RouterEventBatchSink for P {
+    async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
+        let mut first_error = None;
+        for event in events {
+            if let Err(error) = self.publish_event(event).await
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
     }
+}
+
+impl RouterEventBatchSink for EventPlanePublisher {
+    async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
+        match self.0.transport_kind() {
+            // NATS Core retains its existing singleton RouterEvent payload.
+            EventTransportKind::Nats => {
+                let mut first_error = None;
+                for event in events {
+                    if let Err(error) = self.0.publish(event).await
+                        && first_error.is_none()
+                    {
+                        first_error = Some(error);
+                    }
+                }
+                first_error.map_or(Ok(()), Err)
+            }
+            // ZMQ peers must run the same version: its payload is Vec<RouterEvent>.
+            EventTransportKind::Zmq => {
+                let mut first_error = None;
+                for payload in encode_zmq_event_batches(events, MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES)? {
+                    if let Err(error) = self.0.publish_bytes(payload).await
+                        && first_error.is_none()
+                    {
+                        first_error = Some(error);
+                    }
+                }
+                first_error.map_or(Ok(()), Err)
+            }
+        }
+    }
+}
+
+/// Encode an ordered event list into size-bounded ZMQ payloads.
+///
+/// A single event larger than `max_payload_bytes` is emitted intact because the
+/// wire format cannot split an event. All other payloads stay within the limit.
+pub(super) fn encode_zmq_event_batches(
+    events: &[RouterEvent],
+    max_payload_bytes: usize,
+) -> Result<Vec<Vec<u8>>> {
+    if events.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut encoded = Vec::new();
+    let mut pending = vec![events];
+
+    while let Some(batch) = pending.pop() {
+        let payload = rmp_serde::to_vec_named(batch)?;
+        if payload.len() <= max_payload_bytes || batch.len() == 1 {
+            encoded.push(payload);
+            continue;
+        }
+
+        let midpoint = batch.len() / 2;
+        // LIFO worklist: push the latter half first to preserve event order.
+        pending.push(&batch[midpoint..]);
+        pending.push(&batch[..midpoint]);
+    }
+
+    Ok(encoded)
 }
 
 pub(super) struct JetStreamPublisher(pub(super) NatsQueue);
@@ -30,12 +107,12 @@ impl RouterEventSink for JetStreamPublisher {
     }
 }
 
-pub(super) async fn emit<P: RouterEventSink>(
-    publisher: &P,
+pub(super) async fn emit(
     local_indexer: &Option<Arc<LocalKvIndexer>>,
     worker_id: u64,
     storage_tier: StorageTier,
     event: KvCacheEvent,
+    output: &mut Vec<RouterEvent>,
 ) {
     let router_event = RouterEvent::with_storage_tier(worker_id, event, storage_tier);
     if let Some(indexer) = local_indexer
@@ -43,7 +120,5 @@ pub(super) async fn emit<P: RouterEventSink>(
     {
         tracing::warn!(worker_id, error = %e, "Failed to apply event to local indexer");
     }
-    if let Err(e) = publisher.publish_event(&router_event).await {
-        tracing::error!(worker_id, error = %e, "Failed to publish event");
-    }
+    output.push(router_event);
 }

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -16,7 +16,7 @@ use crate::kv_router::KV_EVENT_SUBJECT;
 
 pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
 
-pub(super) const MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS: usize = 32_768;
+pub(super) const MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS: usize = 8_192;
 
 pub(super) trait RouterEventBatchSink: Send + Sync {
     fn publish_events(&self, events: &[RouterEvent]) -> impl Future<Output = Result<()>> + Send;

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -19,11 +19,12 @@ pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
 /// Bound normal event-plane batches while always allowing one complete event.
 ///
 /// The default NATS Core `max_payload` is 1 MiB. Production-shaped batches at
-/// this cap, including one multimodal object with one offset per stored block,
-/// remain below that limit in the wire-size regression tests. Multimodal
-/// metadata is not intrinsically bounded, so an exceptional batch can still
-/// exceed a deployment's configured transport limit and fail under the
-/// existing best-effort publication semantics.
+/// these caps, including sparse one-block events and one multimodal object with
+/// one offset per stored block, remain below that limit in the wire-size
+/// regression tests. Multimodal metadata is not intrinsically bounded, so an
+/// exceptional batch can still exceed a deployment's configured transport
+/// limit and fail under the existing best-effort publication semantics.
+pub(super) const MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH: usize = 128;
 pub(super) const MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS: usize = 8_192;
 
 pub(super) trait RouterEventBatchSink: Send + Sync {
@@ -79,7 +80,11 @@ impl<P: RouterEventSink + Send + Sync> RouterEventBatchSink for P {
 impl RouterEventBatchSink for EventPlanePublisher {
     async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
         let mut failures = PublishFailures::default();
-        for batch in event_plane_event_batches(events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS) {
+        for batch in event_plane_event_batches(
+            events,
+            MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH,
+            MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS,
+        ) {
             if let Err(error) = self.0.publish(&batch).await {
                 let first_event_id = batch.first().map(|event| event.event.event_id);
                 let last_event_id = batch.last().map(|event| event.event.event_id);
@@ -98,10 +103,11 @@ impl RouterEventBatchSink for EventPlanePublisher {
     }
 }
 
-/// Partition ordered events at event boundaries without exceeding the block cap.
-/// A single event larger than the cap is always emitted intact.
+/// Partition ordered events at event boundaries without exceeding either cap.
+/// A single event larger than the block cap is always emitted intact.
 pub(super) fn event_plane_event_batches(
     events: &[RouterEvent],
+    max_events: usize,
     max_blocks: usize,
 ) -> impl Iterator<Item = &[RouterEvent]> {
     let mut batch_start = 0;
@@ -114,12 +120,16 @@ pub(super) fn event_plane_event_batches(
         let mut batch_end = batch_start;
         let mut batch_blocks = 0usize;
         while let Some(event) = events.get(batch_end) {
+            let batch_events = batch_end - batch_start;
             let event_blocks = match &event.event.data {
                 KvCacheEventData::Stored(data) => data.blocks.len(),
                 KvCacheEventData::Removed(data) => data.block_hashes.len(),
                 KvCacheEventData::Cleared => 0,
             };
-            if batch_end > batch_start && batch_blocks.saturating_add(event_blocks) > max_blocks {
+            if batch_events > 0
+                && (batch_events >= max_events
+                    || batch_blocks.saturating_add(event_blocks) > max_blocks)
+            {
                 break;
             }
             batch_blocks = batch_blocks.saturating_add(event_blocks);

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -16,38 +16,85 @@ use crate::kv_router::KV_EVENT_SUBJECT;
 
 pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
 
+/// Bound normal event-plane batches while always allowing one complete event.
+///
+/// The default NATS Core `max_payload` is 1 MiB. Production-shaped batches at
+/// this cap, including one multimodal object with one offset per stored block,
+/// remain below that limit in the wire-size regression tests. Multimodal
+/// metadata is not intrinsically bounded, so an exceptional batch can still
+/// exceed a deployment's configured transport limit and fail under the
+/// existing best-effort publication semantics.
 pub(super) const MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS: usize = 8_192;
 
 pub(super) trait RouterEventBatchSink: Send + Sync {
     fn publish_events(&self, events: &[RouterEvent]) -> impl Future<Output = Result<()>> + Send;
 }
 
+#[derive(Default)]
+struct PublishFailures {
+    publishes: usize,
+    events: usize,
+    first_error: Option<anyhow::Error>,
+}
+
+impl PublishFailures {
+    fn record(&mut self, event_count: usize, error: anyhow::Error) {
+        self.publishes += 1;
+        self.events += event_count;
+        if self.first_error.is_none() {
+            self.first_error = Some(error);
+        }
+    }
+
+    fn into_result(self) -> Result<()> {
+        let Some(first_error) = self.first_error else {
+            return Ok(());
+        };
+        let summary = format!(
+            "{} publish attempt(s) failed; {} event(s) dropped; first error: {first_error}",
+            self.publishes, self.events
+        );
+        Err(first_error.context(summary))
+    }
+}
+
 impl<P: RouterEventSink + Send + Sync> RouterEventBatchSink for P {
     async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
-        let mut first_error = None;
+        let mut failures = PublishFailures::default();
         for event in events {
-            if let Err(error) = self.publish_event(event).await
-                && first_error.is_none()
-            {
-                first_error = Some(error);
+            if let Err(error) = self.publish_event(event).await {
+                tracing::error!(
+                    worker_id = event.worker_id,
+                    event_id = event.event.event_id,
+                    error = %error,
+                    "Failed to publish KV event"
+                );
+                failures.record(1, error);
             }
         }
-        first_error.map_or(Ok(()), Err)
+        failures.into_result()
     }
 }
 
 impl RouterEventBatchSink for EventPlanePublisher {
     async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
-        let mut first_error = None;
+        let mut failures = PublishFailures::default();
         for batch in event_plane_event_batches(events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS) {
-            let payload = encode_event_plane_batch(batch)?;
-            if let Err(error) = self.0.publish_bytes(payload).await
-                && first_error.is_none()
-            {
-                first_error = Some(error);
+            if let Err(error) = self.0.publish(&batch).await {
+                let first_event_id = batch.first().map(|event| event.event.event_id);
+                let last_event_id = batch.last().map(|event| event.event.event_id);
+                tracing::error!(
+                    transport = ?self.0.transport_kind(),
+                    event_count = batch.len(),
+                    ?first_event_id,
+                    ?last_event_id,
+                    error = %error,
+                    "Failed to publish KV event batch"
+                );
+                failures.record(batch.len(), error);
             }
         }
-        first_error.map_or(Ok(()), Err)
+        failures.into_result()
     }
 }
 
@@ -83,11 +130,6 @@ pub(super) fn event_plane_event_batches(
         batch_start = batch_end;
         Some(batch)
     })
-}
-
-/// Encode one complete ordered event-plane batch.
-pub(super) fn encode_event_plane_batch(events: &[RouterEvent]) -> Result<Vec<u8>> {
-    Ok(rmp_serde::to_vec_named(events)?)
 }
 
 pub(super) struct JetStreamPublisher(pub(super) NatsQueue);

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -17,8 +17,6 @@ use crate::kv_router::KV_EVENT_SUBJECT;
 
 pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
 
-pub(super) const MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES: usize = 1024 * 1024;
-
 pub(super) trait RouterEventBatchSink: Send + Sync {
     fn publish_events(&self, events: &[RouterEvent]) -> impl Future<Output = Result<()>> + Send;
 }
@@ -39,6 +37,10 @@ impl<P: RouterEventSink + Send + Sync> RouterEventBatchSink for P {
 
 impl RouterEventBatchSink for EventPlanePublisher {
     async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
         match self.0.transport_kind() {
             // NATS Core retains its existing singleton RouterEvent payload.
             EventTransportKind::Nats => {
@@ -53,50 +55,14 @@ impl RouterEventBatchSink for EventPlanePublisher {
                 first_error.map_or(Ok(()), Err)
             }
             // ZMQ peers must run the same version: its payload is Vec<RouterEvent>.
-            EventTransportKind::Zmq => {
-                let mut first_error = None;
-                for payload in encode_zmq_event_batches(events, MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES)? {
-                    if let Err(error) = self.0.publish_bytes(payload).await
-                        && first_error.is_none()
-                    {
-                        first_error = Some(error);
-                    }
-                }
-                first_error.map_or(Ok(()), Err)
-            }
+            EventTransportKind::Zmq => self.0.publish_bytes(encode_zmq_event_batch(events)?).await,
         }
     }
 }
 
-/// Encode an ordered event list into size-bounded ZMQ payloads.
-///
-/// A single event larger than `max_payload_bytes` is emitted intact because the
-/// wire format cannot split an event. All other payloads stay within the limit.
-pub(super) fn encode_zmq_event_batches(
-    events: &[RouterEvent],
-    max_payload_bytes: usize,
-) -> Result<Vec<Vec<u8>>> {
-    if events.is_empty() {
-        return Ok(Vec::new());
-    }
-
-    let mut encoded = Vec::new();
-    let mut pending = vec![events];
-
-    while let Some(batch) = pending.pop() {
-        let payload = rmp_serde::to_vec_named(batch)?;
-        if payload.len() <= max_payload_bytes || batch.len() == 1 {
-            encoded.push(payload);
-            continue;
-        }
-
-        let midpoint = batch.len() / 2;
-        // LIFO worklist: push the latter half first to preserve event order.
-        pending.push(&batch[midpoint..]);
-        pending.push(&batch[..midpoint]);
-    }
-
-    Ok(encoded)
+/// Encode the complete ordered event list as one ZMQ payload.
+pub(super) fn encode_zmq_event_batch(events: &[RouterEvent]) -> Result<Vec<u8>> {
+    Ok(rmp_serde::to_vec_named(events)?)
 }
 
 pub(super) struct JetStreamPublisher(pub(super) NatsQueue);

--- a/lib/llm/src/kv_router/publisher/sinks.rs
+++ b/lib/llm/src/kv_router/publisher/sinks.rs
@@ -8,14 +8,15 @@ use anyhow::Result;
 
 use dynamo_kv_router::RouterEventSink;
 use dynamo_kv_router::indexer::LocalKvIndexer;
-use dynamo_kv_router::protocols::{KvCacheEvent, RouterEvent, StorageTier};
-use dynamo_runtime::discovery::EventTransportKind;
+use dynamo_kv_router::protocols::{KvCacheEvent, KvCacheEventData, RouterEvent, StorageTier};
 use dynamo_runtime::transports::event_plane::EventPublisher;
 use dynamo_runtime::transports::nats::NatsQueue;
 
 use crate::kv_router::KV_EVENT_SUBJECT;
 
 pub(super) struct EventPlanePublisher(pub(super) EventPublisher);
+
+pub(super) const MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS: usize = 32_768;
 
 pub(super) trait RouterEventBatchSink: Send + Sync {
     fn publish_events(&self, events: &[RouterEvent]) -> impl Future<Output = Result<()>> + Send;
@@ -37,31 +38,55 @@ impl<P: RouterEventSink + Send + Sync> RouterEventBatchSink for P {
 
 impl RouterEventBatchSink for EventPlanePublisher {
     async fn publish_events(&self, events: &[RouterEvent]) -> Result<()> {
-        if events.is_empty() {
-            return Ok(());
-        }
-
-        match self.0.transport_kind() {
-            // NATS Core retains its existing singleton RouterEvent payload.
-            EventTransportKind::Nats => {
-                let mut first_error = None;
-                for event in events {
-                    if let Err(error) = self.0.publish(event).await
-                        && first_error.is_none()
-                    {
-                        first_error = Some(error);
-                    }
-                }
-                first_error.map_or(Ok(()), Err)
+        let mut first_error = None;
+        for batch in event_plane_event_batches(events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS) {
+            let payload = encode_event_plane_batch(batch)?;
+            if let Err(error) = self.0.publish_bytes(payload).await
+                && first_error.is_none()
+            {
+                first_error = Some(error);
             }
-            // ZMQ peers must run the same version: its payload is Vec<RouterEvent>.
-            EventTransportKind::Zmq => self.0.publish_bytes(encode_zmq_event_batch(events)?).await,
         }
+        first_error.map_or(Ok(()), Err)
     }
 }
 
-/// Encode the complete ordered event list as one ZMQ payload.
-pub(super) fn encode_zmq_event_batch(events: &[RouterEvent]) -> Result<Vec<u8>> {
+/// Partition ordered events at event boundaries without exceeding the block cap.
+/// A single event larger than the cap is always emitted intact.
+pub(super) fn event_plane_event_batches(
+    events: &[RouterEvent],
+    max_blocks: usize,
+) -> impl Iterator<Item = &[RouterEvent]> {
+    let mut batch_start = 0;
+
+    std::iter::from_fn(move || {
+        if batch_start == events.len() {
+            return None;
+        }
+
+        let mut batch_end = batch_start;
+        let mut batch_blocks = 0usize;
+        while let Some(event) = events.get(batch_end) {
+            let event_blocks = match &event.event.data {
+                KvCacheEventData::Stored(data) => data.blocks.len(),
+                KvCacheEventData::Removed(data) => data.block_hashes.len(),
+                KvCacheEventData::Cleared => 0,
+            };
+            if batch_end > batch_start && batch_blocks.saturating_add(event_blocks) > max_blocks {
+                break;
+            }
+            batch_blocks = batch_blocks.saturating_add(event_blocks);
+            batch_end += 1;
+        }
+
+        let batch = &events[batch_start..batch_end];
+        batch_start = batch_end;
+        Some(batch)
+    })
+}
+
+/// Encode one complete ordered event-plane batch.
+pub(super) fn encode_event_plane_batch(events: &[RouterEvent]) -> Result<Vec<u8>> {
     Ok(rmp_serde::to_vec_named(events)?)
 }
 

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -3580,20 +3580,6 @@ mod event_plane_batch_tests {
     }
 
     #[test]
-    fn event_plane_batch_encoding_has_no_byte_size_cap() {
-        let events = (0..20_000).map(router_event).collect::<Vec<_>>();
-        let batches = event_plane_event_batches(&events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS)
-            .collect::<Vec<_>>();
-
-        assert_eq!(batches.len(), 1);
-        let encoded = encode_event_plane_batch(batches[0]).unwrap();
-        let decoded = rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded).unwrap();
-
-        assert!(encoded.len() > 1024 * 1024);
-        assert_eq!(decoded, events);
-    }
-
-    #[test]
     fn event_plane_batching_counts_stored_and_removed_blocks() {
         let events = vec![
             stored_router_event(1, 2),

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -3506,9 +3506,7 @@ mod zmq_event_batch_tests {
         ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, RouterEvent,
     };
 
-    use super::super::sinks::{
-        MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES, RouterEventBatchSink, encode_zmq_event_batches,
-    };
+    use super::super::sinks::{RouterEventBatchSink, encode_zmq_event_batch};
 
     fn router_event(event_id: u64) -> RouterEvent {
         RouterEvent::new(
@@ -3528,62 +3526,24 @@ mod zmq_event_batch_tests {
         let events = vec![router_event(1), router_event(2), router_event(3)];
         let expected = rmp_serde::to_vec_named(&events).unwrap();
 
-        let encoded = encode_zmq_event_batches(&events, expected.len()).unwrap();
+        let encoded = encode_zmq_event_batch(&events).unwrap();
 
-        assert_eq!(encoded, vec![expected]);
+        assert_eq!(encoded, expected);
         assert_eq!(
-            rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded[0]).unwrap(),
+            rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded).unwrap(),
             events
         );
     }
 
     #[test]
-    fn zmq_batch_encoding_splits_at_event_boundaries_in_order() {
-        let events = (0..7).map(router_event).collect::<Vec<_>>();
-
-        let encoded = encode_zmq_event_batches(&events, 1).unwrap();
-        let decoded = encoded
-            .iter()
-            .flat_map(|payload| rmp_serde::from_slice::<Vec<RouterEvent>>(payload).unwrap())
-            .collect::<Vec<_>>();
-
-        assert_eq!(encoded.len(), events.len());
-        assert_eq!(decoded, events);
-    }
-
-    #[test]
-    fn zmq_batch_encoding_enforces_one_mib_payload_cap() {
+    fn zmq_batch_encoding_keeps_large_batches_in_one_payload() {
         let events = (0..20_000).map(router_event).collect::<Vec<_>>();
 
-        let encoded = encode_zmq_event_batches(&events, MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES).unwrap();
-        let decoded = encoded
-            .iter()
-            .flat_map(|payload| {
-                assert!(payload.len() <= MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES);
-                rmp_serde::from_slice::<Vec<RouterEvent>>(payload).unwrap()
-            })
-            .collect::<Vec<_>>();
+        let encoded = encode_zmq_event_batch(&events).unwrap();
+        let decoded = rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded).unwrap();
 
-        assert!(encoded.len() > 1);
+        assert!(encoded.len() > 1024 * 1024);
         assert_eq!(decoded, events);
-    }
-
-    #[test]
-    fn zmq_batch_encoding_allows_one_oversized_event() {
-        let event = router_event(1);
-        let encoded = encode_zmq_event_batches(std::slice::from_ref(&event), 1).unwrap();
-
-        assert_eq!(encoded.len(), 1);
-        assert!(encoded[0].len() > 1);
-        assert_eq!(
-            rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded[0]).unwrap(),
-            vec![event]
-        );
-    }
-
-    #[test]
-    fn zmq_batch_encoding_skips_empty_batches() {
-        assert!(encode_zmq_event_batches(&[], 1024).unwrap().is_empty());
     }
 
     #[derive(Clone, Default)]

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -1983,23 +1983,33 @@ mod event_processor_tests {
     #[derive(Debug, Clone)]
     struct MockPublisher {
         events: Arc<Mutex<Vec<RouterEvent>>>,
+        batches: Arc<Mutex<Vec<Vec<RouterEvent>>>>,
     }
 
     impl MockPublisher {
         fn new() -> Self {
             Self {
                 events: Arc::new(Mutex::new(Vec::new())),
+                batches: Arc::new(Mutex::new(Vec::new())),
             }
         }
 
         fn get_events(&self) -> Vec<RouterEvent> {
             self.events.lock().unwrap().clone()
         }
+
+        fn get_batches(&self) -> Vec<Vec<RouterEvent>> {
+            self.batches.lock().unwrap().clone()
+        }
     }
 
-    impl RouterEventSink for MockPublisher {
-        fn publish_event(&self, event: &RouterEvent) -> impl Future<Output = Result<()>> + Send {
-            self.events.lock().unwrap().push(event.clone());
+    impl super::super::sinks::RouterEventBatchSink for MockPublisher {
+        fn publish_events(
+            &self,
+            events: &[RouterEvent],
+        ) -> impl Future<Output = Result<()>> + Send {
+            self.events.lock().unwrap().extend_from_slice(events);
+            self.batches.lock().unwrap().push(events.to_vec());
             async { Ok(()) }
         }
     }
@@ -2182,6 +2192,8 @@ mod event_processor_tests {
                 .collect::<Vec<_>>(),
             vec![1, 2, 3, 4, 5, 6]
         );
+        assert_eq!(publisher.get_batches().len(), 1);
+        assert_eq!(publisher.get_batches()[0], events);
     }
 
     #[tokio::test]
@@ -2205,6 +2217,7 @@ mod event_processor_tests {
 
         let events = publisher.get_events();
         assert_eq!(events.len(), 2);
+        assert_eq!(publisher.get_batches().len(), 2);
         assert!(events.iter().all(|event| {
             matches!(&event.event.data, KvCacheEventData::Removed(data) if data.block_hashes.len() == 1)
         }));
@@ -3483,5 +3496,120 @@ mod event_processor_tests {
         } else {
             panic!("Expected Stored event");
         }
+    }
+}
+
+#[cfg(test)]
+mod zmq_event_batch_tests {
+    use super::*;
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, RouterEvent,
+    };
+
+    use super::super::sinks::{
+        MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES, RouterEventBatchSink, encode_zmq_event_batches,
+    };
+
+    fn router_event(event_id: u64) -> RouterEvent {
+        RouterEvent::new(
+            7,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Removed(KvCacheRemoveData {
+                    block_hashes: vec![ExternalSequenceBlockHash(event_id + 100)],
+                }),
+                dp_rank: (event_id % 2) as u32,
+            },
+        )
+    }
+
+    #[test]
+    fn zmq_batch_encoding_matches_named_msgpack_and_roundtrips() {
+        let events = vec![router_event(1), router_event(2), router_event(3)];
+        let expected = rmp_serde::to_vec_named(&events).unwrap();
+
+        let encoded = encode_zmq_event_batches(&events, expected.len()).unwrap();
+
+        assert_eq!(encoded, vec![expected]);
+        assert_eq!(
+            rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded[0]).unwrap(),
+            events
+        );
+    }
+
+    #[test]
+    fn zmq_batch_encoding_splits_at_event_boundaries_in_order() {
+        let events = (0..7).map(router_event).collect::<Vec<_>>();
+
+        let encoded = encode_zmq_event_batches(&events, 1).unwrap();
+        let decoded = encoded
+            .iter()
+            .flat_map(|payload| rmp_serde::from_slice::<Vec<RouterEvent>>(payload).unwrap())
+            .collect::<Vec<_>>();
+
+        assert_eq!(encoded.len(), events.len());
+        assert_eq!(decoded, events);
+    }
+
+    #[test]
+    fn zmq_batch_encoding_enforces_one_mib_payload_cap() {
+        let events = (0..20_000).map(router_event).collect::<Vec<_>>();
+
+        let encoded = encode_zmq_event_batches(&events, MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES).unwrap();
+        let decoded = encoded
+            .iter()
+            .flat_map(|payload| {
+                assert!(payload.len() <= MAX_ZMQ_KV_EVENT_PAYLOAD_BYTES);
+                rmp_serde::from_slice::<Vec<RouterEvent>>(payload).unwrap()
+            })
+            .collect::<Vec<_>>();
+
+        assert!(encoded.len() > 1);
+        assert_eq!(decoded, events);
+    }
+
+    #[test]
+    fn zmq_batch_encoding_allows_one_oversized_event() {
+        let event = router_event(1);
+        let encoded = encode_zmq_event_batches(std::slice::from_ref(&event), 1).unwrap();
+
+        assert_eq!(encoded.len(), 1);
+        assert!(encoded[0].len() > 1);
+        assert_eq!(
+            rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded[0]).unwrap(),
+            vec![event]
+        );
+    }
+
+    #[test]
+    fn zmq_batch_encoding_skips_empty_batches() {
+        assert!(encode_zmq_event_batches(&[], 1024).unwrap().is_empty());
+    }
+
+    #[derive(Clone, Default)]
+    struct SingletonSink {
+        events: Arc<std::sync::Mutex<Vec<RouterEvent>>>,
+    }
+
+    impl RouterEventSink for SingletonSink {
+        fn publish_event(
+            &self,
+            event: &RouterEvent,
+        ) -> impl Future<Output = anyhow::Result<()>> + Send {
+            self.events.lock().unwrap().push(event.clone());
+            async { Ok(()) }
+        }
+    }
+
+    #[tokio::test]
+    async fn non_zmq_batch_sink_preserves_singleton_publication() {
+        let sink = SingletonSink::default();
+        let events = vec![router_event(1), router_event(2), router_event(3)];
+
+        RouterEventBatchSink::publish_events(&sink, &events)
+            .await
+            .unwrap();
+
+        assert_eq!(*sink.events.lock().unwrap(), events);
     }
 }

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -3503,12 +3503,19 @@ mod event_processor_tests {
 mod event_plane_batch_tests {
     use super::*;
     use dynamo_kv_router::protocols::{
-        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData,
-        KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, RouterEvent,
+        BlockExtraInfo, BlockMmObjectInfo, ExternalSequenceBlockHash, KvCacheEvent,
+        KvCacheEventData, KvCacheRemoveData, KvCacheStoreData, KvCacheStoredBlockData,
+        LocalBlockHash, RouterEvent,
     };
+    use dynamo_runtime::config::environment_names::zmq_broker as broker_env;
+    use dynamo_runtime::distributed::DistributedConfig;
+    use dynamo_runtime::transports::event_plane::{
+        EventPublisher, EventSubscriber, EventTransportKind, MsgpackCodec,
+    };
+    use dynamo_runtime::{DistributedRuntime, Runtime};
 
     use super::super::sinks::{
-        MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS, RouterEventBatchSink, encode_event_plane_batch,
+        EventPlanePublisher, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS, RouterEventBatchSink,
         event_plane_event_batches,
     };
 
@@ -3532,6 +3539,14 @@ mod event_plane_batch_tests {
     }
 
     fn stored_router_event(event_id: u64, block_count: usize) -> RouterEvent {
+        stored_router_event_with_mm(event_id, block_count, false)
+    }
+
+    fn stored_router_event_with_mm(
+        event_id: u64,
+        block_count: usize,
+        with_mm: bool,
+    ) -> RouterEvent {
         RouterEvent::new(
             7,
             KvCacheEvent {
@@ -3545,13 +3560,39 @@ mod event_plane_batch_tests {
                                 event_id * 100_000 + index as u64,
                             ),
                             tokens_hash: LocalBlockHash(event_id * 100_000 + index as u64),
-                            mm_extra_info: None,
+                            mm_extra_info: with_mm.then(|| BlockExtraInfo {
+                                mm_objects: vec![BlockMmObjectInfo {
+                                    mm_hash: event_id * 100_000 + index as u64,
+                                    offsets: vec![(0, 16)],
+                                }],
+                            }),
                         })
                         .collect(),
                 }),
                 dp_rank: (event_id % 2) as u32,
             },
         )
+    }
+
+    fn production_stored_batch(with_mm: bool) -> Vec<RouterEvent> {
+        assert_eq!(
+            MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS % DEFAULT_MAX_BATCH_BLOCKS,
+            0
+        );
+        (0..MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS / DEFAULT_MAX_BATCH_BLOCKS)
+            .map(|event_id| {
+                stored_router_event_with_mm(event_id as u64, DEFAULT_MAX_BATCH_BLOCKS, with_mm)
+            })
+            .collect()
+    }
+
+    fn encoded_wire_size(events: &[RouterEvent]) -> usize {
+        let codec = MsgpackCodec;
+        let payload = codec.encode_payload(&events).unwrap();
+        codec
+            .encode_envelope_parts(u64::MAX, u64::MAX, u64::MAX, KV_EVENT_SUBJECT, &payload)
+            .unwrap()
+            .len()
     }
 
     fn cleared_router_event(event_id: u64) -> RouterEvent {
@@ -3566,16 +3607,19 @@ mod event_plane_batch_tests {
     }
 
     #[test]
-    fn event_plane_batch_encoding_matches_named_msgpack_and_roundtrips() {
-        let events = vec![router_event(1), router_event(2), router_event(3)];
-        let expected = rmp_serde::to_vec_named(&events).unwrap();
+    fn production_event_plane_batches_fit_default_nats_payload() {
+        const NATS_DEFAULT_MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
 
-        let encoded = encode_event_plane_batch(&events).unwrap();
+        let plain_wire_size = encoded_wire_size(&production_stored_batch(false));
+        assert!(
+            plain_wire_size < NATS_DEFAULT_MAX_PAYLOAD_BYTES,
+            "plain production batch encoded to {plain_wire_size} bytes"
+        );
 
-        assert_eq!(encoded, expected);
-        assert_eq!(
-            rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded).unwrap(),
-            events
+        let multimodal_wire_size = encoded_wire_size(&production_stored_batch(true));
+        assert!(
+            multimodal_wire_size < NATS_DEFAULT_MAX_PAYLOAD_BYTES,
+            "single-object multimodal production batch encoded to {multimodal_wire_size} bytes"
         );
     }
 
@@ -3645,5 +3689,108 @@ mod event_plane_batch_tests {
             .unwrap();
 
         assert_eq!(*sink.events.lock().unwrap(), events);
+    }
+
+    #[derive(Clone)]
+    struct FailingSingletonSink {
+        attempted_event_ids: Arc<std::sync::Mutex<Vec<u64>>>,
+        failing_event_ids: Arc<Vec<u64>>,
+    }
+
+    impl RouterEventSink for FailingSingletonSink {
+        fn publish_event(
+            &self,
+            event: &RouterEvent,
+        ) -> impl Future<Output = anyhow::Result<()>> + Send {
+            let event_id = event.event.event_id;
+            self.attempted_event_ids.lock().unwrap().push(event_id);
+            let should_fail = self.failing_event_ids.contains(&event_id);
+            async move {
+                if should_fail {
+                    anyhow::bail!("synthetic publish failure for event {event_id}");
+                }
+                Ok(())
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn batch_sink_reports_each_failure_and_attempts_later_events() {
+        let attempted_event_ids = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let sink = FailingSingletonSink {
+            attempted_event_ids: Arc::clone(&attempted_event_ids),
+            failing_event_ids: Arc::new(vec![2, 4]),
+        };
+        let events = (1..=4).map(router_event).collect::<Vec<_>>();
+
+        let error = RouterEventBatchSink::publish_events(&sink, &events)
+            .await
+            .unwrap_err();
+
+        assert_eq!(*attempted_event_ids.lock().unwrap(), vec![1, 2, 3, 4]);
+        assert_eq!(
+            error.to_string(),
+            "2 publish attempt(s) failed; 2 event(s) dropped; first error: synthetic publish failure for event 2"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_plane_publisher_roundtrips_batch_through_production_codec() {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
+            ],
+            async {
+                let runtime = Runtime::from_current().expect("create runtime handle");
+                let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+                    .await
+                    .expect("create distributed runtime");
+                let component = drt
+                    .namespace("kv-event-batch-codec-test")
+                    .expect("create namespace")
+                    .component("worker")
+                    .expect("create component");
+                let publisher = EventPublisher::for_component_with_transport(
+                    &component,
+                    KV_EVENT_SUBJECT,
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create publisher");
+                let mut subscriber = EventSubscriber::for_component_with_transport(
+                    &component,
+                    KV_EVENT_SUBJECT,
+                    EventTransportKind::Zmq,
+                )
+                .await
+                .expect("create subscriber")
+                .typed::<Vec<RouterEvent>>();
+                let sink = EventPlanePublisher(publisher);
+                let events = vec![router_event(1), router_event(2), router_event(3)];
+
+                let received = tokio::time::timeout(Duration::from_secs(5), async {
+                    loop {
+                        RouterEventBatchSink::publish_events(&sink, &events)
+                            .await
+                            .expect("publish event batch");
+                        match tokio::time::timeout(Duration::from_millis(100), subscriber.next())
+                            .await
+                        {
+                            Ok(Some(Ok((_envelope, received)))) => break received,
+                            Ok(Some(Err(error))) => panic!("receive event batch: {error}"),
+                            Ok(None) => panic!("event-plane stream closed"),
+                            Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+                        }
+                    }
+                })
+                .await
+                .expect("subscriber should receive an event batch");
+
+                assert_eq!(received, events);
+                drt.shutdown();
+            },
+        )
+        .await;
     }
 }

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -3500,33 +3500,77 @@ mod event_processor_tests {
 }
 
 #[cfg(test)]
-mod zmq_event_batch_tests {
+mod event_plane_batch_tests {
     use super::*;
     use dynamo_kv_router::protocols::{
-        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData, RouterEvent,
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheRemoveData,
+        KvCacheStoreData, KvCacheStoredBlockData, LocalBlockHash, RouterEvent,
     };
 
-    use super::super::sinks::{RouterEventBatchSink, encode_zmq_event_batch};
+    use super::super::sinks::{
+        MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS, RouterEventBatchSink, encode_event_plane_batch,
+        event_plane_event_batches,
+    };
 
     fn router_event(event_id: u64) -> RouterEvent {
+        removed_router_event(event_id, 1)
+    }
+
+    fn removed_router_event(event_id: u64, block_count: usize) -> RouterEvent {
         RouterEvent::new(
             7,
             KvCacheEvent {
                 event_id,
                 data: KvCacheEventData::Removed(KvCacheRemoveData {
-                    block_hashes: vec![ExternalSequenceBlockHash(event_id + 100)],
+                    block_hashes: (0..block_count)
+                        .map(|index| ExternalSequenceBlockHash(event_id * 100_000 + index as u64))
+                        .collect(),
                 }),
                 dp_rank: (event_id % 2) as u32,
             },
         )
     }
 
+    fn stored_router_event(event_id: u64, block_count: usize) -> RouterEvent {
+        RouterEvent::new(
+            7,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Stored(KvCacheStoreData {
+                    parent_hash: None,
+                    start_position: None,
+                    blocks: (0..block_count)
+                        .map(|index| KvCacheStoredBlockData {
+                            block_hash: ExternalSequenceBlockHash(
+                                event_id * 100_000 + index as u64,
+                            ),
+                            tokens_hash: LocalBlockHash(event_id * 100_000 + index as u64),
+                            mm_extra_info: None,
+                        })
+                        .collect(),
+                }),
+                dp_rank: (event_id % 2) as u32,
+            },
+        )
+    }
+
+    fn cleared_router_event(event_id: u64) -> RouterEvent {
+        RouterEvent::new(
+            7,
+            KvCacheEvent {
+                event_id,
+                data: KvCacheEventData::Cleared,
+                dp_rank: (event_id % 2) as u32,
+            },
+        )
+    }
+
     #[test]
-    fn zmq_batch_encoding_matches_named_msgpack_and_roundtrips() {
+    fn event_plane_batch_encoding_matches_named_msgpack_and_roundtrips() {
         let events = vec![router_event(1), router_event(2), router_event(3)];
         let expected = rmp_serde::to_vec_named(&events).unwrap();
 
-        let encoded = encode_zmq_event_batch(&events).unwrap();
+        let encoded = encode_event_plane_batch(&events).unwrap();
 
         assert_eq!(encoded, expected);
         assert_eq!(
@@ -3536,14 +3580,58 @@ mod zmq_event_batch_tests {
     }
 
     #[test]
-    fn zmq_batch_encoding_keeps_large_batches_in_one_payload() {
+    fn event_plane_batch_encoding_has_no_byte_size_cap() {
         let events = (0..20_000).map(router_event).collect::<Vec<_>>();
+        let batches = event_plane_event_batches(&events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS)
+            .collect::<Vec<_>>();
 
-        let encoded = encode_zmq_event_batch(&events).unwrap();
+        assert_eq!(batches.len(), 1);
+        let encoded = encode_event_plane_batch(batches[0]).unwrap();
         let decoded = rmp_serde::from_slice::<Vec<RouterEvent>>(&encoded).unwrap();
 
         assert!(encoded.len() > 1024 * 1024);
         assert_eq!(decoded, events);
+    }
+
+    #[test]
+    fn event_plane_batching_counts_stored_and_removed_blocks() {
+        let events = vec![
+            stored_router_event(1, 2),
+            removed_router_event(2, 2),
+            cleared_router_event(3),
+            removed_router_event(4, 1),
+        ];
+
+        let batches = event_plane_event_batches(&events, 4).collect::<Vec<_>>();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0], &events[..3]);
+        assert_eq!(batches[1], &events[3..]);
+    }
+
+    #[test]
+    fn event_plane_batching_allows_one_oversized_event() {
+        let events = vec![removed_router_event(1, 5), removed_router_event(2, 1)];
+
+        let batches = event_plane_event_batches(&events, 4).collect::<Vec<_>>();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0], &events[..1]);
+        assert_eq!(batches[1], &events[1..]);
+    }
+
+    #[test]
+    fn event_plane_batching_enforces_production_block_cap() {
+        let events = (0..=MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS as u64)
+            .map(router_event)
+            .collect::<Vec<_>>();
+
+        let batches = event_plane_event_batches(&events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS)
+            .collect::<Vec<_>>();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0].len(), MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS);
+        assert_eq!(batches[1].len(), 1);
     }
 
     #[derive(Clone, Default)]
@@ -3562,7 +3650,7 @@ mod zmq_event_batch_tests {
     }
 
     #[tokio::test]
-    async fn non_zmq_batch_sink_preserves_singleton_publication() {
+    async fn jetstream_batch_sink_preserves_singleton_publication() {
         let sink = SingletonSink::default();
         let events = vec![router_event(1), router_event(2), router_event(3)];
 

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -3515,8 +3515,8 @@ mod event_plane_batch_tests {
     use dynamo_runtime::{DistributedRuntime, Runtime};
 
     use super::super::sinks::{
-        EventPlanePublisher, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS, RouterEventBatchSink,
-        event_plane_event_batches,
+        EventPlanePublisher, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS,
+        MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH, RouterEventBatchSink, event_plane_event_batches,
     };
 
     fn router_event(event_id: u64) -> RouterEvent {
@@ -3621,6 +3621,31 @@ mod event_plane_batch_tests {
             multimodal_wire_size < NATS_DEFAULT_MAX_PAYLOAD_BYTES,
             "single-object multimodal production batch encoded to {multimodal_wire_size} bytes"
         );
+
+        for with_mm in [false, true] {
+            let sparse_events = (0..MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS as u64)
+                .map(|event_id| stored_router_event_with_mm(event_id, 1, with_mm))
+                .collect::<Vec<_>>();
+            assert!(
+                encoded_wire_size(&sparse_events) > NATS_DEFAULT_MAX_PAYLOAD_BYTES,
+                "sparse multimodal={with_mm} fixture should exceed the NATS payload limit without the event cap"
+            );
+            let batches = event_plane_event_batches(
+                &sparse_events,
+                MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH,
+                MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS,
+            )
+            .collect::<Vec<_>>();
+
+            assert_eq!(batches.len(), 64);
+            assert!(
+                batches.iter().all(|batch| {
+                    batch.len() <= MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH
+                        && encoded_wire_size(batch) < NATS_DEFAULT_MAX_PAYLOAD_BYTES
+                }),
+                "sparse multimodal={with_mm} batch exceeded an event or NATS payload cap"
+            );
+        }
     }
 
     #[test]
@@ -3632,7 +3657,7 @@ mod event_plane_batch_tests {
             removed_router_event(4, 1),
         ];
 
-        let batches = event_plane_event_batches(&events, 4).collect::<Vec<_>>();
+        let batches = event_plane_event_batches(&events, usize::MAX, 4).collect::<Vec<_>>();
 
         assert_eq!(batches.len(), 2);
         assert_eq!(batches[0], &events[..3]);
@@ -3643,7 +3668,7 @@ mod event_plane_batch_tests {
     fn event_plane_batching_allows_one_oversized_event() {
         let events = vec![removed_router_event(1, 5), removed_router_event(2, 1)];
 
-        let batches = event_plane_event_batches(&events, 4).collect::<Vec<_>>();
+        let batches = event_plane_event_batches(&events, usize::MAX, 4).collect::<Vec<_>>();
 
         assert_eq!(batches.len(), 2);
         assert_eq!(batches[0], &events[..1]);
@@ -3652,15 +3677,38 @@ mod event_plane_batch_tests {
 
     #[test]
     fn event_plane_batching_enforces_production_block_cap() {
-        let events = (0..=MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS as u64)
+        let events = vec![
+            removed_router_event(1, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS),
+            router_event(2),
+        ];
+
+        let batches = event_plane_event_batches(
+            &events,
+            MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH,
+            MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS,
+        )
+        .collect::<Vec<_>>();
+
+        assert_eq!(batches.len(), 2);
+        assert_eq!(batches[0], &events[..1]);
+        assert_eq!(batches[1].len(), 1);
+    }
+
+    #[test]
+    fn event_plane_batching_enforces_production_event_cap() {
+        let events = (0..=MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH as u64)
             .map(router_event)
             .collect::<Vec<_>>();
 
-        let batches = event_plane_event_batches(&events, MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS)
-            .collect::<Vec<_>>();
+        let batches = event_plane_event_batches(
+            &events,
+            MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH,
+            MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS,
+        )
+        .collect::<Vec<_>>();
 
         assert_eq!(batches.len(), 2);
-        assert_eq!(batches[0].len(), MAX_EVENT_PLANE_KV_EVENT_BATCH_BLOCKS);
+        assert_eq!(batches[0].len(), MAX_EVENT_PLANE_KV_EVENTS_PER_BATCH);
         assert_eq!(batches[1].len(), 1);
     }
 


### PR DESCRIPTION
## Overview

Native KV event batches can produce multiple ordered `RouterEvent`s after filtering, deduplication, and coalescing. The event plane currently serializes and publishes each resulting event as a separate message, multiplying envelope, serialization, transport, and receiver overhead.

This change publishes ordered `RouterEvent` vectors on both ZMQ and NATS Core, bounded by represented block count and event count rather than serialized byte size. The deprecated durable JetStream path retains its existing singleton payload.

## Summary

- collect the `RouterEvent`s emitted during an event-processor turn without changing coalescing, deduplication, event IDs, or local-indexer application
- partition ordered events before serialization at 128 events or 8,192 represented blocks, whichever limit is reached first, while always allowing at least one complete event per message
- count stored blocks and removed block hashes toward the block cap; `Cleared` events contribute zero blocks
- publish each resulting `Vec<RouterEvent>` through the existing production event-plane codec
- use the same batched payload and frontend decoder for ZMQ and NATS Core
- retain singleton `RouterEvent` publication and consumption for durable JetStream

## Details

The partitioner is allocation-free and never splits a `RouterEvent`. A normal message contains at most 128 events and 8,192 represented blocks. If one event represents more than 8,192 blocks, it is published intact as its own message. There is no serialized-byte-size check, speculative serialization, or subset reserialization.

This is a deliberate hard event-plane wire change: ZMQ and NATS Core publishers and subscribers now encode and decode `Vec<RouterEvent>` only. They must be upgraded together; rolling between singleton and vector payload versions is unsupported. The deprecated durable JetStream path, including the standalone-indexer flow that uses it, remains singleton-based.

NATS Core defaults to a 1 MiB `max_payload`. An unpartitioned adversarial batch containing 8,192 one-block events exceeds that limit because named MessagePack repeats event-level metadata. Regression tests reproduce that case and verify that every 128-event partition remains below 1 MiB, both for plain stored blocks and for one multimodal object with one offset per block. Dense 8,192-block production-shaped batches are also verified below the limit. Multimodal metadata is not intrinsically bounded, so an exceptional single event can still exceed the configured transport limit. That edge case is accepted: the failed publish is logged and dropped under the existing at-most-once semantics, with no retry, requeueing, backpressure, or byte-based splitting.

When one ordered output partitions into multiple event-plane messages, every partition is attempted even if an earlier publish fails. Each failed partition is logged with its transport, event count, and event-ID range, and the returned error reports the exact number of failed publishes and dropped events.

The existing queue sizes, overflow behavior, transport envelopes, publisher sequence numbers, worker event IDs, recovery behavior, shutdown cancellation between decoded events, and public APIs remain unchanged. There is no compatibility fallback or new runtime telemetry.

## Where should the reviewer start?

1. `lib/llm/src/kv_router/publisher/sinks.rs` for event/block partitioning, production-codec publication, and failure reporting
2. `lib/llm/src/kv_router/publisher/event_processor.rs` for ordered output collection and publication boundaries
3. `lib/llm/src/kv_router/indexer/recovery/subscriber.rs` for shared NATS Core/ZMQ batch decoding and ordered frontend delivery

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Validation

- `cargo fmt --package dynamo-llm -- --check`
- `cargo test -p dynamo-llm kv_router::publisher::tests --lib` (78 passed)
- `cargo check -p dynamo-llm --bench kv_router_bench --features kv-router-stress`
- `cargo clippy -p dynamo-llm --lib --tests --no-deps -- -D warnings`
- `git diff --check`
- coverage includes event/block partitioning, both production caps, oversized singleton events, adversarial sparse-event NATS envelope sizes, ordering, deduplication, JetStream singleton behavior, aggregate partial-publish failures, and production-codec publisher/subscriber roundtripping

The existing mocker C512 topology was not used as a performance gate because `dynamo.mocker` feeds singleton native lists directly into the publisher and therefore cannot measure the intended native-batch message reduction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved event delivery by publishing related updates in efficient batches.
  - Preserved event ordering while respecting delivery size limits.
  - Added support for processing multiple incoming events together.

- **Bug Fixes**
  - Improved resilience when receiving event updates, allowing processing to continue after recoverable failures.
  - Ensured pending updates are flushed during shutdown or cancellation.

- **Tests**
  - Added coverage for event batching, encoding, ordering, size limits, and recovery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
