### PR TITLE
refactor(snapshot): run restore FD cleanup after cuda unlock

### DIFF
--- a/deploy/snapshot/internal/criu/restore.go
+++ b/deploy/snapshot/internal/criu/restore.go
@@ -30,55 +30,69 @@ func ExecuteRestore(
 	m *types.CheckpointManifest,
 	checkpointPath string,
 	log logr.Logger,
-) (int32, error) {
+) (int32, func(), error) {
 	settings := m.CRIUDump.CRIU
+
+	// Return the FD closers as cleanup() rather than deferring them here, so the
+	// caller can run them after cuda unlock instead of between the CRIU restore
+	// and unlock. That keeps the window where the restored process runs with CUDA
+	// still locked as short as possible. cleanup is called on the error paths below.
+	var openFiles, inheritedFiles []*os.File
+	cleanup := func() {
+		closeFiles(inheritedFiles)
+		closeFiles(openFiles)
+	}
 
 	// Open image dir FD
 	imageDir, imageDirFD, err := openPathForCRIU(checkpointPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open image directory: %w", err)
+		return 0, nil, fmt.Errorf("failed to open image directory: %w", err)
 	}
-	defer imageDir.Close()
+	openFiles = append(openFiles, imageDir)
 	criuOpts.ImagesDirFd = proto.Int32(imageDirFD)
 
 	// Open work dir FD
 	if settings.WorkDir != "" {
 		if err := os.MkdirAll(settings.WorkDir, 0755); err != nil {
-			return 0, fmt.Errorf("failed to create CRIU work directory: %w", err)
+			cleanup()
+			return 0, nil, fmt.Errorf("failed to create CRIU work directory: %w", err)
 		}
 		workDirFile, workDirFD, err := openPathForCRIU(settings.WorkDir)
 		if err != nil {
-			return 0, fmt.Errorf("failed to open CRIU work directory: %w", err)
+			cleanup()
+			return 0, nil, fmt.Errorf("failed to open CRIU work directory: %w", err)
 		}
-		defer workDirFile.Close()
+		openFiles = append(openFiles, workDirFile)
 		criuOpts.WorkDirFd = proto.Int32(workDirFD)
 	}
 
 	c := criulib.MakeCriu()
 	if _, err := os.Stat(settings.BinaryPath); err != nil {
-		return 0, fmt.Errorf("criu binary not found at %s: %w", settings.BinaryPath, err)
+		cleanup()
+		return 0, nil, fmt.Errorf("criu binary not found at %s: %w", settings.BinaryPath, err)
 	}
 	c.SetCriuPath(settings.BinaryPath)
 
 	netNsFile, err := os.Open(netNsPath)
 	if err != nil {
-		return 0, fmt.Errorf("failed to open net NS at %s: %w", netNsPath, err)
+		cleanup()
+		return 0, nil, fmt.Errorf("failed to open net NS at %s: %w", netNsPath, err)
 	}
-	defer netNsFile.Close()
+	openFiles = append(openFiles, netNsFile)
 	c.AddInheritFd("extNetNs", netNsFile)
 
-	inheritedFiles := registerInheritFDs(c, m.K8s.StdioFDs, log)
-	defer closeFiles(inheritedFiles)
+	inheritedFiles = registerInheritFDs(c, m.K8s.StdioFDs, log)
 
 	notify := &restoreNotify{log: log}
 	log.V(1).Info("Executing go-criu Restore call")
 	if err := c.Restore(criuOpts, notify); err != nil {
 		log.Error(err, "go-criu Restore returned error")
 		logging.LogRestoreErrors(checkpointPath, settings.WorkDir, log)
-		return 0, fmt.Errorf("CRIU restore failed: %w", err)
+		cleanup()
+		return 0, nil, fmt.Errorf("CRIU restore failed: %w", err)
 	}
 
-	return notify.restoredPID, nil
+	return notify.restoredPID, cleanup, nil
 }
 
 // BuildRestoreOpts assembles CriuOpts for a CRIU restore from the checkpoint manifest.

--- a/deploy/snapshot/internal/executor/nsrestore.go
+++ b/deploy/snapshot/internal/executor/nsrestore.go
@@ -122,10 +122,14 @@ func executeRestore(ctx context.Context, criuOpts *criurpc.CriuOpts, m *types.Ch
 
 	// CRIU restore
 	criuRestoreStart := time.Now()
-	restoredPID, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, log)
+	restoredPID, cleanup, err := criu.ExecuteRestore(criuOpts, m, opts.CheckpointPath, log)
 	if err != nil {
 		return nil, 0, err
 	}
+	// Run the restore's FD cleanup at return, after cuda unlock and the
+	// restore-complete sentinel below, so nothing but the required PID resolve
+	// sits between the CRIU restore and unlock. Runs on any return, incl. errors.
+	defer cleanup()
 	timings.criuRestoreDuration = time.Since(criuRestoreStart)
 
 	cudaStart := time.Now()


### PR DESCRIPTION
## What

`ExecuteRestore` deferred its FD closes (image dir, work dir, net ns, inherited stdio), so they ran on return — between the CRIU restore that resumes the process and the cuda-checkpoint restore+unlock in `executeRestore`. This returns them as a `cleanup` func and runs it after unlock. The only work left between the CRIU restore and unlock is the PID resolve that unlock needs (`ReadProcessTable` + `ResolveManifestPIDsToObservedPIDs`).

## Why

The restored process is resumed by CRIU before cuda-checkpoint unlock runs, so it briefly runs with CUDA still locked (a GPU call blocks on the lock until unlock). Deferring the FD cleanup past unlock keeps that window as short as possible and keeps anything but the required PID resolve from sitting between restore and unlock.

Impact on the current path is small — the cleanup here is only fd closes. It's mostly about the ordering, so a later restore path that adds heavier teardown (e.g. S3/streaming staging) can't wedge it between restore and unlock.

## Test

`go build ./...`, `go vet`, and the `internal/{criu,executor,runtime}` unit tests pass.