### PR TITLE
feat(gms): construct RO model on device over single-block scratch

### DIFF
--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -153,11 +153,19 @@ class GMSClientMemoryManager:
         device: int = 0,
         tag: Optional[str] = None,
         scratch_size: int = 512 * 1024 * 1024,
+        single_block: bool = False,
     ) -> None:
         self.socket_path = socket_path
         self.device = device
         self.tag = tag
         self.scratch_size = scratch_size
+        # When True, every scratch mapping aliases ONE shared physical block
+        # instead of minting a fresh block per allocation. Construction-time
+        # weight skeletons make thousands of allocations; without sharing, the
+        # per-allocation blocks would cost hundreds of GiB. The shared handle is
+        # released once the last aliasing VA is torn down.
+        self.single_block = single_block
+        self._shared_scratch_handle: int = 0
         self._vmm = get_vmm()
 
         self._client: Optional[_GMSClientSession] = None
@@ -203,6 +211,10 @@ class GMSClientMemoryManager:
     @property
     def mappings(self) -> Dict[int, LocalMapping]:
         return self._mappings
+
+    @property
+    def scratch_mappings(self) -> Dict[int, "_ScratchMapping"]:
+        return self._scratch_mappings
 
     @property
     def total_bytes(self) -> int:
@@ -516,10 +528,14 @@ class GMSClientMemoryManager:
             if scratch.scratch_handle == 0:
                 continue
             self._vmm.unmap(base_va, scratch.va_reserved_size)
-            self._vmm.release(scratch.scratch_handle)
+            if not self.single_block:
+                self._vmm.release(scratch.scratch_handle)
             scratch.scratch_handle = 0
             unmapped_count += 1
             total_bytes += scratch.va_reserved_size
+        if self.single_block and self._shared_scratch_handle:
+            self._vmm.release(self._shared_scratch_handle)
+            self._shared_scratch_handle = 0
 
         self._va_preserved = True
         self._unmapped = True
@@ -694,15 +710,29 @@ class GMSClientMemoryManager:
         aligned_size = align_to_granularity(size, self.granularity)
         va_reserved_size = align_to_granularity(size, self.scratch_size)
 
-        ok, scratch_handle = self._vmm.create_tolerate_oom(
-            self.scratch_size, self.device
-        )
-        if not ok:
-            raise RuntimeError(
-                f"VMM physical memory allocation failed "
-                f"({self.scratch_size // (1 << 20)} MiB) on "
-                f"{self.device_type.value} device {self.device}"
+        if self.single_block:
+            # One physical block backs every scratch VA in this manager.
+            if self._shared_scratch_handle == 0:
+                ok, self._shared_scratch_handle = self._vmm.create_tolerate_oom(
+                    self.scratch_size, self.device
+                )
+                if not ok:
+                    raise RuntimeError(
+                        f"VMM physical memory allocation failed "
+                        f"({self.scratch_size // (1 << 20)} MiB) on "
+                        f"{self.device_type.value} device {self.device}"
+                    )
+            scratch_handle = self._shared_scratch_handle
+        else:
+            ok, scratch_handle = self._vmm.create_tolerate_oom(
+                self.scratch_size, self.device
             )
+            if not ok:
+                raise RuntimeError(
+                    f"VMM physical memory allocation failed "
+                    f"({self.scratch_size // (1 << 20)} MiB) on "
+                    f"{self.device_type.value} device {self.device}"
+                )
 
         va = self._vmm.address_reserve(va_reserved_size, self.scratch_size)
         for offset in range(0, va_reserved_size, self.scratch_size):
@@ -794,8 +824,18 @@ class GMSClientMemoryManager:
         self._vmm.synchronize()
         if scratch.scratch_handle:
             self._vmm.unmap(base_va, scratch.va_reserved_size)
-            self._vmm.release(scratch.scratch_handle)
+            # In single-block mode the physical is shared; release it once the
+            # last aliasing VA is gone (below), not per entry.
+            if not self.single_block:
+                self._vmm.release(scratch.scratch_handle)
         self._vmm.address_free(base_va, scratch.va_reserved_size)
+        if (
+            self.single_block
+            and self._shared_scratch_handle
+            and not self._scratch_mappings
+        ):
+            self._vmm.release(self._shared_scratch_handle)
+            self._shared_scratch_handle = 0
         return True
 
     # ==================== Lifecycle ====================

--- a/lib/gpu_memory_service/client/torch/allocator.py
+++ b/lib/gpu_memory_service/client/torch/allocator.py
@@ -184,6 +184,7 @@ def get_or_create_scratch_manager(
     *,
     tag: str = "kv_cache",
     scratch_size: int = 512 * 1024 * 1024,
+    single_block: bool = False,
 ) -> "GMSClientMemoryManager":
     """Register an unconnected manager for client-local scratch allocation.
 
@@ -213,6 +214,11 @@ def get_or_create_scratch_manager(
                 f"GMS scratch allocator tag={tag} was initialized with "
                 f"scratch_size={state.manager.scratch_size}, not {scratch_size}"
             )
+        if state.manager.single_block != single_block:
+            raise RuntimeError(
+                f"GMS scratch allocator tag={tag} was initialized with "
+                f"single_block={state.manager.single_block}, not {single_block}"
+            )
         return state.manager
 
     manager = GMSClientMemoryManager(
@@ -220,6 +226,7 @@ def get_or_create_scratch_manager(
         device=device,
         tag=tag,
         scratch_size=scratch_size,
+        single_block=single_block,
     )
     _ensure_callbacks_initialized()
     mem_pool = _create_mem_pool()

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -10,6 +10,7 @@ processes import from GMS metadata (RO).
 
 from __future__ import annotations
 
+import gc
 import logging
 import os
 from typing import TYPE_CHECKING
@@ -259,8 +260,24 @@ def _load_read_mode(
     global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
     try:
-        model = _create_meta_model(vllm_config, model_config)
+        # Construct the RO skeleton on a REAL device (default) rather than on
+        # `meta`. Building on a real device sidesteps the meta-safety hazards
+        # that the meta path is exposed to (.item()/.to(device)/data-dependent
+        # ops during __init__, fake-op signatures, post-load hooks that touch
+        # the device), which is the source of most per-model RO patches. The
+        # meta path is retained behind DYN_GMS_RO_META_CONSTRUCT=1 as a fallback.
+        if os.environ.get("DYN_GMS_RO_META_CONSTRUCT") == "1":
+            model = _create_meta_model(vllm_config, model_config)
+        else:
+            model = _create_device_model(vllm_config, model_config, device_index)
         materialize_module_from_gms(gms_client, model, device_index=device_index)
+        # Params built on the device were replaced by shared GMS views; return
+        # their now-unreferenced garbage backing to the device.
+        _release_construction_memory()
+        # Loud check for the device path's silent-garbage risk: on `meta` an
+        # unmaterialized param stays a meta tensor (caught above + crashes at
+        # forward); on the device path it would hold garbage silently.
+        _warn_on_unbacked_parameters(gms_client, model)
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)
@@ -346,8 +363,112 @@ def _load_write_mode(
     return model.eval()
 
 
+def _create_device_model(
+    vllm_config, model_config, device_index: int
+) -> torch.nn.Module:
+    """Create the RO model on a real CUDA device for materialization.
+
+    Building on a real device (instead of `meta`) lets model ``__init__`` and
+    ``process_weights_after_loading`` run on real tensors, so the meta-device
+    hazards the meta path guards against (``.item()``/``.to(device)``/data
+    dependent ops, custom-op fake signatures, post-load hooks that initialize
+    device scratch) simply do not arise. Parameters are allocated with garbage
+    contents and immediately replaced by ``materialize_module_from_gms`` with
+    shared read-only GMS views; ``process_weights_after_loading`` runs so the
+    derived-tensor structure exists for materialize to fill (its garbage output
+    is overwritten). The garbage backing is returned to the device afterward
+    (see ``_release_construction_memory``).
+
+    NOTE: this transiently allocates a full weight-sized garbage copy on the
+    device before materialization frees it. That fits a single RO engine;
+    memory-optimal construction over aliased scratch backing (required for
+    two-engine colocation) is a planned follow-up.
+    """
+    from vllm.model_executor.model_loader.utils import (
+        initialize_model,
+        process_weights_after_loading,
+    )
+    from vllm.utils.torch_utils import set_default_torch_dtype
+
+    device = torch.device("cuda", device_index)
+    with set_default_torch_dtype(model_config.dtype):
+        with device:
+            model = initialize_model(vllm_config=vllm_config, model_config=model_config)
+        # Runs on real tensors, so post-load hooks that build derived tensors
+        # (e.g. MLA projections, MoE kernels) execute normally rather than being
+        # skipped/swallowed as on the meta path. Values are garbage and are
+        # overwritten by materialize; only the resulting structure matters. A
+        # garbage-value-sensitive hook is unexpected but should not abort
+        # bring-up — materialize + the unbacked-parameter check cover the rest.
+        try:
+            process_weights_after_loading(model, model_config, device)
+        except Exception as e:
+            logger.warning(
+                "[GMS] Read mode: process_weights_after_loading raised during "
+                "device construction (continuing; materialize fills committed "
+                "tensors): %s",
+                e,
+            )
+
+    return model
+
+
+def _release_construction_memory() -> None:
+    """Return device-construction garbage backing to the device after materialize.
+
+    Parameters constructed on the real device were replaced by GMS views, so
+    their original storage is now free-cached in torch's default pool.
+    ``torch.cuda.empty_cache`` is patched to a no-op while GMS mappings are
+    live; the accelerator entrypoint bypasses that patch and is safe here.
+    """
+    try:
+        gc.collect()
+        accelerator = getattr(torch, "accelerator", None)
+        if accelerator is not None:
+            accelerator.empty_cache()
+        else:
+            torch.cuda.empty_cache()
+    except Exception as e:  # pragma: no cover - best effort reclaim
+        logger.debug("[GMS] Could not release construction memory: %s", e)
+
+
+def _warn_on_unbacked_parameters(gms_client, model: torch.nn.Module) -> None:
+    """Warn if any non-empty parameter is not GMS-backed after materialization.
+
+    Preserves the loud-failure property the meta path gets for free: a parameter
+    that was never materialized stays on `meta` there (caught + crashes at
+    forward), but on the device path it would silently retain construction
+    garbage. Flag those instead.
+    """
+    mappings = gms_client.mappings
+
+    def _is_gms_backed(param: torch.Tensor) -> bool:
+        ptr = int(param.data_ptr())
+        return any(
+            va <= ptr < va + mapping.aligned_size for va, mapping in mappings.items()
+        )
+
+    unbacked = [
+        name
+        for name, param in model.named_parameters()
+        if param is not None and param.numel() > 0 and not _is_gms_backed(param)
+    ]
+    if unbacked:
+        logger.warning(
+            "[GMS] Read mode: %d parameter(s) not GMS-backed after materialize "
+            "(possible coverage gap / uninitialized garbage): %s",
+            len(unbacked),
+            unbacked[:10],
+        )
+
+
 def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
-    """Create model on meta device for RO mode materialization."""
+    """Create model on meta device for RO mode materialization (legacy fallback).
+
+    Selected by ``DYN_GMS_RO_META_CONSTRUCT=1``. The default RO path constructs
+    on a real device (see ``_create_device_model``); this is retained as a
+    fallback while the device path is validated.
+    """
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
         process_weights_after_loading,

--- a/lib/gpu_memory_service/integrations/vllm/model_loader.py
+++ b/lib/gpu_memory_service/integrations/vllm/model_loader.py
@@ -10,17 +10,19 @@ processes import from GMS metadata (RO).
 
 from __future__ import annotations
 
-import gc
 import logging
 import os
 from typing import TYPE_CHECKING
 
 import torch
 from gpu_memory_service.client.torch.allocator import (
+    get_gms_client_memory_manager,
     get_or_create_gms_client_memory_manager,
+    get_or_create_scratch_manager,
     gms_use_mem_pool,
 )
 from gpu_memory_service.client.torch.module import (
+    _iter_module_tensors,
     materialize_module_from_gms,
     rebind_nonparameter_tensors,
 )
@@ -31,7 +33,6 @@ from gpu_memory_service.integrations.common.utils import (
     get_gms_lock_mode,
     prepare_gms_write,
     publish_gms_write,
-    setup_meta_tensor_workaround,
     strip_gms_model_loader_config,
 )
 
@@ -53,6 +54,10 @@ if TYPE_CHECKING:
     from gpu_memory_service.client.memory_manager import GMSClientMemoryManager
 
 logger = logging.getLogger(__name__)
+
+# Allocator tag for the transient single-block scratch pool that backs RO model
+# construction (see _create_device_model). Torn down after materialize.
+_CONSTRUCT_TAG = "ro_construct"
 
 # Track imported weights plus the vLLM-local model_memory_usage adjustment.
 _last_imported_weights_bytes: int = 0
@@ -260,24 +265,24 @@ def _load_read_mode(
     global _last_imported_weights_bytes, _last_model_memory_usage_offset_bytes
 
     try:
-        # Construct the RO skeleton on a REAL device (default) rather than on
-        # `meta`. Building on a real device sidesteps the meta-safety hazards
-        # that the meta path is exposed to (.item()/.to(device)/data-dependent
-        # ops during __init__, fake-op signatures, post-load hooks that touch
-        # the device), which is the source of most per-model RO patches. The
-        # meta path is retained behind DYN_GMS_RO_META_CONSTRUCT=1 as a fallback.
-        if os.environ.get("DYN_GMS_RO_META_CONSTRUCT") == "1":
-            model = _create_meta_model(vllm_config, model_config)
-        else:
-            model = _create_device_model(vllm_config, model_config, device_index)
+        # Construct the RO skeleton on a REAL device (over aliased scratch)
+        # rather than on `meta`. Building on a real device sidesteps the
+        # meta-safety hazards the old meta path guarded against (.item()/
+        # .to(device)/data-dependent ops during __init__, fake-op signatures,
+        # post-load hooks that touch the device) — the source of most per-model
+        # RO patches. Construction allocates over a single-block scratch pool so
+        # the garbage skeleton costs one aliased physical block, not a
+        # weights-sized copy (see _create_device_model).
+        model = _create_device_model(vllm_config, model_config, device_index)
+        # materialize runs OUTSIDE the construct scratch pool: parameters are
+        # repointed to committed GMS views and buffers/attrs are cloned into
+        # ordinary (non-scratch) device memory, so nothing the model retains
+        # references construction scratch afterward.
         materialize_module_from_gms(gms_client, model, device_index=device_index)
-        # Params built on the device were replaced by shared GMS views; return
-        # their now-unreferenced garbage backing to the device.
-        _release_construction_memory()
-        # Loud check for the device path's silent-garbage risk: on `meta` an
-        # unmaterialized param stays a meta tensor (caught above + crashes at
-        # forward); on the device path it would hold garbage silently.
-        _warn_on_unbacked_parameters(gms_client, model)
+        # Hard-assert every construction-scratch tensor was replaced, then free
+        # the scratch pool. Any tensor still on scratch would dangle once the
+        # pool is torn down, so this fails loudly rather than serving garbage.
+        _finalize_construction_scratch(model)
 
         # MX: register materialized tensors (available for P2P transfer)
         mx_ctx = get_mx_load_context(vllm_config, model_config)
@@ -366,23 +371,22 @@ def _load_write_mode(
 def _create_device_model(
     vllm_config, model_config, device_index: int
 ) -> torch.nn.Module:
-    """Create the RO model on a real CUDA device for materialization.
+    """Create the RO model on a real CUDA device over aliased scratch backing.
 
-    Building on a real device (instead of `meta`) lets model ``__init__`` and
+    Mirrors KV shadow-mode construction: parameters (and the derived tensors
+    ``process_weights_after_loading`` builds) are allocated through a
+    single-block scratch pool, so the whole garbage skeleton is backed by ONE
+    aliased physical block (~scratch_size) instead of a weights-sized copy —
+    which is what makes this fit the failover colocation budget.
+    ``materialize_module_from_gms`` then repoints each parameter to its committed
+    GMS view; the scratch pool is torn down afterward (see
+    ``_finalize_construction_scratch``).
+
+    Building on a real device (instead of ``meta``) lets model ``__init__`` and
     ``process_weights_after_loading`` run on real tensors, so the meta-device
-    hazards the meta path guards against (``.item()``/``.to(device)``/data
+    hazards the old meta path guarded against (``.item()``/``.to(device)``/data
     dependent ops, custom-op fake signatures, post-load hooks that initialize
-    device scratch) simply do not arise. Parameters are allocated with garbage
-    contents and immediately replaced by ``materialize_module_from_gms`` with
-    shared read-only GMS views; ``process_weights_after_loading`` runs so the
-    derived-tensor structure exists for materialize to fill (its garbage output
-    is overwritten). The garbage backing is returned to the device afterward
-    (see ``_release_construction_memory``).
-
-    NOTE: this transiently allocates a full weight-sized garbage copy on the
-    device before materialization frees it. That fits a single RO engine;
-    memory-optimal construction over aliased scratch backing (required for
-    two-engine colocation) is a planned follow-up.
+    device scratch) simply do not arise.
     """
     from vllm.model_executor.model_loader.utils import (
         initialize_model,
@@ -391,100 +395,79 @@ def _create_device_model(
     from vllm.utils.torch_utils import set_default_torch_dtype
 
     device = torch.device("cuda", device_index)
-    with set_default_torch_dtype(model_config.dtype):
-        with device:
-            model = initialize_model(vllm_config=vllm_config, model_config=model_config)
-        # Runs on real tensors, so post-load hooks that build derived tensors
-        # (e.g. MLA projections, MoE kernels) execute normally rather than being
-        # skipped/swallowed as on the meta path. Values are garbage and are
-        # overwritten by materialize; only the resulting structure matters. A
-        # garbage-value-sensitive hook is unexpected but should not abort
-        # bring-up — materialize + the unbacked-parameter check cover the rest.
-        try:
-            process_weights_after_loading(model, model_config, device)
-        except Exception as e:
-            logger.warning(
-                "[GMS] Read mode: process_weights_after_loading raised during "
-                "device construction (continuing; materialize fills committed "
-                "tensors): %s",
-                e,
-            )
-
-    return model
-
-
-def _release_construction_memory() -> None:
-    """Return device-construction garbage backing to the device after materialize.
-
-    Parameters constructed on the real device were replaced by GMS views, so
-    their original storage is now free-cached in torch's default pool.
-    ``torch.cuda.empty_cache`` is patched to a no-op while GMS mappings are
-    live; the accelerator entrypoint bypasses that patch and is safe here.
-    """
-    try:
-        gc.collect()
-        accelerator = getattr(torch, "accelerator", None)
-        if accelerator is not None:
-            accelerator.empty_cache()
-        else:
-            torch.cuda.empty_cache()
-    except Exception as e:  # pragma: no cover - best effort reclaim
-        logger.debug("[GMS] Could not release construction memory: %s", e)
-
-
-def _warn_on_unbacked_parameters(gms_client, model: torch.nn.Module) -> None:
-    """Warn if any non-empty parameter is not GMS-backed after materialization.
-
-    Preserves the loud-failure property the meta path gets for free: a parameter
-    that was never materialized stays on `meta` there (caught + crashes at
-    forward), but on the device path it would silently retain construction
-    garbage. Flag those instead.
-    """
-    mappings = gms_client.mappings
-
-    def _is_gms_backed(param: torch.Tensor) -> bool:
-        ptr = int(param.data_ptr())
-        return any(
-            va <= ptr < va + mapping.aligned_size for va, mapping in mappings.items()
-        )
-
-    unbacked = [
-        name
-        for name, param in model.named_parameters()
-        if param is not None and param.numel() > 0 and not _is_gms_backed(param)
-    ]
-    if unbacked:
-        logger.warning(
-            "[GMS] Read mode: %d parameter(s) not GMS-backed after materialize "
-            "(possible coverage gap / uninitialized garbage): %s",
-            len(unbacked),
-            unbacked[:10],
-        )
-
-
-def _create_meta_model(vllm_config, model_config) -> torch.nn.Module:
-    """Create model on meta device for RO mode materialization (legacy fallback).
-
-    Selected by ``DYN_GMS_RO_META_CONSTRUCT=1``. The default RO path constructs
-    on a real device (see ``_create_device_model``); this is retained as a
-    fallback while the device path is validated.
-    """
-    from vllm.model_executor.model_loader.utils import (
-        initialize_model,
-        process_weights_after_loading,
+    # Client-local scratch only (no GMS server session): one shared physical
+    # block aliased across every construction allocation.
+    get_or_create_scratch_manager(
+        get_socket_path(device_index, _CONSTRUCT_TAG),
+        device_index,
+        tag=_CONSTRUCT_TAG,
+        single_block=True,
     )
-    from vllm.utils.torch_utils import set_default_torch_dtype
-
-    setup_meta_tensor_workaround()
-    meta_device = torch.device("meta")
-
     with set_default_torch_dtype(model_config.dtype):
-        with meta_device:
-            model = initialize_model(vllm_config=vllm_config, model_config=model_config)
-
-    try:
-        process_weights_after_loading(model, model_config, meta_device)
-    except Exception as e:
-        logger.debug("[GMS] Post-processing on meta tensors: %s", e)
+        with gms_use_mem_pool(_CONSTRUCT_TAG, device):
+            with device:
+                model = initialize_model(
+                    vllm_config=vllm_config, model_config=model_config
+                )
+            # Runs on real tensors, so post-load hooks that build derived tensors
+            # (MLA projections, MoE kernels, ...) execute normally. Values are
+            # garbage and are overwritten by materialize; only the resulting
+            # structure matters, and the scratch-coverage check backstops any
+            # tensor materialize does not replace. A garbage-value-sensitive hook
+            # is unexpected but must not abort bring-up.
+            try:
+                process_weights_after_loading(model, model_config, device)
+            except Exception as e:
+                logger.warning(
+                    "[GMS] Read mode: process_weights_after_loading raised during "
+                    "device construction (continuing; materialize fills committed "
+                    "tensors, scratch-coverage check guards the rest): %s",
+                    e,
+                )
 
     return model
+
+
+def _finalize_construction_scratch(model: torch.nn.Module) -> None:
+    """Assert construction scratch was fully replaced, then free the pool.
+
+    Unlike KV scratch (reallocated in place at the same VA on wake), construction
+    scratch is torn down after materialize. A parameter or buffer still backed by
+    it would dangle into freed memory once the pool is released, so any leftover
+    is a hard error — an uncommitted weight, or a derived tensor materialize never
+    filled — rather than a silently-served garbage/use-after-free model. On
+    success the shared scratch block and all its VA reservations are released and
+    the tag is evicted.
+    """
+    manager = get_gms_client_memory_manager(_CONSTRUCT_TAG)
+    if manager is None:
+        return
+
+    ranges = [
+        (base_va, scratch.va_reserved_size)
+        for base_va, scratch in manager.scratch_mappings.items()
+    ]
+
+    def _in_scratch(t: torch.Tensor) -> bool:
+        ptr = int(t.data_ptr())
+        return any(va <= ptr < va + size for va, size in ranges)
+
+    try:
+        # Enumerate exactly the tensor set materialize operates on (parameters,
+        # buffers, and bare tensor attributes) so a scratch-backed tensor_attr
+        # materialize never replaced is caught too, not just params/buffers.
+        dangling = [
+            name
+            for name, tensor, _ in _iter_module_tensors(model)
+            if tensor.numel() > 0 and _in_scratch(tensor)
+        ]
+        if dangling:
+            raise RuntimeError(
+                f"[GMS] Read mode: {len(dangling)} tensor(s) still backed by "
+                "construction scratch after materialize (uncommitted weight or "
+                f"unfilled derived tensor): {dangling[:10]}"
+            )
+    finally:
+        # Free the shared scratch block + VA reservations and evict the tag,
+        # whether or not the assertion above fired.
+        manager.close()


### PR DESCRIPTION
## Summary

The read-only (RO) GMS path reconstructs the model on the **`meta` device** and materializes the writer's committed weights into it by name. Building on `meta` forces `__init__` and `process_weights_after_loading` to run against meta tensors, which faults on any device-touching init — `.item()`, `.to(device)`, data-dependent ops, custom-op fake signatures, post-load hooks that initialize device scratch. This is the source of most **per-model RO patches**, and why the meta path swallows `process_weights_after_loading` failures rather than surfacing them.

This PR constructs the RO skeleton on a **real CUDA device over aliased single-block scratch**, mirroring how KV shadow-mode already brings the KV cache up cheaply:

- A **single-block scratch pool** (`ro_construct`) backs construction: model `__init__` and `process_weights_after_loading` run on real tensors, but every allocation aliases **one shared physical block** (~`scratch_size`), so the full garbage skeleton costs ~0.5 GiB instead of a weights-sized copy. This is what makes it fit the **failover colocation budget** — a shadow brought up over a live active does not OOM.
- `materialize_module_from_gms` (run **outside** the scratch pool) repoints each parameter to its committed read-only GMS view and clones buffers/attrs into ordinary device memory, so nothing the model retains references construction scratch.
- `_finalize_construction_scratch` **hard-asserts** that no parameter/buffer/tensor-attr still points into construction scratch (which would dangle once the pool is freed — a UAF, unlike KV scratch which is swapped in place at the same VA), then tears the pool down. A leftover means an uncommitted weight or an unfilled derived tensor, and fails loudly instead of serving garbage.

The meta path is **removed entirely** — no fallback flag. `__init__`/`process_weights` running on real tensors removes the meta-safety keyhole, so the class of per-model meta fixes stops being necessary.

### Mechanism parity with KV shadow-mode

| step | KV shadow-mode (existing) | RO construction (this PR) |
|---|---|---|
| cheap alloc | `get_or_create_scratch_manager("kv_cache")` + `gms_use_mem_pool` around `initialize_kv_cache` | `get_or_create_scratch_manager("ro_construct", single_block=True)` + `gms_use_mem_pool` around `initialize_model` + `process_weights` |
| swap to real | `wake_up`: `reallocate_all_handles` → `remap_all_vas` (real KV at **same VA**) | `materialize`: `param.data = committed_view` (weights at **committed VA**) |
| cleanup | scratch persists, dropped on sleep | scratch **torn down** after coverage assert |

The only new scratch capability is opt-in `single_block=True` (one shared physical handle aliased across all scratch VAs, released once the last aliasing VA is gone) — required because construction makes ~thousands of allocations where KV makes ~61.

## Impacted open work

With the meta path removed, these become **unnecessary for the RO path**:

- **vLLM #43926** (DeepSeek-V4 RoPE meta-device consistency, merged) — meta-only concern.
- **vLLM #43927** (WNA16 Marlin MoE fake-op signature) — fake ops only matter for meta tracing.
- **vLLM #43928** (FusedMoE expert-map `.item()` meta-safe) — `.item()` runs fine on a real tensor.
- The **`kimi_k25` vision_tower / mm_projector `.to(device)` meta guard** (local vLLM patch).
- **`setup_meta_tensor_workaround()`** in `integrations/common/utils.py` — no longer called on the vLLM RO path (left defined for other integrations).

Not affected: the materialization / structural-provenance machinery (Dynamo #9854), `patches.py`, and the scratch-KV path — orthogonal.

## Validation

**Qwen3-0.6B TP1 engine-level shadow-failover (nscale B200, this branch overlaid on `ac7b0a5d10` runtime image): 12/14 pass.**

The RO reader (Engine B) exercised this path and its log confirms the intended behavior:

```
[GMS] Registered scratch allocator for tag=ro_construct (device=0)
[GMS] Reserved 512 MiB VA at 0x420000000, aliased 1x 512 MiB scratch across 1 chunks
[GMS] Reserved 512 MiB VA at 0x440000000, aliased 1x 512 MiB scratch across 1 chunks
...  (every construction allocation aliases the SAME shared 512 MiB block)
```

- `D5: Engine B reached STANDBY after import (RO, post-commit)` — model constructed over one shared 512 MiB scratch block, weights materialized, **coverage check passed** (no `still backed by construction scratch` error, no traceback), scratch pool freed.
- `Inference on winner` → `Paris. The capital of France is…`
- `Inference after failover` — active SIGKILLed, standby auto-woke via flock and served (kill→lock 8.2s, kill→generate-registered 8.3s incl. graceful drain).

The 2 failures are **unrelated to this change**: both are the harness's D8 `Scratch-KV engaged` assertion, a marker that no longer exists anywhere in the base image (removed on main since the harness was last updated) — it fails on baseline too, and the actual KV-scratch aliasing is present in the logs.

Still to run (planned with reviewer): canonical pytest `test_shadow_failover_autonomous.py` (TP2, what CI runs), and **Kimi-K2.6-NVFP4 TP8** — the real memory/colocation test that the earlier full-weights-transient approach would OOM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
