### PR TITLE
fix(profiler): enable TRT-LLM chunked prefill in generated configs

### DIFF
--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -27,12 +27,10 @@ from deploy.utils.dynamo_deployment import cleanup_remaining_deployments
 from dynamo.profiler.interpolation import run_interpolation
 from dynamo.profiler.rapid import run_rapid
 from dynamo.profiler.thorough import run_thorough
-from dynamo.profiler.utils.config_modifiers.trtllm import (
-    enable_trtllm_chunked_prefill,
-)
 from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
     PickedParallelConfig,
 )
+from dynamo.profiler.utils.config_modifiers.trtllm import enable_trtllm_chunked_prefill
 from dynamo.profiler.utils.defaults import SearchStrategy
 from dynamo.profiler.utils.dgd_generation import (
     assemble_final_config,

--- a/components/src/dynamo/profiler/profile_sla.py
+++ b/components/src/dynamo/profiler/profile_sla.py
@@ -27,6 +27,9 @@ from deploy.utils.dynamo_deployment import cleanup_remaining_deployments
 from dynamo.profiler.interpolation import run_interpolation
 from dynamo.profiler.rapid import run_rapid
 from dynamo.profiler.thorough import run_thorough
+from dynamo.profiler.utils.config_modifiers.trtllm import (
+    enable_trtllm_chunked_prefill,
+)
 from dynamo.profiler.utils.config_modifiers.parallelization_mapping import (
     PickedParallelConfig,
 )
@@ -468,6 +471,8 @@ async def run_profile(
                     runtime_backend=resolved_backend,
                     model_name_or_path=resolve_model_path(dgdr),
                 )
+                if resolved_backend == "trtllm":
+                    enable_trtllm_chunked_prefill(interpolation_dgd_config)
                 await run_interpolation(
                     dgdr,
                     ops,

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py
@@ -533,6 +533,39 @@ class TestAssembleFinalConfig:
 
     @pytest.mark.pre_merge
     @pytest.mark.gpu_0
+    def test_final_trtllm_config_enables_chunked_prefill(self, tmp_path):
+        dgdr = _make_dgdr()
+        ops = _make_ops(tmp_path)
+        dgd_config = {
+            "kind": "DynamoGraphDeployment",
+            "spec": {
+                "services": {
+                    "decode": {
+                        "componentType": "worker",
+                        "subComponentType": "decode",
+                        "extraPodSpec": {"mainContainer": {"args": []}},
+                    }
+                }
+            },
+        }
+
+        result = assemble_final_config(
+            dgdr,
+            ops,
+            dgd_config,
+            PickedParallelConfig(tp=1),
+            PickedParallelConfig(tp=1),
+            resolved_backend="trtllm",
+        )
+
+        args = result["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"][
+            "args"
+        ]
+        idx = args.index("--trtllm.enable_chunked_prefill")
+        assert args[idx + 1] == "true"
+
+    @pytest.mark.pre_merge
+    @pytest.mark.gpu_0
     def test_none_dgd_config_passes_through_as_none(self, tmp_path):
         dgdr = _make_dgdr()
         ops = _make_ops(tmp_path)

--- a/components/src/dynamo/profiler/tests/unit/test_helpers_thorough.py
+++ b/components/src/dynamo/profiler/tests/unit/test_helpers_thorough.py
@@ -8,6 +8,7 @@ require live K8s deployments and are covered by the mocked end-to-end tests
 in test_profile_sla_dgdr.py.
 """
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pandas as pd
@@ -21,7 +22,10 @@ pytestmark = [
 ]
 
 try:
-    from dynamo.profiler.thorough import _pick_thorough_best_config
+    from dynamo.profiler.thorough import (
+        _enable_chunked_prefill_for_trtllm_candidates,
+        _pick_thorough_best_config,
+    )
     from dynamo.profiler.utils.aic_dataframe import build_decode_row, build_prefill_row
     from dynamo.profiler.utils.dgdr_v1beta1_types import (
         DynamoGraphDeploymentRequestSpec,
@@ -100,6 +104,43 @@ def _mock_result():
 # ---------------------------------------------------------------------------
 # _pick_thorough_best_config
 # ---------------------------------------------------------------------------
+
+
+def test_profile_candidates_enable_trtllm_chunked_prefill():
+    prefill = SimpleNamespace(
+        dgd_config={
+            "spec": {
+                "services": {
+                    "prefill": {
+                        "componentType": "worker",
+                        "subComponentType": "prefill",
+                        "extraPodSpec": {"mainContainer": {"args": []}},
+                    }
+                }
+            }
+        }
+    )
+    decode = SimpleNamespace(
+        dgd_config={
+            "spec": {
+                "services": {
+                    "decode": {
+                        "componentType": "worker",
+                        "subComponentType": "decode",
+                        "extraPodSpec": {"mainContainer": {"args": []}},
+                    }
+                }
+            }
+        }
+    )
+
+    _enable_chunked_prefill_for_trtllm_candidates([prefill], [decode])
+
+    for candidate in (prefill, decode):
+        worker = next(iter(candidate.dgd_config["spec"]["services"].values()))
+        args = worker["extraPodSpec"]["mainContainer"]["args"]
+        idx = args.index("--trtllm.enable_chunked_prefill")
+        assert args[idx + 1] == "true"
 
 
 class TestPickThoroughBestConfig:

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -609,10 +609,7 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
     assert final_args.count("--override-applied") == 1
 
     # Neither merge mutates the clean picked DGD.
-    assert (
-        "tolerations"
-        not in base_dgd["spec"]["services"]["decode"]["extraPodSpec"]
-    )
+    assert "tolerations" not in base_dgd["spec"]["services"]["decode"]["extraPodSpec"]
 
 
 # ---------------------------------------------------------------------------

--- a/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
+++ b/components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py
@@ -451,7 +451,9 @@ _TOLERATION = {"key": "nvidia.com/gpu", "operator": "Exists", "effect": "NoSched
 _BASE_DGD = {
     "spec": {
         "services": {
-            "VllmDecodeWorker": {
+            "decode": {
+                "componentType": "worker",
+                "subComponentType": "decode",
                 "extraPodSpec": {
                     "mainContainer": {"image": "my-image", "args": ["--model", "m"]},
                 },
@@ -465,7 +467,7 @@ _BASE_DGD = {
 _OVERRIDE_DGD = {
     "spec": {
         "services": {
-            "VllmDecodeWorker": {"extraPodSpec": {"tolerations": [_TOLERATION]}},
+            "decode": {"extraPodSpec": {"tolerations": [_TOLERATION]}},
             "GhostService": {"extraPodSpec": {"tolerations": [_TOLERATION]}},
         }
     }
@@ -489,7 +491,7 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
             services[name].setdefault("extraPodSpec", {}).update(
                 service_override["extraPodSpec"]
             )
-        services["VllmDecodeWorker"]["extraPodSpec"]["mainContainer"]["args"].append(
+        services["decode"]["extraPodSpec"]["mainContainer"]["args"].append(
             "--override-applied"
         )
         return result
@@ -508,7 +510,7 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
 
     pick_result = {
         "dgd_config": base_dgd,
-        "resolved_backend": "vllm",
+        "resolved_backend": "trtllm",
         "chosen_exp": "disagg",
         "best_config_df": None,
         "best_latencies": {"ttft": 0.0, "tpot": 0.0, "request_latency": 0.0},
@@ -525,7 +527,7 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
             "dynamo.profiler.profile_sla._extract_profiler_params",
             return_value=(
                 "test/model",
-                "vllm",
+                "trtllm",
                 "h100_sxm",
                 8,
                 4000,
@@ -576,13 +578,17 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
     assert interpolation_kwargs, "run_interpolation was never called"
     disagg_config = interpolation_kwargs["disagg_config"]
 
-    # Tolerations must be present on VllmDecodeWorker before interpolation.
-    eps = disagg_config["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"]
+    # Tolerations and TRT-LLM runtime defaults must be present before interpolation.
+    eps = disagg_config["spec"]["services"]["decode"]["extraPodSpec"]
     assert eps["tolerations"] == [_TOLERATION]
 
     # mainContainer must be preserved (not overwritten by the tolerations merge).
     assert eps["mainContainer"]["image"] == "my-image"
     assert eps["mainContainer"]["args"].count("--override-applied") == 1
+    chunked_prefill_idx = eps["mainContainer"]["args"].index(
+        "--trtllm.enable_chunked_prefill"
+    )
+    assert eps["mainContainer"]["args"][chunked_prefill_idx + 1] == "true"
 
     # GhostService (absent from base DGD) must be silently skipped.
     assert "GhostService" not in disagg_config["spec"]["services"]
@@ -591,13 +597,13 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
     assert assemble_final.call_args.args[2] == base_dgd
     assert len(override_inputs) == 2
     for override_input in override_inputs:
-        args = override_input["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"][
+        args = override_input["spec"]["services"]["decode"]["extraPodSpec"][
             "mainContainer"
         ]["args"]
         assert "--override-applied" not in args
 
     final_config = write_final.call_args.args[1]
-    final_args = final_config["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"][
+    final_args = final_config["spec"]["services"]["decode"]["extraPodSpec"][
         "mainContainer"
     ]["args"]
     assert final_args.count("--override-applied") == 1
@@ -605,7 +611,7 @@ async def test_run_profile_applies_override_once_to_each_consumed_dgd(tmp_path) 
     # Neither merge mutates the clean picked DGD.
     assert (
         "tolerations"
-        not in base_dgd["spec"]["services"]["VllmDecodeWorker"]["extraPodSpec"]
+        not in base_dgd["spec"]["services"]["decode"]["extraPodSpec"]
     )
 
 

--- a/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
+++ b/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
@@ -93,6 +93,13 @@ def test_enable_chunked_prefill_updates_generated_trtllm_workers():
                         }
                     },
                 },
+                "dangling": {
+                    "componentType": "worker",
+                    "subComponentType": "decode",
+                    "extraPodSpec": {
+                        "mainContainer": {"args": ["--trtllm.enable_chunked_prefill"]}
+                    },
+                },
                 "encode": {
                     "componentType": "worker",
                     "subComponentType": "encode",
@@ -111,7 +118,7 @@ def test_enable_chunked_prefill_updates_generated_trtllm_workers():
     assert not any(arg.startswith("--trtllm.") for arg in prefill_args)
     override_idx = prefill_args.index("--override-engine-args")
     override = json.loads(prefill_args[override_idx + 1])
-    assert override["enable_chunked_prefill"] is True
+    assert "enable_chunked_prefill" not in override
     assert override["kv_cache_config"]["tokens_per_block"] == 32
 
     decode_args = result["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"][
@@ -120,6 +127,11 @@ def test_enable_chunked_prefill_updates_generated_trtllm_workers():
     assert decode_args.count("--trtllm.enable_chunked_prefill") == 1
     flag_idx = decode_args.index("--trtllm.enable_chunked_prefill")
     assert decode_args[flag_idx + 1] == "true"
+
+    dangling_args = result["spec"]["services"]["dangling"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert dangling_args == ["--trtllm.enable_chunked_prefill", "true"]
 
     encode_args = result["spec"]["services"]["encode"]["extraPodSpec"]["mainContainer"][
         "args"

--- a/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
+++ b/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
@@ -81,6 +81,13 @@ def test_enable_chunked_prefill_updates_generated_trtllm_workers():
                         }
                     },
                 },
+                "empty_override": {
+                    "componentType": "worker",
+                    "subComponentType": "prefill",
+                    "extraPodSpec": {
+                        "mainContainer": {"args": ["--override-engine-args", "{}"]}
+                    },
+                },
                 "decode": {
                     "componentType": "worker",
                     "subComponentType": "decode",
@@ -118,8 +125,17 @@ def test_enable_chunked_prefill_updates_generated_trtllm_workers():
     assert not any(arg.startswith("--trtllm.") for arg in prefill_args)
     override_idx = prefill_args.index("--override-engine-args")
     override = json.loads(prefill_args[override_idx + 1])
-    assert "enable_chunked_prefill" not in override
+    assert override["enable_chunked_prefill"] is True
     assert override["kv_cache_config"]["tokens_per_block"] == 32
+
+    empty_override_args = result["spec"]["services"]["empty_override"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert not any(arg.startswith("--trtllm.") for arg in empty_override_args)
+    override_idx = empty_override_args.index("--override-engine-args")
+    assert json.loads(empty_override_args[override_idx + 1]) == {
+        "enable_chunked_prefill": True
+    }
 
     decode_args = result["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"][
         "args"

--- a/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
+++ b/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
@@ -4,6 +4,7 @@
 """Unit test for TRT-LLM --override-engine-args / --trtllm.* conflict resolution (GitHub #8659)."""
 
 import json
+import shlex
 
 import pytest
 
@@ -153,3 +154,67 @@ def test_enable_chunked_prefill_updates_generated_trtllm_workers():
         "args"
     ]
     assert encode_args == []
+
+
+def test_enable_chunked_prefill_preserves_shell_form_workers():
+    dynamic_command = (
+        "export READY=1 && python3 -m dynamo.trtllm "
+        '--model-path "${MODEL_PATH}" '
+        "--trtllm.enable_chunked_prefill false && echo ready"
+    )
+    override_command = (
+        "python3 -m dynamo.trtllm "
+        '--model-path "${MODEL_PATH}" '
+        "--override-engine-args "
+        '\'{"kv_cache_config": {"tokens_per_block": 32}}\''
+    )
+    config = {
+        "spec": {
+            "services": {
+                "dynamic": {
+                    "componentType": "worker",
+                    "subComponentType": "decode",
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "command": ["/bin/sh", "-c"],
+                            "args": [dynamic_command],
+                        }
+                    },
+                },
+                "override": {
+                    "componentType": "worker",
+                    "subComponentType": "prefill",
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "command": ["sh", "-c"],
+                            "args": [override_command],
+                        }
+                    },
+                },
+            }
+        }
+    }
+
+    result = enable_trtllm_chunked_prefill(config)
+    result = enable_trtllm_chunked_prefill(result)
+
+    dynamic_args = result["spec"]["services"]["dynamic"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert dynamic_args == [
+        "export READY=1 && python3 -m dynamo.trtllm "
+        '--model-path "${MODEL_PATH}" '
+        "--trtllm.enable_chunked_prefill true && echo ready"
+    ]
+
+    override_args = result["spec"]["services"]["override"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert len(override_args) == 1
+    assert '--model-path "${MODEL_PATH}"' in override_args[0]
+    override_tokens = shlex.split(override_args[0])
+    assert not any(token.startswith("--trtllm.") for token in override_tokens)
+    override_index = override_tokens.index("--override-engine-args")
+    override = json.loads(override_tokens[override_index + 1])
+    assert override["enable_chunked_prefill"] is True
+    assert override["kv_cache_config"]["tokens_per_block"] == 32

--- a/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
+++ b/components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py
@@ -7,7 +7,10 @@ import json
 
 import pytest
 
-from dynamo.profiler.utils.config_modifiers.trtllm import _merge_overrides_into_args
+from dynamo.profiler.utils.config_modifiers.trtllm import (
+    _merge_overrides_into_args,
+    enable_trtllm_chunked_prefill,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -56,3 +59,69 @@ def test_merge_overrides_into_existing_override_engine_args():
     assert merged["cache_transceiver_config"] is None
     assert merged["kv_cache_config"]["enable_block_reuse"] is False
     assert merged["kv_cache_config"]["tokens_per_block"] == 32
+
+
+def test_enable_chunked_prefill_updates_generated_trtllm_workers():
+    prefill_override = json.dumps(
+        {
+            "enable_chunked_prefill": False,
+            "kv_cache_config": {"tokens_per_block": 32},
+        }
+    )
+    config = {
+        "spec": {
+            "services": {
+                "Frontend": {"componentType": "frontend"},
+                "prefill": {
+                    "componentType": "worker",
+                    "subComponentType": "prefill",
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "args": ["--override-engine-args", prefill_override]
+                        }
+                    },
+                },
+                "decode": {
+                    "componentType": "worker",
+                    "subComponentType": "decode",
+                    "extraPodSpec": {
+                        "mainContainer": {
+                            "args": [
+                                "--trtllm.enable_chunked_prefill",
+                                "false",
+                            ]
+                        }
+                    },
+                },
+                "encode": {
+                    "componentType": "worker",
+                    "subComponentType": "encode",
+                    "extraPodSpec": {"mainContainer": {"args": []}},
+                },
+            }
+        }
+    }
+
+    result = enable_trtllm_chunked_prefill(config)
+    result = enable_trtllm_chunked_prefill(result)
+
+    prefill_args = result["spec"]["services"]["prefill"]["extraPodSpec"][
+        "mainContainer"
+    ]["args"]
+    assert not any(arg.startswith("--trtllm.") for arg in prefill_args)
+    override_idx = prefill_args.index("--override-engine-args")
+    override = json.loads(prefill_args[override_idx + 1])
+    assert override["enable_chunked_prefill"] is True
+    assert override["kv_cache_config"]["tokens_per_block"] == 32
+
+    decode_args = result["spec"]["services"]["decode"]["extraPodSpec"]["mainContainer"][
+        "args"
+    ]
+    assert decode_args.count("--trtllm.enable_chunked_prefill") == 1
+    flag_idx = decode_args.index("--trtllm.enable_chunked_prefill")
+    assert decode_args[flag_idx + 1] == "true"
+
+    encode_args = result["spec"]["services"]["encode"]["extraPodSpec"]["mainContainer"][
+        "args"
+    ]
+    assert encode_args == []

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -38,9 +38,7 @@ from dynamo.profiler.utils.aiperf import (
     get_prefill_ttft,
 )
 from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
-from dynamo.profiler.utils.config_modifiers.trtllm import (
-    enable_trtllm_chunked_prefill,
-)
+from dynamo.profiler.utils.config_modifiers.trtllm import enable_trtllm_chunked_prefill
 from dynamo.profiler.utils.dgd_materialization import (
     DGDMaterializationPurpose,
     materialize_dgd,

--- a/components/src/dynamo/profiler/thorough.py
+++ b/components/src/dynamo/profiler/thorough.py
@@ -38,6 +38,9 @@ from dynamo.profiler.utils.aiperf import (
     get_prefill_ttft,
 )
 from dynamo.profiler.utils.config_modifiers import CONFIG_MODIFIERS
+from dynamo.profiler.utils.config_modifiers.trtllm import (
+    enable_trtllm_chunked_prefill,
+)
 from dynamo.profiler.utils.dgd_materialization import (
     DGDMaterializationPurpose,
     materialize_dgd,
@@ -58,6 +61,14 @@ from dynamo.profiler.utils.profile_decode import get_num_request_range
 from dynamo.profiler.utils.profiler_status import ProfilerStatus, write_profiler_status
 
 logger = logging.getLogger(__name__)
+
+
+def _enable_chunked_prefill_for_trtllm_candidates(
+    prefill_candidates, decode_candidates
+) -> None:
+    """Enable chunked prefill on every TRT-LLM profiling candidate."""
+    for candidate in [*prefill_candidates, *decode_candidates]:
+        candidate.dgd_config = enable_trtllm_chunked_prefill(candidate.dgd_config)
 
 
 def _normalize_candidate_model_identity(
@@ -428,6 +439,11 @@ async def run_thorough(
             tolerations=job_tolerations,
             runtime_backend=backend,
             model_name_or_path=local_or_hf_model,
+        )
+
+    if backend == "trtllm":
+        _enable_chunked_prefill_for_trtllm_candidates(
+            prefill_candidates, decode_candidates
         )
 
     # Overrides may carry stale model arguments, so reassert the DGDR model

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -110,12 +110,11 @@ def _merge_overrides_into_args(args: list[str], overrides: dict) -> list[str]:
 
 
 def enable_trtllm_chunked_prefill(config: dict) -> dict:
-    """Enable chunked prefill on every generated TRT-LLM LLM worker.
+    """Enable chunked prefill on generated TRT-LLM workers using dynamic flags.
 
-    Generated configs may express engine options either as ``--trtllm.*``
-    dynamic flags or in an ``--override-engine-args`` JSON object.  Normalize
-    both forms through :func:`_merge_overrides_into_args`, replacing an
-    existing dynamic flag so the result is idempotent and unambiguous.
+    Replace an existing dynamic flag so the result is idempotent.  When a
+    worker uses explicit ``--override-engine-args``, remove its chunked-prefill
+    entry instead of mixing that representation with ``--trtllm.*`` flags.
     """
     services = config.get("spec", {}).get("services", {})
     if not isinstance(services, dict):
@@ -133,7 +132,27 @@ def enable_trtllm_chunked_prefill(config: dict) -> dict:
 
         args = break_arguments(main_container.get("args", []))
         while "--trtllm.enable_chunked_prefill" in args:
-            args = remove_valued_arguments(args, "--trtllm.enable_chunked_prefill")
+            idx = args.index("--trtllm.enable_chunked_prefill")
+            del args[idx]
+            if idx < len(args) and not (
+                isinstance(args[idx], str) and args[idx].startswith("--")
+            ):
+                del args[idx]
+
+        if "--override-engine-args" in args:
+            idx = args.index("--override-engine-args")
+            if idx + 1 < len(args):
+                try:
+                    override = json.loads(args[idx + 1])
+                except json.JSONDecodeError:
+                    pass
+                else:
+                    if isinstance(override, dict):
+                        override.pop("enable_chunked_prefill", None)
+                        args[idx + 1] = json.dumps(override)
+            main_container["args"] = args
+            continue
+
         main_container["args"] = _merge_overrides_into_args(
             args, {"enable_chunked_prefill": True}
         )

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -113,8 +113,8 @@ def enable_trtllm_chunked_prefill(config: dict) -> dict:
     """Enable chunked prefill on generated TRT-LLM workers using dynamic flags.
 
     Replace an existing dynamic flag so the result is idempotent.  When a
-    worker uses explicit ``--override-engine-args``, remove its chunked-prefill
-    entry instead of mixing that representation with ``--trtllm.*`` flags.
+    worker uses explicit ``--override-engine-args``, enable chunked prefill in
+    that JSON representation instead of mixing it with ``--trtllm.*`` flags.
     """
     services = config.get("spec", {}).get("services", {})
     if not isinstance(services, dict):
@@ -148,7 +148,7 @@ def enable_trtllm_chunked_prefill(config: dict) -> dict:
                     pass
                 else:
                     if isinstance(override, dict):
-                        override.pop("enable_chunked_prefill", None)
+                        override["enable_chunked_prefill"] = True
                         args[idx + 1] = json.dumps(override)
             main_container["args"] = args
             continue

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -4,6 +4,7 @@
 import json
 import logging
 import re
+import shlex
 from typing import Tuple
 from uuid import uuid4
 
@@ -45,6 +46,98 @@ DEFAULT_TRTLLM_DISAGG_CONFIG_PATH = resolve_deploy_path(
 DEFAULT_TRTLLM_AGG_CONFIG_PATH = resolve_deploy_path(
     "examples/backends/trtllm/deploy/agg.yaml"
 )
+
+_CHUNKED_PREFILL_FLAG = "--trtllm.enable_chunked_prefill"
+_OVERRIDE_ENGINE_ARGS_FLAG = "--override-engine-args"
+_SHELL_WORD_PATTERN = r"(?:'[^']*'|\"(?:\\.|[^\"\\])*\"|[^\s;&|]+)"
+_SHELL_CHUNKED_PREFILL_PATTERN = re.compile(
+    rf"(?<!\S){re.escape(_CHUNKED_PREFILL_FLAG)}"
+    rf"(?:[ \t]+(?!--){_SHELL_WORD_PATTERN})?"
+)
+_SHELL_OVERRIDE_ENGINE_ARGS_PATTERN = re.compile(
+    rf"(?<!\S){re.escape(_OVERRIDE_ENGINE_ARGS_FLAG)}"
+    rf"[ \t]+(?P<value>{_SHELL_WORD_PATTERN})"
+)
+
+
+def _shell_command_end(command: str) -> int:
+    """Find the end of the ``dynamo.trtllm`` shell command segment."""
+    index = command.find("dynamo.trtllm")
+    if index < 0:
+        return len(command.rstrip())
+
+    quote: str | None = None
+    while index < len(command):
+        char = command[index]
+        if quote is not None:
+            if char == quote:
+                quote = None
+                index += 1
+            elif quote == '"' and char == "\\" and index + 1 < len(command):
+                index += 2
+            else:
+                index += 1
+            continue
+
+        if char in ("'", '"'):
+            quote = char
+            index += 1
+        elif char == "\\" and index + 1 < len(command):
+            index += 2
+        elif char == "&" and index > 0 and command[index - 1] in "<>":
+            index += 1
+        elif char in ";|&\n":
+            return index
+        else:
+            index += 1
+
+    return len(command.rstrip())
+
+
+def _enable_chunked_prefill_in_shell_command(command: str) -> str:
+    """Enable chunked prefill without re-quoting the surrounding shell command."""
+    command = _SHELL_CHUNKED_PREFILL_PATTERN.sub("", command)
+
+    match = _SHELL_OVERRIDE_ENGINE_ARGS_PATTERN.search(command)
+    if match:
+        try:
+            parsed = shlex.split(match.group("value"))
+            override = json.loads(parsed[0]) if len(parsed) == 1 else None
+        except (json.JSONDecodeError, ValueError):
+            return command
+        if isinstance(override, dict):
+            override["enable_chunked_prefill"] = True
+            encoded = shlex.quote(json.dumps(override))
+            start, end = match.span("value")
+            return command[:start] + encoded + command[end:]
+        return command
+
+    insertion = _shell_command_end(command)
+    prefix = command[:insertion].rstrip()
+    suffix = command[insertion:]
+    leading_space = " " if prefix else ""
+    trailing_space = " " if suffix and not suffix[0].isspace() else ""
+    return (
+        f"{prefix}{leading_space}{_CHUNKED_PREFILL_FLAG} true"
+        f"{trailing_space}{suffix}"
+    )
+
+
+def _get_shell_form_command(main_container: dict) -> str | None:
+    """Return the single command string used by a ``sh -c`` container."""
+    command = main_container.get("command")
+    args = main_container.get("args")
+    if (
+        isinstance(command, list)
+        and len(command) >= 2
+        and command[0] in ("sh", "/bin/sh")
+        and command[1] == "-c"
+        and isinstance(args, list)
+        and len(args) == 1
+        and isinstance(args[0], str)
+    ):
+        return args[0]
+    return None
 
 
 def _trtllm_flags(overrides: dict) -> list[str]:
@@ -130,17 +223,24 @@ def enable_trtllm_chunked_prefill(config: dict) -> dict:
         if not isinstance(main_container, dict):
             continue
 
+        shell_command = _get_shell_form_command(main_container)
+        if shell_command is not None:
+            main_container["args"] = [
+                _enable_chunked_prefill_in_shell_command(shell_command)
+            ]
+            continue
+
         args = break_arguments(main_container.get("args", []))
-        while "--trtllm.enable_chunked_prefill" in args:
-            idx = args.index("--trtllm.enable_chunked_prefill")
+        while _CHUNKED_PREFILL_FLAG in args:
+            idx = args.index(_CHUNKED_PREFILL_FLAG)
             del args[idx]
             if idx < len(args) and not (
                 isinstance(args[idx], str) and args[idx].startswith("--")
             ):
                 del args[idx]
 
-        if "--override-engine-args" in args:
-            idx = args.index("--override-engine-args")
+        if _OVERRIDE_ENGINE_ARGS_FLAG in args:
+            idx = args.index(_OVERRIDE_ENGINE_ARGS_FLAG)
             if idx + 1 < len(args):
                 try:
                     override = json.loads(args[idx + 1])

--- a/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
+++ b/components/src/dynamo/profiler/utils/config_modifiers/trtllm.py
@@ -109,6 +109,38 @@ def _merge_overrides_into_args(args: list[str], overrides: dict) -> list[str]:
     return args
 
 
+def enable_trtllm_chunked_prefill(config: dict) -> dict:
+    """Enable chunked prefill on every generated TRT-LLM LLM worker.
+
+    Generated configs may express engine options either as ``--trtllm.*``
+    dynamic flags or in an ``--override-engine-args`` JSON object.  Normalize
+    both forms through :func:`_merge_overrides_into_args`, replacing an
+    existing dynamic flag so the result is idempotent and unambiguous.
+    """
+    services = config.get("spec", {}).get("services", {})
+    if not isinstance(services, dict):
+        return config
+
+    for service in services.values():
+        if not isinstance(service, dict) or service.get("componentType") != "worker":
+            continue
+        if service.get("subComponentType") == "encode":
+            continue
+
+        main_container = service.get("extraPodSpec", {}).get("mainContainer")
+        if not isinstance(main_container, dict):
+            continue
+
+        args = break_arguments(main_container.get("args", []))
+        while "--trtllm.enable_chunked_prefill" in args:
+            args = remove_valued_arguments(args, "--trtllm.enable_chunked_prefill")
+        main_container["args"] = _merge_overrides_into_args(
+            args, {"enable_chunked_prefill": True}
+        )
+
+    return config
+
+
 class TrtllmConfigModifier(BaseConfigModifier):
     BACKEND = "trtllm"
 

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -38,6 +38,9 @@ from dynamo.planner.config.planner_config import (
     PlannerPreDeploymentSweepMode,
 )
 from dynamo.profiler.utils.config import DgdPlannerServiceConfig, set_argument_value
+from dynamo.profiler.utils.config_modifiers.trtllm import (
+    enable_trtllm_chunked_prefill,
+)
 from dynamo.profiler.utils.profile_common import (
     ProfilerOperationalConfig,
     derive_planner_image,
@@ -82,17 +85,19 @@ def assemble_final_config(
 ) -> Any:
     """Apply Dynamo features to the picked DGD config via composable layers.
 
-    1. **Mocker** — swap the base to the mocker DGD template if enabled.
-    2. **vLLM self-benchmark** — when the resolved backend is vLLM, set
+    1. **TRT-LLM runtime defaults** — enable chunked prefill on generated
+       TRT-LLM workers so their token budget may be smaller than the request ISL.
+    2. **Mocker** — swap the base to the mocker DGD template if enabled.
+    3. **vLLM self-benchmark** — when the resolved backend is vLLM, set
        ``DYN_BENCHMARK_MODE`` on each worker so the ``get_perf_metrics``
        endpoint is populated at runtime. The planner consumes this as
        priority 1 of its bootstrap chain, superseding AIC and files.
-    3. **Planner** — inject the Planner service + planner-config ConfigMap.
+    4. **Planner** — inject the Planner service + planner-config ConfigMap.
        When ``aic_perf_model`` is given, it is embedded so the planner can
        initialize the Rust perf shim with native AIC identity. When
        ``aic_spec`` is given (rapid mode), it is embedded so the planner can
        run AIC interpolation at bootstrap if the endpoint is unavailable.
-    4. **Profile data** — attach interpolation-data ConfigMap when mocker
+    5. **Profile data** — attach interpolation-data ConfigMap when mocker
        or planner-thorough is enabled. The ConfigMap is only emitted when
        the picked config is disaggregated AND the interpolation NPZ files
        were produced on disk; rapid-mode deployments never emit it (the
@@ -105,6 +110,9 @@ def assemble_final_config(
     mocker = is_mocker_enabled(dgdr)
     planner = is_planner_enabled(dgdr)
     profile = needs_profile_data(dgdr)
+
+    if not mocker and resolved_backend == "trtllm":
+        enable_trtllm_chunked_prefill(dgd_config)
 
     if not mocker and not planner:
         return dgd_config

--- a/components/src/dynamo/profiler/utils/dgd_generation.py
+++ b/components/src/dynamo/profiler/utils/dgd_generation.py
@@ -38,9 +38,7 @@ from dynamo.planner.config.planner_config import (
     PlannerPreDeploymentSweepMode,
 )
 from dynamo.profiler.utils.config import DgdPlannerServiceConfig, set_argument_value
-from dynamo.profiler.utils.config_modifiers.trtllm import (
-    enable_trtllm_chunked_prefill,
-)
+from dynamo.profiler.utils.config_modifiers.trtllm import enable_trtllm_chunked_prefill
 from dynamo.profiler.utils.profile_common import (
     ProfilerOperationalConfig,
     derive_planner_image,


### PR DESCRIPTION
## Summary

- Enable chunked prefill on generated TRT-LLM prefill/decode candidates and thorough interpolation profiling configs.
- Enable the same runtime setting when assembling the final TRT-LLM DynamoGraphDeployment config while preserving final DGDR override precedence.
- Replace dynamic chunked-prefill flags idempotently, remove `enable_chunked_prefill` from explicit `--override-engine-args` JSON, and safely normalize dangling flags while leaving encode and mocker configs unchanged.

The DYN-3547 thorough decode sweep generated `max_num_tokens=512` while the benchmark sent an ISL of 4000. With chunked prefill disabled, TRT-LLM rejected those requests before decode benchmarking could start.

Linear: https://linear.app/nvidia/issue/DYN-3547

## Validation

- `pytest -q components/src/dynamo/profiler/tests/unit/test_trtllm_override_merge.py components/src/dynamo/profiler/tests/unit/test_profiler_protocol.py components/src/dynamo/profiler/tests/unit/test_helpers_thorough.py components/src/dynamo/profiler/tests/unit/test_helpers_profile_sla.py` (119 passed)
- `ruff check` on all changed Python files
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled TRT-LLM chunked prefill by default for applicable generated configurations and benchmark candidates.
  * Applied the setting consistently across prefill and decode workers while preserving existing engine overrides.
  * Ensured repeated configuration processing remains stable and avoids duplicate settings.

* **Tests**
  * Added coverage for default configuration generation, benchmark candidates, worker argument merging, override preservation, and idempotent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
