### PR TITLE
perf(trtllm): batch worker KV event drains

### DIFF
--- a/components/src/dynamo/trtllm/publisher.py
+++ b/components/src/dynamo/trtllm/publisher.py
@@ -29,7 +29,7 @@ import weakref
 from collections.abc import AsyncGenerator
 from contextlib import asynccontextmanager
 from queue import Queue
-from typing import Any, Awaitable, Callable, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Awaitable, Callable, Dict, Optional, Union, cast
 
 import msgspec
 import zmq
@@ -38,6 +38,9 @@ from prometheus_client import CollectorRegistry
 from dynamo.common.utils.prometheus import LLMBackendMetrics
 from dynamo.llm import FpmDirectPublisher, KvEventPublisher, WorkerMetricsPublisher
 from dynamo.trtllm.utils.request_utils import stored_event_cache_salt
+
+if TYPE_CHECKING:
+    from dynamo._core import KvRemovedEventInput, KvStoredEventInput
 
 logger = logging.getLogger(__name__)
 
@@ -52,6 +55,8 @@ _KV_EVENTS_TIMEOUT_SEC = 0.0
 _PUBLISH_MIN_SLEEP_SEC = 0.01
 _PUBLISH_MAX_SLEEP_SEC = 0.1
 _PUBLISH_BACKOFF_FACTOR = 2.0
+# Keep a continuously ready TRT-LLM iterator from starving its batch handler.
+_POLLING_BATCH_MAX_ITEMS = 256
 _KV_EVENTS_MIN_SLEEP_SEC = 0.005
 _KV_EVENTS_MAX_SLEEP_SEC = 0.02
 _KV_EVENTS_BACKOFF_FACTOR = 1.5
@@ -564,7 +569,7 @@ class Publisher:
     async def _polling_loop(
         self,
         fetch_fn,
-        handler_fn,
+        batch_handler_fn,
         min_sleep: float,
         max_sleep: float,
         backoff_factor: float,
@@ -572,23 +577,43 @@ class Publisher:
     ):
         sleep_s = min_sleep
         while not self._stop_event.is_set():
-            had_data = False
-            batch_size = 0
+            batch = []
+            fetch_error = None
             try:
                 async for item in fetch_fn():
-                    had_data = True
-                    batch_size += 1
-                    handler_fn(item)
+                    batch.append(item)
+                    if len(batch) >= _POLLING_BATCH_MAX_ITEMS:
+                        break
             except (asyncio.TimeoutError, TimeoutError, asyncio.QueueEmpty):
                 pass
             except Exception as e:
-                logging.warning(f"Publisher polling loop error: {e}", exc_info=True)
-                raise
+                fetch_error = e
 
-            if batch_size and batch_size_handler_fn is not None:
-                batch_size_handler_fn(batch_size)
+            if batch:
+                try:
+                    batch_handler_fn(batch)
+                except Exception as e:
+                    logger.warning("Publisher polling loop error: %s", e, exc_info=True)
+                    if fetch_error is not None:
+                        raise e from fetch_error
+                    raise
 
-            if not had_data:
+            if fetch_error is not None:
+                logger.warning(
+                    "Publisher polling loop error: %s",
+                    fetch_error,
+                    exc_info=(
+                        type(fetch_error),
+                        fetch_error,
+                        fetch_error.__traceback__,
+                    ),
+                )
+                raise fetch_error
+
+            if batch and batch_size_handler_fn is not None:
+                batch_size_handler_fn(len(batch))
+
+            if not batch:
                 await asyncio.sleep(sleep_s)
                 sleep_s = min(max_sleep, sleep_s * backoff_factor)
             else:
@@ -758,9 +783,13 @@ class Publisher:
                     # stat shape.
                     logging.warning(f"FPM publish failed: {e}")
 
+        def handle_stats(stats):
+            for stat in stats:
+                handle_stat(stat)
+
         await self._polling_loop(
             lambda: self.engine.llm.get_stats_async(timeout=_STATS_TIMEOUT_SEC),
-            handle_stat,
+            handle_stats,
             _PUBLISH_MIN_SLEEP_SEC,
             _PUBLISH_MAX_SLEEP_SEC,
             _PUBLISH_BACKOFF_FACTOR,
@@ -785,19 +814,25 @@ class Publisher:
             lambda: self.engine.llm.get_kv_cache_events_async(
                 timeout=_KV_EVENTS_TIMEOUT_SEC
             ),
-            self._handle_kv_event,
+            self._handle_kv_event_drain,
             _KV_EVENTS_MIN_SLEEP_SEC,
             _KV_EVENTS_MAX_SLEEP_SEC,
             _KV_EVENTS_BACKOFF_FACTOR,
-            self._record_kv_event_drain_batch,
+            batch_size_handler_fn=self._record_kv_event_drain_batch,
         )
         return True
+
+    def _handle_kv_event_drain(self, events):
+        if self.zmq_kv_event_publisher:
+            self._handle_zmq_kv_event_batch(events)
+        else:
+            self._handle_kv_event_batch(events)
 
     def _record_kv_event_drain_batch(self, batch_size: int) -> None:
         if self.additional_metrics is not None:
             self.additional_metrics.record_kv_event_drain_batch(batch_size)
 
-    def _handle_kv_event(self, event):
+    def _normalize_kv_event(self, event):
         event_id = event["event_id"]
         attention_dp_rank = event.get("attention_dp_rank", 0)
 
@@ -906,39 +941,16 @@ class Publisher:
                 cache_salt is not None,
                 parent_hash is not None,
             )
-            # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
-            # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
-            if self.zmq_kv_event_publisher:
-                # Consolidator enabled: publish to ZMQ only
-                self.zmq_kv_event_publisher.publish_stored(
-                    token_ids,
-                    num_block_tokens,
-                    block_hashes,
-                    parent_hash,
-                    block_mm_infos,
-                    attention_dp_rank,
-                    lora_name,
-                    cache_salt,
-                )
-            elif self.kv_event_publishers:
-                # No consolidator: publish to NATS (router subscribes directly)
-                # Route to correct publisher based on attention_dp_rank
-                publisher = self.kv_event_publishers.get(attention_dp_rank)
-                if publisher:
-                    publisher.publish_stored(
-                        token_ids,
-                        num_block_tokens,
-                        block_hashes,
-                        parent_hash,
-                        block_mm_infos,
-                        lora_name=lora_name,
-                        cache_salt=cache_salt,
-                    )
-                else:
-                    logging.warning(
-                        f"No publisher for attention_dp_rank={attention_dp_rank}, "
-                        f"available ranks: {list(self.kv_event_publishers.keys())}"
-                    )
+            return attention_dp_rank, {
+                "type": "stored",
+                "token_ids": token_ids,
+                "num_block_tokens": num_block_tokens,
+                "block_hashes": block_hashes,
+                "parent_hash": parent_hash,
+                "block_mm_infos": block_mm_infos,
+                "lora_name": lora_name,
+                "cache_salt": cache_salt,
+            }
         elif data["type"] == "removed":
             self.processing_initial_created_events = False
             removed_block_hashes: list[int] = []
@@ -964,26 +976,68 @@ class Publisher:
             if not removed_block_hashes:
                 return
 
-            # Publish to ZMQ if consolidator is enabled, otherwise publish to NATS
-            # Note: event_id is managed internally by the publisher (monotonic counter per dp_rank)
-            if self.zmq_kv_event_publisher:
-                # Consolidator enabled: publish to ZMQ only
-                self.zmq_kv_event_publisher.publish_removed(
-                    removed_block_hashes, attention_dp_rank
-                )
-            elif self.kv_event_publishers:
-                # No consolidator: publish to NATS (router subscribes directly)
-                # Route to correct publisher based on attention_dp_rank
-                publisher = self.kv_event_publishers.get(attention_dp_rank)
-                if publisher:
-                    publisher.publish_removed(removed_block_hashes)
-                else:
-                    logging.warning(
-                        f"No publisher for attention_dp_rank={attention_dp_rank}, "
-                        f"available ranks: {list(self.kv_event_publishers.keys())}"
-                    )
+            return attention_dp_rank, {
+                "type": "removed",
+                "block_hashes": removed_block_hashes,
+            }
         elif data["type"] == "created" and self.processing_initial_created_events:
             self.update_max_window_size(event)
+        return None
+
+    def _handle_zmq_kv_event(self, event):
+        normalized = self._normalize_kv_event(event)
+        if normalized is None:
+            return
+        attention_dp_rank, normalized_event = normalized
+        zmq_publisher = self.zmq_kv_event_publisher
+        assert zmq_publisher is not None
+
+        if normalized_event["type"] == "stored":
+            zmq_publisher.publish_stored(
+                normalized_event["token_ids"],
+                normalized_event["num_block_tokens"],
+                normalized_event["block_hashes"],
+                normalized_event["parent_hash"],
+                normalized_event["block_mm_infos"],
+                attention_dp_rank,
+                normalized_event["lora_name"],
+                normalized_event["cache_salt"],
+            )
+        else:
+            zmq_publisher.publish_removed(
+                normalized_event["block_hashes"], attention_dp_rank
+            )
+
+    def _handle_zmq_kv_event_batch(self, events):
+        """Preserve singleton publication for the optional ZMQ consolidator."""
+        for event in events:
+            self._handle_zmq_kv_event(event)
+
+    def _handle_kv_event_batch(self, events):
+        events_by_rank: dict[int, list["KvStoredEventInput | KvRemovedEventInput"]] = {}
+        for event in events:
+            normalized = self._normalize_kv_event(event)
+            if normalized is not None:
+                attention_dp_rank, normalized_event = normalized
+                if (
+                    normalized_event["type"] == "stored"
+                    and not normalized_event["block_hashes"]
+                ):
+                    continue
+                events_by_rank.setdefault(attention_dp_rank, []).append(
+                    cast("KvStoredEventInput | KvRemovedEventInput", normalized_event)
+                )
+
+        for attention_dp_rank, normalized_events in events_by_rank.items():
+            publisher = (self.kv_event_publishers or {}).get(attention_dp_rank)
+            if publisher:
+                publisher.publish_batch(normalized_events)
+            else:
+                logger.warning(
+                    "No publisher for attention_dp_rank=%s, available ranks: %s",
+                    attention_dp_rank,
+                    list((self.kv_event_publishers or {}).keys()),
+                )
 
     def start(self) -> None:
         # Each ManagedThread owns its own asyncio loop now, so we no longer

--- a/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py
@@ -411,10 +411,12 @@ def test_handle_kv_event_forwards_cache_salt_to_direct_publisher():
     pub.zmq_kv_event_publisher = None
     pub.kv_event_publishers = {0: publisher}
 
-    pub._handle_kv_event(_stored_kv_event())
+    pub._handle_kv_event_batch([_stored_kv_event()])
 
-    publisher.publish_stored.assert_called_once()
-    assert publisher.publish_stored.call_args.kwargs["cache_salt"] == "tenant-a"
+    publisher.publish_batch.assert_called_once()
+    events = publisher.publish_batch.call_args.args[0]
+    assert len(events) == 1
+    assert events[0]["cache_salt"] == "tenant-a"
 
 
 def test_handle_kv_event_forwards_cache_salt_to_zmq_publisher():
@@ -422,10 +424,43 @@ def test_handle_kv_event_forwards_cache_salt_to_zmq_publisher():
     pub.zmq_kv_event_publisher = MagicMock()
     pub.kv_event_publishers = None
 
-    pub._handle_kv_event(_stored_kv_event())
+    pub._handle_zmq_kv_event(_stored_kv_event())
 
     pub.zmq_kv_event_publisher.publish_stored.assert_called_once()
     assert pub.zmq_kv_event_publisher.publish_stored.call_args.args[-1] == "tenant-a"
+
+
+def test_handle_zmq_kv_event_batch_preserves_singleton_publication():
+    pub = _publisher_for_kv_event_test()
+    pub.zmq_kv_event_publisher = MagicMock()
+    pub.kv_event_publishers = None
+    removed = {
+        "event_id": 2,
+        "attention_dp_rank": 0,
+        "data": {"type": "removed", "block_hashes": [123]},
+    }
+
+    pub._handle_kv_event_drain([_stored_kv_event(), removed])
+
+    pub.zmq_kv_event_publisher.publish_stored.assert_called_once()
+    pub.zmq_kv_event_publisher.publish_removed.assert_called_once_with([123], 0)
+
+
+def test_handle_zmq_kv_event_batch_stops_on_malformed_event():
+    pub = _publisher_for_kv_event_test()
+    pub.zmq_kv_event_publisher = MagicMock()
+    pub.kv_event_publishers = None
+    removed = {
+        "event_id": 2,
+        "attention_dp_rank": 0,
+        "data": {"type": "removed", "block_hashes": [123]},
+    }
+
+    with pytest.raises(KeyError, match="event_id"):
+        pub._handle_zmq_kv_event_batch([_stored_kv_event(), {}, removed])
+
+    pub.zmq_kv_event_publisher.publish_stored.assert_called_once()
+    pub.zmq_kv_event_publisher.publish_removed.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -451,22 +486,23 @@ async def test_polling_loop_drops_conflicting_salts_and_processes_next_event(cap
         yield conflicting
         yield valid
 
-    def handle_event(event):
-        pub._handle_kv_event(event)
-        if event["event_id"] == 2:
-            pub._stop_event.set()
+    def handle_events(events):
+        pub._handle_kv_event_batch(events)
+        pub._stop_event.set()
 
     with caplog.at_level(logging.WARNING):
         await pub._polling_loop(
             fetch_events,
-            handle_event,
+            handle_events,
             min_sleep=0.001,
             max_sleep=0.001,
             backoff_factor=1.0,
         )
 
-    publisher.publish_stored.assert_called_once()
-    assert publisher.publish_stored.call_args.kwargs["cache_salt"] == "tenant-c"
+    publisher.publish_batch.assert_called_once()
+    events = publisher.publish_batch.call_args.args[0]
+    assert len(events) == 1
+    assert events[0]["cache_salt"] == "tenant-c"
     assert "Dropping stored KV event with invalid cache namespace" in caplog.text
 
 
@@ -490,50 +526,168 @@ def test_publisher_initializes_fpm_publisher_under_attention_dp(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_kv_event_polling_loop_records_drained_batch_size():
+async def test_stats_polling_processes_complete_drain_through_batch_handler():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+    pub.engine = MagicMock()
+    pub.metrics_publisher = MagicMock()
+    pub.component_gauges = MagicMock()
+    pub.metrics_collector = None
+    pub.fpm_publisher = None
+    pub._fpm_schema_checked = False
+
+    async def fetch_stats(timeout):
+        assert timeout == publisher_mod._STATS_TIMEOUT_SEC
+        yield _build_fake_stat(attentionDpRank=0)
+        yield _build_fake_stat(attentionDpRank=1)
+
+    def publish_metric(*_args, **_kwargs):
+        if pub.metrics_publisher.publish.call_count == 2:
+            pub._stop_event.set()
+
+    pub.engine.llm.get_stats_async = fetch_stats
+    pub.metrics_publisher.publish.side_effect = publish_metric
+
+    assert await pub._publish_stats_task() is True
+
+    assert [call.args[0] for call in pub.metrics_publisher.publish.call_args_list] == [
+        0,
+        1,
+    ]
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_bounds_and_resumes_continuously_ready_producer():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+    batches = []
+    drained_batches = []
+    handler_called = False
+
+    async def continuously_ready_events():
+        event_id = 0
+        while not handler_called:
+            yield {"event_id": event_id}
+            event_id += 1
+            await asyncio.sleep(0)
+        yield {"event_id": event_id}
+
+    events = continuously_ready_events()
+
+    def handle_batch(batch):
+        nonlocal handler_called
+        batches.append(batch)
+        handler_called = True
+        if len(batches) == 2:
+            pub._stop_event.set()
+
+    await asyncio.wait_for(
+        pub._polling_loop(
+            lambda: events,
+            handle_batch,
+            min_sleep=0.001,
+            max_sleep=0.001,
+            backoff_factor=1.0,
+            batch_size_handler_fn=drained_batches.append,
+        ),
+        timeout=1.0,
+    )
+
+    event_count = publisher_mod._POLLING_BATCH_MAX_ITEMS + 1
+    assert [event["event_id"] for batch in batches for event in batch] == list(
+        range(event_count)
+    )
+    assert [len(batch) for batch in batches] == [
+        publisher_mod._POLLING_BATCH_MAX_ITEMS,
+        1,
+    ]
+    assert drained_batches == [publisher_mod._POLLING_BATCH_MAX_ITEMS, 1]
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_backs_off_without_calling_handler_for_empty_drains(
+    monkeypatch,
+):
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+    handler = MagicMock()
+    sleeps = []
+
+    async def fetch_events():
+        if False:
+            yield None
+
+    async def record_sleep(delay):
+        sleeps.append(delay)
+        if len(sleeps) == 3:
+            pub._stop_event.set()
+
+    monkeypatch.setattr(asyncio, "sleep", record_sleep)
+
+    await pub._polling_loop(
+        fetch_events,
+        handler,
+        min_sleep=0.1,
+        max_sleep=0.2,
+        backoff_factor=2.0,
+    )
+
+    assert sleeps == [0.1, 0.2, 0.2]
+    handler.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_delivers_partial_drain_before_fetch_error():
+    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    pub._stop_event = threading.Event()
+    batches = []
+    drained_batches = []
+
+    async def fetch_events():
+        yield {"event_id": 0}
+        yield {"event_id": 1}
+        raise RuntimeError("fetch failed")
+
+    with pytest.raises(RuntimeError, match="fetch failed"):
+        await pub._polling_loop(
+            fetch_events,
+            batches.append,
+            min_sleep=0.001,
+            max_sleep=0.001,
+            backoff_factor=1.0,
+            batch_size_handler_fn=drained_batches.append,
+        )
+
+    assert batches == [[{"event_id": 0}, {"event_id": 1}]]
+    assert drained_batches == []
+
+
+@pytest.mark.asyncio
+async def test_polling_loop_chains_handler_failure_from_fetch_failure():
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
     pub._stop_event = threading.Event()
     drained_batches = []
 
     async def fetch_events():
-        for event_id in range(3):
-            yield {"event_id": event_id}
-
-    def handle_event(event):
-        if event["event_id"] == 2:
-            pub._stop_event.set()
-
-    await pub._polling_loop(
-        fetch_events,
-        handle_event,
-        min_sleep=0.001,
-        max_sleep=0.001,
-        backoff_factor=1.0,
-        batch_size_handler_fn=drained_batches.append,
-    )
-
-    assert drained_batches == [3]
-
-
-@pytest.mark.asyncio
-async def test_polling_loop_reraises_unexpected_handler_error():
-    pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
-    pub._stop_event = threading.Event()
-
-    async def fetch_events():
         yield {"event_id": 0}
+        raise RuntimeError("fetch failed")
 
-    def handle_event(_event):
-        raise RuntimeError("handler failed")
+    def handle_batch(_events):
+        raise ValueError("handler failed")
 
-    with pytest.raises(RuntimeError, match="handler failed"):
+    with pytest.raises(ValueError, match="handler failed") as exc_info:
         await pub._polling_loop(
             fetch_events,
-            handle_event,
+            handle_batch,
             min_sleep=0.001,
             max_sleep=0.001,
             backoff_factor=1.0,
+            batch_size_handler_fn=drained_batches.append,
         )
+
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "fetch failed"
+    assert drained_batches == []
 
 
 def test_managed_thread_stops_after_task_error():
@@ -561,23 +715,31 @@ def test_kv_event_id_gap_records_missing_event_count():
     pub.max_window_size = None
     pub._last_engine_event_id_by_rank = {0: 10}
 
-    pub._handle_kv_event({"event_id": 14, "data": {"type": "created"}})
+    pub._handle_kv_event_batch([{"event_id": 14, "data": {"type": "created"}}])
 
     pub.additional_metrics.record_kv_event_id_gap.assert_called_once_with(3)
 
 
 def test_filtered_kv_events_do_not_create_false_event_id_gaps():
     pub = publisher_mod.Publisher.__new__(publisher_mod.Publisher)
+    publisher = MagicMock()
     pub.additional_metrics = MagicMock()
     pub._last_engine_event_id_by_rank = {0: 10}
     pub.should_drop_event = MagicMock(side_effect=[True, False])
     pub.processing_initial_created_events = True
     pub.max_window_size = None
+    pub.zmq_kv_event_publisher = None
+    pub.kv_event_publishers = {0: publisher}
 
-    pub._handle_kv_event({"event_id": 11, "data": {"type": "stored"}})
-    pub._handle_kv_event({"event_id": 12, "data": {"type": "created"}})
+    pub._handle_kv_event_batch(
+        [
+            {"event_id": 11, "data": {"type": "stored"}},
+            {"event_id": 12, "data": {"type": "created"}},
+        ]
+    )
 
     pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
+    publisher.publish_batch.assert_not_called()
 
 
 def test_partial_only_removed_event_does_not_publish_empty_batch():
@@ -591,12 +753,87 @@ def test_partial_only_removed_event_does_not_publish_empty_batch():
     pub.zmq_kv_event_publisher = None
     pub.kv_event_publishers = {0: kv_event_publisher}
 
-    pub._handle_kv_event(
-        {"event_id": 1, "data": {"type": "removed", "block_hashes": [123]}}
+    pub._handle_kv_event_batch(
+        [{"event_id": 1, "data": {"type": "removed", "block_hashes": [123]}}]
     )
 
     assert pub.partial_block_hashes == set()
-    kv_event_publisher.publish_removed.assert_not_called()
+    kv_event_publisher.publish_batch.assert_not_called()
+
+
+def test_handle_kv_event_batch_groups_mixed_events_per_rank_in_order():
+    pub = _publisher_for_kv_event_test()
+    rank_0 = MagicMock()
+    rank_1 = MagicMock()
+    pub.zmq_kv_event_publisher = None
+    pub.kv_event_publishers = {0: rank_0, 1: rank_1}
+
+    first = _stored_kv_event("tenant-a")
+    first["data"]["lora_name"] = "adapter-a"
+    first["data"]["blocks"][0]["mm_keys"] = [
+        {"type": "mm_key", "hash": "00000000000000ff"}
+    ]
+    second = {
+        "event_id": 1,
+        "attention_dp_rank": 1,
+        "data": {"type": "removed", "block_hashes": [200]},
+    }
+    third = {
+        "event_id": 2,
+        "attention_dp_rank": 0,
+        "data": {"type": "removed", "block_hashes": [123]},
+    }
+
+    pub._handle_kv_event_drain([first, second, third])
+
+    rank_0.publish_batch.assert_called_once()
+    rank_0_events = rank_0.publish_batch.call_args.args[0]
+    assert [event["type"] for event in rank_0_events] == ["stored", "removed"]
+    assert rank_0_events[0]["lora_name"] == "adapter-a"
+    assert rank_0_events[0]["block_mm_infos"] == [
+        {"mm_objects": [{"mm_hash": 255, "offsets": []}]}
+    ]
+    rank_1.publish_batch.assert_called_once_with(
+        [{"type": "removed", "block_hashes": [200]}]
+    )
+
+
+def test_handle_kv_event_batch_preserves_unknown_rank_warning(caplog):
+    pub = _publisher_for_kv_event_test()
+    publisher = MagicMock()
+    pub.zmq_kv_event_publisher = None
+    pub.kv_event_publishers = {0: publisher}
+    event = _stored_kv_event()
+    event["attention_dp_rank"] = 1
+
+    with caplog.at_level(logging.WARNING):
+        pub._handle_kv_event_batch([event])
+
+    publisher.publish_batch.assert_not_called()
+    assert "No publisher for attention_dp_rank=1, available ranks: [0]" in caplog.text
+
+
+def test_handle_kv_event_batch_propagates_malformed_event():
+    pub = _publisher_for_kv_event_test()
+    publisher = MagicMock()
+    pub.zmq_kv_event_publisher = None
+    pub.kv_event_publishers = {0: publisher}
+
+    with pytest.raises(KeyError, match="event_id"):
+        pub._handle_kv_event_batch([{}])
+
+    publisher.publish_batch.assert_not_called()
+
+
+def test_handle_kv_event_batch_propagates_publish_failure():
+    pub = _publisher_for_kv_event_test()
+    publisher = MagicMock()
+    publisher.publish_batch.side_effect = RuntimeError("publish failed")
+    pub.zmq_kv_event_publisher = None
+    pub.kv_event_publishers = {0: publisher}
+
+    with pytest.raises(RuntimeError, match="publish failed"):
+        pub._handle_kv_event_batch([_stored_kv_event()])
 
 
 def test_interleaved_attention_dp_ranks_do_not_create_false_event_id_gaps():
@@ -605,13 +842,14 @@ def test_interleaved_attention_dp_ranks_do_not_create_false_event_id_gaps():
     pub._last_engine_event_id_by_rank = {}
     pub.should_drop_event = MagicMock(return_value=True)
 
-    for event in [
-        {"event_id": 10, "attention_dp_rank": 0},
-        {"event_id": 3, "attention_dp_rank": 1},
-        {"event_id": 11, "attention_dp_rank": 0},
-        {"event_id": 4, "attention_dp_rank": 1},
-    ]:
-        pub._handle_kv_event(event)
+    pub._handle_kv_event_batch(
+        [
+            {"event_id": 10, "attention_dp_rank": 0},
+            {"event_id": 3, "attention_dp_rank": 1},
+            {"event_id": 11, "attention_dp_rank": 0},
+            {"event_id": 4, "attention_dp_rank": 1},
+        ]
+    )
 
     pub.additional_metrics.record_kv_event_id_gap.assert_not_called()
 

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use pythonize::{depythonize, pythonize};
+use serde::Deserialize;
 use std::collections::HashMap;
 use std::ffi::OsString;
 use std::sync::Arc;
@@ -1029,6 +1030,29 @@ pub(crate) struct KvEventPublisher {
     image_token_id: Option<u32>,
 }
 
+#[derive(Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case", deny_unknown_fields)]
+enum KvEventInput {
+    Stored {
+        token_ids: Vec<u32>,
+        num_block_tokens: Vec<u64>,
+        block_hashes: Vec<i64>,
+        parent_hash: Option<i64>,
+        block_mm_infos: Option<Vec<Option<BlockExtraInfo>>>,
+        lora_name: Option<String>,
+        is_eagle: Option<bool>,
+        cache_salt: Option<String>,
+    },
+    Removed {
+        block_hashes: Vec<i64>,
+    },
+}
+
+fn depythonize_kv_event_inputs(events: &Bound<'_, PyAny>) -> PyResult<Vec<KvEventInput>> {
+    depythonize(events)
+        .map_err(|error| PyValueError::new_err(format!("invalid KV event batch: {error}")))
+}
+
 impl KvEventPublisher {
     /// Wrap an already-constructed Rust publisher as the Python pyclass.
     ///
@@ -1050,6 +1074,55 @@ impl KvEventPublisher {
             // carries no image marker; the non-unified path sets it via the
             // constructor.
             image_token_id: None,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn stored_event(
+        &self,
+        event_id: u64,
+        token_ids: &[u32],
+        num_block_tokens: &[u64],
+        block_hashes: &[i64],
+        parent_hash: Option<i64>,
+        block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
+        lora_name: Option<&str>,
+        is_eagle: Option<bool>,
+        cache_salt: Option<&str>,
+    ) -> KvCacheEvent {
+        let block_hashes_u64: Vec<u64> = block_hashes.iter().map(|&hash| hash as u64).collect();
+        KvCacheEvent {
+            event_id,
+            data: KvCacheEventData::Stored(KvCacheStoreData {
+                parent_hash: parent_hash.map(ExternalSequenceBlockHash::from),
+                start_position: None,
+                blocks: create_stored_blocks(
+                    self.kv_block_size as u32,
+                    token_ids,
+                    num_block_tokens,
+                    &block_hashes_u64,
+                    lora_name,
+                    cache_salt,
+                    &self.warning_count,
+                    block_mm_infos,
+                    is_eagle,
+                    self.image_token_id,
+                ),
+            }),
+            dp_rank: self.dp_rank,
+        }
+    }
+
+    fn removed_event(&self, event_id: u64, block_hashes: Vec<i64>) -> KvCacheEvent {
+        KvCacheEvent {
+            event_id,
+            data: KvCacheEventData::Removed(KvCacheRemoveData {
+                block_hashes: block_hashes
+                    .into_iter()
+                    .map(ExternalSequenceBlockHash::from)
+                    .collect(),
+            }),
+            dp_rank: self.dp_rank,
         }
     }
 }
@@ -1143,13 +1216,7 @@ impl KvEventPublisher {
         is_eagle: Option<bool>,
         cache_salt: Option<String>,
     ) -> PyResult<()> {
-        let kv_block_size = self.kv_block_size as u32;
-        let dp_rank = self.dp_rank;
-        let warning_count = self.warning_count.clone();
         let inner = self.inner.clone();
-        let image_token_id = self.image_token_id;
-
-        let event_id = inner.next_event_id();
 
         let mm_infos = block_mm_infos
             .as_ref()
@@ -1157,51 +1224,71 @@ impl KvEventPublisher {
             .transpose()?;
 
         py.allow_threads(|| {
-            let block_hashes_u64: Vec<u64> = block_hashes.iter().map(|&h| h as u64).collect();
-            let event = KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Stored(KvCacheStoreData {
-                    parent_hash: parent_hash.map(ExternalSequenceBlockHash::from),
-                    start_position: None,
-                    blocks: create_stored_blocks(
-                        kv_block_size,
-                        &token_ids,
-                        &num_block_tokens,
-                        &block_hashes_u64,
-                        lora_name.as_deref(),
-                        cache_salt.as_deref(),
-                        &warning_count,
-                        mm_infos.as_deref(),
-                        is_eagle,
-                        image_token_id,
-                    ),
-                }),
-                dp_rank,
-            };
-
+            let event = self.stored_event(
+                inner.next_event_id(),
+                &token_ids,
+                &num_block_tokens,
+                &block_hashes,
+                parent_hash,
+                mm_infos.as_deref(),
+                lora_name.as_deref(),
+                is_eagle,
+                cache_salt.as_deref(),
+            );
             inner.publish(event).map_err(to_pyerr)
         })
     }
 
     fn publish_removed(&self, py: Python, block_hashes: Vec<i64>) -> PyResult<()> {
-        let dp_rank = self.dp_rank;
         let inner = self.inner.clone();
 
-        // Use shared monotonic event_id counter from the inner publisher
-        let event_id = inner.next_event_id();
-
         py.allow_threads(|| {
-            let block_hashes: Vec<ExternalSequenceBlockHash> = block_hashes
-                .into_iter()
-                .map(ExternalSequenceBlockHash::from)
-                .collect();
-            let event = KvCacheEvent {
-                event_id,
-                data: KvCacheEventData::Removed(KvCacheRemoveData { block_hashes }),
-                dp_rank,
-            };
-
+            let event = self.removed_event(inner.next_event_id(), block_hashes);
             inner.publish(event).map_err(to_pyerr)
+        })
+    }
+
+    /// Publish an ordered list of typed KV events as one processor input.
+    ///
+    /// The complete Python list is deserialized before anything is enqueued,
+    /// so invalid input cannot partially publish a batch. Event construction
+    /// and block hashing run without holding the Python GIL.
+    fn publish_batch(&self, py: Python, events: Bound<PyAny>) -> PyResult<()> {
+        let inputs = depythonize_kv_event_inputs(&events)?;
+        let inner = self.inner.clone();
+        py.allow_threads(|| {
+            let mut converted = Vec::with_capacity(inputs.len());
+            for input in inputs {
+                let event_id = inner.next_event_id();
+                let event = match input {
+                    KvEventInput::Stored {
+                        token_ids,
+                        num_block_tokens,
+                        block_hashes,
+                        parent_hash,
+                        block_mm_infos,
+                        lora_name,
+                        is_eagle,
+                        cache_salt,
+                    } => self.stored_event(
+                        event_id,
+                        &token_ids,
+                        &num_block_tokens,
+                        &block_hashes,
+                        parent_hash,
+                        block_mm_infos.as_deref(),
+                        lora_name.as_deref(),
+                        is_eagle,
+                        cache_salt.as_deref(),
+                    ),
+                    KvEventInput::Removed { block_hashes } => {
+                        self.removed_event(event_id, block_hashes)
+                    }
+                };
+                converted.push(event);
+            }
+
+            inner.publish_batch(converted).map_err(to_pyerr)
         })
     }
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -15,7 +15,10 @@ from typing import (
     Sequence,
     Set,
     Tuple,
+    TypedDict,
 )
+
+from typing_extensions import NotRequired
 
 # Import from specialized modules
 from .prometheus_metrics import RuntimeMetrics as PyRuntimeMetrics
@@ -1131,6 +1134,23 @@ class ApproxKvIndexer:
         ...
 
 
+class KvStoredEventInput(TypedDict):
+    type: Literal["stored"]
+    token_ids: List[int]
+    num_block_tokens: List[int]
+    block_hashes: List[int]
+    parent_hash: NotRequired[Optional[int]]
+    block_mm_infos: NotRequired[Optional[List[Optional[Dict[str, Any]]]]]
+    lora_name: NotRequired[Optional[str]]
+    is_eagle: NotRequired[Optional[bool]]
+    cache_salt: NotRequired[Optional[str]]
+
+
+class KvRemovedEventInput(TypedDict):
+    type: Literal["removed"]
+    block_hashes: List[int]
+
+
 class KvEventPublisher:
     """
     A KV event publisher will publish KV events corresponding to the component.
@@ -1157,7 +1177,8 @@ class KvEventPublisher:
         When zmq_endpoint is provided, the publisher subscribes to a ZMQ socket for
         incoming engine events (e.g. from SGLang/vLLM) and relays them to NATS.
 
-        When zmq_endpoint is None, events are pushed manually via publish_stored/publish_removed.
+        When zmq_endpoint is None, events are pushed manually via publish_batch,
+        publish_stored, or publish_removed.
 
         Args:
             endpoint: The endpoint to extract component information from for event publishing
@@ -1167,6 +1188,8 @@ class KvEventPublisher:
             enable_local_indexer: Enable worker-local KV indexer
             zmq_endpoint: Optional ZMQ endpoint for relay mode (e.g. "tcp://127.0.0.1:5557")
             zmq_topic: ZMQ topic to subscribe to (defaults to "" when zmq_endpoint is set)
+            batching_timeout_ms: Cross-list batching timeout in milliseconds. None/0
+                flushes at each submitted source-list boundary.
             kv_state_endpoint: KV event ownership endpoint; defaults to endpoint.
         """
 
@@ -1208,6 +1231,18 @@ class KvEventPublisher:
 
         Args:
             block_hashes: List of block hashes to remove (signed 64-bit integers)
+        """
+        ...
+
+    def publish_batch(
+        self, events: Sequence[KvStoredEventInput | KvRemovedEventInput]
+    ) -> None:
+        """
+        Publish an ordered list of KV events as one processor input.
+
+        The complete list is validated before it is enqueued. Compatible
+        events are coalesced while preserving source order and the processor's
+        existing block-count limits.
         """
         ...
 

--- a/lib/bindings/python/tests/test_kv_event_publisher.py
+++ b/lib/bindings/python/tests/test_kv_event_publisher.py
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.llm import KvEventPublisher
+from dynamo.runtime import DistributedRuntime
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(30)
+@pytest.mark.parametrize("request_plane", ["tcp"], indirect=True)
+async def test_publish_batch_depythonizes_complete_typed_python_list(
+    runtime: DistributedRuntime,
+) -> None:
+    endpoint = runtime.endpoint("test.kv-publisher.generate")
+    publisher = KvEventPublisher(
+        endpoint,
+        worker_id=1,
+        kv_block_size=1,
+        enable_local_indexer=True,
+    )
+
+    try:
+        with pytest.raises(ValueError, match="invalid KV event batch"):
+            publisher.publish_batch(
+                [
+                    {"type": "removed", "block_hashes": [10]},
+                    {
+                        "type": "stored",
+                        "token_ids": [1],
+                        "num_block_tokens": [1],
+                    },
+                ]
+            )
+
+        with pytest.raises(ValueError, match="unknown field.*cache_sal"):
+            publisher.publish_batch(
+                [
+                    {
+                        "type": "stored",
+                        "token_ids": [1],
+                        "num_block_tokens": [1],
+                        "block_hashes": [11],
+                        "cache_sal": "tenant-a",
+                    }
+                ]
+            )
+
+        # A rejected list never reaches the publisher channel; a subsequent
+        # fully valid mixed list exercises the real Python-object depythonize
+        # path and remains independently publishable.
+        publisher.publish_batch(
+            [
+                {"type": "removed", "block_hashes": [10]},
+                {
+                    "type": "stored",
+                    "token_ids": [1],
+                    "num_block_tokens": [1],
+                    "block_hashes": [11],
+                    "parent_hash": 9,
+                    "block_mm_infos": [None],
+                    "lora_name": "adapter-a",
+                    "is_eagle": True,
+                    "cache_salt": "tenant-a",
+                },
+            ]
+        )
+    finally:
+        publisher.shutdown()

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -122,7 +122,8 @@ pub struct KvEventPublisher {
     /// The size of the KV block.
     kv_block_size: u32,
     /// The source of KV events.
-    /// Can be `None` if all events provided through [`KvEventPublisher::publish`].
+    /// Can be `None` if all events are provided through
+    /// [`KvEventPublisher::publish`] or [`KvEventPublisher::publish_batch`].
     source: Option<KvEventSource>,
     /// The cancellation token.
     cancellation_token: CancellationToken,
@@ -404,6 +405,29 @@ impl KvEventPublisher {
 
     pub fn publish(&self, event: KvCacheEvent) -> Result<(), mpsc::error::SendError<KvCacheEvent>> {
         self.send_singleton(PlacementEvent::local_gpu(self.worker_id, event))
+    }
+
+    /// Publish an ordered list of engine events as one processor input.
+    ///
+    /// The processor handles the complete list without receiving another list
+    /// or servicing its batching timer between source events. Existing
+    /// coalescing and block-count limits still apply within the list. Empty
+    /// lists are ignored.
+    pub fn publish_batch(
+        &self,
+        events: Vec<KvCacheEvent>,
+    ) -> Result<(), mpsc::error::SendError<Vec<KvCacheEvent>>> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let placement_events = events
+            .into_iter()
+            .map(|event| PlacementEvent::local_gpu(self.worker_id, event))
+            .collect();
+        self.tx.send(placement_events).map_err(|err| {
+            mpsc::error::SendError(err.0.into_iter().map(|event| event.event).collect())
+        })
     }
 
     pub fn publish_with_storage_tier(

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -21,6 +21,81 @@ mod test_event_processing {
     use dynamo_kv_router::zmq_wire::StoredBlockOptions;
 
     #[test]
+    fn test_publish_batch_ignores_empty_and_preserves_order() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
+        let publisher = KvEventPublisher {
+            kv_block_size: 1,
+            source: None,
+            cancellation_token: CancellationToken::new(),
+            worker_id: 7,
+            tx,
+            next_event_id: Arc::new(AtomicU64::new(0)),
+        };
+
+        publisher.publish_batch(Vec::new()).unwrap();
+        assert!(matches!(
+            rx.try_recv(),
+            Err(mpsc::error::TryRecvError::Empty)
+        ));
+
+        publisher
+            .publish_batch(vec![
+                KvCacheEvent {
+                    event_id: 8,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 1,
+                },
+                KvCacheEvent {
+                    event_id: 9,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 2,
+                },
+            ])
+            .unwrap();
+        let batch = rx.try_recv().unwrap();
+        assert_eq!(batch.len(), 2);
+        assert_eq!(batch[0].event.event_id, 8);
+        assert_eq!(batch[0].event.dp_rank, 1);
+        assert_eq!(batch[1].event.event_id, 9);
+        assert_eq!(batch[1].event.dp_rank, 2);
+    }
+
+    #[test]
+    fn test_publish_batch_closed_channel_returns_original_events_in_order() {
+        let (tx, rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
+        let publisher = KvEventPublisher {
+            kv_block_size: 1,
+            source: None,
+            cancellation_token: CancellationToken::new(),
+            worker_id: 7,
+            tx,
+            next_event_id: Arc::new(AtomicU64::new(0)),
+        };
+        drop(rx);
+
+        let error = publisher
+            .publish_batch(vec![
+                KvCacheEvent {
+                    event_id: 8,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 1,
+                },
+                KvCacheEvent {
+                    event_id: 9,
+                    data: KvCacheEventData::Cleared,
+                    dp_rank: 2,
+                },
+            ])
+            .unwrap_err();
+
+        assert_eq!(error.0.len(), 2);
+        assert_eq!(error.0[0].event_id, 8);
+        assert_eq!(error.0[0].dp_rank, 1);
+        assert_eq!(error.0[1].event_id, 9);
+        assert_eq!(error.0[1].dp_rank, 2);
+    }
+
+    #[test]
     fn test_publish_wraps_events_in_batches() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
         let publisher = KvEventPublisher {


### PR DESCRIPTION
## Summary

- add generic Rust and Python `KvEventPublisher.publish_batch` APIs so one ordered source batch reaches the existing KV event processor as one input
- use one list-based polling callback for legacy TRT events and stats, bounded to 256 items so a continuously ready TRT-LLM iterator cannot starve publication; persistent iterators resume on the next polling turn without reordering or loss
- group direct KV events once per non-empty attention-DP rank in each bounded chunk, while stats and the optional ZMQ consolidator continue to iterate their chunks as singletons
- keep the optional ZMQ path explicitly singleton-only and remove the unused direct singleton-publication fallback
- preserve within-rank order, event-gap tracking, global-attention filtering, existing global partial-block suppression, cache salt, multimodal metadata, LoRA, created events, and unknown-rank handling
- preserve legacy failure and metric semantics: partial fetched chunks publish before fetch errors propagate through `ManagedThread`, failed chunks are not recorded as successfully handled, and consolidator wire messages remain singleton-based
- leave `dynamo.trtllm.unified_main`, vLLM, and SGLang unchanged

## Validation

- `cargo test -p dynamo-llm kv_router::publisher::tests --lib` (80 passed)
- `cargo test --manifest-path lib/bindings/python/Cargo.toml --lib`
- `lib/bindings/python/.venv/bin/python -m pytest -q lib/bindings/python/tests/test_kv_event_publisher.py` (1 passed)
- `PYTHONPATH=components/src lib/bindings/python/.venv/bin/python -m pytest -q components/src/dynamo/trtllm/tests/test_trtllm_fpm_publisher.py` (49 passed)
- `MYPYPATH=components/src:lib/bindings/python/src mypy --explicit-package-bases components/src/dynamo/trtllm/publisher.py` (no issues)
- strict `cargo clippy` for `dynamo-llm` and the Python binding crate with `-D warnings`
- `cargo fmt --all -- --check` for the root and Python binding workspaces
- `pre-commit run --files <changed files>`
- no live TRT-LLM run or heavyweight image pull; the focused legacy adapter suite uses the existing local test environment
