### PR TITLE
fix(kv-router): scrub lookup entry when a remove can't resolve its node

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs
@@ -90,6 +90,15 @@ impl ConcurrentRadixTreeCompressed {
                         block_hash = ?block_hash,
                         "Block not found during remove; skipping"
                     );
+                    // The remove event says this worker evicted the block, so
+                    // any lookup entry for it must not outlive the event. A
+                    // resolve miss with a live entry happens when the hash's
+                    // node was split off and the split child was later dropped
+                    // by clear_children_if_unreachable — without this scrub the
+                    // entry (and the per-worker tracked-block count) leaks
+                    // permanently. Mirrors the scrubs in apply_removed_hash's
+                    // miss branches.
+                    Self::remove_lookup_hashes(lookup, worker, [block_hash]);
                 }
             }
         }

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -1309,3 +1309,73 @@ mod remove_cleanup_tests {
         assert_score(&index, &[1, 2, 3, 8, 9], WorkerWithDpRank::new(0, 0), 5).await;
     }
 }
+
+/// Deterministic reproduction of per-worker lookup-entry leakage under the
+/// split + children-clear + lazy-repair interplay (ai-dynamo/dynamo#10774,
+/// production signature: prefill tracked_blocks climbing ~2x the physical
+/// pool while RSS stays modest).
+///
+/// Two lookup maps emulate two event threads (sticky worker routing means a
+/// worker's events are serialized, but its lookup is never repaired by other
+/// threads' splits except lazily on access):
+///
+/// 1. w1 stores [1,2,3,4] -> node N; w1's lookup has 4 entries -> N.
+/// 2. w2 stores [1,2,9] -> splits N into N=[1,2] with children S=[3,4], X=[9].
+///    w1's entries for the 3,4 externals now point at N but live in S (stale
+///    by design; lazy repair).
+/// 3. w1 removes the head external -> w1 dropped from N, entries for N's edge
+///    scrubbed. w1's stale entries for S's hashes remain.
+/// 4. w2 removes the head external -> N's full_edge_workers empties ->
+///    clear_children_if_unreachable DROPS S and X from N.
+/// 5. w1's removes for the 3,4 externals arrive (the engine evicted them and
+///    the producer is correct): resolve_lookup finds N, N no longer contains
+///    the hashes, and the subtree scan fails because S was detached. The
+///    remove is skipped WITHOUT scrubbing the lookup entries -> they leak
+///    forever and block_count never returns to zero.
+#[test]
+fn remove_after_split_and_children_clear_scrubs_lookup() {
+    let index = ConcurrentRadixTreeCompressed::new();
+    let w1 = worker(1);
+    let w2 = worker(2);
+    let mut l1 = direct_lookup();
+    let mut l2 = direct_lookup();
+
+    // 1. w1 stores the 4-block chain.
+    apply_direct(&index, &mut l1, make_store_event(1, &[1, 2, 3, 4]));
+    assert_eq!(worker_lookup_len(&l1, w1), Some(4));
+
+    // 2. w2 stores a chain sharing the [1,2] prefix, splitting N at pos 2.
+    apply_direct(&index, &mut l2, make_store_event(2, &[1, 2, 9]));
+
+    // 3+4. Remove the shared head block for both workers. This empties N's
+    // full-edge coverage and drops its children (S=[3,4], X=[9]) from the
+    // live tree. (Each remove of the head hash cuts that worker's coverage
+    // of N to zero and eagerly scrubs N's own edge hashes.)
+    let head = remove_hashes_with_parent(&[], &[1, 2]);
+    apply_direct(
+        &index,
+        &mut l1,
+        remove_event(1, 100, 0, vec![head[0], head[1]]),
+    );
+    apply_direct(
+        &index,
+        &mut l2,
+        remove_event(2, 101, 0, vec![head[0], head[1]]),
+    );
+
+    // w1 still holds stale entries for the [3,4] suffix externals.
+    assert_eq!(worker_lookup_len(&l1, w1), Some(2));
+
+    // 5. The engine evicts the suffix blocks; correct producer emits removes.
+    let suffix = remove_hashes_with_parent(&[1, 2], &[3, 4]);
+    apply_direct(&index, &mut l1, remove_event(1, 102, 0, suffix));
+
+    // Every stored block has now been removed for w1: its lookup must be
+    // empty, or tracked_blocks counts phantom blocks forever.
+    assert_eq!(worker_lookup_len(&l1, w1), Some(0));
+
+    // And w2's cleanup path must also drain fully.
+    let w2_leaf = remove_hashes_with_parent(&[1, 2], &[9]);
+    apply_direct(&index, &mut l2, remove_event(2, 103, 0, w2_leaf));
+    assert_eq!(worker_lookup_len(&l2, w2), Some(0));
+}


### PR DESCRIPTION
## Overview:

`ConcurrentRadixTreeCompressed` permanently leaks per-worker lookup entries
when a remove event cannot resolve its node. In `remove.rs::apply_removed`,
the `resolve_lookup → None` branch skips the hash **without removing the
worker's lookup entry** — unlike the two sibling miss-branches in
`apply_removed_hash`, which both scrub. Since the tracked-blocks accounting is
the sum of `WorkerLookup` sizes, every such miss is a phantom tracked block,
and since all the miss paths log at `debug`, the leak is silent in production.

The state is reachable without exotic races — it is the designed interplay of
lazy lookup repair and children-clearing:

1. A cross-thread split moves hash `H` from node `N` to a suffix child `S`.
   The owning worker's lookup entry for `H` still points at `N` (stale by
   design; lazy repair).
2. Coverage-emptying removes drain `N.full_edge_workers`, and
   `clear_children_if_unreachable` drops `N`'s children — detaching `S`.
3. The owner's remove for `H` arrives: `N` no longer contains `H`, and the
   repair scan of `N`'s (now empty) subtree fails. The remove is skipped and
   the entry leaks forever — external sequence hashes are effectively unique,
   so nothing will ever reference that key again.

## Production data (gpt-oss-120b disaggregated, `router_event_threads=4`)

Prefill traffic supplies both ingredients at rate (prefix-fanout splits ×
aggressive unique-chain eviction); decode supplies neither:

- Prefill per-worker tracked blocks climbed monotonically ~19k/h to **1.79×
  the physical KV pool** (397k tracked vs 3 workers × 73,846 blocks) within
  9 h, with no worker churn and a verified-complete remove stream from the
  backend (see NVIDIA/TensorRT-LLM#16335 for the producer-side verification).
- The single-threaded `RadixTree` on the **identical event stream** stays
  bounded at exactly the pool sum.
- With this fix deployed, the same workload oscillates at the pool bound
  (`live prefill workers × 73,846`) in both directions for 24+ h — identical
  behavior to the plain tree.

This is likely a major contributor to the tracked-state growth reported in
#10774 (alongside the backend's missing-remove-events bugs, fixed in
NVIDIA/TensorRT-LLM#16335): mock workers emit remove patterns that rarely
exercise the split + children-clear interleaving, which is consistent with the
difficulty reproducing that issue end-to-end.

## Details:

- One scrub call in the resolve-miss branch, mirroring the scrubs in
  `apply_removed_hash`'s two miss branches. The invariant: a remove event is
  the backend asserting the worker no longer caches the block, so no lookup
  entry for that (worker, hash) may outlive the event — whether or not the
  node can still be found to update coverage.
- Off the hot path: executes only when resolve already missed (entry absent —
  a no-op delete — or entry stale with a failed subtree scan). No locking,
  shape-gate, split, cutoff, or repair semantics are touched, per the module
  guardrails; no benchmark delta is expected. Happy to run the preferred
  Mooncake benchmark setup if desired.
- Deterministic single-threaded reproduction included
  (`remove_after_split_and_children_clear_scrubs_lookup`): two lookup maps
  emulate two event threads through the split → coverage-drain →
  children-clear → remove sequence; it fails with two phantom entries without
  the fix.

@PeaBrane — one related observation for a possible follow-up, flagging rather
than patching per the guardrails: `repair_lookup_for_resolved_node` iterates
all workers and its helper inserts on vacant, so a cross-worker repair can in
principle resurrect entries a worker's removes already scrubbed (when removes
were applied against a detached node copy whose live twin still advertises
coverage). We have not observed a measurable residual from this in production
after this fix, but a repair-only update-without-insert variant may be worth
considering.

## Where should the reviewer start?

`lib/kv-router/src/indexer/concurrent_radix_tree_compressed/remove.rs` — the
`None` arm in `apply_removed`'s resolve match, compared against the two miss
branches in `apply_removed_hash`; then the new test at the bottom of
`concurrent_radix_tree_compressed/tests.rs`.

## Related Issues

**🔗 This PR is linked to an issue:**

- Relates to #10774


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stale lookup data remaining after block removal misses.
  * Ensured removed entries are fully cleared during index updates and subsequent cleanup.

* **Tests**
  * Added regression coverage for lookup cleanup after index splits, child clearing, and lazy removal handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->