### PR TITLE
fix(planner): share tick timestamp for observation scheduling

### DIFF
--- a/components/src/dynamo/planner/core/types.py
+++ b/components/src/dynamo/planner/core/types.py
@@ -23,8 +23,10 @@ class ScheduledTick:
     """Declares when the core next needs to be called, what data it needs,
     and what decisions to make.
 
-    All times are absolute seconds (wall clock for native adapter,
-    simulated clock for replay).
+    ``at_s`` is an absolute wall-clock time for the native adapter and a
+    simulated time for replay. ``at_monotonic_s`` is the matching scheduler
+    timestamp used to make observation-prefetch and plugin-dispatch cadence
+    decisions against the same clock value.
     """
 
     at_s: float
@@ -42,6 +44,7 @@ class ScheduledTick:
     traffic_metrics_duration_s: float = 0.0
     need_worker_states: bool = False
     need_worker_fpm: bool = False
+    at_monotonic_s: Optional[float] = None
 
 
 @dataclass

--- a/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
+++ b/components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py
@@ -571,7 +571,11 @@ class OrchestratorEngineAdapter:
         # 3. Build PipelineContext + baseline and drive the orchestrator.
         ctx = self._tick_input_to_context(tick_input)
         baseline = self._baseline_from_worker_counts(tick_input.worker_counts)
-        outcome = await self._orchestrator.tick(ctx, baseline)
+        outcome = await self._orchestrator.tick(
+            ctx,
+            baseline,
+            tick_now=scheduled_tick.at_monotonic_s,
+        )
 
         # 4. Project PipelineOutcome onto PlannerEffects.
         scale_to = self._project_scale_to(
@@ -866,6 +870,7 @@ class OrchestratorEngineAdapter:
         # described by the separate need_* fields below.
         return ScheduledTick(
             at_s=at_s,
+            at_monotonic_s=at_monotonic,
             run_load_scaling=load_loop_due,
             run_throughput_scaling=throughput_loop_due,
             need_worker_states=True,

--- a/components/src/dynamo/planner/plugins/orchestrator/orchestrator.py
+++ b/components/src/dynamo/planner/plugins/orchestrator/orchestrator.py
@@ -276,6 +276,8 @@ class LocalPlannerOrchestrator:
         self,
         ctx: PipelineContext,
         baseline: Mapping[ComponentKey, int],
+        *,
+        tick_now: Optional[float] = None,
     ) -> PipelineOutcome:
         """Run one tick through PREDICT / PROPOSE / RECONCILE / CONSTRAIN.
 
@@ -283,8 +285,13 @@ class LocalPlannerOrchestrator:
         (``apply`` / ``skip_no_targets`` / ``skip_short_circuit`` /
         ``skip_tick_timeout``) — the caller is responsible for
         projecting ``apply`` onto a ``PlannerConnector``.
+
+        ``tick_now`` is supplied by the engine adapter when it already used
+        that scheduler timestamp to plan observation collection. Direct
+        orchestrator callers may omit it and sample the clock here.
         """
-        tick_now = self._clock.monotonic()
+        if tick_now is None:
+            tick_now = self._clock.monotonic()
         return await run_pipeline(
             ctx=ctx,
             scheduler=self._scheduler,

--- a/components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py
+++ b/components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py
@@ -34,7 +34,7 @@ from dynamo.planner.core.types import (
     WorkerCapabilities,
     WorkerCounts,
 )
-from dynamo.planner.plugins.clock import VirtualClock
+from dynamo.planner.plugins.clock import Clock, VirtualClock
 from dynamo.planner.plugins.merge.types import ChainAugmentOutcome
 from dynamo.planner.plugins.orchestrator.engine_adapter import OrchestratorEngineAdapter
 from dynamo.planner.plugins.orchestrator.pipeline import PipelineOutcome
@@ -523,7 +523,7 @@ async def test_tick_propagates_pipeline_execute_action_to_diagnostics():
         ],
     )
 
-    async def fake_tick(ctx, baseline):
+    async def fake_tick(ctx, baseline, *, tick_now=None):
         return canned_outcome
 
     adapter._orchestrator.tick = fake_tick  # type: ignore[method-assign]
@@ -716,6 +716,79 @@ def test_lazy_fpm_pull_only_when_load_builtin_is_due():
     assert not load_tick.run_throughput_scaling
 
 
+@pytest.mark.asyncio
+async def test_observation_prefetch_and_dispatch_share_tick_timestamp():
+    """A clock advance between adapter and orchestrator must not change due-ness.
+
+    Observation prefetch plans against the next tick's monotonic timestamp. In
+    production, sampling the clock again during dispatch produces a slightly
+    later value. When the load interval equals the pipeline interval, recording
+    that later value as ``last_call_at`` makes the following prefetch check miss
+    by the sampling delta, even though the plugin is due when dispatch runs.
+    """
+
+    class _DriftingMonoClock(Clock):
+        def __init__(self, step: float = 0.001) -> None:
+            self._mono = 0.0
+            self._step = step
+
+        def set_monotonic(self, value: float) -> None:
+            self._mono = value
+
+        def now(self) -> float:
+            return 1.7e9 + self._mono
+
+        def monotonic(self) -> float:
+            current = self._mono
+            self._mono += self._step
+            return current
+
+        async def sleep(self, seconds: float) -> None:  # pragma: no cover
+            return None
+
+    cfg = PlannerConfig.model_validate(
+        {
+            "mode": "agg",
+            "enable_load_scaling": True,
+            "enable_throughput_scaling": False,
+            "optimization_target": "load",
+            "served_model_name": "test",
+            "load_adjustment_interval_seconds": 5.0,
+            "throughput_adjustment_interval_seconds": 60.0,
+            "decode_scale_up_kv_rate": 90.0,
+            "decode_scale_down_kv_rate": 50.0,
+        }
+    )
+    clock = _DriftingMonoClock()
+    adapter = OrchestratorEngineAdapter(cfg, _caps(), clock=clock)
+
+    # Adapter construction registers plugins and may read the clock. Reset it
+    # so this test controls the cadence boundary exactly.
+    clock.set_monotonic(0.0)
+    first = adapter.initial_tick(start_s=0.0)
+    assert first.at_monotonic_s == pytest.approx(5.0)
+    assert first.need_worker_fpm is True
+
+    clock.set_monotonic(first.at_monotonic_s)
+    effects = await adapter.tick(
+        first,
+        TickInput(
+            now_s=first.at_s,
+            worker_counts=WorkerCounts(
+                ready_num_decode=1,
+                expected_num_decode=1,
+            ),
+            fpm_observations=FpmObservations(decode={("w1", 0): _make_fpm("w1")}),
+        ),
+    )
+
+    load_plugin = adapter._orchestrator.registry.get_plugin("builtin_load_propose")
+    assert load_plugin is not None
+    assert load_plugin.last_call_at == pytest.approx(first.at_monotonic_s)
+    assert effects.next_tick is not None
+    assert effects.next_tick.need_worker_fpm is True
+
+
 def test_throughput_only_sla_still_pulls_fpm_for_live_regression():
     cfg = PlannerConfig.model_validate(
         {
@@ -798,7 +871,7 @@ async def test_external_fpm_request_does_not_feed_builtin_regression_early():
     assert tick.need_worker_fpm is True
     assert not tick.run_load_scaling
 
-    async def fake_orchestrator_tick(ctx, baseline):
+    async def fake_orchestrator_tick(ctx, baseline, *, tick_now=None):
         return PipelineOutcome(execute_action="skip_no_targets", final_proposal=None)
 
     adapter._orchestrator.tick = fake_orchestrator_tick  # type: ignore[method-assign]
@@ -832,7 +905,7 @@ async def test_internal_load_tick_feeds_builtin_regression():
     assert tick.need_worker_fpm is True
     assert tick.run_load_scaling
 
-    async def fake_orchestrator_tick(ctx, baseline):
+    async def fake_orchestrator_tick(ctx, baseline, *, tick_now=None):
         return PipelineOutcome(execute_action="skip_no_targets", final_proposal=None)
 
     adapter._orchestrator.tick = fake_orchestrator_tick  # type: ignore[method-assign]
@@ -875,7 +948,7 @@ async def test_disabled_load_scaling_reports_disabled_on_load_tick():
     assert tick.run_load_scaling
     assert not tick.run_throughput_scaling
 
-    async def fake_orchestrator_tick(ctx, baseline):
+    async def fake_orchestrator_tick(ctx, baseline, *, tick_now=None):
         return PipelineOutcome(execute_action="skip_no_targets", final_proposal=None)
 
     adapter._orchestrator.tick = fake_orchestrator_tick  # type: ignore[method-assign]
@@ -899,7 +972,7 @@ async def test_predict_failed_reason_surfaces_on_throughput_tick():
     tick = adapter._compute_next_scheduled_tick()
     assert tick.run_throughput_scaling
 
-    async def fake_orchestrator_tick(ctx, baseline):
+    async def fake_orchestrator_tick(ctx, baseline, *, tick_now=None):
         return PipelineOutcome(
             execute_action="skip_no_targets",
             final_proposal=None,


### PR DESCRIPTION
## Summary

- Backport #11784 to `release/1.3.0`.
- Share one monotonic tick timestamp between the prefetch due-check and plugin dispatch so both observe the same active set.
- Preserve the existing `ScheduledTick` positional argument order and add regression coverage for the shared timestamp.

## Validation

- `.venv/bin/python -m pytest components/src/dynamo/planner/tests/plugins/orchestrator -q` (`87 passed`)
- `.venv/bin/python -m ruff check components/src/dynamo/planner/core/types.py components/src/dynamo/planner/plugins/orchestrator/engine_adapter.py components/src/dynamo/planner/plugins/orchestrator/orchestrator.py components/src/dynamo/planner/tests/plugins/orchestrator/test_engine_adapter.py`
- Stable patch-id matches merge commit `de2ad9b9de09737d553a9b8f2baf917ec7be2ef0` from #11784.
