### PR TITLE
ci(nightly): run GitLab trigger in parallel with tests

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -626,15 +626,10 @@ jobs:
       - compute-release-mode
       - notify-slack-start
       - manual-release-approval
-      - vllm-test
-      - vllm-multi-gpu-test
-      - sglang-test
-      - sglang-multi-gpu-test
-      - sglang-h100-test
-      - trtllm-test
-      - trtllm-multi-gpu-test
+      - vllm-build
+      - sglang-build
+      - trtllm-build
       - dynamo-pipeline
-      - rust-tests
     # !cancelled() lets framework/rust failures fall through; dynamo-pipeline
     # is gated strictly because stage-wheels-artifactory extracts wheels from
     # its image. manual-release-approval is `skipped` on cron, `success` on dispatch.

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -630,11 +630,17 @@ jobs:
       - sglang-build
       - trtllm-build
       - dynamo-pipeline
-    # !cancelled() lets framework/rust failures fall through; dynamo-pipeline
-    # is gated strictly because stage-wheels-artifactory extracts wheels from
-    # its image. manual-release-approval is `skipped` on cron, `success` on dispatch.
+    # !cancelled() lets the job evaluate the explicit gates below rather than
+    # implicitly requiring every need to succeed (notify-slack-start is
+    # best-effort). All three runtime builds and dynamo-pipeline are gated
+    # strictly: release.yml copies their -nightly ECR images to NGC and extracts
+    # wheels from the dynamo-pipeline image, so a failed build must not publish a
+    # partial release. manual-release-approval is `skipped` on cron, `success` on dispatch.
     if: ${{ !cancelled()
         && needs.compute-release-mode.outputs.release == 'true'
+        && needs.vllm-build.result == 'success'
+        && needs.sglang-build.result == 'success'
+        && needs.trtllm-build.result == 'success'
         && needs.dynamo-pipeline.result == 'success'
         && (needs.manual-release-approval.result == 'success'
             || needs.manual-release-approval.result == 'skipped') }}


### PR DESCRIPTION
The nightly `release` job (which stages wheels/NGC and triggers the GitLab release-automation pipeline) depended on the full test matrix, so the GitLab trigger waited out the ~3.5h test suite before firing.

The tests never gated release on pass/fail — the `if:` uses `!cancelled()` and only strictly requires `dynamo-pipeline` — so they were purely a timing barrier. Point `release.needs` at the build jobs (container builds + dynamo-pipeline) instead, so the GitLab trigger and the test matrix both fan out from the builds and run concurrently.

## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nightly release automation to run after runtime build jobs and the pipeline complete.
  * Removed dependencies on the corresponding runtime test stages before triggering releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->