### PR TITLE
chore: bump cudarc version to support CUDA 13.2 build environment (#11758) [cherry-pick → release/1.3.0]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1939,9 +1939,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.3"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6468cb7fa330840f3ebcd8df51edc0e7bf5c18df524792ce6004c6821851cdf3"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "half",
  "libloading 0.9.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ chrono = { version = "0.4", default-features = false, features = [
     "now",
     "serde",
 ] }
-cudarc = { version = "=0.19.3", features = ["cuda-version-from-build-system", "fallback-latest"] }
+cudarc = { version = "=0.19.8", features = ["cuda-version-from-build-system", "fallback-latest"] }
 dashmap = { version = "6.1" }
 moka = { version = "0.12", features = ["future"] }
 derive_builder = { version = "0.20" }

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -1112,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.3"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6468cb7fa330840f3ebcd8df51edc0e7bf5c18df524792ce6004c6821851cdf3"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "libloading 0.9.0",
 ]

--- a/lib/bindings/kvbm/Cargo.toml
+++ b/lib/bindings/kvbm/Cargo.toml
@@ -57,6 +57,6 @@ pyo3-async-runtimes = { version = "0.23.0", default-features = false, features =
 ] }
 
 dlpark = { version = "0.5", features = ["pyo3", "half"], optional = true }
-cudarc = { version = "=0.19.3", features = ["cuda-version-from-build-system", "fallback-latest"], optional = true }
+cudarc = { version = "=0.19.8", features = ["cuda-version-from-build-system", "fallback-latest"], optional = true }
 
 [dev-dependencies]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -1677,9 +1677,9 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.19.3"
+version = "0.19.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6468cb7fa330840f3ebcd8df51edc0e7bf5c18df524792ce6004c6821851cdf3"
+checksum = "42310153e06cf4cd532901f7096beb27504d681736a29ee90728ae4e2d93b2a8"
 dependencies = [
  "libloading 0.9.0",
 ]

--- a/lib/llm/src/block_manager/distributed/nccl_bootstrap.rs
+++ b/lib/llm/src/block_manager/distributed/nccl_bootstrap.rs
@@ -195,6 +195,11 @@ impl NcclBootstrap {
             nvlsCTAs: i32::MIN,
             nChannelsPerNetPeer: i32::MIN,
             nvlinkCentricSched: i32::MIN,
+            // Fields added in NCCL 2.30 (cudarc 0.19.8's `nccl` feature maps to
+            // nccl-02030). i32::MIN is NCCL_CONFIG_UNDEF_INT — "use the default".
+            graphUsageMode: i32::MIN,
+            numRmaCtx: i32::MIN,
+            maxP2pPeers: i32::MIN,
         };
 
         let mut comm: ncclComm_t = std::ptr::null_mut();

--- a/lib/memory/build.rs
+++ b/lib/memory/build.rs
@@ -6,6 +6,22 @@
 //! On macOS, nixl-sys unconditionally links `-lstdc++` which doesn't exist
 //! (macOS uses libc++). We create an empty static archive to satisfy the
 //! linker since libc++ is already linked.
+//!
+//! CUDA 13.2 relocated `CUmemLocation::id` into an anonymous union
+//! (`CUmemLocation_st::__bindgen_anon_1.id`). cudarc regenerates its FFI
+//! bindings per CUDA toolkit version but does not export the detected version
+//! to dependent crates (no `links` key), so we detect it here and expose a
+//! `cuda_mem_location_union` cfg for src/pool/cuda.rs.
+//!
+//! This mirrors cudarc's own detection precedence so our cfg agrees with the
+//! bindings cudarc actually compiled: honor the `CUDARC_CUDA_VERSION` env
+//! override first, then shell out to `nvcc` on PATH, and if neither resolves a
+//! version assume the latest CUDA (which has the union), exactly as cudarc's
+//! `fallback-latest` does. A residual mismatch (e.g. cudarc detecting a version
+//! through a path this script does not replicate) fails loudly at compile time
+//! in src/pool/cuda.rs, not silently at runtime.
+
+use std::process::Command;
 
 fn main() {
     #[cfg(target_os = "macos")]
@@ -19,4 +35,54 @@ fn main() {
 
         println!("cargo:rustc-link-search=native={}", out_dir);
     }
+
+    // Re-evaluate the cfg when the inputs that drive `cuda_version()` change.
+    // cudarc reruns on CUDARC_CUDA_VERSION; PATH covers the `nvcc` lookup.
+    println!("cargo::rerun-if-env-changed=CUDARC_CUDA_VERSION");
+    println!("cargo::rerun-if-env-changed=PATH");
+
+    println!("cargo::rustc-check-cfg=cfg(cuda_mem_location_union)");
+    let is_union = match cuda_version() {
+        Some((major, minor)) => (major, minor) >= (13, 2),
+        None => true, // nvcc unavailable -> cudarc's fallback-latest -> newest -> union
+    };
+    if is_union {
+        println!("cargo::rustc-cfg=cuda_mem_location_union");
+    }
+}
+
+/// Detect the CUDA toolkit `(major, minor)` following cudarc's precedence: the
+/// `CUDARC_CUDA_VERSION` env override wins, otherwise parse `nvcc --version`.
+/// Matching cudarc's order keeps this cfg aligned with the bindings it compiled.
+fn cuda_version() -> Option<(u32, u32)> {
+    cuda_version_from_env().or_else(cuda_version_from_nvcc)
+}
+
+/// Parse `CUDARC_CUDA_VERSION` (encoded `{major}0{minor}0`, e.g. `13020` = 13.2)
+/// the same way cudarc's `detect_version_from_env` does.
+fn cuda_version_from_env() -> Option<(u32, u32)> {
+    let digits: u32 = std::env::var("CUDARC_CUDA_VERSION")
+        .ok()?
+        .trim()
+        .parse()
+        .ok()?;
+    // Encoding is major * 1000 + minor * 10 (patch digit is always 0).
+    Some((digits / 1000, (digits % 1000) / 10))
+}
+
+/// Detect the CUDA toolkit `(major, minor)` from `nvcc --version` on PATH,
+/// parsing the "release X.Y" token exactly as cudarc does.
+fn cuda_version_from_nvcc() -> Option<(u32, u32)> {
+    let output = Command::new("nvcc").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let text = String::from_utf8_lossy(&output.stdout);
+    // "Cuda compilation tools, release 13.2, V13.2.55"
+    let release = text.split("release ").nth(1)?;
+    let version = release.split(',').next()?.trim();
+    let mut parts = version.split('.');
+    let major = parts.next()?.parse().ok()?;
+    let minor = parts.next()?.parse().ok()?;
+    Some((major, minor))
 }

--- a/lib/memory/src/pool/cuda.rs
+++ b/lib/memory/src/pool/cuda.rs
@@ -73,7 +73,17 @@ impl CudaMemPoolBuilder {
         let mut props: CUmemPoolProps = unsafe { std::mem::zeroed() };
         props.allocType = CUmemAllocationType::CU_MEM_ALLOCATION_TYPE_PINNED;
         props.location.type_ = CUmemLocationType::CU_MEM_LOCATION_TYPE_DEVICE;
-        props.location.id = self.context.cu_device();
+        // CUDA 13.2 moved `id` into an anonymous union inside CUmemLocation;
+        // the field path depends on the toolkit (see build.rs).
+        #[cfg(not(cuda_mem_location_union))]
+        {
+            props.location.id = self.context.cu_device();
+        }
+        #[cfg(cuda_mem_location_union)]
+        {
+            // Writing to a union field is safe; only reads are `unsafe`.
+            props.location.__bindgen_anon_1.id = self.context.cu_device();
+        }
 
         let mut pool: CUmemoryPool = ptr::null_mut();
 


### PR DESCRIPTION
Cherry-pick of #11758 to `release/1.3.0`.

Part of the rc21 build-compatibility work tracked in #8480 (needed on the release branch for the SA rc21 run). Companion to the #11741 cherry-pick (#11769).

Bumps cudarc to support the CUDA 13.2 build environment. Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11799" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->