### PR TITLE
fix(router): warn on deprecated enforce-disagg inputs [DYN-3581]

### DIFF
--- a/components/src/dynamo/common/configuration/groups/router_args.py
+++ b/components/src/dynamo/common/configuration/groups/router_args.py
@@ -20,12 +20,7 @@ from typing import Optional
 
 from dynamo.common.configuration.arg_group import ArgGroup
 from dynamo.common.configuration.config_base import ConfigBase
-from dynamo.common.configuration.utils import (
-    add_argument,
-    add_negatable_bool_argument,
-    nullable_float,
-    nullable_int,
-)
+from dynamo.common.configuration.utils import add_argument, nullable_float, nullable_int
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +33,8 @@ _ROUTER_FIELDS: tuple[str, ...] = (
 )
 
 _ENFORCE_DISAGG_DEPRECATION = (
-    "--enforce-disagg and DYN_ENFORCE_DISAGG are deprecated and ignored; "
-    "routing topology and readiness are determined from registered worker types"
+    "%s is deprecated and ignored; disaggregated routing topology and readiness "
+    "are determined automatically from registered worker types"
 )
 
 _ADMISSION_CONTROL_REMOVAL_WARNING = (
@@ -62,6 +57,12 @@ class _IgnoredAdmissionControlAction(argparse.Action):
         logger.warning(_ADMISSION_CONTROL_FLAG_REMOVAL_WARNING)
 
 
+class _DeprecatedEnforceDisaggAction(argparse.BooleanOptionalAction):
+    def __call__(self, parser, namespace, values, option_string=None):
+        logger.warning(_ENFORCE_DISAGG_DEPRECATION, option_string)
+        super().__call__(parser, namespace, values, option_string)
+
+
 class RouterConfigBase(ConfigBase):
     """Mixin carrying the shared router configuration fields."""
 
@@ -75,8 +76,6 @@ class RouterConfigBase(ConfigBase):
 
     def router_kwargs(self) -> dict:
         """Return a dict suitable for ``RouterConfig(mode, kv_config, **kwargs)``."""
-        if self.enforce_disagg:
-            logger.warning(_ENFORCE_DISAGG_DEPRECATION)
         return {f: getattr(self, f) for f in _ROUTER_FIELDS}
 
     def validate_rejection_thresholds(self) -> None:
@@ -138,6 +137,8 @@ class RouterArgGroup(ArgGroup):
     def add_arguments(self, parser) -> None:
         if "DYN_ADMISSION_CONTROL" in os.environ:
             logger.warning(_ADMISSION_CONTROL_REMOVAL_WARNING)
+        if "DYN_ENFORCE_DISAGG" in os.environ:
+            logger.warning(_ENFORCE_DISAGG_DEPRECATION, "DYN_ENFORCE_DISAGG")
 
         g = parser.add_argument_group("Router Options")
 
@@ -203,7 +204,7 @@ class RouterArgGroup(ArgGroup):
             arg_type=int,
             dest="session_affinity_ttl_secs",
         )
-        add_negatable_bool_argument(
+        add_argument(
             g,
             flag_name="--enforce-disagg",
             env_var="DYN_ENFORCE_DISAGG",
@@ -213,6 +214,8 @@ class RouterArgGroup(ArgGroup):
                 "DEPRECATED: accepted for compatibility but ignored. Routing topology and "
                 "readiness are determined from registered worker types."
             ),
+            arg_type=None,
+            action=_DeprecatedEnforceDisaggAction,
         )
         add_argument(
             g,

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -531,7 +531,8 @@ def test_enforce_disagg_cli_is_deprecated_and_not_forwarded(
 
     assert config.enforce_disagg is expected_value
     assert "enforce_disagg" not in kwargs
-    assert f"{flag} is deprecated and ignored" in caplog.text
+    warning = f"{flag} is deprecated and ignored"
+    assert caplog.text.count(warning) == 1
 
 
 @pytest.mark.parametrize("value", ["true", "false"])
@@ -550,7 +551,8 @@ def test_enforce_disagg_environment_is_deprecated_and_not_forwarded(
 
     assert config.enforce_disagg is (value == "true")
     assert "enforce_disagg" not in kwargs
-    assert "DYN_ENFORCE_DISAGG is deprecated and ignored" in caplog.text
+    warning = "DYN_ENFORCE_DISAGG is deprecated and ignored"
+    assert caplog.text.count(warning) == 1
 
 
 def test_admission_control_cli_flag_warns_and_is_ignored(

--- a/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
+++ b/components/src/dynamo/common/tests/configuration/test_kv_router_args.py
@@ -511,28 +511,36 @@ def test_all_rejection_thresholds_and_queue_override_are_forwarded(
     assert config.kv_router_kwargs()["router_queue_threshold"] == 32.0
 
 
+@pytest.mark.parametrize(
+    ("flag", "expected_value"),
+    [("--enforce-disagg", True), ("--no-enforce-disagg", False)],
+)
 def test_enforce_disagg_cli_is_deprecated_and_not_forwarded(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    flag: str,
+    expected_value: bool,
 ) -> None:
     monkeypatch.delenv("DYN_ENFORCE_DISAGG", raising=False)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
 
-    config = FrontendConfig.from_cli_args(parser.parse_args(["--enforce-disagg"]))
+    config = FrontendConfig.from_cli_args(parser.parse_args([flag]))
     config.validate()
     kwargs = config.router_kwargs()
 
-    assert config.enforce_disagg is True
+    assert config.enforce_disagg is expected_value
     assert "enforce_disagg" not in kwargs
-    assert "deprecated and ignored" in caplog.text
+    assert f"{flag} is deprecated and ignored" in caplog.text
 
 
+@pytest.mark.parametrize("value", ["true", "false"])
 def test_enforce_disagg_environment_is_deprecated_and_not_forwarded(
     monkeypatch: pytest.MonkeyPatch,
     caplog: pytest.LogCaptureFixture,
+    value: str,
 ) -> None:
-    monkeypatch.setenv("DYN_ENFORCE_DISAGG", "true")
+    monkeypatch.setenv("DYN_ENFORCE_DISAGG", value)
     parser = argparse.ArgumentParser()
     FrontendArgGroup().add_arguments(parser)
 
@@ -540,9 +548,9 @@ def test_enforce_disagg_environment_is_deprecated_and_not_forwarded(
     config.validate()
     kwargs = config.router_kwargs()
 
-    assert config.enforce_disagg is True
+    assert config.enforce_disagg is (value == "true")
     assert "enforce_disagg" not in kwargs
-    assert "deprecated and ignored" in caplog.text
+    assert "DYN_ENFORCE_DISAGG is deprecated and ignored" in caplog.text
 
 
 def test_admission_control_cli_flag_warns_and_is_ignored(


### PR DESCRIPTION
## Summary

- emit an immediate deprecation warning when either `--enforce-disagg` or `--no-enforce-disagg` is provided
- warn when `DYN_ENFORCE_DISAGG` is present, regardless of its boolean value
- keep the compatibility value parseable while continuing to exclude it from runtime router configuration

The previous warning was gated on the resolved value being true and was delayed until router configuration assembly, so the negated CLI form and a false environment value produced no warning.

## Validation

- `PYTHONPATH=/tmp/dynamo-enforce-disagg-warning/components/src .venv/bin/python -m pytest -p no:cacheprovider -q components/src/dynamo/common/tests/configuration/test_kv_router_args.py` (47 passed)
- `pre-commit run --files components/src/dynamo/common/configuration/groups/router_args.py components/src/dynamo/common/tests/configuration/test_kv_router_args.py`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11800" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deprecation warnings for the `--enforce-disagg` command-line option and `DYN_ENFORCE_DISAGG` environment variable.
  * Warnings now identify the specific option or environment variable that triggered them.
  * Preserved support for enabling or disabling the setting without forwarding the deprecated value to router configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->