### PR TITLE
fix(frontend): raise soft RLIMIT_NOFILE at startup to avoid accept() EMFILE spiral

### DIFF
--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -20,6 +20,7 @@ import argparse
 import asyncio
 import logging
 import os
+import resource
 import signal
 import sys
 from argparse import Namespace
@@ -61,8 +62,6 @@ FRONTEND_FD_LIMIT_TARGET = 8192
 def _raise_fd_limit(target: int = FRONTEND_FD_LIMIT_TARGET) -> None:
     """Raise the process's soft RLIMIT_NOFILE toward `target`, bounded by the
     hard limit. No-op if the soft limit is already >= target."""
-    import resource
-
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
     new_soft = (
         target if hard == resource.RLIM_INFINITY else min(target, hard)

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -51,6 +51,26 @@ logger = logging.getLogger(__name__)
 
 MIN_INITIAL_WORKERS_ENV = "DYN_ROUTER_MIN_INITIAL_WORKERS"
 
+# Default soft limit on most Linux distros is 1024, which can be exhausted by the
+# frontend's TCP listener under high concurrency (see the accept() loop in
+# lib/runtime/src/pipeline/network/tcp/server.rs), causing accept() to fail with
+# EMFILE. Raise it at startup, bounded by whatever hard limit the environment allows.
+FRONTEND_FD_LIMIT_TARGET = 8192
+
+
+def _raise_fd_limit(target: int = FRONTEND_FD_LIMIT_TARGET) -> None:
+    """Raise the process's soft RLIMIT_NOFILE toward `target`, bounded by the
+    hard limit. No-op if the soft limit is already >= target."""
+    import resource
+
+    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+    new_soft = min(target, hard)
+    if new_soft > soft:
+        resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+        logger.info(
+            f"Raised RLIMIT_NOFILE soft limit {soft} -> {new_soft} (hard={hard})"
+        )
+
 
 def setup_engine_factory(
     config: FrontendConfig,
@@ -318,6 +338,7 @@ async def graceful_shutdown(runtime: DistributedRuntime) -> None:
 
 def main() -> None:
     """Entry point for the Dynamo frontend CLI."""
+    _raise_fd_limit()
     uvloop.run(async_main())
 
 

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -64,7 +64,9 @@ def _raise_fd_limit(target: int = FRONTEND_FD_LIMIT_TARGET) -> None:
     import resource
 
     soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    new_soft = min(target, hard)
+    new_soft = (
+        target if hard == resource.RLIM_INFINITY else min(target, hard)
+    )
     if new_soft > soft:
         resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
         logger.info(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -51,17 +51,30 @@ logger = logging.getLogger(__name__)
 
 MIN_INITIAL_WORKERS_ENV = "DYN_ROUTER_MIN_INITIAL_WORKERS"
 
-# Default soft limit on most Linux distros is 1024, which can be exhausted by the
-# frontend's TCP listener under high concurrency (see the accept() loop in
+# The frontend's TCP listener can exhaust the default soft RLIMIT_NOFILE (1024 on
+# most distros) under high concurrency (see the accept() loop in
 # lib/runtime/src/pipeline/network/tcp/server.rs), causing accept() to fail with
-# EMFILE. Raise it at startup, bounded by whatever hard limit the environment allows.
+# EMFILE. At startup we raise the soft limit toward FRONTEND_FD_LIMIT_TARGET,
+# overridable per-deployment via DYN_FRONTEND_FD_LIMIT_TARGET. A non-positive or
+# non-integer value disables the raise, so operators can opt out.
+FRONTEND_FD_LIMIT_ENV = "DYN_FRONTEND_FD_LIMIT_TARGET"
 FRONTEND_FD_LIMIT_TARGET = 8192
 
 
-def _raise_fd_limit(target: int = FRONTEND_FD_LIMIT_TARGET) -> None:
-    """Best-effort: raise the process's soft RLIMIT_NOFILE toward `target`,
-    bounded by the hard limit. No-op if already sufficient, if the Unix-only
-    `resource` module is unavailable (e.g. Windows), or if the raise is denied."""
+def _raise_fd_limit(target: Optional[int] = None) -> None:
+    """Best-effort: raise the process's soft RLIMIT_NOFILE toward `target`
+    (default: the DYN_FRONTEND_FD_LIMIT_TARGET env var, else FRONTEND_FD_LIMIT_TARGET),
+    bounded by the hard limit. A target <= 0 (or a non-integer env value) disables
+    it; also a no-op if already sufficient, if the Unix-only `resource` module is
+    unavailable (e.g. Windows), or if the raise is denied."""
+    if target is None:
+        raw = os.getenv(FRONTEND_FD_LIMIT_ENV, str(FRONTEND_FD_LIMIT_TARGET))
+        try:
+            target = int(raw)
+        except ValueError:
+            target = 0
+    if target <= 0:
+        return
     try:
         import resource
 

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -20,7 +20,6 @@ import argparse
 import asyncio
 import logging
 import os
-import resource
 import signal
 import sys
 from argparse import Namespace
@@ -60,17 +59,24 @@ FRONTEND_FD_LIMIT_TARGET = 8192
 
 
 def _raise_fd_limit(target: int = FRONTEND_FD_LIMIT_TARGET) -> None:
-    """Raise the process's soft RLIMIT_NOFILE toward `target`, bounded by the
-    hard limit. No-op if the soft limit is already >= target."""
-    soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
-    new_soft = (
-        target if hard == resource.RLIM_INFINITY else min(target, hard)
-    )
-    if new_soft > soft:
-        resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
-        logger.info(
-            f"Raised RLIMIT_NOFILE soft limit {soft} -> {new_soft} (hard={hard})"
-        )
+    """Best-effort: raise the process's soft RLIMIT_NOFILE toward `target`,
+    bounded by the hard limit. No-op if already sufficient, if the Unix-only
+    `resource` module is unavailable (e.g. Windows), or if the raise is denied."""
+    try:
+        import resource
+
+        soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        new_soft = target if hard == resource.RLIM_INFINITY else min(target, hard)
+        if new_soft > soft:
+            resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))
+            logger.info(
+                f"Raised RLIMIT_NOFILE soft limit {soft} -> {new_soft} (hard={hard})"
+            )
+    except Exception:
+        # Best-effort hardening; ignore failures (Windows lacks `resource`, or
+        # setrlimit may be denied in a restricted environment).
+        # logger.debug("Could not raise RLIMIT_NOFILE; continuing")
+        pass
 
 
 def setup_engine_factory(

--- a/components/src/dynamo/frontend/main.py
+++ b/components/src/dynamo/frontend/main.py
@@ -79,6 +79,8 @@ def _raise_fd_limit(target: Optional[int] = None) -> None:
         import resource
 
         soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)
+        if soft == resource.RLIM_INFINITY:
+            return  # already unlimited; a finite target would only reduce it
         new_soft = target if hard == resource.RLIM_INFINITY else min(target, hard)
         if new_soft > soft:
             resource.setrlimit(resource.RLIMIT_NOFILE, (new_soft, hard))

--- a/components/src/dynamo/frontend/tests/test_fd_limit.py
+++ b/components/src/dynamo/frontend/tests/test_fd_limit.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Platform-safety tests for the frontend fd-limit hardening (`_raise_fd_limit`).
+
+`resource` is a Unix-only stdlib module, so the hardening must degrade to a
+no-op on platforms without it (e.g. Windows) and must never break startup.
+"""
+
+import builtins
+
+import pytest
+
+from dynamo.frontend.main import FRONTEND_FD_LIMIT_TARGET, _raise_fd_limit
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def test_noop_when_resource_missing(monkeypatch):
+    """Simulate Windows: `import resource` fails -> clean no-op, not ImportError."""
+    real_import = builtins.__import__
+
+    def _no_resource(name, *args, **kwargs):
+        if name == "resource":
+            raise ImportError("simulated Windows: no `resource` module")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _no_resource)
+    _raise_fd_limit()  # must return cleanly
+
+
+def test_swallows_setrlimit_failure(monkeypatch):
+    """A denied setrlimit (restricted environment) is swallowed best-effort."""
+    resource = pytest.importorskip("resource")
+    monkeypatch.setattr(resource, "getrlimit", lambda _res: (64, 1_000_000))
+
+    def _deny(*args, **kwargs):
+        raise ValueError("simulated: not permitted to raise the limit")
+
+    monkeypatch.setattr(resource, "setrlimit", _deny)
+    _raise_fd_limit()  # must return cleanly despite setrlimit raising
+
+
+def test_raises_limit_on_unix(monkeypatch):
+    """On Unix, the soft limit is lifted toward the target (bounded by hard)."""
+    resource = pytest.importorskip("resource")
+    captured = {}
+    monkeypatch.setattr(resource, "getrlimit", lambda _res: (64, 1_000_000))
+    monkeypatch.setattr(
+        resource, "setrlimit", lambda _res, limits: captured.update(limits=limits)
+    )
+    _raise_fd_limit(target=4096)
+    assert captured["limits"] == (4096, 1_000_000)
+
+
+def test_noop_when_already_sufficient(monkeypatch):
+    """No setrlimit call when the soft limit already meets the target."""
+    resource = pytest.importorskip("resource")
+    monkeypatch.setattr(
+        resource, "getrlimit", lambda _res: (FRONTEND_FD_LIMIT_TARGET, 1_000_000)
+    )
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("setrlimit must not be called when already sufficient")
+
+    monkeypatch.setattr(resource, "setrlimit", _fail)
+    _raise_fd_limit()  # soft already == target -> no setrlimit


### PR DESCRIPTION
Fixes the accept() failure spiral described in ai-dynamo/dynamo#11801.

The frontend's TCP accept loop (`lib/runtime/src/pipeline/network/tcp/server.rs`) retries `accept()` with no backoff on failure. Under high concurrency with a non-keep-alive HTTP client, established connections can reach roughly 2x the nominal benchmark concurrency, and the default soft `RLIMIT_NOFILE` (1024 on most distros) gets exhausted, causing `accept()` to fail with EMFILE in a tight zero-backoff loop that also floods stdout (observed 15.8GB/86.9GB logs within minutes).

This raises the process's soft `RLIMIT_NOFILE` at startup (`components/src/dynamo/frontend/main.py`), bounded by whatever hard limit the environment provides. No-op if the environment already has enough headroom. No changes to the accept-loop logic itself.

See ai-dynamo/dynamo#11801 for full repro details, environment, and logs.

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend startup reliability by automatically increasing the process file-descriptor limit when needed.
  * Respects the system’s maximum allowed limit and records the adjustment.