### PR TITLE
fix(profiler): defer aiconfigurator import in replay bench (#11732) [cherry-pick → release/1.3.0]

### DIFF
--- a/components/src/dynamo/profiler/utils/replay_optimize/bench.py
+++ b/components/src/dynamo/profiler/utils/replay_optimize/bench.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from typing import Any
 
 import pandas as pd
-from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
 from .scoring import _pick_best_record
 from .search import optimize_dense_agg_with_replay, optimize_dense_disagg_with_replay
@@ -28,6 +27,10 @@ def compare_aic_and_replay_disagg(
             "compare_aic_and_replay_disagg requires synthetic WorkloadSpec with "
             "requestCount and concurrency"
         )
+
+    # Deferred: aiconfigurator is optional, so the package must import without it
+    # (mirrors aic._load_aiconfigurator_modules). Only this function needs AIC.
+    from aiconfigurator.sdk.task import TaskConfig, TaskRunner
 
     aic_task = TaskConfig(
         serving_mode="disagg",

--- a/container/deps/requirements.planner.txt
+++ b/container/deps/requirements.planner.txt
@@ -3,7 +3,10 @@
 
 # Dependencies required by the planner, profiler, and global_planner services.
 
-aiconfigurator>=0.9.0
+# Cap below 0.10: the 0.10 SDK renamed/removed APIs (sdk.task, cli.main
+# helpers) and changed the AIC Rust engine wire-format, breaking the
+# profiler until the 0.10 migration lands. Remove the cap with that port.
+aiconfigurator>=0.9.0,<0.10.0
 aiofiles<=25.1.0
 aiohttp>=3.9.0,<4.0
 filterpy==1.4.5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,9 @@ sglang = [
 
 mocker = [
     # No direct URL: it blocks the wheel release (PyPI/Warehouse rejects direct references).
-    "aiconfigurator>=0.9.0",
+    # Cap below 0.10: the 0.10 SDK/CLI API and AIC Rust engine wire-format
+    # broke the profiler; lift the cap when the 0.10 migration lands.
+    "aiconfigurator>=0.9.0,<0.10.0",
 ]
 
 [project.entry-points.pytest11]


### PR DESCRIPTION
Cherry-pick of #11732 to `release/1.3.0`.

Fixes the unbounded `aiconfigurator>=0.9.0` resolving to 0.10.0 (NVBug 6464860), which breaks the profiler on any planner-image rebuild. Caps the version and defers the aiconfigurator import. Clean cherry-pick, no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)