### PR TITLE
feat: add native vLLM gRPC sidecar backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3029,6 +3029,8 @@ dependencies = [
  "async-trait",
  "clap",
  "dynamo-backend-common",
+ "dynamo-llm",
+ "dynamo-runtime",
  "dynamo-sidecar-common",
  "futures",
  "prost 0.13.5",
@@ -3040,6 +3042,7 @@ dependencies = [
  "tonic 0.13.1",
  "tonic-build 0.13.1",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/components/src/dynamo/common/backend/publisher.py
+++ b/components/src/dynamo/common/backend/publisher.py
@@ -24,6 +24,7 @@ class ZmqSource:
     endpoint: str
     topic: str = ""
     dp_rank: int = 0
+    image_token_id: Optional[int] = None
 
 
 @dataclass(frozen=True)

--- a/components/src/dynamo/common/backend/tests/test_publisher.py
+++ b/components/src/dynamo/common/backend/tests/test_publisher.py
@@ -40,7 +40,12 @@ pytestmark = [
 
 def test_source_descriptors_carry_payload_and_defaults():
     zmq = ZmqSource(endpoint="tcp://127.0.0.1:5557")
-    assert (zmq.endpoint, zmq.topic, zmq.dp_rank) == ("tcp://127.0.0.1:5557", "", 0)
+    assert (zmq.endpoint, zmq.topic, zmq.dp_rank, zmq.image_token_id) == (
+        "tcp://127.0.0.1:5557",
+        "",
+        0,
+        None,
+    )
 
     seen: list[object] = []
     push = PushSource(on_ready=seen.append, dp_rank=2)

--- a/components/src/dynamo/common/rl/admin.py
+++ b/components/src/dynamo/common/rl/admin.py
@@ -88,9 +88,11 @@ def require_lora_unload_request(request: Mapping[str, Any] | None) -> str:
 class RLRouteRegistry:
     """Registry for worker RL admin route descriptors."""
 
-    # Engine metadata the RL discovery contract carries verbatim. These values are
-    # supplied by the engine that owns them; the registry never derives them.
-    ENGINE_METADATA_KEYS = ("admin_base_url", "world_size", "model")
+    # Framework-neutral engine metadata the RL discovery contract carries verbatim.
+    # Supplied by the engine that owns them; the registry never derives them. Any
+    # RL framework driving collective weight transfer needs these facts, so they
+    # stay engine-descriptive and free of framework-specific topology assumptions.
+    ENGINE_METADATA_KEYS = ("world_size", "model")
 
     def __init__(
         self,

--- a/components/src/dynamo/common/rl/admin.py
+++ b/components/src/dynamo/common/rl/admin.py
@@ -88,23 +88,15 @@ def require_lora_unload_request(request: Mapping[str, Any] | None) -> str:
 class RLRouteRegistry:
     """Registry for worker RL admin route descriptors."""
 
-    # Framework-neutral engine metadata the RL discovery contract carries verbatim.
-    # Supplied by the engine that owns them; the registry never derives them. Any
-    # RL framework driving collective weight transfer needs these facts, so they
-    # stay engine-descriptive and free of framework-specific topology assumptions.
-    ENGINE_METADATA_KEYS = ("world_size", "model")
-
     def __init__(
         self,
         runtime: Any,
         *,
         logger_: logging.Logger | None = None,
-        engine_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         self._runtime = runtime
         self._logger = logger_ or logger
         self.routes: dict[str, RLRouteHandler] = {}
-        self._engine_metadata = dict(engine_metadata or {})
 
     def add_route(self, name: str, handler: RLRouteHandler) -> None:
         self.routes[name] = handler
@@ -124,11 +116,6 @@ class RLRouteRegistry:
             system_url = system_url_fn()
             if system_url:
                 response["system_url"] = system_url
-
-        for key in self.ENGINE_METADATA_KEYS:
-            value = self._engine_metadata.get(key)
-            if value is not None:
-                response[key] = value
 
         return response
 

--- a/components/src/dynamo/common/rl/admin.py
+++ b/components/src/dynamo/common/rl/admin.py
@@ -88,15 +88,21 @@ def require_lora_unload_request(request: Mapping[str, Any] | None) -> str:
 class RLRouteRegistry:
     """Registry for worker RL admin route descriptors."""
 
+    # Engine metadata the RL discovery contract carries verbatim. These values are
+    # supplied by the engine that owns them; the registry never derives them.
+    ENGINE_METADATA_KEYS = ("admin_base_url", "world_size", "model")
+
     def __init__(
         self,
         runtime: Any,
         *,
         logger_: logging.Logger | None = None,
+        engine_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         self._runtime = runtime
         self._logger = logger_ or logger
         self.routes: dict[str, RLRouteHandler] = {}
+        self._engine_metadata = dict(engine_metadata or {})
 
     def add_route(self, name: str, handler: RLRouteHandler) -> None:
         self.routes[name] = handler
@@ -116,6 +122,11 @@ class RLRouteRegistry:
             system_url = system_url_fn()
             if system_url:
                 response["system_url"] = system_url
+
+        for key in self.ENGINE_METADATA_KEYS:
+            value = self._engine_metadata.get(key)
+            if value is not None:
+                response[key] = value
 
         return response
 

--- a/components/src/dynamo/vllm/constants.py
+++ b/components/src/dynamo/vllm/constants.py
@@ -9,7 +9,13 @@ so that existing imports from dynamo.vllm.constants continue to work.
 
 from dynamo.common.constants import DisaggregationMode, EmbeddingTransferMode
 
+# vLLM exposes cache salt as an otherwise-untyped string in KV-event
+# ``extra_keys``. The event decoder recognizes this prefix and restores the
+# caller-visible namespace before hashing.
+DYNAMO_CACHE_SALT_PREFIX = "dynamo-cache-salt:"
+
 __all__ = [
+    "DYNAMO_CACHE_SALT_PREFIX",
     "DisaggregationMode",
     "EmbeddingTransferMode",
 ]

--- a/components/src/dynamo/vllm/engine_generate.py
+++ b/components/src/dynamo/vllm/engine_generate.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Adapt vLLM's token-in/token-out request envelope for Dynamo workers."""
+
+import base64
+import io
+from functools import lru_cache
+from typing import Any
+
+import msgspec
+import numpy as np
+import torch
+from vllm.inputs import TokensPrompt, mm_input
+from vllm.multimodal.inputs import (
+    MultiModalKwargsItem,
+    MultiModalKwargsItems,
+    PlaceholderRange,
+)
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+
+from .constants import DYNAMO_CACHE_SALT_PREFIX
+
+GENERATE_CAPABILITY = "vllm_inference_v1_generate"
+EXACT_MM_ROUTING_CAPABILITY = "vllm_exact_mm_routing"
+
+
+def serialize_routed_experts(routed_experts: Any) -> str | None:
+    """Encode routed experts using vLLM's base64-of-NumPy wire format."""
+    if routed_experts is None:
+        return None
+    buffer = io.BytesIO()
+    np.save(buffer, routed_experts)
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+@lru_cache(maxsize=1)
+def _native_generate_api() -> tuple[Any, Any]:
+    """Load the vLLM-native endpoint adapter only when `/generate` is used."""
+    try:
+        from vllm.entrypoints.scale_out.token_in_token_out.mm_serde import (
+            decode_mm_kwargs_item,
+        )
+        from vllm.entrypoints.scale_out.token_in_token_out.protocol import (
+            GenerateRequest,
+        )
+    except ModuleNotFoundError as exc:
+        expected_module = "vllm.entrypoints.scale_out.token_in_token_out"
+        if exc.name is None or not expected_module.startswith(exc.name):
+            raise
+        from vllm.entrypoints.serve.disagg.mm_serde import decode_mm_kwargs_item
+        from vllm.entrypoints.serve.disagg.protocol import GenerateRequest
+
+    return decode_mm_kwargs_item, GenerateRequest
+
+
+def payload(request: dict[str, Any]) -> dict[str, Any] | None:
+    extra_args = request.get("extra_args")
+    if not isinstance(extra_args, dict):
+        return None
+    value = extra_args.get("vllm_tito")
+    return value if isinstance(value, dict) else None
+
+
+def reconstructed_payload(request: dict[str, Any]) -> dict[str, Any] | None:
+    generate_request = payload(request)
+    if generate_request is None:
+        return None
+
+    token_ids = list(request.get("token_ids") or [])
+    envelope_token_ids = generate_request.get("token_ids")
+    if envelope_token_ids is not None and token_ids != list(envelope_token_ids):
+        raise ValueError("core token_ids do not match extra_args.vllm_tito.token_ids")
+    return {**generate_request, "token_ids": token_ids}
+
+
+def priority(request: dict[str, Any]) -> int:
+    generate_request = payload(request)
+    if generate_request is not None:
+        return int(generate_request.get("priority", 0))
+    routing = request.get("routing") or {}
+    return -int(routing.get("priority", 0))
+
+
+def merge_kv_transfer_params(
+    caller: Any,
+    framework: Any,
+    *,
+    reject_collisions: bool = True,
+) -> dict[str, Any] | Any:
+    if caller is None:
+        return framework
+    if framework is None:
+        return caller
+    if not reject_collisions:
+        return framework
+    if not isinstance(caller, dict) or not isinstance(framework, dict):
+        raise ValueError(
+            "kv_transfer_params from both caller and framework must be objects"
+        )
+    duplicate = caller.keys() & framework.keys()
+    if duplicate:
+        raise ValueError(
+            "caller and framework kv_transfer_params collide on: "
+            + ", ".join(sorted(duplicate))
+        )
+    return {**caller, **framework}
+
+
+def build_prompt(request: dict[str, Any]) -> Any:
+    generate_request = reconstructed_payload(request)
+    if generate_request is None:
+        raise ValueError("extra_args.vllm_tito is missing from token-native request")
+
+    token_ids = generate_request["token_ids"]
+    cache_salt = generate_request.get("cache_salt")
+    event_cache_salt = f"{DYNAMO_CACHE_SALT_PREFIX}{cache_salt}" if cache_salt else None
+    features = generate_request.get("features")
+    if not isinstance(features, dict):
+        prompt = TokensPrompt(prompt_token_ids=token_ids)
+        if event_cache_salt is not None:
+            prompt["cache_salt"] = event_cache_salt
+        return prompt
+
+    mm_hashes = features.get("mm_hashes") or {}
+    placeholders = features.get("mm_placeholders") or {}
+    kwargs_data = features.get("kwargs_data")
+    mm_placeholders: dict[str, list[PlaceholderRange]] = {}
+    for modality, ranges in placeholders.items():
+        modality_ranges = []
+        for item in ranges:
+            length = int(item["length"])
+            is_embed_raw = item.get("is_embed")
+            is_embed = (
+                None
+                if is_embed_raw is None
+                else torch.as_tensor(is_embed_raw, dtype=torch.bool)
+            )
+            if is_embed is not None and (
+                is_embed.ndim != 1 or is_embed.numel() != length
+            ):
+                raise ValueError(
+                    "placeholder is_embed must be one-dimensional and match length"
+                )
+            modality_ranges.append(
+                PlaceholderRange(
+                    offset=int(item["offset"]),
+                    length=length,
+                    is_embed=is_embed,
+                )
+            )
+        mm_placeholders[modality] = modality_ranges
+
+    mm_kwargs: dict[str, list[MultiModalKwargsItem | None]] = {}
+    if isinstance(kwargs_data, dict):
+        decode_mm_kwargs_item, _ = _native_generate_api()
+        for modality, items in kwargs_data.items():
+            mm_kwargs[modality] = [
+                decode_mm_kwargs_item(item) if item is not None else None
+                for item in items
+            ]
+    else:
+        for modality, hashes in mm_hashes.items():
+            mm_kwargs[modality] = [None] * len(hashes)
+
+    return mm_input(
+        prompt_token_ids=token_ids,
+        mm_kwargs=MultiModalKwargsItems(mm_kwargs),
+        mm_hashes=mm_hashes,
+        mm_placeholders=mm_placeholders,
+        cache_salt=event_cache_salt,
+    )
+
+
+def build_sampling_params(
+    request: dict[str, Any],
+    default_sampling_params: dict[str, Any],
+    model_max_len: int | None,
+) -> SamplingParams:
+    generate_request = reconstructed_payload(request)
+    if generate_request is None:
+        raise ValueError("extra_args.vllm_tito is missing from token-native request")
+
+    _, generate_request_type = _native_generate_api()
+    parsed = generate_request_type.model_validate(generate_request)
+    sampling_params = parsed.sampling_params
+    if isinstance(sampling_params, dict):
+        sampling_params = msgspec.convert(sampling_params, type=SamplingParams)
+    if not isinstance(sampling_params, SamplingParams):
+        raise TypeError("vLLM GenerateRequest returned invalid sampling_params")
+
+    raw_params = generate_request.get("sampling_params") or {}
+    if not isinstance(raw_params, dict):
+        raise ValueError("extra_args.vllm_tito.sampling_params must be an object")
+    if "max_tokens" not in raw_params and model_max_len is not None:
+        input_length = len(request.get("token_ids") or [])
+        dynamic_default = max(1, model_max_len - input_length)
+        configured_default = default_sampling_params.get("max_tokens", dynamic_default)
+        sampling_params.max_tokens = min(configured_default, dynamic_default)
+
+    caller_kv = generate_request.get("kv_transfer_params")
+    if caller_kv is not None:
+        extensions = dict(sampling_params.extra_args or {})
+        if "kv_transfer_params" in extensions:
+            raise ValueError(
+                "kv_transfer_params appears in both request and sampling extensions"
+            )
+        extensions["kv_transfer_params"] = caller_kv
+        sampling_params.extra_args = extensions
+
+    sampling_params.output_kind = RequestOutputKind.DELTA
+    return sampling_params

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -87,7 +87,19 @@ from dynamo.vllm.kv_connector_protocols import (
 
 from .args import Config
 from .cache_info import get_configured_kv_event_block_size
-from .constants import DisaggregationMode, EmbeddingTransferMode
+from .constants import (
+    DYNAMO_CACHE_SALT_PREFIX,
+    DisaggregationMode,
+    EmbeddingTransferMode,
+)
+from .engine_generate import build_prompt as _build_engine_generate_prompt
+from .engine_generate import (
+    build_sampling_params as _build_engine_generate_sampling_params,
+)
+from .engine_generate import merge_kv_transfer_params as _merge_kv_transfer_params
+from .engine_generate import payload as _engine_generate_payload
+from .engine_generate import priority as _engine_generate_priority
+from .engine_generate import serialize_routed_experts as _serialize_routed_experts_vllm
 from .engine_monitor import VllmEngineMonitor
 from .lora_state import LoRAState
 from .multimodal_utils.async_vision_encoder import AsyncVisionEncoder
@@ -460,6 +472,21 @@ def _attach_prompt_logprobs_engine_data(
         engine_data["prompt_logprobs"] = prompt_logprobs
 
 
+def _use_prefill_prompt_logprobs(
+    sampling_params: Any,
+    disaggregated_params: Dict[str, Any],
+    engine_generate: bool,
+) -> Optional[list]:
+    """Use prompt logprobs computed by prefill and suppress decode recomputation."""
+    prompt_logprobs = disaggregated_params.get("prompt_logprobs")
+    if not engine_generate or prompt_logprobs is None:
+        return None
+    if not isinstance(prompt_logprobs, list):
+        raise ValueError("prefill prompt_logprobs must be a list")
+    sampling_params.prompt_logprobs = None
+    return prompt_logprobs
+
+
 def _attach_routed_experts_engine_data(
     tok: Dict[str, Any], routed_experts: Dict[str, Any]
 ) -> None:
@@ -501,10 +528,6 @@ def _nvext_extra_field_requested(request: Dict[str, Any], field: str) -> bool:
     )
 
 
-# Must match DYNAMO_CACHE_SALT_PREFIX in lib/kv-router/src/zmq_wire/extra_keys.rs.
-_DYNAMO_CACHE_SALT_PREFIX = "dynamo-cache-salt:"
-
-
 def _apply_nvext_cache_salt(request: Dict[str, Any], prompt: Any) -> None:
     """Pass an internally tagged cache salt to vLLM.
 
@@ -519,7 +542,7 @@ def _apply_nvext_cache_salt(request: Dict[str, Any], prompt: Any) -> None:
     for source in _iter_nvext_sources(request):
         cache_salt = source.get("cache_salt")
         if cache_salt:
-            prompt["cache_salt"] = f"{_DYNAMO_CACHE_SALT_PREFIX}{cache_salt}"
+            prompt["cache_salt"] = f"{DYNAMO_CACHE_SALT_PREFIX}{cache_salt}"
             return
 
 
@@ -702,6 +725,11 @@ def build_sampling_params(
     keep generation_config defaults for Gateway/backward-compatible traffic.
     Stop-token defaults from the model config are still applied later.
     """
+    if _engine_generate_payload(request) is not None:
+        return _build_engine_generate_sampling_params(
+            request, default_sampling_params, model_max_len
+        )
+
     if enable_rl and _is_token_in_request(request):
         # Use vLLM defaults without model generation_config overlays.
         sampling_params = SamplingParams()
@@ -2824,6 +2852,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         priority=0,
         reasoning_ended=None,
         reasoning_parser_kwargs=None,
+        engine_generate: bool = False,
     ):
         try:
             # Log LoRA usage for this generation (debug level to avoid log spam)
@@ -2857,6 +2886,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             # carries None. Capture the first non-None payload and attach it to
             # the final chunk instead of reading res.prompt_logprobs there.
             prompt_logprobs_payload: Optional[list] = None
+            kv_transfer_params: Any = None
             async for res in gen:
                 # res is vllm's RequestOutput
                 if (
@@ -2866,6 +2896,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     prompt_logprobs_payload = _serialize_prompt_logprobs(
                         res.prompt_logprobs
                     )
+                if getattr(res, "kv_transfer_params", None) is not None:
+                    kv_transfer_params = res.kv_transfer_params
 
                 if not res.outputs:
                     self._log_with_lora_context(
@@ -2934,28 +2966,44 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             request_output=res,
                             completion_token_counts=total_output_tokens_by_index,
                         )
-                        if prompt_logprobs_payload is not None:
-                            _attach_prompt_logprobs_engine_data(
-                                out, prompt_logprobs_payload
+                        if engine_generate:
+                            metadata: Dict[str, Any] = {}
+                            if prompt_logprobs_payload is not None:
+                                metadata["prompt_logprobs"] = prompt_logprobs_payload
+                            routed_experts = _serialize_routed_experts_vllm(
+                                raw_routed_experts_by_output.get(output_idx)
                             )
-                        # Emit the EFFECTIVE trim offset: clamp the requested
-                        # routed_experts_prompt_start to the prompt length. vLLM
-                        # clamps the returned routing rows the same way, so an
-                        # out-of-range request (e.g. start=999 on a 100-token
-                        # prompt) would otherwise publish a `start` the consumer
-                        # cannot align to the (clamped) tensor.
-                        raw_start = int(
-                            getattr(sampling_params, "routed_experts_prompt_start", 0)
-                            or 0
-                        )
-                        prompt_len = len(getattr(res, "prompt_token_ids", None) or [])
-                        effective_start = min(raw_start, prompt_len)
-                        routed_experts = _serialize_routed_experts(
-                            raw_routed_experts_by_output.get(output_idx),
-                            start=effective_start,
-                        )
-                        if routed_experts is not None:
-                            _attach_routed_experts_engine_data(out, routed_experts)
+                            if routed_experts is not None:
+                                metadata["routed_experts"] = routed_experts
+                            if kv_transfer_params is not None:
+                                metadata["kv_transfer_params"] = kv_transfer_params
+                            if metadata:
+                                out["engine_data"] = metadata
+                        else:
+                            if prompt_logprobs_payload is not None:
+                                _attach_prompt_logprobs_engine_data(
+                                    out, prompt_logprobs_payload
+                                )
+                            # Emit the effective trim offset for the nvext
+                            # routed-expert representation.
+                            raw_start = int(
+                                getattr(
+                                    sampling_params,
+                                    "routed_experts_prompt_start",
+                                    0,
+                                )
+                                or 0
+                            )
+                            prompt_len = len(
+                                getattr(res, "prompt_token_ids", None) or []
+                            )
+                            effective_start = min(raw_start, prompt_len)
+                            routed_experts = _serialize_routed_experts(
+                                raw_routed_experts_by_output.get(output_idx),
+                                start=effective_start,
+                            )
+                            if routed_experts is not None:
+                                _attach_routed_experts_engine_data(out, routed_experts)
                         # Log completion with LoRA info (debug level to avoid log spam)
                         self._log_with_lora_context(
                             "Completed token generation for request {request_id}{lora_info}: "
@@ -3128,6 +3176,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             kv_params = disaggregated_params.get("kv_transfer_params")
         else:
             kv_params = None
+            disaggregated_params = {}
 
         mode = cast(DisaggregationMode, self.config.disaggregation_mode)
         is_decode_only = mode == DisaggregationMode.DECODE
@@ -3183,32 +3232,76 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             mm_processor_kwargs = prepared_input.mm_processor_kwargs
             pre_rendered = prepared_input.pre_rendered_prompt
 
-        # Build prompt from request. `prompt` is either a pre-rendered
-        # MultiModalInput dict (fast path) or a TokensPrompt/EmbedsPrompt from
-        # `_build_prompt_from_request`. Declare as Any so mypy accepts both
-        # branches without spelling out the full union.
+        is_engine_generate = _engine_generate_payload(request) is not None
+        # The native path and the legacy multimodal path produce different
+        # concrete prompt representations; both satisfy vLLM's prompt contract.
         prompt: Any
-        with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
-            if custom_prompt is not None:
-                prompt = custom_prompt
-                error = None
-            elif pre_rendered is not None:
-                # pre_rendered is a MultiModalInput dict with "type": "multimodal".
-                # The engine's InputProcessor.process_inputs() will see the "type"
-                # key and skip the HF processor entirely.
-                prompt = pre_rendered
-                error = None
-                logger.debug(
-                    "[mm-routing] Request %s: using pre-rendered MultiModalInput",
-                    request_id,
-                )
-            else:
-                prompt, error = self._build_prompt_from_request(
+        if is_engine_generate:
+            prompt = _build_engine_generate_prompt(request)
+            error = None
+        else:
+            has_mm_data = request.get("multi_modal_data") is not None
+            custom_prompt: EmbedsPrompt | TokensPrompt | None = None
+
+            if (
+                mode == DisaggregationMode.AGGREGATED
+                and self._custom_encoder is not None
+                and has_mm_data
+            ):
+                # A configured CustomEncoder owns the aggregated image path. Bypass
+                # raw-media loading and let its decoder-selected adapter prepare the
+                # final engine prompt.
+                custom_prompt, assemble_error = await self._assemble_custom_encoder_prompt(
                     request,
                     request_id,
-                    multi_modal_data,
-                    mm_processor_kwargs=mm_processor_kwargs,
                 )
+                if assemble_error is not None:
+                    yield assemble_error
+                    return
+                multi_modal_data = None
+                mm_processor_kwargs = None
+                pre_rendered = None
+            else:
+                try:
+                    prepared_input = await self._multimodal_request_processor.prepare_input(
+                        request,
+                        request_id,
+                        context,
+                        mode,
+                    )
+                except MissingMultimodalHandoffError as exc:
+                    logger.error("Request %s: %s", request_id, exc)
+                    yield {
+                        "finish_reason": f"error: {exc}",
+                        "index": 0,
+                        "token_ids": [],
+                    }
+                    return
+
+                request = prepared_input.request
+                multi_modal_data = prepared_input.multi_modal_data
+                mm_processor_kwargs = prepared_input.mm_processor_kwargs
+                pre_rendered = prepared_input.pre_rendered_prompt
+
+            with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
+                if custom_prompt is not None:
+                    prompt = custom_prompt
+                    error = None
+                elif pre_rendered is not None:
+                    # pre_rendered is a MultiModalInput dict with "type": "multimodal".
+                    prompt = pre_rendered
+                    error = None
+                    logger.debug(
+                        "[mm-routing] Request %s: using pre-rendered MultiModalInput",
+                        request_id,
+                    )
+                else:
+                    prompt, error = self._build_prompt_from_request(
+                        request,
+                        request_id,
+                        multi_modal_data,
+                        mm_processor_kwargs=mm_processor_kwargs,
+                    )
         if error is not None:
             yield error
             return
@@ -3222,11 +3315,20 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             self.model_max_len,
             enable_rl=self.config.enable_rl,
         )
+        prefill_prompt_logprobs = _use_prefill_prompt_logprobs(
+            sampling_params, disaggregated_params, is_engine_generate
+        )
 
         if kv_params is not None:
             if sampling_params.extra_args is None:
                 sampling_params.extra_args = {}
-            sampling_params.extra_args["kv_transfer_params"] = kv_params
+            sampling_params.extra_args[
+                "kv_transfer_params"
+            ] = _merge_kv_transfer_params(
+                sampling_params.extra_args.get("kv_transfer_params"),
+                kv_params,
+                reject_collisions=is_engine_generate,
+            )
             logger.debug(
                 f"Using disaggregated params from prefill for request {request_id}"
             )
@@ -3247,7 +3349,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             )
         routing = request.get("routing") or {}
         dp_rank = self._to_local_dp_rank(routing.get("dp_rank"))
-        priority = -int(routing.get("priority", 0))
+        priority = _engine_generate_priority(request)
 
         trace_headers = context.trace_headers()
         reasoning_ended, reasoning_parser_kwargs = _request_reasoning_metadata(request)
@@ -3299,6 +3401,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         priority=priority,
                         reasoning_ended=reasoning_ended,
                         reasoning_parser_kwargs=reasoning_parser_kwargs,
+                        engine_generate=is_engine_generate,
                     ):
                         if abort_guard is not None:
                             abort_guard.signal_first_token()
@@ -3313,6 +3416,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                                 request_prompt_token_ids,
                                 accumulated_token_ids,
                                 accumulated_log_probs,
+                            )
+                        if (
+                            prefill_prompt_logprobs is not None
+                            and tok.get("finish_reason") is not None
+                        ):
+                            _attach_prompt_logprobs_engine_data(
+                                tok, prefill_prompt_logprobs
                             )
                         yield tok
                 except EngineDeadError as e:
@@ -3496,29 +3606,35 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
     async def _generate_token_mode(self, request, context, request_id):
         """Generate prefill using internal protocol format (token-in-token-out)."""
-        prepared_input = await self._multimodal_request_processor.prepare_input(
-            request,
-            request_id,
-            context,
-            DisaggregationMode.PREFILL,
-        )
-        request = prepared_input.request
-        multi_modal_data = prepared_input.multi_modal_data
-        mm_processor_kwargs = prepared_input.mm_processor_kwargs
+        is_engine_generate = _engine_generate_payload(request) is not None
+        if is_engine_generate:
+            prompt = _build_engine_generate_prompt(request)
+            multi_modal_data = None
+            mm_processor_kwargs = None
+        else:
+            prepared_input = await self._multimodal_request_processor.prepare_input(
+                request,
+                request_id,
+                context,
+                DisaggregationMode.PREFILL,
+            )
+            request = prepared_input.request
+            multi_modal_data = prepared_input.multi_modal_data
+            mm_processor_kwargs = prepared_input.mm_processor_kwargs
 
-        # Build prompt from request (handles both prompt_embeds and token_ids)
-        prompt, error = self._build_prompt_from_request(
-            request,
-            request_id,
-            multi_modal_data,
-            log_prefix="Prefill ",
-            mm_processor_kwargs=mm_processor_kwargs,
-        )
-        if error is not None:
-            # Prefill errors need disaggregated_params field
-            error["disaggregated_params"] = None
-            yield error
-            return
+            # Build prompt from request (handles both prompt_embeds and token_ids)
+            prompt, error = self._build_prompt_from_request(
+                request,
+                request_id,
+                multi_modal_data,
+                log_prefix="Prefill ",
+                mm_processor_kwargs=mm_processor_kwargs,
+            )
+            if error is not None:
+                # Prefill errors need disaggregated_params field
+                error["disaggregated_params"] = None
+                yield error
+                return
 
         _apply_nvext_cache_salt(request, prompt)
 
@@ -3537,9 +3653,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         )
         if sampling_params.extra_args is None:
             sampling_params.extra_args = {}
-        sampling_params.extra_args[
-            "kv_transfer_params"
-        ] = kv_protocol.prefill_request_kv_transfer_params()
+        sampling_params.extra_args["kv_transfer_params"] = _merge_kv_transfer_params(
+            sampling_params.extra_args.get("kv_transfer_params"),
+            kv_protocol.prefill_request_kv_transfer_params(),
+            reject_collisions=is_engine_generate,
+        )
         # Override for prefill: only generate 1 token
         sampling_params.max_tokens = 1
         sampling_params.min_tokens = 1
@@ -3559,7 +3677,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         routing = request.get("routing") or {}
         dp_rank = self._to_local_dp_rank(routing.get("dp_rank"))
-        priority = -int(routing.get("priority", 0))
+        priority = _engine_generate_priority(request)
 
         trace_headers = context.trace_headers()
         reasoning_ended, reasoning_parser_kwargs = _request_reasoning_metadata(request)
@@ -3589,15 +3707,26 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 self.runtime.shutdown()
                 os._exit(1)
 
+            prompt_logprobs_payload: Optional[list] = None
             async for res in gen:
                 logger.debug(f"kv transfer params: {res.kv_transfer_params}")
+
+                if (
+                    prompt_logprobs_payload is None
+                    and getattr(res, "prompt_logprobs", None) is not None
+                ):
+                    prompt_logprobs_payload = _serialize_prompt_logprobs(
+                        res.prompt_logprobs
+                    )
 
                 token_ids = res.outputs[0].token_ids if res.outputs else []
 
                 # For prefill worker, only one res will be generated,
                 # so we can always build embedding params here without conditionals
                 embedding_params = (
-                    self._multimodal_request_processor.build_prefill_handoff(
+                    None
+                    if is_engine_generate
+                    else self._multimodal_request_processor.build_prefill_handoff(
                         multi_modal_data=multi_modal_data,
                         prompt_token_ids=list(res.prompt_token_ids or []),
                         mm_processor_kwargs=mm_processor_kwargs,
@@ -3609,6 +3738,9 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                     "disaggregated_params": self._build_disaggregated_params(
                         kv_protocol.decode_request_kv_transfer_params(res),
                         embedding_params,
+                        prompt_logprobs=(
+                            prompt_logprobs_payload if is_engine_generate else None
+                        ),
                     ),
                     "completion_usage": BaseWorkerHandler._build_completion_usage(
                         request_output=res,
@@ -3629,7 +3761,11 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                 yield output
 
     def _build_disaggregated_params(
-        self, kv_transfer_params, embedding_params=None, expanded_prompt_token_ids=None
+        self,
+        kv_transfer_params,
+        embedding_params=None,
+        expanded_prompt_token_ids=None,
+        prompt_logprobs=None,
     ):
         disaggregated_params = {}
         if kv_transfer_params is not None:
@@ -3640,6 +3776,8 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             disaggregated_params[
                 "expanded_prompt_token_ids"
             ] = expanded_prompt_token_ids
+        if prompt_logprobs is not None:
+            disaggregated_params["prompt_logprobs"] = prompt_logprobs
 
         return disaggregated_params if disaggregated_params else None
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -156,34 +156,6 @@ def _rl_init_weights_timeout_s() -> float:
     )
 
 
-def _rl_engine_metadata(engine: Any, config: Any) -> dict[str, Any]:
-    """Framework-neutral engine facts carried verbatim by RL discovery.
-
-    ``world_size`` is this engine's communicator size (TP x PP x DP), read from
-    the initialized vLLM runtime rather than recomputed from launch flags.
-
-    Deliberately excludes any engine control URL: the worker is headless, and an
-    ``admin_base_url``-style field encodes one RL framework's topology (an engine
-    that exposes its own HTTP admin) into a contract that must serve any of them.
-    Control endpoints are advertised through ``system_url``/``system_routes``.
-    """
-    metadata: dict[str, Any] = {}
-
-    vllm_config = getattr(engine, "vllm_config", None)
-    parallel = getattr(vllm_config, "parallel_config", None)
-    if parallel is not None:
-        world_size = getattr(parallel, "world_size", None)
-        dp_size = getattr(parallel, "data_parallel_size", 1) or 1
-        if isinstance(world_size, int) and world_size > 0:
-            metadata["world_size"] = world_size * dp_size
-
-    model = getattr(config, "model", None) or getattr(config, "served_model_name", None)
-    if isinstance(model, str) and model.strip():
-        metadata["model"] = model.strip()
-
-    return metadata
-
-
 class _DeferredAbort:
     """Defers engine_client.abort(request_id) until the first engine output.
 
@@ -1160,11 +1132,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.shutdown_event = shutdown_event
         # Request-plane RL method map served by rl_dispatch on
         # dyn://<namespace>.<component>.rl when --enable-rl / DYN_ENABLE_RL is set.
-        self.rl_route_registry = RLRouteRegistry(
-            self.runtime,
-            logger_=logger,
-            engine_metadata=_rl_engine_metadata(engine, config),
-        )
+        self.rl_route_registry = RLRouteRegistry(self.runtime, logger_=logger)
 
         # Load the custom encoder last. If a later init step raised, executor
         # GC would eventually reap the idle actor thread — but only once the
@@ -1617,20 +1585,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # re-enable generation while an update's collective_rpc is still
         # mutating weights (dynamo-ops).
         async with self._pause_lock:
-            # A dirty worker has an unknown weight/cache state: weights may be
-            # installed while stale KV survives. Resuming would silently serve a
-            # mixed state, so the caller must reconcile or restart it first.
-            if getattr(self, "_weight_state", "committed") == "dirty" and not body.get(
-                "force", False
-            ):
-                return {
-                    "status": "error",
-                    "state": "dirty",
-                    "message": (
-                        "worker is dirty after a failed weight update and cannot "
-                        "resume; reconcile or restart it, or pass force=true"
-                    ),
-                }
             try:
                 await self.engine_client.resume_generation()
                 self._paused = False
@@ -1716,13 +1670,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 "status": "error",
                 "message": "request body must be a JSON object",
             }
-        return {
-            "status": "ok",
-            "version": getattr(self, "_weight_version", "initial"),
-            # Lets a caller that lost an update response learn the real outcome
-            # instead of assuming success and resuming a dirty worker.
-            "state": getattr(self, "_weight_state", "committed"),
-        }
+        return {"status": "ok", "version": getattr(self, "_weight_version", "initial")}
 
     async def update_weights_from_disk(self, body: dict) -> dict:
         """Load weights from a shared filesystem checkpoint."""
@@ -1820,38 +1768,21 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             }
             try:
                 await self.engine_client.collective_rpc(rpc, kwargs=rpc_kwargs)
-            except EngineDeadError as e:
-                self._shutdown_on_engine_dead(e)
-            except Exception as e:
-                # Weights may or may not have landed. Treat the worker as dirty:
-                # the caller must reconcile or restart it, never just resume.
-                self._weight_state = "dirty"
-                logger.error(f"[RL] update_weights_from_distributed failed: {e}")
-                return {"status": "error", "state": "dirty", "message": str(e)}
-
-            # Weights are installed from here on. The version must not advance
-            # until stale prefix/KV cache is invalidated too, otherwise the worker
-            # serves old cache under new weights while reporting the old version.
-            try:
                 if reset_prefix_cache:
+                    # Weights changed: stale prefix/KV cache must be invalidated
+                    # before resume so it is not reused under the new weights.
                     await self.engine_client.reset_prefix_cache()
+                self._weight_version = version
+                logger.info(
+                    f"[RL] Weights received via distributed "
+                    f"(version={version}, rpc={rpc})"
+                )
+                return {"status": "ok", "version": version}
             except EngineDeadError as e:
                 self._shutdown_on_engine_dead(e)
             except Exception as e:
-                self._weight_state = "dirty"
-                logger.error(
-                    f"[RL] weights installed (version={version}) but prefix-cache "
-                    f"invalidation failed; worker is dirty and must not resume: {e}"
-                )
-                return {"status": "error", "state": "dirty", "message": str(e)}
-
-            self._weight_version = version
-            self._weight_state = "committed"
-            logger.info(
-                f"[RL] Weights received via distributed "
-                f"(version={version}, rpc={rpc})"
-            )
-            return {"status": "ok", "state": "committed", "version": version}
+                logger.error(f"[RL] update_weights_from_distributed failed: {e}")
+                return {"status": "error", "message": str(e)}
 
     async def update_weights_from_tensor(self, body: dict) -> dict:
         """Not implemented: in-process tensor transfer is not yet supported."""

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -156,6 +156,41 @@ def _rl_init_weights_timeout_s() -> float:
     )
 
 
+# Externally reachable control-plane base URL for this engine, advertised through
+# RL discovery. It is deliberately NOT derived from a bind address: the worker is
+# headless (no vLLM API server), and a guessed URL breaks under Kubernetes, NAT,
+# and split listeners. Deployment supplies it; when unset the field is omitted so
+# consumers fail loudly instead of dialing a wrong endpoint.
+_RL_ADMIN_BASE_URL_ENV = "DYN_RL_ADMIN_BASE_URL"
+
+
+def _rl_engine_metadata(engine: Any, config: Any) -> dict[str, Any]:
+    """Authoritative engine facts carried verbatim by RL discovery.
+
+    ``world_size`` is this engine's communicator size (TP x PP x DP), read from
+    the initialized vLLM runtime rather than recomputed from launch flags.
+    """
+    metadata: dict[str, Any] = {}
+
+    admin_base_url = os.environ.get(_RL_ADMIN_BASE_URL_ENV, "").strip()
+    if admin_base_url:
+        metadata["admin_base_url"] = admin_base_url
+
+    vllm_config = getattr(engine, "vllm_config", None)
+    parallel = getattr(vllm_config, "parallel_config", None)
+    if parallel is not None:
+        world_size = getattr(parallel, "world_size", None)
+        dp_size = getattr(parallel, "data_parallel_size", 1) or 1
+        if isinstance(world_size, int) and world_size > 0:
+            metadata["world_size"] = world_size * dp_size
+
+    model = getattr(config, "model", None) or getattr(config, "served_model_name", None)
+    if isinstance(model, str) and model.strip():
+        metadata["model"] = model.strip()
+
+    return metadata
+
+
 class _DeferredAbort:
     """Defers engine_client.abort(request_id) until the first engine output.
 
@@ -1132,7 +1167,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.shutdown_event = shutdown_event
         # Request-plane RL method map served by rl_dispatch on
         # dyn://<namespace>.<component>.rl when --enable-rl / DYN_ENABLE_RL is set.
-        self.rl_route_registry = RLRouteRegistry(self.runtime, logger_=logger)
+        self.rl_route_registry = RLRouteRegistry(
+            self.runtime,
+            logger_=logger,
+            engine_metadata=_rl_engine_metadata(engine, config),
+        )
 
         # Load the custom encoder last. If a later init step raised, executor
         # GC would eventually reap the idle actor thread — but only once the

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -156,25 +156,18 @@ def _rl_init_weights_timeout_s() -> float:
     )
 
 
-# Externally reachable control-plane base URL for this engine, advertised through
-# RL discovery. It is deliberately NOT derived from a bind address: the worker is
-# headless (no vLLM API server), and a guessed URL breaks under Kubernetes, NAT,
-# and split listeners. Deployment supplies it; when unset the field is omitted so
-# consumers fail loudly instead of dialing a wrong endpoint.
-_RL_ADMIN_BASE_URL_ENV = "DYN_RL_ADMIN_BASE_URL"
-
-
 def _rl_engine_metadata(engine: Any, config: Any) -> dict[str, Any]:
-    """Authoritative engine facts carried verbatim by RL discovery.
+    """Framework-neutral engine facts carried verbatim by RL discovery.
 
     ``world_size`` is this engine's communicator size (TP x PP x DP), read from
     the initialized vLLM runtime rather than recomputed from launch flags.
+
+    Deliberately excludes any engine control URL: the worker is headless, and an
+    ``admin_base_url``-style field encodes one RL framework's topology (an engine
+    that exposes its own HTTP admin) into a contract that must serve any of them.
+    Control endpoints are advertised through ``system_url``/``system_routes``.
     """
     metadata: dict[str, Any] = {}
-
-    admin_base_url = os.environ.get(_RL_ADMIN_BASE_URL_ENV, "").strip()
-    if admin_base_url:
-        metadata["admin_base_url"] = admin_base_url
 
     vllm_config = getattr(engine, "vllm_config", None)
     parallel = getattr(vllm_config, "parallel_config", None)
@@ -1624,6 +1617,20 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # re-enable generation while an update's collective_rpc is still
         # mutating weights (dynamo-ops).
         async with self._pause_lock:
+            # A dirty worker has an unknown weight/cache state: weights may be
+            # installed while stale KV survives. Resuming would silently serve a
+            # mixed state, so the caller must reconcile or restart it first.
+            if getattr(self, "_weight_state", "committed") == "dirty" and not body.get(
+                "force", False
+            ):
+                return {
+                    "status": "error",
+                    "state": "dirty",
+                    "message": (
+                        "worker is dirty after a failed weight update and cannot "
+                        "resume; reconcile or restart it, or pass force=true"
+                    ),
+                }
             try:
                 await self.engine_client.resume_generation()
                 self._paused = False
@@ -1709,7 +1716,13 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 "status": "error",
                 "message": "request body must be a JSON object",
             }
-        return {"status": "ok", "version": getattr(self, "_weight_version", "initial")}
+        return {
+            "status": "ok",
+            "version": getattr(self, "_weight_version", "initial"),
+            # Lets a caller that lost an update response learn the real outcome
+            # instead of assuming success and resuming a dirty worker.
+            "state": getattr(self, "_weight_state", "committed"),
+        }
 
     async def update_weights_from_disk(self, body: dict) -> dict:
         """Load weights from a shared filesystem checkpoint."""
@@ -1807,21 +1820,38 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             }
             try:
                 await self.engine_client.collective_rpc(rpc, kwargs=rpc_kwargs)
-                if reset_prefix_cache:
-                    # Weights changed: stale prefix/KV cache must be invalidated
-                    # before resume so it is not reused under the new weights.
-                    await self.engine_client.reset_prefix_cache()
-                self._weight_version = version
-                logger.info(
-                    f"[RL] Weights received via distributed "
-                    f"(version={version}, rpc={rpc})"
-                )
-                return {"status": "ok", "version": version}
             except EngineDeadError as e:
                 self._shutdown_on_engine_dead(e)
             except Exception as e:
+                # Weights may or may not have landed. Treat the worker as dirty:
+                # the caller must reconcile or restart it, never just resume.
+                self._weight_state = "dirty"
                 logger.error(f"[RL] update_weights_from_distributed failed: {e}")
-                return {"status": "error", "message": str(e)}
+                return {"status": "error", "state": "dirty", "message": str(e)}
+
+            # Weights are installed from here on. The version must not advance
+            # until stale prefix/KV cache is invalidated too, otherwise the worker
+            # serves old cache under new weights while reporting the old version.
+            try:
+                if reset_prefix_cache:
+                    await self.engine_client.reset_prefix_cache()
+            except EngineDeadError as e:
+                self._shutdown_on_engine_dead(e)
+            except Exception as e:
+                self._weight_state = "dirty"
+                logger.error(
+                    f"[RL] weights installed (version={version}) but prefix-cache "
+                    f"invalidation failed; worker is dirty and must not resume: {e}"
+                )
+                return {"status": "error", "state": "dirty", "message": str(e)}
+
+            self._weight_version = version
+            self._weight_state = "committed"
+            logger.info(
+                f"[RL] Weights received via distributed "
+                f"(version={version}, rpc={rpc})"
+            )
+            return {"status": "ok", "state": "committed", "version": version}
 
     async def update_weights_from_tensor(self, body: dict) -> dict:
         """Not implemented: in-process tensor transfer is not yet supported."""

--- a/components/src/dynamo/vllm/kv_event_utils.py
+++ b/components/src/dynamo/vllm/kv_event_utils.py
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared vLLM KV-event routing helpers."""
+
+import logging
+import os
+from typing import Optional
+
+from huggingface_hub import try_to_load_from_cache
+from huggingface_hub.utils import HFValidationError
+from vllm.config import VllmConfig
+
+logger = logging.getLogger(__name__)
+
+
+def resolve_image_token_id(model: str, vllm_config: VllmConfig) -> Optional[int]:
+    """Resolve the placeholder token normalized in vLLM KV events.
+
+    This deliberately uses the same Rust resolver as the frontend MM
+    preprocessor. Returning ``None`` disables worker-side token substitution.
+    """
+    try:
+        from dynamo._core import resolve_routing_image_token_id
+    except ImportError:
+        return None
+
+    model_dir = None
+    try:
+        revision = vllm_config.model_config.revision
+        config_path = try_to_load_from_cache(
+            repo_id=model, filename="config.json", revision=revision
+        )
+        if config_path and isinstance(config_path, str):
+            model_dir = os.path.dirname(config_path)
+    except (HFValidationError, OSError) as exc:
+        logger.debug(
+            "HF cache lookup for %s failed (%s); falling back to raw model arg",
+            model,
+            exc,
+        )
+    if model_dir is None:
+        model_dir = vllm_config.model_config.model
+        logger.debug("Resolved model_dir via raw arg fallback: %s", model_dir)
+
+    return resolve_routing_image_token_id(model, model_dir)

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -14,8 +14,6 @@ if TYPE_CHECKING:
     from dynamo.vllm.omni.args import OmniConfig
 
 import uvloop
-from huggingface_hub import try_to_load_from_cache
-from huggingface_hub.utils import HFValidationError
 from prometheus_client import REGISTRY, CollectorRegistry, multiprocess
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import ZmqEventPublisher
@@ -57,12 +55,15 @@ from .capacity import (
     get_spec_decode_runtime_data,
     per_rank_kv_blocks,
 )
+from .constants import DisaggregationMode
+from .engine_generate import EXACT_MM_ROUTING_CAPABILITY, GENERATE_CAPABILITY
 from .handlers import get_dp_range_for_worker
 from .headless import run_dynamo_headless
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .kv_connector_protocols import (
     disable_hybrid_kv_cache_manager_for_incompatible_pd_connector,
 )
+from .kv_event_utils import resolve_image_token_id
 from .multimodal_utils.cache_config import configure_multimodal_embedding_cache
 from .multimodal_utils.media_config import create_frontend_media_config
 from .publisher import DYNAMO_COMPONENT_REGISTRY, StatLoggerFactory
@@ -311,52 +312,6 @@ def setup_metrics_collection(
             )
 
 
-def _resolve_image_token_id(config: Config, vllm_config: VllmConfig) -> Optional[int]:
-    """Routing-side image-placeholder token id for the served model.
-
-    Resolved via the SAME Rust logic the frontend uses
-    (`dynamo._core.resolve_routing_image_token_id` ->
-    `lightseek_mm::resolve_routing_tokens`), returning `chat_placeholder_token_id`
-    so the KV-event normalizer keys on the identical token the frontend
-    substitutes `pad_value` over — no per-family drift between the two.
-
-    Returns None when the bindings lack the `mm-routing` feature or the model
-    isn't in the MM-routing registry — in both cases the frontend also skips MM
-    routing, so a worker-side no-op is consistent (events pass through).
-    """
-    try:
-        from dynamo._core import resolve_routing_image_token_id
-    except ImportError:
-        return None
-
-    # `model_config.model` is the user-supplied `--model` argument verbatim, so
-    # for HF ids ("Qwen/Qwen3.5-0.8B") it points nowhere on disk. Resolve via
-    # huggingface_hub's public cache lookup with vLLM's revision so we pick
-    # the same snapshot vLLM is using; fall through to the raw path for
-    # local-path users (where the lookup raises HFValidationError).
-    model_dir = None
-    try:
-        revision = vllm_config.model_config.revision
-        cfg = try_to_load_from_cache(
-            repo_id=config.model, filename="config.json", revision=revision
-        )
-        if cfg and isinstance(cfg, str):
-            model_dir = os.path.dirname(cfg)
-    except (HFValidationError, OSError) as exc:
-        logger.debug(
-            "HF cache lookup for %s failed (%s); falling back to raw model arg",
-            config.model,
-            exc,
-        )
-    if model_dir is None:
-        logger.debug(
-            "Resolved model_dir via raw arg fallback: %s",
-            vllm_config.model_config.model,
-        )
-        model_dir = vllm_config.model_config.model
-    return resolve_routing_image_token_id(config.model, model_dir)
-
-
 def setup_kv_event_publisher(
     config: Config,
     generate_endpoint: Endpoint,
@@ -401,7 +356,7 @@ def setup_kv_event_publisher(
     # runs in vLLM BlockStored events to the same canonical pad_value scheme.
     # None (no mm-routing, model not in registry, text-only) leaves events
     # unchanged — consistent with the frontend also skipping MM routing.
-    image_token_id = _resolve_image_token_id(config, vllm_config)
+    image_token_id = resolve_image_token_id(config.model, vllm_config)
 
     for dp_rank in range(dp_start, dp_start + dp_size):
         if consolidator_enabled:
@@ -729,6 +684,11 @@ async def register_vllm_model(
     )
     runtime_config.set_structural_tag_scope(config.dyn_structural_tag_scope)
     runtime_config.set_structural_tag_schema(config.dyn_structural_tag_schema)
+
+    if worker_type != WorkerType.Prefill and model_type != ModelType.Embedding:
+        runtime_config.set_engine_specific(GENERATE_CAPABILITY, "true")
+        if resolve_image_token_id(config.model, vllm_config) is not None:
+            runtime_config.set_engine_specific(EXACT_MM_ROUTING_CAPABILITY, "true")
 
     # Propagate stream_interval so the frontend can respect --stream-interval.
     # set_engine_specific requires a JSON-encoded string (the Rust binding

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -55,7 +55,6 @@ from .capacity import (
     get_spec_decode_runtime_data,
     per_rank_kv_blocks,
 )
-from .constants import DisaggregationMode
 from .engine_generate import EXACT_MM_ROUTING_CAPABILITY, GENERATE_CAPABILITY
 from .handlers import get_dp_range_for_worker
 from .headless import run_dynamo_headless

--- a/components/src/dynamo/vllm/tests/test_vllm_engine_generate.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_engine_generate.py
@@ -1,0 +1,228 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import base64
+import io
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+from vllm.sampling_params import RequestOutputKind, SamplingParams
+
+from dynamo.vllm.engine_generate import (
+    build_prompt,
+    build_sampling_params,
+    merge_kv_transfer_params,
+    serialize_routed_experts,
+)
+from dynamo.vllm.handlers import (
+    BaseWorkerHandler,
+    PrefillWorkerHandler,
+    _use_prefill_prompt_logprobs,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _request(sampling_params=None, **top_level):
+    return {
+        "model": "test-model",
+        "token_ids": [11, 22, 33],
+        "extra_args": {
+            "vllm_tito": {
+                "request_id": "request-1",
+                "model": "test-model",
+                "sampling_params": sampling_params or {},
+                **top_level,
+            }
+        },
+        "routing": {"priority": 4},
+    }
+
+
+def test_text_prompt_and_sampling_preserve_native_generate_contract():
+    request = _request(
+        {"temperature": 0, "max_tokens": 17, "logprobs": 2},
+        cache_salt="checkpoint-7",
+    )
+
+    prompt = build_prompt(request)
+    params = build_sampling_params(
+        request, default_sampling_params={}, model_max_len=64
+    )
+
+    assert prompt["prompt_token_ids"] == [11, 22, 33]
+    assert prompt["cache_salt"] == "dynamo-cache-salt:checkpoint-7"
+    assert params.temperature == 0
+    assert params.max_tokens == 17
+    assert params.logprobs == 2
+    assert params.output_kind is RequestOutputKind.DELTA
+
+
+def test_multimodal_prompt_reconstructs_hashes_placeholders_and_embed_mask():
+    request = _request(
+        features={
+            "mm_hashes": {"image": ["opaque-renderer-image-0"]},
+            "mm_placeholders": {
+                "image": [
+                    {
+                        "offset": 0,
+                        "length": 3,
+                        "is_embed": [False, True, False],
+                    }
+                ]
+            },
+            "kwargs_data": None,
+        }
+    )
+
+    prompt = build_prompt(request)
+
+    assert prompt["type"] == "multimodal"
+    assert prompt["prompt_token_ids"] == [11, 22, 33]
+    assert prompt["mm_hashes"] == {"image": ["opaque-renderer-image-0"]}
+    placeholder = prompt["mm_placeholders"]["image"][0]
+    assert (placeholder.offset, placeholder.length) == (0, 3)
+    assert placeholder.is_embed.tolist() == [False, True, False]
+
+
+def test_multimodal_prompt_rejects_mismatched_embed_mask():
+    request = _request(
+        features={
+            "mm_hashes": {"image": ["opaque-renderer-image-0"]},
+            "mm_placeholders": {
+                "image": [{"offset": 0, "length": 3, "is_embed": [True]}]
+            },
+            "kwargs_data": None,
+        }
+    )
+
+    with pytest.raises(ValueError, match="one-dimensional and match length"):
+        build_prompt(request)
+
+
+def test_native_generate_rejects_conflicting_canonical_state():
+    request = _request({})
+    request["extra_args"]["vllm_tito"]["token_ids"] = [11, 22, 33]
+    request["token_ids"] = [11, 22]
+    with pytest.raises(ValueError, match="do not match"):
+        build_prompt(request)
+
+    with pytest.raises(ValueError, match="collide"):
+        merge_kv_transfer_params({"same": 1}, {"same": 2})
+
+
+def test_legacy_pd_kv_transfer_keeps_framework_state():
+    assert merge_kv_transfer_params(
+        {"remote_host": "caller"},
+        {"remote_host": "prefill", "remote_port": 1234},
+        reject_collisions=False,
+    ) == {"remote_host": "prefill", "remote_port": 1234}
+
+
+def test_routed_experts_use_vllm_base64_numpy_encoding():
+    expected = np.array([[1, 2], [3, 4]], dtype=np.int32)
+
+    encoded = serialize_routed_experts(expected)
+
+    assert encoded is not None
+    decoded = np.load(io.BytesIO(base64.b64decode(encoded)))
+    np.testing.assert_array_equal(decoded, expected)
+
+
+def test_routed_expert_serialization_failure_is_not_silently_dropped():
+    class UnserializableRoutedExperts:
+        def __reduce__(self):
+            raise TypeError("cannot serialize routed experts")
+
+    with pytest.raises(TypeError, match="cannot serialize routed experts"):
+        serialize_routed_experts(UnserializableRoutedExperts())
+
+
+def test_pd_prompt_logprobs_are_composed_from_prefill():
+    payload = [None, {"11": {"logprob": -0.25, "rank": 1}}]
+    disaggregated = PrefillWorkerHandler._build_disaggregated_params(
+        SimpleNamespace(),
+        {"remote_engine_id": "prefill-1"},
+        prompt_logprobs=payload,
+    )
+    assert disaggregated == {
+        "kv_transfer_params": {"remote_engine_id": "prefill-1"},
+        "prompt_logprobs": payload,
+    }
+
+    decode_params = SamplingParams(prompt_logprobs=1)
+    assert _use_prefill_prompt_logprobs(decode_params, disaggregated, True) is payload
+    assert decode_params.prompt_logprobs is None
+
+    legacy_params = SamplingParams(prompt_logprobs=1)
+    assert _use_prefill_prompt_logprobs(legacy_params, disaggregated, False) is None
+    assert legacy_params.prompt_logprobs == 1
+
+
+class _FakeEngineClient:
+    tokenizer = None
+
+    def __init__(self, responses):
+        self.responses = responses
+
+    def generate(self, *args, **kwargs):
+        async def _stream():
+            for response in self.responses:
+                yield response
+
+        return _stream()
+
+
+@pytest.mark.asyncio
+async def test_engine_generate_worker_emits_native_terminal_metadata():
+    routed_experts = np.array([[1, 2]], dtype=np.uint8)
+    responses = [
+        SimpleNamespace(
+            outputs=[
+                SimpleNamespace(
+                    index=0,
+                    token_ids=[41],
+                    finish_reason="length",
+                    stop_reason=None,
+                    logprobs=None,
+                    routed_experts=routed_experts,
+                )
+            ],
+            prompt_token_ids=[11, 22, 33],
+            encoder_prompt_token_ids=None,
+            prompt_logprobs=None,
+            num_cached_tokens=0,
+            kv_transfer_params={"connector": "test"},
+        )
+    ]
+    handler = SimpleNamespace(
+        engine_client=_FakeEngineClient(responses),
+        _extract_logprobs=BaseWorkerHandler._extract_logprobs,
+        _log_with_lora_context=lambda *args, **kwargs: None,
+    )
+
+    chunks = []
+    async for chunk in BaseWorkerHandler.generate_tokens(
+        handler,
+        prompt={"prompt_token_ids": [11, 22, 33]},
+        sampling_params=SamplingParams(max_tokens=1),
+        request_id="request-1",
+        engine_generate=True,
+    ):
+        chunks.append(chunk)
+
+    assert chunks[0]["token_ids"] == [41]
+    assert chunks[0]["finish_reason"] == "length"
+    assert chunks[0]["completion_usage"]["completion_tokens"] == 1
+    assert chunks[0]["engine_data"]["kv_transfer_params"] == {"connector": "test"}
+    decoded = np.load(
+        io.BytesIO(base64.b64decode(chunks[0]["engine_data"]["routed_experts"]))
+    )
+    np.testing.assert_array_equal(decoded, routed_experts)

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -467,6 +467,7 @@ pub enum KvEventSource {
         endpoint: String,
         topic: String,
         dp_rank: u32,
+        image_token_id: Option<u32>,
     },
     Push {
         on_ready: OnPublisherReady,

--- a/lib/backend-common/src/lib.rs
+++ b/lib/backend-common/src/lib.rs
@@ -19,6 +19,7 @@ pub mod engine;
 pub mod error;
 pub mod metrics;
 mod publisher;
+mod rl;
 pub mod run;
 pub mod snapshot_publisher;
 pub mod telemetry;
@@ -41,6 +42,11 @@ pub use engine::{
 };
 pub use error::{BackendError, DynamoError, ErrorType};
 pub use metrics::{ComponentGauges, EngineMetrics, LifecycleGauges};
+pub use rl::RlWorkerMetadata;
 pub use run::{run, run_raw};
 pub use snapshot_publisher::SnapshotPublisher;
 pub use worker::{RuntimeConfig, Worker, WorkerConfig};
+
+pub fn rl_enabled() -> bool {
+    rl::enabled()
+}

--- a/lib/backend-common/src/publisher.rs
+++ b/lib/backend-common/src/publisher.rs
@@ -57,12 +57,15 @@ fn setup_kv_publishers(
         let dp_rank = source.dp_rank();
         let (source_config, on_ready) = match source {
             KvEventSource::Zmq {
-                endpoint, topic, ..
+                endpoint,
+                topic,
+                image_token_id,
+                ..
             } => (
                 Some(KvEventSourceConfig::Zmq {
                     endpoint,
                     topic,
-                    image_token_id: None,
+                    image_token_id,
                 }),
                 None,
             ),

--- a/lib/backend-common/src/rl.rs
+++ b/lib/backend-common/src/rl.rs
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dynamo_runtime::component::{Endpoint, StartedEndpoint};
+use dynamo_runtime::engine_routes::EngineRouteRegistry;
+use dynamo_runtime::pipeline::network::Ingress;
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn,
+};
+use dynamo_runtime::protocols::annotated::Annotated;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use futures::stream;
+use serde_json::{Value, json};
+
+const DEFAULT_RL_ENDPOINT: &str = "rl";
+const TRUE_ENV_VALUES: [&str; 4] = ["1", "true", "yes", "on"];
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct RlWorkerMetadata {
+    pub admin_base_url: String,
+    pub world_size: u32,
+    pub model: String,
+}
+
+pub(crate) fn enabled() -> bool {
+    std::env::var("DYN_ENABLE_RL")
+        .ok()
+        .is_some_and(|value| TRUE_ENV_VALUES.contains(&value.trim().to_ascii_lowercase().as_str()))
+}
+
+pub(crate) struct RlServeEndpoint {
+    started: StartedEndpoint,
+}
+
+impl RlServeEndpoint {
+    pub(crate) async fn shutdown(self) -> anyhow::Result<()> {
+        self.started.shutdown().await
+    }
+}
+
+pub(crate) async fn serve_endpoint(
+    primary: &Endpoint,
+    metadata: RlWorkerMetadata,
+) -> anyhow::Result<RlServeEndpoint> {
+    if metadata.world_size == 0 {
+        anyhow::bail!("RL worker world_size must be positive");
+    }
+    if metadata.model.trim().is_empty() {
+        anyhow::bail!("RL worker model must not be empty");
+    }
+    let endpoint_name = resolve_endpoint_name(&primary.id().name)?;
+    let endpoint = primary.component().endpoint(endpoint_name);
+    let system_url = self_host_base_url(primary.drt())?;
+    let handler = Arc::new(RlRouteHandler {
+        routes: primary.drt().engine_routes().clone(),
+        metadata,
+        system_url,
+    });
+    let ingress = Ingress::for_engine(handler.clone())?;
+    let future = endpoint
+        .endpoint_builder()
+        .handler(ingress)
+        .graceful_shutdown(true)
+        .start_with_registration()
+        .await?;
+    Ok(RlServeEndpoint { started: future })
+}
+
+fn self_host_base_url(drt: &dynamo_runtime::DistributedRuntime) -> anyhow::Result<Option<String>> {
+    let Some(info) = drt.system_status_server_info() else {
+        return Ok(None);
+    };
+    let configured = dynamo_runtime::RuntimeConfig::from_settings()
+        .unwrap_or_default()
+        .system_host;
+    let host = match configured.as_str() {
+        "0.0.0.0" | "::" | "[::]" => dynamo_runtime::utils::local_ip_for_advertise(),
+        _ => configured,
+    };
+    Ok(Some(format!("http://{host}:{}", info.port())))
+}
+
+fn resolve_endpoint_name(primary_name: &str) -> anyhow::Result<String> {
+    let endpoint_name =
+        std::env::var("DYN_RL_ENDPOINT").unwrap_or_else(|_| DEFAULT_RL_ENDPOINT.into());
+    validate_endpoint_name(endpoint_name.trim(), primary_name)
+}
+
+fn validate_endpoint_name(endpoint_name: &str, primary_name: &str) -> anyhow::Result<String> {
+    if endpoint_name.is_empty() {
+        anyhow::bail!("DYN_RL_ENDPOINT must not be empty");
+    }
+    if endpoint_name == primary_name {
+        anyhow::bail!("DYN_RL_ENDPOINT `{endpoint_name}` collides with the serving endpoint");
+    }
+    if !endpoint_name
+        .chars()
+        .all(|character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_'))
+    {
+        anyhow::bail!("DYN_RL_ENDPOINT must contain only letters, digits, '-' or '_'");
+    }
+    Ok(endpoint_name.to_string())
+}
+
+struct RlRouteHandler {
+    routes: EngineRouteRegistry,
+    metadata: RlWorkerMetadata,
+    system_url: Option<String>,
+}
+
+impl RlRouteHandler {
+    fn dispatch(&self, request: &Value) -> Value {
+        let Some(request) = request.as_object() else {
+            return json!({"status": "error", "message": "rl_dispatch: request required"});
+        };
+        let Some(method) = request
+            .get("method")
+            .and_then(Value::as_str)
+            .filter(|value| !value.is_empty())
+        else {
+            return json!({"status": "error", "message": "rl_dispatch: missing 'method' (str)"});
+        };
+        if method != "routes" {
+            return json!({
+                "status": "error",
+                "method": method,
+                "message": "rl request-plane endpoint only supports method='routes'",
+            });
+        }
+
+        let mut routes = self.routes.routes().into_iter().collect::<Vec<_>>();
+        routes.sort();
+        routes.dedup();
+        json!({
+            "status": "ok",
+            "routes": routes,
+            "system_url": self.system_url,
+            "admin_base_url": self.metadata.admin_base_url,
+            "world_size": self.metadata.world_size,
+            "model": self.metadata.model,
+        })
+    }
+}
+
+#[async_trait]
+impl AsyncEngine<SingleIn<Value>, ManyOut<Annotated<Value>>, anyhow::Error> for RlRouteHandler {
+    async fn generate(&self, input: SingleIn<Value>) -> anyhow::Result<ManyOut<Annotated<Value>>> {
+        let (request, context) = input.into_parts();
+        let response = self.dispatch(&request);
+        Ok(ResponseStream::new(
+            Box::pin(stream::once(async move { Annotated::from_data(response) })),
+            context.context(),
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn handler() -> RlRouteHandler {
+        let routes = EngineRouteRegistry::new();
+        routes.register(
+            "update/load_lora",
+            Arc::new(|_| Box::pin(async { Ok(json!({"status": "ok"})) })),
+        );
+        RlRouteHandler {
+            routes,
+            metadata: RlWorkerMetadata {
+                admin_base_url: "http://worker:8120".to_string(),
+                world_size: 2,
+                model: "Qwen/Qwen3-0.6B".to_string(),
+            },
+            system_url: Some("http://worker:8181".to_string()),
+        }
+    }
+
+    #[test]
+    fn routes_request_describes_the_worker_control_surface() {
+        assert_eq!(
+            handler().dispatch(&json!({"method": "routes"})),
+            json!({
+                "status": "ok",
+                "routes": ["update/load_lora"],
+                "system_url": "http://worker:8181",
+                "admin_base_url": "http://worker:8120",
+                "world_size": 2,
+                "model": "Qwen/Qwen3-0.6B",
+            })
+        );
+    }
+
+    #[test]
+    fn endpoint_name_rejects_primary_collisions() {
+        assert!(validate_endpoint_name("", "generate").is_err());
+        assert!(validate_endpoint_name("generate", "generate").is_err());
+        assert!(validate_endpoint_name("../rl", "generate").is_err());
+        assert_eq!(validate_endpoint_name("rl", "generate").unwrap(), "rl");
+    }
+}

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -187,6 +187,8 @@ pub struct WorkerConfig {
     /// roles -- setting it on `Decode` or `Encode` is rejected at
     /// `Worker::run` validation time with `BackendError::InvalidArgument`.
     pub route_to_encoder: bool,
+    /// Metadata published through the optional RL worker-discovery endpoint.
+    pub rl_metadata: Option<crate::RlWorkerMetadata>,
     /// Optional frontend media decoding and fetch policy advertised on the
     /// model deployment card.
     pub media_decoder: Option<MediaDecoder>,
@@ -231,6 +233,7 @@ impl Default for WorkerConfig {
             structural_tag_schema: StructuralTagSchemaMode::Auto,
             runtime: RuntimeConfig::default(),
             route_to_encoder: false,
+            rl_metadata: None,
             media_decoder: None,
             media_fetcher: None,
             default_thinking_mode: None,
@@ -982,7 +985,33 @@ impl Worker {
         let serve_fut = builder.start();
         tokio::pin!(serve_fut);
 
-        tokio::select! {
+        let rl_endpoint = if crate::rl::enabled() {
+            let metadata = self.config.rl_metadata.clone().ok_or_else(|| {
+                err(
+                    ErrorType::Backend(BackendError::InvalidArgument),
+                    "DYN_ENABLE_RL requires worker RL metadata",
+                )
+            })?;
+            let setup = crate::rl::serve_endpoint(&endpoint, metadata)
+                .await
+                .map_err(|error| {
+                    err(
+                        ErrorType::Backend(BackendError::Unknown),
+                        format!("RL endpoint setup: {error}"),
+                    )
+                });
+            match setup {
+                Ok(endpoint) => Some(endpoint),
+                Err(error) => {
+                    self.orchestrator_steps(&endpoint).await;
+                    return Err(error);
+                }
+            }
+        } else {
+            None
+        };
+
+        let serve_result = tokio::select! {
             biased;
             result = &mut serve_fut => {
                 match result {
@@ -993,22 +1022,32 @@ impl Worker {
                         tracing::info!(
                             "Endpoint completed gracefully; running shutdown orchestration"
                         );
+                        Ok(())
                     }
                     // Serve errored; cleanup_once in run() is the safety net.
                     Err(e) => {
-                        return Err(err(
+                        Err(err(
                             ErrorType::Backend(BackendError::Unknown),
                             format!("serve: {e}"),
-                        ));
+                        ))
                     }
                 }
             }
             _ = shutdown.cancelled() => {
                 tracing::info!("Received shutdown signal; running graceful orchestration");
+                Ok(())
             }
-        }
+        };
 
         self.orchestrator_steps(&endpoint).await;
+
+        if let Some(rl_endpoint) = rl_endpoint
+            && let Err(error) = rl_endpoint.shutdown().await
+        {
+            tracing::warn!(%error, "RL discovery endpoint shutdown failed");
+        }
+
+        serve_result?;
         Ok(())
     }
 
@@ -1725,6 +1764,11 @@ async fn build_local_model(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn rl_metadata_is_opt_in() {
+        assert!(WorkerConfig::default().rl_metadata.is_none());
+    }
 
     fn error_type_of(result: Result<ModelType, DynamoError>) -> ErrorType {
         result.unwrap_err().error_type()

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -1568,6 +1568,7 @@ fn depythonize_kv_source(item: &Bound<'_, PyAny>) -> PyResult<RsKvEventSource> {
             endpoint: item.getattr("endpoint")?.extract()?,
             topic: item.getattr("topic")?.extract()?,
             dp_rank,
+            image_token_id: item.getattr("image_token_id")?.extract()?,
         }),
         "PushSource" => {
             // Capture the Python callable as a `PyObject` and wrap in a

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -460,6 +460,7 @@ impl WorkerConfig {
                 structural_tag_schema: st_schema,
                 runtime: runtime.map(|r| r.inner).unwrap_or_default(),
                 route_to_encoder,
+                rl_metadata: None,
                 media_decoder: media_decoder.map(|decoder| decoder.inner),
                 media_fetcher: media_fetcher.map(|fetcher| fetcher.inner),
             },

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -76,6 +76,20 @@ pub fn pad_value_for_mm_hash(mm_hash: u64) -> u32 {
     (MM_PAD_SHIFT_VALUE + (mm_hash & MM_PAD_HASH_MASK)) as u32
 }
 
+/// Map a non-empty multimodal identifier to Dynamo's routing hash.
+///
+/// Preserve vLLM's canonical 64-character hex-digest mapping for compatibility,
+/// and hash shorter opaque identifiers emitted by external renderers with XXH3.
+pub fn hash_mm_identifier(identifier: &str) -> Option<u64> {
+    if identifier.is_empty() {
+        return None;
+    }
+    if identifier.len() == 64 && identifier.chars().all(|c| c.is_ascii_hexdigit()) {
+        return u64::from_str_radix(&identifier[..16], 16).ok();
+    }
+    Some(xxh3::xxh3_64(identifier.as_bytes()))
+}
+
 /// Compute the hash for a sequence of tokens, optionally including multimodal metadata,
 /// LoRA adapter identity, and cache namespace.
 ///
@@ -1329,6 +1343,22 @@ mod tests {
             (MM_PAD_SHIFT_VALUE + 0xCAFE) as u32,
             "high bits above the 30-bit mask must be discarded"
         );
+    }
+
+    #[test]
+    fn mm_identifier_hash_preserves_canonical_vllm_digest_mapping() {
+        let identifier = "0123456789abcdef".repeat(4);
+        assert_eq!(hash_mm_identifier(&identifier), Some(0x0123_4567_89ab_cdef));
+    }
+
+    #[test]
+    fn mm_identifier_hash_supports_opaque_identifiers() {
+        let identifier = "opaque-renderer-image-0";
+        assert_eq!(
+            hash_mm_identifier(identifier),
+            Some(xxh3::xxh3_64(identifier.as_bytes()))
+        );
+        assert_eq!(hash_mm_identifier(""), None);
     }
 
     #[test]

--- a/lib/kv-router/src/zmq_wire/deserialize.rs
+++ b/lib/kv-router/src/zmq_wire/deserialize.rs
@@ -9,7 +9,7 @@ use serde::de::{self, IgnoredAny, MapAccess, SeqAccess, Visitor};
 
 use crate::protocols::BlockExtraInfo;
 
-use super::extra_keys::{extra_keys_to_block_mm_infos, extra_keys_to_cache_namespace};
+use super::extra_keys::{extra_keys_to_block_mm_infos_with_lora, extra_keys_to_cache_namespace};
 use super::filter::{BlockStoredTrailingField, KvCacheEventMetadata, KvCacheEventTrailingField};
 use super::types::{BlockHashValue, ExtraKeyItem, KvTokenIds, Locality, RawKvEvent};
 
@@ -119,9 +119,9 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
                 let cache_namespace = cache_namespace.unwrap_or(None).or_else(|| {
                     extra_keys_to_cache_namespace(extra_keys.as_deref(), lora_name.as_deref())
                 });
-                let block_mm_infos = block_mm_infos
-                    .unwrap_or(None)
-                    .or_else(|| extra_keys_to_block_mm_infos(extra_keys));
+                let block_mm_infos = block_mm_infos.unwrap_or(None).or_else(|| {
+                    extra_keys_to_block_mm_infos_with_lora(extra_keys, lora_name.as_deref())
+                });
                 Ok(RawKvEvent::BlockStored {
                     block_hashes,
                     parent_block_hash: parent_block_hash.unwrap_or(None),
@@ -212,8 +212,9 @@ impl<'de> Visitor<'de> for RawKvEventVisitor {
 
                 let cache_namespace =
                     extra_keys_to_cache_namespace(extra_keys.as_deref(), lora_name.as_deref());
-                let block_mm_infos =
-                    block_mm_infos.or_else(|| extra_keys_to_block_mm_infos(extra_keys));
+                let block_mm_infos = block_mm_infos.or_else(|| {
+                    extra_keys_to_block_mm_infos_with_lora(extra_keys, lora_name.as_deref())
+                });
                 let (raw_token_ids, is_eagle) = normalize_token_ids(token_ids);
 
                 Ok(RawKvEvent::BlockStored {

--- a/lib/kv-router/src/zmq_wire/extra_keys.rs
+++ b/lib/kv-router/src/zmq_wire/extra_keys.rs
@@ -1,7 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo};
+use crate::protocols::{BlockExtraInfo, BlockMmObjectInfo, hash_mm_identifier};
 
 use super::types::ExtraKeyItem;
 
@@ -56,6 +56,13 @@ pub fn extra_keys_to_cache_namespace(
 pub fn extra_keys_to_block_mm_infos(
     extra_keys: Option<Vec<Option<Vec<ExtraKeyItem>>>>,
 ) -> Option<Vec<Option<BlockExtraInfo>>> {
+    extra_keys_to_block_mm_infos_with_lora(extra_keys, None)
+}
+
+pub(crate) fn extra_keys_to_block_mm_infos_with_lora(
+    extra_keys: Option<Vec<Option<Vec<ExtraKeyItem>>>>,
+    lora_name: Option<&str>,
+) -> Option<Vec<Option<BlockExtraInfo>>> {
     let extra_keys = extra_keys?;
     if extra_keys.is_empty() {
         return None;
@@ -68,11 +75,15 @@ pub fn extra_keys_to_block_mm_infos(
                 .unwrap_or_default()
                 .iter()
                 .filter_map(|key| match key {
-                    ExtraKeyItem::Hash(hash)
-                    | ExtraKeyItem::HashWithSignedOffset((hash, _))
-                    | ExtraKeyItem::HashWithUnsignedOffset((hash, _)) => {
-                        parse_mm_hash_from_extra_key(hash)
-                    }
+                    // Bare strings are ambiguous with LoRA names and legacy
+                    // cache salts, so retain the canonical-digest filter.
+                    ExtraKeyItem::Hash(hash) if lora_name == Some(hash.as_str()) => None,
+                    ExtraKeyItem::Hash(hash) => parse_mm_hash_from_extra_key(hash),
+                    // vLLM 0.19+ tags MM identifiers with their block-relative
+                    // offsets. The tuple shape makes arbitrary identifiers
+                    // unambiguous, including hashes supplied by RL renderers.
+                    ExtraKeyItem::HashWithSignedOffset((hash, _))
+                    | ExtraKeyItem::HashWithUnsignedOffset((hash, _)) => hash_mm_identifier(hash),
                     ExtraKeyItem::Bytes(_)
                     | ExtraKeyItem::Signed(_)
                     | ExtraKeyItem::Unsigned(_)
@@ -139,6 +150,52 @@ mod tests {
         assert_eq!(
             extra_keys_to_cache_namespace(Some(&extra_keys), Some("adapter-a")).as_deref(),
             Some("adapter-a")
+        );
+    }
+
+    #[test]
+    fn offset_tagged_opaque_mm_identifier_is_hashed() {
+        let identifier = "opaque-renderer-image-0";
+        let infos = extra_keys_to_block_mm_infos_with_lora(
+            Some(vec![Some(vec![ExtraKeyItem::HashWithSignedOffset((
+                identifier.to_string(),
+                -3,
+            ))])]),
+            None,
+        )
+        .expect("MM block info");
+
+        assert_eq!(
+            infos[0].as_ref().expect("first block").mm_objects[0].mm_hash,
+            hash_mm_identifier(identifier).expect("non-empty identifier")
+        );
+    }
+
+    #[test]
+    fn bare_opaque_string_is_not_treated_as_mm_identifier() {
+        let extra_keys = Some(vec![Some(vec![ExtraKeyItem::Hash(
+            "adapter-or-salt".to_string(),
+        )])]);
+        assert_eq!(extra_keys_to_block_mm_infos(extra_keys), None);
+    }
+
+    #[test]
+    fn canonical_hex_lora_name_is_not_multimodal_metadata() {
+        let lora_name = "a".repeat(64);
+        let identifier = "opaque-image";
+        let infos = extra_keys_to_block_mm_infos_with_lora(
+            Some(vec![Some(vec![
+                ExtraKeyItem::Hash(lora_name.clone()),
+                ExtraKeyItem::HashWithUnsignedOffset((identifier.to_string(), 1)),
+            ])]),
+            Some(&lora_name),
+        )
+        .expect("offset-tagged MM identifier");
+
+        assert_eq!(infos[0].as_ref().expect("first block").mm_objects.len(), 1);
+        assert_eq!(
+            infos[0].as_ref().expect("first block").mm_objects[0].mm_hash,
+            hash_mm_identifier(identifier).expect("non-empty identifier")
         );
     }
 }

--- a/lib/llm/src/discovery.rs
+++ b/lib/llm/src/discovery.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod model;
-pub use model::Model;
+pub use model::{GenerateEngineSelection, Model};
 
 pub mod kv_source_membership;
 pub use kv_source_membership::{

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 use super::ModelManagerError;
 use super::worker_monitor::LoadThresholdConfig;
 use super::worker_set::WorkerSet;
+use crate::local_model::runtime_config::VLLM_EXACT_MM_ROUTING_CAPABILITY;
 use crate::protocols::openai::ParsingOptions;
 
 use crate::types::{
@@ -94,6 +95,15 @@ pub(crate) struct AmbiguousPrefillRouterTopology {
     namespace: String,
     prefill_endpoints: Vec<String>,
     decode_endpoints: Vec<String>,
+}
+
+/// A generate engine and the routing metadata advertised by the same WorkerSet.
+#[derive(Clone)]
+pub struct GenerateEngineSelection {
+    pub engine: GenerateStreamingEngine,
+    pub kv_cache_block_size: u32,
+    pub lora_name: Option<String>,
+    pub supports_exact_mm_routing: bool,
 }
 
 /// Readiness facts for one namespace, from [`Model::evaluate_namespace`].
@@ -713,9 +723,27 @@ impl Model {
             .ok_or_else(|| self.engine_error(self.has_realtime_engine()))
     }
 
-    pub fn get_generate_engine(&self) -> Result<GenerateStreamingEngine, ModelManagerError> {
-        self.select_worker_set_with(|ws| ws.generate_engine.clone())
-            .ok_or_else(|| self.engine_error(self.has_generate_engine()))
+    /// Select a generate engine and its routing metadata atomically from the
+    /// same WorkerSet. Request-side KV hashing must use the block size and LoRA
+    /// identity advertised by the worker set that will route the request.
+    pub fn get_generate_engine(&self) -> Result<GenerateEngineSelection, ModelManagerError> {
+        self.select_worker_set_with(|ws| {
+            ws.generate_engine
+                .clone()
+                .map(|engine| GenerateEngineSelection {
+                    engine,
+                    kv_cache_block_size: ws.card().kv_cache_block_size,
+                    lora_name: ws.card().lora.as_ref().map(|lora| lora.name.clone()),
+                    supports_exact_mm_routing: ws
+                        .card()
+                        .runtime_config
+                        .runtime_data
+                        .get(VLLM_EXACT_MM_ROUTING_CAPABILITY)
+                        .and_then(serde_json::Value::as_bool)
+                        .unwrap_or(false),
+                })
+        })
+        .ok_or_else(|| self.engine_error(self.has_generate_engine()))
     }
 
     // -- Combined engine + parsing options (atomically from one WorkerSet) --
@@ -736,17 +764,6 @@ impl Model {
                 .map(|e| (e, ws.parsing_options()))
         })
         .ok_or_else(|| self.engine_error(self.has_completions_engine()))
-    }
-
-    pub fn get_generate_engine_with_parsing(
-        &self,
-    ) -> Result<(GenerateStreamingEngine, ParsingOptions), ModelManagerError> {
-        self.select_worker_set_with(|ws| {
-            ws.generate_engine
-                .clone()
-                .map(|e| (e, ws.parsing_options()))
-        })
-        .ok_or_else(|| self.engine_error(self.has_generate_engine()))
     }
 
     // -- Worker monitoring (aggregated across WorkerSets) --
@@ -882,8 +899,27 @@ impl Model {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model_card::ModelDeploymentCard;
+    use crate::model_card::{LoraInfo, ModelDeploymentCard};
+    use crate::protocols::common::preprocessor::PreprocessedRequest;
+    use crate::protocols::{Annotated, common::llm_backend::LLMEngineOutput};
+    use async_trait::async_trait;
+    use dynamo_runtime::engine::AsyncEngine;
+    use dynamo_runtime::pipeline::{Error, ManyOut, SingleIn};
     use tokio::sync::watch;
+
+    struct StubGenerateEngine;
+
+    #[async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for StubGenerateEngine
+    {
+        async fn generate(
+            &self,
+            _request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            unimplemented!("stub for generate engine selection tests only")
+        }
+    }
 
     fn make_worker_set(namespace: &str, mdcsum: &str) -> Arc<WorkerSet> {
         Arc::new(WorkerSet::new(
@@ -891,6 +927,37 @@ mod tests {
             mdcsum.to_string(),
             ModelDeploymentCard::default(),
         ))
+    }
+
+    fn make_generate_worker_set(
+        namespace: &str,
+        block_size: u32,
+        lora_name: Option<&str>,
+        supports_exact_mm_routing: bool,
+    ) -> (
+        Arc<WorkerSet>,
+        GenerateStreamingEngine,
+        watch::Sender<Vec<u64>>,
+    ) {
+        let mut card = ModelDeploymentCard::default();
+        card.worker_type = Some(crate::worker_type::WorkerType::Aggregated);
+        card.kv_cache_block_size = block_size;
+        card.lora = lora_name.map(|name| LoraInfo {
+            name: name.to_string(),
+            max_gpu_lora_count: None,
+        });
+        card.runtime_config.runtime_data.insert(
+            VLLM_EXACT_MM_ROUTING_CAPABILITY.to_string(),
+            supports_exact_mm_routing.into(),
+        );
+
+        let engine: GenerateStreamingEngine = Arc::new(StubGenerateEngine);
+        let mut worker_set =
+            WorkerSet::new(namespace.to_string(), format!("{namespace}-checksum"), card);
+        worker_set.generate_engine = Some(engine.clone());
+        let (worker_tx, worker_rx) = watch::channel(vec![1]);
+        worker_set.set_instance_watcher(worker_rx);
+        (Arc::new(worker_set), engine, worker_tx)
     }
 
     /// Create a WorkerSet backed by a watch channel so worker_count reflects the vec length.
@@ -1039,6 +1106,38 @@ mod tests {
         assert!(model.get_images_engine().is_err());
         assert!(model.get_tensor_engine().is_err());
         assert!(model.get_realtime_engine().is_err());
+        assert!(model.get_generate_engine().is_err());
+    }
+
+    #[test]
+    fn test_generate_engine_selection_keeps_worker_set_metadata_atomic() {
+        let model = Model::new("generate-model".to_string());
+        let (worker_set_a, engine_a, worker_tx_a) =
+            make_generate_worker_set("ns-a", 16, None, false);
+        let (worker_set_b, engine_b, worker_tx_b) =
+            make_generate_worker_set("ns-b", 32, Some("adapter-b"), true);
+        worker_tx_b.send(vec![]).expect("disable worker set B");
+        model.add_worker_set("ns-a".to_string(), worker_set_a);
+        model.add_worker_set("ns-b".to_string(), worker_set_b);
+
+        let selection_a = model
+            .get_generate_engine()
+            .expect("select live worker set A");
+        assert!(Arc::ptr_eq(&selection_a.engine, &engine_a));
+        assert_eq!(selection_a.kv_cache_block_size, 16);
+        assert_eq!(selection_a.lora_name, None);
+        assert!(!selection_a.supports_exact_mm_routing);
+
+        worker_tx_a.send(vec![]).expect("disable worker set A");
+        worker_tx_b.send(vec![2]).expect("enable worker set B");
+
+        let selection_b = model
+            .get_generate_engine()
+            .expect("select live worker set B");
+        assert!(Arc::ptr_eq(&selection_b.engine, &engine_b));
+        assert_eq!(selection_b.kv_cache_block_size, 32);
+        assert_eq!(selection_b.lora_name.as_deref(), Some("adapter-b"));
+        assert!(selection_b.supports_exact_mm_routing);
     }
 
     fn make_realtime_worker_set(namespace: &str) -> Arc<WorkerSet> {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -19,7 +19,7 @@ use tokio::sync::oneshot;
 
 use super::worker_monitor::LoadThresholdConfig;
 use super::{
-    KvSourceMembershipWatch, Model, RuntimeConfigWatch, WorkerSet,
+    GenerateEngineSelection, KvSourceMembershipWatch, Model, RuntimeConfigWatch, WorkerSet,
     kv_source_watch::KvSourceMembershipCoordinator, runtime_config_watch,
 };
 
@@ -691,7 +691,7 @@ impl ModelManager {
     pub fn get_generate_engine(
         &self,
         model: &str,
-    ) -> Result<GenerateStreamingEngine, ModelManagerError> {
+    ) -> Result<GenerateEngineSelection, ModelManagerError> {
         self.models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
@@ -730,22 +730,6 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_completions_engine_with_parsing()
-    }
-
-    pub fn get_generate_engine_with_parsing(
-        &self,
-        model: &str,
-    ) -> Result<
-        (
-            GenerateStreamingEngine,
-            crate::protocols::openai::ParsingOptions,
-        ),
-        ModelManagerError,
-    > {
-        self.models
-            .get(model)
-            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
-            .get_generate_engine_with_parsing()
     }
 
     // -- Convenience methods for in-process models (http.rs, grpc.rs) --

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -2369,6 +2369,59 @@ mod tests {
     }
 
     #[test]
+    fn exact_mm_routing_capability_mismatch_never_joins_existing_worker_set() {
+        fn card_with_capability(supports_exact_mm_routing: bool) -> ModelDeploymentCard {
+            let mut card = ModelDeploymentCard::with_name_only("llama");
+            card.model_type = ModelType::Chat;
+            card.worker_type = Some(WorkerType::Aggregated);
+            if supports_exact_mm_routing {
+                card.runtime_config.runtime_data.insert(
+                    crate::local_model::runtime_config::VLLM_EXACT_MM_ROUTING_CAPABILITY
+                        .to_string(),
+                    true.into(),
+                );
+            }
+            card
+        }
+
+        fn assert_second_worker_is_incompatible(first_supports: bool, second_supports: bool) {
+            let first = card_with_capability(first_supports);
+            let second = card_with_capability(second_supports);
+            let endpoint_id = test_endpoint_id("generate");
+            let ws_key = worker_set_key(&endpoint_id, first.model_type, first.worker_type);
+            let model = crate::discovery::Model::new(first.name().to_string());
+            model.add_worker_set(
+                ws_key.clone(),
+                Arc::new(WorkerSet::new(
+                    endpoint_id.namespace,
+                    first.mdcsum().to_string(),
+                    first,
+                )),
+            );
+
+            assert!(
+                !model.is_checksum_compatible(&ws_key, second.mdcsum()),
+                "a worker with a different exact-MM capability must be drained instead of joining"
+            );
+        }
+
+        let absent = card_with_capability(false);
+        let mut explicit_false = card_with_capability(false);
+        explicit_false.runtime_config.runtime_data.insert(
+            crate::local_model::runtime_config::VLLM_EXACT_MM_ROUTING_CAPABILITY.to_string(),
+            false.into(),
+        );
+        assert_eq!(
+            absent.mdcsum(),
+            explicit_false.mdcsum(),
+            "absent and explicit-false capability values are equivalent"
+        );
+
+        assert_second_worker_is_incompatible(false, true);
+        assert_second_worker_is_incompatible(true, false);
+    }
+
+    #[test]
     fn stale_cleanup_cannot_reserve_after_a_new_registration() {
         let operation = InstanceOperation::default();
         let snapshot_generation = operation.current_generation();

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -35,7 +35,7 @@ use super::{RouteDoc, service_v2};
 use crate::discovery::GenerateEngineSelection;
 use crate::protocols::common::preprocessor::{MmRoutingInfo, PreprocessedRequest};
 use crate::protocols::common::timing::RequestTracker;
-use crate::protocols::common::{SamplingOptions, StopConditions};
+use crate::protocols::common::{OutputOptions, SamplingOptions, StopConditions};
 use crate::protocols::openai::generate::{
     GenerateRequest, GenerateResponse, GenerateResponseOptions, SamplingParams, StreamOptions,
 };
@@ -490,6 +490,19 @@ fn preprocessed_from_generate(
     let max_tokens = sampling.max_tokens();
     let min_tokens = sampling.min_tokens();
     let ignore_eos = sampling.ignore_eos();
+    let top_k = sampling.top_k().and_then(|value| i32::try_from(value).ok());
+    let logprobs = sampling
+        .logprobs()
+        .and_then(|value| u32::try_from(value).ok());
+    let prompt_logprobs = sampling
+        .prompt_logprobs()
+        .and_then(|value| u32::try_from(value).ok());
+    let stop_token_ids_hidden = sampling.stop_token_ids().map(<[u32]>::to_vec);
+    let skip_reading_prefix_cache = sampling.skip_reading_prefix_cache();
+    let kv_transfer_params = request
+        .kv_transfer_params
+        .as_ref()
+        .map(|params| serde_json::Value::Object(params.clone()));
     let routing_priority = dynamo_routing_priority(request.priority);
     // With vLLM's default `enable_tower_connector_lora=false`, the vision tower
     // and connector stay on base weights, so MM identifiers are adapter-invariant.
@@ -513,6 +526,17 @@ fn preprocessed_from_generate(
         None
     };
     let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(&request, request_id))?;
+    let mut extra_args = serde_json::Map::new();
+    extra_args.insert("vllm_tito".to_string(), vllm_tito);
+    if let Some(skip_reading_prefix_cache) = skip_reading_prefix_cache {
+        extra_args.insert(
+            "skip_reading_prefix_cache".to_string(),
+            serde_json::Value::Bool(skip_reading_prefix_cache),
+        );
+    }
+    if let Some(kv_transfer_params) = kv_transfer_params {
+        extra_args.insert("kv_transfer_params".to_string(), kv_transfer_params);
+    }
     let tracker = Arc::new(RequestTracker::new());
     tracker.record_isl(request.token_ids.len(), None);
     let GenerateRequest {
@@ -528,13 +552,26 @@ fn preprocessed_from_generate(
             max_tokens,
             min_tokens,
             ignore_eos: Some(ignore_eos),
+            stop_token_ids_hidden,
             ..Default::default()
         })
         .sampling_options(SamplingOptions {
             n: Some(1),
+            temperature: sampling.temperature(),
+            top_p: sampling.top_p(),
+            top_k,
+            min_p: sampling.min_p(),
+            seed: sampling.seed(),
+            presence_penalty: sampling.presence_penalty(),
+            frequency_penalty: sampling.frequency_penalty(),
+            repetition_penalty: sampling.repetition_penalty(),
             ..Default::default()
         })
-        .output_options(Default::default())
+        .output_options(OutputOptions {
+            logprobs,
+            prompt_logprobs,
+            ..Default::default()
+        })
         .mm_routing_info(mm_routing_info)
         .routing(Some(crate::protocols::common::preprocessor::RoutingHints {
             dp_rank: data_parallel_rank,
@@ -547,11 +584,9 @@ fn preprocessed_from_generate(
             priority: Some(routing_priority),
             ..Default::default()
         }))
-        .extra_args(Some(serde_json::json!({
-            // Do not copy token_ids into this envelope. The worker must rebuild
-            // that field from PreprocessedRequest.token_ids after routing.
-            "vllm_tito": vllm_tito,
-        })))
+        // Do not copy token_ids into this envelope. The worker must rebuild
+        // that field from PreprocessedRequest.token_ids after routing.
+        .extra_args(Some(serde_json::Value::Object(extra_args)))
         .tracker(Some(tracker))
         .build()
         .map_err(|error| anyhow::anyhow!("failed to build PreprocessedRequest: {error}"))
@@ -1388,6 +1423,84 @@ mod tests {
         assert_eq!(expected_token_ids, serde_json::json!([1, 2]));
         assert_eq!(envelope, &expected_envelope);
         assert!(envelope.get("token_ids").is_none());
+    }
+
+    #[test]
+    fn native_grpc_fields_are_projected_without_losing_the_vllm_envelope() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2],
+            "sampling_params": {
+                "temperature": 0.7,
+                "top_p": 0.9,
+                "top_k": -1,
+                "min_p": 0.1,
+                "seed": 42,
+                "max_tokens": 8,
+                "min_tokens": 2,
+                "presence_penalty": 0.2,
+                "frequency_penalty": 0.3,
+                "repetition_penalty": 1.1,
+                "stop_token_ids": [99, 100],
+                "ignore_eos": true,
+                "logprobs": 1,
+                "prompt_logprobs": 2,
+                "skip_reading_prefix_cache": true,
+                "skip_special_tokens": false
+            },
+            "kv_transfer_params": {"connector": "opaque"}
+        }))
+        .expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            16,
+            false,
+            None,
+        )
+        .expect("build request");
+
+        assert_eq!(
+            (
+                preprocessed.sampling_options.temperature,
+                preprocessed.sampling_options.top_p,
+                preprocessed.sampling_options.top_k,
+                preprocessed.sampling_options.min_p,
+                preprocessed.sampling_options.seed,
+            ),
+            (Some(0.7), Some(0.9), Some(-1), Some(0.1), Some(42))
+        );
+        assert_eq!(
+            (
+                preprocessed.sampling_options.presence_penalty,
+                preprocessed.sampling_options.frequency_penalty,
+                preprocessed.sampling_options.repetition_penalty,
+            ),
+            (Some(0.2), Some(0.3), Some(1.1))
+        );
+        assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
+        assert_eq!(preprocessed.stop_conditions.min_tokens, Some(2));
+        assert_eq!(
+            preprocessed.stop_conditions.stop_token_ids_hidden,
+            Some(vec![99, 100])
+        );
+        assert_eq!(preprocessed.stop_conditions.ignore_eos, Some(true));
+        assert_eq!(preprocessed.output_options.logprobs, Some(1));
+        assert_eq!(preprocessed.output_options.prompt_logprobs, Some(2));
+        assert_eq!(preprocessed.output_options.skip_special_tokens, None);
+
+        let extra = preprocessed.extra_args.as_ref().expect("extra args");
+        assert_eq!(extra["skip_reading_prefix_cache"], serde_json::json!(true));
+        assert_eq!(
+            extra["kv_transfer_params"],
+            serde_json::json!({"connector": "opaque"})
+        );
+        assert_eq!(
+            extra["vllm_tito"]["sampling_params"]["skip_special_tokens"],
+            serde_json::json!(false)
+        );
     }
 
     #[test]

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -499,6 +499,7 @@ fn preprocessed_from_generate(
         .and_then(|value| u32::try_from(value).ok());
     let stop_token_ids_hidden = sampling.stop_token_ids().map(<[u32]>::to_vec);
     let skip_reading_prefix_cache = sampling.skip_reading_prefix_cache();
+    let cache_salt = request.resolved_cache_salt().map(str::to_owned);
     let kv_transfer_params = request
         .kv_transfer_params
         .as_ref()
@@ -539,11 +540,7 @@ fn preprocessed_from_generate(
     }
     let tracker = Arc::new(RequestTracker::new());
     tracker.record_isl(request.token_ids.len(), None);
-    let GenerateRequest {
-        token_ids,
-        cache_salt,
-        ..
-    } = request;
+    let GenerateRequest { token_ids, .. } = request;
 
     PreprocessedRequest::builder()
         .model(model.to_string())
@@ -1444,6 +1441,7 @@ mod tests {
                 "ignore_eos": true,
                 "logprobs": 1,
                 "prompt_logprobs": 2,
+                "cache_salt": "policy-7",
                 "skip_reading_prefix_cache": true,
                 "skip_special_tokens": false
             },
@@ -1490,6 +1488,13 @@ mod tests {
         assert_eq!(preprocessed.output_options.logprobs, Some(1));
         assert_eq!(preprocessed.output_options.prompt_logprobs, Some(2));
         assert_eq!(preprocessed.output_options.skip_special_tokens, None);
+        assert_eq!(
+            preprocessed
+                .routing
+                .as_ref()
+                .and_then(|routing| routing.cache_namespace.as_deref()),
+            Some("policy-7")
+        );
 
         let extra = preprocessed.extra_args.as_ref().expect("extra args");
         assert_eq!(extra["skip_reading_prefix_cache"], serde_json::json!(true));

--- a/lib/llm/src/http/service/generate.rs
+++ b/lib/llm/src/http/service/generate.rs
@@ -21,21 +21,25 @@ use axum::{
     routing::post,
 };
 use dynamo_runtime::pipeline::{AsyncEngineContext, AsyncEngineContextProvider, Context};
+use futures::StreamExt;
 use serde::Serialize;
 use tracing::Instrument;
 
 use super::disconnect::create_connection_monitor;
-use super::metrics::{CancellationLabels, ErrorType};
+use super::metrics::{CancellationLabels, ErrorType, HttpQueueGuard, ResponseMetricCollector};
 use super::openai::{
     check_model_serving_ready, check_ready, context_from_headers, get_body_limit,
     get_or_create_request_id, smart_json_error_middleware,
 };
 use super::{RouteDoc, service_v2};
-use crate::protocols::common::preprocessor::PreprocessedRequest;
+use crate::discovery::GenerateEngineSelection;
+use crate::protocols::common::preprocessor::{MmRoutingInfo, PreprocessedRequest};
+use crate::protocols::common::timing::RequestTracker;
 use crate::protocols::common::{SamplingOptions, StopConditions};
 use crate::protocols::openai::generate::{
     GenerateRequest, GenerateResponse, GenerateResponseOptions, SamplingParams, StreamOptions,
 };
+use crate::protocols::{Annotated, common::llm_backend::LLMEngineOutput};
 
 const X_REQUEST_ID_HEADER: &str = "x-request-id";
 const X_DATA_PARALLEL_RANK_HEADER: &str = "x-data-parallel-rank";
@@ -118,8 +122,19 @@ fn dynamo_routing_priority(vllm_priority: i32) -> i32 {
     vllm_priority.saturating_neg()
 }
 
-fn generate_dispatch_span(request_id: &str) -> tracing::Span {
-    tracing::info_span!(target: "request_span", "generate", request_id = %request_id)
+fn generate_dispatch_span(request_id: &str, model: &str) -> tracing::Span {
+    tracing::info_span!(
+        target: "request_span",
+        "generate",
+        request_id = %request_id,
+        model = %model,
+        input_tokens = tracing::field::Empty,
+        output_tokens = tracing::field::Empty,
+        ttft_ms = tracing::field::Empty,
+        avg_itl_ms = tracing::field::Empty,
+        prefill_worker_id = tracing::field::Empty,
+        decode_worker_id = tracing::field::Empty,
+    )
 }
 
 async fn run_until_killed<T>(
@@ -204,6 +219,261 @@ impl<'a> VllmTitoEnvelope<'a> {
     }
 }
 
+type MmPlaceholderRange = (usize, usize, u64, Option<Vec<bool>>);
+
+#[inline]
+fn intersecting_mm_ranges<'a>(
+    ranges: &'a [MmPlaceholderRange],
+    block_start: usize,
+    block_end: usize,
+    first_intersecting: &mut usize,
+    mut on_examined: impl FnMut(),
+) -> &'a [MmPlaceholderRange] {
+    while *first_intersecting < ranges.len() {
+        on_examined();
+        if ranges[*first_intersecting].1 > block_start {
+            break;
+        }
+        *first_intersecting += 1;
+    }
+
+    let start = *first_intersecting;
+    let mut end = start;
+    while end < ranges.len() {
+        on_examined();
+        if ranges[end].0 >= block_end {
+            break;
+        }
+        end += 1;
+    }
+
+    &ranges[start..end]
+}
+
+/// Build the routing-only token sequence used by vLLM KV events for multimodal
+/// prompts. The caller-provided `features` object remains opaque to execution;
+/// this projection reads only the hashes and placeholder ranges required to
+/// make request-side KV hashes match worker-side event hashes.
+fn generate_mm_routing_info(
+    request: &GenerateRequest,
+    kv_cache_block_size: u32,
+) -> Result<Option<MmRoutingInfo>, &'static str> {
+    let Some(features) = request.passthrough.get("features") else {
+        return Ok(None);
+    };
+    if features.is_null() {
+        return Ok(None);
+    }
+
+    let features = features
+        .as_object()
+        .ok_or("features must be a JSON object")?;
+    let Some(mm_hashes) = features.get("mm_hashes") else {
+        return Ok(None);
+    };
+    let mm_hashes = mm_hashes
+        .as_object()
+        .ok_or("features.mm_hashes must be a JSON object")?;
+    let mm_placeholders = features
+        .get("mm_placeholders")
+        .and_then(serde_json::Value::as_object)
+        .ok_or("features.mm_placeholders must be a JSON object")?;
+
+    if mm_hashes
+        .keys()
+        .chain(mm_placeholders.keys())
+        .any(|modality| modality != "image")
+    {
+        return Err("exact /generate MM routing currently supports image placeholders only");
+    }
+    if kv_cache_block_size == 0 {
+        return Err("KV cache block size must be non-zero");
+    }
+
+    let (hashes, placeholders) = match (mm_hashes.get("image"), mm_placeholders.get("image")) {
+        (None, None) => return Ok(None),
+        (Some(hashes), Some(placeholders)) => (
+            hashes
+                .as_array()
+                .ok_or("features.mm_hashes.image must be an array")?,
+            placeholders
+                .as_array()
+                .ok_or("features.mm_placeholders.image must be an array")?,
+        ),
+        _ => return Err("image hashes and placeholders must both be present"),
+    };
+    if hashes.len() != placeholders.len() {
+        return Err("image hashes and placeholders must have equal lengths");
+    }
+
+    let mut ranges: Vec<MmPlaceholderRange> = Vec::with_capacity(hashes.len());
+    for (hash, placeholder) in hashes.iter().zip(placeholders) {
+        let hash = hash
+            .as_str()
+            .and_then(dynamo_kv_router::protocols::hash_mm_identifier)
+            .ok_or("multimodal hashes must be non-empty strings")?;
+        let placeholder = placeholder
+            .as_object()
+            .ok_or("multimodal placeholders must be JSON objects")?;
+        let offset = placeholder
+            .get("offset")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .ok_or("multimodal placeholder offsets must be non-negative integers")?;
+        let length = placeholder
+            .get("length")
+            .and_then(serde_json::Value::as_u64)
+            .and_then(|value| usize::try_from(value).ok())
+            .filter(|value| *value > 0)
+            .ok_or("multimodal placeholder lengths must be positive integers")?;
+        let end = offset
+            .checked_add(length)
+            .filter(|end| *end <= request.token_ids.len())
+            .ok_or("multimodal placeholder range exceeds token_ids")?;
+        let is_embed = match placeholder.get("is_embed") {
+            None | Some(serde_json::Value::Null) => {
+                // vLLM 0.24 render responses omit sparse masks. A uniform
+                // placeholder span is safely dense; a mixed span is ambiguous
+                // and must retain token-only routing rather than over-substitute.
+                if request.token_ids[offset..end]
+                    .windows(2)
+                    .any(|pair| pair[0] != pair[1])
+                {
+                    return Err("mixed multimodal placeholder spans require is_embed");
+                }
+                None
+            }
+            Some(value) => {
+                let mask = value
+                    .as_array()
+                    .ok_or("multimodal placeholder is_embed must be an array")?;
+                if mask.len() != length {
+                    return Err(
+                        "multimodal placeholder is_embed length must match placeholder length",
+                    );
+                }
+                let mut parsed = Vec::with_capacity(mask.len());
+                for entry in mask {
+                    parsed.push(
+                        entry
+                            .as_bool()
+                            .ok_or("multimodal placeholder is_embed entries must be booleans")?,
+                    );
+                }
+                Some(parsed)
+            }
+        };
+        ranges.push((offset, end, hash, is_embed));
+    }
+
+    if ranges.is_empty() {
+        return Ok(None);
+    }
+
+    ranges.sort_unstable_by_key(|(offset, _, _, _)| *offset);
+    for pair in ranges.windows(2) {
+        let (_, previous_end, previous_hash, _) = &pair[0];
+        let (next_offset, _, next_hash, _) = &pair[1];
+        if previous_end > next_offset {
+            return Err("multimodal placeholder ranges must not overlap");
+        }
+        if previous_end == next_offset && previous_hash != next_hash {
+            return Err("adjacent multimodal placeholders must share an identifier");
+        }
+    }
+
+    // vLLM's current event normalizer associates MM objects with contiguous
+    // image-token runs by order, clamping excess runs to the last object in a
+    // block. A sparse mask can split one object into multiple runs, so verify
+    // that this run-order mapping still produces the request-side identity.
+    // If it does not, retain correctness by using ordinary token routing.
+    let block_size = kv_cache_block_size as usize;
+    let mut first_intersecting = 0;
+    for block_start in (0..request.token_ids.len()).step_by(block_size) {
+        let block_end = (block_start + block_size).min(request.token_ids.len());
+        let mut worker_objects = Vec::new();
+        let mut expected_by_position = vec![None; block_end - block_start];
+
+        let block_ranges = intersecting_mm_ranges(
+            &ranges,
+            block_start,
+            block_end,
+            &mut first_intersecting,
+            || {},
+        );
+        for (offset, end, hash, is_embed) in block_ranges {
+            let intersection_start = (*offset).max(block_start);
+            let intersection_end = (*end).min(block_end);
+            worker_objects.push(*hash);
+            for global_position in intersection_start..intersection_end {
+                let should_embed = is_embed
+                    .as_ref()
+                    .is_none_or(|mask| mask[global_position - *offset]);
+                if should_embed {
+                    expected_by_position[global_position - block_start] = Some(*hash);
+                }
+            }
+        }
+
+        let mut expected_runs = Vec::new();
+        let mut current_run = None;
+        for expected_hash in expected_by_position {
+            match (current_run, expected_hash) {
+                (None, Some(hash)) => {
+                    current_run = Some(hash);
+                    expected_runs.push(hash);
+                }
+                (Some(current), Some(hash)) if current != hash => {
+                    return Err("adjacent multimodal embed positions must share an identifier");
+                }
+                (Some(_), None) => current_run = None,
+                _ => {}
+            }
+        }
+
+        for (run_index, expected_hash) in expected_runs.into_iter().enumerate() {
+            let worker_hash = worker_objects
+                .get(run_index)
+                .or_else(|| worker_objects.last())
+                .copied();
+            if worker_hash != Some(expected_hash) {
+                return Err(
+                    "sparse multimodal layout cannot be normalized exactly by worker events",
+                );
+            }
+        }
+    }
+
+    let mut routing_token_ids = request.token_ids.clone();
+    for (offset, end, hash, is_embed) in ranges {
+        let pad = dynamo_kv_router::protocols::pad_value_for_mm_hash(hash);
+        if let Some(mask) = is_embed {
+            for (token, should_embed) in routing_token_ids[offset..end].iter_mut().zip(mask) {
+                if should_embed {
+                    *token = pad;
+                }
+            }
+        } else {
+            routing_token_ids[offset..end].fill(pad);
+        }
+    }
+
+    let padded_len = routing_token_ids
+        .len()
+        .div_ceil(block_size)
+        .checked_mul(block_size)
+        .ok_or("multimodal routing token length overflow")?;
+    routing_token_ids.resize(padded_len, 0);
+
+    Ok(Some(MmRoutingInfo {
+        routing_token_ids,
+        // vLLM events are normalized to the same pad-value token scheme, so
+        // MM identity is already present in the alternate routing tokens.
+        block_mm_infos: Vec::new(),
+        expanded_prompt_len: request.token_ids.len(),
+    }))
+}
+
 /// Project routing controls while retaining all engine-owned fields in
 /// `extra_args.vllm_tito`. The backend remains the authority for interpreting
 /// every vLLM-specific field.
@@ -212,13 +482,39 @@ fn preprocessed_from_generate(
     model: &str,
     data_parallel_rank: Option<u32>,
     request_id: &str,
+    kv_cache_block_size: u32,
+    supports_exact_mm_routing: bool,
+    lora_name: Option<String>,
 ) -> anyhow::Result<PreprocessedRequest> {
     let sampling = &request.sampling_params;
     let max_tokens = sampling.max_tokens();
     let min_tokens = sampling.min_tokens();
     let ignore_eos = sampling.ignore_eos();
     let routing_priority = dynamo_routing_priority(request.priority);
+    // With vLLM's default `enable_tower_connector_lora=false`, the vision tower
+    // and connector stay on base weights, so MM identifiers are adapter-invariant.
+    // `lora_name` separately salts the LM KV hashes below, allowing exact MM+LoRA
+    // routing. If tower/connector LoRA is enabled, vLLM scopes MM identifiers by
+    // adapter; that worker capability is not advertised here, so this projection
+    // can miss the correct MM cache owner (suboptimal routing, not unsafe reuse).
+    let mm_routing_info = if supports_exact_mm_routing {
+        match generate_mm_routing_info(&request, kv_cache_block_size) {
+            Ok(info) => info,
+            Err(reason) => {
+                tracing::debug!(
+                    target: "mm_routing",
+                    reason,
+                    "invalid /generate multimodal routing metadata; using token-only routing"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
     let vllm_tito = serde_json::to_value(VllmTitoEnvelope::new(&request, request_id))?;
+    let tracker = Arc::new(RequestTracker::new());
+    tracker.record_isl(request.token_ids.len(), None);
     let GenerateRequest {
         token_ids,
         cache_salt,
@@ -239,9 +535,11 @@ fn preprocessed_from_generate(
             ..Default::default()
         })
         .output_options(Default::default())
+        .mm_routing_info(mm_routing_info)
         .routing(Some(crate::protocols::common::preprocessor::RoutingHints {
             dp_rank: data_parallel_rank,
             expected_output_tokens: max_tokens,
+            lora_name,
             cache_namespace: cache_salt,
             // `priority_jump` is a boost-only scheduler input. Preserve penalties
             // in signed `priority`, matching the standard preprocessor projection.
@@ -254,8 +552,79 @@ fn preprocessed_from_generate(
             // that field from PreprocessedRequest.token_ids after routing.
             "vllm_tito": vllm_tito,
         })))
+        .tracker(Some(tracker))
         .build()
         .map_err(|error| anyhow::anyhow!("failed to build PreprocessedRequest: {error}"))
+}
+
+/// Metrics adapter for the raw engine stream used by `/inference/v1/generate`.
+///
+/// Unlike the OpenAI text endpoints, Generate deliberately bypasses the
+/// tokenizer/postprocessor pipeline that emits `LLMMetricAnnotation`. Its
+/// token IDs are already rendered, so observe the same response metrics from
+/// the raw token deltas while leaving tokenizer and media metrics untouched.
+struct GenerateMetricCollector {
+    response: ResponseMetricCollector,
+    http_queue: Option<HttpQueueGuard>,
+    tracker: Arc<RequestTracker>,
+    input_tokens: usize,
+    output_tokens: usize,
+}
+
+impl GenerateMetricCollector {
+    fn new(
+        metrics: Arc<super::metrics::Metrics>,
+        model: &str,
+        tracker: Arc<RequestTracker>,
+        input_tokens: usize,
+    ) -> Self {
+        let mut response = metrics.clone().create_response_collector(model);
+        response.set_input_sequence_length(input_tokens);
+        Self {
+            response,
+            http_queue: Some(metrics.create_http_queue_guard(model)),
+            tracker,
+            input_tokens,
+            output_tokens: 0,
+        }
+    }
+
+    fn observe(&mut self, annotated: &Annotated<LLMEngineOutput>) {
+        let Some(output) = annotated.data.as_ref() else {
+            return;
+        };
+
+        if let Some(worker) = self.tracker.get_worker_info() {
+            self.response.set_worker_info(
+                worker.prefill_worker_id,
+                worker.prefill_dp_rank,
+                self.tracker.prefill_worker_type().map(String::from),
+                worker.decode_worker_id,
+                worker.decode_dp_rank,
+                self.tracker.decode_worker_type().map(String::from),
+            );
+        }
+
+        let cached_tokens = output
+            .completion_usage
+            .as_ref()
+            .and_then(|usage| usage.prompt_tokens_details.as_ref())
+            .and_then(|details| details.cached_tokens)
+            .map(|tokens| tokens as usize);
+        self.response.observe_cached_tokens(cached_tokens);
+
+        let chunk_tokens = output.token_ids.len();
+        self.output_tokens += chunk_tokens;
+        self.response.observe_current_osl(self.output_tokens);
+        if self.response.is_first_token()
+            && chunk_tokens > 0
+            && let Some(guard) = self.http_queue.take()
+        {
+            drop(guard);
+        }
+        self.response
+            .observe_response(self.input_tokens, chunk_tokens);
+    }
 }
 
 /// Resolve, route, and dispatch a frontend-native token-in/token-out request.
@@ -310,8 +679,13 @@ async fn handler_generate(
         return response.into_response();
     }
 
-    let engine = match state.manager().get_generate_engine(&model) {
-        Ok(engine) => engine,
+    let GenerateEngineSelection {
+        engine,
+        kv_cache_block_size,
+        lora_name,
+        supports_exact_mm_routing,
+    } = match state.manager().get_generate_engine(&model) {
+        Ok(selection) => selection,
         Err(error) => {
             let (status, error_type) = match error {
                 crate::discovery::ModelManagerError::ModelUnavailable(_) => {
@@ -329,6 +703,9 @@ async fn handler_generate(
         &model,
         request_context.data_parallel_rank,
         &request_context.request_id,
+        kv_cache_block_size,
+        supports_exact_mm_routing,
+        lora_name,
     ) {
         Ok(preprocessed) => preprocessed,
         Err(error) => {
@@ -359,7 +736,7 @@ async fn handler_generate(
     )
     .await;
 
-    let dispatch_span = generate_dispatch_span(&request_id);
+    let dispatch_span = generate_dispatch_span(&request_id, &model);
     // Unary work must outlive the Axum handler so dropping the handler can signal
     // the armed connection monitor. The detached dispatch observes that kill at
     // each backend await point and then exits promptly.
@@ -395,12 +772,21 @@ async fn generate_dispatch(
     state: Arc<service_v2::State>,
     response_options: GenerateResponseOptions,
 ) -> Response {
+    let metric_model = state.manager().metric_model_for(&model).to_string();
+    let input_tokens = context.content().token_ids.len();
+    let tracker = context.content().tracker.clone().unwrap_or_else(|| {
+        let tracker = Arc::new(RequestTracker::new());
+        tracker.record_isl(input_tokens, None);
+        tracker
+    });
     let mut inflight_guard = state.metrics_clone().create_inflight_guard(
-        state.manager().metric_model_for(&model),
+        &metric_model,
         super::metrics::Endpoint::Generate,
         false,
         &request_id,
     );
+    let mut metric_collector =
+        GenerateMetricCollector::new(state.metrics_clone(), &metric_model, tracker, input_tokens);
     let request_context = context.context();
     let generate_result =
         match run_until_killed(request_context.as_ref(), engine.generate(context)).await {
@@ -434,7 +820,7 @@ async fn generate_dispatch(
                 tracing::warn!(%request_id, error = %format!("{error:#}"), "engine rejected generate request");
                 state
                     .metrics_clone()
-                    .inc_rejection(&model, super::metrics::Endpoint::Generate);
+                    .inc_rejection(&metric_model, super::metrics::Endpoint::Generate);
                 return generate_error_response(
                     StatusCode::SERVICE_UNAVAILABLE,
                     "service_unavailable",
@@ -447,6 +833,7 @@ async fn generate_dispatch(
     };
 
     let engine_context = stream.context();
+    let stream = stream.inspect(move |annotated| metric_collector.observe(annotated));
     let response_result = match run_until_killed(
         request_context.as_ref(),
         GenerateResponse::from_annotated_stream_with_options(
@@ -502,6 +889,7 @@ mod tests {
             atomic::{AtomicBool, Ordering},
         },
         task::{Context as TaskContext, Poll},
+        time::Duration,
     };
 
     use super::service_v2::{HttpService, VLLM_ENABLE_INFERENCE_V1_GENERATE_ENV};
@@ -583,6 +971,13 @@ mod tests {
 
     struct CancelledEngine;
 
+    struct MetricEngine;
+
+    struct TokenThenPendingEngine {
+        started: Arc<Notify>,
+        dropped: Arc<AtomicBool>,
+    }
+
     #[async_trait::async_trait]
     impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
         for CancelledEngine
@@ -612,6 +1007,66 @@ mod tests {
                 finish_reason: Some(self.0.clone()),
                 ..Default::default()
             })]);
+            Ok(ResponseStream::new(Box::pin(stream), request.context()))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for MetricEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            let first = futures::stream::once(async {
+                Annotated::from_data(LLMEngineOutput {
+                    token_ids: vec![10],
+                    index: Some(0),
+                    ..Default::default()
+                })
+            });
+            let second = futures::stream::once(async {
+                tokio::time::sleep(Duration::from_millis(1)).await;
+                Annotated::from_data(LLMEngineOutput {
+                    token_ids: vec![11],
+                    index: Some(0),
+                    finish_reason: Some(crate::protocols::common::FinishReason::Stop),
+                    completion_usage: Some(dynamo_protocols::types::CompletionUsage {
+                        prompt_tokens: 3,
+                        completion_tokens: 2,
+                        total_tokens: 5,
+                        prompt_tokens_details: Some(dynamo_protocols::types::PromptTokensDetails {
+                            audio_tokens: None,
+                            cached_tokens: Some(2),
+                        }),
+                        completion_tokens_details: None,
+                    }),
+                    ..Default::default()
+                })
+            });
+            let stream = first.chain(second);
+            Ok(ResponseStream::new(Box::pin(stream), request.context()))
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutput>>, Error>
+        for TokenThenPendingEngine
+    {
+        async fn generate(
+            &self,
+            request: SingleIn<PreprocessedRequest>,
+        ) -> Result<ManyOut<Annotated<LLMEngineOutput>>, Error> {
+            let first = futures::stream::once(async {
+                Annotated::from_data(LLMEngineOutput {
+                    token_ids: vec![10],
+                    index: Some(0),
+                    ..Default::default()
+                })
+            });
+            let pending = PendingOperation::new(self.started.clone(), self.dropped.clone());
+            let stream = first.chain(pending);
             Ok(ResponseStream::new(Box::pin(stream), request.context()))
         }
     }
@@ -672,6 +1127,32 @@ mod tests {
                 self.request_id = Some(format!("{value:?}"));
             }
         }
+    }
+
+    #[derive(Clone)]
+    struct InputTokensCaptureLayer(Arc<Mutex<Option<u64>>>);
+
+    impl<S: Subscriber> Layer<S> for InputTokensCaptureLayer {
+        fn on_record(
+            &self,
+            _id: &span::Id,
+            values: &span::Record<'_>,
+            _context: tracing_subscriber::layer::Context<'_, S>,
+        ) {
+            values.record(&mut InputTokensVisitor(self.0.clone()));
+        }
+    }
+
+    struct InputTokensVisitor(Arc<Mutex<Option<u64>>>);
+
+    impl Visit for InputTokensVisitor {
+        fn record_u64(&mut self, field: &Field, value: u64) {
+            if field.name() == "input_tokens" {
+                *self.0.lock().unwrap() = Some(value);
+            }
+        }
+
+        fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
     }
 
     /// Spin up an `HttpService` bound to an ephemeral port and return the port
@@ -843,9 +1324,16 @@ mod tests {
         let request: GenerateRequest =
             serde_json::from_value(raw.clone()).expect("deserialize request");
 
-        let preprocessed =
-            preprocessed_from_generate(request, "test-model", None, "resolved-request")
-                .expect("build request");
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            16,
+            false,
+            None,
+        )
+        .expect("build request");
         assert_eq!(preprocessed.stop_conditions.max_tokens, Some(8));
         assert_eq!(preprocessed.stop_conditions.min_tokens, None);
         assert_eq!(
@@ -890,9 +1378,479 @@ mod tests {
             .and_then(|object| object.remove("token_ids"))
             .expect("token_ids in client request");
         assert_eq!(preprocessed.token_ids, vec![1, 2]);
+        assert_eq!(
+            preprocessed
+                .tracker
+                .as_ref()
+                .and_then(|tracker| tracker.isl_tokens()),
+            Some(2)
+        );
         assert_eq!(expected_token_ids, serde_json::json!([1, 2]));
         assert_eq!(envelope, &expected_envelope);
         assert!(envelope.get("token_ids").is_none());
+    }
+
+    #[test]
+    fn unrelated_features_do_not_attempt_exact_multimodal_routing() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2, 3],
+            "sampling_params": {},
+            "features": {"future_feature": [1, 2, 3]}
+        }))
+        .expect("deserialize request");
+
+        assert!(matches!(generate_mm_routing_info(&request, 16), Ok(None)));
+    }
+
+    #[test]
+    fn malformed_present_mm_hashes_still_disable_exact_multimodal_routing() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2, 3],
+            "sampling_params": {},
+            "features": {"mm_hashes": ["not-an-object"]}
+        }))
+        .expect("deserialize request");
+
+        assert_eq!(
+            generate_mm_routing_info(&request, 16)
+                .expect_err("malformed present metadata must remain an error"),
+            "features.mm_hashes must be a JSON object"
+        );
+    }
+
+    #[test]
+    fn block_range_sweep_is_linear_in_sparse_placeholder_count() {
+        let token_count = 16_384_usize;
+        let block_size = 16_usize;
+        let ranges = (0..token_count)
+            .step_by(2)
+            .map(|offset| (offset, offset + 1, offset as u64, None))
+            .collect::<Vec<_>>();
+        let block_count = token_count.div_ceil(block_size);
+        let mut first_intersecting = 0;
+        let mut visited = 0;
+        let mut examined = 0;
+
+        for block_start in (0..token_count).step_by(block_size) {
+            let block_end = (block_start + block_size).min(token_count);
+            let before = examined;
+            let block_ranges = intersecting_mm_ranges(
+                &ranges,
+                block_start,
+                block_end,
+                &mut first_intersecting,
+                || examined += 1,
+            );
+            visited += block_ranges.len();
+            assert!(examined > before);
+        }
+
+        assert!(visited < ranges.len() + block_count);
+        assert!(examined <= 2 * (ranges.len() + block_count));
+        assert_eq!(first_intersecting, ranges.len() - block_size / 2);
+    }
+
+    #[test]
+    fn multimodal_features_build_exact_routing_tokens_without_changing_execution_payload() {
+        let hash_a = "a".repeat(64);
+        let hash_b = "b".repeat(64);
+        let raw = serde_json::json!({
+            "token_ids": [10, 11, 12, 12, 12, 15, 16, 17, 17, 19],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": [hash_a, hash_b]},
+                "mm_placeholders": {"image": [
+                    {"offset": 2, "length": 3},
+                    {"offset": 7, "length": 2}
+                ]},
+                "kwargs_data": {"image": ["opaque-a", "opaque-b"]}
+            }
+        });
+        let request: GenerateRequest =
+            serde_json::from_value(raw.clone()).expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            4,
+            true,
+            None,
+        )
+        .expect("build request");
+
+        let pad_a = dynamo_kv_router::protocols::pad_value_for_mm_hash(0xaaaaaaaaaaaaaaaa);
+        let pad_b = dynamo_kv_router::protocols::pad_value_for_mm_hash(0xbbbbbbbbbbbbbbbb);
+        let mm = preprocessed
+            .mm_routing_info
+            .as_ref()
+            .expect("multimodal routing projection");
+        assert_eq!(
+            mm.routing_token_ids,
+            vec![10, 11, pad_a, pad_a, pad_a, 15, 16, pad_b, pad_b, 19, 0, 0]
+        );
+        assert!(mm.block_mm_infos.is_empty());
+        assert_eq!(mm.expanded_prompt_len, 10);
+
+        assert_eq!(
+            preprocessed.token_ids,
+            vec![10, 11, 12, 12, 12, 15, 16, 17, 17, 19]
+        );
+        let envelope = preprocessed
+            .extra_args
+            .as_ref()
+            .and_then(|extra| extra.get("vllm_tito"))
+            .expect("vllm_tito envelope");
+        assert_eq!(envelope["features"], raw["features"]);
+    }
+
+    #[test]
+    fn multimodal_routing_requires_worker_capability() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [10, 99, 99, 20],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": ["opaque-image"]},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 2}]}
+            }
+        }))
+        .expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            4,
+            false,
+            None,
+        )
+        .expect("unsupported workers must retain token-only routing");
+
+        assert!(preprocessed.mm_routing_info.is_none());
+        assert_eq!(preprocessed.token_ids, vec![10, 99, 99, 20]);
+    }
+
+    #[test]
+    fn generate_mm_routing_hash_matches_normalized_vllm_worker_event() {
+        let mm_identifier = "1234567890abcdef".repeat(2);
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [10, 99, 99, 20],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": [mm_identifier.clone()]},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 2}]}
+            }
+        }))
+        .expect("deserialize request");
+        let routing = generate_mm_routing_info(&request, 4)
+            .expect("valid MM routing metadata")
+            .expect("MM routing projection");
+        let request_hashes = dynamo_kv_router::protocols::compute_block_hash_for_seq(
+            &routing.routing_token_ids,
+            4,
+            dynamo_kv_router::protocols::BlockHashOptions::default(),
+        );
+
+        let event_block = dynamo_kv_router::zmq_wire::create_stored_block_from_parts(
+            4,
+            7,
+            &[10, 99, 99, 20],
+            dynamo_kv_router::zmq_wire::StoredBlockOptions {
+                mm_extra_info: Some(dynamo_kv_router::protocols::BlockExtraInfo {
+                    mm_objects: vec![dynamo_kv_router::protocols::BlockMmObjectInfo {
+                        mm_hash: dynamo_kv_router::protocols::hash_mm_identifier(&mm_identifier)
+                            .expect("non-empty identifier"),
+                        offsets: vec![(1, 3)],
+                    }],
+                }),
+                image_token_id: Some(99),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(request_hashes[0], event_block.tokens_hash);
+    }
+
+    #[test]
+    fn sparse_mm_embed_mask_matches_normalized_vllm_worker_event() {
+        let mm_identifier = "opaque-renderer-image-0";
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [10, 99, 42, 99, 20],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": [mm_identifier]},
+                "mm_placeholders": {"image": [{
+                    "offset": 1,
+                    "length": 3,
+                    "is_embed": [true, false, true]
+                }]}
+            }
+        }))
+        .expect("deserialize request");
+        let routing = generate_mm_routing_info(&request, 5)
+            .expect("valid sparse MM routing metadata")
+            .expect("MM routing projection");
+        let mm_hash = dynamo_kv_router::protocols::hash_mm_identifier(mm_identifier)
+            .expect("non-empty identifier");
+        let pad = dynamo_kv_router::protocols::pad_value_for_mm_hash(mm_hash);
+        assert_eq!(routing.routing_token_ids, vec![10, pad, 42, pad, 20]);
+
+        let request_hash = dynamo_kv_router::protocols::compute_block_hash_for_seq(
+            &routing.routing_token_ids,
+            5,
+            dynamo_kv_router::protocols::BlockHashOptions::default(),
+        )[0];
+        let event_block = dynamo_kv_router::zmq_wire::create_stored_block_from_parts(
+            5,
+            7,
+            &[10, 99, 42, 99, 20],
+            dynamo_kv_router::zmq_wire::StoredBlockOptions {
+                mm_extra_info: Some(dynamo_kv_router::protocols::BlockExtraInfo {
+                    mm_objects: vec![dynamo_kv_router::protocols::BlockMmObjectInfo {
+                        mm_hash,
+                        offsets: vec![],
+                    }],
+                }),
+                image_token_id: Some(99),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(request_hash, event_block.tokens_hash);
+    }
+
+    #[test]
+    fn mixed_placeholder_span_without_embed_mask_disables_exact_routing() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [10, 99, 42, 99, 20],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": ["image-0"]},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 3}]}
+            }
+        }))
+        .expect("deserialize request");
+
+        assert_eq!(
+            generate_mm_routing_info(&request, 5)
+                .expect_err("an omitted sparse mask must not over-substitute tokens"),
+            "mixed multimodal placeholder spans require is_embed"
+        );
+    }
+
+    #[test]
+    fn sparse_multi_object_block_disables_inexact_projection() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [10, 99, 42, 99, 20, 99, 30],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": ["image-a", "image-b"]},
+                "mm_placeholders": {"image": [
+                    {
+                        "offset": 1,
+                        "length": 3,
+                        "is_embed": [true, false, true]
+                    },
+                    {"offset": 5, "length": 1}
+                ]}
+            }
+        }))
+        .expect("deserialize request");
+
+        assert_eq!(
+            generate_mm_routing_info(&request, 7)
+                .expect_err("worker run-order mapping would assign image B to image A"),
+            "sparse multimodal layout cannot be normalized exactly by worker events"
+        );
+    }
+
+    #[test]
+    fn invalid_multimodal_routing_metadata_falls_back_without_dropping_features() {
+        let raw = serde_json::json!({
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": [""]},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 2}]},
+                "kwargs_data": {"image": ["opaque"]}
+            }
+        });
+        let request: GenerateRequest =
+            serde_json::from_value(raw.clone()).expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            4,
+            true,
+            None,
+        )
+        .expect("malformed routing metadata must not reject execution");
+
+        assert!(preprocessed.mm_routing_info.is_none());
+        assert_eq!(preprocessed.token_ids, vec![1, 2, 3, 4]);
+        let envelope = preprocessed
+            .extra_args
+            .as_ref()
+            .and_then(|extra| extra.get("vllm_tito"))
+            .expect("vllm_tito envelope");
+        assert_eq!(envelope["features"], raw["features"]);
+    }
+
+    #[test]
+    fn default_lora_mode_composes_mm_identity_with_lora_hashing() {
+        let mm_identifier = "opaque-renderer-image-0";
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [10, 99, 99, 20],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": [mm_identifier]},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 2}]}
+            }
+        }))
+        .expect("deserialize request");
+
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "adapter-a",
+            None,
+            "resolved-request",
+            4,
+            true,
+            Some("adapter-a".to_string()),
+        )
+        .expect("build request");
+
+        let routing_tokens = &preprocessed
+            .mm_routing_info
+            .as_ref()
+            .expect("default language-only LoRA keeps MM identifiers stable")
+            .routing_token_ids;
+        assert_eq!(
+            preprocessed
+                .routing
+                .as_ref()
+                .and_then(|routing| routing.lora_name.as_deref()),
+            Some("adapter-a")
+        );
+
+        let request_hash = dynamo_kv_router::protocols::compute_block_hash_for_seq(
+            routing_tokens,
+            4,
+            dynamo_kv_router::protocols::BlockHashOptions {
+                lora_name: Some("adapter-a"),
+                ..Default::default()
+            },
+        )[0];
+        let event_block = dynamo_kv_router::zmq_wire::create_stored_block_from_parts(
+            4,
+            7,
+            &[10, 99, 99, 20],
+            dynamo_kv_router::zmq_wire::StoredBlockOptions {
+                lora_name: Some("adapter-a"),
+                mm_extra_info: Some(dynamo_kv_router::protocols::BlockExtraInfo {
+                    mm_objects: vec![dynamo_kv_router::protocols::BlockMmObjectInfo {
+                        mm_hash: dynamo_kv_router::protocols::hash_mm_identifier(mm_identifier)
+                            .expect("non-empty identifier"),
+                        offsets: vec![(1, 3)],
+                    }],
+                }),
+                image_token_id: Some(99),
+                ..Default::default()
+            },
+        );
+
+        assert_eq!(request_hash, event_block.tokens_hash);
+    }
+
+    #[test]
+    fn overlapping_multimodal_placeholders_disable_mm_routing() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [9, 9, 9, 4],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": ["a".repeat(64), "b".repeat(64)]},
+                "mm_placeholders": {"image": [
+                    {"offset": 0, "length": 2},
+                    {"offset": 1, "length": 2}
+                ]}
+            }
+        }))
+        .expect("deserialize request");
+
+        assert_eq!(
+            generate_mm_routing_info(&request, 4).expect_err("overlap must disable MM routing"),
+            "multimodal placeholder ranges must not overlap"
+        );
+    }
+
+    #[test]
+    fn non_image_modality_disables_exact_mm_projection() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"audio": ["audio-0"]},
+                "mm_placeholders": {"audio": [{"offset": 1, "length": 2}]}
+            }
+        }))
+        .expect("deserialize request");
+
+        assert_eq!(
+            generate_mm_routing_info(&request, 4)
+                .expect_err("non-image modality must disable exact projection"),
+            "exact /generate MM routing currently supports image placeholders only"
+        );
+    }
+
+    #[test]
+    fn image_hashes_and_placeholders_must_be_paired() {
+        for features in [
+            serde_json::json!({
+                "mm_hashes": {"image": ["image-0"]},
+                "mm_placeholders": {}
+            }),
+            serde_json::json!({
+                "mm_hashes": {},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 2}]}
+            }),
+        ] {
+            let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+                "token_ids": [1, 2, 3, 4],
+                "sampling_params": {},
+                "features": features
+            }))
+            .expect("deserialize request");
+
+            assert_eq!(
+                generate_mm_routing_info(&request, 4)
+                    .expect_err("one-sided image metadata must disable exact routing"),
+                "image hashes and placeholders must both be present"
+            );
+        }
+    }
+
+    #[test]
+    fn image_hashes_and_placeholders_must_have_equal_lengths() {
+        let request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "token_ids": [1, 2, 3, 4],
+            "sampling_params": {},
+            "features": {
+                "mm_hashes": {"image": ["image-0", "image-1"]},
+                "mm_placeholders": {"image": [{"offset": 1, "length": 2}]}
+            }
+        }))
+        .expect("deserialize request");
+
+        assert_eq!(
+            generate_mm_routing_info(&request, 4)
+                .expect_err("item count mismatch must disable exact routing"),
+            "image hashes and placeholders must have equal lengths"
+        );
     }
 
     #[test]
@@ -904,9 +1862,16 @@ mod tests {
         }))
         .expect("deserialize request");
 
-        let preprocessed =
-            preprocessed_from_generate(request, "test-model", None, "resolved-request")
-                .expect("build request");
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            16,
+            false,
+            None,
+        )
+        .expect("build request");
         assert_eq!(preprocessed.stop_conditions.max_tokens, None);
         assert_eq!(preprocessed.stop_conditions.min_tokens, None);
         assert_eq!(
@@ -927,9 +1892,16 @@ mod tests {
         }))
         .expect("deserialize request");
 
-        let preprocessed =
-            preprocessed_from_generate(request, "test-model", None, "resolved-request")
-                .expect("build request");
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            None,
+            "resolved-request",
+            16,
+            false,
+            None,
+        )
+        .expect("build request");
         assert_eq!(preprocessed.stop_conditions.min_tokens, Some(0));
     }
 
@@ -963,12 +1935,28 @@ mod tests {
             tracing_subscriber::registry().with(RequestIdCaptureLayer(captured_request_id.clone())),
         );
 
-        let _dispatch_span = generate_dispatch_span("header-request");
+        let dispatch_span = generate_dispatch_span("header-request", "test-model");
 
         assert_eq!(
             captured_request_id.lock().unwrap().as_deref(),
             Some("header-request")
         );
+        let fields = dispatch_span
+            .metadata()
+            .expect("dispatch span metadata")
+            .fields();
+        for field in [
+            "request_id",
+            "model",
+            "input_tokens",
+            "output_tokens",
+            "ttft_ms",
+            "avg_itl_ms",
+            "prefill_worker_id",
+            "decode_worker_id",
+        ] {
+            assert!(fields.field(field).is_some(), "missing span field {field}");
+        }
     }
 
     fn dispatch_test_context() -> Context<PreprocessedRequest> {
@@ -984,7 +1972,54 @@ mod tests {
         )
     }
 
-    fn assert_cancelled_dispatch_metrics(state: &service_v2::State) {
+    fn metric_value<'a>(
+        families: &'a [prometheus::proto::MetricFamily],
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> &'a prometheus::proto::Metric {
+        let family = families
+            .iter()
+            .find(|family| family.name() == name)
+            .unwrap_or_else(|| panic!("missing metric family {name}"));
+        family
+            .get_metric()
+            .iter()
+            .find(|metric| {
+                labels.iter().all(|(expected_name, expected_value)| {
+                    metric.get_label().iter().any(|label| {
+                        label.name() == *expected_name && label.value() == *expected_value
+                    })
+                })
+            })
+            .unwrap_or_else(|| panic!("missing {name} series with labels {labels:?}"))
+    }
+
+    fn histogram_sample_count_or_zero(
+        families: &[prometheus::proto::MetricFamily],
+        name: &str,
+        labels: &[(&str, &str)],
+    ) -> u64 {
+        families
+            .iter()
+            .find(|family| family.name() == name)
+            .and_then(|family| {
+                family.get_metric().iter().find(|metric| {
+                    labels.iter().all(|(expected_name, expected_value)| {
+                        metric.get_label().iter().any(|label| {
+                            label.name() == *expected_name && label.value() == *expected_value
+                        })
+                    })
+                })
+            })
+            .map(|metric| metric.get_histogram().get_sample_count())
+            .unwrap_or(0)
+    }
+
+    fn assert_cancelled_dispatch_metrics(
+        state: &service_v2::State,
+        expected_ttft_samples: u64,
+        expected_osl_samples: u64,
+    ) {
         let metric_model = state.manager().metric_model_for("test-model");
         let metrics = state.metrics_clone();
         assert_eq!(metrics.get_inflight_count(metric_model), 0);
@@ -997,6 +2032,33 @@ mod tests {
                 &ErrorType::Cancelled,
             ),
             1
+        );
+
+        let registry = prometheus::Registry::new();
+        metrics.register(&registry).unwrap();
+        let families = registry.gather();
+        let model_labels = [("model", metric_model)];
+        assert_eq!(
+            metric_value(&families, "dynamo_frontend_queued_requests", &model_labels,)
+                .get_gauge()
+                .value(),
+            0.0
+        );
+        assert_eq!(
+            histogram_sample_count_or_zero(
+                &families,
+                "dynamo_frontend_time_to_first_token_seconds",
+                &model_labels,
+            ),
+            expected_ttft_samples
+        );
+        assert_eq!(
+            histogram_sample_count_or_zero(
+                &families,
+                "dynamo_frontend_output_sequence_tokens",
+                &model_labels,
+            ),
+            expected_osl_samples
         );
     }
 
@@ -1011,7 +2073,7 @@ mod tests {
             .expect("dispatch task panicked");
         assert_eq!(response.status().as_u16(), 499);
         assert!(dropped.load(Ordering::SeqCst));
-        assert_cancelled_dispatch_metrics(state);
+        assert_cancelled_dispatch_metrics(state, 0, 0);
     }
 
     async fn assert_request_kill_interrupts_pending(phase: PendingPhase) {
@@ -1101,11 +2163,15 @@ mod tests {
                 .await;
 
         assert_eq!(response.status().as_u16(), 499);
-        assert_cancelled_dispatch_metrics(state.as_ref());
+        assert_cancelled_dispatch_metrics(state.as_ref(), 0, 0);
     }
 
     #[tokio::test]
     async fn immediate_engine_cancellation_returns_499() {
+        let captured_input_tokens = Arc::new(Mutex::new(None));
+        let subscriber = tracing_subscriber::registry()
+            .with(InputTokensCaptureLayer(captured_input_tokens.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
         let engine: crate::types::openai::generate::GenerateStreamingEngine =
             Arc::new(CancelledEngine);
         let service = HttpService::builder().build().unwrap();
@@ -1119,10 +2185,288 @@ mod tests {
             state.clone(),
             GenerateResponseOptions::default(),
         )
+        .instrument(generate_dispatch_span("req-immediate-cancel", "test-model"))
         .await;
 
         assert_eq!(response.status().as_u16(), 499);
-        assert_cancelled_dispatch_metrics(state.as_ref());
+        assert_eq!(*captured_input_tokens.lock().unwrap(), Some(1));
+        assert_cancelled_dispatch_metrics(state.as_ref(), 0, 0);
+    }
+
+    #[tokio::test]
+    async fn request_kill_after_first_token_records_partial_metrics() {
+        let started = Arc::new(Notify::new());
+        let dropped = Arc::new(AtomicBool::new(false));
+        let engine: crate::types::openai::generate::GenerateStreamingEngine =
+            Arc::new(TokenThenPendingEngine {
+                started: started.clone(),
+                dropped: dropped.clone(),
+            });
+        let context = dispatch_test_context();
+        let request_context = context.context();
+        let service = HttpService::builder().build().unwrap();
+        let state = service.state_clone();
+        let task = tokio::spawn(generate_dispatch(
+            engine,
+            context,
+            "req-token-then-pending".to_string(),
+            "test-model".to_string(),
+            state.clone(),
+            GenerateResponseOptions::default(),
+        ));
+
+        started.notified().await;
+        request_context.kill();
+
+        let response = tokio::time::timeout(Duration::from_secs(1), task)
+            .await
+            .expect("dispatch did not stop promptly after request kill")
+            .expect("dispatch task panicked");
+        assert_eq!(response.status().as_u16(), 499);
+        assert!(dropped.load(Ordering::SeqCst));
+        assert_cancelled_dispatch_metrics(state.as_ref(), 1, 1);
+    }
+
+    #[tokio::test]
+    async fn zero_token_success_records_known_input_tokens_without_output_metrics() {
+        let captured_input_tokens = Arc::new(Mutex::new(None));
+        let subscriber = tracing_subscriber::registry()
+            .with(InputTokensCaptureLayer(captured_input_tokens.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
+        let (response, state) = async {
+            let engine: crate::types::openai::generate::GenerateStreamingEngine =
+                Arc::new(TerminalEngine(crate::protocols::common::FinishReason::Stop));
+            let service = HttpService::builder().build().unwrap();
+            let state = service.state_clone();
+            let response = generate_dispatch(
+                engine,
+                dispatch_test_context(),
+                "req-zero-token".to_string(),
+                "test-model".to_string(),
+                state.clone(),
+                GenerateResponseOptions::default(),
+            )
+            .instrument(generate_dispatch_span("req-zero-token", "test-model"))
+            .await;
+            (response, state)
+        }
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(*captured_input_tokens.lock().unwrap(), Some(1));
+        let metric_model = state.manager().metric_model_for("test-model");
+        assert_eq!(
+            state.metrics_clone().get_request_counter(
+                metric_model,
+                &Endpoint::Generate,
+                &RequestType::Unary,
+                &Status::Success,
+                &ErrorType::None,
+            ),
+            1
+        );
+
+        let registry = prometheus::Registry::new();
+        state.metrics_clone().register(&registry).unwrap();
+        let families = registry.gather();
+        let model_labels = [("model", metric_model)];
+        assert_eq!(
+            metric_value(&families, "dynamo_frontend_queued_requests", &model_labels,)
+                .get_gauge()
+                .value(),
+            0.0
+        );
+        assert_eq!(
+            histogram_sample_count_or_zero(
+                &families,
+                "dynamo_frontend_time_to_first_token_seconds",
+                &model_labels,
+            ),
+            0
+        );
+        assert_eq!(
+            histogram_sample_count_or_zero(
+                &families,
+                "dynamo_frontend_output_sequence_tokens",
+                &model_labels,
+            ),
+            0
+        );
+        assert_eq!(
+            histogram_sample_count_or_zero(
+                &families,
+                "dynamo_frontend_input_sequence_tokens",
+                &model_labels,
+            ),
+            0
+        );
+    }
+
+    #[tokio::test]
+    async fn successful_generate_populates_frontend_metrics() {
+        const MODEL: &str = "generate-metric-test-model";
+        const WORKER_ID: &str = "987654321";
+        const DP_RANK: &str = "3";
+
+        let tracker = Arc::new(RequestTracker::new());
+        tracker.record_isl(3, None);
+        tracker.record_worker(
+            WORKER_ID.parse().unwrap(),
+            Some(DP_RANK.parse().unwrap()),
+            crate::discovery::WORKER_TYPE_DECODE,
+        );
+        let context = Context::new(
+            PreprocessedRequest::builder()
+                .model(MODEL.to_string())
+                .token_ids(vec![1, 2, 3])
+                .stop_conditions(Default::default())
+                .sampling_options(Default::default())
+                .output_options(Default::default())
+                .tracker(Some(tracker))
+                .build()
+                .expect("build metric test request"),
+        );
+        let engine: crate::types::openai::generate::GenerateStreamingEngine =
+            Arc::new(MetricEngine);
+        let service = HttpService::builder().build().unwrap();
+        let state = service.state_clone();
+        let metric_model = state.manager().metric_model_for(MODEL).to_string();
+        let registry = prometheus::Registry::new();
+        state.metrics_clone().register(&registry).unwrap();
+
+        let response = generate_dispatch(
+            engine,
+            context,
+            "req-generate-metrics".to_string(),
+            MODEL.to_string(),
+            state.clone(),
+            GenerateResponseOptions::default(),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(state.metrics_clone().get_inflight_count(&metric_model), 0);
+        assert_eq!(
+            state.metrics_clone().get_request_counter(
+                &metric_model,
+                &Endpoint::Generate,
+                &RequestType::Unary,
+                &Status::Success,
+                &ErrorType::None,
+            ),
+            1
+        );
+
+        let families = registry.gather();
+        let model_labels = [("model", metric_model.as_str())];
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_requests_started_total",
+                &[("model", metric_model.as_str()), ("endpoint", "generate")],
+            )
+            .get_counter()
+            .value(),
+            1.0
+        );
+        assert_eq!(
+            metric_value(&families, "dynamo_frontend_active_requests", &model_labels)
+                .get_gauge()
+                .value(),
+            0.0
+        );
+        assert_eq!(
+            metric_value(&families, "dynamo_frontend_queued_requests", &model_labels)
+                .get_gauge()
+                .value(),
+            0.0
+        );
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_request_duration_seconds",
+                &model_labels,
+            )
+            .get_histogram()
+            .get_sample_count(),
+            1
+        );
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_input_sequence_tokens",
+                &model_labels,
+            )
+            .get_histogram()
+            .get_sample_sum(),
+            3.0
+        );
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_output_sequence_tokens",
+                &model_labels,
+            )
+            .get_histogram()
+            .get_sample_sum(),
+            2.0
+        );
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_output_tokens_total",
+                &model_labels,
+            )
+            .get_counter()
+            .value(),
+            2.0
+        );
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_time_to_first_token_seconds",
+                &model_labels,
+            )
+            .get_histogram()
+            .get_sample_count(),
+            1
+        );
+        assert_eq!(
+            metric_value(
+                &families,
+                "dynamo_frontend_inter_token_latency_seconds",
+                &model_labels,
+            )
+            .get_histogram()
+            .get_sample_count(),
+            1
+        );
+        assert_eq!(
+            metric_value(&families, "dynamo_frontend_cached_tokens", &model_labels,)
+                .get_histogram()
+                .get_sample_sum(),
+            2.0
+        );
+
+        let worker_labels = [WORKER_ID, DP_RANK, crate::discovery::WORKER_TYPE_DECODE];
+        assert_eq!(
+            crate::http::service::metrics::WORKER_LAST_INPUT_SEQUENCE_TOKENS_GAUGE
+                .with_label_values(&worker_labels)
+                .get(),
+            3
+        );
+        assert!(
+            crate::http::service::metrics::WORKER_LAST_TIME_TO_FIRST_TOKEN_GAUGE
+                .with_label_values(&worker_labels)
+                .get()
+                > 0.0
+        );
+        assert!(
+            crate::http::service::metrics::WORKER_LAST_INTER_TOKEN_LATENCY_GAUGE
+                .with_label_values(&worker_labels)
+                .get()
+                > 0.0
+        );
     }
 
     #[test]
@@ -1134,9 +2478,16 @@ mod tests {
         }))
         .expect("deserialize request");
 
-        let preprocessed =
-            preprocessed_from_generate(request, "test-model", Some(3), "resolved-request")
-                .expect("build request");
+        let preprocessed = preprocessed_from_generate(
+            request,
+            "test-model",
+            Some(3),
+            "resolved-request",
+            16,
+            false,
+            None,
+        )
+        .expect("build request");
         let routing = preprocessed.routing.as_ref().expect("routing hints");
 
         assert_eq!(routing.dp_rank, Some(3));

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -1695,6 +1695,15 @@ impl ResponseMetricCollector {
         self.osl = osl;
     }
 
+    /// Seed the known input sequence length for the request summary span.
+    ///
+    /// This deliberately does not publish the input sequence length histogram.
+    /// That histogram remains tied to the first output token so failed or
+    /// cancelled requests do not skew successful-response distributions.
+    pub fn set_input_sequence_length(&mut self, isl: usize) {
+        self.isl = isl;
+    }
+
     /// Check if this will be the first token (before calling observe_response)
     pub fn is_first_token(&self) -> bool {
         self.is_first_token

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -56,6 +56,9 @@ pub const ENV_TOKENIZER_BACKEND: &str = "DYN_TOKENIZER";
 /// surfaces without implementing vLLM's Generate contract.
 pub const VLLM_INFERENCE_V1_GENERATE_CAPABILITY: &str = "vllm_inference_v1_generate";
 
+/// Worker capability for exact multimodal KV routing on vLLM's Generate API.
+pub const VLLM_EXACT_MM_ROUTING_CAPABILITY: &str = "vllm_exact_mm_routing";
+
 /// Tokenizer backend used by the Rust preprocessor for BPE tokenizer.json models.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]

--- a/lib/llm/src/model_card.rs
+++ b/lib/llm/src/model_card.rs
@@ -18,7 +18,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::common::checked_file::CheckedFile;
 use crate::entrypoint::RouterConfig;
-use crate::local_model::runtime_config::ModelRuntimeConfig;
+use crate::local_model::runtime_config::{ModelRuntimeConfig, VLLM_EXACT_MM_ROUTING_CAPABILITY};
 use crate::model_type::{ModelInput, ModelType};
 use crate::protocols::tensor::TensorModelConfig;
 use anyhow::{Context, Result};
@@ -1138,6 +1138,22 @@ impl ModelDeploymentCard {
                     append_indexer_identity_checksum(&mut bytes_to_hash, identity);
                 }
 
+                // A WorkerSet keeps the first worker's model card for request-side
+                // routing metadata. Exact-MM-capable and legacy workers therefore
+                // cannot safely share a set: whichever arrives first would make the
+                // entire set advertise its capability. Preserve the legacy checksum
+                // for absent/false values, but force a drain-and-redeploy boundary
+                // when the capability is enabled.
+                if self
+                    .runtime_config
+                    .runtime_data
+                    .get(VLLM_EXACT_MM_ROUTING_CAPABILITY)
+                    .and_then(serde_json::Value::as_bool)
+                    .unwrap_or(false)
+                {
+                    bytes_to_hash.extend_from_slice(b"dynamo/model-card/vllm-exact-mm-routing/v1");
+                }
+
                 // Aliases participate in the checksum. Every worker in a
                 // deployment carries the same static --served-model-name list,
                 // so their checksums still match and they share one WorkerSet;
@@ -1157,7 +1173,7 @@ impl ModelDeploymentCard {
                     }
                 }
 
-                // TODO: Do we want any of user_data or runtime_config?
+                // TODO: Do we want any of user_data or the rest of runtime_config?
 
                 blake3::hash(&bytes_to_hash).to_string()
             })

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -92,6 +92,10 @@ impl GenerateRequest {
             return Err("sampling_params.max_tokens must be greater than 0.".to_string());
         }
 
+        if self.sampling_params.top_k().is_some_and(|top_k| top_k < -1) {
+            return Err("sampling_params.top_k must be non-negative or -1.".to_string());
+        }
+
         if let Some(prompt_logprobs) = self.sampling_params.prompt_logprobs() {
             if prompt_logprobs < 0 && prompt_logprobs != -1 {
                 return Err(
@@ -151,7 +155,8 @@ pub struct SamplingParams {
     // reads only the controls it needs; `raw` remains authoritative.
     temperature: Option<f32>,
     top_p: Option<f32>,
-    top_k: Option<u32>,
+    // vLLM uses -1 as the sentinel for disabling top-k sampling.
+    top_k: Option<i64>,
     seed: Option<i64>,
     max_tokens: Option<u32>,
     min_tokens: Option<u32>,
@@ -178,6 +183,10 @@ pub struct SamplingParams {
 impl SamplingParams {
     pub fn max_tokens(&self) -> Option<u32> {
         self.max_tokens
+    }
+
+    pub fn top_k(&self) -> Option<i64> {
+        self.top_k
     }
 
     pub fn min_tokens(&self) -> Option<u32> {
@@ -722,6 +731,21 @@ mod tests {
     }
 
     #[test]
+    fn generate_request_preserves_disabled_top_k_sentinel() {
+        let raw_sampling = json!({"top_k": -1});
+        let req: GenerateRequest = serde_json::from_value(json!({
+            "token_ids": [5, 6],
+            "sampling_params": raw_sampling.clone()
+        }))
+        .expect("deserialize");
+
+        assert_eq!(req.sampling_params.top_k, Some(-1));
+        assert_eq!(req.sampling_params.as_value(), &raw_sampling);
+        let back = serde_json::to_value(&req).expect("serialize");
+        assert_eq!(back["sampling_params"], raw_sampling);
+    }
+
+    #[test]
     fn generate_request_matches_rust_integer_types() {
         for raw in [
             json!({
@@ -732,10 +756,6 @@ mod tests {
             json!({
                 "token_ids": [1],
                 "sampling_params": {"max_tokens": -1}
-            }),
-            json!({
-                "token_ids": [1],
-                "sampling_params": {"top_k": -1}
             }),
             json!({
                 "token_ids": [1],
@@ -770,6 +790,13 @@ mod tests {
                     "sampling_params": {"prompt_logprobs": -2}
                 }),
                 "prompt_logprobs",
+            ),
+            (
+                json!({
+                    "token_ids": [1],
+                    "sampling_params": {"top_k": -2}
+                }),
+                "top_k",
             ),
             (
                 json!({

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -181,6 +181,14 @@ pub struct SamplingParams {
 }
 
 impl SamplingParams {
+    pub fn temperature(&self) -> Option<f32> {
+        self.temperature
+    }
+
+    pub fn top_p(&self) -> Option<f32> {
+        self.top_p
+    }
+
     pub fn max_tokens(&self) -> Option<u32> {
         self.max_tokens
     }
@@ -189,8 +197,32 @@ impl SamplingParams {
         self.top_k
     }
 
+    pub fn min_p(&self) -> Option<f32> {
+        self.min_p
+    }
+
+    pub fn seed(&self) -> Option<i64> {
+        self.seed
+    }
+
     pub fn min_tokens(&self) -> Option<u32> {
         self.min_tokens
+    }
+
+    pub fn frequency_penalty(&self) -> Option<f32> {
+        self.frequency_penalty
+    }
+
+    pub fn presence_penalty(&self) -> Option<f32> {
+        self.presence_penalty
+    }
+
+    pub fn repetition_penalty(&self) -> Option<f32> {
+        self.repetition_penalty
+    }
+
+    pub fn stop_token_ids(&self) -> Option<&[u32]> {
+        self.stop_token_ids.as_deref()
     }
 
     pub fn ignore_eos(&self) -> bool {
@@ -203,6 +235,10 @@ impl SamplingParams {
 
     pub fn prompt_logprobs(&self) -> Option<i32> {
         self.prompt_logprobs
+    }
+
+    pub fn skip_reading_prefix_cache(&self) -> Option<bool> {
+        self.skip_reading_prefix_cache
     }
 
     pub fn as_value(&self) -> &Value {

--- a/lib/llm/src/protocols/openai/generate.rs
+++ b/lib/llm/src/protocols/openai/generate.rs
@@ -78,6 +78,12 @@ impl GenerateRequest {
         }
     }
 
+    pub(crate) fn resolved_cache_salt(&self) -> Option<&str> {
+        self.cache_salt
+            .as_deref()
+            .or_else(|| self.sampling_params.cache_salt())
+    }
+
     /// Validate the request-level rules enforced by vLLM's Rust generate route.
     pub fn validate(&self) -> Result<(), String> {
         if self.token_ids.is_empty() {
@@ -118,6 +124,16 @@ impl GenerateRequest {
             return Err(format!(
                 "sampling_params.min_tokens ({min_tokens}) exceeds max_tokens ({max_tokens})."
             ));
+        }
+
+        if let (Some(top_level), Some(nested)) = (
+            self.cache_salt.as_deref(),
+            self.sampling_params.cache_salt(),
+        ) && top_level != nested
+        {
+            return Err(
+                "sampling_params.cache_salt conflicts with the top-level cache_salt.".to_string(),
+            );
         }
 
         Ok(())
@@ -177,6 +193,7 @@ pub struct SamplingParams {
     /// typed view opaque avoids duplicating version-specific vLLM validation.
     structured_outputs: Option<Value>,
     skip_reading_prefix_cache: Option<bool>,
+    cache_salt: Option<String>,
     vllm_xargs: Option<HashMap<String, Value>>,
 }
 
@@ -241,6 +258,10 @@ impl SamplingParams {
         self.skip_reading_prefix_cache
     }
 
+    pub fn cache_salt(&self) -> Option<&str> {
+        self.cache_salt.as_deref()
+    }
+
     pub fn as_value(&self) -> &Value {
         &self.raw
     }
@@ -299,6 +320,7 @@ impl<'de> Deserialize<'de> for SamplingParams {
             logprob_token_ids: field!(logprob_token_ids),
             structured_outputs: field!(structured_outputs),
             skip_reading_prefix_cache: field!(skip_reading_prefix_cache),
+            cache_salt: field!(cache_salt),
             vllm_xargs: field!(vllm_xargs),
             raw,
         })
@@ -840,6 +862,14 @@ mod tests {
                     "sampling_params": {"min_tokens": 3, "max_tokens": 2}
                 }),
                 "min_tokens",
+            ),
+            (
+                json!({
+                    "token_ids": [1],
+                    "sampling_params": {"cache_salt": "policy-1"},
+                    "cache_salt": "policy-2"
+                }),
+                "cache_salt",
             ),
         ];
 

--- a/lib/mocker/servers/vllm/README.md
+++ b/lib/mocker/servers/vllm/README.md
@@ -11,7 +11,7 @@ KV-capacity, prefix-cache, and timing behavior. Its primary purpose is fast,
 repeatable testing of `dynamo-vllm-sidecar` without a model or GPU.
 
 The mock server temporarily imports the generated types exposed by
-`dynamo-vllm-sidecar`, whose proto is vendored unchanged from vLLM v0.25.1.
+`dynamo-vllm-sidecar`, whose `Inference` and `Control` protos are vendored unchanged from the compatible vLLM source revision recorded in the sidecar proto README.
 Both consumers will move to vLLM's upstream package once it is published.
 
 ## Aggregated serving

--- a/lib/mocker/servers/vllm/src/main.rs
+++ b/lib/mocker/servers/vllm/src/main.rs
@@ -7,7 +7,8 @@ use anyhow::Context;
 use clap::Parser;
 use dynamo_mocker::common::protocols::MockEngineArgs;
 use dynamo_vllm_mocker::{MockerServerConfig, ServerMode, VllmMockerService};
-use dynamo_vllm_sidecar::proto::generate_server::GenerateServer;
+use dynamo_vllm_sidecar::proto::control_server::ControlServer;
+use dynamo_vllm_sidecar::proto::inference_server::InferenceServer;
 
 #[derive(Parser, Debug)]
 #[command(
@@ -82,7 +83,8 @@ async fn main() -> anyhow::Result<()> {
         "starting Mocker-backed vLLM gRPC server"
     );
     tonic::transport::Server::builder()
-        .add_service(GenerateServer::new(service))
+        .add_service(InferenceServer::new(service.clone()))
+        .add_service(ControlServer::new(service))
         .serve_with_shutdown(args.listen, async {
             let _ = tokio::signal::ctrl_c().await;
         })

--- a/lib/mocker/servers/vllm/src/server.rs
+++ b/lib/mocker/servers/vllm/src/server.rs
@@ -125,7 +125,7 @@ impl VllmMockerService {
 }
 
 #[tonic::async_trait]
-impl pb::generate_server::Generate for VllmMockerService {
+impl pb::inference_server::Inference for VllmMockerService {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send + 'static>>;
 
@@ -206,6 +206,100 @@ impl pb::generate_server::Generate for VllmMockerService {
             ))?;
         };
         Ok(Response::new(Box::pin(stream)))
+    }
+}
+
+#[tonic::async_trait]
+impl pb::control_server::Control for VllmMockerService {
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::ServerInfo>, Status> {
+        Ok(Response::new(pb::ServerInfo {
+            engine_version: "dynamo-mocker".to_string(),
+            api_version: "vllm".to_string(),
+            instance_id: format!("mocker-{}", self.config.mode),
+            parallelism: Some(pb::ParallelismInfo {
+                tensor_parallel_size: 1,
+                pipeline_parallel_size: 1,
+                data_parallel_size: 1,
+                data_parallel_rank: 0,
+                decode_context_parallel_size: 1,
+                data_parallel_start_rank: 0,
+                managed_data_parallel_size: 1,
+            }),
+            max_model_len: 4096,
+            kv_block_size: 16,
+            total_kv_blocks: 4096,
+            max_running_requests: self.config.max_concurrent_requests as u64,
+            max_batched_tokens: 8192,
+            max_loras: 0,
+            capabilities: vec![
+                "generate.sampling.v2".to_string(),
+                "generate.preprocessed_mm.v1".to_string(),
+                "generate.routed_experts.v1".to_string(),
+            ],
+        }))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::ModelInfo>, Status> {
+        Ok(Response::new(pb::ModelInfo {
+            model_id: self.config.model.clone(),
+            served_model_name: self.config.model.clone(),
+            served_model_aliases: Vec::new(),
+            tokenizer_modes: vec!["auto".to_string()],
+            supports_text_input: true,
+            supports_token_ids_input: true,
+            supports_lora: false,
+            supports_multimodal: false,
+            reasoning_parser: String::new(),
+            tool_call_parser: String::new(),
+        }))
+    }
+
+    async fn abort(
+        &self,
+        _request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        Err(Status::unimplemented("abort"))
+    }
+
+    async fn drain(
+        &self,
+        _request: Request<pb::DrainRequest>,
+    ) -> Result<Response<pb::DrainResponse>, Status> {
+        Err(Status::unimplemented("drain"))
+    }
+
+    async fn load_lora(
+        &self,
+        _request: Request<pb::LoadLoraRequest>,
+    ) -> Result<Response<pb::LoadLoraResponse>, Status> {
+        Err(Status::unimplemented("load_lora"))
+    }
+
+    async fn unload_lora(
+        &self,
+        _request: Request<pb::UnloadLoraRequest>,
+    ) -> Result<Response<pb::UnloadLoraResponse>, Status> {
+        Err(Status::unimplemented("unload_lora"))
+    }
+
+    async fn list_loras(
+        &self,
+        _request: Request<pb::ListLorasRequest>,
+    ) -> Result<Response<pb::ListLorasResponse>, Status> {
+        Err(Status::unimplemented("list_loras"))
+    }
+
+    async fn get_kv_event_sources(
+        &self,
+        _request: Request<pb::GetKvEventSourcesRequest>,
+    ) -> Result<Response<pb::GetKvEventSourcesResponse>, Status> {
+        Err(Status::unimplemented("get_kv_event_sources"))
     }
 }
 

--- a/lib/mocker/servers/vllm/src/server_request.rs
+++ b/lib/mocker/servers/vllm/src/server_request.rs
@@ -292,6 +292,7 @@ impl PreparedRequest {
                 stop_reason: None,
                 kv_transfer_params: (self.mode == ServerMode::Prefill).then(|| self.handoff()),
             }),
+            routed_experts: None,
         }
     }
 

--- a/lib/mocker/servers/vllm/src/server_tests.rs
+++ b/lib/mocker/servers/vllm/src/server_tests.rs
@@ -219,7 +219,7 @@ async fn unary_generate_maps_capacity_rejection_to_resource_exhausted() {
         ids: vec![1, 2, 3, 4, 5],
     }));
 
-    let error = pb::generate_server::Generate::generate(&service, Request::new(oversized))
+    let error = pb::inference_server::Inference::generate(&service, Request::new(oversized))
         .await
         .unwrap_err();
     assert_eq!(error.code(), tonic::Code::ResourceExhausted);
@@ -245,18 +245,18 @@ async fn concurrent_request_limit_rejects_a_stalled_stream() {
     let mut first_request = request("stalled");
     first_request.stopping.as_mut().unwrap().max_new_tokens = 100;
     let first =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(first_request))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(first_request))
             .await
             .unwrap();
 
     let mut queued_request = request("queued");
     queued_request.stopping.as_mut().unwrap().max_new_tokens = 100;
     let queued =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(queued_request))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(queued_request))
             .await
             .unwrap();
 
-    let error = match pb::generate_server::Generate::generate_stream(
+    let error = match pb::inference_server::Inference::generate_stream(
         &service,
         Request::new(request("rejected")),
     )
@@ -312,7 +312,7 @@ async fn unary_generate_accumulates_output_and_terminal_metadata() {
     let service = VllmMockerService::new(MockerServerConfig::default(), admitting_args()).unwrap();
 
     let response =
-        pb::generate_server::Generate::generate(&service, Request::new(request("unary")))
+        pb::inference_server::Inference::generate(&service, Request::new(request("unary")))
             .await
             .unwrap()
             .into_inner();
@@ -355,7 +355,7 @@ async fn streaming_generate_maps_capacity_rejection_to_resource_exhausted() {
     }));
 
     let mut stream =
-        pb::generate_server::Generate::generate_stream(&service, Request::new(oversized))
+        pb::inference_server::Inference::generate_stream(&service, Request::new(oversized))
             .await
             .expect("streaming RPC opens before the scheduler rejects")
             .into_inner();
@@ -384,10 +384,11 @@ async fn streaming_survives_a_producer_that_outruns_a_stalled_consumer() {
     let mut bursty = request("bursty");
     bursty.stopping.as_mut().unwrap().max_new_tokens = 50;
 
-    let mut stream = pb::generate_server::Generate::generate_stream(&service, Request::new(bursty))
-        .await
-        .unwrap()
-        .into_inner();
+    let mut stream =
+        pb::inference_server::Inference::generate_stream(&service, Request::new(bursty))
+            .await
+            .unwrap()
+            .into_inner();
 
     // Stall the consumer so the instant producer fills and overflows the fixed
     // per-request buffer before we read anything.

--- a/lib/mocker/servers/vllm/tests/sidecar.rs
+++ b/lib/mocker/servers/vllm/tests/sidecar.rs
@@ -10,7 +10,8 @@ use dynamo_backend_common::{
 use dynamo_mocker::common::protocols::MockEngineArgs;
 use dynamo_vllm_mocker::{MockerServerConfig, ServerMode, VllmMockerService};
 use dynamo_vllm_sidecar::VllmSidecarEngine;
-use dynamo_vllm_sidecar::proto::generate_server::GenerateServer;
+use dynamo_vllm_sidecar::proto::control_server::ControlServer;
+use dynamo_vllm_sidecar::proto::inference_server::InferenceServer;
 use futures::StreamExt;
 use tokio::net::TcpListener;
 use tokio::sync::oneshot;
@@ -38,7 +39,8 @@ impl RunningServer {
         let server_service = service.clone();
         tokio::spawn(async move {
             tonic::transport::Server::builder()
-                .add_service(GenerateServer::new(server_service))
+                .add_service(InferenceServer::new(server_service.clone()))
+                .add_service(ControlServer::new(server_service))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })
@@ -129,7 +131,7 @@ async fn collect(
         .await
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn sidecar_streams_mocker_tokens_logprobs_and_usage() {
     let server = RunningServer::start(ServerMode::Aggregated, fast_engine_args()).await;
     let engine = sidecar(&server.endpoint, DisaggregationMode::Aggregated);
@@ -156,7 +158,7 @@ async fn sidecar_streams_mocker_tokens_logprobs_and_usage() {
     assert_eq!(server.service.active_request_count(), 0);
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn prefill_handoff_round_trips_through_a_decode_server() {
     let prefill_server = RunningServer::start(ServerMode::Prefill, fast_engine_args()).await;
     let decode_server = RunningServer::start(ServerMode::Decode, fast_engine_args()).await;
@@ -194,7 +196,7 @@ async fn prefill_handoff_round_trips_through_a_decode_server() {
     );
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dropping_sidecar_stream_cancels_mocker_work() {
     let mut args = fast_engine_args();
     args.speedup_ratio = 0.1;

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -12,7 +12,7 @@
 //!
 //! This crate exposes a read-only frontend route. The frontend discovers live
 //! `rl` endpoint instances from Dynamo discovery, then asks each worker for its
-//! available RL admin routes with `{"method": "routes"}` over the request
+//! available Dynamo system routes with `{"method": "routes"}` over the request
 //! plane. It does not expose a frontend fan-out method endpoint.
 
 use std::{
@@ -40,6 +40,7 @@ const DEFAULT_REQUEST_TIMEOUT_SECS: u64 = 30;
 /// Global cap on concurrent per-worker probes (across all in-flight discovery
 /// requests), so a large fleet or many concurrent callers can't fan out without bound.
 const DEFAULT_MAX_CONCURRENT_PROBES: usize = 32;
+pub const RL_WORKERS_PROTOCOL_VERSION: u32 = 1;
 
 type ModelKey = (String, String, u64);
 
@@ -104,7 +105,14 @@ pub struct RlWorkerInfo {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub system_url: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub admin_base_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub world_size: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
+    pub system_routes: Vec<String>,
+    /// Deprecated alias of `system_routes`, emitted for protocol-v1 consumers
+    /// predating the rename. Always identical to `system_routes`; remove in v2.
     pub routes: Vec<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
@@ -112,6 +120,7 @@ pub struct RlWorkerInfo {
 
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct RlWorkersResponse {
+    pub protocol_version: u32,
     pub namespace: String,
     pub workers: Vec<RlWorkerInfo>,
 }
@@ -195,6 +204,7 @@ pub fn rl_router(state: RlDiscoveryState) -> Router {
 async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResponse {
     match list_workers(&state).await {
         Ok(workers) => Json(RlWorkersResponse {
+            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
             namespace: state.config.namespace.clone(),
             workers,
         })
@@ -229,8 +239,7 @@ async fn list_workers(state: &RlDiscoveryState) -> anyhow::Result<Vec<RlWorkerIn
         .list(DiscoveryQuery::NamespacedModels {
             namespace: config.namespace.clone(),
         })
-        .await
-        .unwrap_or_default();
+        .await?;
 
     let models = model_map(model_instances);
     let rl_endpoints = endpoint_instances
@@ -315,12 +324,33 @@ async fn describe_worker(
         call_worker_routes(state, &endpoint, timeout).await
     };
     match tokio::time::timeout(timeout, probe).await {
-        Ok(Ok(routes)) => worker_info(endpoint, model, routes.routes, routes.system_url, None),
-        Ok(Err(err)) => worker_info(endpoint, model, Vec::new(), None, Some(err.to_string())),
+        Ok(Ok(routes)) => {
+            let model = resolve_worker_model(model, routes.model);
+            worker_info(
+                endpoint,
+                model,
+                routes.routes,
+                routes.system_url,
+                routes.admin_base_url,
+                routes.world_size,
+                None,
+            )
+        }
+        Ok(Err(err)) => worker_info(
+            endpoint,
+            model,
+            Vec::new(),
+            None,
+            None,
+            None,
+            Some(err.to_string()),
+        ),
         Err(_) => worker_info(
             endpoint,
             model,
             Vec::new(),
+            None,
+            None,
             None,
             Some(format!(
                 "worker discovery timed out after {}s",
@@ -334,6 +364,9 @@ async fn describe_worker(
 struct WorkerRoutes {
     routes: Vec<String>,
     system_url: Option<String>,
+    admin_base_url: Option<String>,
+    world_size: Option<u32>,
+    model: Option<String>,
 }
 
 async fn call_worker_routes(
@@ -440,18 +473,59 @@ fn parse_worker_routes(value: serde_json::Value) -> anyhow::Result<WorkerRoutes>
         .filter(|url| !url.is_empty())
         .map(ToString::to_string);
 
-    Ok(WorkerRoutes { routes, system_url })
+    let admin_base_url = value
+        .get("admin_base_url")
+        .and_then(|url| url.as_str())
+        .map(str::trim)
+        .filter(|url| !url.is_empty())
+        .map(ToString::to_string);
+    let world_size = match value.get("world_size") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(value) => Some(
+            value
+                .as_u64()
+                .and_then(|size| u32::try_from(size).ok())
+                .filter(|size| *size > 0)
+                .ok_or_else(|| {
+                    anyhow::anyhow!("worker routes response has invalid 'world_size'")
+                })?,
+        ),
+    };
+    let model = match value.get("model") {
+        None | Some(serde_json::Value::Null) => None,
+        Some(serde_json::Value::String(model)) if !model.trim().is_empty() => {
+            Some(model.trim().to_string())
+        }
+        Some(_) => anyhow::bail!("worker routes response has invalid 'model'"),
+    };
+
+    Ok(WorkerRoutes {
+        routes,
+        system_url,
+        admin_base_url,
+        world_size,
+        model,
+    })
+}
+
+fn resolve_worker_model(
+    discovered_model: Option<String>,
+    explicit_model: Option<String>,
+) -> Option<String> {
+    explicit_model.or(discovered_model)
 }
 
 fn worker_info(
     endpoint: Instance,
     model: Option<String>,
-    mut routes: Vec<String>,
+    mut system_routes: Vec<String>,
     system_url: Option<String>,
+    admin_base_url: Option<String>,
+    world_size: Option<u32>,
     error: Option<String>,
 ) -> RlWorkerInfo {
-    routes.sort();
-    routes.dedup();
+    system_routes.sort();
+    system_routes.dedup();
 
     RlWorkerInfo {
         request_plane_url: request_plane_url(&endpoint),
@@ -461,8 +535,11 @@ fn worker_info(
         instance_id: endpoint.instance_id,
         transport: endpoint.transport,
         system_url,
+        admin_base_url,
+        world_size,
         model,
-        routes,
+        routes: system_routes.clone(),
+        system_routes,
         error,
     }
 }
@@ -514,6 +591,42 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    #[test]
+    fn worker_response_names_dynamo_capabilities_system_routes() {
+        let worker = RlWorkerInfo {
+            namespace: "dynamo".to_string(),
+            component: "backend".to_string(),
+            endpoint: "rl".to_string(),
+            instance_id: 1,
+            transport: TransportType::Tcp("127.0.0.1:1".to_string()),
+            request_plane_url: "dyn://dynamo.backend.rl".to_string(),
+            system_url: Some("http://worker:8181".to_string()),
+            admin_base_url: Some("http://worker:8120".to_string()),
+            world_size: Some(2),
+            model: Some("model".to_string()),
+            system_routes: vec!["update/load_lora".to_string()],
+            routes: vec!["update/load_lora".to_string()],
+            error: None,
+        };
+
+        let value = serde_json::to_value(worker).unwrap();
+        assert_eq!(value["system_routes"], json!(["update/load_lora"]));
+        // `routes` is retained as a deprecated alias so protocol-v1 consumers
+        // predating the rename keep working; it must mirror `system_routes`.
+        assert_eq!(value["routes"], value["system_routes"]);
+    }
+
+    #[test]
+    fn workers_response_advertises_protocol_version() {
+        let response = RlWorkersResponse {
+            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
+            namespace: "dynamo".to_string(),
+            workers: Vec::new(),
+        };
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["protocol_version"], json!(1));
+    }
+
     fn model_instance(
         namespace: &str,
         component: &str,
@@ -537,12 +650,56 @@ mod tests {
         let parsed = parse_worker_routes(json!({
             "routes": ["pause_generation", "resume_generation"],
             "system_url": "  http://worker:8080  ",
+            "admin_base_url": "  http://worker:8120  ",
+            "world_size": 2,
+            "model": "  Qwen/Qwen3-0.6B  ",
         }))
         .expect("valid payload");
         let routes: Vec<&str> = parsed.routes.iter().map(String::as_str).collect();
         assert_eq!(routes, ["pause_generation", "resume_generation"]);
         // system_url is trimmed.
         assert_eq!(parsed.system_url.as_deref(), Some("http://worker:8080"));
+        assert_eq!(parsed.admin_base_url.as_deref(), Some("http://worker:8120"));
+        assert_eq!(parsed.world_size, Some(2));
+        assert_eq!(parsed.model.as_deref(), Some("Qwen/Qwen3-0.6B"));
+    }
+
+    #[test]
+    fn explicit_worker_model_wins_over_served_model_alias() {
+        assert_eq!(
+            resolve_worker_model(
+                Some("prime-thunderagent-backend".to_string()),
+                Some("Qwen/Qwen3-0.6B".to_string()),
+            )
+            .as_deref(),
+            Some("Qwen/Qwen3-0.6B")
+        );
+    }
+
+    #[test]
+    fn parse_worker_routes_rejects_invalid_model_metadata() {
+        for model in [serde_json::json!("   "), serde_json::json!(42)] {
+            let error = parse_worker_routes(serde_json::json!({
+                "status": "ok",
+                "routes": [],
+                "model": model,
+            }))
+            .expect_err("invalid model metadata must be rejected");
+            assert!(error.to_string().contains("invalid 'model'"));
+        }
+    }
+
+    #[test]
+    fn parse_worker_routes_rejects_invalid_world_size() {
+        for world_size in [json!(0), json!(-1), json!("2")] {
+            let err = parse_worker_routes(json!({
+                "routes": [],
+                "admin_base_url": "http://worker:8120",
+                "world_size": world_size,
+            }))
+            .unwrap_err();
+            assert!(err.to_string().contains("world_size"));
+        }
     }
 
     #[test]

--- a/lib/rl/src/lib.rs
+++ b/lib/rl/src/lib.rs
@@ -125,6 +125,17 @@ pub struct RlWorkersResponse {
     pub workers: Vec<RlWorkerInfo>,
 }
 
+impl RlWorkersResponse {
+    fn new(namespace: String, mut workers: Vec<RlWorkerInfo>) -> Self {
+        workers.retain(|worker| worker.model.is_some());
+        Self {
+            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
+            namespace,
+            workers,
+        }
+    }
+}
+
 type EndpointKey = (String, String, String);
 
 #[derive(Clone)]
@@ -203,11 +214,10 @@ pub fn rl_router(state: RlDiscoveryState) -> Router {
 
 async fn workers_handler(State(state): State<RlDiscoveryState>) -> impl IntoResponse {
     match list_workers(&state).await {
-        Ok(workers) => Json(RlWorkersResponse {
-            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
-            namespace: state.config.namespace.clone(),
+        Ok(workers) => Json(RlWorkersResponse::new(
+            state.config.namespace.clone(),
             workers,
-        })
+        ))
         .into_response(),
         Err(err) => {
             tracing::error!("failed to list RL workers: {err}");
@@ -617,14 +627,33 @@ mod tests {
     }
 
     #[test]
-    fn workers_response_advertises_protocol_version() {
-        let response = RlWorkersResponse {
-            protocol_version: RL_WORKERS_PROTOCOL_VERSION,
+    fn workers_response_advertises_protocol_version_and_omits_unbound_workers() {
+        let bound = RlWorkerInfo {
             namespace: "dynamo".to_string(),
-            workers: Vec::new(),
+            component: "backend".to_string(),
+            endpoint: "rl".to_string(),
+            instance_id: 1,
+            transport: TransportType::Tcp("127.0.0.1:1".to_string()),
+            request_plane_url: "dyn://dynamo.backend.rl".to_string(),
+            system_url: Some("http://worker:8181".to_string()),
+            admin_base_url: Some("http://worker:8120".to_string()),
+            world_size: Some(2),
+            model: Some("model".to_string()),
+            system_routes: Vec::new(),
+            routes: Vec::new(),
+            error: None,
         };
+        let unbound = RlWorkerInfo {
+            instance_id: 2,
+            model: None,
+            ..bound.clone()
+        };
+
+        let response = RlWorkersResponse::new("dynamo".to_string(), vec![unbound, bound]);
         let value = serde_json::to_value(response).unwrap();
         assert_eq!(value["protocol_version"], json!(1));
+        assert_eq!(value["workers"].as_array().unwrap().len(), 1);
+        assert_eq!(value["workers"][0]["model"], json!("model"));
     }
 
     fn model_instance(

--- a/lib/sidecar/vllm/Cargo.toml
+++ b/lib/sidecar/vllm/Cargo.toml
@@ -21,6 +21,8 @@ path = "src/main.rs"
 
 [dependencies]
 dynamo-backend-common = { workspace = true }
+dynamo-llm = { workspace = true }
+dynamo-runtime = { workspace = true }
 dynamo-sidecar-common = { workspace = true }
 
 anyhow = { workspace = true }
@@ -32,6 +34,7 @@ serde_json = { workspace = true }
 tokio = { workspace = true }
 tokio-util = { workspace = true }
 tracing = { workspace = true }
+url = { workspace = true }
 
 prost = { workspace = true }
 prost-types = { workspace = true }

--- a/lib/sidecar/vllm/build.rs
+++ b/lib/sidecar/vllm/build.rs
@@ -4,7 +4,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .protoc_arg("--experimental_allow_proto3_optional")
-        .compile_protos(&["proto/vllm_grpc.proto"], &["proto"])?;
-    println!("cargo:rerun-if-changed=proto/vllm_grpc.proto");
+        .compile_protos(
+            &["proto/inference.proto", "proto/control.proto"],
+            &["proto"],
+        )?;
+    println!("cargo:rerun-if-changed=proto/inference.proto");
+    println!("cargo:rerun-if-changed=proto/control.proto");
     Ok(())
 }

--- a/lib/sidecar/vllm/proto/README.md
+++ b/lib/sidecar/vllm/proto/README.md
@@ -5,12 +5,9 @@ SPDX-License-Identifier: Apache-2.0
 
 # Vendored vLLM protocol
 
-- Source: `rust/proto/vllm_grpc.proto`
-- Release: `v0.25.1`
-- Commit: `752a3a504485790a2e8491cacbb35c137339ad34`
-- SHA-256: `7cccd0e1b2e54f189550e1090cc80321fc2bbd188c98a4e22701b28fdeb177b6`
+- Sources: `rust/proto/inference.proto` and `rust/proto/control.proto`
+- Commit: `a0d13bb5e70487ea5cb59ca43444ac14c3aaddef`
+- `inference.proto` SHA-256: `09fca71821b9c8a4f1a7196960fc301fca7cd967847cb88c59b164f26167faca`
+- `control.proto` SHA-256: `57917ab1ac0be8f5216b041167903d650be408bcb8b0b8cc4c8a78e591c1cc5c`
 
-The file is copied without modification. Update the revision and checksum when
-updating the protocol. `dynamo-vllm-sidecar` generates and temporarily exports
-these types for `dynamo-vllm-mocker-server`; both consumers will move to the
-upstream package once vLLM publishes it.
+The files are copied without modification. Update the revision and checksums when updating the protocol. `dynamo-vllm-sidecar` generates and temporarily exports these types for `dynamo-vllm-mocker-server`; both consumers will move to the upstream package once vLLM publishes it.

--- a/lib/sidecar/vllm/proto/control.proto
+++ b/lib/sidecar/vllm/proto/control.proto
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+syntax = "proto3";
+package vllm;
+
+service Control {
+  rpc GetServerInfo (GetServerInfoRequest) returns (ServerInfo) {}
+  rpc GetModelInfo (GetModelInfoRequest) returns (ModelInfo) {}
+  rpc Abort (AbortRequest) returns (AbortResponse) {}
+  rpc Drain (DrainRequest) returns (DrainResponse) {}
+
+  rpc LoadLora (LoadLoraRequest) returns (LoadLoraResponse) {}
+  rpc UnloadLora (UnloadLoraRequest) returns (UnloadLoraResponse) {}
+  rpc ListLoras (ListLorasRequest) returns (ListLorasResponse) {}
+
+  rpc GetKvEventSources (GetKvEventSourcesRequest) returns (GetKvEventSourcesResponse) {}
+}
+
+message GetServerInfoRequest {}
+
+message ServerInfo {
+  string engine_version = 1;
+  string api_version = 2;
+  string instance_id = 3;
+  ParallelismInfo parallelism = 4;
+  uint32 max_model_len = 5;
+  uint32 kv_block_size = 6;
+  uint64 total_kv_blocks = 7;
+  uint64 max_running_requests = 8;
+  uint64 max_batched_tokens = 9;
+  uint32 max_loras = 10;
+  repeated string capabilities = 11;
+}
+
+message ParallelismInfo {
+  uint32 tensor_parallel_size = 1;
+  uint32 pipeline_parallel_size = 2;
+  uint32 data_parallel_size = 3;
+  uint32 data_parallel_rank = 4;
+  uint32 decode_context_parallel_size = 5;
+  uint32 data_parallel_start_rank = 6;
+  uint32 managed_data_parallel_size = 7;
+}
+
+message GetModelInfoRequest {}
+
+message ModelInfo {
+  string model_id = 1;
+  string served_model_name = 2;
+  repeated string served_model_aliases = 3;
+  repeated string tokenizer_modes = 4;
+
+  bool supports_text_input = 20;
+  bool supports_token_ids_input = 21;
+  bool supports_lora = 22;
+  bool supports_multimodal = 23;
+  string reasoning_parser = 24;
+  string tool_call_parser = 25;
+}
+
+message AbortRequest {
+  repeated string request_ids = 1;
+}
+
+message AbortResponse {}
+
+message DrainRequest {}
+
+message DrainResponse {
+  DrainState state = 1;
+  uint32 in_flight_requests = 2;
+  string message = 3;
+}
+
+enum DrainState {
+  DRAIN_STATE_UNSPECIFIED = 0;
+  DRAIN_STATE_IN_PROGRESS = 1;
+  DRAIN_STATE_COMPLETE = 2;
+}
+
+// ======================================================================================
+// LoRA lifecycle
+// ======================================================================================
+
+message LoraAdapter {
+  int64 lora_id = 1;
+  string lora_name = 2;
+  string source_path = 3;
+}
+
+message LoadLoraRequest {
+  LoraAdapter adapter = 1;
+  bool load_inplace = 2;
+}
+message LoadLoraResponse {
+  LoraAdapter adapter = 1;
+  bool already_loaded = 2;
+}
+message UnloadLoraRequest { string lora_name = 1; }
+message UnloadLoraResponse { LoraAdapter adapter = 1; }
+message ListLorasRequest {}
+message ListLorasResponse { repeated LoraAdapter adapters = 1; }
+
+// ======================================================================================
+// KV discovery
+// ======================================================================================
+
+message GetKvEventSourcesRequest {}
+message GetKvEventSourcesResponse { repeated KvEventSource sources = 1; }
+
+message KvEventEndpoint {
+  string host = 1;
+  uint32 port = 2;
+  string protocol = 3;
+}
+
+message KvEventSource {
+  string transport = 1;
+  KvEventEndpoint endpoint_addr = 2;
+  string topic = 3;
+  string replay_endpoint = 4;
+  optional uint32 data_parallel_rank = 5;
+  string encoding = 6;
+  uint32 schema_version = 7;
+  uint32 buffer_steps = 8;
+  uint32 hwm = 9;
+  uint32 max_queue_size = 10;
+}

--- a/lib/sidecar/vllm/proto/inference.proto
+++ b/lib/sidecar/vllm/proto/inference.proto
@@ -4,7 +4,7 @@ package vllm;
 import "google/protobuf/struct.proto";
 
 
-service Generate {
+service Inference {
   // Generates text given a prompt
   rpc Generate (GenerateRequest) returns (GenerateResponse) {}
   // Generates text given a prompt, streaming the outputs
@@ -42,21 +42,32 @@ message GenerateRequest {
   uint32 truncate_prompt_tokens = 11;
 
   int32 priority = 12;
+
+  // Multimodal inputs aligned with placeholder markers in token_ids.
+  repeated MediaItem media = 13;
+  // Loaded LoRA name; empty selects the base model.
+  string lora_name = 14;
+  // Lossless JSON object for engine-specific vLLM extensions.
+  optional bytes vllm_xargs_json = 15;
+  // Already-processed multimodal features from the token-in/token-out renderer.
+  repeated PreprocessedMultimodalFeature mm_features = 16;
+  // Skip this many prompt-token routing rows in the returned expert tensor.
+  uint32 routed_experts_prompt_start = 17;
 }
 
 message RandomSampling {
   uint32 num_sequences = 1;  // "n", default (0) means 1
-  uint32 top_k = 2;  // 0 means default
-  float top_p = 3;  // 0 means default
-  float min_p = 4;  // 0 means default
+  optional int32 top_k = 2;
+  optional float top_p = 3;
+  optional float min_p = 4;
   optional int64 seed = 5;
 }
 
 message DecodingParameters {
   // Penalties
-  float presence_penalty = 1;  // Default (0.0) means no penalty
-  float frequency_penalty = 2;  // Default (0.0) means no penalty
-  float repetition_penalty = 3;  // Default (0.0) means no penalty
+  optional float presence_penalty = 1;
+  optional float frequency_penalty = 2;
+  optional float repetition_penalty = 3;
   map<uint32, float> logit_bias = 4;
   repeated uint32 allowed_token_ids = 5;
 
@@ -73,6 +84,10 @@ message DecodingParameters {
     bool json_object = 10;
     string structural_tag = 11;
   }
+  bool structured_output_disable_any_whitespace = 12;
+  bool structured_output_disable_additional_properties = 13;
+  optional string structured_output_whitespace_pattern = 14;
+  repeated string bad_words = 15;
 }
 
 message StoppingCriteria {
@@ -86,6 +101,7 @@ message StoppingCriteria {
   bool include_stop_strings = 5;
 
   bool ignore_eos = 6;
+  optional int64 thinking_token_budget = 7;
 }
 
 message ResponseOptions {
@@ -141,6 +157,13 @@ message SequenceOutput {
 
   // Only present in final output for this sequence
   optional FinishInfo finish_info = 8;
+  optional RoutedExpertsTensor routed_experts = 9;
+}
+
+message RoutedExpertsTensor {
+  string dtype = 1;
+  repeated uint64 shape = 2;
+  bytes data = 3;
 }
 
 // Prompt info, returned in the first response
@@ -192,5 +215,46 @@ message CandidateTokenInfo {
 // Token ids used for prompt
 message TokenIds {
   repeated uint32 ids = 1;
+}
+
+// ======================================================================================
+// Media
+// ======================================================================================
+
+enum Modality {
+  MODALITY_UNSPECIFIED = 0;
+  MODALITY_IMAGE = 1;
+  MODALITY_VIDEO = 2;
+  MODALITY_AUDIO = 3;
+}
+
+message MediaItem {
+  Modality modality = 1;
+  oneof source {
+    string url = 2;
+    string data_uri = 3;
+    bytes raw_bytes = 4;
+  }
+  string mime_type = 5;
+  string uuid = 6;
+}
+
+message MultimodalPlaceholder {
+  uint64 offset = 1;
+  uint64 length = 2;
+  // Empty means every position in the placeholder is an embedding position.
+  repeated bool is_embed = 3;
+}
+
+message PreprocessedMultimodalFeature {
+  string modality = 1;
+  // Canonical modality+kwargs identity. Kept equal to cache_identifier so
+  // Python vLLM cannot prefer an unverified renderer-provided cache key.
+  string mm_hash = 2;
+  MultimodalPlaceholder position = 3;
+  // Python vLLM's inline msgpack encoding. The current gRPC server requires it.
+  optional bytes kwargs_msgpack = 4;
+  // Canonical cache identity derived from modality and kwargs_msgpack.
+  string cache_identifier = 5;
 }
 

--- a/lib/sidecar/vllm/src/args.rs
+++ b/lib/sidecar/vllm/src/args.rs
@@ -16,6 +16,14 @@ pub(crate) struct Args {
     #[arg(long, env = "VLLM_GRPC_ENDPOINT")]
     pub vllm_endpoint: String,
 
+    /// Direct HTTP control endpoint of the same vLLM engine.
+    #[arg(long, env = "VLLM_HTTP_ENDPOINT")]
+    pub admin_endpoint: Option<String>,
+
+    /// Engine-advertised model identity published through RL discovery.
+    #[arg(long, env = "DYN_RL_DISCOVERY_MODEL_NAME")]
+    pub rl_discovery_model_name: Option<String>,
+
     /// Hugging Face model ID or local path used by Dynamo for model-card
     /// registration, tokenization, and chat templates. The released vLLM gRPC
     /// API does not expose this metadata, so it cannot be inferred from the

--- a/lib/sidecar/vllm/src/client.rs
+++ b/lib/sidecar/vllm/src/client.rs
@@ -4,17 +4,42 @@
 use dynamo_backend_common::DynamoError;
 use dynamo_sidecar_common::{
     DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool, GrpcEndpoint, GrpcTransportConfig,
+    connection_timeout,
 };
 
 pub(crate) use dynamo_sidecar_common::{engine_shutdown, invalid_argument, status_to_dynamo};
 
 use crate::proto as pb;
 
+#[derive(Clone, Debug)]
+pub(crate) struct Discovery {
+    pub(crate) server: pb::ServerInfo,
+    pub(crate) model: pb::ModelInfo,
+}
+
 pub(crate) struct VllmClient {
     pool: GrpcChannelPool,
 }
 
 impl VllmClient {
+    pub(crate) async fn connect_and_discover(
+        endpoint: &GrpcEndpoint,
+        transport: GrpcTransportConfig,
+    ) -> Result<(Self, Discovery), DynamoError> {
+        tokio::time::timeout(transport.startup_deadline, async {
+            let client = Self::connect(endpoint, transport).await?;
+            let discovery = client.discover().await?;
+            Ok((client, discovery))
+        })
+        .await
+        .map_err(|_| {
+            connection_timeout(format!(
+                "vLLM gRPC startup deadline {:?} expired during connection or Control discovery",
+                transport.startup_deadline
+            ))
+        })?
+    }
+
     pub(crate) async fn connect(
         endpoint: &GrpcEndpoint,
         transport: GrpcTransportConfig,
@@ -31,7 +56,7 @@ impl VllmClient {
         &self,
         request: pb::GenerateRequest,
     ) -> Result<tonic::Streaming<pb::GenerateResponse>, DynamoError> {
-        let mut client = pb::generate_client::GenerateClient::new(self.pool.next_channel())
+        let mut client = pb::inference_client::InferenceClient::new(self.pool.next_channel())
             .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
             .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
         client
@@ -39,6 +64,23 @@ impl VllmClient {
             .await
             .map(tonic::Response::into_inner)
             .map_err(|status| status_to_dynamo("GenerateStream", status))
+    }
+
+    pub(crate) async fn discover(&self) -> Result<Discovery, DynamoError> {
+        let mut client = pb::control_client::ControlClient::new(self.pool.next_channel())
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+        let server = client
+            .get_server_info(pb::GetServerInfoRequest {})
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(|status| status_to_dynamo("GetServerInfo", status))?;
+        let model = client
+            .get_model_info(pb::GetModelInfoRequest {})
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(|status| status_to_dynamo("GetModelInfo", status))?;
+        Ok(Discovery { server, model })
     }
 }
 

--- a/lib/sidecar/vllm/src/client.rs
+++ b/lib/sidecar/vllm/src/client.rs
@@ -82,6 +82,36 @@ impl VllmClient {
             .map_err(|status| status_to_dynamo("GetModelInfo", status))?;
         Ok(Discovery { server, model })
     }
+
+    pub(crate) async fn load_lora(
+        &self,
+        adapter: pb::LoraAdapter,
+        load_inplace: bool,
+    ) -> Result<pb::LoadLoraResponse, DynamoError> {
+        let mut client = pb::control_client::ControlClient::new(self.pool.next_channel())
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+        client
+            .load_lora(pb::LoadLoraRequest {
+                adapter: Some(adapter),
+                load_inplace,
+            })
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(|status| status_to_dynamo("LoadLora", status))
+    }
+
+    pub(crate) async fn list_loras(&self) -> Result<Vec<pb::LoraAdapter>, DynamoError> {
+        let mut client = pb::control_client::ControlClient::new(self.pool.next_channel())
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE);
+        client
+            .list_loras(pb::ListLorasRequest {})
+            .await
+            .map(tonic::Response::into_inner)
+            .map(|response| response.adapters)
+            .map_err(|status| status_to_dynamo("ListLoras", status))
+    }
 }
 
 pub(crate) fn protocol_error(message: impl Into<String>) -> DynamoError {

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -357,6 +357,7 @@ fn validate_and_remove_vllm_tito(
                 | "prompt_logprobs"
                 | "skip_reading_prefix_cache"
                 | "skip_special_tokens"
+                | "return_token_ids"
         ) {
             return Err(client::invalid_argument(format!(
                 "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC v0.25.1"
@@ -369,6 +370,14 @@ fn validate_and_remove_vllm_tito(
     {
         return Err(client::invalid_argument(
             "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
+        ));
+    }
+    if sampling
+        .get("return_token_ids")
+        .is_some_and(|value| value != &serde_json::Value::Bool(true))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
         ));
     }
 

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -32,6 +32,10 @@ pub(crate) fn build_generate_request(
         request.stop_conditions.min_tokens.unwrap_or(0)
     };
     let mut routing = request.routing;
+    let lora_name = routing
+        .as_mut()
+        .and_then(|routing| routing.lora_name.take())
+        .unwrap_or_default();
     let priority = routing
         .as_ref()
         .and_then(|routing| routing.priority)
@@ -96,7 +100,7 @@ pub(crate) fn build_generate_request(
         truncate_prompt_tokens: 0,
         priority,
         media: Vec::new(),
-        lora_name: String::new(),
+        lora_name,
         vllm_xargs_json: None,
         mm_features: Vec::new(),
         routed_experts_prompt_start: 0,
@@ -454,16 +458,6 @@ fn validate_request(
     if mode.is_encode() {
         return Err(client::invalid_argument(
             "encode mode is not supported by the vLLM sidecar",
-        ));
-    }
-    if request
-        .routing
-        .as_ref()
-        .and_then(|routing| routing.lora_name.as_deref())
-        .is_some_and(|name| !name.is_empty())
-    {
-        return Err(client::invalid_argument(
-            "LoRA request selection is not supported by vLLM gRPC v0.25.1",
         ));
     }
     if request

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -55,17 +55,21 @@ pub(crate) fn build_generate_request(
         sampling: Some(pb::RandomSampling {
             num_sequences: 1,
             top_k: normalize_top_k(sampling.top_k)?,
-            top_p: sampling.top_p.unwrap_or(0.0),
-            min_p: sampling.min_p.unwrap_or(0.0),
+            top_p: sampling.top_p,
+            min_p: sampling.min_p,
             seed: sampling.seed,
         }),
         decoding: Some(pb::DecodingParameters {
-            presence_penalty: sampling.presence_penalty.unwrap_or(0.0),
-            frequency_penalty: sampling.frequency_penalty.unwrap_or(0.0),
-            repetition_penalty: sampling.repetition_penalty.unwrap_or(0.0),
+            presence_penalty: sampling.presence_penalty,
+            frequency_penalty: sampling.frequency_penalty,
+            repetition_penalty: sampling.repetition_penalty,
             logit_bias: Default::default(),
             allowed_token_ids: Vec::new(),
             structured_output: structured_output(sampling.guided_decoding)?,
+            structured_output_disable_any_whitespace: false,
+            structured_output_disable_additional_properties: false,
+            structured_output_whitespace_pattern: None,
+            bad_words: Vec::new(),
         }),
         stopping: Some(pb::StoppingCriteria {
             max_new_tokens,
@@ -77,6 +81,7 @@ pub(crate) fn build_generate_request(
             stop_strings: stop_conditions.stop.unwrap_or_default(),
             include_stop_strings: sampling.include_stop_str_in_output.unwrap_or(false),
             ignore_eos: stop_conditions.ignore_eos.unwrap_or(false),
+            thinking_token_budget: None,
         }),
         response: Some(pb::ResponseOptions {
             prompt_token_ids: prompt_logprobs.is_some(),
@@ -90,6 +95,11 @@ pub(crate) fn build_generate_request(
         kv: Some(kv),
         truncate_prompt_tokens: 0,
         priority,
+        media: Vec::new(),
+        lora_name: String::new(),
+        vllm_xargs_json: None,
+        mm_features: Vec::new(),
+        routed_experts_prompt_start: 0,
     })
 }
 
@@ -104,10 +114,10 @@ fn top_n_candidates(count: u32) -> Result<pb::CandidateTokens, DynamoError> {
     })
 }
 
-fn normalize_top_k(top_k: Option<i32>) -> Result<u32, DynamoError> {
+fn normalize_top_k(top_k: Option<i32>) -> Result<Option<i32>, DynamoError> {
     match top_k {
-        None | Some(-1) | Some(0) => Ok(0),
-        Some(value) if value > 0 => Ok(value as u32),
+        None | Some(-1) | Some(0) => Ok(top_k),
+        Some(value) if value > 0 => Ok(Some(value)),
         Some(value) => Err(client::invalid_argument(format!(
             "top_k must be -1, 0, or positive; got {value}"
         ))),

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -189,6 +189,7 @@ fn build_kv_parameters(
             return Err(client::invalid_argument("extra_args must be a JSON object"));
         }
     };
+    validate_and_remove_vllm_tito(extra.as_mut())?;
     if let Some(extra) = extra.as_ref() {
         for key in extra.keys() {
             if !matches!(
@@ -280,6 +281,98 @@ fn stringify_remote_port(params: &mut serde_json::Value) {
             serde_json::Value::String(port.to_string()),
         );
     }
+}
+
+fn validate_and_remove_vllm_tito(
+    extra: Option<&mut serde_json::Map<String, serde_json::Value>>,
+) -> Result<(), DynamoError> {
+    let Some(envelope) = extra.and_then(|extra| extra.remove("vllm_tito")) else {
+        return Ok(());
+    };
+    let serde_json::Value::Object(envelope) = envelope else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito must be a JSON object",
+        ));
+    };
+
+    for key in envelope.keys() {
+        if !matches!(
+            key.as_str(),
+            "request_id"
+                | "sampling_params"
+                | "model"
+                | "stream"
+                | "stream_options"
+                | "cache_salt"
+                | "priority"
+                | "kv_transfer_params"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.{key} is not supported by vLLM gRPC v0.25.1"
+            )));
+        }
+    }
+
+    if envelope
+        .get("stream")
+        .is_some_and(|stream| stream != &serde_json::Value::Bool(false))
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.stream must be false",
+        ));
+    }
+    if envelope
+        .get("stream_options")
+        .is_some_and(|options| !options.is_null())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.stream_options is not supported by vLLM gRPC v0.25.1",
+        ));
+    }
+
+    let sampling = envelope.get("sampling_params").ok_or_else(|| {
+        client::invalid_argument("extra_args.vllm_tito.sampling_params is required")
+    })?;
+    let serde_json::Value::Object(sampling) = sampling else {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params must be a JSON object",
+        ));
+    };
+    for key in sampling.keys() {
+        if !matches!(
+            key.as_str(),
+            "temperature"
+                | "top_p"
+                | "top_k"
+                | "min_p"
+                | "seed"
+                | "max_tokens"
+                | "min_tokens"
+                | "presence_penalty"
+                | "frequency_penalty"
+                | "repetition_penalty"
+                | "stop_token_ids"
+                | "ignore_eos"
+                | "logprobs"
+                | "prompt_logprobs"
+                | "skip_reading_prefix_cache"
+                | "skip_special_tokens"
+        ) {
+            return Err(client::invalid_argument(format!(
+                "extra_args.vllm_tito.sampling_params.{key} is not supported by vLLM gRPC v0.25.1"
+            )));
+        }
+    }
+    if sampling
+        .get("skip_special_tokens")
+        .is_some_and(|value| !value.is_boolean())
+    {
+        return Err(client::invalid_argument(
+            "extra_args.vllm_tito.sampling_params.skip_special_tokens must be a boolean",
+        ));
+    }
+
+    Ok(())
 }
 
 fn bool_extra(

--- a/lib/sidecar/vllm/src/convert.rs
+++ b/lib/sidecar/vllm/src/convert.rs
@@ -189,7 +189,7 @@ fn build_kv_parameters(
             return Err(client::invalid_argument("extra_args must be a JSON object"));
         }
     };
-    validate_and_remove_vllm_tito(extra.as_mut())?;
+    validate_and_remove_vllm_tito(extra.as_mut(), cache_salt.as_deref())?;
     if let Some(extra) = extra.as_ref() {
         for key in extra.keys() {
             if !matches!(
@@ -285,6 +285,7 @@ fn stringify_remote_port(params: &mut serde_json::Value) {
 
 fn validate_and_remove_vllm_tito(
     extra: Option<&mut serde_json::Map<String, serde_json::Value>>,
+    canonical_cache_salt: Option<&str>,
 ) -> Result<(), DynamoError> {
     let Some(envelope) = extra.and_then(|extra| extra.remove("vllm_tito")) else {
         return Ok(());
@@ -355,6 +356,7 @@ fn validate_and_remove_vllm_tito(
                 | "ignore_eos"
                 | "logprobs"
                 | "prompt_logprobs"
+                | "cache_salt"
                 | "skip_reading_prefix_cache"
                 | "skip_special_tokens"
                 | "return_token_ids"
@@ -380,7 +382,38 @@ fn validate_and_remove_vllm_tito(
             "extra_args.vllm_tito.sampling_params.return_token_ids must be true",
         ));
     }
+    validate_compat_cache_salt(
+        sampling.get("cache_salt"),
+        canonical_cache_salt,
+        "sampling_params.cache_salt",
+    )?;
+    validate_compat_cache_salt(
+        envelope.get("cache_salt"),
+        canonical_cache_salt,
+        "cache_salt",
+    )?;
 
+    Ok(())
+}
+
+fn validate_compat_cache_salt(
+    value: Option<&serde_json::Value>,
+    canonical: Option<&str>,
+    path: &str,
+) -> Result<(), DynamoError> {
+    let Some(value) = value else {
+        return Ok(());
+    };
+    let Some(value) = value.as_str() else {
+        return Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.{path} must be a string"
+        )));
+    };
+    if Some(value) != canonical {
+        return Err(client::invalid_argument(format!(
+            "extra_args.vllm_tito.{path} must match the canonical cache_salt"
+        )));
+    }
     Ok(())
 }
 

--- a/lib/sidecar/vllm/src/discovery.rs
+++ b/lib/sidecar/vllm/src/discovery.rs
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::num::NonZeroUsize;
+
+use dynamo_backend_common::{DisaggregationMode, DynamoError, EngineConfig, LlmRegistration};
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
+
+use crate::client::{self, Discovery, VllmClient};
+use crate::proto as pb;
+
+const EXPECTED_API_VERSION: &str = "vllm";
+const REQUIRED_CAPABILITIES: [&str; 3] = [
+    "generate.sampling.v2",
+    "generate.preprocessed_mm.v1",
+    "generate.routed_experts.v1",
+];
+
+#[derive(Clone, Debug, PartialEq)]
+pub(crate) struct BootstrapIdentity {
+    instance_id: String,
+    model_id: String,
+    served_model_name: String,
+    served_model_aliases: Vec<String>,
+    reasoning_parser: String,
+    tool_call_parser: String,
+    parallelism: Option<pb::ParallelismInfo>,
+}
+
+impl BootstrapIdentity {
+    pub(crate) fn from_discovery(discovery: &Discovery) -> Self {
+        Self {
+            instance_id: discovery.server.instance_id.clone(),
+            model_id: discovery.model.model_id.clone(),
+            served_model_name: discovery.model.served_model_name.clone(),
+            served_model_aliases: discovery.model.served_model_aliases.clone(),
+            reasoning_parser: discovery.model.reasoning_parser.clone(),
+            tool_call_parser: discovery.model.tool_call_parser.clone(),
+            parallelism: discovery.server.parallelism,
+        }
+    }
+
+    pub(crate) fn validate(&self, discovery: &Discovery) -> Result<(), DynamoError> {
+        let live = Self::from_discovery(discovery);
+        if self != &live {
+            return Err(client::invalid_argument(format!(
+                "vLLM identity or topology changed after bootstrap: expected {self:?}, got {live:?}"
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn bootstrap_discover(
+    endpoint: &GrpcEndpoint,
+    transport: GrpcTransportConfig,
+) -> Result<Discovery, DynamoError> {
+    let endpoint = endpoint.clone();
+    std::thread::spawn(move || {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|error| client::engine_shutdown(format!("bootstrap runtime: {error}")))?;
+        runtime.block_on(async {
+            let transport = GrpcTransportConfig {
+                connections: NonZeroUsize::new(1).expect("one is non-zero"),
+                ..transport
+            };
+            let (_, discovery) = VllmClient::connect_and_discover(&endpoint, transport).await?;
+            Ok(discovery)
+        })
+    })
+    .join()
+    .map_err(|_| client::engine_shutdown("vLLM bootstrap thread panicked"))?
+}
+
+pub(crate) fn validate_discovery(discovery: &Discovery) -> Result<(), DynamoError> {
+    if discovery.server.api_version != EXPECTED_API_VERSION {
+        return Err(client::invalid_argument(format!(
+            "vLLM API version `{}` is incompatible with expected `{EXPECTED_API_VERSION}`",
+            discovery.server.api_version
+        )));
+    }
+    for capability in REQUIRED_CAPABILITIES {
+        if !discovery
+            .server
+            .capabilities
+            .iter()
+            .any(|advertised| advertised == capability)
+        {
+            return Err(client::invalid_argument(format!(
+                "vLLM is missing required capability `{capability}`"
+            )));
+        }
+    }
+    if discovery.model.model_id.trim().is_empty() {
+        return Err(client::invalid_argument(
+            "vLLM GetModelInfo returned an empty model_id",
+        ));
+    }
+    if !discovery.model.supports_token_ids_input {
+        return Err(client::invalid_argument(
+            "vLLM must support token-ID input for the Dynamo sidecar",
+        ));
+    }
+    let parallelism =
+        discovery.server.parallelism.as_ref().ok_or_else(|| {
+            client::invalid_argument("vLLM GetServerInfo did not return parallelism")
+        })?;
+    if [
+        parallelism.tensor_parallel_size,
+        parallelism.pipeline_parallel_size,
+        parallelism.data_parallel_size,
+        parallelism.managed_data_parallel_size,
+    ]
+    .contains(&0)
+    {
+        return Err(client::invalid_argument(
+            "vLLM tensor, pipeline, global data, and managed data parallel sizes must be positive",
+        ));
+    }
+    Ok(())
+}
+
+pub(crate) fn inference_world_size(parallelism: &pb::ParallelismInfo) -> Result<u32, DynamoError> {
+    [
+        parallelism.tensor_parallel_size,
+        parallelism.pipeline_parallel_size,
+        parallelism.managed_data_parallel_size,
+    ]
+    .into_iter()
+    .try_fold(1_u32, |world_size, size| {
+        world_size
+            .checked_mul(size)
+            .ok_or_else(|| client::invalid_argument("vLLM inference world size overflow"))
+    })
+}
+
+pub(crate) fn build_engine_config(
+    configured_model_source: &str,
+    discovery: &Discovery,
+    mode: DisaggregationMode,
+) -> EngineConfig {
+    let server = &discovery.server;
+    let model = &discovery.model;
+    let parallelism = server.parallelism.as_ref().expect("validated parallelism");
+    let served_model_name = nonempty(&model.served_model_name)
+        .or_else(|| nonempty(&model.model_id))
+        .or_else(|| Some(configured_model_source.to_string()));
+    let runtime_data = if mode.is_prefill() {
+        Default::default()
+    } else {
+        [(
+            "vllm_inference_v1_generate".to_string(),
+            serde_json::Value::Bool(true),
+        )]
+        .into_iter()
+        .collect()
+    };
+    EngineConfig {
+        model: configured_model_source.to_string(),
+        served_model_name,
+        runtime_data,
+        llm: Some(LlmRegistration {
+            context_length: (server.max_model_len != 0).then_some(server.max_model_len),
+            kv_cache_block_size: (server.kv_block_size != 0).then_some(server.kv_block_size),
+            total_kv_blocks: (server.total_kv_blocks != 0).then_some(server.total_kv_blocks),
+            max_num_seqs: (server.max_running_requests != 0).then_some(server.max_running_requests),
+            max_num_batched_tokens: (server.max_batched_tokens != 0)
+                .then_some(server.max_batched_tokens),
+            data_parallel_size: Some(parallelism.managed_data_parallel_size),
+            data_parallel_start_rank: Some(parallelism.data_parallel_start_rank),
+            bootstrap_host: None,
+            bootstrap_port: None,
+        }),
+    }
+}
+
+pub(crate) fn nonempty(value: &str) -> Option<String> {
+    (!value.trim().is_empty()).then(|| value.trim().to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn discovery() -> Discovery {
+        Discovery {
+            server: pb::ServerInfo {
+                parallelism: Some(pb::ParallelismInfo {
+                    tensor_parallel_size: 2,
+                    pipeline_parallel_size: 3,
+                    data_parallel_size: 8,
+                    managed_data_parallel_size: 4,
+                    data_parallel_start_rank: 4,
+                    ..Default::default()
+                }),
+                max_model_len: 4096,
+                kv_block_size: 16,
+                total_kv_blocks: 512,
+                max_running_requests: 64,
+                max_batched_tokens: 8192,
+                api_version: "vllm".to_string(),
+                capabilities: vec![
+                    "generate.sampling.v2".to_string(),
+                    "generate.preprocessed_mm.v1".to_string(),
+                    "generate.routed_experts.v1".to_string(),
+                ],
+                ..Default::default()
+            },
+            model: pb::ModelInfo {
+                model_id: "Qwen/Qwen3-0.6B".to_string(),
+                served_model_name: "qwen".to_string(),
+                supports_token_ids_input: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    #[test]
+    fn world_size_uses_only_the_managed_dp_span() {
+        let parallelism = discovery().server.parallelism.unwrap();
+        assert_eq!(inference_world_size(&parallelism).unwrap(), 24);
+    }
+
+    #[test]
+    fn discovery_rejects_missing_or_zero_topology() {
+        let mut missing = discovery();
+        missing.server.parallelism = None;
+        assert!(validate_discovery(&missing).is_err());
+
+        let mut zero = discovery();
+        zero.server
+            .parallelism
+            .as_mut()
+            .unwrap()
+            .managed_data_parallel_size = 0;
+        assert!(validate_discovery(&zero).is_err());
+    }
+
+    #[test]
+    fn discovery_rejects_incompatible_wire_contracts() {
+        let mut wrong_version = discovery();
+        wrong_version.server.api_version = "legacy".to_string();
+        assert!(validate_discovery(&wrong_version).is_err());
+
+        for capability in [
+            "generate.sampling.v2",
+            "generate.preprocessed_mm.v1",
+            "generate.routed_experts.v1",
+        ] {
+            let mut missing = discovery();
+            missing
+                .server
+                .capabilities
+                .retain(|candidate| candidate != capability);
+            assert!(validate_discovery(&missing).is_err());
+        }
+    }
+
+    #[test]
+    fn engine_registration_preserves_local_source_and_reports_runtime_capacity() {
+        let discovery = discovery();
+        validate_discovery(&discovery).unwrap();
+        let config = build_engine_config("/models/qwen", &discovery, DisaggregationMode::Decode);
+        assert_eq!(config.model, "/models/qwen");
+        assert_eq!(config.served_model_name.as_deref(), Some("qwen"));
+        let llm = config.llm.unwrap();
+        assert_eq!(llm.context_length, Some(4096));
+        assert_eq!(llm.data_parallel_size, Some(4));
+        assert_eq!(llm.data_parallel_start_rank, Some(4));
+    }
+}

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -8,7 +8,8 @@ use dynamo_backend_common::{
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::stream::BoxStream;
-use tokio::sync::OnceCell;
+use serde_json::json;
+use tokio::sync::{Mutex, OnceCell};
 use tokio_util::sync::CancellationToken;
 
 use crate::args::Args;
@@ -18,6 +19,7 @@ use crate::discovery::{
     BootstrapIdentity, bootstrap_discover, build_engine_config, inference_world_size, nonempty,
     validate_discovery,
 };
+use crate::lora::{next_lora_id, parse_load_lora, publish_lora_model};
 use crate::model::ConfiguredModel;
 
 pub struct VllmSidecarEngine {
@@ -27,6 +29,10 @@ pub struct VllmSidecarEngine {
     transport: GrpcTransportConfig,
     bootstrap_identity: Option<BootstrapIdentity>,
     client: OnceCell<VllmClient>,
+    runtime_endpoint: OnceCell<dynamo_runtime::component::Endpoint>,
+    lora_update_lock: Mutex<()>,
+    supports_lora: bool,
+    max_loras: u32,
     cancel: CancellationToken,
 }
 
@@ -51,6 +57,10 @@ impl VllmSidecarEngine {
             transport,
             bootstrap_identity: None,
             client: OnceCell::new(),
+            runtime_endpoint: OnceCell::new(),
+            lora_update_lock: Mutex::new(()),
+            supports_lora: false,
+            max_loras: 0,
             cancel: CancellationToken::new(),
         }
     }
@@ -124,7 +134,8 @@ impl VllmSidecarEngine {
             None
         };
         let engine = Self::new(endpoint, model.clone(), mode, transport)
-            .with_bootstrap_identity(BootstrapIdentity::from_discovery(&discovery));
+            .with_bootstrap_identity(BootstrapIdentity::from_discovery(&discovery))
+            .with_lora_support(discovery.model.supports_lora, discovery.server.max_loras);
         let (tool_call_parser, reasoning_parser) = if mode.is_prefill() {
             (None, None)
         } else {
@@ -164,6 +175,12 @@ impl VllmSidecarEngine {
 
     fn with_bootstrap_identity(mut self, identity: BootstrapIdentity) -> Self {
         self.bootstrap_identity = Some(identity);
+        self
+    }
+
+    fn with_lora_support(mut self, supports_lora: bool, max_loras: u32) -> Self {
+        self.supports_lora = supports_lora && max_loras > 0;
+        self.max_loras = max_loras;
         self
     }
 }
@@ -309,6 +326,68 @@ impl LLMEngine for VllmSidecarEngine {
                 }
             }
         }))
+    }
+
+    async fn supported_updates(&self) -> Result<Vec<String>, DynamoError> {
+        Ok(if self.supports_lora {
+            vec!["load_lora".to_string()]
+        } else {
+            Vec::new()
+        })
+    }
+
+    async fn engine_update(
+        &self,
+        update: String,
+        body: serde_json::Value,
+    ) -> Result<serde_json::Value, DynamoError> {
+        if update != "load_lora" || !self.supports_lora {
+            return Ok(json!({
+                "status": "error",
+                "message": format!("unsupported engine update: {update}"),
+            }));
+        }
+        let request = parse_load_lora(&body)?;
+        let client = self
+            .client
+            .get()
+            .ok_or_else(|| client::engine_shutdown("vLLM sidecar is not started"))?;
+        let endpoint = self
+            .runtime_endpoint
+            .get()
+            .ok_or_else(|| client::engine_shutdown("vLLM sidecar runtime endpoint is not ready"))?;
+        let _guard = self.lora_update_lock.lock().await;
+        let adapters = client.list_loras().await?;
+        let lora_id = next_lora_id(&adapters, &request.name)?;
+        let response = client
+            .load_lora(
+                crate::proto::LoraAdapter {
+                    lora_id,
+                    lora_name: request.name,
+                    source_path: request.path.to_string_lossy().into_owned(),
+                },
+                request.load_inplace,
+            )
+            .await?;
+        let adapter = response.adapter.ok_or_else(|| {
+            client::protocol_error("LoadLora response did not contain the loaded adapter")
+        })?;
+        publish_lora_model(endpoint, &adapter, self.max_loras).await?;
+        Ok(json!({
+            "status": "success",
+            "lora_name": adapter.lora_name,
+            "lora_id": adapter.lora_id,
+            "already_loaded": response.already_loaded,
+        }))
+    }
+
+    async fn on_endpoint_ready(
+        &self,
+        endpoint: dynamo_runtime::component::Endpoint,
+    ) -> Result<(), DynamoError> {
+        self.runtime_endpoint.set(endpoint).map_err(|_| {
+            client::engine_shutdown("vLLM sidecar runtime endpoint was already initialized")
+        })
     }
 
     async fn cleanup(&self) -> Result<(), DynamoError> {

--- a/lib/sidecar/vllm/src/engine.rs
+++ b/lib/sidecar/vllm/src/engine.rs
@@ -4,7 +4,7 @@
 use async_trait::async_trait;
 use dynamo_backend_common::{
     DisaggregationMode, DynamoError, GenerateContext, LLMEngine, LLMEngineOutput,
-    LLMEngineOutputExt, WorkerConfig, usage,
+    LLMEngineOutputExt, RlWorkerMetadata, WorkerConfig, rl_enabled, usage,
 };
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::stream::BoxStream;
@@ -14,6 +14,10 @@ use tokio_util::sync::CancellationToken;
 use crate::args::Args;
 use crate::client::{self, VllmClient};
 use crate::convert::{ResponseState, build_generate_request};
+use crate::discovery::{
+    BootstrapIdentity, bootstrap_discover, build_engine_config, inference_world_size, nonempty,
+    validate_discovery,
+};
 use crate::model::ConfiguredModel;
 
 pub struct VllmSidecarEngine {
@@ -21,6 +25,7 @@ pub struct VllmSidecarEngine {
     model: ConfiguredModel,
     mode: DisaggregationMode,
     transport: GrpcTransportConfig,
+    bootstrap_identity: Option<BootstrapIdentity>,
     client: OnceCell<VllmClient>,
     cancel: CancellationToken,
 }
@@ -44,6 +49,7 @@ impl VllmSidecarEngine {
             model,
             mode,
             transport,
+            bootstrap_identity: None,
             client: OnceCell::new(),
             cancel: CancellationToken::new(),
         }
@@ -93,7 +99,32 @@ impl VllmSidecarEngine {
             source: args.model_path,
         };
         let mode = args.sidecar.common.disaggregation_mode;
-        let engine = Self::new(endpoint, model.clone(), mode, transport);
+        let discovery = bootstrap_discover(&endpoint, transport)?;
+        validate_discovery(&discovery)?;
+        let rl_metadata = if rl_enabled() {
+            let admin_endpoint = args.admin_endpoint.as_deref().ok_or_else(|| {
+                client::invalid_argument(
+                    "DYN_ENABLE_RL requires --admin-endpoint or VLLM_HTTP_ENDPOINT",
+                )
+            })?;
+            let admin_base_url =
+                GrpcEndpoint::parse(admin_endpoint, "--admin-endpoint")?.to_string();
+            let parallelism = discovery.server.parallelism.as_ref().ok_or_else(|| {
+                client::invalid_argument(
+                    "vLLM GetServerInfo did not return parallelism for RL discovery",
+                )
+            })?;
+            Some(rl_worker_metadata(
+                admin_base_url,
+                inference_world_size(parallelism)?,
+                &discovery.model,
+                args.rl_discovery_model_name.as_deref(),
+            )?)
+        } else {
+            None
+        };
+        let engine = Self::new(endpoint, model.clone(), mode, transport)
+            .with_bootstrap_identity(BootstrapIdentity::from_discovery(&discovery));
         let (tool_call_parser, reasoning_parser) = if mode.is_prefill() {
             (None, None)
         } else {
@@ -115,7 +146,7 @@ impl VllmSidecarEngine {
             endpoint_types: args.sidecar.common.endpoint_types,
             custom_jinja_template: args.sidecar.common.custom_jinja_template,
             model_name: model.source.clone(),
-            served_model_name: None,
+            served_model_name: nonempty(&discovery.model.served_model_name),
             tool_call_parser,
             reasoning_parser,
             exclude_tools_when_tool_choice_none: args
@@ -125,10 +156,49 @@ impl VllmSidecarEngine {
             enable_kv_routing: false,
             disaggregation_mode: mode,
             route_to_encoder: false,
+            rl_metadata,
             ..Default::default()
         };
         Ok((engine, config))
     }
+
+    fn with_bootstrap_identity(mut self, identity: BootstrapIdentity) -> Self {
+        self.bootstrap_identity = Some(identity);
+        self
+    }
+}
+
+pub(crate) fn rl_worker_metadata(
+    admin_base_url: String,
+    world_size: u32,
+    model: &crate::proto::ModelInfo,
+    configured_name: Option<&str>,
+) -> Result<RlWorkerMetadata, DynamoError> {
+    let model_name = match configured_name.map(str::trim) {
+        None => model.model_id.as_str(),
+        Some("") => {
+            return Err(client::invalid_argument(
+                "DYN_RL_DISCOVERY_MODEL_NAME must not be empty",
+            ));
+        }
+        Some(name)
+            if name == model.model_id
+                || name == model.served_model_name
+                || model.served_model_aliases.iter().any(|alias| alias == name) =>
+        {
+            name
+        }
+        Some(name) => {
+            return Err(client::invalid_argument(format!(
+                "RL model name `{name}` is not advertised by vLLM"
+            )));
+        }
+    };
+    Ok(RlWorkerMetadata {
+        admin_base_url,
+        world_size,
+        model: model_name.to_string(),
+    })
 }
 
 #[async_trait]
@@ -146,7 +216,12 @@ impl LLMEngine for VllmSidecarEngine {
             mode = %self.mode,
             "connecting to vLLM gRPC"
         );
-        let client = VllmClient::connect(&self.endpoint, self.transport).await?;
+        let (client, discovery) =
+            VllmClient::connect_and_discover(&self.endpoint, self.transport).await?;
+        validate_discovery(&discovery)?;
+        if let Some(identity) = &self.bootstrap_identity {
+            identity.validate(&discovery)?;
+        }
         let connection_count = client.connection_count();
         self.client
             .set(client)
@@ -158,7 +233,11 @@ impl LLMEngine for VllmSidecarEngine {
             mode = %self.mode,
             "vLLM gRPC transport connected"
         );
-        Ok(self.model.engine_config())
+        Ok(build_engine_config(
+            &self.model.source,
+            &discovery,
+            self.mode,
+        ))
     }
 
     async fn generate(

--- a/lib/sidecar/vllm/src/lib.rs
+++ b/lib/sidecar/vllm/src/lib.rs
@@ -9,6 +9,7 @@ mod convert;
 mod discovery;
 mod engine;
 mod json;
+mod lora;
 mod model;
 
 /// Generated vLLM gRPC types, temporarily exposed for the Mocker server until

--- a/lib/sidecar/vllm/src/lib.rs
+++ b/lib/sidecar/vllm/src/lib.rs
@@ -6,6 +6,7 @@
 mod args;
 mod client;
 mod convert;
+mod discovery;
 mod engine;
 mod json;
 mod model;

--- a/lib/sidecar/vllm/src/lora.rs
+++ b/lib/sidecar/vllm/src/lora.rs
@@ -34,7 +34,11 @@ pub(crate) fn parse_load_lora(body: &Value) -> Result<LoadLoraUpdate, DynamoErro
         .ok_or_else(|| client::invalid_argument("source.uri must be a local file URI"))?;
     let url = url::Url::parse(uri)
         .map_err(|_| client::invalid_argument("source.uri must be a local file URI"))?;
-    if url.scheme() != "file" || url.host_str().is_some_and(|host| host != "localhost") {
+    if url.scheme() != "file"
+        || url.host_str().is_some_and(|host| host != "localhost")
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
         return Err(client::invalid_argument(
             "source.uri must be a local file URI",
         ));

--- a/lib/sidecar/vllm/src/lora.rs
+++ b/lib/sidecar/vllm/src/lora.rs
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::PathBuf;
+
+use dynamo_backend_common::DynamoError;
+use dynamo_llm::local_model::derive_lora_suffix;
+use dynamo_llm::model_card::{LoraInfo, ModelDeploymentCard};
+use dynamo_runtime::component::Endpoint;
+use dynamo_runtime::discovery::{Discovery, DiscoveryInstance, DiscoveryQuery, DiscoverySpec};
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use serde_json::Value;
+
+use crate::client;
+use crate::proto as pb;
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct LoadLoraUpdate {
+    pub(crate) name: String,
+    pub(crate) path: PathBuf,
+    pub(crate) load_inplace: bool,
+}
+
+pub(crate) fn parse_load_lora(body: &Value) -> Result<LoadLoraUpdate, DynamoError> {
+    let name = body
+        .get("lora_name")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|name| !name.is_empty())
+        .ok_or_else(|| client::invalid_argument("lora_name must be a non-empty string"))?;
+    let uri = body
+        .pointer("/source/uri")
+        .and_then(Value::as_str)
+        .ok_or_else(|| client::invalid_argument("source.uri must be a local file URI"))?;
+    let url = url::Url::parse(uri)
+        .map_err(|_| client::invalid_argument("source.uri must be a local file URI"))?;
+    if url.scheme() != "file" || url.host_str().is_some_and(|host| host != "localhost") {
+        return Err(client::invalid_argument(
+            "source.uri must be a local file URI",
+        ));
+    }
+    let path = url
+        .to_file_path()
+        .map_err(|_| client::invalid_argument("source.uri must be a local file URI"))?;
+    if !path.is_absolute() {
+        return Err(client::invalid_argument(
+            "source.uri must be a local file URI",
+        ));
+    }
+    let load_inplace = match body.get("load_inplace") {
+        Some(value) => value
+            .as_bool()
+            .ok_or_else(|| client::invalid_argument("load_inplace must be a boolean"))?,
+        None => true,
+    };
+    Ok(LoadLoraUpdate {
+        name: name.to_string(),
+        path,
+        load_inplace,
+    })
+}
+
+pub(crate) fn next_lora_id(loaded: &[pb::LoraAdapter], name: &str) -> Result<i64, DynamoError> {
+    if let Some(adapter) = loaded.iter().find(|adapter| adapter.lora_name == name) {
+        return (adapter.lora_id > 0)
+            .then_some(adapter.lora_id)
+            .ok_or_else(|| client::invalid_argument("loaded LoRA adapter ID is not positive"));
+    }
+    loaded
+        .iter()
+        .map(|adapter| adapter.lora_id)
+        .max()
+        .unwrap_or(0)
+        .checked_add(1)
+        .filter(|id| *id > 0)
+        .ok_or_else(|| client::invalid_argument("no positive LoRA adapter ID is available"))
+}
+
+pub(crate) async fn publish_lora_model(
+    endpoint: &Endpoint,
+    adapter: &pb::LoraAdapter,
+    max_loras: u32,
+) -> Result<(), DynamoError> {
+    let endpoint_id = endpoint.id();
+    let discovery = endpoint.drt().discovery();
+    publish_lora_model_to_discovery(
+        discovery.as_ref(),
+        &endpoint_id.namespace,
+        &endpoint_id.component,
+        &endpoint_id.name,
+        endpoint.drt().connection_id(),
+        adapter,
+        max_loras,
+    )
+    .await
+}
+
+pub(crate) async fn publish_lora_model_to_discovery(
+    discovery: &dyn Discovery,
+    namespace: &str,
+    component: &str,
+    endpoint: &str,
+    instance_id: u64,
+    adapter: &pb::LoraAdapter,
+    max_loras: u32,
+) -> Result<(), DynamoError> {
+    let models = discovery
+        .list(DiscoveryQuery::EndpointModels {
+            namespace: namespace.to_string(),
+            component: component.to_string(),
+            endpoint: endpoint.to_string(),
+        })
+        .await
+        .map_err(|error| {
+            client::protocol_error(format!("failed to query base model discovery: {error}"))
+        })?;
+    let base = models
+        .iter()
+        .find(|instance| {
+            matches!(
+                instance,
+                DiscoveryInstance::Model {
+                    instance_id: candidate_id,
+                    model_suffix: None,
+                    ..
+                } if *candidate_id == instance_id
+            )
+        })
+        .ok_or_else(|| client::protocol_error("base model is not registered in discovery"))?;
+    let mut card = base
+        .deserialize_model::<ModelDeploymentCard>()
+        .map_err(|error| client::protocol_error(format!("invalid base model card: {error}")))?;
+    if card.source_path.is_none() {
+        card.source_path = Some(card.name().to_string());
+    }
+    card.set_name(&adapter.lora_name);
+    card.aliases.clear();
+    card.lora = Some(LoraInfo {
+        name: adapter.lora_name.clone(),
+        max_gpu_lora_count: (max_loras > 0).then_some(max_loras),
+    });
+    card.user_data = Some(serde_json::json!({
+        "lora_adapter": true,
+        "lora_id": adapter.lora_id,
+    }));
+    let spec = DiscoverySpec::from_model_with_suffix(
+        namespace.to_string(),
+        component.to_string(),
+        endpoint.to_string(),
+        &card,
+        derive_lora_suffix(Some(&adapter.lora_name)),
+    )
+    .map_err(|error| client::protocol_error(format!("failed to build LoRA model card: {error}")))?;
+    discovery.register(spec).await.map_err(|error| {
+        client::protocol_error(format!("failed to publish LoRA model: {error}"))
+    })?;
+    Ok(())
+}

--- a/lib/sidecar/vllm/src/model.rs
+++ b/lib/sidecar/vllm/src/model.rs
@@ -1,20 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use dynamo_backend_common::{EngineConfig, LlmRegistration};
-
 #[derive(Clone, Debug)]
 pub(crate) struct ConfiguredModel {
     pub source: String,
-}
-
-impl ConfiguredModel {
-    pub(crate) fn engine_config(&self) -> EngineConfig {
-        EngineConfig {
-            model: self.source.clone(),
-            served_model_name: None,
-            runtime_data: Default::default(),
-            llm: Some(LlmRegistration::default()),
-        }
-    }
 }

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -821,29 +821,43 @@ async fn prefill_decode_handoff_is_opaque_and_repeatable() {
     }
 }
 
-#[test]
-fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
+#[tokio::test]
+async fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
+    let server = FakeServer::start(FakeInference::default()).await;
     let component = |extra: &[&str]| {
+        let endpoint = server.endpoint.clone();
         let mut argv = vec![
-            "dynamo-vllm-sidecar",
-            "--vllm-endpoint",
-            "127.0.0.1:50051",
-            "--model-path",
-            "test-model",
-            "--component",
-            "custom",
+            "dynamo-vllm-sidecar".to_string(),
+            "--vllm-endpoint".to_string(),
+            endpoint,
+            "--model-path".to_string(),
+            "test-model".to_string(),
+            "--component".to_string(),
+            "custom".to_string(),
         ];
-        argv.extend_from_slice(extra);
-        VllmSidecarEngine::from_args(Some(argv.iter().map(|s| s.to_string()).collect()))
-            .expect("from_args")
-            .1
-            .component
+        argv.extend(extra.iter().map(ToString::to_string));
+        tokio::task::spawn_blocking(move || {
+            VllmSidecarEngine::from_args(Some(argv))
+                .expect("from_args")
+                .1
+                .component
+        })
     };
     // Aggregated keeps the operator-configured component.
-    assert_eq!(component(&[]), "custom");
+    assert_eq!(component(&[]).await.expect("component task"), "custom");
     // Disaggregated roles override to fixed names so the frontend can route.
-    assert_eq!(component(&["--disaggregation-mode", "prefill"]), "prefill");
-    assert_eq!(component(&["--disaggregation-mode", "decode"]), "backend");
+    assert_eq!(
+        component(&["--disaggregation-mode", "prefill"])
+            .await
+            .expect("component task"),
+        "prefill"
+    );
+    assert_eq!(
+        component(&["--disaggregation-mode", "decode"])
+            .await
+            .expect("component task"),
+        "backend"
+    );
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -453,6 +453,7 @@ fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
                 "ignore_eos": true,
                 "logprobs": 1,
                 "prompt_logprobs": 1,
+                "cache_salt": "cache-salt",
                 "skip_special_tokens": false,
                 "return_token_ids": true
             },
@@ -477,6 +478,7 @@ fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
     assert_eq!(wire.temperature, Some(0.2));
     assert_eq!(wire.stopping.as_ref().unwrap().stop_token_ids, [2]);
     assert!(wire.response.as_ref().unwrap().output_logprobs);
+    assert_eq!(wire.kv.as_ref().unwrap().cache_salt, "cache-salt");
 }
 
 #[test]
@@ -505,6 +507,36 @@ fn token_native_compatibility_envelope_rejects_disabled_token_ids() {
         error
             .to_string()
             .contains("sampling_params.return_token_ids must be true")
+    );
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_conflicting_cache_salt() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "max_tokens": 1,
+                "cache_salt": "different-policy-version"
+            },
+            "cache_salt": "cache-salt",
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("duplicate cache salts must match the canonical routing salt");
+
+    assert!(
+        error
+            .to_string()
+            .contains("sampling_params.cache_salt must match the canonical cache_salt")
     );
 }
 

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -12,6 +12,10 @@ use dynamo_backend_common::{
     DisaggregationMode, FinishReason, GenerateContext, LLMEngine, OutputOptions, PrefillResult,
     PreprocessedRequest, SamplingOptions, StopConditions,
 };
+use dynamo_llm::model_card::ModelDeploymentCard;
+use dynamo_runtime::discovery::{
+    Discovery, DiscoveryInstance, DiscoveryQuery, DiscoverySpec, MockDiscovery, SharedMockRegistry,
+};
 use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
 use futures::{Stream, StreamExt};
 use serde_json::json;
@@ -24,6 +28,7 @@ use crate::client::VllmClient;
 use crate::convert::{ResponseState, build_generate_request};
 use crate::engine::{VllmSidecarEngine, rl_worker_metadata};
 use crate::json::{json_to_struct, struct_to_json};
+use crate::lora::{next_lora_id, parse_load_lora, publish_lora_model_to_discovery};
 use crate::model::ConfiguredModel;
 use crate::proto as pb;
 
@@ -168,6 +173,7 @@ struct FakeControl {
     server_info_calls: Arc<AtomicUsize>,
     model_info_calls: Arc<AtomicUsize>,
     hang_server_info: Arc<AtomicBool>,
+    loras: Arc<Mutex<Vec<pb::LoraAdapter>>>,
 }
 
 impl Default for FakeControl {
@@ -213,6 +219,7 @@ impl Default for FakeControl {
             server_info_calls: Arc::new(AtomicUsize::new(0)),
             model_info_calls: Arc::new(AtomicUsize::new(0)),
             hang_server_info: Arc::new(AtomicBool::new(false)),
+            loras: Arc::new(Mutex::new(Vec::new())),
         }
     }
 }
@@ -254,23 +261,47 @@ impl pb::control_server::Control for FakeControl {
 
     async fn load_lora(
         &self,
-        _request: Request<pb::LoadLoraRequest>,
+        request: Request<pb::LoadLoraRequest>,
     ) -> Result<Response<pb::LoadLoraResponse>, Status> {
-        Err(Status::unimplemented("load_lora"))
+        let request = request.into_inner();
+        let adapter = request
+            .adapter
+            .ok_or_else(|| Status::invalid_argument("adapter required"))?;
+        let mut loras = self.loras.lock().await;
+        let already_loaded = loras.iter().any(|item| item.lora_name == adapter.lora_name);
+        if already_loaded && !request.load_inplace {
+            return Err(Status::already_exists("adapter already loaded"));
+        }
+        loras.retain(|item| item.lora_name != adapter.lora_name);
+        loras.push(adapter.clone());
+        Ok(Response::new(pb::LoadLoraResponse {
+            adapter: Some(adapter),
+            already_loaded,
+        }))
     }
 
     async fn unload_lora(
         &self,
-        _request: Request<pb::UnloadLoraRequest>,
+        request: Request<pb::UnloadLoraRequest>,
     ) -> Result<Response<pb::UnloadLoraResponse>, Status> {
-        Err(Status::unimplemented("unload_lora"))
+        let name = request.into_inner().lora_name;
+        let mut loras = self.loras.lock().await;
+        let index = loras
+            .iter()
+            .position(|item| item.lora_name == name)
+            .ok_or_else(|| Status::not_found("adapter not found"))?;
+        Ok(Response::new(pb::UnloadLoraResponse {
+            adapter: Some(loras.remove(index)),
+        }))
     }
 
     async fn list_loras(
         &self,
         _request: Request<pb::ListLorasRequest>,
     ) -> Result<Response<pb::ListLorasResponse>, Status> {
-        Err(Status::unimplemented("list_loras"))
+        Ok(Response::new(pb::ListLorasResponse {
+            adapters: self.loras.lock().await.clone(),
+        }))
     }
 
     async fn get_kv_event_sources(
@@ -637,6 +668,130 @@ impl Drop for FakeServer {
     }
 }
 
+#[test]
+fn load_lora_payload_requires_a_local_file_uri() {
+    let update = parse_load_lora(&json!({
+        "lora_name": "math-r8",
+        "source": {"uri": "file:///shared/adapter/step_1"},
+        "load_inplace": true,
+    }))
+    .expect("valid local LoRA update");
+    assert_eq!(update.name, "math-r8");
+    assert_eq!(update.path.to_string_lossy(), "/shared/adapter/step_1");
+    assert!(update.load_inplace);
+
+    for uri in [
+        "https://example.com/adapter",
+        "file://remote/adapter",
+        "relative",
+    ] {
+        let error = parse_load_lora(&json!({
+            "lora_name": "math-r8",
+            "source": {"uri": uri},
+        }))
+        .expect_err("non-local LoRA URI must be rejected");
+        assert!(error.to_string().contains("local file URI"));
+    }
+}
+
+#[test]
+fn next_lora_id_reuses_existing_name_and_allocates_after_the_highest_id() {
+    let loaded = vec![
+        pb::LoraAdapter {
+            lora_id: 3,
+            lora_name: "other".to_string(),
+            source_path: "/other".to_string(),
+        },
+        pb::LoraAdapter {
+            lora_id: 7,
+            lora_name: "math-r8".to_string(),
+            source_path: "/old".to_string(),
+        },
+    ];
+    assert_eq!(next_lora_id(&loaded, "math-r8").unwrap(), 7);
+    assert_eq!(next_lora_id(&loaded, "new-adapter").unwrap(), 8);
+}
+
+#[tokio::test]
+async fn native_lora_client_loads_in_place_and_lists_the_adapter() {
+    let server = FakeServer::start(FakeInference::default()).await;
+    let client = VllmClient::connect(
+        &GrpcEndpoint::parse(&server.endpoint, "test").unwrap(),
+        GrpcTransportConfig::default(),
+    )
+    .await
+    .unwrap();
+    let adapter = pb::LoraAdapter {
+        lora_id: 1,
+        lora_name: "math-r8".to_string(),
+        source_path: "/shared/adapter/step_1".to_string(),
+    };
+
+    let loaded = client.load_lora(adapter.clone(), true).await.unwrap();
+    assert_eq!(loaded.adapter, Some(adapter.clone()));
+    assert!(!loaded.already_loaded);
+    let loaded_again = client.load_lora(adapter.clone(), true).await.unwrap();
+    assert!(loaded_again.already_loaded);
+    assert_eq!(client.list_loras().await.unwrap(), vec![adapter]);
+}
+
+#[tokio::test]
+async fn loaded_lora_is_published_as_a_sibling_of_the_base_model() {
+    let discovery = MockDiscovery::new(Some(42), SharedMockRegistry::new());
+    let mut base = ModelDeploymentCard::with_name_only("Qwen/Qwen3-0.6B");
+    base.source_path = Some("Qwen/Qwen3-0.6B".to_string());
+    discovery
+        .register(
+            DiscoverySpec::from_model(
+                "test".to_string(),
+                "backend".to_string(),
+                "generate".to_string(),
+                &base,
+            )
+            .unwrap(),
+        )
+        .await
+        .unwrap();
+    let adapter = pb::LoraAdapter {
+        lora_id: 7,
+        lora_name: "math-r8".to_string(),
+        source_path: "/shared/adapter/step_1".to_string(),
+    };
+
+    publish_lora_model_to_discovery(&discovery, "test", "backend", "generate", 42, &adapter, 4)
+        .await
+        .unwrap();
+
+    let models = discovery
+        .list(DiscoveryQuery::EndpointModels {
+            namespace: "test".to_string(),
+            component: "backend".to_string(),
+            endpoint: "generate".to_string(),
+        })
+        .await
+        .unwrap();
+    assert_eq!(models.len(), 2);
+    let lora = models
+        .iter()
+        .find(|instance| {
+            matches!(
+                instance,
+                DiscoveryInstance::Model {
+                    model_suffix: Some(_),
+                    ..
+                }
+            )
+        })
+        .unwrap()
+        .deserialize_model::<ModelDeploymentCard>()
+        .unwrap();
+    assert_eq!(lora.name(), "math-r8");
+    assert_eq!(lora.source_path(), "Qwen/Qwen3-0.6B");
+    assert_eq!(lora.lora.as_ref().unwrap().name, "math-r8");
+    assert_eq!(lora.lora.as_ref().unwrap().max_gpu_lora_count, Some(4));
+    assert_eq!(lora.user_data.as_ref().unwrap()["lora_id"], json!(7));
+}
+
 fn request() -> PreprocessedRequest {
     PreprocessedRequest::builder()
         .model("served-model".to_string())
@@ -858,6 +1013,46 @@ async fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
             .expect("component task"),
         "backend"
     );
+}
+
+#[tokio::test]
+async fn sidecar_advertises_load_lora_only_when_native_server_supports_it() {
+    let mut control = FakeControl::default();
+    control.model_info.supports_lora = true;
+    control.server_info.max_loras = 4;
+    let server = FakeServer::start_with_control(FakeInference::default(), control).await;
+    let endpoint = server.endpoint.clone();
+    let engine = tokio::task::spawn_blocking(move || {
+        VllmSidecarEngine::from_args(Some(vec![
+            "dynamo-vllm-sidecar".to_string(),
+            "--vllm-endpoint".to_string(),
+            endpoint,
+            "--model-path".to_string(),
+            "test-model".to_string(),
+        ]))
+        .expect("LoRA-capable sidecar arguments")
+        .0
+    })
+    .await
+    .unwrap();
+    assert_eq!(engine.supported_updates().await.unwrap(), ["load_lora"]);
+
+    let server = FakeServer::start(FakeInference::default()).await;
+    let endpoint = server.endpoint.clone();
+    let engine = tokio::task::spawn_blocking(move || {
+        VllmSidecarEngine::from_args(Some(vec![
+            "dynamo-vllm-sidecar".to_string(),
+            "--vllm-endpoint".to_string(),
+            endpoint,
+            "--model-path".to_string(),
+            "test-model".to_string(),
+        ]))
+        .expect("base-only sidecar arguments")
+        .0
+    })
+    .await
+    .unwrap();
+    assert!(engine.supported_updates().await.unwrap().is_empty());
 }
 
 #[tokio::test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -433,6 +433,81 @@ fn oversized_logprob_counts_are_rejected() {
 }
 
 #[test]
+fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "temperature": 0.2,
+                "top_p": 0.9,
+                "top_k": 4,
+                "min_p": 0.1,
+                "seed": 123,
+                "max_tokens": 1,
+                "min_tokens": 1,
+                "presence_penalty": 0.3,
+                "frequency_penalty": 0.4,
+                "repetition_penalty": 1.1,
+                "stop_token_ids": [2],
+                "ignore_eos": true,
+                "logprobs": 1,
+                "prompt_logprobs": 1,
+                "skip_special_tokens": false
+            },
+            "model": "served-model",
+            "stream": false,
+            "cache_salt": "cache-salt",
+            "priority": 0
+        },
+        "bypass_prefix_cache": true,
+        "kv_transfer_params": {
+            "connector_data": {"values": [1, true, null]}
+        }
+    }));
+
+    let wire = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect("projected compatibility envelope");
+
+    assert_eq!(wire.temperature, Some(0.2));
+    assert_eq!(wire.stopping.as_ref().unwrap().stop_token_ids, [2]);
+    assert!(wire.response.as_ref().unwrap().output_logprobs);
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_unprojected_fields() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "max_tokens": 1,
+                "future_sampling_field": true
+            },
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("unprojected compatibility fields must fail closed");
+
+    assert!(
+        error
+            .to_string()
+            .contains("extra_args.vllm_tito.sampling_params.future_sampling_field")
+    );
+}
+
+#[test]
 fn rl_metadata_accepts_only_engine_advertised_model_names() {
     let model = FakeControl::default().model_info;
     let default = rl_worker_metadata("http://worker:8120".to_string(), 2, &model, None).unwrap();

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -6,7 +6,7 @@ use std::net::SocketAddr;
 use std::num::NonZeroUsize;
 use std::pin::Pin;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 use dynamo_backend_common::{
     DisaggregationMode, FinishReason, GenerateContext, LLMEngine, OutputOptions, PrefillResult,
@@ -22,13 +22,13 @@ use tonic::{Request, Response, Status};
 
 use crate::client::VllmClient;
 use crate::convert::{ResponseState, build_generate_request};
-use crate::engine::VllmSidecarEngine;
+use crate::engine::{VllmSidecarEngine, rl_worker_metadata};
 use crate::json::{json_to_struct, struct_to_json};
 use crate::model::ConfiguredModel;
 use crate::proto as pb;
 
 #[derive(Clone, Default)]
-struct FakeGenerate {
+struct FakeInference {
     requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
     peers: Arc<Mutex<Vec<SocketAddr>>>,
     reject: Arc<AtomicBool>,
@@ -48,7 +48,7 @@ impl Drop for DropSignal {
 }
 
 #[tonic::async_trait]
-impl pb::generate_server::Generate for FakeGenerate {
+impl pb::inference_server::Inference for FakeInference {
     type GenerateStreamStream =
         Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
 
@@ -161,6 +161,126 @@ impl pb::generate_server::Generate for FakeGenerate {
     }
 }
 
+#[derive(Clone)]
+struct FakeControl {
+    server_info: pb::ServerInfo,
+    model_info: pb::ModelInfo,
+    server_info_calls: Arc<AtomicUsize>,
+    model_info_calls: Arc<AtomicUsize>,
+    hang_server_info: Arc<AtomicBool>,
+}
+
+impl Default for FakeControl {
+    fn default() -> Self {
+        Self {
+            server_info: pb::ServerInfo {
+                engine_version: "test".to_string(),
+                api_version: "vllm".to_string(),
+                instance_id: "instance-1".to_string(),
+                parallelism: Some(pb::ParallelismInfo {
+                    tensor_parallel_size: 1,
+                    pipeline_parallel_size: 1,
+                    data_parallel_size: 1,
+                    data_parallel_rank: 0,
+                    decode_context_parallel_size: 1,
+                    data_parallel_start_rank: 0,
+                    managed_data_parallel_size: 1,
+                }),
+                max_model_len: 4096,
+                kv_block_size: 16,
+                total_kv_blocks: 1024,
+                max_running_requests: 64,
+                max_batched_tokens: 8192,
+                max_loras: 0,
+                capabilities: vec![
+                    "generate.sampling.v2".to_string(),
+                    "generate.preprocessed_mm.v1".to_string(),
+                    "generate.routed_experts.v1".to_string(),
+                ],
+            },
+            model_info: pb::ModelInfo {
+                model_id: "model-source".to_string(),
+                served_model_name: "served-model".to_string(),
+                served_model_aliases: vec!["model-alias".to_string()],
+                tokenizer_modes: vec!["auto".to_string()],
+                supports_text_input: true,
+                supports_token_ids_input: true,
+                supports_lora: false,
+                supports_multimodal: false,
+                reasoning_parser: String::new(),
+                tool_call_parser: String::new(),
+            },
+            server_info_calls: Arc::new(AtomicUsize::new(0)),
+            model_info_calls: Arc::new(AtomicUsize::new(0)),
+            hang_server_info: Arc::new(AtomicBool::new(false)),
+        }
+    }
+}
+
+#[tonic::async_trait]
+impl pb::control_server::Control for FakeControl {
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::ServerInfo>, Status> {
+        self.server_info_calls.fetch_add(1, Ordering::SeqCst);
+        if self.hang_server_info.load(Ordering::SeqCst) {
+            std::future::pending::<()>().await;
+        }
+        Ok(Response::new(self.server_info.clone()))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::ModelInfo>, Status> {
+        self.model_info_calls.fetch_add(1, Ordering::SeqCst);
+        Ok(Response::new(self.model_info.clone()))
+    }
+
+    async fn abort(
+        &self,
+        _request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        Err(Status::unimplemented("abort"))
+    }
+
+    async fn drain(
+        &self,
+        _request: Request<pb::DrainRequest>,
+    ) -> Result<Response<pb::DrainResponse>, Status> {
+        Err(Status::unimplemented("drain"))
+    }
+
+    async fn load_lora(
+        &self,
+        _request: Request<pb::LoadLoraRequest>,
+    ) -> Result<Response<pb::LoadLoraResponse>, Status> {
+        Err(Status::unimplemented("load_lora"))
+    }
+
+    async fn unload_lora(
+        &self,
+        _request: Request<pb::UnloadLoraRequest>,
+    ) -> Result<Response<pb::UnloadLoraResponse>, Status> {
+        Err(Status::unimplemented("unload_lora"))
+    }
+
+    async fn list_loras(
+        &self,
+        _request: Request<pb::ListLorasRequest>,
+    ) -> Result<Response<pb::ListLorasResponse>, Status> {
+        Err(Status::unimplemented("list_loras"))
+    }
+
+    async fn get_kv_event_sources(
+        &self,
+        _request: Request<pb::GetKvEventSourcesRequest>,
+    ) -> Result<Response<pb::GetKvEventSourcesResponse>, Status> {
+        Err(Status::unimplemented("get_kv_event_sources"))
+    }
+}
+
 fn sequence_response(
     terminal: bool,
     logprobs: bool,
@@ -190,6 +310,7 @@ fn sequence_response(
                 stop_reason: Some(pb::finish_info::StopReason::StopTokenId(2)),
                 kv_transfer_params,
             }),
+            routed_experts: None,
         }),
     }
 }
@@ -311,25 +432,51 @@ fn oversized_logprob_counts_are_rejected() {
     assert!(prompt_error.to_string().contains("must fit in i32"));
 }
 
+#[test]
+fn rl_metadata_accepts_only_engine_advertised_model_names() {
+    let model = FakeControl::default().model_info;
+    let default = rl_worker_metadata("http://worker:8120".to_string(), 2, &model, None).unwrap();
+    assert_eq!(default.model, "model-source");
+
+    let alias = rl_worker_metadata(
+        "http://worker:8120".to_string(),
+        2,
+        &model,
+        Some("model-alias"),
+    )
+    .unwrap();
+    assert_eq!(alias.model, "model-alias");
+    assert!(
+        rl_worker_metadata("http://worker:8120".to_string(), 2, &model, Some("unknown"),).is_err()
+    );
+}
+
 struct FakeServer {
     endpoint: String,
-    service: FakeGenerate,
+    service: FakeInference,
+    control: FakeControl,
     shutdown: Option<oneshot::Sender<()>>,
 }
 
 impl FakeServer {
-    async fn start(service: FakeGenerate) -> Self {
+    async fn start(service: FakeInference) -> Self {
+        Self::start_with_control(service, FakeControl::default()).await
+    }
+
+    async fn start_with_control(service: FakeInference, control: FakeControl) -> Self {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let address = listener.local_addr().expect("address");
         let (shutdown, shutdown_rx) = oneshot::channel();
         let server_service = service.clone();
+        let server_control = control.clone();
         tokio::spawn(async move {
             tonic::transport::Server::builder()
                 .add_service(
-                    pb::generate_server::GenerateServer::new(server_service)
+                    pb::inference_server::InferenceServer::new(server_service)
                         .max_encoding_message_size(64 * 1024 * 1024)
                         .max_decoding_message_size(64 * 1024 * 1024),
                 )
+                .add_service(pb::control_server::ControlServer::new(server_control))
                 .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
                     let _ = shutdown_rx.await;
                 })
@@ -339,6 +486,7 @@ impl FakeServer {
         Self {
             endpoint: format!("http://{address}"),
             service,
+            control,
             shutdown: Some(shutdown),
         }
     }
@@ -426,11 +574,13 @@ async fn collect(
 
 #[tokio::test]
 async fn aggregated_generation_converts_request_stream_and_usage() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeInference::default()).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 2);
     let config = engine.start(0).await.expect("start");
     assert_eq!(config.model, "model-source");
-    assert_eq!(config.served_model_name, None);
+    assert_eq!(config.served_model_name, Some("served-model".to_string()));
+    assert_eq!(server.control.server_info_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(server.control.model_info_calls.load(Ordering::SeqCst), 1);
 
     let outputs = collect(&engine, request()).await;
     assert_eq!(outputs.len(), 1);
@@ -451,7 +601,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
     let sampling = sent.sampling.as_ref().unwrap();
     assert_eq!(
         (sampling.top_k, sampling.top_p, sampling.min_p),
-        (4, 0.9, 0.1)
+        (Some(4), Some(0.9), Some(0.1))
     );
     assert_eq!(sampling.seed, Some(123));
     let decoding = sent.decoding.as_ref().unwrap();
@@ -461,7 +611,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
             decoding.frequency_penalty,
             decoding.repetition_penalty,
         ),
-        (0.3, 0.4, 1.1)
+        (Some(0.3), Some(0.4), Some(1.1))
     );
     assert!(matches!(
         decoding.structured_output,
@@ -483,7 +633,7 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 
 #[tokio::test]
 async fn grpc_request_errors_are_propagated() {
-    let service = FakeGenerate::default();
+    let service = FakeInference::default();
     service.reject.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -499,7 +649,7 @@ async fn grpc_request_errors_are_propagated() {
 
 #[tokio::test]
 async fn prefill_decode_handoff_is_opaque_and_repeatable() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeInference::default()).await;
     let prefill = engine(&server.endpoint, DisaggregationMode::Prefill, 1);
     let decode = engine(&server.endpoint, DisaggregationMode::Decode, 1);
     prefill.start(0).await.expect("start prefill");
@@ -561,7 +711,7 @@ fn component_honors_config_for_aggregated_but_fixes_disagg_roles() {
 
 #[tokio::test]
 async fn pool_uses_each_configured_connection() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeInference::default()).await;
     let transport = GrpcTransportConfig {
         connections: NonZeroUsize::new(2).unwrap(),
         ..Default::default()
@@ -596,8 +746,24 @@ async fn pool_uses_each_configured_connection() {
 }
 
 #[tokio::test]
+async fn control_discovery_respects_the_startup_deadline() {
+    let control = FakeControl::default();
+    control.hang_server_info.store(true, Ordering::SeqCst);
+    let server = FakeServer::start_with_control(FakeInference::default(), control).await;
+    let transport = GrpcTransportConfig {
+        connections: NonZeroUsize::new(1).unwrap(),
+        startup_deadline: std::time::Duration::from_millis(100),
+        ..Default::default()
+    };
+    let endpoint = GrpcEndpoint::parse(&server.endpoint, "--vllm-endpoint").unwrap();
+    let result = VllmClient::connect_and_discover(&endpoint, transport).await;
+    let error = result.err().expect("discovery must time out");
+    assert!(format!("{error}").contains("startup deadline"));
+}
+
+#[tokio::test]
 async fn cancellation_drops_the_remote_stream() {
-    let service = FakeGenerate::default();
+    let service = FakeInference::default();
     service.hang.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -626,7 +792,7 @@ async fn cancellation_drops_the_remote_stream() {
 
 #[tokio::test]
 async fn cancellation_interrupts_pending_response_headers() {
-    let service = FakeGenerate::default();
+    let service = FakeInference::default();
     service.hang_before_headers.store(true, Ordering::SeqCst);
     let server = FakeServer::start(service).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
@@ -657,7 +823,7 @@ async fn cancellation_interrupts_pending_response_headers() {
 
 #[tokio::test]
 async fn unsupported_features_fail_before_rpc_submission() {
-    let server = FakeServer::start(FakeGenerate::default()).await;
+    let server = FakeServer::start(FakeInference::default()).await;
     let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
     engine.start(0).await.expect("start");
 

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -453,7 +453,8 @@ fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
                 "ignore_eos": true,
                 "logprobs": 1,
                 "prompt_logprobs": 1,
-                "skip_special_tokens": false
+                "skip_special_tokens": false,
+                "return_token_ids": true
             },
             "model": "served-model",
             "stream": false,
@@ -476,6 +477,35 @@ fn token_native_compatibility_envelope_is_accepted_when_fields_are_projected() {
     assert_eq!(wire.temperature, Some(0.2));
     assert_eq!(wire.stopping.as_ref().unwrap().stop_token_ids, [2]);
     assert!(wire.response.as_ref().unwrap().output_logprobs);
+}
+
+#[test]
+fn token_native_compatibility_envelope_rejects_disabled_token_ids() {
+    let mut request = request();
+    request.extra_args = Some(json!({
+        "vllm_tito": {
+            "request_id": "request-1",
+            "sampling_params": {
+                "max_tokens": 1,
+                "return_token_ids": false
+            },
+            "stream": false,
+            "priority": 0
+        }
+    }));
+
+    let error = build_generate_request(
+        request,
+        "request-1".to_string(),
+        DisaggregationMode::Aggregated,
+    )
+    .expect_err("the token-native sidecar always returns token IDs");
+
+    assert!(
+        error
+            .to_string()
+            .contains("sampling_params.return_token_ids must be true")
+    );
 }
 
 #[test]

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -926,6 +926,24 @@ async fn aggregated_generation_converts_request_stream_and_usage() {
 }
 
 #[tokio::test]
+async fn lora_routing_is_forwarded_to_native_grpc() {
+    let server = FakeServer::start(FakeInference::default()).await;
+    let engine = engine(&server.endpoint, DisaggregationMode::Aggregated, 1);
+    engine.start(0).await.expect("start");
+
+    let mut value = serde_json::to_value(request()).expect("serialize request");
+    value["routing"] = json!({"lora_name": "math-r8"});
+    let request = serde_json::from_value(value).expect("deserialize request");
+    collect(&engine, request).await;
+
+    let requests = server.service.requests.lock().await;
+    assert_eq!(
+        requests.first().expect("recorded request").lora_name,
+        "math-r8"
+    );
+}
+
+#[tokio::test]
 async fn grpc_request_errors_are_propagated() {
     let service = FakeInference::default();
     service.reject.store(true, Ordering::SeqCst);
@@ -1189,11 +1207,9 @@ async fn unsupported_features_fail_before_rpc_submission() {
     multimodal.mm_processor_kwargs = Some(json!({"use_audio_in_video": true}));
     requests.push(multimodal);
 
-    for routing in [json!({"lora_name": "adapter"}), json!({"dp_rank": 1})] {
-        let mut value = serde_json::to_value(request()).expect("serialize request");
-        value["routing"] = routing;
-        requests.push(serde_json::from_value(value).expect("deserialize request"));
-    }
+    let mut value = serde_json::to_value(request()).expect("serialize request");
+    value["routing"] = json!({"dp_rank": 1});
+    requests.push(serde_json::from_value(value).expect("deserialize request"));
 
     for unsupported in requests {
         let context = dynamo_backend_common::testing::mock_context();

--- a/lib/sidecar/vllm/src/tests.rs
+++ b/lib/sidecar/vllm/src/tests.rs
@@ -683,6 +683,8 @@ fn load_lora_payload_requires_a_local_file_uri() {
     for uri in [
         "https://example.com/adapter",
         "file://remote/adapter",
+        "file:///adapter?version=1",
+        "file:///adapter#fragment",
         "relative",
     ] {
         let error = parse_load_lora(&json!({

--- a/lib/sidecar/vllm/tests/executable.rs
+++ b/lib/sidecar/vllm/tests/executable.rs
@@ -18,8 +18,10 @@ fn executable_exposes_native_grpc_configuration() {
     let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
     for flag in [
         "--vllm-endpoint",
+        "--admin-endpoint",
         "--grpc-connections",
         "--model-path",
+        "--rl-discovery-model-name",
         "--disaggregation-mode",
         "--grpc-connect-attempt-timeout-secs",
         "--grpc-retry-interval-secs",


### PR DESCRIPTION
## Overview

Add an out-of-process vLLM backend that connects Dynamo to vLLM's existing native Rust gRPC/token-in-token-out service. The sidecar supports aggregated and disaggregated generation, multimodal inputs, prompt/completion logprobs, KV handoff, runtime LoRA, metrics, session affinity, and opt-in worker discovery for external RL trainers.

Companion PRs:

- Prime-RL discovery/control integration: [PrimeIntellect-ai/prime-rl#3062](https://github.com/PrimeIntellect-ai/prime-rl/pull/3062)
- vLLM native protocol/server: [biswapanda/vllm#1](https://github.com/biswapanda/vllm/pull/1)

Exact tested heads:

| Repository | Commit |
|---|---|
| Dynamo | `fc556d992cd2525eaf6ae0f612f31a46db2e5a7b` |
| Prime-RL | `7a8f90b2495e344f5b9198e20f418c472018b1ad` |
| vLLM | `e74fc3f1b06258e25519a5d5ed4d9a1b05d9a1cb` |

## Architecture

- Dynamo owns frontend routing, distributed discovery, P/D orchestration, worker/system endpoints, and metrics.
- `dynamo-vllm-sidecar` runs out of process and connects to a separately managed vLLM EngineCore/Rust server over the native protocol.
- vLLM owns scheduling, generation, worker extensions, and engine control.
- Native gRPC remains pod-local; the sidecar publishes the vLLM HTTP administration address required by an external trainer.
- Existing in-process vLLM and non-RL Dynamo deployments remain supported.

## Request and response parity

The sidecar maps token IDs, canonical request/model identity, priority, cache salt, DP-rank hints, sampling parameters, stops, structured output, prompt/completion logprobs, streaming usage, multimodal inputs, routed experts, and KV-transfer metadata. Unsupported or malformed fields fail explicitly instead of being silently discarded.

The current branch also bridges token-native response selection, prefix-cache versioning, legacy cache-salt normalization, native LoRA routing, and protocol-v1 control discovery onto the refreshed sidecar foundation.

## RL worker discovery

Discovery is opt-in and served on a separate listener:

```text
DYN_ENABLE_RL=true
DYN_RL_PORT=8001
```

`GET /v1/rl/workers` returns one record per engine endpoint with model identity, direct vLLM admin URL, Dynamo system URL/routes, and engine world size. Probe failures remain record-local so the trainer can reject and retry the complete snapshot. Protocol v1 intentionally does not publish trainer-specific rank offsets or claim an atomic topology epoch.

## Session affinity and LoRA

Prime forwards trajectory identity as the canonical session header. When frontend session affinity is enabled, successive multi-turn requests stay on the same decode worker for the configured idle TTL; ordinary routing remains the fallback for requests without a session key.

The sidecar advertises and forwards native load/unload/list LoRA operations while preserving model and capability metadata across Python/Rust registration. Mixed-capability snapshots are rejected by Prime.

## Validation

The exact final ARM64 stack passed 35 focused Prime-side configuration, discovery, broadcaster, serving-adapter, and rank tests plus explicit non-Dynamo compatibility gates. DIND build/import gates also passed for the Dynamo and vLLM layers.

The stack was deployed as `q06v4i-0803` in `bis-rl-3` with one CPU frontend, one aggregated inference GPU running vLLM-rs/Python EngineCore plus the separate Dynamo sidecar, and one external Prime trainer GPU. Qwen3-0.6B Math completed three trainer and orchestrator steps. `/v1/models` and `/v1/rl/workers` returned HTTP 200, discovery reported one complete `world_size=1` engine, all three policy versions reloaded, and post-update generation returned HTTP 200. The inference worker generated 14,510 tokens at 172.21 tokens/s aggregate with zero container restarts.

Images:

```text
nvcr.io/nvidian/dynamo-dev/biswa@sha256:be98b7cbbea4f3053eb20ad0d0596beab6644f02adc4d01c94ec845603c225dc
nvcr.io/nvidian/dynamo-dev/biswa@sha256:6740b20164a7091b252046b98786fbf39a18902b463eeb5b480384de4e9f4cfb
```

## Review map

- `lib/vllm-sidecar/` — native sidecar request, response, lifecycle, and control bridge
- `lib/rl/` — frontend `/v1/rl/workers` API
- `lib/backend-common/src/rl.rs` — worker metadata endpoint
- frontend generation conversion — canonical Dynamo request contract
- sidecar deployment examples — aggregated and disaggregated launch shapes

## Scope

- RL discovery is disabled unless explicitly enabled.
- The sidecar consumes vLLM's native protocol; it does not depend on `openengine.v1`.
- This PR adds no Prime-RL trainer/orchestrator or Helm-chart code.
- Active collectives are not elastic; topology epochs, worker replacement, and communicator reconstruction remain follow-up work.