### PR TITLE
test(bindings): fix flaky test_chat_completion_success readiness race

### DIFF
--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -127,54 +127,55 @@ async def http_server(runtime: DistributedRuntime):
             raise ValueError(f"Server failed to start: {e}")
 
     server_task = asyncio.create_task(worker())
-    await asyncio.wait_for(start_done.wait(), timeout=30.0)
 
     def raise_if_server_exited():
-        # A finished startup task means the server never stayed up: surface its
-        # exception, or the fact that it exited cleanly (exception() is None).
+        # A finished startup task means the server never came up.
         if server_task.done():
             raise ValueError(
-                f"Server task exited during startup: {server_task.exception()}"
-            )
+                "HTTP server exited during startup"
+            ) from server_task.exception()
 
-    raise_if_server_exited()
+    async def stop_server():
+        service.shutdown()
+        await asyncio.sleep(0.1)  # let the service drain in flight requests
+        if not server_task.done():
+            server_task.cancel()
+            try:
+                await asyncio.wait_for(server_task, timeout=10.0)
+            except asyncio.CancelledError:
+                pass
 
-    # start_done only signals that service.run() returned; the socket is bound
-    # later on the runtime's background threads. Poll until the port actually
-    # accepts a connection so the client can't race ahead of the bind.
-    loop = asyncio.get_running_loop()
-    deadline = loop.time() + 10.0
-    while loop.time() < deadline:
-        try:
-            _, writer = await asyncio.open_connection("localhost", port)
-        except OSError:
-            raise_if_server_exited()
-            await asyncio.sleep(0.1)
-            continue
-        # Connected: the server is listening. Close the probe best-effort; a
-        # reset while tearing down the bare socket doesn't undo readiness.
-        writer.close()
-        try:
-            await writer.wait_closed()
-        except OSError:
-            pass
-        break
-    else:
-        raise TimeoutError(f"HTTP server did not accept connections on port {port}")
+    try:
+        await asyncio.wait_for(start_done.wait(), timeout=30.0)
+        raise_if_server_exited()
+
+        # start_done fires when service.run() returns, but the socket is bound
+        # later on the runtime's background threads; wait until it accepts.
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + 10.0
+        while loop.time() < deadline:
+            try:
+                _, writer = await asyncio.open_connection("localhost", port)
+            except ConnectionError:
+                raise_if_server_exited()
+                await asyncio.sleep(0.1)
+                continue
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except OSError:
+                pass
+            break
+        else:
+            raise TimeoutError(f"HTTP server did not accept connections on port {port}")
+    except BaseException:
+        # Teardown below the yield is skipped when setup fails, so clean up here.
+        await stop_server()
+        raise
 
     yield f"http://localhost:{port}", model_name
 
-    # Teardown: Cancel the server task if it's still running
-    service.shutdown()  # Shutdown service
-    await asyncio.sleep(0.1)  # Give some time for graceful shutdown
-    if not server_task.done():
-        server_task.cancel()
-        try:
-            # Await cancellation to ensure proper cleanup for up to 10s
-            await asyncio.wait_for(server_task, timeout=10.0)
-        except asyncio.CancelledError:
-            print("Server task cancelled during teardown.")
-            pass
+    await stop_server()
 
 
 @pytest.mark.asyncio

--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -144,7 +144,11 @@ async def http_server(runtime: DistributedRuntime):
                 _, writer = await asyncio.open_connection("localhost", port)
                 writer.close()
                 return
-            except ConnectionError:
+            except OSError:
+                # localhost can resolve to both ::1 and 127.0.0.1; when every
+                # address is refused open_connection raises a bare OSError, not
+                # ConnectionError, so the catch cannot be narrowed. The outer
+                # wait_for bounds how long a genuinely-down server retries.
                 raise_if_server_exited()
                 await asyncio.sleep(0.1)
 

--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -143,14 +143,14 @@ async def http_server(runtime: DistributedRuntime):
             try:
                 _, writer = await asyncio.open_connection("localhost", port)
                 writer.close()
-                return
             except OSError:
-                # localhost can resolve to both ::1 and 127.0.0.1; when every
-                # address is refused open_connection raises a bare OSError, not
-                # ConnectionError, so the catch cannot be narrowed. The outer
-                # wait_for bounds how long a genuinely-down server retries.
+                # open_connection raises a bare OSError, not ConnectionError,
+                # when every resolved address is refused; don't narrow this.
                 raise_if_server_exited()
                 await asyncio.sleep(0.1)
+                continue
+            raise_if_server_exited()  # a stale listener may answer; confirm ours bound
+            return
 
     async def stop_server():
         service.shutdown()

--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -128,8 +128,40 @@ async def http_server(runtime: DistributedRuntime):
 
     server_task = asyncio.create_task(worker())
     await asyncio.wait_for(start_done.wait(), timeout=30.0)
-    if server_task.done() and server_task.exception():
-        raise ValueError(f"Server task failed to start {server_task.exception()}")
+
+    def raise_if_server_exited():
+        # A finished startup task means the server never stayed up: surface its
+        # exception, or the fact that it exited cleanly (exception() is None).
+        if server_task.done():
+            raise ValueError(
+                f"Server task exited during startup: {server_task.exception()}"
+            )
+
+    raise_if_server_exited()
+
+    # start_done only signals that service.run() returned; the socket is bound
+    # later on the runtime's background threads. Poll until the port actually
+    # accepts a connection so the client can't race ahead of the bind.
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + 10.0
+    while loop.time() < deadline:
+        try:
+            _, writer = await asyncio.open_connection("localhost", port)
+        except OSError:
+            raise_if_server_exited()
+            await asyncio.sleep(0.1)
+            continue
+        # Connected: the server is listening. Close the probe best-effort; a
+        # reset while tearing down the bare socket doesn't undo readiness.
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except OSError:
+            pass
+        break
+    else:
+        raise TimeoutError(f"HTTP server did not accept connections on port {port}")
+
     yield f"http://localhost:{port}", model_name
 
     # Teardown: Cancel the server task if it's still running

--- a/lib/bindings/python/tests/test_http_server.py
+++ b/lib/bindings/python/tests/test_http_server.py
@@ -16,6 +16,7 @@
 # This test verifies that the HTTP server can be started and responds correctly to requests.
 
 import asyncio
+import contextlib
 import json
 import time
 from typing import AsyncGenerator, Dict
@@ -135,42 +136,30 @@ async def http_server(runtime: DistributedRuntime):
                 "HTTP server exited during startup"
             ) from server_task.exception()
 
+    async def wait_until_accepting():
+        # start_done fires when service.run() returns, but the socket is bound
+        # later on the runtime's background threads; wait until it accepts.
+        while True:
+            try:
+                _, writer = await asyncio.open_connection("localhost", port)
+                writer.close()
+                return
+            except ConnectionError:
+                raise_if_server_exited()
+                await asyncio.sleep(0.1)
+
     async def stop_server():
         service.shutdown()
-        await asyncio.sleep(0.1)  # let the service drain in flight requests
-        if not server_task.done():
-            server_task.cancel()
-            try:
-                await asyncio.wait_for(server_task, timeout=10.0)
-            except asyncio.CancelledError:
-                pass
+        server_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError, Exception):
+            await asyncio.wait_for(server_task, timeout=10.0)
 
     try:
         await asyncio.wait_for(start_done.wait(), timeout=30.0)
         raise_if_server_exited()
-
-        # start_done fires when service.run() returns, but the socket is bound
-        # later on the runtime's background threads; wait until it accepts.
-        loop = asyncio.get_running_loop()
-        deadline = loop.time() + 10.0
-        while loop.time() < deadline:
-            try:
-                _, writer = await asyncio.open_connection("localhost", port)
-            except ConnectionError:
-                raise_if_server_exited()
-                await asyncio.sleep(0.1)
-                continue
-            writer.close()
-            try:
-                await writer.wait_closed()
-            except OSError:
-                pass
-            break
-        else:
-            raise TimeoutError(f"HTTP server did not accept connections on port {port}")
+        await asyncio.wait_for(wait_until_accepting(), timeout=10.0)
     except BaseException:
-        # Teardown below the yield is skipped when setup fails, so clean up here.
-        await stop_server()
+        await stop_server()  # teardown past the yield won't run on setup failure
         raise
 
     yield f"http://localhost:{port}", model_name


### PR DESCRIPTION
## Overview:
`test_http_server.py::test_chat_completion_success` fails intermittently in CI with `aiohttp ClientConnectorError [Errno 111]` connecting to `localhost:8008`. It is a server-readiness race in the test fixture, unrelated to any product change, so it flakes unrelated PRs.

Observed on this run (1 failed / 2040 passed): https://github.com/ai-dynamo/dynamo/actions/runs/29474878470/job/87546934346?pr=11731

## Details:
The `http_server` fixture sets `start_done` as soon as `service.run()` returns a shutdown handle, but the HTTP service binds its socket later on the runtime's background threads. `start_done` therefore signals "run() was called", not "the port is listening". When the client wins that race it connects before the bind completes and gets connection-refused. It usually passes because the bind normally wins the race, but on a cold or loaded runner it does not.

The fixture now polls the port with `asyncio.open_connection` after `start_done` and only yields once the socket accepts a connection, which closes the race window. While here, the duplicated dead-server check is factored into a small `raise_if_server_exited()` helper that also catches a clean early exit, not just an exception.

Reproduced the exact `ClientConnectorError` three times in a dev container on a cold or contended first bind; it passes reliably once the runner is warm. With the readiness poll the client can no longer race the bind by construction.

## Where should the reviewer start?
`lib/bindings/python/tests/test_http_server.py` - the readiness poll added to the `http_server` fixture.

## Related Issues
🚫 This PR is NOT linked to an issue:
- [x] Confirmed - no related issue

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11810" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved HTTP server startup validation.
  * Added connection polling to ensure the server is reachable before tests proceed.
  * Added clearer errors for startup failures and a timeout when the server does not become available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->