### PR TITLE
fix(container): source-build NIXL for the sglang EFA runtime image (DYN-3429)

### DIFF
--- a/container/context.yaml
+++ b/container/context.yaml
@@ -104,6 +104,14 @@ sglang:
     # GPL ffmpeg/codec dpkgs; the GPL imageio-ffmpeg pip binary is replaced by an
     # in-tree LGPL ffmpeg in sglang_runtime.Dockerfile — no dpkg purge needed.)
     baseline_sbom: cuda@8b2705ea
+    # DYN-3429 / NVBug 6431579: EFA FI_MORE hang fix. Only the AWS EFA runtime
+    # overlay (templates/aws.Dockerfile) consumes this, installing a Dynamo-built
+    # nixl-cu13 wheel at this ref over the upstream lmsysorg/sglang nixl-cu13==1.3.0.
+    # Applied only when make_efa is true (see templates/args.Dockerfile), so non-EFA
+    # sglang runtime/dev images keep the framework default nixl_ref (v1.0.1) and the
+    # upstream runtime NIXL stack. Pin the ai-dynamo/nixl release/1.3.1 BRANCH commit;
+    # the v1.3.1 TAG diverged and does NOT carry the fix.
+    nixl_efa_ref: 322ba2a7
   xpu:
     base_image: intel/deep-learning-essentials
     base_image_tag: 2025.3.2-0-devel-ubuntu24.04

--- a/container/templates/args.Dockerfile
+++ b/container/templates/args.Dockerfile
@@ -66,7 +66,13 @@ ARG SCCACHE_REGION=""
 
 # NIXL configuration
 ARG NIXL_UCX_REF={{ context.dynamo.nixl_ucx_ref }}
-{% if "nixl_ref" in context[framework].get(device_key, {}) -%}
+{% if make_efa == true and target == "runtime" and "nixl_efa_ref" in context[framework].get(device_key, {}) -%}
+# DYN-3429 / NVBug 6431579: the AWS EFA runtime build pins the ai-dynamo/nixl
+# release/1.3.1 fix (FI_MORE batching disabled on efa/efa-direct). Scoped to the
+# make_efa runtime image so non-EFA and dev {{ framework }} images keep the default
+# nixl_ref below.
+ARG NIXL_REF={{ context[framework][device_key].nixl_efa_ref }}
+{% elif "nixl_ref" in context[framework].get(device_key, {}) -%}
 ARG NIXL_REF={{ context[framework][device_key].nixl_ref }}
 {% elif "nixl_ref" in context[framework] -%}
 ARG NIXL_REF={{ context[framework].nixl_ref }}

--- a/container/templates/aws.Dockerfile
+++ b/container/templates/aws.Dockerfile
@@ -89,6 +89,27 @@ ENV LD_PRELOAD=/opt/nvidia/nvda_nixl/lib64/libnixl.so
 ENV NIXL_PLUGIN_DIR=/opt/nvidia/nvda_nixl/lib64/plugins
 {% endif %}
 
+{% if framework == "sglang" and target == "runtime" %}
+# DYN-3429 / NVBug 6431579: the upstream lmsysorg/sglang runtime image ships
+# nixl-cu13==1.3.0, whose libfabric rail manager issues unconditional FI_MORE
+# batched writes on efa/efa-direct and hangs. Overlay the Dynamo-built nixl-cu13
+# wheel (compiled from ai-dynamo/nixl @ NIXL_REF in wheel_builder, which the EFA
+# build pins to the release/1.3.1 fix commit) over the inherited one. The fix adds
+# is_efa_provider and gates FI_MORE batching off on EFA. Scoped to the EFA runtime
+# image only; non-EFA sglang images keep the upstream NIXL stack. Runs as root
+# (the USER root above), matching the sglang_runtime pip convention.
+RUN --mount=from=wheel_builder,source=/opt/dynamo/dist/nixl,target=/tmp/nixl-wheel \
+    --mount=type=cache,target=/root/.cache/pip,sharing=locked \
+    NIXL_WHEEL="$(find /tmp/nixl-wheel -name 'nixl_cu*.whl' | head -n1)" && \
+    if [ -z "$NIXL_WHEEL" ]; then \
+        echo "[aws] ERROR: no Dynamo-built nixl-cu wheel in wheel_builder /opt/dynamo/dist/nixl" >&2; \
+        exit 1; \
+    fi && \
+    echo "[aws] sglang NIXL overlay: installing $(basename "$NIXL_WHEEL") over inherited upstream nixl-cu13" && \
+    export PIP_CACHE_DIR=/root/.cache/pip && \
+    pip install --break-system-packages --no-deps --force-reinstall "$NIXL_WHEEL"
+{% endif %}
+
 {% if target == "runtime" %}
 USER dynamo
 {% endif %}

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -687,7 +687,12 @@ RUN echo "$NIXL_LIB_DIR" > /etc/ld.so.conf.d/nixl.conf && \
     echo "$NIXL_PLUGIN_DIR" >> /etc/ld.so.conf.d/nixl.conf && \
     ldconfig
 
-{% if not (framework == "sglang" and device == "cuda" and target in ("runtime", "dev", "local-dev")) %}
+{# SGLang CUDA normally skips the NIXL Python wheel (runtime uses the upstream
+   lmsysorg/sglang NIXL stack; dev links nixl-sys against the native SDK only).
+   Exception: the AWS EFA runtime build (make_efa) needs a Dynamo-built nixl-cu13
+   wheel so templates/aws.Dockerfile can overlay the DYN-3429 fix over the
+   inherited nixl-cu13==1.3.0. #}
+{% if not (framework == "sglang" and device == "cuda" and target in ("runtime", "dev", "local-dev") and not (make_efa == true and target == "runtime")) %}
 # Build NIXL wheel → /opt/dynamo/dist/nixl/nixl*.whl (C++ transport library, all targets)
 ARG PYTHON_VERSION
 RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token \


### PR DESCRIPTION
## What

Fixes the SGLang CUDA **EFA** runtime hang (DYN-3429 / NVBug 6431579) by building a full `nixl-cu13` wheel from source and overlaying it onto the sglang EFA runtime image, replacing the inherited upstream `nixl-cu13==1.3.0`.

## Why

The upstream `lmsysorg/sglang` runtime ships `nixl-cu13==1.3.0`, whose libfabric rail manager issues unconditional `FI_MORE` batched writes on `efa`/`efa-direct` providers and hangs on AWS EFA. The fix is upstream-merged in `ai-dynamo/nixl` at commit **`322ba2a7`** (HEAD of `release/1.3.1`): it adds `is_efa_provider` and disables `FI_MORE` batching on EFA. This consumes that merged fix directly.

We pin the `release/1.3.1` **branch commit `322ba2a7`**, not the `v1.3.1` tag — the tag diverged from the branch and does **not** carry the fix.

This **supersedes** the interim binary-plugin-swap approach in #11549 (same base branch). Core and plugin both come from `322ba2a7`, so the overlay is ABI-coherent.

## How (scoped to the SGLang cuda EFA runtime target only)

- `container/context.yaml`: `sglang.cuda13.0.nixl_efa_ref = 322ba2a7`, consumed only by the EFA runtime build.
- `container/templates/args.Dockerfile`: resolve `NIXL_REF` to `nixl_efa_ref` only when `make_efa` and `target=runtime`.
- `container/templates/wheel_builder.Dockerfile`: build the `nixl-cu13` wheel for the sglang cuda EFA runtime (previously skipped for all sglang cuda runtime/dev/local-dev).
- `container/templates/aws.Dockerfile`: overlay the wheel_builder-built `nixl-cu13` wheel over the inherited one, mirroring the existing trtllm EFA NIXL override.

Rendering the Dockerfile matrix confirms only the sglang EFA runtime render pins `NIXL_REF=322ba2a7`, builds the wheel, and applies the overlay; non-EFA sglang runtime/dev images and every other framework are unchanged.

## Testing

- Verified: `container/render.py` renders the full framework/target/device/EFA matrix cleanly under StrictUndefined; scoping confirmed by grepping the rendered outputs (only sglang cuda EFA runtime changes).
- Still required (needs hardware, not runnable in the authoring env): multi-arch image build of the sglang EFA runtime, then the 9-case SGLang EFA regression on an AWS EFA cluster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
