### PR TITLE
Nmailhot/fix 11628 ffmpeg

### DIFF
--- a/container/compliance/native_packages.yaml
+++ b/container/compliance/native_packages.yaml
@@ -81,7 +81,7 @@ packages:
   # and copied into vllm/sglang runtime (container/templates/vllm_runtime.Dockerfile
   # + sglang_runtime.Dockerfile). Replaces the purged GPL apt ffmpeg.
   - name: ffmpeg
-    version: "8.1"
+    version: "8.1.2"
     license: LGPL-2.1-or-later
     source: https://ffmpeg.org/
     images:

--- a/container/context.yaml
+++ b/container/context.yaml
@@ -43,7 +43,10 @@ dynamo:
   enable_kvbm: "true"
   enable_media_ffmpeg: "false"
   enable_gpu_memory_service: "true"
-  ffmpeg_version: "8.1"
+  # 8.1.2 is an upstream maintenance release that picks up security fixes over
+  # 8.1; combined with the narrowed decoder set in wheel_builder it trims the
+  # media decode surface. Keep in sync with native_packages.yaml's ffmpeg entry.
+  ffmpeg_version: "8.1.2"
   # ffmpeg build inputs (only consumed when ENABLE_MEDIA_FFMPEG=true).
   nv_codec_headers_ref: "n13.0.19.0"
   libvpx_ref: "v1.14.1"

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -294,6 +294,20 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 # Stays LGPL-only: --disable-gpl --disable-nonfree are preserved; H.264 comes from
 # NVIDIA's NVENC (proprietary HW encoder, already a runtime dependency of these
 # GPU images) and VP9 from libvpx (BSD).
+#
+# MEDIA CODEC ALLOWLIST (see OPS-7665): the in-tree libavcodec should carry only
+# the media formats we actually build and use, not ffmpeg's full default decoder
+# set. A blanket --disable-decoders/--disable-demuxers/--disable-parsers plus a
+# narrow allowlist keeps the shipped libav*.so limited to that set (HW NVDEC can
+# be re-added explicitly if a decode feature ever needs H.264/H.265). The
+# allowlist covers exactly two paths: (1) the encode CLI ingesting rawvideo
+# frames from imageio over a pipe, and (2) the Rust media-ffmpeg VideoDecoder
+# decoding VP8/VP9 in mp4/webm/mkv (test fixtures are VP9-in-mp4). Image decode
+# does not use ffmpeg (it goes through the Rust `image` crate), so no still-image
+# decoders are enabled here.
+#
+# Combined with the 8.1 -> 8.1.2 bump below (an upstream maintenance release),
+# this also trims the decoder surface to what we ship.
 # Do not delete the source tarball for legal reasons.
 ARG FFMPEG_VERSION
 ARG NV_CODEC_HEADERS_REF
@@ -346,8 +360,15 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --enable-libvpx \
         --disable-encoders \
         --enable-encoder=h264_nvenc,libvpx_vp9 \
+        --disable-decoders \
+        --enable-decoder=vp8,vp9,rawvideo \
         --disable-muxers \
         --enable-muxer=mov,mp4,matroska,webm \
+        --disable-demuxers \
+        --enable-demuxer=mov,matroska,rawvideo \
+        --disable-parsers \
+        --enable-parser=vp8,vp9 \
+        --disable-protocols \
         --enable-protocol=file,pipe && \
     make -j$(nproc) && \
     make install && \

--- a/container/templates/wheel_builder.Dockerfile
+++ b/container/templates/wheel_builder.Dockerfile
@@ -301,10 +301,17 @@ ENV SCCACHE_BUCKET=${USE_SCCACHE:+${SCCACHE_BUCKET}} \
 # narrow allowlist keeps the shipped libav*.so limited to that set (HW NVDEC can
 # be re-added explicitly if a decode feature ever needs H.264/H.265). The
 # allowlist covers exactly two paths: (1) the encode CLI ingesting rawvideo
-# frames from imageio over a pipe, and (2) the Rust media-ffmpeg VideoDecoder
-# decoding VP8/VP9 in mp4/webm/mkv (test fixtures are VP9-in-mp4). Image decode
-# does not use ffmpeg (it goes through the Rust `image` crate), so no still-image
-# decoders are enabled here.
+# frames from imageio over a pipe and muxing h264_nvenc output into mp4, and
+# (2) the Rust media-ffmpeg VideoDecoder decoding VP8/VP9 in mp4/webm/mkv (test
+# fixtures are VP9-in-mp4). Image decode does not use ffmpeg (it goes through the
+# Rust `image` crate), so no still-image decoders are enabled here.
+#
+# The h264 PARSER (not decoder) is enabled: the ffmpeg CLI attaches an output
+# parser for the encoded stream, and the mov/mp4 muxer needs it to frame
+# h264_nvenc packets and write avcC extradata. Without it the video-generation
+# encode aborts ("Broken pipe" from imageio). This is parse-only for our own
+# encoder output — no H.264 *decoder* is added, so the OPS-7665 decode surface
+# is unchanged.
 #
 # Combined with the 8.1 -> 8.1.2 bump below (an upstream maintenance release),
 # this also trims the decoder surface to what we ship.
@@ -367,7 +374,7 @@ RUN --mount=type=secret,id=aws-web-identity-token,target=/run/secrets/aws-token 
         --disable-demuxers \
         --enable-demuxer=mov,matroska,rawvideo \
         --disable-parsers \
-        --enable-parser=vp8,vp9 \
+        --enable-parser=vp8,vp9,h264 \
         --disable-protocols \
         --enable-protocol=file,pipe && \
     make -j$(nproc) && \

--- a/lib/llm/src/preprocessor/media/README.md
+++ b/lib/llm/src/preprocessor/media/README.md
@@ -52,6 +52,9 @@ register_model(
 > [!WARNING]
 > **Video decoding**: Video decoding needs to be enabled via the `dynamo-llm/media-ffmpeg` rust feature. The following ffmpeg dynamic libraries must be available on the system: `libavcodec`, `libavdevice`, `libavfilter`, `libavformat`, `libswresample`, `libswscale`. These are available in dynamo dockerfiles rendered with `enable_media_ffmpeg` set to true in `container/context.yaml`.
 
+> [!WARNING]
+> **Supported input codecs**: The in-tree ffmpeg is built with a narrow decoder allowlist (VP8/VP9 video in mp4/webm/mkv) — it carries only the media formats we build and use, not ffmpeg's full default set (see `container/templates/wheel_builder.Dockerfile` and OPS-7665). Other codecs, including H.264 and H.265, are intentionally **not** decodable in software; decoding them would require enabling the NVDEC hardware decoders (`h264_cuvid`/`hevc_cuvid`), which is not wired up today.
+
 ## Image decoding options
 
 ### Limits (not overridable at runtime via `media_io_kwargs`)

--- a/lib/llm/src/preprocessor/media/decoders/video.rs
+++ b/lib/llm/src/preprocessor/media/decoders/video.rs
@@ -315,6 +315,9 @@ mod tests {
 
     /// Load test video and parse expected dimensions from filename.
     /// Filename format: "{resolution}_{frames}.mp4" (e.g., "240p_10.mp4" -> 320x240, 10 frames)
+    /// Fixtures are VP9-in-mp4: the in-tree ffmpeg only decodes a narrow
+    /// allowlist (VP8/VP9), so H.264 fixtures would not decode. Regenerate with
+    /// `ffmpeg -f lavfi -i testsrc2=size=WxH:rate=1 -frames:v N -c:v libvpx-vp9 -g 1 -strict -2`.
     fn load_test_video(filename: &str) -> (EncodedMediaData, u32, u32, u32) {
         let path = format!(
             "{}/tests/data/media/{}",

--- a/lib/llm/tests/data/media/2160p_10.mp4
+++ b/lib/llm/tests/data/media/2160p_10.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f82a62d48a38e29ea004d0991adea5cdf2838e17647f24e8350aecc8297b8916
-size 5416
+oid sha256:462fa796a3099539df042a684b944e38acb2b19a2ddcceb760f88c092a1b805d
+size 1009737

--- a/lib/llm/tests/data/media/240p_1.mp4
+++ b/lib/llm/tests/data/media/240p_1.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4442d098b32b29a3e7f9babac257a8c6ab3c4ed41cd2e1ad62df1e4734b92b6b
-size 1597
+oid sha256:ac4dd818eb2b1371b0756704d7322bc64ef8ae9c68f8a6da1a4c12a26326485e
+size 6541

--- a/lib/llm/tests/data/media/240p_10.mp4
+++ b/lib/llm/tests/data/media/240p_10.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:125d25fa5f09f44ae09e79e09d2e6c85a417ae8279a069eaab310b0e28cab18d
-size 1913
+oid sha256:e72a3b7b83ec10000db8071bcafec959f110907d02f88da92ff792463ccb3eed
+size 65804

--- a/lib/llm/tests/data/media/240p_100.mp4
+++ b/lib/llm/tests/data/media/240p_100.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:c534d517ee77150ec971b3568dd999c09bbd4ec7850abed417f063bddb8e514f
-size 4579
+oid sha256:13211b149c490748c2518313eae17181fca1082d7449e9b16a11e6728a0db3b4
+size 659773

--- a/lib/llm/tests/data/media/2p_10.mp4
+++ b/lib/llm/tests/data/media/2p_10.mp4
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:6cb1a8ca5c3ee2391a1606fac4004685e57fcc0ac5277773ccfdada534bb63f3
-size 1832
+oid sha256:ccf744a1e29f99d50d4988637f90a7d1110f3387ea059589c994a8f8ebdc25d4
+size 1180


### PR DESCRIPTION
## Overview:

<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated the bundled FFmpeg version to 8.1.2, including upstream security fixes.
  * Restricted supported media codecs, containers, and protocols to a narrower allowlist.
  * Continued support for VP8/VP9 decoding, with H.264 available for parsing only.
  * Documented current media input limitations, including unavailable H.264/H.265 software decoding and NVDEC support.
  * Updated media fixture documentation to reflect the supported decoder configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->