### PR TITLE
perf(logging): avoid dynamic filter span locks

### DIFF
--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -1520,22 +1520,42 @@ fn filters(config: LoggingConfig) -> LoggingFilter {
 /// `RwLock`, and its span lifecycle callbacks acquire that lock even when the
 /// configured directives are all static.
 fn targets_filter(config: &LoggingConfig, dyn_log: Option<&str>) -> Option<Targets> {
-    let mut directives = vec![config.log_level.clone()];
+    // `EnvFilter::parse_lossy` ignores zero-length comma-separated segments,
+    // but leaves all other text untouched. In particular, do not trim here:
+    // whitespace may make the directive dynamic or invalid.
+    let dyn_directives = dyn_log
+        .into_iter()
+        .flat_map(|value| value.split(',').filter(|directive| !directive.is_empty()));
 
-    if let Some(value) = dyn_log {
+    let mut directives = Vec::new();
+    for directive in dyn_directives {
         // Parsing as `Targets` is also the feature test for whether the
-        // configured directives require EnvFilter's dynamic span matching.
-        value.parse::<Targets>().ok()?;
-        directives.push(value.to_string());
+        // configured directive requires EnvFilter's dynamic span matching.
+        directive.parse::<Targets>().ok()?;
+        directives.push(directive.to_string());
+    }
+
+    // EnvFilter uses the configured default only when DYN_LOG is absent or
+    // contains no directives. A target-only DYN_LOG must leave other targets
+    // disabled rather than inheriting the configured default level.
+    if directives.is_empty() {
+        directives.push(config.log_level.clone());
     }
 
     for (module, level) in &config.log_filters {
         let directive = format!("{module}={level}");
         match directive.parse::<Targets>() {
             Ok(_) => directives.push(directive),
-            Err(e) => {
-                eprintln!("Failed parsing filter '{level}' for module '{module}': {e}");
-            }
+            Err(_) => match directive.parse::<Directive>() {
+                // Valid span or field directives require EnvFilter's dynamic
+                // matching, so do not silently drop a configured filter.
+                Ok(_) => return None,
+                // Preserve the pre-fast-path warn-and-ignore behavior for
+                // directives that neither parser accepts.
+                Err(e) => {
+                    eprintln!("Failed parsing filter '{level}' for module '{module}': {e}");
+                }
+            },
         }
     }
 
@@ -1919,7 +1939,31 @@ pub mod tests {
     use tempfile::NamedTempFile;
 
     #[test]
-    fn target_level_directives_use_static_filter() {
+    fn unset_dyn_log_uses_configured_default() {
+        let filter = targets_filter(&LoggingConfig::default(), None)
+            .expect("an unset DYN_LOG should use Targets");
+
+        assert!(filter.would_enable("request_span", &tracing::Level::TRACE));
+        assert!(filter.would_enable("unlisted_target", &tracing::Level::INFO));
+        assert!(!filter.would_enable("unlisted_target", &tracing::Level::DEBUG));
+        assert!(!filter.would_enable("tower", &tracing::Level::WARN));
+    }
+
+    #[test]
+    fn empty_dyn_log_uses_configured_default() {
+        for dyn_log in ["", ",,"] {
+            let filter = targets_filter(&LoggingConfig::default(), Some(dyn_log))
+                .expect("an empty DYN_LOG should use Targets");
+
+            assert!(filter.would_enable("request_span", &tracing::Level::TRACE));
+            assert!(filter.would_enable("unlisted_target", &tracing::Level::INFO));
+            assert!(!filter.would_enable("unlisted_target", &tracing::Level::DEBUG));
+            assert!(!filter.would_enable("tower", &tracing::Level::WARN));
+        }
+    }
+
+    #[test]
+    fn target_only_dyn_log_does_not_use_configured_default() {
         let filter = targets_filter(
             &LoggingConfig::default(),
             Some("dynamo_runtime::logging=debug"),
@@ -1927,10 +1971,22 @@ pub mod tests {
         .expect("target/level directives should use Targets");
 
         assert!(filter.would_enable("request_span", &tracing::Level::TRACE));
-        assert!(filter.would_enable("unlisted_target", &tracing::Level::INFO));
+        assert!(!filter.would_enable("unlisted_target", &tracing::Level::INFO));
         assert!(!filter.would_enable("unlisted_target", &tracing::Level::DEBUG));
         assert!(filter.would_enable("dynamo_runtime::logging::child", &tracing::Level::DEBUG));
         assert!(!filter.would_enable("tower", &tracing::Level::WARN));
+    }
+
+    #[test]
+    fn trailing_empty_dyn_log_segments_do_not_enable_trace() {
+        let filter = targets_filter(
+            &LoggingConfig::default(),
+            Some("dynamo_runtime::logging=debug,"),
+        )
+        .expect("target/level directives should use Targets");
+
+        assert!(filter.would_enable("dynamo_runtime::logging", &tracing::Level::DEBUG));
+        assert!(!filter.would_enable("unlisted_target", &tracing::Level::TRACE));
     }
 
     #[test]
@@ -1942,6 +1998,19 @@ pub mod tests {
             )
             .is_none()
         );
+    }
+
+    #[test]
+    fn dynamic_log_filters_fall_back_to_env_filter() {
+        let config = LoggingConfig {
+            log_level: DEFAULT_FILTER_LEVEL.to_string(),
+            log_filters: HashMap::from([(
+                "dynamo_runtime[request{model=foo}]".to_string(),
+                "debug".to_string(),
+            )]),
+        };
+
+        assert!(targets_filter(&config, None).is_none());
     }
 
     #[test]

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -1531,7 +1531,7 @@ fn targets_filter(config: &LoggingConfig, dyn_log: Option<&str>) -> Option<Targe
     for directive in dyn_directives {
         // Parsing as `Targets` is also the feature test for whether the
         // configured directive requires EnvFilter's dynamic span matching.
-        directive.parse::<Targets>().ok()?;
+        targets_compatible(directive)?;
         directives.push(directive.to_string());
     }
 
@@ -1544,9 +1544,9 @@ fn targets_filter(config: &LoggingConfig, dyn_log: Option<&str>) -> Option<Targe
 
     for (module, level) in &config.log_filters {
         let directive = format!("{module}={level}");
-        match directive.parse::<Targets>() {
-            Ok(_) => directives.push(directive),
-            Err(_) => match directive.parse::<Directive>() {
+        match targets_compatible(&directive) {
+            Some(()) => directives.push(directive),
+            None => match directive.parse::<Directive>() {
                 // Valid span or field directives require EnvFilter's dynamic
                 // matching, so do not silently drop a configured filter.
                 Ok(_) => return None,
@@ -1565,6 +1565,13 @@ fn targets_filter(config: &LoggingConfig, dyn_log: Option<&str>) -> Option<Targe
 
     directives.push("request_span=trace".to_string());
     directives.join(",").parse::<Targets>().ok()
+}
+
+/// `Targets` accepts bracketed span selectors as literal target names, while
+/// `EnvFilter` interprets them as dynamic span or field selectors. Bracketed
+/// directives therefore require the EnvFilter path even when Targets parses.
+fn targets_compatible(directive: &str) -> Option<()> {
+    (!directive.contains('[') && directive.parse::<Targets>().is_ok()).then_some(())
 }
 
 fn env_filter(config: &LoggingConfig) -> EnvFilter {
@@ -2001,11 +2008,35 @@ pub mod tests {
     }
 
     #[test]
+    fn span_selector_dyn_log_falls_back_to_env_filter() {
+        assert!(
+            targets_filter(
+                &LoggingConfig::default(),
+                Some("dynamo_runtime[request]=debug"),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
     fn dynamic_log_filters_fall_back_to_env_filter() {
         let config = LoggingConfig {
             log_level: DEFAULT_FILTER_LEVEL.to_string(),
             log_filters: HashMap::from([(
                 "dynamo_runtime[request{model=foo}]".to_string(),
+                "debug".to_string(),
+            )]),
+        };
+
+        assert!(targets_filter(&config, None).is_none());
+    }
+
+    #[test]
+    fn span_selector_log_filters_fall_back_to_env_filter() {
+        let config = LoggingConfig {
+            log_level: DEFAULT_FILTER_LEVEL.to_string(),
+            log_filters: HashMap::from([(
+                "dynamo_runtime[request]".to_string(),
                 "debug".to_string(),
             )]),
         };

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -1567,9 +1567,10 @@ fn targets_filter(config: &LoggingConfig, dyn_log: Option<&str>) -> Option<Targe
     directives.join(",").parse::<Targets>().ok()
 }
 
-/// `Targets` accepts bracketed span selectors as literal target names, while
-/// `EnvFilter` interprets them as dynamic span or field selectors. Bracketed
-/// directives therefore require the EnvFilter path even when Targets parses.
+/// An opening `[` begins EnvFilter's span or field selector grammar. Targets
+/// accepts some bracketed forms as literal targets or static field filters, but
+/// routing every bracketed directive through EnvFilter keeps the configuration
+/// language consistent. Curly braces alone remain ordinary target characters.
 fn targets_compatible(directive: &str) -> Option<()> {
     (!directive.contains('[') && directive.parse::<Targets>().is_ok()).then_some(())
 }
@@ -2019,6 +2020,17 @@ pub mod tests {
     }
 
     #[test]
+    fn field_presence_dyn_log_falls_back_to_env_filter() {
+        assert!(
+            targets_filter(
+                &LoggingConfig::default(),
+                Some("dynamo_runtime[{request_id}]=debug"),
+            )
+            .is_none()
+        );
+    }
+
+    #[test]
     fn dynamic_log_filters_fall_back_to_env_filter() {
         let config = LoggingConfig {
             log_level: DEFAULT_FILTER_LEVEL.to_string(),
@@ -2037,6 +2049,19 @@ pub mod tests {
             log_level: DEFAULT_FILTER_LEVEL.to_string(),
             log_filters: HashMap::from([(
                 "dynamo_runtime[request]".to_string(),
+                "debug".to_string(),
+            )]),
+        };
+
+        assert!(targets_filter(&config, None).is_none());
+    }
+
+    #[test]
+    fn field_presence_log_filters_fall_back_to_env_filter() {
+        let config = LoggingConfig {
+            log_level: DEFAULT_FILTER_LEVEL.to_string(),
+            log_filters: HashMap::from([(
+                "dynamo_runtime[{request_id}]".to_string(),
                 "debug".to_string(),
             )]),
         };

--- a/lib/runtime/src/logging.rs
+++ b/lib/runtime/src/logging.rs
@@ -37,6 +37,7 @@ use serde::{Deserialize, Serialize};
 use tracing::level_filters::LevelFilter;
 use tracing::{Event, Subscriber};
 use tracing_subscriber::EnvFilter;
+use tracing_subscriber::filter::Targets;
 use tracing_subscriber::fmt::time::FormatTime;
 use tracing_subscriber::fmt::time::LocalTime;
 use tracing_subscriber::fmt::time::SystemTime;
@@ -68,6 +69,7 @@ use tracing_subscriber::Registry;
 use tracing_subscriber::field::Visit;
 use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::layer::Context;
+use tracing_subscriber::layer::Filter;
 use tracing_subscriber::registry::SpanData;
 use uuid::Uuid;
 
@@ -1421,13 +1423,137 @@ fn setup_logging() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-fn filters(config: LoggingConfig) -> EnvFilter {
+#[allow(clippy::large_enum_variant)] // Constructed once during logging initialization.
+enum LoggingFilter {
+    Targets(Targets),
+    Env(EnvFilter),
+}
+
+impl<S> Filter<S> for LoggingFilter {
+    #[inline]
+    fn enabled(&self, meta: &tracing::Metadata<'_>, cx: &Context<'_, S>) -> bool {
+        match self {
+            Self::Targets(filter) => <Targets as Filter<S>>::enabled(filter, meta, cx),
+            Self::Env(filter) => <EnvFilter as Filter<S>>::enabled(filter, meta, cx),
+        }
+    }
+
+    #[inline]
+    fn callsite_enabled(
+        &self,
+        meta: &'static tracing::Metadata<'static>,
+    ) -> tracing::subscriber::Interest {
+        match self {
+            Self::Targets(filter) => <Targets as Filter<S>>::callsite_enabled(filter, meta),
+            Self::Env(filter) => <EnvFilter as Filter<S>>::callsite_enabled(filter, meta),
+        }
+    }
+
+    #[inline]
+    fn event_enabled(&self, event: &Event<'_>, cx: &Context<'_, S>) -> bool {
+        match self {
+            Self::Targets(filter) => <Targets as Filter<S>>::event_enabled(filter, event, cx),
+            Self::Env(filter) => <EnvFilter as Filter<S>>::event_enabled(filter, event, cx),
+        }
+    }
+
+    #[inline]
+    fn max_level_hint(&self) -> Option<LevelFilter> {
+        match self {
+            Self::Targets(filter) => <Targets as Filter<S>>::max_level_hint(filter),
+            Self::Env(filter) => <EnvFilter as Filter<S>>::max_level_hint(filter),
+        }
+    }
+
+    #[inline]
+    fn on_new_span(&self, attrs: &span::Attributes<'_>, id: &Id, cx: Context<'_, S>) {
+        if let Self::Env(filter) = self {
+            <EnvFilter as Filter<S>>::on_new_span(filter, attrs, id, cx);
+        }
+    }
+
+    #[inline]
+    fn on_record(&self, id: &Id, values: &span::Record<'_>, cx: Context<'_, S>) {
+        if let Self::Env(filter) = self {
+            <EnvFilter as Filter<S>>::on_record(filter, id, values, cx);
+        }
+    }
+
+    #[inline]
+    fn on_enter(&self, id: &Id, cx: Context<'_, S>) {
+        if let Self::Env(filter) = self {
+            <EnvFilter as Filter<S>>::on_enter(filter, id, cx);
+        }
+    }
+
+    #[inline]
+    fn on_exit(&self, id: &Id, cx: Context<'_, S>) {
+        if let Self::Env(filter) = self {
+            <EnvFilter as Filter<S>>::on_exit(filter, id, cx);
+        }
+    }
+
+    #[inline]
+    fn on_close(&self, id: Id, cx: Context<'_, S>) {
+        if let Self::Env(filter) = self {
+            <EnvFilter as Filter<S>>::on_close(filter, id, cx);
+        }
+    }
+}
+
+fn filters(config: LoggingConfig) -> LoggingFilter {
+    let targets = match std::env::var(env_logging::DYN_LOG) {
+        Ok(value) => targets_filter(&config, Some(&value)),
+        Err(std::env::VarError::NotPresent) => targets_filter(&config, None),
+        Err(std::env::VarError::NotUnicode(_)) => None,
+    };
+
+    if let Some(filter) = targets {
+        return LoggingFilter::Targets(filter);
+    }
+
+    LoggingFilter::Env(env_filter(&config))
+}
+
+/// Use the lock-free target/level filter when `DYN_LOG` contains no dynamic
+/// span or field directives. `EnvFilter` tracks dynamic span matches behind an
+/// `RwLock`, and its span lifecycle callbacks acquire that lock even when the
+/// configured directives are all static.
+fn targets_filter(config: &LoggingConfig, dyn_log: Option<&str>) -> Option<Targets> {
+    let mut directives = vec![config.log_level.clone()];
+
+    if let Some(value) = dyn_log {
+        // Parsing as `Targets` is also the feature test for whether the
+        // configured directives require EnvFilter's dynamic span matching.
+        value.parse::<Targets>().ok()?;
+        directives.push(value.to_string());
+    }
+
+    for (module, level) in &config.log_filters {
+        let directive = format!("{module}={level}");
+        match directive.parse::<Targets>() {
+            Ok(_) => directives.push(directive),
+            Err(e) => {
+                eprintln!("Failed parsing filter '{level}' for module '{module}': {e}");
+            }
+        }
+    }
+
+    if span_events_enabled() {
+        directives.push("span_event=trace".to_string());
+    }
+
+    directives.push("request_span=trace".to_string());
+    directives.join(",").parse::<Targets>().ok()
+}
+
+fn env_filter(config: &LoggingConfig) -> EnvFilter {
     let mut filter_layer = EnvFilter::builder()
         .with_default_directive(config.log_level.parse().unwrap())
         .with_env_var(env_logging::DYN_LOG)
         .from_env_lossy();
 
-    for (module, level) in config.log_filters {
+    for (module, level) in &config.log_filters {
         match format!("{module}={level}").parse::<Directive>() {
             Ok(d) => {
                 filter_layer = filter_layer.add_directive(d);
@@ -1791,6 +1917,32 @@ pub mod tests {
     use std::io::{BufRead, BufReader};
     use stdio_override::*;
     use tempfile::NamedTempFile;
+
+    #[test]
+    fn target_level_directives_use_static_filter() {
+        let filter = targets_filter(
+            &LoggingConfig::default(),
+            Some("dynamo_runtime::logging=debug"),
+        )
+        .expect("target/level directives should use Targets");
+
+        assert!(filter.would_enable("request_span", &tracing::Level::TRACE));
+        assert!(filter.would_enable("unlisted_target", &tracing::Level::INFO));
+        assert!(!filter.would_enable("unlisted_target", &tracing::Level::DEBUG));
+        assert!(filter.would_enable("dynamo_runtime::logging::child", &tracing::Level::DEBUG));
+        assert!(!filter.would_enable("tower", &tracing::Level::WARN));
+    }
+
+    #[test]
+    fn dynamic_span_directives_fall_back_to_env_filter() {
+        assert!(
+            targets_filter(
+                &LoggingConfig::default(),
+                Some("dynamo_runtime[request{model=foo}]=debug"),
+            )
+            .is_none()
+        );
+    }
 
     #[test]
     fn otlp_protocol_defaults_to_grpc() {


### PR DESCRIPTION
## Overview:

Use tracing-subscriber's metadata-only `Targets` filter when `DYN_LOG` and Dynamo's configured filters contain only static target/level directives. Preserve `EnvFilter` for dynamic span or field directives, whose matching requires its span-state machinery.

## Details:

- Removes the shared `EnvFilter` span-matcher `RwLock` from the normal static request-span lifecycle while retaining `request_span=trace` and existing span-event behavior.
- Preserves `EnvFilter::parse_lossy` behavior for `DYN_LOG`: zero-length comma-separated segments are ignored without trimming non-empty segments, and the configured default level applies only when no directives remain.
- A non-empty target-only `DYN_LOG` leaves unrelated targets disabled, as it does with `EnvFilter`.
- A dynamic `DYN_LOG` directive or a dynamic configured `log_filters` directive falls back to `EnvFilter`; directives invalid for both parsers retain the existing warning-and-ignore behavior.

## Where should the reviewer start?

Start with `lib/runtime/src/logging.rs`, particularly `targets_filter` and its regression tests. The function selects the static filter only when the complete effective directive set is compatible with `Targets`.

## Related Issues

- [x] Confirmed — no related issue

## Performance impact

`request_span=trace` is a static directive, but the prior implementation always constructed `EnvFilter`. Tower/Hyper enters and exits the request span on every streaming response-body poll; `EnvFilter` takes its dynamic-span lock on these lifecycle callbacks even when no dynamic directives exist. On a 36+36 CPU split-NUMA frontend, that lock consumed 52.105% of frontend samples.

Matched Tyche AgentX c=2048 results (`Qwen/Qwen3-0.6B`, 32 mockers, 1e6 mocker speedup):

- exclusive `EnvFilter` samples: 52.105% -> 0.000%
- frontend CPU: 72.67 -> 35.81 ms/request
- throughput: 932.06 -> 1,133.44 req/s
- post-ramp TTFT p50/p95/p99: 1595.70/2111.06/2233.60 -> 180.93/1026.67/1311.83 ms

The whole-run p99 is ramp-dominated in the patched run: all requests at or above its whole-run p99 threshold began by 24.70 seconds. The post-30-second tail is the representative comparison.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-runtime logging::tests:: -- --nocapture`
- `cargo clippy -p dynamo-runtime --all-targets -- -D warnings`
- Tyche two-node matched on-CPU profile: 226,267 samples, zero lost samples/chunks, zero AIPerf errors or cancellations, and load-node CPU below contamination gates (43.34% average, 75.17% p95).

Benchmark artifacts remain local to the Tyche harness and are not included in this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved logging filter performance by using a faster static filtering approach whenever supported.
  * Preserved support for advanced dynamic logging directives through an automatic fallback.
  * Maintained existing request and span tracing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->