### PR TITLE
feat: preserve eager-tail samples and reorder prefill sweep

### DIFF
--- a/components/src/dynamo/vllm/instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/instrumented_scheduler.py
@@ -251,6 +251,46 @@ def _uniformly_limit_axis(values: Sequence[int], max_samples: int) -> list[int]:
     ]
 
 
+def _limit_cudagraph_axis(
+    values: Sequence[int],
+    capture_sizes: Sequence[int],
+    max_samples: int,
+) -> list[int]:
+    """Limit a graph-aware axis while preserving a small eager tail.
+
+    Values above the largest configured CUDA Graph capture size run eagerly.
+    When those eager-tail values are at most 20% of all candidates, retain the
+    complete tail and spend the remaining sample budget on the graph-covered
+    prefix. If the tail is larger, use the existing uniform whole-axis limit.
+    """
+    if max_samples < 2:
+        raise ValueError("uniform axis sample limits must be at least 2")
+
+    candidates = list(values)
+    if len(candidates) <= max_samples:
+        return candidates
+
+    captures = [int(size) for size in capture_sizes if int(size) >= 1]
+    if not captures:
+        return _uniformly_limit_axis(candidates, max_samples)
+
+    max_capture_size = max(captures)
+    graph_points = [value for value in candidates if value <= max_capture_size]
+    eager_tail = [value for value in candidates if value > max_capture_size]
+
+    # Compare as integers so the inclusive 20% boundary is exact.
+    protect_eager_tail = bool(eager_tail) and len(eager_tail) * 5 <= len(candidates)
+    graph_budget = max_samples - len(eager_tail)
+    if not protect_eager_tail or not graph_points or graph_budget < 1:
+        return _uniformly_limit_axis(candidates, max_samples)
+
+    if graph_budget == 1:
+        limited_graph_points = [graph_points[0]]
+    else:
+        limited_graph_points = _uniformly_limit_axis(graph_points, graph_budget)
+    return limited_graph_points + eager_tail
+
+
 def _cudagraph_axis_points(
     capture_sizes: Sequence[int],
     limit: int,
@@ -1750,14 +1790,15 @@ class InstrumentedScheduler(AsyncScheduler):
             )
             return
 
-        total_prefill_tokens = _cudagraph_axis_points(
+        total_prefill_tokens = _limit_cudagraph_axis(
+            _cudagraph_axis_points(
+                self._bench_prefill_capture_sizes,
+                max_tokens,
+            ),
             self._bench_prefill_capture_sizes,
-            max_tokens,
-        )
-        total_prefill_tokens = _uniformly_limit_axis(
-            total_prefill_tokens,
             self._bench_config.prefill_max_new_token_samples,
         )
+        prefill_points: list[BenchmarkPoint] = []
         for total_tokens in total_prefill_tokens:
             for batch_size in self._bench_prefill_batch_sizes(total_tokens):
                 for total_kv_read_tokens in self._bench_prefill_kv_read_points(
@@ -1776,7 +1817,7 @@ class InstrumentedScheduler(AsyncScheduler):
                         self._bench_prefill_capture_sizes,
                         max_tokens,
                     )
-                    self._bench_grid.append(
+                    prefill_points.append(
                         BenchmarkPoint(
                             point_type="prefill",
                             total_prefill_tokens=total_tokens,
@@ -1792,6 +1833,11 @@ class InstrumentedScheduler(AsyncScheduler):
                             sample_reasons=sample_reasons,
                         )
                     )
+
+        # Generate axes in their natural ascending order, then reverse only the
+        # prefill phase so larger workload coordinates run first.  Keep
+        # decode ordering and the aggregate prefill-before-decode boundary intact.
+        self._bench_grid.extend(reversed(prefill_points))
 
     def _bench_prefill_batch_sizes(self, total_tokens: int) -> list[int]:
         """Return the smallest configured presets from the legal batch axis."""
@@ -2159,12 +2205,12 @@ class InstrumentedScheduler(AsyncScheduler):
             logger.warning("KV cache too small for decode grid, skipping")
             return
 
-        batch_sizes = _cudagraph_axis_points(
+        batch_sizes = _limit_cudagraph_axis(
+            _cudagraph_axis_points(
+                self._bench_decode_capture_sizes,
+                feasible_max_batch,
+            ),
             self._bench_decode_capture_sizes,
-            feasible_max_batch,
-        )
-        batch_sizes = _uniformly_limit_axis(
-            batch_sizes,
             self._bench_config.decode_max_batch_size_samples,
         )
         for batch_size in batch_sizes:

--- a/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py
@@ -1566,6 +1566,36 @@ def test_uniform_axis_limit_retains_endpoints_and_evenly_removes_middle():
         instrumented_scheduler_module._uniformly_limit_axis(values, 1)
 
 
+def test_cudagraph_axis_limit_preserves_eager_tail_below_twenty_percent():
+    capture_sizes = list(range(1, 41))
+    candidates = instrumented_scheduler_module._cudagraph_axis_points(capture_sizes, 80)
+
+    assert candidates == [*range(1, 42), 80]
+    assert instrumented_scheduler_module._limit_cudagraph_axis(
+        candidates, capture_sizes, 4
+    ) == [1, 40, 41, 80]
+
+
+def test_cudagraph_axis_limit_preserves_eager_tail_at_twenty_percent():
+    capture_sizes = list(range(1, 9))
+    candidates = instrumented_scheduler_module._cudagraph_axis_points(capture_sizes, 10)
+
+    assert candidates == list(range(1, 11))
+    assert instrumented_scheduler_module._limit_cudagraph_axis(
+        candidates, capture_sizes, 5
+    ) == [1, 5, 8, 9, 10]
+
+
+def test_cudagraph_axis_limit_uniformly_samples_tail_above_twenty_percent():
+    capture_sizes = [8]
+    candidates = instrumented_scheduler_module._cudagraph_axis_points(capture_sizes, 64)
+
+    assert candidates == [8, 9, 16, 32, 64]
+    assert instrumented_scheduler_module._limit_cudagraph_axis(
+        candidates, capture_sizes, 3
+    ) == [8, 16, 64]
+
+
 def test_cudagraph_axis_appends_exact_non_power_of_two_limit():
     assert instrumented_scheduler_module._cudagraph_axis_points([256], 1000) == [
         256,
@@ -1662,10 +1692,26 @@ def test_prefill_grid_uniformly_limits_new_tokens_batch_and_kv_axes():
             if point.total_prefill_tokens == total_tokens
         ]
         assert len(points) <= 3
-        assert points[0] == 0
-        assert points[-1] == InstrumentedScheduler._bench_max_prefill_kv_read_tokens(
+        assert points[0] == InstrumentedScheduler._bench_max_prefill_kv_read_tokens(
             stub, total_tokens, 1
         )
+        assert points[-1] == 0
+
+
+def test_prefill_grid_runs_larger_workload_coordinates_first():
+    stub = _prefill_grid_stub(num_gpu_blocks=512)
+
+    InstrumentedScheduler._bench_generate_prefill_grid(stub)
+
+    coordinates = [
+        (
+            point.total_prefill_tokens,
+            point.batch_size,
+            point.total_kv_read_tokens,
+        )
+        for point in stub._bench_grid
+    ]
+    assert coordinates == sorted(coordinates, reverse=True)
 
 
 def test_agg_grid_contains_piecewise_prefill_then_full_decode_points():


### PR DESCRIPTION
```markdown
## Overview:

Improve FPM self-benchmark sampling outside the CUDA Graph capture range and run larger prefill workload coordinates first.

## Details:

- Add CUDA Graph-aware axis limiting:
  - When eager-tail candidates are at most 20% of all candidates, preserve the eager tail within the configured sampling budget and uniformly sample the graph-covered region with the remaining budget.
  - When the eager tail exceeds 20%, retain the existing whole-axis uniform sampling behavior.
- Apply the new limiting behavior to:
  - Prefill total-token sampling.
  - Decode batch-size sampling.
- Reverse only the generated prefill sweep so larger `(total_prefill_tokens, batch_size, total_kv_read_tokens)` coordinates run first.
- Preserve the aggregate phase order: all prefill points still run before decode points.
- Add tests for eager-tail ratios below, equal to, and above 20%, as well as prefill execution order.

## Where should the reviewer start?

- `components/src/dynamo/vllm/instrumented_scheduler.py`
  - `_limit_cudagraph_axis`
  - `_bench_generate_prefill_grid`
  - `_bench_generate_decode_grid`
- `components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py`
  - CUDA Graph axis-limiting tests.
  - Prefill ordering test.

## Validation:

- `pre-commit run --files components/src/dynamo/vllm/instrumented_scheduler.py components/src/dynamo/vllm/tests/test_vllm_instrumented_scheduler.py`
- `ruff check` passed.
- Python `compileall` passed.
- Additional sampling-invariant checks passed across 990 generated cases.
- Full vLLM pytest suite was not run locally because the macOS environment does not have vLLM installed.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue
```
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11824" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->