### PR TITLE
feat(router): add gated session affinity trace

### DIFF
--- a/lib/llm/src/kv_router/push_router.rs
+++ b/lib/llm/src/kv_router/push_router.rs
@@ -212,6 +212,7 @@ impl KvPushRouter {
             Ok(selection) => Ok((selection, Some(operation))),
             Err(error) if is_cancelled(&error) => Err(error),
             Err(_) if operation.target().is_some() && explicit.is_none() => {
+                operation.trace_bound_target_fallback_rebind();
                 operation.invalidate();
                 let retry = affinity
                     .acquire_with_context(&session_id, None, request_context.as_ref())
@@ -477,7 +478,10 @@ impl KvPushRouter {
         let Some(operation) = operation else {
             return Ok((metadata, stream));
         };
-        Ok((metadata, operation.into_stream(selected_target, stream)?))
+        Ok((
+            metadata,
+            operation.into_stream(selected_target, phase, stream)?,
+        ))
     }
 }
 
@@ -587,7 +591,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<Annotated<LLMEngineOutpu
             }
         };
         match operation {
-            Some(operation) => operation.into_stream(selected_target, stream),
+            Some(operation) => operation.into_stream(selected_target, phase, stream),
             None => Ok(stream),
         }
     }

--- a/lib/llm/src/session_affinity/coordinator.rs
+++ b/lib/llm/src/session_affinity/coordinator.rs
@@ -25,7 +25,7 @@ use tokio_util::sync::CancellationToken;
 use super::replica_sync::SessionAffinityUpdate;
 use super::{
     LlmResponse, MAX_SESSION_AFFINITY_ENTRIES, MAX_SESSION_AFFINITY_ID_BYTES,
-    MAX_SESSION_AFFINITY_TTL_SECS, replica_sync::ReplicaSyncRuntime,
+    MAX_SESSION_AFFINITY_TTL_SECS, replica_sync::ReplicaSyncRuntime, trace,
 };
 use crate::{
     preprocessor::PreprocessedRequest,
@@ -224,11 +224,15 @@ impl AffinityCoordinator {
                         session_id = %session_id,
                         "session affinity miss: new session, pinning after worker selection"
                     );
-                    return Ok(AffinityAcquire::Initialize(entry.insert_initializing(
-                        &self.inner,
-                        session_id,
+                    let initialization =
+                        entry.insert_initializing(&self.inner, session_id, requested_target);
+                    trace::initialize(
+                        &initialization.session_id,
+                        initialization.revision,
                         requested_target,
-                    )));
+                        "new_session",
+                    );
+                    return Ok(AffinityAcquire::Initialize(initialization));
                 }
                 Entry::Occupied(mut entry) => match entry.get_mut() {
                     AffinityEntry::Initializing { notify, .. } => {
@@ -270,14 +274,21 @@ impl AffinityCoordinator {
                             notify: notify.clone(),
                         };
                         drop(entry);
-                        return Ok(AffinityAcquire::Initialize(AffinityInitialization {
+                        let initialization = AffinityInitialization {
                             coordinator: Arc::downgrade(&self.inner),
                             session_id,
                             revision,
                             notify,
                             requested_target,
                             active: true,
-                        }));
+                        };
+                        trace::initialize(
+                            &initialization.session_id,
+                            initialization.revision,
+                            requested_target,
+                            "idle_ttl_expired",
+                        );
+                        return Ok(AffinityAcquire::Initialize(initialization));
                     }
                     AffinityEntry::Bound {
                         target,
@@ -294,6 +305,7 @@ impl AffinityCoordinator {
                             "session affinity hit: reusing pinned worker"
                         );
                         *active_leases += 1;
+                        trace::bound_reuse(&session_id, *revision, *target, *active_leases);
                         let lease = AffinityLease {
                             coordinator: Arc::downgrade(&self.inner),
                             session_id,
@@ -546,12 +558,16 @@ impl AffinityAcquire {
     pub(crate) fn into_stream(
         self,
         selected_target: AffinityTarget,
+        phase: RequestPhase,
         stream: ManyOut<LlmResponse>,
     ) -> Result<ManyOut<LlmResponse>, Error> {
         match self {
             Self::Initialize(initialization) => {
+                let session_id = initialization.session_id.clone();
+                let revision = initialization.revision;
                 let lease = initialization.commit(selected_target)?;
                 lease.publish(selected_target);
+                trace::bound_dispatch(&session_id, revision, selected_target, phase, "initialize");
                 Ok(lease.into_stream(stream))
             }
             Self::Bound { target, mut lease } => {
@@ -561,8 +577,21 @@ impl AffinityAcquire {
                     return Err(error);
                 }
                 lease.publish(target);
+                trace::bound_dispatch(
+                    &lease.session_id,
+                    lease.revision,
+                    selected_target,
+                    phase,
+                    "bound",
+                );
                 Ok(lease.into_stream(stream))
             }
+        }
+    }
+
+    pub(crate) fn trace_bound_target_fallback_rebind(&self) {
+        if let Self::Bound { target, lease } = self {
+            trace::bound_target_fallback_rebind(&lease.session_id, lease.revision, *target);
         }
     }
 
@@ -606,6 +635,7 @@ impl AffinityInitialization {
             idle_deadline: Instant::now() + inner.ttl,
         };
         drop(entry);
+        trace::commit(&self.session_id, self.revision, target);
         self.active = false;
         self.notify.notify_waiters();
         Ok(AffinityLease {

--- a/lib/llm/src/session_affinity/mod.rs
+++ b/lib/llm/src/session_affinity/mod.rs
@@ -4,6 +4,7 @@
 mod coordinator;
 mod push_router;
 mod replica_sync;
+mod trace;
 
 use std::time::Duration;
 

--- a/lib/llm/src/session_affinity/push_router.rs
+++ b/lib/llm/src/session_affinity/push_router.rs
@@ -127,6 +127,7 @@ impl SessionAffinityPushRouter {
             return Ok(operation);
         }
 
+        operation.trace_bound_target_fallback_rebind();
         operation.invalidate();
         affinity
             .acquire_with_context(session_id, explicit, request_context)
@@ -238,7 +239,7 @@ impl SessionAffinityPushRouter {
                 return Err(error);
             }
         };
-        let stream = operation.into_stream(target, stream)?;
+        let stream = operation.into_stream(target, RequestPhase::Prefill, stream)?;
         Self::record_target(tracker.as_deref(), target);
         Ok((metadata, stream))
     }
@@ -358,7 +359,7 @@ impl AsyncEngine<SingleIn<PreprocessedRequest>, ManyOut<LlmResponse>, Error>
                 return Err(error);
             }
         };
-        let stream = operation.into_stream(target, stream)?;
+        let stream = operation.into_stream(target, phase, stream)?;
         Self::record_target(tracker.as_deref(), target);
         Ok(stream)
     }

--- a/lib/llm/src/session_affinity/tests.rs
+++ b/lib/llm/src/session_affinity/tests.rs
@@ -331,7 +331,11 @@ async fn session_affinity_committed_binding_survives_cancelled_stream_until_ttl(
     let coordinator = coordinator();
     let operation = coordinator.acquire(&session_id(), None).await.unwrap();
     let mut stream = operation
-        .into_stream(target(7, Some(0)), cancelled_response_stream())
+        .into_stream(
+            target(7, Some(0)),
+            RequestPhase::Aggregated,
+            cancelled_response_stream(),
+        )
         .unwrap();
     tokio::time::advance(Duration::from_secs(9)).await;
     assert!(stream.next().await.is_none());
@@ -598,7 +602,11 @@ async fn session_affinity_publishes_after_dispatch_and_lease_completion() {
     let selected_target = target(7, Some(0));
     let operation = coordinator.acquire(&session_id(), None).await.unwrap();
     let stream = operation
-        .into_stream(selected_target, response_stream(1))
+        .into_stream(
+            selected_target,
+            RequestPhase::Aggregated,
+            response_stream(1),
+        )
         .unwrap();
 
     let after_dispatch = updates.recv().await.unwrap();
@@ -621,7 +629,11 @@ async fn session_affinity_completion_restores_expired_remote_binding() {
     let replicated_target = target(7, Some(0));
     let operation = origin.acquire(&session_id(), None).await.unwrap();
     let stream = operation
-        .into_stream(replicated_target, response_stream(1))
+        .into_stream(
+            replicated_target,
+            RequestPhase::Aggregated,
+            response_stream(1),
+        )
         .unwrap();
 
     let after_dispatch = updates.recv().await.unwrap();

--- a/lib/llm/src/session_affinity/trace.rs
+++ b/lib/llm/src/session_affinity/trace.rs
@@ -1,0 +1,268 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::{
+    OnceLock,
+    atomic::{AtomicU64, Ordering},
+};
+
+use super::AffinityTarget;
+use crate::protocols::common::timing::RequestPhase;
+
+const TRACE_ENV: &str = "DYN_ROUTER_SESSION_AFFINITY_TRACE";
+const TRACE_PREFIX_ENV: &str = "DYN_ROUTER_SESSION_AFFINITY_TRACE_PREFIX";
+
+#[derive(Debug, Default, PartialEq, Eq)]
+struct TraceConfig {
+    enabled: bool,
+    session_prefix: Option<String>,
+}
+
+impl TraceConfig {
+    fn from_values(enabled: Option<&str>, session_prefix: Option<&str>) -> Self {
+        Self {
+            enabled: parse_enabled(enabled),
+            session_prefix: session_prefix
+                .map(str::trim)
+                .filter(|prefix| !prefix.is_empty())
+                .map(str::to_string),
+        }
+    }
+
+    fn matches(&self, session_id: &str) -> bool {
+        self.enabled
+            && self
+                .session_prefix
+                .as_deref()
+                .is_none_or(|prefix| session_id.starts_with(prefix))
+    }
+}
+
+static TRACE_CONFIG: OnceLock<TraceConfig> = OnceLock::new();
+static INITIALIZE_COUNT: AtomicU64 = AtomicU64::new(0);
+static COMMIT_COUNT: AtomicU64 = AtomicU64::new(0);
+static BOUND_REUSE_COUNT: AtomicU64 = AtomicU64::new(0);
+static BOUND_DISPATCH_COUNT: AtomicU64 = AtomicU64::new(0);
+static FALLBACK_REBIND_COUNT: AtomicU64 = AtomicU64::new(0);
+
+fn parse_enabled(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "on" | "yes"
+        )
+    })
+}
+
+fn config() -> &'static TraceConfig {
+    TRACE_CONFIG.get_or_init(|| {
+        let enabled = std::env::var(TRACE_ENV).ok();
+        let prefix = std::env::var(TRACE_PREFIX_ENV).ok();
+        TraceConfig::from_values(enabled.as_deref(), prefix.as_deref())
+    })
+}
+
+fn next(counter: &AtomicU64) -> u64 {
+    counter.fetch_add(1, Ordering::Relaxed) + 1
+}
+
+fn fallback_rebind_count() -> u64 {
+    FALLBACK_REBIND_COUNT.load(Ordering::Relaxed)
+}
+
+pub(super) fn initialize(
+    session_id: &str,
+    revision: u64,
+    requested_target: Option<AffinityTarget>,
+    reason: &str,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let requested_worker_bound = requested_target.is_some();
+    let requested_worker_id = requested_target.map(|target| target.worker_id).unwrap_or(0);
+    let requested_dp_rank = requested_target
+        .and_then(|target| target.dp_rank)
+        .map(i64::from)
+        .unwrap_or(-1);
+    let requested_dp_rank_bound = requested_dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let initialize_count = next(&INITIALIZE_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "initialize",
+        session_id,
+        revision,
+        reason,
+        trace_prefix,
+        requested_worker_bound,
+        requested_worker_id,
+        requested_dp_rank_bound,
+        requested_dp_rank,
+        initialize_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn commit(session_id: &str, revision: u64, target: AffinityTarget) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let commit_count = next(&COMMIT_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "commit",
+        session_id,
+        revision,
+        trace_prefix,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        commit_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn bound_reuse(
+    session_id: &str,
+    revision: u64,
+    target: AffinityTarget,
+    active_leases: usize,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let bound_reuse_count = next(&BOUND_REUSE_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "bound_reuse",
+        session_id,
+        revision,
+        trace_prefix,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        active_leases,
+        bound_reuse_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn bound_dispatch(
+    session_id: &str,
+    revision: u64,
+    target: AffinityTarget,
+    phase: RequestPhase,
+    acquisition_kind: &str,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let role = match phase {
+        RequestPhase::Prefill => "context",
+        RequestPhase::Decode => "generation",
+        RequestPhase::Aggregated => "aggregated",
+    };
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let bound_dispatch_count = next(&BOUND_DISPATCH_COUNT);
+    let fallback_rebind_count = fallback_rebind_count();
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "bound_dispatch",
+        session_id,
+        revision,
+        trace_prefix,
+        acquisition_kind,
+        phase = %phase,
+        role,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        bound_dispatch_count,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+pub(super) fn bound_target_fallback_rebind(
+    session_id: &str,
+    revision: u64,
+    target: AffinityTarget,
+) {
+    let config = config();
+    if !config.matches(session_id) {
+        return;
+    }
+
+    let dp_rank = target.dp_rank.map(i64::from).unwrap_or(-1);
+    let dp_rank_bound = dp_rank >= 0;
+    let trace_prefix = config.session_prefix.as_deref().unwrap_or("");
+    let fallback_rebind_count = next(&FALLBACK_REBIND_COUNT);
+    tracing::info!(
+        target: "dynamo::session_affinity",
+        session_affinity_event = "bound_target_fallback_rebind",
+        session_id,
+        revision,
+        trace_prefix,
+        worker_id = target.worker_id,
+        dp_rank_bound,
+        dp_rank,
+        fallback_rebind_count,
+        "session affinity trace"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TraceConfig, parse_enabled};
+
+    #[test]
+    fn session_affinity_trace_gate_is_opt_in_and_prefix_filtered() {
+        for value in [
+            None,
+            Some(""),
+            Some("0"),
+            Some("false"),
+            Some("off"),
+            Some("no"),
+            Some("invalid"),
+        ] {
+            assert!(!parse_enabled(value), "unexpected enabled value: {value:?}");
+        }
+        for value in ["1", "true", "TRUE", " on ", "yes"] {
+            assert!(parse_enabled(Some(value)), "disabled truthy value: {value}");
+        }
+
+        assert!(TraceConfig::from_values(Some("true"), None).matches("any-session"));
+        assert!(TraceConfig::from_values(Some("true"), Some("  ")).matches("any-session"));
+
+        let filtered = TraceConfig::from_values(Some("true"), Some(" dyn-affinity-trace- "));
+        assert!(filtered.matches("dyn-affinity-trace-0001"));
+        assert!(!filtered.matches("benchmark-session-0001"));
+
+        let disabled = TraceConfig::from_values(Some("false"), Some("dyn-affinity-trace-"));
+        assert!(!disabled.matches("dyn-affinity-trace-0001"));
+    }
+}


### PR DESCRIPTION
## Summary

Adds an opt-in, low-overhead diagnostic trace for the session-affinity router, gated
behind `DYN_ROUTER_SESSION_AFFINITY_TRACE` (off by default). When enabled, the affinity
coordinator emits structured `tracing::info!` events (target `dynamo::session_affinity`)
at each affinity lifecycle transition — `initialize`, `commit`, `bound_reuse`,
`bound_dispatch`, and `bound_target_fallback_rebind` — each carrying the session id,
revision, resolved worker id + attention-DP rank, request phase
(context / generation / aggregated), and monotonic per-event counters. An optional
`DYN_ROUTER_SESSION_AFFINITY_TRACE_PREFIX` narrows tracing to session ids with a given
prefix.

This makes it possible to confirm, per request, which worker+rank a session was bound to
and dispatched on — the observability needed to verify that the Dynamo router (not the
engine's attention-DP router) owns worker+rank selection and that a conversation stays
pinned across turns. When the env is unset the config gate short-circuits before any
formatting, so there is no cost on the hot path.

This is the **tracing/logging slice split out of #11702** (the session-affinity header
configuration feature) into its own focused PR. It depends only on the `session_affinity`
module already on `main` — no dependency on the header-config change.

### Changes
- New module `lib/llm/src/session_affinity/trace.rs` — env-gated config + the five trace
  event emitters + atomic counters.
- Hook points in `session_affinity/coordinator.rs` (initialize / dispatch), the two
  `push_router.rs` call paths (a `phase: RequestPhase` argument is threaded to
  `AffinityAcquire::into_stream`), and `kv_router/push_router.rs`.

## Validation
- Rebased cleanly onto current `main` (the `session_affinity` `replica_sync` / revision
  refactor landed after this change's original base); the trace hooks compose with main's
  existing `lease.publish(...)` calls, and the two replica-sync test call sites were
  updated for the new `phase` parameter on `into_stream`.
- `cargo check -p dynamo-llm --all-targets` — passes.
- `cargo fmt -p dynamo-llm -- --check` — clean.
- `cargo clippy -p dynamo-llm --all-targets` — clean (exit 0, no new warnings).

This is the same change as dynamo commit `3fa54e0482fd`, which is bundled in the container
image used for the DeepSeek-V4 disaggregated-serving validation on Lyris GB300.
