### PR TITLE
feat(vllm): add audio transcription serving

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "matchit 0.8.4",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -5575,6 +5576,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.1",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -955,6 +955,7 @@ dependencies = [
  "matchit 0.8.4",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -6046,6 +6047,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.1",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,7 +140,7 @@ tokio = { version = "=1.48.0", features = ["full"] }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.17", features = ["codec", "net", "rt", "io-util"] }
 tower-http = { version = "0.6", features = ["trace"] }
-axum = { version = "=0.8.4", features = ["macros", "ws"] }
+axum = { version = "=0.8.4", features = ["macros", "multipart", "ws"] }
 axum-core = { version = "0.5.2" }
 hyper = { version = "=1.7.0" }
 hyper-util = { version = "=0.1.17" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -154,7 +154,7 @@ tokio = { version = "=1.52.4", features = ["full"] }
 tokio-stream = { version = "0.1" }
 tokio-util = { version = "0.7.17", features = ["codec", "net", "rt", "io-util"] }
 tower-http = { version = "0.6", features = ["trace"] }
-axum = { version = "=0.8.4", features = ["macros", "ws"] }
+axum = { version = "=0.8.4", features = ["macros", "multipart", "ws"] }
 axum-core = { version = "0.5.2" }
 hyper = { version = "=1.7.0" }
 hyper-util = { version = "=0.1.17" }

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -238,6 +238,8 @@ def _unsupported_fpm_trace_role(dynamo_config: Config) -> Optional[str]:
     """Return the worker role when trace-based FPM activation is unsupported."""
     if dynamo_config.embedding_worker:
         return "embedding"
+    if dynamo_config.transcription_worker:
+        return "transcription"
     if dynamo_config.headless:
         return "headless"
     if dynamo_config.disaggregation_mode == DisaggregationMode.ENCODE:

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -313,6 +313,14 @@ def update_engine_config_with_dynamo(
                 "Pooling-family worker: defaulting --enable-prefix-caching to False"
             )
             engine_config.enable_prefix_caching = False
+        elif dynamo_config.transcription_worker:
+            # Whisper is an encoder-decoder model. vLLM does not support
+            # prefix caching for cross-attention KV caches, and enabling it
+            # causes the first transcription request to terminate EngineCore.
+            logger.debug(
+                "Transcription worker: defaulting --enable-prefix-caching to False"
+            )
+            engine_config.enable_prefix_caching = False
         else:
             logger.debug(
                 "--enable-prefix-caching or --no-enable-prefix-caching not specified. "

--- a/components/src/dynamo/vllm/args.py
+++ b/components/src/dynamo/vllm/args.py
@@ -268,6 +268,8 @@ def _unsupported_fpm_trace_role(dynamo_config: Config) -> Optional[str]:
         return "embedding"
     if dynamo_config.classify_worker:
         return "classify"
+    if dynamo_config.transcription_worker:
+        return "transcription"
     if dynamo_config.headless:
         return "headless"
     if dynamo_config.disaggregation_mode == DisaggregationMode.ENCODE:

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -190,6 +190,15 @@ class DynamoVllmArgGroup(ArgGroup):
             "and InstrumentedScheduler injection (none apply to pooling models).",
         )
 
+        add_negatable_bool_argument(
+            g,
+            flag_name="--transcription-worker",
+            env_var="DYN_VLLM_TRANSCRIPTION_WORKER",
+            default=False,
+            help="Run as an aggregated speech-to-text worker using vLLM's native "
+            "OpenAI transcription serving layer.",
+        )
+
         # Headless mode for multi-node TP/PP
         add_negatable_bool_argument(
             g,
@@ -434,6 +443,7 @@ class DynamoVllmConfig(ConfigBase):
         str, EmbeddingTransferMode
     ]  # resolved to enum in validate()
     embedding_worker: bool = False
+    transcription_worker: bool = False
 
     # CustomEncoder (image-only embeddings; worker assembles mixed prompt)
     custom_encoder_class: Optional[str] = None
@@ -475,6 +485,7 @@ class DynamoVllmConfig(ConfigBase):
         self._validate_multimodal_role_exclusivity()
         self._validate_multimodal_requires_flag()
         self._validate_embedding_worker_exclusivity()
+        self._validate_transcription_worker_exclusivity()
         self._validate_custom_encoder()
         self._resolve_legacy_benchmark_sampling()
         self._validate_benchmark_sampling()
@@ -571,6 +582,33 @@ class DynamoVllmConfig(ConfigBase):
         if isinstance(self.embedding_transfer_mode, str):
             self.embedding_transfer_mode = EmbeddingTransferMode(
                 self.embedding_transfer_mode
+            )
+
+    def _validate_transcription_worker_exclusivity(self) -> None:
+        """Transcription workers are standalone aggregated ASR engines."""
+        if not self.transcription_worker:
+            return
+        if self.embedding_worker:
+            raise ValueError(
+                "--transcription-worker cannot be combined with --embedding-worker."
+            )
+        if self.disaggregation_mode != DisaggregationMode.AGGREGATED:
+            mode = (
+                self.disaggregation_mode.value
+                if isinstance(self.disaggregation_mode, DisaggregationMode)
+                else self.disaggregation_mode
+            )
+            raise ValueError(
+                "--transcription-worker is only valid with "
+                f"--disaggregation-mode=agg (got {mode})."
+            )
+        if self._count_multimodal_roles() > 0 or self.enable_multimodal:
+            raise ValueError(
+                "--transcription-worker cannot be combined with multimodal flags."
+            )
+        if self.benchmark_mode is not None:
+            raise ValueError(
+                "--transcription-worker cannot be combined with --benchmark-mode."
             )
 
     def _resolve_disaggregation_mode(self) -> None:

--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -262,6 +262,15 @@ class DynamoVllmArgGroup(ArgGroup):
 
         add_negatable_bool_argument(
             g,
+            flag_name="--transcription-worker",
+            env_var="DYN_VLLM_TRANSCRIPTION_WORKER",
+            default=False,
+            help="Run as an aggregated speech-to-text worker using vLLM's native "
+            "OpenAI transcription serving layer.",
+        )
+
+        add_negatable_bool_argument(
+            g,
             flag_name="--realtime",
             env_var="DYN_VLLM_REALTIME",
             default=False,
@@ -549,6 +558,7 @@ class DynamoVllmConfig(ConfigBase):
     embedding_worker: bool = False
     embedding_frontend_tokenization: bool = False
     embedding_worker_processes: int = 1
+    transcription_worker: bool = False
     realtime: bool = False
     classify_worker: bool = False
 
@@ -608,6 +618,7 @@ class DynamoVllmConfig(ConfigBase):
         self._validate_embedding_frontend_tokenization()
         self._validate_embedding_worker_exclusivity()
         self._validate_embedding_worker_processes()
+        self._validate_transcription_worker_exclusivity()
         self._validate_realtime_worker_exclusivity()
         self._validate_classify_worker_exclusivity()
         self._validate_custom_encoder()
@@ -952,6 +963,46 @@ class DynamoVllmConfig(ConfigBase):
             raise ValueError("--realtime cannot be combined with --benchmark-mode.")
         if getattr(getattr(self, "engine_args", None), "enable_lora", False):
             raise ValueError("--realtime cannot be combined with --enable-lora.")
+
+    def _validate_transcription_worker_exclusivity(self) -> None:
+        """Transcription serving uses a dedicated aggregated ASR worker."""
+        if not self.transcription_worker:
+            return
+        if self.disaggregation_mode != DisaggregationMode.AGGREGATED:
+            mode = (
+                self.disaggregation_mode.value
+                if isinstance(self.disaggregation_mode, DisaggregationMode)
+                else self.disaggregation_mode
+            )
+            raise ValueError(
+                "--transcription-worker is only valid with "
+                f"--disaggregation-mode=agg (got {mode})."
+            )
+        for enabled, option in (
+            (self.embedding_worker, "--embedding-worker"),
+            (self.classify_worker, "--classify-worker"),
+            (self.realtime, "--realtime"),
+            (bool(self.custom_encoder_class), "--custom-encoder-class"),
+            (self.gms_shadow_mode, "--gms-shadow-mode"),
+            (self.enable_rl, "--enable-rl"),
+            (self.headless, "--headless"),
+        ):
+            if enabled:
+                raise ValueError(
+                    f"--transcription-worker cannot be combined with {option}."
+                )
+        if self.enable_multimodal:
+            raise ValueError(
+                "--transcription-worker cannot be combined with multimodal worker flags."
+            )
+        if self.benchmark_mode is not None:
+            raise ValueError(
+                "--transcription-worker cannot be combined with --benchmark-mode."
+            )
+        if getattr(getattr(self, "engine_args", None), "enable_lora", False):
+            raise ValueError(
+                "--transcription-worker cannot be combined with --enable-lora."
+            )
 
     def _validate_classify_worker_exclusivity(self) -> None:
         """Classify worker is aggregated-only and exclusive of multimodal /

--- a/components/src/dynamo/vllm/health_check.py
+++ b/components/src/dynamo/vllm/health_check.py
@@ -7,7 +7,10 @@ vLLM-specific health check configuration.
 This module defines the default health check payload for vLLM backends.
 """
 
+import base64
+import io
 import logging
+import wave
 from typing import TYPE_CHECKING, Any, Optional
 
 from dynamo.health_check import HEALTH_CHECK_KEY, HealthCheckPayload
@@ -144,6 +147,34 @@ class VllmEmbeddingHealthCheckPayload(HealthCheckPayload):
                 specific name to advertise.
         """
         self.default_payload: dict[str, Any] = {"input": "probe"}
+        if model_name is not None:
+            self.default_payload["model"] = model_name
+        super().__init__()
+
+    def to_dict(self) -> dict[str, Any]:
+        return _layer_probe_marker(super().to_dict())
+
+
+def _silent_wav_b64() -> str:
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav:
+        wav.setnchannels(1)
+        wav.setsampwidth(2)
+        wav.setframerate(16_000)
+        wav.writeframes(b"\x00" * 3_200)
+    return base64.b64encode(buffer.getvalue()).decode("ascii")
+
+
+class VllmTranscriptionHealthCheckPayload(HealthCheckPayload):
+    """Real, short ASR probe matching TranscriptionWorkerHandler input."""
+
+    def __init__(self, model_name: Optional[str] = None):
+        self.default_payload: dict[str, Any] = {
+            "audio_b64": _silent_wav_b64(),
+            "filename": "health-check.wav",
+            "language": "en",
+            "response_format": "json",
+        }
         if model_name is not None:
             self.default_payload["model"] = model_name
         super().__init__()

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -39,6 +39,7 @@ def create_config() -> DynamoVllmConfig:
     config.multimodal_decode_worker = False
     config.enable_multimodal = False
     config.embedding_worker = False
+    config.transcription_worker = False
     config.benchmark_mode = None
     config.use_vllm_tokenizer = False
     config.frontend_decoding = False
@@ -189,6 +190,29 @@ class TestEmbeddingWorkerExclusivity:
         config.embedding_worker = False
         config.benchmark_mode = "agg"
         config._validate_embedding_worker_exclusivity()
+
+
+class TestTranscriptionWorkerExclusivity:
+    def test_baseline_aggregated_is_accepted(self):
+        config = create_config()
+        config.transcription_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config._validate_transcription_worker_exclusivity()
+
+    def test_non_aggregated_mode_is_rejected(self):
+        config = create_config()
+        config.transcription_worker = True
+        config.disaggregation_mode = DisaggregationMode.DECODE
+        with pytest.raises(ValueError, match="disaggregation-mode=agg"):
+            config._validate_transcription_worker_exclusivity()
+
+    def test_embedding_combination_is_rejected(self):
+        config = create_config()
+        config.transcription_worker = True
+        config.embedding_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        with pytest.raises(ValueError, match="embedding-worker"):
+            config._validate_transcription_worker_exclusivity()
 
 
 class TestValidateCustomEncoder:

--- a/components/src/dynamo/vllm/tests/test_backend_args.py
+++ b/components/src/dynamo/vllm/tests/test_backend_args.py
@@ -47,6 +47,12 @@ def create_config() -> DynamoVllmConfig:
     config.embedding_worker = False
     config.embedding_frontend_tokenization = False
     config.embedding_worker_processes = 1
+    config.transcription_worker = False
+    config.realtime = False
+    config.classify_worker = False
+    config.custom_encoder_class = None
+    config.gms_shadow_mode = False
+    config.enable_rl = False
     config.headless = False
     config.benchmark_mode = None
     config.use_vllm_tokenizer = False
@@ -277,6 +283,38 @@ class TestEmbeddingFrontendTokenization:
 
         with pytest.raises(argparse.ArgumentTypeError, match="expected one of"):
             DynamoVllmArgGroup().add_arguments(parser)
+
+
+class TestTranscriptionWorkerExclusivity:
+    def test_baseline_aggregated_is_accepted(self):
+        config = create_config()
+        config.transcription_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        config._validate_transcription_worker_exclusivity()
+
+    def test_non_aggregated_mode_is_rejected(self):
+        config = create_config()
+        config.transcription_worker = True
+        config.disaggregation_mode = DisaggregationMode.DECODE
+        with pytest.raises(ValueError, match="disaggregation-mode=agg"):
+            config._validate_transcription_worker_exclusivity()
+
+    @pytest.mark.parametrize(
+        ("option", "value"),
+        [
+            ("embedding_worker", True),
+            ("classify_worker", True),
+            ("realtime", True),
+            ("headless", True),
+        ],
+    )
+    def test_standalone_role_combinations_are_rejected(self, option, value):
+        config = create_config()
+        config.transcription_worker = True
+        config.disaggregation_mode = DisaggregationMode.AGGREGATED
+        setattr(config, option, value)
+        with pytest.raises(ValueError, match=option.replace("_", "-")):
+            config._validate_transcription_worker_exclusivity()
 
 
 class TestRealtimeWorkerExclusivity:

--- a/components/src/dynamo/vllm/tests/test_vllm_health_check_payloads.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_health_check_payloads.py
@@ -9,7 +9,10 @@ overrides. No vllm handler branches on the marker today; this is wire-format
 parity with trtllm/sglang for any future marker-gated behavior.
 """
 
+import base64
+import io
 import json
+import wave
 
 import pytest
 
@@ -19,6 +22,7 @@ from dynamo.vllm.health_check import (
     VllmHealthCheckPayload,
     VllmOmniHealthCheckPayload,
     VllmPrefillHealthCheckPayload,
+    VllmTranscriptionHealthCheckPayload,
 )
 
 pytestmark = [
@@ -32,6 +36,10 @@ PAYLOAD_FACTORIES = [
     pytest.param(VllmHealthCheckPayload, id="VllmHealthCheckPayload"),
     pytest.param(VllmPrefillHealthCheckPayload, id="VllmPrefillHealthCheckPayload"),
     pytest.param(VllmOmniHealthCheckPayload, id="VllmOmniHealthCheckPayload"),
+    pytest.param(
+        VllmTranscriptionHealthCheckPayload,
+        id="VllmTranscriptionHealthCheckPayload",
+    ),
     pytest.param(
         VllmEmbeddingHealthCheckPayload,
         id="VllmEmbeddingHealthCheckPayload",
@@ -89,3 +97,19 @@ def test_embedding_payload_omits_model_when_no_name():
     assert "model" not in payload
     assert payload.get("input") == "probe"
     assert payload.get(HEALTH_CHECK_KEY) is True
+
+
+def test_transcription_payload_contains_valid_short_wav():
+    payload = VllmTranscriptionHealthCheckPayload(model_name="whisper").to_dict()
+
+    assert payload.get("model") == "whisper"
+    assert payload.get("language") == "en"
+    assert payload.get("response_format") == "json"
+    assert payload.get(HEALTH_CHECK_KEY) is True
+
+    audio = base64.b64decode(payload["audio_b64"], validate=True)
+    with wave.open(io.BytesIO(audio), "rb") as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getsampwidth() == 2
+        assert wav.getframerate() == 16_000
+        assert wav.getnframes() == 1_600

--- a/components/src/dynamo/vllm/tests/test_vllm_health_check_payloads.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_health_check_payloads.py
@@ -9,7 +9,10 @@ overrides. No vllm handler branches on the marker today; this is wire-format
 parity with trtllm/sglang for any future marker-gated behavior.
 """
 
+import base64
+import io
 import json
+import wave
 
 import pytest
 
@@ -19,11 +22,13 @@ from dynamo.vllm.health_check import (
     VllmHealthCheckPayload,
     VllmOmniHealthCheckPayload,
     VllmPrefillHealthCheckPayload,
+    VllmTranscriptionHealthCheckPayload,
 )
 
 pytestmark = [
     pytest.mark.unit,
     pytest.mark.vllm,
+    pytest.mark.core,
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
@@ -32,6 +37,10 @@ PAYLOAD_FACTORIES = [
     pytest.param(VllmHealthCheckPayload, id="VllmHealthCheckPayload"),
     pytest.param(VllmPrefillHealthCheckPayload, id="VllmPrefillHealthCheckPayload"),
     pytest.param(VllmOmniHealthCheckPayload, id="VllmOmniHealthCheckPayload"),
+    pytest.param(
+        VllmTranscriptionHealthCheckPayload,
+        id="VllmTranscriptionHealthCheckPayload",
+    ),
     pytest.param(
         VllmEmbeddingHealthCheckPayload,
         id="VllmEmbeddingHealthCheckPayload",
@@ -89,3 +98,19 @@ def test_embedding_payload_omits_model_when_no_name():
     assert "model" not in payload
     assert payload.get("input") == "probe"
     assert payload.get(HEALTH_CHECK_KEY) is True
+
+
+def test_transcription_payload_contains_valid_short_wav():
+    payload = VllmTranscriptionHealthCheckPayload(model_name="whisper").to_dict()
+
+    assert payload.get("model") == "whisper"
+    assert payload.get("language") == "en"
+    assert payload.get("response_format") == "json"
+    assert payload.get(HEALTH_CHECK_KEY) is True
+
+    audio = base64.b64decode(payload["audio_b64"], validate=True)
+    with wave.open(io.BytesIO(audio), "rb") as wav:
+        assert wav.getnchannels() == 1
+        assert wav.getsampwidth() == 2
+        assert wav.getframerate() == 16_000
+        assert wav.getnframes() == 1_600

--- a/components/src/dynamo/vllm/tests/test_vllm_transcription.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_transcription.py
@@ -1,0 +1,154 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("fastapi")
+
+from dynamo.vllm.transcription_handler import TranscriptionWorkerHandler  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.core,
+    pytest.mark.gpu_1,
+    pytest.mark.pre_merge,
+]
+
+
+def make_handler() -> TranscriptionWorkerHandler:
+    handler = TranscriptionWorkerHandler.__new__(TranscriptionWorkerHandler)
+    handler.config = SimpleNamespace(
+        model="openai/whisper-tiny",
+        served_model_name="whisper",
+    )
+    return handler
+
+
+def test_decode_audio_rejects_invalid_base64():
+    with pytest.raises(ValueError, match="invalid base64"):
+        make_handler()._decode_audio({"audio_b64": "not base64"})
+
+
+def test_native_request_forwards_supported_openai_fields():
+    request = make_handler()._native_request(
+        {
+            "filename": "sample.wav",
+            "model": "whisper",
+            "language": "en",
+            "prompt": "NVIDIA Dynamo",
+            "response_format": "verbose_json",
+            "temperature": 0.2,
+            "timestamp_granularities": ["word"],
+        }
+    )
+
+    assert request.file.filename == "sample.wav"
+    assert request.model == "whisper"
+    assert request.language == "en"
+    assert request.prompt == "NVIDIA Dynamo"
+    assert request.response_format == "verbose_json"
+    assert request.timestamp_granularities == ["word"]
+
+
+def test_generate_delegates_to_native_vllm_serving():
+    asyncio.run(_assert_generate_delegates_to_native_vllm_serving())
+
+
+async def _assert_generate_delegates_to_native_vllm_serving():
+    class NativeResponse:
+        def model_dump(self, **_kwargs):
+            return {
+                "text": "hello",
+                "usage": {"type": "duration", "seconds": 1},
+            }
+
+    handler = make_handler()
+    handler._run_with_cancellation = AsyncMock(return_value=NativeResponse())
+    context = object()
+    chunks = [
+        chunk
+        async for chunk in handler.generate(
+            {
+                "audio_b64": base64.b64encode(b"audio").decode("ascii"),
+                "filename": "sample.wav",
+                "response_format": "json",
+            },
+            context,
+        )
+    ]
+
+    assert chunks == [{"text": "hello", "usage": {"type": "duration", "seconds": 1}}]
+    handler._run_with_cancellation.assert_awaited_once()
+
+
+def test_outer_cancellation_stops_native_vllm_inference():
+    asyncio.run(_assert_outer_cancellation_stops_native_vllm_inference())
+
+
+async def _assert_outer_cancellation_stops_native_vllm_inference():
+    inference_started = asyncio.Event()
+    inference_cancelled = asyncio.Event()
+
+    async def create_transcription(*_args, **_kwargs):
+        inference_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            inference_cancelled.set()
+
+    async def wait_for_context_cancellation():
+        await asyncio.Event().wait()
+
+    handler = make_handler()
+    handler.serving = SimpleNamespace(create_transcription=create_transcription)
+    context = SimpleNamespace(async_killed_or_stopped=wait_for_context_cancellation)
+
+    task = asyncio.create_task(
+        handler._run_with_cancellation(b"audio", object(), context)
+    )
+    await inference_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(inference_cancelled.wait(), timeout=1)
+
+
+def test_context_cancellation_stops_native_vllm_inference():
+    asyncio.run(_assert_context_cancellation_stops_native_vllm_inference())
+
+
+async def _assert_context_cancellation_stops_native_vllm_inference():
+    inference_started = asyncio.Event()
+    inference_cancelled = asyncio.Event()
+    context_cancelled = asyncio.Event()
+
+    async def create_transcription(*_args, **_kwargs):
+        inference_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            inference_cancelled.set()
+
+    async def wait_for_context_cancellation():
+        await context_cancelled.wait()
+
+    handler = make_handler()
+    handler.serving = SimpleNamespace(create_transcription=create_transcription)
+    context = SimpleNamespace(async_killed_or_stopped=wait_for_context_cancellation)
+
+    task = asyncio.create_task(
+        handler._run_with_cancellation(b"audio", object(), context)
+    )
+    await inference_started.wait()
+    context_cancelled.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(inference_cancelled.wait(), timeout=1)

--- a/components/src/dynamo/vllm/tests/test_vllm_transcription.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_transcription.py
@@ -7,7 +7,10 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from vllm.entrypoints.openai.engine.protocol import ErrorInfo, ErrorResponse
 
+from dynamo.llm import HttpError
+from dynamo.vllm import transcription_handler
 from dynamo.vllm.transcription_handler import TranscriptionWorkerHandler
 
 pytestmark = [
@@ -24,8 +27,40 @@ def make_handler() -> TranscriptionWorkerHandler:
     handler.config = SimpleNamespace(
         model="openai/whisper-tiny",
         served_model_name="whisper",
+        served_model_aliases=[],
     )
     return handler
+
+
+def test_handler_registers_served_model_aliases(monkeypatch):
+    registered = {}
+
+    class FakeModels:
+        def __init__(self, _engine, base_model_paths):
+            registered["base_model_paths"] = base_model_paths
+
+    monkeypatch.setattr(transcription_handler, "OpenAIServingModels", FakeModels)
+    monkeypatch.setattr(
+        transcription_handler,
+        "OpenAIServingTranscription",
+        lambda *_args, **_kwargs: object(),
+    )
+    monkeypatch.setattr(
+        transcription_handler,
+        "VllmEngineMonitor",
+        lambda *_args, **_kwargs: object(),
+    )
+
+    config = SimpleNamespace(
+        model="openai/whisper-tiny",
+        served_model_name="whisper",
+        served_model_aliases=["whisper-alias", "stt"],
+    )
+    TranscriptionWorkerHandler(runtime=object(), engine=object(), config=config)
+
+    paths = registered["base_model_paths"]
+    assert [path.name for path in paths] == ["whisper", "whisper-alias", "stt"]
+    assert {path.model_path for path in paths} == {"openai/whisper-tiny"}
 
 
 def test_decode_audio_rejects_invalid_base64():
@@ -83,6 +118,37 @@ async def _assert_generate_delegates_to_native_vllm_serving():
 
     assert chunks == [{"text": "hello", "usage": {"type": "duration", "seconds": 1}}]
     handler._run_with_cancellation.assert_awaited_once()
+
+
+def test_generate_preserves_native_vllm_error_status():
+    asyncio.run(_assert_generate_preserves_native_vllm_error_status())
+
+
+async def _assert_generate_preserves_native_vllm_error_status():
+    handler = make_handler()
+    handler._run_with_cancellation = AsyncMock(
+        return_value=ErrorResponse(
+            error=ErrorInfo(
+                message="The model does not exist",
+                type="NotFoundError",
+                code=404,
+            )
+        )
+    )
+
+    with pytest.raises(HttpError, match="The model does not exist") as error:
+        await anext(
+            handler.generate(
+                {
+                    "audio_b64": base64.b64encode(b"audio").decode("ascii"),
+                    "filename": "sample.wav",
+                    "response_format": "json",
+                },
+                object(),
+            )
+        )
+
+    assert error.value.code == 404
 
 
 @pytest.mark.timeout(5)

--- a/components/src/dynamo/vllm/tests/test_vllm_transcription.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_transcription.py
@@ -85,6 +85,7 @@ async def _assert_generate_delegates_to_native_vllm_serving():
     handler._run_with_cancellation.assert_awaited_once()
 
 
+@pytest.mark.timeout(5)
 def test_outer_cancellation_stops_native_vllm_inference():
     asyncio.run(_assert_outer_cancellation_stops_native_vllm_inference())
 
@@ -118,6 +119,7 @@ async def _assert_outer_cancellation_stops_native_vllm_inference():
     await asyncio.wait_for(inference_cancelled.wait(), timeout=1)
 
 
+@pytest.mark.timeout(5)
 def test_context_cancellation_stops_native_vllm_inference():
     asyncio.run(_assert_context_cancellation_stops_native_vllm_inference())
 

--- a/components/src/dynamo/vllm/tests/test_vllm_transcription.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_transcription.py
@@ -1,0 +1,152 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import asyncio
+import base64
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from dynamo.vllm.transcription_handler import TranscriptionWorkerHandler
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def make_handler() -> TranscriptionWorkerHandler:
+    handler = TranscriptionWorkerHandler.__new__(TranscriptionWorkerHandler)
+    handler.config = SimpleNamespace(
+        model="openai/whisper-tiny",
+        served_model_name="whisper",
+    )
+    return handler
+
+
+def test_decode_audio_rejects_invalid_base64():
+    with pytest.raises(ValueError, match="invalid base64"):
+        make_handler()._decode_audio({"audio_b64": "not base64"})
+
+
+def test_native_request_forwards_supported_openai_fields():
+    request = make_handler()._native_request(
+        {
+            "filename": "sample.wav",
+            "model": "whisper",
+            "language": "en",
+            "prompt": "NVIDIA Dynamo",
+            "response_format": "verbose_json",
+            "temperature": 0.2,
+            "timestamp_granularities": ["word"],
+        }
+    )
+
+    assert request.file.filename == "sample.wav"
+    assert request.model == "whisper"
+    assert request.language == "en"
+    assert request.prompt == "NVIDIA Dynamo"
+    assert request.response_format == "verbose_json"
+    assert request.timestamp_granularities == ["word"]
+
+
+def test_generate_delegates_to_native_vllm_serving():
+    asyncio.run(_assert_generate_delegates_to_native_vllm_serving())
+
+
+async def _assert_generate_delegates_to_native_vllm_serving():
+    class NativeResponse:
+        def model_dump(self, **_kwargs):
+            return {
+                "text": "hello",
+                "usage": {"type": "duration", "seconds": 1},
+            }
+
+    handler = make_handler()
+    handler._run_with_cancellation = AsyncMock(return_value=NativeResponse())
+    context = object()
+    chunks = [
+        chunk
+        async for chunk in handler.generate(
+            {
+                "audio_b64": base64.b64encode(b"audio").decode("ascii"),
+                "filename": "sample.wav",
+                "response_format": "json",
+            },
+            context,
+        )
+    ]
+
+    assert chunks == [{"text": "hello", "usage": {"type": "duration", "seconds": 1}}]
+    handler._run_with_cancellation.assert_awaited_once()
+
+
+def test_outer_cancellation_stops_native_vllm_inference():
+    asyncio.run(_assert_outer_cancellation_stops_native_vllm_inference())
+
+
+async def _assert_outer_cancellation_stops_native_vllm_inference():
+    inference_started = asyncio.Event()
+    inference_cancelled = asyncio.Event()
+
+    async def create_transcription(*_args, **_kwargs):
+        inference_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            inference_cancelled.set()
+
+    async def wait_for_context_cancellation():
+        await asyncio.Event().wait()
+
+    handler = make_handler()
+    handler.serving = SimpleNamespace(create_transcription=create_transcription)
+    context = SimpleNamespace(async_killed_or_stopped=wait_for_context_cancellation)
+
+    task = asyncio.create_task(
+        handler._run_with_cancellation(b"audio", object(), context)
+    )
+    await inference_started.wait()
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(inference_cancelled.wait(), timeout=1)
+
+
+def test_context_cancellation_stops_native_vllm_inference():
+    asyncio.run(_assert_context_cancellation_stops_native_vllm_inference())
+
+
+async def _assert_context_cancellation_stops_native_vllm_inference():
+    inference_started = asyncio.Event()
+    inference_cancelled = asyncio.Event()
+    context_cancelled = asyncio.Event()
+
+    async def create_transcription(*_args, **_kwargs):
+        inference_started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            inference_cancelled.set()
+
+    async def wait_for_context_cancellation():
+        await context_cancelled.wait()
+
+    handler = make_handler()
+    handler.serving = SimpleNamespace(create_transcription=create_transcription)
+    context = SimpleNamespace(async_killed_or_stopped=wait_for_context_cancellation)
+
+    task = asyncio.create_task(
+        handler._run_with_cancellation(b"audio", object(), context)
+    )
+    await inference_started.wait()
+    context_cancelled.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    await asyncio.wait_for(inference_cancelled.wait(), timeout=1)

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1384,6 +1384,7 @@ def _make_dynamo_config(**overrides):
         "use_kv_events": False,
         "enable_local_indexer": True,
         "embedding_worker": False,
+        "transcription_worker": False,
         "headless": False,
         "multimodal_worker": False,
         "multimodal_decode_worker": False,
@@ -1584,6 +1585,7 @@ class TestForwardPassMetricsActivation:
         [
             ({}, "unified backend", False),
             ({"embedding_worker": True}, "embedding", True),
+            ({"transcription_worker": True}, "transcription", True),
             ({"headless": True}, "headless", True),
             (
                 {"disaggregation_mode": DisaggregationMode.ENCODE},

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1528,6 +1528,7 @@ def _make_dynamo_config(**overrides):
         "enable_local_indexer": True,
         "embedding_worker": False,
         "classify_worker": False,
+        "transcription_worker": False,
         "headless": False,
         "enable_multimodal": False,
         "fpm_trace": False,
@@ -1767,6 +1768,7 @@ class TestForwardPassMetricsActivation:
         [
             ({"embedding_worker": True}, "embedding"),
             ({"classify_worker": True}, "classify"),
+            ({"transcription_worker": True}, "transcription"),
             ({"headless": True}, "headless"),
             (
                 {"disaggregation_mode": DisaggregationMode.ENCODE},

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -1602,6 +1602,24 @@ class TestPoolingWorkerPrefixCachingDefault:
         assert engine_cfg.enable_prefix_caching is True
 
 
+class TestTranscriptionWorkerPrefixCachingDefault:
+    def test_transcription_defaults_to_disabled(self):
+        dynamo_cfg = _make_dynamo_config(transcription_worker=True)
+        engine_cfg = _make_engine_config_with_runner(enable_prefix_caching=None)
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.enable_prefix_caching is False
+
+    def test_explicit_enable_is_preserved(self):
+        dynamo_cfg = _make_dynamo_config(transcription_worker=True)
+        engine_cfg = _make_engine_config_with_runner(enable_prefix_caching=True)
+
+        update_engine_config_with_dynamo(dynamo_cfg, engine_cfg)
+
+        assert engine_cfg.enable_prefix_caching is True
+
+
 class TestRunnerPreservation:
     """update_engine_config_with_dynamo must not overwrite a user-set --runner."""
 

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -42,6 +42,7 @@ def _make_config(**overrides) -> Mock:
         "route_to_encoder": False,
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "embedding_worker": False,
+        "transcription_worker": False,
     }
     defaults.update(overrides)
     return Mock(**defaults)
@@ -470,6 +471,7 @@ class TestCreate:
         factory._create_prefill_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_decode_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_embedding_worker = AsyncMock()  # type: ignore[assignment]
+        factory._create_transcription_worker = AsyncMock()  # type: ignore[assignment]
         return factory
 
     # Tests for non-legacy worker config, 'route_to_encode' is worker internal config
@@ -520,6 +522,15 @@ class TestCreate:
         await factory.create(Mock(), config, shutdown_event, [])
 
         factory._create_multimodal_encode_worker.assert_called_once()  # type: ignore[union-attr]
+
+    async def test_transcription_worker_takes_priority(
+        self, factory: WorkerFactory
+    ) -> None:
+        config = _make_config(transcription_worker=True)
+        await factory.create(Mock(), config, asyncio.Event(), [])
+
+        factory._create_transcription_worker.assert_called_once()  # type: ignore[union-attr]
+        factory._create_decode_worker.assert_not_called()  # type: ignore[union-attr]
 
     async def test_embedding_worker_takes_priority(
         self, factory: WorkerFactory

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -1239,3 +1239,58 @@ async def test_embedding_worker_registration_and_cleanup(
     assert register_vllm_model.await_args.args[0] == expected_model_input
     assert cleanup_order == ["handler", "client", "resource"]
     assert shutdown_endpoints == [endpoint]
+
+
+@pytest.mark.asyncio
+async def test_transcription_worker_reuses_snapshot_engine(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    endpoint = Mock()
+    endpoint.connection_id.return_value = "worker-1"
+    endpoint.serve_endpoint = AsyncMock()
+    runtime = Mock()
+    runtime.endpoint.return_value = endpoint
+
+    engine_client = Mock()
+    vllm_config = Mock()
+    snapshot_engine: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        None,
+        Mock(),
+    )
+    setup_vllm_engine = Mock()
+    register_vllm_model = AsyncMock()
+    factory = _make_factory(
+        setup_vllm_engine_fn=setup_vllm_engine,
+        register_vllm_model_fn=register_vllm_model,
+    )
+    handler = Mock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.TranscriptionWorkerHandler",
+        Mock(return_value=handler),
+    )
+    monkeypatch.setattr("dynamo.vllm.worker_factory.register_model_taint_route", Mock())
+    monkeypatch.setenv("DYN_FPM_WORKER_ID", "snapshot")
+    config = SimpleNamespace(
+        namespace="ns",
+        component="worker",
+        endpoint="generate",
+        served_model_name="whisper",
+        model="openai/whisper-tiny",
+    )
+
+    await factory._create_transcription_worker(
+        runtime,
+        config,
+        asyncio.Event(),
+        [],
+        snapshot_engine=snapshot_engine,
+    )
+
+    setup_vllm_engine.assert_not_called()
+    assert register_vllm_model.await_args.args[4] is engine_client
+    assert register_vllm_model.await_args.args[5] is vllm_config
+    endpoint.serve_endpoint.assert_awaited_once()
+    handler.cleanup.assert_called_once()

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -41,6 +41,7 @@ def _make_config(**overrides) -> Mock:
         "disaggregation_mode": DisaggregationMode.AGGREGATED,
         "embedding_worker": False,
         "embedding_frontend_tokenization": False,
+        "transcription_worker": False,
         # Pin to the real Config default: an auto-created Mock attribute is
         # truthy, which enables the GMS shadow-mode path and imports the
         # optional gpu_memory_service package (absent in some test images).
@@ -739,6 +740,7 @@ class TestCreate:
         factory._create_prefill_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_decode_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_embedding_worker = AsyncMock()  # type: ignore[assignment]
+        factory._create_transcription_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_realtime_worker = AsyncMock()  # type: ignore[assignment]
         factory._create_classify_worker = AsyncMock()  # type: ignore[assignment]
         return factory
@@ -791,6 +793,15 @@ class TestCreate:
         await factory.create(Mock(), config, shutdown_event, [])
 
         factory._create_multimodal_encode_worker.assert_called_once()  # type: ignore[union-attr]
+
+    async def test_transcription_worker_takes_priority(
+        self, factory: WorkerFactory
+    ) -> None:
+        config = _make_config(transcription_worker=True)
+        await factory.create(Mock(), config, asyncio.Event(), [])
+
+        factory._create_transcription_worker.assert_called_once()  # type: ignore[union-attr]
+        factory._create_decode_worker.assert_not_called()  # type: ignore[union-attr]
 
     async def test_embedding_worker_takes_priority(
         self, factory: WorkerFactory

--- a/components/src/dynamo/vllm/transcription_handler.py
+++ b/components/src/dynamo/vllm/transcription_handler.py
@@ -1,0 +1,140 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamo adapter for vLLM's native OpenAI transcription serving layer."""
+
+import asyncio
+import base64
+import binascii
+import logging
+from io import BytesIO
+from typing import Any, AsyncIterator
+
+from fastapi import UploadFile
+from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+from vllm.entrypoints.openai.models.protocol import BaseModelPath
+from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+from vllm.entrypoints.speech_to_text.transcription.protocol import TranscriptionRequest
+from vllm.entrypoints.speech_to_text.transcription.serving import (
+    OpenAIServingTranscription,
+)
+
+from dynamo._core import Context
+
+from .args import Config
+from .engine_monitor import VllmEngineMonitor
+
+logger = logging.getLogger(__name__)
+
+_TRANSCRIPTION_FIELDS = (
+    "language",
+    "prompt",
+    "response_format",
+    "temperature",
+    "timestamp_granularities",
+)
+
+
+class TranscriptionWorkerHandler:
+    """Serve batch STT requests using vLLM's model-native implementation."""
+
+    def __init__(
+        self,
+        runtime: Any,
+        engine: Any,
+        config: Config,
+        shutdown_event: asyncio.Event | None = None,
+    ) -> None:
+        self.runtime = runtime
+        self.engine_client = engine
+        self.config = config
+        self.shutdown_event = shutdown_event
+        self.engine_monitor = VllmEngineMonitor(runtime, engine, shutdown_event)
+
+        model_name = config.served_model_name or config.model
+        models = OpenAIServingModels(
+            engine,
+            [BaseModelPath(name=model_name, model_path=config.model)],
+        )
+        self.serving = OpenAIServingTranscription(
+            engine,
+            models,
+            request_logger=None,
+        )
+        logger.info("Transcription worker handler initialized for %s", model_name)
+
+    @staticmethod
+    def _decode_audio(request: dict[str, Any]) -> bytes:
+        encoded = request.get("audio_b64")
+        if not isinstance(encoded, str) or not encoded:
+            raise ValueError("Transcription request missing required 'audio_b64' field")
+        try:
+            audio = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise ValueError(
+                "Transcription request contains invalid base64 audio"
+            ) from error
+        if not audio:
+            raise ValueError("Transcription audio must not be empty")
+        return audio
+
+    def _native_request(self, request: dict[str, Any]) -> TranscriptionRequest:
+        filename = request.get("filename") or "audio"
+        upload = UploadFile(file=BytesIO(b""), filename=filename)
+        values = {
+            field: request[field]
+            for field in _TRANSCRIPTION_FIELDS
+            if request.get(field) is not None
+        }
+        granularities = values.pop("timestamp_granularities", None)
+        if granularities is not None:
+            values["timestamp_granularities[]"] = granularities
+        values["file"] = upload
+        values["model"] = (
+            request.get("model") or self.config.served_model_name or self.config.model
+        )
+        return TranscriptionRequest(**values)
+
+    async def _run_with_cancellation(
+        self,
+        audio: bytes,
+        request: TranscriptionRequest,
+        context: Context,
+    ) -> Any:
+        inference = asyncio.create_task(
+            self.serving.create_transcription(audio, request, raw_request=None)
+        )
+        cancelled = asyncio.ensure_future(context.async_killed_or_stopped())
+        try:
+            done, _ = await asyncio.wait(
+                (inference, cancelled), return_when=asyncio.FIRST_COMPLETED
+            )
+            if cancelled in done and not inference.done():
+                raise asyncio.CancelledError
+            return await inference
+        finally:
+            if not inference.done():
+                inference.cancel()
+            await asyncio.gather(inference, return_exceptions=True)
+            if not cancelled.done():
+                cancelled.cancel()
+            await asyncio.gather(cancelled, return_exceptions=True)
+
+    async def generate(
+        self, request: dict[str, Any], context: Context
+    ) -> AsyncIterator[dict[str, Any]]:
+        audio = self._decode_audio(request)
+        native_request = self._native_request(request)
+        if native_request.response_format not in ("json", "verbose_json"):
+            raise ValueError(
+                "Transcription response_format must be 'json' or 'verbose_json'"
+            )
+
+        result = await self._run_with_cancellation(audio, native_request, context)
+        if isinstance(result, ErrorResponse):
+            raise ValueError(result.message)
+        if not hasattr(result, "model_dump"):
+            raise TypeError(
+                f"Unexpected vLLM transcription response type: {type(result).__name__}"
+            )
+        yield result.model_dump(mode="json", exclude_none=True)

--- a/components/src/dynamo/vllm/transcription_handler.py
+++ b/components/src/dynamo/vllm/transcription_handler.py
@@ -1,0 +1,171 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Dynamo adapter for vLLM's native OpenAI transcription serving layer."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import binascii
+import logging
+from io import BytesIO
+from typing import Any, AsyncIterator
+
+from dynamo._core import Context
+
+from .args import Config
+from .engine_monitor import VllmEngineMonitor
+
+_TRANSCRIPTION_IMPORT_ERROR: ImportError | None = None
+try:
+    from fastapi import UploadFile
+    from vllm.entrypoints.openai.engine.protocol import ErrorResponse
+    from vllm.entrypoints.openai.models.protocol import BaseModelPath
+    from vllm.entrypoints.openai.models.serving import OpenAIServingModels
+    from vllm.entrypoints.speech_to_text.transcription.protocol import (
+        TranscriptionRequest,
+    )
+    from vllm.entrypoints.speech_to_text.transcription.serving import (
+        OpenAIServingTranscription,
+    )
+except ImportError as error:
+    UploadFile = None  # type: ignore[assignment, misc]
+    ErrorResponse = None  # type: ignore[assignment, misc]
+    BaseModelPath = None  # type: ignore[assignment, misc]
+    OpenAIServingModels = None  # type: ignore[assignment, misc]
+    TranscriptionRequest = None  # type: ignore[assignment, misc]
+    OpenAIServingTranscription = None  # type: ignore[assignment, misc]
+    _TRANSCRIPTION_IMPORT_ERROR = error
+
+logger = logging.getLogger(__name__)
+
+_TRANSCRIPTION_FIELDS = (
+    "language",
+    "prompt",
+    "response_format",
+    "temperature",
+    "timestamp_granularities",
+)
+
+
+def _require_transcription_dependencies() -> None:
+    if _TRANSCRIPTION_IMPORT_ERROR is not None:
+        raise RuntimeError(
+            "vLLM transcription dependencies are unavailable"
+        ) from _TRANSCRIPTION_IMPORT_ERROR
+
+
+class TranscriptionWorkerHandler:
+    """Serve batch STT requests using vLLM's model-native implementation."""
+
+    def __init__(
+        self,
+        runtime: Any,
+        engine: Any,
+        config: Config,
+        shutdown_event: asyncio.Event | None = None,
+    ) -> None:
+        _require_transcription_dependencies()
+        self.runtime = runtime
+        self.engine_client = engine
+        self.config = config
+        self.shutdown_event = shutdown_event
+        self.engine_monitor = VllmEngineMonitor(runtime, engine, shutdown_event)
+
+        model_name = config.served_model_name or config.model
+        models = OpenAIServingModels(
+            engine,
+            [BaseModelPath(name=model_name, model_path=config.model)],
+        )
+        self.serving = OpenAIServingTranscription(
+            engine,
+            models,
+            request_logger=None,
+        )
+        logger.info("Transcription worker handler initialized for %s", model_name)
+
+    def cleanup(self) -> None:
+        """Release handler-owned resources.
+
+        The worker factory and runtime own the AsyncLLM lifecycle. The engine
+        monitor cancels its background tasks when this handler is released.
+        """
+        return None
+
+    @staticmethod
+    def _decode_audio(request: dict[str, Any]) -> bytes:
+        encoded = request.get("audio_b64")
+        if not isinstance(encoded, str) or not encoded:
+            raise ValueError("Transcription request missing required 'audio_b64' field")
+        try:
+            audio = base64.b64decode(encoded, validate=True)
+        except (binascii.Error, ValueError) as error:
+            raise ValueError(
+                "Transcription request contains invalid base64 audio"
+            ) from error
+        if not audio:
+            raise ValueError("Transcription audio must not be empty")
+        return audio
+
+    def _native_request(self, request: dict[str, Any]) -> TranscriptionRequest:
+        _require_transcription_dependencies()
+        filename = request.get("filename") or "audio"
+        upload = UploadFile(file=BytesIO(b""), filename=filename)
+        values = {
+            field: request[field]
+            for field in _TRANSCRIPTION_FIELDS
+            if request.get(field) is not None
+        }
+        granularities = values.pop("timestamp_granularities", None)
+        if granularities is not None:
+            values["timestamp_granularities[]"] = granularities
+        values["file"] = upload
+        values["model"] = (
+            request.get("model") or self.config.served_model_name or self.config.model
+        )
+        return TranscriptionRequest(**values)
+
+    async def _run_with_cancellation(
+        self,
+        audio: bytes,
+        request: TranscriptionRequest,
+        context: Context,
+    ) -> Any:
+        inference = asyncio.create_task(
+            self.serving.create_transcription(audio, request, raw_request=None)
+        )
+        cancelled = asyncio.ensure_future(context.async_killed_or_stopped())
+        try:
+            done, _ = await asyncio.wait(
+                (inference, cancelled), return_when=asyncio.FIRST_COMPLETED
+            )
+            if cancelled in done and not inference.done():
+                raise asyncio.CancelledError
+            return await inference
+        finally:
+            if not inference.done():
+                inference.cancel()
+            await asyncio.gather(inference, return_exceptions=True)
+            if not cancelled.done():
+                cancelled.cancel()
+            await asyncio.gather(cancelled, return_exceptions=True)
+
+    async def generate(
+        self, request: dict[str, Any], context: Context
+    ) -> AsyncIterator[dict[str, Any]]:
+        audio = self._decode_audio(request)
+        native_request = self._native_request(request)
+        if native_request.response_format not in ("json", "verbose_json"):
+            raise ValueError(
+                "Transcription response_format must be 'json' or 'verbose_json'"
+            )
+
+        result = await self._run_with_cancellation(audio, native_request, context)
+        if ErrorResponse is not None and isinstance(result, ErrorResponse):
+            raise ValueError(result.message)
+        if not hasattr(result, "model_dump"):
+            raise TypeError(
+                f"Unexpected vLLM transcription response type: {type(result).__name__}"
+            )
+        yield result.model_dump(mode="json", exclude_none=True)

--- a/components/src/dynamo/vllm/transcription_handler.py
+++ b/components/src/dynamo/vllm/transcription_handler.py
@@ -13,6 +13,7 @@ from io import BytesIO
 from typing import Any, AsyncIterator
 
 from dynamo._core import Context
+from dynamo.llm import HttpError
 
 from .args import Config
 from .engine_monitor import VllmEngineMonitor
@@ -74,9 +75,10 @@ class TranscriptionWorkerHandler:
         self.engine_monitor = VllmEngineMonitor(runtime, engine, shutdown_event)
 
         model_name = config.served_model_name or config.model
+        model_names = [model_name, *(config.served_model_aliases or [])]
         models = OpenAIServingModels(
             engine,
-            [BaseModelPath(name=model_name, model_path=config.model)],
+            [BaseModelPath(name=name, model_path=config.model) for name in model_names],
         )
         self.serving = OpenAIServingTranscription(
             engine,
@@ -163,7 +165,7 @@ class TranscriptionWorkerHandler:
 
         result = await self._run_with_cancellation(audio, native_request, context)
         if ErrorResponse is not None and isinstance(result, ErrorResponse):
-            raise ValueError(result.message)
+            raise HttpError(result.error.code, result.error.message)
         if not hasattr(result, "model_dump"):
             raise TypeError(
                 f"Unexpected vLLM transcription response type: {type(result).__name__}"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -42,6 +42,7 @@ from .health_check import (
     VllmEmbeddingHealthCheckPayload,
     VllmHealthCheckPayload,
     VllmPrefillHealthCheckPayload,
+    VllmTranscriptionHealthCheckPayload,
 )
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .multimodal_handlers import EncodeWorkerHandler
@@ -537,7 +538,7 @@ SetupMetricsCollectionFn = Callable[..., None]
 
 
 class WorkerFactory:
-    """Factory for creating and initializing multimodal vLLM workers."""
+    """Factory for creating and initializing vLLM workers."""
 
     def __init__(
         self,
@@ -561,7 +562,13 @@ class WorkerFactory:
         shutdown_endpoints: list,
         snapshot_engine: Optional[EngineSetupResult] = None,
     ) -> None:
-        """Create the appropriate multimodal worker based on config flags."""
+        """Create the appropriate worker based on config flags."""
+
+        if config.transcription_worker:
+            await self._create_transcription_worker(
+                runtime, config, shutdown_event, shutdown_endpoints
+            )
+            return
 
         # Embedding worker is selected first because it crosses worker shapes
         # (pooling AsyncLLM, ModelType.Embedding) rather than being a variant
@@ -648,6 +655,57 @@ class WorkerFactory:
             raise
         finally:
             handler.cleanup()
+
+    async def _create_transcription_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,
+    ) -> None:
+        from .transcription_handler import TranscriptionWorkerHandler
+
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        shutdown_endpoints[:] = [generate_endpoint]
+
+        engine_client, vllm_config, _, _, _ = self.setup_vllm_engine(
+            config,
+            None,
+            fpm_worker_id=str(generate_endpoint.connection_id()),
+        )
+        handler = TranscriptionWorkerHandler(
+            runtime=runtime,
+            engine=engine_client,
+            config=config,
+            shutdown_event=shutdown_event,
+        )
+        model_name = config.served_model_name or config.model
+        health_payload = VllmTranscriptionHealthCheckPayload(model_name).to_dict()
+        metric_labels = [
+            (prometheus_names.labels.MODEL, model_name),
+            (prometheus_names.labels.MODEL_NAME, model_name),
+        ]
+
+        logger.info("Starting to serve the transcription worker endpoint...")
+        await asyncio.gather(
+            generate_endpoint.serve_endpoint(
+                handler.generate,
+                metrics_labels=metric_labels,
+                health_check_payload=health_payload,
+            ),
+            self.register_vllm_model(
+                ModelInput.Text,
+                ModelType.Transcriptions,
+                generate_endpoint,
+                config,
+                engine_client,
+                vllm_config,
+                worker_type=WorkerType.Aggregated,
+                needs=[],
+            ),
+        )
 
     async def _create_embedding_worker(
         self,

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -45,6 +45,7 @@ from .health_check import (
     VllmEmbeddingHealthCheckPayload,
     VllmHealthCheckPayload,
     VllmPrefillHealthCheckPayload,
+    VllmTranscriptionHealthCheckPayload,
 )
 from .instrumented_scheduler import ENV_FPM_BENCHMARK_OUTPUT_PATH, ENV_FPM_WORKER_ID
 from .multimodal_handlers import EncodeWorkerHandler
@@ -52,6 +53,7 @@ from .pooling_handlers import ClassifyWorkerHandler
 from .publisher import StatLoggerFactory
 from .realtime import RealtimeHandler, RealtimeTranscriptionHandler
 from .state_agent import StateAgentLifecycle, state_agent_settings
+from .transcription_handler import TranscriptionWorkerHandler
 
 logger = logging.getLogger(__name__)
 
@@ -582,7 +584,7 @@ class _DecodeWorkerLifecycle:
 
 
 class WorkerFactory:
-    """Factory for creating and initializing multimodal vLLM workers."""
+    """Factory for creating and initializing vLLM workers."""
 
     def __init__(
         self,
@@ -645,7 +647,7 @@ class WorkerFactory:
         shutdown_endpoints: list,
         snapshot_engine: Optional[EngineSetupResult] = None,
     ) -> None:
-        """Create the appropriate multimodal worker based on config flags."""
+        """Create the appropriate worker based on config flags."""
 
         if config.realtime:
             await self._create_realtime_worker(
@@ -654,6 +656,12 @@ class WorkerFactory:
                 shutdown_event,
                 shutdown_endpoints,
                 snapshot_engine=snapshot_engine,
+            )
+            return
+
+        if config.transcription_worker:
+            await self._create_transcription_worker(
+                runtime, config, shutdown_event, shutdown_endpoints
             )
             return
 
@@ -844,6 +852,62 @@ class WorkerFactory:
             )
         except Exception as e:
             logger.error(f"Failed to serve encode worker endpoint: {e}")
+            raise
+        finally:
+            handler.cleanup()
+
+    async def _create_transcription_worker(
+        self,
+        runtime: DistributedRuntime,
+        config: Config,
+        shutdown_event: asyncio.Event,
+        shutdown_endpoints: list,
+    ) -> None:
+        generate_endpoint = runtime.endpoint(
+            f"{config.namespace}.{config.component}.{config.endpoint}"
+        )
+        shutdown_endpoints[:] = [generate_endpoint]
+
+        engine_client, vllm_config, _, _, _ = self.setup_vllm_engine(
+            config,
+            None,
+            fpm_worker_id=str(generate_endpoint.connection_id()),
+        )
+        handler = TranscriptionWorkerHandler(
+            runtime=runtime,
+            engine=engine_client,
+            config=config,
+            shutdown_event=shutdown_event,
+        )
+        model_name = config.served_model_name or config.model
+        health_payload = VllmTranscriptionHealthCheckPayload(model_name).to_dict()
+        metric_labels = [
+            (prometheus_names.labels.MODEL, model_name),
+            (prometheus_names.labels.MODEL_NAME, model_name),
+        ]
+
+        register_model_taint_route(runtime, generate_endpoint)
+        logger.info("Starting to serve the transcription worker endpoint...")
+        try:
+            await asyncio.gather(
+                generate_endpoint.serve_endpoint(
+                    handler.generate,
+                    metrics_labels=metric_labels,
+                    health_check_payload=health_payload,
+                ),
+                self.register_vllm_model(
+                    ModelInput.Text,
+                    ModelType.Transcriptions,
+                    generate_endpoint,
+                    config,
+                    engine_client,
+                    vllm_config,
+                    worker_type=WorkerType.Aggregated,
+                    needs=[],
+                ),
+            )
+        except Exception:
+            logger.exception("Failed to serve transcription worker endpoint")
             raise
         finally:
             handler.cleanup()

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -661,7 +661,11 @@ class WorkerFactory:
 
         if config.transcription_worker:
             await self._create_transcription_worker(
-                runtime, config, shutdown_event, shutdown_endpoints
+                runtime,
+                config,
+                shutdown_event,
+                shutdown_endpoints,
+                snapshot_engine=snapshot_engine,
             )
             return
 
@@ -862,17 +866,29 @@ class WorkerFactory:
         config: Config,
         shutdown_event: asyncio.Event,
         shutdown_endpoints: list,
+        snapshot_engine: Optional[EngineSetupResult] = None,
     ) -> None:
         generate_endpoint = runtime.endpoint(
             f"{config.namespace}.{config.component}.{config.endpoint}"
         )
         shutdown_endpoints[:] = [generate_endpoint]
 
-        engine_client, vllm_config, _, _, _ = self.setup_vllm_engine(
-            config,
-            None,
-            fpm_worker_id=str(generate_endpoint.connection_id()),
-        )
+        fpm_worker_id = str(generate_endpoint.connection_id())
+        if snapshot_engine is not None:
+            (
+                engine_client,
+                vllm_config,
+                _default_sampling_params,
+                _prometheus_temp_dir,
+                _component_gauges,
+            ) = snapshot_engine
+            os.environ[ENV_FPM_WORKER_ID] = fpm_worker_id
+        else:
+            engine_client, vllm_config, _, _, _ = self.setup_vllm_engine(
+                config,
+                None,
+                fpm_worker_id=fpm_worker_id,
+            )
         handler = TranscriptionWorkerHandler(
             runtime=runtime,
             engine=engine_client,

--- a/examples/backends/vllm/launch/agg_transcription.sh
+++ b/examples/backends/vllm/launch/agg_transcription.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Aggregated speech-to-text model serving.
+# GPUs: 1
+
+set -e
+trap 'echo Cleaning up...; kill 0' EXIT
+
+SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
+source "$SCRIPT_DIR/../../../common/launch_utils.sh"
+
+MODEL="openai/whisper-tiny"
+EXTRA_ARGS=()
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --model)
+            MODEL="$2"
+            shift 2
+            ;;
+        -h|--help)
+            echo "Usage: $0 [--model <name>] [vLLM options]"
+            exit 0
+            ;;
+        *)
+            EXTRA_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+print_launch_banner --no-curl "Launching Transcription Worker (1 GPU)" "$MODEL" "$HTTP_PORT"
+print_curl_footer <<CURL
+  curl http://localhost:${HTTP_PORT}/v1/audio/transcriptions \
+    -F file=@sample.wav \
+    -F model="${MODEL}" \
+    -F response_format=json
+CURL
+
+python3 -m dynamo.frontend &
+
+DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
+    python3 -m dynamo.vllm \
+    --transcription-worker \
+    --model "$MODEL" \
+    --no-enable-prefix-caching \
+    $GPU_MEM_ARGS \
+    "${EXTRA_ARGS[@]}" &
+
+wait_any_exit

--- a/examples/backends/vllm/launch/agg_transcription.sh
+++ b/examples/backends/vllm/launch/agg_transcription.sh
@@ -17,6 +17,10 @@ EXTRA_ARGS=()
 while [[ $# -gt 0 ]]; do
     case $1 in
         --model)
+            if [[ $# -lt 2 || -z "$2" ]]; then
+                echo "Error: --model requires a model name." >&2
+                exit 2
+            fi
             MODEL="$2"
             shift 2
             ;;

--- a/lib/bindings/kvbm/Cargo.lock
+++ b/lib/bindings/kvbm/Cargo.lock
@@ -452,6 +452,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -4292,6 +4293,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -878,6 +878,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -4905,6 +4906,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.2",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]

--- a/lib/bindings/python/Cargo.lock
+++ b/lib/bindings/python/Cargo.lock
@@ -468,6 +468,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -4624,6 +4625,23 @@ checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
 dependencies = [
  "num-traits",
  "pxfm",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http 1.4.2",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin 0.9.8",
+ "version_check",
 ]
 
 [[package]]

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -884,6 +884,10 @@ impl ModelType {
         inner: llm_rs::model_type::ModelType::Audios,
     };
     #[classattr]
+    const Transcriptions: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Transcriptions,
+    };
+    #[classattr]
     const Videos: Self = ModelType {
         inner: llm_rs::model_type::ModelType::Videos,
     };

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -1036,6 +1036,10 @@ impl ModelType {
         inner: llm_rs::model_type::ModelType::Audios,
     };
     #[classattr]
+    const Transcriptions: Self = ModelType {
+        inner: llm_rs::model_type::ModelType::Transcriptions,
+    };
+    #[classattr]
     const Videos: Self = ModelType {
         inner: llm_rs::model_type::ModelType::Videos,
     };

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1612,6 +1612,7 @@ class ModelType:
     Prefill: ModelType
     Images: ModelType
     Audios: ModelType
+    Transcriptions: ModelType
     Videos: ModelType
     Realtime: ModelType
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -1646,7 +1646,7 @@ class ModelType:
     """OpenAI-style surfaces supported by a model.
 
     Values are Chat, Completions, Embedding, Classify, Pooling, TensorBased,
-    Images, Audios, Videos, Realtime, and Empty (no OpenAI surface).
+    Images, Audios, Transcriptions, Videos, Realtime, and Empty (no OpenAI surface).
     """
     # No OpenAI surface — used by prefill / encode workers whose role is
     # carried by WorkerType. Symmetric with the other ModelType.Foo members.
@@ -1661,6 +1661,7 @@ class ModelType:
     Prefill: ModelType
     Images: ModelType
     Audios: ModelType
+    Transcriptions: ModelType
     Videos: ModelType
     Realtime: ModelType
     # Sequence-classification / cross-encoder pooling models served on /v1/classify.

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -25,7 +25,7 @@ use crate::types::{
         chat_completions::OpenAIChatCompletionsStreamingEngine,
         completions::OpenAICompletionsStreamingEngine, embeddings::OpenAIEmbeddingsStreamingEngine,
         generate::GenerateStreamingEngine, images::OpenAIImagesStreamingEngine,
-        videos::OpenAIVideosStreamingEngine,
+        transcriptions::OpenAITranscriptionsStreamingEngine, videos::OpenAIVideosStreamingEngine,
     },
 };
 
@@ -225,6 +225,12 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_audios_engine())
+    }
+
+    pub fn has_transcriptions_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_transcriptions_engine())
     }
 
     /// Check if any WorkerSet has a realtime engine.
@@ -570,6 +576,13 @@ impl Model {
     pub fn get_audios_engine(&self) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.audios_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_audios_engine()))
+    }
+
+    pub fn get_transcriptions_engine(
+        &self,
+    ) -> Result<OpenAITranscriptionsStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.transcriptions_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_transcriptions_engine()))
     }
 
     pub fn get_tensor_engine(&self) -> Result<TensorStreamingEngine, ModelManagerError> {

--- a/lib/llm/src/discovery/model.rs
+++ b/lib/llm/src/discovery/model.rs
@@ -27,7 +27,7 @@ use crate::types::{
         classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
         embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
         images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
-        videos::OpenAIVideosStreamingEngine,
+        transcriptions::OpenAITranscriptionsStreamingEngine, videos::OpenAIVideosStreamingEngine,
     },
 };
 
@@ -266,6 +266,12 @@ impl Model {
         self.worker_sets
             .iter()
             .any(|entry| entry.value().has_audios_engine())
+    }
+
+    pub fn has_transcriptions_engine(&self) -> bool {
+        self.worker_sets
+            .iter()
+            .any(|entry| entry.value().has_transcriptions_engine())
     }
 
     /// Check if any WorkerSet has a realtime engine.
@@ -591,6 +597,13 @@ impl Model {
     pub fn get_audios_engine(&self) -> Result<OpenAIAudiosStreamingEngine, ModelManagerError> {
         self.select_worker_set_with(|ws| ws.audios_engine.clone())
             .ok_or_else(|| self.engine_error(self.has_audios_engine()))
+    }
+
+    pub fn get_transcriptions_engine(
+        &self,
+    ) -> Result<OpenAITranscriptionsStreamingEngine, ModelManagerError> {
+        self.select_worker_set_with(|ws| ws.transcriptions_engine.clone())
+            .ok_or_else(|| self.engine_error(self.has_transcriptions_engine()))
     }
 
     pub fn get_tensor_engine(&self) -> Result<TensorStreamingEngine, ModelManagerError> {

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -40,7 +40,9 @@ use crate::{
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
-            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+            images::OpenAIImagesStreamingEngine,
+            transcriptions::OpenAITranscriptionsStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -525,6 +527,14 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_transcriptions_models(&self) -> Vec<String> {
+        self.models
+            .iter()
+            .filter(|entry| entry.value().has_transcriptions_engine())
+            .map(|entry| entry.key().clone())
+            .collect()
+    }
+
     pub fn list_videos_models(&self) -> Vec<String> {
         self.models
             .iter()
@@ -625,6 +635,16 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_audios_engine()
+    }
+
+    pub fn get_transcriptions_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAITranscriptionsStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_transcriptions_engine()
     }
 
     pub fn get_realtime_engine(
@@ -858,6 +878,27 @@ impl ModelManager {
             Self::aggregated_local_card(),
         );
         ws.audios_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        Ok(())
+    }
+
+    pub fn add_transcriptions_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAITranscriptionsStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_transcriptions_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_transcriptions_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.transcriptions_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
         Ok(())
     }

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -54,6 +54,7 @@ use crate::{
             classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
             images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
+            transcriptions::OpenAITranscriptionsStreamingEngine,
             videos::OpenAIVideosStreamingEngine,
         },
     },
@@ -1147,6 +1148,16 @@ impl ModelManager {
             .collect()
     }
 
+    pub fn list_transcriptions_models(&self) -> Vec<String> {
+        self.catalog
+            .load()
+            .models
+            .iter()
+            .filter(|(_, model)| model.has_transcriptions_engine())
+            .map(|(name, _)| name.clone())
+            .collect()
+    }
+
     pub fn list_videos_models(&self) -> Vec<String> {
         self.catalog
             .load()
@@ -1304,6 +1315,16 @@ impl ModelManager {
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_audios_engine()
+    }
+
+    pub fn get_transcriptions_engine(
+        &self,
+        model: &str,
+    ) -> Result<OpenAITranscriptionsStreamingEngine, ModelManagerError> {
+        self.models
+            .get(model)
+            .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
+            .get_transcriptions_engine()
     }
 
     pub fn get_realtime_engine(
@@ -1634,6 +1655,29 @@ impl ModelManager {
             Self::aggregated_local_card(),
         );
         ws.audios_engine = Some(engine);
+        model_entry.add_worker_set(namespace, Arc::new(ws));
+        self.publish_catalog_locked();
+        Ok(())
+    }
+
+    pub fn add_transcriptions_model(
+        &self,
+        model: &str,
+        card_checksum: &str,
+        engine: OpenAITranscriptionsStreamingEngine,
+    ) -> Result<(), ModelManagerError> {
+        let _reservation = self.reservation_lock.lock();
+        let model_entry = self.get_or_create_model(model);
+        if model_entry.has_transcriptions_engine() {
+            return Err(ModelManagerError::ModelAlreadyExists(model.to_string()));
+        }
+        let namespace = format!("__local_transcriptions_{}", model);
+        let mut ws = WorkerSet::new(
+            namespace.clone(),
+            card_checksum.to_string(),
+            Self::aggregated_local_card(),
+        );
+        ws.transcriptions_engine = Some(engine);
         model_entry.add_worker_set(namespace, Arc::new(ws));
         self.publish_catalog_locked();
         Ok(())

--- a/lib/llm/src/discovery/model_manager.rs
+++ b/lib/llm/src/discovery/model_manager.rs
@@ -1321,7 +1321,9 @@ impl ModelManager {
         &self,
         model: &str,
     ) -> Result<OpenAITranscriptionsStreamingEngine, ModelManagerError> {
-        self.models
+        self.catalog
+            .load()
+            .models
             .get(model)
             .ok_or_else(|| ModelManagerError::ModelNotFound(model.to_string()))?
             .get_transcriptions_engine()

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -53,6 +53,7 @@ use crate::{
             completions::{NvCreateCompletionRequest, NvCreateCompletionResponse},
             embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
             images::{NvCreateImageRequest, NvImagesResponse},
+            transcriptions::{NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest},
             videos::{NvCreateVideoRequest, NvVideosResponse},
         },
         tensor::{NvCreateTensorRequest, NvCreateTensorResponse},
@@ -239,6 +240,7 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Embedding,
     ModelType::Images,
     ModelType::Audios,
+    ModelType::Transcriptions,
     ModelType::Videos,
     ModelType::TensorBased,
     ModelType::Realtime,
@@ -256,6 +258,8 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_images_models().is_empty()
     } else if model_type == ModelType::Audios {
         manager.list_audios_models().is_empty()
+    } else if model_type == ModelType::Transcriptions {
+        manager.list_transcriptions_models().is_empty()
     } else if model_type == ModelType::Videos {
         manager.list_videos_models().is_empty()
     } else if model_type == ModelType::TensorBased {
@@ -1812,9 +1816,11 @@ impl ModelWatcher {
         else if card.model_input == ModelInput::Text
             && (card.model_type.supports_images()
                 || card.model_type.supports_audios()
+                || card.model_type.supports_transcriptions()
                 || card.model_type.supports_videos())
         {
-            // Image/Audio/Video models can also support chat completions (vLLM omni way)
+            // Text-input media capabilities share this worker-set construction path;
+            // capability bits determine which endpoint routers are installed.
             if card.model_type.supports_chat() {
                 let chat_router = PushRouter::<
                     NvCreateChatCompletionRequest,
@@ -1853,6 +1859,17 @@ impl ModelWatcher {
                 )
                 .await?;
                 worker_set.audios_engine = Some(Arc::new(audios_router));
+            }
+
+            if card.model_type.supports_transcriptions() {
+                let transcriptions_router = PushRouter::<
+                    NvCreateAudioTranscriptionRequest,
+                    Annotated<NvAudioTranscriptionResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.transcriptions_engine = Some(Arc::new(transcriptions_router));
             }
         } else if card.model_input == ModelInput::Text && card.model_type.supports_chat() {
             // Case: Text + Chat (pure text-to-text, no diffusion)
@@ -1945,7 +1962,7 @@ impl ModelWatcher {
             // prefill is routed off `worker_type`.)
             anyhow::bail!(
                 "Unsupported model configuration: {} with {} input. Supported combinations: \
-                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Videos|Embeddings|Realtime), \
+                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Transcriptions|Videos|Embeddings|Realtime), \
                 Tokens+Embeddings, Tensor+TensorBased",
                 card.model_type,
                 card.model_input.as_str()
@@ -2322,6 +2339,7 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Embedding));
         assert!(is_model_type_list_empty(&mm, ModelType::Images));
         assert!(is_model_type_list_empty(&mm, ModelType::Audios));
+        assert!(is_model_type_list_empty(&mm, ModelType::Transcriptions));
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
         assert!(is_model_type_list_empty(&mm, ModelType::Realtime));
@@ -2336,8 +2354,9 @@ mod tests {
     }
 
     #[test]
-    fn test_realtime_in_all_model_types() {
+    fn test_expected_types_in_all_model_types() {
         assert!(ALL_MODEL_TYPES.contains(&ModelType::Realtime));
+        assert!(ALL_MODEL_TYPES.contains(&ModelType::Transcriptions));
     }
 
     #[test]

--- a/lib/llm/src/discovery/watcher.rs
+++ b/lib/llm/src/discovery/watcher.rs
@@ -54,6 +54,7 @@ use crate::{
             embeddings::{NvCreateEmbeddingRequest, NvCreateEmbeddingResponse},
             images::{NvCreateImageRequest, NvImagesResponse},
             pooling::{NvCreatePoolingRequest, NvCreatePoolingResponse},
+            transcriptions::{NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest},
             videos::{NvCreateVideoRequest, NvVideosResponse},
         },
         tensor::{NvCreateTensorRequest, NvCreateTensorResponse},
@@ -236,6 +237,7 @@ const ALL_MODEL_TYPES: &[ModelType] = &[
     ModelType::Embedding,
     ModelType::Images,
     ModelType::Audios,
+    ModelType::Transcriptions,
     ModelType::Videos,
     ModelType::TensorBased,
     ModelType::Realtime,
@@ -255,6 +257,8 @@ fn is_model_type_list_empty(manager: &ModelManager, model_type: ModelType) -> bo
         manager.list_images_models().is_empty()
     } else if model_type == ModelType::Audios {
         manager.list_audios_models().is_empty()
+    } else if model_type == ModelType::Transcriptions {
+        manager.list_transcriptions_models().is_empty()
     } else if model_type == ModelType::Videos {
         manager.list_videos_models().is_empty()
     } else if model_type == ModelType::TensorBased {
@@ -925,6 +929,17 @@ where
                 worker_set.audios_engine = Some(Arc::new(audios_router));
             }
 
+            if card.model_type.supports_transcriptions() {
+                let transcriptions_router = PushRouter::<
+                    NvCreateAudioTranscriptionRequest,
+                    Annotated<NvAudioTranscriptionResponse>,
+                >::from_client_with_monitor(
+                    client.clone(), router_config.router_mode, None
+                )
+                .await?;
+                worker_set.transcriptions_engine = Some(Arc::new(transcriptions_router));
+            }
+
             if card.model_type.supports_realtime() {
                 // `Text` is overloaded for Realtime; its I/O passes through.
                 let realtime_router = PushRouter::<
@@ -1013,7 +1028,7 @@ where
             // prefill is routed off `worker_type`.)
             anyhow::bail!(
                 "Unsupported model configuration: {} with {} input. Supported combinations: \
-                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Videos|Embeddings|Classify|Pooling|Realtime), \
+                Tokens+(Chat|Completions), Text+(Chat|Completions|Images|Audios|Transcriptions|Videos|Embeddings|Classify|Pooling|Realtime), \
                 Tokens+Embeddings, Tensor+TensorBased",
                 card.model_type,
                 card.model_input.as_str()
@@ -1815,6 +1830,7 @@ mod tests {
         assert!(is_model_type_list_empty(&mm, ModelType::Embedding));
         assert!(is_model_type_list_empty(&mm, ModelType::Images));
         assert!(is_model_type_list_empty(&mm, ModelType::Audios));
+        assert!(is_model_type_list_empty(&mm, ModelType::Transcriptions));
         assert!(is_model_type_list_empty(&mm, ModelType::Videos));
         assert!(is_model_type_list_empty(&mm, ModelType::TensorBased));
         assert!(is_model_type_list_empty(&mm, ModelType::Realtime));
@@ -1934,8 +1950,9 @@ mod tests {
     }
 
     #[test]
-    fn test_realtime_in_all_model_types() {
+    fn test_expected_types_in_all_model_types() {
         assert!(ALL_MODEL_TYPES.contains(&ModelType::Realtime));
+        assert!(ALL_MODEL_TYPES.contains(&ModelType::Transcriptions));
     }
 
     #[test]

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -21,7 +21,9 @@ use crate::{
             chat_completions::OpenAIChatCompletionsStreamingEngine,
             completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
-            images::OpenAIImagesStreamingEngine, videos::OpenAIVideosStreamingEngine,
+            images::OpenAIImagesStreamingEngine,
+            transcriptions::OpenAITranscriptionsStreamingEngine,
+            videos::OpenAIVideosStreamingEngine,
         },
     },
 };
@@ -44,6 +46,7 @@ pub struct WorkerSet {
     pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
+    pub(crate) transcriptions_engine: Option<OpenAITranscriptionsStreamingEngine>,
     pub(crate) tensor_engine: Option<TensorStreamingEngine>,
     pub(crate) realtime_engine: Option<RealtimeBidirectionalEngine>,
     pub(crate) generate_engine: Option<GenerateStreamingEngine>,
@@ -79,6 +82,7 @@ impl WorkerSet {
             images_engine: None,
             videos_engine: None,
             audios_engine: None,
+            transcriptions_engine: None,
             tensor_engine: None,
             realtime_engine: None,
             generate_engine: None,
@@ -126,6 +130,10 @@ impl WorkerSet {
         self.audios_engine.is_some()
     }
 
+    pub fn has_transcriptions_engine(&self) -> bool {
+        self.transcriptions_engine.is_some()
+    }
+
     pub fn has_tensor_engine(&self) -> bool {
         self.tensor_engine.is_some()
     }
@@ -155,6 +163,7 @@ impl WorkerSet {
             || self.has_tensor_engine()
             || self.has_videos_engine()
             || self.has_audios_engine()
+            || self.has_transcriptions_engine()
             || self.has_realtime_engine()
             || self.has_generate_engine()
     }

--- a/lib/llm/src/discovery/worker_set.rs
+++ b/lib/llm/src/discovery/worker_set.rs
@@ -27,6 +27,7 @@ use crate::{
             classify::OpenAIClassifyStreamingEngine, completions::OpenAICompletionsStreamingEngine,
             embeddings::OpenAIEmbeddingsStreamingEngine, generate::GenerateStreamingEngine,
             images::OpenAIImagesStreamingEngine, pooling::OpenAIPoolingStreamingEngine,
+            transcriptions::OpenAITranscriptionsStreamingEngine,
             videos::OpenAIVideosStreamingEngine,
         },
     },
@@ -155,6 +156,7 @@ pub struct WorkerSet {
     pub(crate) images_engine: Option<OpenAIImagesStreamingEngine>,
     pub(crate) videos_engine: Option<OpenAIVideosStreamingEngine>,
     pub(crate) audios_engine: Option<OpenAIAudiosStreamingEngine>,
+    pub(crate) transcriptions_engine: Option<OpenAITranscriptionsStreamingEngine>,
     pub(crate) tensor_engine: Option<TensorStreamingEngine>,
     pub(crate) realtime_engine: Option<RealtimeBidirectionalEngine>,
     pub(crate) generate_engine: Option<GenerateStreamingEngine>,
@@ -201,6 +203,7 @@ impl WorkerSet {
             images_engine: None,
             videos_engine: None,
             audios_engine: None,
+            transcriptions_engine: None,
             tensor_engine: None,
             realtime_engine: None,
             generate_engine: None,
@@ -281,6 +284,10 @@ impl WorkerSet {
         self.audios_engine.is_some()
     }
 
+    pub fn has_transcriptions_engine(&self) -> bool {
+        self.transcriptions_engine.is_some()
+    }
+
     pub fn has_tensor_engine(&self) -> bool {
         self.tensor_engine.is_some()
     }
@@ -319,6 +326,7 @@ impl WorkerSet {
             || self.has_tensor_engine()
             || self.has_videos_engine()
             || self.has_audios_engine()
+            || self.has_transcriptions_engine()
             || self.has_realtime_engine()
             || self.has_generate_engine()
     }
@@ -410,6 +418,7 @@ impl WorkerSet {
         retain_for_requests!(images_engine);
         retain_for_requests!(videos_engine);
         retain_for_requests!(audios_engine);
+        retain_for_requests!(transcriptions_engine);
         retain_for_requests!(tensor_engine);
         retain_for_requests!(realtime_engine);
         retain_for_requests!(generate_engine);
@@ -443,6 +452,7 @@ impl WorkerSet {
             images_engine: lora_context_engine(&self.images_engine, &lora_name),
             videos_engine: lora_context_engine(&self.videos_engine, &lora_name),
             audios_engine: lora_context_engine(&self.audios_engine, &lora_name),
+            transcriptions_engine: lora_context_engine(&self.transcriptions_engine, &lora_name),
             tensor_engine: lora_context_engine(&self.tensor_engine, &lora_name),
             // Realtime is bidirectional, so the server-streaming LoRA context wrapper cannot
             // inject the adapter identity. Fail closed instead of serving the base weights.

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -16,6 +16,8 @@ pub enum EndpointType {
     Images,
     /// Audios API (speech/audio generation)
     Audios,
+    /// Audio Transcriptions API (speech-to-text)
+    Transcriptions,
     /// Videos API (video generation)
     Videos,
     /// Realtime API (bidirectional streaming over WebSocket)
@@ -36,6 +38,7 @@ impl EndpointType {
             Self::Embedding => "embedding",
             Self::Images => "images",
             Self::Audios => "audios",
+            Self::Transcriptions => "transcriptions",
             Self::Videos => "videos",
             Self::Realtime => "realtime",
             Self::Responses => "responses",
@@ -51,6 +54,7 @@ impl EndpointType {
             Self::Embedding,
             Self::Images,
             Self::Audios,
+            Self::Transcriptions,
             Self::Videos,
             Self::Realtime,
             Self::Responses,
@@ -82,5 +86,11 @@ mod tests {
     #[test]
     fn generate_in_all() {
         assert!(EndpointType::all().contains(&EndpointType::Generate));
+    }
+
+    #[test]
+    fn transcriptions_is_a_registered_endpoint() {
+        assert_eq!(EndpointType::Transcriptions.as_str(), "transcriptions");
+        assert!(EndpointType::all().contains(&EndpointType::Transcriptions));
     }
 }

--- a/lib/llm/src/endpoint_type.rs
+++ b/lib/llm/src/endpoint_type.rs
@@ -16,6 +16,8 @@ pub enum EndpointType {
     Images,
     /// Audios API (speech/audio generation)
     Audios,
+    /// Audio Transcriptions API (speech-to-text)
+    Transcriptions,
     /// Videos API (video generation)
     Videos,
     /// Realtime API (bidirectional streaming over WebSocket)
@@ -42,6 +44,7 @@ impl EndpointType {
             Self::Embedding => "embedding",
             Self::Images => "images",
             Self::Audios => "audios",
+            Self::Transcriptions => "transcriptions",
             Self::Videos => "videos",
             Self::Realtime => "realtime",
             Self::Classify => "classify",
@@ -60,6 +63,7 @@ impl EndpointType {
             Self::Embedding,
             Self::Images,
             Self::Audios,
+            Self::Transcriptions,
             Self::Videos,
             Self::Realtime,
             Self::Classify,
@@ -94,6 +98,12 @@ mod tests {
     #[test]
     fn generate_in_all() {
         assert!(EndpointType::all().contains(&EndpointType::Generate));
+    }
+
+    #[test]
+    fn transcriptions_is_registered() {
+        assert_eq!(EndpointType::Transcriptions.as_str(), "transcriptions");
+        assert!(EndpointType::all().contains(&EndpointType::Transcriptions));
     }
 
     #[test]

--- a/lib/llm/src/http/service.rs
+++ b/lib/llm/src/http/service.rs
@@ -21,6 +21,7 @@
 mod anthropic;
 pub mod metadata;
 mod openai;
+mod transcriptions;
 
 pub mod busy_threshold;
 pub mod disconnect;

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -457,6 +457,9 @@ pub enum Endpoint {
     /// OAI Audio Speech
     Audios,
 
+    /// OAI Audio Transcriptions
+    Transcriptions,
+
     /// OAI Responses
     Responses,
 
@@ -1470,6 +1473,7 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Images => write!(f, "images"),
             Endpoint::Videos => write!(f, "videos"),
             Endpoint::Audios => write!(f, "audios"),
+            Endpoint::Transcriptions => write!(f, "transcriptions"),
             Endpoint::Responses => write!(f, "responses"),
             Endpoint::AnthropicMessages => write!(f, "anthropic_messages"),
             Endpoint::Tensor => write!(f, "tensor"),
@@ -1487,6 +1491,7 @@ impl Endpoint {
             Endpoint::Images => "images",
             Endpoint::Videos => "videos",
             Endpoint::Audios => "audios",
+            Endpoint::Transcriptions => "transcriptions",
             Endpoint::Responses => "responses",
             Endpoint::AnthropicMessages => "anthropic_messages",
             Endpoint::Tensor => "tensor",

--- a/lib/llm/src/http/service/metrics.rs
+++ b/lib/llm/src/http/service/metrics.rs
@@ -480,6 +480,9 @@ pub enum Endpoint {
     /// OAI Audio Speech
     Audios,
 
+    /// OAI Audio Transcriptions
+    Transcriptions,
+
     /// OAI Responses
     Responses,
 
@@ -1559,6 +1562,7 @@ impl std::fmt::Display for Endpoint {
             Endpoint::Images => write!(f, "images"),
             Endpoint::Videos => write!(f, "videos"),
             Endpoint::Audios => write!(f, "audios"),
+            Endpoint::Transcriptions => write!(f, "transcriptions"),
             Endpoint::Responses => write!(f, "responses"),
             Endpoint::AnthropicMessages => write!(f, "anthropic_messages"),
             Endpoint::Tensor => write!(f, "tensor"),
@@ -1578,6 +1582,7 @@ impl Endpoint {
             Endpoint::Images => "images",
             Endpoint::Videos => "videos",
             Endpoint::Audios => "audios",
+            Endpoint::Transcriptions => "transcriptions",
             Endpoint::Responses => "responses",
             Endpoint::AnthropicMessages => "anthropic_messages",
             Endpoint::Tensor => "tensor",

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -149,7 +149,7 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
 }
 
 /// Extract ErrorType from ErrorResponse for metrics
-fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
+pub(super) fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     classify_error_for_metrics(response.0, &response.1.message)
 }
 
@@ -173,6 +173,10 @@ fn find_invalid_argument_in_chain<'a>(
         current = e.source();
     }
     None
+}
+
+pub(super) fn error_is_invalid_argument(err: &(dyn std::error::Error + 'static)) -> bool {
+    find_invalid_argument_in_chain(err).is_some()
 }
 
 fn find_queue_rejection_in_chain<'a>(
@@ -249,6 +253,20 @@ impl ErrorMessage {
             Json(ErrorMessage {
                 message,
                 error_type,
+                code: code.as_u16(),
+                details: None,
+            }),
+        )
+    }
+
+    /// Invalid request.
+    pub fn bad_request<T: Display>(msg: T) -> ErrorResponse {
+        let code = StatusCode::BAD_REQUEST;
+        (
+            code,
+            Json(ErrorMessage {
+                message: msg.to_string(),
+                error_type: map_error_code_to_error_type(code),
                 code: code.as_u16(),
                 details: None,
             }),

--- a/lib/llm/src/http/service/openai.rs
+++ b/lib/llm/src/http/service/openai.rs
@@ -225,7 +225,7 @@ fn classify_error_for_metrics(code: StatusCode, message: &str) -> ErrorType {
 }
 
 /// Extract ErrorType from ErrorResponse for metrics
-fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
+pub(super) fn extract_error_type_from_response(response: &ErrorResponse) -> ErrorType {
     response
         .1
         .metric_error_type
@@ -276,6 +276,10 @@ pub(crate) fn find_invalid_argument_in_chain<'a>(
         current = e.source();
     }
     None
+}
+
+pub(super) fn error_is_invalid_argument(err: &(dyn std::error::Error + 'static)) -> bool {
+    find_invalid_argument_in_chain(err).is_some()
 }
 
 fn find_queue_rejection_in_chain<'a>(
@@ -365,6 +369,21 @@ impl ErrorMessage {
                 code: code.as_u16(),
                 details: None,
                 metric_error_type: Some(ErrorType::Unavailable),
+            }),
+        )
+    }
+
+    /// Invalid request.
+    pub fn bad_request<T: Display>(msg: T) -> ErrorResponse {
+        let code = StatusCode::BAD_REQUEST;
+        (
+            code,
+            Json(ErrorMessage {
+                message: msg.to_string(),
+                error_type: map_error_code_to_error_type(code),
+                code: code.as_u16(),
+                details: None,
+                metric_error_type: None,
             }),
         )
     }

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -285,6 +285,7 @@ struct StateFlags {
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
     audios_endpoints_enabled: AtomicBool,
+    transcriptions_endpoints_enabled: AtomicBool,
     realtime_endpoints_enabled: AtomicBool,
     responses_endpoints_enabled: AtomicBool,
     anthropic_endpoints_enabled: AtomicBool,
@@ -300,6 +301,9 @@ impl StateFlags {
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Transcriptions => self
+                .transcriptions_endpoints_enabled
+                .load(Ordering::Relaxed),
             EndpointType::Realtime => self.realtime_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Responses => self.responses_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::AnthropicMessages => {
@@ -328,6 +332,9 @@ impl StateFlags {
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Audios => self
                 .audios_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Transcriptions => self
+                .transcriptions_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Realtime => self
                 .realtime_endpoints_enabled
@@ -365,6 +372,7 @@ impl State {
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
                 audios_endpoints_enabled: AtomicBool::new(false),
+                transcriptions_endpoints_enabled: AtomicBool::new(false),
                 realtime_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
@@ -1177,6 +1185,8 @@ impl HttpServiceConfigBuilder {
         let (images_docs, images_route) = super::openai::images_router(state.clone(), None);
         let (videos_docs, videos_route) = super::openai::videos_router(state.clone(), None);
         let (audios_docs, audios_route) = super::openai::audios_router(state.clone(), None);
+        let (transcriptions_docs, transcriptions_route) =
+            super::transcriptions::transcriptions_router(state.clone(), None);
         let (realtime_docs, realtime_route) = super::realtime::realtime_router(state.clone(), None);
         let (responses_docs, responses_route) = super::openai::responses_router(
             state.clone(),
@@ -1190,6 +1200,10 @@ impl HttpServiceConfigBuilder {
         endpoint_routes.insert(EndpointType::Images, (images_docs, images_route));
         endpoint_routes.insert(EndpointType::Videos, (videos_docs, videos_route));
         endpoint_routes.insert(EndpointType::Audios, (audios_docs, audios_route));
+        endpoint_routes.insert(
+            EndpointType::Transcriptions,
+            (transcriptions_docs, transcriptions_route),
+        );
         endpoint_routes.insert(EndpointType::Realtime, (realtime_docs, realtime_route));
         endpoint_routes.insert(EndpointType::Responses, (responses_docs, responses_route));
 

--- a/lib/llm/src/http/service/service_v2.rs
+++ b/lib/llm/src/http/service/service_v2.rs
@@ -383,6 +383,7 @@ struct StateFlags {
     images_endpoints_enabled: AtomicBool,
     videos_endpoints_enabled: AtomicBool,
     audios_endpoints_enabled: AtomicBool,
+    transcriptions_endpoints_enabled: AtomicBool,
     realtime_endpoints_enabled: AtomicBool,
     responses_endpoints_enabled: AtomicBool,
     anthropic_endpoints_enabled: AtomicBool,
@@ -401,6 +402,9 @@ impl StateFlags {
             EndpointType::Images => self.images_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Videos => self.videos_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Audios => self.audios_endpoints_enabled.load(Ordering::Relaxed),
+            EndpointType::Transcriptions => self
+                .transcriptions_endpoints_enabled
+                .load(Ordering::Relaxed),
             EndpointType::Realtime => self.realtime_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::Responses => self.responses_endpoints_enabled.load(Ordering::Relaxed),
             EndpointType::AnthropicMessages => {
@@ -436,6 +440,9 @@ impl StateFlags {
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Audios => self
                 .audios_endpoints_enabled
+                .store(enabled, Ordering::Relaxed),
+            EndpointType::Transcriptions => self
+                .transcriptions_endpoints_enabled
                 .store(enabled, Ordering::Relaxed),
             EndpointType::Realtime => self
                 .realtime_endpoints_enabled
@@ -478,6 +485,7 @@ impl State {
                 images_endpoints_enabled: AtomicBool::new(false),
                 videos_endpoints_enabled: AtomicBool::new(false),
                 audios_endpoints_enabled: AtomicBool::new(false),
+                transcriptions_endpoints_enabled: AtomicBool::new(false),
                 realtime_endpoints_enabled: AtomicBool::new(false),
                 responses_endpoints_enabled: AtomicBool::new(false),
                 anthropic_endpoints_enabled: AtomicBool::new(false),
@@ -1450,6 +1458,8 @@ impl HttpServiceConfigBuilder {
         let (images_docs, images_route) = super::openai::images_router(state.clone(), None);
         let (videos_docs, videos_route) = super::openai::videos_router(state.clone(), None);
         let (audios_docs, audios_route) = super::openai::audios_router(state.clone(), None);
+        let (transcriptions_docs, transcriptions_route) =
+            super::transcriptions::transcriptions_router(state.clone(), None);
         let (realtime_docs, realtime_route) = super::realtime::realtime_router(state.clone(), None);
         let (responses_docs, responses_route) = super::openai::responses_router(
             state.clone(),
@@ -1465,6 +1475,10 @@ impl HttpServiceConfigBuilder {
         endpoint_routes.insert(EndpointType::Images, (images_docs, images_route));
         endpoint_routes.insert(EndpointType::Videos, (videos_docs, videos_route));
         endpoint_routes.insert(EndpointType::Audios, (audios_docs, audios_route));
+        endpoint_routes.insert(
+            EndpointType::Transcriptions,
+            (transcriptions_docs, transcriptions_route),
+        );
         endpoint_routes.insert(EndpointType::Realtime, (realtime_docs, realtime_route));
         endpoint_routes.insert(EndpointType::Responses, (responses_docs, responses_route));
 

--- a/lib/llm/src/http/service/transcriptions.rs
+++ b/lib/llm/src/http/service/transcriptions.rs
@@ -1,0 +1,270 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+use axum::{
+    Json, Router,
+    extract::{Multipart, State, multipart::MultipartRejection},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use base64::Engine as _;
+use futures::StreamExt;
+
+use super::{
+    RouteDoc,
+    metrics::{Endpoint, ErrorType, process_response_and_observe_metrics, request_was_rejected},
+    openai::{
+        ErrorMessage, ErrorResponse, check_model_serving_ready, check_ready, context_from_headers,
+        error_is_invalid_argument, extract_error_type_from_response, get_body_limit,
+        get_or_create_request_id,
+    },
+    service_v2,
+};
+use crate::protocols::openai::transcriptions::{
+    NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest,
+};
+
+#[derive(Default)]
+struct TranscriptionForm {
+    audio_b64: Option<String>,
+    filename: Option<String>,
+    model: Option<String>,
+    language: Option<String>,
+    prompt: Option<String>,
+    response_format: Option<String>,
+    temperature: Option<f64>,
+    timestamp_granularities: Vec<String>,
+}
+
+impl TranscriptionForm {
+    async fn parse(mut multipart: Multipart) -> Result<Self, ErrorResponse> {
+        let mut form = Self::default();
+        while let Some(field) = multipart.next_field().await.map_err(|error| {
+            ErrorMessage::bad_request(format!("Invalid multipart body: {error}"))
+        })? {
+            let name = field.name().unwrap_or_default().to_string();
+            if name == "file" {
+                form.filename = Some(field.file_name().unwrap_or("audio").to_string());
+                let bytes = field.bytes().await.map_err(|error| {
+                    ErrorMessage::bad_request(format!("Failed to read audio file: {error}"))
+                })?;
+                if bytes.is_empty() {
+                    return Err(ErrorMessage::bad_request(
+                        "The audio file must not be empty",
+                    ));
+                }
+                form.audio_b64 = Some(base64::engine::general_purpose::STANDARD.encode(bytes));
+                continue;
+            }
+
+            let value = field.text().await.map_err(|error| {
+                ErrorMessage::bad_request(format!("Failed to read form field `{name}`: {error}"))
+            })?;
+            match name.as_str() {
+                "model" => form.model = nonempty(value),
+                "language" => form.language = nonempty(value),
+                "prompt" => form.prompt = Some(value),
+                "response_format" => form.response_format = nonempty(value),
+                "temperature" => form.temperature = Some(parse_field(&name, &value)?),
+                "timestamp_granularities" | "timestamp_granularities[]" => {
+                    if !value.is_empty() {
+                        form.timestamp_granularities.push(value);
+                    }
+                }
+                "stream" if value.eq_ignore_ascii_case("true") || value == "1" => {
+                    return Err(ErrorMessage::bad_request(
+                        "Streaming transcriptions are not supported yet",
+                    ));
+                }
+                _ => {}
+            }
+        }
+        Ok(form)
+    }
+
+    fn into_request(self) -> Result<NvCreateAudioTranscriptionRequest, ErrorResponse> {
+        let audio_b64 = self
+            .audio_b64
+            .ok_or_else(|| ErrorMessage::bad_request("Missing required `file` field"))?;
+        let response_format = self.response_format.as_deref().unwrap_or("json");
+        if !matches!(response_format, "json" | "verbose_json") {
+            return Err(ErrorMessage::bad_request(format!(
+                "Unsupported response_format `{response_format}`; expected `json` or `verbose_json`"
+            )));
+        }
+        if self
+            .timestamp_granularities
+            .iter()
+            .any(|value| !matches!(value.as_str(), "word" | "segment"))
+        {
+            return Err(ErrorMessage::bad_request(
+                "timestamp_granularities must contain only `word` or `segment`",
+            ));
+        }
+
+        Ok(NvCreateAudioTranscriptionRequest {
+            audio_b64,
+            filename: self.filename.unwrap_or_else(|| "audio".to_string()),
+            model: self.model,
+            language: self.language,
+            prompt: self.prompt,
+            response_format: Some(response_format.to_string()),
+            temperature: self.temperature,
+            timestamp_granularities: (!self.timestamp_granularities.is_empty())
+                .then_some(self.timestamp_granularities),
+        })
+    }
+}
+
+fn nonempty(value: String) -> Option<String> {
+    (!value.is_empty()).then_some(value)
+}
+
+fn parse_field<T>(name: &str, value: &str) -> Result<T, ErrorResponse>
+where
+    T: std::str::FromStr,
+    T::Err: std::fmt::Display,
+{
+    value.parse().map_err(|error| {
+        ErrorMessage::bad_request(format!("Invalid `{name}` value `{value}`: {error}"))
+    })
+}
+
+async fn audio_transcription(
+    State(state): State<Arc<service_v2::State>>,
+    headers: HeaderMap,
+    multipart: Result<Multipart, MultipartRejection>,
+) -> Result<Response, ErrorResponse> {
+    check_ready(&state)?;
+    let multipart = multipart
+        .map_err(|error| ErrorMessage::bad_request(format!("Invalid multipart body: {error}")))?;
+    let mut request = TranscriptionForm::parse(multipart).await?.into_request()?;
+
+    let model = match request.model.clone() {
+        Some(model) => model,
+        None => state
+            .manager()
+            .list_transcriptions_models()
+            .into_iter()
+            .find(|model| state.manager().is_model_ready_to_serve(model))
+            .unwrap_or_default(),
+    };
+    request.model = Some(model.clone());
+    check_model_serving_ready(&state, &model)?;
+
+    let metric_model = state.manager().metric_model_for(&model).to_string();
+    let request_id = get_or_create_request_id(&headers);
+    let request = context_from_headers(request, request_id, &headers)?;
+    let request_id = request.id().to_string();
+    let mut inflight = state.metrics_clone().create_inflight_guard(
+        &metric_model,
+        Endpoint::Transcriptions,
+        false,
+        &request_id,
+    );
+    let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
+    let engine = state
+        .manager()
+        .get_transcriptions_engine(&model)
+        .map_err(|error| {
+            let response = ErrorMessage::from_model_error(&error);
+            inflight.mark_error(extract_error_type_from_response(&response));
+            response
+        })?;
+    let mut response_collector = state
+        .metrics_clone()
+        .create_response_collector(&metric_model);
+
+    let stream = engine.generate(request).await.map_err(|error| {
+        let is_validation = error_is_invalid_argument(error.as_ref());
+        if request_was_rejected(error.as_ref()) {
+            state
+                .metrics_clone()
+                .inc_rejection(&metric_model, Endpoint::Transcriptions);
+        }
+        let response = ErrorMessage::from_anyhow(error, "Failed to transcribe audio");
+        inflight.mark_error(if is_validation {
+            ErrorType::Validation
+        } else {
+            extract_error_type_from_response(&response)
+        });
+        response
+    })?;
+    let mut http_queue_guard = Some(http_queue_guard);
+    let stream = stream.inspect(move |response| {
+        process_response_and_observe_metrics(
+            response,
+            &mut response_collector,
+            &mut http_queue_guard,
+        );
+    });
+    let response = NvAudioTranscriptionResponse::from_annotated_stream(stream)
+        .await
+        .map_err(|error| {
+            tracing::error!(request_id, %error, "Failed to fold transcription response");
+            let is_validation = error_is_invalid_argument(&error);
+            let response = ErrorMessage::from_anyhow(
+                anyhow::Error::new(error),
+                "Failed to fold transcription response",
+            );
+            inflight.mark_error(if is_validation {
+                ErrorType::Validation
+            } else {
+                extract_error_type_from_response(&response)
+            });
+            response
+        })?;
+
+    inflight.mark_ok();
+    Ok((StatusCode::OK, Json(response)).into_response())
+}
+
+pub fn transcriptions_router(
+    state: Arc<service_v2::State>,
+    path: Option<String>,
+) -> (Vec<RouteDoc>, Router) {
+    let path = path.unwrap_or_else(|| "/v1/audio/transcriptions".to_string());
+    let doc = RouteDoc::new(axum::http::Method::POST, &path);
+    let router = Router::new()
+        .route(&path, post(audio_transcription))
+        .layer(axum::extract::DefaultBodyLimit::max(get_body_limit()))
+        .with_state(state);
+    (vec![doc], router)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_non_json_response_formats() {
+        let form = TranscriptionForm {
+            audio_b64: Some("AQ==".to_string()),
+            response_format: Some("srt".to_string()),
+            ..Default::default()
+        };
+        assert_eq!(form.into_request().unwrap_err().0, StatusCode::BAD_REQUEST);
+    }
+
+    #[test]
+    fn builds_transport_neutral_request() {
+        let form = TranscriptionForm {
+            audio_b64: Some("YXVkaW8=".to_string()),
+            filename: Some("sample.wav".to_string()),
+            language: Some("en".to_string()),
+            timestamp_granularities: vec!["word".to_string()],
+            ..Default::default()
+        };
+        let request = form.into_request().unwrap();
+        assert_eq!(request.filename, "sample.wav");
+        assert_eq!(request.audio_b64, "YXVkaW8=");
+        assert_eq!(request.response_format.as_deref(), Some("json"));
+        assert_eq!(
+            request.timestamp_granularities,
+            Some(vec!["word".to_string()])
+        );
+    }
+}

--- a/lib/llm/src/http/service/transcriptions.rs
+++ b/lib/llm/src/http/service/transcriptions.rs
@@ -11,11 +11,17 @@ use axum::{
     routing::post,
 };
 use base64::Engine as _;
+use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
 use futures::StreamExt;
+use tracing::Instrument;
 
 use super::{
     RouteDoc,
-    metrics::{Endpoint, ErrorType, process_response_and_observe_metrics, request_was_rejected},
+    disconnect::create_connection_monitor,
+    metrics::{
+        CancellationLabels, Endpoint, ErrorType, process_response_and_observe_metrics,
+        request_was_rejected,
+    },
     openai::{
         ErrorMessage, ErrorResponse, check_model_serving_ready, check_ready, context_from_headers,
         error_is_invalid_argument, extract_error_type_from_response, get_body_limit,
@@ -155,7 +161,7 @@ async fn audio_transcription(
         .map_err(|error| ErrorMessage::bad_request(format!("Invalid multipart body: {error}")))?;
     let mut request = TranscriptionForm::parse(multipart).await?.into_request()?;
 
-    let model = match request.model.clone() {
+    let model = match request.model.take() {
         Some(model) => model,
         None => state
             .manager()
@@ -171,6 +177,41 @@ async fn audio_transcription(
     let request_id = get_or_create_request_id(&headers);
     let request = context_from_headers(request, request_id, &headers)?;
     let request_id = request.id().to_string();
+    let cancellation_labels = CancellationLabels {
+        model: metric_model.clone(),
+        endpoint: Endpoint::Transcriptions.to_string(),
+        request_type: "unary".to_string(),
+    };
+    let (mut connection_handle, _stream_handle) = create_connection_monitor(
+        request.context(),
+        Some(state.metrics_clone()),
+        cancellation_labels,
+    )
+    .await;
+
+    let response = tokio::spawn(
+        dispatch_audio_transcription(state, request, model, metric_model, request_id)
+            .in_current_span(),
+    )
+    .await
+    .map_err(|error| {
+        ErrorMessage::internal_server_error_with_details(
+            "Failed to await audio transcription task",
+            format!("{error:?}"),
+        )
+    })?;
+
+    connection_handle.disarm();
+    response
+}
+
+async fn dispatch_audio_transcription(
+    state: Arc<service_v2::State>,
+    request: Context<NvCreateAudioTranscriptionRequest>,
+    model: String,
+    metric_model: String,
+    request_id: String,
+) -> Result<Response, ErrorResponse> {
     let mut inflight = state.metrics_clone().create_inflight_guard(
         &metric_model,
         Endpoint::Transcriptions,

--- a/lib/llm/src/http/service/transcriptions.rs
+++ b/lib/llm/src/http/service/transcriptions.rs
@@ -95,6 +95,13 @@ impl TranscriptionForm {
                 "Unsupported response_format `{response_format}`; expected `json` or `verbose_json`"
             )));
         }
+        if self.temperature.is_some_and(|temperature| {
+            !temperature.is_finite() || !(0.0..=1.0).contains(&temperature)
+        }) {
+            return Err(ErrorMessage::bad_request(
+                "temperature must be a finite number between 0 and 1",
+            ));
+        }
         if self
             .timestamp_granularities
             .iter()
@@ -102,6 +109,11 @@ impl TranscriptionForm {
         {
             return Err(ErrorMessage::bad_request(
                 "timestamp_granularities must contain only `word` or `segment`",
+            ));
+        }
+        if !self.timestamp_granularities.is_empty() && response_format != "verbose_json" {
+            return Err(ErrorMessage::bad_request(
+                "timestamp_granularities requires response_format `verbose_json`",
             ));
         }
 
@@ -255,16 +267,39 @@ mod tests {
             audio_b64: Some("YXVkaW8=".to_string()),
             filename: Some("sample.wav".to_string()),
             language: Some("en".to_string()),
+            response_format: Some("verbose_json".to_string()),
             timestamp_granularities: vec!["word".to_string()],
             ..Default::default()
         };
         let request = form.into_request().unwrap();
         assert_eq!(request.filename, "sample.wav");
         assert_eq!(request.audio_b64, "YXVkaW8=");
-        assert_eq!(request.response_format.as_deref(), Some("json"));
+        assert_eq!(request.response_format.as_deref(), Some("verbose_json"));
         assert_eq!(
             request.timestamp_granularities,
             Some(vec!["word".to_string()])
         );
+    }
+
+    #[test]
+    fn rejects_invalid_temperatures() {
+        for temperature in [-0.1, 1.1, f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+            let form = TranscriptionForm {
+                audio_b64: Some("AQ==".to_string()),
+                temperature: Some(temperature),
+                ..Default::default()
+            };
+            assert_eq!(form.into_request().unwrap_err().0, StatusCode::BAD_REQUEST);
+        }
+    }
+
+    #[test]
+    fn rejects_timestamp_granularities_without_verbose_json() {
+        let form = TranscriptionForm {
+            audio_b64: Some("AQ==".to_string()),
+            timestamp_granularities: vec!["word".to_string()],
+            ..Default::default()
+        };
+        assert_eq!(form.into_request().unwrap_err().0, StatusCode::BAD_REQUEST);
     }
 }

--- a/lib/llm/src/http/service/transcriptions.rs
+++ b/lib/llm/src/http/service/transcriptions.rs
@@ -218,7 +218,12 @@ async fn dispatch_audio_transcription(
         false,
         &request_id,
     );
+    // Treat an unexpectedly dropped unary request as cancelled unless a
+    // concrete backend or protocol error below gives us a more specific
+    // classification. This mirrors the streaming and audio-speech paths.
+    inflight.mark_error(ErrorType::Cancelled);
     let http_queue_guard = state.metrics_clone().create_http_queue_guard(&metric_model);
+    let request_context = request.context();
     let engine = state
         .manager()
         .get_transcriptions_engine(&model)
@@ -239,7 +244,9 @@ async fn dispatch_audio_transcription(
                 .inc_rejection(&metric_model, Endpoint::Transcriptions);
         }
         let response = ErrorMessage::from_anyhow(error, "Failed to transcribe audio");
-        inflight.mark_error(if is_validation {
+        inflight.mark_error(if request_context.is_stopped() {
+            ErrorType::Cancelled
+        } else if is_validation {
             ErrorType::Validation
         } else {
             extract_error_type_from_response(&response)
@@ -263,7 +270,9 @@ async fn dispatch_audio_transcription(
                 anyhow::Error::new(error),
                 "Failed to fold transcription response",
             );
-            inflight.mark_error(if is_validation {
+            inflight.mark_error(if request_context.is_stopped() {
+                ErrorType::Cancelled
+            } else if is_validation {
                 ErrorType::Validation
             } else {
                 extract_error_type_from_response(&response)

--- a/lib/llm/src/http/service/transcriptions.rs
+++ b/lib/llm/src/http/service/transcriptions.rs
@@ -11,7 +11,10 @@ use axum::{
     routing::post,
 };
 use base64::Engine as _;
-use dynamo_runtime::pipeline::{AsyncEngineContextProvider, Context};
+use dynamo_runtime::{
+    config::parse_bool,
+    pipeline::{AsyncEngineContextProvider, Context},
+};
 use futures::StreamExt;
 use tracing::Instrument;
 
@@ -80,10 +83,15 @@ impl TranscriptionForm {
                         form.timestamp_granularities.push(value);
                     }
                 }
-                "stream" if value.eq_ignore_ascii_case("true") || value == "1" => {
-                    return Err(ErrorMessage::bad_request(
-                        "Streaming transcriptions are not supported yet",
-                    ));
+                "stream" => {
+                    let stream = parse_bool(&value).map_err(|error| {
+                        ErrorMessage::bad_request(format!("Invalid `stream` value: {error}"))
+                    })?;
+                    if stream {
+                        return Err(ErrorMessage::bad_request(
+                            "Streaming transcriptions are not supported yet",
+                        ));
+                    }
                 }
                 _ => {}
             }

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -52,6 +52,7 @@ bitflags! {
         const Audios = 1 << 6;
         const Videos = 1 << 7;
         const Realtime = 1 << 8;
+        const Transcriptions = 1 << 9;
     }
 }
 
@@ -91,6 +92,9 @@ impl ModelType {
     pub fn supports_realtime(&self) -> bool {
         self.contains(ModelType::Realtime)
     }
+    pub fn supports_transcriptions(&self) -> bool {
+        self.contains(ModelType::Transcriptions)
+    }
 
     pub fn as_vec(&self) -> Vec<&'static str> {
         let mut result = Vec::new();
@@ -120,6 +124,9 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push("realtime");
+        }
+        if self.supports_transcriptions() {
+            result.push("transcriptions");
         }
         result
     }
@@ -154,6 +161,9 @@ impl ModelType {
         }
         if self.supports_realtime() {
             result.push(ModelType::Realtime);
+        }
+        if self.supports_transcriptions() {
+            result.push(ModelType::Transcriptions);
         }
         result
     }
@@ -198,6 +208,9 @@ impl ModelType {
         }
         if self.contains(Self::Realtime) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Realtime);
+        }
+        if self.contains(Self::Transcriptions) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Transcriptions);
         }
         // [gluo NOTE] ModelType::Tensor doesn't map to any endpoint type,
         // current use of endpoint type is LLM specific and so does the HTTP
@@ -311,6 +324,16 @@ mod tests {
         assert_eq!(
             ModelType::Realtime.as_endpoint_types(),
             vec![EndpointType::Realtime]
+        );
+    }
+
+    #[test]
+    fn transcriptions_capability_and_endpoint_mapping() {
+        assert_eq!(ModelType::Transcriptions.bits(), 1 << 9);
+        assert!(ModelType::Transcriptions.supports_transcriptions());
+        assert_eq!(
+            ModelType::Transcriptions.as_endpoint_types(),
+            vec![EndpointType::Transcriptions]
         );
     }
 

--- a/lib/llm/src/model_type.rs
+++ b/lib/llm/src/model_type.rs
@@ -62,6 +62,9 @@ bitflags! {
         /// mounts its `/pooling` alongside those surfaces for every
         /// pooling-runner model.
         const Pooling = 1 << 10;
+        /// Batch speech-to-text through the OpenAI `/v1/audio/transcriptions`
+        /// endpoint.
+        const Transcriptions = 1 << 11;
     }
 }
 
@@ -101,6 +104,9 @@ impl ModelType {
     pub fn supports_realtime(&self) -> bool {
         self.contains(ModelType::Realtime)
     }
+    pub fn supports_transcriptions(&self) -> bool {
+        self.contains(ModelType::Transcriptions)
+    }
     pub fn supports_classify(&self) -> bool {
         self.contains(ModelType::Classify)
     }
@@ -130,6 +136,9 @@ impl ModelType {
         }
         if self.supports_audios() {
             result.push("audios");
+        }
+        if self.supports_transcriptions() {
+            result.push("transcriptions");
         }
         if self.supports_videos() {
             result.push("videos");
@@ -170,6 +179,9 @@ impl ModelType {
         }
         if self.supports_audios() {
             result.push(ModelType::Audios);
+        }
+        if self.supports_transcriptions() {
+            result.push(ModelType::Transcriptions);
         }
         if self.supports_videos() {
             result.push(ModelType::Videos);
@@ -220,6 +232,9 @@ impl ModelType {
         }
         if self.contains(Self::Audios) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Audios);
+        }
+        if self.contains(Self::Transcriptions) {
+            endpoint_types.push(crate::endpoint_type::EndpointType::Transcriptions);
         }
         if self.contains(Self::Videos) {
             endpoint_types.push(crate::endpoint_type::EndpointType::Videos);
@@ -345,6 +360,16 @@ mod tests {
         assert_eq!(
             ModelType::Realtime.as_endpoint_types(),
             vec![EndpointType::Realtime]
+        );
+    }
+
+    #[test]
+    fn transcriptions_capability_and_endpoint_mapping() {
+        assert_eq!(ModelType::Transcriptions.bits(), 1 << 11);
+        assert!(ModelType::Transcriptions.supports_transcriptions());
+        assert_eq!(
+            ModelType::Transcriptions.as_endpoint_types(),
+            vec![EndpointType::Transcriptions]
         );
     }
 

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -24,6 +24,7 @@ pub mod models;
 pub mod responses;
 pub mod stream_aggregator;
 pub mod tools;
+pub mod transcriptions;
 pub mod validate;
 pub mod videos;
 

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -29,6 +29,7 @@ pub mod pooling;
 pub mod responses;
 pub mod stream_aggregator;
 pub mod tools;
+pub mod transcriptions;
 pub mod validate;
 pub mod videos;
 

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use dynamo_runtime::error::DynamoError;
 use futures::{Stream, StreamExt};
 
 use crate::types::Annotated;
@@ -37,4 +38,71 @@ where
     }
 
     Ok(response.unwrap_or_else(T::empty))
+}
+
+/// Collect exactly one data item while preserving a typed backend error.
+///
+/// Unary media APIs use Dynamo's streaming request plane internally even
+/// though their HTTP response is singular. Treating an empty or multi-item
+/// stream as success would hide a broken worker contract.
+pub async fn collect_unary_stream<T, S>(stream: S) -> Result<T, DynamoError>
+where
+    S: Stream<Item = Annotated<T>>,
+{
+    let mut stream = std::pin::pin!(stream);
+    let mut response = None;
+
+    while let Some(delta) = stream.next().await {
+        if delta.is_error() {
+            let fallback = delta
+                .comment
+                .unwrap_or_else(|| vec!["unknown backend error".to_string()])
+                .join(", ");
+            return Err(delta.error.unwrap_or_else(|| DynamoError::msg(fallback)));
+        }
+
+        if let Some(data) = delta.data {
+            if response.replace(data).is_some() {
+                return Err(DynamoError::msg(
+                    "unary response stream produced more than one data item",
+                ));
+            }
+        }
+    }
+
+    response.ok_or_else(|| DynamoError::msg("unary response stream produced no data"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dynamo_runtime::error::ErrorType;
+
+    #[tokio::test]
+    async fn unary_collector_preserves_backend_error_type() {
+        let error = DynamoError::builder()
+            .error_type(ErrorType::InvalidArgument)
+            .message("invalid language")
+            .build();
+        let stream = futures::stream::iter([Annotated {
+            data: None::<usize>,
+            id: None,
+            event: Some("error".to_string()),
+            comment: None,
+            error: Some(error),
+        }]);
+
+        let error = collect_unary_stream(stream).await.unwrap_err();
+
+        assert!(matches!(error.error_type(), ErrorType::InvalidArgument));
+    }
+
+    #[tokio::test]
+    async fn unary_collector_rejects_empty_stream() {
+        let stream = futures::stream::empty::<Annotated<usize>>();
+
+        let error = collect_unary_stream(stream).await.unwrap_err();
+
+        assert!(error.to_string().contains("produced no data"));
+    }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -1,10 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+use dynamo_runtime::error::DynamoError;
 use futures::{Stream, StreamExt};
 
 use crate::types::Annotated;
-use dynamo_runtime::error::DynamoError;
 
 /// Response types whose `Annotated<T>` streams can be folded into a single `T`
 /// using shared aggregation infrastructure.
@@ -37,6 +37,31 @@ where
     }
 
     Ok(response.unwrap_or_else(T::empty))
+}
+
+/// Collect exactly one data item while preserving typed backend errors.
+///
+/// Unary APIs use Dynamo's streaming request plane internally even though
+/// their HTTP response is singular. Empty and multi-item streams violate that
+/// worker contract and are rejected.
+pub async fn collect_unary_stream<T, S>(stream: S) -> Result<T, DynamoError>
+where
+    S: Stream<Item = Annotated<T>>,
+{
+    let mut stream = std::pin::pin!(stream);
+    let mut response = None;
+
+    while let Some(item) = stream.next().await {
+        if let Some(data) = item.into_data()? {
+            if response.replace(data).is_some() {
+                return Err(DynamoError::msg(
+                    "unary response stream produced more than one data item",
+                ));
+            }
+        }
+    }
+
+    response.ok_or_else(|| DynamoError::msg("unary response stream produced no data"))
 }
 
 #[cfg(test)]
@@ -93,5 +118,46 @@ mod tests {
             ErrorType::Backend(BackendError::InvalidArgument)
         );
         assert_eq!(error.message(), "invalid argument");
+    }
+
+    #[tokio::test]
+    async fn unary_collector_preserves_backend_error_type() {
+        let stream = stream::iter(vec![Annotated::<usize>::from_err(
+            DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                .message("invalid language")
+                .build(),
+        )]);
+
+        let error = collect_unary_stream(stream).await.unwrap_err();
+
+        assert_eq!(
+            error.error_type(),
+            ErrorType::Backend(BackendError::InvalidArgument)
+        );
+    }
+
+    #[tokio::test]
+    async fn unary_collector_rejects_empty_and_multi_item_streams() {
+        let empty = stream::empty::<Annotated<usize>>();
+        assert!(
+            collect_unary_stream(empty)
+                .await
+                .unwrap_err()
+                .message()
+                .contains("produced no data")
+        );
+
+        let multiple = stream::iter(vec![
+            Annotated::from_data(1_usize),
+            Annotated::from_data(2_usize),
+        ]);
+        assert!(
+            collect_unary_stream(multiple)
+                .await
+                .unwrap_err()
+                .message()
+                .contains("more than one")
+        );
     }
 }

--- a/lib/llm/src/protocols/openai/stream_aggregator.rs
+++ b/lib/llm/src/protocols/openai/stream_aggregator.rs
@@ -52,12 +52,12 @@ where
     let mut response = None;
 
     while let Some(item) = stream.next().await {
-        if let Some(data) = item.into_data()? {
-            if response.replace(data).is_some() {
-                return Err(DynamoError::msg(
-                    "unary response stream produced more than one data item",
-                ));
-            }
+        if let Some(data) = item.into_data()?
+            && response.replace(data).is_some()
+        {
+            return Err(DynamoError::msg(
+                "unary response stream produced more than one data item",
+            ));
         }
     }
 

--- a/lib/llm/src/protocols/openai/transcriptions.rs
+++ b/lib/llm/src/protocols/openai/transcriptions.rs
@@ -1,0 +1,128 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_runtime::protocols::annotated::AnnotationsProvider;
+use serde::{Deserialize, Serialize};
+use validator::Validate;
+
+mod aggregator;
+
+/// Transport-neutral form of an OpenAI audio transcription request.
+///
+/// The HTTP frontend converts the multipart upload to base64 so the request can
+/// cross any Dynamo request plane without relying on HTTP-specific types.
+#[derive(Serialize, Deserialize, Validate, Debug, Clone)]
+pub struct NvCreateAudioTranscriptionRequest {
+    /// Base64-encoded contents of the uploaded audio file.
+    pub audio_b64: String,
+
+    /// Original upload filename, used by decoders for format detection.
+    pub filename: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub prompt: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub response_format: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp_granularities: Option<Vec<String>>,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct NvAudioTranscriptionUsage {
+    #[serde(rename = "type")]
+    pub usage_type: String,
+    pub seconds: f64,
+}
+
+/// JSON response for the OpenAI audio transcription endpoint.
+#[derive(Serialize, Deserialize, Validate, Debug, Clone, PartialEq)]
+pub struct NvAudioTranscriptionResponse {
+    pub text: String,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub usage: Option<NvAudioTranscriptionUsage>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub duration: Option<serde_json::Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub segments: Option<serde_json::Value>,
+
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub words: Option<serde_json::Value>,
+}
+
+impl NvAudioTranscriptionResponse {
+    pub fn empty() -> Self {
+        Self {
+            text: String::new(),
+            usage: None,
+            language: None,
+            duration: None,
+            segments: None,
+            words: None,
+        }
+    }
+}
+
+impl AnnotationsProvider for NvCreateAudioTranscriptionRequest {
+    fn annotations(&self) -> Option<Vec<String>> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn request_round_trips_openai_fields() {
+        let request: NvCreateAudioTranscriptionRequest =
+            serde_json::from_value(serde_json::json!({
+                "audio_b64": "UklGRg==",
+                "filename": "sample.wav",
+                "model": "openai/whisper-tiny",
+                "language": "en",
+                "response_format": "verbose_json",
+                "timestamp_granularities": ["word"]
+            }))
+            .unwrap();
+
+        assert_eq!(request.filename, "sample.wav");
+        assert_eq!(request.language.as_deref(), Some("en"));
+        assert_eq!(
+            request.timestamp_granularities,
+            Some(vec!["word".to_string()])
+        );
+    }
+
+    #[test]
+    fn response_uses_openai_usage_field_name() {
+        let response = NvAudioTranscriptionResponse {
+            text: "hello".to_string(),
+            usage: Some(NvAudioTranscriptionUsage {
+                usage_type: "duration".to_string(),
+                seconds: 1.25,
+            }),
+            ..NvAudioTranscriptionResponse::empty()
+        };
+
+        let value = serde_json::to_value(response).unwrap();
+        assert_eq!(value["usage"]["type"], "duration");
+        assert_eq!(value["usage"]["seconds"], 1.25);
+    }
+}

--- a/lib/llm/src/protocols/openai/transcriptions/aggregator.rs
+++ b/lib/llm/src/protocols/openai/transcriptions/aggregator.rs
@@ -1,0 +1,18 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_runtime::error::DynamoError;
+use futures::Stream;
+
+use crate::protocols::openai::stream_aggregator::collect_unary_stream;
+use crate::types::Annotated;
+
+use super::NvAudioTranscriptionResponse;
+
+impl NvAudioTranscriptionResponse {
+    pub async fn from_annotated_stream(
+        stream: impl Stream<Item = Annotated<NvAudioTranscriptionResponse>>,
+    ) -> Result<NvAudioTranscriptionResponse, DynamoError> {
+        collect_unary_stream(stream).await
+    }
+}

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -128,6 +128,22 @@ pub mod openai {
         pub type OpenAIAudiosStreamingEngine =
             ServerStreamingEngine<NvCreateAudioSpeechRequest, Annotated<NvAudioSpeechResponse>>;
     }
+
+    pub mod transcriptions {
+        use super::*;
+
+        pub use protocols::openai::transcriptions::{
+            NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest,
+        };
+
+        pub type OpenAITranscriptionsUnaryEngine =
+            UnaryEngine<NvCreateAudioTranscriptionRequest, NvAudioTranscriptionResponse>;
+
+        pub type OpenAITranscriptionsStreamingEngine = ServerStreamingEngine<
+            NvCreateAudioTranscriptionRequest,
+            Annotated<NvAudioTranscriptionResponse>,
+        >;
+    }
 }
 
 pub mod generic {

--- a/lib/llm/src/types.rs
+++ b/lib/llm/src/types.rs
@@ -156,6 +156,22 @@ pub mod openai {
         pub type OpenAIAudiosStreamingEngine =
             ServerStreamingEngine<NvCreateAudioSpeechRequest, Annotated<NvAudioSpeechResponse>>;
     }
+
+    pub mod transcriptions {
+        use super::*;
+
+        pub use protocols::openai::transcriptions::{
+            NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest,
+        };
+
+        pub type OpenAITranscriptionsUnaryEngine =
+            UnaryEngine<NvCreateAudioTranscriptionRequest, NvAudioTranscriptionResponse>;
+
+        pub type OpenAITranscriptionsStreamingEngine = ServerStreamingEngine<
+            NvCreateAudioTranscriptionRequest,
+            Annotated<NvAudioTranscriptionResponse>,
+        >;
+    }
 }
 
 pub mod generic {

--- a/lib/llm/tests/http-service.rs
+++ b/lib/llm/tests/http-service.rs
@@ -576,6 +576,7 @@ fn compute_index(endpoint: &Endpoint, request_type: &RequestType, status: &Statu
         Endpoint::Images => todo!(),
         Endpoint::Videos => todo!(),
         Endpoint::Audios => todo!(),
+        Endpoint::Transcriptions => todo!(),
         Endpoint::Generate => todo!(),
     };
 

--- a/lib/llm/tests/http-transcriptions.rs
+++ b/lib/llm/tests/http-transcriptions.rs
@@ -1,0 +1,182 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Error;
+use base64::Engine as _;
+use dynamo_llm::endpoint_type::EndpointType;
+use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::protocols::Annotated;
+use dynamo_llm::protocols::openai::transcriptions::{
+    NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest,
+};
+use dynamo_runtime::CancellationToken;
+use dynamo_runtime::error::{DynamoError, ErrorType};
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
+};
+use reqwest::StatusCode;
+
+const MODEL: &str = "test-whisper";
+
+struct TestTranscriptionEngine {
+    fail: bool,
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateAudioTranscriptionRequest>,
+        ManyOut<Annotated<NvAudioTranscriptionResponse>>,
+        Error,
+    > for TestTranscriptionEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateAudioTranscriptionRequest>,
+    ) -> Result<ManyOut<Annotated<NvAudioTranscriptionResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let response = if self.fail {
+            let error = DynamoError::builder()
+                .error_type(ErrorType::InvalidArgument)
+                .message("unsupported transcription language")
+                .build();
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            }
+        } else {
+            let audio = base64::engine::general_purpose::STANDARD
+                .decode(&request.audio_b64)
+                .expect("frontend should produce valid base64");
+            Annotated::from_data(NvAudioTranscriptionResponse {
+                text: format!("{}:{}", request.filename, audio.len()),
+                usage: None,
+                language: request.language,
+                duration: None,
+                segments: None,
+                words: None,
+            })
+        };
+        let stream = futures::stream::iter([response]);
+
+        Ok(ResponseStream::new(Box::pin(stream), context.context()))
+    }
+}
+
+struct TestService {
+    base_url: String,
+    client: reqwest::Client,
+    cancel: CancellationToken,
+    join: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl TestService {
+    async fn start(fail: bool) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind test listener");
+        let port = listener
+            .local_addr()
+            .expect("test listener has no local address")
+            .port();
+        let service = HttpService::builder()
+            .host("127.0.0.1")
+            .port(port)
+            .build()
+            .expect("failed to build HTTP service");
+        service.enable_model_endpoint(EndpointType::Transcriptions, true);
+        service
+            .model_manager()
+            .add_transcriptions_model(MODEL, "0", Arc::new(TestTranscriptionEngine { fail }))
+            .expect("failed to register transcription model");
+
+        let cancel = CancellationToken::new();
+        let join = service.spawn_with_listener(cancel.clone(), listener).await;
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("failed to build HTTP client");
+        let base_url = format!("http://127.0.0.1:{port}");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if client
+                    .get(format!("{base_url}/health"))
+                    .send()
+                    .await
+                    .is_ok_and(|response| response.status().is_success())
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("HTTP service did not become healthy");
+
+        Self {
+            base_url,
+            client,
+            cancel,
+            join,
+        }
+    }
+
+    async fn shutdown(self) {
+        self.cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(2), self.join)
+            .await
+            .expect("HTTP service did not stop")
+            .expect("HTTP service task panicked")
+            .expect("HTTP service returned an error");
+    }
+
+    async fn transcribe(&self) -> reqwest::Response {
+        let form = reqwest::multipart::Form::new()
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(b"audio".to_vec())
+                    .file_name("sample.wav")
+                    .mime_str("audio/wav")
+                    .unwrap(),
+            )
+            .text("language", "en")
+            .text("response_format", "json");
+
+        self.client
+            .post(format!("{}/v1/audio/transcriptions", self.base_url))
+            .multipart(form)
+            .send()
+            .await
+            .expect("transcription request failed")
+    }
+}
+
+#[tokio::test]
+async fn multipart_request_uses_default_model_and_returns_json() {
+    let service = TestService::start(false).await;
+
+    let response = service.transcribe().await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response: NvAudioTranscriptionResponse = response.json().await.unwrap();
+    assert_eq!(response.text, "sample.wav:5");
+    assert_eq!(response.language.as_deref(), Some("en"));
+    service.shutdown().await;
+}
+
+#[tokio::test]
+async fn annotated_invalid_argument_returns_bad_request() {
+    let service = TestService::start(true).await;
+
+    let response = service.transcribe().await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    service.shutdown().await;
+}

--- a/lib/llm/tests/http-transcriptions.rs
+++ b/lib/llm/tests/http-transcriptions.rs
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use anyhow::Error;
+use base64::Engine as _;
+use dynamo_llm::endpoint_type::EndpointType;
+use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::protocols::Annotated;
+use dynamo_llm::protocols::openai::transcriptions::{
+    NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest,
+};
+use dynamo_runtime::CancellationToken;
+use dynamo_runtime::error::{BackendError, DynamoError, ErrorType};
+use dynamo_runtime::pipeline::{
+    AsyncEngine, AsyncEngineContextProvider, ManyOut, ResponseStream, SingleIn, async_trait,
+};
+use reqwest::StatusCode;
+
+const MODEL: &str = "test-whisper";
+
+struct TestTranscriptionEngine {
+    fail: bool,
+}
+
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateAudioTranscriptionRequest>,
+        ManyOut<Annotated<NvAudioTranscriptionResponse>>,
+        Error,
+    > for TestTranscriptionEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateAudioTranscriptionRequest>,
+    ) -> Result<ManyOut<Annotated<NvAudioTranscriptionResponse>>, Error> {
+        let (request, context) = request.transfer(());
+        let response = if self.fail {
+            let error = DynamoError::builder()
+                .error_type(ErrorType::Backend(BackendError::InvalidArgument))
+                .message("unsupported transcription language")
+                .build();
+            Annotated {
+                data: None,
+                id: None,
+                event: Some("error".to_string()),
+                comment: None,
+                error: Some(error),
+            }
+        } else {
+            let audio = base64::engine::general_purpose::STANDARD
+                .decode(&request.audio_b64)
+                .expect("frontend should produce valid base64");
+            Annotated::from_data(NvAudioTranscriptionResponse {
+                text: format!("{}:{}", request.filename, audio.len()),
+                usage: None,
+                language: request.language,
+                duration: None,
+                segments: None,
+                words: None,
+            })
+        };
+        let stream = futures::stream::iter([response]);
+
+        Ok(ResponseStream::new(Box::pin(stream), context.context()))
+    }
+}
+
+struct TestService {
+    base_url: String,
+    client: reqwest::Client,
+    cancel: CancellationToken,
+    join: tokio::task::JoinHandle<anyhow::Result<()>>,
+}
+
+impl TestService {
+    async fn start(fail: bool) -> Self {
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("failed to bind test listener");
+        let port = listener
+            .local_addr()
+            .expect("test listener has no local address")
+            .port();
+        let service = HttpService::builder()
+            .host("127.0.0.1")
+            .port(port)
+            .build()
+            .expect("failed to build HTTP service");
+        service
+            .enable_model_endpoint(EndpointType::Transcriptions, true)
+            .expect("failed to enable transcription endpoint");
+        service
+            .model_manager()
+            .add_transcriptions_model(MODEL, "0", Arc::new(TestTranscriptionEngine { fail }))
+            .expect("failed to register transcription model");
+
+        let cancel = CancellationToken::new();
+        let join = service.spawn_with_listener(cancel.clone(), listener).await;
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("failed to build HTTP client");
+        let base_url = format!("http://127.0.0.1:{port}");
+
+        tokio::time::timeout(Duration::from_secs(5), async {
+            loop {
+                if client
+                    .get(format!("{base_url}/health"))
+                    .send()
+                    .await
+                    .is_ok_and(|response| response.status().is_success())
+                {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("HTTP service did not become healthy");
+
+        Self {
+            base_url,
+            client,
+            cancel,
+            join,
+        }
+    }
+
+    async fn shutdown(self) {
+        self.cancel.cancel();
+        tokio::time::timeout(Duration::from_secs(2), self.join)
+            .await
+            .expect("HTTP service did not stop")
+            .expect("HTTP service task panicked")
+            .expect("HTTP service returned an error");
+    }
+
+    async fn transcribe(&self) -> reqwest::Response {
+        let form = reqwest::multipart::Form::new()
+            .part(
+                "file",
+                reqwest::multipart::Part::bytes(b"audio".to_vec())
+                    .file_name("sample.wav")
+                    .mime_str("audio/wav")
+                    .unwrap(),
+            )
+            .text("language", "en")
+            .text("response_format", "json");
+
+        self.client
+            .post(format!("{}/v1/audio/transcriptions", self.base_url))
+            .multipart(form)
+            .send()
+            .await
+            .expect("transcription request failed")
+    }
+}
+
+#[tokio::test]
+async fn multipart_request_uses_default_model_and_returns_json() {
+    let service = TestService::start(false).await;
+
+    let response = service.transcribe().await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let response: NvAudioTranscriptionResponse = response.json().await.unwrap();
+    assert_eq!(response.text, "sample.wav:5");
+    assert_eq!(response.language.as_deref(), Some("en"));
+    service.shutdown().await;
+}
+
+#[tokio::test]
+async fn annotated_invalid_argument_returns_bad_request() {
+    let service = TestService::start(true).await;
+
+    let response = service.transcribe().await;
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    service.shutdown().await;
+}

--- a/lib/llm/tests/http-transcriptions.rs
+++ b/lib/llm/tests/http-transcriptions.rs
@@ -1,7 +1,10 @@
 // SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::Duration;
 
 use anyhow::Error;
@@ -23,6 +26,22 @@ const MODEL: &str = "test-whisper";
 
 struct TestTranscriptionEngine {
     fail: bool,
+}
+
+struct LongRunningTranscriptionEngine {
+    cancelled: Arc<AtomicBool>,
+}
+
+impl LongRunningTranscriptionEngine {
+    fn new() -> Self {
+        Self {
+            cancelled: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn was_cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::Acquire)
+    }
 }
 
 #[async_trait]
@@ -69,6 +88,45 @@ impl
     }
 }
 
+#[async_trait]
+impl
+    AsyncEngine<
+        SingleIn<NvCreateAudioTranscriptionRequest>,
+        ManyOut<Annotated<NvAudioTranscriptionResponse>>,
+        Error,
+    > for LongRunningTranscriptionEngine
+{
+    async fn generate(
+        &self,
+        request: SingleIn<NvCreateAudioTranscriptionRequest>,
+    ) -> Result<ManyOut<Annotated<NvAudioTranscriptionResponse>>, Error> {
+        let (_request, context) = request.transfer(());
+        let context = context.context();
+        let cancelled = self.cancelled.clone();
+        let stream_context = context.clone();
+
+        let stream = async_stream::stream! {
+            tokio::select! {
+                _ = tokio::time::sleep(Duration::from_secs(10)) => {
+                    yield Annotated::from_data(NvAudioTranscriptionResponse {
+                        text: "completed".to_string(),
+                        usage: None,
+                        language: None,
+                        duration: None,
+                        segments: None,
+                        words: None,
+                    });
+                }
+                _ = stream_context.stopped() => {
+                    cancelled.store(true, Ordering::Release);
+                }
+            }
+        };
+
+        Ok(ResponseStream::new(Box::pin(stream), context))
+    }
+}
+
 struct TestService {
     base_url: String,
     client: reqwest::Client,
@@ -78,6 +136,17 @@ struct TestService {
 
 impl TestService {
     async fn start(fail: bool) -> Self {
+        Self::start_with_engine(Arc::new(TestTranscriptionEngine { fail })).await
+    }
+
+    async fn start_with_engine<E>(engine: Arc<E>) -> Self
+    where
+        E: AsyncEngine<
+                SingleIn<NvCreateAudioTranscriptionRequest>,
+                ManyOut<Annotated<NvAudioTranscriptionResponse>>,
+                Error,
+            > + 'static,
+    {
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
             .await
             .expect("failed to bind test listener");
@@ -95,7 +164,7 @@ impl TestService {
             .expect("failed to enable transcription endpoint");
         service
             .model_manager()
-            .add_transcriptions_model(MODEL, "0", Arc::new(TestTranscriptionEngine { fail }))
+            .add_transcriptions_model(MODEL, "0", engine)
             .expect("failed to register transcription model");
 
         let cancel = CancellationToken::new();
@@ -180,5 +249,24 @@ async fn annotated_invalid_argument_returns_bad_request() {
     let response = service.transcribe().await;
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    service.shutdown().await;
+}
+
+#[tokio::test]
+async fn client_disconnect_cancels_transcription() {
+    let engine = Arc::new(LongRunningTranscriptionEngine::new());
+    let service = TestService::start_with_engine(engine.clone()).await;
+
+    let result = tokio::time::timeout(Duration::from_secs(1), service.transcribe()).await;
+    assert!(result.is_err(), "long-running request should time out");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while !engine.was_cancelled() {
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await
+    .expect("client disconnect did not cancel transcription inference");
+
     service.shutdown().await;
 }

--- a/lib/llm/tests/http-transcriptions.rs
+++ b/lib/llm/tests/http-transcriptions.rs
@@ -10,7 +10,11 @@ use std::time::Duration;
 use anyhow::Error;
 use base64::Engine as _;
 use dynamo_llm::endpoint_type::EndpointType;
-use dynamo_llm::http::service::service_v2::HttpService;
+use dynamo_llm::http::service::{
+    Metrics,
+    metrics::{Endpoint, ErrorType as MetricErrorType, RequestType, Status},
+    service_v2::HttpService,
+};
 use dynamo_llm::protocols::Annotated;
 use dynamo_llm::protocols::openai::transcriptions::{
     NvAudioTranscriptionResponse, NvCreateAudioTranscriptionRequest,
@@ -130,6 +134,7 @@ impl
 struct TestService {
     base_url: String,
     client: reqwest::Client,
+    metrics: Arc<Metrics>,
     cancel: CancellationToken,
     join: tokio::task::JoinHandle<anyhow::Result<()>>,
 }
@@ -166,6 +171,7 @@ impl TestService {
             .model_manager()
             .add_transcriptions_model(MODEL, "0", engine)
             .expect("failed to register transcription model");
+        let metrics = service.state_clone().metrics_clone();
 
         let cancel = CancellationToken::new();
         let join = service.spawn_with_listener(cancel.clone(), listener).await;
@@ -194,6 +200,7 @@ impl TestService {
         Self {
             base_url,
             client,
+            metrics,
             cancel,
             join,
         }
@@ -267,6 +274,31 @@ async fn client_disconnect_cancels_transcription() {
     })
     .await
     .expect("client disconnect did not cancel transcription inference");
+
+    tokio::time::timeout(Duration::from_secs(2), async {
+        while service.metrics.get_request_counter(
+            MODEL,
+            &Endpoint::Transcriptions,
+            &RequestType::Unary,
+            &Status::Error,
+            &MetricErrorType::Cancelled,
+        ) != 1
+        {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("client disconnect was not recorded as a cancelled request");
+    assert_eq!(
+        service.metrics.get_request_counter(
+            MODEL,
+            &Endpoint::Transcriptions,
+            &RequestType::Unary,
+            &Status::Error,
+            &MetricErrorType::Internal,
+        ),
+        0,
+    );
 
     service.shutdown().await;
 }

--- a/lib/llm/tests/http-transcriptions.rs
+++ b/lib/llm/tests/http-transcriptions.rs
@@ -216,7 +216,12 @@ impl TestService {
     }
 
     async fn transcribe(&self) -> reqwest::Response {
-        let form = reqwest::multipart::Form::new()
+        self.transcribe_with_form(reqwest::multipart::Form::new())
+            .await
+    }
+
+    async fn transcribe_with_form(&self, form: reqwest::multipart::Form) -> reqwest::Response {
+        let form = form
             .part(
                 "file",
                 reqwest::multipart::Part::bytes(b"audio".to_vec())
@@ -256,6 +261,25 @@ async fn annotated_invalid_argument_returns_bad_request() {
     let response = service.transcribe().await;
 
     assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    service.shutdown().await;
+}
+
+#[tokio::test]
+async fn stream_field_is_parsed_strictly() {
+    let service = TestService::start(false).await;
+
+    for value in ["true", "invalid"] {
+        let response = service
+            .transcribe_with_form(reqwest::multipart::Form::new().text("stream", value))
+            .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST, "stream={value}");
+    }
+
+    let response = service
+        .transcribe_with_form(reqwest::multipart::Form::new().text("stream", "false"))
+        .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
     service.shutdown().await;
 }
 

--- a/lib/runtime/examples/Cargo.lock
+++ b/lib/runtime/examples/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime",
+ "multer",
  "percent-encoding",
  "pin-project-lite",
  "rustversion",
@@ -902,6 +903,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 dependencies = [
  "serde",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2009,6 +2019,23 @@ dependencies = [
  "log",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "multer"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83e87776546dc87511aa5ee218730c92b666d7264ab6ed41f9d215af9cd5224b"
+dependencies = [
+ "bytes",
+ "encoding_rs",
+ "futures-util",
+ "http",
+ "httparse",
+ "memchr",
+ "mime",
+ "spin",
+ "version_check",
 ]
 
 [[package]]
@@ -3340,6 +3367,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "spin"
+version = "0.9.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3763264f6b73151db08c50ff20d7d8a0b8796e021cdea7ceedad07b80155fa0e"
 
 [[package]]
 name = "spki"


### PR DESCRIPTION
## Summary

- Add an OpenAI-compatible `POST /v1/audio/transcriptions` multipart endpoint.
- Route typed transcription requests through Dynamo discovery to a dedicated aggregated vLLM worker.
- Delegate inference to vLLM native `OpenAIServingTranscription`, including health checks and request cancellation.
- Add a launch example plus Rust HTTP integration tests and focused Python unit tests.

## Why

Voice-agent deployments need STT to run behind Dynamo instead of bypassing its frontend and worker lifecycle. Dynamo already has the request plane, discovery, model watching, and vLLM worker infrastructure; this change extends those paths with a transcription model type and keeps the engine-specific inference logic in the vLLM component.

This is the batch STT foundation for the voice-agent roadmap. Realtime audio streaming and `/v1/realtime` transcription sessions remain follow-up work.

## Related issue

- Relates to [DYN-3481](https://linear.app/nvidia/issue/DYN-3481/voice-replace-local-stt-with-a-dynamo-stt-backend).

## Implementation

- Parse the OpenAI multipart request at the HTTP boundary and convert audio to a transport-safe typed request.
- Discover and route `ModelType::Transcriptions` workers using the existing media-worker path.
- Use a generic unary stream collector that preserves typed backend errors and rejects empty or multi-item responses.
- Expose `--transcription-worker` in the vLLM backend and construct the native serving handler from the existing worker factory.

## Validation

- `pre-commit run --from-ref origin/main --to-ref HEAD`
- `pre-commit run --files <review-fixed files>`
- `cargo fmt --all -- --check`
- `cargo clippy -p dynamo-llm --tests -- -D warnings`
- `cargo test -p dynamo-llm --test http-transcriptions` (4 passed)
- `cargo test -p dynamo-truthy --test no_bool_parse_forks` (4 passed)
- `cargo test -p dynamo-llm transcription` (10 matching tests passed)
- Focused vLLM Python unit suite in `nvcr.io/nvstaging/ai-dynamo/vllm-runtime-nightly:20260716-f5b1c1c` with the local source/binding overlay (197 passed)
- `bash -n examples/backends/vllm/launch/agg_transcription.sh`
- Local end-to-end STT -> LLM -> TTS voice-agent cascade validated on GPUs with the same staged runtime and local STT overlay.

## Current scope

- Supports `json` and `verbose_json` response formats.
- Non-streaming transcription only.
- Buffers the complete uploaded audio and base64-encodes it across the request plane; streaming/chunked audio transport is intentionally deferred.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an OpenAI-compatible audio transcription endpoint with multipart uploads and JSON responses.
  - Added transcription model discovery, registration, health checks, metrics, and model capability support.
  - Added vLLM transcription worker support with configurable launch options.
  - Added support for transcription parameters, usage details, language, duration, segments, and word metadata.
- **Bug Fixes**
  - Improved validation and standardized handling of invalid transcription requests and backend errors.
  - Added cancellation support for transcription requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->