### PR TITLE
feat(ext-proc): add vLLM render client for standalone EPP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ version = "1.3.0"
 dependencies = [
  "anyhow",
  "axum 0.8.4",
+ "bytes",
  "dynamo-kv-router",
  "dynamo-llm",
  "dynamo-runtime",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2395,6 +2395,7 @@ name = "dynamo-ext-proc"
 version = "1.3.0"
 dependencies = [
  "anyhow",
+ "axum 0.8.4",
  "dynamo-kv-router",
  "dynamo-llm",
  "dynamo-runtime",
@@ -2405,6 +2406,7 @@ dependencies = [
  "prost 0.13.5",
  "prost-types 0.13.5",
  "rcgen",
+ "reqwest 0.12.28",
  "rustls 0.23.40",
  "rustls-pemfile",
  "serde",

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -27,6 +27,7 @@ kube = { workspace = true }
 prost = { workspace = true }
 prost-types = { workspace = true }
 rcgen = { workspace = true }
+reqwest = { workspace = true }
 rustls = { workspace = true }
 rustls-pemfile = { workspace = true }
 serde = { workspace = true }
@@ -43,6 +44,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["fmt"] }
 uuid = { workspace = true }
 validator = { workspace = true }
+
+[dev-dependencies]
+axum = { workspace = true }
 
 [package.metadata.cargo-machete]
 ignored = ["prost"]

--- a/deploy/inference-gateway/ext-proc/Cargo.toml
+++ b/deploy/inference-gateway/ext-proc/Cargo.toml
@@ -20,6 +20,7 @@ dynamo-kv-router = { workspace = true, features = ["metrics", "runtime-protocols
 dynamo-runtime = { workspace = true }
 
 anyhow = { workspace = true }
+bytes = { workspace = true }
 futures = { workspace = true }
 hyper-util = { workspace = true, features = ["tokio", "http2", "server-auto"] }
 k8s-openapi = { workspace = true }

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -15,7 +15,7 @@ use validator::ValidationError;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
-const DEFAULT_VLLM_RENDER_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_TOKENIZATION_TIMEOUT_MS: u64 = 5_000;
 
 /// Environment variable that selects the EPP operating mode.
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
@@ -75,9 +75,9 @@ pub struct EppStandaloneConfig {
     #[validate(length(min = 1, message = "DYN_EPP_VLLM_RENDER_URL is required"))]
     #[validate(custom(function = "validate_vllm_render_url"))]
     pub vllm_render_url: String,
-    /// Deadline for calls to the vLLM renderer.
-    #[validate(range(min = 1, message = "DYN_EPP_VLLM_RENDER_TIMEOUT_MS must be >= 1"))]
-    pub vllm_render_timeout_ms: u64,
+    /// Deadline for calls to the configured tokenization provider.
+    #[validate(range(min = 1, message = "DYN_EPP_TOKENIZATION_TIMEOUT_MS must be >= 1"))]
+    pub tokenization_timeout_ms: u64,
     /// KV-cache block size; MUST equal the inference engine block size.
     #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
     pub block_size: u32,
@@ -118,8 +118,8 @@ impl EppStandaloneConfig {
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
             vllm_render_url: trimmed(get("DYN_EPP_VLLM_RENDER_URL")).unwrap_or_default(),
-            vllm_render_timeout_ms: opt_parse::<u64>(get, "DYN_EPP_VLLM_RENDER_TIMEOUT_MS")?
-                .unwrap_or(DEFAULT_VLLM_RENDER_TIMEOUT_MS),
+            tokenization_timeout_ms: opt_parse::<u64>(get, "DYN_EPP_TOKENIZATION_TIMEOUT_MS")?
+                .unwrap_or(DEFAULT_TOKENIZATION_TIMEOUT_MS),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
@@ -241,7 +241,7 @@ mod tests {
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
         assert_eq!(cfg.vllm_render_url, "http://vllm-render:8000");
-        assert_eq!(cfg.vllm_render_timeout_ms, DEFAULT_VLLM_RENDER_TIMEOUT_MS);
+        assert_eq!(cfg.tokenization_timeout_ms, DEFAULT_TOKENIZATION_TIMEOUT_MS);
         assert_eq!(cfg.block_size, 16);
         assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
         assert!(cfg.replay_port.is_none());
@@ -378,14 +378,14 @@ mod tests {
     }
 
     #[test]
-    fn vllm_render_timeout_must_be_positive() {
+    fn tokenization_timeout_must_be_positive() {
         assert!(
             parse_cfg(&[
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
                 ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
-                ("DYN_EPP_VLLM_RENDER_TIMEOUT_MS", "0"),
+                ("DYN_EPP_TOKENIZATION_TIMEOUT_MS", "0"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -11,9 +11,11 @@
 //! [`EppStandaloneConfig::validate_config`] for field and cross-field checks.
 
 use validator::Validate;
+use validator::ValidationError;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
+const DEFAULT_VLLM_RENDER_TIMEOUT_MS: u64 = 5_000;
 
 /// Environment variable that selects the EPP operating mode.
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
@@ -69,6 +71,13 @@ pub struct EppStandaloneConfig {
     /// Served/catalog model identity used to group discovered workers.
     #[validate(length(min = 1, message = "DYN_MODEL_NAME is required"))]
     pub model_name: String,
+    /// Base URL of the vLLM renderer used to tokenize chat requests.
+    #[validate(length(min = 1, message = "DYN_EPP_VLLM_RENDER_URL is required"))]
+    #[validate(custom(function = "validate_vllm_render_url"))]
+    pub vllm_render_url: String,
+    /// Deadline for calls to the vLLM renderer.
+    #[validate(range(min = 1, message = "DYN_EPP_VLLM_RENDER_TIMEOUT_MS must be >= 1"))]
+    pub vllm_render_timeout_ms: u64,
     /// KV-cache block size; MUST equal the inference engine block size.
     #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
     pub block_size: u32,
@@ -108,6 +117,9 @@ impl EppStandaloneConfig {
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
+            vllm_render_url: trimmed(get("DYN_EPP_VLLM_RENDER_URL")).unwrap_or_default(),
+            vllm_render_timeout_ms: opt_parse::<u64>(get, "DYN_EPP_VLLM_RENDER_TIMEOUT_MS")?
+                .unwrap_or(DEFAULT_VLLM_RENDER_TIMEOUT_MS),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
@@ -121,6 +133,19 @@ impl EppStandaloneConfig {
     pub fn validate_config(&self) -> anyhow::Result<()> {
         self.validate()
             .map_err(|e| anyhow::anyhow!("invalid {STANDALONE_MODE} EPP config: {e}"))
+    }
+}
+
+fn validate_vllm_render_url(value: &str) -> Result<(), ValidationError> {
+    let valid_url = reqwest::Url::parse(value)
+        .map(|url| matches!(url.scheme(), "http" | "https") && url.host_str().is_some())
+        .unwrap_or(false);
+    if valid_url {
+        Ok(())
+    } else {
+        let mut error = ValidationError::new("vllm_render_url_invalid");
+        error.message = Some("DYN_EPP_VLLM_RENDER_URL must be an absolute HTTP(S) URL".into());
+        Err(error)
     }
 }
 
@@ -205,6 +230,7 @@ mod tests {
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ])
         .expect("config should parse");
@@ -214,6 +240,8 @@ mod tests {
         assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
+        assert_eq!(cfg.vllm_render_url, "http://vllm-render:8000");
+        assert_eq!(cfg.vllm_render_timeout_ms, DEFAULT_VLLM_RENDER_TIMEOUT_MS);
         assert_eq!(cfg.block_size, 16);
         assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
         assert!(cfg.replay_port.is_none());
@@ -228,6 +256,7 @@ mod tests {
             parse_cfg(&[
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
@@ -242,6 +271,7 @@ mod tests {
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ])
         .expect("peer service config should parse");
@@ -256,6 +286,7 @@ mod tests {
             parse_cfg(&[
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
@@ -269,6 +300,7 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
             ])
             .is_err()
@@ -281,6 +313,7 @@ mod tests {
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ("DYN_EPP_KV_EVENT_REPLAY_PORT", "5558"),
         ])
@@ -309,8 +342,51 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
                 ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "0"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn vllm_render_url_is_required() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn vllm_render_url_must_be_http() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "unix:///tmp/vllm.sock"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn vllm_render_timeout_must_be_positive() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_VLLM_RENDER_TIMEOUT_MS", "0"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
         );

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -13,12 +13,12 @@
 use validator::Validate;
 use validator::ValidationError;
 
-use crate::vllm_render_client::parse_vllm_render_base_url;
+use crate::vllm_render_client::parse_tokenizer_service_base_url;
 
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
 const DEFAULT_TOKENIZATION_TIMEOUT_MS: u64 = 5_000;
-const DEFAULT_VLLM_RENDER_MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+const DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Environment variable that selects the EPP operating mode.
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
@@ -57,6 +57,26 @@ impl EppMode {
     }
 }
 
+/// Wire protocol exposed by the configured tokenizer service.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TokenizerProtocol {
+    VllmRender,
+}
+
+impl std::str::FromStr for TokenizerProtocol {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "vllm-render" => Ok(Self::VllmRender),
+            other => anyhow::bail!(
+                "DYN_EPP_TOKENIZER_PROTOCOL has invalid value {other:?}; \
+                 expected \"vllm-render\""
+            ),
+        }
+    }
+}
+
 #[derive(Debug, Clone, Validate)]
 pub struct EppStandaloneConfig {
     /// KV indexer thread-pool size for the in-process selector.
@@ -74,19 +94,18 @@ pub struct EppStandaloneConfig {
     /// Served/catalog model identity used to group discovered workers.
     #[validate(length(min = 1, message = "DYN_MODEL_NAME is required"))]
     pub model_name: String,
-    /// Base URL of the vLLM renderer used to tokenize chat requests.
-    #[validate(length(min = 1, message = "DYN_EPP_VLLM_RENDER_URL is required"))]
-    #[validate(custom(function = "validate_vllm_render_url"))]
-    pub vllm_render_url: String,
+    /// Base URL of the tokenizer service.
+    #[validate(length(min = 1, message = "DYN_EPP_TOKENIZER_SERVICE_URL is required"))]
+    #[validate(custom(function = "validate_tokenizer_service_url"))]
+    pub tokenizer_service_url: String,
+    /// Protocol spoken by the configured tokenizer service.
+    pub tokenizer_protocol: TokenizerProtocol,
     /// Deadline for calls to the configured tokenization provider.
     #[validate(range(min = 1, message = "DYN_EPP_TOKENIZATION_TIMEOUT_MS must be >= 1"))]
     pub tokenization_timeout_ms: u64,
-    /// Maximum successful response body accepted from the vLLM renderer.
-    #[validate(range(
-        min = 1,
-        message = "DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES must be >= 1"
-    ))]
-    pub vllm_render_max_response_bytes: usize,
+    /// Maximum successful response body accepted from the tokenizer service.
+    #[validate(range(min = 1, message = "DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES must be >= 1"))]
+    pub tokenizer_max_response_bytes: usize,
     /// KV-cache block size; MUST equal the inference engine block size.
     #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
     pub block_size: u32,
@@ -119,6 +138,10 @@ impl EppStandaloneConfig {
     }
 
     fn parse(get: &EnvGet) -> anyhow::Result<Self> {
+        let tokenizer_protocol = trimmed(get("DYN_EPP_TOKENIZER_PROTOCOL"))
+            .ok_or_else(|| anyhow::anyhow!("DYN_EPP_TOKENIZER_PROTOCOL is required"))?
+            .parse()?;
+
         Ok(Self {
             selector_threads: opt_parse::<usize>(get, "DYN_EPP_SELECTION_INDEXER_THREADS")?
                 .unwrap_or(DEFAULT_SELECTOR_THREADS),
@@ -126,14 +149,16 @@ impl EppStandaloneConfig {
             inference_pool_name: trimmed(get("DYN_EPP_INFERENCE_POOL_NAME")).unwrap_or_default(),
             namespace: trimmed(get("POD_NAMESPACE")).unwrap_or_default(),
             model_name: trimmed(get("DYN_MODEL_NAME")).unwrap_or_default(),
-            vllm_render_url: trimmed(get("DYN_EPP_VLLM_RENDER_URL")).unwrap_or_default(),
+            tokenizer_service_url: trimmed(get("DYN_EPP_TOKENIZER_SERVICE_URL"))
+                .unwrap_or_default(),
+            tokenizer_protocol,
             tokenization_timeout_ms: opt_parse::<u64>(get, "DYN_EPP_TOKENIZATION_TIMEOUT_MS")?
                 .unwrap_or(DEFAULT_TOKENIZATION_TIMEOUT_MS),
-            vllm_render_max_response_bytes: opt_parse::<usize>(
+            tokenizer_max_response_bytes: opt_parse::<usize>(
                 get,
-                "DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES",
+                "DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES",
             )?
-            .unwrap_or(DEFAULT_VLLM_RENDER_MAX_RESPONSE_BYTES),
+            .unwrap_or(DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
@@ -150,16 +175,19 @@ impl EppStandaloneConfig {
     }
 }
 
-fn validate_vllm_render_url(value: &str) -> Result<(), ValidationError> {
+fn validate_tokenizer_service_url(value: &str) -> Result<(), ValidationError> {
     if value.is_empty() {
         return Ok(());
     }
 
-    parse_vllm_render_base_url(value).map(|_| ()).map_err(|_| {
-        let mut error = ValidationError::new("vllm_render_url_invalid");
-        error.message = Some("DYN_EPP_VLLM_RENDER_URL must be an absolute HTTP(S) URL".into());
-        error
-    })
+    parse_tokenizer_service_base_url(value)
+        .map(|_| ())
+        .map_err(|_| {
+            let mut error = ValidationError::new("tokenizer_service_url_invalid");
+            error.message =
+                Some("DYN_EPP_TOKENIZER_SERVICE_URL must be an absolute HTTP(S) URL".into());
+            error
+        })
 }
 
 /// Trim a raw value and treat empty as absent.
@@ -243,7 +271,8 @@ mod tests {
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ])
         .expect("config should parse");
@@ -253,11 +282,12 @@ mod tests {
         assert_eq!(cfg.inference_pool_name, "vllm-qwen-pool");
         assert_eq!(cfg.namespace, "inference");
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
-        assert_eq!(cfg.vllm_render_url, "http://vllm-render:8000");
+        assert_eq!(cfg.tokenizer_service_url, "http://vllm-render:8000");
+        assert_eq!(cfg.tokenizer_protocol, TokenizerProtocol::VllmRender);
         assert_eq!(cfg.tokenization_timeout_ms, DEFAULT_TOKENIZATION_TIMEOUT_MS);
         assert_eq!(
-            cfg.vllm_render_max_response_bytes,
-            DEFAULT_VLLM_RENDER_MAX_RESPONSE_BYTES
+            cfg.tokenizer_max_response_bytes,
+            DEFAULT_TOKENIZER_MAX_RESPONSE_BYTES
         );
         assert_eq!(cfg.block_size, 16);
         assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
@@ -273,7 +303,8 @@ mod tests {
             parse_cfg(&[
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
@@ -288,7 +319,8 @@ mod tests {
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ])
         .expect("peer service config should parse");
@@ -303,7 +335,8 @@ mod tests {
             parse_cfg(&[
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
@@ -317,7 +350,8 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "0"),
             ])
             .is_err()
@@ -330,7 +364,8 @@ mod tests {
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ("DYN_EPP_KV_EVENT_REPLAY_PORT", "5558"),
         ])
@@ -345,7 +380,8 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
                 ("DYN_EPP_KV_EVENT_REPLAY_PORT", "0"),
             ])
@@ -360,7 +396,8 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
                 ("DYN_EPP_MAX_NUM_BATCHED_TOKENS", "0"),
             ])
@@ -369,12 +406,13 @@ mod tests {
     }
 
     #[test]
-    fn vllm_render_url_is_required() {
+    fn tokenizer_service_url_is_required() {
         assert!(
             parse_cfg(&[
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
@@ -382,13 +420,14 @@ mod tests {
     }
 
     #[test]
-    fn vllm_render_url_must_be_http() {
+    fn tokenizer_service_url_must_be_http() {
         assert!(
             parse_cfg(&[
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "unix:///tmp/vllm.sock"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "unix:///tmp/vllm.sock"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()
@@ -402,7 +441,8 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
                 ("DYN_EPP_TOKENIZATION_TIMEOUT_MS", "0"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
@@ -411,29 +451,63 @@ mod tests {
     }
 
     #[test]
-    fn vllm_render_max_response_bytes_can_be_overridden() {
+    fn tokenizer_max_response_bytes_can_be_overridden() {
         let cfg = parse_cfg(&[
             ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
             ("POD_NAMESPACE", "inference"),
             ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
-            ("DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES", "33554432"),
+            ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+            ("DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES", "33554432"),
             ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
         ])
         .unwrap();
 
-        assert_eq!(cfg.vllm_render_max_response_bytes, 32 * 1024 * 1024);
+        assert_eq!(cfg.tokenizer_max_response_bytes, 32 * 1024 * 1024);
     }
 
     #[test]
-    fn vllm_render_max_response_bytes_must_be_positive() {
+    fn tokenizer_max_response_bytes_must_be_positive() {
         assert!(
             parse_cfg(&[
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
-                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
-                ("DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES", "0"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "vllm-render"),
+                ("DYN_EPP_TOKENIZER_MAX_RESPONSE_BYTES", "0"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn tokenizer_protocol_is_required() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_TOKENIZER_SERVICE_URL", "http://vllm-render:8000"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn unsupported_tokenizer_protocol_fails() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                (
+                    "DYN_EPP_TOKENIZER_SERVICE_URL",
+                    "http://sglang-tokenizer:30000"
+                ),
+                ("DYN_EPP_TOKENIZER_PROTOCOL", "sglang-tokenize"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -329,6 +329,7 @@ mod tests {
                 ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
                 ("POD_NAMESPACE", "inference"),
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
                 ("DYN_EPP_KV_EVENT_REPLAY_PORT", "0"),
             ])

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -18,6 +18,7 @@ use crate::vllm_render_client::parse_vllm_render_base_url;
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
 const DEFAULT_TOKENIZATION_TIMEOUT_MS: u64 = 5_000;
+const DEFAULT_VLLM_RENDER_MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 
 /// Environment variable that selects the EPP operating mode.
 pub const DYN_EPP_MODE: &str = "DYN_EPP_MODE";
@@ -80,6 +81,12 @@ pub struct EppStandaloneConfig {
     /// Deadline for calls to the configured tokenization provider.
     #[validate(range(min = 1, message = "DYN_EPP_TOKENIZATION_TIMEOUT_MS must be >= 1"))]
     pub tokenization_timeout_ms: u64,
+    /// Maximum successful response body accepted from the vLLM renderer.
+    #[validate(range(
+        min = 1,
+        message = "DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES must be >= 1"
+    ))]
+    pub vllm_render_max_response_bytes: usize,
     /// KV-cache block size; MUST equal the inference engine block size.
     #[validate(range(min = 1, message = "DYN_KV_CACHE_BLOCK_SIZE must be >= 1"))]
     pub block_size: u32,
@@ -122,6 +129,11 @@ impl EppStandaloneConfig {
             vllm_render_url: trimmed(get("DYN_EPP_VLLM_RENDER_URL")).unwrap_or_default(),
             tokenization_timeout_ms: opt_parse::<u64>(get, "DYN_EPP_TOKENIZATION_TIMEOUT_MS")?
                 .unwrap_or(DEFAULT_TOKENIZATION_TIMEOUT_MS),
+            vllm_render_max_response_bytes: opt_parse::<usize>(
+                get,
+                "DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES",
+            )?
+            .unwrap_or(DEFAULT_VLLM_RENDER_MAX_RESPONSE_BYTES),
             block_size: opt_parse::<u32>(get, "DYN_KV_CACHE_BLOCK_SIZE")?.unwrap_or(0),
             kv_event_port: opt_parse::<u16>(get, "DYN_EPP_KV_EVENT_PORT")?
                 .unwrap_or(DEFAULT_KV_EVENT_PORT),
@@ -243,6 +255,10 @@ mod tests {
         assert_eq!(cfg.model_name, "Qwen/Qwen3-0.6B");
         assert_eq!(cfg.vllm_render_url, "http://vllm-render:8000");
         assert_eq!(cfg.tokenization_timeout_ms, DEFAULT_TOKENIZATION_TIMEOUT_MS);
+        assert_eq!(
+            cfg.vllm_render_max_response_bytes,
+            DEFAULT_VLLM_RENDER_MAX_RESPONSE_BYTES
+        );
         assert_eq!(cfg.block_size, 16);
         assert_eq!(cfg.kv_event_port, DEFAULT_KV_EVENT_PORT);
         assert!(cfg.replay_port.is_none());
@@ -388,6 +404,36 @@ mod tests {
                 ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
                 ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
                 ("DYN_EPP_TOKENIZATION_TIMEOUT_MS", "0"),
+                ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+            ])
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn vllm_render_max_response_bytes_can_be_overridden() {
+        let cfg = parse_cfg(&[
+            ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+            ("POD_NAMESPACE", "inference"),
+            ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+            ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+            ("DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES", "33554432"),
+            ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
+        ])
+        .unwrap();
+
+        assert_eq!(cfg.vllm_render_max_response_bytes, 32 * 1024 * 1024);
+    }
+
+    #[test]
+    fn vllm_render_max_response_bytes_must_be_positive() {
+        assert!(
+            parse_cfg(&[
+                ("DYN_EPP_INFERENCE_POOL_NAME", "vllm-qwen-pool"),
+                ("POD_NAMESPACE", "inference"),
+                ("DYN_MODEL_NAME", "Qwen/Qwen3-0.6B"),
+                ("DYN_EPP_VLLM_RENDER_URL", "http://vllm-render:8000"),
+                ("DYN_EPP_VLLM_RENDER_MAX_RESPONSE_BYTES", "0"),
                 ("DYN_KV_CACHE_BLOCK_SIZE", "16"),
             ])
             .is_err()

--- a/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
+++ b/deploy/inference-gateway/ext-proc/src/epp_standalone_config.rs
@@ -13,6 +13,8 @@
 use validator::Validate;
 use validator::ValidationError;
 
+use crate::vllm_render_client::parse_vllm_render_base_url;
+
 const DEFAULT_KV_EVENT_PORT: u16 = 5557;
 const DEFAULT_SELECTOR_THREADS: usize = 4;
 const DEFAULT_TOKENIZATION_TIMEOUT_MS: u64 = 5_000;
@@ -137,16 +139,15 @@ impl EppStandaloneConfig {
 }
 
 fn validate_vllm_render_url(value: &str) -> Result<(), ValidationError> {
-    let valid_url = reqwest::Url::parse(value)
-        .map(|url| matches!(url.scheme(), "http" | "https") && url.host_str().is_some())
-        .unwrap_or(false);
-    if valid_url {
-        Ok(())
-    } else {
+    if value.is_empty() {
+        return Ok(());
+    }
+
+    parse_vllm_render_base_url(value).map(|_| ()).map_err(|_| {
         let mut error = ValidationError::new("vllm_render_url_invalid");
         error.message = Some("DYN_EPP_VLLM_RENDER_URL must be an absolute HTTP(S) URL".into());
-        Err(error)
-    }
+        error
+    })
 }
 
 /// Trim a raw value and treat empty as absent.

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -18,8 +18,10 @@ pub mod epp_standalone_config;
 pub mod picker;
 pub mod proto;
 pub mod server;
+pub mod vllm_render_client;
 
 pub use epp::Router;
 pub use epp_standalone_config::{EppMode, EppStandaloneConfig};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;
+pub use vllm_render_client::{VllmRenderClient, VllmRenderError};

--- a/deploy/inference-gateway/ext-proc/src/lib.rs
+++ b/deploy/inference-gateway/ext-proc/src/lib.rs
@@ -21,7 +21,7 @@ pub mod server;
 pub mod vllm_render_client;
 
 pub use epp::Router;
-pub use epp_standalone_config::{EppMode, EppStandaloneConfig};
+pub use epp_standalone_config::{EppMode, EppStandaloneConfig, TokenizerProtocol};
 pub use picker::{Endpoint, EndpointPicker, PickResult, RequestInfo};
 pub use server::ExtProcServer;
 pub use vllm_render_client::{VllmRenderClient, VllmRenderError};

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -1,0 +1,300 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! HTTP client for vLLM's chat render endpoint.
+//!
+//! The client is intentionally limited to protocol handling. Callers decide how
+//! a render failure affects request routing.
+
+use std::time::Duration;
+
+use anyhow::Context;
+use futures::StreamExt;
+use reqwest::header::CONTENT_TYPE;
+use reqwest::{Client, StatusCode, Url};
+use serde::Deserialize;
+use thiserror::Error;
+
+const CHAT_RENDER_PATH: &str = "/v1/chat/completions/render";
+const MAX_ERROR_BODY_BYTES: usize = 1024;
+
+/// Default deadline for a vLLM render request.
+pub const DEFAULT_VLLM_RENDER_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// A reusable client for vLLM's `/v1/chat/completions/render` endpoint.
+#[derive(Clone, Debug)]
+pub struct VllmRenderClient {
+    client: Client,
+    endpoint: Url,
+    timeout: Duration,
+}
+
+/// Failures returned by [`VllmRenderClient::render_chat`].
+#[derive(Debug, Error)]
+pub enum VllmRenderError {
+    /// The renderer could not be reached or the connection failed.
+    #[error("vLLM renderer is unavailable: {source}")]
+    Unavailable {
+        #[source]
+        source: reqwest::Error,
+    },
+    /// The renderer did not complete the request before the configured deadline.
+    #[error("vLLM render request timed out after {timeout:?}: {source}")]
+    Timeout {
+        timeout: Duration,
+        #[source]
+        source: reqwest::Error,
+    },
+    /// The renderer returned an HTTP error response.
+    #[error("vLLM renderer returned {status}: {body}")]
+    UpstreamStatus { status: StatusCode, body: String },
+    /// The renderer returned a successful response that did not match its contract.
+    #[error("vLLM renderer returned an invalid response: {source}")]
+    InvalidResponse {
+        #[source]
+        source: serde_json::Error,
+    },
+}
+
+#[derive(Debug, Deserialize)]
+struct VllmRenderResponse {
+    token_ids: Vec<u32>,
+}
+
+impl VllmRenderClient {
+    /// Build a pooled HTTP client from the vLLM renderer's base URL.
+    ///
+    /// The base URL selects either a local sidecar (for example,
+    /// `http://127.0.0.1:8000`) or an external Service. The vLLM-specific chat
+    /// render path is appended by this client.
+    pub fn new(base_url: &str, timeout: Duration) -> anyhow::Result<Self> {
+        anyhow::ensure!(
+            !timeout.is_zero(),
+            "vLLM render timeout must be greater than zero"
+        );
+
+        let mut endpoint = Url::parse(base_url)
+            .with_context(|| format!("invalid vLLM renderer base URL {base_url:?}"))?;
+        anyhow::ensure!(
+            matches!(endpoint.scheme(), "http" | "https") && endpoint.host_str().is_some(),
+            "vLLM renderer base URL must be an absolute HTTP(S) URL"
+        );
+        endpoint.set_path(CHAT_RENDER_PATH);
+        endpoint.set_query(None);
+        endpoint.set_fragment(None);
+
+        let client = Client::builder()
+            .timeout(timeout)
+            .build()
+            .context("building vLLM renderer HTTP client")?;
+
+        Ok(Self {
+            client,
+            endpoint,
+            timeout,
+        })
+    }
+
+    /// Forward an OpenAI chat-completions JSON body and return its prompt tokens.
+    ///
+    /// The body is sent unchanged so vLLM remains responsible for validating
+    /// engine-specific request fields and applying the chat template.
+    pub async fn render_chat(&self, request_body: &[u8]) -> Result<Vec<u32>, VllmRenderError> {
+        let response = self
+            .client
+            .post(self.endpoint.clone())
+            .header(CONTENT_TYPE, "application/json")
+            .body(request_body.to_vec())
+            .send()
+            .await
+            .map_err(|source| self.classify_transport_error(source))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            return Err(VllmRenderError::UpstreamStatus {
+                status,
+                body: read_error_body(response).await,
+            });
+        }
+
+        let body = response
+            .bytes()
+            .await
+            .map_err(|source| self.classify_transport_error(source))?;
+        let response: VllmRenderResponse = serde_json::from_slice(&body)
+            .map_err(|source| VllmRenderError::InvalidResponse { source })?;
+
+        Ok(response.token_ids)
+    }
+
+    fn classify_transport_error(&self, source: reqwest::Error) -> VllmRenderError {
+        if source.is_timeout() {
+            VllmRenderError::Timeout {
+                timeout: self.timeout,
+                source,
+            }
+        } else {
+            VllmRenderError::Unavailable { source }
+        }
+    }
+}
+
+async fn read_error_body(response: reqwest::Response) -> String {
+    let mut body = Vec::new();
+    let mut stream = response.bytes_stream();
+
+    while body.len() < MAX_ERROR_BODY_BYTES {
+        let Some(chunk) = stream.next().await else {
+            break;
+        };
+        let Ok(chunk) = chunk else {
+            break;
+        };
+        let remaining = MAX_ERROR_BODY_BYTES - body.len();
+        body.extend_from_slice(&chunk[..chunk.len().min(remaining)]);
+    }
+
+    String::from_utf8_lossy(&body).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::body::Bytes;
+    use axum::routing::post;
+    use axum::{Json, Router};
+    use serde_json::json;
+    use tokio::net::TcpListener;
+    use tokio::sync::mpsc;
+    use tokio::task::JoinHandle;
+
+    use super::*;
+
+    async fn spawn_server(router: Router) -> (String, JoinHandle<()>) {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        (format!("http://{address}"), task)
+    }
+
+    #[tokio::test]
+    async fn forwards_body_to_chat_render_endpoint() {
+        let (body_tx, mut body_rx) = mpsc::unbounded_channel();
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(move |body: Bytes| {
+                let body_tx = body_tx.clone();
+                async move {
+                    body_tx.send(body).unwrap();
+                    Json(json!({
+                        "token_ids": [1, 2, 3],
+                        "features": {"ignored": true}
+                    }))
+                }
+            }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let client = VllmRenderClient::new(&base_url, DEFAULT_VLLM_RENDER_TIMEOUT).unwrap();
+        let request =
+            br#"{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hello"}]}"#;
+
+        let token_ids = client.render_chat(request).await.unwrap();
+
+        assert_eq!(token_ids, vec![1, 2, 3]);
+        assert_eq!(body_rx.recv().await.unwrap().as_ref(), request);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn classifies_timeout() {
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(|| async {
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                Json(json!({"token_ids": [1]}))
+            }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let timeout = Duration::from_millis(10);
+        let client = VllmRenderClient::new(&base_url, timeout).unwrap();
+
+        let error = client.render_chat(b"{}").await.unwrap_err();
+
+        assert!(matches!(
+            error,
+            VllmRenderError::Timeout {
+                timeout: actual,
+                ..
+            } if actual == timeout
+        ));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn classifies_unavailable_renderer() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let client =
+            VllmRenderClient::new(&format!("http://{address}"), DEFAULT_VLLM_RENDER_TIMEOUT)
+                .unwrap();
+
+        let error = client.render_chat(b"{}").await.unwrap_err();
+
+        assert!(matches!(error, VllmRenderError::Unavailable { .. }));
+    }
+
+    #[tokio::test]
+    async fn classifies_upstream_status_and_bounds_body() {
+        let response_body = Arc::new("x".repeat(MAX_ERROR_BODY_BYTES * 2));
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(move || {
+                let response_body = response_body.clone();
+                async move {
+                    (
+                        StatusCode::SERVICE_UNAVAILABLE,
+                        response_body.as_str().to_owned(),
+                    )
+                }
+            }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let client = VllmRenderClient::new(&base_url, DEFAULT_VLLM_RENDER_TIMEOUT).unwrap();
+
+        let error = client.render_chat(b"{}").await.unwrap_err();
+
+        match error {
+            VllmRenderError::UpstreamStatus { status, body } => {
+                assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+                assert_eq!(body.len(), MAX_ERROR_BODY_BYTES);
+            }
+            other => panic!("expected upstream status error, got {other:?}"),
+        }
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn classifies_invalid_success_response() {
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(|| async { Json(json!({"prompt": "missing token_ids"})) }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let client = VllmRenderClient::new(&base_url, DEFAULT_VLLM_RENDER_TIMEOUT).unwrap();
+
+        let error = client.render_chat(b"{}").await.unwrap_err();
+
+        assert!(matches!(error, VllmRenderError::InvalidResponse { .. }));
+        server.abort();
+    }
+
+    #[test]
+    fn rejects_invalid_client_config() {
+        assert!(VllmRenderClient::new("unix:///tmp/vllm.sock", Duration::from_secs(1)).is_err());
+        assert!(VllmRenderClient::new("http://127.0.0.1:8000", Duration::ZERO).is_err());
+    }
+}

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -76,7 +76,13 @@ impl VllmRenderClient {
             matches!(endpoint.scheme(), "http" | "https") && endpoint.host_str().is_some(),
             "vLLM renderer base URL must be an absolute HTTP(S) URL"
         );
-        endpoint.set_path(CHAT_RENDER_PATH);
+        {
+            let mut path_segments = endpoint.path_segments_mut().map_err(|_| {
+                anyhow::anyhow!("vLLM renderer base URL cannot be used as a base URL")
+            })?;
+            path_segments.pop_if_empty();
+            path_segments.extend(CHAT_RENDER_PATH.trim_start_matches('/').split('/'));
+        }
         endpoint.set_query(None);
         endpoint.set_fragment(None);
 
@@ -204,6 +210,24 @@ mod tests {
 
         assert_eq!(token_ids, vec![1, 2, 3]);
         assert_eq!(body_rx.recv().await.unwrap().as_ref(), request);
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn preserves_base_url_path_prefix() {
+        const PREFIXED_CHAT_RENDER_PATH: &str = "/gateway/vllm/v1/chat/completions/render";
+
+        let router = Router::new().route(
+            PREFIXED_CHAT_RENDER_PATH,
+            post(|| async { Json(json!({"token_ids": [4, 5]})) }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let client =
+            VllmRenderClient::new(&format!("{base_url}/gateway/vllm/"), TEST_TIMEOUT).unwrap();
+
+        let token_ids = client.render_chat(b"{}").await.unwrap();
+
+        assert_eq!(token_ids, vec![4, 5]);
         server.abort();
     }
 

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -18,9 +18,6 @@ use thiserror::Error;
 const CHAT_RENDER_PATH: &str = "/v1/chat/completions/render";
 const MAX_ERROR_BODY_BYTES: usize = 1024;
 
-/// Default deadline for a vLLM render request.
-pub const DEFAULT_VLLM_RENDER_TIMEOUT: Duration = Duration::from_secs(5);
-
 /// A reusable client for vLLM's `/v1/chat/completions/render` endpoint.
 #[derive(Clone, Debug)]
 pub struct VllmRenderClient {
@@ -171,6 +168,8 @@ mod tests {
 
     use super::*;
 
+    const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+
     async fn spawn_server(router: Router) -> (String, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
@@ -197,7 +196,7 @@ mod tests {
             }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client = VllmRenderClient::new(&base_url, DEFAULT_VLLM_RENDER_TIMEOUT).unwrap();
+        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT).unwrap();
         let request =
             br#"{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hello"}]}"#;
 
@@ -238,9 +237,7 @@ mod tests {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
         drop(listener);
-        let client =
-            VllmRenderClient::new(&format!("http://{address}"), DEFAULT_VLLM_RENDER_TIMEOUT)
-                .unwrap();
+        let client = VllmRenderClient::new(&format!("http://{address}"), TEST_TIMEOUT).unwrap();
 
         let error = client.render_chat(b"{}").await.unwrap_err();
 
@@ -263,7 +260,7 @@ mod tests {
             }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client = VllmRenderClient::new(&base_url, DEFAULT_VLLM_RENDER_TIMEOUT).unwrap();
+        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT).unwrap();
 
         let error = client.render_chat(b"{}").await.unwrap_err();
 
@@ -284,7 +281,7 @@ mod tests {
             post(|| async { Json(json!({"prompt": "missing token_ids"})) }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client = VllmRenderClient::new(&base_url, DEFAULT_VLLM_RENDER_TIMEOUT).unwrap();
+        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT).unwrap();
 
         let error = client.render_chat(b"{}").await.unwrap_err();
 

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -444,7 +444,9 @@ mod tests {
             VllmRenderError::ResponseTooLarge {
                 limit: actual_limit,
                 received,
-            } if actual_limit == limit && received == (FIRST_CHUNK.len() + SECOND_CHUNK.len()) as u64
+            } if actual_limit == limit
+                && received > limit as u64
+                && received <= (FIRST_CHUNK.len() + SECOND_CHUNK.len()) as u64
         ));
         server.abort();
     }

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -9,6 +9,7 @@
 use std::time::Duration;
 
 use anyhow::Context;
+use bytes::Bytes;
 use futures::StreamExt;
 use reqwest::header::CONTENT_TYPE;
 use reqwest::{Client, StatusCode, Url};
@@ -24,6 +25,7 @@ pub struct VllmRenderClient {
     client: Client,
     endpoint: Url,
     timeout: Duration,
+    max_response_bytes: usize,
 }
 
 /// Failures returned by [`VllmRenderClient::render_chat`].
@@ -51,6 +53,9 @@ pub enum VllmRenderError {
         #[source]
         source: serde_json::Error,
     },
+    /// The renderer returned a successful response larger than the configured limit.
+    #[error("vLLM renderer response is too large: {received} bytes exceeds the {limit}-byte limit")]
+    ResponseTooLarge { limit: usize, received: u64 },
 }
 
 #[derive(Debug, Deserialize)]
@@ -75,10 +80,18 @@ impl VllmRenderClient {
     /// The base URL selects either a local sidecar (for example,
     /// `http://127.0.0.1:8000`) or an external Service. The vLLM-specific chat
     /// render path is appended by this client.
-    pub fn new(base_url: &str, timeout: Duration) -> anyhow::Result<Self> {
+    pub fn new(
+        base_url: &str,
+        timeout: Duration,
+        max_response_bytes: usize,
+    ) -> anyhow::Result<Self> {
         anyhow::ensure!(
             !timeout.is_zero(),
             "vLLM render timeout must be greater than zero"
+        );
+        anyhow::ensure!(
+            max_response_bytes > 0,
+            "vLLM render maximum response bytes must be greater than zero"
         );
 
         let mut endpoint = parse_vllm_render_base_url(base_url)?;
@@ -101,6 +114,7 @@ impl VllmRenderClient {
             client,
             endpoint,
             timeout,
+            max_response_bytes,
         })
     }
 
@@ -108,12 +122,12 @@ impl VllmRenderClient {
     ///
     /// The body is sent unchanged so vLLM remains responsible for validating
     /// engine-specific request fields and applying the chat template.
-    pub async fn render_chat(&self, request_body: &[u8]) -> Result<Vec<u32>, VllmRenderError> {
+    pub async fn render_chat(&self, request_body: Bytes) -> Result<Vec<u32>, VllmRenderError> {
         let response = self
             .client
             .post(self.endpoint.clone())
             .header(CONTENT_TYPE, "application/json")
-            .body(request_body.to_vec())
+            .body(request_body)
             .send()
             .await
             .map_err(|source| self.classify_transport_error(source))?;
@@ -126,14 +140,43 @@ impl VllmRenderClient {
             });
         }
 
-        let body = response
-            .bytes()
-            .await
-            .map_err(|source| self.classify_transport_error(source))?;
+        match response.content_length() {
+            Some(received) if received > self.max_response_bytes as u64 => {
+                return Err(VllmRenderError::ResponseTooLarge {
+                    limit: self.max_response_bytes,
+                    received,
+                });
+            }
+            _ => {}
+        }
+
+        let body = self.read_success_body(response).await?;
         let response: VllmRenderResponse = serde_json::from_slice(&body)
             .map_err(|source| VllmRenderError::InvalidResponse { source })?;
 
         Ok(response.token_ids)
+    }
+
+    async fn read_success_body(
+        &self,
+        response: reqwest::Response,
+    ) -> Result<Vec<u8>, VllmRenderError> {
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk.map_err(|source| self.classify_transport_error(source))?;
+            let received = body.len().saturating_add(chunk.len());
+            if received > self.max_response_bytes {
+                return Err(VllmRenderError::ResponseTooLarge {
+                    limit: self.max_response_bytes,
+                    received: received as u64,
+                });
+            }
+            body.extend_from_slice(&chunk);
+        }
+
+        Ok(body)
     }
 
     fn classify_transport_error(&self, source: reqwest::Error) -> VllmRenderError {
@@ -168,11 +211,15 @@ async fn read_error_body(response: reqwest::Response) -> String {
 
 #[cfg(test)]
 mod tests {
+    use std::convert::Infallible;
     use std::sync::Arc;
 
-    use axum::body::Bytes;
+    use axum::body::{Body, Bytes};
+    use axum::http::HeaderMap;
+    use axum::response::Response;
     use axum::routing::post;
     use axum::{Json, Router};
+    use futures::stream;
     use serde_json::json;
     use tokio::net::TcpListener;
     use tokio::sync::mpsc;
@@ -181,6 +228,7 @@ mod tests {
     use super::*;
 
     const TEST_TIMEOUT: Duration = Duration::from_secs(5);
+    const TEST_MAX_RESPONSE_BYTES: usize = 1024;
 
     async fn spawn_server(router: Router) -> (String, JoinHandle<()>) {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -193,13 +241,13 @@ mod tests {
 
     #[tokio::test]
     async fn forwards_body_to_chat_render_endpoint() {
-        let (body_tx, mut body_rx) = mpsc::unbounded_channel();
+        let (request_tx, mut request_rx) = mpsc::unbounded_channel();
         let router = Router::new().route(
             CHAT_RENDER_PATH,
-            post(move |body: Bytes| {
-                let body_tx = body_tx.clone();
+            post(move |headers: HeaderMap, body: Bytes| {
+                let request_tx = request_tx.clone();
                 async move {
-                    body_tx.send(body).unwrap();
+                    request_tx.send((headers, body)).unwrap();
                     Json(json!({
                         "token_ids": [1, 2, 3],
                         "features": {"ignored": true}
@@ -208,14 +256,18 @@ mod tests {
             }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT).unwrap();
-        let request =
-            br#"{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hello"}]}"#;
+        let client =
+            VllmRenderClient::new(&base_url, TEST_TIMEOUT, TEST_MAX_RESPONSE_BYTES).unwrap();
+        let request = Bytes::from_static(
+            br#"{"model":"Qwen/Qwen3-0.6B","messages":[{"role":"user","content":"hello"}]}"#,
+        );
 
-        let token_ids = client.render_chat(request).await.unwrap();
+        let token_ids = client.render_chat(request.clone()).await.unwrap();
 
         assert_eq!(token_ids, vec![1, 2, 3]);
-        assert_eq!(body_rx.recv().await.unwrap().as_ref(), request);
+        let (headers, body) = request_rx.recv().await.unwrap();
+        assert_eq!(body, request);
+        assert_eq!(headers.get(CONTENT_TYPE).unwrap(), "application/json");
         server.abort();
     }
 
@@ -228,10 +280,14 @@ mod tests {
             post(|| async { Json(json!({"token_ids": [4, 5]})) }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client =
-            VllmRenderClient::new(&format!("{base_url}/gateway/vllm/"), TEST_TIMEOUT).unwrap();
+        let client = VllmRenderClient::new(
+            &format!("{base_url}/gateway/vllm/"),
+            TEST_TIMEOUT,
+            TEST_MAX_RESPONSE_BYTES,
+        )
+        .unwrap();
 
-        let token_ids = client.render_chat(b"{}").await.unwrap();
+        let token_ids = client.render_chat(Bytes::from_static(b"{}")).await.unwrap();
 
         assert_eq!(token_ids, vec![4, 5]);
         server.abort();
@@ -248,9 +304,12 @@ mod tests {
         );
         let (base_url, server) = spawn_server(router).await;
         let timeout = Duration::from_millis(10);
-        let client = VllmRenderClient::new(&base_url, timeout).unwrap();
+        let client = VllmRenderClient::new(&base_url, timeout, TEST_MAX_RESPONSE_BYTES).unwrap();
 
-        let error = client.render_chat(b"{}").await.unwrap_err();
+        let error = client
+            .render_chat(Bytes::from_static(b"{}"))
+            .await
+            .unwrap_err();
 
         assert!(matches!(
             error,
@@ -266,12 +325,23 @@ mod tests {
     async fn classifies_unavailable_renderer() {
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
-        drop(listener);
-        let client = VllmRenderClient::new(&format!("http://{address}"), TEST_TIMEOUT).unwrap();
+        let server = tokio::spawn(async move {
+            let (_socket, _) = listener.accept().await.unwrap();
+        });
+        let client = VllmRenderClient::new(
+            &format!("http://{address}"),
+            TEST_TIMEOUT,
+            TEST_MAX_RESPONSE_BYTES,
+        )
+        .unwrap();
 
-        let error = client.render_chat(b"{}").await.unwrap_err();
+        let error = client
+            .render_chat(Bytes::from_static(b"{}"))
+            .await
+            .unwrap_err();
 
         assert!(matches!(error, VllmRenderError::Unavailable { .. }));
+        server.await.unwrap();
     }
 
     #[tokio::test]
@@ -290,9 +360,13 @@ mod tests {
             }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT).unwrap();
+        let client =
+            VllmRenderClient::new(&base_url, TEST_TIMEOUT, TEST_MAX_RESPONSE_BYTES).unwrap();
 
-        let error = client.render_chat(b"{}").await.unwrap_err();
+        let error = client
+            .render_chat(Bytes::from_static(b"{}"))
+            .await
+            .unwrap_err();
 
         match error {
             VllmRenderError::UpstreamStatus { status, body } => {
@@ -305,15 +379,108 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn rejects_declared_response_larger_than_limit() {
+        const RESPONSE_BODY: &[u8] = br#"{"token_ids":[1,2,3]}"#;
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(|| async {
+                Response::builder()
+                    .header(CONTENT_TYPE, "application/json")
+                    .header("content-length", RESPONSE_BODY.len())
+                    .body(Body::from(RESPONSE_BODY))
+                    .unwrap()
+            }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let limit = RESPONSE_BODY.len() - 1;
+        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT, limit).unwrap();
+
+        let error = client
+            .render_chat(Bytes::from_static(b"{}"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            VllmRenderError::ResponseTooLarge {
+                limit: actual_limit,
+                received,
+            } if actual_limit == limit && received == RESPONSE_BODY.len() as u64
+        ));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn rejects_chunked_response_larger_than_limit() {
+        const FIRST_CHUNK: &[u8] = br#"{"token_ids"#;
+        const SECOND_CHUNK: &[u8] = br#":[1,2,3]}"#;
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(|| async {
+                Response::builder()
+                    .header(CONTENT_TYPE, "application/json")
+                    .body(Body::from_stream(stream::iter(vec![
+                        Ok::<Bytes, Infallible>(Bytes::from_static(FIRST_CHUNK)),
+                        Ok::<Bytes, Infallible>(Bytes::from_static(SECOND_CHUNK)),
+                    ])))
+                    .unwrap()
+            }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let limit = FIRST_CHUNK.len();
+        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT, limit).unwrap();
+
+        let error = client
+            .render_chat(Bytes::from_static(b"{}"))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(
+            error,
+            VllmRenderError::ResponseTooLarge {
+                limit: actual_limit,
+                received,
+            } if actual_limit == limit && received == (FIRST_CHUNK.len() + SECOND_CHUNK.len()) as u64
+        ));
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn accepts_response_at_limit() {
+        const RESPONSE_BODY: &[u8] = br#"{"token_ids":[1,2,3]}"#;
+        let router = Router::new().route(
+            CHAT_RENDER_PATH,
+            post(|| async {
+                Response::builder()
+                    .header(CONTENT_TYPE, "application/json")
+                    .header("content-length", RESPONSE_BODY.len())
+                    .body(Body::from(RESPONSE_BODY))
+                    .unwrap()
+            }),
+        );
+        let (base_url, server) = spawn_server(router).await;
+        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT, RESPONSE_BODY.len()).unwrap();
+
+        let token_ids = client.render_chat(Bytes::from_static(b"{}")).await.unwrap();
+
+        assert_eq!(token_ids, vec![1, 2, 3]);
+        server.abort();
+    }
+
+    #[tokio::test]
     async fn classifies_invalid_success_response() {
         let router = Router::new().route(
             CHAT_RENDER_PATH,
             post(|| async { Json(json!({"prompt": "missing token_ids"})) }),
         );
         let (base_url, server) = spawn_server(router).await;
-        let client = VllmRenderClient::new(&base_url, TEST_TIMEOUT).unwrap();
+        let client =
+            VllmRenderClient::new(&base_url, TEST_TIMEOUT, TEST_MAX_RESPONSE_BYTES).unwrap();
 
-        let error = client.render_chat(b"{}").await.unwrap_err();
+        let error = client
+            .render_chat(Bytes::from_static(b"{}"))
+            .await
+            .unwrap_err();
 
         assert!(matches!(error, VllmRenderError::InvalidResponse { .. }));
         server.abort();
@@ -321,7 +488,22 @@ mod tests {
 
     #[test]
     fn rejects_invalid_client_config() {
-        assert!(VllmRenderClient::new("unix:///tmp/vllm.sock", Duration::from_secs(1)).is_err());
-        assert!(VllmRenderClient::new("http://127.0.0.1:8000", Duration::ZERO).is_err());
+        assert!(
+            VllmRenderClient::new(
+                "unix:///tmp/vllm.sock",
+                Duration::from_secs(1),
+                TEST_MAX_RESPONSE_BYTES
+            )
+            .is_err()
+        );
+        assert!(
+            VllmRenderClient::new(
+                "http://127.0.0.1:8000",
+                Duration::ZERO,
+                TEST_MAX_RESPONSE_BYTES
+            )
+            .is_err()
+        );
+        assert!(VllmRenderClient::new("http://127.0.0.1:8000", TEST_TIMEOUT, 0).is_err());
     }
 }

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -58,6 +58,17 @@ struct VllmRenderResponse {
     token_ids: Vec<u32>,
 }
 
+/// Parse and validate a vLLM renderer base URL.
+pub(crate) fn parse_vllm_render_base_url(base_url: &str) -> anyhow::Result<Url> {
+    let url = Url::parse(base_url)
+        .with_context(|| format!("invalid vLLM renderer base URL {base_url:?}"))?;
+    anyhow::ensure!(
+        matches!(url.scheme(), "http" | "https") && url.host_str().is_some(),
+        "vLLM renderer base URL must be an absolute HTTP(S) URL"
+    );
+    Ok(url)
+}
+
 impl VllmRenderClient {
     /// Build a pooled HTTP client from the vLLM renderer's base URL.
     ///
@@ -70,12 +81,7 @@ impl VllmRenderClient {
             "vLLM render timeout must be greater than zero"
         );
 
-        let mut endpoint = Url::parse(base_url)
-            .with_context(|| format!("invalid vLLM renderer base URL {base_url:?}"))?;
-        anyhow::ensure!(
-            matches!(endpoint.scheme(), "http" | "https") && endpoint.host_str().is_some(),
-            "vLLM renderer base URL must be an absolute HTTP(S) URL"
-        );
+        let mut endpoint = parse_vllm_render_base_url(base_url)?;
         {
             let mut path_segments = endpoint.path_segments_mut().map_err(|_| {
                 anyhow::anyhow!("vLLM renderer base URL cannot be used as a base URL")

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -67,13 +67,13 @@ struct VllmRenderResponse {
     token_ids: Vec<u32>,
 }
 
-/// Parse and validate a vLLM renderer base URL.
-pub(crate) fn parse_vllm_render_base_url(base_url: &str) -> anyhow::Result<Url> {
+/// Parse and validate a tokenizer service base URL.
+pub(crate) fn parse_tokenizer_service_base_url(base_url: &str) -> anyhow::Result<Url> {
     let url = Url::parse(base_url)
-        .with_context(|| format!("invalid vLLM renderer base URL {base_url:?}"))?;
+        .with_context(|| format!("invalid tokenizer service base URL {base_url:?}"))?;
     anyhow::ensure!(
         matches!(url.scheme(), "http" | "https") && url.host_str().is_some(),
-        "vLLM renderer base URL must be an absolute HTTP(S) URL"
+        "tokenizer service base URL must be an absolute HTTP(S) URL"
     );
     Ok(url)
 }
@@ -98,7 +98,7 @@ impl VllmRenderClient {
             "vLLM render maximum response bytes must be greater than zero"
         );
 
-        let mut endpoint = parse_vllm_render_base_url(base_url)?;
+        let mut endpoint = parse_tokenizer_service_base_url(base_url)?;
         {
             let mut path_segments = endpoint.path_segments_mut().map_err(|_| {
                 anyhow::anyhow!("vLLM renderer base URL cannot be used as a base URL")

--- a/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
+++ b/deploy/inference-gateway/ext-proc/src/vllm_render_client.rs
@@ -5,6 +5,10 @@
 //!
 //! The client is intentionally limited to protocol handling. Callers decide how
 //! a render failure affects request routing.
+//!
+//! The client sends no `Authorization` header, so it targets unauthenticated
+//! in-cluster renderers (a sidecar or an internal Service). Authenticated
+//! renderers (vLLM `--api-key` / `VLLM_API_KEY`) are a follow-up.
 
 use std::time::Duration;
 


### PR DESCRIPTION
## Summary

- replace the offline tokenizer approach proposed in #11071 with a pooled HTTP client for vLLM's `/v1/chat/completions/render` endpoint
- add explicit standalone configuration through `DYN_EPP_VLLM_RENDER_URL` and the provider-neutral `DYN_EPP_TOKENIZATION_TIMEOUT_MS` (5-second default)
- classify renderer failures as typed `Unavailable`, `Timeout`, `UpstreamStatus`, or `InvalidResponse` errors
- forward the original OpenAI chat-completions JSON body unchanged and parse only the `token_ids` needed for routing

## Scope

This PR is intentionally client/config plumbing only. It does not wire tokenization into endpoint selection and does not choose fallback or request-failure behavior; that policy belongs in the later request-path integration PR.

This PR supports vLLM Render only. SGLang tokenizer support remains a separate follow-up with its own protocol client; both providers can consume the shared tokenization timeout.

## PR train

- stacked on #11070
- intended to replace #11071 without modifying that PR
- aligns with milestone 1 in #11661 (standalone EPP, aggregated vLLM)

## Validation

- `cargo fmt -p dynamo-ext-proc -- --check`
- `cargo test -p dynamo-ext-proc` (28 unit tests + 1 integration test)
- `cargo clippy -p dynamo-ext-proc --no-deps --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for rendering chat requests through a vLLM tokenizer service.
  * Added configuration for the tokenizer service URL and request timeout.
  * Added validation to ensure the service URL and timeout settings are valid.
  * Added clear handling for service timeouts, unavailable services, upstream errors, and invalid responses.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->