### PR TITLE
refactor(operator): extract reconciler setup functions

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -69,8 +69,6 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
-	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/namespace_scope"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/rbac"
@@ -586,14 +584,16 @@ func registerControllers(
 	operatorImage string,
 	operatorPullPolicy corev1.PullPolicy,
 ) error {
-	if err := (&controller.DynamoComponentDeploymentReconciler{
-		Client:                mgr.GetClient(),
-		Recorder:              mgr.GetEventRecorderFor("dynamocomponentdeployment"),
-		Config:                operatorCfg,
-		RuntimeConfig:         runtimeConfig,
+	setupOptions := controller.SetupOptions{
+		Config:        operatorCfg,
+		RuntimeConfig: runtimeConfig,
+	}
+
+	if err := controller.SetupDynamoComponentDeployment(mgr, controller.DynamoComponentDeploymentSetupOptions{
+		SetupOptions:          setupOptions,
 		DockerSecretRetriever: dockerSecretRetriever,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoComponentDeployment controller: %w", err)
+	}); err != nil {
+		return err
 	}
 
 	scaleClient, err := createScalesGetter(mgr)
@@ -603,90 +603,45 @@ func registerControllers(
 
 	rbacManager := rbac.NewManager(mgr.GetClient())
 
-	if err = (&controller.DynamoGraphDeploymentReconciler{
-		Client:                mgr.GetClient(),
-		Recorder:              mgr.GetEventRecorderFor("dynamographdeployment"),
-		Config:                operatorCfg,
-		RuntimeConfig:         runtimeConfig,
-		RestConfig:            mgr.GetConfig(),
+	if err := controller.SetupDynamoGraphDeployment(mgr, controller.DynamoGraphDeploymentSetupOptions{
+		SetupOptions:          setupOptions,
 		DockerSecretRetriever: dockerSecretRetriever,
 		ScaleClient:           scaleClient,
-		SSHKeyManager:         sshKeyManager,
 		RBACManager:           rbacManager,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoGraphDeployment controller: %w", err)
+		SSHKeyManager:         sshKeyManager,
+	}); err != nil {
+		return err
 	}
-
-	if err = (&controller.DynamoGraphDeploymentScalingAdapterReconciler{
-		Client:        mgr.GetClient(),
-		Scheme:        mgr.GetScheme(),
-		Recorder:      mgr.GetEventRecorderFor("dgdscalingadapter"),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DGDScalingAdapter controller: %w", err)
+	if err := controller.SetupDynamoGraphDeploymentScalingAdapter(mgr, setupOptions); err != nil {
+		return err
 	}
-
-	if err = (&controller.DynamoGraphDeploymentRequestReconciler{
-		Client:                  mgr.GetClient(),
-		APIReader:               mgr.GetAPIReader(),
-		Recorder:                mgr.GetEventRecorderFor("dynamographdeploymentrequest"),
-		Config:                  operatorCfg,
-		RuntimeConfig:           runtimeConfig,
-		GPUDiscoveryCache:       gpu.NewGPUDiscoveryCache(),
-		GPUDiscovery:            gpu.NewGPUDiscovery(gpu.ScrapeMetricsEndpoint),
+	if err := controller.SetupDynamoGraphDeploymentRequest(mgr, controller.DynamoGraphDeploymentRequestSetupOptions{
+		SetupOptions:            setupOptions,
+		RBACManager:             rbacManager,
 		OperatorImage:           operatorImage,
 		OperatorImagePullPolicy: operatorPullPolicy,
-		RBACManager:             rbacManager,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoGraphDeploymentRequest controller: %w", err)
+	}); err != nil {
+		return err
 	}
-
-	if err = (&controller.DynamoModelReconciler{
-		Client:         mgr.GetClient(),
-		Recorder:       mgr.GetEventRecorderFor("dynamomodel"),
-		EndpointClient: modelendpoint.NewClient(),
-		Config:         operatorCfg,
-		RuntimeConfig:  runtimeConfig,
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoModel controller: %w", err)
+	if err := controller.SetupDynamoModel(mgr, controller.DynamoModelSetupOptions{
+		SetupOptions: setupOptions,
+	}); err != nil {
+		return err
 	}
-
-	if err = (&controller.CheckpointReconciler{
-		Client:        mgr.GetClient(),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-		Recorder:      mgr.GetEventRecorderFor("checkpoint"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create DynamoCheckpoint controller: %w", err)
+	if err := controller.SetupDynamoCheckpoint(mgr, setupOptions); err != nil {
+		return err
 	}
-
-	if err = (&controller.PodSnapshotReconciler{
-		Client:        mgr.GetClient(),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-		Recorder:      mgr.GetEventRecorderFor("snapshot"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create PodSnapshot controller: %w", err)
+	if err := controller.SetupPodSnapshot(mgr, setupOptions); err != nil {
+		return err
 	}
 
 	if runtimeConfig.Gate.Enabled(features.Grove) {
-		if err = controller.NewFailoverCascadeReconciler(
-			mgr.GetClient(),
-			mgr.GetEventRecorderFor("gms-failover-cascade"),
-		).SetupWithManager(mgr); err != nil {
-			return fmt.Errorf("unable to create GMS FailoverCascade controller: %w", err)
+		if err := controller.SetupFailoverCascade(mgr); err != nil {
+			return err
 		}
 	}
-
-	if err = (&controller.TopologyLabelReconciler{
-		Client:        mgr.GetClient(),
-		NodeReader:    mgr.GetAPIReader(),
-		Config:        operatorCfg,
-		RuntimeConfig: runtimeConfig,
-		Recorder:      mgr.GetEventRecorderFor("topology-label"),
-	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create TopologyLabel controller: %w", err)
+	if err := controller.SetupTopologyLabel(mgr, setupOptions); err != nil {
+		return err
 	}
 
 	setupLog.Info("Controllers registered successfully")

--- a/deploy/operator/internal/controller/common.go
+++ b/deploy/operator/internal/controller/common.go
@@ -50,10 +50,12 @@ func getPvcName(crd metav1.Object, defaultName *string) string {
 	return crd.GetName()
 }
 
-type dockerSecretRetriever interface {
+type DockerSecretRetriever interface {
 	// returns a list of secret names associated with the docker registry
 	GetSecrets(namespace, registry string) ([]string, error)
 }
+
+type dockerSecretRetriever = DockerSecretRetriever
 
 // getComponentNames returns the component names for logging purposes.
 func getComponentNames(components []v1beta1.DynamoComponentDeploymentSharedSpec) []string {

--- a/deploy/operator/internal/controller/setup.go
+++ b/deploy/operator/internal/controller/setup.go
@@ -1,0 +1,193 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package controller
+
+import (
+	"fmt"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/gpu"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/scale"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type SetupOptions struct {
+	Config        *configv1alpha1.OperatorConfiguration
+	RuntimeConfig *commoncontroller.RuntimeConfig
+}
+
+type DynamoComponentDeploymentSetupOptions struct {
+	SetupOptions
+	DockerSecretRetriever DockerSecretRetriever
+}
+
+type DynamoGraphDeploymentSetupOptions struct {
+	SetupOptions
+	DockerSecretRetriever DockerSecretRetriever
+	ScaleClient           scale.ScalesGetter
+	RBACManager           RBACManager
+	SSHKeyManager         *secret.SSHKeyManager
+}
+
+type DynamoGraphDeploymentRequestSetupOptions struct {
+	SetupOptions
+	RBACManager             RBACManager
+	GPUDiscoveryCache       *gpu.GPUDiscoveryCache
+	GPUDiscovery            *gpu.GPUDiscovery
+	OperatorImage           string
+	OperatorImagePullPolicy corev1.PullPolicy
+}
+
+type DynamoModelSetupOptions struct {
+	SetupOptions
+	ModelEndpointClient *modelendpoint.Client
+}
+
+func (o DynamoGraphDeploymentRequestSetupOptions) gpuDiscoveryCache() *gpu.GPUDiscoveryCache {
+	if o.GPUDiscoveryCache != nil {
+		return o.GPUDiscoveryCache
+	}
+	return gpu.NewGPUDiscoveryCache()
+}
+
+func (o DynamoGraphDeploymentRequestSetupOptions) gpuDiscovery() *gpu.GPUDiscovery {
+	if o.GPUDiscovery != nil {
+		return o.GPUDiscovery
+	}
+	return gpu.NewGPUDiscovery(gpu.ScrapeMetricsEndpoint)
+}
+
+func (o DynamoModelSetupOptions) modelEndpointClient() *modelendpoint.Client {
+	if o.ModelEndpointClient != nil {
+		return o.ModelEndpointClient
+	}
+	return modelendpoint.NewClient()
+}
+
+func SetupDynamoComponentDeployment(mgr ctrl.Manager, opts DynamoComponentDeploymentSetupOptions) error {
+	if err := (&DynamoComponentDeploymentReconciler{
+		Client:                mgr.GetClient(),
+		Recorder:              mgr.GetEventRecorderFor("dynamocomponentdeployment"),
+		Config:                opts.Config,
+		RuntimeConfig:         opts.RuntimeConfig,
+		DockerSecretRetriever: opts.DockerSecretRetriever,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create DynamoComponentDeployment controller: %w", err)
+	}
+	return nil
+}
+
+func SetupDynamoGraphDeployment(mgr ctrl.Manager, opts DynamoGraphDeploymentSetupOptions) error {
+	if err := (&DynamoGraphDeploymentReconciler{
+		Client:                mgr.GetClient(),
+		Recorder:              mgr.GetEventRecorderFor("dynamographdeployment"),
+		Config:                opts.Config,
+		RuntimeConfig:         opts.RuntimeConfig,
+		RestConfig:            mgr.GetConfig(),
+		DockerSecretRetriever: opts.DockerSecretRetriever,
+		ScaleClient:           opts.ScaleClient,
+		SSHKeyManager:         opts.SSHKeyManager,
+		RBACManager:           opts.RBACManager,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create DynamoGraphDeployment controller: %w", err)
+	}
+	return nil
+}
+
+func SetupDynamoGraphDeploymentScalingAdapter(mgr ctrl.Manager, opts SetupOptions) error {
+	if err := (&DynamoGraphDeploymentScalingAdapterReconciler{
+		Client:        mgr.GetClient(),
+		Scheme:        mgr.GetScheme(),
+		Recorder:      mgr.GetEventRecorderFor("dgdscalingadapter"),
+		Config:        opts.Config,
+		RuntimeConfig: opts.RuntimeConfig,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create DGDScalingAdapter controller: %w", err)
+	}
+	return nil
+}
+
+func SetupDynamoGraphDeploymentRequest(mgr ctrl.Manager, opts DynamoGraphDeploymentRequestSetupOptions) error {
+	if err := (&DynamoGraphDeploymentRequestReconciler{
+		Client:                  mgr.GetClient(),
+		APIReader:               mgr.GetAPIReader(),
+		Recorder:                mgr.GetEventRecorderFor("dynamographdeploymentrequest"),
+		Config:                  opts.Config,
+		RuntimeConfig:           opts.RuntimeConfig,
+		GPUDiscoveryCache:       opts.gpuDiscoveryCache(),
+		GPUDiscovery:            opts.gpuDiscovery(),
+		OperatorImage:           opts.OperatorImage,
+		OperatorImagePullPolicy: opts.OperatorImagePullPolicy,
+		RBACManager:             opts.RBACManager,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create DynamoGraphDeploymentRequest controller: %w", err)
+	}
+	return nil
+}
+
+func SetupDynamoModel(mgr ctrl.Manager, opts DynamoModelSetupOptions) error {
+	if err := (&DynamoModelReconciler{
+		Client:         mgr.GetClient(),
+		Recorder:       mgr.GetEventRecorderFor("dynamomodel"),
+		EndpointClient: opts.modelEndpointClient(),
+		Config:         opts.Config,
+		RuntimeConfig:  opts.RuntimeConfig,
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create DynamoModel controller: %w", err)
+	}
+	return nil
+}
+
+func SetupDynamoCheckpoint(mgr ctrl.Manager, opts SetupOptions) error {
+	if err := (&CheckpointReconciler{
+		Client:        mgr.GetClient(),
+		Config:        opts.Config,
+		RuntimeConfig: opts.RuntimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("checkpoint"),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create DynamoCheckpoint controller: %w", err)
+	}
+	return nil
+}
+
+func SetupPodSnapshot(mgr ctrl.Manager, opts SetupOptions) error {
+	if err := (&PodSnapshotReconciler{
+		Client:        mgr.GetClient(),
+		Config:        opts.Config,
+		RuntimeConfig: opts.RuntimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("snapshot"),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create PodSnapshot controller: %w", err)
+	}
+	return nil
+}
+
+func SetupFailoverCascade(mgr ctrl.Manager) error {
+	if err := NewFailoverCascadeReconciler(
+		mgr.GetClient(),
+		mgr.GetEventRecorderFor("gms-failover-cascade"),
+	).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create GMS FailoverCascade controller: %w", err)
+	}
+	return nil
+}
+
+func SetupTopologyLabel(mgr ctrl.Manager, opts SetupOptions) error {
+	if err := (&TopologyLabelReconciler{
+		Client:        mgr.GetClient(),
+		NodeReader:    mgr.GetAPIReader(),
+		Config:        opts.Config,
+		RuntimeConfig: opts.RuntimeConfig,
+		Recorder:      mgr.GetEventRecorderFor("topology-label"),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create TopologyLabel controller: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Extract one reusable setup function per operator reconciler.
- Keep production dependency construction and controller registration order unchanged in `cmd/main.go`.
- Allow focused tests such as #11237 to start individual production-configured controllers without duplicating their wiring.

## Related Issues

- Linear: [DYN-3412](https://linear.app/nvidia/issue/DYN-3412)
- Follow-up: #11237
- [x] Confirmed - no related GitHub issue

## Validation

- `make test`
- `make lint`

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11828" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved operator startup and controller registration for more consistent initialization.
  * Standardized shared configuration and dependency setup across deployment, scaling, model, checkpoint, snapshot, failover, and topology features.
  * Preserved automatic handling for optional GPU discovery and model endpoint services.
* **Maintenance**
  * Exposed a reusable secret-retrieval contract for controller integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->