### PR TITLE
feat(trtllm): add TensorRT-LLM native gRPC sidecar backend

### DIFF
--- a/.github/codeowners/areas.yaml
+++ b/.github/codeowners/areas.yaml
@@ -84,6 +84,7 @@ areas:
   - components/src/dynamo/trtllm/utils/
   - components/src/dynamo/trtllm/workers/
   - examples/backends/trtllm/
+  - lib/sidecar/trtllm/
 - label: backend-sglang
   github_team: '@ai-dynamo/dynamo-backend-sglang-codeowners'
   path_globs:

--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -197,6 +197,7 @@ sglang:
   - 'examples/backends/sglang/**'
   - 'components/src/dynamo/sglang*/**'
   - 'lib/sidecar/sglang/**'
+  - 'lib/sidecar/trtllm/**'
   - 'container/templates/sglang_*'
   - 'container/deps/sglang/**'
   - '!**/*.md'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 default_install_hook_types: [pre-commit, commit-msg]
-exclude: ^(src/grpc_generated|.*\.patch$|.*/connect/.*\.py|components/src/dynamo/planner/plugins/proto/v1/plugin_pb2(_grpc)?\.pyi?$|lib/sidecar/vllm/proto/vllm_grpc\.proto$)
+exclude: ^(src/grpc_generated|.*\.patch$|.*/connect/.*\.py|components/src/dynamo/planner/plugins/proto/v1/plugin_pb2(_grpc)?\.pyi?$|lib/sidecar/vllm/proto/vllm_grpc\.proto$|lib/sidecar/trtllm/proto/trtllm_service\.proto$)
 repos:
 - repo: https://github.com/timothycrosley/isort
   rev: 5.12.0

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -84,6 +84,7 @@
 /components/src/dynamo/vllm/tests/                                           @ai-dynamo/dynamo-backend-vllm-codeowners
 
 # === backend-trtllm  (@ai-dynamo/dynamo-backend-trtllm-codeowners) ===
+/lib/sidecar/trtllm/                                                         @ai-dynamo/dynamo-backend-trtllm-codeowners
 /examples/backends/trtllm/                                                   @ai-dynamo/dynamo-backend-trtllm-codeowners
 /components/src/dynamo/trtllm/                                               @ai-dynamo/dynamo-backend-trtllm-codeowners
 /components/src/dynamo/trtllm/tests/                                         @ai-dynamo/dynamo-backend-trtllm-codeowners

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2906,6 +2906,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dynamo-trtllm-sidecar"
+version = "1.3.0"
+dependencies = [
+ "anyhow",
+ "async-stream",
+ "async-trait",
+ "clap",
+ "dynamo-backend-common",
+ "dynamo-sidecar-common",
+ "futures",
+ "prost 0.13.5",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
+ "tracing",
+]
+
+[[package]]
 name = "dynamo-truthy"
 version = "1.3.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ members = [
     "lib/sidecar/common",
     "lib/sidecar/vllm",
     "lib/sidecar/sglang",
+    "lib/sidecar/trtllm",
     "lib/bindings/c",
     "lib/bindings/python/codegen",
     "deploy/inference-gateway/ext-proc",

--- a/lib/sidecar/README.md
+++ b/lib/sidecar/README.md
@@ -7,6 +7,7 @@ runs in a separate process.
 ```text
 common/  Shared gRPC arguments, transport, and errors
 sglang/  SGLang sidecar
+trtllm/  TensorRT-LLM sidecar
 vllm/    vLLM sidecar
 ```
 

--- a/lib/sidecar/common/src/error.rs
+++ b/lib/sidecar/common/src/error.rs
@@ -29,6 +29,10 @@ pub fn cannot_connect(message: impl Into<String>) -> DynamoError {
     backend(BackendError::CannotConnect, message)
 }
 
+pub fn connection_timeout(message: impl Into<String>) -> DynamoError {
+    backend(BackendError::ConnectionTimeout, message)
+}
+
 pub fn status_to_dynamo(rpc: &str, status: tonic::Status) -> DynamoError {
     let kind = match status.code() {
         tonic::Code::InvalidArgument

--- a/lib/sidecar/common/src/lib.rs
+++ b/lib/sidecar/common/src/lib.rs
@@ -11,6 +11,7 @@ mod transport;
 pub use args::{GrpcTransportArgs, GrpcTransportConfig, SidecarArgs};
 pub use endpoint::GrpcEndpoint;
 pub use error::{
-    cannot_connect, engine_shutdown, invalid_argument, protocol_error, status_to_dynamo,
+    cannot_connect, connection_timeout, engine_shutdown, invalid_argument, protocol_error,
+    status_to_dynamo,
 };
 pub use transport::{DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool};

--- a/lib/sidecar/trtllm/Cargo.toml
+++ b/lib/sidecar/trtllm/Cargo.toml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+[package]
+name = "dynamo-trtllm-sidecar"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+description = "Dynamo TensorRT-LLM sidecar backend — drives an out-of-process TensorRT-LLM engine over its native gRPC service through the backend-common LLMEngine trait."
+
+[package.metadata.cargo-machete]
+# Referenced by the protobuf client generated into OUT_DIR at build time.
+ignored = ["prost"]
+
+[[bin]]
+name = "dynamo-trtllm-sidecar"
+path = "src/main.rs"
+
+[dependencies]
+dynamo-backend-common = { workspace = true }
+dynamo-sidecar-common = { workspace = true }
+
+anyhow = { workspace = true }
+async-stream = { workspace = true }
+async-trait = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+futures = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tokio-util = { workspace = true }
+tracing = { workspace = true }
+
+# tonic / prost are pinned per-crate (not workspace deps): tonic 0.13.1
+# depends on prost 0.13.5, matching `lib/llm` and the sglang sidecar.
+prost = { version = "0.13.5" }
+tonic = { version = "0.13.1" }
+
+[build-dependencies]
+tonic-build = { version = "0.13.1" }
+
+[dev-dependencies]
+dynamo-backend-common = { workspace = true, features = ["testing"] }
+tokio-stream = { workspace = true, features = ["net"] }

--- a/lib/sidecar/trtllm/README.md
+++ b/lib/sidecar/trtllm/README.md
@@ -1,0 +1,52 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# TensorRT-LLM sidecar
+
+`dynamo-trtllm-sidecar` connects a Dynamo worker to TensorRT-LLM's native
+`trtllm.TrtllmService` gRPC `Generate` service. It is a standalone Rust
+executable composed with `dynamo_backend_common::run`: TensorRT-LLM runs as its
+own process while the sidecar owns Dynamo worker registration, request
+conversion, transport, cancellation, and abort.
+
+## Supported
+
+- Aggregated generation
+- Token requests through Dynamo preprocessing
+- Sampling, stop conditions, structured output (JSON schema / regex / grammar /
+  structural tag), and logprobs
+- Streaming delta tokens with a terminal usage/finish summary
+- `Abort` on cancellation
+
+The initial protocol does **not** support disaggregated (prefill/decode)
+serving, multimodal input, LoRA, KV-aware routing, encode workers, beam search,
+or `n > 1`. Disaggregation is excluded because the `Generate` response contract
+carries no context-phase handoff.
+
+## Run
+
+Start TensorRT-LLM with its native gRPC listener (TRT-LLM `1.3.0rc21`+):
+
+```bash
+python -m tensorrt_llm.commands.serve <model> --grpc --host 0.0.0.0 --port 50051
+```
+
+This listener is unauthenticated and plaintext. Keep colocated deployments on
+loopback or a private interface. Remote access requires network controls or a
+secure proxy.
+
+Start the Dynamo worker:
+
+```bash
+dynamo-trtllm-sidecar \
+  --trtllm-endpoint 127.0.0.1:50051 \
+  --model-path <model>
+```
+
+Use `TRTLLM_GRPC_ENDPOINT` instead of `--trtllm-endpoint` when the endpoint is
+provided through the environment.
+
+Distribution and container packaging for the executable are intentionally
+deferred to a follow-up change.

--- a/lib/sidecar/trtllm/build.rs
+++ b/lib/sidecar/trtllm/build.rs
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Compiles client stubs from the vendored TensorRT-LLM gRPC contract.
+
+use std::env;
+use std::path::PathBuf;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let manifest_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
+    let proto_dir = manifest_dir.join("proto");
+    let proto_path = proto_dir.join("trtllm_service.proto");
+
+    // `--experimental_allow_proto3_optional` lets older protoc compile the
+    // proto3 `optional` fields (e.g. `top_k`, `temperature`). The flag was
+    // added in protoc 3.12 for exactly this and is a no-op on 3.15+.
+    tonic_build::configure()
+        .protoc_arg("--experimental_allow_proto3_optional")
+        .compile_protos(&[proto_path.as_path()], &[proto_dir.as_path()])?;
+
+    println!("cargo:rerun-if-changed={}", proto_path.display());
+    Ok(())
+}

--- a/lib/sidecar/trtllm/proto/README.md
+++ b/lib/sidecar/trtllm/proto/README.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# Vendored TensorRT-LLM gRPC protocol
+
+- Source package: `smg-grpc-proto`
+- Version: `0.4.14`
+- File: `smg_grpc_proto/proto/trtllm_service.proto`
+- Upstream SHA-256: `ec2f93de3af59047e3779283369eba89c2e6981b27849553144671b1fbc8eea5`
+
+`trtllm_service.proto` here is derived from the upstream file above with a
+single, mechanical edit: the `import "common.proto"` line and the two RPCs that
+reference `smg.grpc.common` types — `GetTokenizer` and `SubscribeKvEvents` — are
+removed. The sidecar drives only `Generate`, so dropping the tokenizer/KV-event
+RPCs lets the contract compile standalone without vendoring `common.proto`.
+Every message the sidecar exchanges is preserved byte-for-byte.
+
+TensorRT-LLM loads the matching generated stubs from `smg-grpc-proto` at
+runtime (`tensorrt_llm/grpc/__init__.py`), first shipped in TRT-LLM
+`1.3.0rc21`. Update the version, checksum, and this note together when bumping
+the protocol.

--- a/lib/sidecar/trtllm/proto/trtllm_service.proto
+++ b/lib/sidecar/trtllm/proto/trtllm_service.proto
@@ -1,0 +1,517 @@
+// SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Derived from the `smg-grpc-proto` package (trtllm_service.proto). The
+// upstream file imports `common.proto` for two optional RPCs — GetTokenizer
+// and SubscribeKvEvents — that this sidecar does not use. Those RPCs and the
+// `import "common.proto"` are removed so the contract compiles standalone;
+// every message the sidecar exchanges is preserved verbatim. See
+// `proto/README.md` for the source revision and checksum.
+
+syntax = "proto3";
+package trtllm;
+
+// TensorRT-LLM gRPC Service
+//
+// This service provides high-performance inference for LLMs using TensorRT-LLM.
+// It accepts pre-tokenized requests and returns raw token IDs, enabling efficient
+// binary communication with external routers (e.g., Shepherd Model Gateway).
+//
+// Key Design Principles:
+// - Pre-tokenized input: Router tokenizes prompt, server tokenizes stop/bad words
+// - Streaming delta mode: Chunks contain only new tokens since last chunk
+// - Full feature support: All TensorRT-LLM capabilities exposed
+
+service TrtllmService {
+  // Generate tokens from pre-tokenized input
+  // Returns a stream of responses containing token IDs
+  rpc Generate(GenerateRequest) returns (stream GenerateResponse);
+
+  // Generate embeddings from pre-tokenized input (for embedding models)
+  rpc Embed(EmbedRequest) returns (EmbedResponse);
+
+  // Health check endpoint
+  rpc HealthCheck(HealthCheckRequest) returns (HealthCheckResponse);
+
+  // Abort a running generation request
+  rpc Abort(AbortRequest) returns (AbortResponse);
+
+  // Get model information (vocab size, max lengths, etc.)
+  rpc GetModelInfo(GetModelInfoRequest) returns (GetModelInfoResponse);
+
+  // Get server information (version, parallelism, etc.)
+  rpc GetServerInfo(GetServerInfoRequest) returns (GetServerInfoResponse);
+}
+
+// ============================================================================
+// Generate Request
+// ============================================================================
+
+message GenerateRequest {
+  // Unique request identifier (assigned by client/router)
+  string request_id = 1;
+
+  // Pre-tokenized input (REQUIRED - router tokenizes)
+  TokenizedInput tokenized = 2;
+
+  // Sampling configuration
+  SamplingConfig sampling_config = 3;
+
+  // Output configuration
+  OutputConfig output_config = 4;
+
+  // Maximum tokens to generate (REQUIRED)
+  uint32 max_tokens = 5;
+
+  // Enable streaming mode
+  bool streaming = 6;
+
+  reserved 7, 8;   // Removed: end_id, pad_id (resolved by TRT-LLM's _setup())
+  reserved 9, 10;  // Removed: bad_words, stop_words (replaced by string fields below)
+
+  // Guided decoding parameters (JSON schema, regex, grammar)
+  optional GuidedDecodingParams guided_decoding = 11;
+
+  // Embedding bias tensor (vocab_size floats, optional)
+  repeated float embedding_bias = 12;
+
+  // LoRA adapter configuration
+  optional LoraConfig lora_config = 13;
+
+  // Prompt tuning configuration
+  optional PromptTuningConfig prompt_tuning_config = 14;
+
+  // Multimodal input (for VLMs)
+  optional MultimodalInput multimodal_input = 15;
+
+  // KV cache retention configuration
+  optional KvCacheRetentionConfig kv_cache_retention = 16;
+
+  // Disaggregated inference parameters
+  optional DisaggregatedParams disaggregated_params = 17;
+
+  // Lookahead decoding configuration
+  optional LookaheadConfig lookahead_config = 18;
+
+  // Cache salt ID for cache hashing
+  optional int64 cache_salt_id = 19;
+
+  // Request arrival time (unix timestamp for metrics)
+  optional double arrival_time = 20;
+
+  // Stop strings (TRT-LLM tokenizes these internally via _setup())
+  repeated string stop = 21;
+
+  // Stop token IDs (generation stops when any of these tokens are produced)
+  repeated uint32 stop_token_ids = 22;
+
+  // Ignore end-of-sequence token (continue generating past EOS)
+  bool ignore_eos = 23;
+
+  // Bad word strings (TRT-LLM tokenizes these internally via _setup())
+  repeated string bad = 24;
+
+  // Bad word token IDs (generation avoids producing these tokens)
+  repeated uint32 bad_token_ids = 25;
+
+  // Include stop tokens in output token IDs (default: false).
+  // When true, stop token IDs are retained in output_token_ids instead of
+  // being stripped.
+  bool include_stop_token_in_output = 26;
+}
+
+// Tokenized input from router
+message TokenizedInput {
+  // Original text (for debugging/logging only, not used for generation)
+  string original_text = 1;
+
+  // Pre-tokenized input token IDs (REQUIRED)
+  repeated uint32 input_token_ids = 2;
+
+  // Query token IDs for VLM star attention (optional)
+  repeated uint32 query_token_ids = 3;
+}
+
+// ============================================================================
+// Sampling Configuration
+// Maps to tensorrt_llm.bindings.executor.SamplingConfig
+// ============================================================================
+
+message SamplingConfig {
+  // Beam width (1 for sampling, >1 for beam search)
+  int32 beam_width = 1;
+
+  // Number of sequences to return
+  uint32 num_return_sequences = 2;
+
+  // Top-K sampling (0 = disabled, considers all tokens)
+  optional int32 top_k = 3;
+
+  // Top-P (nucleus) sampling threshold
+  optional float top_p = 4;
+
+  // Top-P minimum threshold for decay
+  optional float top_p_min = 5;
+
+  // Top-P reset token IDs
+  optional int32 top_p_reset_ids = 6;
+
+  // Top-P decay factor
+  optional float top_p_decay = 7;
+
+  // Random seed for reproducibility
+  optional uint64 seed = 8;
+
+  // Temperature for sampling (0 = greedy, higher = more random)
+  optional float temperature = 9;
+
+  // Minimum tokens to generate before stopping
+  optional uint32 min_tokens = 10;
+
+  // Beam search diversity rate
+  optional float beam_search_diversity_rate = 11;
+
+  // Repetition penalty (>1 discourages, <1 encourages repetition)
+  optional float repetition_penalty = 12;
+
+  // Presence penalty (penalizes tokens that have appeared)
+  optional float presence_penalty = 13;
+
+  // Frequency penalty (penalizes based on frequency of appearance)
+  optional float frequency_penalty = 14;
+
+  // Number of prompt tokens to ignore for penalties
+  optional int32 prompt_ignore_length = 15;
+
+  // Length penalty for beam search
+  optional float length_penalty = 16;
+
+  // Early stopping for beam search
+  optional int32 early_stopping = 17;
+
+  // No repeat n-gram size
+  optional int32 no_repeat_ngram_size = 18;
+
+  // Min-P sampling threshold
+  optional float min_p = 19;
+
+  // Variable beam width array for beam search
+  repeated int32 beam_width_array = 20;
+}
+
+// ============================================================================
+// Output Configuration
+// Maps to tensorrt_llm.bindings.executor.OutputConfig
+// ============================================================================
+
+message OutputConfig {
+  // Number of top log probabilities to return per output token
+  optional int32 logprobs = 1;
+
+  // Number of top log probabilities to return per prompt token
+  optional int32 prompt_logprobs = 2;
+
+  // Return context logits tensor (large, use with caution)
+  bool return_context_logits = 3;
+
+  // Return generation logits tensor (large, use with caution)
+  bool return_generation_logits = 4;
+
+  // Exclude input tokens from output (set to true to enable; TRT-LLM defaults to true internally)
+  bool exclude_input_from_output = 5;
+
+  // Return encoder output (for encoder-decoder models)
+  bool return_encoder_output = 6;
+
+  // Return performance metrics
+  bool return_perf_metrics = 7;
+}
+
+// ============================================================================
+// Guided Decoding
+// ============================================================================
+
+message GuidedDecodingParams {
+  // Guide type enumeration
+  enum GuideType {
+    GUIDE_TYPE_UNSPECIFIED = 0;
+    GUIDE_TYPE_JSON = 1;           // JSON format (any valid JSON)
+    GUIDE_TYPE_JSON_SCHEMA = 2;    // JSON with schema constraint
+    GUIDE_TYPE_REGEX = 3;          // Regular expression constraint
+    GUIDE_TYPE_EBNF_GRAMMAR = 4;   // EBNF grammar constraint
+    GUIDE_TYPE_STRUCTURAL_TAG = 5; // Structural tag (xgrammar backend)
+  }
+
+  GuideType guide_type = 1;
+
+  // Guide content (schema string, regex pattern, or grammar definition)
+  string guide = 2;
+}
+
+// ============================================================================
+// LoRA Configuration
+// ============================================================================
+
+message LoraConfig {
+  // LoRA task/adapter ID
+  int64 task_id = 1;
+
+  // LoRA weights (serialized tensor, optional if already cached)
+  optional bytes weights = 2;
+
+  // LoRA config as JSON string
+  optional string config_json = 3;
+}
+
+// ============================================================================
+// Prompt Tuning Configuration
+// ============================================================================
+
+message PromptTuningConfig {
+  // Embedding table (serialized tensor)
+  bytes embedding_table = 1;
+}
+
+// ============================================================================
+// Multimodal Input (for Vision-Language Models)
+// ============================================================================
+
+message MultimodalInput {
+  // Raw image bytes (JPEG/PNG) for each image in the request.
+  // TRT-LLM's input processor handles hashing, position tracking,
+  // and vision encoding server-side.
+  repeated bytes image_data = 1;
+}
+
+// ============================================================================
+// KV Cache Retention
+// ============================================================================
+
+message KvCacheRetentionConfig {
+  // Retention policy name
+  string policy = 1;
+
+  // Additional configuration as JSON string
+  string config_json = 2;
+}
+
+// ============================================================================
+// Disaggregated Inference
+// ============================================================================
+
+message DisaggregatedParams {
+  // Request type for disaggregated inference
+  enum RequestType {
+    REQUEST_TYPE_CONTEXT_AND_GENERATION = 0;  // Normal full request
+    REQUEST_TYPE_CONTEXT_ONLY = 1;            // Prefill only
+    REQUEST_TYPE_GENERATION_ONLY = 2;         // Decode only
+  }
+
+  RequestType request_type = 1;
+
+  // Context request ID (links context and generation phases)
+  string ctx_request_id = 2;
+
+  // Context phase parameters (for generation_only requests)
+  optional ContextPhaseParams context_phase_params = 3;
+}
+
+message ContextPhaseParams {
+  // First generated token ID from context phase
+  uint32 first_gen_token_id = 1;
+
+  // KV cache block pointers (serialized)
+  bytes kv_cache_blocks = 2;
+}
+
+// ============================================================================
+// Lookahead Decoding
+// ============================================================================
+
+message LookaheadConfig {
+  int32 max_window_size = 1;
+  int32 max_ngram_size = 2;
+  int32 max_verification_set_size = 3;
+}
+
+// ============================================================================
+// Generate Response
+// ============================================================================
+
+message GenerateResponse {
+  // Request ID echo
+  string request_id = 1;
+
+  reserved 4;  // was GenerateError — removed, errors use gRPC status
+
+  // Response type (oneof ensures exactly one is set)
+  oneof response {
+    GenerateStreamChunk chunk = 2;   // Streaming delta
+    GenerateComplete complete = 3;    // Final response
+  }
+}
+
+// Streaming chunk containing delta tokens (new tokens since last chunk)
+message GenerateStreamChunk {
+  // NEW token IDs only (delta from previous chunk)
+  repeated uint32 token_ids = 1;
+
+  // Beam/sequence index (for beam_width > 1 or n > 1)
+  uint32 sequence_index = 2;
+
+  // Token counts for usage tracking
+  uint32 prompt_tokens = 3;
+  uint32 completion_tokens = 4;
+  uint32 cached_tokens = 5;
+
+  // Log probabilities for this chunk's tokens (if requested)
+  repeated TokenLogprob logprobs = 6;
+}
+
+// Final/complete response with all output tokens
+message GenerateComplete {
+  // All output token IDs (cumulative, not delta)
+  repeated uint32 output_token_ids = 1;
+
+  // Beam/sequence index
+  uint32 sequence_index = 2;
+
+  // Finish reason: "stop", "length", "stop_word"
+  string finish_reason = 3;
+
+  // Matched stop information (for stop sequences)
+  oneof matched_stop {
+    string matched_stop_str = 4;     // Stop string that matched (wire-compatible with old stop_reason)
+    uint32 matched_token_id = 13;    // Stop token ID that matched
+  }
+
+  // Token counts for usage tracking
+  uint32 prompt_tokens = 5;
+  uint32 completion_tokens = 6;
+  uint32 cached_tokens = 7;
+
+  // Generation log probabilities (if requested)
+  repeated TokenLogprob logprobs = 8;
+
+  // Prompt log probabilities (if requested)
+  repeated TokenLogprob prompt_logprobs = 9;
+
+  // Performance metrics (if requested)
+  optional PerfMetrics perf_metrics = 10;
+
+  // Context logits (if requested) - serialized float tensor
+  optional bytes context_logits = 11;
+
+  // Generation logits (if requested) - serialized float tensor
+  optional bytes generation_logits = 12;
+}
+
+// Token log probability information
+message TokenLogprob {
+  uint32 token_id = 1;
+  float logprob = 2;
+
+  // Top alternative tokens and their log probabilities
+  repeated TopLogprob top_logprobs = 3;
+}
+
+message TopLogprob {
+  uint32 token_id = 1;
+  float logprob = 2;
+}
+
+// Performance metrics for request
+message PerfMetrics {
+  double arrival_time = 1;           // When request arrived
+  double first_scheduled_time = 2;   // When first scheduled
+  double first_token_time = 3;       // Time to first token (TTFT)
+  double last_token_time = 4;        // When last token generated
+  double kv_cache_transfer_start = 5; // KV cache transfer start (disagg)
+  double kv_cache_transfer_end = 6;   // KV cache transfer end (disagg)
+  int64 kv_cache_size = 7;           // KV cache size in bytes
+}
+
+// ============================================================================
+// Embed Request/Response (for embedding models)
+// ============================================================================
+
+message EmbedRequest {
+  string request_id = 1;
+  TokenizedInput tokenized = 2;
+}
+
+message EmbedResponse {
+  string request_id = 1;
+  repeated float embedding = 2;  // Embedding vector
+  uint32 prompt_tokens = 3;
+}
+
+// ============================================================================
+// Health Check
+// ============================================================================
+
+message HealthCheckRequest {}
+
+message HealthCheckResponse {
+  string status = 1;  // "OK" or error description
+}
+
+// ============================================================================
+// Abort Request
+// ============================================================================
+
+message AbortRequest {
+  string request_id = 1;
+}
+
+message AbortResponse {
+  bool success = 1;
+  string message = 2;
+}
+
+// ============================================================================
+// Model Info
+// ============================================================================
+
+message GetModelInfoRequest {}
+
+message GetModelInfoResponse {
+  string model_id = 1;          // Model identifier/path
+  int32 max_input_len = 2;      // Maximum input length
+  int32 max_seq_len = 3;        // Maximum sequence length (input + output)
+  int32 max_batch_size = 4;     // Maximum batch size
+  int32 vocab_size = 5;         // Vocabulary size
+  int32 hidden_size = 6;        // Hidden dimension
+  int32 num_layers = 7;         // Number of transformer layers
+  int32 num_heads = 8;          // Number of attention heads
+
+  // Supported features
+  repeated string supported_features = 9;  // e.g., "lora", "guided_decoding"
+}
+
+// ============================================================================
+// Server Info
+// ============================================================================
+
+message GetServerInfoRequest {}
+
+message GetServerInfoResponse {
+  string version = 1;               // TensorRT-LLM version
+  string backend = 2;               // "tensorrt" or "pytorch"
+  int32 tensor_parallel_size = 3;   // TP size
+  int32 pipeline_parallel_size = 4; // PP size
+  int32 context_parallel_size = 5;  // CP size
+  int32 world_size = 6;             // Total world size
+}

--- a/lib/sidecar/trtllm/src/args.rs
+++ b/lib/sidecar/trtllm/src/args.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use dynamo_sidecar_common::SidecarArgs;
+
+#[derive(clap::Parser, Clone, Debug)]
+#[command(
+    name = "dynamo-trtllm-sidecar",
+    about = "Run a Dynamo worker against TensorRT-LLM's native gRPC TrtllmService"
+)]
+pub(crate) struct Args {
+    #[command(flatten)]
+    pub sidecar: SidecarArgs,
+
+    /// TensorRT-LLM gRPC endpoint as host:port or an http:// URL.
+    #[arg(long, env = "TRTLLM_GRPC_ENDPOINT")]
+    pub trtllm_endpoint: String,
+
+    /// Hugging Face model ID or local path used for tokenization and templates.
+    #[arg(long)]
+    pub model_path: String,
+
+    /// Model maximum sequence length (input + output). Used to register the
+    /// context length and to derive a default `max_tokens` when a request omits
+    /// one. TensorRT-LLM's `GetModelInfo` gRPC does not report this on current
+    /// releases (it returns zero), so supply it here; otherwise requests that
+    /// omit `max_tokens` are rejected. See the note in `convert.rs`.
+    #[arg(long, env = "TRTLLM_CONTEXT_LENGTH")]
+    pub context_length: Option<u32>,
+}

--- a/lib/sidecar/trtllm/src/client.rs
+++ b/lib/sidecar/trtllm/src/client.rs
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Thin client for TensorRT-LLM's native `trtllm.TrtllmService`.
+
+use std::time::Duration;
+
+use dynamo_backend_common::DynamoError;
+use dynamo_sidecar_common::{
+    DEFAULT_MAX_GRPC_MESSAGE_SIZE, GrpcChannelPool, GrpcEndpoint, GrpcTransportConfig,
+    connection_timeout,
+};
+use tonic::transport::Channel;
+
+pub(crate) use dynamo_sidecar_common::{engine_shutdown, invalid_argument, status_to_dynamo};
+
+use crate::proto as pb;
+use crate::proto::trtllm_service_client::TrtllmServiceClient;
+
+/// Deadline for the one-shot control RPCs issued at startup / on cancel, so a
+/// connected-but-unresponsive server cannot hang `start` or `abort`.
+const RPC_TIMEOUT: Duration = Duration::from_secs(30);
+
+pub(crate) struct TrtllmClient {
+    pool: GrpcChannelPool,
+}
+
+impl TrtllmClient {
+    pub(crate) async fn connect(
+        endpoint: &GrpcEndpoint,
+        transport: GrpcTransportConfig,
+    ) -> Result<Self, DynamoError> {
+        let pool = GrpcChannelPool::connect("TensorRT-LLM", endpoint, transport).await?;
+        Ok(Self { pool })
+    }
+
+    pub(crate) fn connection_count(&self) -> usize {
+        self.pool.len()
+    }
+
+    fn client(&self) -> TrtllmServiceClient<Channel> {
+        TrtllmServiceClient::new(self.pool.next_channel())
+            .max_decoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+            .max_encoding_message_size(DEFAULT_MAX_GRPC_MESSAGE_SIZE)
+    }
+
+    pub(crate) async fn generate(
+        &self,
+        request: pb::GenerateRequest,
+    ) -> Result<tonic::Streaming<pb::GenerateResponse>, DynamoError> {
+        self.client()
+            .generate(request)
+            .await
+            .map(tonic::Response::into_inner)
+            .map_err(|status| status_to_dynamo("Generate", status))
+    }
+
+    /// Queries `GetModelInfo` and returns the reported maximum sequence length
+    /// (input + output) as the registration context length, if positive.
+    pub(crate) async fn model_info(&self) -> Result<Option<u32>, DynamoError> {
+        let info = tokio::time::timeout(
+            RPC_TIMEOUT,
+            self.client().get_model_info(pb::GetModelInfoRequest {}),
+        )
+        .await
+        .map_err(|_| {
+            connection_timeout(format!(
+                "GetModelInfo did not respond within {RPC_TIMEOUT:?}"
+            ))
+        })?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("GetModelInfo", status))?;
+        Ok(u32::try_from(info.max_seq_len).ok().filter(|len| *len > 0))
+    }
+
+    pub(crate) async fn abort(&self, request_id: String) -> Result<(), DynamoError> {
+        let response = tokio::time::timeout(
+            RPC_TIMEOUT,
+            self.client().abort(pb::AbortRequest { request_id }),
+        )
+        .await
+        .map_err(|_| connection_timeout(format!("Abort did not respond within {RPC_TIMEOUT:?}")))?
+        .map(tonic::Response::into_inner)
+        .map_err(|status| status_to_dynamo("Abort", status))?;
+        if !response.success {
+            return Err(protocol_error(format!(
+                "TensorRT-LLM rejected abort: {}",
+                response.message
+            )));
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn protocol_error(message: impl Into<String>) -> DynamoError {
+    dynamo_sidecar_common::protocol_error("TensorRT-LLM", message)
+}

--- a/lib/sidecar/trtllm/src/convert.rs
+++ b/lib/sidecar/trtllm/src/convert.rs
@@ -42,11 +42,11 @@ pub(crate) fn build_generate_request(
         sampling_config: Some(pb::SamplingConfig {
             beam_width: 1,
             num_return_sequences: 1,
-            top_k: normalize_top_k(sampling.top_k),
+            top_k: normalize_top_k(sampling.top_k)?,
             top_p: sampling.top_p,
             temperature: sampling.temperature,
             min_p: sampling.min_p,
-            seed: normalize_seed(sampling.seed),
+            seed: normalize_seed(sampling.seed)?,
             min_tokens: stop.min_tokens,
             repetition_penalty: sampling.repetition_penalty,
             presence_penalty: sampling.presence_penalty,
@@ -54,7 +54,7 @@ pub(crate) fn build_generate_request(
             ..Default::default()
         }),
         output_config: Some(pb::OutputConfig {
-            logprobs: output.logprobs.map(logprob_count).transpose()?,
+            logprobs: output.logprobs.map(request_logprob_count).transpose()?,
             // prompt_logprobs is intentionally not requested: it is rejected in
             // `validate_request` (no `LLMEngineOutput` field to surface it).
             // TRT-LLM streams delta tokens; input tokens must not be echoed.
@@ -67,7 +67,11 @@ pub(crate) fn build_generate_request(
         stop: stop.stop.clone().unwrap_or_default(),
         stop_token_ids: stop_token_ids(request),
         ignore_eos: stop.ignore_eos.unwrap_or(false),
-        include_stop_token_in_output: sampling.include_stop_str_in_output.unwrap_or(false),
+        // `include_stop_token_in_output` retains matched stop *token IDs*, a
+        // different axis from Dynamo's `include_stop_str_in_output` (stop
+        // *strings*). Mapping one to the other would leak hidden stop/EOS tokens,
+        // so leave it at the default (strip) and reject the request-level flag in
+        // `validate_request` instead.
         ..Default::default()
     })
 }
@@ -102,21 +106,35 @@ fn max_tokens(
     Ok(context_length.saturating_sub(prompt_len).max(1))
 }
 
-fn normalize_top_k(top_k: Option<i32>) -> Option<i32> {
-    // Dynamo uses -1 (or absence) for "consider all tokens"; TRT-LLM treats an
-    // unset/0 top_k the same way. Only forward a positive cap.
+fn normalize_top_k(top_k: Option<i32>) -> Result<Option<i32>, DynamoError> {
+    // Dynamo uses -1/0 (or absence) for "consider all tokens"; TRT-LLM treats an
+    // unset top_k the same way. Forward only a positive cap; reject other
+    // negatives rather than silently widening them to "all tokens".
     match top_k {
-        Some(value) if value > 0 => Some(value),
-        _ => None,
+        None | Some(-1) | Some(0) => Ok(None),
+        Some(value) if value > 0 => Ok(Some(value)),
+        Some(value) => Err(client::invalid_argument(format!(
+            "top_k must be -1, 0, or positive; got {value}"
+        ))),
     }
 }
 
-fn normalize_seed(seed: Option<i64>) -> Option<u64> {
-    seed.and_then(|seed| u64::try_from(seed).ok())
+fn normalize_seed(seed: Option<i64>) -> Result<Option<u64>, DynamoError> {
+    // TRT-LLM's seed is `uint64`; reject a negative seed rather than silently
+    // dropping it and losing reproducibility.
+    seed.map(|seed| {
+        u64::try_from(seed)
+            .map_err(|_| client::invalid_argument(format!("seed must be non-negative; got {seed}")))
+    })
+    .transpose()
 }
 
-fn logprob_count(count: u32) -> Result<i32, DynamoError> {
-    i32::try_from(count).map_err(|_| {
+fn request_logprob_count(count: u32) -> Result<i32, DynamoError> {
+    // TRT-LLM computes the selected-token logprob only when at least one logprob
+    // is requested, so floor the wire value at 1: `logprobs=0` (selected token,
+    // no alternatives) still yields the chosen-token logprob. The original count
+    // is preserved in `ResponseState` to decide whether to surface alternatives.
+    i32::try_from(count.max(1)).map_err(|_| {
         client::invalid_argument(format!("logprobs request must fit in i32; got {count}"))
     })
 }
@@ -251,7 +269,50 @@ fn validate_request(request: &PreprocessedRequest) -> Result<(), DynamoError> {
             "KV-aware data-parallel routing is not supported by the TensorRT-LLM sidecar",
         ));
     }
+    if request
+        .routing
+        .as_ref()
+        .and_then(|routing| routing.cache_namespace.as_deref())
+        .is_some_and(|namespace| !namespace.is_empty())
+    {
+        // `cache_namespace` is the request-scoped KV-cache isolation contract. The
+        // proto carries `cache_salt_id`, but TRT-LLM 1.3.0rc21 does not plumb it
+        // through the gRPC servicer, so honoring it would let requests from
+        // different namespaces share prefix-cache entries. Reject until supported.
+        return Err(client::invalid_argument(
+            "cache namespace isolation is not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request
+        .routing
+        .as_ref()
+        .and_then(|routing| routing.priority)
+        .is_some_and(|priority| priority != 0)
+    {
+        // The shared contract forwards a nonzero priority to the engine, but the
+        // TRT-LLM gRPC request has no priority field, so it would be silently
+        // dropped and change queue ordering. Reject until the wire protocol
+        // carries it.
+        return Err(client::invalid_argument(
+            "request priority is not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request.stop_conditions.max_thinking_tokens.is_some() {
+        // A reasoning-token budget the sidecar can neither forward nor enforce.
+        return Err(client::invalid_argument(
+            "max_thinking_tokens is not supported by the TensorRT-LLM sidecar",
+        ));
+    }
     let sampling = &request.sampling_options;
+    if sampling.include_stop_str_in_output == Some(true) {
+        // Retaining stop *strings* has no faithful mapping in the TRT-LLM gRPC
+        // request (its only control, `include_stop_token_in_output`, governs stop
+        // *token IDs* and would leak hidden stop/EOS tokens). Reject rather than
+        // mis-map — consistent with rejecting visible stop token IDs above.
+        return Err(client::invalid_argument(
+            "include_stop_str_in_output is not supported by the TensorRT-LLM sidecar",
+        ));
+    }
     if sampling.n.unwrap_or(1) != 1 {
         return Err(client::invalid_argument("n must be 1"));
     }
@@ -269,7 +330,8 @@ fn validate_request(request: &PreprocessedRequest) -> Result<(), DynamoError> {
 pub(crate) struct ResponseState {
     prompt_tokens: u32,
     completion_tokens: u32,
-    expect_output_logprobs: bool,
+    streamed_tokens: u32,
+    output_logprobs: Option<u32>,
 }
 
 impl ResponseState {
@@ -277,7 +339,8 @@ impl ResponseState {
         Self {
             prompt_tokens: request.token_ids.len() as u32,
             completion_tokens: 0,
-            expect_output_logprobs: request.output_options.logprobs.is_some(),
+            streamed_tokens: 0,
+            output_logprobs: request.output_options.logprobs,
         }
     }
 
@@ -298,7 +361,11 @@ impl ResponseState {
             Some(pb::generate_response::Response::Complete(complete)) => {
                 self.convert_complete(complete).map(Some)
             }
-            None => Ok(None),
+            // A response with neither payload is protocol drift, not an
+            // empty delta — fail rather than silently discard it.
+            None => Err(client::protocol_error(
+                "response carried neither a chunk nor a complete payload",
+            )),
         }
     }
 
@@ -334,6 +401,9 @@ impl ResponseState {
             chunk.prompt_tokens,
             chunk.completion_tokens,
         )?;
+        self.streamed_tokens = self
+            .streamed_tokens
+            .saturating_add(chunk.token_ids.len() as u32);
         if chunk.token_ids.is_empty() {
             return Ok(None);
         }
@@ -357,11 +427,25 @@ impl ResponseState {
             complete.completion_tokens,
         )?;
 
+        // The terminal echoes the cumulative output token IDs (proto: "cumulative,
+        // not delta"). When present they must match what we streamed; a mismatch
+        // is protocol drift. Tolerate an omitted echo (empty) rather than
+        // false-erroring a server that only carries finish state in the terminal.
+        if !complete.output_token_ids.is_empty()
+            && complete.output_token_ids.len() as u32 != self.streamed_tokens
+        {
+            return Err(client::protocol_error(format!(
+                "terminal output_token_ids ({}) do not match {} streamed delta tokens",
+                complete.output_token_ids.len(),
+                self.streamed_tokens
+            )));
+        }
+
         // The delta tokens were already streamed via chunks; the terminal
         // response only carries finish state and usage.
         let mut terminal = LLMEngineOutput {
             index: Some(0),
-            finish_reason: Some(finish_reason(&complete.finish_reason)),
+            finish_reason: Some(finish_reason(&complete.finish_reason)?),
             completion_usage: Some(usage(self.prompt_tokens, self.completion_tokens)),
             ..Default::default()
         };
@@ -379,9 +463,9 @@ impl ResponseState {
         token_ids: &[u32],
         logprobs: &[pb::TokenLogprob],
     ) -> Result<MappedLogprobs, DynamoError> {
-        if !self.expect_output_logprobs {
+        let Some(count) = self.output_logprobs else {
             return Ok((None, None));
-        }
+        };
         // Logprobs were requested, so every delta token must carry one; an empty
         // or short slice is a protocol violation, not a silent no-op.
         if logprobs.len() != token_ids.len() {
@@ -392,6 +476,11 @@ impl ResponseState {
             )));
         }
         let log_probs = logprobs.iter().map(|lp| f64::from(lp.logprob)).collect();
+        if count == 0 {
+            // `logprobs=0` keeps the selected-token logprob but omits the top
+            // alternatives, matching the vLLM sidecar contract.
+            return Ok((Some(log_probs), None));
+        }
         let top_logprobs = logprobs
             .iter()
             .map(|lp| {
@@ -422,12 +511,20 @@ impl ResponseState {
     }
 }
 
-fn finish_reason(reason: &str) -> FinishReason {
-    match reason.trim().to_ascii_lowercase().as_str() {
+fn finish_reason(reason: &str) -> Result<FinishReason, DynamoError> {
+    Ok(match reason.trim().to_ascii_lowercase().as_str() {
         "length" => FinishReason::Length,
         "cancelled" | "canceled" | "aborted" | "timeout" => FinishReason::Cancelled,
         "error" => FinishReason::Error("TensorRT-LLM reported an error finish".to_string()),
-        // "stop", "stop_word", "eos", or an empty string (finished implies stop).
-        _ => FinishReason::Stop,
-    }
+        // Proto-documented stop reasons ("stop", "stop_word"); an empty string is
+        // a bare terminal (finished implies stop).
+        "stop" | "stop_word" | "eos" | "" => FinishReason::Stop,
+        // Fail closed on an unrecognized reason rather than reporting a clean stop
+        // for a version-skewed or malformed terminal.
+        other => {
+            return Err(client::protocol_error(format!(
+                "unknown finish reason {other:?}"
+            )));
+        }
+    })
 }

--- a/lib/sidecar/trtllm/src/convert.rs
+++ b/lib/sidecar/trtllm/src/convert.rs
@@ -1,0 +1,433 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Conversion between Dynamo's `PreprocessedRequest` / `LLMEngineOutput` and
+//! the TensorRT-LLM `TrtllmService` protobuf messages.
+//!
+//! Scope: aggregated generation. Disaggregation, multimodal, LoRA, beam search,
+//! and `n > 1` are rejected before dispatch — the `Generate` response contract
+//! carries no disaggregation handoff, and the sidecar streams a single sequence.
+
+use std::collections::BTreeSet;
+
+use dynamo_backend_common::{
+    DynamoError, FinishReason, LLMEngineOutput, PreprocessedRequest, StopReason, TopLogprob, usage,
+};
+
+use crate::client;
+use crate::proto as pb;
+
+/// Per-chunk logprobs: the selected-token logprob sequence plus the per-token
+/// top-k alternatives, both aligned with the chunk's delta tokens.
+type MappedLogprobs = (Option<Vec<f64>>, Option<Vec<Vec<TopLogprob>>>);
+
+pub(crate) fn build_generate_request(
+    request: &PreprocessedRequest,
+    request_id: &str,
+    context_length: Option<u32>,
+) -> Result<pb::GenerateRequest, DynamoError> {
+    validate_request(request)?;
+
+    let sampling = &request.sampling_options;
+    let stop = &request.stop_conditions;
+    let output = &request.output_options;
+
+    Ok(pb::GenerateRequest {
+        request_id: request_id.to_string(),
+        tokenized: Some(pb::TokenizedInput {
+            original_text: String::new(),
+            input_token_ids: request.token_ids.clone(),
+            query_token_ids: Vec::new(),
+        }),
+        sampling_config: Some(pb::SamplingConfig {
+            beam_width: 1,
+            num_return_sequences: 1,
+            top_k: normalize_top_k(sampling.top_k),
+            top_p: sampling.top_p,
+            temperature: sampling.temperature,
+            min_p: sampling.min_p,
+            seed: normalize_seed(sampling.seed),
+            min_tokens: stop.min_tokens,
+            repetition_penalty: sampling.repetition_penalty,
+            presence_penalty: sampling.presence_penalty,
+            frequency_penalty: sampling.frequency_penalty,
+            ..Default::default()
+        }),
+        output_config: Some(pb::OutputConfig {
+            logprobs: output.logprobs.map(logprob_count).transpose()?,
+            // prompt_logprobs is intentionally not requested: it is rejected in
+            // `validate_request` (no `LLMEngineOutput` field to surface it).
+            // TRT-LLM streams delta tokens; input tokens must not be echoed.
+            exclude_input_from_output: true,
+            ..Default::default()
+        }),
+        max_tokens: max_tokens(request, context_length)?,
+        streaming: true,
+        guided_decoding: guided_decoding(request)?,
+        stop: stop.stop.clone().unwrap_or_default(),
+        stop_token_ids: stop_token_ids(request),
+        ignore_eos: stop.ignore_eos.unwrap_or(false),
+        include_stop_token_in_output: sampling.include_stop_str_in_output.unwrap_or(false),
+        ..Default::default()
+    })
+}
+
+// Temporary workaround: TensorRT-LLM's gRPC `GenerateRequest.max_tokens` is
+// REQUIRED (see proto/trtllm_service.proto), so an omitted `max_tokens` — which
+// the Dynamo frontend forwards as `None` for the backend to default — has no
+// natural value. We mirror the in-process backend's text-only default,
+// `max(1, context_length - prompt_len)` (components/src/dynamo/trtllm
+// `_default_max_tokens`); the sidecar rejects multimodal before dispatch, so
+// `token_ids.len()` is the true prompt length. `context_length` comes from
+// `--context-length` (GetModelInfo returns zero on current releases).
+//
+// Remove when https://github.com/NVIDIA/TensorRT-LLM/issues/16549 lands (gRPC
+// `max_tokens` made optional): drop this fallback, the `--context-length` arg,
+// and the context-length plumbing in `engine.rs`, and forward an omitted
+// `max_tokens` as unset.
+fn max_tokens(
+    request: &PreprocessedRequest,
+    context_length: Option<u32>,
+) -> Result<u32, DynamoError> {
+    if let Some(max_tokens) = request.stop_conditions.max_tokens {
+        return Ok(max_tokens);
+    }
+    let context_length = context_length.ok_or_else(|| {
+        client::invalid_argument(
+            "TensorRT-LLM requires max_tokens, and no model context length is available to \
+             derive a default; specify max_tokens explicitly",
+        )
+    })?;
+    let prompt_len = request.token_ids.len() as u32;
+    Ok(context_length.saturating_sub(prompt_len).max(1))
+}
+
+fn normalize_top_k(top_k: Option<i32>) -> Option<i32> {
+    // Dynamo uses -1 (or absence) for "consider all tokens"; TRT-LLM treats an
+    // unset/0 top_k the same way. Only forward a positive cap.
+    match top_k {
+        Some(value) if value > 0 => Some(value),
+        _ => None,
+    }
+}
+
+fn normalize_seed(seed: Option<i64>) -> Option<u64> {
+    seed.and_then(|seed| u64::try_from(seed).ok())
+}
+
+fn logprob_count(count: u32) -> Result<i32, DynamoError> {
+    i32::try_from(count).map_err(|_| {
+        client::invalid_argument(format!("logprobs request must fit in i32; got {count}"))
+    })
+}
+
+fn stop_token_ids(request: &PreprocessedRequest) -> Vec<u32> {
+    let stop = &request.stop_conditions;
+    let mut ids = BTreeSet::new();
+    for values in [
+        stop.stop_token_ids.as_ref(),
+        stop.stop_token_ids_hidden.as_ref(),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        ids.extend(values.iter().copied());
+    }
+    ids.into_iter().collect()
+}
+
+fn guided_decoding(
+    request: &PreprocessedRequest,
+) -> Result<Option<pb::GuidedDecodingParams>, DynamoError> {
+    let Some(guided) = request.sampling_options.guided_decoding.as_ref() else {
+        return Ok(None);
+    };
+    if guided.backend.is_some() || guided.whitespace_pattern.is_some() {
+        return Err(client::invalid_argument(
+            "guided decoding backend and whitespace_pattern are not supported by TensorRT-LLM gRPC",
+        ));
+    }
+
+    use pb::guided_decoding_params::GuideType;
+    let mut constraints = Vec::new();
+    if let Some(json) = &guided.json {
+        constraints.push((GuideType::JsonSchema, json_guide(json)));
+    }
+    if let Some(regex) = &guided.regex {
+        constraints.push((GuideType::Regex, regex.clone()));
+    }
+    if let Some(grammar) = &guided.grammar {
+        constraints.push((GuideType::EbnfGrammar, grammar.clone()));
+    }
+    if let Some(tag) = &guided.structural_tag {
+        constraints.push((GuideType::StructuralTag, json_guide(tag)));
+    }
+    if guided.choice.is_some() {
+        return Err(client::invalid_argument(
+            "guided decoding `choice` is not supported by TensorRT-LLM gRPC",
+        ));
+    }
+    if constraints.len() > 1 {
+        return Err(client::invalid_argument(
+            "only one guided decoding constraint may be set",
+        ));
+    }
+    Ok(constraints
+        .pop()
+        .map(|(guide_type, guide)| pb::GuidedDecodingParams {
+            guide_type: guide_type as i32,
+            guide,
+        }))
+}
+
+/// A guide is either a JSON string carried verbatim or a JSON value rendered to
+/// its string form (schema / structural tag).
+fn json_guide(value: &serde_json::Value) -> String {
+    match value {
+        serde_json::Value::String(guide) => guide.clone(),
+        value => value.to_string(),
+    }
+}
+
+fn validate_request(request: &PreprocessedRequest) -> Result<(), DynamoError> {
+    if request.token_ids.is_empty() {
+        return Err(client::invalid_argument("token_ids must not be empty"));
+    }
+    if request.prompt_embeds.is_some() {
+        return Err(client::invalid_argument(
+            "prompt embeddings are not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request.multi_modal_data.is_some()
+        || request.mm_routing_info.is_some()
+        || request.encoder_result.is_some()
+    {
+        return Err(client::invalid_argument(
+            "multimodal requests are not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request.prefill_result.is_some() {
+        return Err(client::invalid_argument(
+            "disaggregated (prefill/decode) requests are not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request.output_options.prompt_logprobs.is_some() {
+        // TRT-LLM would compute these, but the terminal `complete` carries them
+        // with no `LLMEngineOutput` field to surface — reject rather than pay for
+        // and drop them.
+        return Err(client::invalid_argument(
+            "prompt logprobs are not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request
+        .stop_conditions
+        .stop_token_ids_visible
+        .as_ref()
+        .is_some_and(|ids| !ids.is_empty())
+    {
+        // A visible stop token must halt generation *and* stay in the output.
+        // TRT-LLM's single `include_stop_token_in_output` flag cannot honor that
+        // per token, so reject rather than silently drop or mis-retain them.
+        return Err(client::invalid_argument(
+            "visible stop token IDs are not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request
+        .routing
+        .as_ref()
+        .and_then(|routing| routing.lora_name.as_deref())
+        .is_some_and(|name| !name.is_empty())
+    {
+        return Err(client::invalid_argument(
+            "LoRA request selection is not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    if request
+        .routing
+        .as_ref()
+        .is_some_and(|routing| routing.dp_rank.is_some() || routing.prefill_dp_rank.is_some())
+    {
+        return Err(client::invalid_argument(
+            "KV-aware data-parallel routing is not supported by the TensorRT-LLM sidecar",
+        ));
+    }
+    let sampling = &request.sampling_options;
+    if sampling.n.unwrap_or(1) != 1 {
+        return Err(client::invalid_argument("n must be 1"));
+    }
+    if sampling.best_of.unwrap_or(1) != 1 {
+        return Err(client::invalid_argument("best_of must be 1"));
+    }
+    if sampling.use_beam_search.unwrap_or(false) {
+        return Err(client::invalid_argument("beam search is not supported"));
+    }
+    Ok(())
+}
+
+/// Streaming response reducer. TRT-LLM streams delta `chunk`s followed by a
+/// single terminal `complete`; this maps each onto an `LLMEngineOutput`.
+pub(crate) struct ResponseState {
+    prompt_tokens: u32,
+    completion_tokens: u32,
+    expect_output_logprobs: bool,
+}
+
+impl ResponseState {
+    pub(crate) fn new(request: &PreprocessedRequest) -> Self {
+        Self {
+            prompt_tokens: request.token_ids.len() as u32,
+            completion_tokens: 0,
+            expect_output_logprobs: request.output_options.logprobs.is_some(),
+        }
+    }
+
+    pub(crate) fn prompt_tokens(&self) -> u32 {
+        self.prompt_tokens
+    }
+
+    pub(crate) fn completion_tokens(&self) -> u32 {
+        self.completion_tokens
+    }
+
+    pub(crate) fn convert(
+        &mut self,
+        response: pb::GenerateResponse,
+    ) -> Result<Option<LLMEngineOutput>, DynamoError> {
+        match response.response {
+            Some(pb::generate_response::Response::Chunk(chunk)) => self.convert_chunk(chunk),
+            Some(pb::generate_response::Response::Complete(complete)) => {
+                self.convert_complete(complete).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Validates the single-sequence invariant and folds the response's usage
+    /// counts into the running totals. Shared by chunk and terminal handling.
+    fn accumulate(
+        &mut self,
+        sequence_index: u32,
+        prompt_tokens: u32,
+        completion_tokens: u32,
+    ) -> Result<(), DynamoError> {
+        if sequence_index != 0 {
+            return Err(client::protocol_error(format!(
+                "received unsupported sequence index {sequence_index}"
+            )));
+        }
+        if prompt_tokens != 0 {
+            self.prompt_tokens = prompt_tokens;
+        }
+        // TRT-LLM reports cumulative (not per-chunk-delta) usage counts, verified
+        // against 1.3.0rc21 over multi-chunk streams; `max` tolerates chunks that
+        // omit the count (report 0) without regressing the running total.
+        self.completion_tokens = self.completion_tokens.max(completion_tokens);
+        Ok(())
+    }
+
+    fn convert_chunk(
+        &mut self,
+        chunk: pb::GenerateStreamChunk,
+    ) -> Result<Option<LLMEngineOutput>, DynamoError> {
+        self.accumulate(
+            chunk.sequence_index,
+            chunk.prompt_tokens,
+            chunk.completion_tokens,
+        )?;
+        if chunk.token_ids.is_empty() {
+            return Ok(None);
+        }
+        let (log_probs, top_logprobs) = self.map_logprobs(&chunk.token_ids, &chunk.logprobs)?;
+        Ok(Some(LLMEngineOutput {
+            token_ids: chunk.token_ids,
+            log_probs,
+            top_logprobs,
+            index: Some(0),
+            ..Default::default()
+        }))
+    }
+
+    fn convert_complete(
+        &mut self,
+        complete: pb::GenerateComplete,
+    ) -> Result<LLMEngineOutput, DynamoError> {
+        self.accumulate(
+            complete.sequence_index,
+            complete.prompt_tokens,
+            complete.completion_tokens,
+        )?;
+
+        // The delta tokens were already streamed via chunks; the terminal
+        // response only carries finish state and usage.
+        let mut terminal = LLMEngineOutput {
+            index: Some(0),
+            finish_reason: Some(finish_reason(&complete.finish_reason)),
+            completion_usage: Some(usage(self.prompt_tokens, self.completion_tokens)),
+            ..Default::default()
+        };
+        terminal.stop_reason = complete.matched_stop.map(|matched| match matched {
+            pb::generate_complete::MatchedStop::MatchedStopStr(value) => StopReason::String(value),
+            pb::generate_complete::MatchedStop::MatchedTokenId(id) => {
+                StopReason::Int(i64::from(id))
+            }
+        });
+        Ok(terminal)
+    }
+
+    fn map_logprobs(
+        &self,
+        token_ids: &[u32],
+        logprobs: &[pb::TokenLogprob],
+    ) -> Result<MappedLogprobs, DynamoError> {
+        if !self.expect_output_logprobs {
+            return Ok((None, None));
+        }
+        // Logprobs were requested, so every delta token must carry one; an empty
+        // or short slice is a protocol violation, not a silent no-op.
+        if logprobs.len() != token_ids.len() {
+            return Err(client::protocol_error(format!(
+                "logprob count {} does not match {} delta tokens",
+                logprobs.len(),
+                token_ids.len()
+            )));
+        }
+        let log_probs = logprobs.iter().map(|lp| f64::from(lp.logprob)).collect();
+        let top_logprobs = logprobs
+            .iter()
+            .map(|lp| {
+                if lp.top_logprobs.is_empty() {
+                    vec![TopLogprob {
+                        rank: 0,
+                        token_id: lp.token_id,
+                        token: None,
+                        logprob: f64::from(lp.logprob),
+                        bytes: None,
+                    }]
+                } else {
+                    lp.top_logprobs
+                        .iter()
+                        .enumerate()
+                        .map(|(rank, candidate)| TopLogprob {
+                            rank: rank as u32,
+                            token_id: candidate.token_id,
+                            token: None,
+                            logprob: f64::from(candidate.logprob),
+                            bytes: None,
+                        })
+                        .collect()
+                }
+            })
+            .collect();
+        Ok((Some(log_probs), Some(top_logprobs)))
+    }
+}
+
+fn finish_reason(reason: &str) -> FinishReason {
+    match reason.trim().to_ascii_lowercase().as_str() {
+        "length" => FinishReason::Length,
+        "cancelled" | "canceled" | "aborted" | "timeout" => FinishReason::Cancelled,
+        "error" => FinishReason::Error("TensorRT-LLM reported an error finish".to_string()),
+        // "stop", "stop_word", "eos", or an empty string (finished implies stop).
+        _ => FinishReason::Stop,
+    }
+}

--- a/lib/sidecar/trtllm/src/engine.rs
+++ b/lib/sidecar/trtllm/src/engine.rs
@@ -1,0 +1,245 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dynamo backend for TensorRT-LLM's native `trtllm.TrtllmService` gRPC server.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use dynamo_backend_common::{
+    AsyncEngineContext, DisaggregationMode, DynamoError, EngineConfig, GenerateContext, LLMEngine,
+    LLMEngineOutput, LLMEngineOutputExt, PreprocessedRequest, WorkerConfig, usage,
+};
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
+use futures::stream::BoxStream;
+use tokio::sync::OnceCell;
+use tokio_util::sync::CancellationToken;
+
+use crate::args::Args;
+use crate::client::{self, TrtllmClient};
+use crate::convert::{ResponseState, build_generate_request};
+use crate::model::ConfiguredModel;
+
+const ALREADY_STARTED: &str = "TensorRT-LLM sidecar has already started";
+
+/// Terminal output emitted when a request is cancelled, carrying the usage
+/// accumulated so far.
+fn cancelled(state: &ResponseState) -> LLMEngineOutput {
+    LLMEngineOutput::cancelled().with_usage(usage(state.prompt_tokens(), state.completion_tokens()))
+}
+
+pub struct TrtllmSidecarEngine {
+    endpoint: GrpcEndpoint,
+    transport: GrpcTransportConfig,
+    model: ConfiguredModel,
+    client: OnceCell<TrtllmClient>,
+    /// Resolved model context length (`--context-length`, else `GetModelInfo`),
+    /// cached at `start` so `generate` can derive a default `max_tokens` for
+    /// requests that omit one.
+    context_length: OnceCell<u32>,
+    cancel: CancellationToken,
+}
+
+impl TrtllmSidecarEngine {
+    pub(crate) fn new(
+        endpoint: GrpcEndpoint,
+        transport: GrpcTransportConfig,
+        model: ConfiguredModel,
+    ) -> Self {
+        Self {
+            endpoint,
+            transport,
+            model,
+            client: OnceCell::new(),
+            context_length: OnceCell::new(),
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    pub fn from_env() -> Result<(Self, WorkerConfig), DynamoError> {
+        Self::from_parsed(<Args as clap::Parser>::parse())
+    }
+
+    pub fn from_args(argv: Vec<String>) -> Result<(Self, WorkerConfig), DynamoError> {
+        let args = <Args as clap::Parser>::try_parse_from(argv)
+            .map_err(|err| client::invalid_argument(err.to_string()))?;
+        Self::from_parsed(args)
+    }
+
+    fn from_parsed(args: Args) -> Result<(Self, WorkerConfig), DynamoError> {
+        if args.model_path.trim().is_empty() {
+            return Err(client::invalid_argument("model-path must not be empty"));
+        }
+        if args.context_length == Some(0) {
+            return Err(client::invalid_argument(
+                "context-length must be greater than zero",
+            ));
+        }
+        if args.sidecar.common.disaggregation_mode != DisaggregationMode::Aggregated {
+            return Err(client::invalid_argument(
+                "the TensorRT-LLM sidecar supports aggregated serving only; the Generate \
+                 response contract carries no disaggregation handoff",
+            ));
+        }
+        if args.sidecar.common.route_to_encoder {
+            return Err(client::invalid_argument(
+                "route-to-encoder is not supported by the TensorRT-LLM sidecar",
+            ));
+        }
+
+        let endpoint = GrpcEndpoint::parse(&args.trtllm_endpoint, "--trtllm-endpoint")?;
+        let transport = args.sidecar.grpc.config();
+        let model = ConfiguredModel {
+            source: args.model_path,
+            context_length: args.context_length,
+        };
+        let engine = Self::new(endpoint, transport, model.clone());
+        let config = WorkerConfig {
+            namespace: args.sidecar.common.namespace,
+            component: args.sidecar.common.component,
+            endpoint: args.sidecar.common.endpoint,
+            endpoint_types: args.sidecar.common.endpoint_types,
+            custom_jinja_template: args.sidecar.common.custom_jinja_template,
+            model_name: model.source.clone(),
+            served_model_name: None,
+            tool_call_parser: args.sidecar.common.dyn_tool_call_parser,
+            reasoning_parser: args.sidecar.common.dyn_reasoning_parser,
+            exclude_tools_when_tool_choice_none: args
+                .sidecar
+                .common
+                .exclude_tools_when_tool_choice_none,
+            enable_kv_routing: false,
+            disaggregation_mode: DisaggregationMode::Aggregated,
+            route_to_encoder: false,
+            ..Default::default()
+        };
+        Ok((engine, config))
+    }
+}
+
+#[async_trait]
+impl LLMEngine for TrtllmSidecarEngine {
+    async fn start(&self, _worker_id: u64) -> Result<EngineConfig, DynamoError> {
+        if self.client.initialized() {
+            return Err(client::engine_shutdown(ALREADY_STARTED));
+        }
+        tracing::info!(
+            endpoint = %self.endpoint,
+            connections = self.transport.connections.get(),
+            "connecting to TensorRT-LLM gRPC"
+        );
+        let client = TrtllmClient::connect(&self.endpoint, self.transport).await?;
+        let connection_count = client.connection_count();
+
+        // Prefer a server-reported context length; fall back to the configured
+        // `--context-length`. GetModelInfo returns zero on current TRT-LLM
+        // releases, so the argument is currently the only source. The resolved
+        // value backs the default-`max_tokens` path in `convert::max_tokens`.
+        let mut model = self.model.clone();
+        match client.model_info().await {
+            Ok(Some(context_length)) => model.context_length = Some(context_length),
+            Ok(None) => {}
+            Err(error) => tracing::warn!(%error, "GetModelInfo failed; using --context-length"),
+        }
+        if let Some(context_length) = model.context_length {
+            let _ = self.context_length.set(context_length);
+        }
+
+        self.client
+            .set(client)
+            .map_err(|_| client::engine_shutdown(ALREADY_STARTED))?;
+        tracing::info!(
+            endpoint = %self.endpoint,
+            connections = connection_count,
+            model = %model.source,
+            "TensorRT-LLM gRPC is ready"
+        );
+        Ok(model.engine_config())
+    }
+
+    async fn generate(
+        &self,
+        request: PreprocessedRequest,
+        ctx: GenerateContext,
+    ) -> Result<BoxStream<'static, Result<LLMEngineOutput, DynamoError>>, DynamoError> {
+        let client = self
+            .client
+            .get()
+            .ok_or_else(|| client::engine_shutdown("TensorRT-LLM sidecar is not started"))?;
+        let request_id = ctx.id().to_string();
+        let proto_request =
+            build_generate_request(&request, &request_id, self.context_length.get().copied())?;
+        let mut state = ResponseState::new(&request);
+        let cancel = self.cancel.clone();
+
+        let stream = tokio::select! {
+            biased;
+            _ = ctx.stopped() => None,
+            _ = cancel.cancelled() => None,
+            result = client.generate(proto_request) => Some(result?),
+        };
+        let Some(mut stream) = stream else {
+            let output = cancelled(&state);
+            return Ok(Box::pin(futures::stream::once(async move { Ok(output) })));
+        };
+
+        Ok(Box::pin(async_stream::stream! {
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = ctx.stopped() => {
+                        yield Ok(cancelled(&state));
+                        break;
+                    }
+                    _ = cancel.cancelled() => {
+                        yield Ok(cancelled(&state));
+                        break;
+                    }
+                    message = stream.message() => {
+                        match message {
+                            Ok(Some(response)) => match state.convert(response) {
+                                Ok(Some(output)) => {
+                                    let terminal = output.finish_reason.is_some();
+                                    yield Ok(output);
+                                    if terminal {
+                                        break;
+                                    }
+                                }
+                                Ok(None) => {}
+                                Err(error) => {
+                                    yield Err(error);
+                                    break;
+                                }
+                            },
+                            Ok(None) => {
+                                yield Err(client::protocol_error(
+                                    "Generate ended before a terminal response",
+                                ));
+                                break;
+                            }
+                            Err(status) => {
+                                yield Err(client::status_to_dynamo("Generate", status));
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }))
+    }
+
+    async fn abort(&self, ctx: Arc<dyn AsyncEngineContext>) {
+        let Some(client) = self.client.get() else {
+            return;
+        };
+        if let Err(error) = client.abort(ctx.id().to_string()).await {
+            tracing::debug!(request_id = ctx.id(), %error, "TensorRT-LLM Abort RPC failed");
+        }
+    }
+
+    async fn cleanup(&self) -> Result<(), DynamoError> {
+        self.cancel.cancel();
+        tracing::info!("TensorRT-LLM sidecar shutdown complete");
+        Ok(())
+    }
+}

--- a/lib/sidecar/trtllm/src/lib.rs
+++ b/lib/sidecar/trtllm/src/lib.rs
@@ -1,0 +1,16 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Dynamo sidecar for TensorRT-LLM's native `TrtllmService` gRPC API.
+
+mod args;
+mod client;
+mod convert;
+mod engine;
+mod model;
+mod proto;
+
+pub use engine::TrtllmSidecarEngine;
+
+#[cfg(test)]
+mod tests;

--- a/lib/sidecar/trtllm/src/main.rs
+++ b/lib/sidecar/trtllm/src/main.rs
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::sync::Arc;
+
+fn main() -> anyhow::Result<()> {
+    let (engine, config) = dynamo_trtllm_sidecar::TrtllmSidecarEngine::from_env()?;
+    dynamo_backend_common::run(Arc::new(engine), config)
+}

--- a/lib/sidecar/trtllm/src/model.rs
+++ b/lib/sidecar/trtllm/src/model.rs
@@ -1,0 +1,36 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::HashMap;
+
+use dynamo_backend_common::{EngineConfig, LlmRegistration};
+
+/// Model identity and registration metadata for the TensorRT-LLM sidecar.
+#[derive(Clone, Debug)]
+pub(crate) struct ConfiguredModel {
+    /// HF repo name or local path used for tokenization and templates.
+    pub source: String,
+    /// Maximum sequence length (input + output), from the `--context-length`
+    /// argument or a server `GetModelInfo` report, if known.
+    pub context_length: Option<u32>,
+}
+
+impl ConfiguredModel {
+    pub(crate) fn engine_config(&self) -> EngineConfig {
+        let mut runtime_data = HashMap::new();
+        runtime_data.insert(
+            "grpc_service".to_string(),
+            serde_json::Value::String("trtllm.TrtllmService".to_string()),
+        );
+
+        EngineConfig {
+            model: self.source.clone(),
+            served_model_name: None,
+            runtime_data,
+            llm: Some(LlmRegistration {
+                context_length: self.context_length,
+                ..Default::default()
+            }),
+        }
+    }
+}

--- a/lib/sidecar/trtllm/src/proto.rs
+++ b/lib/sidecar/trtllm/src/proto.rs
@@ -1,0 +1,12 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Generated protobuf / gRPC types for the `trtllm` package.
+//!
+//! Codegen is driven by `build.rs` from the vendored, checksum-tracked
+//! TensorRT-LLM `trtllm_service.proto`.
+
+#![allow(clippy::all)]
+#![allow(missing_docs)]
+
+tonic::include_proto!("trtllm");

--- a/lib/sidecar/trtllm/src/tests.rs
+++ b/lib/sidecar/trtllm/src/tests.rs
@@ -234,7 +234,6 @@ fn request() -> PreprocessedRequest {
             presence_penalty: Some(0.3),
             frequency_penalty: Some(0.4),
             repetition_penalty: Some(1.1),
-            include_stop_str_in_output: Some(true),
             guided_decoding: Some(dynamo_backend_common::GuidedDecodingOptions {
                 json: Some(json!({"type": "object"})),
                 ..Default::default()
@@ -281,6 +280,18 @@ async fn collect(
         .await
 }
 
+/// Applies `mutate` to a baseline request and asserts `build_generate_request`
+/// rejects it with a message mentioning `expect`.
+fn assert_rejected(mutate: impl FnOnce(&mut PreprocessedRequest), expect: &str) {
+    let mut req = request();
+    mutate(&mut req);
+    let error = build_generate_request(&req, "req", None).expect_err("request must be rejected");
+    assert!(
+        error.to_string().contains(expect),
+        "error {error:?} should mention {expect:?}"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // Request-building unit tests
 // ---------------------------------------------------------------------------
@@ -296,7 +307,9 @@ fn request_maps_sampling_stop_and_output_fields() {
     assert_eq!(proto.max_tokens, 16);
     assert!(proto.streaming);
     assert!(proto.ignore_eos);
-    assert!(proto.include_stop_token_in_output);
+    // Stop-token inclusion is never enabled from `include_stop_str_in_output`
+    // (different axis; would leak hidden stop tokens).
+    assert!(!proto.include_stop_token_in_output);
     assert_eq!(proto.stop, ["done"]);
     assert_eq!(proto.stop_token_ids, [2]);
 
@@ -363,6 +376,78 @@ fn oversized_logprob_count_is_rejected() {
     let error =
         build_generate_request(&req, "req", None).expect_err("oversized logprobs must fail");
     assert!(error.to_string().contains("must fit in i32"));
+}
+
+#[test]
+fn unsupported_request_controls_are_rejected() {
+    // Controls the native gRPC contract can neither forward nor faithfully honor:
+    // reject rather than fail open.
+    assert_rejected(
+        |r| r.sampling_options.include_stop_str_in_output = Some(true),
+        "include_stop_str_in_output",
+    );
+    assert_rejected(
+        |r| r.stop_conditions.max_thinking_tokens = Some(32),
+        "max_thinking_tokens",
+    );
+    assert_rejected(
+        |r| {
+            r.routing = Some(dynamo_backend_common::engine::RoutingHints {
+                cache_namespace: Some("tenant-a".to_string()),
+                ..Default::default()
+            })
+        },
+        "cache namespace",
+    );
+    assert_rejected(
+        |r| {
+            r.routing = Some(dynamo_backend_common::engine::RoutingHints {
+                priority: Some(5),
+                ..Default::default()
+            })
+        },
+        "priority",
+    );
+    // A negative top_k other than -1/0 (the "all tokens" sentinels) is invalid,
+    // not a silent widening to "all tokens".
+    assert_rejected(|r| r.sampling_options.top_k = Some(-5), "top_k must be");
+    assert_rejected(
+        |r| r.sampling_options.seed = Some(-1),
+        "seed must be non-negative",
+    );
+}
+
+#[test]
+fn logprobs_zero_keeps_selected_without_alternatives() {
+    let mut req = request();
+    req.output_options.logprobs = Some(0);
+    // The wire request must still ask TRT-LLM for one logprob so the selected
+    // token's value is computed.
+    let proto = build_generate_request(&req, "req", None).expect("build");
+    assert_eq!(proto.output_config.unwrap().logprobs, Some(1));
+
+    let mut state = ResponseState::new(&req);
+    let chunk = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Chunk(
+            pb::GenerateStreamChunk {
+                token_ids: vec![7],
+                sequence_index: 0,
+                prompt_tokens: 3,
+                completion_tokens: 1,
+                cached_tokens: 0,
+                logprobs: vec![pb::TokenLogprob {
+                    token_id: 7,
+                    logprob: -0.1,
+                    top_logprobs: vec![],
+                }],
+            },
+        )),
+    };
+    let delta = state.convert(chunk).expect("convert").expect("delta");
+    assert_eq!(delta.log_probs.as_deref(), Some(&[f64::from(-0.1_f32)][..]));
+    // logprobs=0 surfaces the selected-token logprob but no top alternatives.
+    assert!(delta.top_logprobs.is_none());
 }
 
 // ---------------------------------------------------------------------------
@@ -445,6 +530,71 @@ fn unsupported_sequence_index_is_rejected() {
         )),
     };
     assert!(state.convert(chunk).is_err());
+}
+
+#[test]
+fn missing_response_payload_is_rejected() {
+    let req = request();
+    let mut state = ResponseState::new(&req);
+    let empty = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: None,
+    };
+    assert!(state.convert(empty).is_err());
+}
+
+#[test]
+fn unknown_finish_reason_is_rejected() {
+    let req = request();
+    let mut state = ResponseState::new(&req);
+    let complete = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Complete(
+            pb::GenerateComplete {
+                finish_reason: "teleported".to_string(),
+                sequence_index: 0,
+                ..Default::default()
+            },
+        )),
+    };
+    assert!(state.convert(complete).is_err());
+}
+
+#[test]
+fn terminal_token_count_mismatch_is_rejected() {
+    let mut req = request();
+    req.output_options.logprobs = None;
+    let mut state = ResponseState::new(&req);
+    // Stream a single delta token...
+    let chunk = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Chunk(
+            pb::GenerateStreamChunk {
+                token_ids: vec![7],
+                sequence_index: 0,
+                prompt_tokens: 3,
+                completion_tokens: 1,
+                cached_tokens: 0,
+                logprobs: vec![],
+            },
+        )),
+    };
+    state.convert(chunk).expect("convert chunk");
+    // ...but the terminal claims two cumulative output tokens.
+    let complete = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Complete(
+            pb::GenerateComplete {
+                output_token_ids: vec![7, 8],
+                sequence_index: 0,
+                finish_reason: "stop".to_string(),
+                prompt_tokens: 3,
+                completion_tokens: 2,
+                ..Default::default()
+            },
+        )),
+    };
+    assert!(state.convert(complete).is_err());
 }
 
 // ---------------------------------------------------------------------------

--- a/lib/sidecar/trtllm/src/tests.rs
+++ b/lib/sidecar/trtllm/src/tests.rs
@@ -1,0 +1,608 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::collections::BTreeSet;
+use std::net::SocketAddr;
+use std::num::NonZeroUsize;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use dynamo_backend_common::{
+    FinishReason, GenerateContext, LLMEngine, OutputOptions, PreprocessedRequest, SamplingOptions,
+    StopConditions, StopReason,
+};
+use dynamo_sidecar_common::{GrpcEndpoint, GrpcTransportConfig};
+use futures::{Stream, StreamExt};
+use serde_json::json;
+use tokio::net::TcpListener;
+use tokio::sync::{Mutex, oneshot};
+use tokio_stream::wrappers::TcpListenerStream;
+use tonic::{Request, Response, Status};
+
+use crate::client::TrtllmClient;
+use crate::convert::{ResponseState, build_generate_request};
+use crate::engine::TrtllmSidecarEngine;
+use crate::model::ConfiguredModel;
+use crate::proto as pb;
+
+// ---------------------------------------------------------------------------
+// Fake TensorRT-LLM gRPC service
+// ---------------------------------------------------------------------------
+
+#[derive(Clone, Default)]
+struct FakeTrtllm {
+    requests: Arc<Mutex<Vec<pb::GenerateRequest>>>,
+    aborts: Arc<Mutex<Vec<String>>>,
+    peers: Arc<Mutex<Vec<SocketAddr>>>,
+    reject: Arc<AtomicBool>,
+    hang: Arc<AtomicBool>,
+}
+
+#[tonic::async_trait]
+impl pb::trtllm_service_server::TrtllmService for FakeTrtllm {
+    type GenerateStream = Pin<Box<dyn Stream<Item = Result<pb::GenerateResponse, Status>> + Send>>;
+
+    async fn generate(
+        &self,
+        request: Request<pb::GenerateRequest>,
+    ) -> Result<Response<Self::GenerateStream>, Status> {
+        if let Some(peer) = request.remote_addr() {
+            self.peers.lock().await.push(peer);
+        }
+        let request = request.into_inner();
+        self.requests.lock().await.push(request.clone());
+        if self.reject.load(Ordering::SeqCst) {
+            return Err(Status::invalid_argument("rejected by fake TensorRT-LLM"));
+        }
+
+        let request_id = request.request_id.clone();
+        let prompt_tokens = request
+            .tokenized
+            .as_ref()
+            .map(|t| t.input_token_ids.len() as u32)
+            .unwrap_or(0);
+        let wants_logprobs = request
+            .output_config
+            .as_ref()
+            .and_then(|o| o.logprobs)
+            .is_some();
+        let hang = self.hang.load(Ordering::SeqCst);
+
+        let stream = async_stream::try_stream! {
+            let logprobs = if wants_logprobs {
+                vec![pb::TokenLogprob {
+                    token_id: 42,
+                    logprob: -0.25,
+                    top_logprobs: vec![pb::TopLogprob { token_id: 43, logprob: -0.5 }],
+                }]
+            } else {
+                Vec::new()
+            };
+
+            yield pb::GenerateResponse {
+                request_id: request_id.clone(),
+                response: Some(pb::generate_response::Response::Chunk(pb::GenerateStreamChunk {
+                    token_ids: vec![42],
+                    sequence_index: 0,
+                    prompt_tokens,
+                    completion_tokens: 1,
+                    cached_tokens: 0,
+                    logprobs,
+                })),
+            };
+
+            if hang {
+                loop {
+                    tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+                }
+            }
+
+            yield pb::GenerateResponse {
+                request_id,
+                response: Some(pb::generate_response::Response::Complete(pb::GenerateComplete {
+                    output_token_ids: vec![42],
+                    sequence_index: 0,
+                    finish_reason: "stop".to_string(),
+                    matched_stop: Some(pb::generate_complete::MatchedStop::MatchedTokenId(2)),
+                    prompt_tokens,
+                    completion_tokens: 1,
+                    cached_tokens: 0,
+                    ..Default::default()
+                })),
+            };
+        };
+        Ok(Response::new(Box::pin(stream)))
+    }
+
+    async fn embed(
+        &self,
+        _request: Request<pb::EmbedRequest>,
+    ) -> Result<Response<pb::EmbedResponse>, Status> {
+        Err(Status::unimplemented("embed is not used"))
+    }
+
+    async fn health_check(
+        &self,
+        _request: Request<pb::HealthCheckRequest>,
+    ) -> Result<Response<pb::HealthCheckResponse>, Status> {
+        Ok(Response::new(pb::HealthCheckResponse {
+            status: "OK".to_string(),
+        }))
+    }
+
+    async fn abort(
+        &self,
+        request: Request<pb::AbortRequest>,
+    ) -> Result<Response<pb::AbortResponse>, Status> {
+        let request_id = request.into_inner().request_id;
+        self.aborts.lock().await.push(request_id.clone());
+        Ok(Response::new(pb::AbortResponse {
+            success: true,
+            message: format!("aborted {request_id}"),
+        }))
+    }
+
+    async fn get_model_info(
+        &self,
+        _request: Request<pb::GetModelInfoRequest>,
+    ) -> Result<Response<pb::GetModelInfoResponse>, Status> {
+        Ok(Response::new(pb::GetModelInfoResponse {
+            model_id: "fake-model".to_string(),
+            max_seq_len: 4096,
+            vocab_size: 32000,
+            ..Default::default()
+        }))
+    }
+
+    async fn get_server_info(
+        &self,
+        _request: Request<pb::GetServerInfoRequest>,
+    ) -> Result<Response<pb::GetServerInfoResponse>, Status> {
+        Ok(Response::new(pb::GetServerInfoResponse {
+            version: "1.3.0rc21".to_string(),
+            backend: "pytorch".to_string(),
+            tensor_parallel_size: 1,
+            pipeline_parallel_size: 1,
+            context_parallel_size: 1,
+            world_size: 1,
+        }))
+    }
+}
+
+struct FakeServer {
+    endpoint: String,
+    service: FakeTrtllm,
+    shutdown: Option<oneshot::Sender<()>>,
+}
+
+impl FakeServer {
+    async fn start(service: FakeTrtllm) -> Self {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let address = listener.local_addr().expect("address");
+        let (shutdown, shutdown_rx) = oneshot::channel();
+        let server_service = service.clone();
+        tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(pb::trtllm_service_server::TrtllmServiceServer::new(
+                    server_service,
+                ))
+                .serve_with_incoming_shutdown(TcpListenerStream::new(listener), async {
+                    let _ = shutdown_rx.await;
+                })
+                .await
+                .expect("serve fake TensorRT-LLM");
+        });
+        Self {
+            endpoint: format!("http://{address}"),
+            service,
+            shutdown: Some(shutdown),
+        }
+    }
+}
+
+impl Drop for FakeServer {
+    fn drop(&mut self) {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn request() -> PreprocessedRequest {
+    PreprocessedRequest::builder()
+        .model("served-model".to_string())
+        .token_ids(vec![11, 22, 33])
+        .stop_conditions(StopConditions {
+            max_tokens: Some(16),
+            min_tokens: Some(1),
+            stop: Some(vec!["done".to_string()]),
+            stop_token_ids_hidden: Some(vec![2]),
+            ignore_eos: Some(true),
+            ..Default::default()
+        })
+        .sampling_options(SamplingOptions {
+            temperature: Some(0.2),
+            top_p: Some(0.9),
+            top_k: Some(4),
+            min_p: Some(0.1),
+            seed: Some(123),
+            presence_penalty: Some(0.3),
+            frequency_penalty: Some(0.4),
+            repetition_penalty: Some(1.1),
+            include_stop_str_in_output: Some(true),
+            guided_decoding: Some(dynamo_backend_common::GuidedDecodingOptions {
+                json: Some(json!({"type": "object"})),
+                ..Default::default()
+            }),
+            ..Default::default()
+        })
+        .output_options(OutputOptions {
+            logprobs: Some(1),
+            ..Default::default()
+        })
+        .build()
+        .expect("request")
+}
+
+fn transport(connections: usize) -> GrpcTransportConfig {
+    GrpcTransportConfig {
+        connections: NonZeroUsize::new(connections).expect("nonzero connections"),
+        ..Default::default()
+    }
+}
+
+fn engine(endpoint: &str, connections: usize) -> TrtllmSidecarEngine {
+    TrtllmSidecarEngine::new(
+        GrpcEndpoint::parse(endpoint, "--trtllm-endpoint").expect("valid test endpoint"),
+        transport(connections),
+        ConfiguredModel {
+            source: "model-source".to_string(),
+            context_length: None,
+        },
+    )
+}
+
+async fn collect(
+    engine: &TrtllmSidecarEngine,
+    request: PreprocessedRequest,
+) -> Vec<dynamo_backend_common::LLMEngineOutput> {
+    let context = dynamo_backend_common::testing::mock_context();
+    engine
+        .generate(request, GenerateContext::new(context, None))
+        .await
+        .expect("generate")
+        .map(|item| item.expect("stream item"))
+        .collect()
+        .await
+}
+
+// ---------------------------------------------------------------------------
+// Request-building unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn request_maps_sampling_stop_and_output_fields() {
+    let proto = build_generate_request(&request(), "req-1", None).expect("build request");
+    assert_eq!(proto.request_id, "req-1");
+    assert_eq!(
+        proto.tokenized.as_ref().unwrap().input_token_ids,
+        [11, 22, 33]
+    );
+    assert_eq!(proto.max_tokens, 16);
+    assert!(proto.streaming);
+    assert!(proto.ignore_eos);
+    assert!(proto.include_stop_token_in_output);
+    assert_eq!(proto.stop, ["done"]);
+    assert_eq!(proto.stop_token_ids, [2]);
+
+    let sampling = proto.sampling_config.as_ref().unwrap();
+    assert_eq!(sampling.top_k, Some(4));
+    assert_eq!(sampling.top_p, Some(0.9));
+    assert_eq!(sampling.min_p, Some(0.1));
+    assert_eq!(sampling.temperature, Some(0.2));
+    assert_eq!(sampling.seed, Some(123));
+    assert_eq!(sampling.repetition_penalty, Some(1.1));
+    assert_eq!(sampling.min_tokens, Some(1));
+
+    let output = proto.output_config.as_ref().unwrap();
+    assert_eq!(output.logprobs, Some(1));
+    assert!(output.exclude_input_from_output);
+
+    let guided = proto.guided_decoding.as_ref().unwrap();
+    assert_eq!(
+        guided.guide_type,
+        pb::guided_decoding_params::GuideType::JsonSchema as i32
+    );
+    assert!(guided.guide.contains("object"));
+}
+
+#[test]
+fn omitted_max_tokens_without_context_length_is_rejected() {
+    let mut req = request();
+    req.stop_conditions.max_tokens = None;
+    let error = build_generate_request(&req, "req", None).expect_err("must require max_tokens");
+    assert!(error.to_string().contains("max_tokens"));
+}
+
+#[test]
+fn omitted_max_tokens_defaults_to_remaining_context() {
+    let mut req = request();
+    req.stop_conditions.max_tokens = None;
+    // request() carries three prompt tokens ([11, 22, 33]); the default fills the
+    // remaining context: max(1, context_length - prompt_len).
+    let proto = build_generate_request(&req, "req", Some(100)).expect("build with fallback");
+    assert_eq!(proto.max_tokens, 97);
+}
+
+#[test]
+fn omitted_max_tokens_default_is_floored_at_one() {
+    let mut req = request();
+    req.stop_conditions.max_tokens = None;
+    // Prompt already fills (or exceeds) the context: default must not underflow to 0.
+    let proto = build_generate_request(&req, "req", Some(2)).expect("build with fallback");
+    assert_eq!(proto.max_tokens, 1);
+}
+
+#[test]
+fn top_k_all_tokens_is_left_unset() {
+    let mut req = request();
+    req.sampling_options.top_k = Some(-1);
+    let proto = build_generate_request(&req, "req", None).expect("build");
+    assert_eq!(proto.sampling_config.unwrap().top_k, None);
+}
+
+#[test]
+fn oversized_logprob_count_is_rejected() {
+    let mut req = request();
+    req.output_options.logprobs = Some(i32::MAX as u32 + 1);
+    let error =
+        build_generate_request(&req, "req", None).expect_err("oversized logprobs must fail");
+    assert!(error.to_string().contains("must fit in i32"));
+}
+
+// ---------------------------------------------------------------------------
+// Response-conversion unit tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn chunk_then_complete_produces_delta_then_terminal_usage() {
+    let req = request();
+    let mut state = ResponseState::new(&req);
+
+    let chunk = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Chunk(
+            pb::GenerateStreamChunk {
+                token_ids: vec![7, 8],
+                sequence_index: 0,
+                prompt_tokens: 3,
+                completion_tokens: 2,
+                cached_tokens: 0,
+                logprobs: vec![
+                    pb::TokenLogprob {
+                        token_id: 7,
+                        logprob: -0.1,
+                        top_logprobs: vec![],
+                    },
+                    pb::TokenLogprob {
+                        token_id: 8,
+                        logprob: -0.2,
+                        top_logprobs: vec![],
+                    },
+                ],
+            },
+        )),
+    };
+    let delta = state.convert(chunk).expect("convert chunk").expect("delta");
+    assert_eq!(delta.token_ids, [7, 8]);
+    assert!(delta.finish_reason.is_none());
+    let log_probs = delta.log_probs.as_ref().expect("log_probs");
+    assert_eq!(log_probs.len(), 2);
+    assert!((log_probs[0] - f64::from(-0.1_f32)).abs() < 1e-9);
+    assert!((log_probs[1] - f64::from(-0.2_f32)).abs() < 1e-9);
+    assert_eq!(delta.top_logprobs.as_ref().unwrap().len(), 2);
+
+    let complete = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Complete(
+            pb::GenerateComplete {
+                output_token_ids: vec![7, 8],
+                sequence_index: 0,
+                finish_reason: "length".to_string(),
+                prompt_tokens: 3,
+                completion_tokens: 2,
+                ..Default::default()
+            },
+        )),
+    };
+    let terminal = state
+        .convert(complete)
+        .expect("convert complete")
+        .expect("terminal");
+    assert!(terminal.token_ids.is_empty());
+    assert_eq!(terminal.finish_reason, Some(FinishReason::Length));
+    let usage = terminal.completion_usage.as_ref().expect("usage");
+    assert_eq!((usage.prompt_tokens, usage.completion_tokens), (3, 2));
+}
+
+#[test]
+fn unsupported_sequence_index_is_rejected() {
+    let req = request();
+    let mut state = ResponseState::new(&req);
+    let chunk = pb::GenerateResponse {
+        request_id: "r".to_string(),
+        response: Some(pb::generate_response::Response::Chunk(
+            pb::GenerateStreamChunk {
+                token_ids: vec![1],
+                sequence_index: 1,
+                ..Default::default()
+            },
+        )),
+    };
+    assert!(state.convert(chunk).is_err());
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests against the fake server
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn aggregated_generation_streams_delta_then_terminal() {
+    let server = FakeServer::start(FakeTrtllm::default()).await;
+    let engine = engine(&server.endpoint, 2);
+    let config = engine.start(0).await.expect("start");
+    assert_eq!(config.model, "model-source");
+    // GetModelInfo reports max_seq_len 4096.
+    assert_eq!(config.llm.unwrap().context_length, Some(4096));
+
+    let outputs = collect(&engine, request()).await;
+    assert_eq!(outputs.len(), 2);
+    assert_eq!(outputs[0].token_ids, [42]);
+    assert!(outputs[0].finish_reason.is_none());
+    assert_eq!(outputs[0].log_probs.as_deref(), Some(&[-0.25][..]));
+
+    let terminal = &outputs[1];
+    assert!(terminal.token_ids.is_empty());
+    assert_eq!(terminal.finish_reason, Some(FinishReason::Stop));
+    assert_eq!(terminal.stop_reason, Some(StopReason::Int(2)));
+    let usage = terminal.completion_usage.as_ref().expect("usage");
+    assert_eq!((usage.prompt_tokens, usage.completion_tokens), (3, 1));
+
+    let requests = server.service.requests.lock().await;
+    let sent = requests.first().expect("recorded request");
+    assert!(sent.streaming);
+    assert_eq!(
+        sent.tokenized.as_ref().unwrap().input_token_ids,
+        [11, 22, 33]
+    );
+}
+
+#[tokio::test]
+async fn grpc_request_errors_are_propagated() {
+    let service = FakeTrtllm::default();
+    service.reject.store(true, Ordering::SeqCst);
+    let server = FakeServer::start(service).await;
+    let engine = engine(&server.endpoint, 1);
+    engine.start(0).await.expect("start");
+
+    // TRT-LLM surfaces an invalid-argument on the initial response header, so
+    // opening the stream fails rather than yielding an error item.
+    let context = dynamo_backend_common::testing::mock_context();
+    let result = engine
+        .generate(request(), GenerateContext::new(context, None))
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn cancellation_yields_a_cancelled_terminal() {
+    let service = FakeTrtllm::default();
+    service.hang.store(true, Ordering::SeqCst);
+    let server = FakeServer::start(service).await;
+    let engine = engine(&server.endpoint, 1);
+    engine.start(0).await.expect("start");
+
+    let context = dynamo_backend_common::testing::mock_context();
+    let mut stream = engine
+        .generate(request(), GenerateContext::new(context.clone(), None))
+        .await
+        .expect("generate");
+    let first = stream.next().await.unwrap().unwrap();
+    assert_eq!(first.token_ids, [42]);
+    context.stop_generating();
+    let terminal = tokio::time::timeout(std::time::Duration::from_secs(2), stream.next())
+        .await
+        .expect("terminal within deadline")
+        .unwrap()
+        .unwrap();
+    assert_eq!(terminal.finish_reason, Some(FinishReason::Cancelled));
+}
+
+#[tokio::test]
+async fn abort_sends_the_abort_rpc_to_the_server() {
+    let server = FakeServer::start(FakeTrtllm::default()).await;
+    let engine = engine(&server.endpoint, 1);
+    engine.start(0).await.expect("start");
+
+    let context = dynamo_backend_common::testing::mock_context();
+    let request_id = context.id().to_string();
+    engine.abort(context).await;
+
+    // The cancelled generation's ID must reach TensorRT-LLM, not just produce a
+    // local terminal, or the server keeps generating.
+    assert_eq!(server.service.aborts.lock().await.as_slice(), [request_id]);
+}
+
+#[tokio::test]
+async fn unsupported_features_fail_before_rpc_submission() {
+    let server = FakeServer::start(FakeTrtllm::default()).await;
+    let engine = engine(&server.endpoint, 1);
+    engine.start(0).await.expect("start");
+
+    let mut multiple = request();
+    multiple.sampling_options.n = Some(2);
+
+    let mut beam = request();
+    beam.sampling_options.use_beam_search = Some(true);
+
+    let mut embeds = request();
+    embeds.prompt_embeds = Some("encoded".to_string());
+
+    let mut prompt_logprobs = request();
+    prompt_logprobs.output_options.prompt_logprobs = Some(1);
+
+    let mut visible_stops = request();
+    visible_stops.stop_conditions.stop_token_ids_visible = Some(vec![7]);
+
+    for unsupported in [multiple, beam, embeds, prompt_logprobs, visible_stops] {
+        let context = dynamo_backend_common::testing::mock_context();
+        let result = engine
+            .generate(unsupported, GenerateContext::new(context, None))
+            .await;
+        assert!(result.is_err());
+    }
+    assert!(server.service.requests.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn pool_uses_each_configured_connection() {
+    let server = FakeServer::start(FakeTrtllm::default()).await;
+    let endpoint =
+        GrpcEndpoint::parse(&server.endpoint, "--trtllm-endpoint").expect("valid endpoint");
+    let client = TrtllmClient::connect(&endpoint, transport(2))
+        .await
+        .expect("connect pool");
+    assert_eq!(client.connection_count(), 2);
+
+    for index in 0..4 {
+        let mut stream = client
+            .generate(pb::GenerateRequest {
+                request_id: format!("request-{index}"),
+                tokenized: Some(pb::TokenizedInput {
+                    input_token_ids: vec![1, 2],
+                    ..Default::default()
+                }),
+                max_tokens: 4,
+                streaming: true,
+                ..Default::default()
+            })
+            .await
+            .expect("start stream");
+        while stream.message().await.expect("message").is_some() {}
+    }
+
+    let ports: BTreeSet<_> = server
+        .service
+        .peers
+        .lock()
+        .await
+        .iter()
+        .map(SocketAddr::port)
+        .collect();
+    assert_eq!(ports.len(), 2);
+}

--- a/lib/sidecar/trtllm/tests/executable.rs
+++ b/lib/sidecar/trtllm/tests/executable.rs
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::process::Command;
+
+#[test]
+fn executable_exposes_native_grpc_configuration() {
+    let output = Command::new(env!("CARGO_BIN_EXE_dynamo-trtllm-sidecar"))
+        .arg("--help")
+        .output()
+        .expect("run dynamo-trtllm-sidecar --help");
+
+    assert!(
+        output.status.success(),
+        "--help failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8(output.stdout).expect("help output is UTF-8");
+    for flag in ["--trtllm-endpoint", "--model-path", "--disaggregation-mode"] {
+        assert!(stdout.contains(flag), "missing {flag} in help output");
+    }
+}


### PR DESCRIPTION
## Summary

Adds `dynamo-trtllm-sidecar`, a standalone Rust worker that drives an out-of-process TensorRT-LLM engine over its native `trtllm.TrtllmService` gRPC (`serve --grpc`, TRT-LLM `1.3.0rc21`+). It composes with `dynamo_backend_common::run` and owns Dynamo worker registration, request conversion, transport, cancellation, and abort; TensorRT-LLM runs as its own process (no Python launcher, no unreleased protocol extensions).

**Supported:** aggregated generation with sampling, stop conditions, structured output (JSON schema / regex / grammar / structural tag), logprobs, streaming deltas + terminal usage, and abort-on-cancel.

**Rejected before dispatch:** disaggregation, multimodal, LoRA, KV-aware routing, encode, beam search, `n > 1`.

**`max_tokens` note:** TensorRT-LLM's gRPC marks `max_tokens` REQUIRED, so an omitted `max_tokens` (which the frontend forwards as `None` for the backend to default) is filled to the model's remaining context via `--context-length`, mirroring the in-process backend's `_default_max_tokens`. The proper fix is upstream — tracked in NVIDIA/TensorRT-LLM#16549.

Container packaging is intentionally deferred to a follow-up.

## Validation

- `cargo test -p dynamo-trtllm-sidecar` — 14 unit tests + the executable-contract test pass
- `cargo clippy -p dynamo-trtllm-sidecar --all-targets` — clean
- `cargo fmt --all -- --check`
- End-to-end against a live `nvcr.io/nvidia/tensorrt-llm/release:1.3.0rc21` gRPC server (Qwen3-0.6B, single GPU) + Dynamo frontend: non-streaming, streaming (SSE deltas + terminal usage), logprobs (incl. top-k), stop conditions, abort-on-cancel, and the omitted-`max_tokens` fallback (`--context-length` → HTTP 200; without it → clean rejection) all verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11840" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a TensorRT-LLM sidecar executable that connects Dynamo workers to TensorRT-LLM through gRPC.
  * Supports streaming text generation, sampling controls, stop conditions, structured output, log probabilities, cancellation, and request aborts.
  * Added configurable endpoint, model path, and context-length options.

* **Documentation**
  * Added setup instructions, supported capabilities, limitations, and protocol documentation.

* **Tests**
  * Added coverage for request handling, streaming responses, cancellation, validation, connection pooling, and command-line configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->