### PR TITLE
feat(planner): support Dynamo traces for load predictor warmup

### DIFF
--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -192,23 +192,19 @@ class NativePlannerBase:
     ) -> Optional[list[TrafficObservation]]:
         if self.config.load_predictor_warmup_trace is None:
             return None
-        try:
-            metrics = extract_metrics_from_trace(
-                self.config.load_predictor_warmup_trace,
-                self.config.throughput_adjustment_interval_seconds,
+        metrics = extract_metrics_from_trace(
+            self.config.load_predictor_warmup_trace,
+            self.config.throughput_adjustment_interval_seconds,
+        )
+        return [
+            TrafficObservation(
+                duration_s=self.config.throughput_adjustment_interval_seconds,
+                num_req=float(m["request_count"]),
+                isl=float(m["avg_isl"]),
+                osl=float(m["avg_osl"]),
             )
-            return [
-                TrafficObservation(
-                    duration_s=self.config.throughput_adjustment_interval_seconds,
-                    num_req=float(m["request_count"]),
-                    isl=float(m["avg_isl"]),
-                    osl=float(m["avg_osl"]),
-                )
-                for m in metrics
-            ]
-        except Exception as exc:
-            logger.warning("Failed to warm load predictors: %s", exc)
-            return None
+            for m in metrics
+        ]
 
     async def _bootstrap_engine_plugins_if_needed(self) -> None:
         # Keep the orchestrator dependency aligned with lazy engine construction.

--- a/components/src/dynamo/planner/core/base.py
+++ b/components/src/dynamo/planner/core/base.py
@@ -39,7 +39,7 @@ from dynamo.planner.environment.state import DeploymentState
 from dynamo.planner.monitoring.diagnostics_recorder import DiagnosticsRecorder
 from dynamo.planner.monitoring.live_dashboard import start_live_dashboard
 from dynamo.planner.monitoring.planner_metrics import PlannerPrometheusMetrics
-from dynamo.planner.offline.trace_data import extract_metrics_from_mooncake
+from dynamo.planner.offline.trace_data import extract_metrics_from_trace
 from dynamo.runtime import DistributedRuntime
 
 if TYPE_CHECKING:
@@ -193,7 +193,7 @@ class NativePlannerBase:
         if self.config.load_predictor_warmup_trace is None:
             return None
         try:
-            metrics = extract_metrics_from_mooncake(
+            metrics = extract_metrics_from_trace(
                 self.config.load_predictor_warmup_trace,
                 self.config.throughput_adjustment_interval_seconds,
             )

--- a/components/src/dynamo/planner/offline/trace_data.py
+++ b/components/src/dynamo/planner/offline/trace_data.py
@@ -4,6 +4,7 @@
 import glob
 import gzip
 import json
+import math
 from collections import defaultdict
 from pathlib import Path
 from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple
@@ -100,7 +101,13 @@ def _number(record: Dict[str, Any], field: str, location: str) -> float:
     value = record.get(field)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError(f"{field} must be numeric at {location}")
-    return float(value)
+    try:
+        number = float(value)
+    except OverflowError as error:
+        raise ValueError(f"{field} must be finite at {location}") from error
+    if not math.isfinite(number):
+        raise ValueError(f"{field} must be finite at {location}")
+    return number
 
 
 def _length(record: Dict[str, Any], field: str, location: str) -> int:

--- a/components/src/dynamo/planner/offline/trace_data.py
+++ b/components/src/dynamo/planner/offline/trace_data.py
@@ -1,87 +1,254 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
+import gzip
 import json
 from collections import defaultdict
-from typing import Any, Dict, List
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Literal, Optional, Sequence, Tuple
+
+TraceFormat = Literal["mooncake", "dynamo"]
+TraceRow = Tuple[float, int, int]
 
 
-def extract_metrics_from_mooncake(
-    dataset: str, throughput_adjustment_interval_seconds: int
-) -> List[Dict[str, Any]]:
-    """
-    Extract metrics from mooncake-style JSONL data.
+def _reject_duplicate_copies(paths: Sequence[Path]) -> List[Path]:
+    selected: Dict[str, Path] = {}
+    for path in paths:
+        key = str(path)[:-3] if path.name.endswith(".jsonl.gz") else str(path)
+        current = selected.get(key)
+        if current is not None and current != path:
+            raise ValueError(
+                f"Both compressed and uncompressed warmup trace copies matched: "
+                f"{current} and {path}. Select one representation with a glob."
+            )
+        selected[key] = path
+    return sorted(selected.values())
 
-    Args:
-        dataset: Path to the JSONL file containing mooncake trace data
-        throughput_adjustment_interval_seconds: Time interval to group requests
 
-    Returns:
-        List of dictionaries (ordered by time) containing metrics for each interval:
-        - interval_start: Start time of the interval (in seconds)
-        - request_count: Total number of requests in the interval
-        - avg_isl: Average input sequence length
-        - avg_osl: Average output sequence length
-
-        Intervals with no requests *between* the first and last active interval
-        are emitted as empty windows (request_count=0, avg_isl=0, avg_osl=0) so
-        gaps in traffic are preserved. This matches the planner's online
-        throughput loop, which feeds zero-traffic windows to the load
-        predictors; collapsing the gaps would let warmup diverge from live
-        behavior. Leading and trailing empty intervals are still omitted (the
-        series starts at the first interval with traffic and ends at the last),
-        matching the predictors' leading-idle skip.
-    """
-    # Read and parse JSONL data from file
-    records = []
-    with open(dataset, "r") as f:
-        for line in f:
-            if line.strip():
-                records.append(json.loads(line))
-
-    interval_groups = defaultdict(list)
-
-    for record in records:
-        timestamp_ms = record["timestamp"]
-        timestamp_sec = timestamp_ms / 1000
-        interval_start = (
-            int(timestamp_sec // throughput_adjustment_interval_seconds)
-            * throughput_adjustment_interval_seconds
+def _resolve_trace_paths(dataset: str) -> List[Path]:
+    path = Path(dataset)
+    if path.is_dir():
+        paths = sorted(
+            candidate
+            for candidate in path.rglob("*")
+            if candidate.is_file()
+            and (
+                candidate.name.endswith(".jsonl")
+                or candidate.name.endswith(".jsonl.gz")
+            )
         )
-        interval_groups[interval_start].append(record)
+    elif glob.has_magic(dataset):
+        paths = sorted(Path(match) for match in glob.glob(dataset, recursive=True))
+        paths = [candidate for candidate in paths if candidate.is_file()]
+    else:
+        paths = [path]
 
-    # Compute metrics for each interval. Walk every interval from the first to
-    # the last active one (step = interval), filling gaps with empty windows so
-    # zero-traffic intervals are preserved (matching the online throughput loop).
+    paths = _reject_duplicate_copies(paths)
+    if not paths:
+        raise ValueError(f"No warmup trace files matched {dataset!r}")
+    return paths
+
+
+def _open_trace(path: Path):
+    if path.suffix == ".gz":
+        return gzip.open(path, "rt", encoding="utf-8")
+    return path.open("r", encoding="utf-8")
+
+
+def _load_json_line(path: Path, line_number: int, line: str) -> Dict[str, Any]:
+    try:
+        record = json.loads(line)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"Invalid JSON at {path}:{line_number}: {error}") from error
+    if not isinstance(record, dict):
+        raise ValueError(f"Trace row at {path}:{line_number} must be a JSON object")
+    return record
+
+
+def _detect_record_format(record: Dict[str, Any]) -> Optional[TraceFormat]:
+    event = record.get("event", record)
+    if isinstance(event, dict) and event.get("schema") == "dynamo.request.trace.v1":
+        return "dynamo"
+    if all(field in record for field in ("timestamp", "input_length", "output_length")):
+        return "mooncake"
+    return None
+
+
+def detect_trace_format(dataset: str) -> Optional[TraceFormat]:
+    """Detect a Mooncake or Dynamo request-trace-v1 warmup dataset.
+
+    ``dataset`` may be a file, a glob, or a directory containing JSONL/JSONL.GZ
+    shards. Empty datasets return ``None``.
+    """
+    for path in _resolve_trace_paths(dataset):
+        with _open_trace(path) as source:
+            for line_number, line in enumerate(source, start=1):
+                if not line.strip():
+                    continue
+                record = _load_json_line(path, line_number, line)
+                trace_format = _detect_record_format(record)
+                if trace_format is None:
+                    raise ValueError(
+                        f"Unsupported warmup trace format at {path}:{line_number}"
+                    )
+                return trace_format
+    return None
+
+
+def _number(record: Dict[str, Any], field: str, location: str) -> float:
+    value = record.get(field)
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError(f"{field} must be numeric at {location}")
+    return float(value)
+
+
+def _length(record: Dict[str, Any], field: str, location: str) -> int:
+    value = record.get(field)
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"{field} must be a non-negative integer at {location}")
+    return value
+
+
+def _parse_mooncake_row(record: Dict[str, Any], location: str) -> TraceRow:
+    return (
+        _number(record, "timestamp", location),
+        _length(record, "input_length", location),
+        _length(record, "output_length", location),
+    )
+
+
+def _parse_dynamo_row(record: Dict[str, Any], location: str) -> Optional[TraceRow]:
+    event = record.get("event", record)
+    if not isinstance(event, dict) or event.get("schema") != "dynamo.request.trace.v1":
+        raise ValueError(f"Expected dynamo.request.trace.v1 at {location}")
+    if event.get("event_type") != "request_end":
+        return None
+
+    request = event.get("request")
+    if not isinstance(request, dict):
+        raise ValueError(f"request_end is missing request payload at {location}")
+    replay = request.get("replay")
+    if not isinstance(replay, dict):
+        raise ValueError(f"request payload is missing replay metrics at {location}")
+    return (
+        _number(request, "request_received_ms", location),
+        _length(replay, "input_length", location),
+        _length(request, "output_tokens", location),
+    )
+
+
+def _iter_trace_rows(
+    paths: Sequence[Path], trace_format: TraceFormat
+) -> Iterator[TraceRow]:
+    for path in paths:
+        with _open_trace(path) as source:
+            for line_number, line in enumerate(source, start=1):
+                if not line.strip():
+                    continue
+                location = f"{path}:{line_number}"
+                record = _load_json_line(path, line_number, line)
+                actual_format = _detect_record_format(record)
+                if actual_format != trace_format:
+                    raise ValueError(
+                        f"Mixed or unsupported warmup trace format at {location}: "
+                        f"expected {trace_format}, found {actual_format or 'unknown'}"
+                    )
+                row = (
+                    _parse_mooncake_row(record, location)
+                    if trace_format == "mooncake"
+                    else _parse_dynamo_row(record, location)
+                )
+                if row is not None:
+                    yield row
+
+
+def _extract_metrics(
+    paths: Sequence[Path],
+    trace_format: TraceFormat,
+    throughput_adjustment_interval_seconds: int,
+) -> List[Dict[str, Any]]:
+    if throughput_adjustment_interval_seconds <= 0:
+        raise ValueError("throughput_adjustment_interval_seconds must be positive")
+
+    # Mooncake timestamps are already relative to the trace start. Dynamo v1
+    # carries absolute request timestamps, so find the global origin first.
+    # This extra streaming pass keeps direct-v1 warmup equivalent to lowering
+    # the same requests to Mooncake without retaining a large trace in memory.
+    origin_ms = 0.0
+    if trace_format == "dynamo":
+        origin_ms = min(
+            (
+                timestamp_ms
+                for timestamp_ms, _, _ in _iter_trace_rows(paths, trace_format)
+            ),
+            default=0.0,
+        )
+
+    interval_ms = throughput_adjustment_interval_seconds * 1000
+    interval_groups: Dict[int, List[int]] = defaultdict(lambda: [0, 0, 0])
+    for timestamp_ms, input_length, output_length in _iter_trace_rows(
+        paths, trace_format
+    ):
+        interval_index = int((timestamp_ms - origin_ms) // interval_ms)
+        interval_start = interval_index * throughput_adjustment_interval_seconds
+        aggregate = interval_groups[interval_start]
+        aggregate[0] += 1
+        aggregate[1] += input_length
+        aggregate[2] += output_length
+
     metrics: List[Dict[str, Any]] = []
     if not interval_groups:
         return metrics
 
-    sorted_starts = sorted(interval_groups.keys())
+    sorted_starts = sorted(interval_groups)
     for interval_start in range(
         sorted_starts[0],
         sorted_starts[-1] + 1,
         throughput_adjustment_interval_seconds,
     ):
-        records_in_interval = interval_groups.get(interval_start, [])
-
-        # Calculate metrics
-        request_count = len(records_in_interval)
-
-        # Calculate average ISL and OSL
-        total_isl = sum(record["input_length"] for record in records_in_interval)
-        total_osl = sum(record["output_length"] for record in records_in_interval)
-
-        avg_isl = total_isl / request_count if request_count > 0 else 0
-        avg_osl = total_osl / request_count if request_count > 0 else 0
-
+        request_count, total_isl, total_osl = interval_groups.get(
+            interval_start, (0, 0, 0)
+        )
         metrics.append(
             {
                 "interval_start": interval_start,
                 "request_count": request_count,
-                "avg_isl": avg_isl,
-                "avg_osl": avg_osl,
+                "avg_isl": total_isl / request_count if request_count else 0,
+                "avg_osl": total_osl / request_count if request_count else 0,
             }
         )
 
     return metrics
+
+
+def extract_metrics_from_trace(
+    dataset: str, throughput_adjustment_interval_seconds: int
+) -> List[Dict[str, Any]]:
+    """Extract warmup metrics from auto-detected Mooncake or Dynamo v1 traces.
+
+    Dynamo v1 inputs may be plain or gzip-compressed and may be supplied as one
+    file, a glob, or a directory of shards. Non-request events are ignored.
+    """
+    paths = _resolve_trace_paths(dataset)
+    trace_format = detect_trace_format(dataset)
+    if trace_format is None:
+        return []
+    return _extract_metrics(paths, trace_format, throughput_adjustment_interval_seconds)
+
+
+def extract_metrics_from_mooncake(
+    dataset: str, throughput_adjustment_interval_seconds: int
+) -> List[Dict[str, Any]]:
+    """Extract warmup metrics from a Mooncake-style JSONL trace.
+
+    Kept for compatibility with callers that explicitly require Mooncake. New
+    planner warmup code should call :func:`extract_metrics_from_trace`.
+    """
+    paths = _resolve_trace_paths(dataset)
+    trace_format = detect_trace_format(dataset)
+    if trace_format is None:
+        return []
+    if trace_format != "mooncake":
+        raise ValueError(f"Expected Mooncake warmup trace, detected {trace_format}")
+    return _extract_metrics(paths, trace_format, throughput_adjustment_interval_seconds)

--- a/components/src/dynamo/planner/tests/offline/test_trace_data.py
+++ b/components/src/dynamo/planner/tests/offline/test_trace_data.py
@@ -193,3 +193,26 @@ def test_unknown_trace_format_is_rejected(tmp_path):
 
     with pytest.raises(ValueError, match="Unsupported warmup trace format"):
         extract_metrics_from_trace(path, 10)
+
+
+@pytest.mark.parametrize(
+    "timestamp",
+    [float("nan"), float("inf"), 10**400],
+    ids=["nan", "infinity", "float-overflow"],
+)
+def test_numeric_timestamp_must_be_finite(tmp_path, timestamp):
+    path = _write_trace(tmp_path, [_rec(timestamp, 100, 10)])
+
+    with pytest.raises(ValueError, match="timestamp must be finite"):
+        extract_metrics_from_trace(path, 10)
+
+
+def test_dynamo_v1_incomplete_request_end_is_rejected(tmp_path):
+    record = _dynamo_rec(100_000, 100, 10)
+    del record["request"]["output_tokens"]
+    path = _write_trace(tmp_path, [record])
+
+    with pytest.raises(
+        ValueError, match="output_tokens must be a non-negative integer"
+    ):
+        extract_metrics_from_trace(path, 10)

--- a/components/src/dynamo/planner/tests/offline/test_trace_data.py
+++ b/components/src/dynamo/planner/tests/offline/test_trace_data.py
@@ -1,24 +1,28 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ``extract_metrics_from_mooncake`` window construction.
+"""Tests for planner warmup trace parsing and window construction.
 
 The planner's online throughput loop feeds *every* interval (including
 zero-traffic ones) to the load predictors, but warmup goes through
-``extract_metrics_from_mooncake``. Before the fix it only emitted intervals
-that contained requests, so middle gaps were collapsed and warmup diverged
-from live behavior. These tests pin the densified behavior: gaps between the
-first and last active interval are emitted as empty windows, while leading and
-trailing empty intervals are omitted.
+the offline trace helpers. These tests pin the densified behavior: gaps between
+the first and last active interval are emitted as empty windows, while leading
+and trailing empty intervals are omitted. They also cover automatic Mooncake
+and Dynamo request trace v1 detection.
 """
 
 from __future__ import annotations
 
+import gzip
 import json
 
 import pytest
 
-from dynamo.planner.offline.trace_data import extract_metrics_from_mooncake
+from dynamo.planner.offline.trace_data import (
+    detect_trace_format,
+    extract_metrics_from_mooncake,
+    extract_metrics_from_trace,
+)
 
 pytestmark = [
     pytest.mark.gpu_0,
@@ -28,14 +32,38 @@ pytestmark = [
 ]
 
 
-def _write_trace(tmp_path, records):
-    path = tmp_path / "trace.jsonl"
-    path.write_text("\n".join(json.dumps(r) for r in records) + "\n")
+def _write_trace(tmp_path, records, name="trace.jsonl"):
+    path = tmp_path / name
+    contents = "\n".join(json.dumps(r) for r in records) + "\n"
+    if path.suffix == ".gz":
+        with gzip.open(path, "wt", encoding="utf-8") as output:
+            output.write(contents)
+    else:
+        path.write_text(contents)
     return str(path)
 
 
 def _rec(timestamp_ms, isl, osl):
     return {"timestamp": timestamp_ms, "input_length": isl, "output_length": osl}
+
+
+def _dynamo_rec(timestamp_ms, isl, osl, *, wrapped=False):
+    event = {
+        "schema": "dynamo.request.trace.v1",
+        "event_type": "request_end",
+        "event_time_unix_ms": timestamp_ms + 1_000,
+        "request": {
+            "request_id": f"request-{timestamp_ms}",
+            "request_received_ms": timestamp_ms,
+            "output_tokens": osl,
+            "replay": {
+                "trace_block_size": 64,
+                "input_length": isl,
+                "input_sequence_hashes": list(range((isl + 63) // 64)),
+            },
+        },
+    }
+    return {"timestamp": timestamp_ms + 1_000, "event": event} if wrapped else event
 
 
 def test_middle_empty_windows_are_preserved(tmp_path):
@@ -85,3 +113,83 @@ def test_intervals_are_contiguous(tmp_path):
 
 def test_empty_trace_returns_empty(tmp_path):
     assert extract_metrics_from_mooncake(_write_trace(tmp_path, []), 10) == []
+
+
+def test_auto_detects_mooncake(tmp_path):
+    path = _write_trace(tmp_path, [_rec(0, 100, 10)])
+
+    assert detect_trace_format(path) == "mooncake"
+    assert extract_metrics_from_trace(path, 10) == extract_metrics_from_mooncake(
+        path, 10
+    )
+
+
+def test_dynamo_v1_matches_lowered_mooncake_windows(tmp_path):
+    mooncake_path = _write_trace(
+        tmp_path,
+        [_rec(0, 100, 10), _rec(5_000, 300, 30), _rec(35_000, 500, 50)],
+        "mooncake.jsonl",
+    )
+    dynamo_path = _write_trace(
+        tmp_path,
+        [
+            _dynamo_rec(100_000, 100, 10),
+            _dynamo_rec(105_000, 300, 30, wrapped=True),
+            {
+                "schema": "dynamo.request.trace.v1",
+                "event_type": "tool_end",
+                "event_time_unix_ms": 110_000,
+            },
+            _dynamo_rec(135_000, 500, 50),
+        ],
+        "dynamo.jsonl.gz",
+    )
+
+    assert detect_trace_format(dynamo_path) == "dynamo"
+    assert extract_metrics_from_trace(dynamo_path, 10) == extract_metrics_from_trace(
+        mooncake_path, 10
+    )
+
+
+def test_dynamo_v1_directory_uses_global_origin_across_shards(tmp_path):
+    trace_dir = tmp_path / "trace-shards"
+    trace_dir.mkdir()
+    _write_trace(
+        trace_dir,
+        [_dynamo_rec(135_000, 500, 50)],
+        "part-2.jsonl.gz",
+    )
+    _write_trace(
+        trace_dir,
+        [_dynamo_rec(100_000, 100, 10)],
+        "part-1.jsonl",
+    )
+    metrics = extract_metrics_from_trace(str(trace_dir), 10)
+
+    assert [metric["interval_start"] for metric in metrics] == [0, 10, 20, 30]
+    assert [metric["request_count"] for metric in metrics] == [1, 0, 0, 1]
+
+
+def test_directory_rejects_compressed_and_uncompressed_copies(tmp_path):
+    trace_dir = tmp_path / "trace-shards"
+    trace_dir.mkdir()
+    record = _dynamo_rec(100_000, 100, 10)
+    _write_trace(trace_dir, [record], "part-1.jsonl")
+    _write_trace(trace_dir, [record], "part-1.jsonl.gz")
+
+    with pytest.raises(ValueError, match="Both compressed and uncompressed"):
+        extract_metrics_from_trace(str(trace_dir), 10)
+
+
+def test_explicit_mooncake_reader_rejects_dynamo(tmp_path):
+    path = _write_trace(tmp_path, [_dynamo_rec(100_000, 100, 10)])
+
+    with pytest.raises(ValueError, match="Expected Mooncake warmup trace"):
+        extract_metrics_from_mooncake(path, 10)
+
+
+def test_unknown_trace_format_is_rejected(tmp_path):
+    path = _write_trace(tmp_path, [{"timestamp": 0, "prompt_tokens": 100}])
+
+    with pytest.raises(ValueError, match="Unsupported warmup trace format"):
+        extract_metrics_from_trace(path, 10)

--- a/components/src/dynamo/planner/tests/unit/test_load_predictor_warmup.py
+++ b/components/src/dynamo/planner/tests/unit/test_load_predictor_warmup.py
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Regression tests for load-predictor warmup failures."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from dynamo.planner.core.base import NativePlannerBase
+
+pytestmark = [
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.planner,
+]
+
+
+def test_invalid_warmup_trace_is_not_silently_ignored(tmp_path):
+    trace = tmp_path / "invalid.jsonl"
+    trace.write_text('{"timestamp": 0, "prompt_tokens": 100}\n')
+    planner = object.__new__(NativePlannerBase)
+    planner.config = SimpleNamespace(
+        load_predictor_warmup_trace=str(trace),
+        throughput_adjustment_interval_seconds=10,
+    )
+
+    with pytest.raises(ValueError, match="Unsupported warmup trace format"):
+        planner._load_predictor_warmup_observations()


### PR DESCRIPTION
## Overview:

Add native `dynamo.request.trace.v1` support to Planner load-predictor warmup while retaining Mooncake compatibility.

## Summary

- Auto-detect Mooncake versus Dynamo request trace v1 from record schema.
- Read JSONL or JSONL.GZ from a file, glob, or directory of shards.
- Stream interval aggregation with bounded memory and normalize Dynamo timestamps across unordered shards.
- Reject mixed, malformed, ambiguous, non-finite, or unrepresentable trace inputs instead of silently producing a partial warmup.
- Propagate configured warmup trace failures so Planner startup cannot silently continue without the requested predictor history.

## Details:

Dynamo v1 inputs are scanned twice: the first pass finds the global first request timestamp across potentially unordered shards, and the second aggregates requests into Planner throughput windows. This preserves parity with lowering the same data to Mooncake without retaining a multi-million-request trace in memory.

Non-`request_end` Dynamo events are ignored. Replay `request_end` rows remain strict because the trace producer emits them only when the request tracker, KV block size, replay input metadata, request timestamp, and final/partial output token count are available. A malformed replay row therefore fails visibly rather than being skipped and changing the workload.

Review follow-up adds explicit rejection of `NaN`, infinity, and integer-to-float overflow, plus regression coverage for error propagation and malformed `request_end` rows.

## Where should the reviewer start?

1. `components/src/dynamo/planner/offline/trace_data.py` — path resolution, format detection, validation, and aggregation.
2. `components/src/dynamo/planner/core/base.py` — Planner warmup integration and failure propagation.
3. `components/src/dynamo/planner/tests/offline/test_trace_data.py` and `components/src/dynamo/planner/tests/unit/test_load_predictor_warmup.py` — behavior and review regressions.

## Related Issues

**🚫 This PR is NOT linked to an issue**:

- [x] Confirmed — no related issue

## Validation

- `.venv/bin/pytest -q components/src/dynamo/planner/tests/unit` — 474 passed
- `.venv/bin/pytest -q components/src/dynamo/planner/tests/offline components/src/dynamo/planner/tests/unit/test_load_predictor_warmup.py` — 24 passed
- `.venv/bin/ruff check components/src/dynamo/planner/offline/trace_data.py components/src/dynamo/planner/core/base.py components/src/dynamo/planner/tests/offline/test_trace_data.py components/src/dynamo/planner/tests/unit/test_load_predictor_warmup.py`
- `.venv/bin/ruff format --check components/src/dynamo/planner/offline/trace_data.py components/src/dynamo/planner/core/base.py components/src/dynamo/planner/tests/offline/test_trace_data.py components/src/dynamo/planner/tests/unit/test_load_predictor_warmup.py`
- `git diff --check`
- Parsed the three real Astra Dynamo v1 warmup datasets; all were auto-detected as Dynamo and request counts matched their split manifests.