### PR TITLE
test(serve): assert distinct workers for agg_router_replicas (OPS-7579)

### DIFF
--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -6,7 +6,6 @@ import logging
 import os
 import platform
 import random
-import types
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -44,52 +43,14 @@ from tests.utils.payload_builder import (
     router_selection_chat_payload_default,
 )
 from tests.utils.payloads import (
+    DistinctRouterWorkersPayload,
     EmbeddingMultiWorkerDispatchPayload,
     EmbeddingPayload,
     LoraTestChatPayload,
     ToolCallingChatPayload,
 )
-from tests.utils.router_nvext import require_router_worker_id
 
 logger = logging.getLogger(__name__)
-
-
-def _assert_distinct_router_workers(payload, min_distinct: int = 2):
-    """Require distinct router routes across repeated requests.
-
-    Binds validate/final_validation with ``types.MethodType`` so ``deepcopy`` in
-    ``run_serve_deployment`` rebinds them to the *copy* whose ``body`` is sent.
-    """
-    payload._min_distinct = min_distinct
-    payload._seen_routes = set()
-    payload._n = 0
-    base_validate = payload.__class__.validate
-
-    def validate(self, response, content):
-        base_validate(self, response, content)
-        worker_id = require_router_worker_id(response.json())
-        # One route identity per response (not independent prefill/decode IDs).
-        route = tuple(
-            worker_id[key]
-            for key in ("prefill_worker_id", "decode_worker_id")
-            if isinstance(worker_id.get(key), int)
-        )
-        if route:
-            self._seen_routes.add(route)
-        self._n += 1
-        # Diversify the prompt so KV affinity does not pin every request.
-        msg = self.body["messages"][0]
-        msg["content"] = msg["content"].split("\n[probe-", 1)[0] + f"\n[probe-{self._n}]"
-
-    def final_validation(self):
-        assert len(self._seen_routes) >= self._min_distinct, (
-            f"expected >= {self._min_distinct} distinct routes across {self._n} "
-            f"requests, got {sorted(self._seen_routes)}"
-        )
-
-    payload.validate = types.MethodType(validate, payload)
-    payload.final_validation = types.MethodType(final_validation, payload)
-    return payload
 
 
 def _is_cuda12() -> bool:
@@ -444,8 +405,11 @@ vllm_configs = {
         ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
-            _assert_distinct_router_workers(
-                router_selection_chat_payload_default(repeat_count=6)
+            # 10 requests keeps the random-tie-break flake probability of not
+            # hitting both replicas at ~2 * 0.5**10 (< 0.2%).
+            router_selection_chat_payload_default(
+                repeat_count=10,
+                payload_cls=DistinctRouterWorkersPayload,
             ),
             kv_events_metrics_payload(system_ports=[DefaultPort.SYSTEM2.value]),
         ],

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -6,6 +6,7 @@ import logging
 import os
 import platform
 import random
+import types
 from dataclasses import dataclass, field
 from typing import Optional
 
@@ -54,31 +55,40 @@ logger = logging.getLogger(__name__)
 
 
 def _assert_distinct_router_workers(payload, min_distinct: int = 2):
-    """Require distinct nvext worker IDs across repeated router requests."""
-    seen: set[int] = set()
-    n = 0
-    orig_validate = payload.validate
+    """Require distinct router routes across repeated requests.
 
-    def validate(response, content):
-        nonlocal n
-        orig_validate(response, content)
+    Binds validate/final_validation with ``types.MethodType`` so ``deepcopy`` in
+    ``run_serve_deployment`` rebinds them to the *copy* whose ``body`` is sent.
+    """
+    payload._min_distinct = min_distinct
+    payload._seen_routes = set()
+    payload._n = 0
+    base_validate = payload.__class__.validate
+
+    def validate(self, response, content):
+        base_validate(self, response, content)
         worker_id = require_router_worker_id(response.json())
-        for key in ("prefill_worker_id", "decode_worker_id"):
-            if isinstance(worker_id.get(key), int):
-                seen.add(worker_id[key])
-        n += 1
+        # One route identity per response (not independent prefill/decode IDs).
+        route = tuple(
+            worker_id[key]
+            for key in ("prefill_worker_id", "decode_worker_id")
+            if isinstance(worker_id.get(key), int)
+        )
+        if route:
+            self._seen_routes.add(route)
+        self._n += 1
         # Diversify the prompt so KV affinity does not pin every request.
-        msg = payload.body["messages"][0]
-        msg["content"] = msg["content"].split("\n[probe-", 1)[0] + f"\n[probe-{n}]"
+        msg = self.body["messages"][0]
+        msg["content"] = msg["content"].split("\n[probe-", 1)[0] + f"\n[probe-{self._n}]"
 
-    def final_validation():
-        assert len(seen) >= min_distinct, (
-            f"expected >= {min_distinct} distinct worker IDs across {n} requests, "
-            f"got {sorted(seen)}"
+    def final_validation(self):
+        assert len(self._seen_routes) >= self._min_distinct, (
+            f"expected >= {self._min_distinct} distinct routes across {self._n} "
+            f"requests, got {sorted(self._seen_routes)}"
         )
 
-    payload.validate = validate
-    payload.final_validation = final_validation
+    payload.validate = types.MethodType(validate, payload)
+    payload.final_validation = types.MethodType(final_validation, payload)
     return payload
 
 

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -48,8 +48,38 @@ from tests.utils.payloads import (
     LoraTestChatPayload,
     ToolCallingChatPayload,
 )
+from tests.utils.router_nvext import require_router_worker_id
 
 logger = logging.getLogger(__name__)
+
+
+def _assert_distinct_router_workers(payload, min_distinct: int = 2):
+    """Require distinct nvext worker IDs across repeated router requests."""
+    seen: set[int] = set()
+    n = 0
+    orig_validate = payload.validate
+
+    def validate(response, content):
+        nonlocal n
+        orig_validate(response, content)
+        worker_id = require_router_worker_id(response.json())
+        for key in ("prefill_worker_id", "decode_worker_id"):
+            if isinstance(worker_id.get(key), int):
+                seen.add(worker_id[key])
+        n += 1
+        # Diversify the prompt so KV affinity does not pin every request.
+        msg = payload.body["messages"][0]
+        msg["content"] = msg["content"].split("\n[probe-", 1)[0] + f"\n[probe-{n}]"
+
+    def final_validation():
+        assert len(seen) >= min_distinct, (
+            f"expected >= {min_distinct} distinct worker IDs across {n} requests, "
+            f"got {sorted(seen)}"
+        )
+
+    payload.validate = validate
+    payload.final_validation = final_validation
+    return payload
 
 
 def _is_cuda12() -> bool:
@@ -400,11 +430,19 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.router,
             pytest.mark.pre_merge,
+            # Per-GPU peak matches other Qwen3-0.6B agg workers (~3.8 GiB);
+            # 2 replicas fit the existing 2x L4 (24 GiB) gpu_2 lane.
+            pytest.mark.profiled_vram_gib(3.8),
+            pytest.mark.requested_vllm_kv_cache_bytes(
+                1_119_388_000
+            ),  # KV cache cap (2x safety over min=559_693_824)
             pytest.mark.timeout(600),
-        ],  # TODO: profile to get max_vram
+        ],
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
-            router_selection_chat_payload_default(),
+            _assert_distinct_router_workers(
+                router_selection_chat_payload_default(repeat_count=6)
+            ),
             kv_events_metrics_payload(system_ports=[DefaultPort.SYSTEM2.value]),
         ],
         env={},

--- a/tests/serve/test_vllm.py
+++ b/tests/serve/test_vllm.py
@@ -440,14 +440,8 @@ vllm_configs = {
             pytest.mark.gpu_2,
             pytest.mark.router,
             pytest.mark.pre_merge,
-            # Per-GPU peak matches other Qwen3-0.6B agg workers (~3.8 GiB);
-            # 2 replicas fit the existing 2x L4 (24 GiB) gpu_2 lane.
-            pytest.mark.profiled_vram_gib(3.8),
-            pytest.mark.requested_vllm_kv_cache_bytes(
-                1_119_388_000
-            ),  # KV cache cap (2x safety over min=559_693_824)
             pytest.mark.timeout(600),
-        ],
+        ],  # TODO: profile to get max_vram
         model="Qwen/Qwen3-0.6B",
         request_payloads=[
             _assert_distinct_router_workers(

--- a/tests/utils/payload_builder.py
+++ b/tests/utils/payload_builder.py
@@ -65,6 +65,7 @@ def chat_payload_default(
     stream: bool = False,
     extra_body: Optional[Dict[str, Any]] = None,
     router_nvext_expectation: RouterNvextExpectation | None = None,
+    payload_cls: type[RouterNvextChatPayload] = RouterNvextChatPayload,
 ) -> ChatPayload:
     body = {
         "messages": [
@@ -89,7 +90,7 @@ def chat_payload_default(
         or ["AI", "knock", "joke", "think", "artificial", "intelligence"],
     }
     if router_nvext_expectation:
-        return RouterNvextChatPayload(
+        return payload_cls(
             **common_args,
             router_nvext_expectation=router_nvext_expectation,
         )
@@ -176,6 +177,7 @@ def router_selection_chat_payload_default(
     max_tokens: int = 1000,
     temperature: float = 0.0,
     stream: bool = False,
+    payload_cls: type[RouterNvextChatPayload] = RouterNvextChatPayload,
 ) -> ChatPayload:
     return chat_payload_default(
         repeat_count=repeat_count,
@@ -186,6 +188,7 @@ def router_selection_chat_payload_default(
         stream=stream,
         extra_body=router_nvext_extra_body(["worker_id"]),
         router_nvext_expectation=RouterNvextExpectation(worker_id=True),
+        payload_cls=payload_cls,
     )
 
 

--- a/tests/utils/payloads.py
+++ b/tests/utils/payloads.py
@@ -30,7 +30,11 @@ import requests
 from dynamo import prometheus_names  # type: ignore[attr-defined]
 from tests.utils.constants import DefaultPort
 from tests.utils.prometheus import sum_metric_samples
-from tests.utils.router_nvext import RouterNvextExpectation, validate_router_nvext
+from tests.utils.router_nvext import (
+    RouterNvextExpectation,
+    require_router_worker_id,
+    validate_router_nvext,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -215,6 +219,41 @@ class RouterNvextChatPayload(ChatPayload):
             response.json(),
             self.router_nvext_expectation,
             context=type(self).__name__,
+        )
+
+
+class DistinctRouterWorkersPayload(RouterNvextChatPayload):
+    """Assert repeated requests spread across >= ``min_distinct`` router workers.
+
+    A short prompt caches no full KV block, so every worker has zero prefix
+    overlap and the router breaks the resulting load tie at random. Over
+    ``repeat_count`` requests that random spread should exercise more than one
+    replica; this records each response's worker route and checks the count.
+    """
+
+    def __init__(self, *args, min_distinct: int = 2, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._min_distinct = min_distinct
+        self._seen_routes: set[tuple[int, ...]] = set()
+        self._request_count = 0
+
+    def validate(self, response: Any, content: str) -> None:
+        super().validate(response, content)
+        worker_id = require_router_worker_id(response.json())
+        # require_router_worker_id guarantees at least one int id, so the route
+        # tuple is never empty.
+        route = tuple(
+            worker_id[key]
+            for key in ("prefill_worker_id", "decode_worker_id")
+            if isinstance(worker_id.get(key), int)
+        )
+        self._seen_routes.add(route)
+        self._request_count += 1
+
+    def final_validation(self) -> None:
+        assert len(self._seen_routes) >= self._min_distinct, (
+            f"expected >= {self._min_distinct} distinct router workers across "
+            f"{self._request_count} requests, got {sorted(self._seen_routes)}"
         )
 
 


### PR DESCRIPTION
## Summary
- Assert that the `agg-router` launch scenario (2 aggregated KV-router replicas) routes across **two distinct** `nvext` worker IDs, covering OPS-7579 / parent OPS-7562.
- Diversify prompts across `repeat_count=6` so KV affinity does not pin every request to the first replica.
- Add `profiled_vram_gib(3.8)` + `requested_vllm_kv_cache_bytes` markers so the scenario fits the existing 2× L4 (`gpu_2`) lane.

## Validation
- [ ] Diff review: single-file change in `tests/serve/test_vllm.py`
- [ ] CI: `pre_merge and vllm and (gpu_2 or gpu_4)` picks up `test_serve_deployment[agg-router]`
- [ ] Confirm assertion fails if only one replica is reached (distinct-worker check)

Refs: OPS-7579, OPS-7562
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11845" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage to verify that repeated router requests are distributed across distinct worker IDs.
  * Updated the aggregation router test to validate load balancing across multiple workers during both prefill and decode operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->