### PR TITLE
feat(vllm): add custom encoder adapter

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -90,7 +90,6 @@ from .engine_monitor import VllmEngineMonitor
 from .multimodal_utils.async_vision_encoder import AsyncVisionEncoder
 from .multimodal_utils.custom_encoder_adapter import (
     CustomEncoderAdapter,
-    PreparedCustomEncoderPrompt,
     create_custom_encoder_adapter,
 )
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
@@ -2926,7 +2925,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         self,
         request: Dict[str, Any],
         request_id: str,
-    ) -> tuple[PreparedCustomEncoderPrompt | None, Dict[str, Any] | None]:
+    ) -> tuple[EmbedsPrompt | TokensPrompt | None, Dict[str, Any] | None]:
         """Run the in-process CustomEncoder and prepare its engine prompt.
 
         The CustomEncoder consumes image URLs directly and emits artifacts. Returns
@@ -3023,7 +3022,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         mode = cast(DisaggregationMode, self.config.disaggregation_mode)
         is_decode_only = mode == DisaggregationMode.DECODE
         has_mm_data = request.get("multi_modal_data") is not None
-        custom_prompt: PreparedCustomEncoderPrompt | None = None
+        custom_prompt: EmbedsPrompt | TokensPrompt | None = None
 
         if (
             mode == DisaggregationMode.AGGREGATED
@@ -3072,7 +3071,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         prompt: Any
         with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
             if custom_prompt is not None:
-                prompt = custom_prompt.prompt
+                prompt = custom_prompt
                 error = None
             elif pre_rendered is not None:
                 # pre_rendered is a MultiModalInput dict with "type": "multimodal".

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -88,7 +88,11 @@ from .args import Config
 from .constants import DisaggregationMode, EmbeddingTransferMode
 from .engine_monitor import VllmEngineMonitor
 from .multimodal_utils.async_vision_encoder import AsyncVisionEncoder
-from .multimodal_utils.embed_assembler import build_mixed_embeds
+from .multimodal_utils.custom_encoder_adapter import (
+    CustomEncoderAdapter,
+    PreparedCustomEncoderPrompt,
+    create_custom_encoder_adapter,
+)
 from .multimodal_utils.prefill_worker_utils import MultiModalEmbeddingLoader
 from .multimodal_utils.request_processor import (
     IMAGE_URL_KEY,
@@ -1027,6 +1031,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # always safe; the encoder itself is loaded last in __init__ (it starts
         # the actor thread) — see _load_custom_encoder below for why.
         self._custom_encoder: Optional[AsyncVisionEncoder] = None
+        self._custom_encoder_adapter: Optional[CustomEncoderAdapter] = None
 
         self.use_vllm_tokenizer = use_vllm_tokenizer
 
@@ -1085,15 +1090,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         custom_encoder_class = config.custom_encoder_class
         if not custom_encoder_class:
             return
-        # The custom encoder path only ever submits a mixed EmbedsPrompt, so fail
-        # fast here if prompt-embeds are disabled rather than loading the encoder
-        # and then rejecting every image request at runtime.
-        if not config.engine_args.enable_prompt_embeds:
-            raise ValueError(
-                "--custom-encoder-class requires --enable-prompt-embeds: the "
-                "custom encoder submits a mixed EmbedsPrompt, which the engine "
-                "cannot accept without prompt-embeds enabled."
-            )
         module_path, _, class_name = custom_encoder_class.rpartition(".")
         backend_cls = getattr(importlib.import_module(module_path), class_name)
         if not (
@@ -1108,15 +1104,24 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # AsyncVisionEncoder glue, which owns the preprocess pool and
         # ThreadedMicroBatcher actor thread. load() runs backend.build() there
         # (the backend picks its own device) and cleans that thread up on failure.
-        encoder = AsyncVisionEncoder(backend_cls())
+        backend = backend_cls()
+        adapter = create_custom_encoder_adapter(
+            backend,
+            self.model_config,
+            config.engine_args,
+            self.engine_client.vllm_config,
+        )
+        encoder = AsyncVisionEncoder(backend)
         encoder.load(config.model)
         # Assign only after a successful load so a failed load (which already shut
         # its own thread down) leaves _custom_encoder None.
         self._custom_encoder = encoder
+        self._custom_encoder_adapter = adapter
         logger.info(
-            "Loaded CustomEncoder %s from %s",
+            "Loaded CustomEncoder %s from %s with %s",
             custom_encoder_class,
             config.model,
+            type(adapter).__name__,
         )
 
     def _shutdown_worker(self) -> NoReturn:
@@ -2466,6 +2471,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             # Run backend.close() on the actor thread, then stop it — executor
             # GC would only end the thread, never call close().
             self._custom_encoder.shutdown()
+            self._custom_encoder = None
+            self._custom_encoder_adapter = None
         for temp_dir in self.temp_dirs:
             try:
                 temp_dir.cleanup()
@@ -2540,7 +2547,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         multi_modal_data: Dict[str, Any] | None,
         log_prefix: str = "",
         mm_processor_kwargs: Dict[str, Any] | None = None,
-        mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None,
     ) -> tuple[TokensPrompt | EmbedsPrompt | None, Dict[str, Any] | None]:
         """
         Build a prompt from request, handling both prompt_embeds and token_ids.
@@ -2552,32 +2558,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             log_prefix: Prefix for log messages (e.g., "Prefill " for prefill requests)
             mm_processor_kwargs: Optional multimodal processor kwargs (e.g.
                 use_audio_in_video) forwarded to the vLLM engine.
-            mixed_embeds: Optional ``(prompt_embeds, prompt_token_ids,
-                prompt_is_token_ids)`` assembled by the aggregated CustomEncoder
-                path. When present, takes the EmbedsPrompt fast path below.
 
         Returns:
             Tuple of (prompt, error_dict) where:
             - On success: (prompt, None)
             - On failure: (None, error_dict to yield)
         """
-        # Fast path: mixed token-ids/embeds prompt from the aggregated
-        # CustomEncoder path, assembled in _generate_token_mode and passed in
-        # explicitly. The image embeds ride on the EmbedsPrompt itself and the
-        # request carries no multi_modal_data, so there is nothing to bind
-        # mm_uuids to here — the normal token path's MM-routing logic below is
-        # intentionally skipped for this path.
-        if mixed_embeds is not None:
-            prompt_embeds, prompt_token_ids, prompt_is_token_ids = mixed_embeds
-            return (
-                EmbedsPrompt(
-                    prompt_embeds=prompt_embeds,
-                    prompt_token_ids=prompt_token_ids,
-                    prompt_is_token_ids=prompt_is_token_ids,
-                ),
-                None,
-            )
-
         if "prompt_embeds" in request and request["prompt_embeds"]:
             if not self.config.engine_args.enable_prompt_embeds:
                 msg = (
@@ -2940,20 +2926,15 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         self,
         request: Dict[str, Any],
         request_id: str,
-        context,
-    ) -> tuple[
-        tuple[torch.Tensor, list[int], list[bool]] | None,
-        Dict[str, Any] | None,
-        Dict[str, Any] | None,
-    ]:
-        """Run the in-process CustomEncoder and assemble a mixed EmbedsPrompt.
+    ) -> tuple[PreparedCustomEncoderPrompt | None, Dict[str, Any] | None]:
+        """Run the in-process CustomEncoder and prepare its engine prompt.
 
-        The CustomEncoder consumes image URLs directly and emits embeds. Returns
-        ``(mixed_embeds, multi_modal_data, error)``:
-        - images present: ``(mixed_embeds, None, None)``,
-        - no image content: ``(None, None, None)`` — text-only request, nothing
+        The CustomEncoder consumes image URLs directly and emits artifacts. Returns
+        ``(prepared_prompt, error)``:
+        - images present: ``(prepared_prompt, None)``,
+        - no image content: ``(None, None)`` — text-only request, nothing
           to assemble or extract (non-image modalities are rejected above),
-        - failure: ``(None, None, error_dict)`` for the caller to yield.
+        - failure: ``(None, error_dict)`` for the caller to yield.
         """
         # Internal invariant: callers guard on `self._custom_encoder is not None`
         # before reaching here. Use an explicit raise (not assert, which is
@@ -2961,6 +2942,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         if self._custom_encoder is None:
             raise RuntimeError(
                 "_assemble_custom_encoder_prompt called without a CustomEncoder"
+            )
+        if self._custom_encoder_adapter is None:
+            raise RuntimeError(
+                "_assemble_custom_encoder_prompt called without an adapter"
             )
         mm_map = request.get("multi_modal_data") or {}
         # CustomEncoder handles images only. Reject any non-image modality
@@ -2972,7 +2957,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 f"unsupported multimodal data: {unsupported}"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         image_items = mm_map.get(IMAGE_URL_KEY) or []
         image_urls = [
@@ -2990,42 +2975,36 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 "'Url'; each item must be a dict with a 'Url' key"
             )
             logger.error("Request %s: %s", request_id, msg)
-            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         if not image_urls:
             # No image items at all — and non-image modalities were already
             # rejected above — so there is nothing to assemble → text-only.
-            return None, None, None
+            return None, None
 
         token_ids: list[int] = request.get("token_ids") or []
-        # encode() is user-supplied code (any exception) and
-        # get_image_placeholder_token_id() can raise (unknown model family), so
-        # keep encode -> placeholder lookup -> assembly inside one guard: a
-        # failure becomes a structured request error instead of escaping the
-        # request coroutine and tearing down the stream.
+        # Both encode() and adapter preparation run user/model-specific code, so
+        # keep them inside one guard. A failure becomes a structured request error
+        # instead of escaping the coroutine and tearing down the stream.
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
-            img_tensors: list[torch.Tensor] = await self._custom_encoder.encode(
-                image_urls
-            )
-            placeholder_id = self._custom_encoder.get_image_placeholder_token_id()
-            prompt_embeds, mixed_token_ids, is_token_ids = build_mixed_embeds(
-                token_ids, img_tensors, placeholder_id
+            encodings = await self._custom_encoder.encode(image_urls)
+            prepared = self._custom_encoder_adapter.prepare_prompt(
+                token_ids,
+                encodings,
             )
         except Exception as exc:
             msg = f"CustomEncoder failed: {exc}"
             logger.exception("Request %s: %s", request_id, msg)
-            return None, None, {"finish_reason": f"error: {msg}", "token_ids": []}
+            return None, {"finish_reason": f"error: {msg}", "token_ids": []}
 
         logger.debug(
-            "Request %s: CustomEncoder assembled %d image(s) → seq_len=%d dtype=%s",
+            "Request %s: CustomEncoder prepared prompt for %d image(s)",
             request_id,
-            len(img_tensors),
-            prompt_embeds.shape[0],
-            prompt_embeds.dtype,
+            len(encodings),
         )
-        return (prompt_embeds, mixed_token_ids, is_token_ids), None, None
+        return prepared, None
 
     async def _generate_token_mode(self, request, context, request_id):
         """Generate tokens using internal protocol format (token-in-token-out)."""
@@ -3044,7 +3023,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         mode = cast(DisaggregationMode, self.config.disaggregation_mode)
         is_decode_only = mode == DisaggregationMode.DECODE
         has_mm_data = request.get("multi_modal_data") is not None
-        mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None
+        custom_prompt: PreparedCustomEncoderPrompt | None = None
 
         if (
             mode == DisaggregationMode.AGGREGATED
@@ -3052,19 +3031,16 @@ class DecodeWorkerHandler(BaseWorkerHandler):
             and has_mm_data
         ):
             # A configured CustomEncoder owns the aggregated image path. Bypass
-            # the normal NIXL/HF request processor and assemble an EmbedsPrompt.
-            (
-                mixed_embeds,
-                multi_modal_data,
-                assemble_error,
-            ) = await self._assemble_custom_encoder_prompt(
+            # raw-media loading and let its decoder-selected adapter prepare the
+            # final engine prompt.
+            custom_prompt, assemble_error = await self._assemble_custom_encoder_prompt(
                 request,
                 request_id,
-                context,
             )
             if assemble_error is not None:
                 yield assemble_error
                 return
+            multi_modal_data = None
             mm_processor_kwargs = None
             pre_rendered = None
         else:
@@ -3095,7 +3071,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         # branches without spelling out the full union.
         prompt: Any
         with _nvtx.annotate("mm_backend:build_prompt", color="yellow"):
-            if pre_rendered is not None:
+            if custom_prompt is not None:
+                prompt = custom_prompt.prompt
+                error = None
+            elif pre_rendered is not None:
                 # pre_rendered is a MultiModalInput dict with "type": "multimodal".
                 # The engine's InputProcessor.process_inputs() will see the "type"
                 # key and skip the HF processor entirely.
@@ -3111,7 +3090,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                     request_id,
                     multi_modal_data,
                     mm_processor_kwargs=mm_processor_kwargs,
-                    mixed_embeds=mixed_embeds,
                 )
         if error is not None:
             yield error

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -3,6 +3,11 @@
 
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.vllm.multimodal_utils.chat_message_utils import extract_user_text
+from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
+    CustomEncoderAdapter,
+    PreparedCustomEncoderPrompt,
+    create_custom_encoder_adapter,
+)
 from dynamo.vllm.multimodal_utils.embed_assembler import build_mixed_embeds
 from dynamo.vllm.multimodal_utils.encode_utils import (
     encode_image_embeddings,
@@ -31,6 +36,9 @@ from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
 
 __all__ = [
     "build_mixed_embeds",
+    "CustomEncoderAdapter",
+    "PreparedCustomEncoderPrompt",
+    "create_custom_encoder_adapter",
     "encode_image_embeddings",
     "extract_user_text",
     "get_encoder_components",

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -5,7 +5,6 @@ from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.vllm.multimodal_utils.chat_message_utils import extract_user_text
 from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
     CustomEncoderAdapter,
-    PreparedCustomEncoderPrompt,
     create_custom_encoder_adapter,
 )
 from dynamo.vllm.multimodal_utils.embed_assembler import build_mixed_embeds
@@ -37,7 +36,6 @@ from dynamo.vllm.multimodal_utils.vision_encoder_backend import (
 __all__ = [
     "build_mixed_embeds",
     "CustomEncoderAdapter",
-    "PreparedCustomEncoderPrompt",
     "create_custom_encoder_adapter",
     "encode_image_embeddings",
     "extract_user_text",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder_adapter.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder_adapter.py
@@ -6,7 +6,6 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
 from typing import Any, Sequence
 
 import torch
@@ -14,13 +13,6 @@ from vllm.inputs import EmbedsPrompt, TokensPrompt
 
 from dynamo.vllm.multimodal_utils.embed_assembler import build_mixed_embeds
 from dynamo.vllm.multimodal_utils.vision_encoder_backend import VisionEncoderBackend
-
-
-@dataclass(frozen=True)
-class PreparedCustomEncoderPrompt:
-    """Final vLLM prompt prepared by a decoder-specific adapter."""
-
-    prompt: EmbedsPrompt | TokensPrompt
 
 
 class CustomEncoderAdapter(ABC):
@@ -31,7 +23,7 @@ class CustomEncoderAdapter(ABC):
         self,
         token_ids: list[int],
         encodings: Sequence[torch.Tensor],
-    ) -> PreparedCustomEncoderPrompt:
+    ) -> EmbedsPrompt | TokensPrompt:
         """Validate encoder artifacts and build the final vLLM prompt."""
 
 
@@ -89,7 +81,7 @@ class _LinearEmbedsAdapter(CustomEncoderAdapter):
         self,
         token_ids: list[int],
         encodings: Sequence[torch.Tensor],
-    ) -> PreparedCustomEncoderPrompt:
+    ) -> EmbedsPrompt | TokensPrompt:
         rows = list(encodings)
         for index, tensor in enumerate(rows):
             if not isinstance(tensor, torch.Tensor):
@@ -111,12 +103,10 @@ class _LinearEmbedsAdapter(CustomEncoderAdapter):
         prompt_embeds, prompt_token_ids, prompt_is_token_ids = build_mixed_embeds(
             token_ids, rows, self._image_token_id
         )
-        return PreparedCustomEncoderPrompt(
-            prompt=EmbedsPrompt(
-                prompt_embeds=prompt_embeds,
-                prompt_token_ids=prompt_token_ids,
-                prompt_is_token_ids=prompt_is_token_ids,
-            )
+        return EmbedsPrompt(
+            prompt_embeds=prompt_embeds,
+            prompt_token_ids=prompt_token_ids,
+            prompt_is_token_ids=prompt_is_token_ids,
         )
 
 

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder_adapter.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder_adapter.py
@@ -1,0 +1,136 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Consumer-selected adapters for in-process custom vision encoders."""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Sequence
+
+import torch
+from vllm.inputs import EmbedsPrompt, TokensPrompt
+
+from dynamo.vllm.multimodal_utils.embed_assembler import build_mixed_embeds
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import VisionEncoderBackend
+
+
+@dataclass(frozen=True)
+class PreparedCustomEncoderPrompt:
+    """Final vLLM prompt prepared by a decoder-specific adapter."""
+
+    prompt: EmbedsPrompt | TokensPrompt
+
+
+class CustomEncoderAdapter(ABC):
+    """Translate encoder artifacts for one resolved downstream decoder."""
+
+    @abstractmethod
+    def prepare_prompt(
+        self,
+        token_ids: list[int],
+        encodings: Sequence[torch.Tensor],
+    ) -> PreparedCustomEncoderPrompt:
+        """Validate encoder artifacts and build the final vLLM prompt."""
+
+
+def _hidden_size(model_config: Any) -> int:
+    getter = getattr(model_config, "get_hidden_size", None)
+    value = getter() if callable(getter) else None
+    if value is None:
+        hf_config = getattr(model_config, "hf_config", None)
+        text_config = getattr(hf_config, "text_config", None)
+        value = getattr(text_config, "hidden_size", None)
+        if value is None:
+            value = getattr(hf_config, "hidden_size", None)
+    if not isinstance(value, int) or isinstance(value, bool) or value < 1:
+        raise ValueError("CustomEncoder could not resolve the decoder hidden size")
+    return value
+
+
+def _is_multimodal_model(model_config: Any) -> bool:
+    value = getattr(model_config, "is_multimodal_model", False)
+    return bool(value() if callable(value) else value)
+
+
+class _LinearEmbedsAdapter(CustomEncoderAdapter):
+    """Build mixed ``EmbedsPrompt`` inputs for a text-only decoder."""
+
+    def __init__(
+        self,
+        backend: VisionEncoderBackend,
+        model_config: Any,
+        engine_args: Any,
+    ) -> None:
+        if model_config is None:
+            raise ValueError("CustomEncoder requires the resolved vLLM ModelConfig")
+        if _is_multimodal_model(model_config):
+            raise ValueError(
+                "CustomEncoder does not yet support this multimodal decoder; "
+                "the linear EmbedsPrompt adapter is only valid for text-only models"
+            )
+        if not getattr(engine_args, "enable_prompt_embeds", False):
+            raise ValueError(
+                "text-only CustomEncoder output requires --enable-prompt-embeds"
+            )
+        image_token_id = getattr(backend, "image_token_id", None)
+        if not isinstance(image_token_id, int) or isinstance(image_token_id, bool):
+            raise ValueError(
+                "text-only CustomEncoder output requires an integer image_token_id"
+            )
+
+        self._image_token_id = image_token_id
+        self._hidden_size = _hidden_size(model_config)
+        model_dtype = getattr(model_config, "dtype", None)
+        self._dtype = model_dtype if isinstance(model_dtype, torch.dtype) else None
+
+    def prepare_prompt(
+        self,
+        token_ids: list[int],
+        encodings: Sequence[torch.Tensor],
+    ) -> PreparedCustomEncoderPrompt:
+        rows = list(encodings)
+        for index, tensor in enumerate(rows):
+            if not isinstance(tensor, torch.Tensor):
+                raise TypeError(
+                    "text-only CustomEncoder must return tensors; "
+                    f"result {index} is {type(tensor).__name__}"
+                )
+            if tensor.dim() != 2 or tensor.shape[1] != self._hidden_size:
+                raise ValueError(
+                    f"image tensor {index} has shape {tuple(tensor.shape)}; "
+                    f"expected 2D with decoder hidden size {self._hidden_size}"
+                )
+            if self._dtype is not None and tensor.dtype != self._dtype:
+                raise ValueError(
+                    f"image tensor {index} has dtype {tensor.dtype}; "
+                    f"expected decoder dtype {self._dtype}"
+                )
+
+        prompt_embeds, prompt_token_ids, prompt_is_token_ids = build_mixed_embeds(
+            token_ids, rows, self._image_token_id
+        )
+        return PreparedCustomEncoderPrompt(
+            prompt=EmbedsPrompt(
+                prompt_embeds=prompt_embeds,
+                prompt_token_ids=prompt_token_ids,
+                prompt_is_token_ids=prompt_is_token_ids,
+            )
+        )
+
+
+def create_custom_encoder_adapter(
+    backend: VisionEncoderBackend,
+    model_config: Any,
+    engine_args: Any,
+    vllm_config: Any | None = None,
+) -> CustomEncoderAdapter:
+    """Create the adapter selected by the resolved downstream decoder.
+
+    The first slice supports text-only decoders. ``vllm_config`` is accepted at
+    this stable factory boundary for model-specific adapters added later.
+    """
+
+    del vllm_config
+    return _LinearEmbedsAdapter(backend, model_config, engine_args)

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_custom_encoder_adapter.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_custom_encoder_adapter.py
@@ -47,14 +47,14 @@ def _engine_args(*, enable_prompt_embeds: bool = True):
 def test_text_decoder_selects_linear_adapter_and_builds_final_prompt():
     adapter = create_custom_encoder_adapter(_Backend(), _model_config(), _engine_args())
 
-    prepared = adapter.prepare_prompt(
+    prompt = adapter.prepare_prompt(
         [1, _IMAGE_TOKEN_ID, 2],
         [torch.ones((2, 4), dtype=torch.bfloat16)],
     )
 
-    assert tuple(prepared.prompt["prompt_embeds"].shape) == (4, 4)
-    assert prepared.prompt["prompt_token_ids"] == [1, 99, 99, 2]
-    assert prepared.prompt["prompt_is_token_ids"] == [True, False, False, True]
+    assert tuple(prompt["prompt_embeds"].shape) == (4, 4)
+    assert prompt["prompt_token_ids"] == [1, 99, 99, 2]
+    assert prompt["prompt_is_token_ids"] == [True, False, False, True]
 
 
 def test_linear_adapter_requires_prompt_embeds_flag():

--- a/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_custom_encoder_adapter.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/test_vllm_custom_encoder_adapter.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
+    create_custom_encoder_adapter,
+)
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import VisionEncoderBackend
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+_IMAGE_TOKEN_ID = 99
+
+
+class _Backend(VisionEncoderBackend):
+    image_token_id = _IMAGE_TOKEN_ID
+
+    def build(self, model_id: str) -> None:
+        pass
+
+    def forward_batch(self, items, target_bucket=None):
+        raise NotImplementedError
+
+
+def _model_config(*, multimodal: bool = False, callable_flag: bool = False):
+    return SimpleNamespace(
+        dtype=torch.bfloat16,
+        get_hidden_size=lambda: 4,
+        is_multimodal_model=(lambda: multimodal) if callable_flag else multimodal,
+    )
+
+
+def _engine_args(*, enable_prompt_embeds: bool = True):
+    return SimpleNamespace(enable_prompt_embeds=enable_prompt_embeds)
+
+
+def test_text_decoder_selects_linear_adapter_and_builds_final_prompt():
+    adapter = create_custom_encoder_adapter(_Backend(), _model_config(), _engine_args())
+
+    prepared = adapter.prepare_prompt(
+        [1, _IMAGE_TOKEN_ID, 2],
+        [torch.ones((2, 4), dtype=torch.bfloat16)],
+    )
+
+    assert tuple(prepared.prompt["prompt_embeds"].shape) == (4, 4)
+    assert prepared.prompt["prompt_token_ids"] == [1, 99, 99, 2]
+    assert prepared.prompt["prompt_is_token_ids"] == [True, False, False, True]
+
+
+def test_linear_adapter_requires_prompt_embeds_flag():
+    with pytest.raises(ValueError, match="--enable-prompt-embeds"):
+        create_custom_encoder_adapter(
+            _Backend(),
+            _model_config(),
+            _engine_args(enable_prompt_embeds=False),
+        )
+
+
+def test_linear_adapter_rejects_multimodal_decoder():
+    with pytest.raises(ValueError, match="multimodal decoder"):
+        create_custom_encoder_adapter(
+            _Backend(), _model_config(multimodal=True), _engine_args()
+        )
+
+
+def test_linear_adapter_calls_real_model_config_multimodal_method():
+    adapter = create_custom_encoder_adapter(
+        _Backend(), _model_config(callable_flag=True), _engine_args()
+    )
+
+    assert adapter is not None
+
+
+@pytest.mark.parametrize(
+    "encoding, match",
+    [
+        (torch.ones((2, 3), dtype=torch.bfloat16), "decoder hidden size 4"),
+        (torch.ones((2, 4), dtype=torch.float16), "decoder dtype"),
+        ("not-a-tensor", "must return tensors"),
+    ],
+)
+def test_linear_adapter_validates_encoder_artifacts(encoding, match):
+    adapter = create_custom_encoder_adapter(_Backend(), _model_config(), _engine_args())
+
+    with pytest.raises((TypeError, ValueError), match=match):
+        adapter.prepare_prompt([_IMAGE_TOKEN_ID], [encoding])

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -51,7 +51,7 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
         encode=AsyncMock(return_value=[torch.ones((2, 4), dtype=torch.bfloat16)])
     )
 
-    prepared, error = await handler._assemble_custom_encoder_prompt(
+    prompt, error = await handler._assemble_custom_encoder_prompt(
         {
             "token_ids": [1, 99, 2],
             "multi_modal_data": {
@@ -62,9 +62,9 @@ async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
     )
 
     assert error is None
-    assert prepared is not None
-    assert tuple(prepared.prompt["prompt_embeds"].shape) == (4, 4)
-    assert prepared.prompt["prompt_token_ids"] == [1, 99, 99, 2]
+    assert prompt is not None
+    assert tuple(prompt["prompt_embeds"].shape) == (4, 4)
+    assert prompt["prompt_token_ids"] == [1, 99, 99, 2]
 
 
 async def test_custom_encoder_handler_preserves_string_error_contract():
@@ -74,7 +74,7 @@ async def test_custom_encoder_handler_preserves_string_error_contract():
         encode=AsyncMock(side_effect=RuntimeError("encoder failed"))
     )
 
-    prepared, error = await handler._assemble_custom_encoder_prompt(
+    prompt, error = await handler._assemble_custom_encoder_prompt(
         {
             "token_ids": [99],
             "multi_modal_data": {
@@ -84,6 +84,6 @@ async def test_custom_encoder_handler_preserves_string_error_contract():
         "request-id",
     )
 
-    assert prepared is None
+    assert prompt is None
     assert error is not None
     assert error["finish_reason"] == "error: CustomEncoder failed: encoder failed"

--- a/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_custom_encoder_handler.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+import torch
+
+from dynamo.vllm.handlers import DecodeWorkerHandler
+from dynamo.vllm.multimodal_utils.custom_encoder_adapter import (
+    create_custom_encoder_adapter,
+)
+from dynamo.vllm.multimodal_utils.vision_encoder_backend import VisionEncoderBackend
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.pre_merge,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.multimodal,
+]
+
+
+class _Backend(VisionEncoderBackend):
+    image_token_id = 99
+
+    def build(self, model_id: str) -> None:
+        pass
+
+    def forward_batch(self, items, target_bucket=None):
+        raise NotImplementedError
+
+
+def _adapter():
+    return create_custom_encoder_adapter(
+        _Backend(),
+        SimpleNamespace(
+            dtype=torch.bfloat16,
+            get_hidden_size=lambda: 4,
+            is_multimodal_model=False,
+        ),
+        SimpleNamespace(enable_prompt_embeds=True),
+    )
+
+
+async def test_custom_encoder_handler_returns_adapter_prepared_prompt():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(
+        encode=AsyncMock(return_value=[torch.ones((2, 4), dtype=torch.bfloat16)])
+    )
+
+    prepared, error = await handler._assemble_custom_encoder_prompt(
+        {
+            "token_ids": [1, 99, 2],
+            "multi_modal_data": {
+                "image_url": [{"Url": "data:image/png;base64,unused"}]
+            },
+        },
+        "request-id",
+    )
+
+    assert error is None
+    assert prepared is not None
+    assert tuple(prepared.prompt["prompt_embeds"].shape) == (4, 4)
+    assert prepared.prompt["prompt_token_ids"] == [1, 99, 99, 2]
+
+
+async def test_custom_encoder_handler_preserves_string_error_contract():
+    handler = object.__new__(DecodeWorkerHandler)
+    handler._custom_encoder_adapter = _adapter()
+    handler._custom_encoder = SimpleNamespace(
+        encode=AsyncMock(side_effect=RuntimeError("encoder failed"))
+    )
+
+    prepared, error = await handler._assemble_custom_encoder_prompt(
+        {
+            "token_ids": [99],
+            "multi_modal_data": {
+                "image_url": [{"Url": "data:image/png;base64,unused"}]
+            },
+        },
+        "request-id",
+    )
+
+    assert prepared is None
+    assert error is not None
+    assert error["finish_reason"] == "error: CustomEncoder failed: encoder failed"

--- a/tests/utils/multimodal.py
+++ b/tests/utils/multimodal.py
@@ -275,7 +275,7 @@ def make_custom_encoder_payload() -> ChatPayload:
         ],
         repeat_count=1,
         expected_response=["42"],
-        expected_log=["Loaded CustomEncoder"],
+        expected_log=["Loaded CustomEncoder", "_LinearEmbedsAdapter"],
         max_tokens=32,
         temperature=0.0,
     )


### PR DESCRIPTION
## Why

Custom encoders should produce artifacts without selecting vLLM prompt semantics. The resolved downstream decoder owns that policy, so its adapter should return the final `EmbedsPrompt` or `TokensPrompt` directly. A one-field result wrapper adds no contract and obscures the handoff.

## What Change

- Add consumer-selected adapters for final vLLM prompt construction.
- Validate text-decoder embeddings against resolved model configuration.
- Return prompt dictionaries directly without an intermediate result wrapper.

## Test Plan

- Adapter and handler unit suites: 9 passed with vLLM 0.25.1.
- Aggregated H100 E2E: HTTP 200, answer `42`, expected adapter logs.