### PR TITLE
refactor(vllm): generalize custom encoder artifacts

### DIFF
--- a/components/src/dynamo/vllm/backend_args.py
+++ b/components/src/dynamo/vllm/backend_args.py
@@ -613,9 +613,9 @@ class DynamoVllmConfig(ConfigBase):
         """Validate the aggregated CustomEncoder configuration.
 
         The encoder runs in-process in a single aggregated worker on the
-        token-in/token-out path and produces image embeds for the mixed
-        EmbedsPrompt, so it is a multimodal, aggregated-only, token-mode
-        component. Enforce those here (fail fast) instead of silently bypassing
+        token-in/token-out path and produces decoder-adapted image artifacts, so
+        it is a multimodal, aggregated-only, token-mode component. Enforce those
+        here (fail fast) instead of silently bypassing
         the multimodal gate at request time, no-op'ing in a decode worker that
         never reaches the custom-encoder branch, or loading the encoder in
         --use-vllm-tokenizer text mode where it is never invoked.

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -3097,10 +3097,10 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         try:
             # AsyncVisionEncoder preprocesses off-thread; its ThreadedMicroBatcher
             # coalesces concurrent calls onto one dedicated actor thread.
-            encodings = await self._custom_encoder.encode(image_urls)
+            artifacts = await self._custom_encoder.encode(image_urls)
             prepared = self._custom_encoder_adapter.prepare_prompt(
                 token_ids,
-                encodings,
+                artifacts,
             )
         except Exception as exc:
             msg = f"CustomEncoder failed: {exc}"
@@ -3110,7 +3110,7 @@ class DecodeWorkerHandler(BaseWorkerHandler):
         logger.debug(
             "Request %s: CustomEncoder prepared prompt for %d image(s)",
             request_id,
-            len(encodings),
+            len(artifacts),
         )
         return prepared, None
 

--- a/components/src/dynamo/vllm/multimodal_utils/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/__init__.py
@@ -4,6 +4,7 @@
 from dynamo.common.multimodal.image_loader import ImageLoader
 from dynamo.vllm.multimodal_utils.chat_message_utils import extract_user_text
 from dynamo.vllm.multimodal_utils.custom_encoder import (
+    ArtifactT,
     CustomEncoderAdapter,
     Preprocessed,
     VisionEncoderBackend,
@@ -38,6 +39,7 @@ __all__ = [
     "encode_image_embeddings",
     "extract_user_text",
     "get_encoder_components",
+    "ArtifactT",
     "Preprocessed",
     "VisionEncoderBackend",
     "ImageLoader",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/__init__.py
@@ -10,6 +10,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.adapter import (
 )
 from dynamo.vllm.multimodal_utils.custom_encoder.async_encoder import AsyncVisionEncoder
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
+    ArtifactT,
     ItemT,
     Preprocessed,
     RawT,
@@ -18,6 +19,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
 
 __all__ = [
     "AsyncVisionEncoder",
+    "ArtifactT",
     "build_mixed_embeds",
     "CustomEncoderAdapter",
     "create_custom_encoder_adapter",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
@@ -6,19 +6,20 @@
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
-from typing import Sequence
+from typing import Generic, Sequence
 
-import torch
 from vllm.inputs import EmbedsPrompt, TokensPrompt
 
+from dynamo.vllm.multimodal_utils.custom_encoder.backend import ArtifactT
 
-class CustomEncoderAdapter(ABC):
+
+class CustomEncoderAdapter(ABC, Generic[ArtifactT]):
     """Translate encoder artifacts for one resolved downstream decoder."""
 
     @abstractmethod
     def prepare_prompt(
         self,
         token_ids: list[int],
-        encodings: Sequence[torch.Tensor],
+        artifacts: Sequence[ArtifactT],
     ) -> EmbedsPrompt | TokensPrompt:
         """Validate encoder artifacts and build the final vLLM prompt."""

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/base.py
@@ -22,4 +22,11 @@ class CustomEncoderAdapter(ABC, Generic[ArtifactT]):
         token_ids: list[int],
         artifacts: Sequence[ArtifactT],
     ) -> EmbedsPrompt | TokensPrompt:
-        """Validate encoder artifacts and build the final vLLM prompt."""
+        """Validate encoder artifacts and build the final vLLM prompt.
+
+        Args:
+            token_ids: Tokenized prompt containing the image placeholders.
+            artifacts: Opaque values returned by the encoder backend, in image
+                order. Each adapter defines and validates its concrete artifact
+                contract.
+        """

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/factory.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/factory.py
@@ -17,10 +17,10 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
 
 
 def create_custom_encoder_adapter(
-    backend: VisionEncoderBackend,
+    backend: VisionEncoderBackend[Any, Any, Any],
     model_config: Any,
     engine_args: Any,
-) -> CustomEncoderAdapter:
+) -> CustomEncoderAdapter[Any]:
     """Create the adapter selected by the resolved downstream decoder."""
 
     return LinearEmbedsAdapter(backend, model_config, engine_args)

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py
@@ -165,12 +165,12 @@ def build_mixed_embeds(
     return prompt_embeds, out_token_ids, is_token_ids
 
 
-class LinearEmbedsAdapter(CustomEncoderAdapter):
+class LinearEmbedsAdapter(CustomEncoderAdapter[torch.Tensor]):
     """Build mixed ``EmbedsPrompt`` inputs for a text-only decoder."""
 
     def __init__(
         self,
-        backend: VisionEncoderBackend,
+        backend: VisionEncoderBackend[Any, Any, torch.Tensor],
         model_config: Any,
         engine_args: Any,
     ) -> None:
@@ -199,9 +199,9 @@ class LinearEmbedsAdapter(CustomEncoderAdapter):
     def prepare_prompt(
         self,
         token_ids: list[int],
-        encodings: Sequence[torch.Tensor],
+        artifacts: Sequence[torch.Tensor],
     ) -> EmbedsPrompt | TokensPrompt:
-        rows = list(encodings)
+        rows = list(artifacts)
         for index, tensor in enumerate(rows):
             if not isinstance(tensor, torch.Tensor):
                 raise TypeError(

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/adapter/linear.py
@@ -201,6 +201,13 @@ class LinearEmbedsAdapter(CustomEncoderAdapter[torch.Tensor]):
         token_ids: list[int],
         artifacts: Sequence[torch.Tensor],
     ) -> EmbedsPrompt | TokensPrompt:
+        """Build a mixed prompt from per-image visual embedding tensors.
+
+        Each artifact must be a CPU tensor shaped
+        ``(n_visual_tokens, decoder_hidden_size)`` with the decoder's dtype.
+        Artifacts must appear in the same order as the image placeholders in
+        ``token_ids``.
+        """
         rows = list(artifacts)
         for index, tensor in enumerate(rows):
             if not isinstance(tensor, torch.Tensor):

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/async_encoder.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/async_encoder.py
@@ -5,7 +5,7 @@
 
 ``AsyncVisionEncoder`` is the **Dynamo-owned** layer the worker talks to. It
 turns the author's synchronous, thread-affine backend into an awaitable
-``encode(raws) -> list[tensor]`` by:
+``encode(raws) -> list[artifact]`` by:
 
 - running ``backend.preprocess`` **off the event loop** on a bounded
   ``ThreadPoolExecutor`` (CPU-heavy fetch / resize / patchify must not serialize
@@ -21,9 +21,8 @@ turns the author's synchronous, thread-affine backend into an awaitable
 
 The backend's ``build`` runs on the batcher's actor thread (so a CUDA graph it
 captures is replayed on the same thread) and its ``close`` runs there at
-teardown. ``load`` fails fast: it re-raises a build error and resolves the image
-placeholder id once, so a misconfigured encoder errors at startup, not on the
-first request.
+teardown. ``load`` re-raises build errors so a misconfigured encoder fails at
+startup, not on the first request.
 """
 
 from __future__ import annotations
@@ -32,9 +31,8 @@ import asyncio
 from concurrent.futures import ThreadPoolExecutor
 from typing import Generic, List
 
-import torch
-
 from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
+    ArtifactT,
     ItemT,
     Preprocessed,
     RawT,
@@ -43,7 +41,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend import (
 from dynamo.vllm.multimodal_utils.custom_encoder.batcher import ThreadedMicroBatcher
 
 
-class AsyncVisionEncoder(Generic[RawT, ItemT]):
+class AsyncVisionEncoder(Generic[RawT, ItemT, ArtifactT]):
     """Drive a ``VisionEncoderBackend`` from the worker's async request path.
 
     The worker calls ``load`` once at startup and ``await``s ``encode`` per
@@ -66,7 +64,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
 
     def __init__(
         self,
-        backend: VisionEncoderBackend[RawT, ItemT],
+        backend: VisionEncoderBackend[RawT, ItemT, ArtifactT],
         *,
         preprocess_concurrency: int | None = None,
         name: str = "vision-encoder",
@@ -98,7 +96,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
         self._backend = backend
         self._preprocess_concurrency = conc
         self._name = name
-        self._batcher: ThreadedMicroBatcher | None = None
+        self._batcher: ThreadedMicroBatcher[ItemT, ArtifactT] | None = None
         self._pool: ThreadPoolExecutor | None = None
 
     # ---- lifecycle ---------------------------------------------------------
@@ -106,10 +104,8 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
     def load(self, model_id: str) -> None:
         """Start the actor thread (running ``backend.build`` on it) and fail fast.
 
-        Re-raises any build error, then ``validate``s the placeholder id so a
-        misconfigured encoder errors at startup instead of on the first request.
-        Single-shot: a second ``load()`` raises rather than orphaning the first
-        batcher's (non-daemon) worker thread and model.
+        Re-raises any build error. Single-shot: a second ``load()`` raises rather
+        than orphaning the first batcher's (non-daemon) worker thread and model.
         """
         if self._batcher is not None:
             raise RuntimeError("AsyncVisionEncoder.load() called twice")
@@ -136,36 +132,21 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
                 else None
             )
             self._batcher.start()  # runs backend.build() on the actor thread
-            self.validate()
         except BaseException:
             self.shutdown()
             raise
 
-    def validate(self) -> None:
-        """Fail-fast check run by ``load`` after ``build``: the author hardcoded a
-        usable ``image_token_id``."""
-        tid = getattr(self._backend, "image_token_id", None)
-        if not isinstance(tid, int) or isinstance(tid, bool):
-            raise ValueError(
-                "VisionEncoderBackend.image_token_id must be a hardcoded int (the "
-                f"image placeholder token id); got {tid!r}"
-            )
-
-    def get_image_placeholder_token_id(self) -> int:
-        """The token id marking image positions (the backend's hardcoded value)."""
-        return self._backend.image_token_id
-
     # ---- request path ------------------------------------------------------
 
-    async def encode(self, raws: List[RawT]) -> List[torch.Tensor]:
+    async def encode(self, raws: List[RawT]) -> List[ArtifactT]:
         """Optionally preprocess (off-loop, with a request-atomicity barrier) then
         batched-encode.
 
         With no preprocess pool (``preprocess_concurrency == 0``) raws go straight
         to the batcher (the backend folds any prep into ``forward_batch``). Returns
-        one ``(n_visual_tokens, lm_hidden_dim)`` tensor per raw input, in order.
-        Raises if any image's preprocess fails (submitting nothing) or if the
-        batched forward fails.
+        one backend-defined artifact per raw input, in order. Raises if any
+        image's preprocess fails (submitting nothing) or if the batched forward
+        fails.
         """
         if self._batcher is None:
             raise RuntimeError("AsyncVisionEncoder.encode() called before load()")
@@ -192,7 +173,7 @@ class AsyncVisionEncoder(Generic[RawT, ItemT]):
                 raise result
         # No exception above ⇒ every settled entry is a Preprocessed. Alias the
         # list gather() already returned rather than copying it.
-        preprocessed: List[Preprocessed] = settled  # type: ignore[assignment]
+        preprocessed: List[Preprocessed[ItemT]] = settled  # type: ignore[assignment]
         items = [p.item for p in preprocessed]
         costs = [p.cost for p in preprocessed]
         return await self._batcher.submit(items, costs)

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/__init__.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/__init__.py
@@ -4,6 +4,7 @@
 """Author-facing custom encoder backend contract."""
 
 from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
+    ArtifactT,
     ItemT,
     Preprocessed,
     RawT,
@@ -11,6 +12,7 @@ from dynamo.vllm.multimodal_utils.custom_encoder.backend.base import (
 )
 
 __all__ = [
+    "ArtifactT",
     "ItemT",
     "Preprocessed",
     "RawT",

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
@@ -149,6 +149,10 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
     ) -> List[ArtifactT]:
         """Encode one cost-bounded batch; one artifact per item, in input order.
 
+        Artifacts are opaque, producer-defined values. Dynamo preserves their
+        order and passes them unchanged to the selected adapter, which owns the
+        concrete artifact contract and validation.
+
         Fence (stream event + sync) and **copy outputs to CPU** before returning,
         so results are safe to consume from another thread. ``target_bucket`` is
         reserved for CUDA-graph batching, once supported (the ladder rung to pad

--- a/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
+++ b/components/src/dynamo/vllm/multimodal_utils/custom_encoder/backend/base.py
@@ -6,15 +6,14 @@
 ``VisionEncoderBackend`` is the **single surface an encoder author implements**.
 It is a pure policy + compute backend: no threads, no futures, no event loop.
 Dynamo owns all the *driving* — the dedicated actor thread, cross-request
-coalescing, the embeds splice, and the lifecycle — via ``ThreadedMicroBatcher``
+coalescing, engine adaptation, and the lifecycle — via ``ThreadedMicroBatcher``
 (the generic cross-request batcher) and ``AsyncVisionEncoder`` (the async
 request-API glue). This module defines only the contract those drivers call.
 
 The encoder runs in the **same process** as the aggregated vLLM worker (no
-separate encode worker, no NIXL transfer): it turns image inputs into the
-visual-token embeddings for each image, and Dynamo splices those embeds into a
-mixed ``EmbedsPrompt`` at the placeholder positions (see
-``adapter.linear.build_mixed_embeds``) for a text-only LM.
+separate encode worker, no NIXL transfer): it turns image inputs into ordered,
+producer-defined artifacts. The resolved downstream decoder selects an adapter
+that validates those artifacts and constructs the final engine prompt.
 
 Division of labour (author vs. Dynamo):
 
@@ -32,20 +31,16 @@ Division of labour (author vs. Dynamo):
   there is no preprocess phase — ``preprocess`` is never called and raws go
   straight to ``forward_batch``. A mismatch (overridden ``preprocess`` with
   ``preprocess_concurrency`` left at ``0``) fails fast at startup.
-- ``forward_batch(items, target_bucket=None) -> list[torch.Tensor]`` — **actor
+- ``forward_batch(items, target_bucket=None) -> list[ArtifactT]`` — **actor
   thread, serialized.** ``items`` are a cost-bounded batch (summed ``cost`` within
   the budget). Fence (stream event + sync) and **copy outputs to CPU** before
-  returning, so results are safe to consume from another thread and splice
-  directly. Returns one ``(n_visual_tokens, lm_hidden_dim)`` **CPU** tensor per
-  item, in input order. ``target_bucket`` is reserved for CUDA-graph batching,
-  once supported (the ladder rung to pad to); it is ``None`` until then.
+  returning, so results are safe to consume from another thread. Returns one
+  artifact per item, in input order. ``target_bucket`` is reserved for CUDA-graph
+  batching, once supported (the ladder rung to pad to); it is ``None`` until then.
 - ``close()`` — actor thread, on teardown. Release any thread-affine resources.
 
 Attributes read **once at setup** (never per-request):
 
-- ``image_token_id`` — the token id marking image positions in the prompt;
-  **hardcode it for your model** (e.g. ``151655`` for Qwen3-VL's ``<|image_pad|>``).
-  Dynamo uses it to locate each image span for the splice.
 - ``max_batch_cost`` — the scalar dispatch ceiling the batcher packs up to; a
   *chosen* budget (a token budget when ``cost`` is a token count). ``None`` (the
   default) ⇒ **pass-through**: no cap (the author owns sizing).
@@ -67,10 +62,9 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import Generic, List, Optional, Sequence, TypeVar
 
-import torch
-
 RawT = TypeVar("RawT")  # raw input the author preprocesses (e.g. an image URL)
 ItemT = TypeVar("ItemT")  # opaque payload preprocess() hands to forward_batch()
+ArtifactT = TypeVar("ArtifactT")  # opaque result consumed by a decoder adapter
 
 
 @dataclass(frozen=True)
@@ -93,22 +87,16 @@ class Preprocessed(Generic[ItemT]):
     cost: int = 1
 
 
-class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
+class VisionEncoderBackend(ABC, Generic[RawT, ItemT, ArtifactT]):
     """Author-written, in-process vision encoder contract.
 
     A pure policy + compute backend — no threads, no futures. Dynamo drives it
     on a dedicated actor thread (``ThreadedMicroBatcher``) and exposes the async
     request API (``AsyncVisionEncoder``). Subclasses implement ``build`` and
-    ``forward_batch`` and set ``image_token_id``; ``preprocess`` (default identity
-    passthrough), ``max_batch_cost``, ``buckets``, and ``preprocess_concurrency``
-    are overridden only as needed.
+    ``forward_batch``; ``preprocess`` (default identity passthrough),
+    ``max_batch_cost``, ``buckets``, and ``preprocess_concurrency`` are overridden
+    only as needed. Artifact interpretation belongs to the selected adapter.
     """
-
-    #: Image placeholder token id — **hardcode it for your model** (e.g. ``151655``
-    #: for Qwen3-VL's ``<|image_pad|>``; resolve it from your tokenizer offline if
-    #: unsure). Dynamo uses it to locate each image span for the splice. Declared
-    #: without a default so a backend that forgets to set it fails fast at startup.
-    image_token_id: int
 
     #: Scalar dispatch ceiling: the batcher packs items up to this summed ``cost``
     #: per ``forward_batch`` call. ``None`` (the default) ⇒ **pass-through**: no cap
@@ -158,14 +146,13 @@ class VisionEncoderBackend(ABC, Generic[RawT, ItemT]):
     @abstractmethod
     def forward_batch(
         self, items: List[ItemT], target_bucket: Optional[int] = None
-    ) -> List[torch.Tensor]:
-        """Encode one cost-bounded batch (actor thread); one tensor per item, in order.
+    ) -> List[ArtifactT]:
+        """Encode one cost-bounded batch; one artifact per item, in input order.
 
         Fence (stream event + sync) and **copy outputs to CPU** before returning,
-        so results are safe to consume from another thread and splice directly.
-        Return one ``(n_visual_tokens, lm_hidden_dim)`` **CPU** tensor per item, in
-        input order. ``target_bucket`` is reserved for CUDA-graph batching, once
-        supported (the ladder rung to pad to), and is ``None`` until then.
+        so results are safe to consume from another thread. ``target_bucket`` is
+        reserved for CUDA-graph batching, once supported (the ladder rung to pad
+        to), and is ``None`` until then.
         """
         ...
 

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_linear.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/adapter/test_vllm_linear.py
@@ -166,6 +166,14 @@ def test_linear_adapter_requires_prompt_embeds_flag():
         )
 
 
+def test_linear_adapter_requires_image_token_id():
+    backend = _Backend()
+    backend.image_token_id = None
+
+    with pytest.raises(ValueError, match="image_token_id"):
+        create_custom_encoder_adapter(backend, _model_config(), _engine_args())
+
+
 def test_linear_adapter_rejects_multimodal_decoder():
     with pytest.raises(ValueError, match="multimodal decoder"):
         create_custom_encoder_adapter(

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/backend/test_vllm_base.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/backend/test_vllm_base.py
@@ -4,9 +4,8 @@
 """Unit tests for the custom encoder backend contract.
 
 Pin the author-facing contract surface: the ``Preprocessed`` carrier (item +
-scalar cost, no bucket_key), the hardcoded ``image_token_id`` attribute, the
-no-device ``build`` signature, and that the ABC cannot be instantiated without
-the required methods.
+scalar cost, no bucket_key), generic forward artifacts, the no-device ``build``
+signature, and that the ABC cannot be instantiated without the required methods.
 """
 
 import pytest
@@ -27,7 +26,7 @@ pytestmark = [
 
 
 class _MinimalBackend(VisionEncoderBackend):
-    """Smallest concrete backend — hardcodes the image token id."""
+    """Smallest concrete backend with an explicit preprocess phase."""
 
     image_token_id = 151655
 
@@ -97,5 +96,4 @@ def test_default_attrs_and_close_noop():
     assert e.buckets is None
     assert e.max_batch_cost is None
     assert e.preprocess_concurrency == 0
-    assert e.image_token_id == 151655
     assert e.close() is None

--- a/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_async_encoder.py
+++ b/components/src/dynamo/vllm/tests/multimodal_utils/custom_encoder/test_vllm_async_encoder.py
@@ -4,9 +4,9 @@
 """Unit tests for the custom encoder async driver.
 
 Pin the glue contract: build / forward / close run on one actor thread; encode
-returns one tensor per raw; the preprocess barrier fails a request atomically
-(no GPU work) if any image's preprocess fails; load fails fast on a build error or
-a missing/invalid hardcoded image_token_id and reaps its thread.
+returns one opaque artifact per raw; the preprocess barrier fails a request
+atomically (no GPU work) if any image's preprocess fails; load fails fast on a
+build error and reaps its thread.
 """
 
 import threading
@@ -102,12 +102,11 @@ async def test_build_and_forward_share_one_non_main_thread():
         enc.shutdown()
 
 
-async def test_load_resolves_placeholder_and_passes_model_id():
+async def test_load_passes_model_id():
     be = _FakeBackend()
     enc = AsyncVisionEncoder(be)
     enc.load("my-model")
     try:
-        assert enc.get_image_placeholder_token_id() == 151655
         assert be.model_id == "my-model"
     finally:
         enc.shutdown()
@@ -170,15 +169,23 @@ def test_load_fails_fast_on_build_error_and_reaps_threads():
     assert enc._pool is None
 
 
-def test_load_fails_fast_on_missing_image_token_id():
-    class _NoTokenId(_FakeBackend):
-        image_token_id = None  # author forgot to hardcode it
+async def test_encode_preserves_opaque_artifacts():
+    class _ArtifactBackend(VisionEncoderBackend):
+        def build(self, model_id):
+            pass
 
-    enc = AsyncVisionEncoder(_NoTokenId())
-    with pytest.raises(ValueError, match="image_token_id"):
-        enc.load("m")
-    assert enc._batcher is None
-    assert enc._pool is None
+        def forward_batch(self, items, target_bucket=None):
+            return [{"source": item} for item in items]
+
+    enc = AsyncVisionEncoder(_ArtifactBackend())
+    enc.load("m")
+    try:
+        assert await enc.encode(["first", "second"]) == [
+            {"source": "first"},
+            {"source": "second"},
+        ]
+    finally:
+        enc.shutdown()
 
 
 def test_shutdown_before_load_is_safe():


### PR DESCRIPTION
_Based on #12416._

## Why

Custom encoder drivers currently hard-code tensor results even though downstream adapters own prompt construction. A generic artifact type lets model-specific adapters consume structured results without teaching the batching and async layers model semantics.

## What Change

- Generalize the backend, async driver, and adapter over `ArtifactT`.
- Keep tensor and placeholder validation inside the linear adapter.
- Preserve opaque artifact ordering through cross-request batching.

## Test Plan

- Focused custom-encoder and handler unit tests: 69 passed.
- Pre-commit hooks passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom vision encoders can now produce backend-specific artifacts, enabling more flexible multimodal processing.
  * Arbitrary encoder artifacts are preserved through asynchronous encoding and prompt preparation.
  * Removed the requirement for a hardcoded image placeholder token.

* **Bug Fixes**
  * Improved validation when required image token configuration is missing.

* **Tests**
  * Added coverage for custom artifact handling, ordering, and configuration validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->