### PR TITLE
feat: Default worker pool size to 1.5x the engine max_num_seqs

### DIFF
--- a/components/src/dynamo/common/backend/engine.py
+++ b/components/src/dynamo/common/backend/engine.py
@@ -131,6 +131,10 @@ class LlmRegistration:
     # them so the frontend's PrefillRouter can take its Bootstrap path.
     bootstrap_host: Optional[str] = None
     bootstrap_port: Optional[int] = None
+    # Backend-normalized sequence capacity owned by this local engine. This is
+    # consumed by worker-side admission and is not published in discovery.
+    # Keep new fields after the legacy positional constructor fields.
+    engine_max_num_seqs: Optional[int] = None
 
 
 @dataclass

--- a/components/src/dynamo/common/backend/tests/test_backend_bindings.py
+++ b/components/src/dynamo/common/backend/tests/test_backend_bindings.py
@@ -21,6 +21,8 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from dynamo.common.backend.engine import LlmRegistration as PyLlmRegistration
+
 pytestmark = [pytest.mark.unit, pytest.mark.gpu_0, pytest.mark.pre_merge]
 
 
@@ -76,6 +78,7 @@ def test_engine_config_full_kwargs_round_trip_through_getters():
             kv_cache_block_size=16,
             total_kv_blocks=1000,
             max_num_seqs=64,
+            engine_max_num_seqs=128,
             max_num_batched_tokens=2048,
         ),
     )
@@ -87,7 +90,34 @@ def test_engine_config_full_kwargs_round_trip_through_getters():
     assert llm.kv_cache_block_size == 16
     assert llm.total_kv_blocks == 1000
     assert llm.max_num_seqs == 64
+    assert llm.engine_max_num_seqs == 128
     assert llm.max_num_batched_tokens == 2048
+
+
+def test_llm_registration_preserves_existing_positional_order():
+    legacy_args = (
+        2048,
+        16,
+        1000,
+        64,
+        2048,
+        2,
+        3,
+        "bootstrap.example",
+        9000,
+    )
+
+    for llm in (
+        PyLlmRegistration(*legacy_args),
+        backend.LlmRegistration(*legacy_args),
+    ):
+        assert llm.max_num_seqs == 64
+        assert llm.max_num_batched_tokens == 2048
+        assert llm.data_parallel_size == 2
+        assert llm.data_parallel_start_rank == 3
+        assert llm.bootstrap_host == "bootstrap.example"
+        assert llm.bootstrap_port == 9000
+        assert llm.engine_max_num_seqs is None
 
 
 def test_worker_config_minimum_args():

--- a/components/src/dynamo/common/configuration/groups/runtime_args.py
+++ b/components/src/dynamo/common/configuration/groups/runtime_args.py
@@ -318,19 +318,17 @@ class DynamoRuntimeArgGroup(ArgGroup):
             "default health_check_payload(). Unified backend only.",
         )
 
-        # Worker-side request admission/rejection. Defaults to None (disabled);
-        # when unset the worker behaves exactly as before. Surfaces an env var —
-        # the Rust runtime reads DYN_ENGINE_REQUEST_LIMIT directly. The Dynamo-side
-        # overflow queue is a small fixed burst (default 16, hard cap N+16) and is
-        # not a user-facing knob; advanced users may override it via the
-        # DYN_DYNAMO_REQUEST_QUEUE_LIMIT env var.
+        # Highest-priority explicit worker-pool size. When unset, TCP admission
+        # uses DYN_TCP_WORKER_POOL_SIZE, automatic backend sizing, or the 10,000
+        # fallback. DYN_DYNAMO_REQUEST_QUEUE_LIMIT controls the logical queue
+        # only when this engine limit is set.
         add_argument(
             g,
             flag_name="--engine-request-limit",
             env_var="DYN_ENGINE_REQUEST_LIMIT",
             default=None,
             arg_type=int,
-            help="Max requests handled concurrently by the engine (worker-pool "
-            "semaphore size). Enables worker-side request rejection when set. "
-            "Disabled by default.",
+            help="Highest-priority explicit TCP worker-pool size. When unset, "
+            "Dynamo uses DYN_TCP_WORKER_POOL_SIZE, automatic sizing from backend "
+            "capacity, or the 10,000 fallback.",
         )

--- a/components/src/dynamo/mocker/config.py
+++ b/components/src/dynamo/mocker/config.py
@@ -377,6 +377,11 @@ def build_runtime_config(
         engine_args.enable_local_indexer and not engine_args.is_decode()
     )
     rc.data_parallel_size = engine_args.dp_size
+    rc.engine_max_num_seqs = (
+        rc.max_num_seqs * max(engine_args.dp_size, 1)
+        if rc.max_num_seqs is not None
+        else None
+    )
     rc.set_engine_specific("output_replay_consumer", "true")
 
     bootstrap_port = engine_args.bootstrap_port

--- a/components/src/dynamo/mocker/tests/unit/test_config.py
+++ b/components/src/dynamo/mocker/tests/unit/test_config.py
@@ -93,6 +93,26 @@ def test_build_runtime_config_uses_normalized_sglang_page_size_alias():
     assert runtime_config.runtime_data["output_replay_consumer"] == "true"
 
 
+@pytest.mark.parametrize(
+    "max_num_seqs, dp_size, expected_engine_max_num_seqs",
+    [
+        (7, 1, 7),
+        (7, 3, 21),
+    ],
+)
+def test_build_runtime_config_normalizes_engine_max_num_seqs(
+    max_num_seqs, dp_size, expected_engine_max_num_seqs
+):
+    engine_args = CONFIG.build_mocker_engine_args(
+        make_args(max_num_seqs=max_num_seqs, dp_size=dp_size)
+    )
+
+    _, runtime_config = CONFIG.build_runtime_config(engine_args)
+
+    assert runtime_config.max_num_seqs == max_num_seqs
+    assert runtime_config.engine_max_num_seqs == expected_engine_max_num_seqs
+
+
 def test_build_mocker_engine_args_rejects_mismatched_sglang_sizes():
     with pytest.raises(Exception, match="block_size and sglang.page_size to match"):
         CONFIG.build_mocker_engine_args(

--- a/components/src/dynamo/sglang/capacity.py
+++ b/components/src/dynamo/sglang/capacity.py
@@ -3,10 +3,25 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 from dynamo.common.native_offloading import native_offloading_capacity
+
+logger = logging.getLogger(__name__)
+
+_INTERNAL_STATE_TIMEOUT_SECONDS = 5.0
+
+# A timed-out probe must survive to release SGLang's queueing communicator.
+_IN_FLIGHT_INTERNAL_STATE_TASKS: set[asyncio.Task[Any]] = set()
+
+
+def _drain_internal_state_task(task: asyncio.Task[Any]) -> None:
+    _IN_FLIGHT_INTERNAL_STATE_TASKS.discard(task)
+    if not task.cancelled():
+        _ = task.exception()
 
 
 @dataclass(frozen=True)
@@ -47,6 +62,52 @@ def per_rank_max_running_requests(server_args: Any) -> int | None:
         return max_running_requests
 
     return max_running_requests // dp_size
+
+
+async def resolve_engine_max_num_seqs(
+    engine: Any, server_args: Any, local_dp_size: int
+) -> int | None:
+    """Return post-initialization concurrent-sequence capacity for this worker.
+
+    SGLang may clamp the configured maximum after KV profiling. Prefer the
+    scheduler-reported effective per-DP value and conservatively use the
+    smallest local rank when every represented rank supplies a usable value.
+    Fall back to the configured per-rank value otherwise.
+    """
+    effective: list[int] = []
+    expected_dp_size = max(local_dp_size, 1)
+    try:
+        state_task = asyncio.create_task(engine.tokenizer_manager.get_internal_state())
+        _IN_FLIGHT_INTERNAL_STATE_TASKS.add(state_task)
+        state_task.add_done_callback(_drain_internal_state_task)
+        states = await asyncio.wait_for(
+            asyncio.shield(state_task),
+            timeout=_INTERNAL_STATE_TIMEOUT_SECONDS,
+        )
+        if isinstance(states, dict):
+            states = [states]
+        if isinstance(states, (list, tuple)) and len(states) == expected_dp_size:
+            for state in states:
+                if not isinstance(state, dict):
+                    continue
+                value = state.get("effective_max_running_requests_per_dp")
+                if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                    effective.append(value)
+    except Exception as exc:
+        logger.warning(
+            "Unable to read SGLang effective scheduler capacity; falling back "
+            "to configured max_running_requests: %s",
+            exc,
+        )
+
+    per_rank = (
+        min(effective)
+        if len(effective) == expected_dp_size
+        else per_rank_max_running_requests(server_args)
+    )
+    if per_rank is None or per_rank <= 0:
+        return None
+    return per_rank * expected_dp_size
 
 
 def tokens_to_kv_blocks(tokens: int, page_size: int | None) -> int:

--- a/components/src/dynamo/sglang/init_diffusion.py
+++ b/components/src/dynamo/sglang/init_diffusion.py
@@ -92,22 +92,22 @@ async def init_llm_diffusion(
     )
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            output_type=parse_endpoint_types(dynamo_args.endpoint_types),
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Aggregated,
+            needs=[],
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                output_type=parse_endpoint_types(dynamo_args.endpoint_types),
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Aggregated,
-                needs=[],
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/init_embedding.py
+++ b/components/src/dynamo/sglang/init_embedding.py
@@ -72,23 +72,23 @@ async def init_embedding(
     ).to_dict()
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Text,
+            output_type=ModelType.Embedding,
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Aggregated,
+            needs=[],
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
                 metrics_labels=metrics_labels,
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Text,
-                output_type=ModelType.Embedding,
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Aggregated,
-                needs=[],
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/init_llm.py
+++ b/components/src/dynamo/sglang/init_llm.py
@@ -144,6 +144,18 @@ async def init_decode(
         decode_needs = []
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            output_type=parse_endpoint_types(dynamo_args.endpoint_types),
+            readiness_gate=ready_event,
+            worker_type=decode_worker_type,
+            needs=decode_needs,
+            # Decode workers serve the LoRA load endpoints, so they may advertise capacity.
+            serves_lora_load=True,
+        )
         gather_tasks = [
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -166,18 +178,6 @@ async def init_decode(
             clear_endpoint.serve_endpoint(
                 handler.clear_kv_blocks,
                 metrics_labels=metrics_labels,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                output_type=parse_endpoint_types(dynamo_args.endpoint_types),
-                readiness_gate=ready_event,
-                worker_type=decode_worker_type,
-                needs=decode_needs,
-                # Decode workers serve the LoRA load endpoints, so they may advertise capacity.
-                serves_lora_load=True,
             ),
         ]
         await asyncio.gather(*gather_tasks)
@@ -283,6 +283,26 @@ async def init_prefill(
     ready_event = asyncio.Event()
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            # Prefill workers have no OpenAI surface — the role is carried
+            # by `worker_type=Prefill` below. We register the legacy
+            # `ModelType.Prefill` marker bit (not a surface) so an OLD
+            # frontend, which detects prefill via that bit, still routes
+            # disaggregated traffic during the cross-version rollout. A new
+            # frontend ignores it and dispatches off `worker_type`.
+            output_type=ModelType.Prefill,
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Prefill,
+            needs=[[WorkerType.Decode]],
+            # Prefill workers also serve the LoRA load endpoints (init_prefill), so they may
+            # advertise capacity.
+            serves_lora_load=True,
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -305,26 +325,6 @@ async def init_prefill(
             clear_endpoint.serve_endpoint(
                 handler.clear_kv_blocks,
                 metrics_labels=metrics_labels,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                # Prefill workers have no OpenAI surface — the role is carried
-                # by `worker_type=Prefill` below. We register the legacy
-                # `ModelType.Prefill` marker bit (not a surface) so an OLD
-                # frontend, which detects prefill via that bit, still routes
-                # disaggregated traffic during the cross-version rollout. A new
-                # frontend ignores it and dispatches off `worker_type`.
-                output_type=ModelType.Prefill,
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Prefill,
-                needs=[[WorkerType.Decode]],
-                # Prefill workers also serve the LoRA load endpoints (init_prefill), so they may
-                # advertise capacity.
-                serves_lora_load=True,
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/init_multimodal.py
+++ b/components/src/dynamo/sglang/init_multimodal.py
@@ -79,6 +79,27 @@ async def init_multimodal_encode_worker(
     ready_event = asyncio.Event()
 
     try:
+        await register_model_with_readiness_gate(
+            None,  # engine
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            # The encode worker is the OpenAI front door for sglang
+            # multimodal: it carries the Chat/Completions surface and
+            # delegates token generation to the internal PD worker via
+            # pd_worker_client. Its `worker_type=Encode` topology role gates
+            # serving on the downstream worker(s) — `needs` is a DNF: a P+D
+            # pair OR a single Aggregated peer — so the model is not
+            # advertised until the whole pipeline is live.
+            output_type=ModelType.Chat | ModelType.Completions,
+            readiness_gate=ready_event,
+            worker_type=WorkerType.Encode,
+            needs=[
+                [WorkerType.Prefill, WorkerType.Decode],
+                [WorkerType.Aggregated],
+            ],
+        )
         _ = await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
@@ -86,27 +107,6 @@ async def init_multimodal_encode_worker(
                 metrics_labels=[
                     (prometheus_names.labels.MODEL, server_args.served_model_name),
                     (prometheus_names.labels.MODEL_NAME, server_args.served_model_name),
-                ],
-            ),
-            register_model_with_readiness_gate(
-                None,  # engine
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                # The encode worker is the OpenAI front door for sglang
-                # multimodal: it carries the Chat/Completions surface and
-                # delegates token generation to the internal PD worker via
-                # pd_worker_client. Its `worker_type=Encode` topology role gates
-                # serving on the downstream worker(s) — `needs` is a DNF: a P+D
-                # pair OR a single Aggregated peer — so the model is not
-                # advertised until the whole pipeline is live.
-                output_type=ModelType.Chat | ModelType.Completions,
-                readiness_gate=ready_event,
-                worker_type=WorkerType.Encode,
-                needs=[
-                    [WorkerType.Prefill, WorkerType.Decode],
-                    [WorkerType.Aggregated],
                 ],
             ),
         )
@@ -173,22 +173,22 @@ async def init_multimodal_worker(
         readiness_needs = [[WorkerType.Encode]]
 
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            output_type=ModelType.Empty,
+            worker_type=readiness_worker_type,
+            needs=readiness_needs,
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 metrics_labels=[("model", server_args.served_model_name)],
                 graceful_shutdown=True,
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                output_type=ModelType.Empty,
-                worker_type=readiness_worker_type,
-                needs=readiness_needs,
             ),
         )
     except Exception as e:
@@ -227,22 +227,22 @@ async def init_multimodal_prefill_worker(
     # the decode worker / prefill router, never by the frontend. Registers a
     # topology card so the serving-readiness gate counts it.
     try:
+        await register_model_with_readiness_gate(
+            engine,
+            generate_endpoint,
+            server_args,
+            dynamo_args,
+            input_type=ModelInput.Tokens,
+            output_type=ModelType.Empty,
+            worker_type=WorkerType.Prefill,
+            needs=[[WorkerType.Decode]],
+        )
         await asyncio.gather(
             generate_endpoint.serve_endpoint(
                 handler.generate,
                 graceful_shutdown=True,
                 metrics_labels=[("model", server_args.served_model_name)],
                 health_check_payload=health_check_payload,
-            ),
-            register_model_with_readiness_gate(
-                engine,
-                generate_endpoint,
-                server_args,
-                dynamo_args,
-                input_type=ModelInput.Tokens,
-                output_type=ModelType.Empty,
-                worker_type=WorkerType.Prefill,
-                needs=[[WorkerType.Decode]],
             ),
         )
     except Exception as e:

--- a/components/src/dynamo/sglang/register.py
+++ b/components/src/dynamo/sglang/register.py
@@ -31,6 +31,7 @@ from dynamo.sglang.capacity import (
     get_hicache_native_offloading_capacity,
     get_spec_decode_runtime_data,
     model_card_dp_rank_bounds,
+    resolve_engine_max_num_seqs,
     runtime_capacity,
 )
 
@@ -38,7 +39,9 @@ SGLANG_HICACHE_MOONCAKE_RUNTIME_KEY = "sglang_hicache_mooncake"
 SPEC_DECODE_RUNTIME_KEY = "spec_decode"
 
 
-def _register_model_source_path(engine: sgl.Engine, server_args: ServerArgs) -> str:
+def _register_model_source_path(
+    engine: Optional[sgl.Engine], server_args: ServerArgs
+) -> str:
     """Pick the path passed to `register_model` for MDC construction.
 
     When `--model-path` is a remote URI (`s3://...`, `gs://...`), SGLang's
@@ -60,6 +63,8 @@ def _register_model_source_path(engine: sgl.Engine, server_args: ServerArgs) -> 
     the Rust-side HF download entirely (lib/bindings/python/rust/lib.rs:314)
     and don't need this rewrite.
     """
+    if engine is None:
+        return server_args.model_path
     try:
         mc = engine.tokenizer_manager.model_config
     except AttributeError:
@@ -88,7 +93,7 @@ def _build_media_decoder_and_fetcher():
 
 
 async def _register_model_with_runtime_config(
-    engine: sgl.Engine,
+    engine: Optional[sgl.Engine],
     endpoint: Endpoint,
     server_args: ServerArgs,
     dynamo_args: DynamoConfig,
@@ -345,7 +350,7 @@ def _eagle_enabled_for(speculative_algorithm: Optional[str]) -> bool:
 
 
 async def _get_runtime_config(
-    engine: sgl.Engine, server_args: ServerArgs, dynamo_args: DynamoConfig
+    engine: Optional[sgl.Engine], server_args: ServerArgs, dynamo_args: DynamoConfig
 ) -> Optional[ModelRuntimeConfig]:
     """Extract runtime configuration from SGLang engine and args.
 
@@ -381,6 +386,10 @@ async def _get_runtime_config(
     registered_dp_size = end_dp_rank - start_dp_rank
     runtime_config.data_parallel_start_rank = start_dp_rank
     runtime_config.data_parallel_size = registered_dp_size
+    if engine is not None:
+        runtime_config.engine_max_num_seqs = await resolve_engine_max_num_seqs(
+            engine, server_args, registered_dp_size
+        )
     if registered_dp_size > 1:
         logging.info(
             "Registering with routable data_parallel rank range [%s, %s)",
@@ -408,14 +417,15 @@ async def _get_runtime_config(
     # Set topology and KV transfer policy for topology-aware routing
     apply_topology_config(runtime_config)
 
-    # Set bootstrap endpoint for disaggregated serving (prefill workers)
-    bootstrap_host, bootstrap_port = _get_bootstrap_info_for_config(engine)
-    if bootstrap_host and bootstrap_port:
-        runtime_config.set_disaggregated_endpoint(bootstrap_host, bootstrap_port)
-        logging.info(
-            f"Publishing disaggregated endpoint to discovery: "
-            f"{bootstrap_host}:{bootstrap_port}"
-        )
+    if engine is not None:
+        # Set bootstrap endpoint for disaggregated serving (prefill workers)
+        bootstrap_host, bootstrap_port = _get_bootstrap_info_for_config(engine)
+        if bootstrap_host and bootstrap_port:
+            runtime_config.set_disaggregated_endpoint(bootstrap_host, bootstrap_port)
+            logging.info(
+                f"Publishing disaggregated endpoint to discovery: "
+                f"{bootstrap_host}:{bootstrap_port}"
+            )
     # In SGLang, these are server_args, not scheduler_info (unlike vLLM)
     # Note: If --max-running-requests is not specified, SGLang uses an internal default
     # undocumented value. The value here will be None if not explicitly set by user.
@@ -456,6 +466,11 @@ async def _get_runtime_config(
             logging.warning(
                 f"Failed to attach Mooncake HiCache runtime metadata to registration: {e}"
             )
+
+    # Encode/proxy workers intentionally have no SGLang engine. All remaining
+    # metadata depends on scheduler state, so their configuration is complete.
+    if engine is None:
+        return runtime_config
 
     try:
         scheduler_info = engine._scheduler_init_result.scheduler_infos[0]
@@ -511,7 +526,7 @@ async def _get_runtime_config(
 
 
 async def register_model_with_readiness_gate(
-    engine: sgl.Engine,
+    engine: Optional[sgl.Engine],
     generate_endpoint: Endpoint,
     server_args: ServerArgs,
     dynamo_args: DynamoConfig,

--- a/components/src/dynamo/sglang/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/sglang/tests/test_runtime_metadata.py
@@ -1,13 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+import dynamo.sglang.capacity as capacity_module
 from dynamo.sglang.capacity import (
     get_hicache_native_offloading_capacity,
     get_spec_decode_runtime_data,
+    resolve_engine_max_num_seqs,
 )
 
 pytestmark = [
@@ -17,6 +21,216 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@pytest.mark.parametrize(
+    ("states", "max_running_requests", "expected"),
+    [
+        ([7, 6, 5], 999, 15),
+        ([7, True, 5], 21, 21),
+    ],
+)
+@pytest.mark.asyncio
+async def test_engine_sequence_capacity_requires_complete_effective_local_ranks(
+    states, max_running_requests, expected
+):
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=AsyncMock(
+                return_value=[
+                    {"effective_max_running_requests_per_dp": value} for value in states
+                ]
+            )
+        )
+    )
+
+    capacity = await resolve_engine_max_num_seqs(
+        engine,
+        SimpleNamespace(max_running_requests=max_running_requests, dp_size=3),
+        local_dp_size=3,
+    )
+
+    assert capacity == expected
+
+
+@pytest.mark.parametrize("failure", ["error", "timeout"])
+@pytest.mark.asyncio
+async def test_engine_sequence_capacity_falls_back_to_configured_per_rank(
+    failure, monkeypatch, caplog
+):
+    release = asyncio.Event()
+
+    async def get_internal_state():
+        if failure == "error":
+            raise RuntimeError("not supported")
+        await release.wait()
+        return []
+
+    monkeypatch.setattr(capacity_module, "_INTERNAL_STATE_TIMEOUT_SECONDS", 0.01)
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(get_internal_state=get_internal_state)
+    )
+
+    capacity = await resolve_engine_max_num_seqs(
+        engine,
+        SimpleNamespace(max_running_requests=24, dp_size=4),
+        local_dp_size=2,
+    )
+
+    assert capacity == 12
+    assert "falling back to configured max_running_requests" in caplog.text
+    if failure == "timeout":
+        release.set()
+        await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_internal_state_timeout_does_not_block_later_calls(monkeypatch):
+    # Keep this backend-heavy import lazy so lightweight collection does not
+    # require an installed SGLang package.
+    from sglang.srt.managers.communicator import FanOutCommunicator
+
+    sent_requests = []
+    communicator = FanOutCommunicator(sent_requests.append, fan_out=1)
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=lambda: communicator(object())
+        )
+    )
+    server_args = SimpleNamespace(max_running_requests=8, dp_size=1)
+
+    monkeypatch.setattr(capacity_module, "_INTERNAL_STATE_TIMEOUT_SECONDS", 0.01)
+    assert await resolve_engine_max_num_seqs(engine, server_args, 1) == 8
+
+    monkeypatch.setattr(capacity_module, "_INTERNAL_STATE_TIMEOUT_SECONDS", 1.0)
+    second_capacity = asyncio.create_task(
+        resolve_engine_max_num_seqs(engine, server_args, 1)
+    )
+    for _ in range(100):
+        if len(communicator._ready_queue) == 1:
+            break
+        await asyncio.sleep(0)
+    assert len(communicator._ready_queue) == 1
+
+    communicator.handle_recv({"effective_max_running_requests_per_dp": 5})
+    for _ in range(100):
+        if len(sent_requests) == 2:
+            break
+        await asyncio.sleep(0)
+    assert len(sent_requests) == 2
+
+    communicator.handle_recv({"effective_max_running_requests_per_dp": 4})
+
+    assert await asyncio.wait_for(second_capacity, timeout=1.0) == 4
+    await asyncio.sleep(0)
+    assert not capacity_module._IN_FLIGHT_INTERNAL_STATE_TASKS
+
+
+@pytest.mark.asyncio
+async def test_engine_sequence_capacity_returns_none_without_usable_limit():
+    engine = SimpleNamespace(
+        tokenizer_manager=SimpleNamespace(
+            get_internal_state=AsyncMock(return_value={"other": 1})
+        )
+    )
+
+    capacity = await resolve_engine_max_num_seqs(
+        engine,
+        SimpleNamespace(max_running_requests=None, dp_size=1),
+        local_dp_size=1,
+    )
+
+    assert capacity is None
+
+
+@pytest.mark.asyncio
+async def test_registration_reports_resolved_local_engine_capacity(monkeypatch):
+    # Keep this backend-heavy import lazy: importing it at module scope breaks
+    # the sglang-light `pytest-marker-report` collection environment.
+    from dynamo.sglang import register
+
+    engine = SimpleNamespace(
+        _scheduler_init_result=SimpleNamespace(scheduler_infos=[{}]),
+    )
+    server_args = SimpleNamespace(
+        context_length=4096,
+        disaggregation_mode=None,
+        max_prefill_tokens=None,
+        page_size=16,
+        speculative_algorithm="NONE",
+    )
+    dynamo_args = register.DynamoConfig()
+    dynamo_args.enable_local_indexer = False
+    resolver = AsyncMock(return_value=15)
+    capacity = SimpleNamespace(
+        max_num_seqs=None,
+        max_num_batched_tokens=None,
+        total_kv_blocks=None,
+    )
+
+    monkeypatch.setattr(register, "resolve_engine_max_num_seqs", resolver)
+    monkeypatch.setattr(register, "model_card_dp_rank_bounds", lambda _: (2, 5))
+    monkeypatch.setattr(register, "get_sglang_worker_group_id", lambda _: None)
+    monkeypatch.setattr(
+        register, "_get_bootstrap_info_for_config", lambda _: (None, None)
+    )
+    monkeypatch.setattr(register, "_get_mooncake_runtime_data", lambda _: None)
+    monkeypatch.setattr(register, "runtime_capacity", lambda *_: capacity)
+
+    runtime_config = await register._get_runtime_config(
+        engine, server_args, dynamo_args
+    )
+
+    resolver.assert_awaited_once_with(engine, server_args, 3)
+    assert runtime_config.engine_max_num_seqs == 15
+
+
+@pytest.mark.asyncio
+async def test_proxy_registration_does_not_report_local_engine_capacity(
+    monkeypatch, caplog
+):
+    # Keep this backend-heavy import lazy: register.py imports
+    # sglang.srt.environ.envs, which is unavailable to the
+    # `pytest-marker-report` collection environment.
+    from dynamo.sglang import register
+
+    server_args = SimpleNamespace(
+        context_length=4096,
+        disaggregation_mode=None,
+        max_prefill_tokens=None,
+        page_size=16,
+        speculative_algorithm="NONE",
+    )
+    dynamo_args = register.DynamoConfig()
+    dynamo_args.enable_local_indexer = False
+    resolver = AsyncMock(return_value=99)
+    bootstrap_resolver = Mock(return_value=(None, None))
+    offloading_resolver = Mock(return_value=None)
+    capacity = SimpleNamespace(
+        max_num_seqs=None,
+        max_num_batched_tokens=None,
+        total_kv_blocks=None,
+    )
+
+    monkeypatch.setattr(register, "resolve_engine_max_num_seqs", resolver)
+    monkeypatch.setattr(register, "model_card_dp_rank_bounds", lambda _: (0, 1))
+    monkeypatch.setattr(register, "get_sglang_worker_group_id", lambda _: None)
+    monkeypatch.setattr(register, "_get_bootstrap_info_for_config", bootstrap_resolver)
+    monkeypatch.setattr(register, "_get_mooncake_runtime_data", lambda _: None)
+    monkeypatch.setattr(register, "runtime_capacity", lambda *_: capacity)
+    monkeypatch.setattr(
+        register, "get_hicache_native_offloading_capacity", offloading_resolver
+    )
+
+    runtime_config = await register._get_runtime_config(None, server_args, dynamo_args)
+
+    resolver.assert_not_awaited()
+    bootstrap_resolver.assert_not_called()
+    offloading_resolver.assert_not_called()
+    assert runtime_config.engine_max_num_seqs is None
+    assert runtime_config.context_length == 4096
+    assert "Failed to get runtime config" not in caplog.text
+    assert "Failed to compute bootstrap address" not in caplog.text
 
 
 def test_spec_decode_runtime_data_uses_speculative_num_steps():

--- a/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/trtllm/tests/test_runtime_metadata.py
@@ -5,7 +5,13 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.trtllm.utils.trtllm_utils import get_spec_decode_runtime_data
+from dynamo.llm import ModelRuntimeConfig
+from dynamo.trtllm.constants import DisaggregationMode
+from dynamo.trtllm.utils.trtllm_utils import (
+    engine_max_num_seqs,
+    get_spec_decode_runtime_data,
+    populate_engine_max_num_seqs,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -13,6 +19,55 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+def test_engine_max_num_seqs_uses_post_init_engine_value():
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=37)),
+        get_attention_dp_size=lambda: 4,
+    )
+
+    # TRT-LLM reports one engine-wide budget; attention DP must not multiply it.
+    assert engine_max_num_seqs(engine) == 37
+
+
+def test_registration_reports_post_init_engine_capacity():
+    runtime_config = ModelRuntimeConfig()
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=37)),
+        get_attention_dp_size=lambda: 4,
+    )
+
+    populate_engine_max_num_seqs(runtime_config, engine)
+
+    assert runtime_config.engine_max_num_seqs == 37
+
+
+def test_encode_registration_without_local_scheduler_reports_no_capacity():
+    runtime_config = ModelRuntimeConfig()
+    runtime_config.engine_max_num_seqs = 37
+    engine = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.ENCODE,
+        encoder_available=False,
+    )
+
+    populate_engine_max_num_seqs(runtime_config, engine)
+
+    assert runtime_config.engine_max_num_seqs is None
+
+
+@pytest.mark.parametrize("value", [None, 0, -1, True, "37"])
+def test_engine_max_num_seqs_ignores_invalid_values(value):
+    engine = SimpleNamespace(
+        llm=SimpleNamespace(args=SimpleNamespace(max_batch_size=value))
+    )
+
+    assert engine_max_num_seqs(engine) is None
+
+
+def test_engine_max_num_seqs_fails_if_engine_contract_changes():
+    with pytest.raises(AttributeError):
+        engine_max_num_seqs(SimpleNamespace())
 
 
 def test_spec_decode_runtime_data_uses_max_draft_len():

--- a/components/src/dynamo/trtllm/utils/trtllm_utils.py
+++ b/components/src/dynamo/trtllm/utils/trtllm_utils.py
@@ -7,6 +7,8 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+from dynamo.trtllm.constants import DisaggregationMode
+
 
 def deep_update(target: dict[str, Any], source: Mapping[str, Any]) -> None:
     """Recursively update nested dictionaries.
@@ -77,3 +79,22 @@ def get_spec_decode_runtime_data(engine_args: Any) -> dict[str, Any] | None:
     if method:
         data["method"] = str(method)
     return data
+
+
+def engine_max_num_seqs(engine: Any) -> int | None:
+    """Return TRT-LLM's post-initialization, engine-wide request capacity."""
+    if (
+        getattr(engine, "disaggregation_mode", None) == DisaggregationMode.ENCODE
+        and not engine.encoder_available
+    ):
+        return None
+
+    value = engine.llm.args.max_batch_size
+    if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+        return None
+    return value
+
+
+def populate_engine_max_num_seqs(runtime_config: Any, engine: Any) -> None:
+    """Publish TRT-LLM's post-initialization capacity on its registration."""
+    runtime_config.engine_max_num_seqs = engine_max_num_seqs(engine)

--- a/components/src/dynamo/trtllm/workers/llm_worker.py
+++ b/components/src/dynamo/trtllm/workers/llm_worker.py
@@ -65,7 +65,11 @@ from dynamo.trtllm.request_handlers.handlers import (
     RequestHandlerConfig,
     RequestHandlerFactory,
 )
-from dynamo.trtllm.utils.trtllm_utils import deep_update, get_spec_decode_runtime_data
+from dynamo.trtllm.utils.trtllm_utils import (
+    deep_update,
+    get_spec_decode_runtime_data,
+    populate_engine_max_num_seqs,
+)
 
 # Default buffer size for kv cache events.
 DEFAULT_KV_EVENT_BUFFER_MAX_SIZE = 100_000
@@ -549,6 +553,7 @@ async def init_llm_worker(
         # Need to get max_num_seqs and max_num_batched_tokens from engine_args
         # because they can be overridden by --extra-engine-args or --override-engine-args
         runtime_config.max_num_seqs = engine_args["max_batch_size"]
+        populate_engine_max_num_seqs(runtime_config, engine)
         runtime_config.max_num_batched_tokens = engine_args["max_num_tokens"]
         runtime_config.reasoning_parser = config.dyn_reasoning_parser
         runtime_config.tool_call_parser = config.dyn_tool_call_parser

--- a/components/src/dynamo/vllm/capacity.py
+++ b/components/src/dynamo/vllm/capacity.py
@@ -10,6 +10,17 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def engine_max_num_seqs(max_num_seqs: int | None, local_dp_size: int) -> int | None:
+    """Normalize vLLM's per-rank scheduler limit to this worker's DP scope."""
+    if (
+        not isinstance(max_num_seqs, int)
+        or isinstance(max_num_seqs, bool)
+        or max_num_seqs <= 0
+    ):
+        return None
+    return max_num_seqs * max(local_dp_size, 1)
+
+
 def per_rank_kv_blocks(
     total_kv_blocks: int | None, data_parallel_size: int
 ) -> int | None:

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -52,6 +52,7 @@ from . import envs
 from .args import Config, _uses_dynamo_connector, configure_rl_logprobs_mode, parse_args
 from .cache_info import get_configured_kv_event_block_size
 from .capacity import (
+    engine_max_num_seqs,
     get_metrics_model_name,
     get_spec_decode_runtime_data,
     per_rank_kv_blocks,
@@ -695,6 +696,9 @@ async def register_vllm_model(
         num_gpu_blocks = 0
     runtime_config.total_kv_blocks = per_rank_kv_blocks(num_gpu_blocks, dp_range[1])
     runtime_config.max_num_seqs = runtime_values["max_num_seqs"]
+    runtime_config.engine_max_num_seqs = engine_max_num_seqs(
+        runtime_values["max_num_seqs"], dp_range[1]
+    )
     runtime_config.max_num_batched_tokens = runtime_values["max_num_batched_tokens"]
     # Decode workers don't create the WorkerKvQuery endpoint, so don't advertise local indexer
     runtime_config.enable_local_indexer = (

--- a/components/src/dynamo/vllm/tests/test_runtime_metadata.py
+++ b/components/src/dynamo/vllm/tests/test_runtime_metadata.py
@@ -5,7 +5,11 @@ from types import SimpleNamespace
 
 import pytest
 
-from dynamo.vllm.capacity import get_metrics_model_name, get_spec_decode_runtime_data
+from dynamo.vllm.capacity import (
+    engine_max_num_seqs,
+    get_metrics_model_name,
+    get_spec_decode_runtime_data,
+)
 
 pytestmark = [
     pytest.mark.unit,
@@ -13,6 +17,14 @@ pytestmark = [
     pytest.mark.gpu_0,
     pytest.mark.pre_merge,
 ]
+
+
+@pytest.mark.parametrize(
+    "max_num_seqs, local_dp_size, expected",
+    [(8, 1, 8), (8, 3, 24), (8, 0, 8), (None, 2, None), (0, 2, None), (True, 2, None)],
+)
+def test_engine_max_num_seqs_normalizes_dp_scope(max_num_seqs, local_dp_size, expected):
+    assert engine_max_num_seqs(max_num_seqs, local_dp_size) == expected
 
 
 def test_spec_decode_runtime_data_uses_vllm_speculative_config():

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -116,6 +116,72 @@ def test_kv_event_block_size_falls_back_to_cache_config():
     assert get_configured_kv_event_block_size(vllm_config) == 16
 
 
+@pytest.mark.asyncio
+async def test_register_vllm_model_reports_normalized_local_engine_capacity(
+    monkeypatch,
+):
+    vllm_main = _load_vllm_main()
+    captured = {}
+
+    async def fake_register_model(*args, **kwargs):
+        captured["runtime_config"] = kwargs["runtime_config"]
+
+    monkeypatch.setattr(vllm_main, "register_model", fake_register_model)
+    monkeypatch.setattr(
+        vllm_main,
+        "get_engine_cache_info",
+        lambda _: {
+            "num_gpu_blocks": 63,
+            "max_num_seqs": 8,
+            "max_num_batched_tokens": 1024,
+            "kv_event_block_size": 16,
+        },
+    )
+    monkeypatch.setattr(vllm_main, "get_dp_range_for_worker", lambda _: (2, 3))
+    monkeypatch.setattr(vllm_main, "get_spec_decode_runtime_data", lambda *_: None)
+    monkeypatch.setattr(vllm_main, "apply_topology_config", lambda _: None)
+    monkeypatch.setattr(
+        vllm_main, "create_frontend_media_config", lambda _: (None, None)
+    )
+
+    config = SimpleNamespace(
+        enable_local_indexer=True,
+        disaggregation_mode=DisaggregationMode.AGGREGATED,
+        dyn_tool_call_parser=None,
+        dyn_reasoning_parser=None,
+        exclude_tools_when_tool_choice_none=True,
+        dyn_enable_structural_tag=False,
+        dyn_structural_tag_scope="auto",
+        dyn_structural_tag_schema="auto",
+        engine_args=SimpleNamespace(stream_interval=None, enable_lora=False),
+        frontend_decoding=False,
+        served_model_name="qwen",
+        custom_jinja_template=None,
+        model="Qwen/Qwen3-0.6B",
+    )
+    vllm_config = SimpleNamespace(
+        model_config=SimpleNamespace(
+            max_model_len=4096,
+            model_weights="",
+            model="Qwen/Qwen3-0.6B",
+        )
+    )
+
+    await vllm_main.register_vllm_model(
+        vllm_main.ModelInput.Tokens,
+        vllm_main.ModelType.Chat,
+        SimpleNamespace(),
+        config,
+        SimpleNamespace(),
+        vllm_config,
+        vllm_main.WorkerType.Aggregated,
+    )
+
+    runtime_config = captured["runtime_config"]
+    assert runtime_config.max_num_seqs == 8
+    assert runtime_config.engine_max_num_seqs == 24
+
+
 def test_custom_jinja_template_invalid_path(mock_vllm_cli):
     """Test that invalid file path raises FileNotFoundError."""
     invalid_path = "/nonexistent/path/to/template.jinja"

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -729,24 +729,24 @@ class WorkerFactory:
 
         logger.info("Starting to serve the embedding worker endpoint...")
         try:
+            await self.register_vllm_model(
+                ModelInput.Text,
+                ModelType.Embedding,
+                generate_endpoint,
+                config,
+                engine_client,
+                vllm_config,
+                # Embedding workers have no prefill/decode split — they
+                # always serve a single pooling pass, so they advertise
+                # as Aggregated with no peer dependencies.
+                worker_type=WorkerType.Aggregated,
+                needs=[],
+            )
             await asyncio.gather(
                 generate_endpoint.serve_endpoint(
                     handler.generate,
                     metrics_labels=[("model", config.model)],
                     health_check_payload=embedding_health_check_payload,
-                ),
-                self.register_vllm_model(
-                    ModelInput.Text,
-                    ModelType.Embedding,
-                    generate_endpoint,
-                    config,
-                    engine_client,
-                    vllm_config,
-                    # Embedding workers have no prefill/decode split — they
-                    # always serve a single pooling pass, so they advertise
-                    # as Aggregated with no peer dependencies.
-                    worker_type=WorkerType.Aggregated,
-                    needs=[],
                 ),
             )
         except Exception as e:

--- a/docs/fault-tolerance/request-rejection.md
+++ b/docs/fault-tolerance/request-rejection.md
@@ -409,29 +409,45 @@ If `active_decode_blocks_threshold` is configured but you suspect `router_track_
 ## Worker-Side Request Admission
 
 In addition to the frontend's metric-driven busy detection above, a worker can
-enforce a hard concurrency cap directly at its request-plane ingress. This is
-disabled by default — when neither knob is set, the worker behaves exactly as
-before (a large pool plus a large overflow queue, no rejection).
+enforce bounded admission directly at its TCP request-plane ingress. The worker
+pool is fixed when the process-global TCP server is first initialized, before a
+capacity-bearing worker is published as ready.
+
+Pool size is resolved in this order:
+
+1. `DYN_ENGINE_REQUEST_LIMIT`;
+2. `DYN_TCP_WORKER_POOL_SIZE`;
+3. `ceil(1.5 * engine_max_num_seqs)`, when the backend reports a normalized
+   engine capacity;
+4. the compatibility fallback, `10000`.
 
 ### Knobs
 
 | Flag | Env var | Meaning |
 | --- | --- | --- |
-| `--engine-request-limit N` | `DYN_ENGINE_REQUEST_LIMIT` | Max requests handled **concurrently by the engine** (the worker-pool semaphore size). Setting this enables worker-side rejection. |
-| _(env-only)_ | `DYN_DYNAMO_REQUEST_QUEUE_LIMIT` | Max requests **waiting in Dynamo** (not yet in the engine) — the overflow queue size. Not a CLI knob; a small fixed burst defaulting to **16** (hard cap `N + 16`). Only takes effect when the engine limit is set. Advanced override only; must be **≥ 2**. |
+| `--engine-request-limit N` | `DYN_ENGINE_REQUEST_LIMIT` | Highest-priority explicit worker-pool size. |
+| _(env-only)_ | `DYN_DYNAMO_REQUEST_QUEUE_LIMIT` | Logical number of requests allowed to wait outside the engine when the engine limit is set. Defaults to **16** and must be **>= 2**. |
+| _(env-only)_ | `DYN_TCP_WORKER_POOL_SIZE` | Explicit worker-pool size used when the engine limit is unset. |
+| _(env-only)_ | `DYN_TCP_WORK_QUEUE_SIZE` | Physical TCP overflow-channel size used when the engine limit is unset. Defaults to **16**. |
 
 When `--engine-request-limit` is set, the worker accepts a request directly into
 the engine while a slot is free; once all `N` engine slots are busy, further
-requests go into the small overflow queue of size `Q`; when the engine **and**
-the queue are both full the worker rejects the request with
+requests wait outside the engine. The overflow channel is sized to `Q - 1`
+because the dispatcher can hold one request while waiting for an engine permit;
+the logical waiting limit remains exactly `Q`, for a hard cap of `N + Q`.
+
+Without the engine limit, the worker uses the explicit TCP pool override,
+automatic backend sizing, or the `10000` fallback. The ordinary TCP overflow
+channel defaults to `16`; the dispatcher can hold one additional request while
+waiting for a worker-pool permit.
+
+When the pool and applicable queue are full, the worker returns
 `Server overloaded: worker at capacity`. The frontend maps this rejection to
-`ResourceExhausted` → **HTTP 529**, and temporarily marks the worker overloaded
-so it is skipped on the next routing decision (cleared automatically on the next
-metric recompute). The effective hard cap is **N + Q** in-flight requests per
-worker. The overflow channel is sized to `Q-1` because the single dispatcher
-holds one request in transit between the queue and the engine; this makes the
-cap exact for **Q ≥ 2** (at `Q = 1` the channel floors at 1, so the queued
-peak is 2 — hence the `Q ≥ 2` requirement).
+`ResourceExhausted` -> **HTTP 529** and temporarily skips that worker until its
+load is recomputed.
+
+The TCP server is process-global and is not resized. If a process hosts multiple
+workers, the first initialization determines its fixed pool and queue sizes.
 
 ### Metrics
 

--- a/lib/backend-common/examples/mocker/src/engine.rs
+++ b/lib/backend-common/examples/mocker/src/engine.rs
@@ -359,6 +359,7 @@ impl LLMEngine for MockerBackend {
                 kv_cache_block_size: Some(self.engine_args.block_size as u32),
                 total_kv_blocks: Some(self.engine_args.num_gpu_blocks as u64),
                 max_num_seqs: self.engine_args.max_num_seqs.map(|v| v as u64),
+                engine_max_num_seqs: self.engine_args.max_num_seqs.map(|v| v as u64),
                 max_num_batched_tokens: self.engine_args.max_num_batched_tokens.map(|v| v as u64),
                 data_parallel_size: None,
                 data_parallel_start_rank: None,
@@ -712,6 +713,7 @@ mod tests {
         assert_eq!(llm.kv_cache_block_size, Some(64));
         assert_eq!(llm.total_kv_blocks, Some(16384));
         assert_eq!(llm.max_num_seqs, Some(256));
+        assert_eq!(llm.engine_max_num_seqs, Some(256));
         assert_eq!(llm.context_length, Some(8192));
         engine.cleanup().await.unwrap();
     }

--- a/lib/backend-common/src/engine.rs
+++ b/lib/backend-common/src/engine.rs
@@ -123,6 +123,9 @@ pub struct LlmRegistration {
     pub total_kv_blocks: Option<u64>,
     /// Maximum number of concurrent in-flight sequences.
     pub max_num_seqs: Option<u64>,
+    /// Normalized concurrent-sequence capacity owned by this local engine.
+    /// Unlike `max_num_seqs`, its DP scope is backend-independent.
+    pub engine_max_num_seqs: Option<u64>,
     /// Maximum tokens the engine will process in a single batched step.
     pub max_num_batched_tokens: Option<u64>,
     /// DP ranks this worker hosts (default 1); the router enumerates per-rank

--- a/lib/backend-common/src/worker.rs
+++ b/lib/backend-common/src/worker.rs
@@ -1653,6 +1653,7 @@ async fn build_local_model(
         context_length: llm.context_length,
         total_kv_blocks: llm.total_kv_blocks,
         max_num_seqs: llm.max_num_seqs,
+        engine_max_num_seqs: llm.engine_max_num_seqs,
         max_num_batched_tokens: llm.max_num_batched_tokens,
         data_parallel_size: llm.data_parallel_size.unwrap_or(1),
         data_parallel_start_rank: llm.data_parallel_start_rank.unwrap_or(0),
@@ -1948,6 +1949,7 @@ mod tests {
                 context_length: Some(32_768),
                 total_kv_blocks: Some(100),
                 max_num_seqs: Some(16),
+                engine_max_num_seqs: Some(32),
                 max_num_batched_tokens: Some(8192),
                 ..Default::default()
             }),
@@ -1962,6 +1964,7 @@ mod tests {
         assert_eq!(runtime_config.context_length, Some(32_768));
         assert_eq!(runtime_config.total_kv_blocks, Some(100));
         assert_eq!(runtime_config.max_num_seqs, Some(16));
+        assert_eq!(runtime_config.engine_max_num_seqs, Some(32));
         assert_eq!(runtime_config.max_num_batched_tokens, Some(8192));
         assert_eq!(runtime_config.tool_call_parser.as_deref(), Some("kimi_k2"));
         assert_eq!(runtime_config.reasoning_parser.as_deref(), Some("kimi_k25"));

--- a/lib/bindings/python/rust/backend.rs
+++ b/lib/bindings/python/rust/backend.rs
@@ -161,6 +161,7 @@ impl LlmRegistration {
         data_parallel_start_rank = None,
         bootstrap_host = None,
         bootstrap_port = None,
+        engine_max_num_seqs = None,
     ))]
     #[allow(clippy::too_many_arguments)]
     fn new(
@@ -173,6 +174,7 @@ impl LlmRegistration {
         data_parallel_start_rank: Option<u32>,
         bootstrap_host: Option<String>,
         bootstrap_port: Option<u16>,
+        engine_max_num_seqs: Option<u64>,
     ) -> Self {
         Self {
             inner: RsLlmRegistration {
@@ -180,6 +182,7 @@ impl LlmRegistration {
                 kv_cache_block_size,
                 total_kv_blocks,
                 max_num_seqs,
+                engine_max_num_seqs,
                 max_num_batched_tokens,
                 data_parallel_size,
                 data_parallel_start_rank,
@@ -204,6 +207,10 @@ impl LlmRegistration {
     #[getter]
     fn max_num_seqs(&self) -> Option<u64> {
         self.inner.max_num_seqs
+    }
+    #[getter]
+    fn engine_max_num_seqs(&self) -> Option<u64> {
+        self.inner.engine_max_num_seqs
     }
     #[getter]
     fn max_num_batched_tokens(&self) -> Option<u64> {
@@ -846,6 +853,7 @@ impl PyEngineCore {
                     kv_cache_block_size: opt_attr::<u32>(&v, "kv_cache_block_size")?,
                     total_kv_blocks: opt_attr::<u64>(&v, "total_kv_blocks")?,
                     max_num_seqs: opt_attr::<u64>(&v, "max_num_seqs")?,
+                    engine_max_num_seqs: opt_attr::<u64>(&v, "engine_max_num_seqs")?,
                     max_num_batched_tokens: opt_attr::<u64>(&v, "max_num_batched_tokens")?,
                     data_parallel_size: opt_attr::<u32>(&v, "data_parallel_size")?,
                     data_parallel_start_rank: opt_attr::<u32>(&v, "data_parallel_start_rank")?,

--- a/lib/bindings/python/rust/llm/local_model.rs
+++ b/lib/bindings/python/rust/llm/local_model.rs
@@ -116,6 +116,11 @@ impl ModelRuntimeConfig {
     }
 
     #[setter]
+    fn set_engine_max_num_seqs(&mut self, capacity: Option<u64>) {
+        self.inner.engine_max_num_seqs = capacity;
+    }
+
+    #[setter]
     fn set_max_num_batched_tokens(&mut self, max_num_batched_tokens: u64) {
         self.inner.max_num_batched_tokens = Some(max_num_batched_tokens);
     }
@@ -211,6 +216,11 @@ impl ModelRuntimeConfig {
     #[getter]
     fn max_num_seqs(&self) -> Option<u64> {
         self.inner.max_num_seqs
+    }
+
+    #[getter]
+    fn engine_max_num_seqs(&self) -> Option<u64> {
+        self.inner.engine_max_num_seqs
     }
 
     #[getter]

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -856,6 +856,7 @@ class ModelRuntimeConfig:
     context_length: int | None
     total_kv_blocks: int | None
     max_num_seqs: int | None
+    engine_max_num_seqs: int | None
     max_num_batched_tokens: int | None
     tool_call_parser: str | None
     reasoning_parser: str | None
@@ -3323,6 +3324,7 @@ class backend:
             data_parallel_start_rank: Optional[int] = None,
             bootstrap_host: Optional[str] = None,
             bootstrap_port: Optional[int] = None,
+            engine_max_num_seqs: Optional[int] = None,
         ) -> None: ...
         @property
         def context_length(self) -> Optional[int]: ...
@@ -3332,6 +3334,8 @@ class backend:
         def total_kv_blocks(self) -> Optional[int]: ...
         @property
         def max_num_seqs(self) -> Optional[int]: ...
+        @property
+        def engine_max_num_seqs(self) -> Optional[int]: ...
         @property
         def max_num_batched_tokens(self) -> Optional[int]: ...
         @property

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -639,6 +639,15 @@ impl LocalModel {
             &self.card,
             model_suffix,
         )?;
+
+        if lora_info.is_none()
+            && let Some(engine_max_num_seqs) = self.runtime_config.worker_pool_engine_max_num_seqs()
+        {
+            endpoint
+                .drt()
+                .network_manager()
+                .set_engine_max_num_seqs_hint(engine_max_num_seqs);
+        }
         let _instance = discovery.register(spec).await?;
 
         Ok(())

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -132,6 +132,12 @@ pub struct ModelRuntimeConfig {
 
     pub max_num_seqs: Option<u64>,
 
+    /// Normalized concurrent-sequence capacity owned by this local engine.
+    /// This is process-local admission metadata and must not be published in
+    /// the discovery model card.
+    #[serde(skip)]
+    pub engine_max_num_seqs: Option<u64>,
+
     pub max_num_batched_tokens: Option<u64>,
 
     pub tool_call_parser: Option<String>,
@@ -265,6 +271,7 @@ impl Default for ModelRuntimeConfig {
             context_length: None,
             total_kv_blocks: None,
             max_num_seqs: None,
+            engine_max_num_seqs: None,
             max_num_batched_tokens: None,
             tool_call_parser: None,
             reasoning_parser: None,
@@ -444,6 +451,13 @@ impl ModelRuntimeConfig {
         self.validate().map_err(|error| error.to_string())
     }
 
+    /// Return the normalized whole-engine maximum used for TCP pool sizing.
+    pub fn worker_pool_engine_max_num_seqs(&self) -> Option<usize> {
+        self.engine_max_num_seqs
+            .and_then(|capacity| usize::try_from(capacity).ok())
+            .filter(|capacity| *capacity > 0)
+    }
+
     pub fn set_engine_specific<T: Serialize>(&mut self, key: &str, value: T) -> anyhow::Result<()> {
         self.runtime_data
             .insert(key.to_string(), serde_json::to_value(value)?);
@@ -527,6 +541,48 @@ impl ModelRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn worker_pool_uses_normalized_engine_max_num_seqs() {
+        let config = ModelRuntimeConfig {
+            max_num_seqs: Some(3),
+            engine_max_num_seqs: Some(9),
+            data_parallel_size: 3,
+            ..Default::default()
+        };
+        assert_eq!(config.worker_pool_engine_max_num_seqs(), Some(9));
+    }
+
+    #[test]
+    fn worker_pool_does_not_infer_capacity_from_public_max_num_seqs() {
+        let without_normalized_hint = ModelRuntimeConfig {
+            max_num_seqs: Some(7),
+            ..Default::default()
+        };
+        assert_eq!(
+            without_normalized_hint.worker_pool_engine_max_num_seqs(),
+            None
+        );
+
+        let zero = ModelRuntimeConfig {
+            engine_max_num_seqs: Some(0),
+            ..Default::default()
+        };
+        assert_eq!(zero.worker_pool_engine_max_num_seqs(), None);
+    }
+
+    #[test]
+    fn engine_max_num_seqs_is_not_serialized() {
+        let config = ModelRuntimeConfig {
+            engine_max_num_seqs: Some(32),
+            ..Default::default()
+        };
+        let serialized = serde_json::to_string(&config).unwrap();
+        assert!(!serialized.contains("engine_max_num_seqs"));
+
+        let deserialized: ModelRuntimeConfig = serde_json::from_str(&serialized).unwrap();
+        assert_eq!(deserialized.engine_max_num_seqs, None);
+    }
 
     // Env-touching tests use `temp_env` (snapshot + restore around the closure) and
     // `#[serial_test::serial]` (serialize against every other env-touching test in the

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -14,7 +14,7 @@ use crate::metrics::work_handler_pool::{
     WORK_HANDLER_QUEUE_DEPTH,
 };
 use crate::pipeline::network::PushWorkHandler;
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use bytes::Bytes;
 use dashmap::DashMap;
 use parking_lot::{Mutex, RwLock};
@@ -33,23 +33,31 @@ use tracing::Instrument;
 const DEFAULT_WORKER_POOL_SIZE: usize = 10000;
 
 /// Default work queue size for TCP request handling
-/// this is 4X the worker pool size to handle burst traffic
-const DEFAULT_WORK_QUEUE_SIZE: usize = 40000;
+/// this is a small overflow queue to handle burst traffic
+const DEFAULT_WORK_QUEUE_SIZE: usize = 16;
 
-/// Get worker pool size from environment or use default
-fn get_worker_pool_size() -> usize {
-    std::env::var("DYN_TCP_WORKER_POOL_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_WORKER_POOL_SIZE)
+fn parse_env_usize_value(name: &str, raw_value: &str) -> Result<usize> {
+    raw_value
+        .parse::<usize>()
+        .map_err(|_| anyhow!("{name} must be a positive integer, got {raw_value:?}"))
 }
 
-/// Get work queue size from environment or use default
-fn get_work_queue_size() -> usize {
-    std::env::var("DYN_TCP_WORK_QUEUE_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_WORK_QUEUE_SIZE)
+fn parse_env_usize(name: &str) -> Result<Option<usize>> {
+    match std::env::var(name) {
+        Ok(raw_value) => parse_env_usize_value(name, &raw_value).map(Some),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(anyhow!("failed to read {name}: {error}")),
+    }
+}
+
+fn validate_tokio_capacity(name: &str, value: usize, minimum: usize) -> Result<usize> {
+    if value < minimum || value > Semaphore::MAX_PERMITS {
+        bail!(
+            "{name} must be between {minimum} and {}, got {value}",
+            Semaphore::MAX_PERMITS
+        );
+    }
+    Ok(value)
 }
 
 /// Default small overflow queue when the engine-request limit is set but the
@@ -64,37 +72,58 @@ const DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT: usize = 16;
 ///
 /// * `DYN_ENGINE_REQUEST_LIMIT` set → pool = engine limit (N), queue = Q
 ///   (default 16). Hard cap N+Q.
-/// * unset → large defaults (10000 / 40000), so rejection only triggers under
-///   extreme saturation.
+/// * otherwise `DYN_TCP_WORKER_POOL_SIZE` set → explicit pool and TCP queue.
+/// * otherwise a reported `engine_max_num_seqs` sizes the pool at 1.5x.
+/// * otherwise the pool falls back to 10000. The TCP queue defaults to 16.
+#[derive(Debug)]
 struct SizingConfig {
     pool_size: usize,
     queue_size: usize,
 }
 
-fn resolve_sizing() -> SizingConfig {
-    match std::env::var("DYN_ENGINE_REQUEST_LIMIT")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-    {
+fn resolve_sizing(
+    engine_max_num_seqs: Option<usize>,
+    env: impl Fn(&str) -> Result<Option<usize>>,
+) -> Result<SizingConfig> {
+    let read_capacity = |name: &str, minimum: usize| {
+        env(name)?
+            .map(|value| validate_tokio_capacity(name, value, minimum))
+            .transpose()
+    };
+
+    let sizing = match read_capacity("DYN_ENGINE_REQUEST_LIMIT", 1)? {
         Some(engine_limit) => {
-            let queue_limit = std::env::var("DYN_DYNAMO_REQUEST_QUEUE_LIMIT")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
+            let queue_limit = read_capacity("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 2)?
                 .unwrap_or(DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT);
             // The single dispatcher holds one request between `recv()` and
             // acquiring an engine permit, so size the channel to limit-1:
             // channel + the dispatcher-held request cap "queued, not in engine"
             // at exactly `limit`.
             SizingConfig {
-                pool_size: engine_limit.max(1),
-                queue_size: queue_limit.saturating_sub(1).max(1),
+                pool_size: engine_limit,
+                queue_size: queue_limit - 1,
             }
         }
-        None => SizingConfig {
-            pool_size: get_worker_pool_size(),
-            queue_size: get_work_queue_size(),
-        },
-    }
+        None => {
+            let pool_size = read_capacity("DYN_TCP_WORKER_POOL_SIZE", 1)?
+                .or_else(|| {
+                    engine_max_num_seqs
+                        .filter(|capacity| *capacity > 0)
+                        .map(|capacity| {
+                            capacity
+                                .saturating_add(capacity.div_ceil(2))
+                                .min(Semaphore::MAX_PERMITS)
+                        })
+                })
+                .unwrap_or(DEFAULT_WORKER_POOL_SIZE);
+            SizingConfig {
+                pool_size,
+                queue_size: read_capacity("DYN_TCP_WORK_QUEUE_SIZE", 1)?
+                    .unwrap_or(DEFAULT_WORK_QUEUE_SIZE),
+            }
+        }
+    };
+    Ok(sizing)
 }
 
 /// RAII guard for `WORK_HANDLER_POOL_ACTIVE_TASKS`. `new()` increments and
@@ -164,11 +193,24 @@ struct EndpointHandler {
 }
 
 impl SharedTcpServer {
-    pub fn new(bind_addr: SocketAddr, cancellation_token: CancellationToken) -> Arc<Self> {
+    pub fn new(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Result<Arc<Self>> {
+        let sizing = resolve_sizing(engine_max_num_seqs, parse_env_usize)?;
+        Ok(Self::new_with_sizing(bind_addr, cancellation_token, sizing))
+    }
+
+    fn new_with_sizing(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        sizing: SizingConfig,
+    ) -> Arc<Self> {
         let SizingConfig {
             pool_size: worker_pool_size,
             queue_size: work_queue_size,
-        } = resolve_sizing();
+        } = sizing;
 
         tracing::info!(
             "Initializing TCP server with dispatcher (concurrency={}, queue={})",
@@ -770,6 +812,116 @@ mod tests {
     use std::time::Duration;
     use tokio::time::Instant;
 
+    fn sizing_env<const N: usize>(
+        values: [(&'static str, usize); N],
+    ) -> impl Fn(&str) -> Result<Option<usize>> {
+        move |name| {
+            Ok(values
+                .iter()
+                .find_map(|(key, value)| (*key == name).then_some(*value)))
+        }
+    }
+
+    fn assert_sizing_error<const N: usize>(
+        values: [(&'static str, usize); N],
+        expected_name: &str,
+    ) {
+        let error = resolve_sizing(None, sizing_env(values))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains(expected_name),
+            "error did not name {expected_name}: {error}"
+        );
+    }
+
+    #[test]
+    fn worker_pool_size_precedence() {
+        // Each case supplies an immutable environment view, so this test is
+        // independent from process-global state and other parallel tests.
+        let sizing = resolve_sizing(
+            Some(20),
+            sizing_env([
+                ("DYN_ENGINE_REQUEST_LIMIT", 7),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 5),
+                ("DYN_TCP_WORKER_POOL_SIZE", 99),
+                ("DYN_TCP_WORK_QUEUE_SIZE", 123),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sizing.pool_size, 7);
+        assert_eq!(sizing.queue_size, 4);
+
+        let sizing = resolve_sizing(
+            Some(20),
+            sizing_env([
+                ("DYN_TCP_WORKER_POOL_SIZE", 99),
+                ("DYN_TCP_WORK_QUEUE_SIZE", 123),
+            ]),
+        )
+        .unwrap();
+        assert_eq!(sizing.pool_size, 99);
+        assert_eq!(sizing.queue_size, 123);
+
+        let sizing =
+            resolve_sizing(Some(20), sizing_env([("DYN_ENGINE_REQUEST_LIMIT", 7)])).unwrap();
+        assert_eq!(sizing.pool_size, 7);
+        // The logical default is 16 queued requests: 15 in the
+        // channel plus one held by the dispatcher.
+        assert_eq!(sizing.queue_size, 15);
+        assert_eq!(sizing.queue_size + 1, 16);
+
+        assert_eq!(resolve_sizing(Some(3), |_| Ok(None)).unwrap().pool_size, 5);
+        assert_eq!(resolve_sizing(Some(8), |_| Ok(None)).unwrap().pool_size, 12);
+        let fallback = resolve_sizing(None, |_| Ok(None)).unwrap();
+        assert_eq!(fallback.pool_size, 10_000);
+        assert_eq!(fallback.queue_size, 16);
+    }
+
+    #[test]
+    fn worker_pool_sizing_rejects_invalid_capacities() {
+        let too_large = Semaphore::MAX_PERMITS + 1;
+
+        for value in [0, too_large] {
+            assert_sizing_error(
+                [("DYN_ENGINE_REQUEST_LIMIT", value)],
+                "DYN_ENGINE_REQUEST_LIMIT",
+            );
+            assert_sizing_error(
+                [
+                    ("DYN_ENGINE_REQUEST_LIMIT", 1),
+                    ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", value),
+                ],
+                "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+            );
+            assert_sizing_error(
+                [("DYN_TCP_WORKER_POOL_SIZE", value)],
+                "DYN_TCP_WORKER_POOL_SIZE",
+            );
+            assert_sizing_error(
+                [("DYN_TCP_WORK_QUEUE_SIZE", value)],
+                "DYN_TCP_WORK_QUEUE_SIZE",
+            );
+        }
+
+        assert_sizing_error(
+            [
+                ("DYN_ENGINE_REQUEST_LIMIT", 1),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 1),
+            ],
+            "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+        );
+    }
+
+    #[test]
+    fn worker_pool_sizing_rejects_malformed_capacity() {
+        let error = parse_env_usize_value("DYN_TCP_WORKER_POOL_SIZE", "not-a-number")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("DYN_TCP_WORKER_POOL_SIZE"));
+        assert!(error.contains("not-a-number"));
+    }
+
     /// Mock handler that simulates slow request processing for testing
     struct SlowMockHandler {
         /// Tracks if a request is currently being processed
@@ -836,7 +988,14 @@ mod tests {
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         // Create SharedTcpServer
-        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+        let server = SharedTcpServer::new_with_sizing(
+            bind_addr,
+            cancellation_token.clone(),
+            SizingConfig {
+                pool_size: 10_000,
+                queue_size: 16,
+            },
+        );
 
         // Create a handler that takes 1s to process requests
         let handler = Arc::new(SlowMockHandler::new(Duration::from_secs(1)));
@@ -1183,20 +1342,16 @@ mod tests {
     async fn test_capacities_published_on_server_init() {
         crate::logging::init();
 
-        // SharedTcpServer::new publishes static capacities. Any test that instantiates
-        // a SharedTcpServer will have populated the gauges; we just assert they're > 0.
+        // Server construction publishes static capacities. Process-global
+        // gauges may also be written by parallel tests, so keep this oracle
+        // intentionally minimal; the process-isolated Mocker E2E checks values.
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
-
-        assert!(
-            WORK_HANDLER_POOL_CAPACITY.get() > 0,
-            "pool_capacity should be set to DEFAULT_WORKER_POOL_SIZE"
-        );
-        assert!(
-            WORK_HANDLER_QUEUE_CAPACITY.get() > 0,
-            "queue_capacity should be set to DEFAULT_WORK_QUEUE_SIZE"
-        );
+        let sizing = resolve_sizing(None, |_| Ok(None)).unwrap();
+        let _server =
+            SharedTcpServer::new_with_sizing(bind_addr, cancellation_token.clone(), sizing);
+        assert!(WORK_HANDLER_POOL_CAPACITY.get() > 0);
+        assert!(WORK_HANDLER_QUEUE_CAPACITY.get() > 0);
         cancellation_token.cancel();
     }
 }

--- a/lib/runtime/src/pipeline/network/manager.rs
+++ b/lib/runtime/src/pipeline/network/manager.rs
@@ -140,6 +140,7 @@ pub struct NetworkManager {
     mode: RequestPlaneMode,
     config: NetworkConfig,
     server: Arc<OnceCell<Arc<dyn RequestPlaneServer>>>,
+    engine_max_num_seqs_hint: OnceLock<usize>,
     cancellation_token: CancellationToken,
     component_registry: crate::component::Registry,
 }
@@ -192,9 +193,19 @@ impl NetworkManager {
             mode,
             config,
             server: Arc::new(OnceCell::new()),
+            engine_max_num_seqs_hint: OnceLock::new(),
             cancellation_token,
             component_registry,
         }
+    }
+
+    /// Record the normalized engine capacity for one-time TCP worker-pool sizing.
+    ///
+    /// This only publishes a startup hint. The request-plane server remains
+    /// uninitialized until Self::server is called. The first recorded hint wins.
+    pub fn set_engine_max_num_seqs_hint(&self, engine_max_num_seqs: usize) {
+        self.engine_max_num_seqs_hint
+            .get_or_init(|| engine_max_num_seqs);
     }
 
     /// Get or create the request plane server
@@ -215,7 +226,10 @@ impl NetworkManager {
     pub async fn server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
         let server = self
             .server
-            .get_or_try_init(async { self.create_server().await })
+            .get_or_try_init(async {
+                let engine_max_num_seqs = self.engine_max_num_seqs_hint.get().copied();
+                self.create_server(engine_max_num_seqs).await
+            })
             .await?;
 
         Ok(server.clone())
@@ -253,14 +267,20 @@ impl NetworkManager {
     // PRIVATE: Server Creation
     // ============================================================================
 
-    async fn create_server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
+    async fn create_server(
+        &self,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Result<Arc<dyn RequestPlaneServer>> {
         match self.mode {
-            RequestPlaneMode::Tcp => self.create_tcp_server().await,
+            RequestPlaneMode::Tcp => self.create_tcp_server(engine_max_num_seqs).await,
             RequestPlaneMode::Nats => self.create_nats_server().await,
         }
     }
 
-    async fn create_tcp_server(&self) -> Result<Arc<dyn RequestPlaneServer>> {
+    async fn create_tcp_server(
+        &self,
+        engine_max_num_seqs: Option<usize>,
+    ) -> Result<Arc<dyn RequestPlaneServer>> {
         // Use the global TCP server to ensure all workers in the same process share
         // a single server. This is critical for correct endpoint routing.
         let server = GLOBAL_TCP_SERVER
@@ -277,7 +297,11 @@ impl NetworkManager {
                     "Creating TCP request plane server"
                 );
 
-                let server = SharedTcpServer::new(bind_addr, GLOBAL_TCP_SERVER_TOKEN.clone());
+                let server = SharedTcpServer::new(
+                    bind_addr,
+                    GLOBAL_TCP_SERVER_TOKEN.clone(),
+                    engine_max_num_seqs,
+                )?;
 
                 // Bind and start server, getting the actual bound address
                 let actual_addr = server.clone().bind_and_start().await?;
@@ -371,5 +395,15 @@ mod tests {
             ),
             Err(err) => assert!(err.to_string().contains("NATS client required")),
         }
+    }
+
+    #[test]
+    fn engine_capacity_hint_does_not_initialize_server() {
+        let manager = manager_for(RequestPlaneMode::Tcp);
+
+        manager.set_engine_max_num_seqs_hint(12);
+
+        assert_eq!(manager.engine_max_num_seqs_hint.get(), Some(&12));
+        assert!(manager.server.get().is_none());
     }
 }

--- a/lib/sidecar/sglang/src/client.rs
+++ b/lib/sidecar/sglang/src/client.rs
@@ -158,6 +158,22 @@ pub async fn health_check(client: &mut Client, deadline: Instant) -> Result<bool
     .map(|response| response.into_inner().healthy)
 }
 
+pub async fn get_load(client: &mut Client, deadline: Instant) -> Result<Vec<Value>, DynamoError> {
+    let response = rpc_with_deadline(
+        "GetLoad",
+        deadline,
+        client.get_load(pb::GetLoadRequest { dp_rank: None }),
+    )
+    .await?
+    .into_inner();
+    let value: Value = serde_json::from_str(&response.json_info)
+        .map_err(|err| protocol_error(format!("invalid GetLoad.json_info: {err}")))?;
+    value
+        .as_array()
+        .cloned()
+        .ok_or_else(|| protocol_error("GetLoad.json_info must be a JSON array"))
+}
+
 pub async fn abort(
     client: &mut Client,
     request: pb::AbortRequest,

--- a/lib/sidecar/sglang/src/engine.rs
+++ b/lib/sidecar/sglang/src/engine.rs
@@ -4,8 +4,10 @@
 //! Dynamo backend for SGLang's native `sglang.runtime.v1` gRPC server.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::net::IpAddr;
 use std::sync::Arc;
+use std::time::Duration;
 
 use async_trait::async_trait;
 use dynamo_backend_common::{
@@ -160,9 +162,23 @@ impl LLMEngine for SglangSidecarEngine {
                 self.disaggregation_mode, observed_mode
             )));
         }
+        let (_, data_parallel_start_rank, data_parallel_size) =
+            data_parallel_scope(&discovery.server_info);
+        let effective_loads = wait_for_effective_loads(
+            |deadline| {
+                let mut control = control.clone();
+                async move { client::get_load(&mut control, deadline).await }
+            },
+            deadline,
+            self.transport.poll_interval,
+            data_parallel_start_rank,
+            data_parallel_size,
+        )
+        .await;
 
         let config = build_engine_config(
             &discovery,
+            effective_loads.as_deref(),
             self.disaggregation_mode,
             self.bootstrap_host.clone(),
             self.bootstrap_port,
@@ -524,8 +540,84 @@ fn is_routable_host(host: &str) -> bool {
         .unwrap_or(true)
 }
 
+fn data_parallel_scope(server_info: &Value) -> (u32, u32, u32) {
+    let dp_size = client::json_u32(server_info, "dp_size").unwrap_or(1).max(1);
+    let enable_dp_attention = server_info
+        .get("enable_dp_attention")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let nnodes = client::json_u32(server_info, "nnodes").unwrap_or(1).max(1);
+    let node_rank = client::json_u32(server_info, "node_rank").unwrap_or(0);
+    let (data_parallel_start_rank, data_parallel_size) = if enable_dp_attention && dp_size > 1 {
+        let local_size = (dp_size / nnodes).max(1);
+        (node_rank.saturating_mul(local_size), local_size)
+    } else {
+        (0, dp_size)
+    };
+    (dp_size, data_parallel_start_rank, data_parallel_size)
+}
+
+async fn wait_for_effective_loads<F, Fut>(
+    mut get_load: F,
+    deadline: Instant,
+    poll_interval: Duration,
+    data_parallel_start_rank: u32,
+    data_parallel_size: u32,
+) -> Option<Vec<Value>>
+where
+    F: FnMut(Instant) -> Fut,
+    Fut: Future<Output = Result<Vec<Value>, DynamoError>>,
+{
+    loop {
+        if Instant::now() >= deadline {
+            tracing::warn!("SGLang effective capacity was unavailable before the startup deadline");
+            return None;
+        }
+
+        if let Ok(loads) = get_load(deadline).await
+            && effective_engine_max_num_seqs(
+                Some(&loads),
+                data_parallel_start_rank,
+                data_parallel_size,
+            )
+            .is_some()
+        {
+            return Some(loads);
+        }
+
+        tokio::time::sleep_until((Instant::now() + poll_interval).min(deadline)).await;
+    }
+}
+
+fn effective_engine_max_num_seqs(
+    loads: Option<&[Value]>,
+    data_parallel_start_rank: u32,
+    data_parallel_size: u32,
+) -> Option<u64> {
+    let loads = loads?;
+    let end_rank = data_parallel_start_rank.checked_add(data_parallel_size)?;
+    let mut smallest = None;
+
+    for rank in data_parallel_start_rank..end_rank {
+        let mut matching = loads
+            .iter()
+            .filter(|load| client::json_u32(load, "dp_rank") == Some(rank));
+        let capacity = matching
+            .next()
+            .and_then(|load| client::json_u64(load, "max_running_requests"))
+            .filter(|capacity| *capacity > 0)?;
+        if matching.next().is_some() {
+            return None;
+        }
+        smallest = Some(smallest.map_or(capacity, |current: u64| current.min(capacity)));
+    }
+
+    smallest.map(|capacity| capacity.saturating_mul(u64::from(data_parallel_size)))
+}
+
 fn build_engine_config(
     discovery: &Discovery,
+    effective_loads: Option<&[Value]>,
     mode: DisaggregationMode,
     bootstrap_host: Option<String>,
     bootstrap_port: Option<u16>,
@@ -538,9 +630,8 @@ fn build_engine_config(
         }
         _ => None,
     };
-    let dp_size = client::json_u32(&discovery.server_info, "dp_size")
-        .unwrap_or(1)
-        .max(1);
+    let (dp_size, data_parallel_start_rank, data_parallel_size) =
+        data_parallel_scope(&discovery.server_info);
     let max_num_seqs =
         client::json_u64(&discovery.server_info, "max_running_requests").map(|value| {
             if dp_size > 1 {
@@ -552,21 +643,11 @@ fn build_engine_config(
     let max_num_batched_tokens =
         client::json_u64(&discovery.server_info, "max_prefill_tokens").or(max_total_tokens);
 
-    let enable_dp_attention = discovery
-        .server_info
-        .get("enable_dp_attention")
-        .and_then(Value::as_bool)
-        .unwrap_or(false);
-    let nnodes = client::json_u32(&discovery.server_info, "nnodes")
-        .unwrap_or(1)
-        .max(1);
-    let node_rank = client::json_u32(&discovery.server_info, "node_rank").unwrap_or(0);
-    let (data_parallel_start_rank, data_parallel_size) = if enable_dp_attention && dp_size > 1 {
-        let local_size = (dp_size / nnodes).max(1);
-        (Some(node_rank.saturating_mul(local_size)), Some(local_size))
-    } else {
-        (Some(0), Some(1))
-    };
+    let engine_max_num_seqs = effective_engine_max_num_seqs(
+        effective_loads,
+        data_parallel_start_rank,
+        data_parallel_size,
+    );
 
     if mode.is_prefill() && (bootstrap_host.is_none() || bootstrap_port.is_none()) {
         return Err(client::protocol_error(
@@ -589,9 +670,10 @@ fn build_engine_config(
             kv_cache_block_size: page_size,
             total_kv_blocks,
             max_num_seqs,
+            engine_max_num_seqs,
             max_num_batched_tokens,
-            data_parallel_size,
-            data_parallel_start_rank,
+            data_parallel_size: Some(data_parallel_size),
+            data_parallel_start_rank: Some(data_parallel_start_rank),
             bootstrap_host: mode.is_prefill().then_some(bootstrap_host).flatten(),
             bootstrap_port: mode.is_prefill().then_some(bootstrap_port).flatten(),
         }),
@@ -600,9 +682,17 @@ fn build_engine_config(
 
 #[cfg(test)]
 mod tests {
-    use serde_json::json;
+    use std::collections::VecDeque;
+    use std::future::ready;
+    use std::time::Duration;
 
-    use super::{Discovery, resolve_bootstrap_host_with_local};
+    use dynamo_backend_common::{DisaggregationMode, DynamoError};
+    use serde_json::json;
+    use tokio::time::Instant;
+
+    use super::{
+        Discovery, build_engine_config, resolve_bootstrap_host_with_local, wait_for_effective_loads,
+    };
 
     fn discovery(server_info: serde_json::Value) -> Discovery {
         Discovery {
@@ -661,5 +751,118 @@ mod tests {
         )
         .unwrap_err();
         assert!(error.to_string().contains("--bootstrap-host"));
+    }
+
+    #[test]
+    fn engine_config_normalizes_max_num_seqs_to_local_dp_scope() {
+        let loads = vec![
+            json!({"dp_rank": 2, "max_running_requests": 12}),
+            json!({"dp_rank": 3, "max_running_requests": 12}),
+        ];
+        let config = build_engine_config(
+            &discovery(json!({
+                "max_running_requests": 48,
+                "dp_size": 4,
+                "enable_dp_attention": true,
+                "nnodes": 2,
+                "node_rank": 1
+            })),
+            Some(&loads),
+            DisaggregationMode::Aggregated,
+            None,
+            None,
+        )
+        .unwrap();
+        let llm = config
+            .llm
+            .expect("SGLang sidecar must register LLM capacity");
+
+        assert_eq!(llm.max_num_seqs, Some(12));
+        assert_eq!(llm.data_parallel_size, Some(2));
+        assert_eq!(llm.data_parallel_start_rank, Some(2));
+        assert_eq!(llm.engine_max_num_seqs, Some(24));
+    }
+
+    #[test]
+    fn engine_config_reports_all_ranks_owned_by_ordinary_dp() {
+        let loads = (0..4)
+            .map(|dp_rank| json!({"dp_rank": dp_rank, "max_running_requests": 12}))
+            .collect::<Vec<_>>();
+        let llm = build_engine_config(
+            &discovery(json!({"max_running_requests": 48, "dp_size": 4})),
+            Some(&loads),
+            DisaggregationMode::Aggregated,
+            None,
+            None,
+        )
+        .unwrap()
+        .llm
+        .unwrap();
+
+        assert_eq!(
+            (
+                llm.data_parallel_start_rank,
+                llm.data_parallel_size,
+                llm.engine_max_num_seqs,
+            ),
+            (Some(0), Some(4), Some(48)),
+        );
+    }
+
+    #[tokio::test]
+    async fn startup_waits_for_complete_effective_capacity() {
+        let mut samples = VecDeque::from([
+            vec![json!({"dp_rank": 0, "max_running_requests": 0})],
+            vec![
+                json!({"dp_rank": 0, "max_running_requests": 12}),
+                json!({"dp_rank": 1, "max_running_requests": 10}),
+            ],
+        ]);
+        let loads = wait_for_effective_loads(
+            |_| ready(Ok::<_, DynamoError>(samples.pop_front().unwrap())),
+            Instant::now() + Duration::from_secs(1),
+            Duration::ZERO,
+            0,
+            2,
+        )
+        .await
+        .expect("a complete positive capacity snapshot");
+
+        let llm = build_engine_config(
+            &discovery(json!({"max_running_requests": 24, "dp_size": 2})),
+            Some(&loads),
+            DisaggregationMode::Aggregated,
+            None,
+            None,
+        )
+        .unwrap()
+        .llm
+        .unwrap();
+
+        assert_eq!(llm.engine_max_num_seqs, Some(20));
+        assert!(samples.is_empty());
+    }
+
+    #[test]
+    fn effective_capacity_requires_all_owned_ranks_and_uses_smallest() {
+        let loads = |capacities: &[u64]| {
+            capacities
+                .iter()
+                .enumerate()
+                .map(|(dp_rank, capacity)| {
+                    json!({"dp_rank": dp_rank, "max_running_requests": capacity})
+                })
+                .collect::<Vec<_>>()
+        };
+        let complete = loads(&[11, 10, 9, 10]);
+        let incomplete = loads(&[12, 12, 12]);
+
+        for (loads, expected) in [
+            (Some(complete.as_slice()), Some(36)),
+            (None, None),
+            (Some(incomplete.as_slice()), None),
+        ] {
+            assert_eq!(super::effective_engine_max_num_seqs(loads, 0, 4), expected);
+        }
     }
 }

--- a/tests/runtime/test_tcp_worker_pool_sizing_e2e.py
+++ b/tests/runtime/test_tcp_worker_pool_sizing_e2e.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end TCP worker-pool startup sizing with a real mocker worker.
+
+Each parameter starts a fresh process so the process-global shared TCP server is
+initialized exactly once. The automatic case covers the complete path from
+mocker capacity normalization through model attachment recording the hint and
+explicit endpoint startup consuming it. Serving before attachment completes
+would initialize the pool at the 10,000 fallback instead of the expected 1.5x
+engine capacity.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+
+import pytest
+import requests
+
+from tests.utils.constants import QWEN
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import ServicePorts
+from tests.utils.prometheus import sum_metric_samples
+
+POOL_CAPACITY_METRIC = "dynamo_work_handler_pool_capacity"
+ENGINE_MAX_NUM_SEQS = 6
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+    pytest.mark.model(QWEN),
+]
+
+
+@pytest.mark.timeout(120)  # Covers the 60s startup timeout plus teardown margin.
+@pytest.mark.parametrize(
+    "engine_request_limit, tcp_worker_pool_size, expected_pool_size",
+    [
+        pytest.param(None, None, 9, id="automatic-1.5x"),
+        pytest.param(None, 13, 13, id="tcp-pool-override"),
+        pytest.param(17, None, 17, id="engine-limit-override"),
+        pytest.param(17, 13, 17, id="engine-limit-precedes-tcp-pool"),
+    ],
+)
+def test_tcp_worker_pool_startup_sizing(
+    request,
+    file_storage_backend,
+    predownload_tokenizers,
+    dynamo_dynamic_ports: ServicePorts,
+    engine_request_limit: int | None,
+    tcp_worker_pool_size: int | None,
+    expected_pool_size: int,
+):
+    system_port = dynamo_dynamic_ports.system_ports[0]
+    namespace = f"test-worker-pool-{uuid.uuid4().hex}"
+    endpoint = f"dyn://{namespace}.mocker.generate"
+    command = [
+        sys.executable,
+        "-m",
+        "dynamo.mocker",
+        "--model-path",
+        QWEN,
+        "--endpoint",
+        endpoint,
+        "--discovery-backend",
+        "file",
+        "--num-workers",
+        "1",
+        "--max-num-seqs",
+        str(ENGINE_MAX_NUM_SEQS),
+        "--data-parallel-size",
+        "1",
+    ]
+
+    env = os.environ.copy()
+    for name in (
+        "DYN_ENGINE_REQUEST_LIMIT",
+        "DYN_TCP_WORKER_POOL_SIZE",
+        "DYN_TCP_WORK_QUEUE_SIZE",
+        "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+        "DYN_TCP_RPC_PORT",
+        "NATS_SERVER",
+    ):
+        env.pop(name, None)
+    env.update(
+        {
+            "DYN_FILE_KV": str(file_storage_backend),
+            "DYN_REQUEST_PLANE": "tcp",
+            "DYN_EVENT_PLANE": "zmq",
+            "DYN_SYSTEM_PORT": str(system_port),
+        }
+    )
+    if engine_request_limit is not None:
+        env["DYN_ENGINE_REQUEST_LIMIT"] = str(engine_request_limit)
+    if tcp_worker_pool_size is not None:
+        env["DYN_TCP_WORKER_POOL_SIZE"] = str(tcp_worker_pool_size)
+
+    metrics_url = f"http://localhost:{system_port}/metrics"
+
+    def reports_expected_pool_capacity(response: requests.Response) -> bool:
+        return (
+            sum_metric_samples(response.text, POOL_CAPACITY_METRIC)
+            == expected_pool_size
+        )
+
+    process = ManagedProcess(
+        command=command,
+        env=env,
+        health_check_urls=[(metrics_url, reports_expected_pool_capacity)],
+        timeout=60,
+        display_output=True,
+        terminate_all_matching_process_names=False,
+        log_dir=f"{request.node.name}_worker_pool",
+        display_name="dynamo-mocker-worker-pool-sizing",
+    )
+    with process:
+        response = requests.get(metrics_url, timeout=5)
+        response.raise_for_status()
+        assert (
+            sum_metric_samples(response.text, POOL_CAPACITY_METRIC)
+            == expected_pool_size
+        )


### PR DESCRIPTION
## Overview:

Dynamically size the fixed TCP worker pool from the local engine’s effective sequence capacity.

When neither request-limit nor TCP-pool overrides are configured, the worker reports its normalized `engine_max_num_seqs` during registration and the TCP server starts with `ceil(1.5 × engine_max_num_seqs)` workers. This aligns TCP admission capacity with the backend while preserving the existing `10,000` compatibility fallback.

## Details:

TCP worker-pool sizing follows this precedence:

1. `DYN_ENGINE_REQUEST_LIMIT`
2. `DYN_TCP_WORKER_POOL_SIZE`
3. `ceil(1.5 × engine_max_num_seqs)`
4. `10,000` fallback

The default `DYN_TCP_WORK_QUEUE_SIZE` is changed to `16`.

Additional changes:

- Add process-local `engine_max_num_seqs` registration metadata, separate from the existing backend-dependent `max_num_seqs`.
- Normalize effective local-engine capacity in:
  - Python vLLM
  - Python SGLang
  - Python TensorRT-LLM
  - Native Rust vLLM
  - Rust SGLang sidecar
  - Python and Rust mockers
- Preserve each backend’s capacity scope:
  - Per-DP-rank values are multiplied by the locally represented DP size.
  - TensorRT-LLM’s engine-wide `max_batch_size` is used without additional DP multiplication.
  - Python SGLang uses its effective post-profile running-request capacity.
- Ensure capacity-bearing model registration completes before the process-global shared TCP server is initialized.
- Keep the worker pool fixed after startup; this change does not introduce runtime resizing.
- Preserve existing Python and PyO3 positional-constructor compatibility.
- Add backend-focused unit tests proving each integration supplies the expected normalized capacity.
- Add a process-isolated runtime integration test covering:
  - Automatic `1.5×` sizing
  - `DYN_TCP_WORKER_POOL_SIZE`
  - `DYN_ENGINE_REQUEST_LIMIT`
  - Engine-limit precedence when both overrides are set

Validation included:

- Rebuilt the Python/Rust runtime binding after rebasing onto current `main`
- `5` focused shared-TCP Rust tests passed
- All `4` runtime pool-sizing integration cases passed
- Applicable pre-commit hooks passed
- Backend-specific capacity normalization tests passed
- Real GPU-backed vLLM worker:
  - `max_num_seqs=4`
  - TCP pool capacity `6`
  - TCP queue size `16`
- Real GPU-backed TensorRT-LLM worker:
  - `max_batch_size=4`
  - TCP pool capacity `6`
  - TCP queue size `16`

## Where should the reviewer start?

1. `lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs`
   - Pool-size precedence, automatic `1.5×` sizing, fallback behavior, and queue sizing.

2. `lib/llm/src/local_model.rs`
   - Passes normalized engine capacity into the TCP server before endpoint serving begins.

3. `lib/llm/src/local_model/runtime_config.rs`
   - Defines and consumes `engine_max_num_seqs`.

4. Backend capacity adapters:
   - `components/src/dynamo/vllm/capacity.py`
   - `components/src/dynamo/sglang/capacity.py`
   - `components/src/dynamo/trtllm/utils/trtllm_utils.py`
   - `lib/vllm-rs-backend/src/backend.rs`
   - `lib/backend/sglang-sidecar/src/engine.rs`

5. `tests/runtime/test_tcp_worker_pool_sizing_e2e.py`
   - Process-level automatic-sizing and override-precedence coverage using a real mocker worker.

## Related Issues

Related #10509 
Closes DIS-2335

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added engine capacity metadata for concurrent sequence handling across supported backends.
  * Worker pools and TCP request handling now size themselves using normalized engine capacity.
  * Exposed engine capacity through runtime configuration and Python APIs.
* **Bug Fixes**
  * Model readiness registration now completes before endpoint serving begins, preventing premature traffic.
  * Improved capacity detection with validation and fallback behavior.
* **Tests**
  * Added coverage for capacity normalization, registration ordering, metadata propagation, and TCP pool sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->