### PR TITLE
ci: run dynamo_llm rust-gpu tests single-threaded to fix teardown SIGSEGV (OPS-7753)

### DIFF
--- a/.github/workflows/dynamo-pipeline.yml
+++ b/.github/workflows/dynamo-pipeline.yml
@@ -151,7 +151,20 @@ jobs:
           rustup component add rustfmt clippy
           cargo fmt -- --check
           cargo clippy --features block-manager,media-ffmpeg,testing-nixl,integration --no-deps --all-targets -- -D warnings
-          cargo test --locked --all-targets --features=block-manager,media-ffmpeg,testing-nixl,integration -- --nocapture
+          # dynamo_llm lib unit tests mutate process env via `temp_env`
+          # (std::env::set_var/remove_var); in a multi-threaded libtest binary that
+          # write reallocates `environ` while another test thread (a parallel test's
+          # std::env::var, or a native UCX/CUDA thread) is inside getenv() -> teardown
+          # SIGSEGV after all tests pass (~14% under CI node contention). getenv/setenv
+          # aren't thread-safe and serial_test can't serialize the readers, so run the
+          # libtest binaries single-threaded via RUST_TEST_THREADS=1. Use the env var,
+          # NOT `-- --test-threads=1`: under --all-targets the CLI flag is also handed
+          # to the criterion `--bench` targets, which reject it ("unexpected argument")
+          # and fail the run; RUST_TEST_THREADS is read by libtest and ignored by
+          # criterion. (Verified on the GPU tester: whole command runs green with
+          # benches; lib suite 7s -> 35s single-threaded, other targets sub-second; and
+          # under 12x contention 3/3 parallel shards segfault vs 0/3 single-threaded.)
+          RUST_TEST_THREADS=1 cargo test --locked --all-targets --features=block-manager,media-ffmpeg,testing-nixl,integration -- --nocapture
           cargo clippy -p kvbm-physical --no-deps --all-targets -- -D warnings
           cargo test --locked -p kvbm-physical --features testing-kvbm -- --nocapture --test-threads=4
           /workspace/container/use-sccache.sh show-stats "Rust Checks"


### PR DESCRIPTION
## Summary

`dynamo-runtime / rust-gpu` intermittently fails (~14%) with the `dynamo_llm`
lib-test binary hitting **SIGSEGV** at process teardown — after every test prints
`ok` but before libtest's `test result:` summary (so it reads as a pod death /
"custom container implementation failed", not a test failure).

Root cause is a **`getenv`/`setenv` data race**. The `dynamo_llm` lib unit tests
mutate process env via `temp_env` (`std::env::set_var`/`remove_var`) in a
multi-threaded libtest binary. That write reallocates `environ` while another
thread — a parallel test's `std::env::var`, or a native UCX/CUDA thread — is
inside `getenv()`, dereferencing freed memory. `getenv`/`setenv` are not
thread-safe; the existing `temp_env` + `#[serial_test::serial]` guard only
serializes the env *writers* against each other, not the concurrent *readers*.

## Fix

Run the rust-gpu libtest binaries single-threaded via the **`RUST_TEST_THREADS=1`
environment variable**, keeping the original single `cargo test --all-targets …
-- --nocapture` command.

Why the env var and not `-- --test-threads=1`: under `--all-targets` the CLI flag
is also handed to the criterion `--bench` targets, which reject it (`error:
unexpected argument '--test-threads'`) and fail the run with exit 2.
`RUST_TEST_THREADS` is read by libtest and ignored by criterion, so the lib/bin/
integration test binaries go single-threaded while the benches are unaffected.
`kvbm-physical`'s explicit `--test-threads=4` still overrides it.

Captured backtrace (GPU tester, under contention):

```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f5b1490a806 in getenv () from /usr/lib/x86_64-linux-gnu/libc.so.6
```

## Validation

The crash only reproduces under **node contention** (not isolated re-runs:
~1010 isolated runs on a local RTX 6000 Ada box + fresh cold CI containers never
crashed). Root-caused and validated on a `prod-tester-amd-gpu-v2` runner:

- A/B over 12x-concurrency shards: **control (parallel) 3/3 shards SIGSEGV**;
  **fixed (single-threaded) 0/3 shards — clean**.
- The exact corrected command (`RUST_TEST_THREADS=1 cargo test --all-targets …`)
  runs **green end-to-end including the criterion benches**; the lib suite goes
  ~7s → ~35s single-threaded.

Cost: the lib suite ~7s → ~35s single-threaded; other test targets are
sub-second (cargo runs test binaries sequentially anyway), so the added rust-gpu
wall time is ~+25–30s.

Linear: OPS-7753

🤖 Generated with [Claude Code](https://claude.com/claude-code)
