### PR TITLE
test(serve): add agg_omni_image H100 launch scenario (OPS-7582)

### DIFF
--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -344,12 +344,37 @@ jobs:
       enable_coverage: true
       run_cpu_only_tests: true
       cpu_only_test_markers: vllm and gpu_0
-      gpu_test_markers: vllm and gpu_1
+      # Exclude h100 tests: they need >24 GiB and run on the vllm-h100-test lane below.
+      gpu_test_markers: vllm and gpu_1 and not h100
       gpu_test_timeout_minutes: 240
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
+      source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
+      image_tag_suffix: '-nightly'
+    secrets: inherit
+
+  vllm-h100-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [vllm-build, resolve-source-sha, compute-release-mode]
+    if: ${{ needs.compute-release-mode.outputs.run_tests == 'true' }}
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      dd_env: nightly
+      dd_flaky_retry_enabled: 'false'
+      test_suite_name: vllm
+      test_type: H100 Test
+      # 80 GiB H100 (aws-dev-02): vLLM tests that exceed the 24 GiB gpu_1 lane
+      # (e.g. Qwen-Image / agg_omni_image ~40–45 GiB).
+      amd_runner: aws-dev-02-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      enable_coverage: true
+      run_sanity_check: false
+      gpu_test_markers: vllm and h100 and gpu_1
+      gpu_test_timeout_minutes: 120
       source_ref: ${{ needs.resolve-source-sha.outputs.source_sha }}
       image_tag_suffix: '-nightly'
     secrets: inherit
@@ -628,6 +653,7 @@ jobs:
       - manual-release-approval
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - sglang-test
       - sglang-multi-gpu-test
       - sglang-h100-test
@@ -657,7 +683,7 @@ jobs:
   coverage-report:
     name: Generate Coverage Report
     runs-on: ubuntu-latest
-    needs: [vllm-test, vllm-multi-gpu-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
     if: always()
     permissions:
       contents: read
@@ -883,7 +909,7 @@ jobs:
   ############################## SLACK NOTIFICATION ##############################
   notify-slack:
     if: always()
-    needs: [vllm-test, vllm-multi-gpu-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
+    needs: [vllm-test, vllm-multi-gpu-test, vllm-h100-test, sglang-test, sglang-multi-gpu-test, sglang-h100-test, trtllm-test, trtllm-multi-gpu-test, rust-tests]
     permissions:
       contents: read
       actions: read   # grant the reusable notifier read access to list this run's jobs

--- a/.github/workflows/nightly-ci.yml
+++ b/.github/workflows/nightly-ci.yml
@@ -341,7 +341,7 @@ jobs:
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
-      enable_coverage: true
+      enable_coverage: 'true'
       run_cpu_only_tests: true
       cpu_only_test_markers: vllm and gpu_0
       # Exclude h100 tests: they need >24 GiB and run on the vllm-h100-test lane below.
@@ -366,12 +366,12 @@ jobs:
       test_suite_name: vllm
       test_type: H100 Test
       # 80 GiB H100 (aws-dev-02): vLLM tests that exceed the 24 GiB gpu_1 lane
-      # (e.g. Qwen-Image / agg_omni_image ~40–45 GiB).
+      # (e.g. Qwen-Image / agg_omni_image ~40-45 GiB).
       amd_runner: aws-dev-02-tester-amd-gpu-v2
       target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
       cuda_version: '["13.0"]'
       platform: '["amd64"]'
-      enable_coverage: true
+      enable_coverage: 'true'
       run_sanity_check: false
       gpu_test_markers: vllm and h100 and gpu_1
       gpu_test_timeout_minutes: 120

--- a/.github/workflows/post-merge-ci.yml
+++ b/.github/workflows/post-merge-ci.yml
@@ -435,7 +435,8 @@ jobs:
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
       cpu_only_test_markers: '(pre_merge or post_merge) and vllm and gpu_0'
-      gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1'
+      # Exclude h100: >24 GiB scenarios (e.g. agg_omni_image) run on dedicated H100 lanes.
+      gpu_test_markers: '(pre_merge or post_merge) and vllm and gpu_1 and not h100'
       gpu_test_timeout_minutes: 120
       # Profiled tests (those carrying @pytest.mark.profiled_vram_gib(N)) run concurrently in
       # the parallel stage; the rest fall through to the sequential stage. 24 GiB admits all

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -68,6 +68,7 @@ jobs:
       - vllm-dev-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-dev-build
@@ -596,12 +597,33 @@ jobs:
       platform: '["amd64", "arm64"]' # arm64 for CPU tests, single GPU tests are skipped
       run_cpu_only_tests: true
       cpu_only_test_markers: pre_merge and vllm and gpu_0
-      gpu_test_markers: pre_merge and vllm and gpu_1
+      # Exclude h100: >24 GiB scenarios (e.g. agg_omni_image) run on vllm-h100-test.
+      gpu_test_markers: pre_merge and vllm and gpu_1 and not h100
       gpu_test_timeout_minutes: 45
       # Profiled tests run in the parallel stage; unprofiled fall through to sequential.
       # 24 GiB admits all currently profiled vLLM tests (max is ~20.4 GiB) on a 48 GiB GPU.
       run_gpu_parallel_tests: true
       gpu_parallel_max_vram_gib: '24'
+    secrets: inherit
+
+  # TEMPORARY (OPS-7582): H100 lane on PR CI to validate agg_omni_image before
+  # flipping the scenario back to nightly-only. Remove once CI passes.
+  vllm-h100-test:
+    name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI
+    needs: [changed-files, vllm-build]
+    if: needs.changed-files.outputs.core == 'true' || needs.changed-files.outputs.vllm == 'true' || needs.changed-files.outputs.deploy == 'true' || needs.changed-files.outputs.sample == 'true'
+    uses: ./.github/workflows/shared-test.yml
+    with:
+      test_suite_name: vllm
+      test_type: H100 Test
+      # 80 GiB H100 (aws-dev-02): Qwen-Image / agg_omni_image ~40–47 GiB.
+      amd_runner: aws-dev-02-tester-amd-gpu-v2
+      target_tag_plain: ${{ needs.vllm-build.outputs.target_tag_plain }}
+      cuda_version: '["13.0"]'
+      platform: '["amd64"]'
+      run_sanity_check: false
+      gpu_test_markers: pre_merge and vllm and h100 and gpu_1
+      gpu_test_timeout_minutes: 120
     secrets: inherit
 
   vllm-multi-gpu-test:
@@ -1578,6 +1600,7 @@ jobs:
       - planner-test
       - vllm-copy-to-acr
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - vllm-efa-build
       - sglang-copy-to-acr
       - sglang-multi-gpu-test
@@ -1615,6 +1638,7 @@ jobs:
       - vllm-build
       - vllm-test
       - vllm-multi-gpu-test
+      - vllm-h100-test
       - vllm-copy-to-acr
       - sglang-build
       - sglang-test

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -606,7 +606,7 @@ jobs:
       gpu_parallel_max_vram_gib: '24'
     secrets: inherit
 
-  # TEMPORARY (OPS-7582): H100 lane on PR CI to validate agg_omni_image before
+  # TEMPORARY (#11854): H100 lane on PR CI to validate agg_omni_image before
   # flipping the scenario back to nightly-only. Remove once CI passes.
   vllm-h100-test:
     name: vllm-runtime # This name overlaps with other vllm jobs to group them in the UI

--- a/examples/backends/vllm/launch/agg_omni_image.sh
+++ b/examples/backends/vllm/launch/agg_omni_image.sh
@@ -6,6 +6,7 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
+source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
 MODEL="Qwen/Qwen-Image"
@@ -26,6 +27,7 @@ while [[ $# -gt 0 ]]; do
 done
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
+GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
 print_launch_banner --no-curl "Launching vLLM-Omni Image Generation (1 GPU)" "$MODEL" "$HTTP_PORT"
 print_curl_footer <<CURL
 curl -s -X POST http://localhost:${HTTP_PORT}/v1/images/generations \\
@@ -50,6 +52,7 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     --model "$MODEL" \
     --output-modalities image \
     --media-output-fs-url file:///tmp/dynamo_media \
+    $GPU_MEM_ARGS \
     "${EXTRA_ARGS[@]}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/backends/vllm/launch/agg_omni_image.sh
+++ b/examples/backends/vllm/launch/agg_omni_image.sh
@@ -6,7 +6,6 @@ set -e
 trap 'echo Cleaning up...; kill 0' EXIT
 
 SCRIPT_DIR="$(dirname "$(readlink -f "$0")")"
-source "$SCRIPT_DIR/../../../common/gpu_utils.sh"
 source "$SCRIPT_DIR/../../../common/launch_utils.sh"
 
 MODEL="Qwen/Qwen-Image"
@@ -27,7 +26,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 HTTP_PORT="${DYN_HTTP_PORT:-8000}"
-GPU_MEM_ARGS=$(build_vllm_gpu_mem_args)
+GPU_MEM_ARGS=()
+read -r -a GPU_MEM_ARGS <<< "$(build_vllm_gpu_mem_args)"
 print_launch_banner --no-curl "Launching vLLM-Omni Image Generation (1 GPU)" "$MODEL" "$HTTP_PORT"
 print_curl_footer <<CURL
 curl -s -X POST http://localhost:${HTTP_PORT}/v1/images/generations \\
@@ -52,7 +52,7 @@ DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT:-8081} \
     --model "$MODEL" \
     --output-modalities image \
     --media-output-fs-url file:///tmp/dynamo_media \
-    $GPU_MEM_ARGS \
+    "${GPU_MEM_ARGS[@]}" \
     "${EXTRA_ARGS[@]}" &
 
 # Exit on first worker failure; kill 0 in the EXIT trap tears down the rest

--- a/examples/common/launch_utils.sh
+++ b/examples/common/launch_utils.sh
@@ -37,6 +37,11 @@ if [[ "${BASH_VERSINFO[0]}" -lt 4 || ( "${BASH_VERSINFO[0]}" -eq 4 && "${BASH_VE
     exit 1
 fi
 
+# GPU memory helpers (build_*_gpu_mem_args). Sourced here so launch scripts
+# only need to source launch_utils.sh.
+# shellcheck source=gpu_utils.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gpu_utils.sh"
+
 EXAMPLE_PROMPT="Who is the tennis GOAT: Federer, Djokovic, or Nadal?"
 EXAMPLE_PROMPT_VISUAL="A golden retriever riding a skateboard through a neon-lit city"
 

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -111,10 +111,10 @@ vllm_omni_configs = {
             pytest.mark.gpu_1,
             pytest.mark.h100,
             # Temporary: pre_merge so PR CI can validate on the H100 lane in
-            # pr.yaml. Flip back to nightly once CI passes (OPS-7582).
+            # pr.yaml. Flip back to nightly once CI passes (#11854).
             pytest.mark.pre_merge,
             pytest.mark.timeout(1800),
-            # Qwen-Image BF16 weights ~40–42 GiB; with VAE tiling/slicing + 2 GiB
+            # Qwen-Image BF16 weights ~40-42 GiB; with VAE tiling/slicing + 2 GiB
             # KV budget, derived peak ≈47 GiB.
             pytest.mark.profiled_vram_gib(47.0),
             # Modest KV pool for diffusion text-encoder/DiT; weights dominate.

--- a/tests/serve/test_vllm_omni.py
+++ b/tests/serve/test_vllm_omni.py
@@ -109,12 +109,16 @@ vllm_omni_configs = {
         ],
         marks=[
             pytest.mark.gpu_1,
-            pytest.mark.xpu_1,
-            pytest.mark.post_merge,
-            pytest.mark.timeout(1200),
-            pytest.mark.skip(
-                reason="Qwen/Qwen-Image requires ~40GB GPU memory, exceeds CI capacity (22GB)"
-            ),
+            pytest.mark.h100,
+            # Temporary: pre_merge so PR CI can validate on the H100 lane in
+            # pr.yaml. Flip back to nightly once CI passes (OPS-7582).
+            pytest.mark.pre_merge,
+            pytest.mark.timeout(1800),
+            # Qwen-Image BF16 weights ~40–42 GiB; with VAE tiling/slicing + 2 GiB
+            # KV budget, derived peak ≈47 GiB.
+            pytest.mark.profiled_vram_gib(47.0),
+            # Modest KV pool for diffusion text-encoder/DiT; weights dominate.
+            pytest.mark.requested_vllm_kv_cache_bytes(2_147_483_648),
         ],
         model="Qwen/Qwen-Image",
         request_payloads=[


### PR DESCRIPTION
## Summary
- Enable the `omni_image` / `agg_omni_image` launch scenario (Qwen-Image ~40–47 GiB) on an **H100** lane, covering OPS-7582 / parent OPS-7562.
- Wire KV/VRAM overrides into `agg_omni_image.sh` via `build_vllm_gpu_mem_args`.
- Add a permanent `vllm-h100-test` job to `nightly-ci.yml`.
- **Temporary for CI validation:** mark the scenario `pre_merge` and add a matching H100 job to `pr.yaml` so PR CI can prove the workflow. After the H100 PR job passes, a follow-up commit will flip the marker + remove the temporary `pr.yaml` lane (keeping nightly).

## Validation
- [ ] PR CI `vllm-h100-test` (`pre_merge and vllm and h100 and gpu_1` on `aws-dev-02-tester-amd-gpu-v2`) passes `test_omni_serve_deployment[omni_image]`
- [ ] Regular `vllm-test` lane excludes `h100` (no OOM on 24 GiB runners)
- [ ] Follow-up: restore `nightly` marker and drop temporary `pr.yaml` H100 job

Refs: OPS-7582, OPS-7562

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added dedicated H100 test lanes for vLLM in pull request and nightly validation.
  - Added GPU memory configuration to the vLLM Omni launcher.

- **Bug Fixes**
  - Improved vLLM Omni test coverage with H100-specific settings, extended timeout, and explicit VRAM and cache constraints.
  - Ensured H100 results are included in status checks, reporting, cleanup, release, and notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->