### PR TITLE
fix(lora): backport disaggregated prefill lifecycle to 1.3.0

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -12,7 +12,6 @@ import os
 import pickle
 import struct
 import tempfile
-import threading
 import time
 from abc import ABC, abstractmethod
 from collections import deque
@@ -21,6 +20,7 @@ from contextlib import asynccontextmanager
 from typing import (
     Any,
     AsyncIterator,
+    Callable,
     Dict,
     Final,
     Generic,
@@ -125,6 +125,7 @@ _GENERATE_REASONING_SUPPORT_CACHE_ATTR = "_dynamo_generate_reasoning_support"
 _DELTA_REQUEST_OUTPUT_KIND = RequestOutputKind.DELTA
 _RL_INIT_WEIGHTS_TIMEOUT_ENV = "DYN_RL_INIT_WEIGHTS_TIMEOUT_S"
 _RL_INIT_WEIGHTS_TIMEOUT_DEFAULT_S = 30.0
+_LORA_LOCK_STRIPES = 64
 _DISTRIBUTED_WEIGHT_UPDATE_RESERVED_KEYS: Final = frozenset(
     {
         "allow_unpaused",
@@ -1051,10 +1052,14 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         self.enable_multimodal = enable_multimodal
         # LoRA tracking: name -> LoRAInfo(id, path)
         self.loaded_loras: dict[str, LoRAInfo] = {}
-        # Per-LoRA locks to prevent concurrent load operations for the same LoRA
-        self._lora_load_locks: dict[str, asyncio.Lock] = {}
-        # Guard lock-map access in case handlers are invoked from multiple threads.
-        self._lora_load_locks_guard = threading.Lock()
+        # Adapters known to have been handed to vLLM. Prefill registration is
+        # metadata-only, but vLLM activates a prefill adapter lazily when an
+        # inference request supplies its LoRARequest.
+        self._engine_loaded_loras: set[str] = set()
+        # Requests and load/unload operations for the same adapter share a lock,
+        # so an unload cannot race with vLLM's lazy adapter activation. A fixed
+        # number of shared locks bounds memory as adapter names come and go.
+        self._lora_load_locks = [asyncio.Lock() for _ in range(_LORA_LOCK_STRIPES)]
         self._paused: bool = False
         self._weight_version: str = "initial"
 
@@ -1945,14 +1950,71 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             )
         return None
 
+    def _track_lora_request_activation(self, lora_request: LoRARequest | None) -> None:
+        """Record adapters handed to vLLM for request-time lazy activation."""
+        if lora_request is not None:
+            self._engine_loaded_loras.add(lora_request.lora_name)
+
+    @staticmethod
+    def _is_lora_not_loaded_error(error: Exception) -> bool:
+        """Return whether vLLM reports an idempotent remove of a missing LoRA."""
+        message = str(error).lower()
+        return "not loaded" in message or "not found" in message
+
     def _get_lora_lock(self, lora_name: str) -> asyncio.Lock:
-        """Get/create the per-LoRA lock without eagerly allocating a new lock each call."""
-        with self._lora_load_locks_guard:
-            lock = self._lora_load_locks.get(lora_name)
-            if lock is None:
-                lock = asyncio.Lock()
-                self._lora_load_locks[lora_name] = lock
-            return lock
+        """Return a bounded lock stripe for a LoRA name."""
+        return self._lora_load_locks[hash(lora_name) % _LORA_LOCK_STRIPES]
+
+    async def _generate_with_lora_admission_lock(
+        self,
+        lora_request: LoRARequest | None,
+        create_generator: Callable[[LoRARequest | None], AsyncIterator[Any]],
+    ) -> AsyncIterator[Any]:
+        """Yield results after atomically admitting a lazy LoRA request.
+
+        vLLM admits an ``AsyncLLM.generate`` request on its first iteration.
+        Holding the adapter lifecycle lock through that iteration prevents an
+        unload from deleting bookkeeping before lazy activation completes.
+        """
+        if lora_request is None or self._preload_lora_into_engine():
+            self._track_lora_request_activation(lora_request)
+            async for result in create_generator(lora_request):
+                yield result
+            return
+
+        lock = self._get_lora_lock(lora_request.lora_name)
+        async with lock:
+            # The adapter may have been unloaded or reloaded at a different path
+            # while this request waited. Look it up again while holding the lock.
+            admitted_lora_request = self._resolve_lora_request(lora_request.lora_name)
+            if admitted_lora_request is None:
+                logger.warning(
+                    "LoRA adapter %s was unloaded before vLLM admission; "
+                    "rejecting the request",
+                    lora_request.lora_name,
+                )
+                raise ValueError(
+                    f"unknown model or LoRA adapter: '{lora_request.lora_name}'"
+                )
+            generator = create_generator(admitted_lora_request)
+            self._track_lora_request_activation(admitted_lora_request)
+            try:
+                first_result = await anext(generator)
+            except StopAsyncIteration:
+                return
+
+        yield first_result
+        async for result in generator:
+            yield result
+
+    def _preload_lora_into_engine(self) -> bool:
+        """Whether lifecycle registration should eagerly activate the adapter.
+
+        Prefill keeps the downloaded adapter metadata and supplies its path in
+        the inference-time ``LoRARequest``. Decode and aggregated workers must
+        be immediately ready to generate and therefore continue to preload.
+        """
+        return self.config.disaggregation_mode != DisaggregationMode.PREFILL
 
     async def load_lora(self, request=None):
         """
@@ -1998,6 +2060,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     old_info = self.loaded_loras.get(lora_name)
                     hot_swap_enabled = env_bool("DYN_LORA_HOTSWAP_ENABLED")
                     is_hot_swap = old_info is not None and hot_swap_enabled
+                    old_engine_loaded = lora_name in self._engine_loaded_loras
 
                     if old_info is not None and not hot_swap_enabled:
                         logger.info(
@@ -2031,9 +2094,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                     # Generate deterministic ID from lora_name before using it
                     lora_id = lora_name_to_id(lora_name)
 
-                    if is_hot_swap and old_info is not None:
+                    if is_hot_swap and old_info is not None and old_engine_loaded:
                         try:
                             await self.engine_client.remove_lora(old_info.id)
+                            self._engine_loaded_loras.discard(lora_name)
                         except Exception as e:
                             logger.error(
                                 f"Failed to remove existing LoRA '{lora_name}' "
@@ -2049,36 +2113,49 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             }
                             return
 
-                    try:
-                        await self.engine_client.add_lora(
-                            LoRARequest(
-                                lora_name=lora_name,
-                                lora_int_id=lora_id,
-                                lora_path=lora_path,
+                    # Initial prefill registration is metadata-only. A hot
+                    # swap must still replace any lazily activated old adapter
+                    # atomically before the prefix cache is reset.
+                    preload_into_engine = (
+                        self._preload_lora_into_engine() or is_hot_swap
+                    )
+                    if preload_into_engine:
+                        try:
+                            await self.engine_client.add_lora(
+                                LoRARequest(
+                                    lora_name=lora_name,
+                                    lora_int_id=lora_id,
+                                    lora_path=lora_path,
+                                )
                             )
-                        )
-                    except Exception as e:
-                        if is_hot_swap and old_info is not None:
-                            try:
-                                await self.engine_client.add_lora(
-                                    LoRARequest(
-                                        lora_name=lora_name,
-                                        lora_int_id=old_info.id,
-                                        lora_path=old_info.path,
+                            self._engine_loaded_loras.add(lora_name)
+                        except Exception as e:
+                            if (
+                                is_hot_swap
+                                and old_info is not None
+                                and old_engine_loaded
+                            ):
+                                try:
+                                    await self.engine_client.add_lora(
+                                        LoRARequest(
+                                            lora_name=lora_name,
+                                            lora_int_id=old_info.id,
+                                            lora_path=old_info.path,
+                                        )
                                     )
-                                )
-                            except Exception as rollback_error:
-                                self.loaded_loras.pop(lora_name, None)
-                                logger.exception(
-                                    f"Rollback failed for LoRA {lora_name}: "
-                                    f"{rollback_error}"
-                                )
-                        yield {
-                            "status": "error",
-                            "message": f"Failed to add LoRA '{lora_name}': {e}",
-                            "lora_name": lora_name,
-                        }
-                        return
+                                    self._engine_loaded_loras.add(lora_name)
+                                except Exception as rollback_error:
+                                    self.loaded_loras.pop(lora_name, None)
+                                    logger.exception(
+                                        f"Rollback failed for LoRA {lora_name}: "
+                                        f"{rollback_error}"
+                                    )
+                            yield {
+                                "status": "error",
+                                "message": f"Failed to add LoRA '{lora_name}': {e}",
+                                "lora_name": lora_name,
+                            }
+                            return
 
                     # Track the LoRA
                     self.loaded_loras[lora_name] = LoRAInfo(id=lora_id, path=lora_path)
@@ -2101,16 +2178,24 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             rolled_back = "tracking only"
                             if old_info is not None:
                                 try:
-                                    await self.engine_client.remove_lora(lora_id)
-                                    await self.engine_client.add_lora(
-                                        LoRARequest(
-                                            lora_name=lora_name,
-                                            lora_int_id=old_info.id,
-                                            lora_path=old_info.path,
+                                    if preload_into_engine:
+                                        await self.engine_client.remove_lora(lora_id)
+                                        self._engine_loaded_loras.discard(lora_name)
+                                    if old_engine_loaded:
+                                        await self.engine_client.add_lora(
+                                            LoRARequest(
+                                                lora_name=lora_name,
+                                                lora_int_id=old_info.id,
+                                                lora_path=old_info.path,
+                                            )
                                         )
-                                    )
+                                        self._engine_loaded_loras.add(lora_name)
                                     self.loaded_loras[lora_name] = old_info
-                                    rolled_back = "engine+tracking"
+                                    rolled_back = (
+                                        "engine+tracking"
+                                        if old_engine_loaded
+                                        else "tracking only"
+                                    )
                                 except Exception as rollback_error:
                                     # Engine is in an indeterminate adapter state;
                                     # drop tracking so we never claim a clean swap.
@@ -2225,12 +2310,15 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                                 f"Failed to publish LoRA {lora_name} ModelDeploymentCard: {e}"
                             )
 
-                            # Rollback: remove the LoRA from the engine to maintain consistency
+                            # Roll back engine state when this worker preloaded;
+                            # prefill only needs to discard the cached metadata.
                             try:
-                                logger.debug(
-                                    f"Rolling back: removing LoRA '{lora_name}' from engine"
-                                )
-                                await self.engine_client.remove_lora(lora_id)
+                                if preload_into_engine:
+                                    logger.debug(
+                                        f"Rolling back: removing LoRA '{lora_name}' from engine"
+                                    )
+                                    await self.engine_client.remove_lora(lora_id)
+                                    self._engine_loaded_loras.discard(lora_name)
                                 self.loaded_loras.pop(lora_name, None)
                                 logger.debug(
                                     f"Successfully rolled back LoRA '{lora_name}'"
@@ -2263,14 +2351,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "hot_swap": is_hot_swap,
                     }
                 finally:
-                    # Avoid lock-map growth on failed loads: if this attempt did not leave the LoRA
-                    # loaded, remove the lock entry (best-effort).
-                    with self._lora_load_locks_guard:
-                        if (
-                            lora_name not in self.loaded_loras
-                            and self._lora_load_locks.get(lora_name) is lock
-                        ):
-                            self._lora_load_locks.pop(lora_name, None)
+                    # Stripes are intentionally retained. Evicting a lock here
+                    # can separate a waiting request from a later lifecycle op.
+                    pass
         except Exception as e:
             logger.exception(f"Failed to load LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
@@ -2305,14 +2388,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
                     logger.debug(f"Unloading LoRA adapter: {lora_name}")
                     lora_id = lora.id
-                    lora_path = lora.path
 
-                    await self.engine_client.remove_lora(lora_id)
-
-                    # Remove from tracking
-                    del self.loaded_loras[lora_name]
-
-                    # Unregister the LoRA model from the model registry
+                    # Stop advertising the adapter before mutating engine or
+                    # tracking state. Otherwise requests can still route here
+                    # after _resolve_lora_request has forgotten the adapter and
+                    # silently execute against the base model.
                     if self.generate_endpoint is not None:
                         logger.debug(
                             f"Unregistering LoRA '{lora_name}' ModelDeploymentCard"
@@ -2329,32 +2409,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             logger.exception(
                                 f"Failed to unregister LoRA {lora_name} ModelDeploymentCard: {e}"
                             )
-
-                            # Rollback: re-add the LoRA to the engine to maintain consistency
-                            try:
-                                logger.debug(
-                                    f"Rolling back: re-adding LoRA '{lora_name}' to engine"
-                                )
-                                await self.engine_client.add_lora(
-                                    LoRARequest(
-                                        lora_name=lora_name,
-                                        lora_int_id=lora_id,
-                                        lora_path=lora_path,
-                                    )
-                                )
-                                # Re-add to tracking
-                                self.loaded_loras[lora_name] = LoRAInfo(
-                                    id=lora_id, path=lora_path
-                                )
-                                logger.debug(
-                                    f"Successfully rolled back LoRA '{lora_name}'"
-                                )
-                            except Exception as rollback_error:
-                                logger.exception(
-                                    f"Failed to rollback LoRA {lora_name}: {rollback_error}"
-                                )
-
-                            # Return error status since unregistration failed
                             yield {
                                 "status": "error",
                                 "message": f"Failed to unregister LoRA '{lora_name}' from discovery registry: {str(e)}",
@@ -2366,6 +2420,19 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             f"Cannot unregister LoRA '{lora_name}': generate_endpoint={self.generate_endpoint}"
                         )
 
+                    # Prefill lifecycle registration is metadata-only, but
+                    # vLLM may have activated the adapter lazily for an
+                    # inference request. Remove only adapters known to have
+                    # reached vLLM.
+                    if lora_name in self._engine_loaded_loras:
+                        try:
+                            await self.engine_client.remove_lora(lora_id)
+                        except Exception as e:
+                            if not self._is_lora_not_loaded_error(e):
+                                raise
+                        self._engine_loaded_loras.discard(lora_name)
+                    del self.loaded_loras[lora_name]
+
                     logger.info(
                         f"Successfully unloaded LoRA adapter: {lora_name} with ID {lora_id}"
                     )
@@ -2376,13 +2443,9 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                         "lora_id": lora_id,
                     }
                 finally:
-                    # Remove lock entry once the LoRA is not loaded (or never was).
-                    with self._lora_load_locks_guard:
-                        if (
-                            lora_name not in self.loaded_loras
-                            and self._lora_load_locks.get(lora_name) is lock
-                        ):
-                            self._lora_load_locks.pop(lora_name, None)
+                    # Stripes are intentionally retained. Evicting a lock here
+                    # can separate a waiting request from a later lifecycle op.
+                    pass
         except Exception as e:
             logger.exception(f"Failed to unload LoRA adapter: {e}")
             yield {"status": "error", "message": str(e)}
@@ -3022,18 +3085,21 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 request_id,
                 lora_request,
             )
-            gen = self.engine_client.generate(
-                prompt,
-                sampling_params,
-                request_id,
-                lora_request=lora_request,
-                data_parallel_rank=data_parallel_rank,
-                trace_headers=trace_headers,
-                priority=priority,
-                **_engine_generate_reasoning_kwargs(
-                    self.engine_client,
-                    reasoning_ended,
-                    reasoning_parser_kwargs,
+            gen = self._generate_with_lora_admission_lock(
+                lora_request,
+                lambda admitted_lora_request: self.engine_client.generate(
+                    prompt,
+                    sampling_params,
+                    request_id,
+                    lora_request=admitted_lora_request,
+                    data_parallel_rank=data_parallel_rank,
+                    trace_headers=trace_headers,
+                    priority=priority,
+                    **_engine_generate_reasoning_kwargs(
+                        self.engine_client,
+                        reasoning_ended,
+                        reasoning_parser_kwargs,
+                    ),
                 ),
             )
 
@@ -3693,18 +3759,21 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         async with self._abort_monitor(context, request_id, is_prefill=True):
             try:
-                gen = self.engine_client.generate(
-                    prompt,
-                    sampling_params,
-                    request_id,
-                    data_parallel_rank=dp_rank,
-                    lora_request=lora_request,
-                    trace_headers=trace_headers,
-                    priority=priority,
-                    **_engine_generate_reasoning_kwargs(
-                        self.engine_client,
-                        reasoning_ended,
-                        reasoning_parser_kwargs,
+                gen = self._generate_with_lora_admission_lock(
+                    lora_request,
+                    lambda admitted_lora_request: self.engine_client.generate(
+                        prompt,
+                        sampling_params,
+                        request_id,
+                        data_parallel_rank=dp_rank,
+                        lora_request=admitted_lora_request,
+                        trace_headers=trace_headers,
+                        priority=priority,
+                        **_engine_generate_reasoning_kwargs(
+                            self.engine_client,
+                            reasoning_ended,
+                            reasoning_parser_kwargs,
+                        ),
                     ),
                 )
             except EngineDeadError as e:

--- a/components/src/dynamo/vllm/llm_engine.py
+++ b/components/src/dynamo/vllm/llm_engine.py
@@ -14,7 +14,7 @@ import logging
 import os
 import tempfile
 from collections.abc import AsyncGenerator
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 from vllm.config import VllmConfig
 from vllm.distributed.kv_events import ZmqEventPublisher
@@ -216,6 +216,10 @@ class VllmLLMEngine(LLMEngine):
         # publishes against it.
         self._endpoint: Optional[Endpoint] = None
         self.loaded_loras: dict[str, LoRAInfo] = {}
+        # Adapters known to have been handed to vLLM. Prefill registration is
+        # metadata-only, but vLLM activates a prefill adapter lazily when an
+        # inference request supplies its LoRARequest.
+        self._engine_loaded_loras: set[str] = set()
         # Adapters whose discovery ModelDeploymentCard is currently published.
         # Tracked separately from `loaded_loras` because the engine load and the
         # discovery publish can diverge on partial failure: an adapter may be
@@ -354,6 +358,7 @@ class VllmLLMEngine(LLMEngine):
             raise RuntimeError("Engine not initialized")
         if self._default_sampling_params is None:
             raise RuntimeError("Engine not initialized")
+        engine_client = self.engine_client
 
         request_id = context.id()
 
@@ -435,18 +440,21 @@ class VllmLLMEngine(LLMEngine):
         lora_request = self._resolve_lora_request(request.get("model"))
         reasoning_ended, reasoning_parser_kwargs = _request_reasoning_metadata(request)
 
-        gen = self.engine_client.generate(
-            prompt,
-            sampling_params,
-            request_id,
-            data_parallel_rank=local_dp_rank,
-            lora_request=lora_request,
-            **_engine_generate_reasoning_kwargs(
-                self.engine_client,
-                reasoning_ended,
-                reasoning_parser_kwargs,
+        gen = self._generate_with_lora_admission_lock(
+            lora_request,
+            lambda admitted_lora_request: engine_client.generate(
+                prompt,
+                sampling_params,
+                request_id,
+                data_parallel_rank=local_dp_rank,
+                lora_request=admitted_lora_request,
+                **_engine_generate_reasoning_kwargs(
+                    engine_client,
+                    reasoning_ended,
+                    reasoning_parser_kwargs,
+                ),
+                **telemetry.engine_trace_kwargs(context),
             ),
-            **telemetry.engine_trace_kwargs(context),
         )
 
         is_prefill = self.disaggregation_mode == DisaggregationMode.PREFILL
@@ -704,6 +712,18 @@ class VllmLLMEngine(LLMEngine):
             raise ValueError(f"unknown model or LoRA adapter: '{model_name}'")
         return None
 
+    def _track_lora_request_activation(self, lora_request: LoRARequest | None) -> None:
+        """Record adapters handed to vLLM for request-time lazy activation.
+
+        Prefill lifecycle registration deliberately does not call ``add_lora``.
+        vLLM can nevertheless load the adapter when this request reaches its
+        scheduler, so unload must attempt a matching removal. A request that
+        fails before vLLM activates the adapter is harmless: unload treats a
+        not-loaded response as idempotent.
+        """
+        if lora_request is not None:
+            self._engine_loaded_loras.add(lora_request.lora_name)
+
     def _get_lora_lock(self, lora_name: str) -> asyncio.Lock:
         """Return the stripe lock that serializes load/unload for ``lora_name``.
 
@@ -714,6 +734,50 @@ class VllmLLMEngine(LLMEngine):
         stripe serialize against each other (harmless on this control path).
         """
         return self._lora_load_locks[hash(lora_name) % _LORA_LOCK_STRIPES]
+
+    async def _generate_with_lora_admission_lock(
+        self,
+        lora_request: LoRARequest | None,
+        create_generator: Callable[[LoRARequest | None], AsyncGenerator[Any, None]],
+    ) -> AsyncGenerator[Any, None]:
+        """Yield results after atomically admitting a lazy LoRA request.
+
+        vLLM admits an ``AsyncLLM.generate`` request on its first iteration.
+        Holding the adapter lifecycle lock through that iteration prevents an
+        unload from deleting bookkeeping before lazy activation completes.
+        """
+        if lora_request is None or self._preload_lora_into_engine():
+            self._track_lora_request_activation(lora_request)
+            async for result in create_generator(lora_request):
+                yield result
+            return
+
+        lock = self._get_lora_lock(lora_request.lora_name)
+        async with lock:
+            # A pending request may have waited behind an unload. Re-resolve
+            # under the lock instead of admitting its stale path afterwards.
+            admitted_lora_request = self._resolve_lora_request(lora_request.lora_name)
+            generator = create_generator(admitted_lora_request)
+            self._track_lora_request_activation(admitted_lora_request)
+            try:
+                first_result = await anext(generator)
+            except StopAsyncIteration:
+                return
+
+        yield first_result
+        async for result in generator:
+            yield result
+
+    def _preload_lora_into_engine(self) -> bool:
+        """Whether lifecycle registration should eagerly activate the adapter.
+
+        A disaggregated prefill worker receives the adapter path again in the
+        per-request ``LoRARequest``. Letting vLLM activate it there avoids
+        consuming a prefill LoRA slot before the adapter is used. Decode and
+        aggregated workers must be immediately ready to generate, so they
+        retain the eager load behavior.
+        """
+        return self.disaggregation_mode != DisaggregationMode.PREFILL
 
     async def _publish_lora_card(self, lora_name: str, lora_id: int) -> None:
         """Publish a LoRA adapter as a ModelDeploymentCard for discovery.
@@ -782,6 +846,7 @@ class VllmLLMEngine(LLMEngine):
             base_model_path=self.engine_args.model,
             worker_type=worker_type,
             needs=needs,
+            max_gpu_lora_count=self.engine_args.max_loras,
         )
 
     def _lora_registration_topology(
@@ -919,13 +984,16 @@ class VllmLLMEngine(LLMEngine):
                 # Deterministic ID from lora_name before using it.
                 lora_id = lora_name_to_id(lora_name)
 
-                await self.engine_client.add_lora(
-                    LoRARequest(
-                        lora_name=lora_name,
-                        lora_int_id=lora_id,
-                        lora_path=lora_path,
+                preload_into_engine = self._preload_lora_into_engine()
+                if preload_into_engine:
+                    await self.engine_client.add_lora(
+                        LoRARequest(
+                            lora_name=lora_name,
+                            lora_int_id=lora_id,
+                            lora_path=lora_path,
+                        )
                     )
-                )
+                    self._engine_loaded_loras.add(lora_name)
 
                 self.loaded_loras[lora_name] = LoRAInfo(id=lora_id, path=lora_path)
                 logger.info(
@@ -962,11 +1030,13 @@ class VllmLLMEngine(LLMEngine):
                         # `loaded_loras` but absent from `_published_loras`,
                         # so a retried load reconciles the publish.
                         try:
-                            logger.debug(
-                                "Rolling back: removing LoRA '%s' from engine",
-                                lora_name,
-                            )
-                            await self.engine_client.remove_lora(lora_id)
+                            if preload_into_engine:
+                                logger.debug(
+                                    "Rolling back: removing LoRA '%s' from engine",
+                                    lora_name,
+                                )
+                                await self.engine_client.remove_lora(lora_id)
+                                self._engine_loaded_loras.discard(lora_name)
                             self.loaded_loras.pop(lora_name, None)
                             logger.debug(
                                 "Successfully rolled back LoRA '%s'", lora_name
@@ -1106,25 +1176,29 @@ class VllmLLMEngine(LLMEngine):
                         lora_name,
                     )
 
-                # Discovery no longer routes to this adapter; remove it from
-                # the engine.
-                try:
-                    await self.engine_client.remove_lora(lora_id)
-                except Exception as e:
-                    # The discovery card is already gone but the engine still
-                    # holds the adapter (loaded-but-unpublished). Leave it in
-                    # loaded_loras so a retried unload skips the unregister
-                    # and retries only the engine removal.
-                    logger.exception(
-                        "Failed to remove LoRA %s from engine: %s",
-                        lora_name,
-                        e,
-                    )
-                    return {
-                        "status": "error",
-                        "message": f"Failed to remove LoRA '{lora_name}' from engine: {str(e)}",
-                        "lora_name": lora_name,
-                    }
+                # Prefill lifecycle registration is metadata-only, but vLLM
+                # may have activated the adapter lazily for an inference
+                # request. Remove only adapters known to have reached vLLM.
+                if lora_name in self._engine_loaded_loras:
+                    try:
+                        await self.engine_client.remove_lora(lora_id)
+                    except Exception as e:
+                        if not self._is_lora_not_loaded_error(e):
+                            # The discovery card is already gone but the engine still
+                            # holds the adapter (loaded-but-unpublished). Leave it in
+                            # loaded_loras so a retried unload skips the unregister
+                            # and retries only the engine removal.
+                            logger.exception(
+                                "Failed to remove LoRA %s from engine: %s",
+                                lora_name,
+                                e,
+                            )
+                            return {
+                                "status": "error",
+                                "message": f"Failed to remove LoRA '{lora_name}' from engine: {str(e)}",
+                                "lora_name": lora_name,
+                            }
+                    self._engine_loaded_loras.discard(lora_name)
 
                 del self.loaded_loras[lora_name]
 
@@ -1142,6 +1216,12 @@ class VllmLLMEngine(LLMEngine):
         except Exception as e:
             logger.exception("Failed to unload LoRA adapter: %s", e)
             return {"status": "error", "message": str(e)}
+
+    @staticmethod
+    def _is_lora_not_loaded_error(error: Exception) -> bool:
+        """Return whether vLLM reports an idempotent remove of a missing LoRA."""
+        message = str(error).lower()
+        return "not loaded" in message or "not found" in message
 
     async def list_loras(self, body: dict) -> dict:
         """List all loaded LoRA adapters as a lora_name -> lora_id mapping."""

--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -829,22 +829,19 @@ async def register_vllm_model(
         worker_type=worker_type,
         needs=needs,
         ignore_weights=should_register_model_ignore_weights(config),
-        # Advertise the worker's LoRA slot budget on the BASE registration so the frontend
-        # allocator can place adapters onto idle-but-LoRA-capable workers before any adapter is
-        # loaded here. Only generative decode/aggregated workers serve the LoRA load endpoints
-        # (load_lora/unload_lora). Prefill and embedding workers register through this same path
-        # but do NOT serve them, so they must not advertise capacity they cannot fulfill — gate on
-        # the model type rather than worker_type (vLLM embedding registers as Aggregated). None
-        # (no capacity) for non-LoRA, prefill, or embedding workers.
-        max_gpu_lora_count=(
-            config.engine_args.max_loras
-            if (
-                getattr(config.engine_args, "enable_lora", False)
-                and model_type not in (ModelType.Prefill, ModelType.Embedding)
-            )
-            else None
-        ),
+        # Advertise LoRA capacity on the BASE card so the frontend can place the first
+        # adapter onto an idle worker. Decode, aggregated, and prefill workers all serve
+        # lifecycle registration; embeddings still do not.
+        max_gpu_lora_count=_base_model_lora_capacity(config, model_type),
     )
+
+
+def _base_model_lora_capacity(config: Config, model_type: ModelType) -> int | None:
+    if not getattr(config.engine_args, "enable_lora", False):
+        return None
+    if model_type == ModelType.Embedding:
+        return None
+    return config.engine_args.max_loras
 
 
 def get_engine_cache_info(engine: AsyncLLM) -> dict[str, Any]:

--- a/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_delta_streaming.py
@@ -77,6 +77,11 @@ def _handler_with_responses(responses):
     handler.runtime = SimpleNamespace(shutdown=lambda: None)
     handler._extract_logprobs = BaseWorkerHandler._extract_logprobs
     handler._log_with_lora_context = _ignore_log
+    # These delta-streaming tests exercise base-model requests only. Model the
+    # no-LoRA branch without constructing the full legacy worker handler.
+    handler._generate_with_lora_admission_lock = (
+        lambda lora_request, create_generator: create_generator(lora_request)
+    )
     return handler
 
 

--- a/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_legacy_lora.py
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Legacy worker-factory LoRA lifecycle tests.
+
+The unified vLLM engine has separate lifecycle coverage. These tests protect
+the still-supported ``BaseWorkerHandler`` path used by release images.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("vllm.lora.request")
+
+from dynamo.common.constants import DisaggregationMode  # noqa: E402
+from dynamo.common.lora.manager import LoRAInfo  # noqa: E402
+from dynamo.llm import ModelType, WorkerType  # noqa: E402
+from dynamo.vllm import handlers as handlers_mod  # noqa: E402
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.vllm,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+def _make_prefill_handler():
+    handler = handlers_mod.PrefillWorkerHandler.__new__(
+        handlers_mod.PrefillWorkerHandler
+    )
+    handler.config = SimpleNamespace(
+        disaggregation_mode=DisaggregationMode.PREFILL,
+        route_to_encoder=False,
+        model="/models/base",
+        dyn_tool_call_parser=None,
+        dyn_reasoning_parser=None,
+        engine_args=SimpleNamespace(block_size=16, max_loras=4),
+    )
+    handler.engine_client = SimpleNamespace(
+        add_lora=AsyncMock(),
+        remove_lora=AsyncMock(),
+        reset_prefix_cache=AsyncMock(),
+    )
+    handler.generate_endpoint = object()
+    handler.model_max_len = 8192
+    handler.loaded_loras = {}
+    handler._engine_loaded_loras = set()
+    handler._lora_load_locks = [
+        asyncio.Lock() for _ in range(handlers_mod._LORA_LOCK_STRIPES)
+    ]
+    return handler
+
+
+@pytest.mark.asyncio
+async def test_prefill_load_records_and_publishes_without_eager_engine_add(
+    monkeypatch,
+):
+    handler = _make_prefill_handler()
+    manager = SimpleNamespace(
+        download_lora=AsyncMock(
+            return_value={"status": "success", "local_path": "/cache/adapter"}
+        )
+    )
+    register = AsyncMock()
+    monkeypatch.delenv("DYN_LORA_HOTSWAP_ENABLED", raising=False)
+    monkeypatch.setattr(handlers_mod, "get_lora_manager", lambda: manager)
+    monkeypatch.setattr(handlers_mod, "lora_name_to_id", lambda _name: 123)
+    monkeypatch.setattr(handlers_mod, "register_model", register)
+
+    results = [
+        result
+        async for result in handler.load_lora(
+            {"lora_name": "adapterA", "source": {"uri": "file:///adapter"}}
+        )
+    ]
+
+    assert results[-1]["status"] == "success"
+    handler.engine_client.add_lora.assert_not_awaited()
+    assert handler.loaded_loras["adapterA"] == LoRAInfo(id=123, path="/cache/adapter")
+    register.assert_awaited_once()
+    kwargs = register.await_args.kwargs
+    assert str(kwargs["model_type"]) == str(ModelType.Prefill)
+    assert kwargs["worker_type"] == WorkerType.Prefill
+    assert kwargs["needs"] == [[WorkerType.Decode]]
+
+
+@pytest.mark.asyncio
+async def test_decode_load_still_eagerly_adds_to_engine(monkeypatch):
+    handler = _make_prefill_handler()
+    handler.config.disaggregation_mode = DisaggregationMode.DECODE
+    manager = SimpleNamespace(
+        download_lora=AsyncMock(
+            return_value={"status": "success", "local_path": "/cache/adapter"}
+        )
+    )
+    monkeypatch.delenv("DYN_LORA_HOTSWAP_ENABLED", raising=False)
+    monkeypatch.setattr(handlers_mod, "get_lora_manager", lambda: manager)
+    monkeypatch.setattr(handlers_mod, "lora_name_to_id", lambda _name: 123)
+    monkeypatch.setattr(handlers_mod, "register_model", AsyncMock())
+
+    results = [
+        result
+        async for result in handler.load_lora(
+            {"lora_name": "adapterA", "source": {"uri": "file:///adapter"}}
+        )
+    ]
+
+    assert results[-1]["status"] == "success"
+    handler.engine_client.add_lora.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_prefill_publish_failure_rolls_back_metadata_only(monkeypatch):
+    handler = _make_prefill_handler()
+    manager = SimpleNamespace(
+        download_lora=AsyncMock(
+            return_value={"status": "success", "local_path": "/cache/adapter"}
+        )
+    )
+    register = AsyncMock(side_effect=RuntimeError("discovery is down"))
+    monkeypatch.delenv("DYN_LORA_HOTSWAP_ENABLED", raising=False)
+    monkeypatch.setattr(handlers_mod, "get_lora_manager", lambda: manager)
+    monkeypatch.setattr(handlers_mod, "lora_name_to_id", lambda _name: 123)
+    monkeypatch.setattr(handlers_mod, "register_model", register)
+
+    results = [
+        result
+        async for result in handler.load_lora(
+            {"lora_name": "adapterA", "source": {"uri": "file:///adapter"}}
+        )
+    ]
+
+    assert results[-1]["status"] == "error"
+    assert "adapterA" not in handler.loaded_loras
+    handler.engine_client.add_lora.assert_not_awaited()
+    handler.engine_client.remove_lora.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_unload_unregisters_before_engine_removal(monkeypatch):
+    handler = _make_prefill_handler()
+    handler.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    handler._engine_loaded_loras = {"adapterA"}
+    order: list[str] = []
+    unregister = AsyncMock(side_effect=lambda **_kwargs: order.append("unregister"))
+    handler.engine_client.remove_lora.side_effect = lambda _id: order.append("remove")
+    monkeypatch.setattr(handlers_mod, "unregister_model", unregister)
+
+    results = [
+        result async for result in handler.unload_lora({"lora_name": "adapterA"})
+    ]
+
+    assert results[-1]["status"] == "success"
+    assert order == ["unregister", "remove"]
+    assert "adapterA" not in handler.loaded_loras
+
+
+@pytest.mark.asyncio
+async def test_legacy_prefill_unload_skips_engine_removal_for_metadata_only_adapter(
+    monkeypatch,
+):
+    handler = _make_prefill_handler()
+    manager = SimpleNamespace(
+        download_lora=AsyncMock(
+            return_value={"status": "success", "local_path": "/cache/adapter"}
+        )
+    )
+    unregister = AsyncMock()
+    monkeypatch.setattr(handlers_mod, "get_lora_manager", lambda: manager)
+    monkeypatch.setattr(handlers_mod, "lora_name_to_id", lambda _name: 123)
+    monkeypatch.setattr(handlers_mod, "register_model", AsyncMock())
+    monkeypatch.setattr(handlers_mod, "unregister_model", unregister)
+
+    load_results = [
+        result
+        async for result in handler.load_lora(
+            {"lora_name": "adapterA", "source": {"uri": "file:///adapter"}}
+        )
+    ]
+    unload_results = [
+        result async for result in handler.unload_lora({"lora_name": "adapterA"})
+    ]
+
+    assert load_results[-1]["status"] == "success"
+    assert unload_results[-1]["status"] == "success"
+    unregister.assert_awaited_once()
+    handler.engine_client.add_lora.assert_not_awaited()
+    handler.engine_client.remove_lora.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_legacy_prefill_unload_removes_request_activated_adapter(monkeypatch):
+    handler = _make_prefill_handler()
+    handler.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    handler._track_lora_request_activation(handler._resolve_lora_request("adapterA"))
+    monkeypatch.setattr(handlers_mod, "unregister_model", AsyncMock())
+
+    results = [
+        result async for result in handler.unload_lora({"lora_name": "adapterA"})
+    ]
+
+    assert results[-1]["status"] == "success"
+    handler.engine_client.remove_lora.assert_awaited_once_with(123)
+
+
+@pytest.mark.asyncio
+async def test_legacy_prefill_request_admission_serializes_with_unload(monkeypatch):
+    handler = _make_prefill_handler()
+    handler.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    monkeypatch.setattr(handlers_mod, "unregister_model", AsyncMock())
+
+    admission_started = asyncio.Event()
+    allow_admission = asyncio.Event()
+    admitted = asyncio.Event()
+
+    async def _blocked_generate(_lora_request):
+        admission_started.set()
+        await allow_admission.wait()
+        admitted.set()
+        yield SimpleNamespace()
+
+    async def _remove_lora(lora_id):
+        assert lora_id == 123
+        assert admitted.is_set()
+
+    handler.engine_client.remove_lora = AsyncMock(side_effect=_remove_lora)
+    admission = handler._generate_with_lora_admission_lock(
+        handler._resolve_lora_request("adapterA"),
+        _blocked_generate,
+    )
+    admission_task = asyncio.create_task(anext(admission))
+    await admission_started.wait()
+
+    async def _unload():
+        return [
+            result async for result in handler.unload_lora({"lora_name": "adapterA"})
+        ]
+
+    unload_task = asyncio.create_task(_unload())
+    await asyncio.sleep(0)
+    assert not unload_task.done()
+    assert "adapterA" in handler.loaded_loras
+
+    allow_admission.set()
+    await admission_task
+    results = await unload_task
+    await admission.aclose()
+
+    assert results[-1]["status"] == "success"
+    handler.engine_client.remove_lora.assert_awaited_once_with(123)
+
+
+@pytest.mark.asyncio
+async def test_legacy_prefill_request_rejects_adapter_unloaded_before_admission(
+    monkeypatch, caplog
+):
+    handler = _make_prefill_handler()
+    handler.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    monkeypatch.setattr(handlers_mod, "unregister_model", AsyncMock())
+    stale_request = handler._resolve_lora_request("adapterA")
+
+    results = [
+        result async for result in handler.unload_lora({"lora_name": "adapterA"})
+    ]
+
+    assert results[-1]["status"] == "success"
+
+    async def _must_not_generate(_lora_request):
+        raise AssertionError("stale request must not reach vLLM")
+        yield  # pragma: no cover - marks this as an async generator
+
+    with pytest.raises(ValueError, match="unknown model or LoRA adapter"):
+        await anext(
+            handler._generate_with_lora_admission_lock(
+                stale_request,
+                _must_not_generate,
+            )
+        )
+
+    assert "adapterA was unloaded before vLLM admission" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_legacy_prefill_unload_treats_missing_request_adapter_as_idempotent(
+    monkeypatch,
+):
+    handler = _make_prefill_handler()
+    handler.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    handler._engine_loaded_loras = {"adapterA"}
+    handler.engine_client.remove_lora.side_effect = RuntimeError("adapter not found")
+    monkeypatch.setattr(handlers_mod, "unregister_model", AsyncMock())
+
+    results = [
+        result async for result in handler.unload_lora({"lora_name": "adapterA"})
+    ]
+
+    assert results[-1]["status"] == "success"
+    assert "adapterA" not in handler.loaded_loras
+
+
+@pytest.mark.asyncio
+async def test_legacy_unload_unregister_failure_preserves_engine_state(monkeypatch):
+    handler = _make_prefill_handler()
+    original = LoRAInfo(id=123, path="/cache/adapter")
+    handler.loaded_loras = {"adapterA": original}
+    monkeypatch.setattr(
+        handlers_mod,
+        "unregister_model",
+        AsyncMock(side_effect=RuntimeError("discovery is down")),
+    )
+
+    results = [
+        result async for result in handler.unload_lora({"lora_name": "adapterA"})
+    ]
+
+    assert results[-1]["status"] == "error"
+    handler.engine_client.remove_lora.assert_not_awaited()
+    assert handler.loaded_loras["adapterA"] == original

--- a/components/src/dynamo/vllm/tests/test_vllm_lora.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_lora.py
@@ -9,6 +9,7 @@ add_lora<->register_model rollback couplings), and the on_endpoint_ready
 handoff. Everything is mocked: no GPU, no real AsyncLLM, no real discovery.
 """
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
@@ -46,6 +47,7 @@ def _make_lora_engine(enable_lora: bool = True, endpoint=None) -> VllmLLMEngine:
             enable_lora=enable_lora,
             model="/models/base",
             block_size=16,
+            max_loras=4,
         ),
         disaggregation_mode=DisaggregationMode.AGGREGATED,
         served_model_name="base-model",
@@ -161,6 +163,15 @@ def test_resolve_lora_request_for_loaded_adapter():
     assert lora_request.lora_path == "/path/a"
 
 
+def test_request_time_activation_is_tracked_for_unload():
+    engine = _make_lora_engine()
+    engine.loaded_loras = {"adapterA": LoRAInfo(id=7, path="/path/a")}
+
+    engine._track_lora_request_activation(engine._resolve_lora_request("adapterA"))
+
+    assert engine._engine_loaded_loras == {"adapterA"}
+
+
 def test_resolve_lora_request_for_base_is_none(monkeypatch):
     monkeypatch.setattr(llm_engine_mod, "get_lora_manager", lambda: MagicMock())
     engine = _make_lora_engine()
@@ -234,6 +245,7 @@ async def test_generate_passes_resolved_lora_request(monkeypatch):
     ]
     assert captured["kwargs"]["lora_request"] is not None
     assert captured["kwargs"]["lora_request"].lora_name == "adapterA"
+    assert "adapterA" in engine._engine_loaded_loras
 
     # Base-model request -> None.
     _ = [
@@ -263,6 +275,140 @@ async def test_load_lora_happy_path(monkeypatch):
     register.assert_awaited_once()
     assert register.await_args.kwargs["lora_name"] == "adapterA"
     assert engine.loaded_loras["adapterA"].id == 123
+
+
+@pytest.mark.asyncio
+async def test_prefill_load_lora_defers_engine_activation(monkeypatch):
+    """Prefill records and advertises the adapter without eagerly loading it.
+
+    The first inference supplies the cached path through ``LoRARequest`` and
+    lets vLLM activate the adapter on demand. Decode and aggregated workers
+    continue to preload so they are ready to generate immediately.
+    """
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    register, _ = _patch_discovery(monkeypatch)
+
+    result = await engine.load_lora(
+        {"lora_name": "adapterA", "source": {"uri": "file:///x"}}
+    )
+
+    assert result["status"] == "success"
+    engine.engine_client.add_lora.assert_not_awaited()
+    assert engine.loaded_loras["adapterA"] == LoRAInfo(id=123, path="/cache/adapter")
+    register.assert_awaited_once()
+    assert register.await_args.kwargs["worker_type"] == WorkerType.Prefill
+    assert register.await_args.kwargs["needs"] == [[WorkerType.Decode]]
+    assert register.await_args.kwargs["max_gpu_lora_count"] == 4
+
+
+@pytest.mark.asyncio
+async def test_prefill_publish_failure_rolls_back_metadata_only(monkeypatch):
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    register, _ = _patch_discovery(monkeypatch)
+    register.side_effect = RuntimeError("discovery is down")
+
+    result = await engine.load_lora(
+        {"lora_name": "adapterA", "source": {"uri": "file:///x"}}
+    )
+
+    assert result["status"] == "error"
+    assert "adapterA" not in engine.loaded_loras
+    engine.engine_client.add_lora.assert_not_awaited()
+    engine.engine_client.remove_lora.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prefill_inference_uses_lifecycle_registered_lora(monkeypatch):
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    engine._default_sampling_params = SimpleNamespace()
+    engine._model_max_len = None
+    engine._dp_range = None
+    _patch_discovery(monkeypatch)
+
+    load_result = await engine.load_lora(
+        {"lora_name": "adapterA", "source": {"uri": "file:///x"}}
+    )
+    assert load_result["status"] == "success"
+    engine.engine_client.add_lora.assert_not_awaited()
+
+    captured: dict = {}
+
+    async def _empty_gen():
+        return
+        yield  # pragma: no cover
+
+    def _fake_generate(*args, **kwargs):
+        captured["kwargs"] = kwargs
+        return _empty_gen()
+
+    engine.engine_client.generate = _fake_generate
+    monkeypatch.setattr(
+        llm_engine_mod,
+        "build_sampling_params",
+        lambda *a, **k: SimpleNamespace(extra_args=None, max_tokens=10, min_tokens=0),
+    )
+    monkeypatch.setattr(
+        llm_engine_mod.telemetry, "engine_trace_kwargs", lambda context: {}
+    )
+
+    _ = [
+        chunk
+        async for chunk in engine.generate(
+            {"token_ids": [1, 2], "model": "adapterA"},
+            SimpleNamespace(id=lambda: "req-1"),
+        )
+    ]
+
+    lora_request = captured["kwargs"]["lora_request"]
+    assert lora_request.lora_name == "adapterA"
+    assert lora_request.lora_path == "/cache/adapter"
+
+
+@pytest.mark.asyncio
+async def test_prefill_request_admission_serializes_with_unload(monkeypatch):
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    _, unregister = _patch_discovery(monkeypatch)
+    engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+
+    admission_started = asyncio.Event()
+    allow_admission = asyncio.Event()
+    admitted = asyncio.Event()
+
+    async def _blocked_generate(_lora_request):
+        admission_started.set()
+        await allow_admission.wait()
+        admitted.set()
+        yield SimpleNamespace()
+
+    async def _remove_lora(lora_id):
+        assert lora_id == 123
+        assert admitted.is_set()
+
+    engine.engine_client.remove_lora = AsyncMock(side_effect=_remove_lora)
+    admission = engine._generate_with_lora_admission_lock(
+        engine._resolve_lora_request("adapterA"),
+        _blocked_generate,
+    )
+    admission_task = asyncio.create_task(anext(admission))
+    await admission_started.wait()
+
+    unload_task = asyncio.create_task(engine.unload_lora({"lora_name": "adapterA"}))
+    await asyncio.sleep(0)
+    assert not unload_task.done()
+    unregister.assert_not_awaited()
+    assert "adapterA" in engine.loaded_loras
+
+    allow_admission.set()
+    await admission_task
+    result = await unload_task
+    await admission.aclose()
+
+    assert result["status"] == "success"
+    engine.engine_client.remove_lora.assert_awaited_once_with(123)
 
 
 @pytest.mark.asyncio
@@ -503,6 +649,7 @@ async def test_unload_lora_happy_path(monkeypatch):
     _, unregister = _patch_discovery(monkeypatch)
     # Healthy adapter: loaded into the engine AND published to discovery.
     engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._engine_loaded_loras = {"adapterA"}
     engine._published_loras = {"adapterA"}
 
     result = await engine.unload_lora({"lora_name": "adapterA"})
@@ -521,6 +668,7 @@ async def test_unload_lora_unregisters_before_engine_removal(monkeypatch):
     engine = _make_lora_engine(endpoint=object())
     _, unregister = _patch_discovery(monkeypatch)
     engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._engine_loaded_loras = {"adapterA"}
     engine._published_loras = {"adapterA"}
 
     order: list[str] = []
@@ -540,6 +688,7 @@ async def test_unload_lora_loaded_but_unpublished_skips_unregister(monkeypatch):
     engine = _make_lora_engine(endpoint=object())
     _, unregister = _patch_discovery(monkeypatch)
     engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._engine_loaded_loras = {"adapterA"}
     # _published_loras intentionally empty.
 
     result = await engine.unload_lora({"lora_name": "adapterA"})
@@ -567,6 +716,7 @@ async def test_unload_lora_happy_path_clears_published(monkeypatch):
     engine = _make_lora_engine(endpoint=object())
     _, unregister = _patch_discovery(monkeypatch)
     engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._engine_loaded_loras = {"adapterA"}
     engine._published_loras = {"adapterA"}
 
     result = await engine.unload_lora({"lora_name": "adapterA"})
@@ -623,6 +773,7 @@ async def test_unload_lora_engine_removal_failure_after_unregister(monkeypatch):
     _, unregister = _patch_discovery(monkeypatch)
     engine.engine_client.remove_lora.side_effect = RuntimeError("engine wedged")
     engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._engine_loaded_loras = {"adapterA"}
     engine._published_loras = {"adapterA"}
 
     result = await engine.unload_lora({"lora_name": "adapterA"})
@@ -632,6 +783,59 @@ async def test_unload_lora_engine_removal_failure_after_unregister(monkeypatch):
     unregister.assert_awaited_once()
     assert "adapterA" not in engine._published_loras
     assert "adapterA" in engine.loaded_loras
+
+
+@pytest.mark.asyncio
+async def test_prefill_unload_skips_engine_removal_for_metadata_only_adapter(
+    monkeypatch,
+):
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    _, unregister = _patch_discovery(monkeypatch)
+
+    load_result = await engine.load_lora(
+        {"lora_name": "adapterA", "source": {"uri": "file:///x"}}
+    )
+    result = await engine.unload_lora({"lora_name": "adapterA"})
+
+    assert load_result["status"] == "success"
+    assert result["status"] == "success"
+    unregister.assert_awaited_once()
+    engine.engine_client.add_lora.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_prefill_unload_removes_request_activated_adapter(monkeypatch):
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    _, unregister = _patch_discovery(monkeypatch)
+    engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._published_loras = {"adapterA"}
+    engine._track_lora_request_activation(engine._resolve_lora_request("adapterA"))
+
+    result = await engine.unload_lora({"lora_name": "adapterA"})
+
+    assert result["status"] == "success"
+    unregister.assert_awaited_once()
+    engine.engine_client.remove_lora.assert_awaited_once_with(123)
+
+
+@pytest.mark.asyncio
+async def test_prefill_unload_treats_missing_request_adapter_as_idempotent(monkeypatch):
+    engine = _make_lora_engine(endpoint=object())
+    engine.disaggregation_mode = DisaggregationMode.PREFILL
+    _, unregister = _patch_discovery(monkeypatch)
+    engine.loaded_loras = {"adapterA": LoRAInfo(id=123, path="/cache/adapter")}
+    engine._published_loras = {"adapterA"}
+    engine._engine_loaded_loras = {"adapterA"}
+    engine.engine_client.remove_lora.side_effect = RuntimeError("adapter not found")
+
+    result = await engine.unload_lora({"lora_name": "adapterA"})
+
+    assert result["status"] == "success"
+    unregister.assert_awaited_once()
+    assert "adapterA" not in engine.loaded_loras
+    engine.engine_client.remove_lora.assert_awaited_once_with(123)
 
 
 # --------------------------------------------------------------------------- #

--- a/components/src/dynamo/vllm/tests/test_vllm_unit.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_unit.py
@@ -4,6 +4,7 @@
 """Unit tests for vLLM backend components."""
 
 import asyncio
+import importlib
 import json
 import re
 import socket
@@ -15,6 +16,7 @@ from unittest.mock import patch
 
 import pytest
 
+import dynamo.llm as dynamo_llm
 from dynamo.vllm.args import (
     _connector_to_kv_transfer_json,
     _is_routable,
@@ -53,6 +55,24 @@ pytestmark = [
 # Create vLLM-specific CLI args fixture
 # This will use monkeypatch to write to argv
 mock_vllm_cli = make_cli_args_fixture("dynamo.vllm")
+
+
+@pytest.mark.parametrize(
+    "enable_lora, model_type, expected",
+    [
+        (True, dynamo_llm.ModelType.Prefill, 3),
+        (True, dynamo_llm.ModelType.Chat, 3),
+        (True, dynamo_llm.ModelType.Embedding, None),
+        (False, dynamo_llm.ModelType.Prefill, None),
+    ],
+)
+def test_base_model_lora_capacity(enable_lora, model_type, expected):
+    config = SimpleNamespace(
+        engine_args=SimpleNamespace(enable_lora=enable_lora, max_loras=3)
+    )
+
+    vllm_main = importlib.import_module("dynamo.vllm.main")
+    assert vllm_main._base_model_lora_capacity(config, model_type) == expected
 
 
 def test_custom_jinja_template_invalid_path(mock_vllm_cli):

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_factory.py
@@ -4,6 +4,7 @@
 """Unit tests for worker_factory.py"""
 
 import asyncio
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -241,17 +242,20 @@ class TestPrefillRegistrationContract:
             model="m",
             frontend_decoding=False,
             enable_multimodal=False,
+            enable_rl=False,
+            engine_args=SimpleNamespace(enable_lora=True),
         )
 
         runtime = Mock()
         runtime.endpoint.return_value = Mock(connection_id=Mock(return_value="cid"))
+        shutdown_endpoints: list = []
 
         with pytest.raises(RuntimeError, match="stop-after-register"):
             await factory._create_prefill_worker(
                 runtime,
                 config,
                 asyncio.Event(),
-                [],
+                shutdown_endpoints,
             )
 
         assert captured["model_input"] == ModelInput.Tokens
@@ -263,3 +267,101 @@ class TestPrefillRegistrationContract:
         if route_to_encoder:
             expected_needs_set.append(WorkerType.Encode)
         assert captured["needs"] == [expected_needs_set]
+        endpoint_names = [call.args[0] for call in runtime.endpoint.call_args_list]
+        assert "dyn.prefill.load_lora" in endpoint_names
+        assert "dyn.prefill.unload_lora" in endpoint_names
+        assert "dyn.prefill.list_loras" in endpoint_names
+        # generate, clear, perf, and all three LoRA lifecycle endpoints.
+        assert len(shutdown_endpoints) == 6
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("lora_enabled", [True, False])
+async def test_prefill_serves_lora_lifecycle_endpoints_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+    lora_enabled: bool,
+) -> None:
+    engine_client = Mock()
+    vllm_config = Mock(additional_config={})
+    engine_tuple: EngineSetupResult = (
+        engine_client,
+        vllm_config,
+        Mock(),
+        "/tmp/prom",
+        Mock(),
+    )
+    factory = WorkerFactory(
+        setup_vllm_engine_fn=Mock(return_value=engine_tuple),
+        setup_kv_event_publisher_fn=Mock(return_value=None),
+        register_vllm_model_fn=AsyncMock(),
+        setup_fpm_relay_fn=Mock(return_value=None),
+        setup_metrics_collection_fn=Mock(),
+    )
+    factory._maybe_get_encode_worker_client = AsyncMock(return_value=None)  # type: ignore[assignment]
+    factory._maybe_wait_for_failover_lock = AsyncMock()  # type: ignore[assignment]
+    factory.register_engine_routes = Mock()  # type: ignore[assignment]
+
+    handler = Mock(embedding_cache_manager=None)
+    handler.cleanup = Mock()
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.PrefillWorkerHandler",
+        Mock(return_value=handler),
+    )
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.VllmPrefillHealthCheckPayload",
+        Mock(return_value=Mock(to_dict=Mock(return_value={}))),
+    )
+
+    async def _noop(*_args, **_kwargs) -> None:
+        return None
+
+    monkeypatch.setattr(
+        "dynamo.vllm.worker_factory.configure_kv_event_block_size", _noop
+    )
+
+    endpoints: dict[str, Mock] = {}
+
+    def _endpoint(name: str) -> Mock:
+        endpoint = Mock(connection_id=Mock(return_value="cid"))
+        endpoint.serve_endpoint = AsyncMock(return_value=None)
+        endpoints[name] = endpoint
+        return endpoint
+
+    runtime = Mock()
+    runtime.endpoint.side_effect = _endpoint
+    config = _make_config(
+        disaggregation_mode=DisaggregationMode.PREFILL,
+        route_to_encoder=False,
+        use_vllm_tokenizer=False,
+        namespace="dyn",
+        component="prefill",
+        endpoint="generate",
+        served_model_name="m",
+        model="m",
+        frontend_decoding=False,
+        enable_multimodal=False,
+        enable_rl=False,
+        engine_args=SimpleNamespace(enable_lora=lora_enabled),
+    )
+    shutdown_endpoints: list = []
+
+    await factory._create_prefill_worker(
+        runtime,
+        config,
+        asyncio.Event(),
+        shutdown_endpoints,
+    )
+
+    lifecycle_names = {
+        "dyn.prefill.load_lora",
+        "dyn.prefill.unload_lora",
+        "dyn.prefill.list_loras",
+    }
+    if lora_enabled:
+        assert lifecycle_names <= endpoints.keys()
+        for name in lifecycle_names:
+            endpoints[name].serve_endpoint.assert_awaited_once()
+        assert len(shutdown_endpoints) == 6
+    else:
+        assert lifecycle_names.isdisjoint(endpoints)
+        assert len(shutdown_endpoints) == 3

--- a/components/src/dynamo/vllm/worker_factory.py
+++ b/components/src/dynamo/vllm/worker_factory.py
@@ -682,6 +682,17 @@ class WorkerFactory:
             if config.enable_rl
             else None
         )
+        lora_enabled = config.engine_args.enable_lora
+        if lora_enabled:
+            load_lora_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.load_lora"
+            )
+            unload_lora_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.unload_lora"
+            )
+            list_loras_endpoint = runtime.endpoint(
+                f"{config.namespace}.{config.component}.list_loras"
+            )
 
         # Use pre-created engine if provided (checkpoint mode), otherwise create new
         fpm_worker_id = str(generate_endpoint.connection_id())
@@ -790,6 +801,10 @@ class WorkerFactory:
         shutdown_endpoints[:] = [generate_endpoint, clear_endpoint, perf_endpoint]
         if rl_endpoint is not None:
             shutdown_endpoints.append(rl_endpoint)
+        if lora_enabled:
+            shutdown_endpoints.extend(
+                [load_lora_endpoint, unload_lora_endpoint, list_loras_endpoint]
+            )
 
         # Prefill workers expose no OpenAI surface — the role is carried by
         # `worker_type=Prefill`. We register the legacy `ModelType.Prefill`
@@ -856,6 +871,23 @@ class WorkerFactory:
                         handler.rl_dispatch,
                         metrics_labels=prefill_metrics_labels,
                     )
+                )
+            if lora_enabled:
+                serve_tasks.extend(
+                    [
+                        load_lora_endpoint.serve_endpoint(
+                            handler.load_lora,
+                            metrics_labels=prefill_metrics_labels,
+                        ),
+                        unload_lora_endpoint.serve_endpoint(
+                            handler.unload_lora,
+                            metrics_labels=prefill_metrics_labels,
+                        ),
+                        list_loras_endpoint.serve_endpoint(
+                            handler.list_loras,
+                            metrics_labels=prefill_metrics_labels,
+                        ),
+                    ]
                 )
             await asyncio.gather(*serve_tasks)
             logger.debug("serve_endpoint completed for prefill worker")

--- a/deploy/operator/api/v1alpha1/dynamo_model_types.go
+++ b/deploy/operator/api/v1alpha1/dynamo_model_types.go
@@ -68,10 +68,16 @@ type EndpointInfo struct {
 	// +optional
 	PodName string `json:"podName,omitempty"`
 
-	// Ready indicates whether the endpoint is ready to serve traffic
-	// For LoRA models: true if the POST /loras request succeeded with a 2xx status code
-	// For base models: always false (no probing performed)
+	// Ready indicates whether this endpoint is ready to serve traffic.
+	// For LoRA models: true only if this endpoint's lifecycle request succeeded.
+	// For base models: always false (no probing performed).
 	Ready bool `json:"ready"`
+
+	// LoRAFallbackCovered indicates a legacy prefill endpoint that cannot manage
+	// LoRAs itself is covered by a capable prefill in the same topology during a
+	// rolling upgrade. It does not make this endpoint ready to serve the adapter.
+	// +optional
+	LoRAFallbackCovered bool `json:"loraFallbackCovered,omitempty"`
 }
 
 // DynamoModelStatus defines the observed state of DynamoModel
@@ -82,6 +88,12 @@ type DynamoModelStatus struct {
 
 	// ReadyEndpoints is the count of endpoints that are ready
 	ReadyEndpoints int `json:"readyEndpoints"`
+
+	// LoRAFallbackCoveredEndpoints is the count of legacy prefill endpoints
+	// covered by a capable prefill during a rolling upgrade. These endpoints are
+	// excluded from ReadyEndpoints because they cannot serve the adapter directly.
+	// +optional
+	LoRAFallbackCoveredEndpoints int `json:"loraFallbackCoveredEndpoints,omitempty"`
 
 	// TotalEndpoints is the total count of endpoints
 	TotalEndpoints int `json:"totalEndpoints"`
@@ -154,11 +166,12 @@ func (m *DynamoModel) IsReady() (bool, string) {
 	if m.Status.TotalEndpoints == 0 {
 		return false, "No endpoints configured"
 	}
-	if m.Status.ReadyEndpoints == 0 {
+	effectiveReadyEndpoints := m.Status.ReadyEndpoints + m.Status.LoRAFallbackCoveredEndpoints
+	if effectiveReadyEndpoints == 0 {
 		return false, "No endpoints ready"
 	}
-	if m.Status.ReadyEndpoints < m.Status.TotalEndpoints {
-		return false, fmt.Sprintf("Only %d/%d endpoints ready", m.Status.ReadyEndpoints, m.Status.TotalEndpoints)
+	if effectiveReadyEndpoints < m.Status.TotalEndpoints {
+		return false, fmt.Sprintf("Only %d/%d endpoints ready", effectiveReadyEndpoints, m.Status.TotalEndpoints)
 	}
 	return true, ""
 }

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamomodels.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamomodels.yaml
@@ -166,20 +166,32 @@ spec:
                       address:
                         description: Address is the full address of the endpoint (e.g., "http://10.0.1.5:9090")
                         type: string
+                      loraFallbackCovered:
+                        description: |-
+                          LoRAFallbackCovered indicates a legacy prefill endpoint that cannot manage
+                          LoRAs itself is covered by a capable prefill in the same topology during a
+                          rolling upgrade. It does not make this endpoint ready to serve the adapter.
+                        type: boolean
                       podName:
                         description: PodName is the name of the pod serving this endpoint
                         type: string
                       ready:
                         description: |-
-                          Ready indicates whether the endpoint is ready to serve traffic
-                          For LoRA models: true if the POST /loras request succeeded with a 2xx status code
-                          For base models: always false (no probing performed)
+                          Ready indicates whether this endpoint is ready to serve traffic.
+                          For LoRA models: true only if this endpoint's lifecycle request succeeded.
+                          For base models: always false (no probing performed).
                         type: boolean
                     required:
                       - address
                       - ready
                     type: object
                   type: array
+                loraFallbackCoveredEndpoints:
+                  description: |-
+                    LoRAFallbackCoveredEndpoints is the count of legacy prefill endpoints
+                    covered by a capable prefill during a rolling upgrade. These endpoints are
+                    excluded from ReadyEndpoints because they cannot serve the adapter directly.
+                  type: integer
                 readyEndpoints:
                   description: ReadyEndpoints is the count of endpoints that are ready
                   type: integer

--- a/deploy/operator/internal/controller/dynamo_model_controller.go
+++ b/deploy/operator/internal/controller/dynamo_model_controller.go
@@ -78,6 +78,7 @@ type DynamoModelReconciler struct {
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamomodels,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamomodels/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=nvidia.com,resources=dynamomodels/finalizers,verbs=update
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=services,verbs=get;list;watch
 // +kubebuilder:rbac:groups=discovery.k8s.io,resources=endpointslices,verbs=get;list;watch
 
@@ -126,6 +127,7 @@ func (r *DynamoModelReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 		model.Status.Endpoints = nil
 		model.Status.TotalEndpoints = 0
 		model.Status.ReadyEndpoints = 0
+		model.Status.LoRAFallbackCoveredEndpoints = 0
 		if err := r.Status().Update(ctx, model); err != nil {
 			return ctrl.Result{}, err
 		}
@@ -137,11 +139,12 @@ func (r *DynamoModelReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	allEndpoints, probeErr := r.EndpointClient.LoadLoRA(ctx, candidates, model)
 
 	// Determine if we need to requeue based on model type
-	// For LoRA models: requeue if there were probe errors OR if not all endpoints are ready
+	// For LoRA models: requeue if there were probe errors OR if not all endpoints
+	// are directly ready or covered by a capable prefill during a rolling upgrade.
 	// For base models: only requeue if there were probe errors (Ready is expected to be false)
 	hasFailures := probeErr != nil
 	if model.IsLoRA() {
-		hasFailures = hasFailures || countReadyEndpoints(allEndpoints) < len(allEndpoints)
+		hasFailures = hasFailures || countServingEndpoints(allEndpoints) < len(allEndpoints)
 	}
 
 	if probeErr != nil {
@@ -163,18 +166,21 @@ func (r *DynamoModelReconciler) Reconcile(ctx context.Context, req ctrl.Request)
 	model.Status.Endpoints = allEndpoints
 	model.Status.TotalEndpoints = len(allEndpoints)
 	model.Status.ReadyEndpoints = countReadyEndpoints(allEndpoints)
+	model.Status.LoRAFallbackCoveredEndpoints = countLoRAFallbackCoveredEndpoints(allEndpoints)
 
 	// Update conditions based on model type
 	if model.IsLoRA() {
-		// For LoRA models, check readiness - condition is True only when ALL endpoints are ready
-		if model.Status.ReadyEndpoints == model.Status.TotalEndpoints && model.Status.TotalEndpoints > 0 {
+		// For LoRA models, the model is ready only when every endpoint is
+		// directly ready or a legacy prefill is covered by a capable peer. Keep
+		// ReadyEndpoints truthful: it counts only endpoints that serve directly.
+		if countServingEndpoints(allEndpoints) == model.Status.TotalEndpoints && model.Status.TotalEndpoints > 0 {
 			r.updateCondition(model, ConditionTypeEndpointsReady, metav1.ConditionTrue, ReasonAllEndpointsReady,
-				fmt.Sprintf("All %d endpoint(s) are ready", model.Status.TotalEndpoints))
+				fmt.Sprintf("All %d endpoint(s) are ready or covered by a capable prefill", model.Status.TotalEndpoints))
 			r.Recorder.Eventf(model, corev1.EventTypeNormal, "EndpointsReady",
-				"All %d endpoints ready for base model %s", model.Status.TotalEndpoints, model.Spec.BaseModelName)
+				"All %d endpoints ready or fallback-covered for base model %s", model.Status.TotalEndpoints, model.Spec.BaseModelName)
 		} else if model.Status.TotalEndpoints > 0 {
 			r.updateCondition(model, ConditionTypeEndpointsReady, metav1.ConditionFalse, ReasonNotReady,
-				fmt.Sprintf("Found %d ready endpoint(s) out of %d total", model.Status.ReadyEndpoints, model.Status.TotalEndpoints))
+				fmt.Sprintf("Found %d ready endpoint(s) and %d fallback-covered endpoint(s) out of %d total", model.Status.ReadyEndpoints, model.Status.LoRAFallbackCoveredEndpoints, model.Status.TotalEndpoints))
 			r.Recorder.Eventf(model, corev1.EventTypeWarning, "NotReady",
 				"Only %d of %d endpoints ready for base model %s", model.Status.ReadyEndpoints, model.Status.TotalEndpoints, model.Spec.BaseModelName)
 		} else {
@@ -221,6 +227,76 @@ func countReadyEndpoints(endpoints []v1alpha1.EndpointInfo) int {
 		}
 	}
 	return count
+}
+
+// countLoRAFallbackCoveredEndpoints counts legacy prefill endpoints covered by
+// a capable prefill during a rolling upgrade. These are intentionally separate
+// from ready endpoints because they do not serve the adapter themselves.
+func countLoRAFallbackCoveredEndpoints(endpoints []v1alpha1.EndpointInfo) int {
+	count := 0
+	for _, ep := range endpoints {
+		if ep.LoRAFallbackCovered {
+			count++
+		}
+	}
+	return count
+}
+
+// countServingEndpoints counts endpoints ready to serve directly plus legacy
+// prefill endpoints covered by a capable prefill in the same topology.
+func countServingEndpoints(endpoints []v1alpha1.EndpointInfo) int {
+	return countReadyEndpoints(endpoints) + countLoRAFallbackCoveredEndpoints(endpoints)
+}
+
+func withPodIdentity(candidate modelendpoint.Candidate, pod *corev1.Pod) modelendpoint.Candidate {
+	identified := candidate
+	identified.KubernetesReady = false
+	for _, condition := range pod.Status.Conditions {
+		if condition.Type == corev1.PodReady {
+			identified.KubernetesReady = condition.Status == corev1.ConditionTrue
+			break
+		}
+	}
+	identified.WorkloadName = ""
+	if graphName := pod.Labels[consts.KubeLabelDynamoGraphDeploymentName]; graphName != "" {
+		identified.GraphDeploymentName = graphName
+	}
+	if componentDeployment := pod.Labels[consts.KubeLabelDynamoSelector]; componentDeployment != "" {
+		identified.WorkloadName = componentDeployment
+	} else {
+		for _, owner := range pod.OwnerReferences {
+			if owner.Controller != nil && *owner.Controller {
+				identified.WorkloadName = owner.Name
+				break
+			}
+		}
+	}
+
+	componentType := pod.Labels[consts.KubeLabelDynamoComponentType]
+	if componentType == consts.ComponentTypeWorker {
+		componentType = pod.Labels[consts.KubeLabelDynamoSubComponentType]
+	}
+	if componentType != consts.ComponentTypePrefill {
+		return identified
+	}
+	for i := range pod.Spec.Containers {
+		container := &pod.Spec.Containers[i]
+		if container.Name != consts.MainContainerName {
+			continue
+		}
+		backend, err := dynamo.DetectBackendFrameworkFromArgs(container.Command, container.Args)
+		if err != nil || backend != dynamo.BackendFrameworkVLLM {
+			return identified
+		}
+		if identified.GraphDeploymentName != "" {
+			identified.LoRAFallbackGroup = "graph:" + identified.GraphDeploymentName
+		} else if identified.WorkloadName != "" {
+			identified.LoRAFallbackGroup = "workload:" + identified.WorkloadName
+		}
+		identified.AllowLoRAManagementUnavailable = identified.LoRAFallbackGroup != ""
+		return identified
+	}
+	return identified
 }
 
 // updateCondition updates or adds a condition to the model's status
@@ -373,6 +449,20 @@ func (r *DynamoModelReconciler) getEndpointCandidates(
 
 	// Extract pod-ready endpoint candidates from all EndpointSlices
 	candidates, serviceNames := modelendpoint.ExtractCandidates(endpointSlices, int32(consts.DynamoSystemPort))
+	if model.IsLoRA() && len(candidates) > 0 {
+		for i := range candidates {
+			pod := &corev1.Pod{}
+			if err := r.Get(ctx, client.ObjectKey{Namespace: model.Namespace, Name: candidates[i].PodName}, pod); err != nil {
+				if k8serrors.IsNotFound(err) {
+					candidates[i].KubernetesReady = false
+					continue
+				}
+				logs.Error(err, "Failed to get endpoint pod for LoRA lifecycle classification", "podName", candidates[i].PodName)
+				return nil, nil, err
+			}
+			candidates[i] = withPodIdentity(candidates[i], pod)
+		}
+	}
 
 	return candidates, serviceNames, nil
 }

--- a/deploy/operator/internal/controller/dynamo_model_controller_unit_test.go
+++ b/deploy/operator/internal/controller/dynamo_model_controller_unit_test.go
@@ -1,0 +1,163 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/modelendpoint"
+)
+
+func TestWithPodIdentityClassifiesLoRAFallback(t *testing.T) {
+	tests := []struct {
+		name      string
+		labels    map[string]string
+		command   []string
+		args      []string
+		wantAllow bool
+		wantGroup string
+	}{
+		{
+			name: "vLLM prefill in graph",
+			labels: map[string]string{
+				consts.KubeLabelDynamoComponentType:       consts.ComponentTypePrefill,
+				consts.KubeLabelDynamoGraphDeploymentName: "graph",
+			},
+			command:   []string{"python3", "-m", "dynamo.vllm"},
+			wantAllow: true,
+			wantGroup: "graph:graph",
+		},
+		{
+			name: "legacy vLLM prefill workload",
+			labels: map[string]string{
+				consts.KubeLabelDynamoComponentType:    consts.ComponentTypeWorker,
+				consts.KubeLabelDynamoSubComponentType: consts.ComponentTypePrefill,
+				consts.KubeLabelDynamoSelector:         "standalone-prefill",
+			},
+			command:   []string{"python3"},
+			args:      []string{"-m", "dynamo.vllm"},
+			wantAllow: true,
+			wantGroup: "workload:standalone-prefill",
+		},
+		{
+			name: "vLLM decode",
+			labels: map[string]string{
+				consts.KubeLabelDynamoComponentType:       consts.ComponentTypeDecode,
+				consts.KubeLabelDynamoGraphDeploymentName: "graph",
+			},
+			command: []string{"python3", "-m", "dynamo.vllm"},
+		},
+		{
+			name: "SGLang prefill",
+			labels: map[string]string{
+				consts.KubeLabelDynamoComponentType:       consts.ComponentTypePrefill,
+				consts.KubeLabelDynamoGraphDeploymentName: "graph",
+			},
+			command: []string{"python3", "-m", "dynamo.sglang"},
+		},
+		{
+			name: "vLLM prefill without topology",
+			labels: map[string]string{
+				consts.KubeLabelDynamoComponentType: consts.ComponentTypePrefill,
+			},
+			command: []string{"python3", "-m", "dynamo.vllm"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Labels: tt.labels},
+				Spec: corev1.PodSpec{Containers: []corev1.Container{{
+					Name:    consts.MainContainerName,
+					Command: tt.command,
+					Args:    tt.args,
+				}}},
+			}
+			identified := withPodIdentity(modelendpoint.Candidate{}, pod)
+			if identified.AllowLoRAManagementUnavailable != tt.wantAllow || identified.LoRAFallbackGroup != tt.wantGroup {
+				t.Fatalf("unexpected fallback classification: %#v", identified)
+			}
+		})
+	}
+}
+
+func TestWithPodIdentityFillsSharedModelSliceMetadata(t *testing.T) {
+	candidate := modelendpoint.Candidate{PodName: "prefill-0"}
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+		consts.KubeLabelDynamoSelector:            "graph-prefill-hash",
+		consts.KubeLabelDynamoComponent:           "prefill",
+		consts.KubeLabelDynamoGraphDeploymentName: "graph",
+	}}}
+
+	identified := withPodIdentity(candidate, pod)
+	if identified.WorkloadName != "graph-prefill-hash" || identified.GraphDeploymentName != "graph" {
+		t.Fatalf("expected pod identity fallback, got %#v", identified)
+	}
+	if candidate.WorkloadName != "" || candidate.GraphDeploymentName != "" {
+		t.Fatal("pod identity fallback must not mutate the input candidate")
+	}
+}
+
+func TestWithPodIdentityUsesControllerOwnerWhenSelectorIsAbsent(t *testing.T) {
+	controller := true
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+		Labels: map[string]string{
+			consts.KubeLabelDynamoComponent:           "prefill",
+			consts.KubeLabelDynamoGraphDeploymentName: "graph",
+		},
+		OwnerReferences: []metav1.OwnerReference{{
+			Kind:       "LeaderWorkerSet",
+			Name:       "graph-prefill-hash",
+			Controller: &controller,
+		}},
+	}}
+
+	identified := withPodIdentity(modelendpoint.Candidate{PodName: "prefill-0"}, pod)
+	if identified.WorkloadName != "graph-prefill-hash" {
+		t.Fatalf("expected controller owner identity fallback, got %#v", identified)
+	}
+}
+
+func TestWithPodIdentityUsesActualPodReadiness(t *testing.T) {
+	tests := []struct {
+		name      string
+		condition corev1.ConditionStatus
+		ready     bool
+	}{
+		{name: "ready", condition: corev1.ConditionTrue, ready: true},
+		{name: "not ready", condition: corev1.ConditionFalse, ready: false},
+		{name: "unknown", condition: corev1.ConditionUnknown, ready: false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pod := &corev1.Pod{Status: corev1.PodStatus{Conditions: []corev1.PodCondition{{
+				Type:   corev1.PodReady,
+				Status: tt.condition,
+			}}}}
+			identified := withPodIdentity(modelendpoint.Candidate{KubernetesReady: !tt.ready}, pod)
+			if identified.KubernetesReady != tt.ready {
+				t.Fatalf("expected readiness %t from Pod condition, got %#v", tt.ready, identified)
+			}
+		})
+	}
+}

--- a/deploy/operator/internal/dynamo/graph.go
+++ b/deploy/operator/internal/dynamo/graph.go
@@ -2731,8 +2731,8 @@ func generateAnnotations(component *v1beta1.DynamoComponentDeploymentSharedSpec,
 	return annotations, nil
 }
 
-// detectBackendFrameworkFromArgs detects the backend framework from command/args
-func detectBackendFrameworkFromArgs(command []string, args []string) (BackendFramework, error) {
+// DetectBackendFrameworkFromArgs detects the backend framework from command/args.
+func DetectBackendFrameworkFromArgs(command []string, args []string) (BackendFramework, error) {
 	// Combine command and args to search through all parts
 	allParts := append(command, args...)
 	fullCommand := strings.Join(allParts, " ")
@@ -2781,7 +2781,7 @@ func determineBackendFramework(
 
 	// Try to detect from command/args
 	if len(command) > 0 || len(args) > 0 {
-		detected, err := detectBackendFrameworkFromArgs(command, args)
+		detected, err := DetectBackendFrameworkFromArgs(command, args)
 		if err == nil {
 			detectedFramework = detected
 		} else {

--- a/deploy/operator/internal/dynamo/graph_test.go
+++ b/deploy/operator/internal/dynamo/graph_test.go
@@ -5081,7 +5081,7 @@ func TestDetectBackendFrameworkFromArgs(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := detectBackendFrameworkFromArgs(tt.command, tt.args)
+			result, err := DetectBackendFrameworkFromArgs(tt.command, tt.args)
 
 			if tt.expectError {
 				if err == nil {

--- a/deploy/operator/internal/modelendpoint/client.go
+++ b/deploy/operator/internal/modelendpoint/client.go
@@ -43,11 +43,19 @@ type Client struct {
 	httpClient *http.Client
 }
 
+type loadLoRAResult struct {
+	endpoint                v1alpha1.EndpointInfo
+	usedUnavailableFallback bool
+}
+
 // NewClient creates a new model endpoint client
 func NewClient() *Client {
 	return &Client{
 		httpClient: &http.Client{
 			Timeout: RequestTimeout,
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
 		},
 	}
 }
@@ -86,41 +94,78 @@ func (c *Client) LoadLoRA(
 	}
 
 	// Build tasks for the worker pool
-	tasks := make([]workerpool.Task[v1alpha1.EndpointInfo], len(candidates))
+	tasks := make([]workerpool.Task[loadLoRAResult], len(candidates))
 	for i, candidate := range candidates {
-		tasks[i] = workerpool.Task[v1alpha1.EndpointInfo]{
+		tasks[i] = workerpool.Task[loadLoRAResult]{
 			Index: i,
-			Work: func(ctx context.Context) (v1alpha1.EndpointInfo, error) {
-				// Load the LoRA on this endpoint (idempotent operation)
+			Work: func(ctx context.Context) (loadLoRAResult, error) {
+				// Always try the lifecycle call first. New vLLM prefill workers
+				// implement it and publish the adapter's prefill model card. During
+				// a rolling upgrade, an explicitly unsupported old prefill worker
+				// may use the narrow compatibility fallback below.
 				err := c.loadLoRA(ctx, candidate.Address, model.Spec.ModelName, sourceURI)
+				if err != nil && candidate.AllowLoRAManagementUnavailable && isLoRAManagementUnavailable(err) {
+					return loadLoRAResult{
+						endpoint: v1alpha1.EndpointInfo{
+							Address: candidate.Address,
+							PodName: candidate.PodName,
+						},
+						usedUnavailableFallback: true,
+					}, nil
+				}
+
 				ready := err == nil
 
-				return v1alpha1.EndpointInfo{
-					Address: candidate.Address,
-					PodName: candidate.PodName,
-					Ready:   ready,
+				return loadLoRAResult{
+					endpoint: v1alpha1.EndpointInfo{
+						Address: candidate.Address,
+						PodName: candidate.PodName,
+						Ready:   ready,
+					},
 				}, err
 			},
 		}
 	}
 
 	// Execute all load operations in parallel with bounded concurrency
-	results, err := workerpool.Execute(ctx, MaxConcurrentOperations, TotalTimeout, tasks)
+	results, _ := workerpool.Execute(ctx, MaxConcurrentOperations, TotalTimeout, tasks)
 
 	// Extract endpoint info from results and collect failures
 	endpoints := make([]v1alpha1.EndpointInfo, len(results))
+	capableVLLMPrefillGroups := make(map[string]struct{})
+	fallbackUsedCount := 0
+	for _, result := range results {
+		candidate := candidates[result.Index]
+		endpoints[result.Index] = result.Value.endpoint
+		if result.Value.usedUnavailableFallback {
+			fallbackUsedCount++
+		} else if candidate.AllowLoRAManagementUnavailable && candidate.LoRAFallbackGroup != "" && result.Value.endpoint.Ready {
+			capableVLLMPrefillGroups[candidate.LoRAFallbackGroup] = struct{}{}
+		}
+	}
+
 	readyCount := 0
+	failureCount := 0
 	var notReadyEndpoints []string
 	for _, result := range results {
-		endpoints[result.Index] = result.Value
-		if result.Value.Ready {
+		candidate := candidates[result.Index]
+		endpoint := &endpoints[result.Index]
+		if result.Value.usedUnavailableFallback {
+			// A legacy prefill can be non-serving only when another capable
+			// vLLM prefill in the same runtime topology published the adapter card.
+			_, covered := capableVLLMPrefillGroups[candidate.LoRAFallbackGroup]
+			endpoint.LoRAFallbackCovered = candidate.LoRAFallbackGroup != "" && covered && candidate.KubernetesReady
+		}
+
+		if endpoint.Ready || endpoint.LoRAFallbackCovered {
 			readyCount++
 		} else {
-			notReadyEndpoints = append(notReadyEndpoints, result.Value.Address)
+			failureCount++
+			notReadyEndpoints = append(notReadyEndpoints, endpoint.Address)
 			if result.Err != nil {
 				logs.Info("Endpoint load operation failed",
-					"address", result.Value.Address,
-					"podName", result.Value.PodName,
+					"address", endpoint.Address,
+					"podName", endpoint.PodName,
 					"error", result.Err)
 			}
 		}
@@ -130,9 +175,14 @@ func (c *Client) LoadLoRA(
 		"total", len(endpoints),
 		"ready", readyCount,
 		"notReady", len(notReadyEndpoints),
+		"loraManagementUnavailableFallbackUsed", fallbackUsedCount,
+		"capableVLLMPrefillGroups", len(capableVLLMPrefillGroups),
 		"notReadyEndpoints", notReadyEndpoints)
 
-	return endpoints, err
+	if failureCount > 0 {
+		return endpoints, fmt.Errorf("%d task(s) failed", failureCount)
+	}
+	return endpoints, nil
 }
 
 // UnloadLoRA unloads a LoRA model from all endpoints in parallel
@@ -152,8 +202,10 @@ func (c *Client) UnloadLoRA(ctx context.Context, candidates []Candidate, modelNa
 		tasks[i] = workerpool.Task[bool]{
 			Index: i,
 			Work: func(ctx context.Context) (bool, error) {
-				// Unload the LoRA from this endpoint (calls method in lora.go)
 				err := c.unloadLoRA(ctx, candidate.Address, modelName)
+				if err != nil && candidate.AllowLoRAManagementUnavailable && isLoRAManagementUnavailable(err) {
+					return true, nil
+				}
 				if err != nil {
 					return false, err
 				}
@@ -163,15 +215,22 @@ func (c *Client) UnloadLoRA(ctx context.Context, candidates []Candidate, modelNa
 	}
 
 	// Execute all unload operations in parallel with bounded concurrency
-	results, err := workerpool.Execute(ctx, MaxConcurrentOperations, TotalTimeout, tasks)
+	results, _ := workerpool.Execute(ctx, MaxConcurrentOperations, TotalTimeout, tasks)
 
 	// Collect successes and failures with details
 	successCount := 0
+	failureCount := 0
+	fallbackEligibleCount := 0
 	var failedEndpoints []string
 	for _, result := range results {
+		if candidates[result.Index].AllowLoRAManagementUnavailable {
+			fallbackEligibleCount++
+		}
+
 		if result.Value {
 			successCount++
 		} else {
+			failureCount++
 			// Log failed endpoint with error details
 			endpoint := candidates[result.Index].Address
 			failedEndpoints = append(failedEndpoints, endpoint)
@@ -185,8 +244,12 @@ func (c *Client) UnloadLoRA(ctx context.Context, candidates []Candidate, modelNa
 	logs.Info("Completed parallel LoRA unload",
 		"total", len(candidates),
 		"successful", successCount,
+		"loraManagementUnavailableFallbackEligible", fallbackEligibleCount,
 		"failed", len(failedEndpoints),
 		"failedEndpoints", failedEndpoints)
 
-	return err
+	if failureCount > 0 {
+		return fmt.Errorf("%d task(s) failed", failureCount)
+	}
+	return nil
 }

--- a/deploy/operator/internal/modelendpoint/client_test.go
+++ b/deploy/operator/internal/modelendpoint/client_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -192,6 +193,289 @@ func TestLoadLoRA(t *testing.T) {
 	}
 }
 
+func TestLoadLoRAAllowsLegacyUnavailableVLLMPrefill(t *testing.T) {
+	var capableLoads atomic.Int32
+	capableServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/loras":
+			capableLoads.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer capableServer.Close()
+
+	var incapableLoads atomic.Int32
+	incapableServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		incapableLoads.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("LoRA management not available: no 'load_lora' handler is registered"))
+	}))
+	defer incapableServer.Close()
+
+	model := &v1alpha1.DynamoModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-lora", Namespace: "default"},
+		Spec: v1alpha1.DynamoModelSpec{
+			ModelName: "test-lora",
+			ModelType: "lora",
+			Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+		},
+	}
+	candidates := []Candidate{
+		{Address: capableServer.URL, PodName: "vllm-decode"},
+		{
+			Address:                        incapableServer.URL,
+			PodName:                        "vllm-prefill",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+			LoRAFallbackGroup:              "graph:a",
+		},
+	}
+
+	endpoints, err := NewClient().LoadLoRA(context.Background(), candidates, model)
+	if err == nil {
+		t.Fatal("all-legacy vLLM prefill must remain not ready without an adapter-prefill card")
+	}
+	if len(endpoints) != 2 {
+		t.Fatalf("expected both physical endpoints in status, got %d: %#v", len(endpoints), endpoints)
+	}
+	if !endpoints[0].Ready || endpoints[1].Ready {
+		t.Fatalf("expected decode ready and legacy-only prefill not ready: %#v", endpoints)
+	}
+	if got := capableLoads.Load(); got != 1 {
+		t.Errorf("expected one load request to capable worker, got %d", got)
+	}
+	if got := incapableLoads.Load(); got != 1 {
+		t.Errorf("expected one compatibility-probed request to vLLM prefill, got %d", got)
+	}
+}
+
+func TestLoadLoRAAllowsLegacyFallbackAlongsideCapableVLLMPrefill(t *testing.T) {
+	newPrefill := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer newPrefill.Close()
+	oldPrefill := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Endpoint 'load_lora' not found in local registry"))
+	}))
+	defer oldPrefill.Close()
+	decode := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer decode.Close()
+
+	model := &v1alpha1.DynamoModel{
+		Spec: v1alpha1.DynamoModelSpec{
+			ModelName: "test-lora",
+			ModelType: "lora",
+			Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+		},
+	}
+	endpoints, err := NewClient().LoadLoRA(context.Background(), []Candidate{
+		{Address: decode.URL, PodName: "decode"},
+		{
+			Address:                        newPrefill.URL,
+			PodName:                        "new-prefill",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+			LoRAFallbackGroup:              "graph:a",
+		},
+		{
+			Address:                        oldPrefill.URL,
+			PodName:                        "old-prefill",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+			LoRAFallbackGroup:              "graph:a",
+		},
+	}, model)
+
+	if err != nil {
+		t.Fatalf("a capable prefill card should permit the legacy rolling fallback: %v", err)
+	}
+	if !endpoints[0].Ready || !endpoints[1].Ready {
+		t.Fatalf("expected the direct-serving endpoints to be ready: %#v", endpoints)
+	}
+	if endpoints[2].Ready || !endpoints[2].LoRAFallbackCovered {
+		t.Fatalf("expected legacy prefill to remain not ready but be fallback-covered: %#v", endpoints)
+	}
+}
+
+func TestLoadLoRADoesNotCoverLegacyPrefillFromAnotherDeployment(t *testing.T) {
+	capable := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer capable.Close()
+	legacy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Endpoint 'load_lora' not found in local registry"))
+	}))
+	defer legacy.Close()
+
+	model := &v1alpha1.DynamoModel{Spec: v1alpha1.DynamoModelSpec{
+		ModelName: "test-lora",
+		ModelType: "lora",
+		Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+	}}
+	endpoints, err := NewClient().LoadLoRA(context.Background(), []Candidate{
+		{
+			Address:                        capable.URL,
+			PodName:                        "prefill-a",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+			LoRAFallbackGroup:              "graph:a",
+		},
+		{
+			Address:                        legacy.URL,
+			PodName:                        "prefill-b",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+			LoRAFallbackGroup:              "graph:b",
+		},
+	}, model)
+
+	if err == nil {
+		t.Fatalf("capable prefill in graph A must not cover legacy graph B: %#v", endpoints)
+	}
+	if len(endpoints) != 2 || !endpoints[0].Ready || endpoints[1].Ready {
+		t.Fatalf("expected graph A ready and legacy graph B not ready, got %#v", endpoints)
+	}
+}
+
+func TestLoadLoRAIncludesCapablePrefill(t *testing.T) {
+	var loads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case r.Method == http.MethodPost && r.URL.Path == "/v1/loras":
+			loads.Add(1)
+			w.WriteHeader(http.StatusOK)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	model := &v1alpha1.DynamoModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-lora", Namespace: "default"},
+		Spec: v1alpha1.DynamoModelSpec{
+			ModelName: "test-lora",
+			ModelType: "lora",
+			Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+		},
+	}
+	endpoints, err := NewClient().LoadLoRA(context.Background(), []Candidate{
+		{
+			Address:                        server.URL,
+			PodName:                        "vllm-prefill",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+		},
+	}, model)
+	if err != nil {
+		t.Fatalf("capable prefill worker must remain eligible: %v", err)
+	}
+	if len(endpoints) != 1 || !endpoints[0].Ready {
+		t.Fatalf("expected capable prefill endpoint to be ready, got %#v", endpoints)
+	}
+	if got := loads.Load(); got != 1 {
+		t.Errorf("expected one load request to capable prefill worker, got %d", got)
+	}
+}
+
+func TestLoadLoRALegacyFallbackRequiresKubernetesReadiness(t *testing.T) {
+	var loads atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		loads.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("Endpoint 'load_lora' not found in local registry"))
+	}))
+	defer server.Close()
+
+	model := &v1alpha1.DynamoModel{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-lora", Namespace: "default"},
+		Spec: v1alpha1.DynamoModelSpec{
+			ModelName: "test-lora",
+			ModelType: "lora",
+			Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+		},
+	}
+	endpoints, err := NewClient().LoadLoRA(context.Background(), []Candidate{
+		{
+			Address:                        server.URL,
+			PodName:                        "vllm-prefill",
+			KubernetesReady:                false,
+			AllowLoRAManagementUnavailable: true,
+		},
+	}, model)
+	if err == nil {
+		t.Fatalf("expected a not-ready error, got endpoints=%#v", endpoints)
+	}
+	if len(endpoints) != 1 || endpoints[0].Ready {
+		t.Fatalf("expected the physical prefill endpoint to remain not ready, got %#v", endpoints)
+	}
+	if got := loads.Load(); got != 1 {
+		t.Errorf("expected one compatibility-probed request to vLLM prefill, got %d", got)
+	}
+}
+
+func TestLoadLoRAManagementUnavailableIsNotAllowedForDecode(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("LoRA management not available: no 'load_lora' handler is registered"))
+	}))
+	defer server.Close()
+
+	model := &v1alpha1.DynamoModel{
+		Spec: v1alpha1.DynamoModelSpec{
+			ModelName: "test-lora",
+			ModelType: "lora",
+			Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+		},
+	}
+	endpoints, err := NewClient().LoadLoRA(context.Background(), []Candidate{
+		{Address: server.URL, PodName: "vllm-decode", KubernetesReady: true},
+	}, model)
+
+	if err == nil {
+		t.Fatalf("decode must not use the prefill compatibility fallback: %#v", endpoints)
+	}
+	if len(endpoints) != 1 || endpoints[0].Ready {
+		t.Fatalf("expected decode endpoint to remain not ready, got %#v", endpoints)
+	}
+}
+
+func TestLoadLoRAGenericPrefillFailureIsNotSwallowed(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("adapter download failed"))
+	}))
+	defer server.Close()
+
+	model := &v1alpha1.DynamoModel{
+		Spec: v1alpha1.DynamoModelSpec{
+			ModelName: "test-lora",
+			ModelType: "lora",
+			Source:    &v1alpha1.ModelSource{URI: "s3://bucket/model"},
+		},
+	}
+	endpoints, err := NewClient().LoadLoRA(context.Background(), []Candidate{
+		{
+			Address:                        server.URL,
+			PodName:                        "vllm-prefill",
+			KubernetesReady:                true,
+			AllowLoRAManagementUnavailable: true,
+		},
+	}, model)
+
+	if err == nil {
+		t.Fatalf("generic prefill failures must not be swallowed: %#v", endpoints)
+	}
+	if len(endpoints) != 1 || endpoints[0].Ready {
+		t.Fatalf("expected failed prefill endpoint to remain not ready, got %#v", endpoints)
+	}
+}
+
 func TestUnloadLoRA(t *testing.T) {
 	successServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify HTTP method
@@ -218,6 +502,14 @@ func TestUnloadLoRA(t *testing.T) {
 		w.WriteHeader(http.StatusInternalServerError)
 	}))
 	defer failingServer.Close()
+
+	var notApplicableUnloads atomic.Int32
+	unsupportedServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		notApplicableUnloads.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("LoRA management not available: no 'unload_lora' handler is registered"))
+	}))
+	defer unsupportedServer.Close()
 
 	tests := []struct {
 		name        string
@@ -257,6 +549,19 @@ func TestUnloadLoRA(t *testing.T) {
 			modelName:   "test-model",
 			expectError: true, // workerpool returns error on any failure
 		},
+		{
+			name: "legacy unavailable worker uses cleanup fallback",
+			candidates: []Candidate{
+				{Address: successServer.URL, PodName: "decode-0"},
+				{
+					Address:                        unsupportedServer.URL,
+					PodName:                        "prefill-0",
+					AllowLoRAManagementUnavailable: true,
+				},
+			},
+			modelName:   "test-model",
+			expectError: false,
+		},
 	}
 
 	for _, tt := range tests {
@@ -272,5 +577,8 @@ func TestUnloadLoRA(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+	if got := notApplicableUnloads.Load(); got != 1 {
+		t.Errorf("expected one compatibility-probed unload request to vLLM prefill, got %d", got)
 	}
 }

--- a/deploy/operator/internal/modelendpoint/discovery.go
+++ b/deploy/operator/internal/modelendpoint/discovery.go
@@ -37,6 +37,7 @@ import (
 func ExtractCandidates(endpointSlices *discoveryv1.EndpointSliceList, port int32) ([]Candidate, map[string]bool) {
 	var candidates []Candidate
 	serviceNames := make(map[string]bool)
+	candidateIndexes := make(map[string]int)
 
 	for _, slice := range endpointSlices.Items {
 		serviceName := slice.Labels[discoveryv1.LabelServiceName]
@@ -54,13 +55,27 @@ func ExtractCandidates(endpointSlices *discoveryv1.EndpointSliceList, port int32
 				continue
 			}
 			podName := ep.TargetRef.Name
+			candidateKey := string(ep.TargetRef.UID)
+			if candidateKey == "" {
+				candidateKey = podName
+			}
+			if index, exists := candidateIndexes[candidateKey]; exists {
+				candidate := &candidates[index]
+				if ep.Conditions.Ready != nil && *ep.Conditions.Ready {
+					candidate.KubernetesReady = true
+				}
+				continue
+			}
 
 			for _, addr := range ep.Addresses {
 				address := "http://" + net.JoinHostPort(addr, strconv.Itoa(int(port)))
+				candidateIndexes[candidateKey] = len(candidates)
 				candidates = append(candidates, Candidate{
-					Address: address,
-					PodName: podName,
+					Address:         address,
+					PodName:         podName,
+					KubernetesReady: ep.Conditions.Ready != nil && *ep.Conditions.Ready,
 				})
+				break
 			}
 		}
 	}

--- a/deploy/operator/internal/modelendpoint/discovery_test.go
+++ b/deploy/operator/internal/modelendpoint/discovery_test.go
@@ -351,7 +351,7 @@ func TestExtractCandidates(t *testing.T) {
 			},
 		},
 		{
-			name: "endpoint with multiple addresses",
+			name: "endpoint with multiple addresses - physical pod included once",
 			endpointSlices: &discoveryv1.EndpointSliceList{
 				Items: []discoveryv1.EndpointSlice{
 					{
@@ -371,15 +371,56 @@ func TestExtractCandidates(t *testing.T) {
 				},
 			},
 			port:                 9090,
-			expectedCandidates:   2, // One candidate per address
+			expectedCandidates:   1,
 			expectedServiceNames: map[string]bool{},
 			validateCandidates: func(t *testing.T, candidates []Candidate) {
-				if len(candidates) != 2 {
-					t.Fatalf("expected 2 candidates, got %d", len(candidates))
+				if len(candidates) != 1 {
+					t.Fatalf("expected 1 candidate, got %d", len(candidates))
 				}
-				// Both should have the same pod name
-				if candidates[0].PodName != testPodWorker0 || candidates[1].PodName != testPodWorker0 {
-					t.Errorf("expected both candidates to have podName %s", testPodWorker0)
+				if candidates[0].PodName != testPodWorker0 {
+					t.Errorf("expected candidate to have podName %s", testPodWorker0)
+				}
+			},
+		},
+		{
+			name: "duplicate pod endpoint across services - included once",
+			endpointSlices: &discoveryv1.EndpointSliceList{
+				Items: []discoveryv1.EndpointSlice{
+					{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+							discoveryv1.LabelServiceName: "component-service",
+						}},
+						Endpoints: []discoveryv1.Endpoint{{
+							Addresses:  []string{"10.0.1.5"},
+							Conditions: discoveryv1.EndpointConditions{Ready: &trueVal},
+							TargetRef:  &corev1.ObjectReference{Kind: "Pod", Name: testPodWorker0},
+						}},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{
+							discoveryv1.LabelServiceName: "base-model-service",
+						}},
+						Endpoints: []discoveryv1.Endpoint{{
+							Addresses:  []string{"10.0.1.5"},
+							Conditions: discoveryv1.EndpointConditions{Ready: &trueVal},
+							TargetRef:  &corev1.ObjectReference{Kind: "Pod", Name: testPodWorker0},
+						}},
+					},
+				},
+			},
+			port:               9090,
+			expectedCandidates: 1,
+			expectedServiceNames: map[string]bool{
+				"component-service":  true,
+				"base-model-service": true,
+			},
+			validateCandidates: func(t *testing.T, candidates []Candidate) {
+				if len(candidates) != 1 {
+					t.Fatalf("expected one candidate, got %d", len(candidates))
+				}
+				candidate := candidates[0]
+				if !candidate.KubernetesReady {
+					t.Fatal("expected Kubernetes readiness to survive deduplication")
 				}
 			},
 		},

--- a/deploy/operator/internal/modelendpoint/lora.go
+++ b/deploy/operator/internal/modelendpoint/lora.go
@@ -21,13 +21,58 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+const maxLoRAErrorResponseBytes = 64 * 1024
+
+type loRAManagementUnavailableError struct {
+	operation  string
+	statusCode int
+	body       string
+}
+
+func (e *loRAManagementUnavailableError) Error() string {
+	return fmt.Sprintf("%s LoRA failed with status %d: %s", e.operation, e.statusCode, e.body)
+}
+
+func isLoRAManagementUnavailable(err error) bool {
+	var target *loRAManagementUnavailableError
+	return errors.As(err, &target)
+}
+
+func loRAManagementError(operation string, statusCode int, body []byte) error {
+	response := string(body)
+	normalized := strings.ToLower(response)
+	missingHandler := strings.Contains(normalized, "lora management not available") ||
+		strings.Contains(normalized, fmt.Sprintf("endpoint '%s_lora' not found in local registry", operation))
+	if statusCode == http.StatusInternalServerError && missingHandler {
+		return &loRAManagementUnavailableError{
+			operation:  operation,
+			statusCode: statusCode,
+			body:       response,
+		}
+	}
+	return fmt.Errorf("%s LoRA failed with status %d: %s", operation, statusCode, response)
+}
+
+func readLoRAErrorResponse(body io.Reader) ([]byte, error) {
+	payload, err := io.ReadAll(io.LimitReader(body, maxLoRAErrorResponseBytes+1))
+	if err != nil {
+		return nil, err
+	}
+	if len(payload) > maxLoRAErrorResponseBytes {
+		return nil, fmt.Errorf("response exceeds %d bytes", maxLoRAErrorResponseBytes)
+	}
+	return payload, nil
+}
 
 // loadLoRA loads a LoRA model on a single endpoint
 func (c *Client) loadLoRA(ctx context.Context, address, modelName, sourceURI string) error {
@@ -70,9 +115,12 @@ func (c *Client) loadLoRA(ctx context.Context, address, modelName, sourceURI str
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := readLoRAErrorResponse(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("load LoRA failed with status %d and unreadable response: %w", resp.StatusCode, readErr)
+		}
 		logs.V(1).Info("Load LoRA failed", "address", address, "status", resp.StatusCode, "body", string(body))
-		return fmt.Errorf("load LoRA failed with status %d: %s", resp.StatusCode, string(body))
+		return loRAManagementError("load", resp.StatusCode, body)
 	}
 
 	logs.Info("Successfully loaded LoRA", "address", address, "modelName", modelName, "sourceURI", sourceURI)
@@ -109,12 +157,15 @@ func (c *Client) unloadLoRA(ctx context.Context, address, modelName string) erro
 	}()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		body, _ := io.ReadAll(resp.Body)
+		body, readErr := readLoRAErrorResponse(resp.Body)
+		if readErr != nil {
+			return fmt.Errorf("unload LoRA failed with status %d and unreadable response: %w", resp.StatusCode, readErr)
+		}
 		logs.V(1).Info("Unload LoRA endpoint returned error status",
 			"address", address,
 			"status", resp.StatusCode,
 			"body", string(body))
-		return fmt.Errorf("unload LoRA failed with status %d: %s", resp.StatusCode, string(body))
+		return loRAManagementError("unload", resp.StatusCode, body)
 	}
 
 	logs.V(1).Info("Successfully unloaded LoRA", "address", address, "modelName", modelName)

--- a/deploy/operator/internal/modelendpoint/lora_test.go
+++ b/deploy/operator/internal/modelendpoint/lora_test.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -207,6 +208,41 @@ func TestLoadLoRA_ResponseHandling(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestLoadLoRARejectsRedirect(t *testing.T) {
+	var redirectedRequests atomic.Int32
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		redirectedRequests.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer redirectTarget.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, redirectTarget.URL+"/v1/loras", http.StatusFound)
+	}))
+	defer server.Close()
+
+	err := NewClient().loadLoRA(context.Background(), server.URL, "test-model", "s3://bucket/model")
+	if err == nil || !strings.Contains(err.Error(), "302") {
+		t.Fatalf("redirect must be rejected as a load failure, got %v", err)
+	}
+	if got := redirectedRequests.Load(); got != 0 {
+		t.Fatalf("LoRA redirect must not be followed, target received %d request(s)", got)
+	}
+}
+
+func TestLoadLoRABoundsErrorResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(strings.Repeat("x", maxLoRAErrorResponseBytes+1)))
+	}))
+	defer server.Close()
+
+	err := NewClient().loadLoRA(context.Background(), server.URL, "test-model", "s3://bucket/model")
+	if err == nil || !strings.Contains(err.Error(), "exceeds") {
+		t.Fatalf("oversized error response must be bounded, got %v", err)
 	}
 }
 

--- a/deploy/operator/internal/modelendpoint/types.go
+++ b/deploy/operator/internal/modelendpoint/types.go
@@ -19,6 +19,16 @@ package modelendpoint
 
 // Candidate represents an endpoint candidate for operations
 type Candidate struct {
-	Address string
-	PodName string
+	Address             string
+	PodName             string
+	WorkloadName        string
+	GraphDeploymentName string
+	KubernetesReady     bool
+	// AllowLoRAManagementUnavailable permits a rolling-upgrade fallback only
+	// when this endpoint explicitly reports that no LoRA lifecycle handler is
+	// registered. Capable endpoints are still called normally.
+	AllowLoRAManagementUnavailable bool
+	// LoRAFallbackGroup identifies the deployment/runtime topology in which a
+	// capable prefill may cover a legacy prefill during a rolling upgrade.
+	LoRAFallbackGroup string
 }

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -792,6 +792,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `endpoints` _[EndpointInfo](#endpointinfo) array_ | Endpoints is the current list of all endpoints for this model |  | Optional: \{\} <br /> |
 | `readyEndpoints` _integer_ | ReadyEndpoints is the count of endpoints that are ready |  |  |
+| `loraFallbackCoveredEndpoints` _integer_ | LoRAFallbackCoveredEndpoints is the count of legacy prefill endpoints<br />covered by a capable prefill during a rolling upgrade. These endpoints are<br />excluded from ReadyEndpoints because they cannot serve the adapter directly. |  | Optional: \{\} <br /> |
 | `totalEndpoints` _integer_ | TotalEndpoints is the total count of endpoints |  |  |
 | `conditions` _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#condition-v1-meta) array_ | Conditions represents the latest available observations of the model's state |  | Optional: \{\} <br /> |
 
@@ -830,7 +831,8 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `address` _string_ | Address is the full address of the endpoint (e.g., "http://10.0.1.5:9090") |  |  |
 | `podName` _string_ | PodName is the name of the pod serving this endpoint |  | Optional: \{\} <br /> |
-| `ready` _boolean_ | Ready indicates whether the endpoint is ready to serve traffic<br />For LoRA models: true if the POST /loras request succeeded with a 2xx status code<br />For base models: always false (no probing performed) |  |  |
+| `ready` _boolean_ | Ready indicates whether this endpoint is ready to serve traffic.<br />For LoRA models: true only if this endpoint's lifecycle request succeeded.<br />For base models: always false (no probing performed). |  |  |
+| `loraFallbackCovered` _boolean_ | LoRAFallbackCovered indicates a legacy prefill endpoint that cannot manage<br />LoRAs itself is covered by a capable prefill in the same topology during a<br />rolling upgrade. It does not make this endpoint ready to serve the adapter. |  | Optional: \{\} <br /> |
 
 
 #### ExtraPodMetadata


### PR DESCRIPTION
## Summary

Backport the DYN-3408 LoRA lifecycle fix from #11520 to `release/1.3.0`.

The operator previously discovered duplicate service endpoints and did not call the LoRA lifecycle API on prefill workers. Disaggregated deployments could therefore publish only the decode adapter model card, leaving the DynamoModel NotReady and the frontend without a complete adapter worker set. Eager prefill loading also consumed a vLLM LoRA slot before the adapter was used.

This backport makes prefill registration publish the adapter topology and cache its deterministic ID/path without eagerly adding it to the engine. The request path supplies the adapter path to vLLM for lazy activation.

Cherry-picked from `19786bf7ae580e9a8cc969704ee70c211171ad85`.

Linear: https://linear.app/nvidia/issue/DYN-3408

## Validation

- Black 23.1.0 passes for all changed Python files.
- Ruff 0.5.2 passes for all changed Python files.
- Python byte-compilation passes.
- `git diff --check` passes.
- Independent release-compatibility review found no material issues.
- Operator Go tests could not complete locally because the container timed out resolving `proxy.golang.org`; release CI remains required.