### PR TITLE
fix(mocker): publish native ZMQ KV batches

### DIFF
--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -418,6 +418,30 @@ impl KvEventPublisher {
         self.send_singleton(placement_event)
     }
 
+    /// Publishes events that share one source visibility boundary.
+    pub fn publish_batch_with_storage_tiers(
+        &self,
+        events: Vec<(KvCacheEvent, StorageTier)>,
+    ) -> Result<(), mpsc::error::SendError<Vec<KvCacheEvent>>> {
+        if events.is_empty() {
+            return Ok(());
+        }
+
+        let events = events
+            .into_iter()
+            .map(|(event, storage_tier)| {
+                PlacementEvent::new(
+                    Placement::local_worker(self.worker_id, event.dp_rank, storage_tier),
+                    event,
+                )
+            })
+            .collect();
+
+        self.tx.send(events).map_err(|err| {
+            mpsc::error::SendError(err.0.into_iter().map(|event| event.event).collect())
+        })
+    }
+
     fn send_singleton(
         &self,
         event: PlacementEvent,

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -21,7 +21,7 @@ mod test_event_processing {
     use dynamo_kv_router::zmq_wire::StoredBlockOptions;
 
     #[test]
-    fn test_publish_wraps_event_in_singleton_batch() {
+    fn test_publish_wraps_events_in_batches() {
         let (tx, mut rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
         let publisher = KvEventPublisher {
             kv_block_size: 1,
@@ -43,19 +43,6 @@ mod test_event_processing {
         assert_eq!(batch.len(), 1);
         assert_eq!(batch[0].event.event_id, 10);
         assert_eq!(batch[0].event.dp_rank, 2);
-    }
-
-    #[test]
-    fn test_publish_batch_preserves_source_boundary() {
-        let (tx, mut rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
-        let publisher = KvEventPublisher {
-            kv_block_size: 1,
-            source: None,
-            cancellation_token: CancellationToken::new(),
-            worker_id: 7,
-            tx,
-            next_event_id: Arc::new(AtomicU64::new(0)),
-        };
 
         publisher
             .publish_batch_with_storage_tiers(vec![

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -45,6 +45,57 @@ mod test_event_processing {
         assert_eq!(batch[0].event.dp_rank, 2);
     }
 
+    #[test]
+    fn test_publish_batch_preserves_source_boundary() {
+        let (tx, mut rx) = mpsc::unbounded_channel::<Vec<PlacementEvent>>();
+        let publisher = KvEventPublisher {
+            kv_block_size: 1,
+            source: None,
+            cancellation_token: CancellationToken::new(),
+            worker_id: 7,
+            tx,
+            next_event_id: Arc::new(AtomicU64::new(0)),
+        };
+
+        publisher
+            .publish_batch_with_storage_tiers(vec![
+                (
+                    KvCacheEvent {
+                        event_id: 10,
+                        data: KvCacheEventData::Cleared,
+                        dp_rank: 2,
+                    },
+                    StorageTier::Device,
+                ),
+                (
+                    KvCacheEvent {
+                        event_id: 11,
+                        data: KvCacheEventData::Cleared,
+                        dp_rank: 3,
+                    },
+                    StorageTier::HostPinned,
+                ),
+            ])
+            .unwrap();
+
+        let batch = rx.try_recv().unwrap();
+        assert_eq!(
+            batch
+                .iter()
+                .map(|event| event.event.event_id)
+                .collect::<Vec<_>>(),
+            vec![10, 11]
+        );
+        assert_eq!(
+            batch[0].placement,
+            Placement::local_worker(7, 2, StorageTier::Device)
+        );
+        assert_eq!(
+            batch[1].placement,
+            Placement::local_worker(7, 3, StorageTier::HostPinned)
+        );
+    }
+
     // ---------------------------------------------------------------------
     // create_stored_block_from_parts --------------------------------------
     // ---------------------------------------------------------------------

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -183,6 +183,15 @@ impl KvCacheEventSink for KvEventSinkAdapter {
             .publish_with_storage_tier(event, storage_tier)
             .map_err(|e| anyhow::anyhow!("Failed to send KV event: {}", e))
     }
+
+    fn publish_batch_with_storage_tiers(
+        &self,
+        events: Vec<(KvCacheEvent, StorageTier)>,
+    ) -> anyhow::Result<()> {
+        self.0
+            .publish_batch_with_storage_tiers(events)
+            .map_err(|e| anyhow::anyhow!("Failed to send KV event batch: {}", e))
+    }
 }
 
 fn generate_random_token() -> TokenIdType {

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -58,6 +58,20 @@ pub struct RawKvEvent {
 /// Trait for publishing transport-specific raw KV event payloads.
 pub trait RawKvEventSink: Send + Sync {
     fn publish(&self, event: RawKvEvent) -> anyhow::Result<()>;
+
+    /// Publishes raw events that share one source visibility boundary.
+    ///
+    /// Implementations that do not have a native batch representation retain
+    /// singleton delivery semantics by default.
+    fn publish_batch(&self, events: Vec<RawKvEvent>) -> anyhow::Result<()> {
+        let mut first_error = None;
+        for event in events {
+            if let Err(error) = self.publish(event) {
+                first_error.get_or_insert(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
 }
 
 /// Shared KV event publisher bundle used by schedulers and KV managers.
@@ -112,6 +126,30 @@ impl KvEventPublishers {
             })?;
         }
 
+        Ok(())
+    }
+
+    /// Publishes a normal KV event without also forwarding it to a raw sink.
+    ///
+    /// Deferred live-scheduler forwarding uses this to preserve existing
+    /// per-event error handling for normal sinks while sending the matching raw
+    /// events as one native batch.
+    pub(crate) fn publish_event_sink_only(
+        &self,
+        event: KvCacheEvent,
+        storage_tier: StorageTier,
+    ) -> anyhow::Result<()> {
+        if let Some(sink) = self.event_sink.as_ref() {
+            sink.publish_with_storage_tier(event, storage_tier)?;
+        }
+        Ok(())
+    }
+
+    /// Publishes raw events as one source visibility boundary.
+    pub(crate) fn publish_raw_batch(&self, events: Vec<RawKvEvent>) -> anyhow::Result<()> {
+        if let Some(sink) = self.raw_sink.as_ref() {
+            sink.publish_batch(events)?;
+        }
         Ok(())
     }
 }
@@ -1396,8 +1434,48 @@ impl MockEngineArgs {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Mutex;
+
     use super::*;
     use serde_json::json;
+
+    #[derive(Default)]
+    struct FailingRawSink {
+        attempts: Mutex<Vec<u64>>,
+    }
+
+    impl RawKvEventSink for FailingRawSink {
+        fn publish(&self, event: RawKvEvent) -> anyhow::Result<()> {
+            self.attempts.lock().unwrap().push(event.event.event_id);
+            if event.event.event_id == 2 {
+                anyhow::bail!("injected raw sink failure");
+            }
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn raw_sink_batch_fallback_attempts_later_events_after_failure() {
+        let sink = FailingRawSink::default();
+        let error = sink
+            .publish_batch(
+                (1..=3)
+                    .map(|event_id| RawKvEvent {
+                        event: KvCacheEvent {
+                            event_id,
+                            data: dynamo_kv_router::protocols::KvCacheEventData::Cleared,
+                            dp_rank: 0,
+                        },
+                        block_token_ids: None,
+                        storage_tier: StorageTier::Device,
+                    })
+                    .collect(),
+            )
+            .unwrap_err();
+
+        assert_eq!(error.to_string(), "injected raw sink failure");
+        assert_eq!(*sink.attempts.lock().unwrap(), vec![1, 2, 3]);
+    }
 
     #[test]
     fn direct_request_priorities_are_backward_compatible() {

--- a/lib/mocker/src/common/protocols.rs
+++ b/lib/mocker/src/common/protocols.rs
@@ -44,6 +44,23 @@ pub trait KvCacheEventSink: Send + Sync {
     ) -> anyhow::Result<()> {
         self.publish(event)
     }
+
+    /// Publishes events that share one source visibility boundary.
+    ///
+    /// Implementations that do not have a native batch representation retain
+    /// singleton delivery semantics by default.
+    fn publish_batch_with_storage_tiers(
+        &self,
+        events: Vec<(KvCacheEvent, StorageTier)>,
+    ) -> anyhow::Result<()> {
+        let mut first_error = None;
+        for (event, storage_tier) in events {
+            if let Err(error) = self.publish_with_storage_tier(event, storage_tier) {
+                first_error.get_or_insert(error);
+            }
+        }
+        first_error.map_or(Ok(()), Err)
+    }
 }
 
 /// Raw KV event payload used by transport-specific publishers such as the
@@ -129,18 +146,16 @@ impl KvEventPublishers {
         Ok(())
     }
 
-    /// Publishes a normal KV event without also forwarding it to a raw sink.
+    /// Publishes normal KV events without also forwarding them to a raw sink.
     ///
-    /// Deferred live-scheduler forwarding uses this to preserve existing
-    /// per-event error handling for normal sinks while sending the matching raw
-    /// events as one native batch.
-    pub(crate) fn publish_event_sink_only(
+    /// Deferred live-scheduler forwarding uses this to preserve its source
+    /// visibility boundary for normal and raw sinks independently.
+    pub(crate) fn publish_event_sink_batch_only(
         &self,
-        event: KvCacheEvent,
-        storage_tier: StorageTier,
+        events: Vec<(KvCacheEvent, StorageTier)>,
     ) -> anyhow::Result<()> {
         if let Some(sink) = self.event_sink.as_ref() {
-            sink.publish_with_storage_tier(event, storage_tier)?;
+            sink.publish_batch_with_storage_tiers(events)?;
         }
         Ok(())
     }

--- a/lib/mocker/src/scheduler/kv_event_sink.rs
+++ b/lib/mocker/src/scheduler/kv_event_sink.rs
@@ -219,10 +219,13 @@ pub(crate) fn publish_deferred_kv_events(
         })
         .collect();
 
-    for event in &raw_events {
-        if let Err(error) = sinks.publish_event_sink_only(event.event.clone(), event.storage_tier) {
-            tracing::warn!("Failed to forward buffered KV event: {error}");
-        }
+    let normal_events = raw_events
+        .iter()
+        .map(|event| (event.event.clone(), event.storage_tier))
+        .collect();
+
+    if let Err(error) = sinks.publish_event_sink_batch_only(normal_events) {
+        tracing::warn!("Failed to forward buffered KV event batch: {error}");
     }
 
     if let Err(error) = sinks.publish_raw_batch(raw_events) {
@@ -255,13 +258,20 @@ mod tests {
 
     #[derive(Default)]
     struct CapturingSink {
-        normal_events: Mutex<Vec<KvCacheEvent>>,
+        normal_batches: Mutex<Vec<Vec<(KvCacheEvent, StorageTier)>>>,
         raw_batches: Mutex<Vec<Vec<RawKvEvent>>>,
     }
 
     impl KvCacheEventSink for CapturingSink {
         fn publish(&self, event: KvCacheEvent) -> Result<()> {
-            self.normal_events.lock().unwrap().push(event);
+            self.publish_batch_with_storage_tiers(vec![(event, StorageTier::Device)])
+        }
+
+        fn publish_batch_with_storage_tiers(
+            &self,
+            events: Vec<(KvCacheEvent, StorageTier)>,
+        ) -> Result<()> {
+            self.normal_batches.lock().unwrap().push(events);
             Ok(())
         }
     }
@@ -278,7 +288,7 @@ mod tests {
     }
 
     #[test]
-    fn deferred_visibility_boundary_emits_one_native_zmq_batch() {
+    fn deferred_visibility_boundary_emits_one_normal_and_raw_batch() {
         let sink = Arc::new(CapturingSink::default());
         let sinks = KvEventPublishers::new(Some(sink.clone()), Some(sink.clone()));
         let stored_data = KvCacheEventData::Stored(KvCacheStoreData {
@@ -292,7 +302,7 @@ mod tests {
         });
 
         publish_deferred_kv_events(&sinks, Vec::new());
-        assert!(sink.normal_events.lock().unwrap().is_empty());
+        assert!(sink.normal_batches.lock().unwrap().is_empty());
         assert!(sink.raw_batches.lock().unwrap().is_empty());
 
         publish_deferred_kv_events(
@@ -311,14 +321,19 @@ mod tests {
                 .collect(),
         );
 
+        let normal_batches = sink.normal_batches.lock().unwrap();
+        assert_eq!(normal_batches.len(), 1);
         assert_eq!(
-            sink.normal_events
-                .lock()
-                .unwrap()
+            normal_batches[0]
                 .iter()
-                .map(|event| event.event_id)
+                .map(|(event, _)| event.event_id)
                 .collect::<Vec<_>>(),
             vec![1, 2]
+        );
+        assert!(
+            normal_batches[0]
+                .iter()
+                .all(|(_, storage_tier)| *storage_tier == StorageTier::Device)
         );
 
         let raw_batches = sink.raw_batches.lock().unwrap();

--- a/lib/mocker/src/scheduler/kv_event_sink.rs
+++ b/lib/mocker/src/scheduler/kv_event_sink.rs
@@ -206,14 +206,27 @@ pub(crate) fn publish_deferred_kv_events(
     sinks: &KvEventPublishers,
     events: Vec<DeferredKvPublish>,
 ) {
-    for event in events {
-        if let Err(error) = sinks.publish_with_storage_tier(
-            event.event,
-            event.block_token_ids.as_deref(),
-            event.storage_tier,
-        ) {
+    if events.is_empty() {
+        return;
+    }
+
+    let raw_events: Vec<RawKvEvent> = events
+        .into_iter()
+        .map(|event| RawKvEvent {
+            event: event.event,
+            block_token_ids: event.block_token_ids,
+            storage_tier: event.storage_tier,
+        })
+        .collect();
+
+    for event in &raw_events {
+        if let Err(error) = sinks.publish_event_sink_only(event.event.clone(), event.storage_tier) {
             tracing::warn!("Failed to forward buffered KV event: {error}");
         }
+    }
+
+    if let Err(error) = sinks.publish_raw_batch(raw_events) {
+        tracing::warn!("Failed to forward buffered raw KV event batch: {error}");
     }
 }
 
@@ -224,5 +237,108 @@ pub(crate) fn publish_deferred_fpm(sink: &FpmPublisher, snapshots: Vec<ForwardPa
         if let Err(error) = sink.publish(snapshot) {
             tracing::warn!("Failed to forward buffered FPM snapshot: {error}");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::{Arc, Mutex};
+
+    use dynamo_kv_router::protocols::{
+        ExternalSequenceBlockHash, KvCacheEvent, KvCacheEventData, KvCacheStoreData,
+        KvCacheStoredBlockData, LocalBlockHash,
+    };
+    use dynamo_kv_router::zmq_wire::decode_event_batch;
+
+    use super::*;
+    use crate::services::zmq_events::encode_event_batch;
+
+    #[derive(Default)]
+    struct CapturingSink {
+        normal_events: Mutex<Vec<KvCacheEvent>>,
+        raw_batches: Mutex<Vec<Vec<RawKvEvent>>>,
+    }
+
+    impl KvCacheEventSink for CapturingSink {
+        fn publish(&self, event: KvCacheEvent) -> Result<()> {
+            self.normal_events.lock().unwrap().push(event);
+            Ok(())
+        }
+    }
+
+    impl RawKvEventSink for CapturingSink {
+        fn publish(&self, event: RawKvEvent) -> Result<()> {
+            self.publish_batch(vec![event])
+        }
+
+        fn publish_batch(&self, events: Vec<RawKvEvent>) -> Result<()> {
+            self.raw_batches.lock().unwrap().push(events);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn deferred_visibility_boundary_emits_one_native_zmq_batch() {
+        let sink = Arc::new(CapturingSink::default());
+        let sinks = KvEventPublishers::new(Some(sink.clone()), Some(sink.clone()));
+        let stored_data = KvCacheEventData::Stored(KvCacheStoreData {
+            parent_hash: None,
+            start_position: None,
+            blocks: vec![KvCacheStoredBlockData {
+                block_hash: ExternalSequenceBlockHash(1),
+                tokens_hash: LocalBlockHash(1),
+                mm_extra_info: None,
+            }],
+        });
+
+        publish_deferred_kv_events(&sinks, Vec::new());
+        assert!(sink.normal_events.lock().unwrap().is_empty());
+        assert!(sink.raw_batches.lock().unwrap().is_empty());
+
+        publish_deferred_kv_events(
+            &sinks,
+            [1, 2]
+                .into_iter()
+                .map(|event_id| DeferredKvPublish {
+                    event: KvCacheEvent {
+                        event_id,
+                        data: stored_data.clone(),
+                        dp_rank: 0,
+                    },
+                    block_token_ids: Some(vec![vec![event_id as u32; 4]]),
+                    storage_tier: StorageTier::Device,
+                })
+                .collect(),
+        );
+
+        assert_eq!(
+            sink.normal_events
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|event| event.event_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+
+        let raw_batches = sink.raw_batches.lock().unwrap();
+        assert_eq!(raw_batches.len(), 1);
+        assert_eq!(
+            raw_batches[0]
+                .iter()
+                .map(|event| event.event.event_id)
+                .collect::<Vec<_>>(),
+            vec![1, 2]
+        );
+        let payload = encode_event_batch(&raw_batches[0], 4, 3)
+            .unwrap()
+            .expect("stored events should produce a payload");
+        let batch =
+            decode_event_batch(&payload).expect("payload should use the native wire format");
+
+        assert_eq!(batch.data_parallel_rank, Some(3));
+        assert_eq!(batch.events.len(), 2);
+        assert_eq!(batch.events[0].event_type_label(), "stored");
+        assert_eq!(batch.events[1].event_type_label(), "stored");
     }
 }

--- a/lib/mocker/src/scheduler/kv_event_sink.rs
+++ b/lib/mocker/src/scheduler/kv_event_sink.rs
@@ -330,11 +330,6 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![1, 2]
         );
-        assert!(
-            normal_batches[0]
-                .iter()
-                .all(|(_, storage_tier)| *storage_tier == StorageTier::Device)
-        );
 
         let raw_batches = sink.raw_batches.lock().unwrap();
         assert_eq!(raw_batches.len(), 1);

--- a/lib/mocker/src/services/zmq_events.rs
+++ b/lib/mocker/src/services/zmq_events.rs
@@ -55,7 +55,7 @@ enum ZmqRawKvEvent {
 }
 
 pub struct ZmqKvEventSink {
-    tx: mpsc::UnboundedSender<RawKvEvent>,
+    tx: mpsc::UnboundedSender<Vec<RawKvEvent>>,
 }
 
 impl ZmqKvEventSink {
@@ -65,7 +65,7 @@ impl ZmqKvEventSink {
         dp_rank: u32,
         block_size: u32,
     ) -> Result<Self> {
-        let (tx, mut rx) = mpsc::unbounded_channel::<RawKvEvent>();
+        let (tx, mut rx) = mpsc::unbounded_channel::<Vec<RawKvEvent>>();
 
         let endpoint = format!("tcp://0.0.0.0:{port}");
         let pub_socket = bind_pub_socket(&endpoint)
@@ -182,29 +182,13 @@ impl ZmqKvEventSink {
                     }
 
                     msg_opt = rx.recv() => {
-                        let Some(msg) = msg_opt else { break };
+                        let Some(raw_events) = msg_opt else { break };
 
-                        let events = convert_to_zmq_events(
-                            &msg.event,
-                            msg.block_token_ids.as_deref(),
-                            block_size,
-                            msg.storage_tier,
-                        );
-                        if events.is_empty() {
-                            continue;
-                        }
-
-                        let timestamp = SystemTime::now()
-                            .duration_since(UNIX_EPOCH)
-                            .unwrap_or_default()
-                            .as_secs_f64();
-
-                        let batch: (f64, Vec<ZmqRawKvEvent>, Option<i32>) =
-                            (timestamp, events, Some(dp_rank as i32));
-                        let payload: Bytes = match rmp_serde::to_vec(&batch) {
-                            Ok(p) => p.into(),
+                        let payload = match encode_event_batch(&raw_events, block_size, dp_rank) {
+                            Ok(Some(payload)) => payload,
+                            Ok(None) => continue,
                             Err(e) => {
-                                tracing::warn!("Failed to serialize ZMQ KV event: {e}");
+                                tracing::warn!("Failed to serialize ZMQ KV event batch: {e}");
                                 continue;
                             }
                         };
@@ -233,14 +217,53 @@ impl ZmqKvEventSink {
 
         Ok(Self { tx })
     }
+
+    fn enqueue(&self, events: Vec<RawKvEvent>) -> anyhow::Result<()> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        self.tx
+            .send(events)
+            .map_err(|_| anyhow::anyhow!("ZMQ event sink channel closed"))
+    }
 }
 
 impl RawKvEventSink for ZmqKvEventSink {
     fn publish(&self, event: RawKvEvent) -> anyhow::Result<()> {
-        self.tx
-            .send(event)
-            .map_err(|_| anyhow::anyhow!("ZMQ event sink channel closed"))
+        self.enqueue(vec![event])
     }
+
+    fn publish_batch(&self, events: Vec<RawKvEvent>) -> anyhow::Result<()> {
+        self.enqueue(events)
+    }
+}
+
+pub(crate) fn encode_event_batch(
+    raw_events: &[RawKvEvent],
+    block_size: u32,
+    dp_rank: u32,
+) -> std::result::Result<Option<Bytes>, rmp_serde::encode::Error> {
+    let events = raw_events
+        .iter()
+        .flat_map(|event| {
+            convert_to_zmq_events(
+                &event.event,
+                event.block_token_ids.as_deref(),
+                block_size,
+                event.storage_tier,
+            )
+        })
+        .collect::<Vec<_>>();
+    if events.is_empty() {
+        return Ok(None);
+    }
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs_f64();
+    let batch: (f64, Vec<ZmqRawKvEvent>, Option<i32>) = (timestamp, events, Some(dp_rank as i32));
+    rmp_serde::to_vec(&batch).map(|payload| Some(payload.into()))
 }
 
 fn convert_to_zmq_events(


### PR DESCRIPTION
## Summary

- Publish every nonempty deferred mocker KV visibility boundary as one native ZMQ event batch.
- Keep normal event sinks per-event while preserving singleton fallback behavior for raw sinks without native batching.

## Details

- Deferred events are converted once, forwarded individually to the normal sink, and emitted as one raw ZMQ batch.
- When both sinks are configured, a normal-sink failure is warned but does not suppress the complete raw batch; the two transports are intentionally independent.
- Default raw batching attempts every event and returns the first failure only after attempting the remainder.

## Where should the reviewer start?

- `lib/mocker/src/scheduler/kv_event_sink.rs`: deferred visibility-boundary forwarding and its coverage.
- `lib/mocker/src/services/zmq_events.rs`: one queued vector maps to one native ZMQ payload.

## Related Issues

- [x] Confirmed — no related issue.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-mocker --lib`
- `cargo clippy -p dynamo-mocker --lib --tests -- -D warnings`