### PR TITLE
refactor(vllm): derive prompt usage from request output

### DIFF
--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2507,7 +2507,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
     def _create_prompt_from_embeddings(
         self, prompt_embeds_base64: str
-    ) -> tuple[EmbedsPrompt, int, torch.Tensor]:
+    ) -> tuple[EmbedsPrompt, torch.Tensor]:
         """
         Decode prompt embeddings and create EmbedsPrompt for vLLM.
 
@@ -2515,9 +2515,8 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             prompt_embeds_base64: Base64-encoded PyTorch tensor
 
         Returns:
-            Tuple of (EmbedsPrompt, sequence_length, tensor) where:
+            Tuple of (EmbedsPrompt, tensor) where:
             - EmbedsPrompt: The vLLM prompt input
-            - sequence_length: Extracted from tensor shape for usage statistics
             - tensor: The decoded tensor (for logging shape/dtype)
 
         Raises:
@@ -2529,13 +2528,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 f"prompt embeds should have dim 2 after vllm processing, but found dim {embeddings_tensor.dim()}"
             )
 
-        # Extract sequence length from tensor shape for usage reporting
-        sequence_length = embeddings_tensor.shape[0]
-
         # EmbedsInputs TypedDict has: {type: 'embeds', prompt_embeds: Tensor, cache_salt?: str}
         prompt = EmbedsPrompt(prompt_embeds=embeddings_tensor)
 
-        return prompt, sequence_length, embeddings_tensor
+        return prompt, embeddings_tensor
 
     def _build_prompt_from_request(
         self,
@@ -2545,7 +2541,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         log_prefix: str = "",
         mm_processor_kwargs: Dict[str, Any] | None = None,
         mixed_embeds: tuple[torch.Tensor, list[int], list[bool]] | None = None,
-    ) -> tuple[TokensPrompt | EmbedsPrompt | None, int | None, Dict[str, Any] | None]:
+    ) -> tuple[TokensPrompt | EmbedsPrompt | None, Dict[str, Any] | None]:
         """
         Build a prompt from request, handling both prompt_embeds and token_ids.
 
@@ -2561,12 +2557,10 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 path. When present, takes the EmbedsPrompt fast path below.
 
         Returns:
-            Tuple of (prompt, embedding_sequence_length, error_dict) where:
-            - On success: (prompt, embedding_sequence_length or None, None)
-            - On failure: (None, None, error_dict to yield)
+            Tuple of (prompt, error_dict) where:
+            - On success: (prompt, None)
+            - On failure: (None, error_dict to yield)
         """
-        embedding_sequence_length = None
-
         # Fast path: mixed token-ids/embeds prompt from the aggregated
         # CustomEncoder path, assembled in _generate_token_mode and passed in
         # explicitly. The image embeds ride on the EmbedsPrompt itself and the
@@ -2575,14 +2569,12 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         # intentionally skipped for this path.
         if mixed_embeds is not None:
             prompt_embeds, prompt_token_ids, prompt_is_token_ids = mixed_embeds
-            seq_len = prompt_embeds.shape[0]
             return (
                 EmbedsPrompt(
                     prompt_embeds=prompt_embeds,
                     prompt_token_ids=prompt_token_ids,
                     prompt_is_token_ids=prompt_is_token_ids,
                 ),
-                seq_len,
                 None,
             )
 
@@ -2597,31 +2589,27 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                 )
                 return (
                     None,
-                    None,
                     {
                         "finish_reason": f"error: Invalid prompt_embeds: {msg}",
                         "token_ids": [],
                     },
                 )
             try:
-                (
-                    prompt,
-                    embedding_sequence_length,
-                    tensor,
-                ) = self._create_prompt_from_embeddings(request["prompt_embeds"])
+                prompt, tensor = self._create_prompt_from_embeddings(
+                    request["prompt_embeds"]
+                )
                 logger.info(
                     f"{log_prefix}Using prompt embeddings: shape={tensor.shape}, "
-                    f"dtype={tensor.dtype}, sequence_length={embedding_sequence_length}, "
+                    f"dtype={tensor.dtype}, sequence_length={tensor.shape[0]}, "
                     f"request_id={request_id}"
                 )
-                return prompt, embedding_sequence_length, None
+                return prompt, None
             except Exception as e:
                 logger.error(
                     f"Failed to process prompt_embeds for {log_prefix.lower().strip() or 'request'} "
                     f"{request_id}: {e}"
                 )
                 return (
-                    None,
                     None,
                     {
                         "finish_reason": f"error: Invalid prompt_embeds: {e}",
@@ -2640,12 +2628,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
             multi_modal_data,
             mm_processor_kwargs,
         )
-        return prompt, embedding_sequence_length, None
+        return prompt, None
 
     @staticmethod
     def _build_completion_usage(
         request_output: RequestOutput,
-        embedding_sequence_length: int | None = None,
         completion_token_counts: dict[int, int] | None = None,
     ) -> Dict[str, Any]:
         """
@@ -2653,8 +2640,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
 
         Args:
             request_output: vLLM RequestOutput object
-            embedding_sequence_length: If using prompt embeddings, the sequence length
-                                     extracted from the embeddings tensor shape
             completion_token_counts: Optional cumulative generated-token counts by
                                      output index. DELTA-mode streams need this
                                      because the final vLLM chunk is not cumulative.
@@ -2662,15 +2647,11 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         Returns:
             Dict with prompt_tokens, completion_tokens, total_tokens, prompt_tokens_details
         """
-        # Determine prompt token count:
-        # - For embeddings: use embedding_sequence_length from tensor shape
-        # - For normal text: use len(prompt_token_ids)
-        if embedding_sequence_length is not None:
-            prompt_tokens = embedding_sequence_length
-        elif request_output.prompt_token_ids:
-            prompt_tokens = len(request_output.prompt_token_ids)
-        else:
-            prompt_tokens = None
+        prompt_tokens = (
+            len(request_output.prompt_token_ids)
+            if request_output.prompt_token_ids is not None
+            else None
+        )
 
         if completion_token_counts is not None:
             completion_tokens = sum(completion_token_counts.values())
@@ -2744,7 +2725,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         request_id,
         data_parallel_rank=None,
         lora_request=None,
-        embedding_sequence_length=None,
         trace_headers=None,
         priority=0,
         reasoning_ended=None,
@@ -2857,7 +2837,6 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
                             "completion_usage"
                         ] = BaseWorkerHandler._build_completion_usage(
                             request_output=res,
-                            embedding_sequence_length=embedding_sequence_length,
                             completion_token_counts=total_output_tokens_by_index,
                         )
                         if prompt_logprobs_payload is not None:
@@ -3121,18 +3100,13 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                 # The engine's InputProcessor.process_inputs() will see the "type"
                 # key and skip the HF processor entirely.
                 prompt = pre_rendered
-                embedding_sequence_length = None
                 error = None
                 logger.debug(
                     "[mm-routing] Request %s: using pre-rendered MultiModalInput",
                     request_id,
                 )
             else:
-                (
-                    prompt,
-                    embedding_sequence_length,
-                    error,
-                ) = self._build_prompt_from_request(
+                prompt, error = self._build_prompt_from_request(
                     request,
                     request_id,
                     multi_modal_data,
@@ -3225,7 +3199,6 @@ class DecodeWorkerHandler(BaseWorkerHandler):
                         request_id,
                         data_parallel_rank=dp_rank,
                         lora_request=lora_request,
-                        embedding_sequence_length=embedding_sequence_length,
                         trace_headers=trace_headers,
                         priority=priority,
                         reasoning_ended=reasoning_ended,
@@ -3429,7 +3402,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
         mm_processor_kwargs = prepared_input.mm_processor_kwargs
 
         # Build prompt from request (handles both prompt_embeds and token_ids)
-        prompt, embedding_sequence_length, error = self._build_prompt_from_request(
+        prompt, error = self._build_prompt_from_request(
             request,
             request_id,
             multi_modal_data,
@@ -3534,7 +3507,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
                     ),
                     "completion_usage": BaseWorkerHandler._build_completion_usage(
                         request_output=res,
-                        embedding_sequence_length=embedding_sequence_length,
                     ),
                 }
 

--- a/components/src/dynamo/vllm/handlers.py
+++ b/components/src/dynamo/vllm/handlers.py
@@ -2649,7 +2649,7 @@ class BaseWorkerHandler(ABC, Generic[RequestT, ResponseT]):
         """
         prompt_tokens = (
             len(request_output.prompt_token_ids)
-            if request_output.prompt_token_ids is not None
+            if request_output.prompt_token_ids
             else None
         )
 

--- a/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
@@ -172,10 +172,9 @@ class TestUsageStatistics:
         [
             ([0] * 10, 5, 10, 15),
             ([1, 2, 3, 4, 5, 6, 7], 3, 7, 10),
-            # Zero sequence length edge case
-            ([], 2, 0, 2),
+            ([], 2, None, None),
         ],
-        ids=["embeddings", "text", "zero-seq-len"],
+        ids=["embeddings", "text", "empty-token-ids"],
     )
     def test_build_completion_usage(
         self,

--- a/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
@@ -168,23 +168,19 @@ class TestUsageStatistics:
     """Tests for usage statistics calculation."""
 
     @pytest.mark.parametrize(
-        "prompt_token_ids,embedding_seq_len,completion_tokens,expected_prompt,expected_total",
+        "prompt_token_ids,completion_tokens,expected_prompt,expected_total",
         [
-            # Embeddings: use embedding_sequence_length
-            ([], 10, 5, 10, 15),
-            # Text: use len(prompt_token_ids)
-            ([1, 2, 3, 4, 5, 6, 7], None, 3, 7, 10),
-            # Embeddings override token_ids
-            ([1, 2, 3], 20, 2, 20, 22),
+            # vLLM uses placeholder IDs for pure embeddings.
+            ([0] * 10, 5, 10, 15),
+            ([1, 2, 3, 4, 5, 6, 7], 3, 7, 10),
             # Zero sequence length edge case
-            ([], 0, 2, 0, 2),
+            ([], 2, 0, 2),
         ],
-        ids=["embeddings", "text", "embeddings-override", "zero-seq-len"],
+        ids=["embeddings", "text", "zero-seq-len"],
     )
     def test_build_completion_usage(
         self,
         prompt_token_ids,
-        embedding_seq_len,
         completion_tokens,
         expected_prompt,
         expected_total,
@@ -195,9 +191,7 @@ class TestUsageStatistics:
         mock_output.outputs = [Mock(token_ids=list(range(completion_tokens)))]
         mock_output.num_cached_tokens = 0
 
-        result = BaseWorkerHandler._build_completion_usage(
-            mock_output, embedding_sequence_length=embedding_seq_len
-        )
+        result = BaseWorkerHandler._build_completion_usage(mock_output)
 
         assert result["prompt_tokens"] == expected_prompt
         assert result["completion_tokens"] == completion_tokens
@@ -210,9 +204,7 @@ class TestUsageStatistics:
         mock_output.outputs = [Mock(token_ids=[1, 2, 3])]
         mock_output.num_cached_tokens = 0
 
-        result = BaseWorkerHandler._build_completion_usage(
-            mock_output, embedding_sequence_length=None
-        )
+        result = BaseWorkerHandler._build_completion_usage(mock_output)
 
         assert result["prompt_tokens"] is None
         assert result["completion_tokens"] == 3
@@ -235,9 +227,7 @@ class TestUsageStatistics:
         mock_output.outputs = [Mock(token_ids=[6, 7])]
         mock_output.num_cached_tokens = num_cached_tokens
 
-        result = BaseWorkerHandler._build_completion_usage(
-            mock_output, embedding_sequence_length=None
-        )
+        result = BaseWorkerHandler._build_completion_usage(mock_output)
 
         assert result["prompt_tokens"] == 5
         assert result["completion_tokens"] == 2

--- a/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py
@@ -170,7 +170,6 @@ class TestUsageStatistics:
     @pytest.mark.parametrize(
         "prompt_token_ids,completion_tokens,expected_prompt,expected_total",
         [
-            # vLLM uses placeholder IDs for pure embeddings.
             ([0] * 10, 5, 10, 15),
             ([1, 2, 3, 4, 5, 6, 7], 3, 7, 10),
             # Zero sequence length edge case

--- a/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
+++ b/components/src/dynamo/vllm/tests/test_vllm_worker_handler.py
@@ -747,7 +747,7 @@ class TestDecodeWorkerMultimodalBranching:
             disaggregation_mode="DECODE",
         )
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, None, {"status": "error", "message": "test stop"})
+            return_value=(None, {"status": "error", "message": "test stop"})
         )
         request = {
             "token_ids": [1, 2, 3],
@@ -780,7 +780,7 @@ class TestDecodeWorkerMultimodalBranching:
         # Return an error from _build_prompt_from_request so _generate_token_mode
         # yields it and returns early — no need to mock the engine.
         handler._build_prompt_from_request = MagicMock(
-            return_value=(None, None, {"status": "error", "message": "test stop"})
+            return_value=(None, {"status": "error", "message": "test stop"})
         )
 
         request = {
@@ -809,7 +809,7 @@ class TestDecodeWorkerMultimodalBranching:
     ):
         handler = _make_decode_handler(disaggregation_mode="AGGREGATED")
 
-        prompt, _, error = handler._build_prompt_from_request(
+        prompt, error = handler._build_prompt_from_request(
             {"token_ids": [1, 2, 3]},
             "request-prompt",
             multi_modal_data=None,
@@ -840,7 +840,7 @@ async def test_prefill_delegates_mode_policy_to_shared_processor():
     )
     handler._multimodal_request_processor = processor
     handler._build_prompt_from_request = MagicMock(
-        return_value=(None, None, {"status": "error", "message": "stop"})
+        return_value=(None, {"status": "error", "message": "stop"})
     )
     context = MagicMock()
 
@@ -1133,9 +1133,7 @@ class TestDeferredAbort:
         handler.input_param_manager = MagicMock()
         handler.input_param_manager.get_input_param.return_value = [1, 2, 3]
         handler._resolve_lora_request = MagicMock(return_value=None)
-        handler._build_prompt_from_request = MagicMock(
-            return_value=(MagicMock(), None, None)
-        )
+        handler._build_prompt_from_request = MagicMock(return_value=(MagicMock(), None))
 
         # Capture the guard created inside the handler and wrap close() so
         # the test can assert that the handler awaited it.

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -266,10 +266,6 @@ class TestPromptEmbedsE2E:
         """
         CRITICAL REGRESSION TEST: Ensure prompt_tokens is correctly reported.
 
-        vLLM represents a pure embedding prompt with one placeholder token ID
-        per embedding row. The worker derives usage from those returned IDs,
-        so this assertion verifies that contract end to end.
-
         Rust tests cannot verify this - it requires E2E validation.
         """
         sequence_length = 20

--- a/tests/frontend/test_prompt_embeds.py
+++ b/tests/frontend/test_prompt_embeds.py
@@ -266,9 +266,9 @@ class TestPromptEmbedsE2E:
         """
         CRITICAL REGRESSION TEST: Ensure prompt_tokens is correctly reported.
 
-        This validates the v2.0.4 fix where prompt_tokens was incorrectly
-        reported as 0 when using embeddings. The worker extracts sequence
-        length from tensor shape and includes it in completion_usage.
+        vLLM represents a pure embedding prompt with one placeholder token ID
+        per embedding row. The worker derives usage from those returned IDs,
+        so this assertion verifies that contract end to end.
 
         Rust tests cannot verify this - it requires E2E validation.
         """


### PR DESCRIPTION
## Why

Dynamo threads an embedding sequence length beside the prompt solely to report usage, duplicating information returned by vLLM. Supported vLLM builds already preserve mixed-prompt token IDs and synthesize one placeholder ID per pure-embedding row, so `RequestOutput.prompt_token_ids` is the authoritative sequence length. Using that output directly removes handler coupling and prevents the prompt builder from deciding response accounting.

## What Change

- Remove embedding sequence-length plumbing from prompt construction and generation.
- Derive prompt usage from returned token IDs, preserving empty-prompt semantics.
- Align unit and E2E coverage with the vLLM output contract.

## Test Plan

Focused unit tests (92 passed, 5 skipped):

```bash
python -m pytest \
  components/src/dynamo/vllm/tests/test_vllm_prompt_embeds.py \
  components/src/dynamo/vllm/tests/test_vllm_worker_handler.py \
  -q
```

Prompt-embeddings E2E on an H100 with Python 3.12.3, vLLM 0.25.1, and `Qwen/Qwen3-0.6B`:

```bash
python -m pytest \
  tests/frontend/test_prompt_embeds.py::TestPromptEmbedsE2E::test_usage_prompt_tokens_not_zero \
  -v -s --timeout=900
```

The fixture launched a real Dynamo frontend and vLLM worker with `--enable-prompt-embeds`. It submitted base64-encoded `20 × 1024` embeddings, then asserted `prompt_tokens == 20` and `total_tokens == prompt_tokens + completion_tokens`. Result: 1 passed in 84.98 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token usage reporting for requests that use prompt embeddings.
  * Ensured prompt token counts are derived consistently across streaming, prefill, and decode flows.
  * Simplified prompt handling to provide more reliable completion usage information.

* **Tests**
  * Updated coverage for embedding-based prompts, cached tokens, and decode-only scenarios.
  * Clarified documentation around placeholder tokens used in embedding prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->