### PR TITLE
fix(llm): normalize disabled top-k sentinels [DYN-3579]

### DIFF
--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -63,6 +63,7 @@ from dynamo.trtllm.utils.disagg_utils import (
 )
 from dynamo.trtllm.utils.request_utils import (
     apply_stop_conditions_to_sampling_params,
+    normalize_top_k_for_trtllm,
     request_cache_salt,
 )
 
@@ -1436,6 +1437,8 @@ class HandlerBase(BaseGenerativeHandler):
             for key, value in request["sampling_options"].items()
             if value is not None
         }
+        if "top_k" in overrides:
+            overrides["top_k"] = normalize_top_k_for_trtllm(overrides["top_k"])
 
         # Convert guided_decoding dict (from Rust serialization) to GuidedDecodingParams.
         # Explicit field mapping avoids breakage if either side adds fields the other

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -110,6 +110,14 @@ class TestOverrideSamplingParams:
         assert result.temperature == original_temperature
         assert result.top_p == original_top_p
 
+    def test_disabled_top_k_sentinel_is_converted(self):
+        sampling_params = MockSamplingParams()
+        request = {"sampling_options": {"top_k": -1}}
+
+        result = HandlerBase._override_sampling_params(sampling_params, request)
+
+        assert result.top_k == 0
+
     def test_truthy_values_are_applied(self):
         """Test that normal truthy values are correctly set."""
         sampling_params = MockSamplingParams()

--- a/components/src/dynamo/trtllm/utils/request_utils.py
+++ b/components/src/dynamo/trtllm/utils/request_utils.py
@@ -5,6 +5,11 @@ from collections.abc import Mapping
 from typing import Any, Optional
 
 
+def normalize_top_k_for_trtllm(top_k: int) -> int:
+    """Translate Dynamo's disabled top-k sentinel to TRT-LLM's sentinel."""
+    return 0 if top_k == -1 else top_k
+
+
 def request_cache_salt(request: Mapping[str, Any]) -> Optional[str]:
     """Return the first non-empty cache_salt, preferring routing hints."""
     routing = request.get("routing") or {}

--- a/lib/llm/src/protocols/openai.rs
+++ b/lib/llm/src/protocols/openai.rs
@@ -119,7 +119,9 @@ impl<T: OpenAISamplingOptionsProvider + CommonExtProvider> SamplingOptionsProvid
                 .map_err(|e| anyhow::anyhow!("Error validating frequency_penalty: {}", e))?;
         let presence_penalty = validate_range(self.get_presence_penalty(), &PRESENCE_PENALTY_RANGE)
             .map_err(|e| anyhow::anyhow!("Error validating presence_penalty: {}", e))?;
-        let top_k = CommonExtProvider::get_top_k(self);
+        // Canonicalize the public disabled sentinels before backend dispatch.
+        // Backend adapters translate -1 when their native API uses a different value.
+        let top_k = CommonExtProvider::get_top_k(self).map(|k| if k == 0 { -1 } else { k });
         let repetition_penalty = CommonExtProvider::get_repetition_penalty(self);
         let include_stop_str_in_output = CommonExtProvider::get_include_stop_str_in_output(self);
         let seed = self.get_seed();

--- a/lib/llm/src/protocols/openai/chat_completions.rs
+++ b/lib/llm/src/protocols/openai/chat_completions.rs
@@ -581,9 +581,54 @@ impl ValidateRequest for NvCreateChatCompletionRequest {
 mod tests {
     use super::*;
     use crate::engines::ValidateRequest;
-    use crate::protocols::common::{OutputOptionsProvider, StopConditionsProvider};
+    use crate::protocols::common::{
+        OutputOptionsProvider, SamplingOptionsProvider, StopConditionsProvider,
+    };
     use dynamo_protocols::types::{ChatCompletionTool, ChatCompletionToolType, FunctionObject};
     use serde_json::json;
+
+    #[test]
+    fn test_top_k_sentinel_contract() {
+        for (top_k, expected) in [(-1, Some(-1)), (0, Some(-1)), (1, Some(1))] {
+            let request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "top_k": top_k
+            }))
+            .expect("Failed to deserialize request");
+
+            ValidateRequest::validate(&request).expect("top_k must be valid");
+            assert_eq!(
+                request
+                    .extract_sampling_options()
+                    .expect("Failed to extract sampling options")
+                    .top_k,
+                expected
+            );
+        }
+
+        let null_request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "top_k": null
+        }))
+        .expect("Failed to deserialize request");
+        assert_eq!(
+            null_request
+                .extract_sampling_options()
+                .expect("Failed to extract sampling options")
+                .top_k,
+            None
+        );
+
+        let invalid_request: NvCreateChatCompletionRequest = serde_json::from_value(json!({
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "top_k": -2
+        }))
+        .expect("Failed to deserialize request");
+        assert!(ValidateRequest::validate(&invalid_request).is_err());
+    }
 
     #[test]
     fn test_skip_special_tokens_none() {

--- a/lib/llm/src/protocols/openai/common_ext.rs
+++ b/lib/llm/src/protocols/openai/common_ext.rs
@@ -21,7 +21,8 @@ pub struct CommonExt {
     #[builder(default, setter(strip_option))]
     pub min_tokens: Option<u32>,
 
-    /// Integer that controls the number of top tokens to consider. Set to -1 to consider all tokens.
+    /// Integer that controls the number of top tokens to consider. Set to -1 or 0 to consider all
+    /// tokens.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[builder(default, setter(strip_option))]
     pub top_k: Option<i32>,

--- a/lib/llm/src/protocols/openai/validate.rs
+++ b/lib/llm/src/protocols/openai/validate.rs
@@ -235,8 +235,8 @@ pub fn validate_top_p(top_p: Option<f32>) -> Result<(), anyhow::Error> {
 pub fn validate_top_k(top_k: Option<i32>) -> Result<(), anyhow::Error> {
     match top_k {
         None => Ok(()),
-        Some(k) if k == -1 || k >= 1 => Ok(()),
-        _ => anyhow::bail!("Top_k must be null, -1, or greater than or equal to 1"),
+        Some(k) if k >= -1 => Ok(()),
+        _ => anyhow::bail!("Top_k must be null or greater than or equal to -1"),
     }
 }
 


### PR DESCRIPTION
## Summary

- accept both `0` and `-1` as public disabled `top_k` sentinels
- canonicalize disabled top-k to `-1` inside Dynamo while preserving `null` as unspecified
- translate the canonical sentinel to TensorRT-LLM's required `0` at the backend boundary
- add regression coverage for the public request contract and the live TensorRT-LLM handler

The mismatch came from Dynamo and TensorRT-LLM using different disabled sentinels. Merely accepting `0` would leak an engine-specific representation into Dynamo, while forwarding Dynamo's `-1` directly would violate TensorRT-LLM's contract.

## Validation

- `cargo test -p dynamo-llm --no-default-features test_top_k_sentinel_contract`
- pre-commit hooks on all changed files
- dependency-free TensorRT-LLM normalization smoke test
- TensorRT-LLM handler regression test added for GPU CI; not run locally because the macOS project venv does not include `torch`/TensorRT-LLM

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11871" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `top_k` sampling compatibility across request handling and inference backends.
  * Disabled `top_k` settings are now translated consistently, preventing unexpected sampling behavior.
  * Updated validation to accept supported disabled-value representations while continuing to reject invalid values.

* **Tests**
  * Added coverage for `top_k` sentinel conversion and request-validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->