### PR TITLE
feat(router): add target-only worker selector adapter

### DIFF
--- a/lib/kv-router/src/lib.rs
+++ b/lib/kv-router/src/lib.rs
@@ -68,5 +68,7 @@ pub use scheduling::LocalScheduler;
 pub use scheduling::PrefillLoadEstimator;
 pub use scheduling::policy::{FcfsPolicy, RouterSchedulingPolicy, SchedulingPolicy, WsptPolicy};
 pub use scheduling::{KvSchedulerError, PotentialLoad, SchedulingRequest, SchedulingResponse};
-pub use selector::{DefaultWorkerSelector, WorkerSelector};
+pub use selector::{
+    DefaultWorkerSelector, TargetWorkerSelector, ValidatedWorkerSelector, WorkerSelector,
+};
 pub use tracking_hash::{TrackingHashAlgorithm, TrackingHashContext, TrackingHashScope};

--- a/lib/kv-router/src/scheduling/filter.rs
+++ b/lib/kv-router/src/scheduling/filter.rs
@@ -129,6 +129,22 @@ impl<'a> RoutingEligibility<'a> {
         false
     }
 
+    /// Classify an empty eligible-candidate scan.
+    pub(crate) fn no_eligible_worker_error<C: WorkerConfigLike>(
+        &self,
+        workers: &HashMap<WorkerId, C>,
+    ) -> KvSchedulerError {
+        if self.has_eligible_worker_ignoring_overload(
+            workers
+                .iter()
+                .map(|(&worker_id, config)| (worker_id, config)),
+        ) {
+            KvSchedulerError::AllEligibleWorkersOverloaded
+        } else {
+            KvSchedulerError::NoEndpoints
+        }
+    }
+
     #[inline]
     pub fn validate_worker_rank<'w, C: WorkerConfigLike>(
         &self,

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -419,15 +419,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                     .map(|(&worker_id, config)| (worker_id, config)),
             )
         {
-            if eligibility.has_eligible_worker_ignoring_overload(
-                workers
-                    .iter()
-                    .map(|(&worker_id, config)| (worker_id, config)),
-            ) {
-                return Err(KvSchedulerError::AllEligibleWorkersOverloaded);
-            }
-
-            return Err(KvSchedulerError::NoEndpoints);
+            return Err(eligibility.no_eligible_worker_error(workers));
         }
 
         let request_blocks = request.request_blocks(block_size);

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -34,7 +34,8 @@ pub trait WorkerSelector<C: WorkerConfigLike> {
 /// Target-only worker selection logic.
 ///
 /// The scheduler resolves pinned requests before invoking this trait. Dynamo validates the
-/// returned target and derives the accounting snapshot before booking it.
+/// returned target and derives the accounting snapshot before booking it. Return `Ok(None)` when
+/// no target is selected and `Err` only when the strategy itself fails.
 pub trait TargetWorkerSelector<C: WorkerConfigLike> {
     fn select_worker(
         &self,
@@ -42,7 +43,7 @@ pub trait TargetWorkerSelector<C: WorkerConfigLike> {
         request: &SchedulingRequest,
         eligibility: RoutingEligibility<'_>,
         block_size: u32,
-    ) -> Result<WorkerWithDpRank, KvSchedulerError>;
+    ) -> Result<Option<WorkerWithDpRank>, String>;
 }
 
 /// A target-only selector wrapped with Dynamo-owned validation and accounting.
@@ -93,7 +94,8 @@ where
             .0
             .select_worker(workers, request, eligibility, block_size)
         {
-            Err(KvSchedulerError::NoEndpoints)
+            Ok(Some(worker)) => worker,
+            Ok(None)
                 if !eligibility.has_eligible_worker(
                     workers
                         .iter()
@@ -102,13 +104,14 @@ where
             {
                 return Err(eligibility.no_eligible_worker_error(workers));
             }
-            result => result?,
+            Ok(None) => return Err(KvSchedulerError::NoEndpoints),
+            Err(error) => return Err(KvSchedulerError::SelectionFailed(error.to_string())),
         };
         eligibility
             .validate_worker_rank(workers, worker)
             .map_err(|error| {
                 tracing::warn!(?worker, %error, "worker selector returned invalid target");
-                KvSchedulerError::InitFailed(format!(
+                KvSchedulerError::SelectionFailed(format!(
                     "worker selector returned ineligible target {worker:?}: {error}"
                 ))
             })?;
@@ -727,8 +730,8 @@ mod tests {
             _request: &SchedulingRequest,
             _eligibility: RoutingEligibility<'_>,
             _block_size: u32,
-        ) -> Result<WorkerWithDpRank, KvSchedulerError> {
-            Ok(self.0)
+        ) -> Result<Option<WorkerWithDpRank>, String> {
+            Ok(Some(self.0))
         }
     }
 
@@ -741,8 +744,22 @@ mod tests {
             _request: &SchedulingRequest,
             _eligibility: RoutingEligibility<'_>,
             _block_size: u32,
-        ) -> Result<WorkerWithDpRank, KvSchedulerError> {
-            Err(KvSchedulerError::NoEndpoints)
+        ) -> Result<Option<WorkerWithDpRank>, String> {
+            Ok(None)
+        }
+    }
+
+    struct FailedSelection;
+
+    impl<C: WorkerConfigLike> TargetWorkerSelector<C> for FailedSelection {
+        fn select_worker(
+            &self,
+            _workers: &HashMap<WorkerId, C>,
+            _request: &SchedulingRequest,
+            _eligibility: RoutingEligibility<'_>,
+            _block_size: u32,
+        ) -> Result<Option<WorkerWithDpRank>, String> {
+            Err("test failure".to_string())
         }
     }
 
@@ -1074,18 +1091,45 @@ mod tests {
 
         let workers = HashMap::from([
             (0, SimpleWorkerConfig::default()),
-            (1, SimpleWorkerConfig::default()),
+            (
+                1,
+                SimpleWorkerConfig {
+                    data_parallel_start_rank: 2,
+                    data_parallel_size: 2,
+                    ..Default::default()
+                },
+            ),
         ]);
         let pinned = WorkerWithDpRank::from_worker_id(0);
-        let mut request = base_request(16);
+        let mut request = base_request(17);
         request.pinned_worker = Some(pinned);
 
-        let result = ValidatedWorkerSelector::new(NoSelection)
+        let result = ValidatedWorkerSelector::new(FailedSelection)
             .select_worker(&workers, &request, request.eligibility(), 16)
             .expect("the host should resolve the pin before invoking the selector");
         assert_eq!(result.worker, pinned);
 
         request.pinned_worker = None;
+        let selected = WorkerWithDpRank::new(1, 3);
+        request
+            .overlap
+            .effective_overlap_blocks
+            .extend([(WorkerWithDpRank::new(1, 2), 1.0), (selected, 3.5)]);
+        request
+            .overlap
+            .effective_cached_tokens
+            .extend([(WorkerWithDpRank::new(1, 2), 16), (selected, 56)]);
+        request.worker_loads =
+            worker_loads_with_active_decode(FxHashMap::from_iter([(selected, 4)]));
+        let result = ValidatedWorkerSelector::new(FixedSelection(selected))
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .expect("valid unpinned target should be accepted");
+        assert_eq!(result.worker, selected);
+        assert_eq!(result.required_blocks, 2);
+        assert_eq!(result.effective_overlap_blocks, 3.5);
+        assert_eq!(result.cached_tokens, 56);
+        assert_eq!(result.potential_decode_blocks, 6);
+
         let invalid = WorkerWithDpRank::from_worker_id(99);
         let result = ValidatedWorkerSelector::new(FixedSelection(invalid)).select_worker(
             &workers,
@@ -1093,7 +1137,7 @@ mod tests {
             request.eligibility(),
             16,
         );
-        assert!(matches!(result, Err(KvSchedulerError::InitFailed(_))));
+        assert!(matches!(result, Err(KvSchedulerError::SelectionFailed(_))));
     }
 
     #[test]
@@ -1120,6 +1164,18 @@ mod tests {
         assert!(matches!(
             result,
             Err(KvSchedulerError::AllEligibleWorkersOverloaded)
+        ));
+
+        let result = ValidatedWorkerSelector::new(FailedSelection).select_worker(
+            &workers,
+            &request,
+            request.eligibility(),
+            16,
+        );
+        assert!(matches!(
+            result,
+            Err(KvSchedulerError::SelectionFailed(message))
+                if message == "test failure"
         ));
     }
 

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -14,9 +14,13 @@ use super::filter::{RoutingEligibility, WorkerEligibilityError};
 use super::types::{KvSchedulerError, SchedulingRequest};
 use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
 
-/// A trait that users can implement to define custom selection logic.
+/// A trait that users can implement to define custom worker selection logic.
 ///
 /// Generic over `C` so that the scheduling layer does not depend on a concrete config type.
+/// This is the original low-level selector contract; implementations own both target selection
+/// and the associated accounting snapshot. New selectors should implement
+/// [`TargetWorkerSelector`] and use [`ValidatedWorkerSelector`] so Dynamo owns validation and
+/// accounting.
 pub trait WorkerSelector<C: WorkerConfigLike> {
     fn select_worker(
         &self,
@@ -25,6 +29,98 @@ pub trait WorkerSelector<C: WorkerConfigLike> {
         eligibility: RoutingEligibility<'_>,
         block_size: u32,
     ) -> Result<WorkerSelectionResult, KvSchedulerError>;
+}
+
+/// Target-only worker selection logic.
+///
+/// The scheduler resolves pinned requests before invoking this trait. Dynamo validates the
+/// returned target and derives the accounting snapshot before booking it.
+pub trait TargetWorkerSelector<C: WorkerConfigLike> {
+    fn select_worker(
+        &self,
+        workers: &HashMap<WorkerId, C>,
+        request: &SchedulingRequest,
+        eligibility: RoutingEligibility<'_>,
+        block_size: u32,
+    ) -> Result<WorkerWithDpRank, KvSchedulerError>;
+}
+
+/// A target-only selector wrapped with Dynamo-owned validation and accounting.
+#[derive(Debug)]
+pub struct ValidatedWorkerSelector<S>(S);
+
+impl<S> ValidatedWorkerSelector<S> {
+    pub fn new(selector: S) -> Self {
+        Self(selector)
+    }
+}
+
+impl<C, S> WorkerSelector<C> for ValidatedWorkerSelector<S>
+where
+    C: WorkerConfigLike,
+    S: TargetWorkerSelector<C>,
+{
+    fn select_worker(
+        &self,
+        workers: &HashMap<WorkerId, C>,
+        request: &SchedulingRequest,
+        eligibility: RoutingEligibility<'_>,
+        block_size: u32,
+    ) -> Result<WorkerSelectionResult, KvSchedulerError> {
+        if let Some(worker) = eligibility.pinned_worker() {
+            eligibility.validate_pinned_worker_allowed()?;
+            match eligibility.validate_worker_rank(workers, worker) {
+                Ok(_) => {
+                    return Ok(WorkerSelectionResult {
+                        worker,
+                        required_blocks: request.request_blocks(block_size),
+                        effective_overlap_blocks: request.effective_overlap_blocks_for(worker),
+                        cached_tokens: request.effective_cached_tokens_for(worker),
+                        potential_decode_blocks: request
+                            .potential_decode_blocks_after_admission(worker, block_size),
+                    });
+                }
+                Err(WorkerEligibilityError::WorkerOverloaded { .. }) => {
+                    return Err(KvSchedulerError::PinnedWorkerOverloaded {
+                        worker_id: worker.worker_id,
+                    });
+                }
+                Err(_) => return Err(KvSchedulerError::NoEndpoints),
+            }
+        }
+
+        let worker = match self
+            .0
+            .select_worker(workers, request, eligibility, block_size)
+        {
+            Err(KvSchedulerError::NoEndpoints)
+                if !eligibility.has_eligible_worker(
+                    workers
+                        .iter()
+                        .map(|(&worker_id, config)| (worker_id, config)),
+                ) =>
+            {
+                return Err(eligibility.no_eligible_worker_error(workers));
+            }
+            result => result?,
+        };
+        eligibility
+            .validate_worker_rank(workers, worker)
+            .map_err(|error| {
+                tracing::warn!(?worker, %error, "worker selector returned invalid target");
+                KvSchedulerError::InitFailed(format!(
+                    "worker selector returned ineligible target {worker:?}: {error}"
+                ))
+            })?;
+        Ok(WorkerSelectionResult {
+            worker,
+            required_blocks: request.request_blocks(block_size),
+            effective_overlap_blocks: request.effective_overlap_blocks_for(worker),
+            cached_tokens: request.effective_cached_tokens_for(worker),
+            potential_decode_blocks: request
+                .potential_decode_blocks_after_admission(worker, block_size),
+        })
+    }
 }
 
 /// Helper function for softmax sampling.
@@ -630,6 +726,34 @@ mod tests {
         }
     }
 
+    struct FixedSelection(WorkerWithDpRank);
+
+    impl<C: WorkerConfigLike> TargetWorkerSelector<C> for FixedSelection {
+        fn select_worker(
+            &self,
+            _workers: &HashMap<WorkerId, C>,
+            _request: &SchedulingRequest,
+            _eligibility: RoutingEligibility<'_>,
+            _block_size: u32,
+        ) -> Result<WorkerWithDpRank, KvSchedulerError> {
+            Ok(self.0)
+        }
+    }
+
+    struct NoSelection;
+
+    impl<C: WorkerConfigLike> TargetWorkerSelector<C> for NoSelection {
+        fn select_worker(
+            &self,
+            _workers: &HashMap<WorkerId, C>,
+            _request: &SchedulingRequest,
+            _eligibility: RoutingEligibility<'_>,
+            _block_size: u32,
+        ) -> Result<WorkerWithDpRank, KvSchedulerError> {
+            Err(KvSchedulerError::NoEndpoints)
+        }
+    }
+
     fn base_request(isl_tokens: usize) -> SchedulingRequest {
         SchedulingRequest {
             mode: ScheduleMode::QueryOnly {
@@ -946,6 +1070,61 @@ mod tests {
             16,
         );
 
+        assert!(matches!(
+            result,
+            Err(KvSchedulerError::AllEligibleWorkersOverloaded)
+        ));
+    }
+
+    #[test]
+    fn validated_selector_keeps_pins_host_owned_and_rejects_invalid_targets() {
+        use crate::test_utils::SimpleWorkerConfig;
+
+        let workers = HashMap::from([
+            (0, SimpleWorkerConfig::default()),
+            (1, SimpleWorkerConfig::default()),
+        ]);
+        let pinned = WorkerWithDpRank::from_worker_id(0);
+        let mut request = base_request(16);
+        request.pinned_worker = Some(pinned);
+
+        let result = ValidatedWorkerSelector::new(NoSelection)
+            .select_worker(&workers, &request, request.eligibility(), 16)
+            .expect("the host should resolve the pin before invoking the selector");
+        assert_eq!(result.worker, pinned);
+
+        request.pinned_worker = None;
+        let invalid = WorkerWithDpRank::from_worker_id(99);
+        let result = ValidatedWorkerSelector::new(FixedSelection(invalid)).select_worker(
+            &workers,
+            &request,
+            request.eligibility(),
+            16,
+        );
+        assert!(matches!(result, Err(KvSchedulerError::InitFailed(_))));
+    }
+
+    #[test]
+    fn validated_selector_classifies_empty_candidate_sets() {
+        use crate::test_utils::SimpleWorkerConfig;
+
+        let selector = ValidatedWorkerSelector::new(NoSelection);
+        let workers = HashMap::from([
+            (0, SimpleWorkerConfig::default()),
+            (1, SimpleWorkerConfig::default()),
+        ]);
+        let request = base_request(16);
+
+        let result = selector.select_worker(&workers, &request, request.eligibility(), 16);
+        assert!(matches!(result, Err(KvSchedulerError::NoEndpoints)));
+
+        let overloaded_worker_ids = HashSet::from([0, 1]);
+        let result = selector.select_worker(
+            &workers,
+            &request,
+            request.eligibility_with_overloaded(Some(&overloaded_worker_ids)),
+            16,
+        );
         assert!(matches!(
             result,
             Err(KvSchedulerError::AllEligibleWorkersOverloaded)

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -58,6 +58,9 @@ pub enum KvSchedulerError {
 
     #[error("failed to initialize event publisher: {0}")]
     InitFailed(String),
+
+    #[error("worker selection failed: {0}")]
+    SelectionFailed(String),
 }
 
 impl KvSchedulerError {

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -289,7 +289,8 @@ impl SchedulingRequest {
         )
     }
 
-    pub(crate) fn effective_cached_tokens_for(&self, worker: WorkerWithDpRank) -> usize {
+    /// Effective cached tokens currently attributed to a worker/rank.
+    pub fn effective_cached_tokens_for(&self, worker: WorkerWithDpRank) -> usize {
         self.overlap
             .effective_cached_tokens
             .get(&worker)
@@ -297,7 +298,8 @@ impl SchedulingRequest {
             .unwrap_or(0)
     }
 
-    pub(crate) fn effective_overlap_blocks_for(&self, worker: WorkerWithDpRank) -> f64 {
+    /// Effective cache overlap currently attributed to a worker/rank.
+    pub fn effective_overlap_blocks_for(&self, worker: WorkerWithDpRank) -> f64 {
         self.overlap
             .effective_overlap_blocks
             .get(&worker)

--- a/lib/kv-router/src/services/selection/error.rs
+++ b/lib/kv-router/src/services/selection/error.rs
@@ -64,11 +64,26 @@ fn scheduler_error_status(error: &KvSchedulerError) -> StatusCode {
         KvSchedulerError::NoEndpoints
         | KvSchedulerError::SubscriberShutdown
         | KvSchedulerError::InitFailed(_) => StatusCode::SERVICE_UNAVAILABLE,
+        KvSchedulerError::SelectionFailed(_) => StatusCode::INTERNAL_SERVER_ERROR,
         KvSchedulerError::AllEligibleWorkersOverloaded
         | KvSchedulerError::PinnedWorkerOverloaded { .. } => StatusCode::TOO_MANY_REQUESTS,
         KvSchedulerError::QueueRejected(_) => StatusCode::SERVICE_UNAVAILABLE,
         KvSchedulerError::PinnedWorkerNotAllowed { .. } => StatusCode::BAD_REQUEST,
         KvSchedulerError::BookingFailed(_) => StatusCode::CONFLICT,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn selector_contract_failures_are_internal_errors() {
+        let error = KvSchedulerError::SelectionFailed("invalid target".to_string());
+        assert_eq!(
+            scheduler_error_status(&error),
+            StatusCode::INTERNAL_SERVER_ERROR
+        );
     }
 }
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Adds a target-only worker-selection API and a Dynamo-owned adapter that validates the selected target and derives cache/load accounting. This lets custom Rust selectors choose placement without taking ownership of scheduler invariants, while leaving every existing selector and runtime path unchanged.

Part of DYN-3598

### How This Was Implemented
- Added `TargetWorkerSelector`, which returns only an eligible `(worker_id, dp_rank)` target.
- Added `ValidatedWorkerSelector`, which implements the existing `WorkerSelector` contract and keeps pins, eligibility validation, overload classification, and accounting host-owned.
- Exposed the existing overlap and cached-token accessors needed by external selector implementations.
- Added focused coverage for pinned targets, invalid custom targets, and empty versus overloaded candidate sets.

<details>
<summary>Walkthrough</summary>

#### Mental model

The scheduler queue still consumes the original `WorkerSelector` contract, whose implementations return a complete `WorkerSelectionResult`. That result contains both the placement decision and Dynamo bookkeeping: the selected worker/rank, required prompt blocks, effective overlap blocks, and cached tokens.

New strategies instead implement `TargetWorkerSelector` and return only `WorkerWithDpRank`. `ValidatedWorkerSelector<S>` adapts that target-only decision back into the existing contract after Dynamo validates the target and derives the bookkeeping from the request.

```mermaid
flowchart LR
    Q["Scheduler queue"] --> W["Existing WorkerSelector contract"]
    T["Custom TargetWorkerSelector"] --> A["ValidatedWorkerSelector adapter"]
    A --> V["Dynamo eligibility validation"]
    V --> C["Dynamo accounting derivation"]
    C --> W
```

The old `WorkerSelector` trait remains unchanged because it is already the queue's integration boundary and is still implemented directly by `DefaultWorkerSelector`. The new adapter satisfies that existing contract, avoiding queue or scheduler changes.

#### Contracts and ownership

`TargetWorkerSelector::select_worker` receives the current worker configurations, `SchedulingRequest`, `RoutingEligibility`, and KV block size. A strategy may inspect request cache/load signals and enumerate workers, but its only successful output is `(worker_id, dp_rank)`.

The worker map is not prefiltered. The strategy can use `RoutingEligibility` while searching, and Dynamo independently validates the returned target afterward. A strategy therefore cannot make the host accept a disallowed worker, an unavailable worker, an invalid DP rank, an overloaded worker, or one whose taints violate the request's routing constraints.

`ValidatedWorkerSelector<S>` is a generic wrapper, not a trait object. It statically implements `WorkerSelector<C>` whenever `S` implements `TargetWorkerSelector<C>`.

#### Request lifecycle

Pinned requests are resolved before custom logic runs. The adapter verifies that the caller allows the pin, that the worker and DP rank exist, that routing constraints are satisfied, and that the worker is not overloaded. It then returns the pinned target without invoking the custom selector.

Pinned failures preserve the existing distinctions: a caller-disallowed pin produces `PinnedWorkerNotAllowed`, an overloaded pin produces `PinnedWorkerOverloaded`, and other unavailable or incompatible pins produce `NoEndpoints`. A custom strategy cannot redirect a pin.

For an unpinned request, the adapter calls the target-only strategy and validates its returned worker/rank with `RoutingEligibility::validate_worker_rank`. An invalid target is logged and converted to `SelectionFailed`, which maps to HTTP 500 because it is a deterministic selector contract failure rather than retryable overload.

#### Empty-candidate errors

`RoutingEligibility::no_eligible_worker_error` distinguishes a structurally empty eligible set from temporary overload. If a worker would be legal when overload filtering is ignored, the result is `AllEligibleWorkersOverloaded`; otherwise it is `NoEndpoints`.

The strategy returns `Ok(None)` when it selects no target and reserves `Err` for a strategy failure. On `Ok(None)`, the adapter returns `AllEligibleWorkersOverloaded` when overload is the only blocker; otherwise it returns `NoEndpoints`. Strategy failures become `SelectionFailed` and do not masquerade as backpressure.

#### Host-derived accounting

After validating the target, Dynamo constructs the complete `WorkerSelectionResult` itself:

```rust
WorkerSelectionResult {
    worker,
    required_blocks: request.request_blocks(block_size),
    effective_overlap_blocks: request.effective_overlap_blocks_for(worker),
    cached_tokens: request.effective_cached_tokens_for(worker),
    potential_decode_blocks:
        request.potential_decode_blocks_after_admission(worker, block_size),
}
```

This keeps the scheduler's cache and load accounting authoritative. In particular, a custom strategy cannot fabricate a larger cache hit or supply inconsistent prompt-block accounting. The existing cached-token and effective-overlap lookup methods are made public so external selectors can read the same normalized values; their behavior is unchanged and missing entries still return zero.

#### Public surface and tests

`TargetWorkerSelector` and `ValidatedWorkerSelector` are re-exported from the `dynamo_kv_router` crate root beside `DefaultWorkerSelector` and `WorkerSelector`.

The focused tests use a selector that always returns a fixed target and one that returns no selection. They prove that pins bypass custom logic, invalid targets are rejected, strategy failures remain distinct, and an empty candidate set is classified differently when all otherwise-eligible workers are overloaded.

#### Boundaries and limitations

No production path constructs `ValidatedWorkerSelector` in this PR. `DefaultWorkerSelector` remains the active concrete selector, so existing routing behavior and the stock hot path are unchanged.

This PR adds no runtime plugin loader, ABI, configuration, frontend wiring, dynamic dispatch, candidate materialization, queue changes, or admission-control behavior. Those layers remain follow-up work under #11875.

</details>

### Validation
- `cargo test -p dynamo-kv-router` — 826 passed, 2 ignored.
- `cargo test -p dynamo-kv-router --features standalone-selection selector_contract_failures_are_internal_errors --lib`
- `cargo clippy -p dynamo-kv-router --all-targets -- -D warnings`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`

### Related Issues
- Relates to #11875
<!-- codex-pr-description:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved worker selection with stronger validation for targeted and pinned-worker requests.
  * Added clearer scheduling information for cached tokens and overlap calculations.
  * Expanded routing capabilities to support validated worker-selection workflows.

* **Bug Fixes**
  * Improved error reporting when no workers are available or all eligible workers are overloaded.
  * Invalid worker selections are now detected and reported more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
