### PR TITLE
fix(runtime): resolve response stream bind hosts safely

### DIFF
--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -51,6 +51,10 @@ use anyhow::{Context, Result, anyhow as error};
 pub trait IpResolver {
     fn local_ip(&self) -> Result<std::net::IpAddr, Error>;
     fn local_ipv6(&self) -> Result<std::net::IpAddr, Error>;
+
+    fn list_afinet_netifas(&self) -> Result<Vec<(String, std::net::IpAddr)>, Error> {
+        list_afinet_netifas()
+    }
 }
 
 // Default implementation using the real local_ip_address crate
@@ -64,6 +68,32 @@ impl IpResolver for DefaultIpResolver {
     fn local_ipv6(&self) -> Result<std::net::IpAddr, Error> {
         local_ipv6()
     }
+}
+
+fn resolve_configured_host<R: IpResolver>(
+    host_or_interface: &str,
+    resolver: &R,
+) -> Result<IpAddr, PipelineError> {
+    if let Ok(ip) = host_or_interface.parse::<IpAddr>() {
+        return Ok(ip);
+    }
+
+    let interfaces = resolver.list_afinet_netifas()?;
+    let interface_found = interfaces.iter().any(|(name, _)| name == host_or_interface);
+    let mut ipv4_addresses: Vec<_> = interfaces
+        .into_iter()
+        .filter_map(|(name, ip)| (name == host_or_interface && ip.is_ipv4()).then_some(ip))
+        .collect();
+    ipv4_addresses.sort_unstable();
+
+    ipv4_addresses.into_iter().next().ok_or_else(|| {
+        let message = if interface_found {
+            format!("Interface has no IPv4 address: {host_or_interface}")
+        } else {
+            format!("Interface not found: {host_or_interface}")
+        };
+        PipelineError::Generic(message)
+    })
 }
 
 #[allow(dead_code)]
@@ -88,7 +118,7 @@ impl ServerOptions {
 /// A Response connection is a connection that is established by a client with the intention of sending
 /// specific data back to the server.
 pub struct TcpStreamServer {
-    local_ip: String,
+    local_ip: IpAddr,
     local_port: u16,
     state: Arc<Mutex<State>>,
 }
@@ -183,19 +213,8 @@ impl TcpStreamServer {
         options: ServerOptions,
         resolver: R,
     ) -> Result<Arc<Self>, PipelineError> {
-        let local_ip = match options.interface {
-            Some(interface) => {
-                let interfaces: HashMap<String, std::net::IpAddr> =
-                    list_afinet_netifas()?.into_iter().collect();
-
-                interfaces
-                    .get(&interface)
-                    .ok_or(PipelineError::Generic(format!(
-                        "Interface not found: {}",
-                        interface
-                    )))?
-                    .to_string()
-            }
+        let local_ip = match options.interface.as_deref() {
+            Some(host) => resolve_configured_host(host, &resolver)?,
             None => {
                 let resolved_ip = resolver.local_ip().or_else(|err| match err {
                     Error::LocalIpAddressNotFound => resolver.local_ipv6(),
@@ -220,13 +239,12 @@ impl TcpStreamServer {
                         )));
                     }
                 }
-                .to_string()
             }
         };
 
         let state = Arc::new(Mutex::new(State::default()));
 
-        let local_port = Self::start(local_ip.clone(), options.port, state.clone())
+        let local_port = Self::start(local_ip, options.port, state.clone())
             .await
             .map_err(|e| {
                 PipelineError::Generic(format!("Failed to start TcpStreamServer: {}", e))
@@ -361,8 +379,8 @@ impl TcpStreamServer {
         state.removed_instances.remove(id);
     }
 
-    async fn start(local_ip: String, local_port: u16, state: Arc<Mutex<State>>) -> Result<u16> {
-        let addr = format!("{}:{}", local_ip, local_port);
+    async fn start(local_ip: IpAddr, local_port: u16, state: Arc<Mutex<State>>) -> Result<u16> {
+        let addr = SocketAddr::new(local_ip, local_port);
         let state_clone = state.clone();
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<u16>>();
         {
@@ -442,7 +460,7 @@ impl ResponseService for TcpStreamServer {
     async fn register(&self, options: StreamOptions) -> PendingConnections {
         // oneshot channels to pass back the sender and receiver objects
 
-        let address = format!("{}:{}", self.local_ip, self.local_port);
+        let address = SocketAddr::new(self.local_ip, self.local_port).to_string();
         tracing::debug!("Registering new TcpStream on {address}");
 
         let send_stream = if options.enable_request_stream {
@@ -552,11 +570,11 @@ impl ResponseService for TcpStreamServer {
 // the sender, then we spawn a task to forward all bytes from the tcp stream
 // to the sender
 async fn tcp_listener(
-    addr: String,
+    addr: SocketAddr,
     state: Arc<Mutex<State>>,
     read_tx: tokio::sync::oneshot::Sender<Result<u16>>,
 ) -> Result<()> {
-    let listener = tokio::net::TcpListener::bind(&addr)
+    let listener = tokio::net::TcpListener::bind(addr)
         .await
         .map_err(|e| anyhow::anyhow!("Failed to start TcpListender on {}: {}", addr, e));
 
@@ -1077,6 +1095,74 @@ mod tests {
         fn local_ipv6(&self) -> Result<std::net::IpAddr, Error> {
             Err(Error::LocalIpAddressNotFound)
         }
+    }
+
+    struct InterfaceIpResolver {
+        interfaces: Vec<(String, IpAddr)>,
+    }
+
+    impl IpResolver for InterfaceIpResolver {
+        fn local_ip(&self) -> Result<IpAddr, Error> {
+            Ok(IpAddr::from([127, 0, 0, 1]))
+        }
+
+        fn local_ipv6(&self) -> Result<IpAddr, Error> {
+            Ok(IpAddr::V6(std::net::Ipv6Addr::LOCALHOST))
+        }
+
+        fn list_afinet_netifas(&self) -> Result<Vec<(String, IpAddr)>, Error> {
+            Ok(self.interfaces.clone())
+        }
+    }
+
+    #[test]
+    fn configured_ip_literal_is_used_directly() {
+        let resolver = InterfaceIpResolver {
+            interfaces: Vec::new(),
+        };
+
+        assert_eq!(
+            resolve_configured_host("172.16.0.87", &resolver).unwrap(),
+            "172.16.0.87".parse::<IpAddr>().unwrap()
+        );
+        assert_eq!(
+            resolve_configured_host("2001:db8::1", &resolver).unwrap(),
+            "2001:db8::1".parse::<IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn configured_interface_selects_ipv4_deterministically() {
+        let resolver = InterfaceIpResolver {
+            interfaces: vec![
+                ("ib0".to_string(), "fe80::1".parse().unwrap()),
+                ("ib0".to_string(), "172.16.96.87".parse().unwrap()),
+                ("eth0".to_string(), "10.52.1.2".parse().unwrap()),
+                ("ib0".to_string(), "172.16.0.87".parse().unwrap()),
+            ],
+        };
+
+        assert_eq!(
+            resolve_configured_host("ib0", &resolver).unwrap(),
+            "172.16.0.87".parse::<IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn configured_interface_requires_ipv4() {
+        let resolver = InterfaceIpResolver {
+            interfaces: vec![("ib0".to_string(), "fe80::1".parse().unwrap())],
+        };
+
+        let error = resolve_configured_host("ib0", &resolver).unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("Interface has no IPv4 address: ib0")
+        );
+
+        let error = resolve_configured_host("missing0", &resolver).unwrap_err();
+        assert!(error.to_string().contains("Interface not found: missing0"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- allow `DYN_TCP_RESPONSE_STREAM_HOST` to accept either an IP address or a network interface name
- deterministically select the lowest IPv4 address when an interface has multiple addresses
- construct response-stream listener and advertised addresses with `SocketAddr` instead of formatting `host:port` strings
- return distinct errors for a missing interface and an interface without an IPv4 address

The existing code always interpreted the override as an interface name. As a result, an IP literal could not be used directly, and text-based address construction was unsafe for IPv6 literals.

This PR is stacked on #11870. Its reviewable diff is the single child commit that updates `lib/runtime/src/pipeline/network/tcp/server.rs`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-runtime --lib pipeline::network::tcp::server::tests` (33 passed)
- the equivalent patch was exercised in the Tyche all-IPoIB AgentX run using explicit response-stream IP addresses, with zero frontend request errors or cancellations
