### PR TITLE
perf(router): shrink admission lease hot-path footprint

### DIFF
--- a/lib/kv-router/src/scheduling/local.rs
+++ b/lib/kv-router/src/scheduling/local.rs
@@ -338,7 +338,7 @@ where
             .map_err(|_| KvSchedulerError::SubscriberShutdown)?;
         match &mut response {
             Ok(response) if response.request_progress.is_some() => {
-                response.admission_lease = cancellation_guard.take().map(|lease| *lease);
+                response.admission_lease = cancellation_guard.take();
             }
             Ok(_) | Err(_) => {
                 if let Some(guard) = cancellation_guard.as_mut() {

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -80,8 +80,8 @@ enum AdmissionCommand {
     EnqueueLeased {
         request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
-        lease: Box<AdmissionLease>,
-        ack_tx: oneshot::Sender<Box<AdmissionLease>>,
+        lease: AdmissionLease,
+        ack_tx: oneshot::Sender<AdmissionLease>,
     },
     Update {
         worker: Option<WorkerWithDpRank>,
@@ -154,6 +154,10 @@ impl AdmissionCleanup {
 /// either phase queues one terminal outcome and coalesces the actor wakeup.
 #[must_use = "dropping the lease reports the request outcome to the scheduler actor"]
 pub struct AdmissionLease {
+    state: Box<AdmissionLeaseState>,
+}
+
+struct AdmissionLeaseState {
     cleanup: Arc<AdmissionCleanup>,
     actor_tx: mpsc::Sender<AdmissionCommand>,
     generation: LifecycleGeneration,
@@ -167,52 +171,52 @@ impl std::fmt::Debug for AdmissionLease {
     fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         formatter
             .debug_struct("AdmissionLease")
-            .field("generation", &self.generation)
-            .field("request_id", &self.request_id)
-            .field("outcome", &self.outcome)
-            .field("dispatched", &self.dispatched)
-            .field("armed", &self.armed)
+            .field("generation", &self.state.generation)
+            .field("request_id", &self.state.request_id)
+            .field("outcome", &self.state.outcome)
+            .field("dispatched", &self.state.dispatched)
+            .field("armed", &self.state.armed)
             .finish_non_exhaustive()
     }
 }
 
 impl AdmissionLease {
     pub fn mark_completed(&mut self, context_tokens: usize) {
-        self.outcome = RequestOutcome::Completed { context_tokens };
+        self.state.outcome = RequestOutcome::Completed { context_tokens };
     }
 
     pub fn mark_aborted(&mut self) {
-        self.outcome = RequestOutcome::Aborted;
+        self.state.outcome = RequestOutcome::Aborted;
     }
 
     pub fn mark_dispatched(&mut self) {
-        self.dispatched = true;
+        self.state.dispatched = true;
     }
 
     pub fn disarm(&mut self) {
-        self.request_id = None;
+        self.state.request_id = None;
     }
 
     fn arm(&mut self) {
-        self.armed = true;
+        self.state.armed = true;
     }
 }
 
 impl Drop for AdmissionLease {
     fn drop(&mut self) {
-        if !self.armed {
+        if !self.state.armed {
             return;
         }
-        let Some(request_id) = self.request_id.take() else {
+        let Some(request_id) = self.state.request_id.take() else {
             return;
         };
-        if self.cleanup.enqueue(AdmissionCleanupEntry {
-            generation: self.generation,
+        if self.state.cleanup.enqueue(AdmissionCleanupEntry {
+            generation: self.state.generation,
             request_id,
-            outcome: self.outcome,
-            dispatched: self.dispatched,
+            outcome: self.state.outcome,
+            dispatched: self.state.dispatched,
         }) {
-            let _ = self.actor_tx.try_send(AdmissionCommand::Cleanup);
+            let _ = self.state.actor_tx.try_send(AdmissionCommand::Cleanup);
         }
     }
 }
@@ -592,8 +596,8 @@ impl<
         &self,
         mut request: SchedulingRequest,
         block_hashes: Option<Vec<LocalBlockHash>>,
-        lease: Option<Box<AdmissionLease>>,
-    ) -> Option<Box<AdmissionLease>> {
+        lease: Option<AdmissionLease>,
+    ) -> Option<AdmissionLease> {
         let Some(lease) = lease else {
             self.enqueue_with_block_hashes(request, block_hashes).await;
             return None;
@@ -630,26 +634,25 @@ impl<
         }
     }
 
-    pub(crate) fn cancellation_guard(
-        &self,
-        request_id: Option<&str>,
-    ) -> Option<Box<AdmissionLease>> {
+    pub(crate) fn cancellation_guard(&self, request_id: Option<&str>) -> Option<AdmissionLease> {
         if !self.queueing_enabled {
             return None;
         }
         let request_id = request_id?.to_owned();
-        Some(Box::new(AdmissionLease {
-            cleanup: Arc::clone(&self.cleanup),
-            actor_tx: self.admission_tx.clone(),
-            generation: LifecycleGeneration(
-                self.next_lifecycle_generation
-                    .fetch_add(1, AtomicOrdering::Relaxed),
-            ),
-            request_id: Some(request_id),
-            outcome: RequestOutcome::Aborted,
-            dispatched: false,
-            armed: false,
-        }))
+        Some(AdmissionLease {
+            state: Box::new(AdmissionLeaseState {
+                cleanup: Arc::clone(&self.cleanup),
+                actor_tx: self.admission_tx.clone(),
+                generation: LifecycleGeneration(
+                    self.next_lifecycle_generation
+                        .fetch_add(1, AtomicOrdering::Relaxed),
+                ),
+                request_id: Some(request_id),
+                outcome: RequestOutcome::Aborted,
+                dispatched: false,
+                armed: false,
+            }),
+        })
     }
 
     /// Called on prefill_complete/free. Drains pending requests while workers have capacity.
@@ -788,9 +791,9 @@ impl<
                     mut lease,
                     ack_tx,
                 } => {
-                    let generation = lease.generation;
+                    let generation = lease.state.generation;
                     debug_assert_eq!(
-                        lease.request_id.as_deref(),
+                        lease.state.request_id.as_deref(),
                         request.mode.tracked_request_id()
                     );
                     let (enqueue_ready, owns_lifecycle) =
@@ -1106,7 +1109,7 @@ impl<
         let mut ready_by_class: HashMap<usize, FxHashSet<_>> = HashMap::new();
         let mut unmanaged_request_ids = HashSet::new();
         for cleanup in dirty {
-            let request_id = cleanup.request_id.as_str();
+            let request_id = &cleanup.request_id;
             let tracked = self.tracked_admissions.get(request_id).copied();
             if tracked.is_some_and(|tracked| tracked.generation != Some(cleanup.generation)) {
                 continue;
@@ -1115,14 +1118,13 @@ impl<
                 made_ready |= self.handle_dispatched(request_id);
             }
 
-            if tracked.is_none_or(|tracked| tracked.worker.is_some()) {
-                let owned_request_id = request_id.to_owned();
-                if self.slots.request_worker(&owned_request_id).is_some() {
-                    if let Err(error) = self.slots.free(&owned_request_id, Instant::now()) {
-                        tracing::error!(%request_id, %error, "Failed to release dropped scheduler booking");
-                    }
-                    made_ready = true;
+            if tracked.is_none_or(|tracked| tracked.worker.is_some())
+                && self.slots.request_worker(request_id).is_some()
+            {
+                if let Err(error) = self.slots.free(request_id, Instant::now()) {
+                    tracing::error!(%request_id, %error, "Failed to release dropped scheduler booking");
                 }
+                made_ready = true;
             }
 
             let Some(tracked) = tracked else {
@@ -2381,7 +2383,7 @@ mod tests {
     async fn enqueue_with_lease(
         queue: &SchedulerQueue<NoopSequencePublisher, SimpleWorkerConfig>,
         request: SchedulingRequest,
-    ) -> Box<AdmissionLease> {
+    ) -> AdmissionLease {
         let request_id = request
             .mode
             .admission_request_id()
@@ -2742,13 +2744,15 @@ policy_classes:
         let cleanup = Arc::new(AdmissionCleanup::default());
         let (actor_tx, mut actor_rx) = mpsc::channel(1);
         let lease = |generation: u64, request_id: &str| AdmissionLease {
-            cleanup: Arc::clone(&cleanup),
-            actor_tx: actor_tx.clone(),
-            generation: LifecycleGeneration(generation),
-            request_id: Some(request_id.to_owned()),
-            outcome: RequestOutcome::Aborted,
-            dispatched: false,
-            armed: true,
+            state: Box::new(AdmissionLeaseState {
+                cleanup: Arc::clone(&cleanup),
+                actor_tx: actor_tx.clone(),
+                generation: LifecycleGeneration(generation),
+                request_id: Some(request_id.to_owned()),
+                outcome: RequestOutcome::Aborted,
+                dispatched: false,
+                armed: true,
+            }),
         };
 
         drop(lease(1, "fast-path"));
@@ -2791,13 +2795,15 @@ policy_classes:
         let cleanup = Arc::new(AdmissionCleanup::default());
         let (actor_tx, _) = mpsc::channel(1);
         let mut lease = AdmissionLease {
-            cleanup: Arc::clone(&cleanup),
-            actor_tx,
-            generation: LifecycleGeneration(1),
-            request_id: Some("late-error".to_owned()),
-            outcome: RequestOutcome::Aborted,
-            dispatched: false,
-            armed: true,
+            state: Box::new(AdmissionLeaseState {
+                cleanup: Arc::clone(&cleanup),
+                actor_tx,
+                generation: LifecycleGeneration(1),
+                request_id: Some("late-error".to_owned()),
+                outcome: RequestOutcome::Aborted,
+                dispatched: false,
+                armed: true,
+            }),
         };
 
         lease.mark_completed(96);


### PR DESCRIPTION
## Overview:

PR #11615 made `AdmissionLease` part of every scheduling response even though its state is only needed for admitted requests. This change keeps the lease's existing heap allocation as its internal representation, shrinking the response passed through the queue, and removes a redundant request-ID allocation during terminal cleanup without changing lifecycle ownership, cancellation, or terminal-state behavior.

## How it works

1. Queue admission creates the same single-owner lease before enqueueing a tracked request, but the public lease now stores its state behind the allocation that already existed for cancellation safety.
2. The scheduler actor moves that small lease value through enqueue acknowledgement and into `SchedulingResponse`; it no longer unboxes a large state object into every response.
3. Selection and `RequestGuard` retain the same `AdmissionLease` API and still transfer cleanup ownership exactly once before backend dispatch.
4. Terminal cleanup borrows the request ID already owned by the cleanup entry when checking and freeing the scheduler slot, avoiding a temporary `String` allocation.
5. Dropping the lease still coalesces the actor wakeup and emits exactly one completed or aborted terminal event.

## Details:

The representation change is private to `AdmissionLease`; `SchedulingResponse::admission_lease` remains `Option<AdmissionLease>`, so callers do not need to adopt a boxed public field. Existing admission lifecycle tests cover enqueue ownership, cancellation, dispatch ordering, completion, abort-after-completion, coalesced cleanup, and dropped leases.

## Performance

Revision labels are baseline `ea89e8bdfcc8b9c95514fa9beabc5bd8296ec546` and candidate `b573ed7011b515a6c1c4b186b9bbc9706a312137`. All summaries are medians from eight raw fresh-process samples per revision in an interleaved ABBA/BAAB order.

`SchedulingResponse` decreased from 152 to 88 bytes: -64 bytes (-42.105%).

For the admission-disabled, concurrency-1 workload, median throughput increased from 683,814.918 to 692,489.416 requests/s: +8,674.498 requests/s (+1.269%), with a 50,000-resample bootstrap 95% interval of +0.590% to +1.883%. Allocated volume fell from 667.523 to 603.523 bytes/request: -64.000 bytes/request (-9.588%); allocation count was unchanged.

For admitted requests at concurrency 1 with one progress update, allocation count fell from 21.032 to 20.032 allocations/request: -1.000 allocation/request (-4.755%), and allocated volume fell from 1,318.602 to 1,237.662 bytes/request: -80.940 bytes/request (-6.138%). Median throughput changed from 474,980.136 to 465,986.569 requests/s: -8,993.567 requests/s (-1.893%), but the bootstrap interval (-2.941% to +0.911%) includes no change.

For admitted requests at concurrency 256 with 16 progress updates and a deterministic 70% completed / 20% explicitly aborted / 10% dropped-lease mix, allocation count fell from 20.124 to 19.149 allocations/request: -0.976 allocation/request (-4.849%), and allocated volume fell from 1,267.424 to 1,195.422 bytes/request: -72.002 bytes/request (-5.681%). Throughput changed from 471,575.568 to 469,322.674 requests/s: -2,252.894 requests/s (-0.478%), with a bootstrap interval of -1.964% to +0.725%. p99 changed from 621.689 to 626.675 microseconds: +4.986 microseconds (+0.802%); both effects are inconclusive.

Validity: these measurements are valid for the exact SHAs and focused CPU actor workloads described below. This is not an end-to-end inference benchmark. The real scheduler, queue actor, selector, booking, progress atomic, lifecycle events, and coalesced cleanup run in the benchmark; the backend response stream and LLM `RequestGuard` boundary are replaced by direct calls in production order. CPU frequency was not locked; comparisons mitigate that caveat with pinned CPUs, fresh processes, and interleaved run order. The allocation reduction happens once per relevant request, but no representative deployment's router CPU share or request rate was established. Amdahl's law therefore limits the measured +1.269% default-path actor result to an upper bound when this actor path is the entire bottleneck; no GPU latency or system-throughput speedup is claimed.

## Benchmark methodology

Prerequisites: Linux x86-64, `taskset`, Rust/Cargo 1.96.1, and the normal Dynamo system build dependencies described in `docs/contribution-guide.md`. Install the declared Rust toolchain with `rustup toolchain install 1.96.1 --profile default`; Cargo downloads the public workspace dependencies during the builds below. No GPU, model, dataset, network service, plugin, driver, or additional runtime package is required.

The reported host used Ubuntu kernel 6.17.0-35-generic, glibc 2.39, an Intel Core Ultra 9 285K, the `powersave` governor, and CPUs 0-7 of a 24-core single-thread-per-core host. Tokio used eight worker threads. No external services run: the harness creates one in-process `LocalScheduler`, an in-memory synthetic worker configuration, request IDs, progress updates, and deterministic terminal outcomes. `CARGO_TARGET_DIR` and `CARGO_BUILD_JOBS` are set by the build commands; no other environment variables or configuration files are required.

Starting from the repository clone, create worktrees for the tested revisions and save the complete harness below as `lib/kv-router/examples/perf_admission_actor.rs` in each worktree:

```bash
git worktree add /tmp/dynamo-perf-base ea89e8bdfcc8b9c95514fa9beabc5bd8296ec546
git worktree add /tmp/dynamo-perf-candidate b573ed7011b515a6c1c4b186b9bbc9706a312137
# Save the Rust block below as lib/kv-router/examples/perf_admission_actor.rs in both worktrees.

CARGO_TARGET_DIR=/tmp/dynamo-target-base CARGO_BUILD_JOBS=16 \
  cargo build --manifest-path /tmp/dynamo-perf-base/Cargo.toml --release \
  -p dynamo-kv-router --features bench --example perf_admission_actor
CARGO_TARGET_DIR=/tmp/dynamo-target-candidate CARGO_BUILD_JOBS=16 \
  cargo build --manifest-path /tmp/dynamo-perf-candidate/Cargo.toml --release \
  -p dynamo-kv-router --features bench --example perf_admission_actor
```

```rust
// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
// SPDX-License-Identifier: Apache-2.0

use std::alloc::{GlobalAlloc, Layout, System};
use std::collections::HashMap;
use std::sync::Arc;
use std::sync::atomic::{AtomicU64, Ordering};
use std::time::{Duration, Instant};

use dynamo_kv_router::scheduling::{
    AdmissionDecision, AdmissionEvent, AdmissionId, AdmissionRequest, NoopOverlapScoresRefresh,
    OverlapSignals, PolicyClassAdmissionStrategies, PolicyClassAdmissionStrategy, PolicyProfile,
    RequestProgress, ScheduleMode, ScheduleRequest, WorkerPlacement,
};
use dynamo_kv_router::test_utils::{NoopSequencePublisher, SimpleWorkerConfig};
use dynamo_kv_router::{
    ActiveSequencesMultiWorker, DefaultWorkerSelector, LocalScheduler, RouterQueuePolicy,
    SchedulingResponse,
};
use tokio::sync::{Barrier, watch};
use tokio_util::sync::CancellationToken;

struct CountingAllocator;
static ALLOCATIONS: AtomicU64 = AtomicU64::new(0);
static ALLOCATED_BYTES: AtomicU64 = AtomicU64::new(0);

unsafe impl GlobalAlloc for CountingAllocator {
    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
        ALLOCATED_BYTES.fetch_add(layout.size() as u64, Ordering::Relaxed);
        unsafe { System.alloc(layout) }
    }
    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
        unsafe { System.dealloc(ptr, layout) }
    }
    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
        ALLOCATIONS.fetch_add(1, Ordering::Relaxed);
        ALLOCATED_BYTES.fetch_add(new_size as u64, Ordering::Relaxed);
        unsafe { System.realloc(ptr, layout, new_size) }
    }
}
#[global_allocator]
static GLOBAL_ALLOCATOR: CountingAllocator = CountingAllocator;

#[derive(Default)]
struct LifecycleStats {
    admitted: AtomicU64,
    dispatched: AtomicU64,
    completed: AtomicU64,
    aborted: AtomicU64,
    retained_progress: AtomicU64,
    terminal_progress_observations: AtomicU64,
}
impl LifecycleStats {
    fn reset(&self) {
        self.admitted.store(0, Ordering::Relaxed);
        self.dispatched.store(0, Ordering::Relaxed);
        self.completed.store(0, Ordering::Relaxed);
        self.aborted.store(0, Ordering::Relaxed);
        self.terminal_progress_observations.store(0, Ordering::Relaxed);
        assert_eq!(self.retained_progress.load(Ordering::Relaxed), 0);
    }
}

struct AlwaysReadyStrategy {
    stats: Arc<LifecycleStats>,
    retain_progress: bool,
    progress: HashMap<AdmissionId, RequestProgress>,
}
impl PolicyClassAdmissionStrategy for AlwaysReadyStrategy {
    fn admit(&mut self, request: AdmissionRequest<'_>) -> AdmissionDecision {
        self.stats.admitted.fetch_add(1, Ordering::Relaxed);
        if self.retain_progress {
            self.progress.insert(request.id(), request.progress().clone());
            self.stats.retained_progress.fetch_add(1, Ordering::Relaxed);
        }
        AdmissionDecision::Ready(WorkerPlacement::Any)
    }
    fn on_event(&mut self, event: AdmissionEvent) -> Vec<dynamo_kv_router::scheduling::AdmissionAction> {
        match event {
            AdmissionEvent::Dispatched { .. } => { self.stats.dispatched.fetch_add(1, Ordering::Relaxed); }
            AdmissionEvent::Completed { id, context_tokens } => {
                self.stats.completed.fetch_add(1, Ordering::Relaxed);
                if let Some(progress) = self.progress.remove(&id) {
                    assert!(progress.context_tokens() <= context_tokens);
                    self.stats.terminal_progress_observations.fetch_add(1, Ordering::Relaxed);
                    self.stats.retained_progress.fetch_sub(1, Ordering::Relaxed);
                }
            }
            AdmissionEvent::Aborted { id } => {
                self.stats.aborted.fetch_add(1, Ordering::Relaxed);
                if self.progress.remove(&id).is_some() {
                    self.stats.retained_progress.fetch_sub(1, Ordering::Relaxed);
                }
            }
            _ => {}
        }
        Vec::new()
    }
}

fn request(id: String, admission: bool) -> ScheduleRequest {
    ScheduleRequest {
        mode: if admission { ScheduleMode::TrackedWithAdmission { request_id: id } } else { ScheduleMode::Tracked { request_id: id } },
        token_seq: None, block_hashes: None, isl_tokens: 64, lora_name: None,
        expected_output_tokens: None, pinned_worker: None, allowed_worker_ids: None,
        routing_constraints: Default::default(), router_config_override: None,
        priority_jump: 0.0, strict_priority: 0, policy_class: None,
        session_id: Some("perf-session".to_owned()), overlap: OverlapSignals::default(),
        shared_cache_hits: None,
    }
}
fn percentile(sorted: &[u64], percentile: f64) -> u64 {
    sorted[((sorted.len() - 1) as f64 * percentile).ceil() as usize]
}

fn main() {
    let mut args = std::env::args().skip(1);
    let admission = match args.next().expect("mode").as_str() { "off" => false, "on" => true, other => panic!("unknown mode {other}") };
    let requests: usize = args.next().unwrap().parse().unwrap();
    let concurrency: usize = args.next().unwrap().parse().unwrap();
    let warmup: usize = args.next().unwrap().parse().unwrap();
    let progress_updates: usize = args.next().unwrap().parse().unwrap();
    let retain_progress: bool = args.next().unwrap().parse().unwrap();
    assert!(requests >= concurrency && concurrency > 0);

    tokio::runtime::Builder::new_multi_thread().worker_threads(8).enable_all().build().unwrap().block_on(async move {
        let slots = Arc::new(ActiveSequencesMultiWorker::new(NoopSequencePublisher, 64, HashMap::from([(0, (0, 1))]), false, 0, "perf-admission"));
        let (_workers_tx, workers_rx) = watch::channel(HashMap::from([(0, SimpleWorkerConfig { max_num_batched_tokens: Some(1_000_000_000), ..Default::default() })]));
        let stats = Arc::new(LifecycleStats::default());
        let mut strategies = PolicyClassAdmissionStrategies::new();
        if admission {
            strategies.insert("default".to_owned(), Box::new(AlwaysReadyStrategy { stats: Arc::clone(&stats), retain_progress, progress: HashMap::new() }));
        }
        let cancel = CancellationToken::new();
        let scheduler = Arc::new(LocalScheduler::new_with_policy_profile_and_admission_strategies(
            Arc::clone(&slots), workers_rx, PolicyProfile::synthetic(None, RouterQueuePolicy::Fcfs), 64,
            DefaultWorkerSelector::new(None, "perf-admission"), None, None::<Arc<NoopOverlapScoresRefresh>>,
            None, Duration::from_secs(60), false, cancel.clone(), "perf-admission", false, strategies,
        ).unwrap());

        async fn one_lifecycle(scheduler: &LocalScheduler<NoopSequencePublisher, SimpleWorkerConfig>, id: String, admission: bool, updates: usize, outcome: usize) {
            let mut response = scheduler.schedule_request(request(id.clone(), admission)).await.unwrap();
            if !admission { scheduler.free(&id).await.unwrap(); return; }
            let updater = response.request_progress.as_ref().unwrap();
            let mut lease = response.admission_lease.take().unwrap();
            lease.mark_dispatched();
            scheduler.mark_dispatched(&id).await;
            for update in 1..=updates { updater.update_context_tokens(64 + update * 16); }
            match outcome % 10 { 0..=6 => lease.mark_completed(64 + updates * 16), 7..=8 => lease.mark_aborted(), _ => {} }
            drop(lease);
        }

        for index in 0..warmup { one_lifecycle(&scheduler, format!("warmup-{index}"), admission, progress_updates, index).await; }
        if admission {
            tokio::time::timeout(Duration::from_secs(10), async {
                while stats.completed.load(Ordering::Relaxed) + stats.aborted.load(Ordering::Relaxed) < warmup as u64 { tokio::task::yield_now().await; }
            }).await.expect("warmup cleanup timed out");
        }
        slots.assert_completely_drained(tokio::time::Instant::now());
        stats.reset();

        let barrier = Arc::new(Barrier::new(concurrency + 1));
        let mut tasks = Vec::with_capacity(concurrency);
        for task_index in 0..concurrency {
            let scheduler = Arc::clone(&scheduler);
            let barrier = Arc::clone(&barrier);
            let task_requests = requests / concurrency + usize::from(task_index < requests % concurrency);
            tasks.push(tokio::spawn(async move {
                let mut latencies = Vec::with_capacity(task_requests);
                barrier.wait().await;
                for sequence in 0..task_requests {
                    let global_sequence = task_index + sequence * concurrency;
                    let started = Instant::now();
                    one_lifecycle(&scheduler, format!("measured-{task_index}-{sequence}"), admission, progress_updates, global_sequence).await;
                    latencies.push(started.elapsed().as_nanos() as u64);
                }
                latencies
            }));
        }
        ALLOCATIONS.store(0, Ordering::Relaxed);
        ALLOCATED_BYTES.store(0, Ordering::Relaxed);
        let started = Instant::now();
        barrier.wait().await;
        let mut latencies = Vec::with_capacity(requests);
        for task in tasks { latencies.extend(task.await.unwrap()); }
        if admission {
            tokio::time::timeout(Duration::from_secs(30), async {
                while stats.completed.load(Ordering::Relaxed) + stats.aborted.load(Ordering::Relaxed) < requests as u64 { tokio::task::yield_now().await; }
            }).await.expect("measured cleanup timed out");
        }
        let elapsed = started.elapsed();
        latencies.sort_unstable();
        let allocations = ALLOCATIONS.load(Ordering::Relaxed);
        let allocated_bytes = ALLOCATED_BYTES.load(Ordering::Relaxed);
        slots.assert_completely_drained(tokio::time::Instant::now());
        assert_eq!(stats.retained_progress.load(Ordering::Relaxed), 0);
        cancel.cancel();
        println!("{{\"admission\":{},\"requests\":{requests},\"concurrency\":{concurrency},\"response_size_bytes\":{},\"elapsed_seconds\":{:.9},\"throughput_requests_per_second\":{:.3},\"p50_latency_us\":{:.3},\"p99_latency_us\":{:.3},\"allocations\":{allocations},\"allocated_bytes\":{allocated_bytes},\"admitted_events\":{},\"dispatched_events\":{},\"completed_events\":{},\"aborted_events\":{}}}",
            admission, std::mem::size_of::<SchedulingResponse>(), elapsed.as_secs_f64(), requests as f64 / elapsed.as_secs_f64(),
            percentile(&latencies, 0.50) as f64 / 1000.0, percentile(&latencies, 0.99) as f64 / 1000.0,
            stats.admitted.load(Ordering::Relaxed), stats.dispatched.load(Ordering::Relaxed),
            stats.completed.load(Ordering::Relaxed), stats.aborted.load(Ordering::Relaxed));
    });
}
```

Run 32,768 warm-up requests and 1,048,576 measured requests per fresh process pinned to CPUs 0-7. For each workload, run baseline, candidate, candidate, baseline, candidate, baseline, baseline, candidate, then repeat that eight-run sequence once. This yields eight measured samples per revision.

Exact baseline commands:

```bash
taskset -c 0-7 /tmp/dynamo-target-base/release/examples/perf_admission_actor off 1048576 1 32768 0 false
taskset -c 0-7 /tmp/dynamo-target-base/release/examples/perf_admission_actor on 1048576 1 32768 1 true
taskset -c 0-7 /tmp/dynamo-target-base/release/examples/perf_admission_actor on 1048576 256 32768 16 true
```

Exact candidate commands replace `dynamo-target-base` with `dynamo-target-candidate`. Each command emits one JSON object containing response size, elapsed time, throughput, p50/p99 latency, allocation totals, allocated bytes, and lifecycle-event counts. Each admitted run must report 1,048,576 admitted and dispatched events, 734,005 completed events, 314,571 aborted events, no retained readers, and a completely drained scheduler. Baseline response size should be 152 bytes and candidate response size 88 bytes.

For each revision/workload/metric, take the median of its eight raw samples. Percentage change is `(candidate_median - baseline_median) / baseline_median * 100`. The reported uncertainty used 50,000 independent with-replacement resamples of the eight baseline and eight candidate values, computed median percentage change per resample with seed 11615, and selected the 2.5th and 97.5th percentiles.

Correctness and static validation:

```bash
CARGO_TARGET_DIR=/tmp/dynamo-target-candidate cargo test -p dynamo-kv-router --lib --no-fail-fast
CARGO_TARGET_DIR=/tmp/dynamo-target-candidate cargo test -p dynamo-llm --lib --no-fail-fast
cargo fmt --all -- --check
CARGO_TARGET_DIR=/tmp/dynamo-target-candidate cargo clippy -p dynamo-kv-router -p dynamo-llm --lib --tests -- -D warnings
```

## Validation

- `cargo test -p dynamo-kv-router --lib --no-fail-fast` — 786 passed, 2 ignored.
- `cargo test -p dynamo-llm --lib --no-fail-fast` — 1,698 passed, 5 ignored.
- `cargo fmt --all -- --check` — passed.
- Strict Clippy for both affected crates — passed.
- Fresh focused checks on this branch: 12 lease-filtered kv-router tests plus cancellation-after-handoff, reused-ID cleanup, and pending-schedule abort tests — all passed.

## Where should the reviewer start?

Start with `AdmissionLease` and `AdmissionLeaseState` in `lib/kv-router/src/scheduling/queue.rs`, then follow the handoff in `lib/kv-router/src/scheduling/local.rs`. The cleanup-loop borrow in `drain_cleanup` is the second allocation reduction.

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

Follow-up to #11615.

<!-- perf-agent-investigation:b27666cc-f0e9-4aef-9250-644b535dbd18 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved admission lease handling for scheduled requests.
  * Simplified lease ownership and cleanup during request cancellation, completion, dispatch, and failure.
  * Preserved existing scheduling behavior while streamlining internal resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->