### PR TITLE
fix(snapshot): write rootfs-diff.tar atomically, handle empty archive

### DIFF
--- a/deploy/snapshot/internal/runtime/overlay.go
+++ b/deploy/snapshot/internal/runtime/overlay.go
@@ -50,12 +50,31 @@ func GetOverlayUpperDir(pid int) (string, error) {
 }
 
 // CaptureRootfsDiff captures the overlay upperdir to a tar file.
+//
+// The archive is written to a temporary file first and renamed atomically on
+// success, so a partial or failed capture never leaves a corrupt archive at the
+// final path.
 func CaptureRootfsDiff(upperDir, checkpointDir string, exclusions types.OverlaySettings, bindMountDests []string) (string, error) {
 	if upperDir == "" {
 		return "", fmt.Errorf("upperdir is empty")
 	}
 
 	rootfsDiffPath := filepath.Join(checkpointDir, rootfsDiffFilename)
+
+	tmpFile, err := os.CreateTemp(checkpointDir, rootfsDiffFilename+".*.tmp")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temporary rootfs diff: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmpPath)
+		return "", fmt.Errorf("failed to close temporary rootfs diff: %w", err)
+	}
+	defer func() {
+		if tmpPath != "" {
+			_ = os.Remove(tmpPath)
+		}
+	}()
 
 	tarArgs := []string{"--xattrs"}
 	for _, excl := range buildExclusions(exclusions) {
@@ -64,13 +83,26 @@ func CaptureRootfsDiff(upperDir, checkpointDir string, exclusions types.OverlayS
 	for _, dest := range bindMountDests {
 		tarArgs = append(tarArgs, "--exclude=."+dest)
 	}
-	tarArgs = append(tarArgs, "-C", upperDir, "-cf", rootfsDiffPath, ".")
+	tarArgs = append(tarArgs, "-C", upperDir, "-cf", tmpPath, ".")
 
 	cmd := exec.Command("tar", tarArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("tar failed: %w (output: %s)", err, string(output))
 	}
+
+	info, err := os.Stat(tmpPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to stat temporary rootfs diff: %w", err)
+	}
+	if info.Size() == 0 {
+		return "", fmt.Errorf("tar produced empty rootfs diff")
+	}
+
+	if err := os.Rename(tmpPath, rootfsDiffPath); err != nil {
+		return "", fmt.Errorf("failed to publish rootfs diff: %w", err)
+	}
+	tmpPath = ""
 
 	return rootfsDiffPath, nil
 }
@@ -120,8 +152,16 @@ func CaptureDeletedFiles(upperDir, checkpointDir string) (bool, error) {
 // ApplyRootfsDiff extracts rootfs-diff.tar into the target root.
 func ApplyRootfsDiff(checkpointPath, targetRoot string, log logr.Logger) error {
 	rootfsDiffPath := filepath.Join(checkpointPath, rootfsDiffFilename)
-	if _, err := os.Stat(rootfsDiffPath); os.IsNotExist(err) {
+	info, err := os.Stat(rootfsDiffPath)
+	if os.IsNotExist(err) {
 		log.V(1).Info("No rootfs-diff.tar, skipping")
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to stat rootfs diff: %w", err)
+	}
+	if info.Size() == 0 {
+		log.V(1).Info("rootfs-diff.tar is empty, skipping")
 		return nil
 	}
 

--- a/deploy/snapshot/internal/runtime/overlay_test.go
+++ b/deploy/snapshot/internal/runtime/overlay_test.go
@@ -234,6 +234,19 @@ func TestApplyRootfsDiff(t *testing.T) {
 			t.Fatal("ApplyRootfsDiff should fail for invalid non-empty archive")
 		}
 	})
+
+	t.Run("non-ENOENT stat error is propagated", func(t *testing.T) {
+		// Pass a regular file as checkpointPath so stat of
+		// checkpointPath/rootfs-diff.tar returns ENOTDIR, not ENOENT.
+		f, err := os.CreateTemp(t.TempDir(), "not-a-dir")
+		if err != nil {
+			t.Fatalf("create temp file: %v", err)
+		}
+		f.Close()
+		if err := ApplyRootfsDiff(f.Name(), t.TempDir(), testr.New(t)); err == nil {
+			t.Fatal("ApplyRootfsDiff should propagate non-ENOENT stat error")
+		}
+	})
 }
 
 func TestCaptureDeletedFiles(t *testing.T) {

--- a/deploy/snapshot/internal/runtime/overlay_test.go
+++ b/deploy/snapshot/internal/runtime/overlay_test.go
@@ -144,6 +144,98 @@ func TestFindWhiteoutFiles(t *testing.T) {
 	}
 }
 
+func TestCaptureRootfsDiff(t *testing.T) {
+	t.Run("writes valid archive atomically", func(t *testing.T) {
+		upperDir := t.TempDir()
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(upperDir, "generated.txt"), []byte("runtime data"), 0644); err != nil {
+			t.Fatalf("write upperdir file: %v", err)
+		}
+
+		got, err := CaptureRootfsDiff(upperDir, checkpointDir, types.OverlaySettings{}, nil)
+		if err != nil {
+			t.Fatalf("CaptureRootfsDiff: %v", err)
+		}
+		want := filepath.Join(checkpointDir, rootfsDiffFilename)
+		if got != want {
+			t.Fatalf("got path %q, want %q", got, want)
+		}
+		info, err := os.Stat(want)
+		if err != nil {
+			t.Fatalf("stat rootfs diff: %v", err)
+		}
+		if info.Size() == 0 {
+			t.Fatal("rootfs diff should not be empty")
+		}
+		matches, err := filepath.Glob(filepath.Join(checkpointDir, rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob temp files: %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("temporary rootfs diff files were not cleaned up: %v", matches)
+		}
+
+		targetRoot := t.TempDir()
+		if err := ApplyRootfsDiff(checkpointDir, targetRoot, testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+		data, err := os.ReadFile(filepath.Join(targetRoot, "generated.txt"))
+		if err != nil {
+			t.Fatalf("read extracted file: %v", err)
+		}
+		if string(data) != "runtime data" {
+			t.Fatalf("extracted data = %q, want %q", string(data), "runtime data")
+		}
+	})
+
+	t.Run("failed capture does not publish partial archive", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		missingUpperDir := filepath.Join(t.TempDir(), "missing")
+
+		if _, err := CaptureRootfsDiff(missingUpperDir, checkpointDir, types.OverlaySettings{}, nil); err == nil {
+			t.Fatal("CaptureRootfsDiff should fail for missing upperdir")
+		}
+		if _, err := os.Stat(filepath.Join(checkpointDir, rootfsDiffFilename)); !os.IsNotExist(err) {
+			t.Fatalf("rootfs diff should not be published after failure, stat error: %v", err)
+		}
+		matches, err := filepath.Glob(filepath.Join(checkpointDir, rootfsDiffFilename+".*.tmp"))
+		if err != nil {
+			t.Fatalf("glob temp files: %v", err)
+		}
+		if len(matches) != 0 {
+			t.Fatalf("temporary rootfs diff files were not cleaned up: %v", matches)
+		}
+	})
+}
+
+func TestApplyRootfsDiff(t *testing.T) {
+	t.Run("missing archive is no-op", func(t *testing.T) {
+		if err := ApplyRootfsDiff(t.TempDir(), t.TempDir(), testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+	})
+
+	t.Run("empty archive is no-op", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), nil, 0644); err != nil {
+			t.Fatalf("write empty rootfs diff: %v", err)
+		}
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err != nil {
+			t.Fatalf("ApplyRootfsDiff: %v", err)
+		}
+	})
+
+	t.Run("non-empty invalid archive fails", func(t *testing.T) {
+		checkpointDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(checkpointDir, rootfsDiffFilename), []byte("not a tar archive"), 0644); err != nil {
+			t.Fatalf("write invalid rootfs diff: %v", err)
+		}
+		if err := ApplyRootfsDiff(checkpointDir, t.TempDir(), testr.New(t)); err == nil {
+			t.Fatal("ApplyRootfsDiff should fail for invalid non-empty archive")
+		}
+	})
+}
+
 func TestCaptureDeletedFiles(t *testing.T) {
 	t.Run("dir with whiteouts writes JSON and returns true", func(t *testing.T) {
 		upperDir := t.TempDir()


### PR DESCRIPTION
## Summary

Port correctness fixes from [Radostin Stoyanov (rst0git)](https://github.com/rst0git) at [doublewordai/dynamo@e7c78a2](https://github.com/doublewordai/dynamo/commit/e7c78a25987e2c8441b5cc5f8101573f0115838b).

- **Atomic capture**: `CaptureRootfsDiff` previously wrote directly to `rootfs-diff.tar`. A failed or interrupted capture left a corrupt partial archive that restore would silently attempt to extract. Now writes to a `.tmp` file and renames atomically on success; `defer` removes the temp on any error path.
- **Empty archive guard**: reject a zero-byte tar (empty upperdir edge case) before publishing.
- **`ApplyRootfsDiff` stat errors**: non-ENOENT stat errors (permissions, I/O failure) were silently swallowed and fell through to `tar -xf`. Now propagated. Zero-byte archive is treated as no-op instead of producing a confusing `tar: archive is empty` error.
- **Tests**: add `TestCaptureRootfsDiff` and `TestApplyRootfsDiff` covering round-trip, no-temp-leak-on-failure, and missing/empty/invalid archive cases. We had zero test coverage of these functions.

## Test plan

- [ ] `go test ./internal/runtime/... -run TestCaptureRootfsDiff` — 2 subtests pass
- [ ] `go test ./internal/runtime/... -run TestApplyRootfsDiff` — 3 subtests pass
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved snapshot root filesystem archive creation to prevent incomplete or empty archives from being published.
  * Added safer handling for archive creation failures, including cleanup of temporary files.
  * Applying snapshots now safely skips missing or empty root filesystem archives while reporting other file access errors.
  * Invalid non-empty archives are correctly rejected instead of being silently ignored.

* **Tests**
  * Added coverage for archive creation, application, cleanup, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->