### PR TITLE
fix(kv-router): prevent lookup repair from restoring removed entries

### DIFF
--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/mod.rs
@@ -19,7 +19,7 @@ use super::{
     MatchDetails, PreBoundEventCounters, SyncIndexer, WorkerLookupStats, WorkerTask,
 };
 use crate::cleanup::{CleanupGuard, CleanupState};
-use crate::lookup_update::update_arc_lookup_for_keys;
+use crate::lookup_update::{update_arc_lookup_for_keys, update_existing_arc_lookup_for_keys};
 use crate::protocols::*;
 
 mod children;

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs
@@ -61,7 +61,7 @@ impl ConcurrentRadixTreeCompressed {
         let mut changed_entries_total = 0u64;
 
         for (&worker, worker_lookup) in lookup.iter_mut() {
-            let _changed_entries = update_arc_lookup_for_keys(
+            let _changed_entries = update_existing_arc_lookup_for_keys(
                 worker_lookup,
                 resolved.lookup_hashes_for_worker_repair(worker, hash, direction),
                 resolved,

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -1379,3 +1379,66 @@ fn remove_after_split_and_children_clear_scrubs_lookup() {
     apply_direct(&index, &mut l2, remove_event(2, 103, 0, w2_leaf));
     assert_eq!(worker_lookup_len(&l2, w2), Some(0));
 }
+
+#[test]
+fn successful_repair_does_not_restore_scrubbed_other_worker_entries() {
+    let index = ConcurrentRadixTreeCompressed::new();
+    let scrubbed_worker = worker(1);
+    let repairing_worker = worker(2);
+    let mut shared_lookup = direct_lookup();
+    let mut splitter_lookup = direct_lookup();
+
+    apply_direct(
+        &index,
+        &mut shared_lookup,
+        make_store_event(1, &[1, 2, 3, 4]),
+    );
+    apply_direct(
+        &index,
+        &mut shared_lookup,
+        make_store_event(2, &[1, 2, 3, 4]),
+    );
+
+    // A split from another event thread leaves both local lookups pointing at
+    // the old prefix node for the [3, 4] suffix.
+    apply_direct(
+        &index,
+        &mut splitter_lookup,
+        make_store_event(3, &[1, 2, 9]),
+    );
+    let suffix_hashes = remove_hashes_with_parent(&[1, 2], &[3, 4]);
+
+    // A resolve-miss remove scrubs lookup state but cannot update coverage on
+    // the node it failed to find. Model that boundary directly while keeping
+    // the resolved live node's coverage intact.
+    let scrubbed_lookup = shared_lookup.get_mut(&scrubbed_worker).unwrap();
+    for hash in &suffix_hashes {
+        scrubbed_lookup.remove(hash);
+    }
+    assert_eq!(worker_lookup_len(&shared_lookup, scrubbed_worker), Some(2));
+    assert_direct_score(&index, &[1, 2, 3, 4], scrubbed_worker, 4);
+
+    // A different worker's stale lookup successfully resolves the suffix and
+    // repairs the event thread's shared lookup map.
+    let resolved = index
+        .resolve_lookup(
+            &mut shared_lookup,
+            repairing_worker,
+            suffix_hashes[0],
+            LookupRepairDirection::TowardTail,
+        )
+        .expect("repairing worker should resolve the split suffix");
+
+    let repairing_lookup = shared_lookup.get(&repairing_worker).unwrap();
+    for hash in &suffix_hashes {
+        assert!(Arc::ptr_eq(repairing_lookup.get(hash).unwrap(), &resolved));
+    }
+
+    let scrubbed_lookup = shared_lookup.get(&scrubbed_worker).unwrap();
+    for hash in suffix_hashes {
+        assert!(
+            !scrubbed_lookup.contains_key(&hash),
+            "repair for another worker restored a scrubbed lookup entry"
+        );
+    }
+}

--- a/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
+++ b/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs
@@ -1416,3 +1416,66 @@ fn remove_after_split_and_children_clear_scrubs_lookup() {
     apply_direct(&index, &mut l2, remove_event(2, 103, 0, w2_leaf));
     assert_eq!(worker_lookup_len(&l2, w2), Some(0));
 }
+
+#[test]
+fn successful_repair_does_not_restore_scrubbed_other_worker_entries() {
+    let index = ConcurrentRadixTreeCompressed::new();
+    let scrubbed_worker = worker(1);
+    let repairing_worker = worker(2);
+    let mut shared_lookup = direct_lookup();
+    let mut splitter_lookup = direct_lookup();
+
+    apply_direct(
+        &index,
+        &mut shared_lookup,
+        make_store_event(1, &[1, 2, 3, 4]),
+    );
+    apply_direct(
+        &index,
+        &mut shared_lookup,
+        make_store_event(2, &[1, 2, 3, 4]),
+    );
+
+    // A split from another event thread leaves both local lookups pointing at
+    // the old prefix node for the [3, 4] suffix.
+    apply_direct(
+        &index,
+        &mut splitter_lookup,
+        make_store_event(3, &[1, 2, 9]),
+    );
+    let suffix_hashes = remove_hashes_with_parent(&[1, 2], &[3, 4]);
+
+    // A resolve-miss remove scrubs lookup state but cannot update coverage on
+    // the node it failed to find. Model that boundary directly while keeping
+    // the resolved live node's coverage intact.
+    let scrubbed_lookup = shared_lookup.get_mut(&scrubbed_worker).unwrap();
+    for hash in &suffix_hashes {
+        scrubbed_lookup.remove(hash);
+    }
+    assert_eq!(worker_lookup_len(&shared_lookup, scrubbed_worker), Some(2));
+    assert_direct_score(&index, &[1, 2, 3, 4], scrubbed_worker, 4);
+
+    // A different worker's stale lookup successfully resolves the suffix and
+    // repairs the event thread's shared lookup map.
+    let resolved = index
+        .resolve_lookup(
+            &mut shared_lookup,
+            repairing_worker,
+            suffix_hashes[0],
+            LookupRepairDirection::TowardTail,
+        )
+        .expect("repairing worker should resolve the split suffix");
+
+    let repairing_lookup = shared_lookup.get(&repairing_worker).unwrap();
+    for hash in &suffix_hashes {
+        assert!(Arc::ptr_eq(repairing_lookup.get(hash).unwrap(), &resolved));
+    }
+
+    let scrubbed_lookup = shared_lookup.get(&scrubbed_worker).unwrap();
+    for hash in suffix_hashes {
+        assert!(
+            !scrubbed_lookup.contains_key(&hash),
+            "repair for another worker restored a scrubbed lookup entry"
+        );
+    }
+}

--- a/lib/kv-router/src/lookup_update.rs
+++ b/lib/kv-router/src/lookup_update.rs
@@ -9,10 +9,9 @@ use rustc_hash::FxHashMap;
 
 /// Update an `Arc` lookup map for keys that should point at `node`.
 ///
-/// Duplicate store/repair paths often revisit keys that already resolve to the
-/// same node. Skipping those replacements avoids unnecessary hash table writes
-/// and `Arc` refcount churn while still repairing stale entries. Returns the
-/// number of entries that were inserted or changed.
+/// Duplicate store paths often revisit keys that already resolve to the same
+/// node. Skipping those replacements avoids unnecessary hash table writes and
+/// `Arc` refcount churn. Returns the number of entries inserted or changed.
 pub(crate) fn update_arc_lookup_for_keys<K, T>(
     lookup: &mut FxHashMap<K, Arc<T>>,
     keys: impl IntoIterator<Item = K>,
@@ -34,6 +33,34 @@ where
                 entry.insert(Arc::clone(node));
                 changed += 1;
             }
+        }
+    }
+
+    changed
+}
+
+/// Update existing `Arc` lookup entries for keys that should point at `node`.
+///
+/// Unlike [`update_arc_lookup_for_keys`], this does not insert missing keys.
+/// Lookup repair uses absence as meaningful state: a remove can scrub an entry
+/// before another worker on the same event thread repairs a stale lookup.
+/// Returns the number of existing entries that changed.
+pub(crate) fn update_existing_arc_lookup_for_keys<K, T>(
+    lookup: &mut FxHashMap<K, Arc<T>>,
+    keys: impl IntoIterator<Item = K>,
+    node: &Arc<T>,
+) -> usize
+where
+    K: Eq + Hash,
+{
+    let mut changed = 0;
+
+    for key in keys {
+        if let Some(entry) = lookup.get_mut(&key)
+            && !Arc::ptr_eq(entry, node)
+        {
+            *entry = Arc::clone(node);
+            changed += 1;
         }
     }
 


### PR DESCRIPTION
## Overview

Lazy lookup repair currently uses an insertion-capable helper for every worker on an event thread. When a remove has already scrubbed one worker's reverse-lookup entries but a resolved live node still carries that worker's coverage, a later repair for another worker recreates the scrubbed entries and can revive phantom tracked blocks. This change makes repair update existing entries only, while store paths retain their insertion behavior.

## How it works

1. A CRTC event worker encounters a stale reverse lookup after another event thread splits a compressed edge and resolves the requested hash in the node's subtree.
2. The resolved node still determines the same direction-aware repair range for every worker represented in the event thread's lookup map.
3. Repair now changes a pointer only when that key already exists. A missing key remains missing because its absence may record a completed remove.
4. Store paths continue using the insertion-capable helper, so new stored blocks still populate vacant lookup entries.
5. The regression test splits a shared edge from another lookup map, scrubs one worker's suffix entries while retaining node coverage, repairs another worker, and verifies that the repairing worker moves to the resolved node without restoring the scrubbed entries.

## Details:

The new update-existing helper preserves the existing pointer-equality fast path and changed-entry accounting, but deliberately has no vacant-entry branch. The repair traversal, direction semantics, locking, node coverage, and store insertion paths are unchanged.

## Where should the reviewer start?

Start with `repair_lookup_for_resolved_node` in `lib/kv-router/src/indexer/concurrent_radix_tree_compressed/repair.rs`, then read `successful_repair_does_not_restore_scrubbed_other_worker_entries` in the adjacent test module.

## Related Issues

Follow-up to #11785.

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue

## Summary

- Keep scrubbed reverse-lookup keys absent during lazy cross-worker repair.
- Preserve insertion semantics for every store path.
- Add deterministic coverage for both the repaired worker and the scrubbed worker.

## Performance

The focused repair-boundary workload exercises the real `repair_lookup_for_resolved_node` implementation with 128 worker lookups and a 64-hash resolved edge. The subtree search and event transport are replaced by prebuilt real `Node` and `WorkerLookup` values; map lookup, direction-aware range generation, hash-table mutation, allocation, and `Arc` reference-count behavior remain production code.

For the scrubbed-entry state, the median of 15 measured batches fell from **71.269 µs per repair** at baseline revision `ea89e8bdfcc8b9c95514fa9beabc5bd8296ec546` to **3.528 µs per repair** at candidate revision `36e5362e6425478b6241a6a2134634979a063f1b`, an absolute reduction of **67.741 µs (95.05%)**. Each batch sample contained 64 independent repairs after one untimed warm-up. The baseline recreated 8,192 lookup entries per repair; the candidate kept the count at zero.

As a safeguard for ordinary repair, the same 128 × 64 workload with all entries present moved from a **74.672 µs median** to **70.789 µs**, a **3.883 µs (5.20%) reduction**. A worker-count sweep at edge length 64 measured baseline medians of **4.294 µs (8 workers)**, **18.457 µs (32 workers)**, and **74.672 µs (128 workers)**, confirming that repair cost scales with the number of visited keys.

The production `ThreadPoolIndexer<ConcurrentRadixTreeCompressed>` Mooncake replay performed a median 54,644 successful repair scans per baseline trial across 2,163,500 events, establishing that the path is active in a supported deployment entry point. Across 20 fresh-process trials, median drain-inclusive throughput was **44.668 million block operations/s** at the baseline and **44.562 million block operations/s** at the candidate: **0.107 million block operations/s lower (0.24%)**, which is no material change. The paired candidate/base ratio mean was **0.9980**, with a **95% t interval of 0.9922–1.0039**.

### Validity and caveats

All focused samples passed their entry-count correctness checks. All full replays were generator-valid, had empty failure-reason lists, preserved exact operation IDs and FIFO ordering, and completed their drains. They were deliberately overloaded: 100.740 million block operations/s were offered and neither revision kept up. The replay is therefore a regression guard, not a capacity or latency claim.

The focused result applies only when repair encounters already-absent keys. The replay establishes repair frequency but does not measure how often that rarer scrub/repair collision occurs in production. No long-duration production RSS run was performed, so the memory claim is limited to retained lookup-entry and `Arc` state. The benchmark host is a 24-core hybrid desktop CPU rather than a server-class benchmark host, so absolute throughput is host-specific.

The published commit `a179fecb6627c9586a285110f63360cf95dd93ae` applies the byte-identical four-file candidate patch to current `main`; intervening changes were limited to unrelated vLLM Python files. Performance was not rerun because the measured repair mechanism and maintained replay code are unchanged.

## Benchmark methodology

### Prerequisites, dependency setup, and environment

- Linux x86_64; the measured run used Ubuntu 24.04 with kernel `6.17.0-35-generic`.
- Rust/Cargo `1.96.1`, selected by the repository's `rust-toolchain.toml`.
- `git`, `curl`, `sha256sum`, `taskset`, and Python 3. The optional counter profile also requires Linux `perf`.
- The measured host was an Intel Core Ultra 9 285K with 24 available logical CPUs (SMT disabled) and 125 GiB RAM.
- Focused trials were pinned to logical CPU 23, reported by `perf` as an Atom/E-core PMU. Full replay used CPUs 0–7 for event issuers, CPU 8 for the query issuer, and CPUs 9–23 for backend work.
- No GPU or external service is required. The replay runs the production thread-pool indexer against in-process issuers and mock workers.

Clone the repository, fetch the public baseline and PR commit, let rustup install the pinned toolchain, and fetch locked Cargo dependencies:

```bash
git clone https://github.com/ai-dynamo/dynamo.git /tmp/dynamo-repair-source
cd /tmp/dynamo-repair-source
git fetch origin ea89e8bdfcc8b9c95514fa9beabc5bd8296ec546 \
  a179fecb6627c9586a285110f63360cf95dd93ae
rustup show
cargo fetch --locked

git worktree add /tmp/dynamo-repair-base \
  ea89e8bdfcc8b9c95514fa9beabc5bd8296ec546
git worktree add /tmp/dynamo-repair-candidate \
  a179fecb6627c9586a285110f63360cf95dd93ae
```

The measurements were collected at baseline SHA `ea89e8bdfcc8b9c95514fa9beabc5bd8296ec546` and candidate SHA `36e5362e6425478b6241a6a2134634979a063f1b`. The public PR commit above contains the same candidate code in all four affected Rust files on top of current `main`.

### Focused repair benchmark

The benchmark harness is intentionally not part of the source change. Save the complete source below as `/tmp/repair_bench_harness.rs`; it is included inside the existing private unit-test module and uses that module's imports and helpers:

```rust
fn repair_bench_env_usize(name: &str, default: usize) -> usize {
    std::env::var(name)
        .ok()
        .and_then(|value| value.parse().ok())
        .unwrap_or(default)
}

fn prepare_repair_bench_lookup(
    workers: usize,
    hashes: &[ExternalSequenceBlockHash],
    stale: &SharedNode,
    mode: &str,
) -> DirectLookup {
    let mut lookup = FxHashMap::with_capacity_and_hasher(workers, FxBuildHasher);
    for worker_id in 0..workers {
        let mut worker_lookup =
            FxHashMap::with_capacity_and_hasher(hashes.len(), FxBuildHasher);
        for &hash in hashes {
            worker_lookup.insert(hash, stale.clone());
        }
        if mode == "vacant" {
            worker_lookup.clear();
        }
        lookup.insert(worker(worker_id as u64), worker_lookup);
    }
    lookup
}

#[test]
#[ignore]
fn benchmark_lookup_repair_boundary() {
    let workers = repair_bench_env_usize("REPAIR_BENCH_WORKERS", 128);
    let edge_len = repair_bench_env_usize("REPAIR_BENCH_EDGE_LEN", 64);
    let batch = repair_bench_env_usize("REPAIR_BENCH_BATCH", 64);
    let samples = repair_bench_env_usize("REPAIR_BENCH_SAMPLES", 15);
    let mode = std::env::var("REPAIR_BENCH_MODE").unwrap_or_else(|_| "vacant".into());
    assert!(mode == "vacant" || mode == "existing");
    assert!(workers > 0 && edge_len > 0 && batch > 0 && samples > 0);

    let index = ConcurrentRadixTreeCompressed::new();
    let local_hashes: Vec<u64> = (1..=edge_len as u64).collect();
    let blocks = stored_data(make_store_event(0, &local_hashes)).blocks;
    let hashes: Vec<_> = blocks.iter().map(|block| block.block_hash).collect();
    let resolved = Arc::new(Node::from_blocks_for_worker(&blocks, worker(0)));
    for worker_id in 1..workers {
        resolved.promote_worker_to_full_edge(worker(worker_id as u64));
    }
    let stale = Arc::new(Node::new());

    let mut warmup = prepare_repair_bench_lookup(workers, &hashes, &stale, &mode);
    index.repair_lookup_for_resolved_node(
        &mut warmup,
        hashes[0],
        &resolved,
        LookupRepairDirection::TowardTail,
    );
    std::hint::black_box(&warmup);

    for sample in 0..samples {
        let mut lookups: Vec<_> = (0..batch)
            .map(|_| prepare_repair_bench_lookup(workers, &hashes, &stale, &mode))
            .collect();
        let started = std::time::Instant::now();
        for lookup in &mut lookups {
            index.repair_lookup_for_resolved_node(
                lookup,
                hashes[0],
                &resolved,
                LookupRepairDirection::TowardTail,
            );
        }
        let elapsed_ns = started.elapsed().as_nanos();
        std::hint::black_box(&lookups);
        let entries_per_lookup = lookups[0]
            .values()
            .map(|worker_lookup| worker_lookup.len())
            .sum::<usize>();
        println!(
            "REPAIR_BENCH mode={mode} workers={workers} edge_len={edge_len} batch={batch} sample={sample} ns_per_repair={:.3} entries_per_lookup={entries_per_lookup}",
            elapsed_ns as f64 / batch as f64,
        );
    }
}
```

Compile the identical harness into both revisions' private unit-test modules:

```bash
for variant in base candidate; do
  REPAIR_TREE="/tmp/dynamo-repair-$variant"
  REPAIR_BUILD="/tmp/dynamo-repair-$variant-target"
  printf '\n#[cfg(feature = "bench")]\ninclude!(env!("REPAIR_BENCH_HARNESS"));\n' \
    >> "$REPAIR_TREE/lib/kv-router/src/indexer/concurrent_radix_tree_compressed/tests.rs"
  REPAIR_BENCH_HARNESS=/tmp/repair_bench_harness.rs \
  CARGO_TARGET_DIR="$REPAIR_BUILD" \
  cargo test --manifest-path "$REPAIR_TREE/Cargo.toml" -p dynamo-kv-router \
    --release --features bench benchmark_lookup_repair_boundary --no-run
done
```

Run baseline then candidate for the vacant mode, followed by baseline then candidate for the existing-entry safeguard. The configuration is 128 workers × 64 hashes, 64 repairs per sample, one untimed warm-up, and 15 measured samples:

```bash
for mode in vacant existing; do
  for variant in base candidate; do
    REPAIR_BUILD="/tmp/dynamo-repair-$variant-target"
    REPAIR_BIN=$(find "$REPAIR_BUILD/release/deps" -maxdepth 1 -type f \
      -perm -111 -name 'dynamo_kv_router-*' -print -quit)
    taskset -c 23 env \
      REPAIR_BENCH_MODE="$mode" \
      REPAIR_BENCH_WORKERS=128 \
      REPAIR_BENCH_EDGE_LEN=64 \
      REPAIR_BENCH_BATCH=64 \
      REPAIR_BENCH_SAMPLES=15 \
      "$REPAIR_BIN" benchmark_lookup_repair_boundary --ignored --nocapture \
      | tee "/tmp/repair-$variant-$mode.txt"
  done
done
```

Each `ns_per_repair` sample is elapsed batch nanoseconds divided by 64 repairs. Compute the median of the 15 samples for each revision and mode:

```bash
python3 - <<'PY'
import pathlib
import re
import statistics

for mode in ("vacant", "existing"):
    for variant in ("base", "candidate"):
        text = pathlib.Path(f"/tmp/repair-{variant}-{mode}.txt").read_text()
        samples = [float(value) for value in re.findall(r"ns_per_repair=([0-9.]+)", text)]
        if len(samples) != 15:
            raise SystemExit(f"expected 15 samples for {variant}/{mode}, got {len(samples)}")
        print(variant, mode, "median_ns_per_repair", statistics.median(samples))
PY
```

Correctness requires `entries_per_lookup=8192` on the baseline vacant run, `0` on the candidate vacant run, and `8192` for both existing-entry runs. The median absolute change is `baseline - candidate`; the percentage reduction is `100 × (baseline - candidate) / baseline`.

For the reported baseline worker-count sweep, keep `REPAIR_BENCH_EDGE_LEN=64` and repeat with `REPAIR_BENCH_WORKERS=8`, `32`, and `128`. To check edge scaling, keep 128 workers and repeat with edge lengths 8, 32, and 64. Keep the same batch size, warm-up, sample count, CPU pin, and median calculation; the medians should grow with the number of visited keys.

### Full Mooncake replay

Download and verify the public trace once; both worktrees use the same input:

```bash
MOONCAKE_TRACE=/tmp/mooncake_trace.jsonl
curl -L \
  https://raw.githubusercontent.com/kvcache-ai/Mooncake/main/FAST25-release/arxiv-trace/mooncake_trace.jsonl \
  -o "$MOONCAKE_TRACE"
echo 'b434f1816a707f4bac697235588184ebc374c9907cb981bb65fb0643471fe711  '"$MOONCAKE_TRACE" \
  | sha256sum -c -
```

Build one optimized binary per revision:

```bash
for variant in base candidate; do
  MOONCAKE_TREE="/tmp/dynamo-repair-$variant"
  MOONCAKE_BUILD="/tmp/dynamo-mooncake-$variant-target"
  CARGO_TARGET_DIR="$MOONCAKE_BUILD" cargo bench \
    --manifest-path "$MOONCAKE_TREE/Cargo.toml" \
    --package dynamo-bench --bench mooncake_bench --no-run
done
```

Run 20 fresh processes per revision, alternating baseline/candidate order between pairs. Use the same CPU masks only when they are valid for the host:

```bash
MOONCAKE_TRACE=/tmp/mooncake_trace.jsonl
MOONCAKE_BASE_BIN=$(find /tmp/dynamo-mooncake-base-target/release/deps \
  -maxdepth 1 -type f -perm -111 -name 'mooncake_bench-*' -print -quit)
MOONCAKE_CANDIDATE_BIN=$(find /tmp/dynamo-mooncake-candidate-target/release/deps \
  -maxdepth 1 -type f -perm -111 -name 'mooncake_bench-*' -print -quit)

for trial in $(seq 1 20); do
  if (( trial % 2 == 1 )); then
    variants=(base candidate)
  else
    variants=(candidate base)
  fi
  for variant in "${variants[@]}"; do
    if [[ "$variant" == base ]]; then
      MOONCAKE_BIN="$MOONCAKE_BASE_BIN"
    else
      MOONCAKE_BIN="$MOONCAKE_CANDIDATE_BIN"
    fi
    MOONCAKE_OUT=$(printf '/tmp/mooncake-%s-%02d.json' "$variant" "$trial")
    "$MOONCAKE_BIN" "$MOONCAKE_TRACE" \
      --query-lanes 128 \
      --issuer-cpus 0-7 \
      --query-issuer-cpu 8 \
      --backend-cpus 9-23 \
      --issuer-spin-us 100 \
      --issue-lag-diagnostic-threshold-us 250 \
      --num-unique-inference-workers 128 \
      --trace-duplication-factor 20 \
      --trace-length-factor 4 \
      --benchmark-duration-ms 750 \
      --result-json-output "$MOONCAKE_OUT" \
      concurrent-radix-tree-compressed --num-event-workers 8
  done
done
```

Each process performs the harness's fixed lookup warm-up and 5,000 ms heap-quiescence period, then replays 472,160 requests and 2,163,500 events (75,554,938 block operations). Require `generator_valid=true`, an empty `failure_reasons` array, exact operation IDs/FIFO ordering, and a completed drain. Calculate the medians, paired candidate/base ratios, and the two-sided 95% Student-t interval as follows (`2.093024` is the 97.5th percentile for 19 degrees of freedom):

```bash
python3 - <<'PY'
import json
import math
import pathlib
import statistics

values = {"base": [], "candidate": []}
for trial in range(1, 21):
    for variant in values:
        path = pathlib.Path(f"/tmp/mooncake-{variant}-{trial:02d}.json")
        result = json.loads(path.read_text())
        if not result["generator_valid"] or result["failure_reasons"]:
            raise SystemExit(f"invalid replay: {path}: {result['failure_reasons']}")
        values[variant].append(float(result["achieved_block_ops_per_sec"]))

ratios = [candidate / base for base, candidate in zip(values["base"], values["candidate"])]
ratio_mean = statistics.fmean(ratios)
ratio_half_width = 2.093024 * statistics.stdev(ratios) / math.sqrt(len(ratios))
for variant in values:
    print(variant, "median_block_ops_per_sec", statistics.median(values[variant]))
print("paired_ratio_mean", ratio_mean)
print("paired_ratio_95pct_t_interval", ratio_mean - ratio_half_width, ratio_mean + ratio_half_width)
PY
```

The expected outcome on comparable hardware is no material throughput change, not the exact throughput of the measured host.

## Validation

The measured candidate passed:

```text
cargo fmt --all -- --check
cargo test -p dynamo-kv-router --features bench
cargo clippy -p dynamo-kv-router --all-targets --features bench -- -D warnings
cargo test -p dynamo-bench --test mooncake_trace --features mocker-kvbm-offload
```

- kv-router: 790 passed, 2 ignored.
- Mooncake integration: 13 passed, 1 ignored.
- Formatting and clippy passed.

After applying the byte-identical patch to current `main`, these quick integration checks also passed:

```text
cargo fmt --all -- --check
cargo test -p dynamo-kv-router --features bench successful_repair_does_not_restore_scrubbed_other_worker_entries
cargo clippy -p dynamo-kv-router --all-targets --features bench -- -D warnings
```

- Targeted regression: 1 passed, 791 filtered out.
- Formatting and clippy passed.

<!-- perf-agent-investigation:4243e368-042b-47b8-b259-1e9972dfb857 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved lookup repair behavior so repairing one worker’s entries no longer restores entries that were intentionally removed from another worker.
  * Preserved existing lookup state while updating only relevant entries during recovery.

* **Tests**
  * Added regression coverage for multi-worker lookup repair and stale-entry removal.
  * Updated documentation for lookup updates and change reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->