### PR TITLE
docs(router): fix stale router user documentation [DYN-3476]

### DIFF
--- a/docs/components/router/router-concepts.md
+++ b/docs/components/router/router-concepts.md
@@ -111,4 +111,6 @@ normalized_load = total_inflight(group) / (instance_count(group) x throughput_we
 
 The throughput weight is `1` for CPU workers and `DYN_ENCODER_CUDA_TO_CPU_RATIO` for non-CPU workers. This lets the router route proportionally to device capability instead of permanently starving slower devices.
 
+A full multimodal embedding-cache hit bypasses the CPU-to-non-CPU ratio. The router instead selects the least-loaded worker among those that hold every distinct cache key in the request. Partial hits continue through the weighted group selection. See [Embedding Cache](../../features/multimodal/embedding-cache.md#cache-aware-routing).
+
 When only one device class is present, the behavior degenerates to standard least-loaded routing.

--- a/docs/components/router/router-examples.md
+++ b/docs/components/router/router-examples.md
@@ -32,7 +32,9 @@ The `KvRouter` provides the following methods:
   - With `request_id`: Updates router lifecycle state to track the request. **Note**: If used with `request_id`, you must call `mark_prefill_complete()` and `free()` at the appropriate lifecycle points to maintain accurate load tracking
   - With `update_indexer=True`: Records the selected worker in the approximate indexer for future overlap predictions. This is only meaningful when `use_kv_events=False`
 
-- **`get_potential_loads(token_ids)`**: Get detailed load information for all workers, including potential prefill tokens and active decode blocks. Returns a list of load dictionaries.
+- **`get_potential_loads(token_ids)`**: Get detailed load information for all workers, including potential prefill tokens, potential decode blocks, and active requests. Returns a list of load dictionaries.
+
+- **`get_overlap_scores(token_ids, ...)`**: Get per-worker KV overlap by storage tier, including shared-cache overlap when configured.
 
 - **`mark_prefill_complete(request_id)`**: Signal that a request has completed its prefill phase. Only used for [manual lifecycle management](#2-manual-state-management-advanced) when using `best_worker()` for manual routing instead of `generate()`.
 

--- a/docs/components/router/router-guide.md
+++ b/docs/components/router/router-guide.md
@@ -120,6 +120,8 @@ normalized_load = total_inflight(group) / (instance_count(group) x throughput_we
 
 The throughput weight is `1` for CPU workers and `DYN_ENCODER_CUDA_TO_CPU_RATIO` for non-CPU workers. The next request is routed to the group with the lower normalized load, then to the least-loaded worker inside that group.
 
+For multimodal requests, a full embedding-cache hit on one or more workers bypasses the CPU-to-non-CPU ratio. The router selects the least-loaded worker among those that hold every distinct embedding-cache key in the request. Partial hits continue through the normal weighted group selection. See [Embedding Cache](../../features/multimodal/embedding-cache.md#cache-aware-routing).
+
 Use `DYN_ENCODER_CUDA_TO_CPU_RATIO` to approximate the throughput ratio of a non-CPU worker relative to one CPU worker. The default is `8`.
 
 When only one device class is present, the policy degenerates to standard least-loaded routing.

--- a/docs/components/router/router-operations.md
+++ b/docs/components/router/router-operations.md
@@ -128,7 +128,7 @@ graph TD
 
 ## Additional Notes
 
-Request-plane transport is independent of KV event transport. The request plane (`DYN_REQUEST_PLANE` or `--request-plane`) controls how requests reach workers. KV events use NATS Core when `--event-plane nats` is set, or ZMQ when `--event-plane zmq` is set. With `--event-plane zmq` and `--discovery-backend file` or `mem`, the router can run without etcd or NATS. When using a NATS-based event plane, NATS is initialized automatically; set `NATS_SERVER=nats://...` to override the default `localhost:4222`.
+Request-plane transport is independent of KV event transport. The request plane (`DYN_REQUEST_PLANE` or `--request-plane`) controls how requests reach workers. ZMQ is the default event plane for every discovery backend, including etcd. Set `--event-plane nats` or `DYN_EVENT_PLANE=nats` to opt into NATS Core. With the default ZMQ event plane, the router does not require NATS; the selected discovery backend still determines whether etcd is required. When using the NATS event plane, NATS is initialized automatically; set `NATS_SERVER=nats://...` to override the default `localhost:4222`.
 
 When `--router-kv-overlap-score-credit` is set to 0, no KV indexer is created and prefix matching is disabled. When `--no-router-kv-events` is set, a KV indexer is still created but no event subscriber is launched; the router predicts cache state from its own routing decisions with TTL-based expiration.
 

--- a/docs/components/router/standalone-indexer.md
+++ b/docs/components/router/standalone-indexer.md
@@ -127,6 +127,9 @@ python -m dynamo.indexer --port 8090 [--threads 4] [--block-size 16 --model-name
 | `--model-name` | `default` | Model name for initial `--workers` |
 | `--routing-group` | `default` | Routing group for initial `--workers` |
 | `--peers` | (none) | Comma-separated peer indexer URLs for P2P recovery on startup |
+| `--access-log` | (none) | Write one JSON access-log record per request to this file |
+| `--trace-id-header` | `x-trace-id` | Request header copied into each access-log record's `trace_id` field |
+| `--access-log-local-time` | disabled | Use local time for access-log timestamps instead of UTC |
 
 ### Shared Startup Gate
 
@@ -167,7 +170,26 @@ The core event counters aggregate process-wide across model and routing-group in
 across all indexer threads. A `duplicate_store` warning is not necessarily an error:
 peer recovery replay can reapply content already restored from a snapshot. Lower-tier
 events and listener transport or replay failures are not represented by these core
-event counters; use the standalone service metrics and logs for those paths.
+event counters; use the standalone service metrics and logs for those paths. These
+device-tier-only semantics apply to the standalone indexer. The frontend-embedded
+router's component-scoped `dynamo_component_kv_cache_events_applied` counter includes
+both device- and lower-tier events. See [KV Indexer Metrics](../../observability/metrics.md#kv-indexer-metrics).
+
+### `POST /reopen_logs` — Reopen the access log
+
+Reopen the file configured by `--access-log` after an external log rotation renames or
+moves the active file. When access logging is disabled, the endpoint returns the same
+successful no-op response.
+
+```bash
+curl -X POST http://localhost:8090/reopen_logs
+```
+
+Returns:
+
+```json
+{"status":"ok"}
+```
 
 ### `POST /register` — Register an endpoint
 

--- a/docs/features/multimodal/embedding-cache.md
+++ b/docs/features/multimodal/embedding-cache.md
@@ -8,7 +8,10 @@ subtitle: Cache vision encoder embeddings to skip re-encoding repeated multimoda
 ## Overview
 
 The embedding cache is a CPU-side LRU cache that stores vision encoder outputs. When the same multimodal content, such as an image or video, appears in multiple requests, the cached embedding is reused instead of running the vision encoder again. This reduces GPU load on the encoder and lowers latency for repeated content.
-> Note: This feature can also be referred to as **encoder cache**. Embedding cache is separate from KV cache, which reuses attention key/value state after prefill to skip prefill and go straight to decode. For KV cache reuse and routing, see [Multimodal KV Routing](multimodal-kv-routing.md).
+
+> [!NOTE]
+> This feature is also called the **encoder cache**. The embedding cache is separate from the KV cache, which reuses attention key/value state after prefill to skip prefill and go straight to decode. For KV cache reuse and routing, see [Multimodal KV Routing](multimodal-kv-routing.md).
+
 ## When to Use
 
 Use the embedding cache when your workload includes repeated multimodal content across requests. Common scenarios:
@@ -65,7 +68,14 @@ cd $DYNAMO_HOME/examples/backends/trtllm
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `--multimodal-embedding-cache-capacity-gb` | CPU-side LRU cache size in GB | 0 (disabled) |
+| `--multimodal-embedding-cache-publisher` | Publish SGLang encode-worker cache changes over the configured event plane for device-aware routing | disabled |
 
 Set the capacity based on your expected working set of unique multimodal content. A larger cache holds more embeddings but consumes more host memory.
+
+### Cache-Aware Routing
+
+For SGLang encode/prefill/decode deployments that use `--router-mode device-aware-weighted`, set both `--multimodal-embedding-cache-capacity-gb` and `--multimodal-embedding-cache-publisher` on the encode worker. The publisher sends cache-key additions and removals over the configured event plane so the router can track which workers hold each requested embedding.
+
+When one or more workers hold every distinct embedding-cache key in a request, the router bypasses the CPU-to-non-CPU ratio and selects the least-loaded full-hit worker. Partial cache hits continue through the normal weighted group selection. The publisher is disabled by default and is not needed for round-robin routing or aggregated deployments.
 
 See the backend-specific documentation ([vLLM](multimodal-vllm.md#embedding-cache), [TRT-LLM](multimodal-trtllm.md#embedding-cache)) for more details.

--- a/docs/getting-started/local-installation.md
+++ b/docs/getting-started/local-installation.md
@@ -93,7 +93,7 @@ Dynamo components discover each other through a shared backend. Two options are 
 | Backend | When to Use | Setup |
 |---|---|---|
 | **File** | Single machine, local development | No setup -- pass `--discovery-backend file` to all components. The event plane automatically defaults to ZMQ (no NATS required). |
-| **etcd** | Multi-node, production | Requires a running etcd instance (default if no flag is specified). The event plane defaults to NATS. |
+| **etcd** | Multi-node, production | Requires a running etcd instance (default if no flag is specified). The event plane still defaults to ZMQ; set `DYN_EVENT_PLANE=nats` to opt into NATS. |
 
 This guide uses `--discovery-backend file`. For etcd setup, see [Service Discovery](../kubernetes/service-discovery.md).
 

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -447,13 +447,16 @@ Gauges track pending work in each router policy class. They are registered by th
 
 #### KV Indexer Metrics
 
-Tracks KV cache events applied to the router's radix tree index. Only appears when `--router-kv-overlap-score-credit` is greater than 0 (default) and workers are publishing KV events. Will not appear if `--router-kv-overlap-score-credit 0` is set or no KV events have been received.
+Tracks KV cache events applied to the frontend-embedded router's radix tree index. The counter includes events applied to both the device tier and lower tiers such as host-pinned memory and disk. Only appears when `--router-kv-overlap-score-credit` is greater than 0 (default) and workers are publishing KV events. Will not appear if `--router-kv-overlap-score-credit 0` is set or no KV events have been received.
 
 | Metric | Type | Description |
 |--------|------|-------------|
 | `dynamo_component_kv_cache_events_applied` | Counter | KV cache events applied to the index |
 
-**Additional labels:** `status` (`ok` / `parent_block_not_found` / `block_not_found` / `invalid_block`), `event_type` (`stored` / `removed` / `cleared`)
+**Additional labels:** `status` (`ok` / `parent_block_not_found` / `block_not_found` / `invalid_block` / `capacity_exhausted` / `indexer_invariant_violation`), `event_type` (`stored` / `removed` / `cleared`)
+
+The standalone indexer exposes the device-tier-only counter
+`dynamo_kvrouter_kv_cache_events_applied`; see the [Standalone KV Indexer](../components/router/standalone-indexer.md).
 
 #### Per-Worker Load and Timing Gauges (`dynamo_frontend_worker_*`)
 

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -652,10 +652,10 @@ class WorkerMetricsPublisher:
 
     async def create_endpoint(self, endpoint: Endpoint) -> None:
         """
-        Initialize the NATS endpoint for publishing worker metrics. Must be awaited.
+        Initialize event-plane publishing for worker metrics. Must be awaited.
 
         Extracts component information from the endpoint to set up metrics publishing
-        on the correct NATS subject for routing decisions.
+        on the endpoint-scoped event subject used for routing decisions.
 
         Args:
             endpoint: The endpoint to extract component information from for metrics publishing
@@ -691,7 +691,7 @@ class MultimodalEmbeddingCachePublisher:
 
     async def create_endpoint(self, endpoint: Endpoint) -> None:
         """
-        Initialize the NATS endpoint for publishing multimodal cache state.
+        Initialize event-plane publishing for multimodal cache state.
 
         Args:
             endpoint: The endpoint to extract component information from.


### PR DESCRIPTION
## Summary

Align router docs and Python API references with current event-plane defaults, standalone indexer options, device-aware embedding-cache routing, and KV indexer metrics.

## Validation

Cross-checked documented defaults, visible CLI flags, production routes, metric labels, and returned fields against current implementations; pre-commit passed for all changed files.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11892" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified device-aware routing behavior for full and partial multimodal embedding-cache hits.
  * Expanded `KvRouter` guidance for load details and cache-overlap scoring.
  * Documented event-plane defaults and NATS configuration.
  * Added standalone indexer access-log options and the `/reopen_logs` endpoint.
  * Added embedding/encoder cache configuration and routing guidance.
  * Updated KV cache metrics, labels, and standalone indexer references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->