### PR TITLE
fix(mocker): stop zeroing cache hits between prefills [DYN-3449]

### DIFF
--- a/lib/llm/src/mocker/metrics.rs
+++ b/lib/llm/src/mocker/metrics.rs
@@ -404,11 +404,12 @@ impl NativeMockerMetrics {
 
                 handles.num_running_reqs.set(clamp_u64_to_i64(running));
                 handles.num_queue_reqs.set(clamp_u64_to_i64(queued));
-                handles.cache_hit_rate.set(if cache_total == 0 {
-                    0.0
-                } else {
-                    cache_hits as f64 / cache_total as f64
-                });
+                // No prefill tokens means no new observation, not a 0% cache hit rate.
+                if cache_total > 0 {
+                    handles
+                        .cache_hit_rate
+                        .set(cache_hits as f64 / cache_total as f64);
+                }
             }
             None => {}
         }
@@ -979,6 +980,35 @@ mod tests {
             metric_labels(request_metric),
             HashSet::from(["model_name".to_string(), "engine_type".to_string()])
         );
+    }
+
+    #[tokio::test]
+    async fn sglang_cache_hit_rate_ignores_passes_without_prefill_tokens() {
+        let registry = MetricsRegistry::new();
+        let metrics = NativeMockerMetrics::new(EngineType::Sglang, 1).unwrap();
+        metrics.register(&registry).unwrap();
+        let _ = metrics
+            .request_timing("llama", 0, false, Instant::now())
+            .await;
+        let cache_hit_rate = || {
+            gather_family(&registry, "sglang:cache_hit_rate")
+                .get_metric()
+                .first()
+                .unwrap()
+                .gauge
+                .as_ref()
+                .unwrap()
+                .value()
+        };
+
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 0, 5, 10));
+        assert_eq!(cache_hit_rate(), 0.5);
+
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 0, 0, 0));
+        assert_eq!(cache_hit_rate(), 0.5);
+
+        metrics.update_scheduler_snapshot(&MockerMetrics::from_parts(0, 0, 10, 0, 0, 0, 0, 10));
+        assert_eq!(cache_hit_rate(), 0.0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Preserves the last SGLang mocker cache-hit observation when a scheduler pass has no prefill tokens, while still reporting genuine 0% hit batches. Adds regression coverage for hit, no-observation, and miss transitions.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11893" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Sglang cache hit-rate reporting by ignoring updates when no prefill tokens are recorded.
  * Preserved the last valid cache hit-rate value until a new observation is available.
  * Added coverage for scheduler updates with missing prefill activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->