### PR TITLE
feat(trtllm): support video_url multimodal inputs

### DIFF
--- a/components/src/dynamo/trtllm/multimodal_processor.py
+++ b/components/src/dynamo/trtllm/multimodal_processor.py
@@ -23,11 +23,13 @@ import httpx
 import torch
 from safetensors.torch import load as safetensors_load
 from safetensors.torch import load_file as safetensors_load_file
+from tensorrt_llm.inputs.utils import async_load_video
 from tensorrt_llm.llmapi.tokenizer import tokenizer_factory
 
 from dynamo.common.http import HttpStatusError
 from dynamo.common.http.url_validator import UrlValidationError
 from dynamo.common.multimodal.image_loader import ImageLoader
+from dynamo.common.multimodal.video_loader import VideoLoader
 from dynamo.runtime.logging import configure_dynamo_logging
 
 configure_dynamo_logging()
@@ -80,6 +82,10 @@ class MultimodalRequestProcessor:
         self.image_loader = ImageLoader(
             enable_frontend_decoding=enable_frontend_decoding
         )
+
+        # Reuse the shared default so this preprocessor and the vLLM/SGLang
+        # backends agree on DYN_MM_VIDEO_NUM_FRAMES.
+        self.num_video_frames = max(1, VideoLoader.NUM_FRAMES_DEFAULT)
 
         # Input processor used only to size an omitted max_tokens (see
         # _expanded_prompt_len). Optional: unavailable for models without a
@@ -413,7 +419,38 @@ class MultimodalRequestProcessor:
                         logging.error(f"Failed to load embeddings: {e}")
                         return None
 
-            # TODO: Add support for video_url, audio_url
+            # Video is forwarded as raw URLs ({"Url": ...}); reject local-file
+            # schemes for the same SSRF reason as the image path above.
+            video_items = multi_modal_data.get("video_url") or []
+            if not isinstance(video_items, list):
+                raise HttpStatusError(
+                    400, "Malformed video_url field: expected a list", str(video_items)
+                )
+            videos = []
+            for item in video_items:
+                url = item.get("Url") if isinstance(item, dict) else item
+                if not isinstance(url, str):
+                    raise HttpStatusError(
+                        400, f"Unsupported video item: {item!r}", str(item)
+                    )
+                if urlparse(url).scheme in ("", "file"):
+                    raise HttpStatusError(
+                        400, "Local file access is not allowed for video", url
+                    )
+                try:
+                    videos.append(await async_load_video(url, self.num_video_frames))
+                except (UrlValidationError, HttpStatusError):
+                    raise
+                except Exception as e:
+                    status = getattr(e, "status", None) or getattr(e, "code", None)
+                    raise HttpStatusError(
+                        status if isinstance(status, int) and status >= 400 else 400,
+                        f"Failed to load video ({url}): {e}",
+                        url,
+                    ) from e
+            if videos:
+                processed_mm_data["video"] = videos
+                logging.info("Loaded %d video(s)", len(videos))
 
             if loaded_embeddings:
                 # For TRT-LLM MM embeddings, the currently


### PR DESCRIPTION
## Summary

The Dynamo TRT-LLM backend supported image multimodal input but silently dropped `video_url` — the worker's `MultimodalRequestProcessor` only read `image_url`, leaving a `# TODO`. Video requests returned HTTP 200 with zero visual tokens and a hallucinated answer. This wires video through the same path as image: the Rust frontend already forwards the raw URL, so the worker decodes it with TRT-LLM's own loader into the shape its input processor already consumes (`VideoData`) and hands it to the engine unchanged.

**Repro:**
```bash
curl localhost:8000/v1/chat/completions -H "Content-Type: application/json" -d '{
  "model": "Qwen/Qwen2.5-VL-7B-Instruct",
  "messages": [{"role":"user","content":[
    {"type":"text","text":"Describe what happens in this video."},
    {"type":"video_url","video_url":{"url":"https://download.samplelib.com/mp4/sample-5s.mp4"}}]}],
  "max_tokens": 100}'
```

**Before:** `200`, `video_count=1`, TTFT ~26ms, 0 vision tokens, deflection ("this is a thumbnail image, not a video").
**After:** `200` with a real description ("a serene park scene... a road with cars and a tram passing by..."); worker logs `Loaded 1 video(s)`.

## Details

All changes are in `components/src/dynamo/trtllm/multimodal_processor.py`. The `video_url` TODO is replaced with a per-item loop that unwraps the frontend's `{"Url": ...}` items and decodes via `async_load_video`, populating `multi_modal_data["video"]`. It mirrors the sibling `image_url` path's guardrails: validates the field is a list, rejects `""`/`file://` schemes (no local-file access), fails loud on unparseable items instead of silently dropping them, preserves the upstream HTTP status on a fetch failure, and reports the exact failing URL. Frame count reuses the shared `VideoLoader.NUM_FRAMES_DEFAULT` contract (`DYN_MM_VIDEO_NUM_FRAMES`, default 32, honoring an operator-set ceiling such as 512) with an invalid-value fallback and a floor of 1. No handler or engine changes — the payload rides the existing `generate_async(inputs=...)` path.

## Validation

Live on `Qwen/Qwen2.5-VL-7B-Instruct` (aggregated), TensorRT-LLM 1.3.0rc20 container:

- Good video URL → `200`, accurate description; worker logs `Loaded 1 video(s)`.
- `file:///etc/hostname` → `400` "Local file access is not allowed"; bare path → `400` (frontend schema).
- Bad HTTP URL → upstream `403` preserved (not flattened to `400`).
- `DYN_MM_VIDEO_NUM_FRAMES` contract: `512`→512 (no clamp), unset→32, `0`→1, invalid→32.
- Image regression → still `200`, correct description.
- `pre-commit run` clean (black/ruff/flake8/isort); `py_compile` clean.

## Known limitations / follow-ups

- `_expanded_prompt_len` counts only image tokens, so an omitted `max_tokens` falls back to the engine default for video-only requests.
- Mixed image+video in one message: the engine's multimodal cache is single-modality; not rejected here yet.
- No per-request cap on videos × frames (OOM headroom); the image path is likewise uncapped.
- Image-embeddings + video in one request: an early return can drop the video (exotic E/P/D path).

## Related Issues

**🚫 This PR is NOT linked to an issue**:
- [x] Confirmed — no related issue
