### PR TITLE
fix(operator): wait for JobComplete before DynamoCheckpoint Ready

### DIFF
--- a/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocheckpoint_types.go
@@ -129,8 +129,8 @@ type DynamoCheckpointJobConfig struct {
 	// +kubebuilder:validation:Minimum=0
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 
-	// Deprecated: TTLSecondsAfterFinished is ignored. Checkpoint Jobs use a fixed
-	// 300 second TTL.
+	// Deprecated: TTLSecondsAfterFinished is ignored. The operator deletes checkpoint
+	// Jobs after recording their terminal outcome.
 	// +optional
 	// +kubebuilder:validation:Minimum=0
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocheckpoints.yaml
@@ -8373,8 +8373,8 @@ spec:
                       type: string
                     ttlSecondsAfterFinished:
                       description: |-
-                        Deprecated: TTLSecondsAfterFinished is ignored. Checkpoint Jobs use a fixed
-                        300 second TTL.
+                        Deprecated: TTLSecondsAfterFinished is ignored. The operator deletes checkpoint
+                        Jobs after recording their terminal outcome.
                       format: int32
                       minimum: 0
                       type: integer

--- a/deploy/operator/internal/controller/checkpoint_coverage_test.go
+++ b/deploy/operator/internal/controller/checkpoint_coverage_test.go
@@ -21,21 +21,28 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/consts"
+	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	snapshotprotocol "github.com/ai-dynamo/dynamo/deploy/snapshot/protocol"
 )
 
 // makeCheckpointReconcilerWithInterceptor mirrors makeCheckpointReconciler but threads
@@ -70,6 +77,16 @@ func healthyCheckpointJob(name string) *batchv1.Job {
 	job.CreationTimestamp = metav1.Now()
 	job.Spec.ActiveDeadlineSeconds = ptr.To(int64(3600))
 	return job
+}
+
+func setCheckpointJobOwner(ckpt *nvidiacomv1alpha1.DynamoCheckpoint, job *batchv1.Job) {
+	job.OwnerReferences = []metav1.OwnerReference{{
+		APIVersion: nvidiacomv1alpha1.GroupVersion.String(),
+		Kind:       "DynamoCheckpoint",
+		Name:       ckpt.Name,
+		UID:        ckpt.UID,
+		Controller: ptr.To(true),
+	}}
 }
 
 // drainEvent reports whether the FakeRecorder emitted an event containing want.
@@ -134,6 +151,334 @@ func TestCheckpointUpdateFailedStatus_StatusErrorDoesNotPanic(t *testing.T) {
 	r.updateFailedStatus(context.Background(), ckpt, errors.New("snapshot boom"))
 	assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseFailed, ckpt.Status.Phase)
 	assert.Contains(t, ckpt.Status.Message, "snapshot boom")
+}
+
+func TestCheckpointHandleCreating_RemovesLegacyTTLAndRetriesUpdate(t *testing.T) {
+	ckpt := newOwnedCheckpoint()
+	ckpt.Status.JobName = defaultCheckpointJobName
+	job := healthyCheckpointJob(defaultCheckpointJobName)
+	job.Spec.TTLSecondsAfterFinished = ptr.To(snapshotprotocol.DefaultCheckpointJobTTLSeconds)
+	setCheckpointJobOwner(ckpt, job)
+
+	updateCalls := 0
+	updateErr := errors.New("update job failed")
+	funcs := interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*batchv1.Job); ok {
+				updateCalls++
+				if updateCalls == 1 {
+					return updateErr
+				}
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+	}
+	r := makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+	r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{Checkpoint: true}}
+
+	_, err := r.handleCreating(context.Background(), ckpt)
+	require.ErrorIs(t, err, updateErr)
+	stored := &batchv1.Job{}
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(job), stored))
+	require.NotNil(t, stored.Spec.TTLSecondsAfterFinished)
+
+	_, err = r.handleCreating(context.Background(), ckpt)
+	require.NoError(t, err)
+	require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(job), stored))
+	assert.Nil(t, stored.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, 2, updateCalls)
+}
+
+func TestCheckpointHandlePendingRecoversOwnedLegacyJob(t *testing.T) {
+	ctx := context.Background()
+	ckpt := newOwnedCheckpoint()
+	ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhasePending
+	job := healthyCheckpointJob(defaultCheckpointJobName)
+	job.Spec.TTLSecondsAfterFinished = ptr.To(snapshotprotocol.DefaultCheckpointJobTTLSeconds)
+	serverLabels := map[string]string{
+		batchv1.ControllerUidLabel: string(job.UID),
+		batchv1.JobNameLabel:       job.Name,
+	}
+	job.Spec.Selector = &metav1.LabelSelector{MatchLabels: serverLabels}
+	job.Spec.Template.Labels = serverLabels
+	setCheckpointJobOwner(ckpt, job)
+
+	updateErr := errors.New("update job failed")
+	statusErr := errors.New("status update failed")
+	jobUpdateCalls := 0
+	statusUpdateCalls := 0
+	funcs := interceptor.Funcs{
+		Update: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.UpdateOption) error {
+			if _, ok := obj.(*batchv1.Job); ok {
+				jobUpdateCalls++
+				if jobUpdateCalls == 1 {
+					return updateErr
+				}
+			}
+			return c.Update(ctx, obj, opts...)
+		},
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			statusUpdateCalls++
+			if statusUpdateCalls == 1 {
+				return statusErr
+			}
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	}
+	r := makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+	r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{Checkpoint: true}}
+
+	_, err := r.handlePending(ctx, ckpt)
+	require.ErrorIs(t, err, updateErr)
+
+	storedCheckpoint := &nvidiacomv1alpha1.DynamoCheckpoint{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), storedCheckpoint))
+	_, err = r.handlePending(ctx, storedCheckpoint)
+	require.ErrorIs(t, err, statusErr)
+
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), storedCheckpoint))
+	_, err = r.handlePending(ctx, storedCheckpoint)
+	require.NoError(t, err)
+
+	storedJob := &batchv1.Job{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(job), storedJob))
+	assert.Nil(t, storedJob.Spec.TTLSecondsAfterFinished)
+	assert.Equal(t, serverLabels, storedJob.Spec.Selector.MatchLabels)
+	assert.Equal(t, serverLabels, storedJob.Spec.Template.Labels)
+	assert.Equal(t, 2, jobUpdateCalls, "owned existing Job must only receive the narrow TTL update")
+
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), storedCheckpoint))
+	assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating, storedCheckpoint.Status.Phase)
+	assert.Equal(t, job.Name, storedCheckpoint.Status.JobName)
+}
+
+func TestCheckpointHandlePendingRecoversOwnedJobWhenRenderingFails(t *testing.T) {
+	ctx := context.Background()
+	ckpt := newOwnedCheckpoint()
+	ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhasePending
+	ckpt.Spec.Job.PodTemplateSpec.Spec.ResourceClaims = []corev1.PodResourceClaim{{
+		Name:                      "gpu",
+		ResourceClaimTemplateName: ptr.To("missing"),
+	}}
+	ckpt.Spec.Job.PodTemplateSpec.Spec.Containers[0].Resources.Claims = []corev1.ResourceClaim{{Name: "gpu"}}
+	job := healthyCheckpointJob(defaultCheckpointJobName)
+	job.Spec.TTLSecondsAfterFinished = ptr.To(snapshotprotocol.DefaultCheckpointJobTTLSeconds)
+	setCheckpointJobOwner(ckpt, job)
+	r := makeCheckpointReconciler(checkpointTestScheme(), ckpt, job)
+	r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{Checkpoint: true}}
+
+	_, err := buildCheckpointJob(ctx, r.Client, r.Config, ckpt, job.Name)
+	require.ErrorContains(t, err, "failed to get ResourceClaimTemplate default/missing")
+	_, err = r.handlePending(ctx, ckpt)
+	require.NoError(t, err)
+
+	storedJob := &batchv1.Job{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(job), storedJob))
+	assert.Nil(t, storedJob.Spec.TTLSecondsAfterFinished)
+	storedCheckpoint := &nvidiacomv1alpha1.DynamoCheckpoint{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), storedCheckpoint))
+	assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating, storedCheckpoint.Status.Phase)
+	assert.Equal(t, job.Name, storedCheckpoint.Status.JobName)
+}
+
+func TestCheckpointReconcilePreservesLegacyReadyJob(t *testing.T) {
+	tests := map[string]batchv1.JobStatus{
+		"Active": {Active: 1},
+		"JobComplete": {Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobComplete,
+			Status: corev1.ConditionTrue,
+		}}},
+		"JobFailed": {Conditions: []batchv1.JobCondition{{
+			Type:   batchv1.JobFailed,
+			Status: corev1.ConditionTrue,
+		}}},
+	}
+
+	for name, status := range tests {
+		t.Run(name, func(t *testing.T) {
+			ctx := context.Background()
+			ckpt := newOwnedCheckpoint()
+			ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseReady
+			ckpt.Status.JobName = defaultCheckpointJobName
+			ckpt.Status.CreatedAt = ptr.To(metav1.NewTime(time.Unix(1, 0)))
+			createdAt := ckpt.Status.CreatedAt.DeepCopy()
+
+			job := healthyCheckpointJob(defaultCheckpointJobName)
+			job.Spec.TTLSecondsAfterFinished = ptr.To(snapshotprotocol.DefaultCheckpointJobTTLSeconds)
+			job.Status = status
+			setCheckpointJobOwner(ckpt, job)
+			r := makeCheckpointReconciler(checkpointTestScheme(), ckpt, job)
+
+			_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(ckpt)})
+			require.NoError(t, err)
+
+			storedCheckpoint := &nvidiacomv1alpha1.DynamoCheckpoint{}
+			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), storedCheckpoint))
+			assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseReady, storedCheckpoint.Status.Phase)
+			assert.Equal(t, createdAt, storedCheckpoint.Status.CreatedAt)
+			assert.False(t, checkpointReadyForJobCleanup(storedCheckpoint))
+
+			storedJob := &batchv1.Job{}
+			require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(job), storedJob))
+			require.NotNil(t, storedJob.Spec.TTLSecondsAfterFinished)
+			assert.Equal(t, snapshotprotocol.DefaultCheckpointJobTTLSeconds, *storedJob.Spec.TTLSecondsAfterFinished)
+		})
+	}
+}
+
+func TestCheckpointTerminalStatusIsDurableBeforeJobCleanup(t *testing.T) {
+	tests := []struct {
+		name       string
+		phase      nvidiacomv1alpha1.DynamoCheckpointPhase
+		complete   bool
+		transition func(context.Context, *CheckpointReconciler, *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error)
+	}{
+		{
+			name:     "Ready",
+			phase:    nvidiacomv1alpha1.DynamoCheckpointPhaseReady,
+			complete: true,
+			transition: func(ctx context.Context, r *CheckpointReconciler, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
+				return r.markCheckpointReady(ctx, ckpt, testHash, "captured")
+			},
+		},
+		{
+			name:  "Failed",
+			phase: nvidiacomv1alpha1.DynamoCheckpointPhaseFailed,
+			transition: func(ctx context.Context, r *CheckpointReconciler, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
+				return r.failCreating(ctx, ckpt, "PodSnapshotFailed", "capture failed")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			ckpt := newOwnedCheckpoint()
+			ckpt.Status.JobName = defaultCheckpointJobName
+			job := healthyCheckpointJob(defaultCheckpointJobName)
+			if tt.complete {
+				markCheckpointJobComplete(job)
+			}
+			setCheckpointJobOwner(ckpt, job)
+			funcs := interceptor.Funcs{
+				Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+					stored := &nvidiacomv1alpha1.DynamoCheckpoint{}
+					require.NoError(t, c.Get(ctx, client.ObjectKeyFromObject(ckpt), stored))
+					assert.Equal(t, tt.phase, stored.Status.Phase)
+					assert.Equal(t, job.Name, stored.Status.JobName)
+					if tt.phase == nvidiacomv1alpha1.DynamoCheckpointPhaseReady {
+						assert.True(t, checkpointReadyForJobCleanup(stored))
+					}
+					return c.Delete(ctx, obj, opts...)
+				},
+			}
+			r := makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+
+			_, err := tt.transition(ctx, r, ckpt)
+			require.NoError(t, err)
+			err = r.Get(ctx, client.ObjectKeyFromObject(job), &batchv1.Job{})
+			assert.True(t, apierrors.IsNotFound(err), "terminal checkpoint Job was not deleted: %v", err)
+		})
+	}
+}
+
+func TestCheckpointStatusUpdateFailureRetainsJob(t *testing.T) {
+	for _, transition := range []func(context.Context, *CheckpointReconciler, *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error){
+		func(ctx context.Context, r *CheckpointReconciler, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
+			return r.markCheckpointReady(ctx, ckpt, testHash, "captured")
+		},
+		func(ctx context.Context, r *CheckpointReconciler, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
+			return r.failCreating(ctx, ckpt, "PodSnapshotFailed", "capture failed")
+		},
+	} {
+		ckpt := newOwnedCheckpoint()
+		ckpt.Status.JobName = defaultCheckpointJobName
+		job := healthyCheckpointJob(defaultCheckpointJobName)
+		setCheckpointJobOwner(ckpt, job)
+		statusErr := errors.New("status update failed")
+		funcs := interceptor.Funcs{
+			SubResourceUpdate: func(context.Context, client.Client, string, client.Object, ...client.SubResourceUpdateOption) error {
+				return statusErr
+			},
+		}
+		r := makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+
+		_, err := transition(context.Background(), r, ckpt)
+		require.ErrorIs(t, err, statusErr)
+		require.NoError(t, r.Get(context.Background(), client.ObjectKeyFromObject(job), &batchv1.Job{}))
+	}
+}
+
+func TestCheckpointDeleteFailureRetriesBeforeArtifactNormalization(t *testing.T) {
+	ctx := context.Background()
+	ckpt := newOwnedCheckpoint()
+	ckpt.Status.JobName = defaultCheckpointJobName
+	ckpt.Annotations = map[string]string{snapshotprotocol.CheckpointArtifactVersionAnnotation: "2"}
+	job := markCheckpointJobComplete(newCheckpointJob(defaultCheckpointJobName))
+	setCheckpointJobOwner(ckpt, job)
+	deleteCalls := 0
+	funcs := interceptor.Funcs{
+		Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deleteCalls++
+			if deleteCalls == 1 {
+				return errors.New("delete failed")
+			}
+			return c.Delete(ctx, obj, opts...)
+		},
+	}
+	r := makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+	r.RuntimeConfig = &commonController.RuntimeConfig{Gate: features.Gates{Checkpoint: true}}
+
+	_, err := r.markCheckpointReady(ctx, ckpt, testHash, "captured")
+	require.ErrorContains(t, err, "delete terminal checkpoint job")
+	stored := &nvidiacomv1alpha1.DynamoCheckpoint{}
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), stored))
+	assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseReady, stored.Status.Phase)
+	assert.Equal(t, job.Name, stored.Status.JobName)
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(job), &batchv1.Job{}))
+
+	_, err = r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(ckpt)})
+	require.NoError(t, err)
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(ckpt), stored))
+	assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating, stored.Status.Phase)
+	assert.Equal(t, "checkpoint-job-"+testHash+"-2", stored.Status.JobName)
+	assert.Equal(t, 2, deleteCalls)
+	err = r.Get(ctx, client.ObjectKeyFromObject(job), &batchv1.Job{})
+	assert.True(t, apierrors.IsNotFound(err), "old Job was not deleted before normalization: %v", err)
+}
+
+func TestCheckpointTerminalCleanupRequiresOwnershipAndUID(t *testing.T) {
+	ctx := context.Background()
+	ckpt := newOwnedCheckpoint()
+	ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseFailed
+	ckpt.Status.JobName = defaultCheckpointJobName
+	job := healthyCheckpointJob(defaultCheckpointJobName)
+	setCheckpointJobOwner(ckpt, job)
+	var deleteUID *types.UID
+	var propagationPolicy *metav1.DeletionPropagation
+	funcs := interceptor.Funcs{
+		Delete: func(_ context.Context, _ client.WithWatch, _ client.Object, opts ...client.DeleteOption) error {
+			deleteOpts := (&client.DeleteOptions{}).ApplyOptions(opts)
+			deleteUID = deleteOpts.Preconditions.UID
+			propagationPolicy = deleteOpts.PropagationPolicy
+			return nil
+		},
+	}
+	r := makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+	require.NoError(t, r.cleanupTerminalCheckpointJob(ctx, ckpt))
+	require.NotNil(t, deleteUID)
+	assert.Equal(t, job.UID, *deleteUID)
+	require.NotNil(t, propagationPolicy)
+	assert.Equal(t, metav1.DeletePropagationBackground, *propagationPolicy)
+
+	job.OwnerReferences = nil
+	deleteUID = nil
+	propagationPolicy = nil
+	r = makeCheckpointReconcilerWithInterceptor(checkpointTestScheme(), funcs, ckpt, job)
+	require.NoError(t, r.cleanupTerminalCheckpointJob(ctx, ckpt))
+	assert.Nil(t, deleteUID, "foreign Job must not be deleted")
+	assert.Nil(t, propagationPolicy, "foreign Job must not be deleted")
+	require.NoError(t, r.Get(ctx, client.ObjectKeyFromObject(job), &batchv1.Job{}))
 }
 
 func TestCheckpointHandleCreating_MultipleOwnedRequeues(t *testing.T) {

--- a/deploy/operator/internal/controller/checkpoint_job.go
+++ b/deploy/operator/internal/controller/checkpoint_job.go
@@ -172,8 +172,6 @@ func buildCheckpointJob(
 		activeDeadlineSeconds = &defaultDeadline
 	}
 
-	ttlSecondsAfterFinish := snapshotprotocol.DefaultCheckpointJobTTLSeconds
-
 	return snapshotprotocol.NewCheckpointJob(podTemplate, snapshotprotocol.CheckpointJobOptions{
 		Namespace:             ckpt.Namespace,
 		CheckpointID:          hash,
@@ -181,7 +179,6 @@ func buildCheckpointJob(
 		SeccompProfile:        config.Checkpoint.EffectiveSeccompProfile(),
 		Name:                  jobName,
 		ActiveDeadlineSeconds: activeDeadlineSeconds,
-		TTLSecondsAfterFinish: &ttlSecondsAfterFinish,
 		WrapLaunchJob:         wrapLaunchJob,
 	})
 }

--- a/deploy/operator/internal/controller/checkpoint_podsnapshot_test.go
+++ b/deploy/operator/internal/controller/checkpoint_podsnapshot_test.go
@@ -55,6 +55,15 @@ func newCheckpointJob(name string) *batchv1.Job {
 	}
 }
 
+// markCheckpointJobComplete stamps JobComplete=True for Ready promotion tests.
+func markCheckpointJobComplete(job *batchv1.Job) *batchv1.Job {
+	job.Status.Conditions = append(job.Status.Conditions, batchv1.JobCondition{
+		Type:   batchv1.JobComplete,
+		Status: corev1.ConditionTrue,
+	})
+	return job
+}
+
 // podNameFromJob derives the test source-pod name for a checkpoint Job.
 func podNameFromJob(jobName string) string {
 	return jobName + "-pod"

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller.go
@@ -139,6 +139,15 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		}
 	}
 
+	// A Failed phase, or Ready with the new success proof, is the durable record that permits
+	// deleting its Job. Do this before duplicate or artifact-version normalization can discard the
+	// retained Job reference.
+	if isTerminalCheckpointPhase(ckpt.Status.Phase) && ckpt.Status.JobName != "" {
+		if err := r.cleanupTerminalCheckpointJob(ctx, ckpt); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
 	needsStatusUpdate := false
 	phaseWasEmpty := ckpt.Status.Phase == ""
 	if ckpt.Status.CheckpointID != checkpointID {
@@ -155,14 +164,13 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 	if existing != nil {
 		ckpt.Status.Phase = nvidiacomv1alpha1.DynamoCheckpointPhaseFailed
-		ckpt.Status.JobName = ""
 		ckpt.Status.CreatedAt = nil
 		ckpt.Status.Message = fmt.Sprintf("checkpoint ID %s is already owned by %s", checkpointID, existing.Name)
 		if err := r.Status().Update(ctx, ckpt); err != nil {
 			logger.Error(err, "Failed to mark duplicate DynamoCheckpoint as failed")
 			return ctrl.Result{}, err
 		}
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, r.cleanupTerminalCheckpointJob(ctx, ckpt)
 	}
 	desiredJobName := snapshotprotocol.GetCheckpointJobName(
 		checkpointID,
@@ -206,7 +214,6 @@ func (r *CheckpointReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	case nvidiacomv1alpha1.DynamoCheckpointPhaseCreating:
 		return r.handleCreating(ctx, ckpt)
 	case nvidiacomv1alpha1.DynamoCheckpointPhaseReady:
-		// Nothing to do, checkpoint is ready
 		return ctrl.Result{}, nil
 	case nvidiacomv1alpha1.DynamoCheckpointPhaseFailed:
 		return ctrl.Result{}, nil
@@ -255,18 +262,37 @@ func (r *CheckpointReconciler) handlePending(ctx context.Context, ckpt *nvidiaco
 		ckpt.Annotations[snapshotprotocol.CheckpointArtifactVersionAnnotation],
 	)
 
-	// Use SyncResource to create/update the checkpoint Job
-	modified, _, err := commonController.SyncResource(ctx, r, ckpt, func(ctx context.Context) (*batchv1.Job, bool, error) {
-		job, err := buildCheckpointJob(ctx, r.Client, r.Config, ckpt, jobName)
-		return job, false, err
-	})
-	if err != nil {
-		logger.Error(err, "Failed to sync checkpoint Job")
+	// Older controllers could create the deterministic Job and crash before recording Creating.
+	// Recover an owned Job without syncing its immutable spec.
+	existingJob := &batchv1.Job{}
+	err := r.Get(ctx, client.ObjectKey{Namespace: ckpt.Namespace, Name: jobName}, existingJob)
+	interruptedCreate := err == nil && metav1.IsControlledBy(existingJob, ckpt)
+	if err != nil && !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err
 	}
+	if interruptedCreate {
+		if err := r.removeCheckpointJobTTL(ctx, ckpt, existingJob); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
 
-	if modified {
-		logger.Info("Created/updated checkpoint Job", "job", jobName)
+	// Use SyncResource to create/update the checkpoint Job
+	if !interruptedCreate {
+		desiredJob, err := buildCheckpointJob(ctx, r.Client, r.Config, ckpt, jobName)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		modified, _, err := commonController.SyncResource(ctx, r, ckpt, func(context.Context) (*batchv1.Job, bool, error) {
+			return desiredJob, false, nil
+		})
+		if err != nil {
+			logger.Error(err, "Failed to sync checkpoint Job")
+			return ctrl.Result{}, err
+		}
+
+		if modified {
+			logger.Info("Created/updated checkpoint Job", "job", jobName)
+		}
 	}
 
 	// Update status to Creating phase
@@ -331,6 +357,9 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 		}
 		return ctrl.Result{}, err
 	}
+	if err := r.removeCheckpointJobTTL(ctx, ckpt, job); err != nil {
+		return ctrl.Result{}, err
+	}
 
 	checkpointID, err := checkpoint.CheckpointID(ckpt)
 	if err != nil {
@@ -392,10 +421,9 @@ func (r *CheckpointReconciler) handleCreating(ctx context.Context, ckpt *nvidiac
 	return r.observePodSnapshot(ctx, ckpt, job, snap, checkpointID)
 }
 
-// handleCreatingJobGone resolves a Creating checkpoint whose Job no longer exists. The checkpoint
-// Job carries a TTL (snapshotprotocol.DefaultCheckpointJobTTLSeconds), so a missing Job is the
-// expected end state of a finished capture: the owned PodSnapshot, not the Job, is the source of
-// truth. Only when no owned PodSnapshot exists can nothing ever complete the checkpoint.
+// handleCreatingJobGone resolves a Creating checkpoint whose Job no longer exists. Ready is only
+// set while the Job is still present (live JobComplete); if the Job is already gone and we are
+// still Creating, observePodSnapshot fails rather than promoting on PodSnapshot alone.
 func (r *CheckpointReconciler) handleCreatingJobGone(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) (ctrl.Result, error) {
 	snap, err := r.findOwnedPodSnapshot(ctx, ckpt)
 	if err != nil {
@@ -424,29 +452,37 @@ func (r *CheckpointReconciler) handleCreatingJobGone(ctx context.Context, ckpt *
 	return r.observePodSnapshot(ctx, ckpt, nil, snap, checkpointID)
 }
 
-// observePodSnapshot maps the owned PodSnapshot's status (and the Job's failure hang guard) onto the
-// DynamoCheckpoint phase. The snapshot is resolved and owner-confirmed by the
-// caller, so this never re-reads it by name. Completion cascades up from PodSnapshotContent →
-// PodSnapshot → DynamoCheckpoint, so this never reads the Job's terminal annotation. The Job is read
-// only on the non-terminal path (the terminal PodSnapshot result always wins); it may be nil when
-// the Job is already gone (TTL-reaped), in which case the hang guard is skipped.
+// observePodSnapshot maps PodSnapshot + Job terminal state onto the DynamoCheckpoint phase.
+// Ready requires a successful bound PodSnapshot and a live JobComplete. JobFailed wins even
+// after PodSnapshot Ready. If the Job is already gone while still Creating, fail rather than
+// Ready (phase=Ready is the durable success record, set only while the Job is present).
 func (r *CheckpointReconciler) observePodSnapshot(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint, job *batchv1.Job, snap *nvidiacomv1alpha1.PodSnapshot, checkpointID string) (ctrl.Result, error) {
-	// A PodSnapshot can fail before it is bound (e.g. the PodSnapshotReconciler rejects the
-	// source pod), so always observe Failed. Ready is only meaningful once bound.
+	// Failed can land before bind; Ready is only meaningful once bound.
 	if nvidiacomv1alpha1.IsPodSnapshotFailed(snap) {
 		return r.failCreating(ctx, ckpt, "PodSnapshotFailed", podSnapshotConditionMessage(snap, nvidiacomv1alpha1.PodSnapshotConditionFailed))
 	}
-	if snap.Status.BoundPodSnapshotContentName != nil && nvidiacomv1alpha1.IsPodSnapshotSucceeded(snap) {
-		return r.markCheckpointReady(ctx, ckpt, checkpointID, podSnapshotConditionMessage(snap, nvidiacomv1alpha1.PodSnapshotConditionReady))
-	}
 
-	// Non-terminal: a failed Job is the hang guard. k8s enforces ActiveDeadlineSeconds and sets
-	// JobFailed (reason DeadlineExceeded) on expiry, which the Owns(&Job) watch delivers — so this is
-	// watch-driven, no self-requeue.
+	podSnapshotReady := snap.Status.BoundPodSnapshotContentName != nil &&
+		nvidiacomv1alpha1.IsPodSnapshotSucceeded(snap)
+
+	// Helper failure must win even if capture already succeeded (Owns(&Job) watch).
 	if failed, message := checkpointJobFailed(job); failed {
 		return r.failCreating(ctx, ckpt, "JobFailed", message)
 	}
-	return ctrl.Result{}, nil
+
+	if !podSnapshotReady {
+		return ctrl.Result{}, nil
+	}
+
+	if job == nil {
+		return r.failCreating(ctx, ckpt, "JobDeletedBeforeComplete",
+			"checkpoint job was deleted before JobComplete was observed")
+	}
+	if !checkpointJobComplete(job) {
+		return ctrl.Result{}, nil
+	}
+
+	return r.markCheckpointReady(ctx, ckpt, checkpointID, podSnapshotConditionMessage(snap, nvidiacomv1alpha1.PodSnapshotConditionReady))
 }
 
 // failCreating marks the DynamoCheckpoint Failed with a completion-condition reason.
@@ -461,10 +497,13 @@ func (r *CheckpointReconciler) failCreating(ctx context.Context, ckpt *nvidiacom
 		Reason:  reason,
 		Message: message,
 	})
-	return ctrl.Result{}, r.Status().Update(ctx, ckpt)
+	if err := r.Status().Update(ctx, ckpt); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, r.cleanupTerminalCheckpointJob(ctx, ckpt)
 }
 
-// markCheckpointReady marks the DynamoCheckpoint Ready after its bound PodSnapshot succeeded.
+// markCheckpointReady marks the DynamoCheckpoint Ready after PodSnapshot success and live JobComplete.
 func (r *CheckpointReconciler) markCheckpointReady(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint, checkpointID, message string) (ctrl.Result, error) {
 	log.FromContext(ctx).Info("Checkpoint ready", "checkpointID", checkpointID)
 	r.Recorder.Event(ckpt, corev1.EventTypeNormal, "CheckpointReady", message)
@@ -475,10 +514,80 @@ func (r *CheckpointReconciler) markCheckpointReady(ctx context.Context, ckpt *nv
 	meta.SetStatusCondition(&ckpt.Status.Conditions, metav1.Condition{
 		Type:    string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCompleted),
 		Status:  metav1.ConditionTrue,
-		Reason:  "PodSnapshotReady",
+		Reason:  "PodSnapshotAndJobReady",
 		Message: message,
 	})
-	return ctrl.Result{}, r.Status().Update(ctx, ckpt)
+	if err := r.Status().Update(ctx, ckpt); err != nil {
+		return ctrl.Result{}, err
+	}
+	return ctrl.Result{}, r.cleanupTerminalCheckpointJob(ctx, ckpt)
+}
+
+// cleanupTerminalCheckpointJob deletes an owned Job only after the checkpoint's terminal phase
+// has been persisted. Terminal-phase reconciles retry API failures.
+func (r *CheckpointReconciler) cleanupTerminalCheckpointJob(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint) error {
+	if !isTerminalCheckpointPhase(ckpt.Status.Phase) {
+		return nil
+	}
+	if ckpt.Status.Phase == nvidiacomv1alpha1.DynamoCheckpointPhaseReady &&
+		!checkpointReadyForJobCleanup(ckpt) {
+		return nil
+	}
+	if ckpt.Status.JobName == "" {
+		return nil
+	}
+
+	job := &batchv1.Job{}
+	if err := r.Get(ctx, client.ObjectKey{Namespace: ckpt.Namespace, Name: ckpt.Status.JobName}, job); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+	if !metav1.IsControlledBy(job, ckpt) {
+		return nil
+	}
+	uid := job.UID
+	if err := r.Delete(ctx, job,
+		client.Preconditions{UID: &uid},
+		client.PropagationPolicy(metav1.DeletePropagationBackground),
+	); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("delete terminal checkpoint job %s/%s: %w", job.Namespace, job.Name, err)
+	}
+	return nil
+}
+
+// removeCheckpointJobTTL migrates operator-owned Jobs created before terminal cleanup became
+// controller-driven. Generic snapshot-protocol Jobs and foreign name collisions are untouched.
+func (r *CheckpointReconciler) removeCheckpointJobTTL(ctx context.Context, ckpt *nvidiacomv1alpha1.DynamoCheckpoint, job *batchv1.Job) error {
+	if !metav1.IsControlledBy(job, ckpt) ||
+		job.Spec.TTLSecondsAfterFinished == nil ||
+		*job.Spec.TTLSecondsAfterFinished != snapshotprotocol.DefaultCheckpointJobTTLSeconds {
+		return nil
+	}
+	job.Spec.TTLSecondsAfterFinished = nil
+	if err := r.Update(ctx, job); err != nil {
+		return fmt.Errorf("remove legacy TTL from checkpoint job %s/%s: %w", job.Namespace, job.Name, err)
+	}
+	return nil
+}
+
+func isTerminalCheckpointPhase(phase nvidiacomv1alpha1.DynamoCheckpointPhase) bool {
+	return phase == nvidiacomv1alpha1.DynamoCheckpointPhaseReady ||
+		phase == nvidiacomv1alpha1.DynamoCheckpointPhaseFailed
+}
+
+func checkpointReadyForJobCleanup(ckpt *nvidiacomv1alpha1.DynamoCheckpoint) bool {
+	condition := meta.FindStatusCondition(
+		ckpt.Status.Conditions,
+		string(nvidiacomv1alpha1.DynamoCheckpointConditionJobCompleted),
+	)
+	return condition != nil &&
+		condition.Status == metav1.ConditionTrue &&
+		condition.Reason == "PodSnapshotAndJobReady"
 }
 
 // podSnapshotConditionMessage returns the message of the named PodSnapshot condition, or "".
@@ -489,8 +598,7 @@ func podSnapshotConditionMessage(snap *nvidiacomv1alpha1.PodSnapshot, condType s
 	return ""
 }
 
-// checkpointJobFailed reports whether the Job has a True JobFailed condition. A nil Job (already
-// deleted) reports false — with the Job gone there is nothing left to hang-guard.
+// checkpointJobFailed reports whether the Job has JobFailed=True. A nil Job reports false.
 func checkpointJobFailed(job *batchv1.Job) (bool, string) {
 	if job == nil {
 		return false, ""
@@ -505,6 +613,19 @@ func checkpointJobFailed(job *batchv1.Job) (bool, string) {
 		}
 	}
 	return false, ""
+}
+
+// checkpointJobComplete reports whether the Job has JobComplete=True.
+func checkpointJobComplete(job *batchv1.Job) bool {
+	if job == nil {
+		return false
+	}
+	for _, condition := range job.Status.Conditions {
+		if condition.Type == batchv1.JobComplete && condition.Status == corev1.ConditionTrue {
+			return true
+		}
+	}
+	return false
 }
 
 //nolint:gocyclo

--- a/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
+++ b/deploy/operator/internal/controller/dynamocheckpoint_controller_test.go
@@ -229,9 +229,9 @@ func TestBuildCheckpointJob(t *testing.T) {
 	// Default deadlines
 	assert.Equal(t, int64(3600), *job.Spec.ActiveDeadlineSeconds)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
-	assert.Equal(t, int32(300), *job.Spec.TTLSecondsAfterFinished)
+	assert.Nil(t, job.Spec.TTLSecondsAfterFinished)
 
-	// Custom active deadlines override defaults, but checkpoint jobs never retry and keep a fixed TTL.
+	// Custom active deadlines override defaults, but checkpoint jobs never retry or use automatic TTL cleanup.
 	deadline := int64(7200)
 	backoff := int32(5)
 	ckpt.Spec.Job.ActiveDeadlineSeconds = &deadline
@@ -240,7 +240,7 @@ func TestBuildCheckpointJob(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, int64(7200), *job.Spec.ActiveDeadlineSeconds)
 	assert.Equal(t, int32(0), *job.Spec.BackoffLimit)
-	assert.Equal(t, int32(300), *job.Spec.TTLSecondsAfterFinished)
+	assert.Nil(t, job.Spec.TTLSecondsAfterFinished)
 
 	// Deprecated identity fields no longer control checkpoint launch wrapping.
 	ckpt.Spec.Identity.TensorParallelSize = 2
@@ -935,9 +935,9 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		return snap
 	}
 
-	t.Run("PodSnapshot Ready transitions checkpoint to Ready", func(t *testing.T) {
+	t.Run("PodSnapshot Ready with JobComplete transitions checkpoint to Ready", func(t *testing.T) {
 		ckpt := makeCreatingCkpt(testHash, defaultCheckpointJobName)
-		job := newCheckpointJob(defaultCheckpointJobName)
+		job := markCheckpointJobComplete(newCheckpointJob(defaultCheckpointJobName))
 		snap := ownedSnapshot(ckpt, nvidiacomv1alpha1.PodSnapshotConditionReady)
 
 		r := makeCheckpointReconciler(s, ckpt, job, snap, newOwnedPod(podNameFromJob(job.Name), job))
@@ -950,6 +950,46 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseReady, updated.Status.Phase)
 		assert.Equal(t, testHash, updated.Status.CheckpointID)
 		assert.NotNil(t, updated.Status.CreatedAt)
+		cond := meta.FindStatusCondition(updated.Status.Conditions, "JobCompleted")
+		require.NotNil(t, cond)
+		assert.Equal(t, "PodSnapshotAndJobReady", cond.Reason)
+	})
+
+	t.Run("PodSnapshot Ready without JobComplete stays Creating", func(t *testing.T) {
+		// Capture done; helpers (e.g. gms-saver) may still be running.
+		ckpt := makeCreatingCkpt(testHash, defaultCheckpointJobName)
+		job := newCheckpointJob(defaultCheckpointJobName)
+		snap := ownedSnapshot(ckpt, nvidiacomv1alpha1.PodSnapshotConditionReady)
+
+		r := makeCheckpointReconciler(s, ckpt, job, snap, newOwnedPod(podNameFromJob(job.Name), job))
+		result, err := r.handleCreating(ctx, ckpt)
+		require.NoError(t, err)
+		assert.Zero(t, result)
+
+		updated := &nvidiacomv1alpha1.DynamoCheckpoint{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: testHash, Namespace: testNamespace}, updated))
+		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseCreating, updated.Status.Phase)
+	})
+
+	t.Run("PodSnapshot Ready with JobFailed transitions to Failed", func(t *testing.T) {
+		// Helper crash after capture must not promote Ready.
+		ckpt := makeCreatingCkpt(testHash, defaultCheckpointJobName)
+		job := newCheckpointJob(defaultCheckpointJobName)
+		job.Status.Conditions = []batchv1.JobCondition{{
+			Type:    batchv1.JobFailed,
+			Status:  corev1.ConditionTrue,
+			Message: "gms-saver exited 1",
+		}}
+		snap := ownedSnapshot(ckpt, nvidiacomv1alpha1.PodSnapshotConditionReady)
+
+		r := makeCheckpointReconciler(s, ckpt, job, snap, newOwnedPod(podNameFromJob(job.Name), job))
+		_, err := r.handleCreating(ctx, ckpt)
+		require.NoError(t, err)
+
+		updated := &nvidiacomv1alpha1.DynamoCheckpoint{}
+		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: testHash, Namespace: testNamespace}, updated))
+		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseFailed, updated.Status.Phase)
+		assert.Contains(t, updated.Status.Message, "gms-saver exited 1")
 	})
 
 	t.Run("PodSnapshot Failed transitions checkpoint to Failed", func(t *testing.T) {
@@ -1123,7 +1163,8 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		assert.Equal(t, "checkpoint job was deleted", updated.Status.Message)
 	})
 
-	t.Run("deleted job with Ready snapshot marks checkpoint Ready", func(t *testing.T) {
+	t.Run("deleted job with Ready snapshot transitions to Failed", func(t *testing.T) {
+		// Ready is only set while the Job is live; an externally deleted Job must not promote Ready.
 		ckpt := makeCreatingCkpt(testHash, "job-deleted")
 		snap := buildPodSnapshot(ckpt, testHash, podNamed("worker-x"))
 		setCheckpointOwner(ckpt, snap)
@@ -1131,7 +1172,6 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 		meta.SetStatusCondition(&snap.Status.Conditions, metav1.Condition{
 			Type: "Ready", Status: metav1.ConditionTrue, Reason: "Captured", Message: "checkpoint captured",
 		})
-		// Job TTL-reaped after the capture succeeded: the snapshot result must win over JobDeleted.
 		r := makeCheckpointReconciler(s, ckpt, snap)
 
 		_, err := r.handleCreating(ctx, ckpt)
@@ -1139,12 +1179,11 @@ func TestCheckpointReconciler_HandleCreating(t *testing.T) {
 
 		updated := &nvidiacomv1alpha1.DynamoCheckpoint{}
 		require.NoError(t, r.Get(ctx, types.NamespacedName{Name: testHash, Namespace: testNamespace}, updated))
-		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseReady, updated.Status.Phase)
-		assert.Equal(t, testHash, updated.Status.CheckpointID)
+		assert.Equal(t, nvidiacomv1alpha1.DynamoCheckpointPhaseFailed, updated.Status.Phase)
 		cond := meta.FindStatusCondition(updated.Status.Conditions, "JobCompleted")
 		require.NotNil(t, cond)
-		assert.Equal(t, metav1.ConditionTrue, cond.Status)
-		assert.Equal(t, "PodSnapshotReady", cond.Reason)
+		assert.Equal(t, "JobDeletedBeforeComplete", cond.Reason)
+		assert.Contains(t, updated.Status.Message, "before JobComplete was observed")
 	})
 
 	t.Run("deleted job with Failed snapshot transitions to Failed", func(t *testing.T) {

--- a/docs/kubernetes/api-reference.md
+++ b/docs/kubernetes/api-reference.md
@@ -308,7 +308,7 @@ _Appears in:_
 | `sharedMemory` _[SharedMemorySpec](#sharedmemoryspec)_ | SharedMemory controls the tmpfs mounted at /dev/shm for the checkpoint Job pod.<br />When omitted, checkpoint Jobs use the same default 8Gi tmpfs as Dynamo components. |  | Optional: \{\} <br /> |
 | `activeDeadlineSeconds` _integer_ | ActiveDeadlineSeconds specifies the maximum time the Job can run | 3600 | Minimum: 1 <br />Optional: \{\} <br /> |
 | `backoffLimit` _integer_ | Deprecated: BackoffLimit is ignored. Checkpoint Jobs never retry. |  | Minimum: 0 <br />Optional: \{\} <br /> |
-| `ttlSecondsAfterFinished` _integer_ | Deprecated: TTLSecondsAfterFinished is ignored. Checkpoint Jobs use a fixed<br />300 second TTL. |  | Minimum: 0 <br />Optional: \{\} <br /> |
+| `ttlSecondsAfterFinished` _integer_ | Deprecated: TTLSecondsAfterFinished is ignored. The operator deletes checkpoint<br />Jobs after recording their terminal outcome. |  | Minimum: 0 <br />Optional: \{\} <br /> |
 
 
 #### DynamoCheckpointPhase


### PR DESCRIPTION
## Summary
- After #10951, `DynamoCheckpoint` became `Ready` as soon as the owned `PodSnapshot` succeeded. That signal only means the **target-container CRIU dump** finished.
- With Snapshot + GMS, `gms-saver` is a separate Job container that exits only after tensors are on disk. Promoting Ready on PodSnapshot alone races the saver and can admit restore pods before GMS artifacts exist.
- Restore readiness: require **PodSnapshot Ready ∧ JobComplete** while the Job is still present; honor **JobFailed even after PodSnapshot Ready** so a saver/helper failure cannot promote a partial checkpoint. TTL-reaped Jobs keep the existing PodSnapshot-as-durable-success path (k8s only TTL-deletes finished Jobs).
- No PodSnapshot / PodSnapshotContent CRD changes — GMS save completion belongs at the DynamoCheckpoint/Job layer.

## Validation
- [x] `go test ./internal/controller/ -run TestCheckpointReconciler_HandleCreating` (from `deploy/operator`)
- [x] New cases: Ready without JobComplete stays Creating; Ready + JobFailed → Failed; Ready + JobComplete → Ready (`PodSnapshotAndJobReady`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Checkpoints now become Ready only after both the PodSnapshot and associated Job complete successfully.
  * Failed checkpoint Jobs now take priority, even when the PodSnapshot is ready.
  * Checkpoints remain Creating while the Job is still incomplete.
  * Updated readiness status messaging to reflect both completion requirements.

* **Tests**
  * Added coverage for successful, incomplete, and failed checkpoint Job scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->