### PR TITLE
fix(mocker): make replay outputs deterministic [DYN-3850]

### DIFF
--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -5,12 +5,13 @@ use std::cmp::Ordering;
 use std::collections::BinaryHeap;
 
 use anyhow::{Context, Result, anyhow, bail};
+use rand::SeedableRng;
 use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
 use rustc_hash::FxHashMap;
 use uuid::Uuid;
 
 use super::types::{AgenticTrace, ReadyTurn, ReplayRequestHashes, Trace};
+use super::{SYNTHETIC_OUTPUT_SEED, planned_output_token_ids};
 use crate::common::protocols::DirectRequest;
 
 #[derive(Debug)]
@@ -38,20 +39,6 @@ struct AgenticState {
 enum PromptMode {
     Full,
     DeltaCumulative,
-}
-
-const SYNTHETIC_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;
-
-fn planned_output_token_ids(
-    authored: Option<Vec<u32>>,
-    max_output_tokens: usize,
-    output_rng: &mut StdRng,
-) -> Vec<u32> {
-    authored.unwrap_or_else(|| {
-        (0..max_output_tokens)
-            .map(|_| output_rng.random::<u32>())
-            .collect()
-    })
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/lib/mocker/src/loadgen/driver.rs
+++ b/lib/mocker/src/loadgen/driver.rs
@@ -40,7 +40,19 @@ enum PromptMode {
     DeltaCumulative,
 }
 
-const SYNTHETIC_DELTA_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;
+const SYNTHETIC_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;
+
+fn planned_output_token_ids(
+    authored: Option<Vec<u32>>,
+    max_output_tokens: usize,
+    output_rng: &mut StdRng,
+) -> Vec<u32> {
+    authored.unwrap_or_else(|| {
+        (0..max_output_tokens)
+            .map(|_| output_rng.random::<u32>())
+            .collect()
+    })
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum TurnOutcome {
@@ -312,6 +324,7 @@ impl WorkloadDriver {
         let mut remaining_dependencies = Vec::with_capacity(trace.turns.len());
         let mut ready_after_ms = Vec::with_capacity(trace.turns.len());
         let mut sessions = Vec::with_capacity(trace.turns.len());
+        let mut output_rng = StdRng::seed_from_u64(SYNTHETIC_OUTPUT_SEED);
 
         for (session_index, turn) in trace.turns.into_iter().enumerate() {
             for dependency in &turn.wait_for {
@@ -325,6 +338,11 @@ impl WorkloadDriver {
 
             let replay_hashes = Some(turn.to_replay_hashes(trace_block_size, engine_block_size)?);
             let tokens = turn.synthesize_tokens(trace_block_size)?;
+            let output_token_ids = Some(planned_output_token_ids(
+                turn.output_token_ids,
+                turn.max_output_tokens,
+                &mut output_rng,
+            ));
             let next_ready_at_ms = if turn.wait_for.is_empty() {
                 Some(turn.first_ready_timestamp_ms.unwrap_or(0.0))
             } else {
@@ -337,7 +355,7 @@ impl WorkloadDriver {
                     replay_key: turn.replay_key,
                     tokens,
                     max_output_tokens: turn.max_output_tokens,
-                    output_token_ids: turn.output_token_ids,
+                    output_token_ids,
                     delay_after_previous_ms: turn.delay_after_dependencies_ms,
                     priority: turn.priority,
                     strict_priority: turn.strict_priority,
@@ -390,7 +408,7 @@ impl WorkloadDriver {
             u32::try_from(engine_block_size).context("engine_block_size does not fit in u32")?;
         let trace_block_size = trace.block_size;
         let is_concurrency = matches!(&policy, SchedulingPolicy::Concurrency(_));
-        let mut output_rng = StdRng::seed_from_u64(SYNTHETIC_DELTA_OUTPUT_SEED);
+        let mut output_rng = StdRng::seed_from_u64(SYNTHETIC_OUTPUT_SEED);
         let sessions: Vec<SessionRuntime> = trace
             .sessions
             .into_iter()
@@ -410,15 +428,11 @@ impl WorkloadDriver {
                             None
                         };
                         let tokens = turn.synthesize_tokens(trace_block_size)?;
-                        let output_token_ids = match turn.output_token_ids {
-                            Some(output_token_ids) => Some(output_token_ids),
-                            None if prompt_mode == PromptMode::DeltaCumulative => Some(
-                                (0..turn.max_output_tokens)
-                                    .map(|_| output_rng.random::<u32>())
-                                    .collect(),
-                            ),
-                            None => None,
-                        };
+                        let output_token_ids = Some(planned_output_token_ids(
+                            turn.output_token_ids,
+                            turn.max_output_tokens,
+                            &mut output_rng,
+                        ));
                         Ok(TurnRuntime {
                             request_id: None,
                             tokens,
@@ -798,6 +812,26 @@ mod tests {
     use super::*;
     use crate::loadgen::{AgenticTrace, AgenticTurnTrace, SessionTrace, Trace, TurnTrace};
 
+    fn assert_deterministic_output_plan(
+        mut first_driver: WorkloadDriver,
+        mut second_driver: WorkloadDriver,
+        expected_len: usize,
+    ) {
+        let first = first_driver.pop_ready(0.0, usize::MAX);
+        let second = second_driver.pop_ready(0.0, usize::MAX);
+
+        assert_eq!(first.len(), 1);
+        assert_eq!(second.len(), 1);
+        assert_eq!(
+            first[0].request.output_token_ids,
+            second[0].request.output_token_ids
+        );
+        assert_eq!(
+            first[0].request.output_token_ids.as_ref().map(Vec::len),
+            Some(expected_len)
+        );
+    }
+
     fn two_session_trace() -> Trace {
         Trace {
             block_size: 1,
@@ -1151,6 +1185,47 @@ mod tests {
         assert!(
             driver.is_drained(),
             "is_drained must become true so run_workload can exit"
+        );
+    }
+
+    #[test]
+    fn full_prompt_modes_plan_missing_output_token_ids_deterministically() {
+        let trace = Trace {
+            block_size: 1,
+            sessions: vec![SessionTrace {
+                session_id: "a".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![TurnTrace {
+                    input_length: 2,
+                    max_output_tokens: 3,
+                    hash_ids: vec![10, 11],
+                    ..Default::default()
+                }],
+            }],
+        };
+        assert_deterministic_output_plan(
+            WorkloadDriver::new_trace(trace.clone(), 1).unwrap(),
+            WorkloadDriver::new_trace(trace, 1).unwrap(),
+            3,
+        );
+
+        let trace = AgenticTrace {
+            block_size: 1,
+            turns: vec![AgenticTurnTrace {
+                request_id: "r1".into(),
+                session_id: "a".into(),
+                input_length: 2,
+                max_output_tokens: 3,
+                hash_ids: vec![10, 11],
+                first_ready_timestamp_ms: Some(0.0),
+                prefix_reset: true,
+                ..Default::default()
+            }],
+        };
+        assert_deterministic_output_plan(
+            WorkloadDriver::new_agentic_trace(trace.clone(), 1).unwrap(),
+            WorkloadDriver::new_agentic_trace(trace, 1).unwrap(),
+            3,
         );
     }
 

--- a/lib/mocker/src/loadgen/mod.rs
+++ b/lib/mocker/src/loadgen/mod.rs
@@ -5,6 +5,9 @@ mod driver;
 mod trace;
 mod types;
 
+use rand::Rng;
+use rand::rngs::StdRng;
+
 pub use driver::WorkloadDriver;
 pub use trace::validate_trace_files;
 pub use types::{
@@ -14,6 +17,20 @@ pub use types::{
     SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace, effective_replay_key,
     output_replay_id_annotation,
 };
+
+pub(super) const SYNTHETIC_OUTPUT_SEED: u64 = 0xD37A_0A7E_5EED;
+
+pub(super) fn planned_output_token_ids(
+    authored: Option<Vec<u32>>,
+    max_output_tokens: usize,
+    output_rng: &mut StdRng,
+) -> Vec<u32> {
+    authored.unwrap_or_else(|| {
+        (0..max_output_tokens)
+            .map(|_| output_rng.random::<u32>())
+            .collect()
+    })
+}
 
 #[cfg(test)]
 mod tests;

--- a/lib/mocker/src/loadgen/tests.rs
+++ b/lib/mocker/src/loadgen/tests.rs
@@ -141,6 +141,43 @@ fn test_from_mooncake_single_turn_preserves_fields() {
 }
 
 #[test]
+fn single_turn_requests_plan_missing_output_tokens_deterministically() {
+    let trace = Trace {
+        block_size: 1,
+        sessions: vec![
+            SessionTrace {
+                session_id: "missing".into(),
+                first_arrival_timestamp_ms: Some(0.0),
+                turns: vec![TurnTrace {
+                    input_length: 2,
+                    max_output_tokens: 3,
+                    hash_ids: vec![10, 11],
+                    ..Default::default()
+                }],
+            },
+            SessionTrace {
+                session_id: "authored".into(),
+                first_arrival_timestamp_ms: Some(1.0),
+                turns: vec![TurnTrace {
+                    input_length: 1,
+                    max_output_tokens: 2,
+                    output_token_ids: Some(vec![20, 21]),
+                    hash_ids: vec![12],
+                    ..Default::default()
+                }],
+            },
+        ],
+    };
+
+    let first = trace.to_single_turn_requests().unwrap();
+    let second = trace.to_single_turn_requests().unwrap();
+
+    assert_eq!(first[0].output_token_ids, second[0].output_token_ids);
+    assert_eq!(first[0].output_token_ids.as_ref().map(Vec::len), Some(3));
+    assert_eq!(first[1].output_token_ids.as_deref(), Some(&[20, 21][..]));
+}
+
+#[test]
 fn test_from_mooncake_preserves_output_token_replay_keys() {
     let file = write_trace(&[
         serde_json::json!({

--- a/lib/mocker/src/loadgen/trace.rs
+++ b/lib/mocker/src/loadgen/trace.rs
@@ -29,6 +29,7 @@ use super::types::{
     ReplayRequestHashes, RouterSequence, SequenceHashMode, SessionPartitionSpec, SessionTrace,
     SyntheticTraceSpec, Trace, TraceFileFormat, TurnTrace, effective_replay_key,
 };
+use super::{SYNTHETIC_OUTPUT_SEED, planned_output_token_ids};
 use crate::common::protocols::DirectRequest;
 
 #[derive(Debug, Deserialize)]
@@ -884,6 +885,7 @@ impl Trace {
 
     pub fn to_single_turn_requests(&self) -> Result<Vec<DirectRequest>> {
         let mut requests = Vec::with_capacity(self.sessions.len());
+        let mut output_rng = StdRng::seed_from_u64(SYNTHETIC_OUTPUT_SEED);
         for session in &self.sessions {
             if session.turns.len() != 1 {
                 bail!(
@@ -892,11 +894,17 @@ impl Trace {
                     session.turns.len()
                 );
             }
-            requests.push(session.turns[0].to_direct_request(
+            let mut request = session.turns[0].to_direct_request(
                 self.block_size,
                 Uuid::new_v4(),
                 session.first_arrival_timestamp_ms,
-            )?);
+            )?;
+            request.output_token_ids = Some(planned_output_token_ids(
+                request.output_token_ids,
+                request.max_output_tokens,
+                &mut output_rng,
+            ));
+            requests.push(request);
         }
         Ok(requests)
     }


### PR DESCRIPTION
## Summary

- plan deterministic synthetic output IDs for standard and agentic full-prompt replay when traces omit them
- preserve authored output IDs and prevent backend-specific random token fallbacks from changing replay KV events
- add regression coverage for identical output plans across identical replay drivers

This stabilizes the CKF parity corpus, where randomized generated-output blocks could move a legitimate 16-bit fingerprint false hit in or out of the test between runs.

## Validation

- cargo test --locked -p dynamo-mocker loadgen::driver::tests
- cargo test --locked -p dynamo-bench --test mooncake_trace mooncake_trace_replays_through_fixed_d16_ckf -- --nocapture (repeated; all post-fix runs passed with zero mismatches)
- cargo fmt --all -- --check
- pre-commit run --files lib/mocker/src/loadgen/driver.rs
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11902" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured workloads consistently receive planned output tokens when none are provided.
  * Made generated output-token plans deterministic across standard and agentic workloads.
  * Preserved authored output tokens when they are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->