### PR TITLE
feat(operator): migrate CRD storage to v1beta1

### DIFF
--- a/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
+++ b/deploy/helm/charts/platform/components/operator/files/manager-role.yaml
@@ -61,6 +61,24 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamocomponentdeployment_types.go
@@ -263,7 +263,6 @@ type DynamoComponentDeploymentStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:storageversion
 // +kubebuilder:deprecatedversion:warning="nvidia.com/v1alpha1 DynamoComponentDeployment is deprecated; use nvidia.com/v1beta1 DynamoComponentDeployment"
 // +kubebuilder:printcolumn:name="DynamoComponent",type="string",JSONPath=".spec.dynamoComponent",description="Dynamo component"
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Available"

--- a/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeployment_types.go
@@ -336,7 +336,6 @@ type ServiceReplicaStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:storageversion
 // +kubebuilder:deprecatedversion:warning="nvidia.com/v1alpha1 DynamoGraphDeployment is deprecated; use nvidia.com/v1beta1 DynamoGraphDeployment"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=dgd

--- a/deploy/operator/api/v1alpha1/dynamographdeploymentscalingadapter_types.go
+++ b/deploy/operator/api/v1alpha1/dynamographdeploymentscalingadapter_types.go
@@ -67,7 +67,6 @@ type DynamoGraphDeploymentScalingAdapterStatus struct {
 }
 
 // +kubebuilder:object:root=true
-// +kubebuilder:storageversion
 // +kubebuilder:deprecatedversion:warning="nvidia.com/v1alpha1 DynamoGraphDeploymentScalingAdapter is deprecated; use nvidia.com/v1beta1 DynamoGraphDeploymentScalingAdapter"
 // +kubebuilder:subresource:status
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector

--- a/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
+++ b/deploy/operator/api/v1beta1/dynamocomponentdeployment_types.go
@@ -245,6 +245,7 @@ type DynamoComponentDeploymentStatus struct {
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=dcd
 // +kubebuilder:printcolumn:name="Available",type="string",JSONPath=".status.conditions[?(@.type=='Available')].status",description="Available"
 // +kubebuilder:printcolumn:name="Backend",type="string",JSONPath=`.spec.backendFramework`,description="Backend framework (sglang, vllm, trtllm)"
@@ -252,9 +253,8 @@ type DynamoComponentDeploymentStatus struct {
 
 // DynamoComponentDeployment is the Schema for the dynamocomponentdeployments API.
 //
-// v1beta1 is a served version: the API server accepts reads and writes
-// against it, and transparently converts to/from v1alpha1 (still the
-// storage version until a later MR flips it). Conversion goes through the
+// v1beta1 is the storage version. The API server transparently converts
+// to and from the served v1alpha1 version through
 // operator's conversion webhook; see api/v1alpha1/*_conversion.go.
 type DynamoComponentDeployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/deploy/operator/api/v1beta1/dynamographdeployment_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeployment_types.go
@@ -167,6 +167,7 @@ const (
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:resource:shortName=dgd
 // +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=`.status.conditions[?(@.type=="Ready")].status`,description="Ready status of the graph deployment"
 // +kubebuilder:printcolumn:name="Backend",type="string",JSONPath=`.spec.backendFramework`,description="Backend framework (sglang, vllm, trtllm)"
@@ -174,9 +175,8 @@ const (
 
 // DynamoGraphDeployment is the Schema for the dynamographdeployments API.
 //
-// v1beta1 is a served version: the API server accepts reads and writes
-// against it, and transparently converts to/from v1alpha1 (still the
-// storage version until a later MR flips it). Conversion goes through the
+// v1beta1 is the storage version. The API server transparently converts
+// to and from the served v1alpha1 version through
 // operator's conversion webhook; see api/v1alpha1/*_conversion.go.
 type DynamoGraphDeployment struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/deploy/operator/api/v1beta1/dynamographdeploymentscalingadapter_types.go
+++ b/deploy/operator/api/v1beta1/dynamographdeploymentscalingadapter_types.go
@@ -75,6 +75,7 @@ type DynamoGraphDeploymentScalingAdapterStatus struct {
 
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:storageversion
 // +kubebuilder:subresource:scale:specpath=.spec.replicas,statuspath=.status.replicas,selectorpath=.status.selector
 // +kubebuilder:printcolumn:name="DGD",type="string",JSONPath=".spec.dgdRef.name",description="DynamoGraphDeployment name"
 // +kubebuilder:printcolumn:name="COMPONENT",type="string",JSONPath=".spec.dgdRef.componentName",description="Component name"
@@ -90,8 +91,8 @@ type DynamoGraphDeploymentScalingAdapterStatus struct {
 // ensuring that only the adapter controller modifies the DGD's component replicas.
 // This prevents conflicts when multiple autoscaling mechanisms are in play.
 //
-// v1alpha1 remains the storage version; conversion between served versions is
-// handled by the operator's conversion webhook
+// v1beta1 is the storage version; conversion to and from the served v1alpha1
+// version is handled by the operator's conversion webhook
 // (see api/v1alpha1/dynamographdeploymentscalingadapter_conversion.go).
 type DynamoGraphDeploymentScalingAdapter struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -45,6 +45,7 @@ import (
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrlcontroller "sigs.k8s.io/controller-runtime/pkg/controller"
 
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
@@ -68,6 +69,7 @@ import (
 	internalcert "github.com/ai-dynamo/dynamo/deploy/operator/internal/cert"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/controller"
 	commonController "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/crdmigrator"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/namespace_scope"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/observability"
@@ -586,6 +588,36 @@ func registerControllers(
 	operatorImage string,
 	operatorPullPolicy corev1.PullPolicy,
 ) error {
+	if operatorCfg.Namespace.Restricted == "" {
+		// The cluster-wide manager cache covers all namespaces. ExcludedNamespaces only filters
+		// business-controller events and does not narrow the cache used by the migrator.
+		migrator := &crdmigrator.CRDMigrator{
+			Client:    mgr.GetClient(),
+			APIReader: mgr.GetAPIReader(),
+			Config: map[client.Object]crdmigrator.ByObjectConfig{
+				&nvidiacomv1beta1.DynamoComponentDeployment{}: {
+					UseCache:                            true,
+					UseStatusForStorageVersionMigration: true,
+				},
+				&nvidiacomv1beta1.DynamoGraphDeployment{}: {
+					UseCache:                            true,
+					UseStatusForStorageVersionMigration: true,
+				},
+				&nvidiacomv1beta1.DynamoGraphDeploymentRequest{}: {
+					UseCache:                            true,
+					UseStatusForStorageVersionMigration: true,
+				},
+				&nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}: {
+					UseCache:                            true,
+					UseStatusForStorageVersionMigration: true,
+				},
+			},
+		}
+		if err := migrator.SetupWithManager(mgr, ctrlcontroller.Options{MaxConcurrentReconciles: 1}); err != nil {
+			return fmt.Errorf("unable to create CRD migrator controller: %w", err)
+		}
+	}
+
 	setupOptions := controller.SetupOptions{
 		Config:        operatorCfg,
 		RuntimeConfig: runtimeConfig,

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamocomponentdeployments.yaml
@@ -11700,7 +11700,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -11721,9 +11721,8 @@ spec:
           description: |-
             DynamoComponentDeployment is the Schema for the dynamocomponentdeployments API.
 
-            v1beta1 is a served version: the API server accepts reads and writes
-            against it, and transparently converts to/from v1alpha1 (still the
-            storage version until a later MR flips it). Conversion goes through the
+            v1beta1 is the storage version. The API server transparently converts
+            to and from the served v1alpha1 version through
             operator's conversion webhook; see api/v1alpha1/*_conversion.go.
           properties:
             apiVersion:
@@ -20629,7 +20628,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
   conversion:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeployments.yaml
@@ -12130,7 +12130,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         status: {}
     - additionalPrinterColumns:
@@ -12151,9 +12151,8 @@ spec:
           description: |-
             DynamoGraphDeployment is the Schema for the dynamographdeployments API.
 
-            v1beta1 is a served version: the API server accepts reads and writes
-            against it, and transparently converts to/from v1alpha1 (still the
-            storage version until a later MR flips it). Conversion goes through the
+            v1beta1 is the storage version. The API server transparently converts
+            to and from the served v1alpha1 version through
             operator's conversion webhook; see api/v1alpha1/*_conversion.go.
           properties:
             apiVersion:
@@ -21497,7 +21496,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         status: {}
   conversion:

--- a/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentscalingadapters.yaml
+++ b/deploy/operator/config/crd/bases/nvidia.com_dynamographdeploymentscalingadapters.yaml
@@ -117,7 +117,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: true
+      storage: false
       subresources:
         scale:
           labelSelectorPath: .status.selector
@@ -152,8 +152,8 @@ spec:
             ensuring that only the adapter controller modifies the DGD's component replicas.
             This prevents conflicts when multiple autoscaling mechanisms are in play.
 
-            v1alpha1 remains the storage version; conversion between served versions is
-            handled by the operator's conversion webhook
+            v1beta1 is the storage version; conversion to and from the served v1alpha1
+            version is handled by the operator's conversion webhook
             (see api/v1alpha1/dynamographdeploymentscalingadapter_conversion.go).
           properties:
             apiVersion:
@@ -233,7 +233,7 @@ spec:
               type: object
           type: object
       served: true
-      storage: false
+      storage: true
       subresources:
         scale:
           labelSelectorPath: .status.selector

--- a/deploy/operator/config/rbac/role.yaml
+++ b/deploy/operator/config/rbac/role.yaml
@@ -61,6 +61,24 @@ rules:
   - update
   - watch
 - apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - apps
   resources:
   - daemonsets

--- a/deploy/operator/internal/crdmigrator/AGENTS.md
+++ b/deploy/operator/internal/crdmigrator/AGENTS.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# CRD Migrator Maintenance
+
+- This package is derived from
+  `kubernetes-sigs/cluster-api/controllers/crdmigrator` at Cluster API v1.13.4,
+  commit `27f464418c195d96ae2ef4b96f3b6a047ea89310`.
+- The TTL cache is derived from `kubernetes-sigs/cluster-api/util/cache/cache.go`
+  at the same version and commit. Keep its expiration and periodic sweep
+  behavior aligned with upstream.
+- Keep the package free of `sigs.k8s.io/cluster-api` imports. It may depend on
+  the Go standard library, Kubernetes libraries, and controller-runtime.
+- Preserve the upstream and NVIDIA copyright notices and the source reference
+  in derived files.
+- When controller-runtime is upgraded, compare this package and its tests with
+  the current Cluster API migrator. Pay particular attention to controller
+  setup, server-side apply, pagination, conflict handling, managedFields
+  cleanup, and storage-version completion semantics.
+- Port relevant upstream bug fixes and tests. Document intentional differences
+  in the source and keep them as small as possible.

--- a/deploy/operator/internal/crdmigrator/cache.go
+++ b/deploy/operator/internal/crdmigrator/cache.go
@@ -1,0 +1,75 @@
+/*
+SPDX-FileCopyrightText: Copyright 2024 The Kubernetes Authors.
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Derived from kubernetes-sigs/cluster-api/util/cache/cache.go at v1.13.4,
+commit 27f464418c195d96ae2ef4b96f3b6a047ea89310.
+*/
+
+package crdmigrator
+
+import (
+	"time"
+
+	kcache "k8s.io/client-go/tools/cache"
+)
+
+const expirationInterval = 10 * time.Hour
+
+type cacheEntry interface {
+	Key() string
+}
+
+type ttlCache[E cacheEntry] interface {
+	Add(entry E)
+	Has(key string) (E, bool)
+	Len() int
+	DeleteAll()
+}
+
+func newTTLCache[E cacheEntry](ttl time.Duration) ttlCache[E] {
+	return newTTLCacheWithExpirationInterval[E](ttl, expirationInterval)
+}
+
+// newTTLCacheWithExpirationInterval provides a shorter cleanup interval for tests while preserving
+// the upstream production default in newTTLCache.
+func newTTLCacheWithExpirationInterval[E cacheEntry](ttl, interval time.Duration) ttlCache[E] {
+	c := &expiringCache[E]{
+		Store: kcache.NewTTLStore(func(obj any) (string, error) {
+			return obj.(E).Key(), nil
+		}, ttl),
+	}
+	go func() {
+		for {
+			// List clears expired entries that the TTL store otherwise expires lazily.
+			c.List()
+			time.Sleep(interval)
+		}
+	}()
+	return c
+}
+
+type expiringCache[E cacheEntry] struct {
+	kcache.Store
+}
+
+func (c *expiringCache[E]) Add(entry E) {
+	_ = c.Store.Add(entry)
+}
+
+func (c *expiringCache[E]) Has(key string) (E, bool) {
+	item, exists, _ := c.GetByKey(key)
+	if exists {
+		return item.(E), true
+	}
+	return *new(E), false
+}
+
+func (c *expiringCache[E]) Len() int {
+	return len(c.ListKeys())
+}
+
+func (c *expiringCache[E]) DeleteAll() {
+	_ = c.Store.Replace(nil, "")
+}

--- a/deploy/operator/internal/crdmigrator/crd_migrator.go
+++ b/deploy/operator/internal/crdmigrator/crd_migrator.go
@@ -1,0 +1,400 @@
+/*
+SPDX-FileCopyrightText: Copyright 2025 The Kubernetes Authors.
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Derived from kubernetes-sigs/cluster-api/controllers/crdmigrator at v1.13.4,
+commit 27f464418c195d96ae2ef4b96f3b6a047ea89310.
+*/
+
+// Package crdmigrator contains a controller-runtime-only CRD migrator.
+package crdmigrator
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	"k8s.io/client-go/util/retry"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	// ObservedGenerationAnnotation records the CRD generation reconciled by the migrator.
+	// Dynamo uses an NVIDIA-owned domain instead of the upstream Cluster API annotation domain.
+	ObservedGenerationAnnotation = "crd-migration.nvidia.com/observed-generation"
+	storageMigrationCacheTTL     = time.Hour
+)
+
+// Phase identifies a phase of CRD migration.
+type Phase string
+
+const (
+	// StorageVersionMigrationPhase rewrites objects into the current storage version.
+	StorageVersionMigrationPhase Phase = "StorageVersionMigration"
+	// CleanupManagedFieldsPhase removes managedFields entries for unserved versions.
+	CleanupManagedFieldsPhase Phase = "CleanupManagedFields"
+)
+
+// ByObjectConfig configures migration for one registered object type.
+type ByObjectConfig struct {
+	UseCache                            bool
+	UseStatusForStorageVersionMigration bool
+}
+
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=apiextensions.k8s.io,resources=customresourcedefinitions/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=nvidia.com,resources=dynamocomponentdeployments;dynamographdeployments;dynamographdeploymentrequests;dynamographdeploymentscalingadapters,verbs=get;list;watch;update;patch
+// +kubebuilder:rbac:groups=nvidia.com,resources=dynamocomponentdeployments/status;dynamographdeployments/status;dynamographdeploymentrequests/status;dynamographdeploymentscalingadapters/status,verbs=get;update;patch
+
+// CRDMigrator migrates the configured CRDs.
+type CRDMigrator struct {
+	Client    client.Client
+	APIReader client.Reader
+
+	SkipCRDMigrationPhases []Phase
+	Config                 map[client.Object]ByObjectConfig
+
+	phases          sets.Set[Phase]
+	configByCRDName map[string]ByObjectConfig
+	migrated        ttlCache[objectEntry]
+}
+
+// SetupWithManager registers the migrator with a controller-runtime manager.
+func (r *CRDMigrator) SetupWithManager(mgr ctrl.Manager, options controller.Options) error {
+	if err := r.setup(mgr.GetScheme()); err != nil {
+		return err
+	}
+	if r.phases.Len() == 0 {
+		return nil
+	}
+
+	return builder.ControllerManagedBy(mgr).
+		For(&apiextensionsv1.CustomResourceDefinition{}, builder.OnlyMetadata,
+			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
+		Named("crdmigrator").
+		WithOptions(options).
+		Complete(r)
+}
+
+func (r *CRDMigrator) setup(scheme *runtime.Scheme) error {
+	// Validate the required clients and per-object migration configuration.
+	if r.Client == nil || r.APIReader == nil || len(r.Config) == 0 {
+		return errors.New("Client and APIReader must not be nil and Config must not be empty")
+	}
+
+	// Resolve the migration phases enabled for this controller.
+	r.phases = sets.New(StorageVersionMigrationPhase, CleanupManagedFieldsPhase)
+	for _, phase := range r.SkipCRDMigrationPhases {
+		if !r.phases.Has(phase) {
+			return fmt.Errorf("invalid phase %q specified in SkipCRDMigrationPhases", phase)
+		}
+		r.phases.Delete(phase)
+	}
+
+	// Index each object configuration by its derived CRD name.
+	r.configByCRDName = make(map[string]ByObjectConfig, len(r.Config))
+	for obj, cfg := range r.Config {
+		gvk, err := apiutil.GVKForObject(obj, scheme)
+		if err != nil {
+			return fmt.Errorf("get GVK for configured object: %w", err)
+		}
+		resource, _ := meta.UnsafeGuessKindToResource(gvk.GroupKind().WithVersion(gvk.Version))
+		name := resource.Resource + "." + gvk.Group
+		if _, exists := r.configByCRDName[name]; exists {
+			return fmt.Errorf("duplicate migration configuration for CRD %s", name)
+		}
+		r.configByCRDName[name] = cfg
+	}
+	// Initialize the cache that suppresses duplicate storage-version rewrites.
+	r.migrated = newTTLCache[objectEntry](storageMigrationCacheTTL)
+	return nil
+}
+
+// Reconcile migrates a configured CRD to its declared storage and served versions.
+func (r *CRDMigrator) Reconcile(ctx context.Context, req ctrl.Request) (_ ctrl.Result, reterr error) {
+	// Ignore CRDs that are not configured for migration.
+	cfg, ok := r.configByCRDName[req.Name]
+	if !ok {
+		return ctrl.Result{}, nil
+	}
+
+	// Use the cached generation to skip CRDs that already completed migration.
+	partial := &metav1.PartialObjectMetadata{}
+	partial.SetGroupVersionKind(apiextensionsv1.SchemeGroupVersion.WithKind("CustomResourceDefinition"))
+	if err := r.Client.Get(ctx, req.NamespacedName, partial); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	currentGeneration := strconv.FormatInt(partial.Generation, 10)
+	if partial.Annotations[ObservedGenerationAnnotation] == currentGeneration {
+		return ctrl.Result{}, nil
+	}
+
+	// Read the live CRD before evaluating its storage and served versions.
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := r.APIReader.Get(ctx, req.NamespacedName, crd); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(err)
+	}
+	currentGeneration = strconv.FormatInt(crd.Generation, 10)
+	storageVersion, err := storageVersionForCRD(crd)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Record the observed generation only after every enabled migration phase succeeds.
+	defer func() {
+		if reterr != nil {
+			return
+		}
+		before := crd.DeepCopy()
+		if crd.Annotations == nil {
+			crd.Annotations = map[string]string{}
+		}
+		crd.Annotations[ObservedGenerationAnnotation] = currentGeneration
+		if err := r.Client.Patch(ctx, crd, client.MergeFrom(before)); err != nil {
+			reterr = errors.Join(reterr, fmt.Errorf("patch CRD %s completion annotation: %w", crd.Name, err))
+		}
+	}()
+
+	// List custom resources when either enabled phase needs to inspect them.
+	var objects []client.Object
+	if (r.phases.Has(StorageVersionMigrationPhase) && storageVersionMigrationRequired(crd, storageVersion)) || r.phases.Has(CleanupManagedFieldsPhase) {
+		objects, err = r.listCustomResources(ctx, crd, cfg, storageVersion)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+
+	// Rewrite objects into the storage version, then prune storedVersions to that version.
+	if r.phases.Has(StorageVersionMigrationPhase) && storageVersionMigrationRequired(crd, storageVersion) {
+		if err := r.migrateStorageVersion(ctx, crd, cfg, objects, storageVersion); err != nil {
+			return ctrl.Result{}, err
+		}
+		before := crd.DeepCopy()
+		crd.Status.StoredVersions = []string{storageVersion}
+		patch := client.MergeFromWithOptions(before, client.MergeFromWithOptimisticLock{})
+		if err := r.Client.Status().Patch(ctx, crd, patch); err != nil {
+			return ctrl.Result{}, fmt.Errorf("patch CRD %s storedVersions: %w", crd.Name, err)
+		}
+	}
+
+	// Remove managed-fields entries that reference API versions no longer served by the CRD.
+	if r.phases.Has(CleanupManagedFieldsPhase) {
+		if err := r.cleanupManagedFields(ctx, crd, objects, cfg, storageVersion); err != nil {
+			return ctrl.Result{}, err
+		}
+	}
+	return ctrl.Result{}, nil
+}
+
+func storageVersionForCRD(crd *apiextensionsv1.CustomResourceDefinition) (string, error) {
+	for _, version := range crd.Spec.Versions {
+		if version.Storage {
+			return version.Name, nil
+		}
+	}
+	return "", fmt.Errorf("could not find storage version for CRD %s", crd.Name)
+}
+
+func storageVersionMigrationRequired(crd *apiextensionsv1.CustomResourceDefinition, storageVersion string) bool {
+	return len(crd.Status.StoredVersions) != 1 || crd.Status.StoredVersions[0] != storageVersion
+}
+
+func (r *CRDMigrator) listCustomResources(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, cfg ByObjectConfig, storageVersion string) ([]client.Object, error) {
+	gvk := schema.GroupVersionKind{Group: crd.Spec.Group, Version: storageVersion, Kind: crd.Spec.Names.ListKind}
+	if cfg.UseCache {
+		obj, err := r.Client.Scheme().New(gvk)
+		if err != nil {
+			return nil, fmt.Errorf("create %s list: %w", crd.Spec.Names.Kind, err)
+		}
+		list, ok := obj.(client.ObjectList)
+		if !ok {
+			return nil, fmt.Errorf("%s is not an ObjectList", crd.Spec.Names.ListKind)
+		}
+		if err := r.Client.List(ctx, list); err != nil {
+			return nil, fmt.Errorf("list %s via cache: %w", crd.Spec.Names.Kind, err)
+		}
+		return extractObjects(list)
+	}
+
+	list := &metav1.PartialObjectMetadataList{}
+	list.SetGroupVersionKind(gvk)
+	var result []client.Object
+	for {
+		if err := r.APIReader.List(ctx, list, client.Continue(list.Continue), client.Limit(500)); err != nil {
+			return nil, fmt.Errorf("list %s via live client: %w", crd.Spec.Names.Kind, err)
+		}
+		items, err := extractObjects(list)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, items...)
+		if list.Continue == "" {
+			return result, nil
+		}
+	}
+}
+
+func extractObjects(list client.ObjectList) ([]client.Object, error) {
+	items, err := meta.ExtractList(list)
+	if err != nil {
+		return nil, fmt.Errorf("extract list items: %w", err)
+	}
+	result := make([]client.Object, 0, len(items))
+	for _, item := range items {
+		obj, ok := item.(client.Object)
+		if !ok {
+			return nil, fmt.Errorf("list item %T is not a client.Object", item)
+		}
+		result = append(result, obj)
+	}
+	return result, nil
+}
+
+func (r *CRDMigrator) migrateStorageVersion(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, cfg ByObjectConfig, objects []client.Object, storageVersion string) error {
+	if len(objects) == 0 {
+		return nil
+	}
+	gvk := schema.GroupVersionKind{Group: crd.Spec.Group, Version: storageVersion, Kind: crd.Spec.Names.Kind}
+	ctrl.LoggerFrom(ctx).Info("Running storage version migration", "apiVersion", storageVersion, "objects", len(objects), "kind", gvk.Kind)
+
+	var errs []error
+	for _, obj := range objects {
+		entry := objectEntry{
+			Kind:          gvk.Kind,
+			ObjectKey:     client.ObjectKeyFromObject(obj),
+			CRDGeneration: crd.Generation,
+		}
+		if _, alreadyMigrated := r.migrated.Has(entry.Key()); alreadyMigrated {
+			r.migrated.Add(entry)
+			continue
+		}
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(gvk)
+		u.SetNamespace(obj.GetNamespace())
+		u.SetName(obj.GetName())
+		u.SetUID(obj.GetUID())
+		u.SetResourceVersion(obj.GetResourceVersion())
+
+		var err error
+		if cfg.UseStatusForStorageVersionMigration {
+			err = r.Client.Status().Apply(ctx, client.ApplyConfigurationFromUnstructured(u), client.FieldOwner("crdmigrator"))
+		} else {
+			err = r.Client.Apply(ctx, client.ApplyConfigurationFromUnstructured(u), client.FieldOwner("crdmigrator"))
+		}
+		if err != nil && !apierrors.IsNotFound(err) && !apierrors.IsConflict(err) {
+			errs = append(errs, fmt.Errorf("%s: %w", klog.KObj(u), err))
+			continue
+		}
+		r.migrated.Add(entry)
+	}
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("migrate storage version of %s objects: %w", gvk.Kind, err)
+	}
+	return nil
+}
+
+func (r *CRDMigrator) cleanupManagedFields(ctx context.Context, crd *apiextensionsv1.CustomResourceDefinition, objects []client.Object, cfg ByObjectConfig, storageVersion string) error {
+	served := sets.New[string]()
+	for _, version := range crd.Spec.Versions {
+		if version.Served {
+			served.Insert(crd.Spec.Group + "/" + version.Name)
+		}
+	}
+
+	var errs []error
+	for _, obj := range objects {
+		if len(obj.GetManagedFields()) == 0 {
+			continue
+		}
+		var getErr error
+		err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			getErr = nil
+			managedFields, removed := filterManagedFields(obj, served)
+			if !removed {
+				return nil
+			}
+			if len(managedFields) == 0 {
+				fields, err := json.Marshal(map[string]any{"f:metadata": map[string]any{"f:name": map[string]any{}}})
+				if err != nil {
+					return fmt.Errorf("create seeding managedFields entry: %w", err)
+				}
+				first := obj.GetManagedFields()[0]
+				managedFields = append(managedFields, metav1.ManagedFieldsEntry{
+					Manager: first.Manager, Operation: first.Operation,
+					APIVersion: crd.Spec.Group + "/" + storageVersion,
+					Time:       ptr.To(metav1.Now()), FieldsType: "FieldsV1",
+					FieldsV1: &metav1.FieldsV1{Raw: fields},
+				})
+			}
+			patch, err := json.Marshal([]map[string]any{
+				{"op": "replace", "path": "/metadata/managedFields", "value": managedFields},
+				{"op": "replace", "path": "/metadata/resourceVersion", "value": obj.GetResourceVersion()},
+			})
+			if err != nil {
+				return fmt.Errorf("marshal managedFields patch: %w", err)
+			}
+			err = r.Client.Patch(ctx, obj, client.RawPatch(types.JSONPatchType, patch))
+			if err == nil || apierrors.IsNotFound(err) {
+				return nil
+			}
+			if apierrors.IsConflict(err) {
+				if cfg.UseCache {
+					getErr = r.Client.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+				} else {
+					getErr = r.APIReader.Get(ctx, client.ObjectKeyFromObject(obj), obj)
+				}
+			}
+			return err
+		})
+		if err != nil {
+			errs = append(errs, errors.Join(fmt.Errorf("%s: %w", klog.KObj(obj), err), getErr))
+		}
+	}
+	if err := errors.Join(errs...); err != nil {
+		return fmt.Errorf("clean managedFields of %s objects: %w", crd.Spec.Names.Kind, err)
+	}
+	return nil
+}
+
+func filterManagedFields(obj client.Object, served sets.Set[string]) ([]metav1.ManagedFieldsEntry, bool) {
+	filtered := make([]metav1.ManagedFieldsEntry, 0, len(obj.GetManagedFields()))
+	removed := false
+	for _, entry := range obj.GetManagedFields() {
+		if served.Has(entry.APIVersion) {
+			filtered = append(filtered, entry)
+		} else {
+			removed = true
+		}
+	}
+	return filtered, removed
+}
+
+type objectEntry struct {
+	Kind          string
+	ObjectKey     client.ObjectKey
+	CRDGeneration int64
+}
+
+func (e objectEntry) Key() string {
+	return fmt.Sprintf("%s %s %d", e.Kind, e.ObjectKey, e.CRDGeneration)
+}

--- a/deploy/operator/internal/crdmigrator/crd_migrator_test.go
+++ b/deploy/operator/internal/crdmigrator/crd_migrator_test.go
@@ -1,0 +1,244 @@
+/*
+SPDX-FileCopyrightText: Copyright 2025 The Kubernetes Authors.
+SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Tests derived in part from kubernetes-sigs/cluster-api/controllers/crdmigrator and
+kubernetes-sigs/cluster-api/util/cache at v1.13.4,
+commit 27f464418c195d96ae2ef4b96f3b6a047ea89310.
+*/
+
+package crdmigrator
+
+import (
+	"context"
+	"sort"
+	"testing"
+	"time"
+
+	operatorv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestSetup(t *testing.T) {
+	t.Log("Define valid and invalid migrator setup cases")
+	tests := []struct {
+		name      string
+		valid     bool
+		wantNames []string
+	}{
+		{
+			name:  "builds expected Dynamo CRD names",
+			valid: true,
+			wantNames: []string{
+				"dynamocomponentdeployments.nvidia.com",
+				"dynamographdeploymentrequests.nvidia.com",
+				"dynamographdeployments.nvidia.com",
+				"dynamographdeploymentscalingadapters.nvidia.com",
+			},
+		},
+		{name: "rejects missing clients and config"},
+	}
+
+	t.Log("Run each migrator setup case")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Arrange a scheme and the requested migrator configuration")
+			scheme := runtime.NewScheme()
+			migrator := &CRDMigrator{}
+			if tt.valid {
+				if err := operatorv1beta1.AddToScheme(scheme); err != nil {
+					t.Fatal(err)
+				}
+				c := fake.NewClientBuilder().WithScheme(scheme).Build()
+				migrator.Client = c
+				migrator.APIReader = c
+				migrator.Config = map[client.Object]ByObjectConfig{
+					&operatorv1beta1.DynamoComponentDeployment{}:           {},
+					&operatorv1beta1.DynamoGraphDeployment{}:               {},
+					&operatorv1beta1.DynamoGraphDeploymentRequest{}:        {},
+					&operatorv1beta1.DynamoGraphDeploymentScalingAdapter{}: {},
+				}
+			}
+
+			t.Log("Run migrator setup")
+			err := migrator.setup(scheme)
+
+			t.Log("Verify setup validation and configured CRD names")
+			if !tt.valid {
+				if err == nil {
+					t.Fatal("setup succeeded without clients and config")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			gotNames := make([]string, 0, len(migrator.configByCRDName))
+			for name := range migrator.configByCRDName {
+				gotNames = append(gotNames, name)
+			}
+			sort.Strings(gotNames)
+			if len(gotNames) != len(tt.wantNames) {
+				t.Fatalf("configured CRDs = %v, want %v", gotNames, tt.wantNames)
+			}
+			for i := range tt.wantNames {
+				if gotNames[i] != tt.wantNames[i] {
+					t.Fatalf("configured CRDs = %v, want %v", gotNames, tt.wantNames)
+				}
+			}
+		})
+	}
+}
+
+func TestReconcileEmptyCRDConvergesStoredVersionsAndAnnotation(t *testing.T) {
+	t.Log("Arrange the API schemes used by the CRD migrator")
+	scheme := runtime.NewScheme()
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+	if err := operatorv1beta1.AddToScheme(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Arrange an empty CRD that still records the old storage version")
+	crd := &apiextensionsv1.CustomResourceDefinition{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "dynamocomponentdeployments.nvidia.com",
+			Generation: 7,
+		},
+		Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+			Group: "nvidia.com",
+			Names: apiextensionsv1.CustomResourceDefinitionNames{
+				Plural: "dynamocomponentdeployments", Kind: "DynamoComponentDeployment",
+				ListKind: "DynamoComponentDeploymentList",
+			},
+			Scope: apiextensionsv1.NamespaceScoped,
+			Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+				{Name: "v1alpha1", Served: true},
+				{Name: "v1beta1", Served: true, Storage: true},
+			},
+		},
+		Status: apiextensionsv1.CustomResourceDefinitionStatus{StoredVersions: []string{"v1alpha1", "v1beta1"}},
+	}
+
+	t.Log("Arrange the fake client and configured migrator")
+	c := fake.NewClientBuilder().WithScheme(scheme).WithStatusSubresource(crd).WithObjects(crd).Build()
+	migrator := &CRDMigrator{
+		Client: c, APIReader: c,
+		Config: map[client.Object]ByObjectConfig{
+			&operatorv1beta1.DynamoComponentDeployment{}: {UseStatusForStorageVersionMigration: true},
+		},
+	}
+	if err := migrator.setup(scheme); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Reconcile the CRD storage version")
+	if _, err := migrator.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: crd.Name}}); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Read the reconciled CRD")
+	got := &apiextensionsv1.CustomResourceDefinition{}
+	if err := c.Get(context.Background(), client.ObjectKey{Name: crd.Name}, got); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Verify the storage version and observed generation converged")
+	if len(got.Status.StoredVersions) != 1 || got.Status.StoredVersions[0] != "v1beta1" {
+		t.Fatalf("storedVersions = %v, want [v1beta1]", got.Status.StoredVersions)
+	}
+	if got.Annotations[ObservedGenerationAnnotation] != "7" {
+		t.Fatalf("observed generation = %q, want 7", got.Annotations[ObservedGenerationAnnotation])
+	}
+}
+
+func TestFilterManagedFields(t *testing.T) {
+	t.Log("Define managed-fields filtering cases")
+	tests := []struct {
+		name            string
+		managedVersions []string
+		servedVersions  []string
+		wantVersions    []string
+		wantRemoved     bool
+	}{
+		{
+			name:            "removes unserved versions",
+			managedVersions: []string{"nvidia.com/v1alpha1", "nvidia.com/v1beta1"},
+			servedVersions:  []string{"nvidia.com/v1beta1"},
+			wantVersions:    []string{"nvidia.com/v1beta1"},
+			wantRemoved:     true,
+		},
+		{
+			name:            "keeps all served versions",
+			managedVersions: []string{"nvidia.com/v1alpha1", "nvidia.com/v1beta1"},
+			servedVersions:  []string{"nvidia.com/v1alpha1", "nvidia.com/v1beta1"},
+			wantVersions:    []string{"nvidia.com/v1alpha1", "nvidia.com/v1beta1"},
+		},
+		{
+			name:            "removes all unserved versions",
+			managedVersions: []string{"nvidia.com/v1alpha1"},
+			servedVersions:  []string{"nvidia.com/v1beta1"},
+			wantRemoved:     true,
+		},
+	}
+
+	t.Log("Run each managed-fields filtering case")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Log("Arrange managed fields and the served API versions")
+			managedFields := make([]metav1.ManagedFieldsEntry, 0, len(tt.managedVersions))
+			for _, version := range tt.managedVersions {
+				managedFields = append(managedFields, metav1.ManagedFieldsEntry{APIVersion: version})
+			}
+			obj := &operatorv1beta1.DynamoComponentDeployment{
+				ObjectMeta: metav1.ObjectMeta{ManagedFields: managedFields},
+			}
+
+			t.Log("Filter managed fields for unserved API versions")
+			got, removed := filterManagedFields(obj, sets.New(tt.servedVersions...))
+
+			t.Log("Verify only served managed fields remain")
+			if removed != tt.wantRemoved {
+				t.Fatalf("removed = %t, want %t", removed, tt.wantRemoved)
+			}
+			if len(got) != len(tt.wantVersions) {
+				t.Fatalf("managed fields = %v, want API versions %v", got, tt.wantVersions)
+			}
+			for i := range tt.wantVersions {
+				if got[i].APIVersion != tt.wantVersions[i] {
+					t.Fatalf("managed fields = %v, want API versions %v", got, tt.wantVersions)
+				}
+			}
+		})
+	}
+}
+
+func TestTTLCacheSweepsExpiredEntries(t *testing.T) {
+	t.Log("Arrange a short-lived cache entry and confirm it is initially present")
+	cache := newTTLCacheWithExpirationInterval[objectEntry](time.Millisecond, time.Millisecond)
+	entry := objectEntry{Kind: "DynamoGraphDeployment", ObjectKey: client.ObjectKey{Name: "object"}, CRDGeneration: 1}
+	cache.Add(entry)
+	if _, ok := cache.Has(entry.Key()); !ok {
+		t.Fatal("entry missing before expiry")
+	}
+
+	t.Log("Wait for the periodic sweep without reading the entry by key")
+	deadline := time.Now().Add(time.Second)
+	for cache.Len() != 0 && time.Now().Before(deadline) {
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Log("Verify the periodic sweep reclaimed the expired entry")
+	if cache.Len() != 0 {
+		t.Fatal("expired entry was not removed by the periodic sweep")
+	}
+}

--- a/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/dynamo-operator.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/kubernetes/kubernetes-operator/dynamo-operator.md
@@ -146,6 +146,25 @@ For user-focused workflows, see:
 - **[Managing Models with DynamoModel Guide](managing-models-dynamomodel.md)**
 - **[Snapshotting GPU Workers](snapshot.md)** for `DynamoCheckpoint`
 
+### CRD Storage Migration
+
+The cluster-wide Operator automatically migrates existing resources to the current Custom Resource
+Definition (CRD) storage version. Migration requires no user action under normal circumstances. The
+`v1alpha1` API remains served during migration, so existing manifests, clients, and older Operator
+versions continue to work through the conversion webhook.
+
+To verify migration progress, inspect the CRD:
+
+```bash
+kubectl get crd dynamographdeployments.nvidia.com \
+  -o jsonpath='generation={.metadata.generation}{"\n"}observedGeneration={.metadata.annotations.crd-migration\.nvidia\.com/observed-generation}{"\n"}storedVersions={.status.storedVersions}{"\n"}'
+```
+
+Migration is complete when the observed-generation annotation matches the CRD generation and
+`status.storedVersions` contains only the CRD's current storage version. The Operator retries
+transient failures. If these values do not converge, check the Operator and conversion webhook before
+upgrading to a release that stops serving `v1alpha1`.
+
 ## Webhooks
 
 The Dynamo Operator uses **Kubernetes admission webhooks** for real-time validation and mutation of custom resources before they are persisted to the cluster. Webhooks are a required component of the operator and ensure that invalid configurations are rejected immediately at the API server level.

--- a/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
+++ b/docs/fern/pages/reference/kubernetes-api/additional-resources/api-reference-k8s.md
@@ -2080,9 +2080,8 @@ _Appears in:_
 
 DynamoComponentDeployment is the Schema for the dynamocomponentdeployments API.
 
-v1beta1 is a served version: the API server accepts reads and writes
-against it, and transparently converts to/from v1alpha1 (still the
-storage version until a later MR flips it). Conversion goes through the
+v1beta1 is the storage version. The API server transparently converts
+to and from the served v1alpha1 version through
 operator's conversion webhook; see api/v1alpha1/*_conversion.go.
 
 
@@ -2177,9 +2176,8 @@ _Appears in:_
 
 DynamoGraphDeployment is the Schema for the dynamographdeployments API.
 
-v1beta1 is a served version: the API server accepts reads and writes
-against it, and transparently converts to/from v1alpha1 (still the
-storage version until a later MR flips it). Conversion goes through the
+v1beta1 is the storage version. The API server transparently converts
+to and from the served v1alpha1 version through
 operator's conversion webhook; see api/v1alpha1/*_conversion.go.
 
 
@@ -2327,8 +2325,8 @@ The adapter acts as an intermediary between autoscalers and the DGD,
 ensuring that only the adapter controller modifies the DGD's component replicas.
 This prevents conflicts when multiple autoscaling mechanisms are in play.
 
-v1alpha1 remains the storage version; conversion between served versions is
-handled by the operator's conversion webhook
+v1beta1 is the storage version; conversion to and from the served v1alpha1
+version is handled by the operator's conversion webhook
 (see api/v1alpha1/dynamographdeploymentscalingadapter_conversion.go).
 
 


### PR DESCRIPTION
## Summary

- port the Cluster API CRD migrator as a controller-runtime-only internal package with upstream provenance
- promote DynamoComponentDeployment, DynamoGraphDeployment, DynamoGraphDeploymentRequest, and DynamoGraphDeploymentScalingAdapter storage to v1beta1 while continuing to serve v1alpha1
- register asynchronous migration in the cluster-wide operator, add RBAC, generated manifests, tests, and operator documentation

Part of #11642

## Validation

- GOCACHE=/private/tmp/dynamo-go-cache go test ./internal/crdmigrator ./api ./api/v1alpha1 ./api/v1beta1 ./cmd -count=1
- GOCACHE=/private/tmp/dynamo-go-cache go vet ./internal/crdmigrator ./cmd ./api/...
- verified the migrator dependency graph contains no sigs.k8s.io/cluster-api dependency
- make manifests
- rendered the operator Helm chart in cluster-wide and namespace-restricted modes
- Kind Kubernetes 1.36 upgrade E2E: created v1alpha1-stored objects for all four CRDs, installed the modified operator, verified storedVersions and observed-generation converged to v1beta1, and read every object through both v1beta1 and v1alpha1 APIs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic migration of Dynamo custom resources to the v1beta1 storage version.
  * Maintained transparent compatibility with served v1alpha1 APIs.
  * Added migration progress tracking, retries, and cleanup handling.

* **Documentation**
  * Documented migration behavior, completion checks, retries, and restricted-namespace considerations.
  * Updated Kubernetes API references to identify v1beta1 as the storage version.

* **Bug Fixes**
  * Improved operator permissions for monitoring and updating custom resource definitions and their statuses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->