### PR TITLE
fix(runtime): skip link-local when binding TCP stream to interface

### DIFF
--- a/docs/fern/pages/reference/components/runtime-configuration.mdx
+++ b/docs/fern/pages/reference/components/runtime-configuration.mdx
@@ -134,7 +134,8 @@ Unless a field is marked environment-only, it has both a CLI flag and an environ
 <ParamField path="DYN_TCP_RESPONSE_STREAM_HOST" type="string" default="auto-detected local address">
   IPv4 or IPv6 address, or exact network interface name, used to bind and advertise the TCP response
   stream server. If an interface name occurs more than once in the operating system's interface
-  list, Dynamo uses the last address. Dynamo trims whitespace and treats an empty value as unset.
+  list, Dynamo uses the last usable address, skipping link-local, multicast, broadcast, and
+  unspecified addresses. Dynamo trims whitespace and treats an empty value as unset.
   Unspecified addresses such as `0.0.0.0` and `::` are invalid.
 </ParamField>
 
@@ -156,7 +157,8 @@ Unless a field is marked environment-only, it has both a CLI flag and an environ
 <ParamField path="DYN_EVENT_PLANE_HOST" type="string" default="auto-detected local address">
   IPv4 or IPv6 address, or exact network interface name, advertised by direct ZMQ event publishers.
   If an interface name occurs more than once in the operating system's interface list, Dynamo uses
-  the last address. Dynamo trims whitespace and treats an empty value as unset. Unspecified addresses
+  the last usable address, skipping link-local, multicast, broadcast, and unspecified addresses.
+  Dynamo trims whitespace and treats an empty value as unset. Unspecified addresses
   such as `0.0.0.0` and `::` are invalid.
 
   This variable changes the discovery address, not the listener address. Direct ZMQ continues to bind

--- a/lib/runtime/src/config/environment_names.rs
+++ b/lib/runtime/src/config/environment_names.rs
@@ -747,6 +747,7 @@ pub mod tcp_response_stream {
 
     /// IP address or exact interface used to bind and advertise the TCP response stream server.
     /// Unspecified addresses are rejected.
+    /// Interface addresses that are link-local, multicast, broadcast, or unspecified are skipped.
     /// If unset, the server auto-detects a routable local IP.
     pub const DYN_TCP_RESPONSE_STREAM_HOST: &str = "DYN_TCP_RESPONSE_STREAM_HOST";
 
@@ -809,6 +810,7 @@ pub mod event_plane {
 
     /// IP address or exact interface advertised by direct ZMQ event publishers.
     /// Unspecified addresses are rejected.
+    /// Interface addresses that are link-local, multicast, broadcast, or unspecified are skipped.
     /// If unset, the runtime auto-detects a local IP address.
     pub const DYN_EVENT_PLANE_HOST: &str = "DYN_EVENT_PLANE_HOST";
 

--- a/lib/runtime/src/pipeline/network/tcp/server.rs
+++ b/lib/runtime/src/pipeline/network/tcp/server.rs
@@ -88,7 +88,7 @@ impl ServerOptions {
 /// A Response connection is a connection that is established by a client with the intention of sending
 /// specific data back to the server.
 pub struct TcpStreamServer {
-    local_ip: String,
+    local_ip: IpAddr,
     local_port: u16,
     state: Arc<Mutex<State>>,
 }
@@ -170,6 +170,35 @@ fn prune_tombstones(tombstones: &mut HashMap<EndpointInstanceId, Instant>, now: 
     tombstones.retain(|_, ts| now.saturating_duration_since(*ts) < TOMBSTONE_TTL);
 }
 
+fn is_interface_bind_ip(addr: &IpAddr) -> bool {
+    match addr {
+        IpAddr::V4(v4) => {
+            !v4.is_unspecified() && !v4.is_broadcast() && !v4.is_multicast() && !v4.is_link_local()
+        }
+        IpAddr::V6(v6) => !v6.is_unicast_link_local() && !v6.is_multicast() && !v6.is_unspecified(),
+    }
+}
+
+fn select_interface_bind_ip(interface: &str, candidates: Vec<(String, IpAddr)>) -> Option<IpAddr> {
+    candidates
+        .into_iter()
+        .find_map(|(name, addr)| (name == interface && is_interface_bind_ip(&addr)).then_some(addr))
+}
+
+fn resolve_interface_bind_ip(interface: &str) -> Result<IpAddr, PipelineError> {
+    if let Ok(addr) = interface.parse::<IpAddr>() {
+        return (!addr.is_unspecified()).then_some(addr).ok_or_else(|| {
+            PipelineError::Generic("TCP response stream host cannot be unspecified".to_string())
+        });
+    }
+
+    select_interface_bind_ip(interface, list_afinet_netifas()?).ok_or_else(|| {
+        PipelineError::Generic(format!(
+            "Interface not found or has no bindable unicast address: {interface}"
+        ))
+    })
+}
+
 impl TcpStreamServer {
     pub fn options_builder() -> ServerOptionsBuilder {
         ServerOptionsBuilder::default()
@@ -184,18 +213,7 @@ impl TcpStreamServer {
         resolver: R,
     ) -> Result<Arc<Self>, PipelineError> {
         let local_ip = match options.interface {
-            Some(interface) => {
-                let interfaces: HashMap<String, std::net::IpAddr> =
-                    list_afinet_netifas()?.into_iter().collect();
-
-                interfaces
-                    .get(&interface)
-                    .ok_or(PipelineError::Generic(format!(
-                        "Interface not found: {}",
-                        interface
-                    )))?
-                    .to_string()
-            }
+            Some(interface) => resolve_interface_bind_ip(&interface)?,
             None => {
                 let resolved_ip = resolver.local_ip().or_else(|err| match err {
                     Error::LocalIpAddressNotFound => resolver.local_ipv6(),
@@ -220,13 +238,12 @@ impl TcpStreamServer {
                         )));
                     }
                 }
-                .to_string()
             }
         };
 
         let state = Arc::new(Mutex::new(State::default()));
 
-        let local_port = Self::start(local_ip.clone(), options.port, state.clone())
+        let local_port = Self::start(local_ip, options.port, state.clone())
             .await
             .map_err(|e| {
                 PipelineError::Generic(format!("Failed to start TcpStreamServer: {}", e))
@@ -361,8 +378,8 @@ impl TcpStreamServer {
         state.removed_instances.remove(id);
     }
 
-    async fn start(local_ip: String, local_port: u16, state: Arc<Mutex<State>>) -> Result<u16> {
-        let addr = format!("{}:{}", local_ip, local_port);
+    async fn start(local_ip: IpAddr, local_port: u16, state: Arc<Mutex<State>>) -> Result<u16> {
+        let addr = SocketAddr::new(local_ip, local_port);
         let state_clone = state.clone();
         let (ready_tx, ready_rx) = tokio::sync::oneshot::channel::<Result<u16>>();
         {
@@ -442,7 +459,7 @@ impl ResponseService for TcpStreamServer {
     async fn register(&self, options: StreamOptions) -> PendingConnections {
         // oneshot channels to pass back the sender and receiver objects
 
-        let address = format!("{}:{}", self.local_ip, self.local_port);
+        let address = SocketAddr::new(self.local_ip, self.local_port).to_string();
         tracing::debug!("Registering new TcpStream on {address}");
 
         let send_stream = if options.enable_request_stream {
@@ -552,7 +569,7 @@ impl ResponseService for TcpStreamServer {
 // the sender, then we spawn a task to forward all bytes from the tcp stream
 // to the sender
 async fn tcp_listener(
-    addr: String,
+    addr: SocketAddr,
     state: Arc<Mutex<State>>,
     read_tx: tokio::sync::oneshot::Sender<Result<u16>>,
 ) -> Result<()> {
@@ -1065,6 +1082,45 @@ mod tests {
     use crate::pipeline::network::tcp::client::TcpClient;
     use tokio::io::{AsyncWriteExt, ReadHalf, WriteHalf};
     use tokio::net::TcpStream;
+
+    #[test]
+    fn interface_bind_filter_rejects_invalid_addresses() {
+        for addr in [
+            "0.0.0.0",
+            "169.254.1.1",
+            "224.0.0.1",
+            "255.255.255.255",
+            "::",
+            "fe80::1",
+            "ff02::1",
+        ] {
+            assert!(!is_interface_bind_ip(&addr.parse().unwrap()));
+        }
+    }
+
+    #[test]
+    fn interface_bind_selector_accepts_loopback() {
+        let candidates = vec![("lo".to_string(), "127.0.0.1".parse().unwrap())];
+        assert_eq!(
+            select_interface_bind_ip("lo", candidates).unwrap(),
+            "127.0.0.1".parse::<IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn literal_ips_bypass_filter_and_format_as_socket_addresses() {
+        for literal in ["127.0.0.1", "169.254.1.1"] {
+            assert_eq!(
+                resolve_interface_bind_ip(literal).unwrap(),
+                literal.parse::<IpAddr>().unwrap()
+            );
+        }
+        for wildcard in ["0.0.0.0", "::"] {
+            assert!(resolve_interface_bind_ip(wildcard).is_err());
+        }
+        let ip = resolve_interface_bind_ip("2001:db8::5").unwrap();
+        assert_eq!(SocketAddr::new(ip, 1234).to_string(), "[2001:db8::5]:1234");
+    }
 
     // Mock resolver that always fails to simulate the fallback scenario
     struct FailingIpResolver;

--- a/lib/runtime/src/utils/ip_resolver.rs
+++ b/lib/runtime/src/utils/ip_resolver.rs
@@ -64,10 +64,27 @@ fn host_override_from_lookup(
     Ok((!value.is_empty()).then(|| value.to_string()))
 }
 
+/// Decide whether an interface address can be used to bind and advertise.
+///
+/// Unspecified, broadcast, multicast, and link-local addresses are skipped
+/// because binding to them fails or advertises an unreachable endpoint.
+/// Loopback is intentionally allowed on both families so interfaces like `lo`
+/// keep working for local-only setups.
+fn is_usable_unicast(ip: &IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(v4) => {
+            !v4.is_unspecified() && !v4.is_broadcast() && !v4.is_multicast() && !v4.is_link_local()
+        }
+        IpAddr::V6(v6) => !v6.is_unspecified() && !v6.is_multicast() && !v6.is_unicast_link_local(),
+    }
+}
+
 /// Resolve a configured host as an IP literal or exact network interface name.
 ///
-/// Interface lookup preserves the existing TCP response-stream behavior: when
-/// an interface name occurs more than once, the last enumerated address wins.
+/// IP literals are used as-is. Interface lookup skips link-local, multicast,
+/// broadcast, and unspecified addresses, and among the remaining usable
+/// addresses the last enumerated one wins (the existing TCP response-stream
+/// tie-break).
 pub(crate) fn resolve_host_or_interface<R: IpResolver>(
     host_or_interface: &str,
     resolver: &R,
@@ -75,16 +92,28 @@ pub(crate) fn resolve_host_or_interface<R: IpResolver>(
     let host_or_interface = host_or_interface.trim();
     let ip = match host_or_interface.parse::<IpAddr>() {
         Ok(ip) => ip,
-        Err(_) => resolver
-            .list_afinet_netifas()?
-            .into_iter()
-            .filter_map(|(name, ip)| (name == host_or_interface).then_some(ip))
-            .next_back()
-            .ok_or_else(|| {
-                anyhow::anyhow!(
+        Err(_) => {
+            let mut seen = false;
+            let mut selected = None;
+            for (name, candidate) in resolver.list_afinet_netifas()? {
+                if name != host_or_interface {
+                    continue;
+                }
+                seen = true;
+                if is_usable_unicast(&candidate) {
+                    selected = Some(candidate);
+                }
+            }
+            match selected {
+                Some(ip) => ip,
+                None if seen => bail!(
+                    "interface '{host_or_interface}' has no usable unicast address (link-local, multicast, broadcast, and unspecified addresses are skipped)"
+                ),
+                None => bail!(
                     "'{host_or_interface}' is not a valid IP address and no network interface with that name was found"
-                )
-            })?,
+                ),
+            }
+        }
     };
     if ip.to_canonical().is_unspecified() {
         bail!("unspecified IP addresses cannot be advertised");
@@ -259,6 +288,95 @@ mod tests {
                 .to_string(),
             "'missing0' is not a valid IP address and no network interface with that name was found"
         );
+    }
+
+    #[test]
+    fn interface_lookup_skips_link_local_addresses() {
+        for interfaces in [
+            vec![
+                ("eth0".to_string(), "fe80::1".parse().unwrap()),
+                ("eth0".to_string(), "169.254.10.10".parse().unwrap()),
+                ("eth0".to_string(), "192.0.2.10".parse().unwrap()),
+            ],
+            vec![
+                ("eth0".to_string(), "192.0.2.10".parse().unwrap()),
+                ("eth0".to_string(), "169.254.10.10".parse().unwrap()),
+                ("eth0".to_string(), "fe80::1".parse().unwrap()),
+            ],
+        ] {
+            let resolver = MockIpResolver {
+                v4: Err(Error::LocalIpAddressNotFound),
+                v6: Err(Error::LocalIpAddressNotFound),
+                interfaces,
+            };
+            assert_eq!(
+                resolve_host_or_interface("eth0", &resolver).unwrap(),
+                "192.0.2.10".parse::<IpAddr>().unwrap()
+            );
+        }
+    }
+
+    #[test]
+    fn interface_lookup_skips_multicast_and_broadcast() {
+        let resolver = MockIpResolver {
+            v4: Err(Error::LocalIpAddressNotFound),
+            v6: Err(Error::LocalIpAddressNotFound),
+            interfaces: vec![
+                ("eth0".to_string(), "224.0.0.1".parse().unwrap()),
+                ("eth0".to_string(), "255.255.255.255".parse().unwrap()),
+                ("eth0".to_string(), "ff02::1".parse().unwrap()),
+                ("eth0".to_string(), "192.0.2.20".parse().unwrap()),
+            ],
+        };
+
+        assert_eq!(
+            resolve_host_or_interface("eth0", &resolver).unwrap(),
+            "192.0.2.20".parse::<IpAddr>().unwrap()
+        );
+    }
+
+    #[test]
+    fn interface_with_only_unusable_addresses_is_rejected() {
+        let resolver = MockIpResolver {
+            v4: Err(Error::LocalIpAddressNotFound),
+            v6: Err(Error::LocalIpAddressNotFound),
+            interfaces: vec![("eth0".to_string(), "fe80::1".parse().unwrap())],
+        };
+
+        assert_eq!(
+            resolve_host_or_interface("eth0", &resolver)
+                .unwrap_err()
+                .to_string(),
+            "interface 'eth0' has no usable unicast address (link-local, multicast, broadcast, and unspecified addresses are skipped)"
+        );
+    }
+
+    #[test]
+    fn loopback_interface_addresses_remain_usable() {
+        for (interfaces, expected) in [
+            (
+                vec![("lo".to_string(), "127.0.0.1".parse().unwrap())],
+                "127.0.0.1",
+            ),
+            (
+                vec![
+                    ("lo".to_string(), "127.0.0.1".parse().unwrap()),
+                    ("lo".to_string(), "::1".parse().unwrap()),
+                ],
+                "::1",
+            ),
+        ] {
+            let resolver = MockIpResolver {
+                v4: Err(Error::LocalIpAddressNotFound),
+                v6: Err(Error::LocalIpAddressNotFound),
+                interfaces,
+            };
+
+            assert_eq!(
+                resolve_host_or_interface("lo", &resolver).unwrap(),
+                expected.parse::<IpAddr>().unwrap()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Overview

Resolve TCP response-stream startup failures when a configured network interface has multiple addresses and a link-local address is selected.

## Summary

- preserve all addresses returned for the configured interface instead of collapsing them into a `HashMap`
- select the first routable unicast address, skipping loopback, link-local, multicast, unspecified, and broadcast addresses
- preserve explicit IP literals, including wildcard addresses
- use `IpAddr` and `SocketAddr` internally so IPv6 bind and advertised endpoints are formatted correctly

## Details

Interface-name resolution previously collected `(interface, address)` pairs into a `HashMap<String, IpAddr>`. Interfaces commonly have several IPv4 and IPv6 addresses, so this discarded all but one address and could leave an IPv6 link-local address. Binding that address without a scope ID fails on Linux.

The new resolution path scans all addresses for the requested interface and chooses the first routable unicast address. Explicit IP literals continue to bypass interface filtering.

## Where should the reviewer start?

`lib/runtime/src/pipeline/network/tcp/server.rs`, starting with `is_routable_unicast` and `resolve_interface_bind_ip`.

## Validation

- `cargo test -p dynamo-runtime --lib` — 489 passed, 2 ignored
- `cargo clippy -p dynamo-runtime --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- generated format-patch applies cleanly to `origin/main`

## Related Issues
 #8058/#8059 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TCP server binding when configured with a network interface name.
  * Prevented binding to invalid or non-routable addresses, including loopback, multicast, unspecified, and link-local addresses.
  * Added support for IP address literals with more reliable listener address handling.
  * Improved error reporting when no suitable address is available for the selected interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->