### PR TITLE
refactor(operator): centralize API scheme installation

### DIFF
--- a/deploy/operator/api/config/install.go
+++ b/deploy/operator/api/config/install.go
@@ -1,0 +1,18 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Package config contains the Dynamo operator configuration APIs.
+package config
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+)
+
+// Install registers all operator configuration API versions in scheme.
+func Install(scheme *runtime.Scheme) error {
+	return v1alpha1.AddToScheme(scheme)
+}

--- a/deploy/operator/api/config/install.go
+++ b/deploy/operator/api/config/install.go
@@ -8,11 +8,12 @@ package config
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
 // Install registers all operator configuration API versions in scheme.
-func Install(scheme *runtime.Scheme) error {
-	return v1alpha1.AddToScheme(scheme)
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
 }

--- a/deploy/operator/api/install.go
+++ b/deploy/operator/api/install.go
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Package api contains the Dynamo Kubernetes APIs.
+package api
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
+	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+)
+
+// Install registers all Dynamo API versions in scheme.
+func Install(scheme *runtime.Scheme) error {
+	if err := v1alpha1.AddToScheme(scheme); err != nil {
+		return err
+	}
+	return v1beta1.AddToScheme(scheme)
+}

--- a/deploy/operator/api/install.go
+++ b/deploy/operator/api/install.go
@@ -8,15 +8,14 @@ package api
 
 import (
 	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
 	"github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
 )
 
 // Install registers all Dynamo API versions in scheme.
-func Install(scheme *runtime.Scheme) error {
-	if err := v1alpha1.AddToScheme(scheme); err != nil {
-		return err
-	}
-	return v1beta1.AddToScheme(scheme)
+func Install(scheme *runtime.Scheme) {
+	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(v1beta1.AddToScheme(scheme))
 }

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -145,7 +145,7 @@ func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
 func initCRDSchemes() {
 	utilruntime.Must(clientgoscheme.AddToScheme(crdScheme))
 
-	utilruntime.Must(dynamoapi.Install(crdScheme))
+	dynamoapi.Install(crdScheme)
 
 	utilruntime.Must(lwsscheme.AddToScheme(crdScheme))
 
@@ -164,7 +164,7 @@ func initCRDSchemes() {
 }
 
 func initConfigScheme() {
-	utilruntime.Must(configapi.Install(configScheme))
+	configapi.Install(configScheme)
 }
 
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -61,6 +61,8 @@ import (
 	volcanoscheme "volcano.sh/apis/pkg/client/clientset/versioned/scheme"
 
 	semver "github.com/Masterminds/semver/v3"
+	dynamoapi "github.com/ai-dynamo/dynamo/deploy/operator/api"
+	configapi "github.com/ai-dynamo/dynamo/deploy/operator/api/config"
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 	configvalidation "github.com/ai-dynamo/dynamo/deploy/operator/api/config/validation"
 	nvidiacomv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1alpha1"
@@ -143,9 +145,7 @@ func createScalesGetter(mgr ctrl.Manager) (scale.ScalesGetter, error) {
 func initCRDSchemes() {
 	utilruntime.Must(clientgoscheme.AddToScheme(crdScheme))
 
-	utilruntime.Must(nvidiacomv1alpha1.AddToScheme(crdScheme))
-
-	utilruntime.Must(nvidiacomv1beta1.AddToScheme(crdScheme))
+	utilruntime.Must(dynamoapi.Install(crdScheme))
 
 	utilruntime.Must(lwsscheme.AddToScheme(crdScheme))
 
@@ -164,7 +164,7 @@ func initCRDSchemes() {
 }
 
 func initConfigScheme() {
-	utilruntime.Must(configv1alpha1.AddToScheme(configScheme))
+	utilruntime.Must(configapi.Install(configScheme))
 }
 
 // +kubebuilder:rbac:groups=authentication.k8s.io,resources=tokenreviews,verbs=create


### PR DESCRIPTION
## Summary

- Add root-level `Install(*runtime.Scheme) error` functions for the Dynamo and operator configuration APIs.
- Use those installers in operator startup so API packages own their version registration.

## Related Issues

- Linear: [DYN-3412](https://linear.app/nvidia/issue/DYN-3412)
- [x] Confirmed - no related GitHub issue

## Validation

- `go test ./api ./api/config ./cmd -count=1`
- `make lint`
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11906" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Kubernetes API scheme registration for Dynamo and operator configuration resources.
  * Ensured supported API versions are consistently available during operator startup.
* **Refactor**
  * Streamlined initialization of custom resource and configuration types through centralized registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->