### PR TITLE
refactor(operator): extract webhook setup

### DIFF
--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -74,10 +74,7 @@ import (
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/rbac"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secret"
 	"github.com/ai-dynamo/dynamo/deploy/operator/internal/secrets"
-	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
-	webhookdefaulting "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
-	webhookmutation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/mutation"
-	webhookvalidation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/validation"
+	webhooksetup "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/setup"
 	grovev1alpha1 "github.com/ai-dynamo/grove/operator/api/core/v1alpha1"
 	istioclientsetscheme "istio.io/client-go/pkg/clientset/versioned/scheme"
 	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
@@ -655,16 +652,6 @@ func registerWebhookHandlers(
 	operatorVersion string,
 	gate features.Gate,
 ) error {
-	isClusterWide := operatorCfg.Namespace.Restricted == ""
-	if isClusterWide {
-		setupLog.Info("Configuring webhooks with lease-based namespace exclusion for cluster-wide mode")
-		internalwebhook.SetExcludedNamespaces(runtimeConfig.ExcludedNamespaces)
-	} else {
-		setupLog.Info("Configuring webhooks for namespace-restricted mode (no lease checking)",
-			"restrictedNamespace", operatorCfg.Namespace.Restricted)
-		internalwebhook.SetExcludedNamespaces(nil)
-	}
-
 	var operatorPrincipal string
 	if sa, ns := os.Getenv("POD_SERVICE_ACCOUNT"), os.Getenv("POD_NAMESPACE"); sa != "" && ns != "" {
 		operatorPrincipal = fmt.Sprintf("system:serviceaccount:%s:%s", ns, sa)
@@ -681,77 +668,14 @@ func registerWebhookHandlers(
 		)
 	}
 
-	setupLog.Info("Registering validation webhooks")
-
-	dcdHandler := webhookvalidation.NewDynamoComponentDeploymentHandler()
-	if err := dcdHandler.RegisterWithManager(mgr, gate); err != nil {
-		return fmt.Errorf("unable to register DynamoComponentDeployment webhook: %w", err)
-	}
-
-	dgdHandler := webhookvalidation.NewDynamoGraphDeploymentHandler(mgr, operatorPrincipal)
-	if err := dgdHandler.RegisterWithManager(mgr, gate); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeployment webhook: %w", err)
-	}
-
-	dckptHandler := webhookvalidation.NewDynamoCheckpointHandler()
-	if err := dckptHandler.RegisterWithManager(mgr, gate); err != nil {
-		return fmt.Errorf("unable to register DynamoCheckpoint webhook: %w", err)
-	}
-
-	dmHandler := webhookvalidation.NewDynamoModelHandler()
-	if err := dmHandler.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoModel webhook: %w", err)
-	}
-
-	dgdrHandler := webhookvalidation.NewDynamoGraphDeploymentRequestHandler()
-	if err := dgdrHandler.RegisterWithManager(mgr, gate); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest webhook: %w", err)
-	}
-
-	if isClusterWide {
-		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
-			Complete(); err != nil {
-			return fmt.Errorf("unable to register DynamoGraphDeploymentRequest conversion webhook: %w", err)
-		}
-
-		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeployment{}).
-			Complete(); err != nil {
-			return fmt.Errorf("unable to register DynamoGraphDeployment conversion webhook: %w", err)
-		}
-
-		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoComponentDeployment{}).
-			Complete(); err != nil {
-			return fmt.Errorf("unable to register DynamoComponentDeployment conversion webhook: %w", err)
-		}
-
-		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}).
-			Complete(); err != nil {
-			return fmt.Errorf("unable to register DynamoGraphDeploymentScalingAdapter conversion webhook: %w", err)
-		}
-	}
-
-	setupLog.Info("Registering defaulting webhooks")
-
-	dcdDefaulter := webhookdefaulting.NewDCDDefaulter()
-	if err := dcdDefaulter.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoComponentDeployment defaulting webhook: %w", err)
-	}
-
-	dgdDefaulter := webhookdefaulting.NewDGDDefaulter(operatorVersion)
-	if err := dgdDefaulter.RegisterWithManager(mgr, gate); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeployment defaulting webhook: %w", err)
-	}
-
-	dgdrDefaulter := webhookdefaulting.NewDGDRDefaulter(operatorVersion)
-	if err := dgdrDefaulter.RegisterWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest defaulting webhook: %w", err)
-	}
-
-	setupLog.Info("Registering mutation webhooks")
-
-	podCheckpointRestoreMutator := webhookmutation.NewPodCheckpointRestoreMutator(mgr.GetClient(), operatorCfg)
-	if err := podCheckpointRestoreMutator.RegisterWithManager(mgr, gate); err != nil {
-		return fmt.Errorf("unable to register Pod checkpoint restore mutating webhook: %w", err)
+	if err := webhooksetup.SetupAll(mgr, webhooksetup.Options{
+		Config:            operatorCfg,
+		RuntimeConfig:     runtimeConfig,
+		OperatorVersion:   operatorVersion,
+		OperatorPrincipal: operatorPrincipal,
+		Gate:              gate,
+	}); err != nil {
+		return err
 	}
 
 	setupLog.Info("Webhooks registered successfully")

--- a/deploy/operator/cmd/main.go
+++ b/deploy/operator/cmd/main.go
@@ -668,7 +668,7 @@ func registerWebhookHandlers(
 		)
 	}
 
-	if err := webhooksetup.SetupAll(mgr, webhooksetup.Options{
+	if err := webhooksetup.Setup(mgr, webhooksetup.Options{
 		Config:            operatorCfg,
 		RuntimeConfig:     runtimeConfig,
 		OperatorVersion:   operatorVersion,

--- a/deploy/operator/internal/webhook/setup/setup.go
+++ b/deploy/operator/internal/webhook/setup/setup.go
@@ -27,7 +27,7 @@ type Options struct {
 	Gate              features.Gate
 }
 
-func SetupAll(mgr ctrl.Manager, opts Options) error {
+func Setup(mgr ctrl.Manager, opts Options) error {
 	if opts.Config == nil {
 		return fmt.Errorf("operator configuration is required")
 	}

--- a/deploy/operator/internal/webhook/setup/setup.go
+++ b/deploy/operator/internal/webhook/setup/setup.go
@@ -1,0 +1,118 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package setup
+
+import (
+	"fmt"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+	nvidiacomv1beta1 "github.com/ai-dynamo/dynamo/deploy/operator/api/v1beta1"
+	commoncontroller "github.com/ai-dynamo/dynamo/deploy/operator/internal/controller_common"
+	"github.com/ai-dynamo/dynamo/deploy/operator/internal/features"
+	internalwebhook "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook"
+	webhookdefaulting "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/defaulting"
+	webhookmutation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/mutation"
+	webhookvalidation "github.com/ai-dynamo/dynamo/deploy/operator/internal/webhook/validation"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+type Options struct {
+	Config            *configv1alpha1.OperatorConfiguration
+	RuntimeConfig     *commoncontroller.RuntimeConfig
+	OperatorVersion   string
+	OperatorPrincipal string
+	Gate              features.Gate
+}
+
+func SetupAll(mgr ctrl.Manager, opts Options) error {
+	if opts.Config == nil {
+		return fmt.Errorf("operator configuration is required")
+	}
+	if opts.RuntimeConfig == nil {
+		return fmt.Errorf("runtime configuration is required")
+	}
+	cfg := opts.Config
+	runtimeConfig := opts.RuntimeConfig
+	gate := opts.Gate
+	if gate == nil {
+		gate = runtimeConfig.Gate
+	}
+
+	isClusterWide := cfg.Namespace.Restricted == ""
+	if isClusterWide {
+		internalwebhook.SetExcludedNamespaces(runtimeConfig.ExcludedNamespaces)
+	} else {
+		internalwebhook.SetExcludedNamespaces(nil)
+	}
+
+	dcdHandler := webhookvalidation.NewDynamoComponentDeploymentHandler()
+	if err := dcdHandler.RegisterWithManager(mgr, gate); err != nil {
+		return fmt.Errorf("unable to register DynamoComponentDeployment webhook: %w", err)
+	}
+
+	dgdHandler := webhookvalidation.NewDynamoGraphDeploymentHandler(mgr, opts.OperatorPrincipal)
+	if err := dgdHandler.RegisterWithManager(mgr, gate); err != nil {
+		return fmt.Errorf("unable to register DynamoGraphDeployment webhook: %w", err)
+	}
+
+	dckptHandler := webhookvalidation.NewDynamoCheckpointHandler()
+	if err := dckptHandler.RegisterWithManager(mgr, gate); err != nil {
+		return fmt.Errorf("unable to register DynamoCheckpoint webhook: %w", err)
+	}
+
+	dmHandler := webhookvalidation.NewDynamoModelHandler()
+	if err := dmHandler.RegisterWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to register DynamoModel webhook: %w", err)
+	}
+
+	dgdrHandler := webhookvalidation.NewDynamoGraphDeploymentRequestHandler()
+	if err := dgdrHandler.RegisterWithManager(mgr, gate); err != nil {
+		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest webhook: %w", err)
+	}
+
+	if isClusterWide {
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentRequest{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoGraphDeploymentRequest conversion webhook: %w", err)
+		}
+
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeployment{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoGraphDeployment conversion webhook: %w", err)
+		}
+
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoComponentDeployment{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoComponentDeployment conversion webhook: %w", err)
+		}
+
+		if err := ctrl.NewWebhookManagedBy(mgr, &nvidiacomv1beta1.DynamoGraphDeploymentScalingAdapter{}).
+			Complete(); err != nil {
+			return fmt.Errorf("unable to register DynamoGraphDeploymentScalingAdapter conversion webhook: %w", err)
+		}
+	}
+
+	dcdDefaulter := webhookdefaulting.NewDCDDefaulter()
+	if err := dcdDefaulter.RegisterWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to register DynamoComponentDeployment defaulting webhook: %w", err)
+	}
+
+	dgdDefaulter := webhookdefaulting.NewDGDDefaulter(opts.OperatorVersion)
+	if err := dgdDefaulter.RegisterWithManager(mgr, gate); err != nil {
+		return fmt.Errorf("unable to register DynamoGraphDeployment defaulting webhook: %w", err)
+	}
+
+	dgdrDefaulter := webhookdefaulting.NewDGDRDefaulter(opts.OperatorVersion)
+	if err := dgdrDefaulter.RegisterWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to register DynamoGraphDeploymentRequest defaulting webhook: %w", err)
+	}
+
+	podCheckpointRestoreMutator := webhookmutation.NewPodCheckpointRestoreMutator(mgr.GetClient(), cfg)
+	if err := podCheckpointRestoreMutator.RegisterWithManager(mgr, gate); err != nil {
+		return fmt.Errorf("unable to register Pod checkpoint restore mutating webhook: %w", err)
+	}
+	return nil
+}

--- a/deploy/operator/internal/webhook/setup/setup_test.go
+++ b/deploy/operator/internal/webhook/setup/setup_test.go
@@ -1,0 +1,27 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+package setup
+
+import (
+	"testing"
+
+	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
+)
+
+func TestSetupAllRequiresOperatorConfiguration(t *testing.T) {
+	wantErr := "operator configuration is required"
+	if err := SetupAll(nil, Options{}); err == nil || err.Error() != wantErr {
+		t.Fatalf("SetupAll() error = %v, want %q", err, wantErr)
+	}
+}
+
+func TestSetupAllRequiresRuntimeConfiguration(t *testing.T) {
+	wantErr := "runtime configuration is required"
+	opts := Options{Config: &configv1alpha1.OperatorConfiguration{}}
+	if err := SetupAll(nil, opts); err == nil || err.Error() != wantErr {
+		t.Fatalf("SetupAll() error = %v, want %q", err, wantErr)
+	}
+}

--- a/deploy/operator/internal/webhook/setup/setup_test.go
+++ b/deploy/operator/internal/webhook/setup/setup_test.go
@@ -11,17 +11,17 @@ import (
 	configv1alpha1 "github.com/ai-dynamo/dynamo/deploy/operator/api/config/v1alpha1"
 )
 
-func TestSetupAllRequiresOperatorConfiguration(t *testing.T) {
+func TestSetupRequiresOperatorConfiguration(t *testing.T) {
 	wantErr := "operator configuration is required"
-	if err := SetupAll(nil, Options{}); err == nil || err.Error() != wantErr {
-		t.Fatalf("SetupAll() error = %v, want %q", err, wantErr)
+	if err := Setup(nil, Options{}); err == nil || err.Error() != wantErr {
+		t.Fatalf("Setup() error = %v, want %q", err, wantErr)
 	}
 }
 
-func TestSetupAllRequiresRuntimeConfiguration(t *testing.T) {
+func TestSetupRequiresRuntimeConfiguration(t *testing.T) {
 	wantErr := "runtime configuration is required"
 	opts := Options{Config: &configv1alpha1.OperatorConfiguration{}}
-	if err := SetupAll(nil, opts); err == nil || err.Error() != wantErr {
-		t.Fatalf("SetupAll() error = %v, want %q", err, wantErr)
+	if err := Setup(nil, opts); err == nil || err.Error() != wantErr {
+		t.Fatalf("Setup() error = %v, want %q", err, wantErr)
 	}
 }


### PR DESCRIPTION
## Summary

- Extract production admission and conversion registration into `internal/webhook/setup`.
- Keep `cmd/main.go` responsible only for assembling runtime options and the operator principal.

## Related Issues

- Linear: [DYN-3412](https://linear.app/nvidia/issue/DYN-3412)
- [x] Confirmed - no related GitHub issue

## Validation

- `go test ./internal/webhook/... ./cmd -count=1`
- `make lint`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized setup for the operator’s validation, conversion, defaulting, and pod checkpoint restore webhooks.
  * Webhook behavior now supports cluster-wide and namespace-restricted configurations.
  * Webhook registration can incorporate the operator’s service account identity and feature settings.

* **Bug Fixes**
  * Added validation and clear errors when required operator or runtime configuration is unavailable.

* **Tests**
  * Added coverage for missing configuration scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->