### PR TITLE
docs(vllm): note PdConnector hybrid-model requirement

### DIFF
--- a/docs/components/kvbm/kvbm-guide.md
+++ b/docs/components/kvbm/kvbm-guide.md
@@ -219,6 +219,9 @@ curl localhost:8000/v1/chat/completions \
 
 KVBM supports disaggregated serving where prefill and decode operations run on separate workers. KVBM is enabled on the prefill worker to offload KV cache.
 
+> [!IMPORTANT]
+> When using a hybrid model with `PdConnector`, pass `--disable-hybrid-kv-cache-manager` to every vLLM worker in the deployment, including both prefill and decode workers. `PdConnector` is not compatible with vLLM's hybrid KV cache manager.
+
 ### Disaggregated Serving with vLLM
 
 ```bash

--- a/docs/integrations/flexkv-integration.md
+++ b/docs/integrations/flexkv-integration.md
@@ -96,6 +96,9 @@ python -m dynamo.vllm \
 
 > **Note:** Disaggregated FlexKV serving is experimental. The prefill worker must use `PdConnector` with two sub-connectors: `FlexKVConnectorV1` (KV cache offloading) and `NixlConnector` (P/D KV transfer). Using `FlexKVConnectorV1` alone as the top-level connector in disaggregated mode is **not supported** and will result in a `TypeError`.
 
+> [!IMPORTANT]
+> When using a hybrid model with `PdConnector`, pass `--disable-hybrid-kv-cache-manager` to every vLLM worker in the deployment, including both prefill and decode workers. `PdConnector` is not compatible with vLLM's hybrid KV cache manager.
+
 FlexKV can be used with disaggregated prefill/decode serving. The prefill worker uses FlexKV for KV cache offloading, while NIXL handles KV transfer between prefill and decode workers. The `PdConnector` wraps both connectors so they work together.
 
 ### Supported connector configuration

--- a/docs/integrations/lmcache-integration.md
+++ b/docs/integrations/lmcache-integration.md
@@ -78,6 +78,9 @@ In aggregated mode, the system uses:
 
 Disaggregated serving separates prefill and decode operations into dedicated workers. This provides better resource utilization and scalability for production deployments.
 
+> [!IMPORTANT]
+> When using a hybrid model with `PdConnector`, pass `--disable-hybrid-kv-cache-manager` to every vLLM worker in the deployment, including both prefill and decode workers. `PdConnector` is not compatible with vLLM's hybrid KV cache manager.
+
 ### Deployment
 
 Use the provided disaggregated launch script (requires at least 2 GPUs):


### PR DESCRIPTION
## Summary

- Document the hybrid-model `PdConnector` compatibility requirement in the KVBM, LMCache, and FlexKV guides.
- Specify `--disable-hybrid-kv-cache-manager` for prefill and decode vLLM workers.

## Validation

- `fern check`
- `fern docs broken-links`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for hybrid-model deployments using `PdConnector`.
  * Clarified that `--disable-hybrid-kv-cache-manager` must be enabled on every vLLM worker, including prefill and decode workers.
  * Noted that `PdConnector` is incompatible with vLLM’s hybrid KV cache manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->