### PR TITLE
feat(gms): reduce footprint of scratch KV during failover

### DIFF
--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -37,14 +37,10 @@ from typing import Dict, List, Optional
 from gpu_memory_service.client.session import _GMSClientSession
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.protocol.messages import GetAllocationResponse
-from gpu_memory_service.common.utils import align_to_granularity, is_truthy_env
+from gpu_memory_service.common.utils import align_to_granularity
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, get_vmm_device_type
 
 logger = logging.getLogger(__name__)
-
-# Opt-in (client-only debug knob): back every scratch mapping with ONE shared
-# physical granule instead of one per mapping. Off by default.
-ENV_SCRATCH_SINGLE_BLOCK = "DYN_GMS_SCRATCH_SINGLE_BLOCK"
 
 
 class StaleMemoryLayoutError(Exception):
@@ -177,8 +173,7 @@ class GMSClientMemoryManager:
         # Optional single-block scratch: alias ALL scratch mappings onto one
         # shared physical granule (N KV layers -> one scratch_size block instead
         # of N). Created lazily on the first scratch mapping, released once when
-        # the last one is torn down. Off by default (per-mapping granule).
-        self._single_block_scratch: bool = is_truthy_env(ENV_SCRATCH_SINGLE_BLOCK)
+        # the last one is torn down.
         self._shared_scratch_handle: int = 0
 
         self._unmapped = False
@@ -526,14 +521,12 @@ class GMSClientMemoryManager:
             if scratch.scratch_handle == 0:
                 continue
             self._vmm.unmap(base_va, scratch.va_reserved_size)
-            if not self._single_block_scratch:
-                self._vmm.release(scratch.scratch_handle)
             scratch.scratch_handle = 0
             unmapped_count += 1
             total_bytes += scratch.va_reserved_size
-        # Single-block: every mapping aliased one shared granule; release it once
-        # after all ranges are unmapped.
-        if self._single_block_scratch and self._shared_scratch_handle != 0:
+        # Every mapping aliased the one shared granule; release it once, after all
+        # ranges are unmapped.
+        if self._shared_scratch_handle != 0:
             self._vmm.release(self._shared_scratch_handle)
             self._shared_scratch_handle = 0
 
@@ -710,7 +703,7 @@ class GMSClientMemoryManager:
         aligned_size = align_to_granularity(size, self.granularity)
         va_reserved_size = align_to_granularity(size, self.scratch_size)
 
-        if self._single_block_scratch and self._shared_scratch_handle != 0:
+        if self._shared_scratch_handle != 0:
             # Reuse the one shared granule; every mapping aliases it.
             scratch_handle = self._shared_scratch_handle
         else:
@@ -723,8 +716,7 @@ class GMSClientMemoryManager:
                     f"({self.scratch_size // (1 << 20)} MiB) on "
                     f"{self.device_type.value} device {self.device}"
                 )
-            if self._single_block_scratch:
-                self._shared_scratch_handle = scratch_handle
+            self._shared_scratch_handle = scratch_handle
 
         va = self._vmm.address_reserve(va_reserved_size, self.scratch_size)
         for offset in range(0, va_reserved_size, self.scratch_size):
@@ -816,14 +808,11 @@ class GMSClientMemoryManager:
         self._vmm.synchronize()
         if scratch.scratch_handle:
             self._vmm.unmap(base_va, scratch.va_reserved_size)
-            if self._single_block_scratch:
-                # Shared granule: release only once the last mapping is gone
-                # (this entry was already popped above).
-                if self._shared_scratch_handle != 0 and not self._scratch_mappings:
-                    self._vmm.release(self._shared_scratch_handle)
-                    self._shared_scratch_handle = 0
-            else:
-                self._vmm.release(scratch.scratch_handle)
+            # Shared granule: release only once the last mapping is gone
+            # (this entry was already popped above).
+            if self._shared_scratch_handle != 0 and not self._scratch_mappings:
+                self._vmm.release(self._shared_scratch_handle)
+                self._shared_scratch_handle = 0
         self._vmm.address_free(base_va, scratch.va_reserved_size)
         return True
 

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -170,10 +170,8 @@ class GMSClientMemoryManager:
         self._mappings: Dict[int, LocalMapping] = {}
         self._inverse_mapping: Dict[str, int] = {}
         self._scratch_mappings: Dict[int, _ScratchMapping] = {}
-        # Optional single-block scratch: alias ALL scratch mappings onto one
-        # shared physical granule (N KV layers -> one scratch_size block instead
-        # of N). Created lazily on the first scratch mapping, released once when
-        # the last one is torn down.
+        # All scratch mappings alias ONE shared physical granule (N KV layers ->
+        # one scratch_size block, not N). Created lazily, released once.
         self._shared_scratch_handle: int = 0
 
         self._unmapped = False

--- a/lib/gpu_memory_service/client/memory_manager.py
+++ b/lib/gpu_memory_service/client/memory_manager.py
@@ -37,10 +37,14 @@ from typing import Dict, List, Optional
 from gpu_memory_service.client.session import _GMSClientSession
 from gpu_memory_service.common.locks import GrantedLockType, RequestedLockType
 from gpu_memory_service.common.protocol.messages import GetAllocationResponse
-from gpu_memory_service.common.utils import align_to_granularity
+from gpu_memory_service.common.utils import align_to_granularity, is_truthy_env
 from gpu_memory_service.common.vmm import VMMDeviceType, get_vmm, get_vmm_device_type
 
 logger = logging.getLogger(__name__)
+
+# Opt-in (client-only debug knob): back every scratch mapping with ONE shared
+# physical granule instead of one per mapping. Off by default.
+ENV_SCRATCH_SINGLE_BLOCK = "DYN_GMS_SCRATCH_SINGLE_BLOCK"
 
 
 class StaleMemoryLayoutError(Exception):
@@ -170,6 +174,12 @@ class GMSClientMemoryManager:
         self._mappings: Dict[int, LocalMapping] = {}
         self._inverse_mapping: Dict[str, int] = {}
         self._scratch_mappings: Dict[int, _ScratchMapping] = {}
+        # Optional single-block scratch: alias ALL scratch mappings onto one
+        # shared physical granule (N KV layers -> one scratch_size block instead
+        # of N). Created lazily on the first scratch mapping, released once when
+        # the last one is torn down. Off by default (per-mapping granule).
+        self._single_block_scratch: bool = is_truthy_env(ENV_SCRATCH_SINGLE_BLOCK)
+        self._shared_scratch_handle: int = 0
 
         self._unmapped = False
         self._aborted = False
@@ -516,10 +526,16 @@ class GMSClientMemoryManager:
             if scratch.scratch_handle == 0:
                 continue
             self._vmm.unmap(base_va, scratch.va_reserved_size)
-            self._vmm.release(scratch.scratch_handle)
+            if not self._single_block_scratch:
+                self._vmm.release(scratch.scratch_handle)
             scratch.scratch_handle = 0
             unmapped_count += 1
             total_bytes += scratch.va_reserved_size
+        # Single-block: every mapping aliased one shared granule; release it once
+        # after all ranges are unmapped.
+        if self._single_block_scratch and self._shared_scratch_handle != 0:
+            self._vmm.release(self._shared_scratch_handle)
+            self._shared_scratch_handle = 0
 
         self._va_preserved = True
         self._unmapped = True
@@ -694,15 +710,21 @@ class GMSClientMemoryManager:
         aligned_size = align_to_granularity(size, self.granularity)
         va_reserved_size = align_to_granularity(size, self.scratch_size)
 
-        ok, scratch_handle = self._vmm.create_tolerate_oom(
-            self.scratch_size, self.device
-        )
-        if not ok:
-            raise RuntimeError(
-                f"VMM physical memory allocation failed "
-                f"({self.scratch_size // (1 << 20)} MiB) on "
-                f"{self.device_type.value} device {self.device}"
+        if self._single_block_scratch and self._shared_scratch_handle != 0:
+            # Reuse the one shared granule; every mapping aliases it.
+            scratch_handle = self._shared_scratch_handle
+        else:
+            ok, scratch_handle = self._vmm.create_tolerate_oom(
+                self.scratch_size, self.device
             )
+            if not ok:
+                raise RuntimeError(
+                    f"VMM physical memory allocation failed "
+                    f"({self.scratch_size // (1 << 20)} MiB) on "
+                    f"{self.device_type.value} device {self.device}"
+                )
+            if self._single_block_scratch:
+                self._shared_scratch_handle = scratch_handle
 
         va = self._vmm.address_reserve(va_reserved_size, self.scratch_size)
         for offset in range(0, va_reserved_size, self.scratch_size):
@@ -794,7 +816,14 @@ class GMSClientMemoryManager:
         self._vmm.synchronize()
         if scratch.scratch_handle:
             self._vmm.unmap(base_va, scratch.va_reserved_size)
-            self._vmm.release(scratch.scratch_handle)
+            if self._single_block_scratch:
+                # Shared granule: release only once the last mapping is gone
+                # (this entry was already popped above).
+                if self._shared_scratch_handle != 0 and not self._scratch_mappings:
+                    self._vmm.release(self._shared_scratch_handle)
+                    self._shared_scratch_handle = 0
+            else:
+                self._vmm.release(scratch.scratch_handle)
         self._vmm.address_free(base_va, scratch.va_reserved_size)
         return True
 
@@ -819,6 +848,7 @@ class GMSClientMemoryManager:
             self._mappings.clear()
             self._inverse_mapping.clear()
             self._scratch_mappings.clear()
+            self._shared_scratch_handle = 0
         else:
             self._vmm.synchronize()
             for base_va in list(self._scratch_mappings.keys()):

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -8,6 +8,8 @@ Patches:
   - request_memory: bypasses the free>=requested check during deferred-KV init.
   - NixlConnector.register_kv_caches: defers registration during the scratch
     phase and stashes the dict for replay at wake.
+  - init_kv_cache: scopes the scratch mem-pool to the raw KV tensors only, so
+    BlockTables / workspace / pointer tensors keep real (un-aliased) memory.
 
 The torch.cuda.empty_cache patch lives in integrations/common/patches.py.
 """
@@ -25,6 +27,7 @@ logger = logging.getLogger(__name__)
 _memory_snapshot_patched = False
 _request_memory_patched = False
 _register_kv_caches_patched = False
+_kv_cache_pool_scope_patched = False
 
 
 # =============================================================================
@@ -177,6 +180,57 @@ def patch_register_kv_caches() -> None:
 # =============================================================================
 
 
+def patch_kv_cache_pool_scope() -> None:
+    """Scope the GMS scratch mem-pool to the raw KV cache tensors only.
+
+    GMSWorker.initialize_from_config no longer wraps the whole
+    initialize_kv_cache() in gms_use_mem_pool; it lets this patch wrap ONLY
+    init_kv_cache (the raw KV tensor allocation). Everything else
+    initialize_kv_cache touches -- BlockTables, the FlashInfer workspace,
+    block-table pointer tensors -- then uses normal CUDA memory.
+
+    This matters for single-block scratch: if those metadata buffers share the
+    one aliased scratch granule with the KV cache, a KV write clobbers the
+    block-table pointer tensor and the block-table gather kernel dereferences a
+    garbage pointer -> illegal memory access. (Per-mapping scratch happened to
+    keep them correct only because each metadata buffer was < one granule, so it
+    never self-aliased; single-block collapses everything onto one granule.)
+    """
+    global _kv_cache_pool_scope_patched
+
+    if _kv_cache_pool_scope_patched:
+        return
+
+    try:
+        import torch
+        from gpu_memory_service.client.torch.allocator import gms_use_mem_pool
+        from vllm.v1.worker.gpu import model_runner as gpu_model_runner
+
+        original_init_kv_cache = gpu_model_runner.init_kv_cache
+    except (ImportError, AttributeError) as exc:
+        logger.debug("[GMS Patch] init_kv_cache pool-scope not available: %s", exc)
+        return
+
+    def patched_init_kv_cache(*args, **kwargs):
+        # Only the scratch path narrows the scope here; the sleep-mode path keeps
+        # its own gms_use_mem_pool wrap in worker.py.
+        if not is_scratch_kv_enabled():
+            return original_init_kv_cache(*args, **kwargs)
+        device = kwargs.get("device")
+        if device is None:
+            device = next((a for a in args if isinstance(a, torch.device)), None)
+        if device is None:
+            device = torch.device("cuda", torch.cuda.current_device())
+        with gms_use_mem_pool("kv_cache", device):
+            return original_init_kv_cache(*args, **kwargs)
+
+    gpu_model_runner.init_kv_cache = patched_init_kv_cache
+    _kv_cache_pool_scope_patched = True
+    logger.info(
+        "[GMS Patch] Scoped scratch mem-pool to init_kv_cache (KV tensors only)"
+    )
+
+
 def apply_scratch_kv_patches() -> None:
     """Apply scratch-KV monkey-patches. No-ops when scratch KV is disabled."""
     if not is_scratch_kv_enabled():
@@ -184,4 +238,5 @@ def apply_scratch_kv_patches() -> None:
 
     patch_request_memory()
     patch_register_kv_caches()
+    patch_kv_cache_pool_scope()
     logger.info("[GMS Patch] applied")

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -212,15 +212,12 @@ def patch_kv_cache_pool_scope() -> None:
         return
 
     def patched_init_kv_cache(*args, **kwargs):
-        # Only the scratch path narrows the scope here; the sleep-mode path keeps
-        # its own gms_use_mem_pool wrap in worker.py.
-        if not is_scratch_kv_enabled():
-            return original_init_kv_cache(*args, **kwargs)
-        device = kwargs.get("device")
-        if device is None:
-            device = next((a for a in args if isinstance(a, torch.device)), None)
-        if device is None:
-            device = torch.device("cuda", torch.cuda.current_device())
+        # Installed only in shadow mode (apply_scratch_kv_patches runs only when
+        # is_scratch_kv_enabled), so always scope the KV allocation to the pool.
+        # init_kv_cache allocates on the worker's current CUDA device, which is
+        # exactly where the pool must apply.
+        assert torch.cuda.is_available(), "GMS scratch KV requires CUDA"
+        device = torch.device("cuda", torch.cuda.current_device())
         with gms_use_mem_pool("kv_cache", device):
             return original_init_kv_cache(*args, **kwargs)
 

--- a/lib/gpu_memory_service/integrations/vllm/patches.py
+++ b/lib/gpu_memory_service/integrations/vllm/patches.py
@@ -181,20 +181,12 @@ def patch_register_kv_caches() -> None:
 
 
 def patch_kv_cache_pool_scope() -> None:
-    """Scope the GMS scratch mem-pool to the raw KV cache tensors only.
+    """Scope the scratch mem-pool to init_kv_cache (the raw KV tensors) only.
 
-    GMSWorker.initialize_from_config no longer wraps the whole
-    initialize_kv_cache() in gms_use_mem_pool; it lets this patch wrap ONLY
-    init_kv_cache (the raw KV tensor allocation). Everything else
-    initialize_kv_cache touches -- BlockTables, the FlashInfer workspace,
-    block-table pointer tensors -- then uses normal CUDA memory.
-
-    This matters for single-block scratch: if those metadata buffers share the
-    one aliased scratch granule with the KV cache, a KV write clobbers the
-    block-table pointer tensor and the block-table gather kernel dereferences a
-    garbage pointer -> illegal memory access. (Per-mapping scratch happened to
-    keep them correct only because each metadata buffer was < one granule, so it
-    never self-aliased; single-block collapses everything onto one granule.)
+    Keeps BlockTables / workspace / the block-table pointer tensor on real memory.
+    Single-block scratch aliases everything in the pool onto one granule, so a KV
+    write over that pointer tensor would corrupt the block-table gather kernel
+    (-> illegal memory access).
     """
     global _kv_cache_pool_scope_patched
 
@@ -212,10 +204,8 @@ def patch_kv_cache_pool_scope() -> None:
         return
 
     def patched_init_kv_cache(*args, **kwargs):
-        # Installed only in shadow mode (apply_scratch_kv_patches runs only when
-        # is_scratch_kv_enabled), so always scope the KV allocation to the pool.
-        # init_kv_cache allocates on the worker's current CUDA device, which is
-        # exactly where the pool must apply.
+        # Installed only in shadow mode, so always scope to the pool. init_kv_cache
+        # allocates on the worker's current device.
         assert torch.cuda.is_available(), "GMS scratch KV requires CUDA"
         device = torch.device("cuda", torch.cuda.current_device())
         with gms_use_mem_pool("kv_cache", device):

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -272,12 +272,8 @@ class GMSWorker(Worker):
             # Client-local scratch only — no GMS server session at init.
             # wake_up will connect RW and allocate fresh server backing.
             get_or_create_scratch_manager(socket, device, tag="kv_cache")
-            # NOTE: the scratch mem-pool is scoped to init_kv_cache (the raw KV
-            # tensors) by patch_kv_cache_pool_scope(), NOT the whole
-            # initialize_kv_cache. BlockTables / FlashInfer workspace / pointer
-            # tensors must get real memory: under single-block scratch they would
-            # otherwise alias the one KV granule and a KV write would clobber the
-            # block-table pointers -> illegal memory access in the gather kernel.
+            # The scratch pool is scoped to the KV tensors by
+            # patch_kv_cache_pool_scope(), not the whole initialize_kv_cache.
             self.model_runner.initialize_kv_cache(kv_cache_config)
         elif self.vllm_config.model_config.enable_sleep_mode:
             get_or_create_gms_client_memory_manager(

--- a/lib/gpu_memory_service/integrations/vllm/worker.py
+++ b/lib/gpu_memory_service/integrations/vllm/worker.py
@@ -272,8 +272,13 @@ class GMSWorker(Worker):
             # Client-local scratch only — no GMS server session at init.
             # wake_up will connect RW and allocate fresh server backing.
             get_or_create_scratch_manager(socket, device, tag="kv_cache")
-            with gms_use_mem_pool("kv_cache", torch.device(f"cuda:{device}")):
-                self.model_runner.initialize_kv_cache(kv_cache_config)
+            # NOTE: the scratch mem-pool is scoped to init_kv_cache (the raw KV
+            # tensors) by patch_kv_cache_pool_scope(), NOT the whole
+            # initialize_kv_cache. BlockTables / FlashInfer workspace / pointer
+            # tensors must get real memory: under single-block scratch they would
+            # otherwise alias the one KV granule and a KV write would clobber the
+            # block-table pointers -> illegal memory access in the gather kernel.
+            self.model_runner.initialize_kv_cache(kv_cache_config)
         elif self.vllm_config.model_config.enable_sleep_mode:
             get_or_create_gms_client_memory_manager(
                 socket,


### PR DESCRIPTION
Reduce the footprint of "scratch" KV by having all allocations alias to the same granule of device memory. Scratch memory is now the same regardless of how many allocations there are.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved scratch memory management by sharing a single physical allocation across scratch mappings.
  * Enhanced vLLM KV-cache handling so only KV tensors use scratch memory, while related structures remain on standard memory.

* **Bug Fixes**
  * Improved cleanup and lifecycle handling to prevent duplicate releases and stale scratch allocations.
  * Corrected scratch-mode KV-cache initialization and deferred registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->