### PR TITLE
fix(multimodal): force vLLM V1 model runner in disaggregated EPD encode worker (OPS-7720)

### DIFF
--- a/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_e_pd.sh
@@ -124,8 +124,18 @@ fi
 # GPU0 peak ~13.5 GB at DYN_ENCODE_GPU_MEM=0.05, 0.5, 0.9 (identical within jitter).
 # The static peak is bounded by the model's fp16 weights (~14 GB), independent
 # of GPU size. So sizing for this script: encoder needs ~14 GB free per worker GPU.
+#
+# VLLM_USE_V2_MODEL_RUNNER=0 forces vLLM's V1 model runner for the encode worker.
+# vLLM 0.25.x's V2 model runner has a broken encoder-only init for dense VLMs:
+# the mm_encoder_only load runs a memory profile_run that executes the language
+# model on Meta tensors, hitting the `_C::rms_norm` custom op (no fake/Meta
+# kernel) and crashing at startup with NotImplementedError even under
+# --enforce-eager. The V1 runner keeps vLLM's encoder-only vision tower (no full
+# model load). Short-term workaround; drop it (set VLLM_USE_V2_MODEL_RUNNER=1)
+# once the V2 encoder-only path is fixed upstream. MoE VLMs are unaffected.
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utilization $DYN_ENCODE_GPU_MEM)..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+VLLM_USE_V2_MODEL_RUNNER=${VLLM_USE_V2_MODEL_RUNNER:-0} \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
 python -m dynamo.vllm \
   --enable-multimodal \

--- a/examples/backends/vllm/launch/disagg_multimodal_epd.sh
+++ b/examples/backends/vllm/launch/disagg_multimodal_epd.sh
@@ -199,8 +199,18 @@ VLLM_ZMQ_PORT_DECODE=${VLLM_ZMQ_PORT_DECODE:-20082}
 #     is ignored.
 # For LLaVA-1.5-7b the encoder peak is ~13.5 GB regardless of GPU size or fraction
 # (verified empirically for the e_pd topology — same load path applies here).
+#
+# VLLM_USE_V2_MODEL_RUNNER=0 forces vLLM's V1 model runner for the encode worker.
+# vLLM 0.25.x's V2 model runner has a broken encoder-only init for dense VLMs:
+# the mm_encoder_only load runs a memory profile_run that executes the language
+# model on Meta tensors, hitting the `_C::rms_norm` custom op (no fake/Meta
+# kernel) and crashing at startup with NotImplementedError even under
+# --enforce-eager. The V1 runner keeps vLLM's encoder-only vision tower (no full
+# model load). Short-term workaround; drop it (set VLLM_USE_V2_MODEL_RUNNER=1)
+# once the V2 encoder-only path is fixed upstream. MoE VLMs are unaffected.
 echo "Starting encode worker on GPU $DYN_ENCODE_WORKER_GPU (--gpu-memory-utilization $DYN_ENCODE_GPU_MEM)..."
 DYN_SYSTEM_PORT=${DYN_SYSTEM_PORT1:-8081} \
+VLLM_USE_V2_MODEL_RUNNER=${VLLM_USE_V2_MODEL_RUNNER:-0} \
 VLLM_NIXL_SIDE_CHANNEL_PORT=$VLLM_NIXL_SIDE_CHANNEL_PORT_ENCODE \
 CUDA_VISIBLE_DEVICES=$DYN_ENCODE_WORKER_GPU \
 python -m dynamo.vllm --enable-multimodal --disaggregation-mode encode --model $MODEL_NAME --gpu-memory-utilization $DYN_ENCODE_GPU_MEM $EXTRA_ARGS --kv-transfer-config '{"kv_connector":"NixlConnector","kv_role":"kv_both"}' --kv-events-config "{\"publisher\":\"zmq\",\"topic\":\"kv-events\",\"endpoint\":\"tcp://*:${VLLM_ZMQ_PORT_ENCODE}\"}" &


### PR DESCRIPTION
## Overview

The disaggregated multimodal **E/P/D** encode worker crashes at startup for Qwen3-VL on vLLM 0.25.1, so `mm_epd`, `mm_e_pd`, and `mm_epd_video` all fail. Root cause is vLLM 0.25.1's **V2 model runner**, whose encoder-only init is broken for dense VLMs. Force the **V1 model runner** on the encode worker as a short-term workaround — this keeps vLLM's encoder-only vision tower (no transformers / full-model fallback).

## Details

The encode worker's `load_vision_model()` takes the `mm_encoder_only=True` vLLM path. On the V2 model runner, engine init runs `determine_available_memory → profile_run → _dummy_run`, and in encoder-only mode `qwen3_vl.forward` still executes the **language model on Meta tensors** → `RMSNorm → _C::rms_norm`, which has no fake/Meta kernel → `NotImplementedError` at startup. This is **not** a torch.compile issue (`--enforce-eager` is already honored; it's the memory-profiling pass). The aggregated path uses vLLM's in-engine encoder and never calls `load_vision_model()`, which is why `agg_*` passes while every EPD variant fails.

**Fix:** set `VLLM_USE_V2_MODEL_RUNNER=0` (overridable) on the encode worker in both EPD launch scripts. The V1 runner keeps vLLM's encoder-only vision tower — **no full-model / transformers fallback, no extra VRAM**. Short-term workaround until the V2 encoder-only path is fixed upstream; MoE VLMs are unaffected.

**Validated on gpu-ts:** `load_vision_model(Qwen3-VL-2B-Instruct-FP8)` crashes on the default V2 runner (`_C::rms_norm` meta) and loads the vLLM `Qwen3_VisionTransformer` with `VLLM_USE_V2_MODEL_RUNNER=0`. (An earlier `VLLM_ENCODER=0` iteration passed `mm_epd_video` in pre_merge GPU CI at 112s; this V1-runner approach is preferred per review because it keeps the vLLM encoder path instead of falling back to a full transformers load.)

## Where should the reviewer start?

- `examples/backends/vllm/launch/disagg_multimodal_epd.sh` and `disagg_multimodal_e_pd.sh` — the one-line `VLLM_USE_V2_MODEL_RUNNER=${VLLM_USE_V2_MODEL_RUNNER:-0}` env on the encode worker + the root-cause comment above it.

## Related Issues

Tracked in Linear: **OPS-7720** — `[test failure] test_serve_deployment[mm_epd_qwen3-vl-2b-2]`.

- [x] No GitHub issue — tracked in Linear (OPS-7720).

Follow-ups: fix vLLM's V2-model-runner encoder-only init upstream, then drop the workaround; the EPD serve tests were skipped in the vLLM-bump PR #11606, which is why this regressed silently.
