### PR TITLE
feat(mocker): add framework-neutral host offload core

### DIFF
--- a/lib/mocker/src/host_offload/events.rs
+++ b/lib/mocker/src/host_offload/events.rs
@@ -1,0 +1,249 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Normalized events emitted by the host-offload core.
+
+use serde::{Deserialize, Serialize};
+
+/// Framework-neutral identity for one logical KV block.
+///
+/// The token digest is scoped by its logical parent and KV group so identical
+/// token chunks in different prefixes or groups do not alias. It does not
+/// expose framework block ids or physical cache locations.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+pub struct HostBlockKey {
+    pub group_index: u32,
+    pub parent: Option<[u8; 32]>,
+    pub token_digest: [u8; 32],
+}
+
+impl HostBlockKey {
+    pub fn new(group_index: u32, parent: Option<[u8; 32]>, token_digest: [u8; 32]) -> Self {
+        Self {
+            group_index,
+            parent,
+            token_digest,
+        }
+    }
+}
+
+/// Opaque location of a source or destination block in G1.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct G1Location(u64);
+
+impl G1Location {
+    pub fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Opaque id used to correlate queued and completed transfers.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct TransferId(u64);
+
+impl TransferId {
+    pub fn new(raw: u64) -> Self {
+        Self(raw)
+    }
+
+    pub fn get(self) -> u64 {
+        self.0
+    }
+}
+
+/// Direction of a simulated host transfer.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferDirection {
+    G1ToG2,
+    G2ToG1,
+}
+
+/// Scheduler action that had to wait for a pending G1-to-G2 store.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SourceFenceReason {
+    SourceReuse,
+    RequestPreemption,
+}
+
+/// Stable event vocabulary shared by offline replay and real-engine parity
+/// traces. Times are relative simulation times in milliseconds.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "event", rename_all = "snake_case")]
+pub enum HostOffloadEvent {
+    StorePrepared {
+        at_ms: f64,
+        transfer_id: TransferId,
+        key: HostBlockKey,
+        source: G1Location,
+        bytes: usize,
+    },
+    StoreQueued {
+        at_ms: f64,
+        transfer_id: TransferId,
+        key: HostBlockKey,
+        source: G1Location,
+        bytes: usize,
+    },
+    StoreCompleted {
+        at_ms: f64,
+        transfer_id: TransferId,
+        key: HostBlockKey,
+    },
+    LoadQueued {
+        at_ms: f64,
+        transfer_id: TransferId,
+        key: HostBlockKey,
+        destination: G1Location,
+        bytes: usize,
+    },
+    LoadCompleted {
+        at_ms: f64,
+        transfer_id: TransferId,
+        key: HostBlockKey,
+    },
+    G2Evicted {
+        at_ms: f64,
+        key: HostBlockKey,
+    },
+    CapacityRetry {
+        at_ms: f64,
+        key: HostBlockKey,
+    },
+    SourceFenced {
+        at_ms: f64,
+        transfer_id: TransferId,
+        key: HostBlockKey,
+        source: G1Location,
+        reason: SourceFenceReason,
+    },
+}
+
+impl HostOffloadEvent {
+    pub fn at_ms(&self) -> f64 {
+        match self {
+            Self::StorePrepared { at_ms, .. }
+            | Self::StoreQueued { at_ms, .. }
+            | Self::StoreCompleted { at_ms, .. }
+            | Self::LoadQueued { at_ms, .. }
+            | Self::LoadCompleted { at_ms, .. }
+            | Self::G2Evicted { at_ms, .. }
+            | Self::CapacityRetry { at_ms, .. }
+            | Self::SourceFenced { at_ms, .. } => *at_ms,
+        }
+    }
+
+    pub fn key(&self) -> HostBlockKey {
+        match self {
+            Self::StorePrepared { key, .. }
+            | Self::StoreQueued { key, .. }
+            | Self::StoreCompleted { key, .. }
+            | Self::LoadQueued { key, .. }
+            | Self::LoadCompleted { key, .. }
+            | Self::G2Evicted { key, .. }
+            | Self::CapacityRetry { key, .. }
+            | Self::SourceFenced { key, .. } => *key,
+        }
+    }
+
+    pub fn transfer_direction(&self) -> Option<TransferDirection> {
+        match self {
+            Self::StorePrepared { .. }
+            | Self::StoreQueued { .. }
+            | Self::StoreCompleted { .. }
+            | Self::SourceFenced { .. } => Some(TransferDirection::G1ToG2),
+            Self::LoadQueued { .. } | Self::LoadCompleted { .. } => Some(TransferDirection::G2ToG1),
+            Self::G2Evicted { .. } | Self::CapacityRetry { .. } => None,
+        }
+    }
+}
+
+/// Destination for normalized host-offload events.
+pub trait HostOffloadEventSink: Send + Sync {
+    fn record(&self, event: &HostOffloadEvent);
+}
+
+/// Default sink for callers that do not request host-offload tracing.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct NoopHostOffloadEventSink;
+
+impl HostOffloadEventSink for NoopHostOffloadEventSink {
+    fn record(&self, _event: &HostOffloadEvent) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use super::*;
+
+    fn key(group_index: u32) -> HostBlockKey {
+        HostBlockKey::new(group_index, Some([1; 32]), [2; 32])
+    }
+
+    #[test]
+    fn logical_key_includes_group_and_parent() {
+        let base = key(0);
+        let another_group = key(1);
+        let another_parent = HostBlockKey::new(0, Some([3; 32]), [2; 32]);
+
+        assert_ne!(base, another_group);
+        assert_ne!(base, another_parent);
+    }
+
+    #[test]
+    fn typed_events_report_time_key_and_direction() {
+        let event = HostOffloadEvent::StoreQueued {
+            at_ms: 12.5,
+            transfer_id: TransferId::new(7),
+            key: key(0),
+            source: G1Location::new(11),
+            bytes: 4096,
+        };
+
+        assert_eq!(event.at_ms(), 12.5);
+        assert_eq!(event.key(), key(0));
+        assert_eq!(event.transfer_direction(), Some(TransferDirection::G1ToG2));
+
+        let eviction = HostOffloadEvent::G2Evicted {
+            at_ms: 15.0,
+            key: key(0),
+        };
+        assert_eq!(eviction.transfer_direction(), None);
+    }
+
+    #[test]
+    fn event_serialization_has_stable_discriminator_and_opaque_ids() {
+        let event = HostOffloadEvent::LoadQueued {
+            at_ms: 2.0,
+            transfer_id: TransferId::new(4),
+            key: key(0),
+            destination: G1Location::new(9),
+            bytes: 1024,
+        };
+        let value = serde_json::to_value(event).unwrap();
+
+        assert_eq!(value["event"], "load_queued");
+        assert_eq!(value["transfer_id"], 4);
+        assert_eq!(value["destination"], 9);
+        assert_eq!(value["bytes"], 1024);
+    }
+
+    #[test]
+    fn noop_sink_is_object_safe() {
+        let sink: Arc<dyn HostOffloadEventSink> = Arc::new(NoopHostOffloadEventSink);
+        let event = HostOffloadEvent::CapacityRetry {
+            at_ms: 3.0,
+            key: key(0),
+        };
+
+        sink.record(&event);
+    }
+}

--- a/lib/mocker/src/host_offload/eviction.rs
+++ b/lib/mocker/src/host_offload/eviction.rs
@@ -1,0 +1,173 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! G2 eviction ordering independent of residency and capacity accounting.
+
+use std::collections::BTreeSet;
+
+use anyhow::{Result, bail};
+use rustc_hash::FxHashMap;
+
+use super::{G2EvictionPolicy, HostBlockKey};
+
+/// Ordering callbacks consumed by the G2 residency manager.
+///
+/// The manager remains authoritative for whether a block exists, is resident,
+/// is pinned, or is protected by the cohort being admitted. A strategy only
+/// tracks eviction order. Victim selection is a non-mutating preview so the
+/// manager can reject an atomic admission without rolling strategy state back.
+pub(super) trait G2EvictionStrategy: Send {
+    /// A pending store became resident and eligible for future eviction.
+    fn on_resident(&mut self, key: HostBlockKey);
+
+    /// A resident, unpinned block was accessed.
+    fn on_access(&mut self, key: HostBlockKey);
+
+    /// A resident block transitioned from unpinned to pinned.
+    fn on_pin(&mut self, key: HostBlockKey);
+
+    /// A resident block transitioned from pinned to unpinned.
+    fn on_unpin(&mut self, key: HostBlockKey);
+
+    /// The manager committed removal of a resident block.
+    fn on_remove(&mut self, key: HostBlockKey);
+
+    /// Preview up to `count` victims in policy order.
+    ///
+    /// `is_eligible` is supplied by the manager and captures its canonical pin
+    /// state plus admission-specific protection. This method must not mutate
+    /// strategy state.
+    fn select_victims(
+        &self,
+        count: usize,
+        is_eligible: &mut dyn FnMut(HostBlockKey) -> bool,
+    ) -> Vec<HostBlockKey>;
+}
+
+pub(super) fn build_g2_eviction_strategy(
+    policy: G2EvictionPolicy,
+) -> Result<Box<dyn G2EvictionStrategy>> {
+    match policy {
+        G2EvictionPolicy::Lru => Ok(Box::new(LruEviction::default())),
+        unsupported => bail!("unsupported G2 eviction policy: {unsupported:?}"),
+    }
+}
+
+#[derive(Default)]
+struct LruEviction {
+    recency_clock: u64,
+    last_touch: FxHashMap<HostBlockKey, u64>,
+    oldest_first: BTreeSet<(u64, HostBlockKey)>,
+}
+
+impl LruEviction {
+    fn mark_mru(&mut self, key: HostBlockKey) {
+        if let Some(previous) = self.last_touch.remove(&key) {
+            let removed = self.oldest_first.remove(&(previous, key));
+            debug_assert!(removed);
+        }
+        self.recency_clock = self
+            .recency_clock
+            .checked_add(1)
+            .expect("G2 recency counter exhausted");
+        let previous = self.last_touch.insert(key, self.recency_clock);
+        debug_assert!(previous.is_none());
+        let inserted = self.oldest_first.insert((self.recency_clock, key));
+        debug_assert!(inserted);
+    }
+
+    fn remove_from_order(&mut self, key: HostBlockKey) {
+        if let Some(last_touch) = self.last_touch.remove(&key) {
+            let removed = self.oldest_first.remove(&(last_touch, key));
+            debug_assert!(removed);
+        }
+    }
+}
+
+impl G2EvictionStrategy for LruEviction {
+    fn on_resident(&mut self, key: HostBlockKey) {
+        debug_assert!(!self.last_touch.contains_key(&key));
+        self.mark_mru(key);
+    }
+
+    fn on_access(&mut self, key: HostBlockKey) {
+        debug_assert!(self.last_touch.contains_key(&key));
+        self.mark_mru(key);
+    }
+
+    fn on_pin(&mut self, key: HostBlockKey) {
+        debug_assert!(self.last_touch.contains_key(&key));
+        self.remove_from_order(key);
+    }
+
+    fn on_unpin(&mut self, key: HostBlockKey) {
+        debug_assert!(!self.last_touch.contains_key(&key));
+        self.mark_mru(key);
+    }
+
+    fn on_remove(&mut self, key: HostBlockKey) {
+        self.remove_from_order(key);
+    }
+
+    fn select_victims(
+        &self,
+        count: usize,
+        is_eligible: &mut dyn FnMut(HostBlockKey) -> bool,
+    ) -> Vec<HostBlockKey> {
+        self.oldest_first
+            .iter()
+            .map(|(_, key)| *key)
+            .filter(|key| is_eligible(*key))
+            .take(count)
+            .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn key(value: u8) -> HostBlockKey {
+        HostBlockKey::new(0, None, [value; 32])
+    }
+
+    #[test]
+    fn lru_callbacks_control_order_without_owning_eligibility() {
+        let mut lru = LruEviction::default();
+        lru.on_resident(key(1));
+        lru.on_resident(key(2));
+        lru.on_resident(key(3));
+        lru.on_access(key(1));
+
+        lru.on_pin(key(2));
+        let mut exclude_three = |candidate| candidate != key(3);
+        assert_eq!(lru.select_victims(2, &mut exclude_three), vec![key(1)]);
+
+        lru.on_unpin(key(2));
+        assert_eq!(
+            lru.select_victims(2, &mut exclude_three),
+            vec![key(1), key(2)]
+        );
+
+        lru.on_remove(key(1));
+        let mut all = |_| true;
+        assert_eq!(lru.select_victims(3, &mut all), vec![key(3), key(2)]);
+    }
+
+    #[test]
+    fn victim_preview_does_not_mutate_lru_order() {
+        let mut lru = LruEviction::default();
+        lru.on_resident(key(1));
+        lru.on_resident(key(2));
+        let mut all = |_| true;
+
+        assert_eq!(lru.select_victims(2, &mut all), vec![key(1), key(2)]);
+        assert_eq!(lru.select_victims(2, &mut all), vec![key(1), key(2)]);
+    }
+
+    #[test]
+    fn unsupported_policy_is_rejected_by_the_strategy_factory() {
+        assert!(build_g2_eviction_strategy(G2EvictionPolicy::Arc).is_err());
+        assert!(build_g2_eviction_strategy(G2EvictionPolicy::RetentionPriorityLru).is_err());
+    }
+}

--- a/lib/mocker/src/host_offload/manager.rs
+++ b/lib/mocker/src/host_offload/manager.rs
@@ -1,0 +1,1277 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Framework-neutral G2 residency and transfer simulation.
+//!
+//! Framework adapters decide when blocks are eligible for store or load. This
+//! manager owns the shared mechanics: G2 capacity, pluggable eviction,
+//! asynchronous transfer timing, source fences, and normalized trace events.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+
+use anyhow::{Result, bail};
+use rustc_hash::{FxHashMap, FxHashSet};
+
+use super::eviction::{G2EvictionStrategy, build_g2_eviction_strategy};
+use super::{
+    CapacityHandling, G1Location, HostBlockKey, HostOffloadEvent, HostOffloadEventSink,
+    PostLoadResidency, ResolvedHostOffloadPolicy, SourceFenceReason, TransferId,
+};
+
+/// Physical parameters for one G2 simulation.
+///
+/// The initial vLLM adapter is restricted to one worker/rank. Multi-rank
+/// integration must resolve vLLM's engine-global logical capacity before it
+/// can be reported as framework-native parity.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct HostOffloadConfig {
+    pub capacity_blocks: usize,
+    pub block_bytes: usize,
+    /// `0.0` means zero simulated transfer latency.
+    pub d2h_bandwidth_gbps: f64,
+    /// `0.0` means zero simulated transfer latency.
+    pub h2d_bandwidth_gbps: f64,
+}
+
+/// One logical block in a framework-selected store job.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct StoreBlock {
+    pub key: HostBlockKey,
+    pub source: G1Location,
+}
+
+/// One logical block in a framework-selected load job.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct LoadBlock {
+    pub key: HostBlockKey,
+    pub destination: G1Location,
+}
+
+impl HostOffloadConfig {
+    pub fn validate(self) -> Result<Self> {
+        if self.capacity_blocks == 0 {
+            bail!("host-offload G2 capacity must be greater than zero");
+        }
+        if self.block_bytes == 0 {
+            bail!("host-offload block size must be greater than zero bytes");
+        }
+        let max_transfer_bytes = self
+            .capacity_blocks
+            .checked_mul(self.block_bytes)
+            .ok_or_else(|| anyhow::anyhow!("host-offload G2 capacity in bytes overflowed"))?;
+        validate_bandwidth("D2H", self.d2h_bandwidth_gbps, max_transfer_bytes)?;
+        validate_bandwidth("H2D", self.h2d_bandwidth_gbps, max_transfer_bytes)?;
+        Ok(self)
+    }
+}
+
+/// Result of atomically preparing a framework-selected store batch.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PrepareStoreOutcome {
+    Prepared {
+        transfer_id: TransferId,
+        stored_blocks: usize,
+    },
+    AlreadyPresent,
+    RetryCapacity,
+}
+
+/// One prepared store submitted to the D2H transfer lane.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SubmittedStore {
+    pub transfer_id: TransferId,
+    pub completes_at_ms: f64,
+}
+
+/// Visibility of one G2 key during framework prefix lookup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum G2Lookup {
+    Miss,
+    Pending { transfer_id: TransferId },
+    Hit,
+}
+
+/// Result of loading one visible G2 block into a reserved G1 destination.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum LoadScheduleOutcome {
+    Queued {
+        transfer_id: TransferId,
+        completes_at_ms: f64,
+        loaded_blocks: usize,
+    },
+    Miss,
+}
+
+/// Pending stores that constrain source reuse or request preemption.
+#[derive(Clone, Debug, PartialEq)]
+pub struct SourceFence {
+    pub until_ms: f64,
+    pub transfer_ids: Vec<TransferId>,
+}
+
+/// Whether the supplied G1 sources are safe to reuse at the current time.
+#[derive(Clone, Debug, PartialEq)]
+pub enum SourceFenceOutcome {
+    /// No matching store is prepared or in flight.
+    Ready,
+    /// Matching stores have not entered the D2H lane. The framework must
+    /// submit prepared stores and query the fence again.
+    NeedsSubmission { transfer_ids: Vec<TransferId> },
+    /// Matching stores are in flight until the reported deadline.
+    Pending(SourceFence),
+}
+
+/// Transfer completion returned to the framework adapter.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum CompletedTransfer {
+    Store {
+        transfer_id: TransferId,
+        blocks: Vec<StoreBlock>,
+    },
+    Load {
+        transfer_id: TransferId,
+        blocks: Vec<LoadBlock>,
+    },
+}
+
+/// State changes produced by advancing the simulation clock.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct HostOffloadEffects {
+    pub completed: Vec<CompletedTransfer>,
+}
+
+/// G2 residency, transfer, and capacity core shared by framework profiles.
+pub struct HostOffloadManager {
+    policy: ResolvedHostOffloadPolicy,
+    config: HostOffloadConfig,
+    entries: FxHashMap<HostBlockKey, G2Entry>,
+    eviction: Box<dyn G2EvictionStrategy>,
+    free_slots: Vec<usize>,
+    transfers: FxHashMap<TransferId, PendingTransfer>,
+    prepared_stores: VecDeque<TransferId>,
+    stores_by_source: FxHashMap<G1Location, Vec<TransferId>>,
+    d2h: FifoTransferLane,
+    h2d: FifoTransferLane,
+    next_transfer_id: u64,
+    current_time_ms: f64,
+    event_sink: Option<Arc<dyn HostOffloadEventSink>>,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct G2Entry {
+    slot: usize,
+    state: G2EntryState,
+    pins: usize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum G2EntryState {
+    PendingStore {
+        transfer_id: TransferId,
+        source: G1Location,
+    },
+    Resident,
+}
+
+#[derive(Clone, Debug)]
+struct PendingTransfer {
+    phase: TransferPhase,
+    kind: PendingTransferKind,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+enum TransferPhase {
+    Prepared,
+    Submitted { completes_at_ms: f64 },
+}
+
+#[derive(Clone, Debug)]
+enum PendingTransferKind {
+    Store { blocks: Vec<StoreBlock> },
+    Load { blocks: Vec<LoadBlock> },
+}
+
+#[derive(Clone, Copy, Debug)]
+struct FifoTransferLane {
+    bytes_per_ms: f64,
+    tail_ms: f64,
+}
+
+impl FifoTransferLane {
+    fn new(gbps: f64) -> Self {
+        let bytes_per_ms = if gbps > 0.0 {
+            gbps * 1_000_000.0
+        } else {
+            f64::INFINITY
+        };
+        Self {
+            bytes_per_ms,
+            tail_ms: 0.0,
+        }
+    }
+
+    fn submit(&mut self, now_ms: f64, bytes: usize) -> f64 {
+        let start_ms = now_ms.max(self.tail_ms);
+        let duration_ms = if self.bytes_per_ms.is_finite() {
+            bytes as f64 / self.bytes_per_ms
+        } else {
+            0.0
+        };
+        self.tail_ms = start_ms + duration_ms;
+        self.tail_ms
+    }
+}
+
+impl HostOffloadManager {
+    pub fn new(config: HostOffloadConfig, policy: ResolvedHostOffloadPolicy) -> Result<Self> {
+        Self::build(config, policy, None)
+    }
+
+    pub fn with_event_sink(
+        config: HostOffloadConfig,
+        policy: ResolvedHostOffloadPolicy,
+        event_sink: Arc<dyn HostOffloadEventSink>,
+    ) -> Result<Self> {
+        Self::build(config, policy, Some(event_sink))
+    }
+
+    fn build(
+        config: HostOffloadConfig,
+        policy: ResolvedHostOffloadPolicy,
+        event_sink: Option<Arc<dyn HostOffloadEventSink>>,
+    ) -> Result<Self> {
+        let config = config.validate()?;
+        validate_supported_policy(policy)?;
+        let eviction = build_g2_eviction_strategy(policy.g2_eviction())?;
+        let free_slots = (0..config.capacity_blocks).rev().collect();
+        Ok(Self {
+            policy,
+            config,
+            entries: FxHashMap::default(),
+            eviction,
+            free_slots,
+            transfers: FxHashMap::default(),
+            prepared_stores: VecDeque::new(),
+            stores_by_source: FxHashMap::default(),
+            d2h: FifoTransferLane::new(config.d2h_bandwidth_gbps),
+            h2d: FifoTransferLane::new(config.h2d_bandwidth_gbps),
+            next_transfer_id: 0,
+            current_time_ms: 0.0,
+            event_sink,
+        })
+    }
+
+    pub fn policy(&self) -> ResolvedHostOffloadPolicy {
+        self.policy
+    }
+
+    pub fn config(&self) -> HostOffloadConfig {
+        self.config
+    }
+
+    /// Atomically reserve G2 capacity and prepare one D2H store job for a
+    /// framework-selected block batch.
+    ///
+    /// The adapter must call [`Self::tick`] at the start of each scheduler
+    /// pass before scheduling work at that pass's time.
+    pub fn prepare_store(&mut self, blocks: &[StoreBlock], now_ms: f64) -> PrepareStoreOutcome {
+        let now_ms = self.prepare_schedule(now_ms);
+        let protected: Vec<_> = blocks.iter().map(|block| block.key).collect();
+        let mut seen = FxHashSet::default();
+        let blocks: Vec<_> = blocks
+            .iter()
+            .copied()
+            .filter(|block| seen.insert(block.key) && !self.entries.contains_key(&block.key))
+            .collect();
+        if blocks.is_empty() {
+            return PrepareStoreOutcome::AlreadyPresent;
+        }
+
+        let Some(slots) = self.reserve_g2_slots(blocks.len(), &protected, now_ms) else {
+            for block in &blocks {
+                self.record(HostOffloadEvent::CapacityRetry {
+                    at_ms: now_ms,
+                    key: block.key,
+                });
+            }
+            return PrepareStoreOutcome::RetryCapacity;
+        };
+
+        let transfer_id = self.next_transfer_id();
+        for (block, slot) in blocks.iter().zip(slots) {
+            self.entries.insert(
+                block.key,
+                G2Entry {
+                    slot,
+                    state: G2EntryState::PendingStore {
+                        transfer_id,
+                        source: block.source,
+                    },
+                    pins: 0,
+                },
+            );
+            let source_jobs = self.stores_by_source.entry(block.source).or_default();
+            if !source_jobs.contains(&transfer_id) {
+                source_jobs.push(transfer_id);
+            }
+            self.record(HostOffloadEvent::StorePrepared {
+                at_ms: now_ms,
+                transfer_id,
+                key: block.key,
+                source: block.source,
+                bytes: self.config.block_bytes,
+            });
+        }
+        self.transfers.insert(
+            transfer_id,
+            PendingTransfer {
+                phase: TransferPhase::Prepared,
+                kind: PendingTransferKind::Store {
+                    blocks: blocks.clone(),
+                },
+            },
+        );
+        self.prepared_stores.push_back(transfer_id);
+        PrepareStoreOutcome::Prepared {
+            transfer_id,
+            stored_blocks: blocks.len(),
+        }
+    }
+
+    /// Submit every prepared store at the beginning of an engine step.
+    ///
+    /// Stores share one FIFO D2H lane and are submitted in transfer-id order,
+    /// which is their framework preparation order.
+    pub fn submit_prepared_stores(&mut self, now_ms: f64) -> Vec<SubmittedStore> {
+        let now_ms = self.prepare_schedule(now_ms);
+        let mut submitted = Vec::with_capacity(self.prepared_stores.len());
+        while let Some(transfer_id) = self.prepared_stores.pop_front() {
+            let blocks = match &self
+                .transfers
+                .get(&transfer_id)
+                .expect("prepared store must remain registered")
+                .kind
+            {
+                PendingTransferKind::Store { blocks } => blocks.clone(),
+                PendingTransferKind::Load { .. } => {
+                    unreachable!("prepared queue can contain only store jobs")
+                }
+            };
+            let completes_at_ms = self.d2h.submit(now_ms, self.transfer_bytes(blocks.len()));
+            let transfer = self
+                .transfers
+                .get_mut(&transfer_id)
+                .expect("prepared store must remain registered");
+            debug_assert_eq!(transfer.phase, TransferPhase::Prepared);
+            transfer.phase = TransferPhase::Submitted { completes_at_ms };
+            for block in &blocks {
+                self.record(HostOffloadEvent::StoreQueued {
+                    at_ms: now_ms,
+                    transfer_id,
+                    key: block.key,
+                    source: block.source,
+                    bytes: self.config.block_bytes,
+                });
+            }
+            submitted.push(SubmittedStore {
+                transfer_id,
+                completes_at_ms,
+            });
+        }
+        submitted
+    }
+
+    /// Query one host key. Framework adapters own prefix scanning because
+    /// pending results have framework-specific deferral behavior.
+    pub fn lookup(&self, key: HostBlockKey) -> G2Lookup {
+        match self.entries.get(&key).map(|entry| entry.state) {
+            None => G2Lookup::Miss,
+            Some(G2EntryState::PendingStore { transfer_id, .. }) => {
+                G2Lookup::Pending { transfer_id }
+            }
+            Some(G2EntryState::Resident) => G2Lookup::Hit,
+        }
+    }
+
+    /// Mark one visible G2 block most-recently used.
+    ///
+    /// Framework adapters own batch ordering. For example, vLLM touches a
+    /// logical prefix in reverse order so its earliest block becomes MRU.
+    pub fn touch(&mut self, key: HostBlockKey) {
+        if self
+            .entries
+            .get(&key)
+            .is_some_and(|entry| entry.state == G2EntryState::Resident && entry.pins == 0)
+        {
+            self.touch_resident(key);
+        }
+    }
+
+    /// Enqueue one load job for a visible G2 block batch.
+    pub fn schedule_load(&mut self, blocks: &[LoadBlock], now_ms: f64) -> LoadScheduleOutcome {
+        self.schedule_load_not_before(blocks, now_ms, now_ms)
+    }
+
+    /// Enqueue one load job after an external source-reuse fence.
+    ///
+    /// `now_ms` is the scheduler decision time, while `not_before_ms` is the
+    /// earliest instant at which the worker may start H2D. This models vLLM's
+    /// allocation-before-worker-flush ordering: the destination may be
+    /// reserved immediately, but cannot be overwritten until a pending D2H
+    /// reading that physical block completes.
+    pub fn schedule_load_not_before(
+        &mut self,
+        blocks: &[LoadBlock],
+        now_ms: f64,
+        not_before_ms: f64,
+    ) -> LoadScheduleOutcome {
+        let now_ms = self.prepare_schedule(now_ms);
+        assert_valid_time("host-offload load not-before time", not_before_ms);
+        let not_before_ms = not_before_ms.max(now_ms);
+        if blocks.is_empty()
+            || blocks.len() > self.config.capacity_blocks
+            || blocks.iter().any(|block| {
+                !self
+                    .entries
+                    .get(&block.key)
+                    .is_some_and(|entry| entry.state == G2EntryState::Resident)
+            })
+        {
+            return LoadScheduleOutcome::Miss;
+        }
+        for block in blocks {
+            let became_pinned = {
+                let entry = self
+                    .entries
+                    .get_mut(&block.key)
+                    .expect("validated G2 load block must remain resident");
+                let became_pinned = entry.pins == 0;
+                entry.pins = entry
+                    .pins
+                    .checked_add(1)
+                    .expect("G2 load pin count exhausted");
+                became_pinned
+            };
+            if became_pinned {
+                self.eviction.on_pin(block.key);
+            }
+        }
+
+        let transfer_id = self.next_transfer_id();
+        let bytes = self.transfer_bytes(blocks.len());
+        let completes_at_ms = self.h2d.submit(not_before_ms, bytes);
+        self.transfers.insert(
+            transfer_id,
+            PendingTransfer {
+                phase: TransferPhase::Submitted { completes_at_ms },
+                kind: PendingTransferKind::Load {
+                    blocks: blocks.to_vec(),
+                },
+            },
+        );
+        for block in blocks {
+            self.record(HostOffloadEvent::LoadQueued {
+                at_ms: now_ms,
+                transfer_id,
+                key: block.key,
+                destination: block.destination,
+                bytes: self.config.block_bytes,
+            });
+        }
+        LoadScheduleOutcome::Queued {
+            transfer_id,
+            completes_at_ms,
+            loaded_blocks: blocks.len(),
+        }
+    }
+
+    /// Cancel an in-flight load and release its G2 pins. The H2D lane tail is
+    /// intentionally left unchanged so loads already queued behind it keep a
+    /// conservative completion time.
+    pub fn cancel_load(&mut self, transfer_id: TransferId) -> bool {
+        let Some(transfer) = self.transfers.remove(&transfer_id) else {
+            return false;
+        };
+        let PendingTransferKind::Load { blocks } = transfer.kind else {
+            self.transfers.insert(transfer_id, transfer);
+            return false;
+        };
+        for block in blocks {
+            let became_evictable = {
+                let entry = self
+                    .entries
+                    .get_mut(&block.key)
+                    .expect("cancelled load must retain its G2 entry");
+                entry.pins = entry
+                    .pins
+                    .checked_sub(1)
+                    .expect("cancelled G2 load must hold a pin");
+                entry.pins == 0
+            };
+            if became_evictable {
+                self.eviction.on_unpin(block.key);
+            }
+        }
+        true
+    }
+
+    /// Report what must happen before the supplied G1 sources can be reused or
+    /// released by preemption.
+    ///
+    /// When this returns [`SourceFenceOutcome::NeedsSubmission`], framework
+    /// adapters that flush as part of their fence semantics must call
+    /// [`Self::submit_prepared_stores`] and query again.
+    pub fn fence_sources(
+        &mut self,
+        sources: &[G1Location],
+        reason: SourceFenceReason,
+        now_ms: f64,
+    ) -> SourceFenceOutcome {
+        let now_ms = self.prepare_schedule(now_ms);
+        let mut needs_submission = Vec::new();
+        let mut pending = Vec::new();
+        let mut fenced_blocks = Vec::new();
+        let mut until_ms = now_ms;
+        for source in sources {
+            let Some(ids) = self.stores_by_source.get(source) else {
+                continue;
+            };
+            for transfer_id in ids {
+                let Some(transfer) = self.transfers.get(transfer_id) else {
+                    continue;
+                };
+                let PendingTransferKind::Store { blocks } = &transfer.kind else {
+                    continue;
+                };
+                match transfer.phase {
+                    TransferPhase::Prepared => needs_submission.push(*transfer_id),
+                    TransferPhase::Submitted { completes_at_ms } => {
+                        until_ms = until_ms.max(completes_at_ms);
+                        pending.push(*transfer_id);
+                        fenced_blocks.extend(
+                            blocks
+                                .iter()
+                                .filter(|block| block.source == *source)
+                                .map(|block| (*transfer_id, *block)),
+                        );
+                    }
+                }
+            }
+        }
+
+        if !needs_submission.is_empty() {
+            needs_submission.sort_unstable();
+            needs_submission.dedup();
+            return SourceFenceOutcome::NeedsSubmission {
+                transfer_ids: needs_submission,
+            };
+        }
+        if pending.is_empty() {
+            return SourceFenceOutcome::Ready;
+        }
+
+        pending.sort_unstable();
+        pending.dedup();
+        fenced_blocks
+            .sort_unstable_by_key(|(transfer_id, block)| (*transfer_id, block.source, block.key));
+        fenced_blocks.dedup();
+        for (transfer_id, block) in fenced_blocks {
+            self.record(HostOffloadEvent::SourceFenced {
+                at_ms: now_ms,
+                transfer_id,
+                key: block.key,
+                source: block.source,
+                reason,
+            });
+        }
+        SourceFenceOutcome::Pending(SourceFence {
+            until_ms,
+            transfer_ids: pending,
+        })
+    }
+
+    /// Advance transfer state and make completed stores visible in G2.
+    pub fn tick(&mut self, now_ms: f64) -> HostOffloadEffects {
+        assert_valid_time("host-offload tick", now_ms);
+        if now_ms < self.current_time_ms {
+            return HostOffloadEffects::default();
+        }
+        self.current_time_ms = now_ms;
+        let mut ready: Vec<_> = self
+            .transfers
+            .iter()
+            .filter_map(|(id, transfer)| {
+                let TransferPhase::Submitted { completes_at_ms } = transfer.phase else {
+                    return None;
+                };
+                (completes_at_ms <= now_ms).then_some((completes_at_ms, *id))
+            })
+            .collect();
+        ready.sort_by(|left, right| {
+            left.0
+                .total_cmp(&right.0)
+                .then_with(|| left.1.cmp(&right.1))
+        });
+
+        let mut effects = HostOffloadEffects::default();
+        for (completes_at_ms, transfer_id) in ready {
+            let transfer = self
+                .transfers
+                .remove(&transfer_id)
+                .expect("ready transfer must remain registered");
+            match transfer.kind {
+                PendingTransferKind::Store { blocks } => {
+                    // The framework does not expose a semantic recency order
+                    // among blocks completing in one job. Keep adapter order
+                    // deterministic; parity workloads must touch blocks before
+                    // asserting an LRU victim from such a tie.
+                    for block in &blocks {
+                        let entry = self
+                            .entries
+                            .get_mut(&block.key)
+                            .expect("pending store must reserve a G2 entry");
+                        debug_assert_eq!(
+                            entry.state,
+                            G2EntryState::PendingStore {
+                                transfer_id,
+                                source: block.source
+                            }
+                        );
+                        entry.state = G2EntryState::Resident;
+                        self.remove_source_transfer(block.source, transfer_id);
+                        self.eviction.on_resident(block.key);
+                        self.record(HostOffloadEvent::StoreCompleted {
+                            at_ms: completes_at_ms,
+                            transfer_id,
+                            key: block.key,
+                        });
+                    }
+                    effects.completed.push(CompletedTransfer::Store {
+                        transfer_id,
+                        blocks,
+                    });
+                }
+                PendingTransferKind::Load { blocks } => {
+                    for block in &blocks {
+                        let became_evictable = {
+                            let entry = self
+                                .entries
+                                .get_mut(&block.key)
+                                .expect("in-flight load must pin a G2 entry");
+                            entry.pins = entry
+                                .pins
+                                .checked_sub(1)
+                                .expect("completed G2 load must hold a pin");
+                            entry.pins == 0
+                        };
+                        if became_evictable {
+                            self.eviction.on_unpin(block.key);
+                        }
+                        self.record(HostOffloadEvent::LoadCompleted {
+                            at_ms: completes_at_ms,
+                            transfer_id,
+                            key: block.key,
+                        });
+                    }
+                    effects.completed.push(CompletedTransfer::Load {
+                        transfer_id,
+                        blocks,
+                    });
+                }
+            }
+        }
+        effects
+    }
+
+    pub fn next_deadline(&self) -> Option<f64> {
+        self.transfers
+            .values()
+            .filter_map(|transfer| match transfer.phase {
+                TransferPhase::Prepared => None,
+                TransferPhase::Submitted { completes_at_ms } => Some(completes_at_ms),
+            })
+            .min_by(f64::total_cmp)
+    }
+
+    pub fn has_pending_work(&self) -> bool {
+        !self.transfers.is_empty()
+    }
+
+    /// Prepared stores require another engine step even though they do not
+    /// have a transfer deadline yet.
+    pub fn needs_engine_step(&self) -> bool {
+        !self.prepared_stores.is_empty()
+    }
+
+    /// Blocks consuming G2 capacity, including pending stores.
+    pub fn used_blocks(&self) -> usize {
+        self.entries.len()
+    }
+
+    /// Visible, fully stored blocks.
+    pub fn resident_blocks(&self) -> usize {
+        self.entries
+            .values()
+            .filter(|entry| entry.state == G2EntryState::Resident)
+            .count()
+    }
+
+    pub fn is_resident(&self, key: HostBlockKey) -> bool {
+        self.entries
+            .get(&key)
+            .is_some_and(|entry| entry.state == G2EntryState::Resident)
+    }
+
+    pub fn resident_snapshot(&self) -> Vec<HostBlockKey> {
+        let mut keys: Vec<_> = self
+            .entries
+            .iter()
+            .filter_map(|(key, entry)| (entry.state == G2EntryState::Resident).then_some(*key))
+            .collect();
+        keys.sort_unstable_by(|left, right| {
+            left.group_index
+                .cmp(&right.group_index)
+                .then_with(|| left.parent.cmp(&right.parent))
+                .then_with(|| left.token_digest.cmp(&right.token_digest))
+        });
+        keys
+    }
+
+    fn reserve_g2_slots(
+        &mut self,
+        needed: usize,
+        protected: &[HostBlockKey],
+        now_ms: f64,
+    ) -> Option<Vec<usize>> {
+        debug_assert!(needed > 0);
+        let to_evict = needed.saturating_sub(self.free_slots.len());
+        let protected: FxHashSet<_> = protected.iter().copied().collect();
+        let entries = &self.entries;
+        let victims = self.eviction.select_victims(to_evict, &mut |key| {
+            !protected.contains(&key)
+                && entries
+                    .get(&key)
+                    .is_some_and(|entry| entry.state == G2EntryState::Resident && entry.pins == 0)
+        });
+        if victims.len() < to_evict {
+            return None;
+        }
+
+        for victim in victims {
+            let entry = self
+                .entries
+                .remove(&victim)
+                .expect("selected G2 victim must remain resident");
+            debug_assert_eq!(entry.state, G2EntryState::Resident);
+            debug_assert_eq!(entry.pins, 0);
+            self.eviction.on_remove(victim);
+            self.free_slots.push(entry.slot);
+            self.record(HostOffloadEvent::G2Evicted {
+                at_ms: now_ms,
+                key: victim,
+            });
+        }
+
+        Some(
+            (0..needed)
+                .map(|_| {
+                    self.free_slots
+                        .pop()
+                        .expect("validated G2 capacity must provide enough slots")
+                })
+                .collect(),
+        )
+    }
+
+    fn prepare_schedule(&mut self, now_ms: f64) -> f64 {
+        assert_valid_time("host-offload schedule time", now_ms);
+        let now_ms = now_ms.max(self.current_time_ms);
+        assert!(
+            self.next_deadline()
+                .is_none_or(|deadline| deadline >= now_ms),
+            "tick must process host-offload completions through {now_ms} ms before scheduling"
+        );
+        self.current_time_ms = now_ms;
+        now_ms
+    }
+
+    fn touch_resident(&mut self, key: HostBlockKey) {
+        let entry = self.entries.get(&key).expect("touched G2 block must exist");
+        debug_assert_eq!(entry.state, G2EntryState::Resident);
+        debug_assert_eq!(entry.pins, 0);
+        self.eviction.on_access(key);
+    }
+
+    fn next_transfer_id(&mut self) -> TransferId {
+        let id = TransferId::new(self.next_transfer_id);
+        self.next_transfer_id = self
+            .next_transfer_id
+            .checked_add(1)
+            .expect("host-offload transfer id counter exhausted");
+        id
+    }
+
+    fn transfer_bytes(&self, blocks: usize) -> usize {
+        self.config
+            .block_bytes
+            .checked_mul(blocks)
+            .expect("host-offload transfer byte count overflowed")
+    }
+
+    fn remove_source_transfer(&mut self, source: G1Location, transfer_id: TransferId) {
+        let remove_entry = if let Some(ids) = self.stores_by_source.get_mut(&source) {
+            ids.retain(|id| *id != transfer_id);
+            ids.is_empty()
+        } else {
+            false
+        };
+        if remove_entry {
+            self.stores_by_source.remove(&source);
+        }
+    }
+
+    fn record(&self, event: HostOffloadEvent) {
+        if let Some(event_sink) = &self.event_sink {
+            event_sink.record(&event);
+        }
+    }
+}
+
+fn validate_bandwidth(direction: &str, gbps: f64, max_transfer_bytes: usize) -> Result<()> {
+    if !gbps.is_finite() || gbps < 0.0 {
+        bail!("host-offload {direction} bandwidth must be finite and non-negative, got {gbps}");
+    }
+    let bytes_per_ms = gbps * 1_000_000.0;
+    if !bytes_per_ms.is_finite() {
+        bail!("host-offload {direction} bandwidth conversion overflowed");
+    }
+    if gbps > 0.0 {
+        let max_duration_ms = max_transfer_bytes as f64 / bytes_per_ms;
+        if !max_duration_ms.is_finite() {
+            bail!("host-offload {direction} worst-case transfer duration overflowed");
+        }
+    }
+    Ok(())
+}
+
+fn validate_supported_policy(policy: ResolvedHostOffloadPolicy) -> Result<()> {
+    // The neutral manager validates only policy dimensions that alter its G2
+    // mechanics. Every framework adapter must exhaustively validate the
+    // remaining scheduler-owned dimensions before constructing this manager.
+    if policy.capacity_handling() != CapacityHandling::EvictOrRetry {
+        bail!("the host-offload PoC supports only evict-or-retry capacity handling");
+    }
+    if policy.post_load_residency() != PostLoadResidency::RetainG2Copy {
+        bail!("the host-offload PoC supports only retaining the G2 copy after load");
+    }
+    Ok(())
+}
+
+fn assert_valid_time(label: &str, time_ms: f64) {
+    assert!(
+        time_ms.is_finite() && time_ms >= 0.0,
+        "{label} must be finite and non-negative, got {time_ms}"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use super::*;
+
+    #[derive(Default)]
+    struct CapturingSink(Mutex<Vec<HostOffloadEvent>>);
+
+    impl HostOffloadEventSink for CapturingSink {
+        fn record(&self, event: &HostOffloadEvent) {
+            self.0.lock().unwrap().push(event.clone());
+        }
+    }
+
+    fn key(value: u8) -> HostBlockKey {
+        HostBlockKey::new(0, None, [value; 32])
+    }
+
+    fn store(key_value: u8, source: u64) -> StoreBlock {
+        StoreBlock {
+            key: key(key_value),
+            source: G1Location::new(source),
+        }
+    }
+
+    fn load(key_value: u8, destination: u64) -> LoadBlock {
+        LoadBlock {
+            key: key(key_value),
+            destination: G1Location::new(destination),
+        }
+    }
+
+    fn manager(capacity_blocks: usize) -> HostOffloadManager {
+        HostOffloadManager::new(
+            HostOffloadConfig {
+                capacity_blocks,
+                block_bytes: 1_000_000,
+                d2h_bandwidth_gbps: 1.0,
+                h2d_bandwidth_gbps: 1.0,
+            },
+            ResolvedHostOffloadPolicy::vllm_offloading_connector_defaults(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn store_is_prepared_then_submitted_on_the_next_step() {
+        let mut manager = manager(1);
+        let outcome = manager.prepare_store(&[store(1, 10)], 0.0);
+        assert_eq!(
+            outcome,
+            PrepareStoreOutcome::Prepared {
+                transfer_id: TransferId::new(0),
+                stored_blocks: 1,
+            }
+        );
+        assert_eq!(manager.used_blocks(), 1);
+        assert_eq!(manager.resident_blocks(), 0);
+        assert_eq!(
+            manager.lookup(key(1)),
+            G2Lookup::Pending {
+                transfer_id: TransferId::new(0)
+            }
+        );
+        assert!(manager.needs_engine_step());
+        assert_eq!(manager.next_deadline(), None);
+        assert!(manager.tick(0.5).completed.is_empty());
+
+        assert_eq!(
+            manager.submit_prepared_stores(1.0),
+            vec![SubmittedStore {
+                transfer_id: TransferId::new(0),
+                completes_at_ms: 2.0,
+            }]
+        );
+        assert!(!manager.needs_engine_step());
+        assert_eq!(manager.next_deadline(), Some(2.0));
+
+        assert!(manager.tick(1.5).completed.is_empty());
+        let effects = manager.tick(2.0);
+        assert_eq!(manager.resident_blocks(), 1);
+        assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+        assert_eq!(
+            effects.completed,
+            vec![CompletedTransfer::Store {
+                transfer_id: TransferId::new(0),
+                blocks: vec![store(1, 10)],
+            }]
+        );
+    }
+
+    #[test]
+    fn batch_store_becomes_visible_atomically() {
+        let mut manager = manager(2);
+        assert_eq!(
+            manager.prepare_store(&[store(1, 1), store(2, 2)], 0.0),
+            PrepareStoreOutcome::Prepared {
+                transfer_id: TransferId::new(0),
+                stored_blocks: 2,
+            }
+        );
+        assert_eq!(
+            manager.submit_prepared_stores(1.0),
+            vec![SubmittedStore {
+                transfer_id: TransferId::new(0),
+                completes_at_ms: 3.0,
+            }]
+        );
+
+        manager.tick(2.0);
+        assert_eq!(
+            manager.lookup(key(1)),
+            G2Lookup::Pending {
+                transfer_id: TransferId::new(0)
+            }
+        );
+        assert_eq!(
+            manager.lookup(key(2)),
+            G2Lookup::Pending {
+                transfer_id: TransferId::new(0)
+            }
+        );
+        let effects = manager.tick(3.0);
+        assert_eq!(manager.resident_snapshot(), vec![key(1), key(2)]);
+        assert_eq!(
+            effects.completed,
+            vec![CompletedTransfer::Store {
+                transfer_id: TransferId::new(0),
+                blocks: vec![store(1, 1), store(2, 2)],
+            }]
+        );
+    }
+
+    #[test]
+    fn presence_filter_deduplicates_pending_and_resident_stores() {
+        let mut manager = manager(1);
+        manager.prepare_store(&[store(1, 10)], 0.0);
+        assert_eq!(
+            manager.prepare_store(&[store(1, 11)], 0.0),
+            PrepareStoreOutcome::AlreadyPresent
+        );
+        manager.submit_prepared_stores(0.0);
+        manager.tick(1.0);
+        assert_eq!(
+            manager.prepare_store(&[store(1, 11)], 1.0),
+            PrepareStoreOutcome::AlreadyPresent
+        );
+    }
+
+    #[test]
+    fn store_batch_protects_existing_input_keys_from_eviction() {
+        let mut manager = manager(1);
+        manager.prepare_store(&[store(1, 1)], 0.0);
+        manager.submit_prepared_stores(0.0);
+        manager.tick(1.0);
+
+        assert_eq!(
+            manager.prepare_store(&[store(1, 1), store(2, 2)], 1.0),
+            PrepareStoreOutcome::RetryCapacity
+        );
+        assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+        assert_eq!(manager.lookup(key(2)), G2Lookup::Miss);
+
+        // A rejected atomic admission only previews victims. The next
+        // unprotected admission must still be able to select the same LRU.
+        assert!(matches!(
+            manager.prepare_store(&[store(3, 3)], 1.0),
+            PrepareStoreOutcome::Prepared { .. }
+        ));
+        assert_eq!(manager.lookup(key(1)), G2Lookup::Miss);
+    }
+
+    #[test]
+    fn vllm_touch_order_controls_lru_victim() {
+        let mut manager = manager(2);
+        manager.prepare_store(&[store(1, 1), store(2, 2)], 0.0);
+        manager.submit_prepared_stores(0.0);
+        manager.tick(2.0);
+        // vLLM reverses the logical prefix when applying LRU touches.
+        manager.touch(key(2));
+        manager.touch(key(1));
+
+        manager.prepare_store(&[store(3, 3)], 2.0);
+        assert!(manager.is_resident(key(1)));
+        assert!(!manager.is_resident(key(2)));
+        assert!(!manager.is_resident(key(3)));
+    }
+
+    #[test]
+    fn pinned_load_causes_capacity_retry_not_drop() {
+        let mut manager = manager(1);
+        manager.prepare_store(&[store(1, 1)], 0.0);
+        manager.submit_prepared_stores(0.0);
+        manager.tick(1.0);
+        manager.schedule_load(&[load(1, 9)], 1.0);
+
+        assert_eq!(
+            manager.prepare_store(&[store(2, 2)], 1.0),
+            PrepareStoreOutcome::RetryCapacity
+        );
+        assert!(manager.is_resident(key(1)));
+
+        manager.tick(2.0);
+        assert!(matches!(
+            manager.prepare_store(&[store(2, 2)], 2.0),
+            PrepareStoreOutcome::Prepared { .. }
+        ));
+        assert!(!manager.is_resident(key(1)));
+    }
+
+    #[test]
+    fn cancelled_load_returns_g2_block_to_evictable_lru() {
+        let mut manager = manager(1);
+        manager.prepare_store(&[store(1, 1)], 0.0);
+        manager.submit_prepared_stores(0.0);
+        manager.tick(1.0);
+        let transfer_id = match manager.schedule_load(&[load(1, 9)], 1.0) {
+            LoadScheduleOutcome::Queued { transfer_id, .. } => transfer_id,
+            outcome => panic!("resident block must queue a load, got {outcome:?}"),
+        };
+
+        assert_eq!(
+            manager.prepare_store(&[store(2, 2)], 1.0),
+            PrepareStoreOutcome::RetryCapacity,
+            "in-flight load must pin its G2 source"
+        );
+        assert!(manager.cancel_load(transfer_id));
+        assert!(matches!(
+            manager.prepare_store(&[store(2, 2)], 1.0),
+            PrepareStoreOutcome::Prepared { .. }
+        ));
+        assert!(!manager.is_resident(key(1)));
+    }
+
+    #[test]
+    fn manager_eligibility_excludes_pinned_and_cohort_protected_blocks() {
+        let mut manager = manager(3);
+        manager.prepare_store(&[store(1, 1), store(2, 2), store(3, 3)], 0.0);
+        manager.submit_prepared_stores(0.0);
+        manager.tick(3.0);
+
+        manager.schedule_load(&[load(1, 10)], 3.0);
+        assert!(matches!(
+            manager.prepare_store(&[store(2, 2), store(4, 4)], 3.0),
+            PrepareStoreOutcome::Prepared { .. }
+        ));
+
+        assert!(manager.is_resident(key(1)), "pinned block was evicted");
+        assert!(manager.is_resident(key(2)), "protected block was evicted");
+        assert!(!manager.is_resident(key(3)), "eligible LRU was retained");
+        assert!(matches!(manager.lookup(key(4)), G2Lookup::Pending { .. }));
+    }
+
+    #[test]
+    fn load_completion_reinserts_block_at_mru() {
+        let mut manager = manager(2);
+        manager.prepare_store(&[store(1, 1), store(2, 2)], 0.0);
+        manager.submit_prepared_stores(0.0);
+        manager.tick(2.0);
+
+        manager.schedule_load(&[load(1, 10)], 2.0);
+        // Active blocks are outside the evictable LRU; framework touches
+        // during the load must not reinsert them early.
+        manager.touch(key(1));
+        manager.tick(3.0);
+        manager.prepare_store(&[store(3, 3)], 3.0);
+
+        assert!(manager.is_resident(key(1)));
+        assert!(!manager.is_resident(key(2)));
+    }
+
+    #[test]
+    fn directional_lanes_overlap_and_each_lane_is_fifo() {
+        let mut manager = manager(3);
+        manager.prepare_store(&[store(1, 1)], 0.0);
+        assert_eq!(manager.submit_prepared_stores(0.0)[0].completes_at_ms, 1.0);
+        manager.tick(1.0);
+        manager.prepare_store(&[store(2, 2)], 1.0);
+        manager.prepare_store(&[store(3, 3)], 1.0);
+        let submitted = manager.submit_prepared_stores(1.0);
+        assert_eq!(submitted[0].completes_at_ms, 2.0);
+        assert_eq!(submitted[1].completes_at_ms, 3.0);
+        assert!(matches!(
+            manager.schedule_load(&[load(1, 10)], 1.0),
+            LoadScheduleOutcome::Queued {
+                completes_at_ms: 2.0,
+                loaded_blocks: 1,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn source_fence_reports_pending_store_deadline() {
+        let sink = Arc::new(CapturingSink::default());
+        let mut manager = HostOffloadManager::with_event_sink(
+            HostOffloadConfig {
+                capacity_blocks: 1,
+                block_bytes: 1_000_000,
+                d2h_bandwidth_gbps: 1.0,
+                h2d_bandwidth_gbps: 1.0,
+            },
+            ResolvedHostOffloadPolicy::vllm_offloading_connector_defaults(),
+            sink.clone(),
+        )
+        .unwrap();
+        manager.prepare_store(&[store(1, 7)], 0.0);
+
+        assert_eq!(
+            manager.fence_sources(&[G1Location::new(7)], SourceFenceReason::SourceReuse, 0.25),
+            SourceFenceOutcome::NeedsSubmission {
+                transfer_ids: vec![TransferId::new(0)]
+            }
+        );
+        manager.submit_prepared_stores(0.25);
+
+        let SourceFenceOutcome::Pending(fence) =
+            manager.fence_sources(&[G1Location::new(7)], SourceFenceReason::SourceReuse, 0.25)
+        else {
+            panic!("submitted store must produce a pending source fence");
+        };
+        assert_eq!(fence.until_ms, 1.25);
+        assert_eq!(fence.transfer_ids, vec![TransferId::new(0)]);
+        assert_eq!(
+            manager.fence_sources(&[G1Location::new(99)], SourceFenceReason::SourceReuse, 0.25),
+            SourceFenceOutcome::Ready
+        );
+        let events = sink.0.lock().unwrap();
+        assert!(matches!(events[0], HostOffloadEvent::StorePrepared { .. }));
+        assert!(matches!(events[1], HostOffloadEvent::StoreQueued { .. }));
+        assert!(matches!(
+            events[2],
+            HostOffloadEvent::SourceFenced {
+                reason: SourceFenceReason::SourceReuse,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn invalid_capacity_and_bandwidth_are_rejected() {
+        let policy = ResolvedHostOffloadPolicy::vllm_offloading_connector_defaults();
+        let invalid_capacity = HostOffloadConfig {
+            capacity_blocks: 0,
+            block_bytes: 1,
+            d2h_bandwidth_gbps: 1.0,
+            h2d_bandwidth_gbps: 1.0,
+        };
+        assert!(HostOffloadManager::new(invalid_capacity, policy).is_err());
+
+        let invalid_bandwidth = HostOffloadConfig {
+            capacity_blocks: 1,
+            block_bytes: 1,
+            d2h_bandwidth_gbps: f64::NAN,
+            h2d_bandwidth_gbps: 1.0,
+        };
+        assert!(HostOffloadManager::new(invalid_bandwidth, policy).is_err());
+
+        let negative_bandwidth = HostOffloadConfig {
+            capacity_blocks: 1,
+            block_bytes: 1,
+            d2h_bandwidth_gbps: 1.0,
+            h2d_bandwidth_gbps: -1.0,
+        };
+        assert!(HostOffloadManager::new(negative_bandwidth, policy).is_err());
+
+        let overflowing_capacity = HostOffloadConfig {
+            capacity_blocks: usize::MAX,
+            block_bytes: 2,
+            d2h_bandwidth_gbps: 1.0,
+            h2d_bandwidth_gbps: 1.0,
+        };
+        assert!(HostOffloadManager::new(overflowing_capacity, policy).is_err());
+
+        let overflowing_duration = HostOffloadConfig {
+            capacity_blocks: 1,
+            block_bytes: usize::MAX,
+            d2h_bandwidth_gbps: f64::MIN_POSITIVE,
+            h2d_bandwidth_gbps: 1.0,
+        };
+        assert!(HostOffloadManager::new(overflowing_duration, policy).is_err());
+    }
+
+    #[test]
+    fn oversized_load_batch_is_rejected_before_transfer_sizing() {
+        let mut manager = manager(1);
+        assert!(matches!(
+            manager.prepare_store(&[store(1, 10)], 0.0),
+            PrepareStoreOutcome::Prepared { .. }
+        ));
+        manager.submit_prepared_stores(0.0);
+        manager.tick(1.0);
+
+        assert_eq!(
+            manager.schedule_load(&[load(1, 20), load(1, 21)], 1.0),
+            LoadScheduleOutcome::Miss
+        );
+    }
+}

--- a/lib/mocker/src/host_offload/mod.rs
+++ b/lib/mocker/src/host_offload/mod.rs
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Framework-native host-offload simulation primitives.
+//!
+//! The types in this module deliberately avoid framework and KVBM identifiers.
+//! Framework adapters resolve their behavior into [`ResolvedHostOffloadPolicy`]
+//! and interact with the offload core through logical block keys and opaque G1
+//! locations.
+
+mod events;
+mod eviction;
+mod manager;
+mod policy;
+
+pub use events::{
+    G1Location, HostBlockKey, HostOffloadEvent, HostOffloadEventSink, NoopHostOffloadEventSink,
+    SourceFenceReason, TransferDirection, TransferId,
+};
+pub use manager::{
+    CompletedTransfer, G2Lookup, HostOffloadConfig, HostOffloadEffects, HostOffloadManager,
+    LoadBlock, LoadScheduleOutcome, PrepareStoreOutcome, SourceFence, SourceFenceOutcome,
+    StoreBlock, SubmittedStore,
+};
+pub use policy::{
+    CapacityHandling, G2EvictionPolicy, LoadAdmissionHeadroom, LoadExecution, LoadFence,
+    LookupOrder, LookupTiming, LookupTouch, PostLoadResidency, ResolvedHostOffloadPolicy,
+    SchedulerRetry, StoreAdmission, StoreCadence, StoreCohort, StoreExecution, StoreFence,
+    StoreScope, StoreSubmitTiming, StoreTrigger, TransferExecution,
+};

--- a/lib/mocker/src/host_offload/policy.rs
+++ b/lib/mocker/src/host_offload/policy.rs
@@ -1,0 +1,435 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Resolved framework behavior for host-offload simulation.
+//!
+//! Policy dimensions are independent so later framework adapters can select a
+//! new combination without replacing the shared residency and transfer core.
+//! The PoC intentionally exposes only the default vLLM `OffloadingConnector`
+//! resolver; custom and additional framework resolvers can be added once their
+//! behavior is implemented and covered by parity tests.
+
+use serde::Serialize;
+
+/// Scheduler point at which the host tier is consulted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LookupTiming {
+    /// Consult G2 before reserving or allocating the G1 destination.
+    BeforeG1Allocation,
+    /// Consult G2 only after G1 capacity has been allocated.
+    AfterG1Allocation,
+}
+
+/// Order in which cache tiers contribute to a request's reusable prefix.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LookupOrder {
+    /// Match the local G1 prefix first, then scan its contiguous suffix in G2.
+    G1ThenG2,
+    /// Match the host-resident G2 prefix before consulting G1.
+    G2ThenG1,
+}
+
+/// G2 recency updates performed by a framework lookup.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LookupTouch {
+    None,
+    /// Touch only the contiguous G2 prefix returned by the lookup.
+    MatchedPrefix,
+    /// Touch every candidate in reverse logical request order. This includes
+    /// resident candidates after a prefix gap and applies to misses and
+    /// deferred lookups as well as hits.
+    AllCandidatesReverseLogical,
+}
+
+/// How a waiting request is retried when the current pass cannot admit it.
+///
+/// Both choices retain the request for a later scheduler pass. They differ in
+/// whether unrelated waiting requests may still be considered in this pass.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SchedulerRetry {
+    RetryNextPassAndContinue,
+    RetryNextPassAndStop,
+}
+
+/// Logical G1 headroom applied before a new asynchronous host load starts.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadAdmissionHeadroom {
+    None,
+    /// Subtract the unfinished block footprint of every prefill already in
+    /// flight. This prevents multiple non-preemptible loads from committing
+    /// more eventual G1 residency than the worker can satisfy.
+    InflightPrefillRemainders,
+}
+
+/// The scheduler event that creates a store opportunity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreTrigger {
+    BlocksCompleted,
+    RequestCompleted,
+    G1Eviction,
+    RequestSuspended,
+}
+
+/// How often eligible store work is collected from its trigger.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreCadence {
+    Immediate,
+    OncePerEngineStep,
+    OncePerRequest,
+}
+
+/// Capacity-admission cohort formed from eligible store blocks.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreCohort {
+    /// Admit each eligible block independently.
+    IndividualBlocks,
+    /// Admit a request's eligible blocks as one cohort.
+    PerRequest,
+    /// Admit all eligible blocks observed in an engine step as one cohort.
+    EngineStep,
+}
+
+/// The request-owned KV eligible for a store.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreScope {
+    PromptOnly,
+    PromptAndDecode,
+    SuspendedRequest,
+}
+
+/// The filter applied before a store is admitted.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case", tag = "kind")]
+pub enum StoreAdmission {
+    /// Store only blocks that are not already resident in G2.
+    MissingFromG2,
+    /// Require a minimum number of observations in addition to presence.
+    MinimumFrequency { observations: u32 },
+    /// Require a minimum framework retention priority in addition to presence.
+    MinimumRetentionPriority { priority: i32 },
+}
+
+/// What to do when a store cannot immediately reserve G2 capacity.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CapacityHandling {
+    /// Reclaim an evictable G2 block, or leave the store cursor in place so a
+    /// later scheduler pass retries the same block.
+    EvictOrRetry,
+    Skip,
+}
+
+/// Whether transfer completion is on the current scheduler critical path.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TransferExecution {
+    Async,
+    Sync,
+}
+
+/// Scheduler point at which a prepared store enters the transfer lane.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreSubmitTiming {
+    Immediate,
+    NextEngineStep,
+}
+
+/// Dependency that may wait for an asynchronous store.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StoreFence {
+    SourceReuseOrPreemption,
+}
+
+/// Resolved store execution behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct StoreExecution {
+    mode: TransferExecution,
+    submit_timing: StoreSubmitTiming,
+    fence: Option<StoreFence>,
+}
+
+impl StoreExecution {
+    pub fn mode(self) -> TransferExecution {
+        self.mode
+    }
+
+    pub fn submit_timing(self) -> StoreSubmitTiming {
+        self.submit_timing
+    }
+
+    pub fn fence(self) -> Option<StoreFence> {
+        self.fence
+    }
+}
+
+/// Dependency that may wait for an asynchronous load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LoadFence {
+    DependentRequest,
+}
+
+/// Resolved load execution behavior.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct LoadExecution {
+    mode: TransferExecution,
+    fence: Option<LoadFence>,
+}
+
+impl LoadExecution {
+    pub fn mode(self) -> TransferExecution {
+        self.mode
+    }
+
+    pub fn fence(self) -> Option<LoadFence> {
+        self.fence
+    }
+}
+
+/// Victim selection in the host-resident tier.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum G2EvictionPolicy {
+    Lru,
+    Arc,
+    RetentionPriorityLru,
+}
+
+/// Residency of a host block after a successful G2-to-G1 load.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PostLoadResidency {
+    RetainG2Copy,
+    ReleaseG2Copy,
+}
+
+/// Fully resolved target framework behavior consumed by the scheduler adapter
+/// and shared offload core.
+///
+/// Fields are private so unsupported policy combinations cannot be presented
+/// as native framework behavior. Add a resolver only with the corresponding
+/// implementation and parity coverage. A transition gap must be called out at
+/// the adapter boundary rather than silently ignored.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]
+pub struct ResolvedHostOffloadPolicy {
+    lookup_timing: LookupTiming,
+    lookup_order: LookupOrder,
+    lookup_touch: LookupTouch,
+    lookup_deferred_retry: SchedulerRetry,
+    g1_capacity_retry: SchedulerRetry,
+    load_admission_headroom: LoadAdmissionHeadroom,
+    store_trigger: StoreTrigger,
+    store_cadence: StoreCadence,
+    store_cohort: StoreCohort,
+    store_scope: StoreScope,
+    store_admission: StoreAdmission,
+    capacity_handling: CapacityHandling,
+    store_execution: StoreExecution,
+    load_execution: LoadExecution,
+    g2_eviction: G2EvictionPolicy,
+    post_load_residency: PostLoadResidency,
+}
+
+impl ResolvedHostOffloadPolicy {
+    /// Resolve the default CPU path of vLLM's `OffloadingConnector`.
+    pub fn vllm_offloading_connector_defaults() -> Self {
+        Self {
+            // vLLM first resolves the local prefix, then asks the connector
+            // for a contiguous G2 suffix before allocating destination slots.
+            lookup_timing: LookupTiming::BeforeG1Allocation,
+            lookup_order: LookupOrder::G1ThenG2,
+            lookup_touch: LookupTouch::AllCandidatesReverseLogical,
+            // A pending store or an already in-flight load defers only this
+            // request; the waiting queue continues. G1 allocation failure
+            // stops the waiting loop. Both cases retry on a later pass.
+            lookup_deferred_retry: SchedulerRetry::RetryNextPassAndContinue,
+            g1_capacity_retry: SchedulerRetry::RetryNextPassAndStop,
+            load_admission_headroom: LoadAdmissionHeadroom::InflightPrefillRemainders,
+            store_trigger: StoreTrigger::BlocksCompleted,
+            store_cadence: StoreCadence::OncePerEngineStep,
+            store_cohort: StoreCohort::PerRequest,
+            store_scope: StoreScope::PromptOnly,
+            store_admission: StoreAdmission::MissingFromG2,
+            capacity_handling: CapacityHandling::EvictOrRetry,
+            store_execution: StoreExecution {
+                mode: TransferExecution::Async,
+                submit_timing: StoreSubmitTiming::NextEngineStep,
+                fence: Some(StoreFence::SourceReuseOrPreemption),
+            },
+            load_execution: LoadExecution {
+                mode: TransferExecution::Async,
+                fence: Some(LoadFence::DependentRequest),
+            },
+            g2_eviction: G2EvictionPolicy::Lru,
+            post_load_residency: PostLoadResidency::RetainG2Copy,
+        }
+    }
+
+    pub fn lookup_timing(self) -> LookupTiming {
+        self.lookup_timing
+    }
+
+    pub fn lookup_order(self) -> LookupOrder {
+        self.lookup_order
+    }
+
+    pub fn lookup_touch(self) -> LookupTouch {
+        self.lookup_touch
+    }
+
+    pub fn lookup_deferred_retry(self) -> SchedulerRetry {
+        self.lookup_deferred_retry
+    }
+
+    pub fn g1_capacity_retry(self) -> SchedulerRetry {
+        self.g1_capacity_retry
+    }
+
+    pub fn load_admission_headroom(self) -> LoadAdmissionHeadroom {
+        self.load_admission_headroom
+    }
+
+    pub fn store_trigger(self) -> StoreTrigger {
+        self.store_trigger
+    }
+
+    pub fn store_cadence(self) -> StoreCadence {
+        self.store_cadence
+    }
+
+    pub fn store_cohort(self) -> StoreCohort {
+        self.store_cohort
+    }
+
+    pub fn store_scope(self) -> StoreScope {
+        self.store_scope
+    }
+
+    pub fn store_admission(self) -> StoreAdmission {
+        self.store_admission
+    }
+
+    pub fn capacity_handling(self) -> CapacityHandling {
+        self.capacity_handling
+    }
+
+    pub fn store_execution(self) -> StoreExecution {
+        self.store_execution
+    }
+
+    pub fn load_execution(self) -> LoadExecution {
+        self.load_execution
+    }
+
+    pub fn g2_eviction(self) -> G2EvictionPolicy {
+        self.g2_eviction
+    }
+
+    pub fn post_load_residency(self) -> PostLoadResidency {
+        self.post_load_residency
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vllm_defaults_resolve_every_policy_dimension() {
+        let policy = ResolvedHostOffloadPolicy::vllm_offloading_connector_defaults();
+
+        assert_eq!(policy.lookup_timing(), LookupTiming::BeforeG1Allocation);
+        assert_eq!(policy.lookup_order(), LookupOrder::G1ThenG2);
+        assert_eq!(
+            policy.lookup_touch(),
+            LookupTouch::AllCandidatesReverseLogical
+        );
+        assert_eq!(
+            policy.lookup_deferred_retry(),
+            SchedulerRetry::RetryNextPassAndContinue
+        );
+        assert_eq!(
+            policy.g1_capacity_retry(),
+            SchedulerRetry::RetryNextPassAndStop
+        );
+        assert_eq!(
+            policy.load_admission_headroom(),
+            LoadAdmissionHeadroom::InflightPrefillRemainders
+        );
+        assert_eq!(policy.store_trigger(), StoreTrigger::BlocksCompleted);
+        assert_eq!(policy.store_cadence(), StoreCadence::OncePerEngineStep);
+        assert_eq!(policy.store_cohort(), StoreCohort::PerRequest);
+        assert_eq!(policy.store_scope(), StoreScope::PromptOnly);
+        assert_eq!(policy.store_admission(), StoreAdmission::MissingFromG2);
+        assert_eq!(policy.capacity_handling(), CapacityHandling::EvictOrRetry);
+        assert_eq!(policy.store_execution().mode(), TransferExecution::Async);
+        assert_eq!(
+            policy.store_execution().submit_timing(),
+            StoreSubmitTiming::NextEngineStep
+        );
+        assert_eq!(
+            policy.store_execution().fence(),
+            Some(StoreFence::SourceReuseOrPreemption)
+        );
+        assert_eq!(policy.load_execution().mode(), TransferExecution::Async);
+        assert_eq!(
+            policy.load_execution().fence(),
+            Some(LoadFence::DependentRequest)
+        );
+        assert_eq!(policy.g2_eviction(), G2EvictionPolicy::Lru);
+        assert_eq!(
+            policy.post_load_residency(),
+            PostLoadResidency::RetainG2Copy
+        );
+    }
+
+    #[test]
+    fn resolved_policy_serializes_with_named_dimensions() {
+        let policy = ResolvedHostOffloadPolicy::vllm_offloading_connector_defaults();
+        let value = serde_json::to_value(policy).unwrap();
+
+        assert_eq!(value["lookup_timing"], "before_g1_allocation");
+        assert_eq!(value["lookup_order"], "g1_then_g2");
+        assert_eq!(value["lookup_touch"], "all_candidates_reverse_logical");
+        assert_eq!(
+            value["lookup_deferred_retry"],
+            "retry_next_pass_and_continue"
+        );
+        assert_eq!(value["g1_capacity_retry"], "retry_next_pass_and_stop");
+        assert_eq!(
+            value["load_admission_headroom"],
+            "inflight_prefill_remainders"
+        );
+        assert_eq!(value["store_trigger"], "blocks_completed");
+        assert_eq!(value["store_cadence"], "once_per_engine_step");
+        assert_eq!(value["store_cohort"], "per_request");
+        assert_eq!(value["store_scope"], "prompt_only");
+        assert_eq!(value["store_admission"]["kind"], "missing_from_g2");
+        assert_eq!(value["capacity_handling"], "evict_or_retry");
+        assert_eq!(value["store_execution"]["mode"], "async");
+        assert_eq!(
+            value["store_execution"]["submit_timing"],
+            "next_engine_step"
+        );
+        assert_eq!(
+            value["store_execution"]["fence"],
+            "source_reuse_or_preemption"
+        );
+        assert_eq!(value["load_execution"]["mode"], "async");
+        assert_eq!(value["load_execution"]["fence"], "dependent_request");
+        assert!(value.get("g1_eviction").is_none());
+        assert_eq!(value["g2_eviction"], "lru");
+        assert_eq!(value["post_load_residency"], "retain_g2_copy");
+    }
+}

--- a/lib/mocker/src/lib.rs
+++ b/lib/mocker/src/lib.rs
@@ -10,6 +10,7 @@
 pub mod cache;
 pub mod common;
 pub mod engine;
+pub mod host_offload;
 pub mod kv_manager;
 #[cfg(feature = "kvbm-offload")]
 pub mod kvbm_offload;

--- a/lib/mocker/tests/host_offload_async.rs
+++ b/lib/mocker/tests/host_offload_async.rs
@@ -1,0 +1,581 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Scheduler-facing characterization tests for asynchronous host offload.
+//!
+//! These tests exercise only the public API that a future vLLM scheduler
+//! adapter will consume. They use simulation timestamps and normalized events;
+//! wall-clock timing is intentionally outside the contract.
+
+use std::sync::{Arc, Mutex};
+
+use dynamo_mocker::host_offload::{
+    CompletedTransfer, G1Location, G2Lookup, HostBlockKey, HostOffloadConfig, HostOffloadEvent,
+    HostOffloadEventSink, HostOffloadManager, LoadBlock, LoadScheduleOutcome, PrepareStoreOutcome,
+    ResolvedHostOffloadPolicy, SourceFenceOutcome, SourceFenceReason, StoreBlock, SubmittedStore,
+    TransferId,
+};
+
+#[derive(Default)]
+struct CapturingSink(Mutex<Vec<HostOffloadEvent>>);
+
+impl CapturingSink {
+    fn snapshot(&self) -> Vec<HostOffloadEvent> {
+        self.0.lock().unwrap().clone()
+    }
+
+    fn drain(&self) -> Vec<HostOffloadEvent> {
+        std::mem::take(&mut *self.0.lock().unwrap())
+    }
+}
+
+impl HostOffloadEventSink for CapturingSink {
+    fn record(&self, event: &HostOffloadEvent) {
+        self.0.lock().unwrap().push(event.clone());
+    }
+}
+
+fn key(value: u8) -> HostBlockKey {
+    HostBlockKey::new(0, None, [value; 32])
+}
+
+fn source(value: u64) -> G1Location {
+    G1Location::new(value)
+}
+
+fn store(key_value: u8, source_value: u64) -> StoreBlock {
+    StoreBlock {
+        key: key(key_value),
+        source: source(source_value),
+    }
+}
+
+fn load(key_value: u8, destination: u64) -> LoadBlock {
+    LoadBlock {
+        key: key(key_value),
+        destination: G1Location::new(destination),
+    }
+}
+
+fn manager(capacity_blocks: usize, sink: Arc<CapturingSink>) -> HostOffloadManager {
+    HostOffloadManager::with_event_sink(
+        HostOffloadConfig {
+            capacity_blocks,
+            // At 1 GB/s, each block takes exactly one simulation millisecond.
+            block_bytes: 1_000_000,
+            d2h_bandwidth_gbps: 1.0,
+            h2d_bandwidth_gbps: 1.0,
+        },
+        ResolvedHostOffloadPolicy::vllm_offloading_connector_defaults(),
+        sink,
+    )
+    .unwrap()
+}
+
+#[test]
+fn repeated_prefix_stays_pending_until_next_step_store_completes() {
+    let sink = Arc::new(CapturingSink::default());
+    let mut manager = manager(2, sink.clone());
+    let blocks = [store(1, 101), store(2, 102)];
+
+    assert_eq!(
+        manager.prepare_store(&blocks, 5.0),
+        PrepareStoreOutcome::Prepared {
+            transfer_id: TransferId::new(0),
+            stored_blocks: 2,
+        }
+    );
+    assert!(manager.needs_engine_step());
+    assert_eq!(manager.next_deadline(), None);
+    assert_eq!(
+        manager.lookup(key(1)),
+        G2Lookup::Pending {
+            transfer_id: TransferId::new(0),
+        }
+    );
+    assert_eq!(
+        manager.lookup(key(2)),
+        G2Lookup::Pending {
+            transfer_id: TransferId::new(0),
+        }
+    );
+    assert_eq!(
+        sink.snapshot(),
+        vec![
+            HostOffloadEvent::StorePrepared {
+                at_ms: 5.0,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+                source: source(101),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::StorePrepared {
+                at_ms: 5.0,
+                transfer_id: TransferId::new(0),
+                key: key(2),
+                source: source(102),
+                bytes: 1_000_000,
+            },
+        ]
+    );
+
+    // A repeated prefix lookup/store attempt while D2H is pending neither
+    // makes the prefix visible nor creates a duplicate transfer.
+    assert!(manager.tick(7.0).completed.is_empty());
+    assert_eq!(
+        manager.prepare_store(&blocks, 7.0),
+        PrepareStoreOutcome::AlreadyPresent
+    );
+    assert_eq!(
+        manager.lookup(key(1)),
+        G2Lookup::Pending {
+            transfer_id: TransferId::new(0)
+        }
+    );
+    assert_eq!(sink.snapshot().len(), 2);
+
+    assert_eq!(
+        manager.submit_prepared_stores(8.0),
+        vec![SubmittedStore {
+            transfer_id: TransferId::new(0),
+            completes_at_ms: 10.0,
+        }]
+    );
+    assert!(!manager.needs_engine_step());
+    assert_eq!(manager.next_deadline(), Some(10.0));
+    assert!(manager.tick(9.0).completed.is_empty());
+    assert_eq!(
+        manager.lookup(key(1)),
+        G2Lookup::Pending {
+            transfer_id: TransferId::new(0)
+        }
+    );
+    assert_eq!(
+        manager.schedule_load(&[load(1, 201)], 9.0),
+        LoadScheduleOutcome::Miss
+    );
+
+    assert_eq!(
+        manager.tick(10.0).completed,
+        vec![CompletedTransfer::Store {
+            transfer_id: TransferId::new(0),
+            blocks: blocks.to_vec(),
+        }]
+    );
+    assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+    assert_eq!(manager.lookup(key(2)), G2Lookup::Hit);
+    assert_eq!(manager.resident_snapshot(), vec![key(1), key(2)]);
+    assert_eq!(
+        sink.snapshot()[2..],
+        [
+            HostOffloadEvent::StoreQueued {
+                at_ms: 8.0,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+                source: source(101),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::StoreQueued {
+                at_ms: 8.0,
+                transfer_id: TransferId::new(0),
+                key: key(2),
+                source: source(102),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::StoreCompleted {
+                at_ms: 10.0,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+            },
+            HostOffloadEvent::StoreCompleted {
+                at_ms: 10.0,
+                transfer_id: TransferId::new(0),
+                key: key(2),
+            },
+        ]
+    );
+}
+
+#[test]
+fn d2h_and_h2d_lanes_overlap_but_each_direction_remains_fifo() {
+    let sink = Arc::new(CapturingSink::default());
+    let mut manager = manager(4, sink.clone());
+
+    manager.prepare_store(&[store(1, 101), store(2, 102)], 0.0);
+    manager.submit_prepared_stores(0.0);
+    manager.tick(2.0);
+    sink.drain();
+
+    manager.prepare_store(&[store(3, 103)], 2.0);
+    manager.prepare_store(&[store(4, 104)], 2.0);
+    assert_eq!(
+        manager.submit_prepared_stores(2.0),
+        vec![
+            SubmittedStore {
+                transfer_id: TransferId::new(1),
+                completes_at_ms: 3.0,
+            },
+            SubmittedStore {
+                transfer_id: TransferId::new(2),
+                completes_at_ms: 4.0,
+            },
+        ]
+    );
+    assert_eq!(
+        manager.schedule_load(&[load(1, 201)], 2.0),
+        LoadScheduleOutcome::Queued {
+            transfer_id: TransferId::new(3),
+            completes_at_ms: 3.0,
+            loaded_blocks: 1,
+        }
+    );
+    assert_eq!(
+        manager.schedule_load(&[load(2, 202)], 2.0),
+        LoadScheduleOutcome::Queued {
+            transfer_id: TransferId::new(4),
+            completes_at_ms: 4.0,
+            loaded_blocks: 1,
+        }
+    );
+
+    // The first D2H and first H2D complete together at 3 ms. Each lane's
+    // second job remains serialized until 4 ms.
+    assert_eq!(
+        manager.tick(3.0).completed,
+        vec![
+            CompletedTransfer::Store {
+                transfer_id: TransferId::new(1),
+                blocks: vec![store(3, 103)],
+            },
+            CompletedTransfer::Load {
+                transfer_id: TransferId::new(3),
+                blocks: vec![load(1, 201)],
+            },
+        ]
+    );
+    assert_eq!(manager.next_deadline(), Some(4.0));
+    assert_eq!(
+        manager.tick(4.0).completed,
+        vec![
+            CompletedTransfer::Store {
+                transfer_id: TransferId::new(2),
+                blocks: vec![store(4, 104)],
+            },
+            CompletedTransfer::Load {
+                transfer_id: TransferId::new(4),
+                blocks: vec![load(2, 202)],
+            },
+        ]
+    );
+
+    let events = sink.snapshot();
+    let completion_trace: Vec<_> = events
+        .iter()
+        .filter(|event| {
+            matches!(
+                event,
+                HostOffloadEvent::StoreCompleted { .. } | HostOffloadEvent::LoadCompleted { .. }
+            )
+        })
+        .map(|event| (event.at_ms(), event.key()))
+        .collect();
+    assert_eq!(
+        completion_trace,
+        vec![(3.0, key(3)), (3.0, key(1)), (4.0, key(4)), (4.0, key(2)),]
+    );
+}
+
+#[test]
+fn source_reuse_fence_reports_an_explicitly_submitted_store_deadline() {
+    let sink = Arc::new(CapturingSink::default());
+    let mut manager = manager(2, sink.clone());
+    let blocks = [store(1, 101), store(2, 102)];
+
+    manager.prepare_store(&blocks, 0.0);
+    assert_eq!(
+        manager.fence_sources(&[source(101)], SourceFenceReason::SourceReuse, 0.25),
+        SourceFenceOutcome::NeedsSubmission {
+            transfer_ids: vec![TransferId::new(0)]
+        }
+    );
+    manager.submit_prepared_stores(0.25);
+    let SourceFenceOutcome::Pending(fence) =
+        manager.fence_sources(&[source(101)], SourceFenceReason::SourceReuse, 0.25)
+    else {
+        panic!("submitted store must produce a pending source fence");
+    };
+
+    assert_eq!(fence.until_ms, 2.25);
+    assert_eq!(fence.transfer_ids, vec![TransferId::new(0)]);
+    assert!(!manager.needs_engine_step());
+    assert_eq!(manager.next_deadline(), Some(2.25));
+    assert!(manager.tick(2.0).completed.is_empty());
+    assert_eq!(
+        manager.lookup(key(1)),
+        G2Lookup::Pending {
+            transfer_id: TransferId::new(0)
+        }
+    );
+    assert_eq!(manager.tick(fence.until_ms).completed.len(), 1);
+    assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+
+    assert_eq!(
+        sink.snapshot(),
+        vec![
+            HostOffloadEvent::StorePrepared {
+                at_ms: 0.0,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+                source: source(101),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::StorePrepared {
+                at_ms: 0.0,
+                transfer_id: TransferId::new(0),
+                key: key(2),
+                source: source(102),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::StoreQueued {
+                at_ms: 0.25,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+                source: source(101),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::StoreQueued {
+                at_ms: 0.25,
+                transfer_id: TransferId::new(0),
+                key: key(2),
+                source: source(102),
+                bytes: 1_000_000,
+            },
+            HostOffloadEvent::SourceFenced {
+                at_ms: 0.25,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+                source: source(101),
+                reason: SourceFenceReason::SourceReuse,
+            },
+            HostOffloadEvent::StoreCompleted {
+                at_ms: 2.25,
+                transfer_id: TransferId::new(0),
+                key: key(1),
+            },
+            HostOffloadEvent::StoreCompleted {
+                at_ms: 2.25,
+                transfer_id: TransferId::new(0),
+                key: key(2),
+            },
+        ]
+    );
+}
+
+#[test]
+fn preemption_caller_flushes_all_stores_then_fences_selected_sources() {
+    let sink = Arc::new(CapturingSink::default());
+    let mut manager = manager(2, sink.clone());
+
+    manager.prepare_store(&[store(1, 101)], 0.0);
+    manager.prepare_store(&[store(2, 102)], 0.0);
+    manager.submit_prepared_stores(0.5);
+    let SourceFenceOutcome::Pending(fence) =
+        manager.fence_sources(&[source(102)], SourceFenceReason::RequestPreemption, 0.5)
+    else {
+        panic!("submitted store must produce a pending preemption fence");
+    };
+
+    // Both worker-local stores are flushed to the FIFO lane. Only the second
+    // transfer guards the preempted request's source, so the reported fence is
+    // its later deadline.
+    assert_eq!(fence.until_ms, 2.5);
+    assert_eq!(fence.transfer_ids, vec![TransferId::new(1)]);
+    assert!(!manager.needs_engine_step());
+    assert_eq!(manager.next_deadline(), Some(1.5));
+
+    let events = sink.snapshot();
+    let queued: Vec<_> = events
+        .iter()
+        .filter_map(|event| match event {
+            HostOffloadEvent::StoreQueued {
+                at_ms,
+                transfer_id,
+                key,
+                ..
+            } => Some((*at_ms, *transfer_id, *key)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        queued,
+        vec![
+            (0.5, TransferId::new(0), key(1)),
+            (0.5, TransferId::new(1), key(2)),
+        ]
+    );
+    assert!(events.iter().any(|event| {
+        matches!(
+            event,
+            HostOffloadEvent::SourceFenced {
+                at_ms: 0.5,
+                transfer_id,
+                key: event_key,
+                source: event_source,
+                reason: SourceFenceReason::RequestPreemption,
+            } if *transfer_id == TransferId::new(1)
+                && *event_key == key(2)
+                && *event_source == source(102)
+        )
+    }));
+    assert!(!events.iter().any(|event| {
+        matches!(
+            event,
+            HostOffloadEvent::SourceFenced { key: event_key, .. }
+                if *event_key == key(1)
+        )
+    }));
+}
+
+#[test]
+fn capacity_retry_survives_pending_store_and_pinned_load_then_retries_same_block() {
+    let sink = Arc::new(CapturingSink::default());
+    let mut manager = manager(2, sink.clone());
+
+    manager.prepare_store(&[store(1, 101)], 0.0);
+    manager.submit_prepared_stores(0.0);
+    manager.tick(1.0);
+    sink.drain();
+
+    // One slot is held by an unsubmitted store. The other is resident but
+    // pinned by an H2D load, leaving no legal LRU victim.
+    manager.prepare_store(&[store(2, 102)], 1.0);
+    manager.schedule_load(&[load(1, 201)], 1.0);
+    assert_eq!(
+        manager.prepare_store(&[store(3, 103)], 1.0),
+        PrepareStoreOutcome::RetryCapacity
+    );
+    assert_eq!(manager.lookup(key(3)), G2Lookup::Miss);
+    assert_eq!(manager.used_blocks(), 2);
+    assert!(sink.snapshot().iter().any(|event| {
+        matches!(
+            event,
+            HostOffloadEvent::CapacityRetry {
+                at_ms: 1.0,
+                key: event_key,
+            } if *event_key == key(3)
+        )
+    }));
+
+    manager.submit_prepared_stores(1.0);
+    manager.tick(2.0);
+    assert_eq!(
+        manager.prepare_store(&[store(3, 103)], 2.0),
+        PrepareStoreOutcome::Prepared {
+            transfer_id: TransferId::new(3),
+            stored_blocks: 1,
+        }
+    );
+    assert_eq!(
+        manager.lookup(key(3)),
+        G2Lookup::Pending {
+            transfer_id: TransferId::new(3)
+        }
+    );
+    assert!(!manager.is_resident(key(2)));
+    assert!(manager.is_resident(key(1)));
+
+    let events = sink.snapshot();
+    let retry_index = events
+        .iter()
+        .position(|event| matches!(event, HostOffloadEvent::CapacityRetry { .. }))
+        .unwrap();
+    let eviction_index = events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                HostOffloadEvent::G2Evicted {
+                    at_ms: 2.0,
+                    key: event_key,
+                } if *event_key == key(2)
+            )
+        })
+        .unwrap();
+    let retry_store_index = events
+        .iter()
+        .position(|event| {
+            matches!(
+                event,
+                HostOffloadEvent::StorePrepared {
+                    at_ms: 2.0,
+                    transfer_id,
+                    key: event_key,
+                    ..
+                } if *transfer_id == TransferId::new(3) && *event_key == key(3)
+            )
+        })
+        .unwrap();
+    assert!(retry_index < eviction_index && eviction_index < retry_store_index);
+}
+
+#[test]
+fn completed_load_retains_the_g2_copy_for_a_second_load() {
+    let sink = Arc::new(CapturingSink::default());
+    let mut manager = manager(1, sink.clone());
+
+    manager.prepare_store(&[store(1, 101)], 0.0);
+    manager.submit_prepared_stores(0.0);
+    manager.tick(1.0);
+
+    assert_eq!(
+        manager.schedule_load(&[load(1, 201)], 1.0),
+        LoadScheduleOutcome::Queued {
+            transfer_id: TransferId::new(1),
+            completes_at_ms: 2.0,
+            loaded_blocks: 1,
+        }
+    );
+    assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+    manager.tick(2.0);
+    assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+    assert_eq!(manager.resident_snapshot(), vec![key(1)]);
+
+    assert_eq!(
+        manager.schedule_load(&[load(1, 202)], 2.0),
+        LoadScheduleOutcome::Queued {
+            transfer_id: TransferId::new(2),
+            completes_at_ms: 3.0,
+            loaded_blocks: 1,
+        }
+    );
+    manager.tick(3.0);
+    assert_eq!(manager.lookup(key(1)), G2Lookup::Hit);
+    assert_eq!(manager.used_blocks(), 1);
+    assert_eq!(manager.resident_blocks(), 1);
+
+    let events = sink.snapshot();
+    assert_eq!(
+        events
+            .iter()
+            .filter(|event| matches!(event, HostOffloadEvent::StorePrepared { .. }))
+            .count(),
+        1
+    );
+    assert_eq!(
+        events
+            .iter()
+            .filter_map(|event| match event {
+                HostOffloadEvent::LoadCompleted {
+                    at_ms,
+                    transfer_id,
+                    key: event_key,
+                } => Some((*at_ms, *transfer_id, *event_key)),
+                _ => None,
+            })
+            .collect::<Vec<_>>(),
+        vec![
+            (2.0, TransferId::new(1), key(1)),
+            (3.0, TransferId::new(2), key(1)),
+        ]
+    );
+}


### PR DESCRIPTION
## Overview:

This is the first PR in a series adding framework-native host-offload simulation to Mocker.

It introduces a framework-neutral core for G1↔G2 policy, G2 residency, capacity management, transfer timing, and eviction. Framework adapters will select a resolved policy and translate scheduler decisions into logical store/load operations.

This PR intentionally does not wire the core into the Mocker scheduler or expose user configuration. The legacy KVBM offload path remains unchanged.

Follow-up PRs will add:

1. Native G1 reservation lifecycle
2. The vLLM `OffloadingConnector` adapter
3. vLLM scheduler integration
4. Python and CLI controls

## Details:

<!-- Describe the changes made in this PR. -->

## Where should the reviewer start?

<!-- call out specific files that should be looked at closely -->

## Related Issues

> ⚠️ **This section is required.** Choose one path below and delete the other.

**🔗 This PR is linked to an issue:**
<!-- Replace XXXX with the real issue number e.g.
     Single issue  → Closes #8480
     Multiple issues → Closes #8480, Closes #8481

     Use `Relates to #XXXX` when this PR references, depends on,
     or partially addresses an issue. This links the PR to the issue
     but does not automatically close it.
-->

- Closes #XXXX

**🚫 This PR is NOT linked to an issue**:
- [ ] Confirmed — no related issue
