### PR TITLE
perf(router): batch active sequence replica events

### DIFF
--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -626,6 +626,16 @@ pub struct ActiveSequenceEvent {
     pub lora_name: Option<String>,
 }
 
+/// Ordered active-sequence lifecycle events carried by one replica-sync message.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct ActiveSequenceEventBatch {
+    pub events: Vec<ActiveSequenceEvent>,
+}
+
+/// Shared cooperative batch limits for active-sequence replica sync.
+pub const MAX_REPLICA_BATCH_EVENTS: usize = 256;
+pub const MAX_REPLICA_BATCH_DURATION: Duration = Duration::from_millis(1);
+
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
 pub struct PrefillLoadHint {
     pub initial_effective_prefill_tokens: usize,

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -626,7 +626,7 @@ pub struct ActiveSequenceEvent {
     pub lora_name: Option<String>,
 }
 
-/// Ordered active-sequence lifecycle events carried by one replica-sync message.
+/// Active-sequence lifecycle events carried in publisher-queue arrival order.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct ActiveSequenceEventBatch {
     pub events: Vec<ActiveSequenceEvent>,

--- a/lib/kv-router/src/sequences/multi_worker.rs
+++ b/lib/kv-router/src/sequences/multi_worker.rs
@@ -95,6 +95,14 @@ pub trait SequencePublisher: Send + Sync {
         event: &ActiveSequenceEvent,
     ) -> impl Future<Output = anyhow::Result<()>> + Send;
 
+    /// Publish an owned replica-sync event, avoiding a clone when supported by the transport.
+    fn publish_event_owned(
+        &self,
+        event: ActiveSequenceEvent,
+    ) -> impl Future<Output = anyhow::Result<()>> + Send {
+        async move { self.publish_event(&event).await }
+    }
+
     /// Fire-and-forget publish of an [`ActiveLoad`] metric payload.
     fn publish_load(&self, load: ActiveLoad);
 
@@ -429,10 +437,12 @@ impl<P: SequencePublisher + 'static> ActiveSequencesMultiWorker<P> {
         // can mirror the same oldest-prefill anchor instead of approximating from receive time.
         let publisher = Arc::clone(&self.publisher);
         tokio::spawn(async move {
-            if let Err(e) = publisher.publish_event(&event).await {
+            let request_id = event.request_id.clone();
+            let worker = event.worker;
+            if let Err(e) = publisher.publish_event_owned(event).await {
                 tracing::error!(
-                    request_id = %event.request_id,
-                    worker = ?event.worker,
+                    request_id = %request_id,
+                    worker = ?worker,
                     "failed to publish active sequence event: {e}"
                 );
             }

--- a/lib/kv-router/src/sequences/replica_sync.rs
+++ b/lib/kv-router/src/sequences/replica_sync.rs
@@ -6,17 +6,17 @@ use std::sync::Arc;
 use std::task::Poll;
 
 use rustc_hash::FxHashMap;
-use tokio::time::{Duration, Instant};
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use super::multi_worker::{
     ActiveSequencesMultiWorker, ReplicaWorkerPolicy, SequencePublisher, SequenceSubscriber,
 };
 use super::prompt_registry::WorkerLoadSnapshot;
-use crate::protocols::{ActiveSequenceEvent, ActiveSequenceEventData, WorkerWithDpRank};
-
-const MAX_REPLICA_BATCH_EVENTS: usize = 256;
-const MAX_REPLICA_BATCH_DURATION: Duration = Duration::from_millis(1);
+use crate::protocols::{
+    ActiveSequenceEvent, ActiveSequenceEventData, MAX_REPLICA_BATCH_DURATION,
+    MAX_REPLICA_BATCH_EVENTS, WorkerWithDpRank,
+};
 
 #[derive(Default)]
 struct ReplicaBatchEffects {

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -11,15 +11,23 @@ pub use dynamo_kv_router::multi_worker_sequence::{
     ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
     SequenceSubscriber,
 };
-use dynamo_kv_router::protocols::{ActiveLoad, ActiveSequenceEvent, WorkerWithDpRank};
+use dynamo_kv_router::protocols::{
+    ActiveLoad, ActiveSequenceEvent, ActiveSequenceEventBatch, MAX_REPLICA_BATCH_DURATION,
+    MAX_REPLICA_BATCH_EVENTS, WorkerWithDpRank,
+};
 pub use dynamo_kv_router::sequence::{ActiveSequences, RequestId};
 
 use anyhow::Result;
+use bytes::Bytes;
 use dynamo_runtime::component::Endpoint;
-use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber};
-use std::collections::HashMap;
+use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber, MsgpackCodec};
+use serde::Serialize;
+use std::collections::{HashMap, VecDeque};
+use std::ops::Range;
 use std::sync::Arc;
 use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+use tokio::time::Instant;
 use tokio_util::sync::CancellationToken;
 
 use super::metrics::{RouterWorkerStatusMetrics, WORKER_LOAD_METRICS};
@@ -28,16 +36,36 @@ use crate::local_model::runtime_config::ModelRuntimeConfig;
 #[cfg(test)]
 use dynamo_kv_router::protocols::PrefillLoadHint;
 
+const REPLICA_EVENT_CHANNEL_CAPACITY: usize = 100_000;
+const MAX_REPLICA_BATCH_PAYLOAD_BYTES: usize = 1_000_000;
+
+#[derive(Serialize)]
+struct ActiveSequenceEventBatchRef<'a> {
+    events: &'a [ActiveSequenceEvent],
+}
+
+struct EncodedReplicaBatch {
+    event_range: Range<usize>,
+    payload: Bytes,
+    oversized: bool,
+}
+
 /// Concrete [`SequencePublisher`] backed by NATS [`EventPublisher`] and Prometheus gauges.
 pub struct RuntimeSequencePublisher {
-    event_publisher: EventPublisher,
+    event_tx: Option<mpsc::Sender<ActiveSequenceEvent>>,
     metrics_publisher: Arc<EventPublisher>,
     worker_status_metrics: Arc<RouterWorkerStatusMetrics>,
 }
 
 impl SequencePublisher for RuntimeSequencePublisher {
     async fn publish_event(&self, event: &ActiveSequenceEvent) -> anyhow::Result<()> {
-        self.event_publisher.publish(event).await
+        let Some(event_tx) = &self.event_tx else {
+            return Ok(());
+        };
+        event_tx
+            .send(event.clone())
+            .await
+            .map_err(|_| anyhow::anyhow!("active-sequence replica publisher is closed"))
     }
 
     fn publish_load(&self, load: ActiveLoad) {
@@ -95,16 +123,176 @@ impl SequencePublisher for RuntimeSequencePublisher {
     }
 }
 
+fn encode_replica_batch(events: &[ActiveSequenceEvent]) -> Result<Bytes> {
+    MsgpackCodec.encode_payload(&ActiveSequenceEventBatchRef { events })
+}
+
+fn encode_replica_batch_partitions(
+    events: &[ActiveSequenceEvent],
+) -> Result<Vec<EncodedReplicaBatch>> {
+    let mut batches = Vec::new();
+    let mut batch_start = 0;
+
+    while batch_start < events.len() {
+        let remaining = &events[batch_start..];
+        let remaining_payload = encode_replica_batch(remaining)?;
+        if remaining_payload.len() <= MAX_REPLICA_BATCH_PAYLOAD_BYTES {
+            batches.push(EncodedReplicaBatch {
+                event_range: batch_start..events.len(),
+                payload: remaining_payload,
+                oversized: false,
+            });
+            break;
+        }
+
+        let first_payload = encode_replica_batch(&remaining[..1])?;
+        if first_payload.len() > MAX_REPLICA_BATCH_PAYLOAD_BYTES {
+            batches.push(EncodedReplicaBatch {
+                event_range: batch_start..batch_start + 1,
+                payload: first_payload,
+                oversized: true,
+            });
+            batch_start += 1;
+            continue;
+        }
+
+        let mut best_len = 1;
+        let mut best_payload = first_payload;
+        let mut low = 2;
+        let mut high = remaining.len() - 1;
+        while low <= high {
+            let candidate_len = low + (high - low) / 2;
+            let candidate_payload = encode_replica_batch(&remaining[..candidate_len])?;
+            if candidate_payload.len() <= MAX_REPLICA_BATCH_PAYLOAD_BYTES {
+                best_len = candidate_len;
+                best_payload = candidate_payload;
+                low = candidate_len + 1;
+            } else {
+                high = candidate_len - 1;
+            }
+        }
+
+        batches.push(EncodedReplicaBatch {
+            event_range: batch_start..batch_start + best_len,
+            payload: best_payload,
+            oversized: false,
+        });
+        batch_start += best_len;
+    }
+
+    Ok(batches)
+}
+
+async fn publish_replica_batch(publisher: &EventPublisher, events: &[ActiveSequenceEvent]) {
+    let batches = match encode_replica_batch_partitions(events) {
+        Ok(batches) => batches,
+        Err(error) => {
+            tracing::error!(
+                event_count = events.len(),
+                error = %error,
+                "Failed to encode active-sequence replica batch"
+            );
+            return;
+        }
+    };
+
+    for batch in batches {
+        let batch_events = &events[batch.event_range.clone()];
+        let first_request_id = &batch_events
+            .first()
+            .expect("replica batch must contain an event")
+            .request_id;
+        let last_request_id = &batch_events
+            .last()
+            .expect("replica batch must contain an event")
+            .request_id;
+
+        if batch.oversized {
+            tracing::warn!(
+                request_id = %first_request_id,
+                payload_bytes = batch.payload.len(),
+                max_payload_bytes = MAX_REPLICA_BATCH_PAYLOAD_BYTES,
+                "Active-sequence replica event exceeds the batch payload limit; publishing intact"
+            );
+        }
+
+        if let Err(error) = publisher.publish_bytes_ref(batch.payload.as_ref()).await {
+            tracing::error!(
+                transport = ?publisher.transport_kind(),
+                event_count = batch_events.len(),
+                payload_bytes = batch.payload.len(),
+                first_request_id = %first_request_id,
+                last_request_id = %last_request_id,
+                error = %error,
+                "Failed to publish active-sequence replica batch"
+            );
+        }
+    }
+}
+
+async fn collect_replica_batch(
+    first_event: ActiveSequenceEvent,
+    event_rx: &mut mpsc::Receiver<ActiveSequenceEvent>,
+    cancellation_token: &CancellationToken,
+) -> (Vec<ActiveSequenceEvent>, bool) {
+    let mut events = Vec::with_capacity(MAX_REPLICA_BATCH_EVENTS);
+    events.push(first_event);
+    let deadline = Instant::now() + MAX_REPLICA_BATCH_DURATION;
+    let flush_timer = tokio::time::sleep_until(deadline);
+    tokio::pin!(flush_timer);
+
+    while events.len() < MAX_REPLICA_BATCH_EVENTS {
+        tokio::select! {
+            _ = cancellation_token.cancelled() => return (events, true),
+            _ = &mut flush_timer => break,
+            event = event_rx.recv() => match event {
+                Some(event) => events.push(event),
+                None => return (events, true),
+            },
+        }
+    }
+
+    (events, false)
+}
+
+async fn run_replica_batch_publisher(
+    publisher: EventPublisher,
+    mut event_rx: mpsc::Receiver<ActiveSequenceEvent>,
+    cancellation_token: CancellationToken,
+) {
+    loop {
+        let first_event = tokio::select! {
+            _ = cancellation_token.cancelled() => break,
+            event = event_rx.recv() => match event {
+                Some(event) => event,
+                None => break,
+            },
+        };
+        let (events, stop_after_flush) =
+            collect_replica_batch(first_event, &mut event_rx, &cancellation_token).await;
+        publish_replica_batch(&publisher, &events).await;
+        if stop_after_flush {
+            break;
+        }
+    }
+}
+
 /// Concrete [`SequenceSubscriber`] backed by NATS typed event stream.
 pub struct RuntimeSequenceSubscriber {
-    inner: dynamo_runtime::transports::event_plane::TypedEventSubscriber<ActiveSequenceEvent>,
+    inner: dynamo_runtime::transports::event_plane::TypedEventSubscriber<ActiveSequenceEventBatch>,
+    pending: VecDeque<ActiveSequenceEvent>,
 }
 
 impl SequenceSubscriber for RuntimeSequenceSubscriber {
     async fn next_event(&mut self) -> Option<anyhow::Result<ActiveSequenceEvent>> {
-        match self.inner.next().await? {
-            Ok((_envelope, event)) => Some(Ok(event)),
-            Err(e) => Some(Err(e)),
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return Some(Ok(event));
+            }
+            match self.inner.next().await? {
+                Ok((_envelope, batch)) => self.pending.extend(batch.events),
+                Err(error) => return Some(Err(error)),
+            }
         }
     }
 
@@ -112,11 +300,16 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
         &mut self,
         cx: &mut Context<'_>,
     ) -> Poll<Option<anyhow::Result<ActiveSequenceEvent>>> {
-        match self.inner.poll_next(cx) {
-            Poll::Ready(Some(Ok((_envelope, event)))) => Poll::Ready(Some(Ok(event))),
-            Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
-            Poll::Ready(None) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
+        loop {
+            if let Some(event) = self.pending.pop_front() {
+                return Poll::Ready(Some(Ok(event)));
+            }
+            match self.inner.poll_next(cx) {
+                Poll::Ready(Some(Ok((_envelope, batch)))) => self.pending.extend(batch.events),
+                Poll::Ready(Some(Err(error))) => return Poll::Ready(Some(Err(error))),
+                Poll::Ready(None) => return Poll::Ready(None),
+                Poll::Pending => return Poll::Pending,
+            }
         }
     }
 }
@@ -135,13 +328,25 @@ pub async fn create_multi_worker_sequences(
     worker_type: &'static str,
     cancellation_token: CancellationToken,
 ) -> Result<Arc<ActiveSequencesMulti>> {
-    let event_publisher = EventPublisher::for_endpoint(&endpoint, ACTIVE_SEQUENCES_SUBJECT).await?;
+    let event_tx = if replica_sync {
+        let event_publisher =
+            EventPublisher::for_endpoint(&endpoint, ACTIVE_SEQUENCES_SUBJECT).await?;
+        let (event_tx, event_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
+        tokio::spawn(run_replica_batch_publisher(
+            event_publisher,
+            event_rx,
+            cancellation_token.child_token(),
+        ));
+        Some(event_tx)
+    } else {
+        None
+    };
     let metrics_publisher =
         Arc::new(EventPublisher::for_endpoint(&endpoint, KV_METRICS_SUBJECT).await?);
     let worker_status_metrics = RouterWorkerStatusMetrics::from_component(endpoint.component());
 
     let publisher = RuntimeSequencePublisher {
-        event_publisher,
+        event_tx,
         metrics_publisher,
         worker_status_metrics,
     };
@@ -170,8 +375,11 @@ pub async fn create_multi_worker_sequences(
     if replica_sync {
         let subscriber = EventSubscriber::for_endpoint(&endpoint, ACTIVE_SEQUENCES_SUBJECT)
             .await?
-            .typed::<ActiveSequenceEvent>();
-        let subscriber = RuntimeSequenceSubscriber { inner: subscriber };
+            .typed::<ActiveSequenceEventBatch>();
+        let subscriber = RuntimeSequenceSubscriber {
+            inner: subscriber,
+            pending: VecDeque::new(),
+        };
         arc.start_replica_sync(subscriber, cancellation_token.child_token());
     }
 
@@ -183,6 +391,7 @@ pub async fn create_multi_worker_sequences(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_kv_router::protocols::ActiveSequenceEventData;
     use dynamo_runtime::{DistributedRuntime, Runtime, distributed::DistributedConfig};
     use tokio::time::Instant;
 
@@ -191,6 +400,136 @@ mod tests {
             initial_effective_prefill_tokens: tokens,
             expected_prefill_duration: None,
         })
+    }
+
+    fn free_event(request_id: impl Into<String>) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::Free,
+            router_id: 7,
+            lora_name: None,
+        }
+    }
+
+    fn large_add_event(request_id: impl Into<String>, hashes: usize) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.into(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data: ActiveSequenceEventData::AddRequest {
+                token_sequence: Some(vec![u64::MAX; hashes]),
+                track_prefill_tokens: true,
+                expected_output_tokens: None,
+                prefill_load_hint: None,
+            },
+            router_id: 7,
+            lora_name: None,
+        }
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn active_sequence_batch_collection_uses_time_and_count_caps() {
+        let (event_tx, mut event_rx) = mpsc::channel(MAX_REPLICA_BATCH_EVENTS + 1);
+        for request_id in 0..100 {
+            event_tx
+                .send(free_event(format!("free-{request_id}")))
+                .await
+                .unwrap();
+        }
+
+        let first = event_rx.recv().await.unwrap();
+        let start = Instant::now();
+        let (events, stop) =
+            collect_replica_batch(first, &mut event_rx, &CancellationToken::new()).await;
+        assert!(!stop);
+        assert_eq!(events.len(), 100);
+        assert_eq!(Instant::now() - start, MAX_REPLICA_BATCH_DURATION);
+        let batches = encode_replica_batch_partitions(&events).unwrap();
+        assert_eq!(batches.len(), 1);
+        let decoded: ActiveSequenceEventBatch =
+            MsgpackCodec.decode_payload(&batches[0].payload).unwrap();
+        assert_eq!(decoded.events.len(), 100);
+        for (request_id, event) in decoded.events.iter().enumerate() {
+            assert_eq!(event.request_id, format!("free-{request_id}"));
+        }
+
+        for request_id in 0..=MAX_REPLICA_BATCH_EVENTS {
+            event_tx
+                .send(free_event(format!("count-{request_id}")))
+                .await
+                .unwrap();
+        }
+        let first = event_rx.recv().await.unwrap();
+        let start = Instant::now();
+        let (events, stop) =
+            collect_replica_batch(first, &mut event_rx, &CancellationToken::new()).await;
+        assert!(!stop);
+        assert_eq!(events.len(), MAX_REPLICA_BATCH_EVENTS);
+        assert_eq!(Instant::now(), start);
+        assert_eq!(event_rx.len(), 1);
+
+        let last = event_rx.recv().await.unwrap();
+        let (remaining, stop) =
+            collect_replica_batch(last, &mut event_rx, &CancellationToken::new()).await;
+        assert!(!stop);
+        assert_eq!(remaining.len(), 1);
+    }
+
+    #[test]
+    fn active_sequence_batches_split_at_payload_limit_and_roundtrip() {
+        const NATS_DEFAULT_MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
+
+        let max_payload = vec![0; MAX_REPLICA_BATCH_PAYLOAD_BYTES];
+        let max_sized_envelope = MsgpackCodec
+            .encode_envelope_parts(
+                u64::MAX,
+                u64::MAX,
+                u64::MAX,
+                ACTIVE_SEQUENCES_SUBJECT,
+                &max_payload,
+            )
+            .unwrap();
+        assert!(max_sized_envelope.len() < NATS_DEFAULT_MAX_PAYLOAD_BYTES);
+
+        let events = vec![
+            large_add_event("large-0", 80_000),
+            large_add_event("large-1", 80_000),
+        ];
+        assert!(encode_replica_batch(&events).unwrap().len() > MAX_REPLICA_BATCH_PAYLOAD_BYTES);
+
+        let batches = encode_replica_batch_partitions(&events).unwrap();
+        assert_eq!(batches.len(), 2);
+        let mut decoded_request_ids = Vec::new();
+        for batch in &batches {
+            assert!(!batch.oversized);
+            assert!(batch.payload.len() <= MAX_REPLICA_BATCH_PAYLOAD_BYTES);
+            let envelope = MsgpackCodec
+                .encode_envelope_parts(
+                    u64::MAX,
+                    u64::MAX,
+                    u64::MAX,
+                    ACTIVE_SEQUENCES_SUBJECT,
+                    batch.payload.as_ref(),
+                )
+                .unwrap();
+            assert!(envelope.len() < NATS_DEFAULT_MAX_PAYLOAD_BYTES);
+
+            let decoded: ActiveSequenceEventBatch =
+                MsgpackCodec.decode_payload(&batch.payload).unwrap();
+            decoded_request_ids.extend(decoded.events.into_iter().map(|event| event.request_id));
+        }
+        assert_eq!(decoded_request_ids, ["large-0", "large-1"]);
+    }
+
+    #[test]
+    fn active_sequence_batch_preserves_single_oversized_event() {
+        let events = vec![large_add_event("oversized", 120_000)];
+        let batches = encode_replica_batch_partitions(&events).unwrap();
+
+        assert_eq!(batches.len(), 1);
+        assert!(batches[0].oversized);
+        assert!(batches[0].payload.len() > MAX_REPLICA_BATCH_PAYLOAD_BYTES);
+        assert_eq!(batches[0].event_range, 0..1);
     }
 
     #[tokio::test]

--- a/lib/llm/src/kv_router/sequence.rs
+++ b/lib/llm/src/kv_router/sequence.rs
@@ -5,7 +5,7 @@
 //!
 //! This module provides the concrete [`SequencePublisher`] and [`SequenceSubscriber`]
 //! implementations that wire the runtime-agnostic business logic (in `dynamo_kv_router`)
-//! to NATS event transport and Prometheus metrics.
+//! to the configured event transport and Prometheus metrics.
 
 pub use dynamo_kv_router::multi_worker_sequence::{
     ActiveSequencesMultiWorker, SequenceError, SequencePublisher, SequenceRequest,
@@ -18,12 +18,12 @@ use dynamo_kv_router::protocols::{
 pub use dynamo_kv_router::sequence::{ActiveSequences, RequestId};
 
 use anyhow::Result;
-use bytes::Bytes;
 use dynamo_runtime::component::Endpoint;
-use dynamo_runtime::transports::event_plane::{EventPublisher, EventSubscriber, MsgpackCodec};
-use serde::Serialize;
+use dynamo_runtime::traits::DistributedRuntimeProvider;
+use dynamo_runtime::transports::event_plane::{
+    EventPublisher, EventSubscriber, EventTransportKind, TypedEventSubscriber,
+};
 use std::collections::{HashMap, VecDeque};
-use std::ops::Range;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc;
@@ -35,37 +35,62 @@ use crate::kv_router::{ACTIVE_SEQUENCES_SUBJECT, KV_METRICS_SUBJECT};
 use crate::local_model::runtime_config::ModelRuntimeConfig;
 #[cfg(test)]
 use dynamo_kv_router::protocols::PrefillLoadHint;
+#[cfg(test)]
+use dynamo_runtime::transports::event_plane::MsgpackCodec;
 
+// Match the existing standalone replica-sync queue. Senders wait asynchronously when it is full,
+// preserving the pre-existing fire-and-forget behavior rather than dropping lifecycle events.
 const REPLICA_EVENT_CHANNEL_CAPACITY: usize = 100_000;
-const MAX_REPLICA_BATCH_PAYLOAD_BYTES: usize = 1_000_000;
 
-#[derive(Serialize)]
-struct ActiveSequenceEventBatchRef<'a> {
-    events: &'a [ActiveSequenceEvent],
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ActiveSequenceEventWireFormat {
+    Singleton,
+    Batch,
 }
 
-struct EncodedReplicaBatch {
-    event_range: Range<usize>,
-    payload: Bytes,
-    oversized: bool,
+fn active_sequence_event_wire_format(
+    transport_kind: EventTransportKind,
+) -> ActiveSequenceEventWireFormat {
+    match transport_kind {
+        EventTransportKind::Nats => ActiveSequenceEventWireFormat::Singleton,
+        EventTransportKind::Zmq => ActiveSequenceEventWireFormat::Batch,
+    }
 }
 
-/// Concrete [`SequencePublisher`] backed by NATS [`EventPublisher`] and Prometheus gauges.
+enum ActiveSequenceEventPublisher {
+    Nats(Box<EventPublisher>),
+    Zmq(mpsc::Sender<ActiveSequenceEvent>),
+}
+
+/// Concrete [`SequencePublisher`] backed by the runtime event plane and Prometheus gauges.
 pub struct RuntimeSequencePublisher {
-    event_tx: Option<mpsc::Sender<ActiveSequenceEvent>>,
+    event_publisher: Option<ActiveSequenceEventPublisher>,
     metrics_publisher: Arc<EventPublisher>,
     worker_status_metrics: Arc<RouterWorkerStatusMetrics>,
 }
 
-impl SequencePublisher for RuntimeSequencePublisher {
-    async fn publish_event(&self, event: &ActiveSequenceEvent) -> anyhow::Result<()> {
-        let Some(event_tx) = &self.event_tx else {
+impl RuntimeSequencePublisher {
+    async fn publish_owned_event(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
+        let Some(event_publisher) = &self.event_publisher else {
             return Ok(());
         };
-        event_tx
-            .send(event.clone())
-            .await
-            .map_err(|_| anyhow::anyhow!("active-sequence replica publisher is closed"))
+        match event_publisher {
+            ActiveSequenceEventPublisher::Nats(publisher) => publisher.publish(&event).await,
+            ActiveSequenceEventPublisher::Zmq(event_tx) => event_tx
+                .send(event)
+                .await
+                .map_err(|_| anyhow::anyhow!("active-sequence replica publisher is closed")),
+        }
+    }
+}
+
+impl SequencePublisher for RuntimeSequencePublisher {
+    async fn publish_event(&self, event: &ActiveSequenceEvent) -> anyhow::Result<()> {
+        self.publish_owned_event(event.clone()).await
+    }
+
+    async fn publish_event_owned(&self, event: ActiveSequenceEvent) -> anyhow::Result<()> {
+        self.publish_owned_event(event).await
     }
 
     fn publish_load(&self, load: ActiveLoad) {
@@ -123,110 +148,27 @@ impl SequencePublisher for RuntimeSequencePublisher {
     }
 }
 
-fn encode_replica_batch(events: &[ActiveSequenceEvent]) -> Result<Bytes> {
-    MsgpackCodec.encode_payload(&ActiveSequenceEventBatchRef { events })
-}
+async fn publish_replica_batch(publisher: &EventPublisher, events: Vec<ActiveSequenceEvent>) {
+    let batch = ActiveSequenceEventBatch { events };
+    let first_request_id = &batch
+        .events
+        .first()
+        .expect("replica batch must contain an event")
+        .request_id;
+    let last_request_id = &batch
+        .events
+        .last()
+        .expect("replica batch must contain an event")
+        .request_id;
 
-fn encode_replica_batch_partitions(
-    events: &[ActiveSequenceEvent],
-) -> Result<Vec<EncodedReplicaBatch>> {
-    let mut batches = Vec::new();
-    let mut batch_start = 0;
-
-    while batch_start < events.len() {
-        let remaining = &events[batch_start..];
-        let remaining_payload = encode_replica_batch(remaining)?;
-        if remaining_payload.len() <= MAX_REPLICA_BATCH_PAYLOAD_BYTES {
-            batches.push(EncodedReplicaBatch {
-                event_range: batch_start..events.len(),
-                payload: remaining_payload,
-                oversized: false,
-            });
-            break;
-        }
-
-        let first_payload = encode_replica_batch(&remaining[..1])?;
-        if first_payload.len() > MAX_REPLICA_BATCH_PAYLOAD_BYTES {
-            batches.push(EncodedReplicaBatch {
-                event_range: batch_start..batch_start + 1,
-                payload: first_payload,
-                oversized: true,
-            });
-            batch_start += 1;
-            continue;
-        }
-
-        let mut best_len = 1;
-        let mut best_payload = first_payload;
-        let mut low = 2;
-        let mut high = remaining.len() - 1;
-        while low <= high {
-            let candidate_len = low + (high - low) / 2;
-            let candidate_payload = encode_replica_batch(&remaining[..candidate_len])?;
-            if candidate_payload.len() <= MAX_REPLICA_BATCH_PAYLOAD_BYTES {
-                best_len = candidate_len;
-                best_payload = candidate_payload;
-                low = candidate_len + 1;
-            } else {
-                high = candidate_len - 1;
-            }
-        }
-
-        batches.push(EncodedReplicaBatch {
-            event_range: batch_start..batch_start + best_len,
-            payload: best_payload,
-            oversized: false,
-        });
-        batch_start += best_len;
-    }
-
-    Ok(batches)
-}
-
-async fn publish_replica_batch(publisher: &EventPublisher, events: &[ActiveSequenceEvent]) {
-    let batches = match encode_replica_batch_partitions(events) {
-        Ok(batches) => batches,
-        Err(error) => {
-            tracing::error!(
-                event_count = events.len(),
-                error = %error,
-                "Failed to encode active-sequence replica batch"
-            );
-            return;
-        }
-    };
-
-    for batch in batches {
-        let batch_events = &events[batch.event_range.clone()];
-        let first_request_id = &batch_events
-            .first()
-            .expect("replica batch must contain an event")
-            .request_id;
-        let last_request_id = &batch_events
-            .last()
-            .expect("replica batch must contain an event")
-            .request_id;
-
-        if batch.oversized {
-            tracing::warn!(
-                request_id = %first_request_id,
-                payload_bytes = batch.payload.len(),
-                max_payload_bytes = MAX_REPLICA_BATCH_PAYLOAD_BYTES,
-                "Active-sequence replica event exceeds the batch payload limit; publishing intact"
-            );
-        }
-
-        if let Err(error) = publisher.publish_bytes_ref(batch.payload.as_ref()).await {
-            tracing::error!(
-                transport = ?publisher.transport_kind(),
-                event_count = batch_events.len(),
-                payload_bytes = batch.payload.len(),
-                first_request_id = %first_request_id,
-                last_request_id = %last_request_id,
-                error = %error,
-                "Failed to publish active-sequence replica batch"
-            );
-        }
+    if let Err(error) = publisher.publish(&batch).await {
+        tracing::error!(
+            event_count = batch.events.len(),
+            first_request_id = %first_request_id,
+            last_request_id = %last_request_id,
+            error = %error,
+            "Failed to publish active-sequence replica batch"
+        );
     }
 }
 
@@ -270,17 +212,46 @@ async fn run_replica_batch_publisher(
         };
         let (events, stop_after_flush) =
             collect_replica_batch(first_event, &mut event_rx, &cancellation_token).await;
-        publish_replica_batch(&publisher, &events).await;
+        publish_replica_batch(&publisher, events).await;
         if stop_after_flush {
             break;
         }
     }
 }
 
-/// Concrete [`SequenceSubscriber`] backed by NATS typed event stream.
+enum ActiveSequenceEventSubscriber {
+    Nats(TypedEventSubscriber<ActiveSequenceEvent>),
+    Zmq(TypedEventSubscriber<ActiveSequenceEventBatch>),
+}
+
+/// Concrete [`SequenceSubscriber`] backed by the configured runtime event transport.
 pub struct RuntimeSequenceSubscriber {
-    inner: dynamo_runtime::transports::event_plane::TypedEventSubscriber<ActiveSequenceEventBatch>,
+    inner: ActiveSequenceEventSubscriber,
     pending: VecDeque<ActiveSequenceEvent>,
+}
+
+impl RuntimeSequenceSubscriber {
+    pub(crate) async fn for_endpoint(endpoint: &Endpoint) -> Result<Self> {
+        let transport_kind = endpoint.drt().default_event_transport_kind();
+        let subscriber = EventSubscriber::for_endpoint_with_transport(
+            endpoint,
+            ACTIVE_SEQUENCES_SUBJECT,
+            transport_kind,
+        )
+        .await?;
+        let inner = match active_sequence_event_wire_format(transport_kind) {
+            ActiveSequenceEventWireFormat::Singleton => {
+                ActiveSequenceEventSubscriber::Nats(subscriber.typed::<ActiveSequenceEvent>())
+            }
+            ActiveSequenceEventWireFormat::Batch => {
+                ActiveSequenceEventSubscriber::Zmq(subscriber.typed::<ActiveSequenceEventBatch>())
+            }
+        };
+        Ok(Self {
+            inner,
+            pending: VecDeque::new(),
+        })
+    }
 }
 
 impl SequenceSubscriber for RuntimeSequenceSubscriber {
@@ -289,9 +260,17 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
             if let Some(event) = self.pending.pop_front() {
                 return Some(Ok(event));
             }
-            match self.inner.next().await? {
-                Ok((_envelope, batch)) => self.pending.extend(batch.events),
-                Err(error) => return Some(Err(error)),
+            match &mut self.inner {
+                ActiveSequenceEventSubscriber::Nats(subscriber) => {
+                    return match subscriber.next().await? {
+                        Ok((_envelope, event)) => Some(Ok(event)),
+                        Err(error) => Some(Err(error)),
+                    };
+                }
+                ActiveSequenceEventSubscriber::Zmq(subscriber) => match subscriber.next().await? {
+                    Ok((_envelope, batch)) => self.pending.extend(batch.events),
+                    Err(error) => return Some(Err(error)),
+                },
             }
         }
     }
@@ -304,11 +283,21 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
             if let Some(event) = self.pending.pop_front() {
                 return Poll::Ready(Some(Ok(event)));
             }
-            match self.inner.poll_next(cx) {
-                Poll::Ready(Some(Ok((_envelope, batch)))) => self.pending.extend(batch.events),
-                Poll::Ready(Some(Err(error))) => return Poll::Ready(Some(Err(error))),
-                Poll::Ready(None) => return Poll::Ready(None),
-                Poll::Pending => return Poll::Pending,
+            match &mut self.inner {
+                ActiveSequenceEventSubscriber::Nats(subscriber) => {
+                    return match subscriber.poll_next(cx) {
+                        Poll::Ready(Some(Ok((_envelope, event)))) => Poll::Ready(Some(Ok(event))),
+                        Poll::Ready(Some(Err(error))) => Poll::Ready(Some(Err(error))),
+                        Poll::Ready(None) => Poll::Ready(None),
+                        Poll::Pending => Poll::Pending,
+                    };
+                }
+                ActiveSequenceEventSubscriber::Zmq(subscriber) => match subscriber.poll_next(cx) {
+                    Poll::Ready(Some(Ok((_envelope, batch)))) => self.pending.extend(batch.events),
+                    Poll::Ready(Some(Err(error))) => return Poll::Ready(Some(Err(error))),
+                    Poll::Ready(None) => return Poll::Ready(None),
+                    Poll::Pending => return Poll::Pending,
+                },
             }
         }
     }
@@ -317,7 +306,7 @@ impl SequenceSubscriber for RuntimeSequenceSubscriber {
 /// Type alias for the runtime-wired multi-worker sequence tracker.
 pub type ActiveSequencesMulti = ActiveSequencesMultiWorker<RuntimeSequencePublisher>;
 
-/// Convenience async constructor that creates the NATS publishers/subscribers
+/// Convenience async constructor that creates the event-plane publishers/subscribers
 /// and returns an `Arc<ActiveSequencesMulti>` with replica sync already running.
 pub async fn create_multi_worker_sequences(
     endpoint: Endpoint,
@@ -328,16 +317,28 @@ pub async fn create_multi_worker_sequences(
     worker_type: &'static str,
     cancellation_token: CancellationToken,
 ) -> Result<Arc<ActiveSequencesMulti>> {
-    let event_tx = if replica_sync {
-        let event_publisher =
-            EventPublisher::for_endpoint(&endpoint, ACTIVE_SEQUENCES_SUBJECT).await?;
-        let (event_tx, event_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
-        tokio::spawn(run_replica_batch_publisher(
-            event_publisher,
-            event_rx,
-            cancellation_token.child_token(),
-        ));
-        Some(event_tx)
+    let event_publisher = if replica_sync {
+        let transport_kind = endpoint.drt().default_event_transport_kind();
+        let event_publisher = EventPublisher::for_endpoint_with_transport(
+            &endpoint,
+            ACTIVE_SEQUENCES_SUBJECT,
+            transport_kind,
+        )
+        .await?;
+        match active_sequence_event_wire_format(transport_kind) {
+            ActiveSequenceEventWireFormat::Singleton => Some(ActiveSequenceEventPublisher::Nats(
+                Box::new(event_publisher),
+            )),
+            ActiveSequenceEventWireFormat::Batch => {
+                let (event_tx, event_rx) = mpsc::channel(REPLICA_EVENT_CHANNEL_CAPACITY);
+                tokio::spawn(run_replica_batch_publisher(
+                    event_publisher,
+                    event_rx,
+                    cancellation_token.child_token(),
+                ));
+                Some(ActiveSequenceEventPublisher::Zmq(event_tx))
+            }
+        }
     } else {
         None
     };
@@ -346,7 +347,7 @@ pub async fn create_multi_worker_sequences(
     let worker_status_metrics = RouterWorkerStatusMetrics::from_component(endpoint.component());
 
     let publisher = RuntimeSequencePublisher {
-        event_tx,
+        event_publisher,
         metrics_publisher,
         worker_status_metrics,
     };
@@ -373,13 +374,7 @@ pub async fn create_multi_worker_sequences(
     let arc = Arc::new(multi_worker);
 
     if replica_sync {
-        let subscriber = EventSubscriber::for_endpoint(&endpoint, ACTIVE_SEQUENCES_SUBJECT)
-            .await?
-            .typed::<ActiveSequenceEventBatch>();
-        let subscriber = RuntimeSequenceSubscriber {
-            inner: subscriber,
-            pending: VecDeque::new(),
-        };
+        let subscriber = RuntimeSequenceSubscriber::for_endpoint(&endpoint).await?;
         arc.start_replica_sync(subscriber, cancellation_token.child_token());
     }
 
@@ -412,21 +407,6 @@ mod tests {
         }
     }
 
-    fn large_add_event(request_id: impl Into<String>, hashes: usize) -> ActiveSequenceEvent {
-        ActiveSequenceEvent {
-            request_id: request_id.into(),
-            worker: WorkerWithDpRank::new(1, 0),
-            data: ActiveSequenceEventData::AddRequest {
-                token_sequence: Some(vec![u64::MAX; hashes]),
-                track_prefill_tokens: true,
-                expected_output_tokens: None,
-                prefill_load_hint: None,
-            },
-            router_id: 7,
-            lora_name: None,
-        }
-    }
-
     #[tokio::test(start_paused = true)]
     async fn active_sequence_batch_collection_uses_time_and_count_caps() {
         let (event_tx, mut event_rx) = mpsc::channel(MAX_REPLICA_BATCH_EVENTS + 1);
@@ -444,10 +424,10 @@ mod tests {
         assert!(!stop);
         assert_eq!(events.len(), 100);
         assert_eq!(Instant::now() - start, MAX_REPLICA_BATCH_DURATION);
-        let batches = encode_replica_batch_partitions(&events).unwrap();
-        assert_eq!(batches.len(), 1);
-        let decoded: ActiveSequenceEventBatch =
-            MsgpackCodec.decode_payload(&batches[0].payload).unwrap();
+        let payload = MsgpackCodec
+            .encode_payload(&ActiveSequenceEventBatch { events })
+            .unwrap();
+        let decoded: ActiveSequenceEventBatch = MsgpackCodec.decode_payload(&payload).unwrap();
         assert_eq!(decoded.events.len(), 100);
         for (request_id, event) in decoded.events.iter().enumerate() {
             assert_eq!(event.request_id, format!("free-{request_id}"));
@@ -469,67 +449,49 @@ mod tests {
         assert_eq!(event_rx.len(), 1);
 
         let last = event_rx.recv().await.unwrap();
+        let start = Instant::now();
         let (remaining, stop) =
             collect_replica_batch(last, &mut event_rx, &CancellationToken::new()).await;
         assert!(!stop);
         assert_eq!(remaining.len(), 1);
+        assert_eq!(Instant::now() - start, MAX_REPLICA_BATCH_DURATION);
     }
 
     #[test]
-    fn active_sequence_batches_split_at_payload_limit_and_roundtrip() {
-        const NATS_DEFAULT_MAX_PAYLOAD_BYTES: usize = 1024 * 1024;
+    fn active_sequence_wire_format_uses_singletons_only_for_nats() {
+        assert_eq!(
+            active_sequence_event_wire_format(EventTransportKind::Nats),
+            ActiveSequenceEventWireFormat::Singleton
+        );
+        assert_eq!(
+            active_sequence_event_wire_format(EventTransportKind::Zmq),
+            ActiveSequenceEventWireFormat::Batch
+        );
 
-        let max_payload = vec![0; MAX_REPLICA_BATCH_PAYLOAD_BYTES];
-        let max_sized_envelope = MsgpackCodec
-            .encode_envelope_parts(
-                u64::MAX,
-                u64::MAX,
-                u64::MAX,
-                ACTIVE_SEQUENCES_SUBJECT,
-                &max_payload,
-            )
+        let event = free_event("request");
+        let singleton_payload = MsgpackCodec.encode_payload(&event).unwrap();
+        let decoded_singleton: ActiveSequenceEvent =
+            MsgpackCodec.decode_payload(&singleton_payload).unwrap();
+        assert_eq!(decoded_singleton.request_id, "request");
+        assert!(
+            MsgpackCodec
+                .decode_payload::<ActiveSequenceEventBatch>(&singleton_payload)
+                .is_err()
+        );
+
+        let batch_payload = MsgpackCodec
+            .encode_payload(&ActiveSequenceEventBatch {
+                events: vec![event],
+            })
             .unwrap();
-        assert!(max_sized_envelope.len() < NATS_DEFAULT_MAX_PAYLOAD_BYTES);
-
-        let events = vec![
-            large_add_event("large-0", 80_000),
-            large_add_event("large-1", 80_000),
-        ];
-        assert!(encode_replica_batch(&events).unwrap().len() > MAX_REPLICA_BATCH_PAYLOAD_BYTES);
-
-        let batches = encode_replica_batch_partitions(&events).unwrap();
-        assert_eq!(batches.len(), 2);
-        let mut decoded_request_ids = Vec::new();
-        for batch in &batches {
-            assert!(!batch.oversized);
-            assert!(batch.payload.len() <= MAX_REPLICA_BATCH_PAYLOAD_BYTES);
-            let envelope = MsgpackCodec
-                .encode_envelope_parts(
-                    u64::MAX,
-                    u64::MAX,
-                    u64::MAX,
-                    ACTIVE_SEQUENCES_SUBJECT,
-                    batch.payload.as_ref(),
-                )
-                .unwrap();
-            assert!(envelope.len() < NATS_DEFAULT_MAX_PAYLOAD_BYTES);
-
-            let decoded: ActiveSequenceEventBatch =
-                MsgpackCodec.decode_payload(&batch.payload).unwrap();
-            decoded_request_ids.extend(decoded.events.into_iter().map(|event| event.request_id));
-        }
-        assert_eq!(decoded_request_ids, ["large-0", "large-1"]);
-    }
-
-    #[test]
-    fn active_sequence_batch_preserves_single_oversized_event() {
-        let events = vec![large_add_event("oversized", 120_000)];
-        let batches = encode_replica_batch_partitions(&events).unwrap();
-
-        assert_eq!(batches.len(), 1);
-        assert!(batches[0].oversized);
-        assert!(batches[0].payload.len() > MAX_REPLICA_BATCH_PAYLOAD_BYTES);
-        assert_eq!(batches[0].event_range, 0..1);
+        let decoded_batch: ActiveSequenceEventBatch =
+            MsgpackCodec.decode_payload(&batch_payload).unwrap();
+        assert_eq!(decoded_batch.events[0].request_id, "request");
+        assert!(
+            MsgpackCodec
+                .decode_payload::<ActiveSequenceEvent>(&batch_payload)
+                .is_err()
+        );
     }
 
     #[tokio::test]

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -743,6 +743,12 @@ impl Default for LoadEstimator {
 mod tests {
     use super::*;
     use dynamo_kv_router::protocols::{ActiveSequenceEventBatch, WorkerWithDpRank};
+    use dynamo_runtime::config::environment_names::zmq_broker as broker_env;
+    use dynamo_runtime::distributed::DistributedConfig;
+    use dynamo_runtime::transports::event_plane::EventPublisher;
+    use dynamo_runtime::{DistributedRuntime, Runtime};
+
+    use crate::kv_router::ACTIVE_SEQUENCES_SUBJECT;
 
     fn lora_event(
         request_id: &str,
@@ -767,34 +773,98 @@ mod tests {
         }
     }
 
-    #[test]
-    fn mixed_replica_batch_updates_lora_load_in_order() {
-        let estimator = LoadEstimator::new();
-        let batch = ActiveSequenceEventBatch {
-            events: vec![
-                lora_event("alpha", Some("lora-alpha"), add_request()),
-                lora_event(
-                    "alpha",
-                    Some("lora-alpha"),
-                    ActiveSequenceEventData::MarkPrefillCompleted,
-                ),
-                lora_event("beta", Some("lora-beta"), add_request()),
-                lora_event("alpha", Some("lora-alpha"), ActiveSequenceEventData::Free),
-                lora_event("no-lora", None, add_request()),
+    #[tokio::test]
+    async fn mixed_replica_batch_updates_lora_load_in_order() {
+        temp_env::async_with_vars(
+            [
+                (broker_env::DYN_ZMQ_BROKER_URL, None::<&str>),
+                (broker_env::DYN_ZMQ_BROKER_ENABLED, None::<&str>),
             ],
-        };
-        for event in batch.events {
-            estimator.handle_event(event);
-        }
+            async {
+                let runtime = Runtime::from_current().expect("create runtime handle");
+                let drt = DistributedRuntime::new(runtime, DistributedConfig::process_local())
+                    .await
+                    .expect("create distributed runtime");
+                let endpoint = drt
+                    .namespace(format!("lora-replica-batch-test-{}", uuid::Uuid::new_v4()))
+                    .expect("create namespace")
+                    .component("worker")
+                    .expect("create component")
+                    .endpoint("generate");
+                let publisher = EventPublisher::for_endpoint(&endpoint, ACTIVE_SEQUENCES_SUBJECT)
+                    .await
+                    .expect("create publisher");
+                let mut subscriber = RuntimeSequenceSubscriber::for_endpoint(&endpoint)
+                    .await
+                    .expect("create sequence subscriber");
+                let batch = ActiveSequenceEventBatch {
+                    events: vec![
+                        lora_event("alpha", Some("lora-alpha"), add_request()),
+                        lora_event(
+                            "alpha",
+                            Some("lora-alpha"),
+                            ActiveSequenceEventData::MarkPrefillCompleted,
+                        ),
+                        lora_event("beta", Some("lora-beta"), add_request()),
+                        lora_event("alpha", Some("lora-alpha"), ActiveSequenceEventData::Free),
+                        lora_event("no-lora", None, add_request()),
+                    ],
+                };
 
-        let inflight = estimator.get_inflight_counts();
-        assert!(!inflight.contains_key("lora-alpha"));
-        assert_eq!(inflight.get("lora-beta"), Some(&1));
+                let events = tokio::time::timeout(Duration::from_secs(5), async {
+                    loop {
+                        publisher
+                            .publish(&batch)
+                            .await
+                            .expect("publish active-sequence batch");
+                        let receive_batch = async {
+                            let mut events = Vec::with_capacity(batch.events.len());
+                            while events.len() < batch.events.len() {
+                                match subscriber.next_event().await {
+                                    Some(Ok(event)) => events.push(event),
+                                    Some(Err(error)) => {
+                                        panic!("receive active-sequence batch: {error}")
+                                    }
+                                    None => panic!("active-sequence event stream closed"),
+                                }
+                            }
+                            events
+                        };
+                        match tokio::time::timeout(Duration::from_millis(100), receive_batch).await
+                        {
+                            Ok(events) => break events,
+                            Err(_) => tokio::time::sleep(Duration::from_millis(10)).await,
+                        }
+                    }
+                })
+                .await
+                .expect("subscriber should receive an active-sequence batch");
 
-        let arrivals = estimator.get_raw_arrival_counts();
-        assert_eq!(arrivals.get("lora-alpha"), Some(&1));
-        assert_eq!(arrivals.get("lora-beta"), Some(&1));
-        assert_eq!(arrivals.len(), 2);
+                assert_eq!(
+                    events
+                        .iter()
+                        .map(|event| event.request_id.as_str())
+                        .collect::<Vec<_>>(),
+                    vec!["alpha", "alpha", "beta", "alpha", "no-lora"]
+                );
+
+                let estimator = LoadEstimator::new();
+                for event in events {
+                    estimator.handle_event(event);
+                }
+
+                let inflight = estimator.get_inflight_counts();
+                assert!(!inflight.contains_key("lora-alpha"));
+                assert_eq!(inflight.get("lora-beta"), Some(&1));
+
+                let arrivals = estimator.get_raw_arrival_counts();
+                assert_eq!(arrivals.get("lora-alpha"), Some(&1));
+                assert_eq!(arrivals.get("lora-beta"), Some(&1));
+                assert_eq!(arrivals.len(), 2);
+                drt.shutdown();
+            },
+        )
+        .await;
     }
 
     #[test]

--- a/lib/llm/src/lora/load_estimator.rs
+++ b/lib/llm/src/lora/load_estimator.rs
@@ -19,10 +19,9 @@ use dashmap::DashMap;
 use dynamo_kv_router::protocols::{ActiveSequenceEvent, ActiveSequenceEventData};
 use dynamo_runtime::component::{Component, Endpoint};
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use dynamo_runtime::transports::event_plane::EventSubscriber;
 
-use crate::kv_router::ACTIVE_SEQUENCES_SUBJECT;
 use crate::kv_router::scheduler::KvScheduler;
+use crate::kv_router::sequence::{RuntimeSequenceSubscriber, SequenceSubscriber};
 use crate::lora::config::PredictorType;
 use crate::lora::predictor::{EmaPredictor, LoadPredictor};
 
@@ -498,18 +497,16 @@ impl LoadEstimator {
         endpoint: &Endpoint,
         cancel_token: &tokio_util::sync::CancellationToken,
     ) -> anyhow::Result<()> {
-        let mut subscriber = EventSubscriber::for_endpoint(endpoint, ACTIVE_SEQUENCES_SUBJECT)
-            .await?
-            .typed::<ActiveSequenceEvent>();
+        let mut subscriber = RuntimeSequenceSubscriber::for_endpoint(endpoint).await?;
 
         tracing::info!("Started LORA load event subscription");
 
         loop {
             tokio::select! {
                 _ = cancel_token.cancelled() => return Ok(()),
-                result = subscriber.next() => {
+                result = subscriber.next_event() => {
                     match result {
-                        Some(Ok((_envelope, event))) => {
+                        Some(Ok(event)) => {
                             self.handle_event(event);
                         }
                         Some(Err(e)) => {
@@ -745,6 +742,60 @@ impl Default for LoadEstimator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use dynamo_kv_router::protocols::{ActiveSequenceEventBatch, WorkerWithDpRank};
+
+    fn lora_event(
+        request_id: &str,
+        lora_name: Option<&str>,
+        data: ActiveSequenceEventData,
+    ) -> ActiveSequenceEvent {
+        ActiveSequenceEvent {
+            request_id: request_id.to_string(),
+            worker: WorkerWithDpRank::new(1, 0),
+            data,
+            router_id: 7,
+            lora_name: lora_name.map(str::to_string),
+        }
+    }
+
+    fn add_request() -> ActiveSequenceEventData {
+        ActiveSequenceEventData::AddRequest {
+            token_sequence: None,
+            track_prefill_tokens: false,
+            expected_output_tokens: None,
+            prefill_load_hint: None,
+        }
+    }
+
+    #[test]
+    fn mixed_replica_batch_updates_lora_load_in_order() {
+        let estimator = LoadEstimator::new();
+        let batch = ActiveSequenceEventBatch {
+            events: vec![
+                lora_event("alpha", Some("lora-alpha"), add_request()),
+                lora_event(
+                    "alpha",
+                    Some("lora-alpha"),
+                    ActiveSequenceEventData::MarkPrefillCompleted,
+                ),
+                lora_event("beta", Some("lora-beta"), add_request()),
+                lora_event("alpha", Some("lora-alpha"), ActiveSequenceEventData::Free),
+                lora_event("no-lora", None, add_request()),
+            ],
+        };
+        for event in batch.events {
+            estimator.handle_event(event);
+        }
+
+        let inflight = estimator.get_inflight_counts();
+        assert!(!inflight.contains_key("lora-alpha"));
+        assert_eq!(inflight.get("lora-beta"), Some(&1));
+
+        let arrivals = estimator.get_raw_arrival_counts();
+        assert_eq!(arrivals.get("lora-alpha"), Some(&1));
+        assert_eq!(arrivals.get("lora-beta"), Some(&1));
+        assert_eq!(arrivals.len(), 2);
+    }
 
     #[test]
     fn set_config_rebuilds_existing_counter_geometry() {


### PR DESCRIPTION
## Summary

Batch frontend active-sequence replica-sync lifecycle events on ZMQ while preserving singleton NATS publication and the existing receive-side coalescing behavior.

## Overview:

Reduce ZMQ message fanout by collecting lifecycle events with the shared 256-event and 1 ms policy. NATS keeps the existing ActiveSequenceEvent wire format, so no batch payload-size cap or partitioning is required.

## Details:

- Select singleton or batched publication from the runtime event transport.
- Publish each NATS lifecycle event immediately with the existing singleton wire format.
- Send ZMQ lifecycle events through the existing 100,000-event bounded queue and publish one ActiveSequenceEventBatch per collection window.
- Decode NATS singletons and ZMQ batches through one shared transport-aware subscriber used by replica apply and LoRA load tracking.
- Preserve the public by-reference SequencePublisher method and add a default owned helper; only the runtime overrides the owned path to avoid cloning large AddRequest token vectors.
- Keep receive-side ReplicaBatchEffects coalescing, best-effort failures, and standalone slot-tracker wire behavior unchanged.

## Where should the reviewer start?

- lib/llm/src/kv_router/sequence.rs for transport selection, ZMQ batching, and shared subscriber flattening.
- lib/llm/src/lora/load_estimator.rs for reuse of the shared subscriber and the LoRA regression test.
- lib/kv-router/src/sequences/multi_worker.rs for the source-compatible owned-event helper.

## Related Issues

**This PR is NOT linked to an issue:**
- [x] Confirmed — no related issue

## Validation

- cargo fmt --all -- --check
- cargo test -p dynamo-llm kv_router::sequence::tests --lib
- cargo test -p dynamo-llm mixed_replica_batch_updates_lora_load_in_order --lib
- cargo test -p dynamo-kv-router replica_sync --lib
- cargo test -p dynamo-kv-router --features standalone-slot-tracker scoped_publisher_drops_when_outbound_channel_is_full --lib
- cargo clippy -p dynamo-kv-router -p dynamo-llm -p dynamo-mocker --lib --tests -- -D warnings
- cargo clippy -p dynamo-kv-router --features standalone-slot-tracker --lib --tests -- -D warnings