### PR TITLE
[no validation recipes] docs: correct YouTube branding in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Or view the source: [`docs/contribution-guide.md`](docs/contribution-guide.md)
 - [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf)
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [Office Hours](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
-- [Community Meetings](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([Youtube](https://www.youtube.com/@ai-dynamo-community)) -- Weekly (Wed 10:30 AM PT) development community meetings
+- [Community Meetings](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([YouTube](https://www.youtube.com/@ai-dynamo-community)) -- Weekly (Wed 10:30 AM PT) development community meetings
 - [Dynamo Day Recordings](https://nvevents.nvidia.com/dynamoday)
 
 Dynamo requires all contributions to be signed off with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). This certifies that you have the right to submit your contribution under the project's [Apache 2.0 license](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE).


### PR DESCRIPTION
> **Merge held — customs refused: no validation recipes ran.** The recorded evidence does not support the declared verdict. The plan named no validation recipes and the registry is empty; nothing was validated.

**AI review assessment:** `unsound` — the recorded evidence does not support the declared verdict. This assessment is advisory only and does not constitute merge approval.

## Summary

Corrects the YouTube branding in `CONTRIBUTING.md`: changes the Community Meetings link label from "Youtube" to "YouTube". One file, one line changed, signed off with DCO.

## Evidence [no validation recipes]

_Generated from validation/registry.jsonl — do not edit by hand._

| Recipe | Status | Command | Evidence | Note |
|---|---|---|---|---|


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the capitalization of “YouTube” in the Community Meetings quick link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->