### PR TITLE
feat(runtime): size TCP worker pool from engine capacity

### DIFF
--- a/docs/fern/pages/developer-guide/knowledge-base/concepts/fault-tolerance/request-rejection-architecture.md
+++ b/docs/fern/pages/developer-guide/knowledge-base/concepts/fault-tolerance/request-rejection-architecture.md
@@ -109,6 +109,10 @@ returns `Server overloaded: worker at capacity`; the Frontend maps the resulting
 The effective maximum is `N + Q` requests. `DYN_DYNAMO_REQUEST_QUEUE_LIMIT` defaults to `16`, is an
 advanced override, must be at least `2`, and is read only when the engine limit is enabled.
 
+When `DYN_ENGINE_REQUEST_LIMIT` is unset and the backend reports capacity, the worker pool is sized
+to `ceil(1.5 × max_num_seqs × data_parallel_size)`. `DYN_TCP_WORKER_POOL_SIZE` overrides this
+automatic sizing.
+
 ### Overflow Channel Sizing
 
 The channel capacity is `Q - 1` because one dispatcher task can hold a request between the queue and

--- a/lib/llm/src/local_model.rs
+++ b/lib/llm/src/local_model.rs
@@ -669,6 +669,15 @@ impl LocalModel {
         }
 
         // Register the Model Deployment Card via discovery interface
+        if lora_info.is_none()
+            && let Some(engine_capacity) = self.runtime_config.tcp_worker_pool_capacity_hint()
+        {
+            endpoint
+                .drt()
+                .network_manager()
+                .set_engine_capacity_hint(engine_capacity)
+                .await?;
+        }
         register_model_card(endpoint, &self.card).await?;
 
         Ok(())

--- a/lib/llm/src/local_model/runtime_config.rs
+++ b/lib/llm/src/local_model/runtime_config.rs
@@ -455,6 +455,15 @@ impl ModelRuntimeConfig {
         self.validate().map_err(|error| error.to_string())
     }
 
+    /// Derive the automatic TCP pool hint from existing engine registration fields.
+    pub(crate) fn tcp_worker_pool_capacity_hint(&self) -> Option<usize> {
+        let max_num_seqs = usize::try_from(self.max_num_seqs?).ok()?;
+        let data_parallel_size = usize::try_from(self.data_parallel_size).ok()?;
+        max_num_seqs
+            .checked_mul(data_parallel_size)
+            .filter(|capacity| *capacity > 0)
+    }
+
     pub fn set_engine_specific<T: Serialize>(&mut self, key: &str, value: T) -> anyhow::Result<()> {
         self.runtime_data
             .insert(key.to_string(), serde_json::to_value(value)?);
@@ -538,6 +547,42 @@ impl ModelRuntimeConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tcp_worker_pool_capacity_hint_uses_existing_registration_fields() {
+        let config = ModelRuntimeConfig {
+            max_num_seqs: Some(3),
+            data_parallel_size: 3,
+            ..Default::default()
+        };
+        assert_eq!(config.tcp_worker_pool_capacity_hint(), Some(9));
+    }
+
+    #[test]
+    fn tcp_worker_pool_capacity_hint_rejects_missing_zero_and_overflow() {
+        for config in [
+            ModelRuntimeConfig {
+                max_num_seqs: None,
+                ..Default::default()
+            },
+            ModelRuntimeConfig {
+                max_num_seqs: Some(0),
+                ..Default::default()
+            },
+            ModelRuntimeConfig {
+                max_num_seqs: Some(3),
+                data_parallel_size: 0,
+                ..Default::default()
+            },
+            ModelRuntimeConfig {
+                max_num_seqs: Some(u64::MAX),
+                data_parallel_size: 2,
+                ..Default::default()
+            },
+        ] {
+            assert_eq!(config.tcp_worker_pool_capacity_hint(), None);
+        }
+    }
 
     // Env-touching tests use `temp_env` (snapshot + restore around the closure) and
     // `#[serial_test::serial]` (serialize against every other env-touching test in the

--- a/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
+++ b/lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs
@@ -14,7 +14,7 @@ use crate::metrics::work_handler_pool::{
     WORK_HANDLER_QUEUE_DEPTH,
 };
 use crate::pipeline::network::PushWorkHandler;
-use anyhow::Result;
+use anyhow::{Result, anyhow, bail};
 use bytes::Bytes;
 use dashmap::DashMap;
 use parking_lot::{Mutex, RwLock};
@@ -24,7 +24,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Instant;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
+use tokio::sync::{Notify, OnceCell, OwnedSemaphorePermit, Semaphore};
 use tokio_util::bytes::BytesMut;
 use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
@@ -33,23 +33,30 @@ use tracing::Instrument;
 const DEFAULT_WORKER_POOL_SIZE: usize = 10000;
 
 /// Default work queue size for TCP request handling
-/// this is 4X the worker pool size to handle burst traffic
 const DEFAULT_WORK_QUEUE_SIZE: usize = 40000;
 
-/// Get worker pool size from environment or use default
-fn get_worker_pool_size() -> usize {
-    std::env::var("DYN_TCP_WORKER_POOL_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_WORKER_POOL_SIZE)
+fn parse_env_usize_value(name: &str, raw_value: &str) -> Result<usize> {
+    raw_value
+        .parse::<usize>()
+        .map_err(|_| anyhow!("{name} must be a positive integer, got {raw_value:?}"))
 }
 
-/// Get work queue size from environment or use default
-fn get_work_queue_size() -> usize {
-    std::env::var("DYN_TCP_WORK_QUEUE_SIZE")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-        .unwrap_or(DEFAULT_WORK_QUEUE_SIZE)
+fn parse_env_usize(name: &str) -> Result<Option<usize>> {
+    match std::env::var(name) {
+        Ok(raw_value) => parse_env_usize_value(name, &raw_value).map(Some),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(error) => Err(anyhow!("failed to read {name}: {error}")),
+    }
+}
+
+fn validate_tokio_capacity(name: &str, value: usize, minimum: usize) -> Result<usize> {
+    if value < minimum || value > Semaphore::MAX_PERMITS {
+        bail!(
+            "{name} must be between {minimum} and {}, got {value}",
+            Semaphore::MAX_PERMITS
+        );
+    }
+    Ok(value)
 }
 
 /// Default small overflow queue when the engine-request limit is set but the
@@ -64,37 +71,64 @@ const DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT: usize = 16;
 ///
 /// * `DYN_ENGINE_REQUEST_LIMIT` set → pool = engine limit (N), queue = Q
 ///   (default 16). Hard cap N+Q.
-/// * unset → large defaults (10000 / 40000), so rejection only triggers under
-///   extreme saturation.
+/// * otherwise `DYN_TCP_WORKER_POOL_SIZE` set → explicit pool and TCP queue.
+/// * otherwise a retained engine-capacity hint sets the initial pool size; without
+///   one, the pool starts at 10000 and may be updated once. The TCP queue defaults
+///   to 40000.
+#[derive(Debug)]
 struct SizingConfig {
     pool_size: usize,
     queue_size: usize,
+    accepts_engine_capacity_hint: bool,
 }
 
-fn resolve_sizing() -> SizingConfig {
-    match std::env::var("DYN_ENGINE_REQUEST_LIMIT")
-        .ok()
-        .and_then(|s| s.parse::<usize>().ok())
-    {
+fn worker_pool_size_for_engine_capacity(engine_capacity: usize) -> usize {
+    engine_capacity
+        .saturating_add(engine_capacity.div_ceil(2))
+        .min(Semaphore::MAX_PERMITS)
+}
+
+fn resolve_sizing(
+    env: impl Fn(&str) -> Result<Option<usize>>,
+    engine_capacity_hint: Option<usize>,
+) -> Result<SizingConfig> {
+    let read_capacity = |name: &str, minimum: usize| {
+        env(name)?
+            .map(|value| validate_tokio_capacity(name, value, minimum))
+            .transpose()
+    };
+
+    let sizing = match read_capacity("DYN_ENGINE_REQUEST_LIMIT", 1)? {
         Some(engine_limit) => {
-            let queue_limit = std::env::var("DYN_DYNAMO_REQUEST_QUEUE_LIMIT")
-                .ok()
-                .and_then(|s| s.parse::<usize>().ok())
+            let queue_limit = read_capacity("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 2)?
                 .unwrap_or(DEFAULT_DYNAMO_REQUEST_QUEUE_LIMIT);
             // The single dispatcher holds one request between `recv()` and
             // acquiring an engine permit, so size the channel to limit-1:
             // channel + the dispatcher-held request cap "queued, not in engine"
             // at exactly `limit`.
             SizingConfig {
-                pool_size: engine_limit.max(1),
-                queue_size: queue_limit.saturating_sub(1).max(1),
+                pool_size: engine_limit,
+                queue_size: queue_limit - 1,
+                accepts_engine_capacity_hint: false,
             }
         }
-        None => SizingConfig {
-            pool_size: get_worker_pool_size(),
-            queue_size: get_work_queue_size(),
-        },
-    }
+        None => {
+            let explicit_pool_size = read_capacity("DYN_TCP_WORKER_POOL_SIZE", 1)?;
+            let automatic_pool_size = engine_capacity_hint
+                .filter(|capacity| *capacity > 0)
+                .map(worker_pool_size_for_engine_capacity);
+            SizingConfig {
+                pool_size: explicit_pool_size
+                    .or(automatic_pool_size)
+                    .unwrap_or(DEFAULT_WORKER_POOL_SIZE),
+                queue_size: read_capacity("DYN_TCP_WORK_QUEUE_SIZE", 1)?
+                    .unwrap_or(DEFAULT_WORK_QUEUE_SIZE),
+                accepts_engine_capacity_hint: explicit_pool_size.is_none()
+                    && automatic_pool_size.is_none(),
+            }
+        }
+    };
+    Ok(sizing)
 }
 
 /// RAII guard for `WORK_HANDLER_POOL_ACTIVE_TASKS`. `new()` increments and
@@ -147,6 +181,12 @@ pub struct SharedTcpServer {
     /// Worker-pool semaphore bounding concurrent in-engine requests. Shared with
     /// `read_loop` so it can front-acquire a permit and dispatch directly.
     engine_sem: Arc<Semaphore>,
+    /// Pool size selected when this server was constructed.
+    initial_worker_pool_size: usize,
+    /// Explicit environment overrides disable automatic sizing.
+    accepts_engine_capacity_hint: bool,
+    /// Serializes the single allowed fallback-to-engine-capacity update.
+    engine_capacity_update: OnceCell<()>,
     /// Overflow-queue capacity; `read_loop` compares against it to tell whether
     /// the queue is empty for the FIFO direct-dispatch rule.
     queue_capacity: usize,
@@ -164,11 +204,25 @@ struct EndpointHandler {
 }
 
 impl SharedTcpServer {
-    pub fn new(bind_addr: SocketAddr, cancellation_token: CancellationToken) -> Arc<Self> {
+    pub fn new(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        engine_capacity_hint: Option<usize>,
+    ) -> Result<Arc<Self>> {
+        let sizing = resolve_sizing(parse_env_usize, engine_capacity_hint)?;
+        Ok(Self::new_with_sizing(bind_addr, cancellation_token, sizing))
+    }
+
+    fn new_with_sizing(
+        bind_addr: SocketAddr,
+        cancellation_token: CancellationToken,
+        sizing: SizingConfig,
+    ) -> Arc<Self> {
         let SizingConfig {
             pool_size: worker_pool_size,
             queue_size: work_queue_size,
-        } = resolve_sizing();
+            accepts_engine_capacity_hint,
+        } = sizing;
 
         tracing::info!(
             "Initializing TCP server with dispatcher (concurrency={}, queue={})",
@@ -204,8 +258,56 @@ impl SharedTcpServer {
             cancellation_token,
             work_tx,
             engine_sem,
+            initial_worker_pool_size: worker_pool_size,
+            accepts_engine_capacity_hint,
+            engine_capacity_update: OnceCell::new(),
             queue_capacity: work_queue_size,
         })
+    }
+
+    /// Apply the first engine-capacity hint when no explicit pool override was set.
+    pub async fn update_worker_pool_from_engine_capacity(
+        &self,
+        engine_capacity: usize,
+    ) -> Result<()> {
+        if !self.accepts_engine_capacity_hint || engine_capacity == 0 {
+            return Ok(());
+        }
+
+        self.engine_capacity_update
+            .get_or_try_init(|| async {
+                let worker_pool_size = worker_pool_size_for_engine_capacity(engine_capacity);
+
+                if worker_pool_size < self.initial_worker_pool_size {
+                    let permits_to_remove =
+                        u32::try_from(self.initial_worker_pool_size - worker_pool_size)
+                            .map_err(|_| anyhow!("TCP worker-pool shrink exceeds u32"))?;
+                    let permit = self
+                        .engine_sem
+                        .clone()
+                        .acquire_many_owned(permits_to_remove)
+                        .await
+                        .map_err(|_| anyhow!("TCP worker-pool semaphore closed during sizing"))?;
+                    permit.forget();
+                } else if worker_pool_size > self.initial_worker_pool_size {
+                    self.engine_sem
+                        .add_permits(worker_pool_size - self.initial_worker_pool_size);
+                }
+
+                WORK_HANDLER_POOL_CAPACITY.set(crate::metrics::prometheus_names::clamp_u64_to_i64(
+                    worker_pool_size as u64,
+                ));
+                tracing::info!(
+                    engine_capacity,
+                    previous_concurrency = self.initial_worker_pool_size,
+                    concurrency = worker_pool_size,
+                    "Updated TCP worker dispatcher concurrency from engine capacity"
+                );
+                Ok::<(), anyhow::Error>(())
+            })
+            .await?;
+
+        Ok(())
     }
 
     /// Start the worker pool dispatcher that processes requests with bounded concurrency
@@ -770,6 +872,218 @@ mod tests {
     use std::time::Duration;
     use tokio::time::Instant;
 
+    fn sizing_env<const N: usize>(
+        values: [(&'static str, usize); N],
+    ) -> impl Fn(&str) -> Result<Option<usize>> {
+        move |name| {
+            Ok(values
+                .iter()
+                .find_map(|(key, value)| (*key == name).then_some(*value)))
+        }
+    }
+
+    fn assert_sizing_error<const N: usize>(
+        values: [(&'static str, usize); N],
+        expected_name: &str,
+    ) {
+        let error = resolve_sizing(sizing_env(values), None)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            error.contains(expected_name),
+            "error did not name {expected_name}: {error}"
+        );
+    }
+
+    fn test_server(pool_size: usize, accepts_engine_capacity_hint: bool) -> Arc<SharedTcpServer> {
+        SharedTcpServer::new_with_sizing(
+            "127.0.0.1:0".parse().unwrap(),
+            CancellationToken::new(),
+            SizingConfig {
+                pool_size,
+                queue_size: DEFAULT_WORK_QUEUE_SIZE,
+                accepts_engine_capacity_hint,
+            },
+        )
+    }
+
+    #[test]
+    fn worker_pool_size_precedence() {
+        // Each case supplies an immutable environment view, so this test is
+        // independent from process-global state and other parallel tests.
+        let sizing = resolve_sizing(
+            sizing_env([
+                ("DYN_ENGINE_REQUEST_LIMIT", 7),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 5),
+                ("DYN_TCP_WORKER_POOL_SIZE", 99),
+                ("DYN_TCP_WORK_QUEUE_SIZE", 123),
+            ]),
+            Some(6),
+        )
+        .unwrap();
+        assert_eq!(sizing.pool_size, 7);
+        assert_eq!(sizing.queue_size, 4);
+        assert!(!sizing.accepts_engine_capacity_hint);
+
+        let sizing = resolve_sizing(
+            sizing_env([
+                ("DYN_TCP_WORKER_POOL_SIZE", 99),
+                ("DYN_TCP_WORK_QUEUE_SIZE", 123),
+            ]),
+            Some(6),
+        )
+        .unwrap();
+        assert_eq!(sizing.pool_size, 99);
+        assert_eq!(sizing.queue_size, 123);
+
+        assert!(!sizing.accepts_engine_capacity_hint);
+        let sizing =
+            resolve_sizing(sizing_env([("DYN_ENGINE_REQUEST_LIMIT", 7)]), Some(6)).unwrap();
+        assert_eq!(sizing.pool_size, 7);
+        // The logical default is 16 queued requests: 15 in the
+        // channel plus one held by the dispatcher.
+        assert_eq!(sizing.queue_size, 15);
+        assert_eq!(sizing.queue_size + 1, 16);
+
+        assert_eq!(worker_pool_size_for_engine_capacity(3), 5);
+        assert_eq!(worker_pool_size_for_engine_capacity(8), 12);
+        let fallback = resolve_sizing(|_| Ok(None), None).unwrap();
+        assert_eq!(fallback.pool_size, 10_000);
+        assert_eq!(fallback.queue_size, 40_000);
+        assert!(fallback.accepts_engine_capacity_hint);
+    }
+
+    #[tokio::test]
+    async fn engine_capacity_hint_before_server_creation_sets_initial_pool_size() {
+        let cancellation_token = CancellationToken::new();
+        let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
+        let sizing = resolve_sizing(|_| Ok(None), Some(6)).unwrap();
+        let server =
+            SharedTcpServer::new_with_sizing(bind_addr, cancellation_token.clone(), sizing);
+
+        assert_eq!(server.initial_worker_pool_size, 9);
+        assert_eq!(server.engine_sem.available_permits(), 9);
+        assert!(!server.accepts_engine_capacity_hint);
+
+        cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn late_engine_capacity_updates_only_the_fallback_pool() {
+        let server = test_server(DEFAULT_WORKER_POOL_SIZE, true);
+
+        assert_eq!(server.engine_sem.available_permits(), 10_000);
+        server
+            .update_worker_pool_from_engine_capacity(6)
+            .await
+            .unwrap();
+        assert_eq!(server.engine_sem.available_permits(), 9);
+
+        // A later registration cannot resize the process-global pool again.
+        server
+            .update_worker_pool_from_engine_capacity(20)
+            .await
+            .unwrap();
+        assert_eq!(server.engine_sem.available_permits(), 9);
+
+        let overridden = test_server(13, false);
+        overridden
+            .update_worker_pool_from_engine_capacity(6)
+            .await
+            .unwrap();
+        assert_eq!(overridden.engine_sem.available_permits(), 13);
+
+        server.cancellation_token.cancel();
+        overridden.cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn late_engine_capacity_shrink_waits_for_active_permits() {
+        let server = test_server(10, true);
+        let last_needed = server.engine_sem.clone().acquire_owned().await.unwrap();
+        let active = server
+            .engine_sem
+            .clone()
+            .acquire_many_owned(3)
+            .await
+            .unwrap();
+
+        let update = server.update_worker_pool_from_engine_capacity(2);
+        tokio::pin!(update);
+
+        // Target 3 needs seven free permits; four active permits leave only six.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), &mut update)
+                .await
+                .is_err()
+        );
+        drop(last_needed);
+        tokio::time::timeout(Duration::from_secs(1), &mut update)
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(server.engine_sem.available_permits(), 0);
+
+        drop(active);
+        assert_eq!(server.engine_sem.available_permits(), 3);
+        server.cancellation_token.cancel();
+    }
+
+    #[tokio::test]
+    async fn late_engine_capacity_grows_the_fallback_pool() {
+        let server = test_server(DEFAULT_WORKER_POOL_SIZE, true);
+        server
+            .update_worker_pool_from_engine_capacity(8_000)
+            .await
+            .unwrap();
+        assert_eq!(server.engine_sem.available_permits(), 12_000);
+        server.cancellation_token.cancel();
+    }
+
+    #[test]
+    fn worker_pool_sizing_rejects_invalid_capacities() {
+        let too_large = Semaphore::MAX_PERMITS + 1;
+
+        for value in [0, too_large] {
+            assert_sizing_error(
+                [("DYN_ENGINE_REQUEST_LIMIT", value)],
+                "DYN_ENGINE_REQUEST_LIMIT",
+            );
+            assert_sizing_error(
+                [
+                    ("DYN_ENGINE_REQUEST_LIMIT", 1),
+                    ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", value),
+                ],
+                "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+            );
+            assert_sizing_error(
+                [("DYN_TCP_WORKER_POOL_SIZE", value)],
+                "DYN_TCP_WORKER_POOL_SIZE",
+            );
+            assert_sizing_error(
+                [("DYN_TCP_WORK_QUEUE_SIZE", value)],
+                "DYN_TCP_WORK_QUEUE_SIZE",
+            );
+        }
+
+        assert_sizing_error(
+            [
+                ("DYN_ENGINE_REQUEST_LIMIT", 1),
+                ("DYN_DYNAMO_REQUEST_QUEUE_LIMIT", 1),
+            ],
+            "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+        );
+    }
+
+    #[test]
+    fn worker_pool_sizing_rejects_malformed_capacity() {
+        let error = parse_env_usize_value("DYN_TCP_WORKER_POOL_SIZE", "not-a-number")
+            .unwrap_err()
+            .to_string();
+        assert!(error.contains("DYN_TCP_WORKER_POOL_SIZE"));
+        assert!(error.contains("not-a-number"));
+    }
+
     /// Mock handler that simulates slow request processing for testing
     struct SlowMockHandler {
         /// Tracks if a request is currently being processed
@@ -836,7 +1150,15 @@ mod tests {
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
 
         // Create SharedTcpServer
-        let server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
+        let server = SharedTcpServer::new_with_sizing(
+            bind_addr,
+            cancellation_token.clone(),
+            SizingConfig {
+                pool_size: 10_000,
+                queue_size: 16,
+                accepts_engine_capacity_hint: false,
+            },
+        );
 
         // Create a handler that takes 1s to process requests
         let handler = Arc::new(SlowMockHandler::new(Duration::from_secs(1)));
@@ -1183,20 +1505,16 @@ mod tests {
     async fn test_capacities_published_on_server_init() {
         crate::logging::init();
 
-        // SharedTcpServer::new publishes static capacities. Any test that instantiates
-        // a SharedTcpServer will have populated the gauges; we just assert they're > 0.
+        // Server construction publishes static capacities. Process-global
+        // gauges may also be written by parallel tests, so keep this oracle
+        // intentionally minimal; the process-isolated Mocker E2E checks values.
         let cancellation_token = CancellationToken::new();
         let bind_addr: SocketAddr = "127.0.0.1:0".parse().unwrap();
-        let _server = SharedTcpServer::new(bind_addr, cancellation_token.clone());
-
-        assert!(
-            WORK_HANDLER_POOL_CAPACITY.get() > 0,
-            "pool_capacity should be set to DEFAULT_WORKER_POOL_SIZE"
-        );
-        assert!(
-            WORK_HANDLER_QUEUE_CAPACITY.get() > 0,
-            "queue_capacity should be set to DEFAULT_WORK_QUEUE_SIZE"
-        );
+        let sizing = resolve_sizing(|_| Ok(None), None).unwrap();
+        let _server =
+            SharedTcpServer::new_with_sizing(bind_addr, cancellation_token.clone(), sizing);
+        assert!(WORK_HANDLER_POOL_CAPACITY.get() > 0);
+        assert!(WORK_HANDLER_QUEUE_CAPACITY.get() > 0);
         cancellation_token.cancel();
     }
 }

--- a/lib/runtime/src/pipeline/network/manager.rs
+++ b/lib/runtime/src/pipeline/network/manager.rs
@@ -38,6 +38,9 @@ static ACTUAL_TCP_RPC_PORT: OnceLock<u16> = OnceLock::new();
 static GLOBAL_TCP_SERVER: tokio::sync::OnceCell<Arc<SharedTcpServer>> =
     tokio::sync::OnceCell::const_new();
 
+/// First valid process-wide engine capacity reported for automatic TCP sizing.
+static GLOBAL_ENGINE_CAPACITY_HINT: OnceLock<usize> = OnceLock::new();
+
 /// Process-wide cancellation token for the global TCP server.
 ///
 /// This token is independent of any individual runtime's cancellation token so that
@@ -197,6 +200,28 @@ impl NetworkManager {
         }
     }
 
+    /// Record the first engine capacity without starting the request-plane server.
+    pub async fn set_engine_capacity_hint(&self, engine_capacity: usize) -> Result<()> {
+        if !matches!(self.mode, RequestPlaneMode::Tcp) || engine_capacity == 0 {
+            return Ok(());
+        }
+
+        GLOBAL_ENGINE_CAPACITY_HINT.get_or_init(|| engine_capacity);
+        self.apply_engine_capacity_hint().await
+    }
+
+    async fn apply_engine_capacity_hint(&self) -> Result<()> {
+        if matches!(self.mode, RequestPlaneMode::Tcp)
+            && let Some(engine_capacity) = GLOBAL_ENGINE_CAPACITY_HINT.get().copied()
+            && let Some(server) = GLOBAL_TCP_SERVER.get()
+        {
+            server
+                .update_worker_pool_from_engine_capacity(engine_capacity)
+                .await?;
+        }
+        Ok(())
+    }
+
     /// Get or create the request plane server
     ///
     /// The server is created lazily on first access and cached for subsequent calls.
@@ -217,6 +242,7 @@ impl NetworkManager {
             .server
             .get_or_try_init(async { self.create_server().await })
             .await?;
+        self.apply_engine_capacity_hint().await?;
 
         Ok(server.clone())
     }
@@ -277,7 +303,11 @@ impl NetworkManager {
                     "Creating TCP request plane server"
                 );
 
-                let server = SharedTcpServer::new(bind_addr, GLOBAL_TCP_SERVER_TOKEN.clone());
+                let server = SharedTcpServer::new(
+                    bind_addr,
+                    GLOBAL_TCP_SERVER_TOKEN.clone(),
+                    GLOBAL_ENGINE_CAPACITY_HINT.get().copied(),
+                )?;
 
                 // Bind and start server, getting the actual bound address
                 let actual_addr = server.clone().bind_and_start().await?;
@@ -346,6 +376,11 @@ impl NetworkManager {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::metrics::work_handler_pool::WORK_HANDLER_POOL_CAPACITY;
+    use std::process::Command;
+
+    const SERVER_FIRST_CHILD_ENV: &str = "DYN_TEST_SERVER_FIRST_ENGINE_CAPACITY_HINT";
+    const SERVER_FIRST_TEST_NAME: &str = "pipeline::network::manager::tests::server_first_engine_capacity_hint_updates_global_server";
 
     fn manager_for(mode: RequestPlaneMode) -> NetworkManager {
         NetworkManager::new(
@@ -371,5 +406,49 @@ mod tests {
             ),
             Err(err) => assert!(err.to_string().contains("NATS client required")),
         }
+    }
+
+    #[test]
+    fn server_first_engine_capacity_hint_updates_global_server() {
+        if std::env::var_os(SERVER_FIRST_CHILD_ENV).is_none() {
+            let mut command = Command::new(std::env::current_exe().unwrap());
+            command
+                .args(["--exact", SERVER_FIRST_TEST_NAME, "--nocapture"])
+                .env(SERVER_FIRST_CHILD_ENV, "1")
+                .env("DYN_TCP_RPC_HOST", "127.0.0.1");
+            for name in [
+                "DYN_ENGINE_REQUEST_LIMIT",
+                "DYN_TCP_WORKER_POOL_SIZE",
+                "DYN_TCP_WORK_QUEUE_SIZE",
+                "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+                "DYN_TCP_RPC_PORT",
+            ] {
+                command.env_remove(name);
+            }
+
+            let output = command.output().unwrap();
+            assert!(
+                output.status.success(),
+                "child test failed\nstdout:\n{}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            return;
+        }
+
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(async {
+                let server_manager = manager_for(RequestPlaneMode::Tcp);
+                server_manager.server().await.unwrap();
+                assert_eq!(WORK_HANDLER_POOL_CAPACITY.get(), 10_000);
+
+                let hint_manager = manager_for(RequestPlaneMode::Tcp);
+                hint_manager.set_engine_capacity_hint(8_000).await.unwrap();
+                assert_eq!(WORK_HANDLER_POOL_CAPACITY.get(), 12_000);
+                GLOBAL_TCP_SERVER_TOKEN.cancel();
+            });
     }
 }

--- a/tests/runtime/test_tcp_worker_pool_sizing_e2e.py
+++ b/tests/runtime/test_tcp_worker_pool_sizing_e2e.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end TCP worker-pool startup sizing with a real mocker worker.
+
+Each parameter starts a fresh process so the process-global shared TCP server is
+initialized exactly once. The automatic case covers the complete path from
+mocker `max_num_seqs * data_parallel_size`, through model attachment, to the
+eventual TCP worker-pool capacity. A focused runtime unit test separately forces
+the server-first, late-hint ordering.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import uuid
+
+import pytest
+import requests
+
+from tests.utils.constants import QWEN
+from tests.utils.managed_process import ManagedProcess
+from tests.utils.port_utils import ServicePorts
+from tests.utils.prometheus import sum_metric_samples
+
+POOL_CAPACITY_METRIC = "dynamo_work_handler_pool_capacity"
+MAX_NUM_SEQS = 3
+DATA_PARALLEL_SIZE = 2
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.integration,
+    pytest.mark.gpu_0,
+    pytest.mark.core,
+    pytest.mark.model(QWEN),
+]
+
+
+@pytest.mark.timeout(120)  # Covers the 60s startup timeout plus teardown margin.
+@pytest.mark.parametrize(
+    "engine_request_limit, tcp_worker_pool_size, expected_pool_size",
+    [
+        pytest.param(None, None, 9, id="automatic-1.5x"),
+        pytest.param(None, 13, 13, id="tcp-pool-override"),
+        pytest.param(17, None, 17, id="engine-limit-override"),
+        pytest.param(17, 13, 17, id="engine-limit-precedes-tcp-pool"),
+    ],
+)
+def test_tcp_worker_pool_startup_sizing(
+    request,
+    file_storage_backend,
+    predownload_tokenizers,
+    dynamo_dynamic_ports: ServicePorts,
+    engine_request_limit: int | None,
+    tcp_worker_pool_size: int | None,
+    expected_pool_size: int,
+):
+    system_port = dynamo_dynamic_ports.system_ports[0]
+    namespace = f"test-worker-pool-{uuid.uuid4().hex}"
+    endpoint = f"dyn://{namespace}.mocker.generate"
+    command = [
+        sys.executable,
+        "-m",
+        "dynamo.mocker",
+        "--model-path",
+        QWEN,
+        "--endpoint",
+        endpoint,
+        "--discovery-backend",
+        "file",
+        "--num-workers",
+        "1",
+        "--max-num-seqs",
+        str(MAX_NUM_SEQS),
+        "--data-parallel-size",
+        str(DATA_PARALLEL_SIZE),
+    ]
+
+    env = os.environ.copy()
+    for name in (
+        "DYN_ENGINE_REQUEST_LIMIT",
+        "DYN_TCP_WORKER_POOL_SIZE",
+        "DYN_TCP_WORK_QUEUE_SIZE",
+        "DYN_DYNAMO_REQUEST_QUEUE_LIMIT",
+        "DYN_TCP_RPC_PORT",
+        "NATS_SERVER",
+    ):
+        env.pop(name, None)
+    env.update(
+        {
+            "DYN_FILE_KV": str(file_storage_backend),
+            "DYN_REQUEST_PLANE": "tcp",
+            "DYN_EVENT_PLANE": "zmq",
+            "DYN_SYSTEM_PORT": str(system_port),
+        }
+    )
+    if engine_request_limit is not None:
+        env["DYN_ENGINE_REQUEST_LIMIT"] = str(engine_request_limit)
+    if tcp_worker_pool_size is not None:
+        env["DYN_TCP_WORKER_POOL_SIZE"] = str(tcp_worker_pool_size)
+
+    metrics_url = f"http://localhost:{system_port}/metrics"
+
+    def reports_expected_pool_capacity(response: requests.Response) -> bool:
+        return (
+            sum_metric_samples(response.text, POOL_CAPACITY_METRIC)
+            == expected_pool_size
+        )
+
+    process = ManagedProcess(
+        command=command,
+        env=env,
+        health_check_urls=[(metrics_url, reports_expected_pool_capacity)],
+        timeout=60,
+        display_output=True,
+        terminate_all_matching_process_names=False,
+        log_dir=f"{request.node.name}_worker_pool",
+        display_name="dynamo-mocker-worker-pool-sizing",
+    )
+    with process:
+        response = requests.get(metrics_url, timeout=5)
+        response.raise_for_status()
+        assert (
+            sum_metric_samples(response.text, POOL_CAPACITY_METRIC)
+            == expected_pool_size
+        )


### PR DESCRIPTION
## Overview:

Dynamically size the process-global TCP worker pool from the existing backend registration fields:

`ceil(1.5 × max_num_seqs × data_parallel_size)`

The sizing precedence is:

1. `DYN_ENGINE_REQUEST_LIMIT`
2. `DYN_TCP_WORKER_POOL_SIZE`
3. Automatic engine-capacity sizing
4. `10,000` compatibility fallback

Backends that do not report valid capacity metadata continue using the fallback.

## Details:

- Derive the local engine-capacity hint from the existing per-DP-rank `max_num_seqs` and local `data_parallel_size` fields.
- Avoid adding a new `engine_max_num_seqs` registration field or backend-facing API.
- Support either startup order:
  - If the hint arrives first, retain it until the TCP server starts.
  - If the server starts first, initialize with the fallback and apply one later automatic pool adjustment.
- Await the adjustment before publishing the capacity-bearing worker to discovery.
- Keep explicit environment overrides fixed and ignore later capacity hints.
- Preserve existing queue defaults: the TCP work queue remains `40,000`, while the separate engine-request queue default remains `16` when `DYN_ENGINE_REQUEST_LIMIT` is enabled.
- Validate malformed, zero, and out-of-range TCP pool and queue settings.
- Add focused unit coverage for:
  - Capacity multiplication and invalid metadata.
  - Sizing precedence, rounding, fallback, and invalid environment values.
  - Server-first late capacity adjustment.
  - Explicit override immutability.
- Add a process-isolated Mocker E2E covering:
  - Automatic sizing: `ceil(1.5 × 3 × 2) = 9`.
  - `DYN_TCP_WORKER_POOL_SIZE`.
  - `DYN_ENGINE_REQUEST_LIMIT`.
  - Engine-request-limit precedence when both overrides are set.

This PR does not change backend-specific capacity reporting. Python TensorRT-LLM’s per-DP-rank reporting correction is handled separately.

## Where should the reviewer start?

1. `lib/runtime/src/pipeline/network/ingress/shared_tcp_endpoint.rs`
   - Sizing precedence, fallback, and the one-time late pool adjustment.

2. `lib/llm/src/local_model/runtime_config.rs`
   - Checked derivation of the capacity hint from existing registration fields.

3. `lib/llm/src/local_model.rs`
   - Capacity hint submission before model discovery publication.

4. `lib/runtime/src/pipeline/network/manager.rs`
   - Process-global hint retention and support for both startup orders.

5. `tests/runtime/test_tcp_worker_pool_sizing_e2e.py`
   - Mocker E2E coverage for automatic sizing and environment precedence.

## Related Issues

**🚫 This PR is NOT linked to a GitHub issue**:

- [x] Confirmed — no related GitHub issue
- Closes DIS-2466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * TCP worker-pool capacity can now be sized automatically from model and data-parallel settings.
  * Running services can adjust worker capacity dynamically when engine capacity becomes available, without restarting.
  * Explicit configuration continues to take precedence over automatic sizing.

* **Bug Fixes**
  * Improved validation and handling of invalid or unsupported capacity settings.
  * Added clearer queue sizing behavior and capacity metrics.

* **Documentation**
  * Updated fault-tolerance guidance to describe automatic worker-pool sizing and configuration precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->