### PR TITLE
[1/1 validated] docs(contributing): fix YouTube branding in community links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Or view the source: [`docs/contribution-guide.md`](docs/contribution-guide.md)
 - [CNCF Slack (`#ai-dynamo`)](https://communityinviter.com/apps/cloud-native/cncf)
 - [Discord](https://discord.gg/D92uqZRjCZ)
 - [Office Hours](https://www.youtube.com/playlist?list=PL5B692fm6--tgryKu94h2Zb7jTFM3Go4X)
-- [Community Meetings](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([Youtube](https://www.youtube.com/@ai-dynamo-community)) -- Weekly (Wed 10:30 AM PT) development community meetings
+- [Community Meetings](https://docs.google.com/document/d/1uR8xD_hlYGwV6QspvSc36k1H-wo1BUcVmFbHH9xlXd8/view) ([YouTube](https://www.youtube.com/@ai-dynamo-community)) -- Weekly (Wed 10:30 AM PT) development community meetings
 - [Dynamo Day Recordings](https://nvevents.nvidia.com/dynamoday)
 
 Dynamo requires all contributions to be signed off with the [Developer Certificate of Origin (DCO)](https://developercertificate.org/). This certifies that you have the right to submit your contribution under the project's [Apache 2.0 license](https://github.com/ai-dynamo/dynamo/blob/main/LICENSE).


### PR DESCRIPTION
> 🤖 **Automated AI review — advisory.** An AI agent's judgment of whether this change is logically sound on the evidence; not a merge authorization. CI, customs, and a human reviewer hold that.

## Assessment: sound

## Findings

- **Git state — clean commit on real branch.** The repo is on branch `docs/fix-youtube-branding--39deb3e36221` (not the upstream default `main`). The commit SHA is `8a20115e80e8a08e51a7729426de30a4cc744f99`. The working tree is clean.

- **Diff scope matches plan.** The diff is limited to a single line in `CONTRIBUTING.md`: `Youtube` → `YouTube` on line 39. No other files were modified. The plan's non-goals (no runtime claim, no changes outside `CONTRIBUTING.md`, no test additions) are fully respected.

- **Validation recipe executed and passed.** The validator ran `pre-commit run --files CONTRIBUTING.md --hook-stage manual`. The customs registry records exit code `0`. All applicable hooks passed (`codespell`, `check for case conflicts`, `check for merge conflicts`, `mixed line ending`, `trim trailing whitespace`, `check that scripts with shebangs are executable`, `Report pytest markers`).

- **No new infrastructure added.** The change is a single-character docs typo fix; no test infrastructure, fixtures, or harnesses were introduced.

- **Verdict is unqualified.** `change-validation.md` records `Verdict: pass` with no hedging. No recipes were blocked or skipped.

## Evidence [1/1 validated]

_Generated from validation/registry.jsonl — do not edit by hand._

| Recipe | Status | Command | Evidence | Note |
|---|---|---|---|---|
| 01-python-lint | validated | `pre-commit run --files CONTRIBUTING.md --hook-stage manual` | validation/logs/2026-07-20T23-53-34.954Z-pre-commit-23d0.log |  |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the capitalization of the “YouTube” label in the Community Meetings quick link.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->