### PR TITLE
feat: add router decision metrics

### DIFF
--- a/dev/observability/grafana_dashboards/dynamo.json
+++ b/dev/observability/grafana_dashboards/dynamo.json
@@ -2610,10 +2610,587 @@
       "type": "timeseries"
     },
     {
-      "collapsed": false,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "KV-router worker-selection decisions per second, broken down by cache-hit outcome and worker type.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "x": 0,
         "y": 55,
+        "w": 8,
+        "h": 8
+      },
+      "id": 112,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type, decision) (rate(dynamo_component_router_decisions_total{model=\"$model\"}[$__rate_interval]))",
+          "legendFormat": "{{worker_type}} | {{decision}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Router Decision Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Rate at which the KV router selects each backend worker/rank for the selected model.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 8,
+        "y": 55,
+        "w": 8,
+        "h": 8
+      },
+      "id": 113,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type, router_worker_id, dp_rank) (rate(dynamo_component_router_selected_worker_total{model=\"$model\"}[$__rate_interval]))",
+          "legendFormat": "worker={{router_worker_id}} | dp={{dp_rank}} | type={{worker_type}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Selected Worker Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Eligible worker/rank count considered for each KV-router decision.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 16,
+        "y": 55,
+        "w": 8,
+        "h": 8
+      },
+      "id": 114,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.50, sum by (worker_type, le) (rate(dynamo_component_router_candidate_workers_bucket{model=\"$model\"}[$__rate_interval])))",
+          "legendFormat": "P50 | {{worker_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (worker_type, le) (rate(dynamo_component_router_candidate_workers_bucket{model=\"$model\"}[$__rate_interval])))",
+          "legendFormat": "P90 | {{worker_type}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type) (rate(dynamo_component_router_candidate_workers_sum{model=\"$model\"}[$__rate_interval])) / clamp_min(sum by (worker_type) (rate(dynamo_component_router_candidate_workers_count{model=\"$model\"}[$__rate_interval])), 1)",
+          "legendFormat": "Average | {{worker_type}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(1.0, sum by (worker_type, le) (rate(dynamo_component_router_candidate_workers_bucket{model=\"$model\"}[$__rate_interval])))",
+          "legendFormat": "MAX | {{worker_type}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Candidate Workers",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "Average and p90 KV-overlap credit and worker-load score for the selected worker, measured in block units.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "short",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 0,
+        "y": 63,
+        "w": 12,
+        "h": 8
+      },
+      "id": 115,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type) (rate(dynamo_component_router_kv_overlap_score_sum{model=\"$model\"}[$__rate_interval])) / clamp_min(sum by (worker_type) (rate(dynamo_component_router_kv_overlap_score_count{model=\"$model\"}[$__rate_interval])), 1)",
+          "legendFormat": "kv overlap avg | {{worker_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (worker_type, le) (rate(dynamo_component_router_kv_overlap_score_bucket{model=\"$model\"}[$__rate_interval])))",
+          "legendFormat": "kv overlap P90 | {{worker_type}}",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type) (rate(dynamo_component_router_worker_load_score_sum{model=\"$model\"}[$__rate_interval])) / clamp_min(sum by (worker_type) (rate(dynamo_component_router_worker_load_score_count{model=\"$model\"}[$__rate_interval])), 1)",
+          "legendFormat": "worker load avg | {{worker_type}}",
+          "range": true,
+          "refId": "C"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.90, sum by (worker_type, le) (rate(dynamo_component_router_worker_load_score_bucket{model=\"$model\"}[$__rate_interval])))",
+          "legendFormat": "worker load P90 | {{worker_type}}",
+          "range": true,
+          "refId": "D"
+        }
+      ],
+      "title": "Router Score Components",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${datasource}"
+      },
+      "description": "No-candidate and tie-break decision rates. No-candidate spikes usually mean discovery, allowlist, taint, or overload constraints removed every eligible worker/rank.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "reqps",
+          "noValue": "0"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "x": 12,
+        "y": 63,
+        "w": 12,
+        "h": 8
+      },
+      "id": 116,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.5.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type) (rate(dynamo_component_router_no_candidates_total{model=\"$model\"}[$__rate_interval]))",
+          "legendFormat": "no candidates | {{worker_type}}",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${datasource}"
+          },
+          "editorMode": "code",
+          "expr": "sum by (worker_type, reason) (rate(dynamo_component_router_tie_breaks_total{model=\"$model\"}[$__rate_interval]))",
+          "legendFormat": "tie={{reason}} | {{worker_type}}",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Router Selection Edge Cases",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "x": 0,
+        "y": 71,
         "w": 24,
         "h": 1
       },
@@ -2687,7 +3264,7 @@
       },
       "gridPos": {
         "x": 0,
-        "y": 56,
+        "y": 72,
         "w": 8,
         "h": 8
       },
@@ -2809,7 +3386,7 @@
       },
       "gridPos": {
         "x": 8,
-        "y": 56,
+        "y": 72,
         "w": 8,
         "h": 8
       },
@@ -2950,7 +3527,7 @@
       },
       "gridPos": {
         "x": 16,
-        "y": 56,
+        "y": 72,
         "w": 8,
         "h": 8
       },

--- a/docs/observability/metrics.md
+++ b/docs/observability/metrics.md
@@ -388,7 +388,7 @@ Not all metrics appear in every deployment. The chart below shows which metric g
 
 | Metric Group | Frontend + KV (agg) | Frontend + KV (disagg) | Frontend + non-KV (round-robin/random/direct) | Standalone Router |
 |---|---|---|---|---|
-| `dynamo_component_router_*` (request metrics) | Registered and populated | Registered and populated | Registered, **always zero** | Populated (on `DYN_SYSTEM_PORT`) |
+| `dynamo_component_router_*` (request and decision metrics) | Registered and populated | Registered and populated | Registered, **not populated** | Populated (on `DYN_SYSTEM_PORT`) |
 | `dynamo_router_overhead_*` (routing overhead) | Registered and populated | Registered and populated | **Not registered** | **Not created** |
 | `dynamo_frontend_router_queue_*` (queue depth) | Registered; populated when a CLI or policy-class queue threshold is set | Registered; populated when a CLI or policy-class queue threshold is set | **Not registered** | **Not created** |
 | `dynamo_component_kv_cache_events_applied` (indexer) | Populated when KV events are received | Populated when KV events are received | **Not registered** | Populated when KV events are received |
@@ -396,7 +396,7 @@ Not all metrics appear in every deployment. The chart below shows which metric g
 
 **Key:**
 - **Registered and populated**: Metric appears at `/metrics` with real values
-- **Registered, always zero**: Metric appears at `/metrics` but the counter/histogram is never incremented (useful for dashboards that expect the metric to exist)
+- **Registered, not populated**: Metric family exists, but counters and histograms do not receive observations. For labeled metrics, no time series appears until a label combination is observed.
 - **Not registered / Not created**: Metric does not appear at `/metrics` at all
 
 **Scrape endpoints:**
@@ -406,9 +406,9 @@ Not all metrics appear in every deployment. The chart below shows which metric g
 
 #### Router Request Metrics (`dynamo_component_router_*`)
 
-Histograms and counters for aggregate request-level statistics. Eagerly registered via `from_component()` with the DRT `MetricsRegistry` hierarchy. On the frontend, exposed at `/metrics` on the HTTP port (default 8000) via the `drt_metrics` bridge. On the standalone router (`python -m dynamo.router`), exposed on `DYN_SYSTEM_PORT` when set. Populated per-request when `--router-mode kv` is active; registered with zero values in non-KV modes.
+Histograms and counters for aggregate request-level statistics. Eagerly registered via `from_component()` with the DRT `MetricsRegistry` hierarchy. On the frontend, exposed at `/metrics` on the HTTP port (default 8000) via the `drt_metrics` bridge. On the standalone router (`python -m dynamo.router`), exposed on `DYN_SYSTEM_PORT` when set. Populated per request when `--router-mode kv` is active; registered but not populated in non-KV modes.
 
-All metrics carry the standard hierarchy labels (`dynamo_namespace`, `dynamo_component`, `dynamo_endpoint`).
+All metrics carry the standard hierarchy labels (`dynamo_namespace`, `dynamo_component`, `dynamo_endpoint`). Decision metrics also carry `model` and `worker_type`. Worker-selection metrics use `router_worker_id` for the selected backend worker because `worker_id` is reserved for the metric producer's discovery identity.
 
 | Metric | Type | Description |
 |--------|------|-------------|
@@ -419,6 +419,16 @@ All metrics carry the standard hierarchy labels (`dynamo_namespace`, `dynamo_com
 | `dynamo_component_router_input_sequence_tokens` | Histogram | Input sequence length (tokens) |
 | `dynamo_component_router_output_sequence_tokens` | Histogram | Output sequence length (tokens) |
 | `dynamo_component_router_kv_hit_rate` | Histogram | Predicted KV cache hit rate at routing time (0.0-1.0) |
+| `dynamo_component_router_kv_transfer_estimated_latency_seconds` | Histogram | Upper-bound KV transfer latency estimate in disaggregated serving |
+| `dynamo_component_router_shared_cache_hit_rate` | Histogram | Fraction of request blocks found in the shared KV cache (0.0-1.0) |
+| `dynamo_component_router_shared_cache_beyond_blocks` | Histogram | Shared cache blocks beyond the selected worker's device overlap |
+| `dynamo_component_router_decisions_total` | Counter | Worker-selection decisions by cache outcome. Labels: `model`, `worker_type`, `decision` (`cache_hit` or `cache_miss`) |
+| `dynamo_component_router_selected_worker_total` | Counter | Times each backend worker/rank was selected. Labels: `model`, `worker_type`, `router_worker_id`, `dp_rank` |
+| `dynamo_component_router_candidate_workers` | Histogram | Eligible worker/ranks considered for each router decision. Labels: `model`, `worker_type` |
+| `dynamo_component_router_kv_overlap_score` | Histogram | Cache-overlap credit applied to the selected worker, in block units. Labels: `model`, `worker_type` |
+| `dynamo_component_router_worker_load_score` | Histogram | Selected worker load score before cache-overlap credit, in block units. Labels: `model`, `worker_type` |
+| `dynamo_component_router_tie_breaks_total` | Counter | Decisions resolved by a tie-break. Labels: `model`, `worker_type`, `reason` |
+| `dynamo_component_router_no_candidates_total` | Counter | Decisions where no eligible worker/rank existed. Labels: `model`, `worker_type` |
 
 #### Per-Request Routing Overhead (`dynamo_router_overhead_*`)
 

--- a/lib/bindings/python/src/dynamo/prometheus_names.py
+++ b/lib/bindings/python/src/dynamo/prometheus_names.py
@@ -59,6 +59,14 @@ class frontend_perf:
     TOKENIZE_SECONDS = "tokenize_seconds"
     # Template application time in preprocessor
     TEMPLATE_SECONDS = "template_seconds"
+    # L1 tokenizer cache hits (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
+    TOKENIZER_CACHE_HITS_TOTAL = "tokenizer_cache_hits_total"
+    # L1 tokenizer cache misses (cumulative); enabled unless DYN_TOKENIZER_CACHE=0
+    TOKENIZER_CACHE_MISSES_TOTAL = "tokenizer_cache_misses_total"
+    # Tokens returned from the L1 tokenizer prefix cache (cumulative, labeled by model)
+    TOKENIZER_CACHE_CACHED_TOKENS_TOTAL = "tokenizer_cache_cached_tokens_total"
+    # Tokens freshly encoded after an L1 tokenizer prefix-cache lookup (cumulative, labeled by model)
+    TOKENIZER_CACHE_UNCACHED_TOKENS_TOTAL = "tokenizer_cache_uncached_tokens_total"
     # Cumulative detokenization time (microseconds); pair with DETOKENIZE_TOKEN_COUNT
     DETOKENIZE_TOTAL_US = "detokenize_total_us"
     # Total tokens detokenized; use rate(total_us)/rate(count) for per-token average
@@ -98,6 +106,10 @@ class frontend_service:
     KV_HIT_RATE = "kv_hit_rate"
     # Upper-bound estimation of KV cache transfer latency in disaggregated serving (seconds)
     KV_TRANSFER_ESTIMATED_LATENCY_SECONDS = "kv_transfer_estimated_latency_seconds"
+    # Shared cache hit rate (0.0-1.0): fraction of request blocks found in shared cache
+    SHARED_CACHE_HIT_RATE = "shared_cache_hit_rate"
+    # Shared cache blocks beyond device overlap for the selected worker
+    SHARED_CACHE_BEYOND_BLOCKS = "shared_cache_beyond_blocks"
     # Number of cached tokens (prefix cache hits) per request
     CACHED_TOKENS = "cached_tokens"
     # Tokenizer latency in milliseconds
@@ -112,9 +124,7 @@ class frontend_service:
     # Separate from `REQUEST_DURATION_SECONDS` so its buckets can be sized for
     # pooling-model latencies (sub-second) without sacrificing resolution.
     EMBEDDING_LATENCY_SECONDS = "embedding_latency_seconds"
-    # Number of `image_url` content parts per request (histogram). Named
-    # `images_per_request` so the auto-emitted `_sum` (cumulative image volume),
-    # `_count` (requests observed), and `_bucket` all read naturally.
+    # Number of `image_url` content parts per request (histogram)
     IMAGES_PER_REQUEST = "images_per_request"
     # Number of `video_url` content parts per request (histogram)
     VIDEOS_PER_REQUEST = "videos_per_request"
@@ -164,7 +174,7 @@ class frontend_service:
     WORKER_LAST_INTER_TOKEN_LATENCY_SECONDS = "worker_last_inter_token_latency_seconds"
     # Number of requests pending in the router's scheduler queue (gauge per worker_type)
     ROUTER_QUEUE_PENDING_REQUESTS = "router_queue_pending_requests"
-    # Number of replicas allocated for a LoRA adapter
+    # Number of replicas allocated for a LoRA adapter (gauge per LoRA)
     LORA_REPLICA_FACTOR = "lora_replica_factor"
     # Whether a LoRA adapter is actively receiving traffic (1=active, 0=inactive)
     LORA_IS_ACTIVE = "lora_is_active"
@@ -261,16 +271,6 @@ class kvstats:
     TOTAL_BLOCKS = "total_blocks"
     # GPU cache usage as a percentage (0.0-1.0)
     GPU_CACHE_USAGE_PERCENT = "gpu_cache_usage_percent"
-    # Prefix cache hit rate (0.0-1.0), portable across vLLM / SGLang / TRT-LLM
-    KV_CACHE_HIT_RATE = "kv_cache_hit_rate"
-
-
-class lifecycle:
-    """Worker-lifecycle timing gauges. Set once per worker run by the
-    framework, not by the engine."""
-
-    CLEANUP_TIME_SECONDS = "cleanup_time_seconds"
-    DRAIN_TIME_SECONDS = "drain_time_seconds"
 
 
 class labels:
@@ -328,6 +328,9 @@ class name_prefix:
     TRANSPORT = "dynamo_transport"
     # Prefix for work-handler transport breakdown metrics (backend side)
     WORK_HANDLER = "dynamo_work_handler"
+    # Prefix for request admission/rejection control metrics (e.g.
+    # `dynamo_rejection_request_total`).
+    REJECTION = "dynamo_rejection"
     # Prefix for tokio runtime metrics (poll times, queue depths, stalls).
     TOKIO = "dynamo_tokio"
     # Prefix for per-phase routing overhead latency (hashing, scheduling).
@@ -355,6 +358,20 @@ class router:
     REQUESTS_STARTED_TOTAL = "router_requests_started_total"
     # Total number of requests processed by the router
     REQUESTS_TOTAL = "router_requests_total"
+    # Total number of worker-selection decisions by cache outcome
+    DECISIONS_TOTAL = "router_decisions_total"
+    # Total number of times each backend worker/rank was selected by the router
+    SELECTED_WORKER_TOTAL = "router_selected_worker_total"
+    # Number of eligible candidate worker/ranks considered for a router decision
+    CANDIDATE_WORKERS = "router_candidate_workers"
+    # Cache-overlap score credited to the selected worker at decision time
+    KV_OVERLAP_SCORE = "router_kv_overlap_score"
+    # Load score for the selected worker at decision time
+    WORKER_LOAD_SCORE = "router_worker_load_score"
+    # Total number of router decisions resolved by a tie-break
+    TIE_BREAKS_TOTAL = "router_tie_breaks_total"
+    # Total number of router decisions where no eligible worker/rank existed
+    NO_CANDIDATES_TOTAL = "router_no_candidates_total"
     # Total number of remote indexer overlap queries that failed
     REMOTE_INDEXER_QUERY_FAILURES_TOTAL = "router_remote_indexer_query_failures_total"
     # Total number of remote indexer routing-decision writes that failed
@@ -371,6 +388,10 @@ class router:
     OUTPUT_SEQUENCE_TOKENS = "router_output_sequence_tokens"
     # Predicted KV cache hit rate at routing time (0.0-1.0)
     KV_HIT_RATE = "router_kv_hit_rate"
+    # Shared cache hit rate (0.0-1.0): fraction of request blocks found in shared cache
+    SHARED_CACHE_HIT_RATE = "router_shared_cache_hit_rate"
+    # Shared cache blocks beyond device overlap for the selected worker
+    SHARED_CACHE_BEYOND_BLOCKS = "router_shared_cache_beyond_blocks"
     # Whether the router currently has a worker/dp_rank registered (1 = registered)
     WORKER_REGISTERED = "router_worker_registered"
 
@@ -396,6 +417,10 @@ class routing_overhead:
     SCHEDULING_MS = "overhead_scheduling_ms"
     # Total routing overhead per request
     TOTAL_MS = "overhead_total_ms"
+    # Time spent querying the shared KV cache (Mooncake)
+    SHARED_CACHE_QUERY_MS = "overhead_shared_cache_query_ms"
+    # Total shared cache query errors (timeouts, HTTP failures)
+    SHARED_CACHE_ERRORS_TOTAL = "shared_cache_errors_total"
 
 
 class task_tracker:
@@ -488,8 +513,8 @@ class work_handler:
     # Configured capacity of the bounded work queue (gauge, static)
     QUEUE_CAPACITY = "queue_capacity"
     # Total times enqueuing work failed because the dispatcher channel was closed.
-    # tokio bounded mpsc applies backpressure on full — saturation shows up as
-    # rising QUEUE_DEPTH toward QUEUE_CAPACITY.
+    # Note: tokio bounded mpsc applies backpressure on full — it does NOT increment
+    # this counter. Saturation shows up as rising `QUEUE_DEPTH` toward `QUEUE_CAPACITY`.
     ENQUEUE_REJECTED_TOTAL = "enqueue_rejected_total"
     # Time spent waiting to acquire a worker-pool permit (histogram)
     PERMIT_WAIT_SECONDS = "permit_wait_seconds"

--- a/lib/kv-router/src/protocols.rs
+++ b/lib/kv-router/src/protocols.rs
@@ -547,6 +547,46 @@ pub struct WorkerSelectionResult {
 
     /// Approximate cached-token count derived from the weighted cache hit.
     pub cached_tokens: usize,
+
+    /// Request-local telemetry captured while selecting this worker.
+    pub telemetry: WorkerSelectionTelemetry,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub struct WorkerSelectionTelemetry {
+    /// Number of eligible worker/ranks evaluated by the selector.
+    pub candidate_workers: usize,
+
+    /// Scores for the selected worker, when the selector exposes them.
+    pub selected_scores: Option<WorkerSelectionScores>,
+
+    /// Tie-break reason, when the decision required one.
+    pub tie_break: Option<WorkerSelectionTieBreak>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct WorkerSelectionScores {
+    /// Cache-overlap credit, in block units, applied to the selected worker.
+    pub kv_overlap_score: f64,
+
+    /// Load score before cache-overlap credit, in block units.
+    pub worker_load_score: f64,
+
+    /// Final score used for selection after cache credit and routing constraints.
+    pub final_score: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerSelectionTieBreak {
+    EqualScore,
+}
+
+impl WorkerSelectionTieBreak {
+    pub fn as_label(self) -> &'static str {
+        match self {
+            Self::EqualScore => "equal_score",
+        }
+    }
 }
 
 /// Active load metrics for a worker, used for overload detection.

--- a/lib/kv-router/src/scheduling/queue.rs
+++ b/lib/kv-router/src/scheduling/queue.rs
@@ -1461,6 +1461,7 @@ impl<
             effective_overlap_blocks: selection.effective_overlap_blocks,
             cached_tokens: selection.cached_tokens,
             selected_worker_tiers,
+            selection_telemetry: selection.telemetry,
             request_progress,
             lifecycle_lease: None,
         };
@@ -1826,6 +1827,7 @@ mod tests {
                 required_blocks: request.request_blocks(block_size),
                 effective_overlap_blocks: request.effective_overlap_blocks_for(worker),
                 cached_tokens: request.effective_cached_tokens_for(worker),
+                telemetry: Default::default(),
             })
         }
     }

--- a/lib/kv-router/src/scheduling/selector.rs
+++ b/lib/kv-router/src/scheduling/selector.rs
@@ -8,7 +8,10 @@ use rustc_hash::FxHashMap;
 use super::config::KvRouterConfig;
 use super::filter::{RoutingEligibility, WorkerEligibilityError};
 use super::types::{KvSchedulerError, SchedulingRequest};
-use crate::protocols::{WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerWithDpRank};
+use crate::protocols::{
+    WorkerConfigLike, WorkerId, WorkerSelectionResult, WorkerSelectionScores,
+    WorkerSelectionTelemetry, WorkerSelectionTieBreak, WorkerWithDpRank,
+};
 
 /// A trait that users can implement to define custom selection logic.
 ///
@@ -97,6 +100,27 @@ struct LogitWeights {
     shared_cache_multiplier: f64,
 }
 
+#[derive(Debug, Clone, Copy)]
+struct WorkerScore {
+    kv_overlap_score: f64,
+    worker_load_score: f64,
+    final_score: f64,
+}
+
+impl WorkerScore {
+    fn telemetry(self, candidate_workers: usize) -> WorkerSelectionTelemetry {
+        WorkerSelectionTelemetry {
+            candidate_workers,
+            selected_scores: Some(WorkerSelectionScores {
+                kv_overlap_score: self.kv_overlap_score,
+                worker_load_score: self.worker_load_score,
+                final_score: self.final_score,
+            }),
+            tie_break: None,
+        }
+    }
+}
+
 impl DefaultWorkerSelector {
     pub fn new(kv_router_config: Option<KvRouterConfig>, worker_type: &'static str) -> Self {
         Self {
@@ -105,7 +129,7 @@ impl DefaultWorkerSelector {
         }
     }
 
-    fn worker_logit(
+    fn worker_score(
         &self,
         request: &SchedulingRequest,
         worker: WorkerWithDpRank,
@@ -113,7 +137,7 @@ impl DefaultWorkerSelector {
         min_active_prefill_tokens: usize,
         weights: LogitWeights,
         formula_name: &'static str,
-    ) -> f64 {
+    ) -> WorkerScore {
         let block_size_f64 = block_size as f64;
         let effective_overlap_blocks = request.effective_overlap_blocks_for(worker);
         let has_tier_overlap_blocks = !request.overlap.tier_overlap_blocks.device.is_empty()
@@ -205,6 +229,7 @@ impl DefaultWorkerSelector {
         let worker_load = worker_load.unwrap_or_default();
         let decode_cost_blocks = worker_load.potential_decode_blocks() as f64;
         let logit = prefill_cost_blocks + decode_cost_blocks;
+        let worker_load_score = raw_prefill_blocks + decode_cost_blocks;
 
         if shared_beyond > 0 {
             tracing::debug!(
@@ -232,7 +257,11 @@ impl DefaultWorkerSelector {
             );
         }
 
-        logit
+        WorkerScore {
+            kv_overlap_score: overlap_credit_blocks,
+            worker_load_score,
+            final_score: logit,
+        }
     }
 }
 
@@ -300,7 +329,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             }
 
             let min_active_prefill_tokens = request.worker_load_for(worker).active_prefill_tokens;
-            let logit = self.worker_logit(
+            let score = self.worker_score(
                 request,
                 worker,
                 block_size,
@@ -316,7 +345,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 self.worker_type,
                 worker.worker_id,
                 worker.dp_rank,
-                logit,
+                score.final_score,
                 effective_overlap_blocks,
             );
 
@@ -325,6 +354,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 required_blocks: request_blocks,
                 effective_overlap_blocks,
                 cached_tokens,
+                telemetry: score.telemetry(1),
             });
         }
 
@@ -344,8 +374,8 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             } else {
                 0
             };
-        let get_score = |worker: WorkerWithDpRank| -> f64 {
-            let base_score = self.worker_logit(
+        let get_score = |worker: WorkerWithDpRank| -> WorkerScore {
+            let mut score = self.worker_score(
                 request,
                 worker,
                 block_size,
@@ -354,53 +384,73 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 "Formula",
             );
             let Some(config) = workers.get(&worker.worker_id) else {
-                return base_score;
+                return score;
             };
-            match request
+            if let Some(multiplier) = request
                 .routing_constraints
                 .preferred_taint_multiplier(config.taints())
             {
                 // NOTE: This multiplicative bias assumes a non-negative score. Negative
                 // overlap scores expose its pre-existing sign sensitivity; keep it for now.
-                Some(multiplier) => base_score * multiplier,
-                None => base_score,
+                score.final_score *= multiplier;
             }
+            score
         };
 
-        let (best_worker, best_logit) = if temperature == 0.0 {
+        let (best_worker, best_score, candidate_workers, tie_break) = if temperature == 0.0 {
             let mut best_worker = None;
-            let mut best_logit = f64::INFINITY;
+            let mut best_score = None;
             let mut tie_count = 0usize;
+            let mut candidate_workers = 0usize;
             eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
                 let score = get_score(worker);
-                if score < best_logit {
+                candidate_workers += 1;
+                if best_score.is_none_or(|best: WorkerScore| score.final_score < best.final_score) {
                     best_worker = Some(worker);
-                    best_logit = score;
+                    best_score = Some(score);
                     tie_count = 1;
                     return;
                 }
 
-                if score == best_logit {
+                if best_score.is_some_and(|best| score.final_score == best.final_score) {
                     tie_count += 1;
                     // Reservoir sampling keeps tied minima uniform without collecting workers.
                     if fastrand::usize(0..tie_count) == 0 {
                         best_worker = Some(worker);
+                        best_score = Some(score);
                     }
                 }
             });
 
             (
                 best_worker.expect("eligible worker rank non-empty"),
-                best_logit,
+                best_score.expect("eligible worker rank non-empty"),
+                candidate_workers,
+                (tie_count > 1).then_some(WorkerSelectionTieBreak::EqualScore),
             )
         } else {
             let mut worker_logits = FxHashMap::default();
+            let mut worker_scores = FxHashMap::default();
             eligibility.for_each_eligible_worker_rank(workers, |worker, _| {
                 let score = get_score(worker);
-                worker_logits.insert(worker, score);
+                worker_logits.insert(worker, score.final_score);
+                worker_scores.insert(worker, score);
             });
 
-            softmax_sample(&worker_logits, temperature)
+            let (worker, _) = softmax_sample(&worker_logits, temperature);
+            (
+                worker,
+                *worker_scores
+                    .get(&worker)
+                    .expect("sampled worker score must exist"),
+                worker_scores.len(),
+                None,
+            )
+        };
+        let best_logit = best_score.final_score;
+        let telemetry = WorkerSelectionTelemetry {
+            tie_break,
+            ..best_score.telemetry(candidate_workers)
         };
 
         let best_host_pinned_overlap_blocks = request
@@ -437,6 +487,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
                 required_blocks: request_blocks,
                 effective_overlap_blocks,
                 cached_tokens,
+                telemetry,
             });
         }
 
@@ -465,6 +516,7 @@ impl<C: WorkerConfigLike> WorkerSelector<C> for DefaultWorkerSelector {
             required_blocks: request_blocks,
             effective_overlap_blocks: best_overlap,
             cached_tokens: best_cached_tokens,
+            telemetry,
         })
     }
 }
@@ -711,6 +763,12 @@ mod tests {
                 30 => selected[2] = true,
                 worker_id => panic!("unexpected worker id: {worker_id}"),
             }
+            assert_eq!(result.telemetry.candidate_workers, 3);
+            assert_eq!(
+                result.telemetry.tie_break,
+                Some(WorkerSelectionTieBreak::EqualScore)
+            );
+            assert!(result.telemetry.selected_scores.is_some());
         }
 
         let selected_count = selected.into_iter().filter(|seen| *seen).count();
@@ -755,6 +813,9 @@ mod tests {
             .unwrap();
 
         assert_eq!(result.worker.worker_id, 1);
+        assert_eq!(result.telemetry.candidate_workers, 1);
+        assert_eq!(result.telemetry.tie_break, None);
+        assert!(result.telemetry.selected_scores.is_some());
     }
 
     #[test]
@@ -1337,13 +1398,17 @@ mod tests {
         };
 
         assert_eq!(
-            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
+            selector
+                .worker_score(&request, worker, 16, 0, weights, "test")
+                .final_score,
             7.0
         );
 
         request.track_prefill_tokens = false;
         assert_eq!(
-            selector.worker_logit(&request, worker, 16, 0, weights, "test"),
+            selector
+                .worker_score(&request, worker, 16, 0, weights, "test")
+                .final_score,
             -7.0
         );
     }

--- a/lib/kv-router/src/scheduling/types.rs
+++ b/lib/kv-router/src/scheduling/types.rs
@@ -15,7 +15,7 @@ use super::prefill_load::effective_prefill_tokens;
 pub use crate::protocols::PotentialLoad;
 use crate::protocols::{
     LocalBlockHash, RoutingConstraints, SharedCacheHits, WorkerConfigLike, WorkerId,
-    WorkerWithDpRank,
+    WorkerSelectionTelemetry, WorkerWithDpRank,
 };
 use crate::scheduling::policy_queue::QueueRejection;
 use crate::scheduling::queue_admission::RequestProgressUpdater;
@@ -76,6 +76,7 @@ pub struct SchedulingResponse {
     pub effective_overlap_blocks: f64,
     pub cached_tokens: usize,
     pub selected_worker_tiers: SelectedWorkerTierSnapshot,
+    pub selection_telemetry: WorkerSelectionTelemetry,
     pub request_progress: Option<RequestProgressUpdater>,
     pub lifecycle_lease: Option<super::queue::RequestLifecycleLease>,
 }

--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -218,6 +218,8 @@ where
     /// narrowed to the LoRA's allocated/loaded replicas inside `find_best_match_details`,
     /// covering both the decode and prefill routers (both built via `kv_chooser_for`).
     lora_filter: Option<Arc<crate::lora::LoraFilter>>,
+    metrics_model: String,
+    worker_type: &'static str,
 }
 
 impl<Sel> KvRouter<Sel>
@@ -240,6 +242,7 @@ where
         shared_cache: Option<Box<dyn SharedKvCache>>,
         lora_filter: Option<Arc<crate::lora::LoraFilter>>,
     ) -> Result<Self> {
+        let metrics_model = model_name.clone().unwrap_or_else(|| "unknown".to_string());
         let kv_router_config = kv_router_config.unwrap_or_default();
         kv_router_config.validate().map_err(anyhow::Error::msg)?;
         let component = endpoint.component();
@@ -355,6 +358,8 @@ where
             _served_indexer_handle: served_indexer_handle,
             shared_cache,
             lora_filter,
+            metrics_model,
+            worker_type,
         })
     }
 
@@ -695,7 +700,14 @@ where
             Err(KvSchedulerError::QueueRejected(rejection)) => {
                 return Ok((FindBestMatchOutcome::QueueRejected { rejection }, None));
             }
-            Err(error) => return Err(map_scheduler_error(error)),
+            Err(error) => {
+                if matches!(error, KvSchedulerError::NoEndpoints)
+                    && let Some(m) = metrics::RouterRequestMetrics::get()
+                {
+                    m.observe_no_candidates(&self.metrics_model, self.worker_type);
+                }
+                return Err(map_scheduler_error(error));
+            }
         };
         let total_elapsed = start.elapsed();
         let routing_hashes = routing_block_hashes.map(RoutingDecisionHashes::from_local_hashes);
@@ -721,6 +733,16 @@ where
             }
             let beyond = hits.hits_beyond(response.effective_overlap_blocks.round() as u32);
             m.shared_cache_beyond_blocks.observe(beyond as f64);
+        }
+
+        if let Some(m) = metrics::RouterRequestMetrics::get() {
+            m.observe_selection_decision(
+                &self.metrics_model,
+                self.worker_type,
+                response.best_worker,
+                response.cached_tokens,
+                response.selection_telemetry,
+            );
         }
 
         #[cfg(feature = "bench")]
@@ -1354,6 +1376,7 @@ mod tests {
                 required_blocks: request.isl_tokens.div_ceil(block_size as usize) as u64,
                 effective_overlap_blocks: 0.0,
                 cached_tokens: 0,
+                telemetry: Default::default(),
             })
         }
     }

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -46,18 +46,16 @@
 use std::sync::{Arc, LazyLock, OnceLock};
 use std::time::Duration;
 
+use dynamo_kv_router::protocols::{WorkerSelectionTelemetry, WorkerWithDpRank};
 use dynamo_runtime::component::Component;
 use dynamo_runtime::metrics::MetricsHierarchy;
 use dynamo_runtime::metrics::prometheus_names::{
     frontend_service, kv_publisher, labels, name_prefix, router, router_request, routing_overhead,
 };
-
-/// Build a router metric name: `"router_" + frontend_service_suffix`.
-fn router_metric(suffix: &str) -> String {
-    format!("{}{}", router_request::METRIC_PREFIX, suffix)
-}
 use dynamo_runtime::traits::DistributedRuntimeProvider;
-use prometheus::{HistogramOpts, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts};
+use prometheus::{
+    HistogramOpts, HistogramVec, IntCounter, IntCounterVec, IntGauge, IntGaugeVec, Opts,
+};
 
 use crate::http::service::metrics::generate_log_buckets;
 
@@ -65,6 +63,15 @@ pub(crate) const ROUTER_WORKER_ID_LABEL: &str = "router_worker_id";
 const TARGET_NAMESPACE_LABEL: &str = "target_namespace";
 const TARGET_COMPONENT_LABEL: &str = "target_component";
 const TARGET_ENDPOINT_LABEL: &str = "target_endpoint";
+const DECISION_LABEL: &str = "decision";
+const REASON_LABEL: &str = "reason";
+const DECISION_CACHE_HIT: &str = "cache_hit";
+const DECISION_CACHE_MISS: &str = "cache_miss";
+
+/// Build a router metric name: `"router_" + frontend_service_suffix`.
+fn router_metric(suffix: &str) -> String {
+    format!("{}{}", router_request::METRIC_PREFIX, suffix)
+}
 
 /// Buckets for CPU-bound compute phases (block hashing, sequence hashing).
 fn compute_overhead_buckets() -> Vec<f64> {
@@ -74,6 +81,16 @@ fn compute_overhead_buckets() -> Vec<f64> {
 /// Buckets for async phases (indexer find_matches, scheduling, total).
 fn async_overhead_buckets() -> Vec<f64> {
     prometheus::exponential_buckets(0.01, 3.0, 17).unwrap()
+}
+
+/// Buckets for eligible candidate worker/rank counts per router decision.
+fn candidate_worker_buckets() -> Vec<f64> {
+    prometheus::exponential_buckets(1.0, 2.0, 12).unwrap()
+}
+
+/// Buckets for non-negative router score components measured in block units.
+fn router_score_buckets() -> Vec<f64> {
+    prometheus::exponential_buckets(0.5, 2.0, 18).unwrap()
 }
 
 // ---------------------------------------------------------------------------
@@ -647,6 +664,13 @@ pub struct RouterRequestMetrics {
     pub kv_transfer_estimated_latency_seconds: prometheus::Histogram,
     pub shared_cache_hit_rate: prometheus::Histogram,
     pub shared_cache_beyond_blocks: prometheus::Histogram,
+    pub decisions_total: prometheus::IntCounterVec,
+    pub selected_worker_total: prometheus::IntCounterVec,
+    pub candidate_workers: HistogramVec,
+    pub kv_overlap_score: HistogramVec,
+    pub worker_load_score: HistogramVec,
+    pub tie_breaks_total: prometheus::IntCounterVec,
+    pub no_candidates_total: prometheus::IntCounterVec,
 }
 
 static ROUTER_REQUEST_METRICS: OnceLock<Arc<RouterRequestMetrics>> = OnceLock::new();
@@ -763,6 +787,71 @@ impl RouterRequestMetrics {
                         Some(prometheus::exponential_buckets(1.0, 2.0, 12).unwrap()),
                     )
                     .expect("failed to create router_shared_cache_beyond_blocks");
+                let decisions_total = metrics
+                    .create_intcountervec(
+                        router::DECISIONS_TOTAL,
+                        "Total number of worker-selection decisions by cache outcome",
+                        &[labels::MODEL, labels::WORKER_TYPE, DECISION_LABEL],
+                        extra_labels,
+                    )
+                    .expect("failed to create router_decisions_total");
+                let selected_worker_total = metrics
+                    .create_intcountervec(
+                        router::SELECTED_WORKER_TOTAL,
+                        "Total number of times each backend worker/rank was selected by the router",
+                        &[
+                            labels::MODEL,
+                            labels::WORKER_TYPE,
+                            ROUTER_WORKER_ID_LABEL,
+                            labels::DP_RANK,
+                        ],
+                        extra_labels,
+                    )
+                    .expect("failed to create router_selected_worker_total");
+                let candidate_workers = metrics
+                    .create_histogramvec(
+                        router::CANDIDATE_WORKERS,
+                        "Number of eligible candidate worker/ranks considered for a router decision",
+                        &[labels::MODEL, labels::WORKER_TYPE],
+                        extra_labels,
+                        Some(candidate_worker_buckets()),
+                    )
+                    .expect("failed to create router_candidate_workers");
+                let kv_overlap_score = metrics
+                    .create_histogramvec(
+                        router::KV_OVERLAP_SCORE,
+                        "Cache-overlap score credited to the selected worker at decision time",
+                        &[labels::MODEL, labels::WORKER_TYPE],
+                        extra_labels,
+                        Some(router_score_buckets()),
+                    )
+                    .expect("failed to create router_kv_overlap_score");
+                let worker_load_score = metrics
+                    .create_histogramvec(
+                        router::WORKER_LOAD_SCORE,
+                        "Load score for the selected worker at decision time",
+                        &[labels::MODEL, labels::WORKER_TYPE],
+                        extra_labels,
+                        Some(router_score_buckets()),
+                    )
+                    .expect("failed to create router_worker_load_score");
+                let tie_breaks_total = metrics
+                    .create_intcountervec(
+                        router::TIE_BREAKS_TOTAL,
+                        "Total number of router decisions resolved by a tie-break",
+                        &[labels::MODEL, labels::WORKER_TYPE, REASON_LABEL],
+                        extra_labels,
+                    )
+                    .expect("failed to create router_tie_breaks_total");
+                let no_candidates_total = metrics
+                    .create_intcountervec(
+                        router::NO_CANDIDATES_TOTAL,
+                        "Total number of router decisions where no eligible worker/rank existed",
+                        &[labels::MODEL, labels::WORKER_TYPE],
+                        extra_labels,
+                    )
+                    .expect("failed to create router_no_candidates_total");
+
                 Arc::new(Self {
                     requests_total,
                     time_to_first_token_seconds,
@@ -773,9 +862,71 @@ impl RouterRequestMetrics {
                     kv_transfer_estimated_latency_seconds,
                     shared_cache_hit_rate,
                     shared_cache_beyond_blocks,
+                    decisions_total,
+                    selected_worker_total,
+                    candidate_workers,
+                    kv_overlap_score,
+                    worker_load_score,
+                    tie_breaks_total,
+                    no_candidates_total,
                 })
             })
             .clone()
+    }
+
+    pub fn observe_selection_decision(
+        &self,
+        model: &str,
+        worker_type: &str,
+        worker: WorkerWithDpRank,
+        cached_tokens: usize,
+        telemetry: WorkerSelectionTelemetry,
+    ) {
+        let has_cache_hit = cached_tokens > 0
+            || telemetry
+                .selected_scores
+                .is_some_and(|scores| scores.kv_overlap_score > 0.0);
+        let decision = if has_cache_hit {
+            DECISION_CACHE_HIT
+        } else {
+            DECISION_CACHE_MISS
+        };
+        self.decisions_total
+            .with_label_values(&[model, worker_type, decision])
+            .inc();
+
+        let worker_id = worker.worker_id.to_string();
+        let dp_rank = worker.dp_rank.to_string();
+        self.selected_worker_total
+            .with_label_values(&[model, worker_type, &worker_id, &dp_rank])
+            .inc();
+
+        if telemetry.candidate_workers > 0 {
+            self.candidate_workers
+                .with_label_values(&[model, worker_type])
+                .observe(telemetry.candidate_workers as f64);
+        }
+
+        if let Some(scores) = telemetry.selected_scores {
+            self.kv_overlap_score
+                .with_label_values(&[model, worker_type])
+                .observe(scores.kv_overlap_score.max(0.0));
+            self.worker_load_score
+                .with_label_values(&[model, worker_type])
+                .observe(scores.worker_load_score.max(0.0));
+        }
+
+        if let Some(tie_break) = telemetry.tie_break {
+            self.tie_breaks_total
+                .with_label_values(&[model, worker_type, tie_break.as_label()])
+                .inc();
+        }
+    }
+
+    pub fn observe_no_candidates(&self, model: &str, worker_type: &str) {
+        self.no_candidates_total
+            .with_label_values(&[model, worker_type])
+            .inc();
     }
 }
 
@@ -837,6 +988,43 @@ mod tests {
         let mut buffer = Vec::new();
         encoder.encode(&registry.gather(), &mut buffer).unwrap();
         String::from_utf8(buffer).unwrap()
+    }
+
+    fn test_histogram(name: &str) -> prometheus::Histogram {
+        prometheus::Histogram::with_opts(
+            prometheus::HistogramOpts::new(name, "test").buckets(vec![1.0, 2.0, 4.0]),
+        )
+        .unwrap()
+    }
+
+    fn test_router_request_metrics(
+        decisions_total: IntCounterVec,
+        selected_worker_total: IntCounterVec,
+        candidate_workers: HistogramVec,
+        kv_overlap_score: HistogramVec,
+        worker_load_score: HistogramVec,
+        tie_breaks_total: IntCounterVec,
+        no_candidates_total: IntCounterVec,
+    ) -> RouterRequestMetrics {
+        RouterRequestMetrics {
+            requests_total: prometheus::IntCounter::new("test_router_requests_total", "test")
+                .unwrap(),
+            time_to_first_token_seconds: test_histogram("test_router_ttft_seconds"),
+            inter_token_latency_seconds: test_histogram("test_router_itl_seconds"),
+            input_sequence_tokens: test_histogram("test_router_input_sequence_tokens"),
+            output_sequence_tokens: test_histogram("test_router_output_sequence_tokens"),
+            kv_hit_rate: test_histogram("test_router_kv_hit_rate"),
+            kv_transfer_estimated_latency_seconds: test_histogram("test_router_kv_transfer"),
+            shared_cache_hit_rate: test_histogram("test_router_shared_cache_hit_rate"),
+            shared_cache_beyond_blocks: test_histogram("test_router_shared_cache_beyond_blocks"),
+            decisions_total,
+            selected_worker_total,
+            candidate_workers,
+            kv_overlap_score,
+            worker_load_score,
+            tie_breaks_total,
+            no_candidates_total,
+        }
     }
 
     #[test]
@@ -1122,6 +1310,195 @@ dynamo_frontend_router_queue_pending_requests{model=\"model\",policy_class=\"def
             Duration::from_millis(1),
         );
         // Reaching here without panic confirms saturating_sub works
+    }
+
+    #[test]
+    fn test_router_decision_metrics_pef() {
+        use dynamo_kv_router::protocols::{WorkerSelectionScores, WorkerSelectionTieBreak};
+
+        let registry = prometheus::Registry::new();
+        let decisions_total = IntCounterVec::new(
+            Opts::new(
+                format!("{}_{}", name_prefix::COMPONENT, router::DECISIONS_TOTAL),
+                "Total number of worker-selection decisions by cache outcome",
+            ),
+            &[labels::MODEL, labels::WORKER_TYPE, DECISION_LABEL],
+        )
+        .unwrap();
+        let selected_worker_total = IntCounterVec::new(
+            Opts::new(
+                format!(
+                    "{}_{}",
+                    name_prefix::COMPONENT,
+                    router::SELECTED_WORKER_TOTAL
+                ),
+                "Total number of times each backend worker/rank was selected by the router",
+            ),
+            &[
+                labels::MODEL,
+                labels::WORKER_TYPE,
+                ROUTER_WORKER_ID_LABEL,
+                labels::DP_RANK,
+            ],
+        )
+        .unwrap();
+        let candidate_workers = HistogramVec::new(
+            HistogramOpts::new(
+                format!("{}_{}", name_prefix::COMPONENT, router::CANDIDATE_WORKERS),
+                "Number of eligible candidate worker/ranks considered for a router decision",
+            )
+            .buckets(vec![1.0, 2.0, 4.0]),
+            &[labels::MODEL, labels::WORKER_TYPE],
+        )
+        .unwrap();
+        let kv_overlap_score = HistogramVec::new(
+            HistogramOpts::new(
+                format!("{}_{}", name_prefix::COMPONENT, router::KV_OVERLAP_SCORE),
+                "Cache-overlap score credited to the selected worker at decision time",
+            )
+            .buckets(vec![1.0, 2.0, 4.0]),
+            &[labels::MODEL, labels::WORKER_TYPE],
+        )
+        .unwrap();
+        let worker_load_score = HistogramVec::new(
+            HistogramOpts::new(
+                format!("{}_{}", name_prefix::COMPONENT, router::WORKER_LOAD_SCORE),
+                "Load score for the selected worker at decision time",
+            )
+            .buckets(vec![1.0, 4.0, 8.0]),
+            &[labels::MODEL, labels::WORKER_TYPE],
+        )
+        .unwrap();
+        let tie_breaks_total = IntCounterVec::new(
+            Opts::new(
+                format!("{}_{}", name_prefix::COMPONENT, router::TIE_BREAKS_TOTAL),
+                "Total number of router decisions resolved by a tie-break",
+            ),
+            &[labels::MODEL, labels::WORKER_TYPE, REASON_LABEL],
+        )
+        .unwrap();
+        let no_candidates_total = IntCounterVec::new(
+            Opts::new(
+                format!("{}_{}", name_prefix::COMPONENT, router::NO_CANDIDATES_TOTAL),
+                "Total number of router decisions where no eligible worker/rank existed",
+            ),
+            &[labels::MODEL, labels::WORKER_TYPE],
+        )
+        .unwrap();
+
+        registry
+            .register(Box::new(decisions_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(selected_worker_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(candidate_workers.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(kv_overlap_score.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(worker_load_score.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(tie_breaks_total.clone()))
+            .unwrap();
+        registry
+            .register(Box::new(no_candidates_total.clone()))
+            .unwrap();
+
+        let metrics = test_router_request_metrics(
+            decisions_total,
+            selected_worker_total,
+            candidate_workers,
+            kv_overlap_score,
+            worker_load_score,
+            tie_breaks_total,
+            no_candidates_total,
+        );
+
+        metrics.observe_selection_decision(
+            "model-a",
+            "decode",
+            WorkerWithDpRank::new(7, 1),
+            64,
+            WorkerSelectionTelemetry {
+                candidate_workers: 3,
+                selected_scores: Some(WorkerSelectionScores {
+                    kv_overlap_score: 2.0,
+                    worker_load_score: 6.0,
+                    final_score: 4.0,
+                }),
+                tie_break: Some(WorkerSelectionTieBreak::EqualScore),
+            },
+        );
+        metrics.observe_selection_decision(
+            "model-a",
+            "decode",
+            WorkerWithDpRank::new(8, 2),
+            0,
+            WorkerSelectionTelemetry {
+                candidate_workers: 2,
+                selected_scores: Some(WorkerSelectionScores {
+                    kv_overlap_score: 0.0,
+                    worker_load_score: 5.0,
+                    final_score: 5.0,
+                }),
+                tie_break: None,
+            },
+        );
+        metrics.observe_no_candidates("model-a", "prefill");
+
+        let output = gather_pef(&registry);
+        assert!(
+            output.contains(
+                "dynamo_component_router_decisions_total{decision=\"cache_hit\",model=\"model-a\",worker_type=\"decode\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_decisions_total{decision=\"cache_miss\",model=\"model-a\",worker_type=\"decode\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_selected_worker_total{dp_rank=\"1\",model=\"model-a\",router_worker_id=\"7\",worker_type=\"decode\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_candidate_workers_count{model=\"model-a\",worker_type=\"decode\"} 2"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_kv_overlap_score_sum{model=\"model-a\",worker_type=\"decode\"} 2"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_worker_load_score_sum{model=\"model-a\",worker_type=\"decode\"} 11"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_tie_breaks_total{model=\"model-a\",reason=\"equal_score\",worker_type=\"decode\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
+        assert!(
+            output.contains(
+                "dynamo_component_router_no_candidates_total{model=\"model-a\",worker_type=\"prefill\"} 1"
+            ),
+            "\nActual PEF:\n{output}"
+        );
     }
 
     #[test]

--- a/lib/runtime/src/metrics.rs
+++ b/lib/runtime/src/metrics.rs
@@ -91,6 +91,19 @@ pub trait PrometheusMetric: prometheus::core::Collector + Clone + Send + Sync + 
     {
         panic!("with_opts_and_label_names is not implemented for this metric type");
     }
+
+    /// Create a new histogram vector with custom buckets.
+    /// This is a default implementation that will panic for non-HistogramVec metrics.
+    fn with_histogram_opts_and_label_names(
+        _opts: prometheus::HistogramOpts,
+        _label_names: &[&str],
+        _buckets: Option<Vec<f64>>,
+    ) -> Result<Self, prometheus::Error>
+    where
+        Self: Sized,
+    {
+        panic!("with_histogram_opts_and_label_names is not implemented for this metric type");
+    }
 }
 
 // Implement the trait for Counter, IntCounter, and Gauge
@@ -194,6 +207,26 @@ impl PrometheusMetric for prometheus::CounterVec {
         label_names: &[&str],
     ) -> Result<Self, prometheus::Error> {
         prometheus::CounterVec::new(opts, label_names)
+    }
+}
+
+impl PrometheusMetric for prometheus::HistogramVec {
+    fn with_opts(_opts: prometheus::Opts) -> Result<Self, prometheus::Error> {
+        Err(prometheus::Error::Msg(
+            "HistogramVec requires label names, use with_histogram_opts_and_label_names instead"
+                .to_string(),
+        ))
+    }
+
+    fn with_histogram_opts_and_label_names(
+        mut opts: prometheus::HistogramOpts,
+        label_names: &[&str],
+        buckets: Option<Vec<f64>>,
+    ) -> Result<Self, prometheus::Error> {
+        if let Some(custom_buckets) = buckets {
+            opts = opts.buckets(custom_buckets);
+        }
+        prometheus::HistogramVec::new(opts, label_names)
     }
 }
 
@@ -354,6 +387,15 @@ pub fn create_metric<T: PrometheusMetric, H: MetricsHierarchy + ?Sized>(
             opts = opts.const_label(key.clone(), value.clone());
         }
         T::with_histogram_opts_and_buckets(opts, buckets)?
+    } else if std::any::TypeId::of::<T>() == std::any::TypeId::of::<prometheus::HistogramVec>() {
+        // Special handling for HistogramVec with label names and custom buckets.
+        let mut opts = prometheus::HistogramOpts::new(&metric_name, metric_desc);
+        for (key, value) in &updated_labels {
+            opts = opts.const_label(key.clone(), value.clone());
+        }
+        let label_names = const_labels
+            .ok_or_else(|| anyhow::anyhow!("HistogramVec requires const_labels parameter"))?;
+        T::with_histogram_opts_and_label_names(opts, label_names, buckets)?
     } else if std::any::TypeId::of::<T>() == std::any::TypeId::of::<prometheus::IntCounterVec>() {
         // Special handling for IntCounterVec with label names
         // const_labels parameter is required for IntCounterVec
@@ -428,7 +470,7 @@ impl<H: MetricsHierarchy> Metrics<H> {
     // - GaugeVec: ✅ IMPLEMENTED - create_gaugevec()
     // - GaugeHistogram: create_gauge_histogram() - for gauge histograms
     // - Histogram: ✅ IMPLEMENTED - create_histogram()
-    // - HistogramVec with custom buckets: create_histogram_with_buckets()
+    // - HistogramVec: ✅ IMPLEMENTED - create_histogramvec()
     // - Info: create_info() - for info metrics with labels
     // - IntCounter: ✅ IMPLEMENTED - create_intcounter()
     // - IntCounterVec: ✅ IMPLEMENTED - create_intcountervec()
@@ -507,6 +549,25 @@ impl<H: MetricsHierarchy> Metrics<H> {
         buckets: Option<Vec<f64>>,
     ) -> anyhow::Result<prometheus::Histogram> {
         create_metric(&self.hierarchy, name, description, labels, buckets, None)
+    }
+
+    /// Create a HistogramVec metric with label names and custom buckets.
+    pub fn create_histogramvec(
+        &self,
+        name: &str,
+        description: &str,
+        const_labels: &[&str],
+        const_label_values: &[(&str, &str)],
+        buckets: Option<Vec<f64>>,
+    ) -> anyhow::Result<prometheus::HistogramVec> {
+        create_metric(
+            &self.hierarchy,
+            name,
+            description,
+            const_label_values,
+            buckets,
+            Some(const_labels),
+        )
     }
 
     /// Create an IntCounter metric
@@ -1072,6 +1133,32 @@ mod test_helpers {
 mod test_metricsregistry_units {
     use super::*;
 
+    struct TestHierarchy {
+        registry: MetricsRegistry,
+    }
+
+    impl TestHierarchy {
+        fn new() -> Self {
+            Self {
+                registry: MetricsRegistry::new(),
+            }
+        }
+    }
+
+    impl MetricsHierarchy for TestHierarchy {
+        fn basename(&self) -> String {
+            "test".to_string()
+        }
+
+        fn parent_hierarchies(&self) -> Vec<&dyn MetricsHierarchy> {
+            Vec::new()
+        }
+
+        fn get_metrics_registry(&self) -> &MetricsRegistry {
+            &self.registry
+        }
+    }
+
     #[test]
     fn test_build_component_metric_name_with_prefix() {
         // Test that build_component_metric_name correctly prepends the dynamo_component prefix
@@ -1133,6 +1220,41 @@ mod test_metricsregistry_units {
         assert!(parse_prometheus_metric("metric_name").is_none()); // No value
 
         println!("✓ Prometheus metric parsing works correctly!");
+    }
+
+    #[test]
+    fn test_create_histogramvec_observes_dynamic_labels() {
+        use super::test_helpers::parse_prometheus_metric;
+
+        let hierarchy = TestHierarchy::new();
+        let histogram = hierarchy
+            .metrics()
+            .create_histogramvec(
+                "test_histogramvec",
+                "A test histogram vector",
+                &[labels::MODEL],
+                &[("scope", "router")],
+                Some(vec![1.0, 2.0, 4.0]),
+            )
+            .unwrap();
+        histogram.with_label_values(&["model-a"]).observe(1.5);
+
+        let output = hierarchy.metrics().prometheus_expfmt().unwrap();
+        let sum = output
+            .lines()
+            .filter_map(parse_prometheus_metric)
+            .find(|(name, _, _)| name == "dynamo_component_test_histogramvec_sum")
+            .expect("histogramvec sum should be exported");
+        assert_eq!(sum.1.get(labels::MODEL), Some(&"model-a".to_string()));
+        assert_eq!(sum.1.get("scope"), Some(&"router".to_string()));
+        assert_eq!(sum.2, 1.5);
+
+        let count = output
+            .lines()
+            .filter_map(parse_prometheus_metric)
+            .find(|(name, _, _)| name == "dynamo_component_test_histogramvec_count")
+            .expect("histogramvec count should be exported");
+        assert_eq!(count.2, 1.0);
     }
 
     #[test]

--- a/lib/runtime/src/metrics/prometheus_names.rs
+++ b/lib/runtime/src/metrics/prometheus_names.rs
@@ -607,6 +607,27 @@ pub mod router {
     /// Total number of requests processed by the router
     pub const REQUESTS_TOTAL: &str = "router_requests_total";
 
+    /// Total number of worker-selection decisions by cache outcome
+    pub const DECISIONS_TOTAL: &str = "router_decisions_total";
+
+    /// Total number of times each backend worker/rank was selected by the router
+    pub const SELECTED_WORKER_TOTAL: &str = "router_selected_worker_total";
+
+    /// Number of eligible candidate worker/ranks considered for a router decision
+    pub const CANDIDATE_WORKERS: &str = "router_candidate_workers";
+
+    /// Cache-overlap score credited to the selected worker at decision time
+    pub const KV_OVERLAP_SCORE: &str = "router_kv_overlap_score";
+
+    /// Load score for the selected worker at decision time
+    pub const WORKER_LOAD_SCORE: &str = "router_worker_load_score";
+
+    /// Total number of router decisions resolved by a tie-break
+    pub const TIE_BREAKS_TOTAL: &str = "router_tie_breaks_total";
+
+    /// Total number of router decisions where no eligible worker/rank existed
+    pub const NO_CANDIDATES_TOTAL: &str = "router_no_candidates_total";
+
     /// Total number of remote indexer overlap queries that failed
     pub const REMOTE_INDEXER_QUERY_FAILURES_TOTAL: &str =
         "router_remote_indexer_query_failures_total";


### PR DESCRIPTION
## Summary

- Add component-scoped KV-router decision metrics for cache-hit outcome, selected worker/rank, candidate count, score components, tie-breaks, and no-candidate decisions.
- Thread selector telemetry through `WorkerSelectionResult` and `SchedulingResponse`, and observe it from `KvRouter` success/error paths.
- Add `HistogramVec` support to the runtime metrics helper, regenerate Python Prometheus-name constants, document the new metrics, and extend the Grafana dashboard KV Routing row.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p dynamo-runtime metrics`
- `cargo test -p dynamo-kv-router scheduling`
- `cargo test -p dynamo-llm --no-default-features test_router_decision_metrics_pef`
- `jq empty dev/observability/grafana_dashboards/dynamo.json`
- `python3 -m py_compile lib/bindings/python/src/dynamo/prometheus_names.py`
- `cargo run -p dynamo-codegen --bin gen-python-prometheus-names`

Note: `cargo test -p dynamo-llm test_router_decision_metrics_pef` with default features does not compile on this macOS host because existing block-manager code references Linux-only `numa`, `fallocate`, and `O_DIRECT` APIs. The same focused metrics test passes with `--no-default-features`.