### PR TITLE
chore(recipes): cherry-pick GLM-5.2 recipes (#11926) to release/1.3.0-glm-5.2-dev.1

### DIFF
--- a/recipes/README.md
+++ b/recipes/README.md
@@ -43,6 +43,7 @@ These recipes demonstrate aggregated or disaggregated serving:
 | **[GPT-OSS-120B](gpt-oss-120b/trtllm/agg/)** | TensorRT-LLM | Aggregated | 4x GB200 | ✅ | ✅ | Blackwell only, WideEP | ❌ |
 | **[GPT-OSS-120B](gpt-oss-120b/trtllm/disagg/)** | TensorRT-LLM | Disaggregated | 5x Blackwell (GB200/B200) | ✅ | ✅ | Prefill/Decode split | ❌ |
 | **[GLM-5-NVFP4](glm-5-nvfp4/sglang/disagg/)** | SGLang | Disagg Prefill/Decode | 20x GB200 | ✅ | ✅ | NVFP4, EAGLE speculative decoding, TP16 decode + TP4 prefill, stable SGLang runtime image | ❌ |
+| **[GLM-5.2](glm-5.2/)** | SGLang | Aggregated + Disaggregated | 16x/20x B200 or 24x/16x H200 | ✅ | ✅ | B200 NVFP4 or H200 FP8 with FP8 KV, KV-aware routing, EAGLE, B200 HiCache CPU offload, agentic trace profile | ❌ |
 | **[DeepSeek-R1](deepseek-r1/sglang/disagg-8gpu/)** | SGLang | Disagg WideEP | 16x H200 | ✅ | ❌ | TP=8, single-node. Use `model-download-sglang.yaml` | ❌ |
 | **[DeepSeek-R1](deepseek-r1/sglang/disagg-16gpu/)** | SGLang | Disagg WideEP | 32x H200 | ✅ | ❌ | TP=16, multi-node. Use `model-download-sglang.yaml` | ❌ |
 | **[DeepSeek-R1](deepseek-r1/trtllm/disagg/wide_ep/gb200/)** | TensorRT-LLM | Disagg WideEP (GB200) | 36x GB200 | ✅ | ✅ | Multi-node: 8 decode + 1 prefill nodes | ❌ |

--- a/recipes/glm-5.2/README.md
+++ b/recipes/glm-5.2/README.md
@@ -1,0 +1,115 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# GLM-5.2 Recipes
+
+Recipes for [GLM-5.2](https://huggingface.co/zai-org/GLM-5.2).
+
+## Configurations
+
+Dynamo + SGLang deployment profiles for the B200 and H200 agentic workload:
+
+|                          | B200 aggregated agentic                    | B200 disaggregated agentic                 | H200 aggregated agentic                    | H200 disaggregated agentic                 |
+| ------------------------ | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ |
+| **GPU** (per worker)     | 4x B200                                    | 4x B200 prefill + 8x B200 decode           | 8x H200                                    | 8x H200 prefill + 8x H200 decode           |
+| **Mode**                 | Aggregated                                 | Prefill/decode disaggregated               | Aggregated                                 | Prefill/decode disaggregated               |
+| **Framework**            | SGLang                                     | SGLang                                     | SGLang                                     | SGLang                                     |
+| **Precision**            | NVFP4 + FP8 KV                             | NVFP4 + FP8 KV                             | FP8 + FP8 KV                               | FP8 + FP8 KV                               |
+| **Parallelism**          | DTP4                                       | DEP4 / DTP8                                | TP8/EP8                                    | TP8/EP8 prefill / TP8/DP8/EP1 decode       |
+| **Routing**              | KV-aware                                   | KV-aware                                   | KV-aware                                   | KV-aware                                   |
+| **Speculative decoding** | EAGLE-style MTP (DL=3, SpeedBench AL=2.69) | EAGLE-style MTP (DL=3, SpeedBench AL=2.69) | EAGLE-style MTP (DL=3, SpeedBench AL=2.69) | EAGLE-style MTP (DL=3, SpeedBench AL=2.69) |
+| **Context length**       | 500,000                                    | 500,000                                    | 250,000                                    | 250,000                                    |
+| **KV cache offloading**  | HiCache CPU                                | HiCache CPU                                | None                                       | None                                       |
+| **KV transfer**          | N/A                                        | NIXL/UCX over IB                           | N/A                                        | NIXL/UCX over IB                           |
+
+
+## Supported features
+
+- Modalities: Text
+- Reasoning
+- Tool calling
+
+## Prerequisites
+
+1. **Dynamo Platform installed** — see [Kubernetes Deployment Guide](../../docs/kubernetes/README.md).
+2. **Hugging Face token** with access to `nvidia/GLM-5.2-NVFP4` for B200 or
+   `zai-org/GLM-5.2-FP8` for H200.
+
+## Quick Start
+
+### 1. Create namespace and secret
+
+```bash
+export NAMESPACE=your-namespace
+kubectl create namespace ${NAMESPACE}
+kubectl create secret generic hf-token-secret \
+  --from-literal=HF_TOKEN="your-token" \
+  -n ${NAMESPACE}
+```
+
+### 2. Create storage
+
+> [!NOTE]
+> Edit `model-cache/model-cache.yaml` and set `storageClassName` to a
+> ReadWriteMany storage class available on the target cluster.
+
+```bash
+kubectl apply -f model-cache/model-cache.yaml -n ${NAMESPACE}
+```
+
+### 3. Download the model
+
+Edit `model-cache/model-download.yaml` and remove the `hf download` command for
+the checkpoint that does not match the target SKU.
+
+```bash
+kubectl apply -f model-cache/model-download.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/model-download -n ${NAMESPACE} --timeout=7200s
+```
+
+### 4. Deploy the DGD
+
+Deploy the target DGD:
+
+```bash
+SKU=b200 # or h200
+MODE=agg # or disagg
+kubectl apply -f sglang/${MODE}-${SKU}-agentic/deploy.yaml -n ${NAMESPACE}
+```
+
+
+
+### 5. Benchmark
+
+See [perf/README.md](perf/README.md) for the full benchmark workflow — trace staging on the PVC, running the AIPerf trace-replay Job, running a concurrency sweep, and fetching artifacts.
+
+## Optimization targets
+
+
+| Workload | Median ISL | Median OSL | KV cache hit rate | User output tok/s |
+| -------- | ---------- | ---------- | ----------------- | ----------------- |
+| Agentic  | 64k        | 400        | 90%               | 50                |
+
+
+Modified Mooncake traces are provided to showcase the value of KV-aware routing and CPU offloading, see [perf/README.md](perf/README.md) for details.
+
+## Performance results
+
+
+| Workload             | Recipe                 | SKU  | Concurrency | System output tok/s/gpu | User output tok/s (P50) | TTFT P50 (ms) |
+| -------------------- | ---------------------- | ---- | ----------- | ----------------------- | ----------------------- | ------------- |
+| Agentic (15% subset) | Aggregated (4 workers) | B200 | 64          | 176.420                 | 57.493                  | 355.555       |
+| Agentic (15% subset) | Disaggregated (3P1D)   | B200 | 128         | 320.907                 | 65.105                  | 1938.059      |
+| Agentic (15% subset) | Aggregated (3 workers) | H200 | 32          | 54.550                  | 52.370                  | 1790.000      |
+| Agentic (15% subset) | Disaggregated (1P1D)   | H200 | 24          | 68.860                  | 53.880                  | 1874.000      |
+
+
+
+## Limitations
+
+- B200 recipes support up to 500K context lengths. The full 1M context length is not supported out of the box.
+- H200 recipes support up to 250K context lengths.
+- Structured decoding works with reasoning enabled: the generated JSON is populated in the `content` field and the chain-of-thought in `reasoning_content`. This requires both `--dyn-reasoning-parser glm45` (frontend) and `--reasoning-parser glm45` (engine), which the recipes set.
+- `n>1` requests are not supported with the disaggregated recipe

--- a/recipes/glm-5.2/model-cache/model-cache.yaml
+++ b/recipes/glm-5.2/model-cache/model-cache.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: model-cache
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1200Gi
+  # Edit this
+  storageClassName: "your-storage-class-name"

--- a/recipes/glm-5.2/model-cache/model-download.yaml
+++ b/recipes/glm-5.2/model-cache/model-download.yaml
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: model-download
+spec:
+  backoffLimit: 3
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: model-download
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: model-download
+          image: python:3.10-slim
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+          command: ["sh", "-c"]
+          envFrom:
+            - secretRef:
+                name: hf-token-secret
+          env:
+            - name: HF_HOME
+              value: /model-cache
+            - name: HF_XET_HIGH_PERFORMANCE
+              value: "1"
+          args:
+            - |
+              set -eux
+              pip install --no-cache-dir huggingface_hub==1.16.4
+              hf download nvidia/GLM-5.2-NVFP4
+              hf download zai-org/GLM-5.2-FP8
+          volumeMounts:
+            - name: model-cache
+              mountPath: /model-cache
+      volumes:
+        - name: model-cache
+          persistentVolumeClaim:
+            claimName: model-cache

--- a/recipes/glm-5.2/perf/README.md
+++ b/recipes/glm-5.2/perf/README.md
@@ -1,0 +1,154 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# GLM-5.2 Benchmark Recipe
+
+A single [AIPerf](https://github.com/ai-dynamo/aiperf) trace-replay Job —
+[`perf.yaml`](perf.yaml) — covers all four GLM-5.2 DGDs. Set `ENDPOINT` for the
+target DGD and `SYNTHESIS_MAX_ISL` for its context limit.
+
+The Job waits for the target model on the DGD frontend, runs a short warmup,
+replays the configured trace at one `CONCURRENCY` value, and writes raw
+artifacts to the shared `model-cache` PVC. The benchmark pod is co-located with
+a DGD frontend through `podAffinity`.
+
+## Targeting a variant
+
+Edit the `env` block in [`perf.yaml`](perf.yaml) and update the `podAffinity` `values` list to contain only the target DGD name, so the benchmark pod is co-located with the correct frontend:
+
+| Variant target | `ENDPOINT` | `SYNTHESIS_MAX_ISL` | `TRACE_FILE` |
+| --- | --- | --- | --- |
+| B200 aggregate agentic | `glm52-agg-b200-agentic-frontend:8000` | `500000` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` |
+| B200 disaggregated agentic | `glm52-disagg-b200-agentic-frontend:8000` | `500000` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` |
+| H200 aggregate agentic | `glm52-agg-h200-agentic-frontend:8000` | `250000` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` |
+| H200 disaggregated agentic | `glm52-disagg-h200-agentic-frontend:8000` | `250000` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` |
+
+If you run more than one benchmark in the same namespace, also update
+`metadata.name` and `labels.app` so Jobs and artifact directories stay
+distinct.
+
+## Dataset
+
+The benchmark replays a
+[Mooncake-format](https://github.com/kvcache-ai/Mooncake) trace through
+`--custom-dataset-type mooncake_trace`. Each JSONL line describes one request
+with `input_length`, `output_length`, and `hash_ids`.
+
+This recipe benchmarks the same 64K-ISL / 400-OSL / 90%-KV-reuse agentic trace
+shared across the agentic recipes, so rather than duplicate the Git-LFS blob it
+is referenced from the Kimi-K2.6 recipe via a symlink under [`traces`](traces):
+
+```text
+traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+  -> ../../../kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+```
+
+The default 15% trace contains 3,541 requests. Its SHA-256 is
+`f20d3f2bc83dd1306cda659fbe34e7c4d85ca5497626c98bc0b1c4d2211379d0`.
+
+## Workflow
+
+```bash
+export NAMESPACE=your-namespace
+```
+
+### 1. Deploy the DGD
+
+See the deployment instructions in the [recipe README](../README.md).
+
+### 2. Stage the trace on the PVC
+
+Materialize the Git LFS trace files, then copy them through a helper pod that
+mounts `model-cache`:
+
+```bash
+git lfs pull --include='recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl'
+
+kubectl run pvc-helper -n ${NAMESPACE} \
+  --image=busybox:1.36 --restart=Never \
+  --overrides='{"spec":{"containers":[{"name":"helper","image":"busybox:1.36","command":["sleep","3600"],"volumeMounts":[{"name":"model-cache","mountPath":"/model-cache"}]}],"volumes":[{"name":"model-cache","persistentVolumeClaim":{"claimName":"model-cache"}}]}}' \
+  --command -- sleep 3600
+
+TRACE_SOURCE="$(git rev-parse --show-toplevel)/recipes/kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
+kubectl exec -n "${NAMESPACE}" pvc-helper -- mkdir -p /model-cache/traces
+kubectl cp "${TRACE_SOURCE}" \
+  "${NAMESPACE}/pvc-helper:/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl"
+```
+
+Keep `pvc-helper` for fetching artifacts, or delete it after staging.
+
+### 3. Run the benchmark
+
+```bash
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl logs -n ${NAMESPACE} -l job-name=glm52-bench -f
+kubectl wait --for=condition=Complete job/glm52-bench \
+  -n ${NAMESPACE} --timeout=10800s
+```
+
+The Job uses `nvcr.io/nvidia/ai-dynamo/aiperf:0.11.0` directly and does
+not install or patch AIPerf at runtime.
+
+### 4. Fetch artifacts
+
+```bash
+kubectl cp \
+  ${NAMESPACE}/pvc-helper:/model-cache/perf/<epoch>_glm52-bench \
+  ./results
+```
+
+### 5. Cleanup
+
+```bash
+kubectl delete job glm52-bench -n ${NAMESPACE}
+kubectl delete pod pvc-helper -n ${NAMESPACE}
+```
+
+## Running a concurrency sweep
+
+`perf.yaml` runs one `CONCURRENCY` value. Clear SGLang KV state and Dynamo
+frontend/router state between independent runs:
+
+```bash
+kubectl delete job glm52-bench -n ${NAMESPACE} --ignore-not-found
+
+DGD=glm52-agg-b200-agentic # Choose one of the four variant names above.
+kubectl delete pods -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD}
+kubectl wait --for=condition=Ready pod -n ${NAMESPACE} \
+  -l nvidia.com/dynamo-graph-deployment-name=${DGD} \
+  --timeout=7200s
+
+# Update CONCURRENCY in perf.yaml before each run.
+kubectl apply -f perf.yaml -n ${NAMESPACE}
+kubectl wait --for=condition=Complete job/glm52-bench \
+  -n ${NAMESPACE} --timeout=10800s
+```
+
+Do not compare partial runs. A completed run must account for successful,
+errored, and unfinished requests before reporting aggregate throughput.
+
+## Tunable environment variables
+
+| Variable | Default | Notes |
+| --- | --- | --- |
+| `ENDPOINT` | `glm52-agg-b200-agentic-frontend:8000` | Change per DGD variant |
+| `TRACE_FILE` | `/model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl` | 3,541-request 15% agent trace |
+| `SYNTHESIS_MAX_ISL` | `500000` | Use `250000` for H200 recipes |
+| `CONCURRENCY` | `64` | Single value; reset server state between values |
+| `TARGET_MODEL` | `zai-org/GLM-5.2` | Must match `--served-model-name` |
+
+## Artifacts
+
+Results are written to:
+
+```text
+/model-cache/perf/<epoch>_<job-name>/
+  warmup/
+  GLM-5.2_trace_c<concurrency>_<timestamp>/
+    profile_export_aiperf.json
+    inputs.json
+    ...
+```

--- a/recipes/glm-5.2/perf/perf.yaml
+++ b/recipes/glm-5.2/perf/perf.yaml
@@ -1,0 +1,220 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# AIPerf trace-replay benchmark for GLM-5.2 DGDs.
+#
+# One Job covers the aggregate and disaggregated B200 and H200 agentic
+# variants. Edit ENDPOINT and SYNTHESIS_MAX_ISL below to select a DGD. Restart
+# the DGD pods between independent concurrency points so SGLang and Dynamo
+# routing state are reset.
+#
+# Prerequisites:
+# - Target DGD is Ready (see ../README.md)
+# - model-cache PVC contains TRACE_FILE
+#
+# Results: /model-cache/perf/<epoch>_<job-name>/
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: glm52-bench
+spec:
+  backoffLimit: 1
+  activeDeadlineSeconds: 10800
+  completions: 1
+  parallelism: 1
+  template:
+    metadata:
+      labels:
+        app: glm52-bench
+    spec:
+      # Co-locate the benchmark pod with a DGD frontend. Keep only the target
+      # DGD in values when both variants are deployed in the same namespace.
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: nvidia.com/dynamo-component-type
+                operator: In
+                values:
+                - frontend
+              - key: nvidia.com/dynamo-graph-deployment-name
+                operator: In
+                values:
+                - glm52-agg-b200-agentic  # Update to match your ENDPOINT target DGD
+            topologyKey: kubernetes.io/hostname
+      # tolerations: # Uncomment and populate for tainted frontend nodes.
+      containers:
+      - name: perf
+        image: nvcr.io/nvidia/ai-dynamo/aiperf:0.11.0
+        imagePullPolicy: IfNotPresent
+        workingDir: /app
+        command:
+        - /bin/bash
+        - -c
+        - |
+          set -euo pipefail
+          ulimit -n 600000
+          export COLUMNS=200
+          EPOCH=$(/busybox/date +%s)
+
+          wait_for_model_ready() {
+            python3 - <<'PY'
+          import json
+          import os
+          import time
+          import urllib.request
+
+          endpoint = os.environ["ENDPOINT"]
+          model = os.environ["TARGET_MODEL"]
+          max_attempts = int(os.environ.get("WAIT_FOR_MODEL_MAX_ATTEMPTS", "720"))
+          url = f"http://{endpoint}/v1/models"
+
+          print(f"Waiting for model '{model}' at {url} (max {max_attempts} attempts) ...")
+          for attempt in range(1, max_attempts + 1):
+              try:
+                  with urllib.request.urlopen(url, timeout=5) as response:
+                      payload = json.load(response)
+                  if any(item.get("id") == model for item in payload.get("data", [])):
+                      print(json.dumps(payload, indent=2))
+                      raise SystemExit(0)
+              except Exception:
+                  pass
+
+              if attempt == max_attempts:
+                  break
+              timestamp = time.strftime("%H:%M:%S")
+              print(f"[{timestamp}] not ready (attempt {attempt}/{max_attempts}), sleeping 5s")
+              time.sleep(5)
+
+          raise SystemExit(
+              f"model '{model}' did not become ready after {max_attempts} attempts"
+          )
+          PY
+          }
+
+          if [ ! -f "$TRACE_FILE" ]; then
+            echo "ERROR: trace file not found at ${TRACE_FILE}"
+            echo "Copy it onto the PVC via a helper pod, e.g.:"
+            echo " kubectl cp <local_trace.jsonl> <ns>/<helper-pod>:${TRACE_FILE}"
+            exit 1
+          fi
+
+          wait_for_model_ready
+          ROOT_DIR="${ROOT_ARTIFACT_DIR}/${EPOCH}_${JOB_NAME}"
+          /busybox/mkdir -p "$ROOT_DIR"
+          echo "=============================================="
+          echo "Trace Replay Benchmark (aiperf)"
+          echo "=============================================="
+          echo "Endpoint:     http://${ENDPOINT}"
+          echo "Model:        ${TARGET_MODEL}"
+          echo "Trace file:   ${TRACE_FILE}"
+          echo "Concurrency:  ${CONCURRENCY}"
+          echo "Artifact root:${ROOT_DIR}"
+          echo "=============================================="
+
+          # Warmup
+          WARMUP_DIR="${ROOT_DIR}/warmup"
+          /busybox/mkdir -p "$WARMUP_DIR"
+          aiperf profile \
+            -m "$TARGET_MODEL" \
+            --tokenizer "$TARGET_MODEL" \
+            --tokenizer-trust-remote-code \
+            --url "http://$ENDPOINT" \
+            --streaming \
+            --ui simple \
+            --isl 8000 \
+            --osl 400 \
+            --concurrency 1 \
+            --request-count 5 \
+            --artifact-dir "$WARMUP_DIR"
+          echo "Warmup complete"
+
+          MODEL_BASE="${TARGET_MODEL##*/}"
+          TS=$(/busybox/date +'%Y%m%d_%H%M%S')
+          RUN_DIR="${ROOT_DIR}/${MODEL_BASE}_trace_c${CONCURRENCY}_${TS}"
+          /busybox/mkdir -p "$RUN_DIR"
+          aiperf profile \
+            -m "$TARGET_MODEL" \
+            --tokenizer "$TARGET_MODEL" \
+            --tokenizer-trust-remote-code \
+            --input-file "$TRACE_FILE" \
+            --custom-dataset-type mooncake_trace \
+            --synthesis-max-isl "$SYNTHESIS_MAX_ISL" \
+            --synthesis-max-osl 12000 \
+            --num-requests $(/busybox/wc -l < "${TRACE_FILE}") \
+            --dataset-sampling-strategy sequential \
+            --url "http://$ENDPOINT" \
+            --streaming \
+            --use-server-token-count \
+            --extra-inputs ignore_eos:true \
+            --concurrency "$CONCURRENCY" \
+            --random-seed 42 \
+            --ui simple \
+            --artifact-dir "$RUN_DIR" \
+            --request-timeout-seconds 3900 \
+            --workers-max "$CONCURRENCY" \
+            --export-http-trace
+          echo "Concurrency ${CONCURRENCY} complete; artifacts in ${RUN_DIR}"
+          /busybox/ls -la "$RUN_DIR" || true
+          echo ""
+          echo "Done. Root: ${ROOT_DIR}"
+        env:
+        # --- Edit ENDPOINT to target one of the four GLM-5.2 DGDs. ---
+        - name: ENDPOINT
+          value: glm52-agg-b200-agentic-frontend:8000
+        - name: TRACE_FILE
+          value: /model-cache/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+        - name: SYNTHESIS_MAX_ISL
+          value: "500000"
+        - name: CONCURRENCY
+          value: "64"
+        # --- The remainder is shared across all four variants. ---
+        - name: TARGET_MODEL
+          value: zai-org/GLM-5.2
+        - name: AIPERF_HTTP_CONNECTION_LIMIT
+          value: "200"
+        - name: AIPERF_HTTP_SO_RCVTIMEO
+          value: "120"
+        - name: AIPERF_SERVICE_PROFILE_CONFIGURE_TIMEOUT
+          value: "3600"
+        - name: AIPERF_DATASET_CONFIGURATION_TIMEOUT
+          value: "3600"
+        - name: JOB_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.labels['job-name']
+        - name: ROOT_ARTIFACT_DIR
+          value: /model-cache/perf
+        - name: HF_HOME
+          value: /model-cache
+        - name: PYTHONUNBUFFERED
+          value: "1"
+        resources:
+          requests:
+            cpu: "4"
+            memory: 8Gi
+          limits:
+            cpu: "16"
+            memory: 64Gi
+        volumeMounts:
+        - name: model-cache
+          mountPath: /model-cache
+      restartPolicy: Never
+      volumes:
+      - name: model-cache
+        persistentVolumeClaim:
+          claimName: model-cache

--- a/recipes/glm-5.2/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
+++ b/recipes/glm-5.2/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl
@@ -1,0 +1,1 @@
+../../../kimi-k2.6/perf/traces/64k_400_90kv_agent_new_noschedule_short_15perc.jsonl

--- a/recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glm52-agg-b200-agentic-sglang-config
+  labels:
+    app.kubernetes.io/name: glm52-agg-b200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  agg.yaml: |-
+    model-path: nvidia/GLM-5.2-NVFP4
+    served-model-name: zai-org/GLM-5.2
+    trust-remote-code: true
+    tensor-parallel-size: 4
+    data-parallel-size: 4
+    enable-dp-attention: true
+    moe-runner-backend: flashinfer_trtllm
+    moe-a2a-backend: none
+    fp4-gemm-backend: flashinfer_trtllm
+    speculative-attention-mode: decode
+    quantization: modelopt_fp4
+    kv-cache-dtype: fp8_e4m3
+    context-length: 500000
+    speculative-algorithm: EAGLE
+    speculative-num-steps: 3
+    speculative-eagle-topk: 1
+    speculative-num-draft-tokens: 4
+    max-running-requests: 128
+    cuda-graph-max-bs: 128
+    watchdog-timeout: 3600
+    mem-fraction-static: 0.927
+    enable-dp-lm-head: true
+    enable-metrics: true
+    speculative-moe-runner-backend: flashinfer_cutlass
+    speculative-moe-a2a-backend: none
+    enable-flashinfer-allreduce-fusion: true
+    hicache-size: 200
+    enable-hierarchical-cache: true
+    kv-events-config:
+      publisher: zmq
+      topic: kv-events
+      endpoint: tcp://*:5557
+    model-loader-extra-config:
+      enable_multithread_load: true
+      num_threads: 32
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: glm52-agg-b200-agentic
+spec:
+  backendFramework: sglang
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources: {}
+      replicas: 1
+
+    - name: agg
+      type: worker
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          containers:
+            - name: main
+              args:
+                - --config
+                - /etc/sglang/agg.yaml
+                - --dyn-tool-call-parser
+                - glm47
+                - --dyn-reasoning-parser
+                - glm45
+                - --reasoning-parser
+                - glm45
+              command:
+                - python3
+                - -m
+                - dynamo.sglang
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: DYN_SGL_ALLOW_TOP_LOGPROBS
+                  value: "1"
+                # Synthetic MTP acceptance length for performance benchmarking.
+                # - name: SGLANG_SIMULATE_ACC_LEN
+                #   value: "2.69"
+                # - name: SGLANG_SIMULATE_ACC_METHOD
+                #   value: match-expected
+                # - name: SGLANG_SIMULATE_ACC_TOKEN_ID
+                #   value: "32"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  memory: 1Ti
+                limits:
+                  nvidia.com/gpu: "4"
+                  memory: 1Ti
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_PTRACE
+                    - SYS_RESOURCE
+              startupProbe:
+                failureThreshold: 120
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /etc/sglang
+                  name: sglang-config
+                  readOnly: true
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: sglang-config
+              configMap:
+                name: glm52-agg-b200-agentic-sglang-config
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 4

--- a/recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml
@@ -1,0 +1,167 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glm52-agg-h200-agentic-sglang-config
+  labels:
+    app.kubernetes.io/name: glm52-agg-h200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  agg.yaml: |-
+    model-path: zai-org/GLM-5.2-FP8
+    served-model-name: zai-org/GLM-5.2
+    trust-remote-code: true
+    quantization: fp8
+    kv-cache-dtype: fp8_e4m3
+    context-length: 250000
+    mem-fraction-static: 0.90
+    speculative-algorithm: EAGLE
+    speculative-num-steps: 3
+    speculative-eagle-topk: 1
+    speculative-num-draft-tokens: 4
+    tensor-parallel-size: 8
+    ep-size: 8
+    attention-backend: dsa
+    dsa-prefill-backend: flashmla_kv
+    enable-prefill-cp: true
+    cp-strategy: interleave
+    moe-a2a-backend: none
+    fp8-gemm-backend: flashinfer_deepgemm
+    watchdog-timeout: 3600
+    enable-metrics: true
+    kv-events-config:
+      publisher: zmq
+      topic: kv-events
+      endpoint: tcp://*:5557
+    model-loader-extra-config:
+      enable_multithread_load: true
+      num_threads: 32
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: glm52-agg-h200-agentic
+spec:
+  backendFramework: sglang
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources: {}
+      replicas: 1
+
+    - name: agg
+      type: worker
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+          containers:
+            - name: main
+              args:
+                - --config
+                - /etc/sglang/agg.yaml
+                - --dyn-tool-call-parser
+                - glm47
+                - --dyn-reasoning-parser
+                - glm45
+                - --reasoning-parser
+                - glm45
+              command:
+                - python3
+                - -m
+                - dynamo.sglang
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: DYN_SGL_ALLOW_TOP_LOGPROBS
+                  value: "1"
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: DYN_FORWARDPASS_METRIC_PORT
+                  value: ""
+                # Synthetic MTP acceptance length for performance benchmarking.
+                # - name: SGLANG_SIMULATE_ACC_LEN
+                #   value: "2.69"
+                # - name: SGLANG_SIMULATE_ACC_METHOD
+                #   value: match-expected
+                # - name: SGLANG_SIMULATE_ACC_TOKEN_ID
+                #   value: "32"
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  memory: 1Ti
+                limits:
+                  nvidia.com/gpu: "8"
+                  memory: 1Ti
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_PTRACE
+                    - SYS_RESOURCE
+              startupProbe:
+                failureThreshold: 120
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /etc/sglang
+                  name: sglang-config
+                  readOnly: true
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: sglang-config
+              configMap:
+                name: glm52-agg-h200-agentic-sglang-config
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 3

--- a/recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml
@@ -1,0 +1,322 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glm52-disagg-b200-agentic-sglang-config
+  labels:
+    app.kubernetes.io/name: glm52-disagg-b200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  prefill.yaml: |-
+    model-path: nvidia/GLM-5.2-NVFP4
+    served-model-name: zai-org/GLM-5.2
+    # Decode connects to the pod IP advertised by Dynamo, so the SGLang
+    # bootstrap server must not use its loopback-only default.
+    host: 0.0.0.0
+    trust-remote-code: true
+    tensor-parallel-size: 4
+    data-parallel-size: 4
+    enable-dp-attention: true
+    ep-size: 4
+    quantization: modelopt_fp4
+    kv-cache-dtype: fp8_e4m3
+    context-length: 500000
+    mem-fraction-static: 0.93
+    attention-backend: dsa
+    dsa-prefill-backend: trtllm
+    dsa-decode-backend: trtllm
+    moe-runner-backend: flashinfer_trtllm_routed
+    chunked-prefill-size: 16384
+    max-prefill-tokens: 32768
+    max-running-requests: 32
+    watchdog-timeout: 3600
+    cuda-graph-backend-prefill: disabled
+    cuda-graph-backend-decode: disabled
+    disaggregation-mode: prefill
+    disaggregation-transfer-backend: nixl
+    disaggregation-bootstrap-port: 12345
+    speculative-algorithm: EAGLE
+    speculative-num-steps: 3
+    speculative-eagle-topk: 1
+    speculative-num-draft-tokens: 4
+    enable-dp-lm-head: true
+    hicache-size: 200
+    enable-hierarchical-cache: true
+    kv-events-config:
+      publisher: zmq
+      topic: kv-events
+      endpoint: tcp://*:5557
+    model-loader-extra-config:
+      enable_multithread_load: true
+      num_threads: 32
+    disable-overlap-schedule: true
+    enable-metrics: true
+
+  decode.yaml: |-
+    model-path: nvidia/GLM-5.2-NVFP4
+    served-model-name: zai-org/GLM-5.2
+    trust-remote-code: true
+    tensor-parallel-size: 8
+    data-parallel-size: 8
+    enable-dp-attention: true
+    moe-a2a-backend: none
+    fp4-gemm-backend: flashinfer_cutlass
+    enable-symm-mem: true
+    quantization: modelopt_fp4
+    kv-cache-dtype: fp8_e4m3
+    context-length: 500000
+    disaggregation-mode: decode
+    disaggregation-transfer-backend: nixl
+    disaggregation-bootstrap-port: 12345
+    speculative-algorithm: EAGLE
+    speculative-num-steps: 3
+    speculative-eagle-topk: 1
+    speculative-num-draft-tokens: 4
+    speculative-attention-mode: decode
+    max-running-requests: 256
+    watchdog-timeout: 3600
+    cuda-graph-max-bs: 256
+    mem-fraction-static: 0.87
+    enable-metrics: true
+    speculative-moe-runner-backend: flashinfer_cutlass
+    speculative-moe-a2a-backend: none
+    num-continuous-decode-steps: 3
+    enable-flashinfer-allreduce-fusion: true
+    enable-dp-lm-head: true
+    model-loader-extra-config:
+      enable_multithread_load: true
+      num_threads: 32
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: glm52-disagg-b200-agentic
+spec:
+  backendFramework: sglang
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources: {}
+      replicas: 1
+
+    - name: prefill
+      type: prefill
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          containers:
+            - name: main
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  ulimit -l unlimited || true
+                  ulimit -n 1048576 || true
+                  UCX_NET_DEVICES="$(nvidia-smi topo -m | awk 'BEGIN{split("PIX PXB NODE PHB SYS", pri)} $1 ~ /^NIC[0-9]+:/ {gsub(":", "", $1); nic[$1]=$2; next} /CPU Affinity/ && /NIC/ {for (i=1; i<=NF; i++) if ($i ~ /^NIC[0-9]+$/) {idx=i+1; cols[++n]=idx; col[idx]=$i}; next} $1 ~ /^GPU[0-9]+$/ {g++; for (c=1; c<=n; c++) {idx=cols[c]; rel[g,c]=$idx}; next} END{for (r=1; r<=g; r++) for (p=1; p<=5; p++) {found=0; for (c=1; c<=n; c++) {dev=nic[col[cols[c]]]; if (rel[r,c] != pri[p] || dev == "" || dev ~ /bond/) continue; if (system("[ -d /sys/class/infiniband/" dev " ]") == 0) {found=1; if (!seen[dev]++) out=out (out ? "," : "") dev ":1"}} if (found) break} if (!out) exit 1; print out}')"
+                  : "${UCX_NET_DEVICES:?no GPU-local InfiniBand devices found from nvidia-smi topo -m}"
+                  export UCX_NET_DEVICES
+                  export SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS="{\"ucx_devices\":\"${UCX_NET_DEVICES}\",\"ucx_error_handling_mode\":\"peer\"}"
+                  echo "dynamic UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+                  exec python3 -m dynamo.sglang \
+                    --config /etc/sglang/prefill.yaml \
+                    --dyn-tool-call-parser glm47 \
+                    --dyn-reasoning-parser glm45 \
+                    --reasoning-parser glm45
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: DYN_SGL_ALLOW_TOP_LOGPROBS
+                  value: "1"
+                - name: SGLANG_DISAGGREGATION_NIXL_BACKEND
+                  value: UCX
+                - name: UCX_TLS
+                  value: cuda_ipc,cuda_copy,rc
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: "4"
+                  rdma/shared_ib: "1"
+                  memory: 1Ti
+                limits:
+                  nvidia.com/gpu: "4"
+                  rdma/shared_ib: "1"
+                  memory: 1Ti
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_PTRACE
+                    - SYS_RESOURCE
+              startupProbe:
+                failureThreshold: 120
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /etc/sglang
+                  name: sglang-config
+                  readOnly: true
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: sglang-config
+              configMap:
+                name: glm52-disagg-b200-agentic-sglang-config
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 3
+
+    - name: decode
+      type: decode
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-B200
+          containers:
+            - name: main
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  ulimit -l unlimited || true
+                  ulimit -n 1048576 || true
+                  UCX_NET_DEVICES="$(nvidia-smi topo -m | awk 'BEGIN{split("PIX PXB NODE PHB SYS", pri)} $1 ~ /^NIC[0-9]+:/ {gsub(":", "", $1); nic[$1]=$2; next} /CPU Affinity/ && /NIC/ {for (i=1; i<=NF; i++) if ($i ~ /^NIC[0-9]+$/) {idx=i+1; cols[++n]=idx; col[idx]=$i}; next} $1 ~ /^GPU[0-9]+$/ {g++; for (c=1; c<=n; c++) {idx=cols[c]; rel[g,c]=$idx}; next} END{for (r=1; r<=g; r++) for (p=1; p<=5; p++) {found=0; for (c=1; c<=n; c++) {dev=nic[col[cols[c]]]; if (rel[r,c] != pri[p] || dev == "" || dev ~ /bond/) continue; if (system("[ -d /sys/class/infiniband/" dev " ]") == 0) {found=1; if (!seen[dev]++) out=out (out ? "," : "") dev ":1"}} if (found) break} if (!out) exit 1; print out}')"
+                  : "${UCX_NET_DEVICES:?no GPU-local InfiniBand devices found from nvidia-smi topo -m}"
+                  export UCX_NET_DEVICES
+                  export SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS="{\"ucx_devices\":\"${UCX_NET_DEVICES}\",\"ucx_error_handling_mode\":\"peer\"}"
+                  echo "dynamic UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+                  exec python3 -m dynamo.sglang \
+                    --config /etc/sglang/decode.yaml \
+                    --dyn-tool-call-parser glm47 \
+                    --dyn-reasoning-parser glm45 \
+                    --reasoning-parser glm45
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: DYN_SGL_ALLOW_TOP_LOGPROBS
+                  value: "1"
+                # Synthetic MTP acceptance length for performance benchmarking.
+                # - name: SGLANG_SIMULATE_ACC_LEN
+                #   value: "2.69"
+                # - name: SGLANG_SIMULATE_ACC_METHOD
+                #   value: match-expected
+                # - name: SGLANG_SIMULATE_ACC_TOKEN_ID
+                #   value: "32"
+                - name: SGLANG_DISAGGREGATION_WAITING_TIMEOUT
+                  value: "3600"
+                - name: SGLANG_DISAGGREGATION_NIXL_BACKEND
+                  value: UCX
+                - name: UCX_TLS
+                  value: cuda_ipc,cuda_copy,rc
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  rdma/shared_ib: "1"
+                  memory: 200Gi
+                limits:
+                  nvidia.com/gpu: "8"
+                  rdma/shared_ib: "1"
+                  memory: 200Gi
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_PTRACE
+                    - SYS_RESOURCE
+              startupProbe:
+                failureThreshold: 120
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /etc/sglang
+                  name: sglang-config
+                  readOnly: true
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: sglang-config
+              configMap:
+                name: glm52-disagg-b200-agentic-sglang-config
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1

--- a/recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml
@@ -1,0 +1,347 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: glm52-disagg-h200-agentic-sglang-config
+  labels:
+    app.kubernetes.io/name: glm52-disagg-h200-agentic
+    app.kubernetes.io/part-of: dynamo
+data:
+  prefill.yaml: |-
+    model-path: zai-org/GLM-5.2-FP8
+    served-model-name: zai-org/GLM-5.2
+    # Decode connects to the pod IP advertised by Dynamo, so the SGLang
+    # bootstrap server must not use its loopback-only default.
+    host: 0.0.0.0
+    trust-remote-code: true
+    tensor-parallel-size: 8
+    data-parallel-size: 1
+    ep-size: 8
+    moe-a2a-backend: none
+    kv-cache-dtype: fp8_e4m3
+    fp8-gemm-backend: flashinfer_deepgemm
+    mem-fraction-static: 0.92
+    max-running-requests: 64
+    attention-backend: dsa
+    dsa-prefill-backend: flashmla_kv
+    enable-prefill-cp: true
+    cp-strategy: interleave
+    disable-overlap-schedule: true
+    cuda-graph-backend-prefill: disabled
+    cuda-graph-backend-decode: disabled
+    speculative-algorithm: EAGLE
+    speculative-num-steps: 3
+    speculative-eagle-topk: 1
+    speculative-num-draft-tokens: 4
+    context-length: 250000
+    watchdog-timeout: 3600
+    disaggregation-mode: prefill
+    disaggregation-transfer-backend: nixl
+    disaggregation-bootstrap-port: 12345
+    enable-metrics: true
+    kv-events-config:
+      publisher: zmq
+      topic: kv-events
+      endpoint: tcp://*:5557
+    model-loader-extra-config:
+      enable_multithread_load: true
+      num_threads: 32
+
+  decode.yaml: |-
+    model-path: zai-org/GLM-5.2-FP8
+    served-model-name: zai-org/GLM-5.2
+    host: 0.0.0.0
+    trust-remote-code: true
+    tensor-parallel-size: 8
+    data-parallel-size: 8
+    enable-dp-attention: true
+    ep-size: 1
+    moe-a2a-backend: none
+    fp8-gemm-backend: deep_gemm
+    enforce-shared-experts-fusion: true
+    kv-cache-dtype: fp8_e4m3
+    context-length: 250000
+    mem-fraction-static: 0.88
+    max-running-requests: 64
+    cuda-graph-max-bs: 64
+    cuda-graph-bs:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 20
+      - 24
+      - 28
+      - 32
+      - 36
+      - 40
+      - 44
+      - 48
+      - 52
+      - 56
+      - 60
+      - 64
+    attention-backend: dsa
+    dsa-prefill-backend: flashmla_kv
+    dsa-decode-backend: flashmla_kv
+    speculative-algorithm: EAGLE
+    speculative-num-steps: 3
+    speculative-eagle-topk: 1
+    speculative-num-draft-tokens: 4
+    watchdog-timeout: 3600
+    disaggregation-mode: decode
+    disaggregation-transfer-backend: nixl
+    disaggregation-bootstrap-port: 12345
+    enable-metrics: true
+---
+apiVersion: nvidia.com/v1beta1
+kind: DynamoGraphDeployment
+metadata:
+  name: glm52-disagg-h200-agentic
+spec:
+  backendFramework: sglang
+  components:
+    - name: Frontend
+      type: frontend
+      podTemplate:
+        spec:
+          containers:
+            - name: main
+              command:
+                - python3
+              args:
+                - -m
+                - dynamo.frontend
+                - --trust-remote-code
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: DYN_ROUTER_MODE
+                  value: kv
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources: {}
+      replicas: 1
+
+    - name: prefill
+      type: prefill
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+          containers:
+            - name: main
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  ulimit -l unlimited || true
+                  ulimit -n 1048576 || true
+                  UCX_NET_DEVICES="$(nvidia-smi topo -m | awk 'BEGIN{split("PIX PXB NODE PHB SYS", pri)} $1 ~ /^NIC[0-9]+:/ {gsub(":", "", $1); nic[$1]=$2; next} /CPU Affinity/ && /NIC/ {for (i=1; i<=NF; i++) if ($i ~ /^NIC[0-9]+$/) {idx=i+1; cols[++n]=idx; col[idx]=$i}; next} $1 ~ /^GPU[0-9]+$/ {g++; for (c=1; c<=n; c++) {idx=cols[c]; rel[g,c]=$idx}; next} END{for (r=1; r<=g; r++) for (p=1; p<=5; p++) {found=0; for (c=1; c<=n; c++) {dev=nic[col[cols[c]]]; if (rel[r,c] != pri[p] || dev == "" || dev ~ /bond/) continue; if (system("[ -d /sys/class/infiniband/" dev " ]") == 0) {found=1; if (!seen[dev]++) out=out (out ? "," : "") dev ":1"}} if (found) break} if (!out) exit 1; print out}')"
+                  : "${UCX_NET_DEVICES:?no GPU-local InfiniBand devices found from nvidia-smi topo -m}"
+                  export UCX_NET_DEVICES
+                  export SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS="{\"ucx_devices\":\"${UCX_NET_DEVICES}\",\"ucx_error_handling_mode\":\"peer\"}"
+                  echo "dynamic UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+                  exec python3 -m dynamo.sglang \
+                    --config /etc/sglang/prefill.yaml \
+                    --dyn-tool-call-parser glm47 \
+                    --dyn-reasoning-parser glm45 \
+                    --reasoning-parser glm45
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: DYN_SGL_ALLOW_TOP_LOGPROBS
+                  value: "1"
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: DYN_FORWARDPASS_METRIC_PORT
+                  value: ""
+                - name: SGLANG_DISAGGREGATION_NIXL_BACKEND
+                  value: UCX
+                - name: UCX_TLS
+                  value: cuda_ipc,cuda_copy,rc
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  rdma/ib: "8"
+                  memory: 1Ti
+                limits:
+                  nvidia.com/gpu: "8"
+                  rdma/ib: "8"
+                  memory: 1Ti
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_PTRACE
+                    - SYS_RESOURCE
+              startupProbe:
+                failureThreshold: 120
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /etc/sglang
+                  name: sglang-config
+                  readOnly: true
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: sglang-config
+              configMap:
+                name: glm52-disagg-h200-agentic-sglang-config
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1
+
+    - name: decode
+      type: decode
+      sharedMemorySize: 64Gi
+      podTemplate:
+        spec:
+          affinity:
+            nodeAffinity:
+              requiredDuringSchedulingIgnoredDuringExecution:
+                nodeSelectorTerms:
+                  - matchExpressions:
+                      - key: nvidia.com/gpu.product
+                        operator: In
+                        values:
+                          - NVIDIA-H200
+            podAffinity:
+              preferredDuringSchedulingIgnoredDuringExecution:
+                - weight: 100
+                  podAffinityTerm:
+                    labelSelector:
+                      matchLabels:
+                        nvidia.com/dynamo-component-type: prefill
+                        nvidia.com/dynamo-graph-deployment-name: glm52-disagg-h200-agentic
+                    topologyKey: topology.kubernetes.io/zone
+          containers:
+            - name: main
+              command:
+                - /bin/bash
+                - -lc
+              args:
+                - |
+                  set -euo pipefail
+                  ulimit -l unlimited || true
+                  ulimit -n 1048576 || true
+                  UCX_NET_DEVICES="$(nvidia-smi topo -m | awk 'BEGIN{split("PIX PXB NODE PHB SYS", pri)} $1 ~ /^NIC[0-9]+:/ {gsub(":", "", $1); nic[$1]=$2; next} /CPU Affinity/ && /NIC/ {for (i=1; i<=NF; i++) if ($i ~ /^NIC[0-9]+$/) {idx=i+1; cols[++n]=idx; col[idx]=$i}; next} $1 ~ /^GPU[0-9]+$/ {g++; for (c=1; c<=n; c++) {idx=cols[c]; rel[g,c]=$idx}; next} END{for (r=1; r<=g; r++) for (p=1; p<=5; p++) {found=0; for (c=1; c<=n; c++) {dev=nic[col[cols[c]]]; if (rel[r,c] != pri[p] || dev == "" || dev ~ /bond/) continue; if (system("[ -d /sys/class/infiniband/" dev " ]") == 0) {found=1; if (!seen[dev]++) out=out (out ? "," : "") dev ":1"}} if (found) break} if (!out) exit 1; print out}')"
+                  : "${UCX_NET_DEVICES:?no GPU-local InfiniBand devices found from nvidia-smi topo -m}"
+                  export UCX_NET_DEVICES
+                  export SGLANG_DISAGGREGATION_NIXL_BACKEND_PARAMS="{\"ucx_devices\":\"${UCX_NET_DEVICES}\",\"ucx_error_handling_mode\":\"peer\"}"
+                  echo "dynamic UCX_NET_DEVICES=${UCX_NET_DEVICES}"
+                  exec python3 -m dynamo.sglang \
+                    --config /etc/sglang/decode.yaml \
+                    --dyn-tool-call-parser glm47 \
+                    --dyn-reasoning-parser glm45 \
+                    --reasoning-parser glm45
+              env:
+                - name: POD_UID
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.uid
+                - name: HF_HOME
+                  value: /model-cache
+                - name: DYN_SGL_ALLOW_TOP_LOGPROBS
+                  value: "1"
+                - name: PYTHONUNBUFFERED
+                  value: "1"
+                - name: DYN_FORWARDPASS_METRIC_PORT
+                  value: ""
+                # Synthetic MTP acceptance length for performance benchmarking.
+                # - name: SGLANG_SIMULATE_ACC_LEN
+                #   value: "2.69"
+                # - name: SGLANG_SIMULATE_ACC_METHOD
+                #   value: match-expected
+                # - name: SGLANG_SIMULATE_ACC_TOKEN_ID
+                #   value: "32"
+                - name: SGLANG_DISAGGREGATION_WAITING_TIMEOUT
+                  value: "3600"
+                - name: SGLANG_DISAGGREGATION_NIXL_BACKEND
+                  value: UCX
+                - name: UCX_TLS
+                  value: cuda_ipc,cuda_copy,rc
+              envFrom:
+                - secretRef:
+                    name: hf-token-secret
+              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              imagePullPolicy: Always
+              resources:
+                requests:
+                  nvidia.com/gpu: "8"
+                  rdma/ib: "8"
+                  memory: 200Gi
+                limits:
+                  nvidia.com/gpu: "8"
+                  rdma/ib: "8"
+                  memory: 200Gi
+              securityContext:
+                runAsUser: 0
+                capabilities:
+                  add:
+                    - IPC_LOCK
+                    - SYS_PTRACE
+                    - SYS_RESOURCE
+              startupProbe:
+                failureThreshold: 120
+                httpGet:
+                  path: /live
+                  port: 9090
+                periodSeconds: 60
+                timeoutSeconds: 20
+              volumeMounts:
+                - mountPath: /etc/sglang
+                  name: sglang-config
+                  readOnly: true
+                - mountPath: /model-cache
+                  name: model-cache
+              workingDir: /workspace/
+          volumes:
+            - name: sglang-config
+              configMap:
+                name: glm52-disagg-h200-agentic-sglang-config
+            - name: model-cache
+              persistentVolumeClaim:
+                claimName: model-cache
+          tolerations:
+            - key: nvidia.com/gpu
+              operator: Equal
+              value: "true"
+              effect: NoSchedule
+      replicas: 1


### PR DESCRIPTION
Cherry-picks the merged #11926 squash (`0237635a42dd75326ba26f18e0e928740968d6cf`) onto `release/1.3.0-glm-5.2-dev.1`.

## Summary

- Adds the GLM-5.2 SGLang aggregated and disaggregated B200/H200 recipes, model-cache manifests, and AIPerf workflow.
- Carries the reasoning/tool-call parser fixes, `top_logprobs` enablement, published image tag, and benchmark documentation from #11926.
- `recipes/glm-5.2/` is byte-identical to `main` (verified with `git diff origin/main -- recipes/glm-5.2`).
- The GLM-5.2 row added to `recipes/README.md` matches `main`; unrelated release-branch drift in that index remains untouched.
- No unrelated main changes were included.

## Release note

The manifests still use the `nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1` registry path exactly as merged in #11926. Per the on-demand release runbook, the public-image switch should first land on `main` and then be cherry-picked here before the tagged release is published.

## Validation

- Clean cherry-pick from the release branch tip.
- `git diff --check origin/release/1.3.0-glm-5.2-dev.1..HEAD` passed.
- Shared Kimi-K2.6 trace symlink target exists on the release branch.
- Local `pre-commit` executable was unavailable; PR CI is expected to run the repository checks.

cc @nealvaidya @rmccorm4 @PeaBrane
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11935" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->