### PR TITLE
perf(kv-router): ingest direct ZMQ events concurrently [DYN-3849]

### DIFF
--- a/lib/llm/src/kv_router.rs
+++ b/lib/llm/src/kv_router.rs
@@ -210,6 +210,7 @@ where
     cancellation_token: CancellationToken,
     client: Client,
     is_eagle: bool,
+    kv_event_subscription: Option<indexer::KvEventSubscriptionHandle>,
     _served_indexer_handle: Option<ServedIndexerHandle>,
     /// Optional external shared KV cache pool. When present, `find_best_match`
     /// queries it in parallel with the indexer and factors shared hits into scoring.
@@ -298,30 +299,34 @@ where
         .await?;
 
         // Start KV event subscription if needed — skip when using a remote indexer.
-        if kv_router_config.use_remote_indexer {
+        let kv_event_subscription = if kv_router_config.use_remote_indexer {
             tracing::info!("Skipping KV event subscription (using remote indexer)");
+            None
         } else if kv_router_config.should_subscribe_to_kv_events() {
             let membership_watch = kv_source_membership.ok_or_else(|| {
                 anyhow::anyhow!(
                     "KV source membership watch is required when local KV event subscription is enabled"
                 )
             })?;
-            indexer::start_subscriber(
-                endpoint.clone(),
-                indexer.clone(),
-                membership_watch,
-                model_name.clone().unwrap_or_else(|| "unknown".to_string()),
-                worker_type,
-                cancellation_token.child_token(),
+            Some(
+                indexer::start_subscriber(
+                    endpoint.clone(),
+                    indexer.clone(),
+                    membership_watch,
+                    model_name.clone().unwrap_or_else(|| "unknown".to_string()),
+                    worker_type,
+                    cancellation_token.child_token(),
+                )
+                .await?,
             )
-            .await?;
         } else {
             tracing::info!(
                 "Skipping KV event subscription (use_kv_events={}, overlap_score_credit={})",
                 kv_router_config.use_kv_events,
                 kv_router_config.overlap_score_credit,
             );
-        }
+            None
+        };
 
         let served_indexer_handle = if kv_router_config.serve_indexer {
             let model_name = model_name.clone().ok_or_else(|| {
@@ -352,6 +357,7 @@ where
             cancellation_token,
             client,
             is_eagle,
+            kv_event_subscription,
             _served_indexer_handle: served_indexer_handle,
             shared_cache,
             lora_filter,
@@ -369,6 +375,14 @@ where
 
     pub fn kv_router_config(&self) -> &KvRouterConfig {
         &self.kv_router_config
+    }
+
+    /// Cancel background work and wait for KV event ingestion to stop.
+    pub async fn shutdown(mut self) {
+        self.cancellation_token.cancel();
+        if let Some(subscription) = self.kv_event_subscription.take() {
+            subscription.shutdown().await;
+        }
     }
 
     pub fn is_eagle(&self) -> bool {

--- a/lib/llm/src/kv_router/indexer/mod.rs
+++ b/lib/llm/src/kv_router/indexer/mod.rs
@@ -37,8 +37,9 @@ pub use self::side::SideIndexer;
 #[cfg(feature = "ckf-diagnostics")]
 pub(crate) use recovery::WorkerQueryHealthSnapshot;
 pub(crate) use recovery::{
-    DEFAULT_RECOVERY_ATTEMPT_TIMEOUT, RecoveryResetReason, RecoverySupervisor, RecoveryTarget,
-    SourceEpoch, TargetFaultDisposition, start_target_subscriber,
+    DEFAULT_RECOVERY_ATTEMPT_TIMEOUT, KvEventSubscriptionHandle, RecoveryResetReason,
+    RecoverySupervisor, RecoveryTarget, SourceEpoch, TargetFaultDisposition,
+    start_target_subscriber,
 };
 pub(crate) use recovery::{start_subscriber, start_worker_kv_query_endpoint};
 

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -1,0 +1,836 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
+
+use anyhow::Result;
+use dynamo_kv_router::protocols::{KV_EVENT_SUBJECT, RouterEvent};
+use dynamo_runtime::{
+    component::Component,
+    discovery::{
+        DiscoveryEvent, DiscoveryInstance, DiscoveryInstanceId, DiscoveryQuery,
+        EventChannelInstanceId, EventChannelQuery, EventTransport,
+    },
+    protocols::EndpointId,
+    traits::DistributedRuntimeProvider,
+    transports::event_plane::zmq_transport::ZmqWireStream,
+    transports::event_plane::{Codec, EventScope, ZmqSubTransport},
+};
+use futures::StreamExt;
+use tokio::{
+    sync::{mpsc, oneshot},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+
+use super::{
+    IndexerRecoveryTarget,
+    subscriber::{
+        clear_mismatch_metric_on_cancellation, update_mismatch_metric,
+        update_subscription_failure_metric,
+    },
+    worker_query::{ReadyKvSource, WorkerQueryClient},
+};
+use crate::{
+    discovery::{KvSourceMembershipView, KvSourceMembershipWatch},
+    kv_router::metrics::{KvZmqIngressMetrics, RouterWorkerStatusMetrics},
+};
+
+const INITIAL_BACKOFF: Duration = Duration::from_millis(100);
+const MAX_BACKOFF: Duration = Duration::from_secs(5);
+const SOURCE_JOIN_TIMEOUT: Duration = Duration::from_secs(5);
+const SIGNAL_CAPACITY: usize = 1024;
+
+enum ScopeExit {
+    Rebind,
+    Retry,
+    Stop,
+}
+
+enum SourceSignal {
+    Ready {
+        publisher_id: u64,
+        task_generation: u64,
+        activate: oneshot::Sender<()>,
+    },
+    Disconnected {
+        publisher_id: u64,
+        task_generation: u64,
+    },
+}
+
+struct SourceTask {
+    endpoint: String,
+    task_generation: u64,
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+    state: SourceState,
+}
+
+enum SourceState {
+    Connecting,
+    Preconnected { activate: oneshot::Sender<()> },
+    Active { bindings: HashSet<ReadyKvSource> },
+    Fenced,
+}
+
+impl SourceState {
+    fn is_ready(&self) -> bool {
+        matches!(self, Self::Preconnected { .. } | Self::Active { .. })
+    }
+
+    fn active_bindings(&self) -> Option<&HashSet<ReadyKvSource>> {
+        match self {
+            Self::Active { bindings } => Some(bindings),
+            _ => None,
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn run_direct_zmq_supervisor(
+    component: Component,
+    serving_endpoint: EndpointId,
+    client: Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    mut membership_watch: KvSourceMembershipWatch,
+    model: String,
+    worker_type: &'static str,
+    cancellation_token: CancellationToken,
+    mut startup_ready: Option<oneshot::Sender<Result<(), String>>>,
+) {
+    let status_metrics = RouterWorkerStatusMetrics::from_component(&component);
+    let ingress_metrics = KvZmqIngressMetrics::from_component(&component);
+    let mut retry_delay = INITIAL_BACKOFF;
+
+    loop {
+        let view = membership_watch.borrow_and_update().clone();
+        update_mismatch_metric(
+            &status_metrics,
+            &view,
+            &model,
+            worker_type,
+            &serving_endpoint,
+        );
+
+        let Some(kv_state_endpoint) = view.resolved_kv_state_endpoint().cloned() else {
+            client
+                .sync_membership_with_ready_sources(&HashSet::new())
+                .await;
+            if let Some(ready) = startup_ready.take() {
+                let _ = ready.send(Ok(()));
+            }
+            tokio::select! {
+                _ = cancellation_token.cancelled() => break,
+                changed = membership_watch.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                }
+            }
+            continue;
+        };
+
+        let scope_cancel = cancellation_token.child_token();
+        let query = DiscoveryQuery::EventChannels(EventChannelQuery::endpoint_topic(
+            kv_state_endpoint.clone(),
+            KV_EVENT_SUBJECT,
+        ));
+        let stream = match component
+            .drt()
+            .discovery()
+            .list_and_watch(query, Some(scope_cancel.clone()))
+            .await
+        {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::error!(%error, %kv_state_endpoint, "Failed to watch direct-ZMQ KV event channels");
+                update_subscription_failure_metric(
+                    &status_metrics,
+                    &view,
+                    &model,
+                    worker_type,
+                    &serving_endpoint,
+                );
+                client
+                    .sync_membership_with_ready_sources(&HashSet::new())
+                    .await;
+                if let Some(ready) = startup_ready.take() {
+                    let _ = ready.send(Ok(()));
+                }
+                if !wait_for_retry(retry_delay, &mut membership_watch, &cancellation_token).await {
+                    break;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+
+        client
+            .sync_membership_with_ready_sources(&HashSet::new())
+            .await;
+        if let Some(ready) = startup_ready.take() {
+            let _ = ready.send(Ok(()));
+        }
+
+        let exit = consume_scope(
+            stream,
+            &client,
+            &kv_state_endpoint,
+            &mut membership_watch,
+            &status_metrics,
+            &ingress_metrics,
+            &model,
+            worker_type,
+            &serving_endpoint,
+            &cancellation_token,
+        )
+        .await;
+        scope_cancel.cancel();
+
+        match exit {
+            ScopeExit::Rebind => retry_delay = INITIAL_BACKOFF,
+            ScopeExit::Retry => {
+                let view = membership_watch.borrow().clone();
+                update_subscription_failure_metric(
+                    &status_metrics,
+                    &view,
+                    &model,
+                    worker_type,
+                    &serving_endpoint,
+                );
+                if !wait_for_retry(retry_delay, &mut membership_watch, &cancellation_token).await {
+                    break;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+            }
+            ScopeExit::Stop => break,
+        }
+    }
+
+    client.shutdown().await;
+    clear_mismatch_metric_on_cancellation(
+        &status_metrics,
+        &cancellation_token,
+        &model,
+        worker_type,
+        &serving_endpoint,
+    );
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn consume_scope(
+    mut discovery_stream: dynamo_runtime::discovery::DiscoveryStream,
+    client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    kv_state_endpoint: &EndpointId,
+    membership_watch: &mut KvSourceMembershipWatch,
+    status_metrics: &RouterWorkerStatusMetrics,
+    ingress_metrics: &Arc<KvZmqIngressMetrics>,
+    model: &str,
+    worker_type: &str,
+    serving_endpoint: &EndpointId,
+    cancellation_token: &CancellationToken,
+) -> ScopeExit {
+    let expected_scope = EventScope::Endpoint {
+        endpoint: kv_state_endpoint.clone(),
+    };
+    let (signal_tx, mut signal_rx) = mpsc::channel(SIGNAL_CAPACITY);
+    let mut sources = HashMap::<u64, SourceTask>::new();
+    let mut invalid_publishers = HashSet::new();
+    let mut next_task_generation = 1_u64;
+    let mut exit = ScopeExit::Retry;
+
+    loop {
+        tokio::select! {
+            biased;
+            _ = cancellation_token.cancelled() => {
+                exit = ScopeExit::Stop;
+                break;
+            }
+            changed = membership_watch.changed() => {
+                if changed.is_err() {
+                    exit = ScopeExit::Stop;
+                    break;
+                }
+                membership_watch.borrow_and_update();
+                if membership_watch.borrow().resolved_kv_state_endpoint() != Some(kv_state_endpoint) {
+                    exit = ScopeExit::Rebind;
+                    break;
+                }
+                let view = membership_watch.borrow().clone();
+                reconcile_sources(
+                    client,
+                    view.clone(),
+                    &mut sources,
+                    ingress_metrics,
+                    &signal_tx,
+                    cancellation_token,
+                    &mut next_task_generation,
+                ).await;
+                update_mismatch_metric(
+                    status_metrics,
+                    &view,
+                    model,
+                    worker_type,
+                    serving_endpoint,
+                );
+            }
+            signal = signal_rx.recv() => {
+                let Some(signal) = signal else {
+                    break;
+                };
+                match signal {
+                    SourceSignal::Ready { publisher_id, task_generation, activate } => {
+                        let Some(source) = sources.get_mut(&publisher_id) else {
+                            continue;
+                        };
+                        if source.task_generation != task_generation {
+                            continue;
+                        }
+                        transition_source_state(
+                            source,
+                            SourceState::Preconnected { activate },
+                            ingress_metrics,
+                        );
+                        ingress_metrics.increment_lifecycle("preconnected");
+                        let view = membership_watch.borrow().clone();
+                        reconcile_sources(
+                            client,
+                            view,
+                            &mut sources,
+                            ingress_metrics,
+                            &signal_tx,
+                            cancellation_token,
+                            &mut next_task_generation,
+                        ).await;
+                    }
+                    SourceSignal::Disconnected { publisher_id, task_generation } => {
+                        let Some(source) = sources.get_mut(&publisher_id) else {
+                            continue;
+                        };
+                        if source.task_generation != task_generation {
+                            continue;
+                        }
+                        transition_source_state(source, SourceState::Fenced, ingress_metrics);
+                        ingress_metrics.increment_lifecycle("reconnect");
+                        client.fence_transport(publisher_id).await;
+                        let view = membership_watch.borrow().clone();
+                        reconcile_sources(
+                            client,
+                            view,
+                            &mut sources,
+                            ingress_metrics,
+                            &signal_tx,
+                            cancellation_token,
+                            &mut next_task_generation,
+                        ).await;
+                    }
+                }
+            }
+            event = discovery_stream.next() => {
+                let Some(event) = event else {
+                    tracing::error!(%kv_state_endpoint, "Direct-ZMQ event-channel discovery stream ended");
+                    break;
+                };
+                match event {
+                    Ok(DiscoveryEvent::Added(DiscoveryInstance::EventChannel {
+                        scope,
+                        topic,
+                        instance_id,
+                        transport,
+                    })) if scope == expected_scope && topic == KV_EVENT_SUBJECT => {
+                        let EventTransport::Zmq { endpoint } = transport else {
+                            tracing::warn!(publisher_id = instance_id, "Ignoring non-direct-ZMQ event channel in direct ingress");
+                            continue;
+                        };
+                        if invalid_publishers.contains(&instance_id) {
+                            continue;
+                        }
+                        if let Some(existing) = sources.get(&instance_id) {
+                            if existing.endpoint == endpoint {
+                                continue;
+                            }
+                            tracing::error!(
+                                publisher_id = instance_id,
+                                old_endpoint = %existing.endpoint,
+                                new_endpoint = %endpoint,
+                                "Direct-ZMQ publisher changed its immutable channel endpoint"
+                            );
+                            let existing = sources.remove(&instance_id).expect("entry was present");
+                            stop_source(existing, ingress_metrics).await;
+                            client.fence_transport(instance_id).await;
+                            invalid_publishers.insert(instance_id);
+                            let view = membership_watch.borrow().clone();
+                            reconcile_sources(
+                                client,
+                                view,
+                                &mut sources,
+                                ingress_metrics,
+                                &signal_tx,
+                                cancellation_token,
+                                &mut next_task_generation,
+                            ).await;
+                            continue;
+                        }
+
+                        let task_generation = next_task_generation;
+                        next_task_generation = next_task_generation.wrapping_add(1);
+                        let source = spawn_source(
+                            instance_id,
+                            endpoint,
+                            task_generation,
+                            signal_tx.clone(),
+                            client.clone(),
+                            ingress_metrics.clone(),
+                            cancellation_token.child_token(),
+                        );
+                        sources.insert(instance_id, source);
+                        ingress_metrics.increment_lifecycle("started");
+                    }
+                    Ok(DiscoveryEvent::Removed(DiscoveryInstanceId::EventChannel(
+                        EventChannelInstanceId { scope, topic, instance_id },
+                    ))) if scope == expected_scope && topic == KV_EVENT_SUBJECT => {
+                        invalid_publishers.remove(&instance_id);
+                        if let Some(source) = sources.remove(&instance_id) {
+                            stop_source(source, ingress_metrics).await;
+                            client.fence_transport(instance_id).await;
+                            ingress_metrics.increment_lifecycle("removed");
+                            let view = membership_watch.borrow().clone();
+                            reconcile_sources(
+                                client,
+                                view,
+                                &mut sources,
+                                ingress_metrics,
+                                &signal_tx,
+                                cancellation_token,
+                                &mut next_task_generation,
+                            ).await;
+                        }
+                    }
+                    Ok(DiscoveryEvent::Added(_)) | Ok(DiscoveryEvent::Removed(_)) => {}
+                    Err(error) => {
+                        tracing::error!(%error, %kv_state_endpoint, "Direct-ZMQ event-channel discovery failed");
+                        break;
+                    }
+                }
+            }
+        }
+    }
+
+    let stopped_sources = sources.into_iter().collect::<Vec<_>>();
+    for (_, source) in &stopped_sources {
+        source.cancel.cancel();
+    }
+    let publisher_ids = stopped_sources
+        .iter()
+        .map(|(publisher_id, _)| *publisher_id)
+        .collect::<Vec<_>>();
+    futures::future::join_all(
+        stopped_sources
+            .into_iter()
+            .map(|(_, source)| stop_source(source, ingress_metrics)),
+    )
+    .await;
+    for publisher_id in publisher_ids {
+        client.fence_transport(publisher_id).await;
+    }
+    client
+        .sync_membership_with_ready_sources(&HashSet::new())
+        .await;
+    exit
+}
+
+async fn reconcile_sources(
+    client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    preliminary_view: KvSourceMembershipView,
+    sources: &mut HashMap<u64, SourceTask>,
+    metrics: &Arc<KvZmqIngressMetrics>,
+    signal_tx: &mpsc::Sender<SourceSignal>,
+    cancellation_token: &CancellationToken,
+    next_task_generation: &mut u64,
+) {
+    let preliminary_ready = ready_sources(&preliminary_view, sources);
+    let obsolete: Vec<_> = sources
+        .iter()
+        .filter_map(|(publisher_id, source)| {
+            source.state.active_bindings().and_then(|active| {
+                (active != &bindings_for_publisher(&preliminary_ready, *publisher_id))
+                    .then_some(*publisher_id)
+            })
+        })
+        .collect();
+    for publisher_id in obsolete {
+        restart_source(
+            publisher_id,
+            client,
+            sources,
+            metrics,
+            signal_tx,
+            cancellation_token,
+            next_task_generation,
+        )
+        .await;
+    }
+
+    let preconnected_ready = ready_sources(&preliminary_view, sources);
+    let current_view = client
+        .sync_membership_with_ready_sources(&preconnected_ready)
+        .await;
+    let current_ready = ready_sources(&current_view, sources);
+    let stale_after_sync: Vec<_> = sources
+        .iter()
+        .filter_map(|(publisher_id, source)| {
+            source.state.active_bindings().and_then(|active| {
+                (active != &bindings_for_publisher(&current_ready, *publisher_id))
+                    .then_some(*publisher_id)
+            })
+        })
+        .collect();
+    for publisher_id in stale_after_sync {
+        restart_source(
+            publisher_id,
+            client,
+            sources,
+            metrics,
+            signal_tx,
+            cancellation_token,
+            next_task_generation,
+        )
+        .await;
+    }
+
+    let ready_publishers = current_ready
+        .iter()
+        .map(|ready| ready.source_id.publisher_id)
+        .collect::<HashSet<_>>();
+    for publisher_id in ready_publishers {
+        let bindings = bindings_for_publisher(&current_ready, publisher_id);
+        if !bindings.is_subset(&preconnected_ready) {
+            continue;
+        }
+        let Some(source) = sources.get_mut(&publisher_id) else {
+            continue;
+        };
+        if source.state.active_bindings() == Some(&bindings) {
+            continue;
+        }
+        let SourceState::Preconnected { activate } =
+            std::mem::replace(&mut source.state, SourceState::Fenced)
+        else {
+            continue;
+        };
+        metrics.decrement_sources("preconnected");
+        if activate.send(()).is_ok() {
+            source.state = SourceState::Active { bindings };
+            metrics.increment_sources("active");
+            metrics.increment_lifecycle("activated");
+        }
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn restart_source(
+    publisher_id: u64,
+    client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    sources: &mut HashMap<u64, SourceTask>,
+    metrics: &Arc<KvZmqIngressMetrics>,
+    signal_tx: &mpsc::Sender<SourceSignal>,
+    cancellation_token: &CancellationToken,
+    next_task_generation: &mut u64,
+) {
+    let Some(source) = sources.remove(&publisher_id) else {
+        return;
+    };
+    let endpoint = source.endpoint.clone();
+    stop_source(source, metrics).await;
+    client.fence_transport(publisher_id).await;
+
+    let task_generation = *next_task_generation;
+    *next_task_generation = (*next_task_generation).wrapping_add(1);
+    sources.insert(
+        publisher_id,
+        spawn_source(
+            publisher_id,
+            endpoint,
+            task_generation,
+            signal_tx.clone(),
+            client.clone(),
+            metrics.clone(),
+            cancellation_token.child_token(),
+        ),
+    );
+    metrics.increment_lifecycle("replaced");
+}
+
+fn ready_sources(
+    view: &KvSourceMembershipView,
+    sources: &HashMap<u64, SourceTask>,
+) -> HashSet<ReadyKvSource> {
+    view.sources
+        .iter()
+        .filter_map(|(worker, status)| {
+            let source = status.active_source()?;
+            let transport = sources.get(&source.publisher_id)?;
+            if !transport.state.is_ready() {
+                return None;
+            }
+            Some(ReadyKvSource {
+                source_id: source.source_id(),
+                lifecycle_generation: view.lifecycle_generation(worker).unwrap_or(0),
+            })
+        })
+        .collect()
+}
+
+fn bindings_for_publisher(
+    ready: &HashSet<ReadyKvSource>,
+    publisher_id: u64,
+) -> HashSet<ReadyKvSource> {
+    ready
+        .iter()
+        .filter(|binding| binding.source_id.publisher_id == publisher_id)
+        .cloned()
+        .collect()
+}
+
+fn spawn_source(
+    publisher_id: u64,
+    endpoint: String,
+    task_generation: u64,
+    signal_tx: mpsc::Sender<SourceSignal>,
+    client: Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    metrics: Arc<KvZmqIngressMetrics>,
+    cancel: CancellationToken,
+) -> SourceTask {
+    let task_cancel = cancel.clone();
+    let task_endpoint = endpoint.clone();
+    let handle = tokio::spawn(async move {
+        run_source(
+            publisher_id,
+            task_endpoint,
+            task_generation,
+            signal_tx,
+            client,
+            metrics,
+            task_cancel,
+        )
+        .await;
+    });
+    SourceTask {
+        endpoint,
+        task_generation,
+        cancel,
+        handle,
+        state: SourceState::Connecting,
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn run_source(
+    publisher_id: u64,
+    endpoint: String,
+    task_generation: u64,
+    signal_tx: mpsc::Sender<SourceSignal>,
+    client: Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    metrics: Arc<KvZmqIngressMetrics>,
+    cancel: CancellationToken,
+) {
+    let mut retry_delay = INITIAL_BACKOFF;
+    loop {
+        let stream = tokio::select! {
+            _ = cancel.cancelled() => return,
+            stream = ZmqSubTransport::connect_single_consumer(&endpoint, KV_EVENT_SUBJECT) => stream,
+        };
+        let mut stream = match stream {
+            Ok(stream) => stream,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, %endpoint, "Failed to connect direct-ZMQ KV source");
+                if signal_tx
+                    .send(SourceSignal::Disconnected {
+                        publisher_id,
+                        task_generation,
+                    })
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                if !sleep_or_cancel(retry_delay, &cancel).await {
+                    return;
+                }
+                retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+                continue;
+            }
+        };
+        retry_delay = INITIAL_BACKOFF;
+
+        let (activate, activation) = oneshot::channel();
+        if signal_tx
+            .send(SourceSignal::Ready {
+                publisher_id,
+                task_generation,
+                activate,
+            })
+            .await
+            .is_err()
+        {
+            return;
+        }
+
+        let activated = tokio::select! {
+            _ = cancel.cancelled() => return,
+            activated = activation => activated.is_ok(),
+        };
+        if !activated {
+            return;
+        }
+
+        tokio::select! {
+            biased;
+            _ = cancel.cancelled() => return,
+            _ = consume_connection(publisher_id, &mut stream, &client, &metrics) => {}
+        }
+        if signal_tx
+            .send(SourceSignal::Disconnected {
+                publisher_id,
+                task_generation,
+            })
+            .await
+            .is_err()
+        {
+            return;
+        }
+        if !sleep_or_cancel(retry_delay, &cancel).await {
+            return;
+        }
+        retry_delay = (retry_delay * 2).min(MAX_BACKOFF);
+    }
+}
+
+async fn consume_connection(
+    publisher_id: u64,
+    stream: &mut ZmqWireStream,
+    client: &Arc<WorkerQueryClient<IndexerRecoveryTarget>>,
+    metrics: &KvZmqIngressMetrics,
+) {
+    let codec = Codec::default();
+    loop {
+        let result = stream.next().await;
+        let Some(result) = result else {
+            return;
+        };
+        let message = match result {
+            Ok(message) => message,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, "Direct-ZMQ KV source stream failed");
+                return;
+            }
+        };
+
+        let envelope = match codec.decode_envelope(&message.payload) {
+            Ok(envelope) => envelope,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV envelope");
+                metrics.increment_lifecycle("envelope_decode_error");
+                continue;
+            }
+        };
+        if envelope.publisher_id != publisher_id
+            || envelope.publisher_id != message.publisher_id
+            || envelope.sequence != message.sequence
+            || envelope.topic != KV_EVENT_SUBJECT
+        {
+            tracing::warn!(
+                publisher_id,
+                frame_publisher_id = message.publisher_id,
+                frame_sequence = message.sequence,
+                envelope_publisher_id = envelope.publisher_id,
+                envelope_sequence = envelope.sequence,
+                envelope_topic = %envelope.topic,
+                "Dropping direct-ZMQ KV envelope with inconsistent attribution"
+            );
+            metrics.increment_lifecycle("identity_mismatch");
+            continue;
+        }
+        let events = match codec.decode_payload::<Vec<RouterEvent>>(&envelope.payload) {
+            Ok(events) => events,
+            Err(error) => {
+                tracing::warn!(%error, publisher_id, "Failed to decode direct-ZMQ KV payload");
+                metrics.increment_lifecycle("payload_decode_error");
+                continue;
+            }
+        };
+        client.handle_live_batch(publisher_id, events).await;
+        metrics.increment_batch();
+    }
+}
+
+async fn stop_source(source: SourceTask, metrics: &KvZmqIngressMetrics) {
+    leave_source_state(&source.state, metrics);
+    source.cancel.cancel();
+    stop_source_handle(source.handle, metrics).await;
+}
+
+fn transition_source_state(
+    source: &mut SourceTask,
+    next: SourceState,
+    metrics: &KvZmqIngressMetrics,
+) {
+    leave_source_state(&source.state, metrics);
+    enter_source_state(&next, metrics);
+    source.state = next;
+}
+
+fn enter_source_state(state: &SourceState, metrics: &KvZmqIngressMetrics) {
+    match state {
+        SourceState::Preconnected { .. } => metrics.increment_sources("preconnected"),
+        SourceState::Active { .. } => metrics.increment_sources("active"),
+        SourceState::Connecting | SourceState::Fenced => {}
+    }
+}
+
+fn leave_source_state(state: &SourceState, metrics: &KvZmqIngressMetrics) {
+    match state {
+        SourceState::Preconnected { .. } => metrics.decrement_sources("preconnected"),
+        SourceState::Active { .. } => metrics.decrement_sources("active"),
+        SourceState::Connecting | SourceState::Fenced => {}
+    }
+}
+
+async fn stop_source_handle(mut handle: JoinHandle<()>, metrics: &KvZmqIngressMetrics) {
+    match tokio::time::timeout(SOURCE_JOIN_TIMEOUT, &mut handle).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) if error.is_cancelled() => {}
+        Ok(Err(error)) => {
+            tracing::warn!(%error, "Direct-ZMQ source task failed during shutdown");
+        }
+        Err(_) => {
+            handle.abort();
+            let _ = handle.await;
+            metrics.increment_lifecycle("forced_abort");
+        }
+    }
+    metrics.increment_lifecycle("stopped");
+}
+
+async fn wait_for_retry(
+    delay: Duration,
+    membership_watch: &mut KvSourceMembershipWatch,
+    cancellation_token: &CancellationToken,
+) -> bool {
+    tokio::select! {
+        _ = cancellation_token.cancelled() => false,
+        changed = membership_watch.changed() => changed.is_ok(),
+        _ = tokio::time::sleep(delay) => true,
+    }
+}
+
+async fn sleep_or_cancel(delay: Duration, cancellation_token: &CancellationToken) -> bool {
+    tokio::select! {
+        _ = cancellation_token.cancelled() => false,
+        _ = tokio::time::sleep(delay) => true,
+    }
+}

--- a/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/direct_zmq.rs
@@ -517,10 +517,13 @@ async fn reconcile_sources(
         if source.state.active_bindings() == Some(&bindings) {
             continue;
         }
+        if !matches!(&source.state, SourceState::Preconnected { .. }) {
+            continue;
+        }
         let SourceState::Preconnected { activate } =
             std::mem::replace(&mut source.state, SourceState::Fenced)
         else {
-            continue;
+            unreachable!("source state was checked above");
         };
         metrics.decrement_sources("preconnected");
         if activate.send(()).is_ok() {

--- a/lib/llm/src/kv_router/indexer/recovery/mod.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/mod.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
+mod direct_zmq;
 mod subscriber;
 mod target;
 mod worker_query;
@@ -8,7 +9,9 @@ mod worker_query_endpoint;
 mod worker_query_state;
 mod worker_query_transport;
 
-pub(crate) use subscriber::{RecoverySupervisor, start_subscriber, start_target_subscriber};
+pub(crate) use subscriber::{
+    KvEventSubscriptionHandle, RecoverySupervisor, start_subscriber, start_target_subscriber,
+};
 pub(crate) use target::{IndexerRecoveryTarget, RecoveryResetReason, RecoveryTarget, SourceEpoch};
 pub(crate) use worker_query::DEFAULT_RECOVERY_ATTEMPT_TIMEOUT;
 pub(crate) use worker_query::TargetFaultDisposition;

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -294,6 +294,8 @@ pub(super) fn clear_mismatch_metric_on_cancellation(
     );
 }
 
+/// Dropping this handle cancels the KV event subscription.
+#[must_use = "dropping the handle cancels the KV event subscription"]
 pub(crate) struct KvEventSubscriptionHandle {
     cancel: CancellationToken,
     completion: Option<oneshot::Receiver<()>>,

--- a/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/subscriber.rs
@@ -10,13 +10,16 @@ use dynamo_runtime::{
     discovery::EventTransportKind,
     protocols::EndpointId,
     traits::DistributedRuntimeProvider,
-    transports::event_plane::{EventSubscriber, TypedEventSubscriber},
+    transports::event_plane::{EventSubscriber, TypedEventSubscriber, uses_direct_zmq},
 };
 use tokio::sync::{Semaphore, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
-use super::{IndexerRecoveryTarget, RecoveryTarget, worker_query::WorkerQueryClient};
+use super::{
+    IndexerRecoveryTarget, RecoveryTarget, direct_zmq::run_direct_zmq_supervisor,
+    worker_query::WorkerQueryClient,
+};
 use crate::{
     discovery::{KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus},
     kv_router::{Indexer, metrics::RouterWorkerStatusMetrics},
@@ -160,16 +163,13 @@ async fn run_subscription_supervisor<T: RecoveryTarget>(
     }
 
     client.shutdown().await;
-    if cancellation_token.is_cancelled() {
-        metrics.set_kv_event_source_mismatch_workers(
-            &model,
-            worker_type,
-            &serving_endpoint.namespace,
-            &serving_endpoint.component,
-            &serving_endpoint.name,
-            0,
-        );
-    }
+    clear_mismatch_metric_on_cancellation(
+        &metrics,
+        &cancellation_token,
+        &model,
+        worker_type,
+        &serving_endpoint,
+    );
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -231,7 +231,7 @@ async fn wait_for_retry(
     }
 }
 
-fn update_mismatch_metric(
+pub(super) fn update_mismatch_metric(
     metrics: &RouterWorkerStatusMetrics,
     view: &KvSourceMembershipView,
     model: &str,
@@ -257,7 +257,7 @@ fn update_mismatch_metric(
     );
 }
 
-fn update_subscription_failure_metric(
+pub(super) fn update_subscription_failure_metric(
     metrics: &RouterWorkerStatusMetrics,
     view: &KvSourceMembershipView,
     model: &str,
@@ -274,6 +274,46 @@ fn update_subscription_failure_metric(
     );
 }
 
+pub(super) fn clear_mismatch_metric_on_cancellation(
+    metrics: &RouterWorkerStatusMetrics,
+    cancellation_token: &CancellationToken,
+    model: &str,
+    worker_type: &str,
+    serving_endpoint: &EndpointId,
+) {
+    if !cancellation_token.is_cancelled() {
+        return;
+    }
+    metrics.set_kv_event_source_mismatch_workers(
+        model,
+        worker_type,
+        &serving_endpoint.namespace,
+        &serving_endpoint.component,
+        &serving_endpoint.name,
+        0,
+    );
+}
+
+pub(crate) struct KvEventSubscriptionHandle {
+    cancel: CancellationToken,
+    completion: Option<oneshot::Receiver<()>>,
+}
+
+impl KvEventSubscriptionHandle {
+    pub(crate) async fn shutdown(mut self) {
+        self.cancel.cancel();
+        if let Some(completion) = self.completion.take() {
+            let _ = completion.await;
+        }
+    }
+}
+
+impl Drop for KvEventSubscriptionHandle {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+    }
+}
+
 pub async fn start_subscriber(
     endpoint: Endpoint,
     indexer: Indexer,
@@ -281,31 +321,79 @@ pub async fn start_subscriber(
     model: String,
     worker_type: &'static str,
     cancellation_token: CancellationToken,
-) -> Result<()> {
+) -> Result<KvEventSubscriptionHandle> {
     let transport_kind = endpoint.component().drt().default_event_transport_kind();
+    let direct_zmq = uses_direct_zmq(transport_kind);
+    let cancel = cancellation_token.child_token();
     let client = WorkerQueryClient::spawn(
         endpoint.component().clone(),
         IndexerRecoveryTarget::new(indexer),
         membership_watch.clone(),
-        cancellation_token.child_token(),
+        cancel.child_token(),
     )
     .await?;
+
+    if !direct_zmq {
+        tracing::info!(
+            transport = ?transport_kind,
+            "Using aggregated KV event subscriber"
+        );
+        let (startup_tx, startup_rx) = oneshot::channel();
+        let (completion_tx, completion_rx) = oneshot::channel();
+        let task_cancel = cancel.clone();
+        tokio::spawn(async move {
+            run_subscription_supervisor(
+                endpoint.component().clone(),
+                endpoint.id(),
+                client,
+                transport_kind,
+                membership_watch,
+                model,
+                worker_type,
+                task_cancel,
+                Some(startup_tx),
+            )
+            .await;
+            let _ = completion_tx.send(());
+        });
+        startup_rx.await.map_err(|_| {
+            anyhow::anyhow!("KV event subscription supervisor exited before reporting readiness")
+        })?;
+        return Ok(KvEventSubscriptionHandle {
+            cancel,
+            completion: Some(completion_rx),
+        });
+    }
+
+    tracing::info!("Using direct-ZMQ KV event ingress on the application runtime");
     let (startup_tx, startup_rx) = oneshot::channel();
-    tokio::spawn(run_subscription_supervisor(
-        endpoint.component().clone(),
-        endpoint.id(),
-        client,
-        transport_kind,
-        membership_watch,
-        model,
-        worker_type,
-        cancellation_token,
-        Some(startup_tx),
-    ));
-    startup_rx.await.map_err(|_| {
-        anyhow::anyhow!("KV event subscription supervisor exited before reporting readiness")
-    })?;
-    Ok(())
+    let (completion_tx, completion_rx) = oneshot::channel();
+    let task_cancel = cancel.clone();
+    tokio::spawn(async move {
+        run_direct_zmq_supervisor(
+            endpoint.component().clone(),
+            endpoint.id(),
+            client,
+            membership_watch,
+            model,
+            worker_type,
+            task_cancel,
+            Some(startup_tx),
+        )
+        .await;
+        let _ = completion_tx.send(());
+    });
+
+    startup_rx
+        .await
+        .map_err(|_| {
+            anyhow::anyhow!("Direct-ZMQ ingress supervisor exited before reporting readiness")
+        })?
+        .map_err(anyhow::Error::msg)?;
+    Ok(KvEventSubscriptionHandle {
+        cancel,
+        completion: Some(completion_rx),
+    })
 }
 
 pub(crate) struct RecoverySupervisor<T: RecoveryTarget> {
@@ -373,4 +461,28 @@ pub(crate) async fn start_target_subscriber<T: RecoveryTarget>(
         cancel,
         task,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn subscription_handle_shutdown_waits_for_completion() {
+        let cancel = CancellationToken::new();
+        let task_cancel = cancel.clone();
+        let (completion_tx, completion_rx) = oneshot::channel();
+        tokio::spawn(async move {
+            task_cancel.cancelled().await;
+            let _ = completion_tx.send(());
+        });
+        let handle = KvEventSubscriptionHandle {
+            cancel,
+            completion: Some(completion_rx),
+        };
+
+        tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+            .await
+            .expect("subscription shutdown should complete");
+    }
 }

--- a/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
+++ b/lib/llm/src/kv_router/indexer/recovery/worker_query.rs
@@ -1,7 +1,11 @@
 // SPDX-FileCopyrightText: Copyright (c) 2024-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 // SPDX-License-Identifier: Apache-2.0
 
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::Duration,
+};
 
 use anyhow::{Context, Result};
 use dashmap::DashMap;
@@ -20,7 +24,7 @@ use super::target::{IndexerRecoveryTarget, RecoveryResetReason, RecoveryTarget, 
 use super::worker_query_state::{LiveEventAction, PendingDrainPlan, RankState, RecoveryKey};
 use super::worker_query_transport::{RuntimeWorkerQueryTransport, WorkerQueryTransport};
 use crate::discovery::{
-    KvEventSource, KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus,
+    KvEventSource, KvSourceId, KvSourceMembershipView, KvSourceMembershipWatch, KvSourceStatus,
 };
 
 const RECOVERY_MAX_RETRIES: u32 = 8;
@@ -73,6 +77,12 @@ pub(crate) enum TargetFaultDisposition {
     ResetLiveOnly,
     Fenced,
     Stale,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub(crate) struct ReadyKvSource {
+    pub(crate) source_id: KvSourceId,
+    pub(crate) lifecycle_generation: u64,
 }
 
 #[cfg(feature = "ckf-diagnostics")]
@@ -171,7 +181,7 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
     }
 
     #[cfg(test)]
-    fn new_target_for_test(
+    pub(super) fn new_target_for_test(
         target: T,
         membership_rx: watch::Receiver<KvSourceMembershipView>,
         transport: Arc<dyn WorkerQueryTransport>,
@@ -216,6 +226,38 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
         let _sync = self.membership_sync.lock().await;
         let view = self.membership_rx.borrow().clone();
         self.reconcile_view(view.clone()).await;
+        view
+    }
+
+    /// Apply membership only for source incarnations whose direct transport is preconnected.
+    ///
+    /// The semantic membership watch remains authoritative. Transport readiness can only
+    /// suppress an otherwise active source; it can never introduce one.
+    pub(crate) async fn sync_membership_with_ready_sources(
+        self: &Arc<Self>,
+        ready_sources: &HashSet<ReadyKvSource>,
+    ) -> KvSourceMembershipView {
+        let _sync = self.membership_sync.lock().await;
+        let view = self.membership_rx.borrow().clone();
+        let mut effective = view.clone();
+        for (worker, status) in &mut effective.sources {
+            let Some(source) = status.active_source() else {
+                continue;
+            };
+            let lifecycle_generation = effective
+                .lifecycle_generations
+                .get(worker)
+                .copied()
+                .unwrap_or(0);
+            let ready = ReadyKvSource {
+                source_id: source.source_id(),
+                lifecycle_generation,
+            };
+            if !ready_sources.contains(&ready) {
+                *status = KvSourceStatus::Missing;
+            }
+        }
+        self.reconcile_view(effective).await;
         view
     }
 
@@ -527,6 +569,56 @@ impl<T: RecoveryTarget> WorkerQueryClient<T> {
         slot.rank = RankState::default();
         slot.rejected_generation = Some(source_epoch.get());
         TargetFaultDisposition::Fenced
+    }
+
+    /// Fence one active publisher after a direct transport discontinuity.
+    ///
+    /// Unlike a protocol rejection, the same membership generation may reactivate after a
+    /// replacement socket is preconnected. The reset barrier makes any already-enqueued old
+    /// event visible before that reactivation.
+    pub(crate) async fn fence_transport(self: &Arc<Self>, publisher_id: u64) -> bool {
+        let _sync = self.membership_sync.lock().await;
+        let Some(active) = self
+            .publisher_bindings
+            .get(&publisher_id)
+            .map(|entry| entry.clone())
+        else {
+            return false;
+        };
+        let binding = active.binding;
+        let key = (
+            binding.source.worker.worker_id,
+            binding.source.worker.dp_rank,
+        );
+        let mut slot = active.slot.lock().await;
+        if !slot
+            .active
+            .as_ref()
+            .is_some_and(|current| Arc::ptr_eq(current, &binding))
+        {
+            return false;
+        }
+
+        self.deactivate_locked(key, &mut slot).await;
+        if let Err(error) = self
+            .reset_rank_for_reason_or_fence(
+                key,
+                binding.epoch,
+                &mut slot,
+                RecoveryResetReason::Lifecycle,
+            )
+            .await
+        {
+            tracing::error!(
+                %error,
+                publisher_id,
+                worker_id = key.0,
+                dp_rank = key.1,
+                "Failed to reset KV state after direct-ZMQ transport discontinuity"
+            );
+        }
+        slot.rank = RankState::default();
+        true
     }
 
     /// Handle one event envelope after a single immutable publisher lookup.
@@ -1045,7 +1137,10 @@ mod tests {
             KvSourceAmbiguity, KvSourceMembershipCoordinator, KvSourceMembershipView,
             KvStateEndpointResolution, runtime_config_watch,
         },
-        kv_router::indexer::{Indexer, LowerTierIndexers},
+        kv_router::{
+            indexer::{Indexer, LowerTierIndexers},
+            metrics::RouterWorkerStatusMetrics,
+        },
         local_model::runtime_config::ModelRuntimeConfig,
         model_card::ModelDeploymentCard,
     };
@@ -1066,6 +1161,27 @@ mod tests {
     #[derive(Clone, Default)]
     struct RecordingTarget {
         calls: Arc<Mutex<Vec<TargetCall>>>,
+    }
+
+    #[derive(Clone)]
+    struct BlockingTarget {
+        blocked_worker: WorkerId,
+        blocked_started: Arc<Notify>,
+        blocked_release: Arc<Notify>,
+        other_admitted: Arc<Notify>,
+        calls: Arc<Mutex<Vec<(WorkerId, u64)>>>,
+    }
+
+    impl BlockingTarget {
+        fn new(blocked_worker: WorkerId) -> Self {
+            Self {
+                blocked_worker,
+                blocked_started: Arc::new(Notify::new()),
+                blocked_release: Arc::new(Notify::new()),
+                other_admitted: Arc::new(Notify::new()),
+                calls: Arc::new(Mutex::new(Vec::new())),
+            }
+        }
     }
 
     impl RecoveryTarget for RecordingTarget {
@@ -1106,6 +1222,47 @@ mod tests {
                 .lock()
                 .await
                 .push(TargetCall::Reset(source_epoch, reason));
+            Ok(())
+        }
+    }
+
+    impl RecoveryTarget for BlockingTarget {
+        async fn admit_event(
+            &self,
+            _source_epoch: SourceEpoch,
+            event: RouterEvent,
+        ) -> anyhow::Result<()> {
+            if event.worker_id == self.blocked_worker && event.event.event_id == 1 {
+                self.blocked_started.notify_one();
+                self.blocked_release.notified().await;
+            }
+            self.calls
+                .lock()
+                .await
+                .push((event.worker_id, event.event.event_id));
+            if event.worker_id != self.blocked_worker {
+                self.other_admitted.notify_one();
+            }
+            Ok(())
+        }
+
+        async fn replace_rank(
+            &self,
+            _source_epoch: SourceEpoch,
+            _worker_id: WorkerId,
+            _dp_rank: DpRank,
+            _events: Vec<RouterEvent>,
+        ) -> anyhow::Result<()> {
+            Ok(())
+        }
+
+        async fn reset_rank(
+            &self,
+            _source_epoch: SourceEpoch,
+            _worker_id: WorkerId,
+            _dp_rank: DpRank,
+            _reason: RecoveryResetReason,
+        ) -> anyhow::Result<()> {
             Ok(())
         }
     }
@@ -1283,6 +1440,171 @@ mod tests {
                 dp_rank: worker.dp_rank,
             },
         )
+    }
+
+    fn ready_source(source: &KvEventSource, lifecycle_generation: u64) -> ReadyKvSource {
+        ReadyKvSource {
+            source_id: source.source_id(),
+            lifecycle_generation,
+        }
+    }
+
+    #[tokio::test]
+    async fn direct_transport_gate_requires_the_exact_source_generation() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let worker = WorkerWithDpRank::new(42, 4);
+        let source = source_for(&kv_endpoint, worker, 100, None);
+        let view = membership_view(
+            &serving,
+            &kv_endpoint,
+            [(worker, KvSourceStatus::ActiveLiveOnly(source.clone()), 7)],
+        );
+        let (_tx, rx) = watch::channel(view);
+        let client = WorkerQueryClient::new_target_for_test(
+            RecordingTarget::default(),
+            rx,
+            Arc::new(MockTransport::default()),
+        );
+
+        client
+            .sync_membership_with_ready_sources(&HashSet::new())
+            .await;
+        assert!(!client.publisher_bindings.contains_key(&source.publisher_id));
+
+        client
+            .sync_membership_with_ready_sources(&HashSet::from([ready_source(&source, 6)]))
+            .await;
+        assert!(!client.publisher_bindings.contains_key(&source.publisher_id));
+
+        client
+            .sync_membership_with_ready_sources(&HashSet::from([ready_source(&source, 7)]))
+            .await;
+        assert!(client.publisher_bindings.contains_key(&source.publisher_id));
+    }
+
+    #[tokio::test]
+    async fn transport_fence_resets_before_same_generation_reactivation() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let worker = WorkerWithDpRank::new(42, 4);
+        let source = source_for(&kv_endpoint, worker, 100, None);
+        let view = membership_view(
+            &serving,
+            &kv_endpoint,
+            [(worker, KvSourceStatus::ActiveLiveOnly(source.clone()), 7)],
+        );
+        let (_tx, rx) = watch::channel(view);
+        let target = RecordingTarget::default();
+        let client = WorkerQueryClient::new_target_for_test(
+            target.clone(),
+            rx,
+            Arc::new(MockTransport::default()),
+        );
+        let ready = HashSet::from([ready_source(&source, 7)]);
+        client.sync_membership_with_ready_sources(&ready).await;
+        client.handle_live_batch(100, vec![store(1)]).await;
+        target.calls.lock().await.clear();
+
+        assert!(client.fence_transport(100).await);
+        assert!(!client.publisher_bindings.contains_key(&100));
+        client.handle_live_batch(100, vec![store(2)]).await;
+        assert_eq!(
+            target.calls.lock().await.as_slice(),
+            &[TargetCall::Reset(
+                SourceEpoch::new(7),
+                RecoveryResetReason::Lifecycle
+            )]
+        );
+
+        client.sync_membership_with_ready_sources(&ready).await;
+        assert!(client.publisher_bindings.contains_key(&100));
+        client.handle_live_batch(100, vec![store(3)]).await;
+        assert_eq!(
+            target.calls.lock().await.as_slice(),
+            &[
+                TargetCall::Reset(SourceEpoch::new(7), RecoveryResetReason::Lifecycle),
+                TargetCall::Admit(SourceEpoch::new(7), 3),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn independent_source_handlers_enter_worker_query_concurrently_and_keep_fifo() {
+        let serving = EndpointId::from("test.router.generate");
+        let kv_endpoint = EndpointId::from("test.router.kv");
+        let worker_a = WorkerWithDpRank::new(42, 4);
+        let worker_b = WorkerWithDpRank::new(43, 4);
+        let source_a = source_for(&kv_endpoint, worker_a, 100, None);
+        let source_b = source_for(&kv_endpoint, worker_b, 200, None);
+        let view = membership_view(
+            &serving,
+            &kv_endpoint,
+            [
+                (
+                    worker_a,
+                    KvSourceStatus::ActiveLiveOnly(source_a.clone()),
+                    1,
+                ),
+                (
+                    worker_b,
+                    KvSourceStatus::ActiveLiveOnly(source_b.clone()),
+                    1,
+                ),
+            ],
+        );
+        let (_tx, rx) = watch::channel(view);
+        let target = BlockingTarget::new(worker_a.worker_id);
+        let client = WorkerQueryClient::new_target_for_test(
+            target.clone(),
+            rx,
+            Arc::new(MockTransport::default()),
+        );
+        client
+            .sync_membership_with_ready_sources(&HashSet::from([
+                ready_source(&source_a, 1),
+                ready_source(&source_b, 1),
+            ]))
+            .await;
+
+        let source_a_client = client.clone();
+        let source_a_task = tokio::spawn(async move {
+            source_a_client
+                .handle_live_batch(100, vec![store_for(worker_a, 1), store_for(worker_a, 2)])
+                .await;
+        });
+        tokio::time::timeout(Duration::from_secs(1), target.blocked_started.notified())
+            .await
+            .expect("source A should block inside admission");
+
+        let source_b_client = client.clone();
+        let source_b_task = tokio::spawn(async move {
+            source_b_client
+                .handle_live_batch(200, vec![store_for(worker_b, 1), store_for(worker_b, 2)])
+                .await;
+        });
+        tokio::time::timeout(Duration::from_secs(1), target.other_admitted.notified())
+            .await
+            .expect("source B should enter admission while source A is blocked");
+
+        target.blocked_release.notify_one();
+        source_a_task.await.unwrap();
+        source_b_task.await.unwrap();
+        let calls = target.calls.lock().await.clone();
+        let a_ids = calls
+            .iter()
+            .filter_map(|(worker_id, event_id)| {
+                (*worker_id == worker_a.worker_id).then_some(*event_id)
+            })
+            .collect::<Vec<_>>();
+        let b_ids = calls
+            .iter()
+            .filter_map(|(worker_id, event_id)| {
+                (*worker_id == worker_b.worker_id).then_some(*event_id)
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(a_ids, vec![1, 2]);
+        assert_eq!(b_ids, vec![1, 2]);
     }
 
     #[tokio::test]
@@ -2452,7 +2774,7 @@ mod tests {
             );
             let membership_watch = membership_coordinator.subscribe();
             let mut membership_observer = membership_watch.clone();
-            crate::kv_router::indexer::recovery::subscriber::start_subscriber(
+            let subscription = crate::kv_router::indexer::recovery::subscriber::start_subscriber(
                 serving.clone(),
                 indexer,
                 membership_watch,
@@ -2742,7 +3064,27 @@ mod tests {
             assert!(!contains_rank_block(&final_events, delayed_rank, 2));
             assert!(configs.borrow().contains_key(&logical_worker_id));
 
+            let status_metrics = RouterWorkerStatusMetrics::from_component(&frontend);
+            let mismatch_labels = [
+                "test-model",
+                "decode",
+                serving_id.namespace.as_str(),
+                serving_id.component.as_str(),
+                serving_id.name.as_str(),
+            ];
+            status_metrics
+                .kv_event_source_mismatch_workers
+                .with_label_values(&mismatch_labels)
+                .set(4);
             cancel.cancel();
+            subscription.shutdown().await;
+            assert_eq!(
+                status_metrics
+                    .kv_event_source_mismatch_workers
+                    .with_label_values(&mismatch_labels)
+                    .get(),
+                0
+            );
             for source in &replacement_node_1_sources {
                 source_discovery
                     .unregister(source.instance.clone())

--- a/lib/llm/src/kv_router/metrics.rs
+++ b/lib/llm/src/kv_router/metrics.rs
@@ -193,6 +193,72 @@ pub(crate) fn kv_publisher_metrics() -> Option<Arc<KvPublisherMetrics>> {
 }
 
 // ---------------------------------------------------------------------------
+// Direct-ZMQ KV ingress metrics
+// ---------------------------------------------------------------------------
+
+pub(crate) struct KvZmqIngressMetrics {
+    sources: IntGaugeVec,
+    batches_total: IntCounter,
+    lifecycle_total: IntCounterVec,
+}
+
+static KV_ZMQ_INGRESS_METRICS: OnceLock<Arc<KvZmqIngressMetrics>> = OnceLock::new();
+
+impl KvZmqIngressMetrics {
+    pub(crate) fn from_component(component: &Component) -> Arc<Self> {
+        KV_ZMQ_INGRESS_METRICS
+            .get_or_init(|| {
+                let metrics = component.metrics();
+                let sources = metrics
+                    .create_intgaugevec(
+                        "router_kv_zmq_ingress_sources",
+                        "Number of direct-ZMQ KV ingress sources by lifecycle state",
+                        &["state"],
+                        &[],
+                    )
+                    .expect("failed to create router_kv_zmq_ingress_sources gauge");
+                let batches_total = metrics
+                    .create_intcounter(
+                        "router_kv_zmq_ingress_batches_total",
+                        "Total direct-ZMQ KV ingress batches handed to WorkerQueryClient",
+                        &[],
+                    )
+                    .expect("failed to create router_kv_zmq_ingress_batches_total counter");
+                let lifecycle_total = metrics
+                    .create_intcountervec(
+                        "router_kv_zmq_ingress_lifecycle_total",
+                        "Total direct-ZMQ KV ingress lifecycle transitions and errors",
+                        &["action"],
+                        &[],
+                    )
+                    .expect("failed to create router_kv_zmq_ingress_lifecycle_total counter");
+                Arc::new(Self {
+                    sources,
+                    batches_total,
+                    lifecycle_total,
+                })
+            })
+            .clone()
+    }
+
+    pub(crate) fn increment_sources(&self, state: &'static str) {
+        self.sources.with_label_values(&[state]).inc();
+    }
+
+    pub(crate) fn decrement_sources(&self, state: &'static str) {
+        self.sources.with_label_values(&[state]).dec();
+    }
+
+    pub(crate) fn increment_batch(&self) {
+        self.batches_total.inc();
+    }
+
+    pub(crate) fn increment_lifecycle(&self, action: &'static str) {
+        self.lifecycle_total.with_label_values(&[action]).inc();
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Router worker status metrics (component-scoped gauges)
 // ---------------------------------------------------------------------------
 

--- a/lib/runtime/src/transports/event_plane/mod.rs
+++ b/lib/runtime/src/transports/event_plane/mod.rs
@@ -56,6 +56,31 @@ struct BrokerEndpoints {
     xpub_endpoints: Vec<String>,
 }
 
+/// Whether the configured event plane selects direct per-publisher ZMQ sockets.
+///
+/// This intentionally answers only the topology question needed by specialized
+/// consumers. Broker discovery and connection errors remain owned by the normal
+/// [`EventSubscriber`] construction path.
+pub fn uses_direct_zmq(transport_kind: EventTransportKind) -> bool {
+    uses_direct_zmq_from_lookup(transport_kind, |key| std::env::var_os(key))
+}
+
+fn uses_direct_zmq_from_lookup(
+    transport_kind: EventTransportKind,
+    mut get_env: impl FnMut(&str) -> Option<std::ffi::OsString>,
+) -> bool {
+    if transport_kind != EventTransportKind::Zmq {
+        return false;
+    }
+
+    if get_env(crate::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_URL).is_some() {
+        return false;
+    }
+
+    !get_env(crate::config::environment_names::zmq_broker::DYN_ZMQ_BROKER_ENABLED)
+        .is_some_and(|value| crate::config::is_truthy(&value.to_string_lossy()))
+}
+
 /// Resolve ZMQ broker endpoints from environment or discovery
 /// Returns None if broker mode is not configured (direct mode)
 async fn resolve_zmq_broker(
@@ -886,6 +911,40 @@ fn current_timestamp_ms() -> u64 {
 mod tests {
     use super::*;
     use crate::config::environment_names::zmq_broker as broker_env;
+
+    #[test]
+    fn direct_zmq_topology_selection_is_narrow() {
+        let lookup = |url: Option<&str>, enabled: Option<&str>| {
+            let url = url.map(std::ffi::OsString::from);
+            let enabled = enabled.map(std::ffi::OsString::from);
+            move |key: &str| match key {
+                broker_env::DYN_ZMQ_BROKER_URL => url.clone(),
+                broker_env::DYN_ZMQ_BROKER_ENABLED => enabled.clone(),
+                _ => None,
+            }
+        };
+
+        assert!(uses_direct_zmq_from_lookup(
+            EventTransportKind::Zmq,
+            lookup(None, None)
+        ));
+        assert!(!uses_direct_zmq_from_lookup(
+            EventTransportKind::Zmq,
+            lookup(Some("xsub=tcp://broker:5555,xpub=tcp://broker:5556"), None)
+        ));
+        assert!(!uses_direct_zmq_from_lookup(
+            EventTransportKind::Zmq,
+            lookup(None, Some("true"))
+        ));
+        assert!(uses_direct_zmq_from_lookup(
+            EventTransportKind::Zmq,
+            lookup(None, Some("false"))
+        ));
+        assert!(!uses_direct_zmq_from_lookup(
+            EventTransportKind::Nats,
+            lookup(None, None)
+        ));
+    }
 
     #[tokio::test]
     async fn direct_zmq_endpoint_scopes_are_isolated() {

--- a/lib/runtime/src/transports/event_plane/zmq_transport.rs
+++ b/lib/runtime/src/transports/event_plane/zmq_transport.rs
@@ -211,13 +211,27 @@ pub struct ZmqSubTransport {
     socket_pump_handle: Arc<AbortOnDropHandle<()>>,
 }
 
+/// One validated multipart message from a direct ZMQ publisher.
+pub struct ZmqWireMessage {
+    pub publisher_id: u64,
+    pub sequence: u64,
+    pub payload: Bytes,
+}
+
+pub type ZmqWireStream =
+    std::pin::Pin<Box<dyn futures::Stream<Item = Result<ZmqWireMessage>> + Send>>;
+
 impl ZmqSubTransport {
+    fn connect_socket(endpoint: &str, topic: &str) -> Result<Subscribe> {
+        let ctx = shared_zmq_context();
+        Ok(configure_subscribe_builder(subscribe(&ctx))
+            .connect(endpoint)?
+            .subscribe(topic.as_bytes())?)
+    }
+
     /// Create a new ZMQ subscriber by connecting to a single endpoint.
     pub async fn connect(endpoint: &str, topic: &str) -> Result<Self> {
-        let ctx = shared_zmq_context();
-        let socket = configure_subscribe_builder(subscribe(&ctx))
-            .connect(endpoint)?
-            .subscribe(topic.as_bytes())?;
+        let socket = Self::connect_socket(endpoint, topic)?;
 
         tracing::info!(
             endpoint = %endpoint,
@@ -233,6 +247,48 @@ impl ZmqSubTransport {
             broadcast_tx,
             socket_pump_handle: Arc::new(AbortOnDropHandle::new(pump_handle)),
         })
+    }
+
+    /// Connect one consumer directly to one ZMQ publisher.
+    ///
+    /// Unlike [`Self::connect`], this stream owns and polls the socket directly. It
+    /// therefore has no background pump or lossy broadcast hop and naturally
+    /// applies backpressure at the configured ZMQ receive HWM.
+    pub async fn connect_single_consumer(endpoint: &str, topic: &str) -> Result<ZmqWireStream> {
+        let mut socket = Self::connect_socket(endpoint, topic)?;
+        let expected_topic = topic.as_bytes().to_vec();
+
+        tracing::info!(
+            endpoint,
+            topic,
+            rcvhwm = ZMQ_RCVHWM,
+            "Direct ZMQ single-consumer stream connected"
+        );
+
+        let stream = stream! {
+            while let Some(result) = socket.next().await {
+                let frames = match result {
+                    Ok(frames) => frames,
+                    Err(error) => {
+                        yield Err(error.into());
+                        break;
+                    }
+                };
+
+                match decode_multipart(frames, &expected_topic) {
+                    Ok(message) => yield Ok(ZmqWireMessage {
+                        publisher_id: message.publisher_id,
+                        sequence: message.sequence,
+                        payload: message.payload,
+                    }),
+                    Err(error) => {
+                        tracing::warn!(%error, "Dropping malformed direct-ZMQ message");
+                    }
+                }
+            }
+        };
+
+        Ok(Box::pin(stream))
     }
 
     /// Connect to broker's XPUB endpoint (broker mode)
@@ -289,7 +345,7 @@ impl ZmqSubTransport {
                     break;
                 };
 
-                let mut frames = match result {
+                let frames = match result {
                     Ok(frames) => frames,
                     Err(error) => {
                         tracing::error!(error = %error, "ZMQ receive error in socket pump");
@@ -297,47 +353,14 @@ impl ZmqSubTransport {
                     }
                 };
 
-                if frames.len() != 4 {
-                    tracing::warn!(
-                        frame_count = frames.len(),
-                        "Unexpected multipart frame count in socket pump"
-                    );
-                    continue;
-                }
-
-                let publisher_id_bytes = &frames[1];
-                if publisher_id_bytes.len() != 8 {
-                    tracing::warn!(
-                        actual = publisher_id_bytes.len(),
-                        "Invalid publisher_id frame in socket pump"
-                    );
-                    continue;
-                }
-                let publisher_id = u64::from_be_bytes(publisher_id_bytes[..].try_into().unwrap());
-
-                let sequence_bytes = &frames[2];
-                if sequence_bytes.len() != 8 {
-                    tracing::warn!(
-                        actual = sequence_bytes.len(),
-                        "Invalid sequence frame in socket pump"
-                    );
-                    continue;
-                }
-                let sequence = u64::from_be_bytes(sequence_bytes[..].try_into().unwrap());
-
-                tracing::trace!(
-                    publisher_id = publisher_id,
-                    sequence = sequence,
-                    "Socket pump received ZMQ message"
-                );
-
-                let Some(frame_message) = frames.pop_back() else {
-                    continue;
-                };
-                let frame_bytes = Bytes::from_owner(ZmqMessageOwner(frame_message));
-                match Frame::decode(frame_bytes) {
-                    Ok(frame) => {
-                        let _ = broadcast_tx.send(frame.payload);
+                match decode_multipart(frames, &[]) {
+                    Ok(message) => {
+                        tracing::trace!(
+                            publisher_id = message.publisher_id,
+                            sequence = message.sequence,
+                            "Socket pump received ZMQ message"
+                        );
+                        let _ = broadcast_tx.send(message.payload);
                     }
                     Err(error) => {
                         tracing::warn!(error = %error, "Failed to decode ZMQ frame in socket pump");
@@ -348,6 +371,52 @@ impl ZmqSubTransport {
             tracing::info!("ZMQ socket pump task terminated");
         })
     }
+}
+
+struct DecodedZmqMessage {
+    publisher_id: u64,
+    sequence: u64,
+    payload: Bytes,
+}
+
+fn decode_multipart(mut frames: Multipart, expected_topic: &[u8]) -> Result<DecodedZmqMessage> {
+    if frames.len() != 4 {
+        anyhow::bail!("unexpected ZMQ multipart frame count: {}", frames.len());
+    }
+
+    if !expected_topic.is_empty() && &frames[0][..] != expected_topic {
+        anyhow::bail!("ZMQ message topic disagrees with the exact subscription topic");
+    }
+
+    let publisher_id_bytes = &frames[1];
+    if publisher_id_bytes.len() != 8 {
+        anyhow::bail!(
+            "invalid ZMQ publisher ID frame length: {}",
+            publisher_id_bytes.len()
+        );
+    }
+    let publisher_id = u64::from_be_bytes(publisher_id_bytes[..].try_into().unwrap());
+
+    let sequence_bytes = &frames[2];
+    if sequence_bytes.len() != 8 {
+        anyhow::bail!(
+            "invalid ZMQ sequence frame length: {}",
+            sequence_bytes.len()
+        );
+    }
+    let sequence = u64::from_be_bytes(sequence_bytes[..].try_into().unwrap());
+
+    let frame_message = frames
+        .pop_back()
+        .ok_or_else(|| anyhow!("ZMQ multipart message has no payload frame"))?;
+    let frame_bytes = Bytes::from_owner(ZmqMessageOwner(frame_message));
+    let frame = Frame::decode(frame_bytes)?;
+
+    Ok(DecodedZmqMessage {
+        publisher_id,
+        sequence,
+        payload: frame.payload,
+    })
 }
 
 #[async_trait]
@@ -478,6 +547,80 @@ mod tests {
         assert_eq!(decoded.publisher_id, 12345);
         assert_eq!(decoded.sequence, 1);
         assert_eq!(decoded.topic, topic);
+    }
+
+    #[tokio::test]
+    async fn single_consumer_preserves_wire_identity_and_exact_topic() {
+        let endpoint = format!("inproc://dynamo-zmq-single-consumer-{}", std::process::id());
+        let topic = "single-consumer";
+        let (publisher, _) = ZmqPubTransport::bind(&endpoint, topic).await.unwrap();
+        let mut stream = ZmqSubTransport::connect_single_consumer(&endpoint, topic)
+            .await
+            .unwrap();
+        let codec = MsgpackCodec;
+        let anchor = EventEnvelope {
+            publisher_id: 41,
+            sequence: 1,
+            published_at: 1,
+            topic: topic.to_string(),
+            payload: Bytes::from_static(b"anchor"),
+        };
+        let anchor_bytes = codec.encode_envelope(&anchor).unwrap();
+
+        let wire = timeout(Duration::from_secs(2), async {
+            loop {
+                publisher
+                    .publish(topic, anchor_bytes.clone())
+                    .await
+                    .unwrap();
+                if let Ok(Some(Ok(message))) =
+                    timeout(Duration::from_millis(25), stream.next()).await
+                {
+                    break message;
+                }
+            }
+        })
+        .await
+        .expect("single-consumer socket should become ready");
+        assert_eq!(wire.publisher_id, anchor.publisher_id);
+        assert_eq!(wire.sequence, anchor.sequence);
+        assert_eq!(
+            codec.decode_envelope(&wire.payload).unwrap().payload,
+            anchor.payload
+        );
+
+        let sentinel = EventEnvelope {
+            publisher_id: 41,
+            sequence: 2,
+            published_at: 2,
+            topic: topic.to_string(),
+            payload: Bytes::from_static(b"sentinel"),
+        };
+        let sentinel_bytes = codec.encode_envelope(&sentinel).unwrap();
+        let framed = Frame::new(sentinel_bytes.clone()).encode().to_vec();
+        send_raw(
+            &publisher,
+            vec![
+                format!("{topic}-prefix-collision").into_bytes(),
+                sentinel.publisher_id.to_be_bytes().to_vec(),
+                sentinel.sequence.to_be_bytes().to_vec(),
+                framed,
+            ],
+        )
+        .await;
+        publisher.publish(topic, sentinel_bytes).await.unwrap();
+
+        let wire = timeout(Duration::from_secs(2), stream.next())
+            .await
+            .expect("valid event should follow an exact-topic rejection")
+            .expect("single-consumer stream should remain open")
+            .expect("valid event should decode");
+        assert_eq!(wire.publisher_id, sentinel.publisher_id);
+        assert_eq!(wire.sequence, sentinel.sequence);
+        assert_eq!(
+            codec.decode_envelope(&wire.payload).unwrap().payload,
+            sentinel.payload
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Deliver direct-ZMQ KV events through one FIFO task per publisher on the application Tokio runtime, allowing different publishers to enter `WorkerQueryClient` concurrently.
- Add a true single-consumer ZMQ stream that retains native subject filtering, frame validation, `Codec` decoding, and the 100k receive HWM while bypassing the lossy 1,024-entry broadcast hop.
- Preserve membership fencing, recovery mutex and sequence validation, flume/CRTC admission, per-source reconnect/replacement, deterministic shutdown, and lifecycle/error metrics.
- Leave NATS, brokered ZMQ, generic subscribers, and request-plane TCP unchanged.

This is the transport and lifecycle base for #11899. The dedicated ingress runtime and `DYN_ROUTER_ZMQ_INGRESS_THREADS` tuning/rollback are intentionally separated into stacked PR #11925.

Reviewer guide: `direct_zmq.rs` and `worker_query.rs` contain the source lifecycle and live-ingestion semantics; `zmq_transport.rs` contains the single-consumer transport primitive; `subscriber.rs` selects direct ZMQ and runs it on the application runtime.

## Validation

- Same Mooncake corpus: current aggregation **555k events/s**; direct delivery on the application runtime **963k events/s** (**1.73x**).
- Constrained runs with four CRTC workers retained **1.54x / 2.02x / 2.12x** aggregate throughput at 4 / 8 / 16 CPUs respectively.
- The broader RCA completed 310 valid runs with exact issued/decoded/handled/applied accounting and zero ordering errors; receive/decode sustained roughly 1.7-1.9M events/s, locating the remaining saturation downstream in CRTC rather than this transport path.
- Two-node live-mocker coexistence measured 560.83 ms request p99 for direct-on-main versus 560.94 ms for aggregation, with exact event accounting.
- `cargo test -p dynamo-llm --no-default-features direct_zmq_multi_node_replacement_isolated_by_global_rank` (1 passed)
- `cargo test -p dynamo-llm --no-default-features kv_router::indexer::recovery::subscriber::tests --lib` (1 passed)
- `cargo test -p dynamo-runtime direct_zmq_topology_selection_is_narrow --lib` (1 passed)
- The combined stack previously passed `cargo test -p dynamo-llm --no-default-features`; formatting, DCO hooks, and `git diff --check` pass on this split.

<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11938" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added direct ZMQ event ingestion for faster, single-consumer processing of live updates.
  * Added lifecycle monitoring for ingestion sources, batches, and transitions.
* **Bug Fixes**
  * Improved handling of publisher changes, disconnects, stale connections, and malformed or mismatched messages.
  * Ensured event-processing metrics reset correctly after shutdown.
* **Reliability**
  * Added graceful cancellation and cleanup for background event processing.
  * Improved reconnection behavior with controlled retry backoff.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->