### PR TITLE
fix(recipes): use public GLM-5.2 SGLang image

### DIFF
--- a/recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml
@@ -72,7 +72,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -125,7 +125,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:

--- a/recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml
@@ -65,7 +65,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -122,7 +122,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:

--- a/recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml
@@ -115,7 +115,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -170,7 +170,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:
@@ -275,7 +275,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:

--- a/recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -182,7 +182,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:
@@ -300,7 +300,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:


### PR DESCRIPTION
## Overview

Updates the GLM-5.2 SGLang recipes to use the public NGC registry instead of `nvstaging`, so external users can deploy the `v1.3.0-glm-5.2-dev.1` image without internal registry access.

## Details

- Replaces all 10 occurrences of:
  - `nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1`
  - with `nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1`
- Covers aggregated and disaggregated B200/H200 profiles.
- Makes no other recipe changes.

## Validation

- Confirmed zero old `nvstaging` references remain under `recipes/glm-5.2/sglang`.
- Confirmed exactly 10 public-registry references are present.
- `git diff --check` passes.
- YAML files have no IDE diagnostics.
- Public registry manifest was not queried locally because Docker is unavailable in this environment; image promotion should be confirmed before merge/release publication.

## Where should reviewer start?

Review any one image-line change, for example `recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml`; all other changes are identical registry substitutions.

## Related Issues

Follow-up to #11926 and its release-branch cherry-pick #11937.
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11939" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated SGLang runtime container images for GLM-5.2 agentic deployments to use the production NVIDIA registry.
  * Applied the image update across frontend, aggregation, prefill, and decode components for B200 and H200 configurations.
  * No deployment settings, versions, or runtime behavior were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->