### PR TITLE
fix(recipes): cherry-pick public GLM-5.2 image (#11939)

### DIFF
--- a/recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/agg-b200-agentic/deploy.yaml
@@ -72,7 +72,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -125,7 +125,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:

--- a/recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/agg-h200-agentic/deploy.yaml
@@ -65,7 +65,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -122,7 +122,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:

--- a/recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/disagg-b200-agentic/deploy.yaml
@@ -115,7 +115,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -170,7 +170,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:
@@ -275,7 +275,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:

--- a/recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml
+++ b/recipes/glm-5.2/sglang/disagg-h200-agentic/deploy.yaml
@@ -123,7 +123,7 @@ spec:
                       fieldPath: metadata.uid
                 - name: DYN_ROUTER_MODE
                   value: kv
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources: {}
       replicas: 1
@@ -182,7 +182,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:
@@ -300,7 +300,7 @@ spec:
               envFrom:
                 - secretRef:
                     name: hf-token-secret
-              image: nvcr.io/nvstaging/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
+              image: nvcr.io/nvidia/ai-dynamo/sglang-runtime:1.3.0-glm-5.2-dev.1
               imagePullPolicy: Always
               resources:
                 requests:


### PR DESCRIPTION
## Summary

Cherry-picks the merged #11939 commit (`9ab57d7ecefdd2a2af2e2a2c889724a157457cd6`) onto `release/1.3.0-glm-5.2-dev.1`.

- Updates all four GLM-5.2 SGLang deployment profiles from `nvcr.io/nvstaging` to the public `nvcr.io/nvidia` registry
- Preserves the release image tag `1.3.0-glm-5.2-dev.1`
- Uses a signed-off cherry-pick commit

## Verification

- [x] All four changed recipe files are byte-identical to `main`
- [x] No matching `nvstaging` image references remain
- [x] Ten public `nvcr.io/nvidia` image references are present
- [x] `git diff --check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://nvidia.devinenterprise.com/review/ai-dynamo/dynamo/pull/11940" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->