### PR TITLE
fix(backends): reject unsupported multimodal UUIDs Part 2

### DIFF
--- a/components/src/dynamo/common/multimodal/cache_uuid.py
+++ b/components/src/dynamo/common/multimodal/cache_uuid.py
@@ -10,7 +10,7 @@ def reject_unsupported_multimodal_uuids(multi_modal_uuids: object) -> None:
     if multi_modal_uuids is None:
         return
 
-    unsupported = "Image UUID caching is supported only by the vLLM backend"
+    unsupported = "Cache UUIDs are supported only by the vLLM backend"
     if not isinstance(multi_modal_uuids, Mapping):
         raise ValueError(unsupported)
 

--- a/components/src/dynamo/common/multimodal/cache_uuid.py
+++ b/components/src/dynamo/common/multimodal/cache_uuid.py
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend capability guard for client-provided multimodal cache UUIDs."""
+
+from collections.abc import Mapping, Sequence
+
+
+def reject_unsupported_multimodal_uuids(
+    multi_modal_uuids: Mapping[str, Sequence[str | None]] | None,
+    *,
+    backend: str,
+) -> None:
+    if not multi_modal_uuids or not any(
+        uuid is not None for uuids in multi_modal_uuids.values() for uuid in uuids
+    ):
+        return
+
+    raise ValueError(
+        "Image UUID caching is supported only by the vLLM "
+        f"backend; {backend} does not support the `uuid` field"
+    )

--- a/components/src/dynamo/common/multimodal/cache_uuid.py
+++ b/components/src/dynamo/common/multimodal/cache_uuid.py
@@ -6,17 +6,16 @@
 from collections.abc import Mapping, Sequence
 
 
-def reject_unsupported_multimodal_uuids(
-    multi_modal_uuids: Mapping[str, Sequence[str | None]] | None,
-    *,
-    backend: str,
-) -> None:
-    if not multi_modal_uuids or not any(
-        uuid is not None for uuids in multi_modal_uuids.values() for uuid in uuids
-    ):
+def reject_unsupported_multimodal_uuids(multi_modal_uuids: object) -> None:
+    if multi_modal_uuids is None:
         return
 
-    raise ValueError(
-        "Image UUID caching is supported only by the vLLM "
-        f"backend; {backend} does not support the `uuid` field"
-    )
+    unsupported = "Image UUID caching is supported only by the vLLM backend"
+    if not isinstance(multi_modal_uuids, Mapping):
+        raise ValueError(unsupported)
+
+    for uuids in multi_modal_uuids.values():
+        if not isinstance(uuids, Sequence) or isinstance(uuids, (str, bytes)):
+            raise ValueError(unsupported)
+        if any(uuid is not None for uuid in uuids):
+            raise ValueError(unsupported)

--- a/components/src/dynamo/common/tests/multimodal/test_cache_uuid.py
+++ b/components/src/dynamo/common/tests/multimodal/test_cache_uuid.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from dynamo.common.multimodal.cache_uuid import (
+    reject_unsupported_multimodal_uuids,
+)
+
+pytestmark = [
+    pytest.mark.unit,
+    pytest.mark.gpu_0,
+    pytest.mark.pre_merge,
+]
+
+
+@pytest.mark.parametrize(
+    "multi_modal_uuids",
+    [
+        None,
+        {},
+        {"image_url": [None, None]},
+        {"image_url": [None], "video_url": [None]},
+    ],
+)
+def test_allows_requests_without_cache_uuids(multi_modal_uuids) -> None:
+    reject_unsupported_multimodal_uuids(
+        multi_modal_uuids,
+        backend="test backend",
+    )
+
+
+def test_rejects_request_with_cache_uuid() -> None:
+    with pytest.raises(
+        ValueError,
+        match="supported only by the vLLM backend",
+    ):
+        reject_unsupported_multimodal_uuids(
+            {"image_url": [None, "cached-image"]},
+            backend="test backend",
+        )

--- a/components/src/dynamo/common/tests/multimodal/test_cache_uuid.py
+++ b/components/src/dynamo/common/tests/multimodal/test_cache_uuid.py
@@ -3,9 +3,7 @@
 
 import pytest
 
-from dynamo.common.multimodal.cache_uuid import (
-    reject_unsupported_multimodal_uuids,
-)
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 
 pytestmark = [
     pytest.mark.unit,
@@ -23,11 +21,8 @@ pytestmark = [
         {"image_url": [None], "video_url": [None]},
     ],
 )
-def test_allows_requests_without_cache_uuids(multi_modal_uuids) -> None:
-    reject_unsupported_multimodal_uuids(
-        multi_modal_uuids,
-        backend="test backend",
-    )
+def test_allows_requests_without_cache_uuids(multi_modal_uuids: object) -> None:
+    reject_unsupported_multimodal_uuids(multi_modal_uuids)
 
 
 def test_rejects_request_with_cache_uuid() -> None:
@@ -35,7 +30,22 @@ def test_rejects_request_with_cache_uuid() -> None:
         ValueError,
         match="supported only by the vLLM backend",
     ):
-        reject_unsupported_multimodal_uuids(
-            {"image_url": [None, "cached-image"]},
-            backend="test backend",
-        )
+        reject_unsupported_multimodal_uuids({"image_url": [None, "cached-image"]})
+
+
+@pytest.mark.parametrize(
+    "multi_modal_uuids",
+    [
+        [],
+        "cached-image",
+        {"image_url": None},
+        {"image_url": "cached-image"},
+        {"image_url": 123},
+    ],
+)
+def test_rejects_malformed_cache_uuid_metadata(multi_modal_uuids: object) -> None:
+    with pytest.raises(
+        ValueError,
+        match="supported only by the vLLM backend",
+    ):
+        reject_unsupported_multimodal_uuids(multi_modal_uuids)

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -9,6 +9,8 @@ token layout the transferred KV depends on.
 import logging
 from typing import Any, Dict, Optional
 
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
+
 logger = logging.getLogger(__name__)
 
 IMAGE_URL_KEY = "image_url"
@@ -52,8 +54,11 @@ def _raw_multimodal_content_types(request: Dict[str, Any]) -> set[str]:
 
 
 def raise_if_unextracted_multimodal(request: Dict[str, Any]) -> None:
-    """Reject raw multimodal messages that were not extracted by the frontend."""
+    """Reject unsupported UUIDs or media not extracted by the frontend."""
 
+    reject_unsupported_multimodal_uuids(
+        request.get("multi_modal_uuids"), backend="SGLang"
+    )
     mm_data = _multi_modal_data(request)
     raw_types = _raw_multimodal_content_types(request)
     if not (mm_data or raw_types):

--- a/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py
@@ -56,9 +56,7 @@ def _raw_multimodal_content_types(request: Dict[str, Any]) -> set[str]:
 def raise_if_unextracted_multimodal(request: Dict[str, Any]) -> None:
     """Reject unsupported UUIDs or media not extracted by the frontend."""
 
-    reject_unsupported_multimodal_uuids(
-        request.get("multi_modal_uuids"), backend="SGLang"
-    )
+    reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
     mm_data = _multi_modal_data(request)
     raw_types = _raw_multimodal_content_types(request)
     if not (mm_data or raw_types):

--- a/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py
@@ -137,6 +137,7 @@ class PrefillWorkerHandler(BaseWorkerHandler):
 
         # Prefill encodes the media so the KV it transfers carries the vision
         # context; decode extracts the same URLs to match the token layout.
+        raise_if_unextracted_multimodal(inner_request)
         mm_kwargs = build_disagg_mm_kwargs(inner_request)
 
         routing = inner_request.get("routing") or {}
@@ -153,8 +154,6 @@ class PrefillWorkerHandler(BaseWorkerHandler):
             logging.debug(
                 f"Prefill request {context.id()} will use LoRA adapter: {lora_path}"
             )
-
-        raise_if_unextracted_multimodal(inner_request)
 
         results = await self.engine.async_generate(
             **input_param,

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -439,9 +439,7 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         Returns:
             Tuple of (image_urls, video_urls) lists.
         """
-        reject_unsupported_multimodal_uuids(
-            request.get("multi_modal_uuids"), backend="SGLang"
-        )
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
         mm_data = request.get("multi_modal_data")
         if not mm_data:
             raise ValueError("multi_modal_data is required for the encode worker.")

--- a/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
+++ b/components/src/dynamo/sglang/request_handlers/multimodal/encode_worker_handler.py
@@ -25,6 +25,7 @@ from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
 from dynamo.common.multimodal import EMBEDDING_SENDER_FACTORIES
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 from dynamo.common.utils import nvtx_utils as _nvtx
 from dynamo.llm import MultimodalEmbeddingCachePublisher
 from dynamo.sglang.args import Config
@@ -432,9 +433,15 @@ class MultimodalEncodeWorkerHandler(BaseWorkerHandler[SglangMultimodalRequest, s
         The Rust frontend populates multi_modal_data with the format:
             {"image_url": [{"Url": "https://..."}, ...], "video_url": [{"Url": "https://..."}, ...]}
 
+        Multimodal cache UUIDs are rejected before URL extraction because
+        SGLang cannot resolve payload-free media slots.
+
         Returns:
             Tuple of (image_urls, video_urls) lists.
         """
+        reject_unsupported_multimodal_uuids(
+            request.get("multi_modal_uuids"), backend="SGLang"
+        )
         mm_data = request.get("multi_modal_data")
         if not mm_data:
             raise ValueError("multi_modal_data is required for the encode worker.")

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -20,6 +20,7 @@ from dynamo.sglang.request_handlers.llm.mm_disagg_utils import (
     extract_media_urls,
     raise_if_unextracted_multimodal,
 )
+from dynamo.sglang.request_handlers.llm.prefill_handler import PrefillWorkerHandler
 from dynamo.sglang.request_handlers.multimodal.worker_handler import StreamProcessor
 
 pytestmark = [
@@ -68,6 +69,29 @@ def test_build_disagg_mm_kwargs_includes_audio_urls():
         "audio_data": ["https://example.com/audio.wav"],
         "video_data": ["https://example.com/video.mp4"],
     }
+
+
+@pytest.mark.asyncio
+@pytest.mark.multimodal
+async def test_prefill_rejects_cache_uuid_before_building_media_kwargs():
+    handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
+    handler.bootstrap_host = "127.0.0.1"
+    handler.bootstrap_port = 1234
+    handler._generate_bootstrap_room = lambda: "room"
+    handler._get_input_param = lambda request: {}
+    context = SimpleNamespace(
+        id=lambda: "request-id",
+        trace_id="trace-id",
+    )
+    request = {
+        "token_ids": [1, 2, 3],
+        "multi_modal_data": {"image_url": [{"UuidOnly": "cached-image"}]},
+        "multi_modal_uuids": {"image_url": ["cached-image"]},
+    }
+
+    with pytest.raises(ValueError, match="supported only by the vLLM backend"):
+        async for _ in handler.generate(request, context):
+            pass
 
 
 def test_extract_media_urls_returns_none_for_missing_modality():
@@ -353,6 +377,16 @@ class TestMultimodalGuard:
 
     def test_text_only_request_bypasses_guard(self):
         raise_if_unextracted_multimodal({"token_ids": [10, 20, 30]})
+
+    @pytest.mark.multimodal
+    def test_rejects_multimodal_cache_uuid(self):
+        with pytest.raises(ValueError, match="supported only by the vLLM backend"):
+            raise_if_unextracted_multimodal(
+                {
+                    "token_ids": [10, 20, 30],
+                    "multi_modal_uuids": {"image_url": ["cached-image"]},
+                }
+            )
 
 
 def test_build_logprob_kwargs_allows_chosen_token_logprobs(monkeypatch):

--- a/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_decode_handler.py
@@ -73,7 +73,21 @@ def test_build_disagg_mm_kwargs_includes_audio_urls():
 
 @pytest.mark.asyncio
 @pytest.mark.multimodal
-async def test_prefill_rejects_cache_uuid_before_building_media_kwargs():
+async def test_prefill_rejects_cache_uuid_before_building_media_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    build_media_kwargs_called = False
+
+    def record_build_media_kwargs(_request):
+        nonlocal build_media_kwargs_called
+        build_media_kwargs_called = True
+        return {}
+
+    monkeypatch.setattr(
+        "dynamo.sglang.request_handlers.llm.prefill_handler.build_disagg_mm_kwargs",
+        record_build_media_kwargs,
+    )
+
     handler = PrefillWorkerHandler.__new__(PrefillWorkerHandler)
     handler.bootstrap_host = "127.0.0.1"
     handler.bootstrap_port = 1234
@@ -92,6 +106,8 @@ async def test_prefill_rejects_cache_uuid_before_building_media_kwargs():
     with pytest.raises(ValueError, match="supported only by the vLLM backend"):
         async for _ in handler.generate(request, context):
             pass
+
+    assert not build_media_kwargs_called
 
 
 def test_extract_media_urls_returns_none_for_missing_modality():

--- a/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
+++ b/components/src/dynamo/sglang/tests/test_sglang_multimodal_video.py
@@ -65,6 +65,18 @@ def test_extract_media_urls_supports_mixed_image_and_video():
     assert video_urls == ["https://example.com/clip.mp4"]
 
 
+@pytest.mark.multimodal
+def test_extract_media_urls_rejects_multimodal_cache_uuid():
+    handler = MultimodalEncodeWorkerHandler.__new__(MultimodalEncodeWorkerHandler)
+
+    with pytest.raises(ValueError, match="supported only by the vLLM backend"):
+        handler._extract_media_urls(
+            {
+                "multi_modal_uuids": {"image_url": ["cached-image"]},
+            }
+        )
+
+
 @pytest.mark.asyncio
 async def test_build_mm_items_routes_video_to_video_data():
     embeddings = torch.arange(24, dtype=torch.float16).reshape(6, 4)

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -13,6 +13,7 @@ from dynamo._core import Context
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
 from dynamo.trtllm.request_handlers.handler_base import (
     HandlerBase,
@@ -40,6 +41,11 @@ class AggregatedHandler(HandlerBase):
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:
         """Generate response, optionally using remote encoder for multimodal."""
+        # Reject before optional remote encoder/cache work. HandlerBase keeps a
+        # second guard as a backstop for paths without these early side effects.
+        reject_unsupported_multimodal_uuids(
+            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
+        )
         logging.debug(f"AggregatedHandler Request ID: {context.id()}")
 
         embeddings: Optional[Union[torch.Tensor, dict]] = None

--- a/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
+++ b/components/src/dynamo/trtllm/request_handlers/aggregated_handler.py
@@ -43,9 +43,7 @@ class AggregatedHandler(HandlerBase):
         """Generate response, optionally using remote encoder for multimodal."""
         # Reject before optional remote encoder/cache work. HandlerBase keeps a
         # second guard as a backstop for paths without these early side effects.
-        reject_unsupported_multimodal_uuids(
-            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
-        )
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
         logging.debug(f"AggregatedHandler Request ID: {context.id()}")
 
         embeddings: Optional[Union[torch.Tensor, dict]] = None

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -37,6 +37,7 @@ from dynamo._core import Client, Context
 from dynamo.common.backend import logprobs as _shared_logprobs
 from dynamo.common.backend.engine import is_generation_stage
 from dynamo.common.constants import DisaggregationMode as CommonDisaggregationMode
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 from dynamo.common.utils.structural_tag import serialize_structural_tag
 from dynamo.health_check import HEALTH_CHECK_KEY
 from dynamo.llm.exceptions import EngineShutdown
@@ -790,6 +791,10 @@ class HandlerBase(BaseGenerativeHandler):
         Returns:
             Processed input for TRT-LLM (dict with prompt/token_ids, or raw token_ids)
         """
+        reject_unsupported_multimodal_uuids(
+            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
+        )
+
         # DECODE mode: Use prefill metadata to skip re-processing multimodal content
         # Per TRT-LLM team: DECODE never needs to reload images - KV cache has the context
         has_prefill_metadata = epd_metadata and (

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -791,9 +791,7 @@ class HandlerBase(BaseGenerativeHandler):
         Returns:
             Processed input for TRT-LLM (dict with prompt/token_ids, or raw token_ids)
         """
-        reject_unsupported_multimodal_uuids(
-            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
-        )
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
 
         # DECODE mode: Use prefill metadata to skip re-processing multimodal content
         # Per TRT-LLM team: DECODE never needs to reload images - KV cache has the context

--- a/components/src/dynamo/trtllm/request_handlers/handler_base.py
+++ b/components/src/dynamo/trtllm/request_handlers/handler_base.py
@@ -791,8 +791,6 @@ class HandlerBase(BaseGenerativeHandler):
         Returns:
             Processed input for TRT-LLM (dict with prompt/token_ids, or raw token_ids)
         """
-        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
-
         # DECODE mode: Use prefill metadata to skip re-processing multimodal content
         # Per TRT-LLM team: DECODE never needs to reload images - KV cache has the context
         has_prefill_metadata = epd_metadata and (
@@ -957,6 +955,8 @@ class HandlerBase(BaseGenerativeHandler):
             embeddings: Optional tensor or dict containing embeddings for multimodal processing
             ep_disaggregated_params: Optional DisaggregatedParams from encode worker (full EPD flow)
         """
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
+
         request_token_ids = request.get("token_ids")
         logging.debug(
             "Request summary: token_ids=%s keys=%s has_embeddings=%s has_ep_disaggregated_params=%s",

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -9,6 +9,7 @@ from dynamo._core import Context
 from dynamo.common.memory.multimodal_embedding_cache_manager import (
     MultimodalEmbeddingCacheManager,
 )
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 from dynamo.runtime.logging import configure_dynamo_logging
 from dynamo.trtllm.encode_helper import EncodeHelper
 from dynamo.trtllm.multimodal.embedding_fetcher import fetch_embeddings_from_encoder
@@ -69,6 +70,10 @@ class EncodeHandler(HandlerBase):
     async def generate(
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:
+        # EncodeHelper bypasses HandlerBase input preparation.
+        reject_unsupported_multimodal_uuids(
+            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
+        )
         logging.debug(f"New Request ID: {context.id()}")
         if self.multimodal_processor is None:
             logging.error("encode handler: no multimodal_processor configured")
@@ -136,6 +141,11 @@ class PrefillHandler(HandlerBase):
         Prefill worker: process prompt and return disaggregated_params.
         Frontend routes to decode workers automatically.
         """
+        # Reject before optional remote encoder/cache work. HandlerBase keeps a
+        # second guard as a backstop for paths without these early side effects.
+        reject_unsupported_multimodal_uuids(
+            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
+        )
         logging.debug(f"Prefill Request ID: {context.id()}")
         request_token_ids = request.get("token_ids")
         logging.debug(

--- a/components/src/dynamo/trtllm/request_handlers/handlers.py
+++ b/components/src/dynamo/trtllm/request_handlers/handlers.py
@@ -71,9 +71,7 @@ class EncodeHandler(HandlerBase):
         self, request: dict, context: Context
     ) -> AsyncGenerator[dict, None]:
         # EncodeHelper bypasses HandlerBase input preparation.
-        reject_unsupported_multimodal_uuids(
-            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
-        )
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
         logging.debug(f"New Request ID: {context.id()}")
         if self.multimodal_processor is None:
             logging.error("encode handler: no multimodal_processor configured")
@@ -143,9 +141,7 @@ class PrefillHandler(HandlerBase):
         """
         # Reject before optional remote encoder/cache work. HandlerBase keeps a
         # second guard as a backstop for paths without these early side effects.
-        reject_unsupported_multimodal_uuids(
-            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
-        )
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
         logging.debug(f"Prefill Request ID: {context.id()}")
         request_token_ids = request.get("token_ids")
         logging.debug(

--- a/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_uuid_guard.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_uuid_guard.py
@@ -14,10 +14,7 @@ if not torch.cuda.is_available():
 
 from dynamo.trtllm.request_handlers.aggregated_handler import AggregatedHandler
 from dynamo.trtllm.request_handlers.handler_base import HandlerBase
-from dynamo.trtllm.request_handlers.handlers import (
-    EncodeHandler,
-    PrefillHandler,
-)
+from dynamo.trtllm.request_handlers.handlers import EncodeHandler, PrefillHandler
 from dynamo.trtllm.tests.request_handlers.utils import create_mock_context
 from dynamo.trtllm.tests.utils import create_mock_request_handler_config
 

--- a/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_uuid_guard.py
+++ b/components/src/dynamo/trtllm/tests/request_handlers/test_trtllm_uuid_guard.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for rejecting vLLM-only multimodal cache UUIDs."""
+
+import pytest
+import torch
+
+if not torch.cuda.is_available():
+    pytest.skip(
+        "Skipping because TensorRT-LLM imports require a CUDA-capable GPU.",
+        allow_module_level=True,
+    )
+
+from dynamo.trtllm.request_handlers.aggregated_handler import AggregatedHandler
+from dynamo.trtllm.request_handlers.handler_base import HandlerBase
+from dynamo.trtllm.request_handlers.handlers import (
+    EncodeHandler,
+    PrefillHandler,
+)
+from dynamo.trtllm.tests.request_handlers.utils import create_mock_context
+from dynamo.trtllm.tests.utils import create_mock_request_handler_config
+
+pytestmark = [
+    pytest.mark.pre_merge,
+    pytest.mark.unit,
+    pytest.mark.trtllm,
+    pytest.mark.multimodal,
+    pytest.mark.gpu_1,
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("handler_type", "disaggregation_mode"),
+    [
+        (EncodeHandler, "encode"),
+        (PrefillHandler, "prefill"),
+        (AggregatedHandler, "prefill_and_decode"),
+    ],
+)
+async def test_handler_rejects_multimodal_cache_uuid(
+    handler_type: type[HandlerBase], disaggregation_mode: str
+) -> None:
+    config = create_mock_request_handler_config(disaggregation_mode=disaggregation_mode)
+    handler = handler_type(config)
+    request = {"multi_modal_uuids": {"image_url": ["cached-image"]}}
+
+    with pytest.raises(ValueError, match="supported only by the vLLM backend"):
+        async for _ in handler.generate(request, create_mock_context()):
+            pass

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -3,6 +3,7 @@
 
 import asyncio
 import re as re_mod
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any
 from unittest import mock
@@ -543,15 +544,26 @@ class TestMultimodalGuard:
 
     @pytest.mark.asyncio
     @pytest.mark.multimodal
-    async def test_rejects_multimodal_cache_uuid(self):
-        handler = self._make_handler(multimodal_processor=MagicMock())
+    async def test_rejected_cache_uuid_does_not_mutate_request(self):
+        handler = _ConcreteHandler.__new__(_ConcreteHandler)
         request = {
             "token_ids": [1, 2, 3],
             "multi_modal_uuids": {"image_url": ["cached-image"]},
+            "max_tokens": 8,
+            "prefill_result": {
+                "disaggregated_params": {
+                    "worker_id": 7,
+                    "_epd_metadata": {"_prefill_prompt": "describe image"},
+                }
+            },
         }
+        original_request = deepcopy(request)
 
         with pytest.raises(ValueError, match="supported only by the vLLM backend"):
-            await self._prepare(handler, request)
+            async for _ in handler._generate_locally_impl(request, MagicMock()):
+                pass
+
+        assert request == original_request
 
     @pytest.mark.asyncio
     async def test_decode_with_prefill_metadata_bypasses_guard(self):

--- a/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
+++ b/components/src/dynamo/trtllm/tests/test_trtllm_handler_base.py
@@ -542,6 +542,18 @@ class TestMultimodalGuard:
         assert result == [10, 20, 30]
 
     @pytest.mark.asyncio
+    @pytest.mark.multimodal
+    async def test_rejects_multimodal_cache_uuid(self):
+        handler = self._make_handler(multimodal_processor=MagicMock())
+        request = {
+            "token_ids": [1, 2, 3],
+            "multi_modal_uuids": {"image_url": ["cached-image"]},
+        }
+
+        with pytest.raises(ValueError, match="supported only by the vLLM backend"):
+            await self._prepare(handler, request)
+
+    @pytest.mark.asyncio
     async def test_decode_with_prefill_metadata_bypasses_guard(self):
         handler = self._make_handler(multimodal_processor=None)
         handler.disaggregation_mode = DisaggregationMode.DECODE

--- a/examples/backends/trtllm/mm_router_worker/handler.py
+++ b/examples/backends/trtllm/mm_router_worker/handler.py
@@ -8,6 +8,7 @@ MM Router Handler - Routes requests to best TRT-LLM worker based on KV cache ove
 import logging
 from typing import Any, AsyncGenerator
 
+from dynamo.common.multimodal.cache_uuid import reject_unsupported_multimodal_uuids
 from dynamo.llm import KvRouter
 from dynamo.runtime.logging import configure_dynamo_logging
 
@@ -68,6 +69,11 @@ class MMRouterHandler:
         Yields:
             Response chunks from the downstream TRT-LLM worker via KvRouter
         """
+        # Reject before the router downloads media or forwards the request.
+        reject_unsupported_multimodal_uuids(
+            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
+        )
+
         # Extract messages from extra_args (set by Frontend preprocessor)
         messages = request.get("extra_args", {}).get("messages", [])
         image_urls = extract_image_urls(messages)

--- a/examples/backends/trtllm/mm_router_worker/handler.py
+++ b/examples/backends/trtllm/mm_router_worker/handler.py
@@ -70,9 +70,7 @@ class MMRouterHandler:
             Response chunks from the downstream TRT-LLM worker via KvRouter
         """
         # Reject before the router downloads media or forwards the request.
-        reject_unsupported_multimodal_uuids(
-            request.get("multi_modal_uuids"), backend="TensorRT-LLM"
-        )
+        reject_unsupported_multimodal_uuids(request.get("multi_modal_uuids"))
 
         # Extract messages from extra_args (set by Frontend preprocessor)
         messages = request.get("extra_args", {}).get("messages", [])


### PR DESCRIPTION
## Overview:

Explicitly reject client-provided multimodal cache UUIDs in SGLang and TensorRT-LLM instead of silently ignoring them or failing later with backend-specific errors.

This is Part 2 of the UUID passthrough. It depends on #11943 and is intentionally limited to unsupported-backend capability guards.

## Details:

- Add a shared guard that rejects any non-null multimodal UUID while allowing absent or all-null UUID maps.
- Reject UUID requests before SGLang disaggregated prefill preprocessing.
- Guard SGLang decode and multimodal encode paths.
- Guard the relevant TensorRT-LLM aggregated, prefill, encode, and shared generation paths.
- Add coverage for the shared guard and backend entry points.
- Keep vLLM as the only backend supporting cached multimodal UUIDs.

## Where should the reviewer start?
1. `components/src/dynamo/common/multimodal/cache_uuid.py` — shared capability guard.
2. `components/src/dynamo/sglang/request_handlers/llm/prefill_handler.py` — guard ordering before multimodal preprocessing.
3. `components/src/dynamo/sglang/request_handlers/llm/mm_disagg_utils.py` — SGLang request validation.
4. `components/src/dynamo/trtllm/request_handlers/handler_base.py` — shared TensorRT-LLM backstop.
5. `components/src/dynamo/trtllm/request_handlers/handlers.py` — entry points that require earlier rejection.

## Related Issues
- Depends on #11943


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added validation to reject malformed or unsupported multimodal cache UUIDs.
  - Requests using image cache UUIDs with non-vLLM backends now fail early with a clear error message.
  - Validation occurs before media extraction, routing, encoding, or generation work begins.

- **Tests**
  - Added coverage for valid, malformed, and unsupported multimodal cache UUID requests across supported request-handling paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->