### PR TITLE
feat(multimodal): native Rust video token expansion for MM-aware KV routing

### DIFF
--- a/components/src/dynamo/vllm/main.py
+++ b/components/src/dynamo/vllm/main.py
@@ -294,23 +294,30 @@ def setup_metrics_collection(
             )
 
 
-def _resolve_image_token_id(config: Config, vllm_config: VllmConfig) -> Optional[int]:
-    """Routing-side image-placeholder token id for the served model.
+def _resolve_routing_token_ids(
+    config: Config, vllm_config: VllmConfig
+) -> tuple[Optional[int], Optional[int]]:
+    """Routing-side (image, video) placeholder token ids for the served model.
 
     Resolved via the SAME Rust logic the frontend uses
-    (`dynamo._core.resolve_routing_image_token_id` ->
-    `lightseek_mm::resolve_routing_tokens`), returning `chat_placeholder_token_id`
-    so the KV-event normalizer keys on the identical token the frontend
+    (`dynamo._core.resolve_routing_image_token_id` /
+    `resolve_routing_video_token_id` -> `lightseek_mm::resolve_routing_tokens`)
+    so the KV-event normalizer keys on the identical tokens the frontend
     substitutes `pad_value` over — no per-family drift between the two.
 
-    Returns None when the bindings lack the `mm-routing` feature or the model
-    isn't in the MM-routing registry — in both cases the frontend also skips MM
-    routing, so a worker-side no-op is consistent (events pass through).
+    Returns (None, None) when the bindings lack the `mm-routing` feature or
+    the model isn't in the MM-routing registry — in both cases the frontend
+    also skips MM routing, so a worker-side no-op is consistent (events pass
+    through).
     """
     try:
         from dynamo._core import resolve_routing_image_token_id
     except ImportError:
-        return None
+        return None, None
+    try:
+        from dynamo._core import resolve_routing_video_token_id
+    except ImportError:
+        resolve_routing_video_token_id = None
 
     # `model_config.model` is the user-supplied `--model` argument verbatim, so
     # for HF ids ("Qwen/Qwen3.5-0.8B") it points nowhere on disk. Resolve via
@@ -337,7 +344,13 @@ def _resolve_image_token_id(config: Config, vllm_config: VllmConfig) -> Optional
             vllm_config.model_config.model,
         )
         model_dir = vllm_config.model_config.model
-    return resolve_routing_image_token_id(config.model, model_dir)
+    image_token_id = resolve_routing_image_token_id(config.model, model_dir)
+    video_token_id = (
+        resolve_routing_video_token_id(config.model, model_dir)
+        if resolve_routing_video_token_id is not None
+        else None
+    )
+    return image_token_id, video_token_id
 
 
 def setup_kv_event_publisher(
@@ -384,12 +397,13 @@ def setup_kv_event_publisher(
     dp_start, dp_size = get_dp_range_for_worker(vllm_config)
     kv_publishers = []
     kv_event_block_size = get_configured_kv_event_block_size(vllm_config)
-    # The image-placeholder token id the frontend substitutes pad_value over.
-    # Passed to the KV publisher so the router-side normalizer rewrites those
-    # runs in vLLM BlockStored events to the same canonical pad_value scheme.
-    # None (no mm-routing, model not in registry, text-only) leaves events
-    # unchanged — consistent with the frontend also skipping MM routing.
-    image_token_id = _resolve_image_token_id(config, vllm_config)
+    # The image/video placeholder token ids the frontend substitutes
+    # pad_value over. Passed to the KV publisher so the router-side normalizer
+    # rewrites those runs in vLLM BlockStored events to the same canonical
+    # pad_value scheme. None (no mm-routing, model not in registry, text-only)
+    # leaves events unchanged — consistent with the frontend also skipping MM
+    # routing.
+    image_token_id, video_token_id = _resolve_routing_token_ids(config, vllm_config)
 
     for dp_rank in range(dp_start, dp_start + dp_size):
         if consolidator_enabled:
@@ -416,6 +430,7 @@ def setup_kv_event_publisher(
             enable_local_indexer=config.enable_local_indexer,
             dp_rank=dp_rank,
             image_token_id=image_token_id,
+            video_token_id=video_token_id,
         )
         kv_publishers.append(kv_publisher)
 

--- a/lib/backend-common/src/publisher.rs
+++ b/lib/backend-common/src/publisher.rs
@@ -61,6 +61,7 @@ fn setup_kv_publishers(
                     endpoint,
                     topic,
                     image_token_id: None,
+                    video_token_id: None,
                 }),
                 None,
             ),

--- a/lib/bindings/python/rust/lib.rs
+++ b/lib/bindings/python/rust/lib.rs
@@ -169,6 +169,8 @@ fn _core(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(lora_name_to_id, m)?)?;
     #[cfg(feature = "mm-routing")]
     m.add_function(wrap_pyfunction!(resolve_routing_image_token_id, m)?)?;
+    #[cfg(feature = "mm-routing")]
+    m.add_function(wrap_pyfunction!(resolve_routing_video_token_id, m)?)?;
     m.add_function(wrap_pyfunction!(log_message, m)?)?;
     m.add_function(wrap_pyfunction!(register_model, m)?)?;
     m.add_function(wrap_pyfunction!(unregister_model, m)?)?;
@@ -343,6 +345,23 @@ fn resolve_routing_image_token_id(model_id: &str, model_dir: &str) -> Option<u32
     let dir = std::path::Path::new(model_dir);
     llm_rs::preprocessor::lightseek_mm::resolve_routing_tokens(model_id, dir)
         .chat_placeholder_token_id
+}
+
+/// Routing-side video-placeholder token id (`config.json`'s
+/// `video_token_id`), the token the frontend substitutes pad_value over for
+/// video content. Same resolution logic as the frontend
+/// (`lightseek_mm::resolve_routing_tokens`), so the KV-event normalizer and
+/// the router key on the identical token id.
+///
+/// Returns `None` when the config lacks the field or can't be read — the
+/// frontend then also skips video MM routing, so a worker-side no-op is
+/// consistent.
+#[cfg(feature = "mm-routing")]
+#[pyfunction]
+#[pyo3(text_signature = "(model_id, model_dir)")]
+fn resolve_routing_video_token_id(model_id: &str, model_dir: &str) -> Option<u32> {
+    let dir = std::path::Path::new(model_dir);
+    llm_rs::preprocessor::lightseek_mm::resolve_routing_tokens(model_id, dir).video_token_id
 }
 
 /// Create an engine and attach it to an endpoint to make it visible to the frontend.

--- a/lib/bindings/python/rust/llm/kv.rs
+++ b/lib/bindings/python/rust/llm/kv.rs
@@ -908,7 +908,7 @@ impl KvEventPublisher {
     ///         Use ``50`` to allow compatible tails to span lists for up to 50 ms.
     ///         Maximum allowed is 15_000 (15 seconds); larger values are capped.
     #[new]
-    #[pyo3(signature = (endpoint, worker_id=None, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_ms=llm_rs::kv_router::publisher::DEFAULT_BATCHING_TIMEOUT_MS, image_token_id=None))]
+    #[pyo3(signature = (endpoint, worker_id=None, kv_block_size=0, dp_rank=0, enable_local_indexer=false, zmq_endpoint=None, zmq_topic=None, batching_timeout_ms=llm_rs::kv_router::publisher::DEFAULT_BATCHING_TIMEOUT_MS, image_token_id=None, video_token_id=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         endpoint: Endpoint,
@@ -920,11 +920,13 @@ impl KvEventPublisher {
         zmq_topic: Option<String>,
         batching_timeout_ms: Option<u64>,
         image_token_id: Option<u32>,
+        video_token_id: Option<u32>,
     ) -> PyResult<Self> {
         let source_config = zmq_endpoint.map(|ep| KvEventSourceConfig::Zmq {
             endpoint: ep,
             topic: zmq_topic.unwrap_or_default(),
             image_token_id,
+            video_token_id,
         });
 
         if kv_block_size == 0 {
@@ -998,6 +1000,7 @@ impl KvEventPublisher {
                         mm_infos.as_deref(),
                         is_eagle,
                         None, // image_token_id: publish path keeps caller-supplied mm_infos
+                        None, // video_token_id: same
                     ),
                 }),
                 dp_rank,

--- a/lib/bindings/python/src/dynamo/_core.pyi
+++ b/lib/bindings/python/src/dynamo/_core.pyi
@@ -2349,6 +2349,13 @@ async def run_input(runtime: DistributedRuntime, input: str, engine_config: Engi
     """Start an engine, connect it to an input, and run until stopped."""
     ...
 
+
+def resolve_routing_video_token_id(model_id: str, model_dir: str) -> Optional[int]:
+    """Routing-side video-placeholder token id (config.json `video_token_id`).
+
+    Same resolution logic as the frontend; None disables video MM routing.
+    """
+    ...
 def run_mocker_trace_replay(
     trace_files: Sequence[str | os.PathLike[str]],
     extra_engine_args: Optional[MockEngineArgs] = None,

--- a/lib/kv-router/src/zmq_wire/convert.rs
+++ b/lib/kv-router/src/zmq_wire/convert.rs
@@ -21,6 +21,7 @@ pub fn convert_event(
     worker: WorkerWithDpRank,
     warning_count: &Arc<AtomicU32>,
     image_token_id: Option<u32>,
+    video_token_id: Option<u32>,
 ) -> Option<PlacementEvent> {
     let storage_tier = match &raw {
         RawKvEvent::BlockStored { medium, .. } | RawKvEvent::BlockRemoved { medium, .. } => {
@@ -96,6 +97,7 @@ pub fn convert_event(
                         block_mm_infos.as_deref(),
                         is_eagle,
                         image_token_id,
+                        video_token_id,
                     ),
                 }),
                 dp_rank,
@@ -129,25 +131,41 @@ pub fn convert_event(
     ))
 }
 
-/// Rewrite each `image_token_id` run in `token_ids` to `pad_value(mm_hash)`,
-/// one mm_hash per run in order, so the recomputed `tokens_hash` matches the
-/// frontend's pad_value expansion. Exact when images are separated by a
-/// non-image token (true for Qwen2/2.5/3-VL); a run-vs-mm_object count mismatch
-/// (adjacent images, no separator) is logged below rather than silent.
-fn substitute_pad_values(token_ids: &[u32], image_token_id: u32, mm_objects: &[u64]) -> Vec<u32> {
+/// Rewrite each placeholder run (`image_token_id` or `video_token_id`) in
+/// `token_ids` to `pad_value(mm_hash)`, one mm_hash per run in order, so the
+/// recomputed `tokens_hash` matches the frontend's pad_value expansion. A run
+/// is a maximal stretch of one placeholder id; an id change starts a new run.
+/// Exact when each mm object contributes one run to the block (true for
+/// images and Qwen2/2.5-VL video). Qwen3-VL video emits several
+/// `video_token_id` runs per clip (timestamp/vision tokens separate frame
+/// groups); runs beyond the object list clamp to the last object, which is
+/// correct unless a block mixes such tail runs with a later mm object — that
+/// count mismatch is logged below rather than silent. vLLM 0.19+ extra_keys
+/// carry per-object start offsets that would make the assignment exact; use
+/// them here if the clamp ever shows up in practice.
+fn substitute_pad_values(
+    token_ids: &[u32],
+    image_token_id: Option<u32>,
+    video_token_id: Option<u32>,
+    mm_objects: &[u64],
+) -> Vec<u32> {
+    let is_placeholder = |t: u32| Some(t) == image_token_id || Some(t) == video_token_id;
     let mut out = Vec::with_capacity(token_ids.len());
     // `obj_idx` advances once per completed run, so run N fills with
     // mm_objects[N], clamped to the last object if runs outnumber mm_objects.
     let mut obj_idx = 0usize;
-    let mut in_run = false;
+    let mut current_run: Option<u32> = None;
     let mut runs = 0usize;
     // pad_value for the current run, computed once on entry and reused for the
     // rest of the run (one mm_hash per run, so it's constant within a run).
     let mut run_pad = 0u32;
     for &t in token_ids {
-        if t == image_token_id {
-            if !in_run {
-                in_run = true;
+        if is_placeholder(t) {
+            if current_run != Some(t) {
+                if current_run.is_some() {
+                    obj_idx += 1;
+                }
+                current_run = Some(t);
                 runs += 1;
                 // Safety: the sole caller (`create_stored_block_from_parts`)
                 // only reaches here with a non-empty `mm_objects`, so `last()`
@@ -160,8 +178,7 @@ fn substitute_pad_values(token_ids: &[u32], image_token_id: u32, mm_objects: &[u
             }
             out.push(run_pad);
         } else {
-            if in_run {
-                in_run = false;
+            if current_run.take().is_some() {
                 obj_idx += 1;
             }
             out.push(t);
@@ -171,7 +188,7 @@ fn substitute_pad_values(token_ids: &[u32], image_token_id: u32, mm_objects: &[u
         tracing::debug!(
             runs,
             mm_objects = mm_objects.len(),
-            "image_token_id run count != mm_object count; pad_value assignment is best-effort by run order"
+            "placeholder run count != mm_object count; pad_value assignment is best-effort by run order"
         );
     }
     out
@@ -184,6 +201,7 @@ pub struct StoredBlockOptions<'a> {
     pub mm_extra_info: Option<BlockExtraInfo>,
     pub is_eagle: Option<bool>,
     pub image_token_id: Option<u32>,
+    pub video_token_id: Option<u32>,
 }
 
 pub fn create_stored_block_from_parts(
@@ -198,18 +216,21 @@ pub fn create_stored_block_from_parts(
         mm_extra_info,
         is_eagle,
         image_token_id,
+        video_token_id,
     } = options;
 
-    // When the model has a routing image token and this block carries mm
-    // objects (vLLM events), normalize to the canonical pad_value scheme:
-    // substitute pad_value over the image_token_id runs and hash WITHOUT
+    // When the model has a routing image/video token and this block carries
+    // mm objects (vLLM events), normalize to the canonical pad_value scheme:
+    // substitute pad_value over the placeholder runs and hash WITHOUT
     // block_mm_infos, matching the frontend. sglang events carry no
-    // image_token_id tokens nor mm_extra_info, so they take the else branch
+    // placeholder tokens nor mm_extra_info, so they take the else branch
     // unchanged.
-    let tokens_hash = match (image_token_id, mm_extra_info.as_ref()) {
-        (Some(img_tok), Some(info)) if !info.mm_objects.is_empty() => {
+    let has_placeholder_id = image_token_id.is_some() || video_token_id.is_some();
+    let tokens_hash = match mm_extra_info.as_ref() {
+        Some(info) if has_placeholder_id && !info.mm_objects.is_empty() => {
             let mm_hashes: Vec<u64> = info.mm_objects.iter().map(|o| o.mm_hash).collect();
-            let substituted = substitute_pad_values(token_ids, img_tok, &mm_hashes);
+            let substituted =
+                substitute_pad_values(token_ids, image_token_id, video_token_id, &mm_hashes);
             compute_block_hash_for_seq(
                 &substituted,
                 kv_block_size,
@@ -263,6 +284,7 @@ pub fn create_stored_blocks(
     block_mm_infos: Option<&[Option<BlockExtraInfo>]>,
     is_eagle: Option<bool>,
     image_token_id: Option<u32>,
+    video_token_id: Option<u32>,
 ) -> Vec<KvCacheStoredBlockData> {
     let mut blocks: Vec<KvCacheStoredBlockData> = Vec::new();
 
@@ -310,6 +332,7 @@ pub fn create_stored_blocks(
                 mm_extra_info,
                 is_eagle,
                 image_token_id,
+                video_token_id,
             },
         ));
         token_offset += *num_tokens_it as usize;
@@ -363,6 +386,70 @@ mod normalize_tests {
             stored.tokens_hash, expected,
             "normalized vLLM event hash must match frontend pad_value hash"
         );
+    }
+
+    /// A vLLM Qwen3-VL video block interleaves timestamp/vision text tokens
+    /// with several `video_token_id` runs of the SAME clip. All runs must
+    /// normalize to the same pad_value (clamp to the single mm object) so the
+    /// hash matches the frontend's expansion of that structure.
+    #[test]
+    fn vllm_video_multi_run_normalizes_to_frontend_pad_value_hash() {
+        let block_size = 8u32;
+        let video_token_id = 151656u32;
+        let mm_hash = 0x1234_5678_9abc_def0u64;
+        // [ts][vs][pad pad][ve][ts][vs][pad] — two runs, one video.
+        let vllm_tokens = vec![
+            77u32,
+            151652,
+            video_token_id,
+            video_token_id,
+            151653,
+            88,
+            151652,
+            video_token_id,
+        ];
+        let mm_info = BlockExtraInfo {
+            mm_objects: vec![BlockMmObjectInfo {
+                mm_hash,
+                offsets: vec![],
+            }],
+        };
+
+        let stored = create_stored_block_from_parts(
+            block_size,
+            0xabcd,
+            &vllm_tokens,
+            StoredBlockOptions {
+                mm_extra_info: Some(mm_info),
+                image_token_id: Some(151655),
+                video_token_id: Some(video_token_id),
+                ..Default::default()
+            },
+        );
+
+        let pad = pad_value_for_mm_hash(mm_hash);
+        let frontend_tokens = vec![77u32, 151652, pad, pad, 151653, 88, 151652, pad];
+        let expected =
+            compute_block_hash_for_seq(&frontend_tokens, block_size, BlockHashOptions::default())
+                [0];
+        assert_eq!(stored.tokens_hash, expected);
+    }
+
+    /// Adjacent image and video runs (id change, no separator token) are
+    /// distinct runs and consume mm_objects in order.
+    #[test]
+    fn adjacent_image_video_runs_map_to_distinct_objects() {
+        let img = 151655u32;
+        let vid = 151656u32;
+        let (hash_a, hash_b) = (11u64, 22u64);
+        let out = substitute_pad_values(
+            &[1, img, img, vid, 2],
+            Some(img),
+            Some(vid),
+            &[hash_a, hash_b],
+        );
+        let (pad_a, pad_b) = (pad_value_for_mm_hash(hash_a), pad_value_for_mm_hash(hash_b));
+        assert_eq!(out, vec![1, pad_a, pad_a, pad_b, 2]);
     }
 
     /// sglang-style events carry no image_token_id tokens nor mm_extra_info, so

--- a/lib/kv-router/src/zmq_wire/mod.rs
+++ b/lib/kv-router/src/zmq_wire/mod.rs
@@ -45,6 +45,9 @@ pub struct ZmqEventNormalizer {
     /// Lets `convert_event` normalize vLLM BlockStored events to the canonical
     /// pad_value scheme. `None` for text-only models / non-MM deployments.
     image_token_id: Option<u32>,
+    /// Model's video placeholder token id, same role as `image_token_id` for
+    /// video placeholder runs. `None` for models without video MM routing.
+    video_token_id: Option<u32>,
     warning_count: Arc<AtomicU32>,
     group_metadata: FxHashMap<(DpRank, u32), KvCacheGroupMetadata>,
     cache_namespaces: FxHashMap<(WorkerWithDpRank, u64), CacheNamespaceState>,
@@ -90,6 +93,7 @@ impl ZmqEventNormalizer {
         Self {
             kv_block_size,
             image_token_id: None,
+            video_token_id: None,
             warning_count: Arc::new(AtomicU32::new(0)),
             group_metadata: FxHashMap::default(),
             cache_namespaces: FxHashMap::default(),
@@ -100,6 +104,7 @@ impl ZmqEventNormalizer {
         Self {
             kv_block_size,
             image_token_id: None,
+            video_token_id: None,
             warning_count,
             group_metadata: FxHashMap::default(),
             cache_namespaces: FxHashMap::default(),
@@ -111,6 +116,13 @@ impl ZmqEventNormalizer {
     /// models (leave unset).
     pub fn with_image_token_id(mut self, image_token_id: Option<u32>) -> Self {
         self.image_token_id = image_token_id;
+        self
+    }
+
+    /// Set the model's video placeholder token id so vLLM BlockStored events
+    /// with video content get normalized to the canonical pad_value scheme.
+    pub fn with_video_token_id(mut self, video_token_id: Option<u32>) -> Self {
+        self.video_token_id = video_token_id;
         self
     }
 
@@ -151,6 +163,7 @@ impl ZmqEventNormalizer {
             worker,
             &self.warning_count,
             self.image_token_id,
+            self.video_token_id,
         )
     }
 

--- a/lib/kv-router/src/zmq_wire/tests.rs
+++ b/lib/kv-router/src/zmq_wire/tests.rs
@@ -740,6 +740,7 @@ fn test_convert_event_bigram_emits_eagle_windows() {
         WorkerWithDpRank::new(3, 0),
         &warning_count,
         None,
+        None,
     );
 
     match placement_event.unwrap().event.data {
@@ -823,6 +824,7 @@ fn cpu_event_with_placeholder_payload_is_dropped_safely() {
         WorkerWithDpRank::new(7, 0),
         &warning_count,
         None,
+        None,
     )
     .unwrap();
 
@@ -852,6 +854,7 @@ fn cpu_event_with_full_payload_is_indexable() {
         4,
         WorkerWithDpRank::new(7, 0),
         &warning_count,
+        None,
         None,
     )
     .unwrap();

--- a/lib/llm/src/kv_router/publisher/mod.rs
+++ b/lib/llm/src/kv_router/publisher/mod.rs
@@ -79,6 +79,9 @@ pub enum KvEventSourceConfig {
         /// vLLM BlockStored events to the canonical pad_value scheme. `None`
         /// for text-only / non-MM deployments (normalization is a no-op).
         image_token_id: Option<u32>,
+        /// Model video-placeholder token id, same role as `image_token_id`
+        /// for video placeholder runs. `None` disables video normalization.
+        video_token_id: Option<u32>,
     },
 }
 
@@ -103,6 +106,7 @@ impl KvEventSource {
                 endpoint,
                 topic,
                 image_token_id,
+                video_token_id,
             } => {
                 let zmq_handle = component
                     .drt()
@@ -117,6 +121,7 @@ impl KvEventSource {
                         kv_block_size,
                         next_event_id,
                         image_token_id,
+                        video_token_id,
                     ));
 
                 Ok(KvEventSource::Zmq { zmq_handle })

--- a/lib/llm/src/kv_router/publisher/tests.rs
+++ b/lib/llm/src/kv_router/publisher/tests.rs
@@ -120,6 +120,7 @@ mod test_event_processing {
             None,
             None,
             None,
+            None,
         );
 
         assert_eq!(blocks.len(), 2);
@@ -134,6 +135,7 @@ mod test_event_processing {
             None,
             Some("tenant-a"),
             &Arc::new(AtomicU32::new(0)),
+            None,
             None,
             None,
             None,
@@ -173,6 +175,7 @@ mod test_event_processing {
             None,
             None,
             None,
+            None,
         );
 
         // should early-exit as second has mismatch
@@ -207,6 +210,7 @@ mod test_event_processing {
             kv_block_size,
             WorkerWithDpRank::from_worker_id(1),
             &Arc::new(AtomicU32::new(0)),
+            None,
             None,
         )
         .unwrap();
@@ -255,6 +259,7 @@ mod test_event_processing {
             WorkerWithDpRank::from_worker_id(1),
             &wc,
             None,
+            None,
         )
         .unwrap();
         let lora_out = convert_event(
@@ -263,6 +268,7 @@ mod test_event_processing {
             kv_block_size,
             WorkerWithDpRank::from_worker_id(1),
             &wc,
+            None,
             None,
         )
         .unwrap();
@@ -323,6 +329,7 @@ mod test_event_processing {
             WorkerWithDpRank::from_worker_id(1),
             &wc,
             None,
+            None,
         )
         .unwrap();
         let out2 = convert_event(
@@ -331,6 +338,7 @@ mod test_event_processing {
             kv_block_size,
             WorkerWithDpRank::from_worker_id(1),
             &wc,
+            None,
             None,
         )
         .unwrap();
@@ -422,6 +430,7 @@ mod test_event_processing {
             WorkerWithDpRank::from_worker_id(1),
             &Arc::new(AtomicU32::new(0)),
             None,
+            None,
         )
         .unwrap();
 
@@ -438,6 +447,7 @@ mod test_event_processing {
             kv_block_size,
             WorkerWithDpRank::from_worker_id(1),
             &Arc::new(AtomicU32::new(0)),
+            None,
             None,
         )
         .unwrap();
@@ -1070,6 +1080,7 @@ mod tests_startup_helpers {
                 4,
                 next_event_id,
                 None,
+                None,
             )
         });
 
@@ -1196,6 +1207,7 @@ mod tests_startup_helpers {
                 4,
                 Arc::new(AtomicU64::new(0)),
                 None,
+                None,
             )
         });
 
@@ -1278,7 +1290,7 @@ mod tests_startup_helpers {
         let listener_handle = tokio::spawn({
             let token = token.clone();
             let endpoint = endpoint.clone();
-            start_zmq_listener(endpoint, topic, 1, tx, token, 4, next_event_id, None)
+            start_zmq_listener(endpoint, topic, 1, tx, token, 4, next_event_id, None, None)
         });
 
         tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;

--- a/lib/llm/src/kv_router/publisher/zmq_listener.rs
+++ b/lib/llm/src/kv_router/publisher/zmq_listener.rs
@@ -24,6 +24,7 @@ pub(super) async fn start_zmq_listener(
     kv_block_size: u32,
     next_event_id: Arc<AtomicU64>,
     image_token_id: Option<u32>,
+    video_token_id: Option<u32>,
 ) {
     tracing::debug!(
         "KVEventPublisher connecting to ZMQ endpoint {} (topic '{}')",
@@ -31,7 +32,9 @@ pub(super) async fn start_zmq_listener(
         zmq_topic
     );
 
-    let mut normalizer = ZmqEventNormalizer::new(kv_block_size).with_image_token_id(image_token_id);
+    let mut normalizer = ZmqEventNormalizer::new(kv_block_size)
+        .with_image_token_id(image_token_id)
+        .with_video_token_id(video_token_id);
     let socket = match connect_sub_socket(&zmq_endpoint, Some(&zmq_topic)).await {
         Ok(socket) => socket,
         Err(error) => {

--- a/lib/llm/src/mocker.rs
+++ b/lib/llm/src/mocker.rs
@@ -534,6 +534,7 @@ impl MockEngine {
                                 endpoint: format!("tcp://127.0.0.1:{zmq_port}"),
                                 topic: String::new(),
                                 image_token_id: None,
+                                video_token_id: None,
                             });
                             match KvEventPublisher::new_with_local_indexer(
                                 comp.clone(),

--- a/lib/llm/src/preprocessor.rs
+++ b/lib/llm/src/preprocessor.rs
@@ -14,6 +14,8 @@
 #[cfg(feature = "mm-routing")]
 pub mod lightseek_mm;
 pub mod media;
+#[cfg(feature = "mm-routing")]
+pub mod mm_video;
 pub mod prompt;
 pub mod speculative_prefill;
 mod structural_tag;
@@ -175,13 +177,39 @@ struct ReasoningState {
     guided_json_bypass_decision: Option<bool>,
 }
 
-/// Per-image routing payload accumulated by `gather_multi_modal_data` and
+/// Media modality of an [`MmMediaEntry`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MmModality {
+    Image,
+    Video,
+}
+
+/// Per-media routing payload accumulated by `gather_multi_modal_data` and
 /// consumed by `gather_mm_exact_routing_info`.
-#[derive(Debug, Clone, Copy)]
-pub struct MmImageEntry {
+#[derive(Debug, Clone)]
+pub struct MmMediaEntry {
+    pub modality: MmModality,
     pub mm_hash: u64,
     pub width: u32,
     pub height: u32,
+    /// Sampled frame count; 1 for images. Video token counts depend on it.
+    pub num_frames: usize,
+    /// Sampled frame timestamps in seconds. Only populated for video on the
+    /// frontend-decoding path; Qwen3-VL interleaves them as text tokens.
+    pub sampled_timestamps: Vec<f64>,
+}
+
+impl MmMediaEntry {
+    fn image(mm_hash: u64, width: u32, height: u32) -> Self {
+        Self {
+            modality: MmModality::Image,
+            mm_hash,
+            width,
+            height,
+            num_frames: 1,
+            sampled_timestamps: Vec::new(),
+        }
+    }
 }
 
 /// Per-request media content-part counts, carried to the metrics annotation.
@@ -294,6 +322,19 @@ pub struct OpenAIPreprocessor {
     /// back to text-prefix routing.
     #[cfg(feature = "mm-routing")]
     routing_image_token_id: Option<crate::protocols::TokenIdType>,
+    /// Per-video token-count engine (in-tree Qwen-VL math; see `mm_video`).
+    /// `None` when the feature is disabled or the family is unsupported.
+    #[cfg(feature = "mm-routing")]
+    video_token_counter: Option<mm_video::VideoTokenCounter>,
+    /// Video-placeholder token id from `config.json`'s `video_token_id`.
+    /// `None` disables video MM-aware routing for this model.
+    #[cfg(feature = "mm-routing")]
+    routing_video_token_id: Option<crate::protocols::TokenIdType>,
+    /// `(vision_start_token_id, vision_end_token_id)` from `config.json`.
+    /// Qwen3-VL replaces the whole `<start><video_pad><end>` triple during
+    /// expansion, so matching needs both bounds.
+    #[cfg(feature = "mm-routing")]
+    routing_vision_bounds: Option<(crate::protocols::TokenIdType, crate::protocols::TokenIdType)>,
     /// BOS token id to prepend to the routing-side sequence so per-block
     /// hashes match the backend's HF processor output on models with
     /// `add_bos_token: true` (LLaVA-1.5 and other `LlamaTokenizer`
@@ -316,17 +357,17 @@ impl OpenAIPreprocessor {
     }
 
     /// Prompt length for sizing the omitted-`max_tokens` cap. Prefers the
-    /// MM-expanded length; a 0 (serde-default / absent) counts as missing. With
-    /// images but no expanded length, defers to the backend (`None`); text-only
-    /// uses `token_ids_len`.
+    /// MM-expanded length; a 0 (serde-default / absent) counts as missing.
+    /// With images/videos but no expanded length, defers to the backend
+    /// (`None`); text-only uses `token_ids_len`.
     fn effective_prompt_len_for_cap(
         expanded_prompt_len: Option<usize>,
-        has_images: bool,
+        has_expandable_media: bool,
         token_ids_len: usize,
     ) -> Option<usize> {
         match expanded_prompt_len {
             Some(n) if n > 0 => Some(n),
-            _ if has_images => None,
+            _ if has_expandable_media => None,
             _ => Some(token_ids_len),
         }
     }
@@ -589,80 +630,124 @@ impl OpenAIPreprocessor {
         };
 
         #[cfg(feature = "mm-routing")]
-        let (image_token_counter, routing_image_token_id, bos_token_string) =
-            match image_token_inputs {
-                Some((model_id, model_type, model_dir)) => {
-                    // Resolve counter + image-token id independently so the
-                    // summary log can name which piece is missing.
-                    let (counter, counter_err): (
-                        Option<lightseek_mm::LightseekMmCounter>,
-                        Option<String>,
-                    ) = match lightseek_mm::LightseekMmCounter::try_new(
-                        &model_id,
-                        Some(&model_type),
-                        &model_dir,
-                    ) {
-                        Ok(c) => (Some(c), None),
-                        Err(e) => (None, Some(e.to_string())),
-                    };
-                    // One-shot config/tokenizer_config read for all
-                    // routing-side token info. Parsing lives next to the
-                    // spec resolution in the MM-routing module.
-                    let routing_tokens =
-                        lightseek_mm::resolve_routing_tokens(&model_id, &model_dir);
-                    // `chat_placeholder_token_id` already prefers config.json's
-                    // explicit field and falls back to the spec value, so it's
-                    // the single id used both for the engagement gate and the
-                    // routing-fill below.
-                    let img_tok = routing_tokens.chat_placeholder_token_id;
-                    let bos_tok_string = routing_tokens.bos_token_string;
+        let (
+            image_token_counter,
+            video_token_counter,
+            routing_image_token_id,
+            routing_video_token_id,
+            routing_vision_bounds,
+            bos_token_string,
+        ) = match image_token_inputs {
+            Some((model_id, model_type, model_dir)) => {
+                // Resolve counter + image-token id independently so the
+                // summary log can name which piece is missing.
+                let (counter, counter_err): (
+                    Option<lightseek_mm::LightseekMmCounter>,
+                    Option<String>,
+                ) = match lightseek_mm::LightseekMmCounter::try_new(
+                    &model_id,
+                    Some(&model_type),
+                    &model_dir,
+                ) {
+                    Ok(c) => (Some(c), None),
+                    Err(e) => (None, Some(e.to_string())),
+                };
+                // One-shot config/tokenizer_config read for all
+                // routing-side token info. Parsing lives next to the
+                // spec resolution in the MM-routing module.
+                let routing_tokens = lightseek_mm::resolve_routing_tokens(&model_id, &model_dir);
+                // `chat_placeholder_token_id` already prefers config.json's
+                // explicit field and falls back to the spec value, so it's
+                // the single id used both for the engagement gate and the
+                // routing-fill below.
+                let img_tok = routing_tokens.chat_placeholder_token_id;
+                let bos_tok_string = routing_tokens.bos_token_string;
 
-                    match (counter.is_some(), img_tok.is_some()) {
-                        (true, true) => tracing::info!(
+                // Video counting is in-tree (`mm_video`) — the upstream
+                // image crate has no temporal API. Unsupported families
+                // simply leave video routing off; image routing is
+                // unaffected.
+                let video_counter = match mm_video::VideoTokenCounter::try_new(
+                    &model_id,
+                    Some(&model_type),
+                    &model_dir,
+                ) {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        tracing::debug!(
                             target: "mm_routing",
                             model = %model_id,
-                            model_dir = %model_dir.display(),
-                            "MM-aware KV routing enabled"
-                        ),
-                        (counter_ok, img_ok) => {
-                            let mut reasons: Vec<String> = Vec::new();
-                            if !counter_ok {
-                                reasons.push(format!(
-                                    "model not supported by the MM-routing registry ({})",
-                                    counter_err.as_deref().unwrap_or("unknown error")
-                                ));
-                            }
-                            if !img_ok {
-                                reasons.push(
-                                    "image-placeholder token unresolvable from \
+                            err = %e,
+                            "video token counter unavailable; video MM-aware routing disabled"
+                        );
+                        None
+                    }
+                };
+                let video_tok = routing_tokens.video_token_id;
+                let vision_bounds = routing_tokens
+                    .vision_start_token_id
+                    .zip(routing_tokens.vision_end_token_id);
+                if video_counter.is_some() && video_tok.is_some() {
+                    tracing::info!(
+                        target: "mm_routing",
+                        model = %model_id,
+                        "video MM-aware KV routing enabled (frontend-decode path)"
+                    );
+                }
+
+                match (counter.is_some(), img_tok.is_some()) {
+                    (true, true) => tracing::info!(
+                        target: "mm_routing",
+                        model = %model_id,
+                        model_dir = %model_dir.display(),
+                        "MM-aware KV routing enabled"
+                    ),
+                    (counter_ok, img_ok) => {
+                        let mut reasons: Vec<String> = Vec::new();
+                        if !counter_ok {
+                            reasons.push(format!(
+                                "model not supported by the MM-routing registry ({})",
+                                counter_err.as_deref().unwrap_or("unknown error")
+                            ));
+                        }
+                        if !img_ok {
+                            reasons.push(
+                                "image-placeholder token unresolvable from \
                                  config.json / processor_config.json / \
                                  tokenizer_config.json / vocab probe"
-                                        .to_string(),
-                                );
-                            }
-                            tracing::warn!(
-                                target: "mm_routing",
-                                model = %model_id,
-                                reasons = %reasons.join("; "),
-                                "{} is not supported for MM-aware KV routing ({}). \
-                                 Falling back to KV routing without MM awareness — \
-                                 text-prefix overlap still works but the router \
-                                 cannot distinguish requests by image content.",
-                                model_id,
-                                reasons.join("; ")
+                                    .to_string(),
                             );
                         }
+                        tracing::warn!(
+                            target: "mm_routing",
+                            model = %model_id,
+                            reasons = %reasons.join("; "),
+                            "{} is not supported for MM-aware KV routing ({}). \
+                             Falling back to KV routing without MM awareness — \
+                             text-prefix overlap still works but the router \
+                             cannot distinguish requests by image content.",
+                            model_id,
+                            reasons.join("; ")
+                        );
                     }
-                    (counter, img_tok, bos_tok_string)
                 }
-                None => {
-                    tracing::debug!(
-                        target: "mm_routing",
-                        "model directory not derivable from MDC; MM-aware routing disabled"
-                    );
-                    (None, None, None)
-                }
-            };
+                (
+                    counter,
+                    video_counter,
+                    img_tok,
+                    video_tok,
+                    vision_bounds,
+                    bos_tok_string,
+                )
+            }
+            None => {
+                tracing::debug!(
+                    target: "mm_routing",
+                    "model directory not derivable from MDC; MM-aware routing disabled"
+                );
+                (None, None, None, None, None, None)
+            }
+        };
 
         // Force the dim-fetch HTTP client to build at startup for any
         // MM-routable preprocessor, so TLS / env-var / reqwest-init
@@ -731,6 +816,12 @@ impl OpenAIPreprocessor {
             image_token_counter,
             #[cfg(feature = "mm-routing")]
             routing_image_token_id,
+            #[cfg(feature = "mm-routing")]
+            video_token_counter,
+            #[cfg(feature = "mm-routing")]
+            routing_video_token_id,
+            #[cfg(feature = "mm-routing")]
+            routing_vision_bounds,
             #[cfg(feature = "mm-routing")]
             routing_prepend_bos,
         }))
@@ -809,7 +900,7 @@ impl OpenAIPreprocessor {
         };
         TOKENIZE_SECONDS.observe(tokenize_start.elapsed().as_secs_f64());
 
-        let _mm_image_entries = self
+        let _mm_media_entries = self
             .gather_multi_modal_data(
                 request,
                 &mut builder,
@@ -819,11 +910,11 @@ impl OpenAIPreprocessor {
             .await
             .with_context(|| "Failed to gather multimodal data")?;
 
-        // Build the MM-aware view (expanded routing_token_ids + per-block
-        // mm_hashes) for the KV router. No-op when no images are present or
-        // the model has no resolved image-placeholder.
+        // Build the MM-aware view (expanded routing_token_ids) for the KV
+        // router. No-op when no image/video media is present or the model has
+        // no resolved placeholder tokens.
         #[cfg(feature = "mm-routing")]
-        self.gather_mm_exact_routing_info(&mut builder, &_mm_image_entries, &token_ids)
+        self.gather_mm_exact_routing_info(&mut builder, &_mm_media_entries, &token_ids)
             .with_context(|| "Failed to build MM routing info")?;
 
         // Install tokens on the builder. Done after MM routing built its
@@ -847,19 +938,20 @@ impl OpenAIPreprocessor {
         // preserve omission so backend adapters can compute the dynamic cap from their
         // effective prompt length/tokenization.
         //
-        // Multimodal `token_ids` carry unexpanded image placeholders, so prefer
-        // the MM-expanded length when available, else defer to the backend.
-        let has_images = preprocessed
-            .multi_modal_data
-            .as_ref()
-            .and_then(|m| m.get("image_url"))
-            .is_some_and(|v| !v.is_empty());
+        // Multimodal `token_ids` carry unexpanded image/video placeholders,
+        // so prefer the MM-expanded length when available, else defer to the
+        // backend.
+        let has_expandable_media = preprocessed.multi_modal_data.as_ref().is_some_and(|m| {
+            ["image_url", "video_url"]
+                .iter()
+                .any(|key| m.get(*key).is_some_and(|v| !v.is_empty()))
+        });
         let effective_prompt_len = Self::effective_prompt_len_for_cap(
             preprocessed
                 .mm_routing_info
                 .as_ref()
                 .map(|mm| mm.expanded_prompt_len),
-            has_images,
+            has_expandable_media,
             preprocessed.token_ids.len(),
         );
         if preprocessed.stop_conditions.max_tokens.is_none()
@@ -1172,7 +1264,7 @@ impl OpenAIPreprocessor {
         // forwarding on the same placeholder-count precondition as
         // `gather_mm_exact_routing_info`, so the two never diverge.
         token_ids: &[crate::protocols::TokenIdType],
-    ) -> Result<Vec<MmImageEntry>> {
+    ) -> Result<Vec<MmMediaEntry>> {
         // `token_ids` is only consumed by the mm-routing `mm_hashes` gate below.
         #[cfg(not(feature = "mm-routing"))]
         let _ = token_ids;
@@ -1180,25 +1272,31 @@ impl OpenAIPreprocessor {
         let mut media_map: MultimodalDataMap = HashMap::new();
         let mut fetch_tasks: Vec<(String, &ChatCompletionRequestUserMessageContentPart)> =
             Vec::new();
-        // Per-image (mm_hash, width, height) for the MM-routing path.
-        // Accumulated in message order so we don't walk messages twice.
-        // Cleared and returned to the caller; empty for non-image / text-only requests.
+        // Per-media (modality, mm_hash, dims, frames) for the MM-routing
+        // path. Accumulated in message order so we don't walk messages twice.
+        // Cleared and returned to the caller; empty for text-only requests.
         #[cfg(feature = "mm-routing")]
-        let mut mm_image_entries: Vec<MmImageEntry> = Vec::new();
+        let mut mm_media_entries: Vec<MmMediaEntry> = Vec::new();
         // Total `image_url` content parts in the request. Bumped at every
         // image part regardless of which fetch path handles it. Used at
-        // `mm_hashes` forwarding time: if `mm_image_entries.len()` is
+        // `mm_hashes` forwarding time: if the resolved image-entry count is
         // smaller, we omit `mm_hashes` for the whole request rather than
         // ship a partial / misaligned UUID list to vLLM.
         //
         // The mismatch is only reachable on the URL-passthrough path
         // (no media_loader): each `fetch_image_dims_uncached` failure logs
-        // a warn and skips its `mm_image_entries.push`, but doesn't abort
+        // a warn and skips its entry push, but doesn't abort
         // the request. The decoded path (`has_media_loader`) propagates
         // any dim-fetch failure via `?`, so the request errors out before
         // mm_hashes forwarding is even considered.
         #[cfg(feature = "mm-routing")]
         let mut total_image_count: usize = 0;
+        // Total `video_url` content parts. Video entries are only resolvable
+        // on the frontend-decoding path (frame sampling determines the token
+        // count), so a passthrough video keeps this total ahead of the
+        // resolved entries and fails the gate closed to text-prefix routing.
+        #[cfg(feature = "mm-routing")]
+        let mut total_video_count: usize = 0;
         // For the URL-passthrough case (media_loader is None) we collect image
         // URLs here and resolve dims via header-only HTTP after the loop so we
         // can issue all fetches in parallel.
@@ -1227,8 +1325,10 @@ impl OpenAIPreprocessor {
                         _ => continue,
                     };
                     #[cfg(feature = "mm-routing")]
-                    if type_str == "image_url" {
-                        total_image_count += 1;
+                    match type_str {
+                        "image_url" => total_image_count += 1,
+                        "video_url" => total_video_count += 1,
+                        _ => {}
                     }
                     fetch_tasks.push((type_str.to_string(), content_part));
                 } else {
@@ -1245,10 +1345,17 @@ impl OpenAIPreprocessor {
                         _ => continue,
                     };
                     #[cfg(feature = "mm-routing")]
-                    if type_str == "image_url" {
-                        total_image_count += 1;
-                        let mm_hash = Self::hash_image_url(url.as_str());
-                        url_passthrough_images.push((mm_hash, url.to_string()));
+                    match type_str {
+                        "image_url" => {
+                            total_image_count += 1;
+                            let mm_hash = Self::hash_image_url(url.as_str());
+                            url_passthrough_images.push((mm_hash, url.to_string()));
+                        }
+                        // URL-passthrough video is not MM-routable: the token
+                        // count depends on frame sampling only the decode path
+                        // performs. Counting it fails the gate closed.
+                        "video_url" => total_video_count += 1,
+                        _ => {}
                     }
                     media_map
                         .entry(type_str.to_string())
@@ -1271,52 +1378,115 @@ impl OpenAIPreprocessor {
                 // if one item fails, errors the whole request, other items will be cleaned up by Drop
                 let rdma_descriptor = result?;
 
-                // Decoded RDMA descriptor carries shape `[H, W, C]`.
-                // Image-only; MM-routing doesn't cover audio/video.
+                // Decoded RDMA descriptors carry shape `[H, W, C]` for
+                // images and `[T, H, W, C]` for video. Audio is not
+                // MM-routable yet.
                 #[cfg(feature = "mm-routing")]
-                if type_str == "image_url" {
-                    let shape = &rdma_descriptor.tensor_info.shape;
-                    if shape.len() >= 2 {
-                        let h = shape[0] as u32;
-                        let w = shape[1] as u32;
-                        let url_str = match _content_part {
-                            ChatCompletionRequestUserMessageContentPart::ImageUrl(p) => {
-                                p.image_url.url.as_str()
+                match type_str.as_str() {
+                    "image_url" => {
+                        let shape = &rdma_descriptor.tensor_info.shape;
+                        if shape.len() >= 2 {
+                            let h = shape[0] as u32;
+                            let w = shape[1] as u32;
+                            let url_str = match _content_part {
+                                ChatCompletionRequestUserMessageContentPart::ImageUrl(p) => {
+                                    p.image_url.url.as_str()
+                                }
+                                _ => unreachable!(
+                                    "rdma image_url descriptor only originates from ImageUrl content parts"
+                                ),
+                            };
+                            // Frontend-decode path: hash the decoded RGB bytes so
+                            // the same image reached via different (signed) URLs
+                            // collides on the same `mm_hash` and routes to the
+                            // worker that already has those KV blocks. Fall back
+                            // to URL hashing only if the descriptor lost local
+                            // storage (e.g. reconstructed from the wire), which
+                            // shouldn't happen on the frontend.
+                            let (mm_hash, hash_source) = match rdma_descriptor.content_hash() {
+                                Some(h) => (h, "decoded_bytes"),
+                                None => (Self::hash_image_url(url_str), "url_fallback"),
+                            };
+                            if let Some(counter) = self.image_token_counter.as_ref() {
+                                let n = counter.count_tokens(w, h);
+                                tracing::debug!(
+                                    target: "mm_routing",
+                                    model = counter.model_id(),
+                                    width = w,
+                                    height = h,
+                                    tokens = n,
+                                    mm_hash = mm_hash,
+                                    source = hash_source,
+                                    "image-token count"
+                                );
                             }
-                            _ => unreachable!(
-                                "rdma image_url descriptor only originates from ImageUrl content parts"
-                            ),
-                        };
-                        // Frontend-decode path: hash the decoded RGB bytes so
-                        // the same image reached via different (signed) URLs
-                        // collides on the same `mm_hash` and routes to the
-                        // worker that already has those KV blocks. Fall back
-                        // to URL hashing only if the descriptor lost local
-                        // storage (e.g. reconstructed from the wire), which
-                        // shouldn't happen on the frontend.
-                        let (mm_hash, hash_source) = match rdma_descriptor.content_hash() {
-                            Some(h) => (h, "decoded_bytes"),
-                            None => (Self::hash_image_url(url_str), "url_fallback"),
-                        };
-                        if let Some(counter) = self.image_token_counter.as_ref() {
-                            let n = counter.count_tokens(w, h);
-                            tracing::debug!(
-                                target: "mm_routing",
-                                model = counter.model_id(),
-                                width = w,
-                                height = h,
-                                tokens = n,
-                                mm_hash = mm_hash,
-                                source = hash_source,
-                                "image-token count"
-                            );
+                            mm_media_entries.push(MmMediaEntry::image(mm_hash, w, h));
                         }
-                        mm_image_entries.push(MmImageEntry {
-                            mm_hash,
-                            width: w,
-                            height: h,
-                        });
                     }
+                    "video_url" => {
+                        let shape = &rdma_descriptor.tensor_info.shape;
+                        if shape.len() == 4 {
+                            let num_frames = shape[0];
+                            let h = shape[1] as u32;
+                            let w = shape[2] as u32;
+                            let url_str = match _content_part {
+                                ChatCompletionRequestUserMessageContentPart::VideoUrl(p) => {
+                                    p.video_url.url.as_str()
+                                }
+                                _ => unreachable!(
+                                    "rdma video_url descriptor only originates from VideoUrl content parts"
+                                ),
+                            };
+                            // Same content-hash rationale as images: decoded
+                            // frame bytes, so rotating signed URLs of the same
+                            // clip share KV blocks.
+                            let (mm_hash, hash_source) = match rdma_descriptor.content_hash() {
+                                Some(hash) => (hash, "decoded_bytes"),
+                                None => (Self::hash_image_url(url_str), "url_fallback"),
+                            };
+                            // Sampled-frame timestamps ride on the decoder
+                            // metadata; Qwen3-VL interleaves them as text
+                            // tokens in the expanded sequence.
+                            #[cfg(feature = "media-ffmpeg")]
+                            let sampled_timestamps = match &rdma_descriptor.tensor_info.metadata {
+                                Some(media::DecodedMediaMetadata::Video(v)) => {
+                                    v.sampled_timestamps.clone()
+                                }
+                                _ => Vec::new(),
+                            };
+                            #[cfg(not(feature = "media-ffmpeg"))]
+                            let sampled_timestamps: Vec<f64> = Vec::new();
+                            if let Some(counter) = self.video_token_counter.as_ref() {
+                                match counter.count_tokens(num_frames, h, w) {
+                                    Ok(n) => tracing::debug!(
+                                        target: "mm_routing",
+                                        model = counter.model_id(),
+                                        num_frames,
+                                        width = w,
+                                        height = h,
+                                        tokens = n,
+                                        mm_hash = mm_hash,
+                                        source = hash_source,
+                                        "video-token count"
+                                    ),
+                                    Err(e) => tracing::debug!(
+                                        target: "mm_routing",
+                                        err = %e,
+                                        "video-token count failed"
+                                    ),
+                                }
+                            }
+                            mm_media_entries.push(MmMediaEntry {
+                                modality: MmModality::Video,
+                                mm_hash,
+                                width: w,
+                                height: h,
+                                num_frames,
+                                sampled_timestamps,
+                            });
+                        }
+                    }
+                    _ => {}
                 }
 
                 media_map
@@ -1354,11 +1524,7 @@ impl OpenAIPreprocessor {
                                 "image-token count"
                             );
                         }
-                        mm_image_entries.push(MmImageEntry {
-                            mm_hash,
-                            width: w,
-                            height: h,
-                        });
+                        mm_media_entries.push(MmMediaEntry::image(mm_hash, w, h));
                     }
                     Err(e) => {
                         // Redact `data:` URIs to just the media-type prefix —
@@ -1429,75 +1595,242 @@ impl OpenAIPreprocessor {
             // positions the backend derives from `multi_modal_data`, and
             // the wrong UUIDs would get injected onto the wrong images.
             //
-            // Also gate on the single-token placeholder count matching the
-            // image count — the same precondition `gather_mm_exact_routing_info`
-            // uses to build routing info. Forwarding `mm_hashes` makes the
-            // worker pad_value-key its KV blocks; if the router then falls back
-            // to plain `token_ids` (e.g. numbered-placeholder models like Phi-3,
-            // where the count won't match), the keys diverge and overlap is
-            // lost. Keeping both gated together leaves that fallback as clean
-            // text-prefix routing.
+            // Also gate on the placeholder structure matching per modality —
+            // the same precondition `gather_mm_exact_routing_info` uses to
+            // build routing info. Forwarding `mm_hashes` makes the worker
+            // pad_value-key its KV blocks; if the router then falls back to
+            // plain `token_ids` (e.g. numbered-placeholder models like Phi-3,
+            // where the count won't match, or URL-passthrough video, whose
+            // token count is unknowable without frame sampling), the keys
+            // diverge and overlap is lost. Keeping both gated together leaves
+            // that fallback as clean text-prefix routing.
             #[cfg(feature = "mm-routing")]
-            if let Some(find_token_id) = self.routing_image_token_id
-                && !mm_image_entries.is_empty()
-                && mm_image_entries.len() == total_image_count
-                && token_ids.iter().filter(|&&t| t == find_token_id).count()
-                    == mm_image_entries.len()
             {
-                let hexes: Vec<serde_json::Value> = mm_image_entries
+                let n_images = mm_media_entries
                     .iter()
-                    .map(|e| serde_json::Value::String(format!("{:016x}", e.mm_hash)))
-                    .collect();
-                extra_args["mm_hashes"] = serde_json::Value::Array(hexes);
-            } else if !mm_image_entries.is_empty() && self.routing_image_token_id.is_some() {
-                tracing::warn!(
-                    target: "mm_routing",
-                    resolved = mm_image_entries.len(),
-                    expected = total_image_count,
-                    "mm-routing: exact MM routing info not built (dim resolution or placeholder-count mismatch); skipping mm_hashes forwarding"
-                );
+                    .filter(|e| e.modality == MmModality::Image)
+                    .count();
+                let n_videos = mm_media_entries.len() - n_images;
+                if !mm_media_entries.is_empty()
+                    && n_images == total_image_count
+                    && n_videos == total_video_count
+                    && self.mm_placeholders_match(token_ids, n_images, n_videos)
+                {
+                    let hexes = |modality: MmModality| -> Vec<serde_json::Value> {
+                        mm_media_entries
+                            .iter()
+                            .filter(|e| e.modality == modality)
+                            .map(|e| serde_json::Value::String(format!("{:016x}", e.mm_hash)))
+                            .collect()
+                    };
+                    let image_hexes = hexes(MmModality::Image);
+                    let video_hexes = hexes(MmModality::Video);
+                    // Legacy image-only key, still read by backends that
+                    // predate the by-modality form.
+                    if !image_hexes.is_empty() {
+                        extra_args["mm_hashes"] = serde_json::Value::Array(image_hexes.clone());
+                    }
+                    // Grouped form (`{"image": [...], "video": [...]}`) —
+                    // the only key that can carry video identities.
+                    if !video_hexes.is_empty() {
+                        let mut by_modality = serde_json::Map::new();
+                        if !image_hexes.is_empty() {
+                            by_modality
+                                .insert("image".to_string(), serde_json::Value::Array(image_hexes));
+                        }
+                        by_modality
+                            .insert("video".to_string(), serde_json::Value::Array(video_hexes));
+                        extra_args["mm_hashes_by_modality"] =
+                            serde_json::Value::Object(by_modality);
+                    }
+                } else if !mm_media_entries.is_empty() || total_video_count > 0 {
+                    tracing::warn!(
+                        target: "mm_routing",
+                        resolved_images = n_images,
+                        expected_images = total_image_count,
+                        resolved_videos = n_videos,
+                        expected_videos = total_video_count,
+                        "mm-routing: exact MM routing info not built (dim/frame resolution or placeholder mismatch); skipping mm_hashes forwarding"
+                    );
+                }
             }
 
             builder.extra_args(Some(extra_args));
         }
 
         #[cfg(feature = "mm-routing")]
-        return Ok(mm_image_entries);
+        return Ok(mm_media_entries);
         #[cfg(not(feature = "mm-routing"))]
         Ok(Vec::new())
     }
 
+    /// True when the tokenized prompt's placeholder structure can be aligned
+    /// to the resolved media entries: exactly one `routing_image_token_id`
+    /// per image (Qwen-VL `<|image_pad|>`, LLaVA `<image>`), and per video
+    /// either one `routing_video_token_id` (Qwen2/2.5-VL) or one
+    /// `<vision_start><video_pad><vision_end>` triple (Qwen3-VL). Any other
+    /// shape (e.g. numbered-text placeholders that BPE-shatter) can't be
+    /// aligned here. Shared by `mm_hashes` forwarding and
+    /// `gather_mm_exact_routing_info` so worker-side keying and router-side
+    /// expansion never diverge.
+    #[cfg(feature = "mm-routing")]
+    fn mm_placeholders_match(
+        &self,
+        token_ids: &[crate::protocols::TokenIdType],
+        n_images: usize,
+        n_videos: usize,
+    ) -> bool {
+        if n_images + n_videos == 0 {
+            return false;
+        }
+        if n_images > 0 {
+            if self.image_token_counter.is_none() {
+                return false;
+            }
+            let Some(img_tok) = self.routing_image_token_id else {
+                return false;
+            };
+            if token_ids.iter().filter(|&&t| t == img_tok).count() != n_images {
+                return false;
+            }
+        }
+        if n_videos > 0 {
+            let Some(counter) = self.video_token_counter.as_ref() else {
+                return false;
+            };
+            let Some(vid_tok) = self.routing_video_token_id else {
+                return false;
+            };
+            if counter.family().expands_placeholder_triple() {
+                let Some((vs, ve)) = self.routing_vision_bounds else {
+                    return false;
+                };
+                if Self::count_video_triples(token_ids, vs, vid_tok, ve) != n_videos {
+                    return false;
+                }
+            } else if token_ids.iter().filter(|&&t| t == vid_tok).count() != n_videos {
+                return false;
+            }
+        }
+        true
+    }
+
+    /// Count `<vision_start><video_pad><vision_end>` triples. Windows can't
+    /// double-count: a match's end token differs from the start token, so
+    /// triples never overlap.
+    #[cfg(feature = "mm-routing")]
+    fn count_video_triples(
+        token_ids: &[crate::protocols::TokenIdType],
+        vision_start: crate::protocols::TokenIdType,
+        video_tok: crate::protocols::TokenIdType,
+        vision_end: crate::protocols::TokenIdType,
+    ) -> usize {
+        token_ids
+            .windows(3)
+            .filter(|w| w[0] == vision_start && w[1] == video_tok && w[2] == vision_end)
+            .count()
+    }
+
+    /// Routing-side replacement for one video placeholder.
+    /// Qwen2/2.5-VL: N pad_value tokens replacing `<|video_pad|>` in place.
+    /// Qwen3-VL: the whole placeholder triple becomes, per temporal grid
+    /// group, `<ts text><vision_start><pad_value x per_group><vision_end>`,
+    /// with the timestamp text encoded by the model tokenizer — mirroring the
+    /// backend HF processor so per-block hashes align. `None` means this
+    /// video can't be expanded exactly (missing timestamps, count failure);
+    /// the caller skips MM routing for the request.
+    #[cfg(feature = "mm-routing")]
+    fn video_replacement_tokens(
+        &self,
+        entry: &MmMediaEntry,
+    ) -> Option<Vec<crate::protocols::TokenIdType>> {
+        use dynamo_kv_router::protocols::pad_value_for_mm_hash;
+
+        let counter = self.video_token_counter.as_ref()?;
+        let pad = pad_value_for_mm_hash(entry.mm_hash);
+        if !counter.family().expands_placeholder_triple() {
+            let n = match counter.count_tokens(entry.num_frames, entry.height, entry.width) {
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "mm_routing",
+                        err = %e,
+                        "video token count failed; skipping MM routing info"
+                    );
+                    return None;
+                }
+            };
+            return Some(vec![pad; n]);
+        }
+
+        let (vision_start, vision_end) = self.routing_vision_bounds?;
+        if entry.sampled_timestamps.len() != entry.num_frames {
+            tracing::warn!(
+                target: "mm_routing",
+                num_frames = entry.num_frames,
+                timestamps = entry.sampled_timestamps.len(),
+                "sampled timestamps do not cover the decoded frames; skipping MM routing info"
+            );
+            return None;
+        }
+        let per_group =
+            match counter.tokens_per_frame_group(entry.num_frames, entry.height, entry.width) {
+                Ok(n) => n,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "mm_routing",
+                        err = %e,
+                        "video frame-group token count failed; skipping MM routing info"
+                    );
+                    return None;
+                }
+            };
+        let group_timestamps = counter.group_timestamps(&entry.sampled_timestamps);
+        // Rough capacity: label tokens vary per timestamp; 8 is a safe upper
+        // bound for "<123.4 seconds>" under BPE without being wasteful.
+        let mut out = Vec::with_capacity(group_timestamps.len() * (per_group + 10));
+        for ts in group_timestamps {
+            let label = mm_video::VideoTokenCounter::timestamp_label(ts);
+            let encoding = match self.tokenizer.encode(&label) {
+                Ok(encoding) => encoding,
+                Err(e) => {
+                    tracing::warn!(
+                        target: "mm_routing",
+                        err = %e,
+                        "timestamp label failed to encode; skipping MM routing info"
+                    );
+                    return None;
+                }
+            };
+            out.extend_from_slice(encoding.token_ids());
+            out.push(vision_start);
+            out.extend(std::iter::repeat_n(pad, per_group));
+            out.push(vision_end);
+        }
+        Some(out)
+    }
+
     /// Build `MmRoutingInfo` for exact MM-aware KV routing. The worker-bound
     /// `token_ids` are unchanged — only the routing-side view is expanded.
-    /// Supports single-special-token placeholder families (Qwen-VL, LLaVA).
+    /// Images: single-special-token placeholder families (Qwen-VL, LLaVA).
+    /// Videos: Qwen-VL families, frontend-decoding path only — the token
+    /// count depends on the frontend's frame sampling, which is exactly why
+    /// URL-passthrough video stays on text-prefix routing.
     /// Returns `Ok(())` with no work performed on any precondition miss
     /// (caller falls back to text-prefix routing).
     #[cfg(feature = "mm-routing")]
     pub fn gather_mm_exact_routing_info(
         &self,
         builder: &mut PreprocessedRequestBuilder,
-        mm_image_entries: &[MmImageEntry],
+        mm_media_entries: &[MmMediaEntry],
         token_ids: &[crate::protocols::TokenIdType],
     ) -> Result<()> {
         use crate::protocols::common::preprocessor::MmRoutingInfo;
+        use dynamo_kv_router::protocols::pad_value_for_mm_hash;
 
-        if mm_image_entries.is_empty() {
+        if mm_media_entries.is_empty() {
             return Ok(());
         }
-        let Some(find_token_id) = self.routing_image_token_id else {
-            tracing::debug!(
-                target: "mm_routing",
-                "routing_image_token_id unresolved; skipping MM routing info"
-            );
-            return Ok(());
-        };
-        let Some(counter) = self.image_token_counter.as_ref() else {
-            tracing::debug!(
-                target: "mm_routing",
-                "image_token_counter unavailable; skipping MM routing info"
-            );
-            return Ok(());
-        };
         let block_size = self.kv_cache_block_size;
         if block_size == 0 {
             tracing::debug!(
@@ -1507,33 +1840,48 @@ impl OpenAIPreprocessor {
             return Ok(());
         }
 
-        // Single-special-token placeholders (Qwen-VL `<|image_pad|>`, LLaVA
-        // `<image>`) emit exactly one `find_token_id` per image in the
-        // tokenized prompt. Any other shape (e.g. numbered-text placeholders
-        // that BPE-shatter) can't be aligned to images here, so we skip MM
-        // routing and let the caller fall back to text-prefix routing.
-        let placeholder_count = token_ids.iter().filter(|&&t| t == find_token_id).count();
-        if placeholder_count != mm_image_entries.len() {
+        let images: Vec<&MmMediaEntry> = mm_media_entries
+            .iter()
+            .filter(|e| e.modality == MmModality::Image)
+            .collect();
+        let videos: Vec<&MmMediaEntry> = mm_media_entries
+            .iter()
+            .filter(|e| e.modality == MmModality::Video)
+            .collect();
+        if !self.mm_placeholders_match(token_ids, images.len(), videos.len()) {
             tracing::warn!(
                 target: "mm_routing",
-                placeholder_count,
-                image_count = mm_image_entries.len(),
-                routing_image_token_id = find_token_id,
-                "placeholder token count in tokenized prompt does not match image count; \
+                n_images = images.len(),
+                n_videos = videos.len(),
+                "placeholder structure in tokenized prompt does not match media entries; \
                  skipping MM routing info (text-prefix routing only)"
             );
             return Ok(());
         }
-        let normalized_token_ids = token_ids;
 
-        // Compute per-image N via the registry + run the expansion.
-        let n_tokens: Vec<usize> = mm_image_entries
-            .iter()
-            .map(|e| counter.count_tokens(e.width, e.height))
-            .collect();
-        let n_total: usize = n_tokens.iter().sum();
+        // Per-image pad fill via the registry counter; per-video full
+        // replacement streams. `mm_placeholders_match` guaranteed the
+        // counters and token ids exist for the modalities present.
+        let mut image_fill: Vec<(crate::protocols::TokenIdType, usize)> =
+            Vec::with_capacity(images.len());
+        if let Some(counter) = self.image_token_counter.as_ref() {
+            for e in &images {
+                image_fill.push((
+                    pad_value_for_mm_hash(e.mm_hash),
+                    counter.count_tokens(e.width, e.height),
+                ));
+            }
+        }
+        let mut video_fill: Vec<Vec<crate::protocols::TokenIdType>> =
+            Vec::with_capacity(videos.len());
+        for e in &videos {
+            match self.video_replacement_tokens(e) {
+                Some(v) => video_fill.push(v),
+                None => return Ok(()),
+            }
+        }
 
-        // Canonical pad_value fill at image positions for ALL backends. sglang
+        // Canonical pad_value fill at media positions for ALL backends. sglang
         // consumes pad_value natively; vLLM events are normalized to pad_value
         // in the kv-router (see `create_stored_blocks`), so the frontend stays
         // backend-agnostic. pad_value formula pinned by
@@ -1542,23 +1890,31 @@ impl OpenAIPreprocessor {
         // Prepend the routing-side BOS for `add_bos_token: true` models
         // (LlamaTokenizer family, e.g. LLaVA-1.5) so per-block hashes match
         // the backend's HF processor output.
+        let video_triple = self
+            .video_token_counter
+            .as_ref()
+            .is_some_and(|c| c.family().expands_placeholder_triple());
+        let img_tok = self.routing_image_token_id;
+        let vid_tok = self.routing_video_token_id;
+        let vision_bounds = self.routing_vision_bounds;
+
+        let n_total: usize = image_fill.iter().map(|(_, n)| *n).sum::<usize>()
+            + video_fill.iter().map(|v| v.len()).sum::<usize>();
         let bos_extra = self.routing_prepend_bos.is_some() as usize;
         let mut expanded: Vec<crate::protocols::TokenIdType> =
-            Vec::with_capacity(normalized_token_ids.len() + n_total + bos_extra);
+            Vec::with_capacity(token_ids.len() + n_total + bos_extra);
         if let Some(bos) = self.routing_prepend_bos {
             expanded.push(bos);
         }
-        let mut i = 0usize;
-        for &t in normalized_token_ids.iter() {
-            if t == find_token_id && i < mm_image_entries.len() {
-                let fill_token =
-                    dynamo_kv_router::protocols::pad_value_for_mm_hash(mm_image_entries[i].mm_hash);
-                expanded.extend(std::iter::repeat_n(fill_token, n_tokens[i]));
-                i += 1;
-            } else {
-                expanded.push(t);
-            }
-        }
+        expand_media_placeholders(
+            &mut expanded,
+            token_ids,
+            img_tok,
+            &image_fill,
+            vid_tok,
+            video_triple.then_some(vision_bounds).flatten(),
+            &video_fill,
+        );
 
         // Unpadded expanded length, before the block-padding added below.
         let expanded_prompt_len = expanded.len();
@@ -1580,7 +1936,8 @@ impl OpenAIPreprocessor {
         // side channel.
         tracing::debug!(
             target: "mm_routing",
-            n_images = mm_image_entries.len(),
+            n_images = images.len(),
+            n_videos = videos.len(),
             block_size,
             total_tokens,
             "MmRoutingInfo built (exact, pad_value)"
@@ -4733,5 +5090,133 @@ mod tests {
             s3a, s3b,
             "s3:// query params identify objects and must not collide"
         );
+    }
+}
+
+/// Expand media placeholders in `token_ids` into `out`, in prompt order.
+/// Images: one `image_token` becomes its pad_value run from `image_fill`.
+/// Videos: with `triple_bounds` set (Qwen3-VL), a
+/// `<vision_start><video_token><vision_end>` triple is replaced wholesale by
+/// the next `video_fill` stream; otherwise a single `video_token` is
+/// replaced in place (Qwen2/2.5-VL). Placeholders beyond the fill lists are
+/// copied through untouched — callers validate counts beforehand.
+#[cfg(feature = "mm-routing")]
+fn expand_media_placeholders(
+    out: &mut Vec<crate::protocols::TokenIdType>,
+    token_ids: &[crate::protocols::TokenIdType],
+    image_token: Option<crate::protocols::TokenIdType>,
+    image_fill: &[(crate::protocols::TokenIdType, usize)],
+    video_token: Option<crate::protocols::TokenIdType>,
+    triple_bounds: Option<(crate::protocols::TokenIdType, crate::protocols::TokenIdType)>,
+    video_fill: &[Vec<crate::protocols::TokenIdType>],
+) {
+    let (mut img_i, mut vid_i) = (0usize, 0usize);
+    let mut i = 0usize;
+    while i < token_ids.len() {
+        let t = token_ids[i];
+        if Some(t) == image_token && img_i < image_fill.len() {
+            let (pad, n) = image_fill[img_i];
+            out.extend(std::iter::repeat_n(pad, n));
+            img_i += 1;
+            i += 1;
+        } else if let Some((vs, ve)) = triple_bounds
+            && vid_i < video_fill.len()
+            && i + 2 < token_ids.len()
+            && t == vs
+            && Some(token_ids[i + 1]) == video_token
+            && token_ids[i + 2] == ve
+        {
+            out.extend_from_slice(&video_fill[vid_i]);
+            vid_i += 1;
+            i += 3;
+        } else if triple_bounds.is_none() && Some(t) == video_token && vid_i < video_fill.len() {
+            out.extend_from_slice(&video_fill[vid_i]);
+            vid_i += 1;
+            i += 1;
+        } else {
+            out.push(t);
+            i += 1;
+        }
+    }
+}
+
+#[cfg(all(test, feature = "mm-routing"))]
+mod mm_expand_tests {
+    use super::expand_media_placeholders;
+
+    const IMG: u32 = 151655;
+    const VID: u32 = 151656;
+    const VS: u32 = 151652;
+    const VE: u32 = 151653;
+
+    fn expand(
+        token_ids: &[u32],
+        image_fill: &[(u32, usize)],
+        triple: bool,
+        video_fill: &[Vec<u32>],
+    ) -> Vec<u32> {
+        let mut out = Vec::new();
+        expand_media_placeholders(
+            &mut out,
+            token_ids,
+            Some(IMG),
+            image_fill,
+            Some(VID),
+            triple.then_some((VS, VE)),
+            video_fill,
+        );
+        out
+    }
+
+    /// Qwen2/2.5-VL: single video placeholder expands in place; the
+    /// template's vision start/end tokens stay as-is.
+    #[test]
+    fn single_token_video_expands_in_place() {
+        let out = expand(&[1, VS, VID, VE, 2], &[], false, &[vec![900, 900, 900]]);
+        assert_eq!(out, vec![1, VS, 900, 900, 900, VE, 2]);
+    }
+
+    /// Qwen3-VL: the whole triple is replaced by the per-frame-group stream
+    /// (which carries its own vision start/end pairs).
+    #[test]
+    fn triple_video_replaced_wholesale() {
+        let ts = [70u32, 71];
+        let stream = vec![
+            ts[0], ts[1], VS, 900, 900, VE, ts[0], ts[1], VS, 900, 900, VE,
+        ];
+        let out = expand(&[1, VS, VID, VE, 2], &[], true, &[stream.clone()]);
+        let mut expected = vec![1u32];
+        expected.extend_from_slice(&stream);
+        expected.push(2);
+        assert_eq!(out, expected);
+    }
+
+    /// Mixed prompt: image and video placeholders each consume their own
+    /// queue in prompt order.
+    #[test]
+    fn mixed_image_and_video() {
+        let out = expand(
+            &[1, IMG, 2, VS, VID, VE, 3, IMG],
+            &[(801, 2), (802, 1)],
+            true,
+            &[vec![905, 905]],
+        );
+        assert_eq!(out, vec![1, 801, 801, 2, 905, 905, 3, 802]);
+    }
+
+    /// Placeholders beyond the fill lists copy through untouched — the
+    /// caller's count validation makes this unreachable, but stay safe.
+    #[test]
+    fn surplus_placeholders_copy_through() {
+        let out = expand(&[IMG, IMG], &[(801, 1)], false, &[]);
+        assert_eq!(out, vec![801, IMG]);
+    }
+
+    /// An image triple (`<vs><image_pad><ve>`) must not match the video
+    /// triple pattern.
+    #[test]
+    fn image_triple_not_confused_with_video_triple() {
+        let out = expand(&[VS, IMG, VE], &[(801, 3)], true, &[vec![999]]);
+        assert_eq!(out, vec![VS, 801, 801, 801, VE]);
     }
 }

--- a/lib/llm/src/preprocessor/lightseek_mm.rs
+++ b/lib/llm/src/preprocessor/lightseek_mm.rs
@@ -235,6 +235,16 @@ pub struct RoutingTokens {
     /// produce the routing-side prepend id. `None` for models that don't
     /// prepend BOS.
     pub bos_token_string: Option<String>,
+    /// Literal `video_token_id` from `config.json` (Qwen-VL families): the
+    /// token the chat template emits per video and the backend HF processor
+    /// expands per patch. `None` disables video MM-aware routing.
+    pub video_token_id: Option<TokenIdType>,
+    /// Literal `vision_start_token_id` from `config.json`. Needed to match
+    /// Qwen3-VL's `<|vision_start|><|video_pad|><|vision_end|>` placeholder
+    /// triple, which is replaced wholesale during expansion.
+    pub vision_start_token_id: Option<TokenIdType>,
+    /// Literal `vision_end_token_id` from `config.json` (see above).
+    pub vision_end_token_id: Option<TokenIdType>,
 }
 
 /// Resolve all routing-side token info from a model directory in a single
@@ -252,16 +262,28 @@ pub fn resolve_routing_tokens(model_id: &str, model_dir: &Path) -> RoutingTokens
         .and_then(|c| resolve_image_token_id_with_config(model_id, model_dir, c));
     let chat_placeholder_token_id = config
         .as_ref()
-        .and_then(extract_chat_placeholder_from_config)
+        .and_then(|c| extract_token_id_field(c, "image_token_id"))
         .or(image_token_id);
     let bos_token_string = tokenizer_config
         .as_ref()
         .and_then(extract_bos_token_from_tokenizer_config);
+    let video_token_id = config
+        .as_ref()
+        .and_then(|c| extract_token_id_field(c, "video_token_id"));
+    let vision_start_token_id = config
+        .as_ref()
+        .and_then(|c| extract_token_id_field(c, "vision_start_token_id"));
+    let vision_end_token_id = config
+        .as_ref()
+        .and_then(|c| extract_token_id_field(c, "vision_end_token_id"));
 
     RoutingTokens {
         image_token_id,
         chat_placeholder_token_id,
         bos_token_string,
+        video_token_id,
+        vision_start_token_id,
+        vision_end_token_id,
     }
 }
 
@@ -297,12 +319,13 @@ fn read_json(model_dir: &Path, filename: &str) -> Option<serde_json::Value> {
     }
 }
 
-/// Read the literal `image_token_id` field from a pre-parsed `config.json`.
-/// Used by Qwen2-VL / Qwen2.5-VL where the chat-template-emitted placeholder
-/// differs from the per-patch expansion token returned by the spec.
-fn extract_chat_placeholder_from_config(config: &serde_json::Value) -> Option<TokenIdType> {
+/// Read a literal token-id field from a pre-parsed `config.json`. Used for
+/// `image_token_id` (Qwen2-VL / Qwen2.5-VL, where the chat-template-emitted
+/// placeholder differs from the per-patch expansion token returned by the
+/// spec), `video_token_id`, and the `vision_start/end_token_id` pair.
+fn extract_token_id_field(config: &serde_json::Value, field: &str) -> Option<TokenIdType> {
     config
-        .get("image_token_id")
+        .get(field)
         .and_then(|x| x.as_u64())
         .and_then(|id| u32::try_from(id).ok())
 }

--- a/lib/llm/src/preprocessor/media.rs
+++ b/lib/llm/src/preprocessor/media.rs
@@ -7,7 +7,7 @@ mod loader;
 mod rdma;
 
 pub use common::EncodedMediaData;
-pub use decoders::{Decoder, ImageDecoder, MediaDecoder};
+pub use decoders::{DecodedMediaMetadata, Decoder, ImageDecoder, MediaDecoder};
 pub use loader::{MediaFetcher, MediaLoader};
 
 pub use rdma::{DecodedMediaData, RdmaMediaDataDescriptor, get_nixl_agent, get_nixl_metadata};

--- a/lib/llm/src/preprocessor/mm_video.rs
+++ b/lib/llm/src/preprocessor/mm_video.rs
@@ -514,4 +514,144 @@ mod tests {
             );
         }
     }
+
+    /// End-to-end parity against a REAL vLLM engine's KV events: the routing
+    /// stream rebuilt here (pre-expansion prompt ids + VideoTokenCounter +
+    /// pad_value fill) must block-hash identically to the engine's
+    /// BlockStored events after the production ZMQ normalization
+    /// (`decode_event_batch` + `ZmqEventNormalizer` with the video token id).
+    /// Capture with `e2e_capture.py`; run with:
+    /// `DYN_MM_VIDEO_E2E_CAPTURE=e2e_capture.json cargo test -p dynamo-llm \
+    ///    --no-default-features --features mm-routing --lib \
+    ///    vllm_e2e_event_parity -- --ignored --nocapture`
+    #[test]
+    #[ignore = "requires a vLLM KV-event capture via DYN_MM_VIDEO_E2E_CAPTURE"]
+    fn vllm_e2e_event_parity() {
+        use base64::Engine as _;
+        use dynamo_kv_router::protocols::{
+            BlockHashOptions, KvCacheEventData, WorkerWithDpRank, compute_block_hash_for_seq,
+            pad_value_for_mm_hash,
+        };
+        use dynamo_kv_router::zmq_wire::{ZmqEventNormalizer, decode_event_batch};
+
+        let path = std::env::var("DYN_MM_VIDEO_E2E_CAPTURE")
+            .expect("set DYN_MM_VIDEO_E2E_CAPTURE to the capture json path");
+        let fx: serde_json::Value =
+            serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+        let u32s = |v: &serde_json::Value| -> Vec<u32> {
+            v.as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_u64().unwrap() as u32)
+                .collect()
+        };
+
+        let dir = std::path::PathBuf::from(fx["local_dir"].as_str().unwrap());
+        let model_id = fx["model_id"].as_str().unwrap();
+        let block_size = fx["kv_block_size"].as_u64().unwrap() as usize;
+        let mm_hash = fx["mm_hash_u64"].as_u64().unwrap();
+        let video_tok = fx["video_token_id"].as_u64().unwrap() as u32;
+        let image_tok = fx["image_token_id"].as_u64().map(|x| x as u32);
+        let t = fx["num_frames"].as_u64().unwrap() as usize;
+        let h = fx["height"].as_u64().unwrap() as u32;
+        let w = fx["width"].as_u64().unwrap() as u32;
+
+        // ---- Frontend side: independent rebuild of the routing stream ----
+        let counter = VideoTokenCounter::try_new(model_id, None, &dir).unwrap();
+        let n = counter.count_tokens(t, h, w).unwrap();
+        let pre_ids = u32s(&fx["pre_expansion_input_ids"]);
+        assert_eq!(
+            pre_ids.iter().filter(|&&x| x == video_tok).count(),
+            1,
+            "expected exactly one video placeholder in the chat prompt"
+        );
+        let pad = pad_value_for_mm_hash(mm_hash);
+        let mut routing: Vec<u32> = Vec::with_capacity(pre_ids.len() + n);
+        for &tok in &pre_ids {
+            if tok == video_tok {
+                routing.extend(std::iter::repeat_n(pad, n));
+            } else {
+                routing.push(tok);
+            }
+        }
+
+        // Cross-check the expansion against the engine's actual prompt: same
+        // length, pad exactly where the engine has video_token_id.
+        let engine_prompt = u32s(&fx["engine_prompt_token_ids"]);
+        assert_eq!(routing.len(), engine_prompt.len(), "expanded prompt length");
+        for (i, (&r, &e)) in routing.iter().zip(engine_prompt.iter()).enumerate() {
+            if e == video_tok {
+                assert_eq!(r, pad, "expected pad at video position {i}");
+            } else {
+                assert_eq!(r, e, "token mismatch at {i}");
+            }
+        }
+
+        let frontend_hashes =
+            compute_block_hash_for_seq(&routing, block_size as u32, BlockHashOptions::default());
+
+        // ---- Event side: production decode + normalization ----
+        let mut normalizer = ZmqEventNormalizer::new(block_size as u32)
+            .with_image_token_id(image_tok)
+            .with_video_token_id(Some(video_tok));
+        let worker = WorkerWithDpRank::from_worker_id(0);
+        let mut event_hashes = Vec::new();
+        let mut normalized_mm_blocks = 0usize;
+        for (i, payload_b64) in fx["raw_event_payloads_b64"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .enumerate()
+        {
+            let payload = base64::engine::general_purpose::STANDARD
+                .decode(payload_b64.as_str().unwrap())
+                .unwrap();
+            let batch = decode_event_batch(&payload).unwrap();
+            for raw in batch.events {
+                let Some(placement) = normalizer.normalize(raw, i as u64, worker) else {
+                    continue;
+                };
+                if let KvCacheEventData::Stored(store) = placement.event.data {
+                    for b in store.blocks {
+                        if b.mm_extra_info.is_some() {
+                            normalized_mm_blocks += 1;
+                        }
+                        event_hashes.push(b.tokens_hash);
+                    }
+                }
+            }
+        }
+
+        // The engine also stores warm-up and generated-token blocks, so the
+        // video prompt's whole blocks must appear as a contiguous run inside
+        // the stored-hash sequence, in order.
+        let prompt_blocks = routing.len() / block_size;
+        assert!(prompt_blocks > 0, "prompt shorter than one block");
+        assert!(
+            event_hashes.len() >= prompt_blocks,
+            "engine stored {} blocks, need at least {prompt_blocks}",
+            event_hashes.len()
+        );
+        assert!(
+            normalized_mm_blocks > 0,
+            "no event block carried mm extra keys — uuid forwarding broken?"
+        );
+        let expected = &frontend_hashes[..prompt_blocks];
+        let found = event_hashes
+            .windows(prompt_blocks)
+            .any(|run| run == expected);
+        assert!(
+            found,
+            "frontend block hashes not found as a run in {} stored event hashes \
+             (first frontend hash {:?}, event hashes {:?})",
+            event_hashes.len(),
+            expected.first(),
+            &event_hashes[..event_hashes.len().min(8)]
+        );
+        println!(
+            "e2e parity ok: {model_id} — {prompt_blocks} prompt blocks match \
+             ({} video tokens, {normalized_mm_blocks} mm blocks normalized)",
+            n
+        );
+    }
 }

--- a/lib/llm/src/preprocessor/mm_video.rs
+++ b/lib/llm/src/preprocessor/mm_video.rs
@@ -1,0 +1,411 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Pure-Rust per-video token counting for MM-aware KV routing. Compiled only
+//! when the `mm-routing` cargo feature is enabled.
+//!
+//! Unlike the image path (`lightseek_mm`, backed by the external
+//! `llm-multimodal` crate), video counting is implemented in-tree: the
+//! upstream crate's `calculate_num_tokens(width, height)` has no temporal
+//! parameter (verified through 1.8.0). This module reproduces the HF
+//! processor math for the Qwen-VL video families from
+//! `preprocessor_config.json` / `video_preprocessor_config.json` directly.
+//!
+//! The token count depends on the *sampled* frame count `T`, which only the
+//! frontend-decoding path knows exactly (the frontend samples frames and
+//! ships the decoded tensor to the backend). URL-passthrough video is
+//! therefore not routable — callers skip building MM routing info for it.
+
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow};
+
+/// Qwen-VL video families with distinct expansion structure or resize
+/// budgets. Qwen2-VL and Qwen2.5-VL share per-frame resize + a single
+/// `<|video_pad|>` placeholder; Qwen3-VL budgets the full `T*H*W` volume and
+/// interleaves per-frame-group timestamp text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VideoFamily {
+    Qwen2Vl,
+    Qwen25Vl,
+    Qwen3Vl,
+}
+
+impl VideoFamily {
+    /// Prefer the `model_type` config field; fall back to HF-id/path
+    /// substrings, mirroring the image registry's matching convention.
+    fn detect(model_id: &str, model_type: Option<&str>) -> Option<Self> {
+        match model_type {
+            Some("qwen2_vl") => return Some(Self::Qwen2Vl),
+            Some("qwen2_5_vl") => return Some(Self::Qwen25Vl),
+            Some("qwen3_vl") | Some("qwen3_vl_moe") => return Some(Self::Qwen3Vl),
+            _ => {}
+        }
+        let id = model_id.to_ascii_lowercase().replace('_', "-");
+        if id.contains("qwen3-vl") {
+            Some(Self::Qwen3Vl)
+        } else if id.contains("qwen2.5-vl") || id.contains("qwen2-5-vl") {
+            Some(Self::Qwen25Vl)
+        } else if id.contains("qwen2-vl") {
+            Some(Self::Qwen2Vl)
+        } else {
+            None
+        }
+    }
+
+    /// Whether the chat template's `<|vision_start|><|video_pad|><|vision_end|>`
+    /// triple is replaced wholesale with per-frame-group segments (Qwen3-VL),
+    /// as opposed to expanding the single `<|video_pad|>` token in place.
+    pub fn expands_placeholder_triple(&self) -> bool {
+        matches!(self, Self::Qwen3Vl)
+    }
+}
+
+/// Maps `(num_frames, width, height) → num_video_tokens` for a single model
+/// using the model's HF video-processing parameters.
+pub struct VideoTokenCounter {
+    family: VideoFamily,
+    patch_size: usize,
+    merge_size: usize,
+    temporal_patch_size: usize,
+    min_pixels: usize,
+    max_pixels: usize,
+    model_id: String,
+}
+
+impl VideoTokenCounter {
+    /// Returns `Err` when the model family is not a supported Qwen-VL video
+    /// family or no processor config is readable. Callers should treat the
+    /// error as "video MM-aware routing disabled for this model" rather than
+    /// failing the request. Sync filesystem I/O by design — called once per
+    /// model at preprocessor construction, like `LightseekMmCounter::try_new`.
+    pub fn try_new(model_id: &str, model_type: Option<&str>, model_dir: &Path) -> Result<Self> {
+        let family = VideoFamily::detect(model_id, model_type).ok_or_else(|| {
+            anyhow!(
+                "mm-routing: no video token counter for model_id={:?} model_type={:?}",
+                model_id,
+                model_type
+            )
+        })?;
+
+        // Newer Transformers splits video params into
+        // `video_preprocessor_config.json`; older releases keep them in
+        // `preprocessor_config.json`. Prefer the video-specific file.
+        let json = ["video_preprocessor_config.json", "preprocessor_config.json"]
+            .iter()
+            .find_map(|name| std::fs::read_to_string(model_dir.join(name)).ok())
+            .with_context(|| {
+                format!(
+                    "mm-routing: no readable (video_)preprocessor_config.json under {}",
+                    model_dir.display()
+                )
+            })?;
+        let config: serde_json::Value = serde_json::from_str(&json)
+            .with_context(|| "mm-routing: failed to parse video processor config")?;
+
+        Self::from_config(family, &config, model_id)
+    }
+
+    /// Build from a pre-parsed processor config. Field fallbacks follow the
+    /// HF schema across Transformers versions: `patch_size` may be a scalar
+    /// or `{height, width}`; the pixel budget is `min_pixels`/`max_pixels`
+    /// or `size.shortest_edge`/`size.longest_edge`.
+    fn from_config(
+        family: VideoFamily,
+        config: &serde_json::Value,
+        model_id: &str,
+    ) -> Result<Self> {
+        let scalar = |v: &serde_json::Value| -> Option<usize> {
+            v.as_u64().map(|x| x as usize).or_else(|| {
+                v.get("height")
+                    .or_else(|| v.get("width"))
+                    .and_then(|d| d.as_u64())
+                    .map(|x| x as usize)
+            })
+        };
+        let field = |name: &str| config.get(name).and_then(&scalar);
+        let size_field = |name: &str| {
+            config
+                .get("size")
+                .and_then(|s| s.get(name))
+                .and_then(|v| v.as_u64())
+                .map(|x| x as usize)
+        };
+
+        // Per-family HF defaults, used only when the config omits a field.
+        let (d_patch, d_min, d_max) = match family {
+            // Qwen2VLImageProcessor defaults (also processes Qwen2/2.5-VL video).
+            VideoFamily::Qwen2Vl | VideoFamily::Qwen25Vl => (14, 56 * 56, 28 * 28 * 1280),
+            // Qwen3VLVideoProcessor defaults; max budgets the T*H*W volume.
+            VideoFamily::Qwen3Vl => (16, 65_536, 16_777_216),
+        };
+
+        let counter = Self {
+            family,
+            patch_size: field("patch_size").unwrap_or(d_patch),
+            merge_size: field("merge_size").unwrap_or(2),
+            temporal_patch_size: field("temporal_patch_size").unwrap_or(2),
+            min_pixels: field("min_pixels")
+                .or_else(|| size_field("shortest_edge"))
+                .unwrap_or(d_min),
+            max_pixels: field("max_pixels")
+                .or_else(|| size_field("longest_edge"))
+                .unwrap_or(d_max),
+            model_id: model_id.to_string(),
+        };
+        if counter.patch_size == 0
+            || counter.merge_size == 0
+            || counter.temporal_patch_size == 0
+            || counter.min_pixels == 0
+            || counter.min_pixels > counter.max_pixels
+        {
+            return Err(anyhow!(
+                "mm-routing: invalid video processor config for {model_id}"
+            ));
+        }
+        Ok(counter)
+    }
+
+    pub fn model_id(&self) -> &str {
+        &self.model_id
+    }
+
+    pub fn family(&self) -> VideoFamily {
+        self.family
+    }
+
+    /// Dimension alignment factor: dims must be divisible by
+    /// `patch_size * merge_size`.
+    fn factor(&self) -> usize {
+        self.patch_size * self.merge_size
+    }
+
+    /// HF `smart_resize`: round dims to the nearest factor multiple
+    /// (Python `round()` is banker's rounding, hence `round_ties_even`),
+    /// then rescale into the pixel budget. `volume_frames` is the padded
+    /// temporal extent the budget applies to: 1 for per-frame budgets
+    /// (Qwen2/2.5-VL), `t_bar` for the Qwen3-VL video volume budget.
+    /// HF quirk preserved: the over-budget threshold uses padded frames
+    /// while the rescale beta uses the actual pixel volume.
+    fn smart_resize(
+        &self,
+        height: usize,
+        width: usize,
+        volume_frames: usize,
+        beta_frames: usize,
+    ) -> Result<(usize, usize)> {
+        let factor = self.factor() as f64;
+        if height == 0 || width == 0 {
+            return Err(anyhow!("mm-routing: zero video frame dimension"));
+        }
+        let (max_d, min_d) = (height.max(width) as f64, height.min(width) as f64);
+        if max_d / min_d > 200.0 {
+            return Err(anyhow!("mm-routing: video aspect ratio exceeds 200:1"));
+        }
+
+        let mut h_bar =
+            ((height as f64 / factor).round_ties_even() as usize).max(1) * self.factor();
+        let mut w_bar = ((width as f64 / factor).round_ties_even() as usize).max(1) * self.factor();
+        h_bar = h_bar.max(self.factor());
+        w_bar = w_bar.max(self.factor());
+
+        let resized = volume_frames as f64 * (h_bar * w_bar) as f64;
+        let actual = (beta_frames * height * width) as f64;
+        if resized > self.max_pixels as f64 {
+            let beta = (actual / self.max_pixels as f64).sqrt();
+            h_bar = ((height as f64 / beta / factor).floor() as usize) * self.factor();
+            w_bar = ((width as f64 / beta / factor).floor() as usize) * self.factor();
+            h_bar = h_bar.max(self.factor());
+            w_bar = w_bar.max(self.factor());
+        } else if resized < self.min_pixels as f64 {
+            let beta = (self.min_pixels as f64 / actual).sqrt();
+            h_bar = ((height as f64 * beta / factor).ceil() as usize) * self.factor();
+            w_bar = ((width as f64 * beta / factor).ceil() as usize) * self.factor();
+        }
+        Ok((h_bar, w_bar))
+    }
+
+    /// `(grid_t, grid_h, grid_w)` for a sampled clip. `grid_t` reflects the
+    /// HF frame padding to a multiple of `temporal_patch_size` (the last
+    /// frame is repeated), i.e. `ceil(T / temporal_patch_size)`.
+    fn grid_thw(
+        &self,
+        num_frames: usize,
+        height: u32,
+        width: u32,
+    ) -> Result<(usize, usize, usize)> {
+        if num_frames == 0 {
+            return Err(anyhow!("mm-routing: zero sampled video frames"));
+        }
+        let grid_t = num_frames.div_ceil(self.temporal_patch_size);
+        let (h_bar, w_bar) = match self.family {
+            VideoFamily::Qwen2Vl | VideoFamily::Qwen25Vl => {
+                // Per-frame pixel budget, applied to each frame identically.
+                self.smart_resize(height as usize, width as usize, 1, 1)?
+            }
+            VideoFamily::Qwen3Vl => {
+                // Volume budget over the padded clip.
+                let t_bar = grid_t * self.temporal_patch_size;
+                self.smart_resize(height as usize, width as usize, t_bar, num_frames)?
+            }
+        };
+        Ok((grid_t, h_bar / self.patch_size, w_bar / self.patch_size))
+    }
+
+    /// Total `<|video_pad|>` tokens the backend HF processor emits for this
+    /// clip: `grid_t * grid_h * grid_w / merge_size^2`.
+    pub fn count_tokens(&self, num_frames: usize, height: u32, width: u32) -> Result<usize> {
+        let (t, h, w) = self.grid_thw(num_frames, height, width)?;
+        Ok(t * h * w / (self.merge_size * self.merge_size))
+    }
+
+    /// Qwen3-VL: `<|video_pad|>` tokens per temporal grid group
+    /// (`grid_h * grid_w / merge_size^2`).
+    pub fn tokens_per_frame_group(
+        &self,
+        num_frames: usize,
+        height: u32,
+        width: u32,
+    ) -> Result<usize> {
+        let (_, h, w) = self.grid_thw(num_frames, height, width)?;
+        Ok(h * w / (self.merge_size * self.merge_size))
+    }
+
+    /// Qwen3-VL: one timestamp per temporal grid group, the midpoint of the
+    /// group's first and last sampled-frame timestamps. Matches the HF video
+    /// processor's grouping of `sampled_timestamps` by `temporal_patch_size`.
+    pub fn group_timestamps(&self, sampled_timestamps: &[f64]) -> Vec<f64> {
+        sampled_timestamps
+            .chunks(self.temporal_patch_size)
+            .map(|chunk| {
+                let first = chunk[0];
+                let last = chunk.last().copied().unwrap_or(first);
+                (first + last) / 2.0
+            })
+            .collect()
+    }
+
+    /// Qwen3-VL timestamp text inserted before each frame group, e.g.
+    /// `<3.5 seconds>`. One decimal place, matching the HF chat processor's
+    /// `f"<{timestamp:.1f} seconds>"`.
+    pub fn timestamp_label(timestamp: f64) -> String {
+        format!("<{timestamp:.1} seconds>")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn qwen3(config: &str) -> VideoTokenCounter {
+        VideoTokenCounter::from_config(
+            VideoFamily::Qwen3Vl,
+            &serde_json::from_str(config).unwrap(),
+            "Qwen/Qwen3-VL-2B-Instruct",
+        )
+        .unwrap()
+    }
+
+    fn qwen2(config: &str) -> VideoTokenCounter {
+        VideoTokenCounter::from_config(
+            VideoFamily::Qwen2Vl,
+            &serde_json::from_str(config).unwrap(),
+            "Qwen/Qwen2-VL-7B-Instruct",
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn family_detection_prefers_model_type() {
+        assert_eq!(
+            VideoFamily::detect("/models/finetune", Some("qwen2_5_vl")),
+            Some(VideoFamily::Qwen25Vl)
+        );
+        assert_eq!(
+            VideoFamily::detect("Qwen/Qwen3-VL-2B-Instruct", None),
+            Some(VideoFamily::Qwen3Vl)
+        );
+        assert_eq!(
+            VideoFamily::detect("/models/Qwen2.5-VL-7B/", None),
+            Some(VideoFamily::Qwen25Vl)
+        );
+        assert_eq!(VideoFamily::detect("llava-1.5", None), None);
+    }
+
+    #[test]
+    fn parses_min_max_pixels_and_size_fallback() {
+        let a = qwen2(
+            r#"{"patch_size": 14, "merge_size": 2, "temporal_patch_size": 2,
+                          "min_pixels": 3136, "max_pixels": 1003520}"#,
+        );
+        assert_eq!(
+            (a.patch_size, a.min_pixels, a.max_pixels),
+            (14, 3136, 1003520)
+        );
+
+        let b = qwen3(
+            r#"{"patch_size": 16, "size": {"shortest_edge": 65536, "longest_edge": 16777216}}"#,
+        );
+        assert_eq!((b.min_pixels, b.max_pixels), (65_536, 16_777_216));
+    }
+
+    /// Qwen2-VL per-frame budget: a 224x224 clip resizes to itself
+    /// (factor 28 aligned, inside [3136, 1003520]); 8 frames with
+    /// temporal_patch_size 2 give grid_t=4; tokens = 4*16*16/4.
+    #[test]
+    fn qwen2_vl_video_token_count() {
+        let c = qwen2(
+            r#"{"patch_size": 14, "merge_size": 2, "temporal_patch_size": 2,
+                          "min_pixels": 3136, "max_pixels": 1003520}"#,
+        );
+        assert_eq!(c.count_tokens(8, 224, 224).unwrap(), 256);
+        // Odd frame count pads up: T=5 -> grid_t=3.
+        assert_eq!(c.count_tokens(5, 224, 224).unwrap(), 3 * 64);
+    }
+
+    /// Qwen3-VL volume budget: 640x360, factor 32 ->
+    /// h_bar = round_ties_even(360/32)=11 -> 352, w_bar = 20 -> 640.
+    /// T=16 volume 16*352*640 within budget; grid_t=8, grid_h=352/16=22,
+    /// grid_w=640/16=40 -> 8*22*40/4 = 1760 tokens, 220 per frame group.
+    #[test]
+    fn qwen3_vl_video_token_count() {
+        let c = qwen3(
+            r#"{"patch_size": 16, "merge_size": 2, "temporal_patch_size": 2,
+                          "min_pixels": 65536, "max_pixels": 16777216}"#,
+        );
+        assert_eq!(c.count_tokens(16, 360, 640).unwrap(), 1760);
+        assert_eq!(c.tokens_per_frame_group(16, 360, 640).unwrap(), 220);
+    }
+
+    /// Over-budget Qwen3-VL clip scales down: threshold uses padded frames,
+    /// beta uses actual pixels (HF quirk).
+    #[test]
+    fn qwen3_vl_volume_downscale() {
+        let c = qwen3(
+            r#"{"patch_size": 16, "merge_size": 2, "temporal_patch_size": 2,
+                          "min_pixels": 65536, "max_pixels": 16777216}"#,
+        );
+        // 64 frames of 1080x1920: volume 64*1088*1920 = 133.7M > 16.7M budget.
+        let n = c.count_tokens(64, 1080, 1920).unwrap();
+        let (t, h, w) = c.grid_thw(64, 1080, 1920).unwrap();
+        assert_eq!(t, 32);
+        // Post-rescale volume must fit the budget.
+        assert!(t * 2 * (h * 16) * (w * 16) <= 16_777_216);
+        assert_eq!(n, t * h * w / 4);
+    }
+
+    #[test]
+    fn group_timestamps_midpoint_and_tail() {
+        let c = qwen3(r#"{"temporal_patch_size": 2}"#);
+        assert_eq!(
+            c.group_timestamps(&[0.0, 0.5, 1.0, 1.5, 2.0]),
+            vec![0.25, 1.25, 2.0]
+        );
+    }
+
+    #[test]
+    fn timestamp_label_one_decimal() {
+        assert_eq!(VideoTokenCounter::timestamp_label(1.25), "<1.2 seconds>");
+        assert_eq!(VideoTokenCounter::timestamp_label(3.0), "<3.0 seconds>");
+    }
+}

--- a/lib/llm/src/preprocessor/mm_video.rs
+++ b/lib/llm/src/preprocessor/mm_video.rs
@@ -408,4 +408,110 @@ mod tests {
         assert_eq!(VideoTokenCounter::timestamp_label(1.25), "<1.2 seconds>");
         assert_eq!(VideoTokenCounter::timestamp_label(3.0), "<3.0 seconds>");
     }
+
+    /// Parity against real HF processor outputs (counts AND the full
+    /// expanded token stream). Fixtures are produced by running the pinned
+    /// Transformers processors over synthetic clips; regenerate them when
+    /// bumping the supported Transformers range. Run with:
+    /// `DYN_MM_VIDEO_FIXTURE=a.json;b.json cargo test -p dynamo-llm \
+    ///    --no-default-features --features mm-routing hf_fixture_parity \
+    ///    -- --ignored --nocapture`
+    #[test]
+    #[ignore = "requires HF-generated fixture files via DYN_MM_VIDEO_FIXTURE"]
+    fn hf_fixture_parity() {
+        let paths = std::env::var("DYN_MM_VIDEO_FIXTURE")
+            .expect("set DYN_MM_VIDEO_FIXTURE to ';'-separated fixture json paths");
+        let u32s = |v: &serde_json::Value| -> Vec<u32> {
+            v.as_array()
+                .unwrap()
+                .iter()
+                .map(|x| x.as_u64().unwrap() as u32)
+                .collect()
+        };
+        for path in paths.split(';').filter(|p| !p.is_empty()) {
+            let fx: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(path).unwrap()).unwrap();
+            let model_id = fx["model_id"].as_str().unwrap();
+            let dir = std::path::PathBuf::from(fx["local_dir"].as_str().unwrap());
+            let counter = VideoTokenCounter::try_new(model_id, None, &dir).unwrap();
+            let video_tok = fx["video_token_id"].as_u64().unwrap() as u32;
+            let pre_ids = u32s(&fx["pre_expansion_input_ids"]);
+            let tokenizer = crate::tokenizers::Tokenizer::from_file(
+                dir.join("tokenizer.json").to_str().unwrap(),
+            )
+            .unwrap();
+            for case in fx["cases"].as_array().unwrap() {
+                let t = case["num_frames"].as_u64().unwrap() as usize;
+                let h = case["height"].as_u64().unwrap() as u32;
+                let w = case["width"].as_u64().unwrap() as u32;
+                let label = format!("{model_id} T={t} {h}x{w}");
+                let expect_n = case["n_video_tokens"].as_u64().unwrap() as usize;
+                let grid = u32s(&case["video_grid_thw"]);
+                let expect_ids = u32s(&case["expanded_input_ids"]);
+
+                assert_eq!(
+                    counter.count_tokens(t, h, w).unwrap(),
+                    expect_n,
+                    "count {label}"
+                );
+                let per_group = counter.tokens_per_frame_group(t, h, w).unwrap();
+                assert_eq!(per_group, expect_n / grid[0] as usize, "per-group {label}");
+
+                // Rebuild the expansion exactly as the frontend does, filling
+                // video positions with video_tok instead of pad_value, so the
+                // result must be bit-identical to HF's expanded input_ids.
+                let rebuilt = if counter.family().expands_placeholder_triple() {
+                    let vs = fx["vision_start_token_id"].as_u64().unwrap() as u32;
+                    let ve = fx["vision_end_token_id"].as_u64().unwrap() as u32;
+                    let ts: Vec<f64> = case["sampled_timestamps"]
+                        .as_array()
+                        .unwrap()
+                        .iter()
+                        .map(|x| x.as_f64().unwrap())
+                        .collect();
+                    let mut repl = Vec::new();
+                    for g in counter.group_timestamps(&ts) {
+                        let enc = tokenizer
+                            .encode(&VideoTokenCounter::timestamp_label(g))
+                            .unwrap();
+                        repl.extend_from_slice(enc.token_ids());
+                        repl.push(vs);
+                        repl.extend(std::iter::repeat_n(video_tok, per_group));
+                        repl.push(ve);
+                    }
+                    let mut out = Vec::with_capacity(pre_ids.len() + repl.len());
+                    let mut i = 0usize;
+                    while i < pre_ids.len() {
+                        if i + 2 < pre_ids.len()
+                            && pre_ids[i] == vs
+                            && pre_ids[i + 1] == video_tok
+                            && pre_ids[i + 2] == ve
+                        {
+                            out.extend_from_slice(&repl);
+                            i += 3;
+                        } else {
+                            out.push(pre_ids[i]);
+                            i += 1;
+                        }
+                    }
+                    out
+                } else {
+                    let mut out = Vec::with_capacity(pre_ids.len() + expect_n);
+                    for &tok in &pre_ids {
+                        if tok == video_tok {
+                            out.extend(std::iter::repeat_n(video_tok, expect_n));
+                        } else {
+                            out.push(tok);
+                        }
+                    }
+                    out
+                };
+                assert_eq!(rebuilt, expect_ids, "expanded ids {label}");
+            }
+            println!(
+                "fixture parity ok: {model_id} ({} cases)",
+                fx["cases"].as_array().unwrap().len()
+            );
+        }
+    }
 }

--- a/lib/llm/tests/data/mm_video/e2e_capture.py
+++ b/lib/llm/tests/data/mm_video/e2e_capture.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Capture vLLM KV events for a video request, for Dynamo MM-routing parity.
+
+Runs a real vLLM engine with ZMQ KV events, submits one Qwen2.5-VL video
+request with a fixed multi_modal_uuid (the frontend-forwarded mm_hash), and
+dumps the raw event payloads plus everything the Rust parity test needs to
+rebuild the frontend routing stream independently.
+"""
+import base64
+import json
+import os
+import threading
+
+import numpy as np
+import zmq
+
+MODEL = "Qwen/Qwen2.5-VL-3B-Instruct"
+# vLLM's publisher binds only when the endpoint contains a wildcard
+# (kv_events.py "bind if wildcard" heuristic); the subscriber connects.
+PUB_ENDPOINT = "tcp://*:56797"
+SUB_ENDPOINT = "tcp://127.0.0.1:56797"
+MM_HASH_U64 = 0xABCDEF0123456789
+UUID_HEX = f"{MM_HASH_U64:016x}".ljust(64, "0")
+T, H, W = 8, 224, 224
+BLOCK_SIZE = 16
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "e2e_capture.json")
+
+payloads = []
+stop = threading.Event()
+
+
+def subscriber():
+    ctx = zmq.Context()
+    s = ctx.socket(zmq.SUB)
+    s.connect(SUB_ENDPOINT)
+    s.setsockopt_string(zmq.SUBSCRIBE, "")
+    s.setsockopt(zmq.RCVTIMEO, 500)
+    while not stop.is_set():
+        try:
+            parts = s.recv_multipart()
+        except zmq.Again:
+            continue
+        payloads.append(base64.b64encode(parts[-1]).decode())
+    s.close()
+    ctx.term()
+
+
+def main():
+    sub = threading.Thread(target=subscriber, daemon=True)
+    sub.start()
+
+    from huggingface_hub import snapshot_download
+    from transformers import AutoProcessor
+    from vllm import LLM, SamplingParams
+    from vllm.config import KVEventsConfig
+
+    local = snapshot_download(MODEL, allow_patterns=["*.json", "*.txt", "*.model"])
+    proc = AutoProcessor.from_pretrained(local)
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {"type": "video"},
+                {"type": "text", "text": "Describe the video."},
+            ],
+        }
+    ]
+    text = proc.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+    pre_ids = proc.tokenizer(text, add_special_tokens=False).input_ids
+
+    llm = LLM(
+        model=MODEL,
+        max_model_len=4096,
+        gpu_memory_utilization=0.5,
+        limit_mm_per_prompt={"video": 1},
+        block_size=BLOCK_SIZE,
+        kv_events_config=KVEventsConfig(
+            enable_kv_cache_events=True,
+            publisher="zmq",
+            endpoint=PUB_ENDPOINT,
+        ),
+    )
+
+    import time
+
+    # Warm-up text request: vLLM starts its ZMQ publisher thread lazily on the
+    # first request, and a fresh SUB socket drops messages published during
+    # the join window (slow joiner). Let the publisher come up, then wait for
+    # the subscription to propagate before the request we actually capture.
+    llm.generate(
+        [{"prompt": "Warm up."}], SamplingParams(max_tokens=1, temperature=0.0)
+    )
+    time.sleep(3)
+
+    rng = np.random.default_rng(42)
+    video = rng.integers(0, 255, size=(T, H, W, 3), dtype=np.uint8)
+    req = {
+        "prompt": text,
+        "multi_modal_data": {"video": video},
+        "multi_modal_uuids": {"video": [UUID_HEX]},
+    }
+    out = llm.generate([req], SamplingParams(max_tokens=8, temperature=0.0))
+    prompt_token_ids = list(out[0].prompt_token_ids)
+
+    time.sleep(3)  # let the publisher flush
+    stop.set()
+    sub.join(timeout=5)
+
+    cfg = json.load(open(os.path.join(local, "config.json")))
+    json.dump(
+        {
+            "model_id": MODEL,
+            "local_dir": local,
+            "mm_hash_u64": MM_HASH_U64,
+            "uuid_hex": UUID_HEX,
+            "num_frames": T,
+            "height": H,
+            "width": W,
+            "kv_block_size": BLOCK_SIZE,
+            "video_token_id": cfg["video_token_id"],
+            "image_token_id": cfg.get("image_token_id"),
+            "pre_expansion_input_ids": pre_ids,
+            "engine_prompt_token_ids": prompt_token_ids,
+            "raw_event_payloads_b64": payloads,
+        },
+        open(OUT, "w"),
+    )
+    n_video = sum(1 for x in prompt_token_ids if x == cfg["video_token_id"])
+    print("engine prompt len:", len(prompt_token_ids), "video tokens:", n_video)
+    print("captured payloads:", len(payloads))
+    print("wrote", OUT)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/llm/tests/data/mm_video/gen_fixture.py
+++ b/lib/llm/tests/data/mm_video/gen_fixture.py
@@ -1,0 +1,112 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Generate MM-routing video fixtures from the real HF processors.
+
+For each model and (T, H, W) case, runs the HF video pipeline the backend
+(vLLM) would run and records everything the Rust `VideoTokenCounter` +
+expansion must reproduce:
+  - total video token count (count of video_token_id in expanded input_ids)
+  - the full expanded input_ids for a 1-video chat prompt
+  - the pre-expansion input_ids (placeholder triple / single token intact)
+  - video_grid_thw, per-frame timestamps handed to the processor
+
+Torch CPU only; downloads config/tokenizer JSONs (no weights).
+"""
+import json
+import os
+import sys
+
+import numpy as np
+import torch
+from huggingface_hub import snapshot_download
+from transformers import AutoProcessor
+
+OUT_DIR = os.path.dirname(os.path.abspath(__file__))
+
+CASES = [(8, 224, 224), (5, 224, 224), (16, 360, 640), (12, 480, 854), (64, 1080, 1920)]
+FPS = 2.0  # sampled fps we pretend our frontend decoder used
+
+
+def frames(t, h, w):
+    rng = np.random.default_rng(1234)
+    return rng.integers(0, 255, size=(t, h, w, 3), dtype=np.uint8)
+
+
+def chat_text(proc, num_videos=1):
+    content = [{"type": "video"}] * num_videos + [{"type": "text", "text": "Describe."}]
+    messages = [{"role": "user", "content": content}]
+    return proc.apply_chat_template(messages, tokenize=False, add_generation_prompt=True)
+
+
+def run_model(model_id, out_name):
+    local = snapshot_download(model_id, allow_patterns=["*.json", "*.txt", "*.model"])
+    proc = AutoProcessor.from_pretrained(local)
+    cfg = json.load(open(os.path.join(local, "config.json")))
+    video_token_id = cfg["video_token_id"]
+    fixture = {
+        "model_id": model_id,
+        "local_dir": local,
+        "video_token_id": video_token_id,
+        "vision_start_token_id": cfg.get("vision_start_token_id"),
+        "vision_end_token_id": cfg.get("vision_end_token_id"),
+        "transformers_version": __import__("transformers").__version__,
+        "fps": FPS,
+        "cases": [],
+    }
+    text = chat_text(proc)
+    pre_ids = proc.tokenizer(text, add_special_tokens=False).input_ids
+    fixture["pre_expansion_input_ids"] = pre_ids
+
+    for (t, h, w) in CASES:
+        video = frames(t, h, w)
+        ts = [i / FPS for i in range(t)]
+        metadata = {
+            "fps": FPS,
+            "total_num_frames": t,
+            "duration": t / FPS,
+            "frames_indices": list(range(t)),
+            "video_backend": "opencv",
+        }
+        kwargs = dict(
+            text=[text],
+            videos=[torch.from_numpy(video).permute(0, 3, 1, 2)],
+            video_metadata=[metadata],
+            return_tensors="pt",
+            do_sample_frames=False,
+        )
+        try:
+            out = proc(**kwargs)
+        except TypeError:
+            kwargs.pop("do_sample_frames")
+            out = proc(**kwargs)
+        input_ids = out["input_ids"][0].tolist()
+        grid = out["video_grid_thw"][0].tolist()
+        n_video_tokens = sum(1 for x in input_ids if x == video_token_id)
+        fixture["cases"].append(
+            {
+                "num_frames": t,
+                "height": h,
+                "width": w,
+                "sampled_timestamps": ts,
+                "video_grid_thw": grid,
+                "n_video_tokens": n_video_tokens,
+                "expanded_input_ids": input_ids,
+            }
+        )
+        print(f"{model_id} T={t} {h}x{w}: grid={grid} video_tokens={n_video_tokens}")
+
+    path = os.path.join(OUT_DIR, out_name)
+    json.dump(fixture, open(path, "w"))
+    print("wrote", path)
+
+
+if __name__ == "__main__":
+    which = sys.argv[1] if len(sys.argv) > 1 else "all"
+    if which in ("all", "qwen25"):
+        run_model("Qwen/Qwen2.5-VL-3B-Instruct", "fixture_qwen2_5_vl.json")
+    if which in ("all", "qwen3"):
+        for mid in ("Qwen/Qwen3-VL-2B-Instruct", "Qwen/Qwen3-VL-4B-Instruct"):
+            try:
+                run_model(mid, "fixture_qwen3_vl.json")
+                break
+            except Exception as e:
+                print(f"{mid} failed: {e}", file=sys.stderr)


### PR DESCRIPTION
## Overview:

  The Dynamo frontend already does native Rust token expansion for **images** behind the
  `mm-routing` feature: each image placeholder is expanded into N `pad_value(mm_hash)`
  tokens so the KV router's block hashes match the workers' KV events. **Video was
  explicitly excluded** (`preprocessor.rs`: "Image-only; MM-routing doesn't cover
  audio/video"), so video requests fell back to text-prefix routing and the router could
  not see video KV reuse at all. Video token expansion only existed in HF-processor-based
  Python paths (vLLM `InputProcessor`, TRT-LLM `AutoProcessor`).

  This PR extends the proven image pad_value pipeline to **video, natively in Rust** — no
  HF process on the routing path. The upstream image-counting crate (`llm-multimodal`,
  verified through 1.8.0) has no temporal API, so video counting is implemented in-tree.

  Scope: Qwen2-VL / Qwen2.5-VL / Qwen3-VL, **frontend-decoding path only** — the token
  count depends on the sampled frame count `T`, which only the frontend (which samples the
  frames and ships the decoded tensor to the backend) knows exactly. URL-passthrough video
  is counted but never resolved, so the gate fails closed to clean text-prefix routing.

## Details:

  **Frontend (`lib/llm`, `mm-routing` feature)**
  - New `preprocessor/mm_video.rs`: `VideoTokenCounter` reproduces the HF video math from
    `(video_)preprocessor_config.json` — smart_resize (banker's rounding) → grid_thw →
    token count. Qwen2/2.5-VL use the per-frame pixel budget; Qwen3-VL budgets the padded
    `T*H*W` volume (including the HF quirk: over-budget threshold uses padded frames,
    rescale beta uses actual pixels).
  - `resolve_routing_tokens` additionally resolves `video_token_id` and the
    `vision_start/end_token_id` pair from `config.json`.
  - `gather_multi_modal_data` resolves video entries on the decode path: `[T,H,W,C]`
    tensor shape for dims/frames, decoded-bytes content hash for `mm_hash`, decoder
    `sampled_timestamps` for Qwen3-VL.
  - `gather_mm_exact_routing_info` expands both modalities. Qwen2/2.5-VL video replaces
    the single `<|video_pad|>` in place with `pad_value × N`. Qwen3-VL replaces the whole
    `<vision_start><video_pad><vision_end>` triple with per-frame-group
    `<ts text><vision_start><pad_value × n><vision_end>` segments, timestamp text encoded
    with the model tokenizer — mirroring the backend HF processor so per-block hashes
    align. Worker-bound `token_ids` remain untouched (routing-side view only).
  - `mm_hashes` forwarding gains the grouped `mm_hashes_by_modality` form (already
    consumed by the vLLM component) and gates per modality via a shared
    `mm_placeholders_match` precondition, so worker-side keying and router-side expansion
    can never diverge.

  **Event side (`lib/kv-router`)**
  - `substitute_pad_values` now normalizes `video_token_id` runs in vLLM BlockStored
    events alongside image runs (an id change starts a new run — Qwen3-VL emits several
    video runs per clip).
  - `StoredBlockOptions` / `create_stored_blocks` / `convert_event` / `ZmqEventNormalizer`
    carry the new optional `video_token_id`.

  **Plumbing**
  - `KvEventSourceConfig::Zmq.video_token_id`, pyo3 `KvEventPublisher(video_token_id=...)`,
    new `resolve_routing_video_token_id` binding; the vLLM component resolves and passes
    both ids to its KV event publishers.

 **Verification (all passing)**
  - Unit: counter math, config parsing, expansion structure (`mm_video::tests`,
    `mm_expand_tests`); kv-router normalization parity tests incl. multi-run video blocks.
  - **HF fixture parity** (`hf_fixture_parity`, ignored): bit-exact against real HF
    processors (Transformers 4.57.1) for Qwen2.5-VL-3B and Qwen3-VL-2B — token counts and
    the full expanded `input_ids` (including Qwen3-VL timestamp interleave) across five
    (T,H,W) cases each, including the 1080p/T=64 volume-downscale case.
  - **End-to-end vLLM parity** (`vllm_e2e_event_parity`, ignored): captured real vLLM
    0.25.1 KV events (H200) for a video request with a forwarded `multi_modal_uuid`; the
    production decode + normalization path hashes identically to the independently rebuilt
    frontend routing stream — 17/17 prompt blocks, mm extra_keys normalized on all of them.
  - Fixture/capture generators are included under `lib/llm/tests/data/mm_video/`.

  **Out of scope / follow-ups:** audio; URL-passthrough video (no cheap probe analogous to
  the image header dim-fetch); sglang component video uuid forwarding; eventual
  convergence with the in-tree `dynamo-multimodal` preprocessing crate (the counter
  interface is kept swappable so that merge is an implementation swap, not a call-site
  change).

  ## Where should the reviewer start?

  1. `lib/llm/src/preprocessor/mm_video.rs` — the new counter: HF math reproduction and
     its fixture-pinned tests (`hf_fixture_parity`, `vllm_e2e_event_parity`).
  2. `lib/llm/src/preprocessor.rs` — `gather_mm_exact_routing_info` /
     `video_replacement_tokens` / `mm_placeholders_match`: the expansion and the
     fail-closed gating.
  3. `lib/kv-router/src/zmq_wire/convert.rs` — `substitute_pad_values` run semantics for
     video and the normalization parity tests.
  4. `components/src/dynamo/vllm/main.py` — worker-side token-id resolution mirroring the
     frontend.

  ## Related Issues

  **🚫 This PR is NOT linked to an issue**:
  - [x] Confirmed — no related issue